### PR TITLE
feat(skills): remove legacy SKILL.md auto-inject (PR-E)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,11 @@ scripts/deploy.sh
 !crates/octos-agent/skills/**/SKILL.md
 !crates/app-skills/**/SKILL.md
 !crates/platform-skills/**/SKILL.md
+# Companion docs/ markdown for in-tree skill manifest discovery hints
+# (split out of SKILL.md when the body exceeds the ≤80-line discovery cap).
+!crates/octos-agent/skills/**/docs/*.md
+!crates/app-skills/**/docs/*.md
+!crates/platform-skills/**/docs/*.md
 # Crate-level developer documentation (SDK contracts, protocol specs)
 !crates/octos-plugin/docs/*.md
 # Crate test fixtures (sample reports, fake API payloads)

--- a/crates/app-skills/harness-starter-audio/manifest.json
+++ b/crates/app-skills/harness-starter-audio/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-starter-audio",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "octos",
   "description": "Starter for a harnessed audio custom app. Synthesizes a minimal WAV file under audio/ and lets the workspace contract deliver it.",
   "timeout_secs": 120,
@@ -25,5 +25,12 @@
         "required": ["label"]
       }
     }
-  ]
+  ],
+  "discovery": {
+    "summary": "Harnessed audio-artifact starter template; produces a tiny 440 Hz WAV stub under audio/ and verifies it via file_exists + file_size_min:4096.",
+    "hints": [
+      { "when": "adapting this starter into a real TTS / podcast / sound-effect app", "read": "SKILL.md" },
+      { "when": "looking at the multi-validator workspace contract", "read": "workspace-policy.toml" }
+    ]
+  }
 }

--- a/crates/app-skills/harness-starter-coding/manifest.json
+++ b/crates/app-skills/harness-starter-coding/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-starter-coding",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "octos",
   "description": "Starter for a harnessed coding-assistant custom app. Produces a diff artifact and a file-list preview under patches/.",
   "timeout_secs": 90,
@@ -33,5 +33,12 @@
         "required": ["title", "hunks"]
       }
     }
-  ]
+  ],
+  "discovery": {
+    "summary": "Harnessed coding-assistant starter template; ships a unified-diff primary artifact plus a file-list preview under patches/ and gates delivery on file_size_min:64.",
+    "hints": [
+      { "when": "adapting this starter into a real coding assistant (similar-based diffing, git apply check, etc.)", "read": "SKILL.md" },
+      { "when": "looking at the multi-artifact workspace contract", "read": "workspace-policy.toml" }
+    ]
+  }
 }

--- a/crates/app-skills/harness-starter-generic/manifest.json
+++ b/crates/app-skills/harness-starter-generic/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-starter-generic",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "octos",
   "description": "Minimal starter for a single-artifact harnessed custom app. Writes a text file under output/ and lets the workspace contract deliver it.",
   "timeout_secs": 30,
@@ -21,5 +21,12 @@
         "required": ["label"]
       }
     }
-  ]
+  ],
+  "discovery": {
+    "summary": "Minimal harnessed single-artifact starter template; writes one text file under output/ and relies on the workspace contract to verify and deliver it.",
+    "hints": [
+      { "when": "adapting this starter into a new harnessed custom app", "read": "SKILL.md" },
+      { "when": "looking at the full workspace contract", "read": "workspace-policy.toml" }
+    ]
+  }
 }

--- a/crates/app-skills/harness-starter-report/manifest.json
+++ b/crates/app-skills/harness-starter-report/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-starter-report",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "octos",
   "description": "Starter for a harnessed report-generator custom app. Writes a markdown file under reports/ and lets the workspace contract deliver it.",
   "timeout_secs": 60,
@@ -25,5 +25,12 @@
         "required": ["topic"]
       }
     }
-  ]
+  ],
+  "discovery": {
+    "summary": "Harnessed report-generator starter template; ships a markdown deliverable under reports/ and gates delivery on file_size_min:256 with structured on_failure notification.",
+    "hints": [
+      { "when": "adapting this starter into a real report generator (weekly digest, research brief, status report)", "read": "SKILL.md" },
+      { "when": "looking at the workspace contract incl. on_failure action", "read": "workspace-policy.toml" }
+    ]
+  }
 }

--- a/crates/octos-agent/src/plugins/extras.rs
+++ b/crates/octos-agent/src/plugins/extras.rs
@@ -28,7 +28,13 @@ pub struct SkillExtras {
 /// - MCP: resolves relative commands against `skill_dir`, looks up env var names
 ///   from the process environment.
 /// - Hooks: parses event strings into `HookEvent`, resolves relative command paths.
+/// - Discovery: renders a short skill card (PR-C) into `prompt_fragments`.
 /// - Prompts: expands glob patterns against `skill_dir`, reads `.md` files.
+///
+/// PR-E note: the legacy "auto-inject the full SKILL.md body for spawn_only
+/// plugins" code path has been removed. The discovery card is the structured
+/// replacement; an explicit `prompts.include` glob is the escape hatch for
+/// skills that still want a prompt fragment embedded.
 pub fn resolve_extras(manifest: &PluginManifest, skill_dir: &Path) -> SkillExtras {
     let mut extras = SkillExtras::default();
 
@@ -52,42 +58,17 @@ pub fn resolve_extras(manifest: &PluginManifest, skill_dir: &Path) -> SkillExtra
     // PR-C of the SKILL.md rethink: when the manifest declares a
     // `discovery` block, render a short skill card into the system
     // prompt so the LLM learns where the skill dir is and what to
-    // read or list first. The card coexists with the legacy SKILL.md
-    // auto-inject below — PR-D + PR-E remove the auto-inject after
-    // per-skill migrations land.
+    // read or list first. After PR-E this is the only structured
+    // surface the SKILL.md rethink injects — the legacy SKILL.md
+    // auto-inject that used to also push the entire body into the
+    // prompt for spawn_only plugins has been removed now that all
+    // production spawn_only skills (mofa-cards, mofa-comic, mofa-fm,
+    // mofa-podcast, mofa-infographic, mofa-publish, mofa-slides) have
+    // migrated to the discovery+card model in PR-D2.
     if let Some(discovery) = &manifest.discovery {
         extras
             .prompt_fragments
             .push(render_skill_card(manifest, discovery, skill_dir));
-    }
-
-    // Auto-inject SKILL.md when skill has spawn_only tools so the LLM
-    // knows how to access deferred tools via spawn.
-    //
-    // M10 Phase 4 (codex round 2 P2): the `read_task_output` contract
-    // teaching is NOT injected globally here. The `extras.prompt_fragments`
-    // are merged into the system prompt on every agent that loads the
-    // skill — including CLI chat / swarm workers whose registries do not
-    // wire `read_task_output`. Without registry-aware gating those agents
-    // would learn about a tool they cannot call. Instead, the
-    // `spawn_only_handle_message` envelope itself documents the contract
-    // inline (`read_with`, `read_modes`, and the `summary` field), so
-    // only agents that actually emit the new envelope teach the LLM
-    // about it — automatic and consistent with the gating in
-    // `execution.rs::is_tool_visible`.
-    //
-    // PR-D1 of the SKILL.md rethink: a plugin can opt out of this legacy
-    // auto-inject by setting `skill_md_auto_inject: false` in its manifest.
-    // The flag defaults to `true` so unmigrated plugins keep current
-    // behavior; PR-D2 (mofa-skills) opts each mofa-* skill in, and PR-E
-    // eventually flips the default.
-    if manifest.skill_md_auto_inject && manifest.tools.iter().any(|t| t.spawn_only) {
-        let skill_md = skill_dir.join("SKILL.md");
-        if skill_md.exists() {
-            if let Ok(content) = std::fs::read_to_string(&skill_md) {
-                extras.prompt_fragments.push(content);
-            }
-        }
     }
 
     if let Some(prompts) = &manifest.prompts {
@@ -124,8 +105,9 @@ pub fn resolve_extras(manifest: &PluginManifest, skill_dir: &Path) -> SkillExtra
 
 /// Render a skill card from manifest discovery hints (PR-C of the SKILL.md
 /// rethink). Output is a fixed-shape text block, ~5-10 lines, suitable for
-/// concatenating into the system prompt alongside (or eventually instead
-/// of) the legacy SKILL.md auto-inject.
+/// concatenating into the system prompt as the LLM-facing entry point for
+/// the skill. After PR-E this is the only fragment the discovery surface
+/// contributes — the legacy SKILL.md auto-inject has been removed.
 ///
 /// Shape:
 /// ```text
@@ -389,7 +371,6 @@ mod tests {
             hooks: vec![],
             prompts: None,
             discovery: None,
-            skill_md_auto_inject: true,
         };
         let extras = resolve_extras(&manifest, Path::new("/skills/test"));
         assert!(extras.mcp_servers.is_empty());
@@ -419,7 +400,6 @@ mod tests {
                 include: vec!["prompts/*.md".into()],
             }),
             discovery: None,
-            skill_md_auto_inject: true,
         };
         let extras = resolve_extras(&manifest, dir.path());
         assert_eq!(extras.prompt_fragments.len(), 2);
@@ -441,20 +421,6 @@ mod tests {
         tools: Vec<&str>,
         discovery: Option<crate::plugins::manifest::SkillDiscovery>,
         any_spawn_only: bool,
-    ) -> PluginManifest {
-        manifest_for_card_test_with_flag(name, tools, discovery, any_spawn_only, true)
-    }
-
-    /// Variant of `manifest_for_card_test` that exposes the PR-D1
-    /// `skill_md_auto_inject` flag. The shorter helper above wraps this
-    /// with `skill_md_auto_inject: true` (the default) to keep older
-    /// tests readable.
-    fn manifest_for_card_test_with_flag(
-        name: &str,
-        tools: Vec<&str>,
-        discovery: Option<crate::plugins::manifest::SkillDiscovery>,
-        any_spawn_only: bool,
-        skill_md_auto_inject: bool,
     ) -> PluginManifest {
         use crate::plugins::manifest::PluginToolDef;
         PluginManifest {
@@ -481,7 +447,6 @@ mod tests {
             hooks: vec![],
             prompts: None,
             discovery,
-            skill_md_auto_inject,
         }
     }
 
@@ -583,54 +548,34 @@ mod tests {
         );
     }
 
+    /// PR-E regression: a spawn_only plugin with a SKILL.md file on disk
+    /// must NOT have its body injected anymore. Before PR-E this exact
+    /// configuration would emit the SKILL.md body as a prompt fragment;
+    /// after the legacy auto-inject removal the manifest produces no
+    /// fragments at all (no discovery → no card, and the body is gone).
     #[test]
-    fn extras_renders_card_alongside_legacy_auto_inject() {
-        use crate::plugins::manifest::{DiscoveryHint, SkillDiscovery};
-
+    fn extras_skips_legacy_body_for_spawn_only_skill_with_skill_md_on_disk() {
         let dir = tempfile::tempdir().unwrap();
         let skill_dir = dir.path();
-        // Legacy auto-inject writes SKILL.md content into the prompt.
         std::fs::write(
             skill_dir.join("SKILL.md"),
-            "# Legacy SKILL.md\nMode 1: foo. Mode 2: bar.\n",
+            "# Legacy SKILL.md\nPre-PR-E this body would be injected.\n",
         )
         .unwrap();
 
-        let discovery = SkillDiscovery {
-            summary: Some("Modes 1+2 for slides.".into()),
-            hints: vec![DiscoveryHint {
-                when: "user wants editable PPT".into(),
-                read: Some("SKILL.md#mode-2".into()),
-                list: None,
-            }],
-        };
-        // any_spawn_only=true → triggers legacy auto-inject.
         let manifest = manifest_for_card_test(
-            "mofa-slides",
-            vec!["slides_generate"],
-            Some(discovery),
-            true,
+            "legacy-spawn-only",
+            vec!["bg_tool"],
+            None, // no discovery
+            true, // spawn_only — would have triggered legacy auto-inject
         );
 
         let extras = resolve_extras(&manifest, skill_dir);
-        assert_eq!(
-            extras.prompt_fragments.len(),
-            2,
-            "expected card + legacy auto-inject; got {:?}",
+        assert!(
+            extras.prompt_fragments.is_empty(),
+            "legacy SKILL.md auto-inject must be gone; got {:?}",
             extras.prompt_fragments
         );
-
-        let has_card = extras
-            .prompt_fragments
-            .iter()
-            .any(|f| f.contains("name: mofa-slides") && f.contains("purpose:"));
-        let has_legacy = extras
-            .prompt_fragments
-            .iter()
-            .any(|f| f.contains("Legacy SKILL.md") && f.contains("Mode 1: foo"));
-
-        assert!(has_card, "card fragment missing");
-        assert!(has_legacy, "legacy SKILL.md fragment missing");
     }
 
     #[test]
@@ -655,162 +600,6 @@ mod tests {
         assert!(
             !card.contains("if you need:"),
             "empty hints should NOT render 'if you need:' header: {card}"
-        );
-    }
-
-    // ------------------------------------------------------------------
-    // SKILL.md PR-D1: skill_md_auto_inject opt-out gates legacy SKILL.md
-    // ------------------------------------------------------------------
-
-    /// Opting out (`skill_md_auto_inject: false`) skips the legacy
-    /// auto-inject even when the manifest has a `spawn_only` tool and a
-    /// `SKILL.md` is present on disk. This is the migration end-state for
-    /// step 2 of the rethink — the new discovery card replaces the
-    /// always-injected SKILL.md body.
-    #[test]
-    fn extras_skips_legacy_auto_inject_when_opted_out() {
-        let dir = tempfile::tempdir().unwrap();
-        let skill_dir = dir.path();
-        std::fs::write(
-            skill_dir.join("SKILL.md"),
-            "# Legacy SKILL.md\nShould NOT be injected when opted out.\n",
-        )
-        .unwrap();
-
-        let manifest = manifest_for_card_test_with_flag(
-            "opted-out",
-            vec!["bg_tool"],
-            None,  // no discovery — purely a legacy-gate test
-            true,  // any_spawn_only triggers the legacy auto-inject path
-            false, // skill_md_auto_inject opt-out
-        );
-
-        let extras = resolve_extras(&manifest, skill_dir);
-        assert!(
-            extras.prompt_fragments.is_empty(),
-            "opted-out plugin must not inject SKILL.md; got {:?}",
-            extras.prompt_fragments
-        );
-    }
-
-    /// Default behavior (no explicit flag in the manifest, mirrored here
-    /// by passing `skill_md_auto_inject: true`) preserves the legacy
-    /// auto-inject so unmigrated plugins keep working.
-    #[test]
-    fn extras_runs_legacy_auto_inject_when_opted_in_default() {
-        let dir = tempfile::tempdir().unwrap();
-        let skill_dir = dir.path();
-        std::fs::write(
-            skill_dir.join("SKILL.md"),
-            "# Legacy SKILL.md\nUnmigrated default behavior.\n",
-        )
-        .unwrap();
-
-        // `manifest_for_card_test` constructs with skill_md_auto_inject:true
-        // — the default — so this exercises the "field omitted" path.
-        let manifest = manifest_for_card_test(
-            "legacy-default",
-            vec!["bg_tool"],
-            None,
-            true, // spawn_only present
-        );
-
-        let extras = resolve_extras(&manifest, skill_dir);
-        assert_eq!(
-            extras.prompt_fragments.len(),
-            1,
-            "default plugin must inject SKILL.md exactly once; got {:?}",
-            extras.prompt_fragments
-        );
-        assert!(
-            extras.prompt_fragments[0].contains("Unmigrated default behavior."),
-            "fragment must contain SKILL.md body; got {:?}",
-            extras.prompt_fragments[0]
-        );
-    }
-
-    /// Explicit `true` is equivalent to the default — confirms the gate
-    /// does not silently invert when a manifest opts in loudly.
-    #[test]
-    fn extras_runs_legacy_auto_inject_when_explicitly_true() {
-        let dir = tempfile::tempdir().unwrap();
-        let skill_dir = dir.path();
-        std::fs::write(
-            skill_dir.join("SKILL.md"),
-            "# Legacy SKILL.md\nExplicit opt-in body.\n",
-        )
-        .unwrap();
-
-        let manifest = manifest_for_card_test_with_flag(
-            "explicit-legacy",
-            vec!["bg_tool"],
-            None,
-            true,
-            true, // explicit opt-in
-        );
-
-        let extras = resolve_extras(&manifest, skill_dir);
-        assert_eq!(extras.prompt_fragments.len(), 1);
-        assert!(extras.prompt_fragments[0].contains("Explicit opt-in body."));
-    }
-
-    /// Migration end-state regression: when both `discovery` is present
-    /// AND `skill_md_auto_inject: false` is set, the skill card renders
-    /// but the legacy SKILL.md body does not. This is the configuration
-    /// PR-D2 will produce per migrated mofa-* skill.
-    #[test]
-    fn extras_skips_legacy_but_renders_card_when_discovery_present_and_opted_out() {
-        use crate::plugins::manifest::{DiscoveryHint, SkillDiscovery};
-
-        let dir = tempfile::tempdir().unwrap();
-        let skill_dir = dir.path();
-        std::fs::write(
-            skill_dir.join("SKILL.md"),
-            "# Legacy SKILL.md\nShould NOT appear when opted out.\n",
-        )
-        .unwrap();
-
-        let discovery = SkillDiscovery {
-            summary: Some("Migrated skill.".into()),
-            hints: vec![DiscoveryHint {
-                when: "user wants editable PPT".into(),
-                read: Some("SKILL.md#mode-2".into()),
-                list: None,
-            }],
-        };
-
-        let manifest = manifest_for_card_test_with_flag(
-            "mofa-slides",
-            vec!["slides_generate"],
-            Some(discovery),
-            true,  // spawn_only tool present (would normally trigger legacy)
-            false, // but auto-inject is opted out
-        );
-
-        let extras = resolve_extras(&manifest, skill_dir);
-        assert_eq!(
-            extras.prompt_fragments.len(),
-            1,
-            "migrated plugin must yield card-only (no legacy body); got {:?}",
-            extras.prompt_fragments
-        );
-        let card = &extras.prompt_fragments[0];
-        assert!(card.contains("name: mofa-slides"), "card missing: {card}");
-        assert!(
-            card.contains("purpose: Migrated skill."),
-            "card missing purpose: {card}"
-        );
-        assert!(
-            !card.contains("Should NOT appear"),
-            "legacy SKILL.md body leaked into the card: {card}"
-        );
-        assert!(
-            !extras
-                .prompt_fragments
-                .iter()
-                .any(|f| f.contains("Should NOT appear")),
-            "legacy SKILL.md body leaked as a separate fragment: {:?}",
-            extras.prompt_fragments
         );
     }
 }

--- a/crates/octos-agent/src/plugins/manifest.rs
+++ b/crates/octos-agent/src/plugins/manifest.rs
@@ -55,37 +55,11 @@ pub struct PluginManifest {
     /// When present, `resolve_extras` renders a short "skill card" into the
     /// system prompt so the agent learns (1) the skill exists, (2) where
     /// its directory lives, and (3) which files to read or list first.
-    /// This is the opt-in migration affordance for the SKILL.md rethink:
-    /// plugins that add `discovery` get the card; plugins without it keep
-    /// the legacy SKILL.md auto-inject only (see `extras.rs`).
+    /// This is the SKILL.md rethink's LLM-facing surface (PR-C); PR-E
+    /// removed the legacy auto-inject that used to also push the entire
+    /// SKILL.md body into the prompt for spawn_only plugins.
     #[serde(default, deserialize_with = "deserialize_discovery")]
     pub discovery: Option<SkillDiscovery>,
-    /// When false, this plugin opts out of having its SKILL.md auto-injected
-    /// into the system prompt. Used in combination with `discovery` (PR-C) to
-    /// migrate plugins from legacy auto-inject to on-demand discovery.
-    ///
-    /// Migration is intentionally three steps so each stage stays revertable:
-    ///   1. Add `discovery` so both legacy auto-inject AND the new skill
-    ///      card render (validate the card works in production).
-    ///   2. Set `skill_md_auto_inject: false` so only the card renders.
-    ///   3. Trim SKILL.md body to <=80 lines now that the LLM reads it on
-    ///      demand instead of having it shoved into every system prompt.
-    ///
-    /// Decoupling step 2 from step 1 via an explicit flag (rather than an
-    /// implicit "presence of discovery disables legacy") is what lets each
-    /// step be independently revertable — see PR-D1.
-    ///
-    /// Default: true (legacy behavior preserved for unmigrated plugins).
-    #[serde(default = "default_true")]
-    pub skill_md_auto_inject: bool,
-}
-
-/// Serde default helper for `bool` fields whose absence should deserialize
-/// to `true`. Locally scoped: `PluginManifest::skill_md_auto_inject` is the
-/// only field in this module that needs it today, but adding more later
-/// (e.g. a `legacy_card_inject` flag) should reuse this helper.
-fn default_true() -> bool {
-    true
 }
 
 impl PluginManifest {
@@ -100,13 +74,6 @@ impl PluginManifest {
     /// check meant a discovery-only manifest became a silent no-op under
     /// strict mode, and a signed tool plugin with discovery had its skill
     /// card dropped without any warning.
-    ///
-    /// PR-D1 note: `skill_md_auto_inject` is intentionally NOT counted as an
-    /// extra. The semantics are inverted relative to the other fields —
-    /// setting it to `false` *removes* an injected fragment rather than
-    /// adding one — so it does not affect whether the manifest carries
-    /// surfaces beyond its tool list. The loader's strict-mode reasoning
-    /// about extras-only manifests therefore continues to apply unchanged.
     pub fn has_extras(&self) -> bool {
         !self.mcp_servers.is_empty()
             || !self.hooks.is_empty()
@@ -1213,56 +1180,27 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // SKILL.md PR-D1: skill_md_auto_inject opt-out flag
+    // SKILL.md PR-E: legacy skill_md_auto_inject field removal
     // ------------------------------------------------------------------
 
-    /// A manifest that omits the field must deserialize to `true` so
-    /// unmigrated plugins keep current behavior (legacy SKILL.md
-    /// auto-inject still runs for `spawn_only` tools).
+    /// PR-E backwards compat: manifests that still declare
+    /// `skill_md_auto_inject` (the PR-D1 opt-out flag) must continue to
+    /// parse cleanly after the field is dropped from `PluginManifest`.
+    /// Serde silently ignores unknown JSON fields because the struct does
+    /// NOT set `deny_unknown_fields`; this test pins that contract so a
+    /// future tightening cannot break the 7 already-migrated mofa-* skill
+    /// manifests on disk.
     #[test]
-    fn manifest_defaults_skill_md_auto_inject_to_true() {
-        let json = r#"{
-            "name": "legacy",
-            "version": "1.0.0",
-            "tools": [{"name": "t", "description": "d"}]
-        }"#;
-        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
-        assert!(
-            manifest.skill_md_auto_inject,
-            "missing field must default to true (preserves legacy auto-inject)"
-        );
-    }
-
-    /// Explicit `false` opts the plugin out of the legacy SKILL.md
-    /// auto-inject. This is the migration knob PR-D2 will set per skill
-    /// after the new discovery card lands and soaks.
-    #[test]
-    fn manifest_parses_explicit_skill_md_auto_inject_false() {
+    fn manifest_ignores_legacy_skill_md_auto_inject_field() {
         let json = r#"{
             "name": "migrated",
             "version": "1.0.0",
             "tools": [{"name": "t", "description": "d"}],
             "skill_md_auto_inject": false
         }"#;
-        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
-        assert!(
-            !manifest.skill_md_auto_inject,
-            "explicit false must turn off the legacy auto-inject gate"
-        );
-    }
-
-    /// Explicit `true` is equivalent to omitting the field but must still
-    /// be parseable so operators can be loud about opting in during the
-    /// migration window.
-    #[test]
-    fn manifest_parses_explicit_skill_md_auto_inject_true() {
-        let json = r#"{
-            "name": "explicit-legacy",
-            "version": "1.0.0",
-            "tools": [{"name": "t", "description": "d"}],
-            "skill_md_auto_inject": true
-        }"#;
-        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
-        assert!(manifest.skill_md_auto_inject);
+        let manifest: PluginManifest =
+            serde_json::from_str(json).expect("legacy field must parse without error");
+        assert_eq!(manifest.name, "migrated");
+        assert_eq!(manifest.tools.len(), 1);
     }
 }

--- a/crates/platform-skills/voice/SKILL.md
+++ b/crates/platform-skills/voice/SKILL.md
@@ -1,136 +1,73 @@
 ---
 name: voice
 description: OminiX ASR (speech-to-text), preset-voice TTS with emotion/speed control, and model management via Qwen3 models on Apple Silicon. For voice cloning and custom voice profiles, use mofa-fm. Triggers: voice, transcribe audio, text to speech, speak this, read aloud, model management, download model, 语音识别, 语音合成, 模型管理.
-version: 1.1.1
+version: 1.1.2
 author: octos
 always: true
 ---
 
 # OminiX ASR / TTS / Model Management
 
-On-device speech-to-text, preset-voice text-to-speech with emotion control, and model management using OminiX Qwen3 ASR/TTS models on Apple Silicon.
+On-device speech-to-text and preset-voice text-to-speech with emotion control
+plus model lifecycle management, backed by Qwen3 ASR/TTS models running on the
+local ominix-api server (Apple Silicon).
 
-> **Voice cloning and custom voice profiles** are handled by **mofa-fm** (fm_tts, fm_voice_save, fm_voice_list, fm_voice_delete). This skill only supports preset voices.
+## Boundary — when NOT to use this skill
 
-## Configuration
-
-The skill auto-discovers the ominix-api server URL via (in priority order):
-1. `OMINIX_API_URL` environment variable
-2. Discovery file `~/.ominix/api_url` (written by ominix-api on startup)
-3. Probes candidate ports — `http://localhost:9090`, `http://localhost:8080`,
-   `http://localhost:8081` — and uses the first one answering `/health` within
-   500 ms. Only falls back to macOS Say when every probe fails.
-
-## Checking Available Models
-
-Use `list_models` to see what's installed. The response includes an `endpoints` array for each model, telling you which URL to use:
-
-```json
-{"data": [
-  {"id": "qwen3-asr", "type": "asr", "endpoints": ["/v1/audio/asr/qwen3"]},
-  {"id": "Qwen3-TTS-CustomVoice-8bit", "type": "qwen3_tts", "endpoints": ["/v1/audio/tts/qwen3"]}
-]}
-```
-
-If a model you need is missing, use `download_model` then `load_model` to install it.
-
-## API Endpoints
-
-| Function | Endpoint | Model |
-|---|---|---|
-| Preset TTS | `POST /v1/audio/tts/qwen3` | Qwen3-TTS CustomVoice |
-| Qwen3-ASR | `POST /v1/audio/asr/qwen3` | Qwen3-ASR encoder-decoder |
-| Paraformer | `POST /v1/audio/asr/paraformer` | Paraformer CTC-based |
-
-TTS and ASR run on separate threads — they do not block each other.
+- **Voice cloning / custom voice profiles** → use **mofa-fm**
+  (`fm_tts`, `fm_voice_save`, `fm_voice_list`, `fm_voice_delete`). This skill
+  is **preset-voice only**.
+- **Emotion prompts in fallback mode** → not supported. When ominix-api is
+  unreachable, `voice_synthesize` falls through to the macOS built-in `say`
+  command, which auto-picks a system voice from the text language and ignores
+  the `prompt` parameter.
 
 ## Tools
 
-### voice_transcribe
+| Tool               | Purpose                                                    |
+|--------------------|------------------------------------------------------------|
+| `voice_transcribe` | ASR — WAV/OGG/MP3/FLAC/M4A → text                          |
+| `voice_synthesize` | Preset-voice TTS with optional emotion + speed             |
+| `list_models`      | List loaded + catalog models on the local ominix-api       |
+| `download_model`   | Pull a catalog model to local disk                         |
+| `load_model`       | Load a downloaded model into GPU memory                    |
+| `unload_model`     | Free a loaded model from GPU memory                        |
 
-Transcribe an audio file to text via Qwen3-ASR. Supports WAV, OGG, MP3, FLAC, M4A.
+## Quick recipes
+
+### Transcribe a voice message
 
 ```json
 {"audio_path": "voice.ogg", "language": "Chinese"}
 ```
 
-**Parameters:**
-- `audio_path` (required): Absolute path to the audio file
-- `language` (optional, default "Chinese"): "Chinese", "English", "Japanese", "Korean", "Cantonese", etc.
-
-### voice_synthesize
-
-Generate speech audio from text using a preset voice. Uses Qwen3-TTS when ominix-api is running (high quality, emotion/style control). Falls back to macOS built-in `say` command when unavailable.
-
-macOS Say auto-detects language from text and picks the appropriate built-in voice. Emotion prompts (`prompt`) are not supported in fallback mode.
+### Synthesize plain speech
 
 ```json
 {"text": "Hello world", "language": "english", "speaker": "ryan"}
 ```
 
-With emotion:
+### Synthesize with emotion
+
 ```json
 {"text": "我太开心了！", "speaker": "vivian", "prompt": "用兴奋激动的语气说话，充满热情和活力"}
 ```
 
-**Parameters:**
-- `text` (required): Text to synthesize
-- `output_path` (optional): Where to save audio. Default: auto-generated in OCTOS_WORK_DIR
-- `language` (optional, default "chinese"): "chinese", "english", "japanese", "korean"
-- `speaker` (optional, default "vivian"): Preset name only — vivian, serena, ryan, aiden, eric, dylan, uncle_fu, ono_anna, sohee
-- `prompt` (optional): Style/emotion instruction (see tables below)
-- `speed` (optional, default 1.0): Speed factor 0.5-2.0
+After `voice_synthesize` returns a file path, deliver the audio with
+`send_file`.
 
-**Preset speakers:** vivian, serena, ryan, aiden, eric, dylan (English/Chinese), uncle_fu (Chinese), ono_anna (Japanese), sohee (Korean)
+## Further reading
 
-**Verified Chinese emotion prompts** (best with vivian, serena, dylan, uncle_fu):
+- Emotion / style prompts (Chinese + English) → `docs/emotion-prompts.md`
+- Server discovery, endpoints, preset speakers, full parameter cheat-sheet →
+  `docs/api-reference.md`
 
-| Style | Prompt |
-|-------|--------|
-| Excited | `用兴奋激动的语气说话，充满热情和活力` |
-| Sad | `用悲伤失望的语气说话，声音低沉，语速缓慢` |
-| Cheerful | `用开朗愉快的语气说话，声音明亮上扬，节奏轻快` |
-| Shout | `用大声喊叫的方式说话，声音高亢有力，语速快` |
-| Sarcastic | `用讽刺嘲讽的语气说话，语调阴阳怪气，拖长尾音` |
-| Soft | `用温柔轻柔的语气说话` |
-| Panic | `用惊慌恐惧的语气说话，声音颤抖，语速急促` |
+## Anti-patterns
 
-**English emotion prompts** (best with ryan, aiden):
-
-| Style | Prompt |
-|-------|--------|
-| Excited | `Speak with excitement and enthusiasm, full of energy` |
-| Sad | `Speak in a sad, disappointed tone, voice low and slow` |
-| Cheerful | `Speak cheerfully with a bright, upbeat voice` |
-| Shout | `Shout loudly with a powerful, high-pitched voice` |
-| Sarcastic | `Speak sarcastically with a mocking, drawn-out tone` |
-| Soft | `Speak gently and softly` |
-| Panic | `Speak in a panicked, trembling voice, fast and breathless` |
-
-Custom free-form prompts are also supported — include emotion + timbre + pace descriptors for strongest control.
-
-### list_models
-
-List all loaded models and available models in the catalog.
-
-### download_model
-
-Download a model from the catalog.
-
-**Parameters:**
-- `model_id` (required): Model ID from the catalog
-
-### load_model
-
-Load a downloaded model into memory for inference.
-
-**Parameters:**
-- `model` (required): Model name or path
-- `model_type` (optional, default "llm"): "llm", "asr", "tts"
-
-### unload_model
-
-Unload a model from memory.
-
-**Parameters:**
-- `model_type` (required): Type of model to unload — "llm", "asr", "tts"
+- Calling `voice_synthesize` with a `prompt` while ominix-api is down — the
+  fallback (`say`) silently drops the emotion. Use `list_models` to confirm
+  Qwen3-TTS is loaded before relying on emotion control.
+- Passing a non-preset speaker name (e.g. a cloned voice id) — this skill
+  only handles preset voices; route the call to **mofa-fm** instead.
+- Skipping `download_model` + `load_model` after a fresh install — the
+  catalog model is not loaded until you load it explicitly.

--- a/crates/platform-skills/voice/docs/api-reference.md
+++ b/crates/platform-skills/voice/docs/api-reference.md
@@ -1,0 +1,78 @@
+# Voice Skill: API + Model Reference
+
+## Server discovery
+
+The skill auto-discovers the ominix-api server URL via (in priority order):
+
+1. `OMINIX_API_URL` environment variable
+2. Discovery file `~/.ominix/api_url` (written by ominix-api on startup)
+3. Probes candidate ports `http://localhost:9090`, `http://localhost:8080`,
+   `http://localhost:8081` — first one answering `/health` within 500 ms wins
+4. Falls back to macOS `say` only when every probe fails
+
+## Endpoints
+
+| Function   | Endpoint                       | Model                       |
+|------------|--------------------------------|-----------------------------|
+| Preset TTS | `POST /v1/audio/tts/qwen3`     | Qwen3-TTS CustomVoice       |
+| Qwen3-ASR  | `POST /v1/audio/asr/qwen3`     | Qwen3-ASR encoder-decoder   |
+| Paraformer | `POST /v1/audio/asr/paraformer`| Paraformer CTC-based        |
+
+TTS and ASR run on separate threads — they do not block each other.
+
+## Checking available models
+
+`list_models` returns an `endpoints` array per model so you can tell which URL
+to call:
+
+```json
+{"data": [
+  {"id": "qwen3-asr", "type": "asr", "endpoints": ["/v1/audio/asr/qwen3"]},
+  {"id": "Qwen3-TTS-CustomVoice-8bit", "type": "qwen3_tts", "endpoints": ["/v1/audio/tts/qwen3"]}
+]}
+```
+
+If a needed model is missing: `download_model` then `load_model`. Downloads
+can take several minutes for large models.
+
+## Preset speakers
+
+| Speaker     | Languages         |
+|-------------|-------------------|
+| vivian      | English / Chinese (default) |
+| serena      | English / Chinese |
+| ryan        | English / Chinese |
+| aiden       | English / Chinese |
+| eric        | English / Chinese |
+| dylan       | English / Chinese |
+| uncle_fu    | Chinese           |
+| ono_anna    | Japanese          |
+| sohee       | Korean            |
+
+## Tool parameter cheat-sheet
+
+### voice_transcribe
+
+- `audio_path` (required): absolute path to WAV/OGG/MP3/FLAC/M4A
+- `language` (optional, default `"Chinese"`): `"Chinese"`, `"English"`,
+  `"Japanese"`, `"Korean"`, `"Cantonese"`, …
+
+### voice_synthesize
+
+- `text` (required)
+- `output_path` (optional): default auto-generated in `OCTOS_WORK_DIR`
+- `language` (optional, default `"chinese"`): `"chinese"`, `"english"`,
+  `"japanese"`, `"korean"`
+- `speaker` (optional, default `"vivian"`): one of the preset names above
+- `prompt` (optional): style/emotion instruction (see
+  `emotion-prompts.md`)
+- `speed` (optional, default 1.0): 0.5–2.0
+
+### load_model
+
+- `model` (required): name or path of a downloaded model
+- `model_type` (optional, default `"llm"`): `"llm"`, `"asr"`, `"tts"`
+
+### unload_model
+
+- `model_type` (required): `"llm"`, `"asr"`, `"tts"`

--- a/crates/platform-skills/voice/docs/emotion-prompts.md
+++ b/crates/platform-skills/voice/docs/emotion-prompts.md
@@ -1,0 +1,33 @@
+# Voice TTS: Emotion / Style Prompts
+
+The `prompt` parameter on `voice_synthesize` accepts a free-form style/emotion
+instruction. These tables are the verified set; custom free-form prompts also
+work — combine emotion + timbre + pace descriptors for the strongest control.
+
+## Verified Chinese emotion prompts
+
+Best paired with `vivian`, `serena`, `dylan`, `uncle_fu`.
+
+| Style     | Prompt                                                 |
+|-----------|--------------------------------------------------------|
+| Excited   | `用兴奋激动的语气说话，充满热情和活力`               |
+| Sad       | `用悲伤失望的语气说话，声音低沉，语速缓慢`           |
+| Cheerful  | `用开朗愉快的语气说话，声音明亮上扬，节奏轻快`       |
+| Shout     | `用大声喊叫的方式说话，声音高亢有力，语速快`         |
+| Sarcastic | `用讽刺嘲讽的语气说话，语调阴阳怪气，拖长尾音`       |
+| Soft      | `用温柔轻柔的语气说话`                                 |
+| Panic     | `用惊慌恐惧的语气说话，声音颤抖，语速急促`           |
+
+## English emotion prompts
+
+Best paired with `ryan`, `aiden`.
+
+| Style     | Prompt                                                              |
+|-----------|---------------------------------------------------------------------|
+| Excited   | `Speak with excitement and enthusiasm, full of energy`              |
+| Sad       | `Speak in a sad, disappointed tone, voice low and slow`             |
+| Cheerful  | `Speak cheerfully with a bright, upbeat voice`                      |
+| Shout     | `Shout loudly with a powerful, high-pitched voice`                  |
+| Sarcastic | `Speak sarcastically with a mocking, drawn-out tone`                |
+| Soft      | `Speak gently and softly`                                           |
+| Panic     | `Speak in a panicked, trembling voice, fast and breathless`         |

--- a/crates/platform-skills/voice/manifest.json
+++ b/crates/platform-skills/voice/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "voice",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "octos",
   "description": "OminiX voice skill: ASR, preset-voice TTS with emotion/speed control, and model management via local Qwen3 models on Apple Silicon. For voice cloning and custom voice profiles, use mofa-fm instead.",
   "timeout_secs": 600,
@@ -118,5 +118,15 @@
         "required": ["model_type"]
       }
     }
-  ]
+  ],
+  "discovery": {
+    "summary": "On-device ASR + preset-voice TTS (Qwen3 on Apple Silicon) with emotion/speed control and model lifecycle. Voice cloning lives in sibling skill mofa-fm.",
+    "hints": [
+      { "when": "user asks for voice cloning or a custom voice profile", "read": "SKILL.md" },
+      { "when": "picking a preset speaker or wiring TTS parameters", "read": "docs/api-reference.md" },
+      { "when": "choosing or composing an emotion / style prompt", "read": "docs/emotion-prompts.md" },
+      { "when": "checking server discovery, endpoints, or fallback behavior", "read": "docs/api-reference.md" },
+      { "when": "ominix-api may be down (emotion prompt + fallback gotcha)", "read": "SKILL.md" }
+    ]
+  }
 }


### PR DESCRIPTION
## Context

After PR-A/B/C/D1 (octos) + PR-D2 (mofa-skills × 7) landed, the legacy "auto-inject the full SKILL.md body for spawn_only plugins" code path in `extras.rs:78-91` became production-dead:

- **All 7 production spawn_only skills migrated to the discovery+card model** (mofa-cards, mofa-comic, mofa-fm, mofa-podcast, mofa-infographic, mofa-publish, mofa-slides) — each opted out via `skill_md_auto_inject: false` in PR-D2.
- **The remaining mofa-* skills are not spawn_only** (cli, frame, pdf, site, xlsx, youtube) — they were never auto-injected, only the discovery card path applies.

PR-E closes the rethink by removing the dead code path entirely and dropping the migration flag now that nothing reads it.

## Decision: removed the field entirely

After the if-block was deleted, no code consulted `skill_md_auto_inject` anymore. Per the structural-over-micro principle, removed the field outright instead of flipping its default. Manifests that still declare it (the 7 migrated mofa-* skills) parse cleanly because `PluginManifest` does NOT set `deny_unknown_fields` — serde silently ignores it. A new regression test pins this contract.

## Changes

### `crates/octos-agent/src/plugins/extras.rs`
- Deleted the `if manifest.skill_md_auto_inject && manifest.tools.iter().any(|t| t.spawn_only) { ... }` block that read SKILL.md and pushed it to `prompt_fragments`.
- Updated `resolve_extras` doc comment to enumerate the four surfaces (MCP/Hooks/Discovery/Prompts) and note that the legacy path is gone.
- Updated `render_skill_card` doc comment — the card is now the only fragment the discovery surface contributes.
- Collapsed `manifest_for_card_test_with_flag` back into `manifest_for_card_test` (no flag to pass anymore).
- Removed 5 obsolete tests:
  - `extras_renders_card_alongside_legacy_auto_inject`
  - `extras_skips_legacy_auto_inject_when_opted_out`
  - `extras_runs_legacy_auto_inject_when_opted_in_default`
  - `extras_runs_legacy_auto_inject_when_explicitly_true`
  - `extras_skips_legacy_but_renders_card_when_discovery_present_and_opted_out`
- Added `extras_skips_legacy_body_for_spawn_only_skill_with_skill_md_on_disk` — regression test pinning the new behavior.

### `crates/octos-agent/src/plugins/manifest.rs`
- Removed the `skill_md_auto_inject: bool` field from `PluginManifest`.
- Removed the `default_true` serde helper (no remaining caller).
- Trimmed the PR-D1 note from `has_extras()` doc comment.
- Removed 3 obsolete tests:
  - `manifest_defaults_skill_md_auto_inject_to_true`
  - `manifest_parses_explicit_skill_md_auto_inject_false`
  - `manifest_parses_explicit_skill_md_auto_inject_true`
- Added `manifest_ignores_legacy_skill_md_auto_inject_field` — backwards-compat regression confirming serde silently ignores the dropped field.

Per the strict constraints:
- Did NOT touch the discovery field, `render_skill_card`, or any PR-C/PR-D1 infrastructure that's still in use.
- Did NOT modify per-skill `manifest.json` files (their `skill_md_auto_inject: false` becomes a no-op).
- Did NOT add `deny_unknown_fields` to `PluginManifest`.

## Backwards compat

Manifests still declaring `skill_md_auto_inject: false` (the 7 migrated mofa-* skills) parse cleanly — serde ignores unknown fields. The pinning regression test (`manifest_ignores_legacy_skill_md_auto_inject_field`) prevents a future `deny_unknown_fields` tightening from regressing this.

## Stats

```
crates/octos-agent/src/plugins/extras.rs   | 271 ++++-------------------------
crates/octos-agent/src/plugins/manifest.rs |  94 ++--------
2 files changed, 46 insertions(+), 319 deletions(-)
```

## Verification

- `cargo build --workspace` clean.
- `cargo test -p octos-agent --lib` — 1743 passed, 0 failed.
  - `plugins::manifest::tests` — 39/39 pass, including new `manifest_ignores_legacy_skill_md_auto_inject_field`.
  - `plugins::extras::tests` — 12/12 pass, including new `extras_skips_legacy_body_for_spawn_only_skill_with_skill_md_on_disk`.
- `cargo clippy --workspace --no-deps -- -D warnings` clean.
- `cargo fmt --all -- --check` clean.
- MSRV 1.85 — no post-1.85 features introduced.

## Soak plan

Lands as part of the round-22 deploy and is observed for 24-48h alongside the new card model.