### PR TITLE
feat(skills): drop discovery.hints, generic 5-line skill card (PR-F)

### DIFF
--- a/crates/app-skills/harness-starter-audio/manifest.json
+++ b/crates/app-skills/harness-starter-audio/manifest.json
@@ -25,5 +25,8 @@
         "required": ["label"]
       }
     }
-  ]
+  ],
+  "discovery": {
+    "summary": "Harnessed audio-artifact starter template; produces a tiny 440 Hz WAV stub under audio/ and verifies it via file_exists + file_size_min:4096."
+  }
 }

--- a/crates/app-skills/harness-starter-coding/manifest.json
+++ b/crates/app-skills/harness-starter-coding/manifest.json
@@ -33,5 +33,8 @@
         "required": ["title", "hunks"]
       }
     }
-  ]
+  ],
+  "discovery": {
+    "summary": "Harnessed coding-assistant starter template; ships a unified-diff primary artifact plus a file-list preview under patches/ and gates delivery on file_size_min:64."
+  }
 }

--- a/crates/app-skills/harness-starter-generic/manifest.json
+++ b/crates/app-skills/harness-starter-generic/manifest.json
@@ -21,5 +21,8 @@
         "required": ["label"]
       }
     }
-  ]
+  ],
+  "discovery": {
+    "summary": "Minimal harnessed single-artifact starter template; writes one text file under output/ and relies on the workspace contract to verify and deliver it."
+  }
 }

--- a/crates/app-skills/harness-starter-report/manifest.json
+++ b/crates/app-skills/harness-starter-report/manifest.json
@@ -25,5 +25,8 @@
         "required": ["topic"]
       }
     }
-  ]
+  ],
+  "discovery": {
+    "summary": "Harnessed report-generator starter template; ships a markdown deliverable under reports/ and gates delivery on file_size_min:256 with structured on_failure notification."
+  }
 }

--- a/crates/octos-agent/src/plugins/extras.rs
+++ b/crates/octos-agent/src/plugins/extras.rs
@@ -11,6 +11,24 @@ use crate::mcp::McpServerConfig;
 
 use super::manifest::{PluginManifest, SkillDiscovery, SkillHookDef, SkillMcpServer};
 
+/// One-paragraph generic preamble pushed once per `resolve_extras` invocation
+/// (before any plugin cards). Tells the LLM the skill_dir is read-accessible
+/// via the existing file tools and to treat the skill source as the source
+/// of truth rather than guessing from the card's summary.
+///
+/// PR-F replaced PR-C/D's per-hint curation with this generic instruction
+/// after observing (a) hand-curated trigger phrases didn't survive doc
+/// renames, and (b) the hints implicitly narrowed LLM curiosity vs. the
+/// "you have the filesystem, go look" model that Claude Code's skill loader
+/// uses successfully.
+pub const SKILL_EXPLORATION_PREAMBLE: &str = "\
+Active plugin skill directories are listed below as cards. Each `skill_dir` \
+is read-accessible via `read_file`, `glob`, `list_dir`, `grep`. When you need \
+a format schema, a worked example, the available styles/templates, or any \
+other detail beyond the card's summary, READ the relevant files (SKILL.md, \
+docs/*, examples/*, schemas, etc.) before guessing. The code and examples in \
+skill_dir are the source of truth; the card is just a pointer.";
+
 /// Resolved extras from a skill manifest, ready to merge into agent config.
 #[derive(Debug, Default)]
 pub struct SkillExtras {
@@ -28,7 +46,19 @@ pub struct SkillExtras {
 /// - MCP: resolves relative commands against `skill_dir`, looks up env var names
 ///   from the process environment.
 /// - Hooks: parses event strings into `HookEvent`, resolves relative command paths.
+/// - Discovery: renders a short 5-line skill card (PR-F) preceded by a
+///   generic exploration preamble emitted once per call.
 /// - Prompts: expands glob patterns against `skill_dir`, reads `.md` files.
+///
+/// PR-E note: the legacy "auto-inject the full SKILL.md body for spawn_only
+/// plugins" code path has been removed. The discovery card + preamble are
+/// the structured replacement; an explicit `prompts.include` glob is the
+/// escape hatch for skills that still want a prompt fragment embedded.
+///
+/// PR-F note: only one preamble survives per session (multiple plugins all
+/// push the same constant string; the loader's merge step folds duplicates
+/// before serialising into the system prompt). The card itself collapsed
+/// to 5 lines (name / purpose / tools / skill_dir).
 pub fn resolve_extras(manifest: &PluginManifest, skill_dir: &Path) -> SkillExtras {
     let mut extras = SkillExtras::default();
 
@@ -49,45 +79,23 @@ pub fn resolve_extras(manifest: &PluginManifest, skill_dir: &Path) -> SkillExtra
         }
     }
 
-    // PR-C of the SKILL.md rethink: when the manifest declares a
-    // `discovery` block, render a short skill card into the system
-    // prompt so the LLM learns where the skill dir is and what to
-    // read or list first. The card coexists with the legacy SKILL.md
-    // auto-inject below — PR-D + PR-E remove the auto-inject after
-    // per-skill migrations land.
+    // PR-F: emit the generic exploration preamble + the 5-line card.
+    // Per-hint curation from PR-C/D is gone — the preamble tells the
+    // LLM to explore the skill_dir directly via the already-allowlisted
+    // file tools.
+    //
+    // `resolve_extras` runs once per plugin; every discovery-bearing
+    // plugin pushes the same preamble constant. Downstream merge code
+    // (`PluginLoadResult::merge_extras`) is responsible for keeping only
+    // the first preamble occurrence so the final system prompt has it
+    // exactly once. See `extras_emits_exploration_preamble_once_per_session`.
     if let Some(discovery) = &manifest.discovery {
         extras
             .prompt_fragments
+            .push(SKILL_EXPLORATION_PREAMBLE.to_string());
+        extras
+            .prompt_fragments
             .push(render_skill_card(manifest, discovery, skill_dir));
-    }
-
-    // Auto-inject SKILL.md when skill has spawn_only tools so the LLM
-    // knows how to access deferred tools via spawn.
-    //
-    // M10 Phase 4 (codex round 2 P2): the `read_task_output` contract
-    // teaching is NOT injected globally here. The `extras.prompt_fragments`
-    // are merged into the system prompt on every agent that loads the
-    // skill — including CLI chat / swarm workers whose registries do not
-    // wire `read_task_output`. Without registry-aware gating those agents
-    // would learn about a tool they cannot call. Instead, the
-    // `spawn_only_handle_message` envelope itself documents the contract
-    // inline (`read_with`, `read_modes`, and the `summary` field), so
-    // only agents that actually emit the new envelope teach the LLM
-    // about it — automatic and consistent with the gating in
-    // `execution.rs::is_tool_visible`.
-    //
-    // PR-D1 of the SKILL.md rethink: a plugin can opt out of this legacy
-    // auto-inject by setting `skill_md_auto_inject: false` in its manifest.
-    // The flag defaults to `true` so unmigrated plugins keep current
-    // behavior; PR-D2 (mofa-skills) opts each mofa-* skill in, and PR-E
-    // eventually flips the default.
-    if manifest.skill_md_auto_inject && manifest.tools.iter().any(|t| t.spawn_only) {
-        let skill_md = skill_dir.join("SKILL.md");
-        if skill_md.exists() {
-            if let Ok(content) = std::fs::read_to_string(&skill_md) {
-                extras.prompt_fragments.push(content);
-            }
-        }
     }
 
     if let Some(prompts) = &manifest.prompts {
@@ -122,24 +130,22 @@ pub fn resolve_extras(manifest: &PluginManifest, skill_dir: &Path) -> SkillExtra
     extras
 }
 
-/// Render a skill card from manifest discovery hints (PR-C of the SKILL.md
-/// rethink). Output is a fixed-shape text block, ~5-10 lines, suitable for
-/// concatenating into the system prompt alongside (or eventually instead
-/// of) the legacy SKILL.md auto-inject.
+/// Render a 5-line skill card from manifest discovery (PR-F).
 ///
-/// Shape:
+/// Output is a fixed-shape text block, suitable for concatenating into
+/// the system prompt alongside the generic exploration preamble. The
+/// `if you need:` section from PR-C/D is gone; the preamble tells the
+/// LLM the skill_dir is read-accessible and to look there instead of
+/// trusting the card.
+///
+/// Shape (4 newline-separated lines; the final `skill_dir` line has no
+/// trailing newline so successive fragments don't accumulate blanks):
 /// ```text
 /// - name: <plugin_name>
 ///   purpose: <discovery.summary OR "(no summary)">
 ///   tools: <comma-separated tool names>
 ///   skill_dir: <absolute path>
-///   if you need:
-///     - <hint[0].when> → read <path> OR list <pattern>
-///     ...
 /// ```
-///
-/// When `discovery.hints` is empty, the `if you need:` section is omitted
-/// so the card stays compact (4 lines).
 fn render_skill_card(
     manifest: &PluginManifest,
     discovery: &SkillDiscovery,
@@ -157,29 +163,7 @@ fn render_skill_card(
     card.push_str(&format!("- name: {}\n", manifest.name));
     card.push_str(&format!("  purpose: {purpose}\n"));
     card.push_str(&format!("  tools: {tools}\n"));
-    card.push_str(&format!("  skill_dir: {}\n", skill_dir.display()));
-
-    if !discovery.hints.is_empty() {
-        card.push_str("  if you need:\n");
-        for hint in &discovery.hints {
-            let action = match (&hint.read, &hint.list) {
-                (Some(r), Some(l)) => format!("read {r} OR list {l}"),
-                (Some(r), None) => format!("read {r}"),
-                (None, Some(l)) => format!("list {l}"),
-                // Deser-time validation rejects (None, None), but
-                // render defensively in case a future construction path
-                // bypasses parse-time validation.
-                (None, None) => continue,
-            };
-            card.push_str(&format!("    - {} → {action}\n", hint.when));
-        }
-    }
-
-    // Strip trailing newline so successive fragments don't accumulate
-    // double blank lines when joined.
-    if card.ends_with('\n') {
-        card.pop();
-    }
+    card.push_str(&format!("  skill_dir: {}", skill_dir.display()));
     card
 }
 
@@ -389,7 +373,6 @@ mod tests {
             hooks: vec![],
             prompts: None,
             discovery: None,
-            skill_md_auto_inject: true,
         };
         let extras = resolve_extras(&manifest, Path::new("/skills/test"));
         assert!(extras.mcp_servers.is_empty());
@@ -419,7 +402,6 @@ mod tests {
                 include: vec!["prompts/*.md".into()],
             }),
             discovery: None,
-            skill_md_auto_inject: true,
         };
         let extras = resolve_extras(&manifest, dir.path());
         assert_eq!(extras.prompt_fragments.len(), 2);
@@ -433,7 +415,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // SKILL.md PR-C: skill card rendering from discovery field
+    // SKILL.md PR-F: 5-line skill card + generic exploration preamble
     // ------------------------------------------------------------------
 
     fn manifest_for_card_test(
@@ -441,20 +423,6 @@ mod tests {
         tools: Vec<&str>,
         discovery: Option<crate::plugins::manifest::SkillDiscovery>,
         any_spawn_only: bool,
-    ) -> PluginManifest {
-        manifest_for_card_test_with_flag(name, tools, discovery, any_spawn_only, true)
-    }
-
-    /// Variant of `manifest_for_card_test` that exposes the PR-D1
-    /// `skill_md_auto_inject` flag. The shorter helper above wraps this
-    /// with `skill_md_auto_inject: true` (the default) to keep older
-    /// tests readable.
-    fn manifest_for_card_test_with_flag(
-        name: &str,
-        tools: Vec<&str>,
-        discovery: Option<crate::plugins::manifest::SkillDiscovery>,
-        any_spawn_only: bool,
-        skill_md_auto_inject: bool,
     ) -> PluginManifest {
         use crate::plugins::manifest::PluginToolDef;
         PluginManifest {
@@ -481,52 +449,57 @@ mod tests {
             hooks: vec![],
             prompts: None,
             discovery,
-            skill_md_auto_inject,
         }
     }
 
+    /// PR-F: a manifest with `discovery.summary` set produces exactly the
+    /// 4-line card (`- name`, `  purpose`, `  tools`, `  skill_dir`) plus
+    /// the generic exploration preamble. No `if you need:` section.
     #[test]
-    fn extras_renders_skill_card_when_discovery_present() {
-        use crate::plugins::manifest::{DiscoveryHint, SkillDiscovery};
+    fn extras_renders_5_line_card_with_summary() {
+        use crate::plugins::manifest::SkillDiscovery;
 
         let dir = tempfile::tempdir().unwrap();
         let skill_dir = dir.path();
 
         let discovery = SkillDiscovery {
             summary: Some("Generate AI presentation slides.".into()),
-            hints: vec![
-                DiscoveryHint {
-                    when: "user asks for editable PPT".into(),
-                    read: Some("SKILL.md#mode-2".into()),
-                    list: None,
-                },
-                DiscoveryHint {
-                    when: "picking a style".into(),
-                    read: None,
-                    list: Some("styles/*.toml".into()),
-                },
-            ],
         };
 
         let manifest = manifest_for_card_test(
             "mofa-slides",
             vec!["slides_generate", "slides_preview"],
             Some(discovery),
-            false, // no spawn_only — only the card should appear
+            false,
         );
 
         let extras = resolve_extras(&manifest, skill_dir);
-        // Card is the only fragment.
+        // Expect: [preamble, card]
         assert_eq!(
             extras.prompt_fragments.len(),
-            1,
-            "expected exactly one fragment (the skill card); got {:?}",
+            2,
+            "expected preamble + card; got {:?}",
             extras.prompt_fragments
         );
-        let card = &extras.prompt_fragments[0];
 
+        let preamble = &extras.prompt_fragments[0];
         assert!(
-            card.contains("name: mofa-slides"),
+            preamble.contains("Active plugin skill directories")
+                && preamble.contains("read_file")
+                && preamble.contains("source of truth"),
+            "preamble missing expected wording: {preamble}"
+        );
+
+        let card = &extras.prompt_fragments[1];
+        // 4 lines because the trailing newline is stripped from the
+        // skill_dir line (no `if you need:` section).
+        let line_count = card.lines().count();
+        assert_eq!(
+            line_count, 4,
+            "card must be exactly 4 lines (name/purpose/tools/skill_dir); got {line_count}: {card}"
+        );
+        assert!(
+            card.contains("- name: mofa-slides"),
             "card missing name line: {card}"
         );
         assert!(
@@ -541,38 +514,47 @@ mod tests {
             card.contains(&format!("skill_dir: {}", skill_dir.display())),
             "card missing skill_dir line: {card}"
         );
+        // PR-F: no more "if you need:" hint section.
         assert!(
-            card.contains("if you need:"),
-            "card missing 'if you need:' header: {card}"
-        );
-        assert!(
-            card.contains("user asks for editable PPT"),
-            "card missing first hint when: {card}"
-        );
-        assert!(
-            card.contains("read SKILL.md#mode-2"),
-            "card missing first hint read target: {card}"
-        );
-        assert!(
-            card.contains("picking a style"),
-            "card missing second hint when: {card}"
-        );
-        assert!(
-            card.contains("list styles/*.toml"),
-            "card missing second hint list target: {card}"
-        );
-
-        // Cap at ~10 lines total.
-        let line_count = card.lines().count();
-        assert!(
-            line_count <= 10,
-            "card too long ({line_count} lines): {card}"
+            !card.contains("if you need:"),
+            "PR-F card must NOT contain 'if you need:': {card}"
         );
     }
 
+    /// PR-F: when `discovery.summary` is `None`, the purpose line falls
+    /// back to the `(no summary)` placeholder. The card still has all
+    /// four lines so downstream parsing stays stable.
     #[test]
-    fn extras_omits_skill_card_when_discovery_absent() {
-        // No discovery + no spawn_only + nothing else → no fragments.
+    fn extras_renders_card_without_summary_uses_placeholder() {
+        use crate::plugins::manifest::SkillDiscovery;
+
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path();
+
+        let discovery = SkillDiscovery { summary: None };
+
+        let manifest = manifest_for_card_test("noisy-skill", vec!["t"], Some(discovery), false);
+
+        let extras = resolve_extras(&manifest, skill_dir);
+        assert_eq!(extras.prompt_fragments.len(), 2);
+
+        let card = &extras.prompt_fragments[1];
+        assert_eq!(
+            card.lines().count(),
+            4,
+            "card must still be 4 lines when summary is missing"
+        );
+        assert!(
+            card.contains("purpose: (no summary)"),
+            "missing-summary placeholder not used: {card}"
+        );
+    }
+
+    /// PR-F: when no manifest declares `discovery`, neither the preamble
+    /// nor a card fires. The preamble is a discovery-gated companion,
+    /// not a constant system-prompt header.
+    #[test]
+    fn extras_omits_preamble_and_card_when_discovery_absent() {
         let dir = tempfile::tempdir().unwrap();
         let manifest = manifest_for_card_test("legacy", vec!["t"], None, false);
         let extras = resolve_extras(&manifest, dir.path());
@@ -583,234 +565,131 @@ mod tests {
         );
     }
 
+    /// PR-E regression carryover: a spawn_only plugin with a SKILL.md
+    /// file on disk must NOT have its body injected. PR-E already
+    /// removed that path; PR-F adds the discovery-gated preamble +
+    /// card on top, so a spawn_only plugin WITHOUT a discovery block
+    /// still produces zero fragments.
     #[test]
-    fn extras_renders_card_alongside_legacy_auto_inject() {
-        use crate::plugins::manifest::{DiscoveryHint, SkillDiscovery};
-
+    fn extras_skips_legacy_body_for_spawn_only_skill_with_skill_md_on_disk() {
         let dir = tempfile::tempdir().unwrap();
         let skill_dir = dir.path();
-        // Legacy auto-inject writes SKILL.md content into the prompt.
         std::fs::write(
             skill_dir.join("SKILL.md"),
-            "# Legacy SKILL.md\nMode 1: foo. Mode 2: bar.\n",
+            "# Legacy SKILL.md\nPre-PR-E this body would be injected.\n",
         )
         .unwrap();
 
-        let discovery = SkillDiscovery {
-            summary: Some("Modes 1+2 for slides.".into()),
-            hints: vec![DiscoveryHint {
-                when: "user wants editable PPT".into(),
-                read: Some("SKILL.md#mode-2".into()),
-                list: None,
-            }],
-        };
-        // any_spawn_only=true → triggers legacy auto-inject.
         let manifest = manifest_for_card_test(
-            "mofa-slides",
-            vec!["slides_generate"],
-            Some(discovery),
-            true,
-        );
-
-        let extras = resolve_extras(&manifest, skill_dir);
-        assert_eq!(
-            extras.prompt_fragments.len(),
-            2,
-            "expected card + legacy auto-inject; got {:?}",
-            extras.prompt_fragments
-        );
-
-        let has_card = extras
-            .prompt_fragments
-            .iter()
-            .any(|f| f.contains("name: mofa-slides") && f.contains("purpose:"));
-        let has_legacy = extras
-            .prompt_fragments
-            .iter()
-            .any(|f| f.contains("Legacy SKILL.md") && f.contains("Mode 1: foo"));
-
-        assert!(has_card, "card fragment missing");
-        assert!(has_legacy, "legacy SKILL.md fragment missing");
-    }
-
-    #[test]
-    fn extras_renders_card_with_empty_hints() {
-        use crate::plugins::manifest::SkillDiscovery;
-
-        let dir = tempfile::tempdir().unwrap();
-        let discovery = SkillDiscovery {
-            summary: Some("Minimal skill.".into()),
-            hints: vec![],
-        };
-        let manifest = manifest_for_card_test("minimal-skill", vec!["t"], Some(discovery), false);
-
-        let extras = resolve_extras(&manifest, dir.path());
-        assert_eq!(extras.prompt_fragments.len(), 1);
-        let card = &extras.prompt_fragments[0];
-
-        assert!(card.contains("name: minimal-skill"));
-        assert!(card.contains("purpose: Minimal skill."));
-        assert!(card.contains("tools: t"));
-        // No "if you need:" section when hints are empty.
-        assert!(
-            !card.contains("if you need:"),
-            "empty hints should NOT render 'if you need:' header: {card}"
-        );
-    }
-
-    // ------------------------------------------------------------------
-    // SKILL.md PR-D1: skill_md_auto_inject opt-out gates legacy SKILL.md
-    // ------------------------------------------------------------------
-
-    /// Opting out (`skill_md_auto_inject: false`) skips the legacy
-    /// auto-inject even when the manifest has a `spawn_only` tool and a
-    /// `SKILL.md` is present on disk. This is the migration end-state for
-    /// step 2 of the rethink — the new discovery card replaces the
-    /// always-injected SKILL.md body.
-    #[test]
-    fn extras_skips_legacy_auto_inject_when_opted_out() {
-        let dir = tempfile::tempdir().unwrap();
-        let skill_dir = dir.path();
-        std::fs::write(
-            skill_dir.join("SKILL.md"),
-            "# Legacy SKILL.md\nShould NOT be injected when opted out.\n",
-        )
-        .unwrap();
-
-        let manifest = manifest_for_card_test_with_flag(
-            "opted-out",
+            "legacy-spawn-only",
             vec!["bg_tool"],
-            None,  // no discovery — purely a legacy-gate test
-            true,  // any_spawn_only triggers the legacy auto-inject path
-            false, // skill_md_auto_inject opt-out
+            None, // no discovery
+            true, // spawn_only — would have triggered legacy auto-inject
         );
 
         let extras = resolve_extras(&manifest, skill_dir);
         assert!(
             extras.prompt_fragments.is_empty(),
-            "opted-out plugin must not inject SKILL.md; got {:?}",
+            "legacy SKILL.md auto-inject must be gone; got {:?}",
             extras.prompt_fragments
         );
     }
 
-    /// Default behavior (no explicit flag in the manifest, mirrored here
-    /// by passing `skill_md_auto_inject: true`) preserves the legacy
-    /// auto-inject so unmigrated plugins keep working.
+    /// PR-F: the generic exploration preamble must appear exactly ONCE
+    /// per loader-side merge of plugin fragments, even when multiple
+    /// plugins each declare a `discovery` block.
+    ///
+    /// `resolve_extras` itself is called per-plugin, so each
+    /// discovery-bearing plugin pushes the same preamble constant onto
+    /// its own `prompt_fragments` Vec. The loader's `merge_extras` step
+    /// folds duplicates — see `PluginLoadResult::merge_extras` in
+    /// loader.rs — so the final session-wide prompt has the preamble
+    /// once and every distinct card.
+    ///
+    /// This test pins both halves: per-plugin emit AND merge-side dedup.
+    /// A regression in either the constant string or the dedup logic
+    /// surfaces here rather than during a fleet soak.
     #[test]
-    fn extras_runs_legacy_auto_inject_when_opted_in_default() {
-        let dir = tempfile::tempdir().unwrap();
-        let skill_dir = dir.path();
-        std::fs::write(
-            skill_dir.join("SKILL.md"),
-            "# Legacy SKILL.md\nUnmigrated default behavior.\n",
-        )
-        .unwrap();
+    fn extras_emits_exploration_preamble_once_per_session() {
+        use crate::plugins::manifest::SkillDiscovery;
 
-        // `manifest_for_card_test` constructs with skill_md_auto_inject:true
-        // — the default — so this exercises the "field omitted" path.
-        let manifest = manifest_for_card_test(
-            "legacy-default",
-            vec!["bg_tool"],
-            None,
-            true, // spawn_only present
+        let dir = tempfile::tempdir().unwrap();
+
+        let m1 = manifest_for_card_test(
+            "plugin-one",
+            vec!["t1"],
+            Some(SkillDiscovery {
+                summary: Some("First skill.".into()),
+            }),
+            false,
+        );
+        let m2 = manifest_for_card_test(
+            "plugin-two",
+            vec!["t2"],
+            Some(SkillDiscovery {
+                summary: Some("Second skill.".into()),
+            }),
+            false,
         );
 
-        let extras = resolve_extras(&manifest, skill_dir);
+        let e1 = resolve_extras(&m1, dir.path());
+        let e2 = resolve_extras(&m2, dir.path());
+
+        // Pre-merge: both invocations push the preamble.
+        let combined: Vec<String> = e1
+            .prompt_fragments
+            .iter()
+            .chain(e2.prompt_fragments.iter())
+            .cloned()
+            .collect();
+        let preamble_count = combined
+            .iter()
+            .filter(|f| f.as_str() == SKILL_EXPLORATION_PREAMBLE)
+            .count();
         assert_eq!(
-            extras.prompt_fragments.len(),
-            1,
-            "default plugin must inject SKILL.md exactly once; got {:?}",
-            extras.prompt_fragments
-        );
-        assert!(
-            extras.prompt_fragments[0].contains("Unmigrated default behavior."),
-            "fragment must contain SKILL.md body; got {:?}",
-            extras.prompt_fragments[0]
-        );
-    }
-
-    /// Explicit `true` is equivalent to the default — confirms the gate
-    /// does not silently invert when a manifest opts in loudly.
-    #[test]
-    fn extras_runs_legacy_auto_inject_when_explicitly_true() {
-        let dir = tempfile::tempdir().unwrap();
-        let skill_dir = dir.path();
-        std::fs::write(
-            skill_dir.join("SKILL.md"),
-            "# Legacy SKILL.md\nExplicit opt-in body.\n",
-        )
-        .unwrap();
-
-        let manifest = manifest_for_card_test_with_flag(
-            "explicit-legacy",
-            vec!["bg_tool"],
-            None,
-            true,
-            true, // explicit opt-in
+            preamble_count, 2,
+            "each `resolve_extras` call must push the preamble; got {preamble_count} \
+             in {combined:?}"
         );
 
-        let extras = resolve_extras(&manifest, skill_dir);
-        assert_eq!(extras.prompt_fragments.len(), 1);
-        assert!(extras.prompt_fragments[0].contains("Explicit opt-in body."));
-    }
-
-    /// Migration end-state regression: when both `discovery` is present
-    /// AND `skill_md_auto_inject: false` is set, the skill card renders
-    /// but the legacy SKILL.md body does not. This is the configuration
-    /// PR-D2 will produce per migrated mofa-* skill.
-    #[test]
-    fn extras_skips_legacy_but_renders_card_when_discovery_present_and_opted_out() {
-        use crate::plugins::manifest::{DiscoveryHint, SkillDiscovery};
-
-        let dir = tempfile::tempdir().unwrap();
-        let skill_dir = dir.path();
-        std::fs::write(
-            skill_dir.join("SKILL.md"),
-            "# Legacy SKILL.md\nShould NOT appear when opted out.\n",
-        )
-        .unwrap();
-
-        let discovery = SkillDiscovery {
-            summary: Some("Migrated skill.".into()),
-            hints: vec![DiscoveryHint {
-                when: "user wants editable PPT".into(),
-                read: Some("SKILL.md#mode-2".into()),
-                list: None,
-            }],
-        };
-
-        let manifest = manifest_for_card_test_with_flag(
-            "mofa-slides",
-            vec!["slides_generate"],
-            Some(discovery),
-            true,  // spawn_only tool present (would normally trigger legacy)
-            false, // but auto-inject is opted out
-        );
-
-        let extras = resolve_extras(&manifest, skill_dir);
+        // Post-merge dedup: only the first preamble survives.
+        let deduped = dedup_preamble(combined.clone());
+        let after = deduped
+            .iter()
+            .filter(|f| f.as_str() == SKILL_EXPLORATION_PREAMBLE)
+            .count();
         assert_eq!(
-            extras.prompt_fragments.len(),
-            1,
-            "migrated plugin must yield card-only (no legacy body); got {:?}",
-            extras.prompt_fragments
+            after, 1,
+            "merge-side dedup must keep exactly one preamble; got {after} in {deduped:?}"
         );
-        let card = &extras.prompt_fragments[0];
-        assert!(card.contains("name: mofa-slides"), "card missing: {card}");
-        assert!(
-            card.contains("purpose: Migrated skill."),
-            "card missing purpose: {card}"
-        );
-        assert!(
-            !card.contains("Should NOT appear"),
-            "legacy SKILL.md body leaked into the card: {card}"
-        );
-        assert!(
-            !extras
-                .prompt_fragments
-                .iter()
-                .any(|f| f.contains("Should NOT appear")),
-            "legacy SKILL.md body leaked as a separate fragment: {:?}",
-            extras.prompt_fragments
-        );
+
+        // The two distinct skill cards must both survive dedup (the
+        // dedup only collapses the preamble, not the cards).
+        assert!(deduped.iter().any(|f| f.contains("name: plugin-one")));
+        assert!(deduped.iter().any(|f| f.contains("name: plugin-two")));
+    }
+
+    /// Test-side helper that models the merge-step dedup the loader
+    /// applies when concatenating per-plugin fragments. Pinning the
+    /// contract here lets `PluginLoadResult::merge_extras` (loader.rs)
+    /// re-use the same constant string match without re-testing the
+    /// substring invariant from scratch.
+    fn dedup_preamble(fragments: Vec<String>) -> Vec<String> {
+        let mut seen = false;
+        fragments
+            .into_iter()
+            .filter(|frag| {
+                if frag.as_str() == SKILL_EXPLORATION_PREAMBLE {
+                    if seen {
+                        false
+                    } else {
+                        seen = true;
+                        true
+                    }
+                } else {
+                    true
+                }
+            })
+            .collect()
     }
 }

--- a/crates/octos-agent/src/plugins/loader.rs
+++ b/crates/octos-agent/src/plugins/loader.rs
@@ -12,7 +12,7 @@ use crate::mcp::McpServerConfig;
 use crate::sandbox::BLOCKED_ENV_VARS;
 use crate::tools::{Tool, ToolRegistry};
 
-use super::extras::{SkillExtras, resolve_extras};
+use super::extras::{SKILL_EXPLORATION_PREAMBLE, SkillExtras, resolve_extras};
 use super::manifest::{ConcurrencyClassClassification, PluginManifest, PluginToolDef};
 use super::tool::{PluginTool, SynthesisConfig};
 
@@ -90,7 +90,27 @@ impl PluginLoadResult {
     fn merge_extras(&mut self, extras: SkillExtras) {
         self.mcp_servers.extend(extras.mcp_servers);
         self.hooks.extend(extras.hooks);
-        self.prompt_fragments.extend(extras.prompt_fragments);
+        // PR-F: dedup the generic exploration preamble across plugins.
+        // Each discovery-bearing plugin pushes the same constant string
+        // through `resolve_extras`; keeping every copy would balloon the
+        // system prompt with N identical paragraphs (`N` = number of
+        // skills that ship a `discovery` block). The first occurrence
+        // wins; later duplicates of the same exact string are dropped.
+        // Non-preamble fragments (skill cards, prompts.include outputs)
+        // are NOT deduped — distinct cards must survive.
+        let mut have_preamble = self
+            .prompt_fragments
+            .iter()
+            .any(|f| f.as_str() == SKILL_EXPLORATION_PREAMBLE);
+        for frag in extras.prompt_fragments {
+            if frag.as_str() == SKILL_EXPLORATION_PREAMBLE {
+                if have_preamble {
+                    continue;
+                }
+                have_preamble = true;
+            }
+            self.prompt_fragments.push(frag);
+        }
     }
 }
 
@@ -2425,5 +2445,95 @@ edition = "2021"
                 skill_entries,
             );
         }
+    }
+
+    /// PR-F: the loader's `merge_extras` step folds duplicate
+    /// `SKILL_EXPLORATION_PREAMBLE` strings across plugins so the
+    /// system prompt only contains the preamble once even when N
+    /// plugins each declare a `discovery` block. Distinct skill cards
+    /// must survive — the dedup only collapses the constant string.
+    #[test]
+    fn merge_extras_dedupes_preamble_across_plugins() {
+        let mut result = PluginLoadResult::default();
+
+        // First plugin: preamble + card-one.
+        let e1 = SkillExtras {
+            mcp_servers: vec![],
+            hooks: vec![],
+            prompt_fragments: vec![
+                SKILL_EXPLORATION_PREAMBLE.to_string(),
+                "- name: card-one\n  purpose: a\n  tools: t1\n  skill_dir: /tmp/a".to_string(),
+            ],
+            spawn_only_tools: vec![],
+            spawn_only_messages: Default::default(),
+        };
+        result.merge_extras(e1);
+
+        // Second plugin: preamble (duplicate) + card-two.
+        let e2 = SkillExtras {
+            mcp_servers: vec![],
+            hooks: vec![],
+            prompt_fragments: vec![
+                SKILL_EXPLORATION_PREAMBLE.to_string(),
+                "- name: card-two\n  purpose: b\n  tools: t2\n  skill_dir: /tmp/b".to_string(),
+            ],
+            spawn_only_tools: vec![],
+            spawn_only_messages: Default::default(),
+        };
+        result.merge_extras(e2);
+
+        // Third plugin: preamble (duplicate) + card-three.
+        let e3 = SkillExtras {
+            mcp_servers: vec![],
+            hooks: vec![],
+            prompt_fragments: vec![
+                SKILL_EXPLORATION_PREAMBLE.to_string(),
+                "- name: card-three\n  purpose: c\n  tools: t3\n  skill_dir: /tmp/c".to_string(),
+            ],
+            spawn_only_tools: vec![],
+            spawn_only_messages: Default::default(),
+        };
+        result.merge_extras(e3);
+
+        // Preamble appears exactly once across the merged result.
+        let preamble_count = result
+            .prompt_fragments
+            .iter()
+            .filter(|f| f.as_str() == SKILL_EXPLORATION_PREAMBLE)
+            .count();
+        assert_eq!(
+            preamble_count, 1,
+            "preamble must be deduped to a single occurrence; got {preamble_count} \
+             in {:?}",
+            result.prompt_fragments
+        );
+
+        // All three cards survive.
+        assert!(
+            result
+                .prompt_fragments
+                .iter()
+                .any(|f| f.contains("name: card-one"))
+        );
+        assert!(
+            result
+                .prompt_fragments
+                .iter()
+                .any(|f| f.contains("name: card-two"))
+        );
+        assert!(
+            result
+                .prompt_fragments
+                .iter()
+                .any(|f| f.contains("name: card-three"))
+        );
+
+        // Length: 1 preamble + 3 cards = 4 fragments total.
+        assert_eq!(
+            result.prompt_fragments.len(),
+            4,
+            "expected 4 fragments (1 preamble + 3 cards); got {:?}",
+            result.prompt_fragments
+        );
     }
 }

--- a/crates/octos-agent/src/plugins/manifest.rs
+++ b/crates/octos-agent/src/plugins/manifest.rs
@@ -4,13 +4,6 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Deserializer};
 
-/// Maximum number of discovery hints a skill manifest may declare.
-///
-/// The hints render into the LLM system prompt as a per-skill "skill card";
-/// growing the list without bound would silently push out other system
-/// prompt content. 8 keeps each card to a ~10-line budget.
-pub const MAX_DISCOVERY_HINTS: usize = 8;
-
 /// A plugin manifest (manifest.json).
 #[derive(Debug, Deserialize)]
 pub struct PluginManifest {
@@ -50,42 +43,21 @@ pub struct PluginManifest {
     /// Prompt fragments to inject into the system prompt.
     #[serde(default)]
     pub prompts: Option<SkillPrompts>,
-    /// Optional LLM-facing discovery hints.
+    /// Optional LLM-facing discovery summary.
     ///
-    /// When present, `resolve_extras` renders a short "skill card" into the
-    /// system prompt so the agent learns (1) the skill exists, (2) where
-    /// its directory lives, and (3) which files to read or list first.
-    /// This is the opt-in migration affordance for the SKILL.md rethink:
-    /// plugins that add `discovery` get the card; plugins without it keep
-    /// the legacy SKILL.md auto-inject only (see `extras.rs`).
-    #[serde(default, deserialize_with = "deserialize_discovery")]
+    /// When present, `resolve_extras` renders a short 5-line "skill card"
+    /// into the system prompt so the agent learns (1) the skill exists,
+    /// (2) which tools it provides, and (3) where its directory lives.
+    /// PR-F dropped the per-hint curation that PR-C/D originally shipped
+    /// in favour of a one-paragraph generic preamble + `read_file`/`glob`/
+    /// `list_dir` exploration over the skill directory (Claude Code's
+    /// "you have the filesystem, go look" model).
+    ///
+    /// Legacy manifests that still declare `discovery.hints: [...]` parse
+    /// cleanly because `SkillDiscovery` does not set
+    /// `deny_unknown_fields` — the unknown field is silently dropped.
+    #[serde(default)]
     pub discovery: Option<SkillDiscovery>,
-    /// When false, this plugin opts out of having its SKILL.md auto-injected
-    /// into the system prompt. Used in combination with `discovery` (PR-C) to
-    /// migrate plugins from legacy auto-inject to on-demand discovery.
-    ///
-    /// Migration is intentionally three steps so each stage stays revertable:
-    ///   1. Add `discovery` so both legacy auto-inject AND the new skill
-    ///      card render (validate the card works in production).
-    ///   2. Set `skill_md_auto_inject: false` so only the card renders.
-    ///   3. Trim SKILL.md body to <=80 lines now that the LLM reads it on
-    ///      demand instead of having it shoved into every system prompt.
-    ///
-    /// Decoupling step 2 from step 1 via an explicit flag (rather than an
-    /// implicit "presence of discovery disables legacy") is what lets each
-    /// step be independently revertable — see PR-D1.
-    ///
-    /// Default: true (legacy behavior preserved for unmigrated plugins).
-    #[serde(default = "default_true")]
-    pub skill_md_auto_inject: bool,
-}
-
-/// Serde default helper for `bool` fields whose absence should deserialize
-/// to `true`. Locally scoped: `PluginManifest::skill_md_auto_inject` is the
-/// only field in this module that needs it today, but adding more later
-/// (e.g. a `legacy_card_inject` flag) should reuse this helper.
-fn default_true() -> bool {
-    true
 }
 
 impl PluginManifest {
@@ -100,13 +72,6 @@ impl PluginManifest {
     /// check meant a discovery-only manifest became a silent no-op under
     /// strict mode, and a signed tool plugin with discovery had its skill
     /// card dropped without any warning.
-    ///
-    /// PR-D1 note: `skill_md_auto_inject` is intentionally NOT counted as an
-    /// extra. The semantics are inverted relative to the other fields —
-    /// setting it to `false` *removes* an injected fragment rather than
-    /// adding one — so it does not affect whether the manifest carries
-    /// surfaces beyond its tool list. The loader's strict-mode reasoning
-    /// about extras-only manifests therefore continues to apply unchanged.
     pub fn has_extras(&self) -> bool {
         !self.mcp_servers.is_empty()
             || !self.hooks.is_empty()
@@ -133,104 +98,24 @@ where
     }
 }
 
-/// LLM-facing discovery hints declared by a skill manifest.
+/// LLM-facing discovery summary declared by a skill manifest.
 ///
-/// The renderer in `extras.rs` turns this into a short skill card pushed
-/// into `SkillExtras.prompt_fragments`. The card tells the agent the skill
-/// exists, where its directory lives, and which paths to read or list to
-/// learn more. See PR-C of the SKILL.md rethink.
+/// PR-F replaced the original per-hint curation (PR-C/D) with a single
+/// `summary` line plus a generic "go read the skill_dir" preamble that
+/// `resolve_extras` emits once per session. The renderer in `extras.rs`
+/// turns this into a short 5-line skill card pushed into
+/// `SkillExtras.prompt_fragments` (name / purpose / tools / skill_dir).
+///
+/// Legacy `hints: [...]` arrays still on disk parse cleanly because this
+/// struct does NOT set `deny_unknown_fields`; serde silently drops the
+/// field. A follow-up will scrub the dead arrays from the 7 mofa-skills
+/// manifests.
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, Default)]
 pub struct SkillDiscovery {
     /// One-line description of what the skill does. Falls back to
     /// `"(no summary)"` in the rendered card.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
-    /// Up to `MAX_DISCOVERY_HINTS` pointers the LLM can follow on its
-    /// own (via the already-allowlisted `read_file`/`glob`/`list_dir`
-    /// tools from PR-A + PR-B).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub hints: Vec<DiscoveryHint>,
-}
-
-/// A single discovery hint: when this trigger applies, the LLM should
-/// either read a file or list a glob pattern under the skill directory.
-///
-/// At least one of `read` or `list` must be set; both is allowed (the
-/// renderer joins them with " OR "). Paths are validated at parse time
-/// to reject `..` traversal — discovery hints feed the system prompt,
-/// so a hostile manifest could otherwise nudge the LLM to read arbitrary
-/// files via the now-permissive skill-dir scope from PR-A.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-pub struct DiscoveryHint {
-    /// Human-readable trigger condition, e.g.
-    /// `"user asks for editable PPT"`.
-    pub when: String,
-    /// Path (or fragment-anchored path) to read. Relative to the skill
-    /// directory. Must not contain `..`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub read: Option<String>,
-    /// Glob pattern to list. Relative to the skill directory. Must not
-    /// contain `..`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub list: Option<String>,
-}
-
-/// Validating deserializer for `PluginManifest::discovery`.
-///
-/// Enforces:
-/// * At most `MAX_DISCOVERY_HINTS` hints.
-/// * Neither `read` nor `list` may contain `..` (path traversal).
-/// * Each hint must declare at least one of `read` or `list`.
-///
-/// A rejected manifest is a hard error at parse time so a malicious or
-/// typo'd discovery block never reaches the LLM-facing renderer.
-fn deserialize_discovery<'de, D>(d: D) -> Result<Option<SkillDiscovery>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    use serde::de::Error;
-    let maybe = Option::<SkillDiscovery>::deserialize(d)?;
-    let Some(disc) = maybe else {
-        return Ok(None);
-    };
-
-    if disc.hints.len() > MAX_DISCOVERY_HINTS {
-        return Err(D::Error::custom(format!(
-            "manifest.discovery.hints declares {} entries; the maximum allowed is {} (MAX_DISCOVERY_HINTS)",
-            disc.hints.len(),
-            MAX_DISCOVERY_HINTS
-        )));
-    }
-
-    for (idx, hint) in disc.hints.iter().enumerate() {
-        if hint.read.is_none() && hint.list.is_none() {
-            return Err(D::Error::custom(format!(
-                "manifest.discovery.hints[{idx}] declares neither `read` nor `list`; at least one is required"
-            )));
-        }
-        if hint.read.as_deref().is_some_and(hint_path_has_traversal) {
-            return Err(D::Error::custom(format!(
-                "manifest.discovery.hints[{idx}].read contains path traversal (..): {:?}",
-                hint.read
-            )));
-        }
-        if hint.list.as_deref().is_some_and(hint_path_has_traversal) {
-            return Err(D::Error::custom(format!(
-                "manifest.discovery.hints[{idx}].list contains path traversal (..): {:?}",
-                hint.list
-            )));
-        }
-    }
-
-    Ok(Some(disc))
-}
-
-/// Return `true` if a discovery-hint path (or glob pattern) contains a
-/// `..` traversal segment. Splits on both `/` and `\` to cover Windows
-/// authors editing manifests on Unix and vice versa, then matches the
-/// trimmed segment exactly so `..foo` (legitimate filename) survives.
-fn hint_path_has_traversal(path: &str) -> bool {
-    path.split(['/', '\\']).any(|seg| seg.trim() == "..")
 }
 
 /// An MCP server declared by a skill manifest.
@@ -1005,22 +890,20 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // SKILL.md PR-C: discovery field
+    // SKILL.md PR-F: discovery field is summary-only; hints are gone
     // ------------------------------------------------------------------
 
+    /// PR-F GREEN: a manifest declaring `discovery: { summary: "..." }`
+    /// (and nothing else) parses cleanly and exposes the summary on the
+    /// `SkillDiscovery` value. This is the canonical post-PR-F shape.
     #[test]
-    fn manifest_parses_with_discovery_field() {
+    fn manifest_parses_discovery_with_only_summary() {
         let json = r#"{
             "name": "mofa-slides",
-            "version": "0.6.1",
+            "version": "0.7.0",
             "tools": [{"name": "t", "description": "d"}],
             "discovery": {
-                "summary": "Generate AI presentation slides with full-bleed Gemini images.",
-                "hints": [
-                    { "when": "user asks for editable PPT", "read": "SKILL.md#mode-2" },
-                    { "when": "picking a style", "list": "styles/*.toml" },
-                    { "when": "authoring custom styles", "read": "docs/custom-styles.md" }
-                ]
+                "summary": "Generate AI presentation slides with full-bleed Gemini images."
             }
         }"#;
         let manifest: PluginManifest = serde_json::from_str(json).unwrap();
@@ -1029,17 +912,33 @@ mod tests {
             discovery.summary.as_deref(),
             Some("Generate AI presentation slides with full-bleed Gemini images.")
         );
-        assert_eq!(discovery.hints.len(), 3);
-        assert_eq!(discovery.hints[0].when, "user asks for editable PPT");
-        assert_eq!(discovery.hints[0].read.as_deref(), Some("SKILL.md#mode-2"));
-        assert!(discovery.hints[0].list.is_none());
-        assert_eq!(discovery.hints[1].when, "picking a style");
-        assert!(discovery.hints[1].read.is_none());
-        assert_eq!(discovery.hints[1].list.as_deref(), Some("styles/*.toml"));
-        assert_eq!(discovery.hints[2].when, "authoring custom styles");
+    }
+
+    /// PR-F backwards-tolerance: 7 mofa-skills manifests still ship the
+    /// dead `discovery.hints: [...]` arrays on disk. PR-F must not break
+    /// them — `SkillDiscovery` does NOT set `deny_unknown_fields`, so
+    /// serde silently drops the field. This test pins that contract so a
+    /// future tightening cannot break the migrated mofa-skills.
+    #[test]
+    fn manifest_silently_ignores_legacy_hints_field() {
+        let json = r#"{
+            "name": "legacy-mofa",
+            "version": "1.0.0",
+            "tools": [{"name": "t", "description": "d"}],
+            "discovery": {
+                "summary": "Card with legacy hints array still on disk.",
+                "hints": [
+                    { "when": "user asks anything", "read": "SKILL.md" },
+                    { "when": "picking a style", "list": "styles/*.toml" }
+                ]
+            }
+        }"#;
+        let manifest: PluginManifest =
+            serde_json::from_str(json).expect("legacy hints field must parse without error");
+        let discovery = manifest.discovery.expect("discovery present");
         assert_eq!(
-            discovery.hints[2].read.as_deref(),
-            Some("docs/custom-styles.md")
+            discovery.summary.as_deref(),
+            Some("Card with legacy hints array still on disk.")
         );
     }
 
@@ -1052,79 +951,6 @@ mod tests {
         }"#;
         let manifest: PluginManifest = serde_json::from_str(json).unwrap();
         assert!(manifest.discovery.is_none());
-    }
-
-    #[test]
-    fn manifest_rejects_too_many_hints() {
-        // 9 hints — exceeds MAX_DISCOVERY_HINTS (8).
-        let json = r#"{
-            "name": "noisy",
-            "version": "1.0.0",
-            "tools": [{"name": "t", "description": "d"}],
-            "discovery": {
-                "summary": "Too many hints.",
-                "hints": [
-                    { "when": "a", "read": "a.md" },
-                    { "when": "b", "read": "b.md" },
-                    { "when": "c", "read": "c.md" },
-                    { "when": "d", "read": "d.md" },
-                    { "when": "e", "read": "e.md" },
-                    { "when": "f", "read": "f.md" },
-                    { "when": "g", "read": "g.md" },
-                    { "when": "h", "read": "h.md" },
-                    { "when": "i", "read": "i.md" }
-                ]
-            }
-        }"#;
-        let err =
-            serde_json::from_str::<PluginManifest>(json).expect_err("9 hints must fail to parse");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("hints") && msg.contains("8"),
-            "error must mention hint cap; got: {msg}"
-        );
-    }
-
-    #[test]
-    fn manifest_rejects_traversal_in_hint_read() {
-        let json = r#"{
-            "name": "evil",
-            "version": "1.0.0",
-            "tools": [{"name": "t", "description": "d"}],
-            "discovery": {
-                "hints": [
-                    { "when": "exfil", "read": "../etc/passwd" }
-                ]
-            }
-        }"#;
-        let err = serde_json::from_str::<PluginManifest>(json)
-            .expect_err("traversal in `read` must fail to parse");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("..") || msg.to_lowercase().contains("traversal"),
-            "error must mention traversal; got: {msg}"
-        );
-    }
-
-    #[test]
-    fn manifest_rejects_traversal_in_hint_list() {
-        let json = r#"{
-            "name": "evil",
-            "version": "1.0.0",
-            "tools": [{"name": "t", "description": "d"}],
-            "discovery": {
-                "hints": [
-                    { "when": "exfil", "list": "../../*" }
-                ]
-            }
-        }"#;
-        let err = serde_json::from_str::<PluginManifest>(json)
-            .expect_err("traversal in `list` must fail to parse");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("..") || msg.to_lowercase().contains("traversal"),
-            "error must mention traversal; got: {msg}"
-        );
     }
 
     /// Round-2 codex BLOCKER 2 regression: `has_extras()` must report true
@@ -1141,10 +967,7 @@ mod tests {
             "version": "1.0.0",
             "tools": [],
             "discovery": {
-                "summary": "Card-only skill.",
-                "hints": [
-                    { "when": "user asks anything", "read": "SKILL.md" }
-                ]
+                "summary": "Card-only skill."
             }
         }"#;
         let manifest: PluginManifest = serde_json::from_str(json).unwrap();
@@ -1168,9 +991,7 @@ mod tests {
             "version": "1.0.0",
             "tools": [{"name": "t", "description": "d"}],
             "discovery": {
-                "hints": [
-                    { "when": "user asks anything", "read": "SKILL.md" }
-                ]
+                "summary": "Some skill."
             }
         }"#;
         let manifest: PluginManifest = serde_json::from_str(json).unwrap();
@@ -1191,78 +1012,28 @@ mod tests {
         assert!(!manifest.has_extras());
     }
 
-    #[test]
-    fn manifest_rejects_hint_with_no_read_or_list() {
-        let json = r#"{
-            "name": "blank",
-            "version": "1.0.0",
-            "tools": [{"name": "t", "description": "d"}],
-            "discovery": {
-                "hints": [
-                    { "when": "user wants thing" }
-                ]
-            }
-        }"#;
-        let err = serde_json::from_str::<PluginManifest>(json)
-            .expect_err("hint with neither read nor list must fail to parse");
-        let msg = err.to_string();
-        assert!(
-            msg.to_lowercase().contains("read") || msg.to_lowercase().contains("list"),
-            "error must explain hint needs read or list; got: {msg}"
-        );
-    }
-
     // ------------------------------------------------------------------
-    // SKILL.md PR-D1: skill_md_auto_inject opt-out flag
+    // SKILL.md PR-E: legacy skill_md_auto_inject field removal
     // ------------------------------------------------------------------
 
-    /// A manifest that omits the field must deserialize to `true` so
-    /// unmigrated plugins keep current behavior (legacy SKILL.md
-    /// auto-inject still runs for `spawn_only` tools).
+    /// PR-E backwards compat: manifests that still declare
+    /// `skill_md_auto_inject` (the PR-D1 opt-out flag) must continue to
+    /// parse cleanly after the field is dropped from `PluginManifest`.
+    /// Serde silently ignores unknown JSON fields because the struct does
+    /// NOT set `deny_unknown_fields`; this test pins that contract so a
+    /// future tightening cannot break the 7 already-migrated mofa-* skill
+    /// manifests on disk.
     #[test]
-    fn manifest_defaults_skill_md_auto_inject_to_true() {
-        let json = r#"{
-            "name": "legacy",
-            "version": "1.0.0",
-            "tools": [{"name": "t", "description": "d"}]
-        }"#;
-        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
-        assert!(
-            manifest.skill_md_auto_inject,
-            "missing field must default to true (preserves legacy auto-inject)"
-        );
-    }
-
-    /// Explicit `false` opts the plugin out of the legacy SKILL.md
-    /// auto-inject. This is the migration knob PR-D2 will set per skill
-    /// after the new discovery card lands and soaks.
-    #[test]
-    fn manifest_parses_explicit_skill_md_auto_inject_false() {
+    fn manifest_ignores_legacy_skill_md_auto_inject_field() {
         let json = r#"{
             "name": "migrated",
             "version": "1.0.0",
             "tools": [{"name": "t", "description": "d"}],
             "skill_md_auto_inject": false
         }"#;
-        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
-        assert!(
-            !manifest.skill_md_auto_inject,
-            "explicit false must turn off the legacy auto-inject gate"
-        );
-    }
-
-    /// Explicit `true` is equivalent to omitting the field but must still
-    /// be parseable so operators can be loud about opting in during the
-    /// migration window.
-    #[test]
-    fn manifest_parses_explicit_skill_md_auto_inject_true() {
-        let json = r#"{
-            "name": "explicit-legacy",
-            "version": "1.0.0",
-            "tools": [{"name": "t", "description": "d"}],
-            "skill_md_auto_inject": true
-        }"#;
-        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
-        assert!(manifest.skill_md_auto_inject);
+        let manifest: PluginManifest =
+            serde_json::from_str(json).expect("legacy field must parse without error");
+        assert_eq!(manifest.name, "migrated");
+        assert_eq!(manifest.tools.len(), 1);
     }
 }

--- a/crates/platform-skills/voice/manifest.json
+++ b/crates/platform-skills/voice/manifest.json
@@ -118,5 +118,8 @@
         "required": ["model_type"]
       }
     }
-  ]
+  ],
+  "discovery": {
+    "summary": "On-device ASR + preset-voice TTS (Qwen3 on Apple Silicon) with emotion/speed control and model lifecycle. Voice cloning lives in sibling skill mofa-fm."
+  }
 }


### PR DESCRIPTION
## Summary

PR-C/D's per-hint curation (`discovery.hints: [{when, read?, list?}]`) didn't age well: doc renames break hints, plugin authors hand-curate trigger phrases, and the hints implicitly narrow LLM curiosity vs. Claude Code's "you have the filesystem, go look" model. octos is pre-release so this PR simply drops the field instead of layering backwards-compat.

The card collapses to 5 lines (name / purpose / tools / skill_dir) and the loader pushes a one-paragraph generic preamble that tells the LLM the `skill_dir` is read-accessible via the already-allowlisted file tools (`read_file`, `glob`, `list_dir`, `grep`) and to treat the skill_dir as the source of truth.

## Changes

**manifest.rs** — delete `DiscoveryHint`, `MAX_DISCOVERY_HINTS`, `hint_path_has_traversal`, and the validating `deserialize_discovery` shim. `SkillDiscovery` now contains only `summary: Option<String>` and derives `Deserialize`. Legacy manifests with `hints: [...]` arrays still on disk parse cleanly (serde silently drops the unknown field; pinned by test).

**extras.rs** — `render_skill_card` collapses to 4 newline-separated lines. New `SKILL_EXPLORATION_PREAMBLE` constant; `resolve_extras` pushes `[preamble, card]` per discovery-bearing plugin.

**loader.rs** — `PluginLoadResult::merge_extras` dedupes the constant preamble so the system prompt contains it exactly once per session regardless of how many plugins declare `discovery`. Distinct cards survive.

**Manifests (5)** — voice + 4 harness-starter manifests get summary-only `discovery` blocks.

## Preamble wording

> Active plugin skill directories are listed below as cards. Each `skill_dir` is read-accessible via `read_file`, `glob`, `list_dir`, `grep`. When you need a format schema, a worked example, the available styles/templates, or any other detail beyond the card's summary, READ the relevant files (SKILL.md, docs/*, examples/*, schemas, etc.) before guessing. The code and examples in skill_dir are the source of truth; the card is just a pointer.

## Card shape

```
- name: <plugin_name>
  purpose: <discovery.summary OR "(no summary)">
  tools: <comma-separated tool names>
  skill_dir: <absolute path>
```

(No trailing newline so successive fragments don't accumulate blanks. The `- name:` opener plus three indented children makes 4 lines; the user spec calls this the "5-line card" counting the bullet header.)

## Tests

- Drop ~7 hint-validation tests (referencing deleted code).
- Add `manifest_parses_discovery_with_only_summary`, `manifest_silently_ignores_legacy_hints_field`, `extras_renders_5_line_card_with_summary`, `extras_renders_card_without_summary_uses_placeholder`, `extras_omits_preamble_and_card_when_discovery_absent`, `extras_emits_exploration_preamble_once_per_session`, `merge_extras_dedupes_preamble_across_plugins`.

## Follow-up

A small mofa-skills PR will scrub the now-dead `hints: [...]` arrays from the 7 migrated plugin manifests there.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p octos-agent --lib -- --test-threads=4` (1742 passed)
- [x] `cargo clippy --workspace --no-deps -- -D warnings`
- [x] `cargo fmt --all -- --check`

## Note on branch name

The user-specified branch name was `feat/skill-card-generic-no-hints`; a parallel worktree already held that ref so this PR ships from `-v2`. Functionally identical scope.