### PR TITLE
feat(appui): wire projection.envelope.v1 capability negotiation (γ-1)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -49,14 +49,14 @@ use octos_core::ui_protocol::{
     UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1, UI_PROTOCOL_FEATURE_CONTEXT_LIFECYCLE_V1,
     UI_PROTOCOL_FEATURE_FILE_ATTACHED_V1, UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1,
     UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1, UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1,
-    UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1, UI_PROTOCOL_FEATURE_REVIEW_START_V1,
-    UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1, UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
-    UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1, UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1,
-    UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1, UiAgentRecord, UiArtifactPaneItem,
-    UiArtifactPaneSnapshot, UiCommand, UiContextCompactionRecord, UiContextNormalizationReport,
-    UiContextState, UiCursor, UiFileMutationNotice, UiGitHistoryItem, UiGitPaneSnapshot,
-    UiGitStatusItem, UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation, UiProgressEvent,
-    UiProgressMetadata, UiProtocolCapabilities, UiRpcResult, UiWorkspacePaneEntry,
+    UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1, UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1,
+    UI_PROTOCOL_FEATURE_REVIEW_START_V1, UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1,
+    UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1, UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1,
+    UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1, UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1, UiAgentRecord,
+    UiArtifactPaneItem, UiArtifactPaneSnapshot, UiCommand, UiContextCompactionRecord,
+    UiContextNormalizationReport, UiContextState, UiCursor, UiFileMutationNotice, UiGitHistoryItem,
+    UiGitPaneSnapshot, UiGitStatusItem, UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation,
+    UiProgressEvent, UiProgressMetadata, UiProtocolCapabilities, UiRpcResult, UiWorkspacePaneEntry,
     UiWorkspacePaneSnapshot, UnsupportedCapabilityReport, approval_cancelled_reasons,
     approval_kinds, hydrate_sections, progress_kinds, thread_status,
 };
@@ -923,6 +923,15 @@ struct ConnectionUiFeatures {
     /// where the richer envelopes' placement logic dropped PPTX
     /// deliveries on the SPA's chat thread.
     file_attached: bool,
+    /// UPCR-2026-014 M9-γ `projection.envelope.v1` negotiated. When set,
+    /// the client opts in to the canonical [`Envelope`] shape (spec
+    /// § 14) for projected events. γ-1 wires capability negotiation
+    /// only — no emit site references this flag yet, and legacy
+    /// `message/delta`, `message/persisted`, `tool/*`, and
+    /// `turn/completed` notifications continue to flow on the wire.
+    /// γ-2 (follow-up) gates emission on this flag; γ-3 deletes the
+    /// legacy notifications.
+    projection_envelope: bool,
     /// M12 Phase D-1 `auxiliary.rest_to_ws.v1` negotiated. Unlocks the
     /// thirteen auxiliary JSON-RPC methods (`session/list`,
     /// `session/snapshot`, `session/messages_page`, `session/status.get`,
@@ -997,6 +1006,11 @@ impl ConnectionUiFeatures {
             ),
             spawn_complete: has_ui_feature(headers, query, UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1),
             file_attached: has_ui_feature(headers, query, UI_PROTOCOL_FEATURE_FILE_ATTACHED_V1),
+            projection_envelope: has_ui_feature(
+                headers,
+                query,
+                UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1,
+            ),
             auxiliary_rest_to_ws_v1: has_ui_feature(
                 headers,
                 query,
@@ -1046,6 +1060,7 @@ impl ConnectionUiFeatures {
             message_persisted: true,
             spawn_complete: true,
             file_attached: true,
+            projection_envelope: true,
             auxiliary_rest_to_ws_v1: true,
             coding_autonomy_v1: true,
             coding_agent_control_v1: true,
@@ -1081,6 +1096,7 @@ impl ConnectionUiFeatures {
             message_persisted: has(UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1),
             spawn_complete: has(UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1),
             file_attached: has(UI_PROTOCOL_FEATURE_FILE_ATTACHED_V1),
+            projection_envelope: has(UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1),
             auxiliary_rest_to_ws_v1: has(UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1),
             coding_autonomy_v1: has(UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1),
             coding_agent_control_v1: has(UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1),
@@ -1139,6 +1155,9 @@ impl ConnectionUiFeatures {
         }
         if self.file_attached {
             requested.push(UI_PROTOCOL_FEATURE_FILE_ATTACHED_V1);
+        }
+        if self.projection_envelope {
+            requested.push(UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1);
         }
         if self.auxiliary_rest_to_ws_v1 {
             requested.push(UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1);
@@ -22181,6 +22200,7 @@ ignore = []
                 message_persisted: false,
                 spawn_complete: false,
                 file_attached: false,
+                projection_envelope: false,
                 auxiliary_rest_to_ws_v1: false,
                 coding_autonomy_v1: false,
                 coding_agent_control_v1: false,
@@ -22241,6 +22261,7 @@ ignore = []
                 message_persisted: false,
                 spawn_complete: false,
                 file_attached: false,
+                projection_envelope: false,
                 auxiliary_rest_to_ws_v1: false,
                 coding_autonomy_v1: false,
                 coding_agent_control_v1: false,
@@ -22346,6 +22367,7 @@ ignore = []
                 message_persisted: false,
                 spawn_complete: false,
                 file_attached: false,
+                projection_envelope: false,
                 auxiliary_rest_to_ws_v1: false,
                 coding_autonomy_v1: false,
                 coding_agent_control_v1: false,
@@ -22406,6 +22428,7 @@ ignore = []
                 message_persisted: false,
                 spawn_complete: false,
                 file_attached: false,
+                projection_envelope: false,
                 auxiliary_rest_to_ws_v1: false,
                 coding_autonomy_v1: false,
                 coding_agent_control_v1: false,
@@ -22459,6 +22482,7 @@ ignore = []
                 message_persisted: false,
                 spawn_complete: false,
                 file_attached: false,
+                projection_envelope: false,
                 auxiliary_rest_to_ws_v1: false,
                 coding_autonomy_v1: false,
                 coding_agent_control_v1: false,
@@ -22555,6 +22579,7 @@ ignore = []
                 message_persisted: false,
                 spawn_complete: false,
                 file_attached: false,
+                projection_envelope: false,
                 auxiliary_rest_to_ws_v1: false,
                 coding_autonomy_v1: false,
                 coding_agent_control_v1: false,
@@ -24341,6 +24366,7 @@ ignore = []
                 message_persisted: false,
                 spawn_complete: false,
                 file_attached: false,
+                projection_envelope: false,
                 auxiliary_rest_to_ws_v1: false,
                 coding_autonomy_v1: false,
                 coding_agent_control_v1: false,
@@ -24678,6 +24704,85 @@ ignore = []
                 "{method} must NOT be advertised without auxiliary.rest_to_ws.v1"
             );
         }
+    }
+
+    // ----- M9-γ-1: projection.envelope.v1 capability negotiation -----
+    //
+    // γ-1 wires capability negotiation only — no emit site references the
+    // new field yet, and legacy notifications continue to flow on the wire.
+    // The tests below mirror the `event.spawn_complete.v1` recipe and
+    // capture each of the six wiring sites (struct field, header parse,
+    // stdio defaults, requested-token rebuild, negotiated advertisement,
+    // notification methods list) so γ-2 emit-site wiring can land
+    // additively without touching the negotiation surface.
+
+    #[test]
+    fn projection_envelope_v1_negotiated_capabilities_include_only_when_requested() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            UI_FEATURES_HEADER,
+            UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1
+                .parse()
+                .expect("header value"),
+        );
+        let features = ConnectionUiFeatures::from_headers_and_query(&headers, None);
+        assert!(features.projection_envelope);
+        let capabilities = features.negotiated_capabilities();
+        assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1));
+    }
+
+    #[test]
+    fn projection_envelope_v1_negotiated_capabilities_omit_when_not_requested() {
+        let mut headers = HeaderMap::new();
+        // Request a different feature so `header_present == true` but
+        // `projection.envelope.v1` is strictly opt-in.
+        headers.insert(
+            UI_FEATURES_HEADER,
+            UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1
+                .parse()
+                .expect("header value"),
+        );
+        let features = ConnectionUiFeatures::from_headers_and_query(&headers, None);
+        assert!(!features.projection_envelope);
+        let capabilities = features.negotiated_capabilities();
+        assert!(!capabilities.supports_feature(UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1));
+    }
+
+    #[test]
+    fn projection_envelope_v1_in_stdio_defaults() {
+        // Stdio mode opts in to every known feature by construction so
+        // `octos serve --stdio` clients see the full v1 surface without
+        // needing to send a feature header.
+        let features = ConnectionUiFeatures::stdio_defaults();
+        assert!(features.projection_envelope);
+        let capabilities = features.negotiated_capabilities();
+        assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1));
+    }
+
+    #[test]
+    fn projection_envelope_client_hello_feature_tokens_round_trip() {
+        let features = ConnectionUiFeatures::from_requested_feature_tokens(
+            [UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1],
+            false,
+        );
+        assert!(features.projection_envelope);
+        assert!(features.header_present);
+        assert!(!features.stdio_transport);
+        let capabilities = features.negotiated_capabilities();
+        assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1));
+    }
+
+    #[test]
+    fn projection_envelope_method_in_notification_methods_list() {
+        assert!(
+            octos_core::ui_protocol::UI_PROTOCOL_NOTIFICATION_METHODS
+                .contains(&octos_core::ui_protocol::methods::PROJECTION_ENVELOPE),
+            "projection/envelope must be reserved in the notification methods list"
+        );
+        assert_eq!(
+            octos_core::ui_protocol::methods::PROJECTION_ENVELOPE,
+            "projection/envelope"
+        );
     }
 
     #[test]

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -976,6 +976,14 @@ pub mod methods {
     /// event mirroring the SSE `file:` frame from `files_to_send` tool
     /// surfaces.
     pub const FILE_ATTACHED: &str = "file/attached";
+    /// UPCR-2026-014 (M9-γ) `projection/envelope` — canonical projection
+    /// envelope notification (spec § 14). γ-1 reserves the method name
+    /// in the notification methods list as part of capability negotiation
+    /// wire-up; γ-2 (follow-up) will gate emission on the
+    /// `projection.envelope.v1` feature and delete the legacy
+    /// `message/delta`, `message/persisted`, `tool/*`, and
+    /// `turn/completed` notifications it supersedes.
+    pub const PROJECTION_ENVELOPE: &str = "projection/envelope";
     /// UPCR-2026-014 (M9-α-9) `session/event` — wrapper envelope for
     /// legacy `/api/sessions/:id/events/stream` SSE frames bridged onto
     /// the unified v1 surface.
@@ -1140,6 +1148,7 @@ pub const UI_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &[
     methods::MESSAGE_PERSISTED,
     methods::TURN_SPAWN_COMPLETE,
     methods::FILE_ATTACHED,
+    methods::PROJECTION_ENVELOPE,
     methods::SESSION_EVENT,
     methods::ROUTER_STATUS,
     methods::ROUTER_FAILOVER,
@@ -5833,6 +5842,7 @@ mod tests {
                 "message/persisted",
                 "turn/spawn_complete",
                 "file/attached",
+                "projection/envelope",
                 "session/event",
                 "router/status",
                 "router/failover",
@@ -5995,6 +6005,7 @@ mod tests {
                     "message/persisted",
                     "turn/spawn_complete",
                     "file/attached",
+                    "projection/envelope",
                     "session/event",
                     "router/status",
                     "router/failover",


### PR DESCRIPTION
## Context

M9-γ Envelope canonical projection (spec § 14) has the feature flag
registered in `UI_PROTOCOL_KNOWN_FEATURES` but no `ConnectionUiFeatures`
field to honour it, so a client sending
`X-Octos-Ui-Features: projection.envelope.v1` saw the token in
`negotiated_capabilities.supported_features` but the server had no
struct field to gate on later. This PR closes that gap — clients can
now negotiate the feature and the server will know.

This is **γ-1** of the wire-up plan (closes octos #1328). **γ-2**
(server emits canonical `Envelope`, deletes legacy emit) ships in a
follow-up.

## Why this is small + isolated

- No backwards compatibility burden — pre-release.
- No emit site references the new field yet. Legacy `message/delta`,
  `message/persisted`, `tool/*`, and `turn/completed` notifications
  continue to flow on the wire on connections that do not negotiate
  `projection.envelope.v1`. γ-2 gates emission; γ-3 deletes the legacy
  notifications.
- `live_event_passes_capability_filter` semantics unchanged.
- `octos-web` client unchanged.

## Changes

Wire-up sites (model on `event.spawn_complete.v1`):

- `ConnectionUiFeatures::projection_envelope` field (alphabetised
  within the M9 cluster, right after `file_attached`).
- `from_headers_and_query` — read `projection.envelope.v1` token.
- `stdio_defaults` — opt in by default for `octos serve --stdio`.
- `from_requested_feature_tokens` — honour token on hello rebuild.
- `negotiated_capabilities` — advertise when negotiated.
- `methods::PROJECTION_ENVELOPE = "projection/envelope"` constant in
  `octos-core::ui_protocol::methods` and registration in
  `UI_PROTOCOL_NOTIFICATION_METHODS` (golden wire-shape tests updated
  to include the reserved method name).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p octos-cli --features api projection_envelope -- --test-threads=4` — 5 new tests pass.
- [x] `cargo test -p octos-core ui_protocol` — 107/107 pass (golden tests at lines 5822-5859 and 5987-6022 still pass with `projection/envelope` reserved in the notification methods list).
- [x] `cargo test -p octos-cli --features api --lib -- --test-threads=1` — 1420/1420 pass serially. (Parallel runs flake on two pre-existing tests; baseline reproduces the same flake without this PR.)
- [x] `cargo fmt --all -- --check`
- [x] No new clippy warnings touching `ui_protocol.rs` (pre-existing 48 warnings in `octos-cli` are not introduced by this PR).
- [x] MSRV 1.85 — no let-chains in changed code.

## New tests

- `projection_envelope_v1_negotiated_capabilities_include_only_when_requested`
- `projection_envelope_v1_negotiated_capabilities_omit_when_not_requested`
- `projection_envelope_v1_in_stdio_defaults`
- `projection_envelope_client_hello_feature_tokens_round_trip`
- `projection_envelope_method_in_notification_methods_list`

Closes #1328.