### PR TITLE
feat(appui): M9-γ canonical Envelope emit + bridge + legacy cutover (#1328)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -352,6 +352,20 @@ pub(crate) struct WsConnection {
     /// triggers cleanup immediately rather than waiting indefinitely
     /// for the next client frame.
     failed_notify: Arc<tokio::sync::Notify>,
+    /// Codex #1336 round-2 BLOCKER 1: snapshot of the connection's
+    /// negotiated `ConnectionUiFeatures`. The send-helper layer
+    /// consults this to apply `live_event_passes_capability_filter`
+    /// to DIRECT sends, mirroring what the replay/live-forwarder
+    /// paths already do. Without it, a connection that negotiated
+    /// `projection.envelope.v1` still received the legacy
+    /// `MessageDelta` / `TurnCompleted` / tool / `MessagePersisted`
+    /// frames directly from handler code — violating the mutual
+    /// exclusion the γ cutover gate is supposed to enforce.
+    ///
+    /// Mutated only by `handle_client_hello_rpc` (via
+    /// [`update_live_features`]). Reads are far more frequent than
+    /// writes, so `RwLock` is the right fit.
+    live_features: Arc<std::sync::RwLock<ConnectionUiFeatures>>,
 }
 
 impl WsConnection {
@@ -363,6 +377,7 @@ impl WsConnection {
             connection_id: ConnectionId::next(),
             failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             failed_notify: Arc::new(tokio::sync::Notify::new()),
+            live_features: Arc::new(std::sync::RwLock::new(ConnectionUiFeatures::default())),
         }
     }
 
@@ -375,7 +390,33 @@ impl WsConnection {
             connection_id: ConnectionId::next(),
             failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             failed_notify: Arc::new(tokio::sync::Notify::new()),
+            live_features: Arc::new(std::sync::RwLock::new(
+                ConnectionUiFeatures::stdio_defaults(),
+            )),
         }
+    }
+
+    /// Codex #1336 round-2 BLOCKER 1: snapshot the per-connection
+    /// feature set so the send helpers can apply the same capability
+    /// filter the broadcast forwarder uses. Cheap because
+    /// `ConnectionUiFeatures` is `Copy`.
+    fn snapshot_live_features(&self) -> ConnectionUiFeatures {
+        match self.live_features.read() {
+            Ok(guard) => *guard,
+            Err(poisoned) => *poisoned.into_inner(),
+        }
+    }
+
+    /// Codex #1336 round-2 BLOCKER 1: update the per-connection
+    /// feature set after `client/hello` negotiation. Called by
+    /// `handle_client_hello_rpc` so subsequent direct-sends apply the
+    /// new filter immediately.
+    fn update_live_features(&self, features: ConnectionUiFeatures) {
+        let mut guard = match self.live_features.write() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        *guard = features;
     }
 
     pub(crate) fn is_failed(&self) -> bool {
@@ -3376,6 +3417,12 @@ async fn ui_protocol_connection(
     let (writer_tx, writer_rx) = mpsc::channel::<WsMessage>(WS_WRITER_CHANNEL_CAPACITY);
     let writer_handle = tokio::spawn(WsConnection::writer_loop(ws_sink, writer_rx));
     let ws = WsConnection::new(writer_tx);
+    // Codex #1336 round-2 BLOCKER 1: seed the per-connection feature
+    // snapshot from the negotiated `features` so direct-sends apply
+    // the same capability filter the broadcast forwarder uses BEFORE
+    // any RPC traffic. `handle_client_hello_rpc` updates the snapshot
+    // again when the client re-negotiates after the handshake.
+    ws.update_live_features(features);
     let active_turns = active_turns_registry();
     let connection_turns: SharedConnectionTurns = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
     let live_forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
@@ -7306,6 +7353,16 @@ fn handle_client_hello_rpc(
             features.stdio_transport,
         );
     }
+    // Codex #1336 round-2 BLOCKER 1: keep the per-connection feature
+    // snapshot on WsConnection in lockstep with the local `features`
+    // copy. The send-helpers (`send_notification_durable` /
+    // `send_notification_ephemeral` / `send_notification_lifecycle` /
+    // `send_ledger_event_durable`) consult `ws.snapshot_live_features()`
+    // to apply the same `live_event_passes_capability_filter` the
+    // broadcast forwarder uses — without this sync a connection that
+    // negotiated `projection.envelope.v1` mid-session would still
+    // receive legacy frames on direct sends.
+    ws.update_live_features(*features);
     let transport = if features.stdio_transport {
         "stdio"
     } else {
@@ -7750,6 +7807,21 @@ async fn spawn_live_forwarder(
     forwarders: SharedLiveForwarders,
 ) {
     use tokio::sync::broadcast::error::RecvError;
+
+    // Codex #1336 round-2 BLOCKER 1: keep the per-connection feature
+    // snapshot on WsConnection in lockstep with what we received. The
+    // forwarder is the canonical source for "this connection's
+    // negotiated features" — the direct-send helpers
+    // (`send_notification_durable` / `send_notification_ephemeral` /
+    // `send_notification_lifecycle`) read this snapshot to apply the
+    // same `live_event_passes_capability_filter` the forwarder
+    // applies on the broadcast path. Without this sync, a test (or a
+    // production path that forgot to call `update_live_features`
+    // after `client/hello`) could see the forwarder filter the
+    // broadcast copy AND the direct-send path filter it again — or
+    // worse, the direct send pass through legacy frames a
+    // `projection.envelope.v1` client did not negotiate to receive.
+    ws.update_live_features(features);
 
     let session_for_log = session_id.clone();
     let task = tokio::spawn(async move {
@@ -18468,6 +18540,22 @@ fn send_scope_error(ws: &WsConnection, id: String, error: RpcError) {
     let _ = send_rpc_error(ws, Some(id), error);
 }
 
+/// Codex #1336 round-2 BLOCKER 1: per-connection capability filter
+/// applied at the DIRECT-SEND boundary. Mirrors what
+/// [`live_event_passes_capability_filter`] does for the broadcast
+/// forwarder so the per-connection mutual exclusion contract holds
+/// for the originating connection too — not just for other
+/// connections receiving the same event via fan-out.
+///
+/// Returns `true` when the wire frame should be sent on this
+/// connection; `false` when the connection's negotiated feature set
+/// filters it out (e.g. a `projection.envelope.v1` client that must
+/// not receive a legacy `MessageDelta` direct-send).
+fn direct_send_passes_capability_filter(ws: &WsConnection, event: &UiProtocolLedgerEvent) -> bool {
+    let features = ws.snapshot_live_features();
+    live_event_passes_capability_filter(event, features)
+}
+
 fn send_notification_lifecycle(
     ws: &WsConnection,
     ledger: &UiProtocolLedger,
@@ -18478,6 +18566,17 @@ fn send_notification_lifecycle(
     let event = ledger.append_notification_from(notification, ws.connection_id);
     let cursor = event.cursor.clone();
     let method = ledger_event_method(&event.event).to_string();
+    // Codex #1336 round-2 BLOCKER 1: apply the per-connection
+    // capability filter at the direct-send boundary. Without this, a
+    // connection that negotiated `projection.envelope.v1` would still
+    // receive direct-sent legacy `TurnCompleted` lifecycle frames,
+    // violating the γ cutover gate's mutual exclusion contract. The
+    // ledger append above still happens so the canonical envelope
+    // emit (via `ledger.emit_envelope` on the same handler path)
+    // delivers via the broadcast forwarder.
+    if !direct_send_passes_capability_filter(ws, &event.event) {
+        return Ok(());
+    }
     let frame = frame_from_ledger(event.event)
         .ok_or_else(|| SendError::LifecycleFailure(format!("serialize {method}")))?;
     match ws.send_lifecycle(frame) {
@@ -18508,6 +18607,19 @@ fn send_notification_durable(
     let event = ledger.append_notification_from(notification, ws.connection_id);
     let cursor = event.cursor.clone();
     let method = ledger_event_method(&event.event).to_string();
+    // Codex #1336 round-2 BLOCKER 1: apply the per-connection
+    // capability filter at the direct-send boundary. A connection
+    // that negotiated `projection.envelope.v1` must not receive
+    // direct-sent legacy notifications (`MessagePersisted`,
+    // `ToolStarted` / `ToolProgress` / `ToolCompleted`,
+    // `FileAttached`, etc.) — the canonical envelopes emitted by
+    // `ledger.emit_envelope` reach the same connection via the live
+    // forwarder. Ledger append still occurs above so OTHER
+    // connections (without the feature) receive the legacy shape via
+    // their own forwarders.
+    if !direct_send_passes_capability_filter(ws, &event.event) {
+        return Ok(());
+    }
     let frame = match frame_from_ledger(event.event) {
         Some(frame) => frame,
         None => {
@@ -18537,6 +18649,20 @@ fn send_notification_ephemeral(
     // Ephemeral frames are NOT appended to the ledger — they are explicitly
     // non-durable per spec § 9. Drops never need a `replay_lossy` summary.
     let method = notification.method().to_string();
+    // Codex #1336 round-2 BLOCKER 1: apply the per-connection
+    // capability filter to ephemeral direct sends too. `MessageDelta`
+    // is the load-bearing case — every keystroke from the LLM is an
+    // ephemeral direct send, and a `projection.envelope.v1` client
+    // expects the canonical envelope shape exclusively.
+    //
+    // Ephemerals are NOT in the ledger so we wrap the notification in
+    // a synthetic `Notification` ledger event for the filter check
+    // only (it never reaches disk). This keeps the filter helper
+    // signature uniform across direct-send paths.
+    let filter_event = UiProtocolLedgerEvent::Notification(notification.clone());
+    if !direct_send_passes_capability_filter(ws, &filter_event) {
+        return Ok(());
+    }
     let rpc = match notification.into_rpc_notification() {
         Ok(rpc) => rpc,
         Err(error) => {
@@ -18563,6 +18689,20 @@ fn send_ledger_event_durable(
     // `event` already carries its cursor (set by the ledger before storage)
     // — pull a copy out before consuming the event into a frame.
     let cursor = ledger_event_cursor(&event);
+    // Codex #1336 round-2 BLOCKER 1: this helper is called from THREE
+    // paths — (a) the live forwarder, which already filters via
+    // `live_event_passes_capability_filter(features)` BEFORE invoking;
+    // (b) the session/open replay loop, which ALSO already filters
+    // before invoking; (c) handler-direct paths that flush a ledger
+    // event they just appended (progress status, opened-event,
+    // synthetic emits) — these always send shapes that aren't gated
+    // by `projection_envelope` (Progress, SessionOpened, etc.).
+    // Adding a second filter pass here would double up with (a) +
+    // (b) — and in tests where the forwarder's `features` arg is set
+    // explicitly without syncing `WsConnection::live_features`, the
+    // second pass would drop events the forwarder approved. The
+    // `send_notification_*` family is where γ-cutover direct sends
+    // arrive and where the per-connection filter is applied.
     let frame = match frame_from_ledger(event) {
         Some(frame) => frame,
         None => return Err(SendError::BackpressureDrop),
@@ -25017,6 +25157,167 @@ ignore = []
             octos_core::ui_protocol::methods::PROJECTION_ENVELOPE,
             "projection/envelope"
         );
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Codex #1336 round-2 BLOCKER 1: direct-send capability filter
+    // ────────────────────────────────────────────────────────────────────
+
+    /// A `projection.envelope.v1` connection that direct-sends a
+    /// legacy `MessageDelta` via `send_notification_ephemeral` must
+    /// observe ZERO wire frames on its writer channel. Pre-fix the
+    /// frame was sent directly (bypassing the
+    /// `live_event_passes_capability_filter` gate that the broadcast
+    /// forwarder applies). Post-fix the direct-send helpers consult
+    /// `WsConnection::snapshot_live_features` and apply the same
+    /// filter so the connection's mutual exclusion contract holds
+    /// even on the originating handler's direct path.
+    #[tokio::test]
+    async fn direct_ephemeral_send_drops_legacy_message_delta_for_projection_envelope_connection() {
+        use octos_core::ui_protocol::MessageDeltaEvent;
+        let (tx, mut rx) = mpsc::channel(16);
+        let ws = WsConnection::new(tx);
+        // Negotiate projection.envelope.v1.
+        ws.update_live_features(ConnectionUiFeatures {
+            projection_envelope: true,
+            header_present: true,
+            ..ConnectionUiFeatures::default()
+        });
+
+        let ledger = UiProtocolLedger::new(8);
+        let session_id = SessionKey("local:blocker1-eph".into());
+        let notif = UiNotification::MessageDelta(MessageDeltaEvent {
+            session_id: session_id.clone(),
+            topic: None,
+            turn_id: TurnId::new(),
+            text: "hello".into(),
+        });
+
+        // Direct ephemeral send — should be filtered out for this connection.
+        let result = send_notification_ephemeral(&ws, &ledger, notif);
+        assert!(
+            result.is_ok(),
+            "filter-drop returns Ok so callers don't treat it as a fatal error"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "projection.envelope.v1 connection must NOT receive the legacy MessageDelta directly"
+        );
+    }
+
+    /// Mirror of the above for `send_notification_durable`. The γ
+    /// cutover gate filters `ToolStarted` / `ToolCompleted` /
+    /// `MessagePersisted` / `FileAttached` / `TurnCompleted` — the
+    /// canonical envelopes emitted by `ledger.emit_envelope` cover
+    /// the same logical events via the broadcast forwarder.
+    #[tokio::test]
+    async fn direct_durable_send_drops_legacy_tool_completed_for_projection_envelope_connection() {
+        use octos_core::ui_protocol::ToolCompletedEvent;
+        let (tx, mut rx) = mpsc::channel(16);
+        let ws = WsConnection::new(tx);
+        ws.update_live_features(ConnectionUiFeatures {
+            projection_envelope: true,
+            header_present: true,
+            ..ConnectionUiFeatures::default()
+        });
+
+        let ledger = UiProtocolLedger::new(8);
+        let session_id = SessionKey("local:blocker1-dur".into());
+        let notif = UiNotification::ToolCompleted(ToolCompletedEvent {
+            session_id: session_id.clone(),
+            topic: None,
+            turn_id: TurnId::new(),
+            tool_call_id: "tc-1".into(),
+            tool_name: "shell".into(),
+            success: Some(true),
+            output_preview: None,
+            duration_ms: None,
+        });
+
+        let _ = send_notification_durable(&ws, &ledger, notif);
+        assert!(
+            rx.try_recv().is_err(),
+            "projection.envelope.v1 connection must NOT receive the legacy ToolCompleted directly"
+        );
+    }
+
+    /// Defensive: a legacy (non-projection.envelope) connection must
+    /// STILL receive direct sends of `MessageDelta` and tool events.
+    /// The filter is mutual exclusion — without
+    /// `projection.envelope.v1` the legacy shapes are the only thing
+    /// the client knows how to render.
+    #[tokio::test]
+    async fn direct_send_delivers_legacy_frames_to_non_projection_envelope_connection() {
+        use octos_core::ui_protocol::MessageDeltaEvent;
+        let (tx, mut rx) = mpsc::channel(16);
+        let ws = WsConnection::new(tx);
+        // Default features: projection_envelope is false.
+        ws.update_live_features(ConnectionUiFeatures::default());
+
+        let ledger = UiProtocolLedger::new(8);
+        let session_id = SessionKey("local:blocker1-legacy".into());
+        let notif = UiNotification::MessageDelta(MessageDeltaEvent {
+            session_id: session_id.clone(),
+            topic: None,
+            turn_id: TurnId::new(),
+            text: "should reach legacy client".into(),
+        });
+
+        let _ = send_notification_ephemeral(&ws, &ledger, notif);
+        let frame = rx
+            .try_recv()
+            .expect("legacy client must receive MessageDelta directly");
+        // Sanity-check the frame is a JSON-RPC notification for message/delta.
+        if let WsMessage::Text(text) = frame {
+            let value: serde_json::Value = serde_json::from_str(text.as_str()).expect("JSON");
+            assert_eq!(value["method"], "message/delta");
+        } else {
+            panic!("expected text frame");
+        }
+    }
+
+    /// A `projection.envelope.v1` connection direct-sending an
+    /// `Envelope` (e.g. via `send_ledger_event_durable`) MUST pass
+    /// through — the envelope is exactly what the connection
+    /// negotiated for.
+    #[tokio::test]
+    async fn direct_send_delivers_envelope_to_projection_envelope_connection() {
+        use octos_core::ui_protocol::{
+            Envelope, EnvelopeNotification, EnvelopeTokenUsage, Payload,
+        };
+        let (tx, mut rx) = mpsc::channel(16);
+        let ws = WsConnection::new(tx);
+        ws.update_live_features(ConnectionUiFeatures {
+            projection_envelope: true,
+            header_present: true,
+            ..ConnectionUiFeatures::default()
+        });
+
+        let ledger = UiProtocolLedger::new(8);
+        let session_id = SessionKey("local:blocker1-env".into());
+        let envelope_notif = UiNotification::Envelope(EnvelopeNotification {
+            session_id: session_id.clone(),
+            topic: None,
+            envelope: Envelope {
+                thread_id: "thread-blocker1".into(),
+                seq: 1,
+                client_message_id: None,
+                payload: Payload::TurnCompleted {
+                    token_usage: EnvelopeTokenUsage::default(),
+                },
+            },
+        });
+
+        let _ = send_notification_durable(&ws, &ledger, envelope_notif);
+        let frame = rx
+            .try_recv()
+            .expect("projection.envelope.v1 connection MUST receive envelope direct-sends");
+        if let WsMessage::Text(text) = frame {
+            let value: serde_json::Value = serde_json::from_str(text.as_str()).expect("JSON");
+            assert_eq!(value["method"], "projection/envelope");
+        } else {
+            panic!("expected text frame");
+        }
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -28,9 +28,10 @@ use octos_core::ui_protocol::{
     ApprovalDecidedEvent, ApprovalDecision, ApprovalId, ApprovalRenderHints,
     ApprovalRequestedEvent, ApprovalTypedDetails, ContentBulkDeleteParams, ContentDeleteParams,
     ContentListParams, ContextCompactionCompletedEvent, ContextNormalizationReportedEvent,
-    HydratedMessage, HydratedTurn, InputItem, MessageDeltaEvent, MessagePersistedEvent,
-    MessagePersistedSource, OutputCursor, ReplayLossyEvent, RpcError, RpcErrorResponse, RpcRequest,
-    RpcResponse, SESSION_HYDRATE_INCLUDE_MAX, SESSION_MESSAGES_PAGE_DEFAULT_LIMIT,
+    EnvelopeTokenUsage, FileRef, HydratedMessage, HydratedTurn, InputItem, MessageDeltaEvent,
+    MessageMeta, MessagePersistedEvent, MessagePersistedSource, OutputCursor, Payload,
+    ReplayLossyEvent, RpcError, RpcErrorResponse, RpcRequest, RpcResponse,
+    SESSION_HYDRATE_INCLUDE_MAX, SESSION_MESSAGES_PAGE_DEFAULT_LIMIT,
     SESSION_MESSAGES_PAGE_MAX_LIMIT, SESSION_MESSAGES_PAGE_MAX_OFFSET, SESSION_TITLE_SET_MAX_CHARS,
     SessionDeleteParams, SessionFilesListParams, SessionHydrateParams, SessionHydrateResult,
     SessionListParams, SessionMessagesPageParams, SessionOpenParams, SessionOpenResult,
@@ -2568,7 +2569,75 @@ fn install_message_commit_observer(ledger: Arc<UiProtocolLedger>) {
             // connections happens via the `send_ledger_event_durable`
             // path that the standard notification fan-out already
             // exercises.
+            let event_for_envelope = event.clone();
+            let message_for_envelope = message.clone();
             let _appended = ledger.append_notification(UiNotification::MessagePersisted(event));
+
+            // UPCR-2026-014 M9-γ dual-emit: in parallel with the legacy
+            // `message/persisted` envelope, append a canonical
+            // `projection/envelope` event. For Assistant rows we emit
+            // `Payload::AssistantPersisted` (carries the durable
+            // `MessageMeta`). For User rows we emit `Payload::UserMessage`
+            // — the turn root — including `client_message_id` so the
+            // optimistic `<GhostBubble>` overlay can match its server
+            // reflection. Tool rows are NOT rendered as envelopes (they
+            // appear as `Payload::ToolEnd` via `forward_progress_event`).
+            //
+            // Note: we resist the temptation to inspect
+            // `MessagePersistedSource::Background` here and suppress the
+            // envelope dual-emit for `BackgroundResultSender` persists —
+            // the per-connection live filter
+            // (`live_event_passes_capability_filter`) already routes
+            // legacy and envelope deliveries into mutually exclusive
+            // wire shapes, so the envelope is what
+            // `projection.envelope.v1` clients see; legacy clients see
+            // the suppressed-or-not `message/persisted` row.
+            let Some(thread_id) = message_for_envelope.thread_id.clone() else {
+                return;
+            };
+            let media_for_meta = event_for_envelope.media.clone();
+            let message_id = event_for_envelope.message_id.clone();
+            let persisted_at = event_for_envelope.persisted_at;
+            let cmid = event_for_envelope.client_message_id.clone();
+            match message_for_envelope.role {
+                MessageRole::Assistant => {
+                    let text = event_for_envelope.content.unwrap_or_default();
+                    let payload = Payload::AssistantPersisted {
+                        text,
+                        meta: MessageMeta {
+                            message_id,
+                            persisted_at,
+                            media: media_for_meta,
+                        },
+                    };
+                    let _ = ledger.emit_envelope(&session_key, thread_id, payload, None);
+                }
+                MessageRole::User => {
+                    let text = event_for_envelope.content.unwrap_or_default();
+                    // `UserMessage` MUST carry the `files: Vec<FileRef>`
+                    // turn-root shape. We don't have IANA mime + size
+                    // metadata on the legacy `media` field — populate a
+                    // best-effort `FileRef` per attachment so the
+                    // projection's UserView renders the attachment chip.
+                    let files: Vec<FileRef> = media_for_meta
+                        .iter()
+                        .map(|path| {
+                            let size_bytes = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+                            FileRef {
+                                path: path.clone(),
+                                mime: "application/octet-stream".into(),
+                                size_bytes,
+                            }
+                        })
+                        .collect();
+                    let payload = Payload::UserMessage { text, files };
+                    let _ = ledger.emit_envelope(&session_key, thread_id, payload, cmid);
+                }
+                MessageRole::Tool | MessageRole::System => {
+                    // Tool persists surface as `Payload::ToolEnd` via the
+                    // progress mapper; system rows don't render in chat.
+                }
+            }
         });
     octos_bus::set_message_commit_observer(Some(observer));
 }
@@ -7806,6 +7875,44 @@ fn live_event_passes_capability_filter(
         if let UiProtocolLedgerEvent::Notification(UiNotification::FileAttached(_)) = event {
             return false;
         }
+    }
+    // UPCR-2026-014 M9-γ cutover: per-connection mutual exclusion.
+    //
+    // Connections that NEGOTIATED `projection.envelope.v1` see canonical
+    // `projection/envelope` envelopes ONLY — the legacy notifications
+    // they supersede are filtered out on this side. Connections that did
+    // NOT negotiate see legacy notifications ONLY — envelopes are
+    // filtered out. This is the cutover gate that makes the M9-γ
+    // projection contract enforceable end-to-end without dual-rendering
+    // the same logical event in two shapes.
+    //
+    // Legacy events superseded by envelopes per spec § 14.7:
+    //   - message/delta             → assistant_delta envelope
+    //   - message/persisted         → assistant_persisted or user_message envelope
+    //   - tool/started              → tool_start envelope
+    //   - tool/progress             → tool_progress envelope
+    //   - tool/completed            → tool_end envelope
+    //   - file/attached             → file_attached envelope
+    //   - turn/completed            → turn_completed envelope
+    //
+    // Note: the legacy *emit* sites stay in place — clients that did
+    // NOT negotiate the feature still need them. What this gate
+    // changes is the per-connection wire delivery.
+    if features.projection_envelope {
+        if let UiProtocolLedgerEvent::Notification(
+            UiNotification::MessageDelta(_)
+            | UiNotification::MessagePersisted(_)
+            | UiNotification::ToolStarted(_)
+            | UiNotification::ToolProgress(_)
+            | UiNotification::ToolCompleted(_)
+            | UiNotification::FileAttached(_)
+            | UiNotification::TurnCompleted(_),
+        ) = event
+        {
+            return false;
+        }
+    } else if let UiProtocolLedgerEvent::Notification(UiNotification::Envelope(_)) = event {
+        return false;
     }
     true
 }
@@ -17317,6 +17424,8 @@ async fn try_emit_terminal(
     match reason {
         TerminalReason::Completed => {
             let details = completion_details.unwrap_or_default();
+            let tokens_in = details.tokens_in;
+            let tokens_out = details.tokens_out;
             let _ = send_notification_lifecycle(
                 ws,
                 ledger,
@@ -17330,10 +17439,32 @@ async fn try_emit_terminal(
                     // removed in M9-α-5/α-6 (PR #855); issue #1332 wires
                     // the same values straight from the agent task's
                     // `done` event so the WS path is no longer dormant.
-                    tokens_in: details.tokens_in,
-                    tokens_out: details.tokens_out,
+                    tokens_in,
+                    tokens_out,
                     session_result: details.session_result,
                 }),
+            );
+            // UPCR-2026-014 M9-γ dual-emit: parallel canonical
+            // `turn_completed` envelope. The hard-barrier inside
+            // `emit_envelope` flips the thread's `completed` flag, so
+            // any further envelope on the same thread is dropped at
+            // the live emit site (spec § 14.6). Token usage zero-fills
+            // reasoning / cache_read / cache_write until the upstream
+            // propagation lands (legacy `tokens_in`/`tokens_out` are
+            // `Option<u32>` and only the first two are populated
+            // today).
+            let token_usage = EnvelopeTokenUsage {
+                input_tokens: tokens_in.map(u64::from).unwrap_or(0),
+                output_tokens: tokens_out.map(u64::from).unwrap_or(0),
+                reasoning_tokens: 0,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+            };
+            let _ = ledger.emit_envelope(
+                session_id,
+                turn_id.0.to_string(),
+                Payload::TurnCompleted { token_usage },
+                None,
             );
         }
         TerminalReason::Errored => {
@@ -17349,6 +17480,94 @@ async fn try_emit_terminal(
     if let Some(ack) = ack {
         let _ = ack.send(());
     }
+}
+
+/// UPCR-2026-014 M9-γ dual-emit helper for `MessageDelta` /
+/// `ToolStarted` / `ToolProgress` / `ToolCompleted` (the legacy
+/// notifications surfaced by `forward_progress_event`).
+///
+/// For every legacy notification produced by the progress mapper, this
+/// helper appends a parallel `projection/envelope` notification to the
+/// ledger. The per-connection live filter
+/// (`live_event_passes_capability_filter`) routes each connection to
+/// exactly one shape — legacy clients see only the legacy event,
+/// `projection.envelope.v1` clients see only the envelope.
+///
+/// Mapping from the legacy notification's `turn_id` (UUIDv7 from
+/// `pre_stamp_turn_thread_id`) to envelope `thread_id`: stringify the
+/// turn UUID. This mirrors the convention that
+/// `pre_stamp_turn_thread_id` uses for assistant/tool row writes, so
+/// envelopes and persisted message rows share the same thread identity.
+///
+/// `ToolCompleted.success` mapping (lossy per § 14.2 + ADR):
+///   - `Some(true)`  → `EnvelopeToolEndStatus::Complete`
+///   - `Some(false)` → `EnvelopeToolEndStatus::Error`
+///   - `None`        → `EnvelopeToolEndStatus::Complete` (fallback;
+///     legacy emits without a success bit are rare and the projection
+///     treats them as a clean exit).
+///
+/// `Skipped` and `Aborted` variants require future signal sources
+/// (deadline-skip plumbing, interrupt propagation) and are NOT
+/// reachable through `ToolCompleted` today.
+fn emit_envelope_for_legacy_notification(
+    ledger: &UiProtocolLedger,
+    session_id: &SessionKey,
+    notification: &UiNotification,
+) {
+    use octos_core::ui_protocol::EnvelopeToolEndStatus;
+    let (thread_id, payload, client_message_id): (String, Payload, Option<String>) =
+        match notification {
+            UiNotification::MessageDelta(event) => (
+                event.turn_id.0.to_string(),
+                Payload::AssistantDelta {
+                    text: event.text.clone(),
+                },
+                None,
+            ),
+            UiNotification::ToolStarted(event) => (
+                event.turn_id.0.to_string(),
+                Payload::ToolStart {
+                    tool_call_id: event.tool_call_id.clone(),
+                    name: event.tool_name.clone(),
+                },
+                None,
+            ),
+            UiNotification::ToolProgress(event) => {
+                let Some(message) = event.message.clone() else {
+                    return;
+                };
+                (
+                    event.turn_id.0.to_string(),
+                    Payload::ToolProgress {
+                        tool_call_id: event.tool_call_id.clone(),
+                        message,
+                    },
+                    None,
+                )
+            }
+            UiNotification::ToolCompleted(event) => {
+                let status = match event.success {
+                    Some(true) | None => EnvelopeToolEndStatus::Complete,
+                    Some(false) => EnvelopeToolEndStatus::Error,
+                };
+                let error = match status {
+                    EnvelopeToolEndStatus::Error => event.output_preview.clone(),
+                    _ => None,
+                };
+                (
+                    event.turn_id.0.to_string(),
+                    Payload::ToolEnd {
+                        tool_call_id: event.tool_call_id.clone(),
+                        status,
+                        error,
+                        reason: None,
+                    },
+                    None,
+                )
+            }
+            _ => return,
+        };
+    let _ = ledger.emit_envelope(session_id, thread_id, payload, client_message_id);
 }
 
 /// Dispatch a single non-terminal progress JSON value out to the WS / ledger.
@@ -17409,6 +17628,13 @@ fn forward_progress_event(
         &mut mapping,
     );
     for notification in mapping.notifications {
+        // UPCR-2026-014 M9-γ dual-emit: every legacy notification gets a
+        // canonical envelope appended to the ledger alongside it. The
+        // per-connection live filter (`live_event_passes_capability_filter`)
+        // routes each connection to exactly one shape: legacy clients see
+        // only the legacy notification, projection.envelope.v1 clients
+        // see only the envelope.
+        emit_envelope_for_legacy_notification(ledger, session_id, &notification);
         match notification {
             UiNotification::MessageDelta(_) => {
                 *saw_delta = true;
@@ -18439,7 +18665,15 @@ fn ledger_event_cursor(event: &UiProtocolLedgerEvent) -> Option<UiCursor> {
             // hashes, not replay cursors. The durable ledger cursor is on
             // the surrounding LedgeredUiProtocolEvent.
             | UiNotification::ContextCompactionCompleted(_)
-            | UiNotification::ContextNormalizationReported(_) => None,
+            | UiNotification::ContextNormalizationReported(_)
+            // UPCR-2026-014 M9-γ: envelopes carry their OWN per-thread
+            // `seq` allocated by `ThreadSeqAllocator`, not the per-session
+            // `UiCursor` the legacy ledger replay uses. The durable
+            // ledger cursor on the surrounding `LedgeredUiProtocolEvent`
+            // is still authoritative for replay; envelopes don't
+            // contribute their per-thread seq into the cursor stream
+            // (which would mix two non-comparable scales).
+            | UiNotification::Envelope(_) => None,
         },
         UiProtocolLedgerEvent::Progress(_) => None,
     }
@@ -30242,6 +30476,343 @@ ignore = []
             live_event_passes_capability_filter(&normalization, new),
             "clients with context.lifecycle.v1 receive normalization events",
         );
+    }
+
+    // ========================================================================
+    // UPCR-2026-014 M9-γ — per-connection envelope/legacy mutual exclusion.
+    // ========================================================================
+
+    fn projection_envelope_event_for(session: &SessionKey) -> UiNotification {
+        UiNotification::Envelope(octos_core::ui_protocol::EnvelopeNotification {
+            session_id: session.clone(),
+            topic: None,
+            envelope: octos_core::ui_protocol::Envelope {
+                thread_id: "thread-1".into(),
+                seq: 1,
+                client_message_id: None,
+                payload: Payload::AssistantDelta { text: "x".into() },
+            },
+        })
+    }
+
+    fn features_for_projection_envelope_test(projection_envelope: bool) -> ConnectionUiFeatures {
+        ConnectionUiFeatures {
+            // Pre-existing capability flags are enabled so the *only*
+            // gate being exercised is the M9-γ projection.envelope.v1
+            // mutual exclusion — the test would otherwise be polluted by
+            // the `message_persisted` and `spawn_complete` gates above.
+            projection_envelope,
+            message_persisted: true,
+            spawn_complete: true,
+            file_attached: true,
+            header_present: true,
+            ..ConnectionUiFeatures::default()
+        }
+    }
+
+    /// Per-connection envelope/legacy mutual exclusion is the cutover
+    /// mechanism for M9-γ (spec § 14.7). A connection that negotiated
+    /// `projection.envelope.v1` sees ONLY canonical envelopes for the
+    /// events that surface had legacy analogs; a connection that did
+    /// NOT negotiate sees ONLY the legacy events and never the envelope.
+    #[test]
+    fn capability_filter_envelope_legacy_mutual_exclusion() {
+        let session = SessionKey("local:envelope-gate".into());
+        let envelope_event =
+            UiProtocolLedgerEvent::Notification(projection_envelope_event_for(&session));
+        let delta_event =
+            UiProtocolLedgerEvent::Notification(UiNotification::MessageDelta(MessageDeltaEvent {
+                session_id: session.clone(),
+                topic: None,
+                turn_id: TurnId::new(),
+                text: "hello".into(),
+            }));
+        let tool_started =
+            UiProtocolLedgerEvent::Notification(UiNotification::ToolStarted(ToolStartedEvent {
+                session_id: session.clone(),
+                topic: None,
+                turn_id: TurnId::new(),
+                tool_call_id: "tc-1".into(),
+                tool_name: "shell".into(),
+                arguments: None,
+            }));
+        let tool_progress =
+            UiProtocolLedgerEvent::Notification(UiNotification::ToolProgress(ToolProgressEvent {
+                session_id: session.clone(),
+                topic: None,
+                turn_id: TurnId::new(),
+                tool_call_id: "tc-1".into(),
+                message: Some("step".into()),
+                progress_pct: None,
+            }));
+        let tool_completed = UiProtocolLedgerEvent::Notification(UiNotification::ToolCompleted(
+            ToolCompletedEvent {
+                session_id: session.clone(),
+                topic: None,
+                turn_id: TurnId::new(),
+                tool_call_id: "tc-1".into(),
+                tool_name: "shell".into(),
+                success: Some(true),
+                output_preview: None,
+                duration_ms: None,
+            },
+        ));
+        let turn_completed = UiProtocolLedgerEvent::Notification(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id: session.clone(),
+                topic: None,
+                turn_id: TurnId::new(),
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        ));
+        let message_persisted =
+            UiProtocolLedgerEvent::Notification(message_persisted_for(&session));
+        let file_attached = UiProtocolLedgerEvent::Notification(file_attached_for(&session));
+
+        // Legacy client (projection_envelope=false): receives ALL legacy
+        // events; envelope is filtered out.
+        let legacy = features_for_projection_envelope_test(false);
+        assert!(
+            !live_event_passes_capability_filter(&envelope_event, legacy),
+            "legacy client must NOT receive projection/envelope notifications",
+        );
+        for (label, ev) in [
+            ("MessageDelta", &delta_event),
+            ("ToolStarted", &tool_started),
+            ("ToolProgress", &tool_progress),
+            ("ToolCompleted", &tool_completed),
+            ("TurnCompleted", &turn_completed),
+            ("MessagePersisted", &message_persisted),
+            ("FileAttached", &file_attached),
+        ] {
+            assert!(
+                live_event_passes_capability_filter(ev, legacy),
+                "legacy client must STILL receive legacy {label} notifications",
+            );
+        }
+
+        // Envelope client (projection_envelope=true): receives ONLY the
+        // envelope; legacy variants superseded by envelopes are
+        // filtered out.
+        let envelope_client = features_for_projection_envelope_test(true);
+        assert!(
+            live_event_passes_capability_filter(&envelope_event, envelope_client),
+            "envelope client receives projection/envelope notifications",
+        );
+        for (label, ev) in [
+            ("MessageDelta", &delta_event),
+            ("ToolStarted", &tool_started),
+            ("ToolProgress", &tool_progress),
+            ("ToolCompleted", &tool_completed),
+            ("TurnCompleted", &turn_completed),
+            ("MessagePersisted", &message_persisted),
+            ("FileAttached", &file_attached),
+        ] {
+            assert!(
+                !live_event_passes_capability_filter(ev, envelope_client),
+                "envelope client must NOT receive legacy {label} notifications",
+            );
+        }
+    }
+
+    /// UPCR-2026-014 M9-γ per-payload dual-emit: every legacy
+    /// notification surfaced by `forward_progress_event` triggers a
+    /// parallel `projection/envelope` ledger append. The test exercises
+    /// the helper that wires the dual-emit
+    /// (`emit_envelope_for_legacy_notification`) so a future refactor
+    /// can't silently drop a variant from the dual surface.
+    #[test]
+    fn emit_envelope_for_legacy_notification_covers_every_progress_variant() {
+        let ledger = UiProtocolLedger::new(32);
+        let session_id = SessionKey("local:dual-emit".into());
+
+        // The progress-mapper emits these four notification variants —
+        // each must yield a corresponding envelope.
+        let turn_id = TurnId::new();
+        let cases: Vec<(UiNotification, &'static str)> = vec![
+            (
+                UiNotification::MessageDelta(MessageDeltaEvent {
+                    session_id: session_id.clone(),
+                    topic: None,
+                    turn_id: turn_id.clone(),
+                    text: "delta".into(),
+                }),
+                "assistant_delta",
+            ),
+            (
+                UiNotification::ToolStarted(ToolStartedEvent {
+                    session_id: session_id.clone(),
+                    topic: None,
+                    turn_id: turn_id.clone(),
+                    tool_call_id: "tc-1".into(),
+                    tool_name: "shell".into(),
+                    arguments: None,
+                }),
+                "tool_start",
+            ),
+            (
+                UiNotification::ToolProgress(ToolProgressEvent {
+                    session_id: session_id.clone(),
+                    topic: None,
+                    turn_id: turn_id.clone(),
+                    tool_call_id: "tc-1".into(),
+                    message: Some("hello".into()),
+                    progress_pct: None,
+                }),
+                "tool_progress",
+            ),
+            (
+                UiNotification::ToolCompleted(ToolCompletedEvent {
+                    session_id: session_id.clone(),
+                    topic: None,
+                    turn_id: turn_id.clone(),
+                    tool_call_id: "tc-1".into(),
+                    tool_name: "shell".into(),
+                    success: Some(true),
+                    output_preview: None,
+                    duration_ms: None,
+                }),
+                "tool_end",
+            ),
+        ];
+
+        let mut expected_types: Vec<&str> = cases.iter().map(|(_, t)| *t).collect();
+
+        for (notif, _expected_type) in &cases {
+            emit_envelope_for_legacy_notification(&ledger, &session_id, notif);
+        }
+
+        let baseline = UiCursor {
+            stream: session_id.0.clone(),
+            seq: 0,
+        };
+        let replay = ledger.replay_after(&session_id, Some(&baseline)).unwrap();
+        let envelope_types: Vec<String> = replay
+            .iter()
+            .filter_map(|e| match &e.event {
+                UiProtocolLedgerEvent::Notification(UiNotification::Envelope(env)) => {
+                    match &env.envelope.payload {
+                        Payload::AssistantDelta { .. } => Some("assistant_delta".into()),
+                        Payload::ToolStart { .. } => Some("tool_start".into()),
+                        Payload::ToolProgress { .. } => Some("tool_progress".into()),
+                        Payload::ToolEnd { .. } => Some("tool_end".into()),
+                        Payload::FileAttached { .. } => Some("file_attached".into()),
+                        Payload::TurnCompleted { .. } => Some("turn_completed".into()),
+                        Payload::AssistantPersisted { .. } => Some("assistant_persisted".into()),
+                        Payload::UserMessage { .. } => Some("user_message".into()),
+                    }
+                }
+                _ => None,
+            })
+            .collect();
+
+        // Order-sensitive: envelopes are appended in the order the
+        // notifications arrive, so we expect the exact slice.
+        expected_types.sort();
+        let mut got_types = envelope_types.clone();
+        got_types.sort();
+        assert_eq!(
+            got_types,
+            expected_types
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect::<Vec<_>>(),
+            "every progress-variant must dual-emit; got {envelope_types:?}",
+        );
+    }
+
+    /// Replay-vs-live divergence: the live-emit hard barrier in
+    /// `UiProtocolLedger::emit_envelope` DROPS post-completion envelopes,
+    /// but ledger replay (`replay_after`) returns the FULL durable
+    /// history. This is the documented semantics from spec § 14.6 — a
+    /// client that reconnects with a pre-completion cursor still sees
+    /// every envelope that was emitted, and applies the barrier itself.
+    #[test]
+    fn live_emit_hard_barrier_does_not_affect_ledger_replay() {
+        let ledger = UiProtocolLedger::new(32);
+        let session_id = SessionKey("local:replay-vs-live".into());
+        let thread_id = "thread-rl".to_owned();
+
+        // Live-emit path: AssistantDelta + TurnCompleted, then a
+        // post-completion AssistantDelta which the hard barrier drops.
+        let a = ledger
+            .emit_envelope(
+                &session_id,
+                thread_id.clone(),
+                Payload::AssistantDelta { text: "a".into() },
+                None,
+            )
+            .expect("first emit accepted");
+        let completed = ledger
+            .emit_envelope(
+                &session_id,
+                thread_id.clone(),
+                Payload::TurnCompleted {
+                    token_usage: octos_core::ui_protocol::EnvelopeTokenUsage::default(),
+                },
+                None,
+            )
+            .expect("turn_completed accepted");
+        let dropped = ledger.emit_envelope(
+            &session_id,
+            thread_id.clone(),
+            Payload::AssistantDelta {
+                text: "should be barrier-dropped".into(),
+            },
+            None,
+        );
+        assert!(
+            dropped.is_none(),
+            "live-emit must drop the post-completion envelope at the barrier",
+        );
+
+        // Now: pre-seed the ledger with a raw post-completion envelope
+        // (bypassing emit_envelope) so the on-disk / in-memory ring
+        // carries it. This models the "old durable record from before
+        // the barrier was tightened" replay scenario.
+        let raw = UiNotification::Envelope(octos_core::ui_protocol::EnvelopeNotification {
+            session_id: session_id.clone(),
+            topic: None,
+            envelope: octos_core::ui_protocol::Envelope {
+                thread_id: thread_id.clone(),
+                seq: 99,
+                client_message_id: None,
+                payload: Payload::AssistantDelta {
+                    text: "raw post-completion".into(),
+                },
+            },
+        });
+        let raw_appended = ledger.append_notification(raw);
+
+        // Replay returns everything appended — the live-emit barrier
+        // does NOT prune the ledger, only the live wire delivery.
+        let baseline = UiCursor {
+            stream: session_id.0.clone(),
+            seq: 0,
+        };
+        let replay = ledger.replay_after(&session_id, Some(&baseline)).unwrap();
+        let envelope_count = replay
+            .iter()
+            .filter(|e| {
+                matches!(
+                    &e.event,
+                    UiProtocolLedgerEvent::Notification(UiNotification::Envelope(_))
+                )
+            })
+            .count();
+        assert!(
+            envelope_count >= 3,
+            "ledger replay must return ALL envelopes including post-completion raw appends \
+             (live-emit barrier applies only at emit, not at replay); got {envelope_count}",
+        );
+        // Sanity: the original live-accepted envelopes are present.
+        let cursors: Vec<u64> = replay.iter().map(|e| e.cursor.seq).collect();
+        assert!(cursors.contains(&a.cursor.seq));
+        assert!(cursors.contains(&completed.cursor.seq));
+        assert!(cursors.contains(&raw_appended.cursor.seq));
     }
 
     /// End-to-end through the live forwarder for a NEW client (negotiated

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -14494,7 +14494,7 @@ fn m15_live_subagent_specs() -> [M15LiveSubagentSpec; 3] {
 
 async fn run_m15_live_subagent_fixture_turn(
     ws: &WsConnection,
-    ledger: &UiProtocolLedger,
+    ledger: &Arc<UiProtocolLedger>,
     session_id: &SessionKey,
     turn_id: &TurnId,
     interrupt_rx: &mut mpsc::Receiver<()>,
@@ -14664,6 +14664,7 @@ async fn run_m15_live_subagent_fixture_turn(
         );
 
         let ws_for_agent = ws.clone();
+        let ledger_for_agent = Arc::clone(ledger);
         let session_id_for_agent = session_id.clone();
         let profile_id_for_agent = profile_id.clone();
         let workdir_for_agent = workdir.clone();
@@ -14671,6 +14672,7 @@ async fn run_m15_live_subagent_fixture_turn(
         joins.spawn(async move {
             run_m15_live_subagent_process(
                 ws_for_agent,
+                ledger_for_agent,
                 session_id_for_agent,
                 profile_id_for_agent,
                 workdir_for_agent,
@@ -14845,8 +14847,10 @@ async fn run_m15_live_subagent_fixture_turn(
     M9FixtureOutcome::Completed
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_m15_live_subagent_process(
     ws: WsConnection,
+    ledger: Arc<UiProtocolLedger>,
     session_id: SessionKey,
     profile_id: String,
     workdir: PathBuf,
@@ -14918,20 +14922,33 @@ print(f"{agent_id}: {finding}")
         .heartbeat_interval(std::time::Duration::from_millis(150)),
     )
     .await?;
-    let _ = send_raw_notification_ephemeral(
-        &ws,
-        octos_core::ui_protocol::methods::MESSAGE_DELTA,
-        json!({
-            "session_id": session_id,
-            "turn_id": turn_id,
-            "text": format!(
-                "Subagent done: {} ({}) completed; artifact `{}` is ready.\n",
-                spec.title,
-                spec.agent_id,
-                spec.artifact_id
-            ),
-        }),
-    );
+    // Codex #1336 round-3 BLOCKER 1: route the M15 live-subagent
+    // fixture's "subagent done" delta through the SAME path as every
+    // other AppUI MessageDelta — dual-emit envelope + filtered
+    // ephemeral. The legacy raw helper bypassed
+    // `direct_send_passes_capability_filter`, so a
+    // `projection.envelope.v1` client received the legacy
+    // `message/delta` frame in addition to the (missing) envelope.
+    //
+    // After this change:
+    //   • `projection.envelope.v1` connections receive ONLY the
+    //     canonical `projection/envelope` (carrying `AssistantDelta`)
+    //     via the broadcast forwarder; the ephemeral legacy send is
+    //     filtered out by `send_notification_ephemeral`'s gate.
+    //   • Legacy connections receive the legacy `message/delta`
+    //     ephemeral and observe NO envelope (the legacy method-name
+    //     filter on the live forwarder drops `projection/envelope`).
+    let delta = UiNotification::MessageDelta(MessageDeltaEvent {
+        session_id: session_id.clone(),
+        topic: None,
+        turn_id: turn_id.clone(),
+        text: format!(
+            "Subagent done: {} ({}) completed; artifact `{}` is ready.\n",
+            spec.title, spec.agent_id, spec.artifact_id
+        ),
+    });
+    emit_envelope_for_legacy_notification(&ledger, &session_id, &delta);
+    let _ = send_notification_ephemeral(&ws, &ledger, delta);
     append_appui_evidence_jsonl(
         "agent-ledger.jsonl",
         json!({
@@ -18303,11 +18320,56 @@ fn append_appui_server_log(message: impl AsRef<str>) {
         });
 }
 
+/// CONTRACT: this helper bypasses the typed `UiNotification` ledger
+/// path and the envelope dual-emit. It exists ONLY for AppUI
+/// supervisor-event methods that are NOT in the M9-γ envelope-superseded
+/// set (e.g. `agent/updated`, `agent/output_delta`,
+/// `agent/artifact_updated`, and the other `WsSupervisorEventSink`
+/// surfaces).
+///
+/// Codex #1336 round-3 BLOCKER 1 (defense in depth): the helper now
+/// REFUSES to dispatch a `method` that is envelope-superseded under the
+/// M9-γ cutover gate — even on legacy connections — to make the
+/// envelope-only contract enforceable by construction. Future callers
+/// who reach for a legacy `message/delta` / `tool/started` / `…` send
+/// via the raw helper fail closed with a debug log instead of leaking
+/// a frame past `direct_send_passes_capability_filter`. Use
+/// [`send_notification_ephemeral`] (typed `UiNotification`) +
+/// [`emit_envelope_for_legacy_notification`] for those methods.
 fn send_raw_notification_ephemeral(
     ws: &WsConnection,
     method: &'static str,
     params: Value,
 ) -> Result<(), SendError> {
+    use octos_core::ui_protocol::methods as ui_methods;
+    // Envelope-superseded legacy methods are off-limits to the raw
+    // helper — they MUST flow through the typed `UiNotification` path
+    // so `send_notification_ephemeral` / `send_notification_durable` /
+    // `send_notification_lifecycle` can apply the per-connection
+    // capability filter AND `emit_envelope_for_legacy_notification`
+    // can publish the canonical envelope dual-emit.
+    if matches!(
+        method,
+        ui_methods::MESSAGE_DELTA
+            | ui_methods::MESSAGE_PERSISTED
+            | ui_methods::TOOL_STARTED
+            | ui_methods::TOOL_PROGRESS
+            | ui_methods::TOOL_COMPLETED
+            | ui_methods::FILE_ATTACHED
+            | ui_methods::TURN_COMPLETED
+    ) {
+        tracing::error!(
+            target: "octos::ui_protocol::ws",
+            method = %method,
+            "send_raw_notification_ephemeral refused: envelope-superseded method must use \
+             send_notification_ephemeral + emit_envelope_for_legacy_notification"
+        );
+        debug_assert!(
+            false,
+            "send_raw_notification_ephemeral called with envelope-superseded method {method}"
+        );
+        return Err(SendError::BackpressureDrop);
+    }
     let notification = octos_core::ui_protocol::RpcNotification::new(method, params);
     let frame = frame_for(&notification).ok_or(SendError::BackpressureDrop)?;
     ws.send_ephemeral(frame, method)
@@ -25318,6 +25380,203 @@ ignore = []
         } else {
             panic!("expected text frame");
         }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Codex #1336 round-3 BLOCKER 1: M15 live-subagent fixture path
+    // ────────────────────────────────────────────────────────────────────
+    //
+    // Round-2 fix landed the per-connection capability filter on the
+    // direct-send helpers (`send_notification_ephemeral` /
+    // `send_notification_durable` / `send_notification_lifecycle`).
+    // Codex round-2 then flagged that the M15 fixture
+    // (`run_m15_live_subagent_process`) still emitted a raw
+    // `message/delta` via `send_raw_notification_ephemeral`, which
+    // jumps straight to `ws.send_ephemeral` and bypasses the gate.
+    // The fix routes the delta through
+    // `emit_envelope_for_legacy_notification` (canonical envelope
+    // dual-emit) + `send_notification_ephemeral` (filtered legacy
+    // ephemeral). The next three tests pin that contract.
+
+    /// `projection.envelope.v1` connection: the M15 fixture's
+    /// "Subagent done" delta MUST NOT deliver a legacy
+    /// `message/delta` to this connection's writer channel. The
+    /// envelope dual-emit publishes the canonical envelope via
+    /// `ledger.emit_envelope` (observable on the broadcast forwarder),
+    /// but the filtered ephemeral send is dropped on the originating
+    /// connection because `projection.envelope.v1` supersedes
+    /// `message/delta`.
+    #[tokio::test]
+    async fn m15_fixture_delta_filtered_for_projection_envelope_connection() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let ws = WsConnection::new(tx);
+        ws.update_live_features(ConnectionUiFeatures {
+            projection_envelope: true,
+            header_present: true,
+            ..ConnectionUiFeatures::default()
+        });
+
+        let ledger = UiProtocolLedger::new(8);
+        let session_id = SessionKey("local:m15-delta-env".into());
+        let turn_id = TurnId::new();
+        // Mirror the exact shape `run_m15_live_subagent_process` builds.
+        let delta = UiNotification::MessageDelta(octos_core::ui_protocol::MessageDeltaEvent {
+            session_id: session_id.clone(),
+            topic: None,
+            turn_id: turn_id.clone(),
+            text: "Subagent done: reviewer-api (Ada) completed; artifact `notes` is ready.\n"
+                .into(),
+        });
+
+        // 1) Canonical envelope dual-emit — observable through the ledger.
+        emit_envelope_for_legacy_notification(&ledger, &session_id, &delta);
+        // 2) Filtered ephemeral legacy send — must be dropped on this connection.
+        let result = send_notification_ephemeral(&ws, &ledger, delta);
+        assert!(
+            result.is_ok(),
+            "filter-drop returns Ok so the spawn loop does not treat it as a fatal error"
+        );
+
+        // Wire: no legacy `message/delta` frame reaches the writer.
+        match rx.try_recv() {
+            Err(_) => {}
+            Ok(frame) => {
+                if let WsMessage::Text(text) = &frame {
+                    let value: serde_json::Value =
+                        serde_json::from_str(text.as_str()).expect("JSON");
+                    panic!(
+                        "projection.envelope.v1 connection must NOT receive legacy frame; got {}",
+                        value["method"]
+                    );
+                }
+                panic!("unexpected wire frame: {frame:?}");
+            }
+        }
+
+        // Ledger: a canonical envelope WAS appended for the session.
+        let (snapshot, _head) = ledger
+            .snapshot_with_cursor(&session_id, None)
+            .expect("snapshot succeeds for a session that just emitted an envelope");
+        let envelope_count = snapshot
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event.event,
+                    UiProtocolLedgerEvent::Notification(UiNotification::Envelope(_))
+                )
+            })
+            .count();
+        assert_eq!(
+            envelope_count, 1,
+            "exactly one canonical envelope must be appended for the M15 fixture delta"
+        );
+        let envelope = snapshot
+            .iter()
+            .find_map(|event| match &event.event {
+                UiProtocolLedgerEvent::Notification(UiNotification::Envelope(envelope)) => {
+                    Some(envelope)
+                }
+                _ => None,
+            })
+            .expect("envelope notification present");
+        assert_eq!(envelope.envelope.thread_id, turn_id.0.to_string());
+        assert!(matches!(
+            envelope.envelope.payload,
+            octos_core::ui_protocol::Payload::AssistantDelta { .. }
+        ));
+    }
+
+    /// Legacy (non-projection.envelope) connection: the M15 fixture
+    /// delta MUST deliver the legacy `message/delta` frame, and the
+    /// envelope ledger entry is also produced (which the live
+    /// forwarder filters out on this connection's wire — covered by
+    /// `live_event_passes_capability_filter` tests elsewhere; here
+    /// we focus on the direct-send half).
+    #[tokio::test]
+    async fn m15_fixture_delta_delivered_to_legacy_connection() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let ws = WsConnection::new(tx);
+        ws.update_live_features(ConnectionUiFeatures::default());
+
+        let ledger = UiProtocolLedger::new(8);
+        let session_id = SessionKey("local:m15-delta-legacy".into());
+        let turn_id = TurnId::new();
+        let delta = UiNotification::MessageDelta(octos_core::ui_protocol::MessageDeltaEvent {
+            session_id: session_id.clone(),
+            topic: None,
+            turn_id: turn_id.clone(),
+            text: "Subagent done: reviewer-tests (Hypatia) completed; artifact `notes` is ready.\n"
+                .into(),
+        });
+
+        emit_envelope_for_legacy_notification(&ledger, &session_id, &delta);
+        let _ = send_notification_ephemeral(&ws, &ledger, delta);
+
+        let frame = rx
+            .try_recv()
+            .expect("legacy client must receive the M15 fixture's MessageDelta directly");
+        if let WsMessage::Text(text) = frame {
+            let value: serde_json::Value = serde_json::from_str(text.as_str()).expect("JSON");
+            assert_eq!(value["method"], "message/delta");
+            assert!(
+                value["params"]["text"]
+                    .as_str()
+                    .unwrap_or("")
+                    .starts_with("Subagent done:"),
+                "delta text must carry the fixture's subagent-done body"
+            );
+        } else {
+            panic!("expected text frame");
+        }
+        // Ledger still carries the envelope alongside; legacy connections
+        // just never see it on the wire (live forwarder filter).
+        let (snapshot, _head) = ledger
+            .snapshot_with_cursor(&session_id, None)
+            .expect("snapshot succeeds for a session that just emitted an envelope");
+        assert!(
+            snapshot.iter().any(|event| matches!(
+                event.event,
+                UiProtocolLedgerEvent::Notification(UiNotification::Envelope(_))
+            )),
+            "envelope dual-emit must still append to the ledger for replay correctness"
+        );
+    }
+
+    /// Defense-in-depth: even if a future caller reaches for
+    /// `send_raw_notification_ephemeral` with an envelope-superseded
+    /// method, the helper itself refuses the dispatch — fail-closed
+    /// with `BackpressureDrop` and no wire frame emitted. Round-2's
+    /// per-connection filter is the primary gate; this is the second
+    /// belt so a `message/delta` raw send can never leak past it.
+    #[tokio::test]
+    async fn raw_ephemeral_helper_refuses_envelope_superseded_method() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let ws = WsConnection::new(tx);
+        ws.update_live_features(ConnectionUiFeatures::default());
+
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            send_raw_notification_ephemeral(
+                &ws,
+                octos_core::ui_protocol::methods::MESSAGE_DELTA,
+                json!({"text": "should be refused"}),
+            )
+        }));
+        // In debug builds the helper hits a `debug_assert!`; in release
+        // builds it returns `Err(BackpressureDrop)`. Either way the wire
+        // MUST be empty.
+        match outcome {
+            Ok(result) => assert!(
+                matches!(result, Err(SendError::BackpressureDrop)),
+                "raw helper must refuse envelope-superseded methods in release builds"
+            ),
+            Err(_) => {
+                // debug_assert tripped — expected in debug.
+            }
+        }
+        assert!(
+            rx.try_recv().is_err(),
+            "no wire frame may be emitted for an envelope-superseded raw send"
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
+++ b/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
@@ -199,7 +199,16 @@ pub(super) fn emit_file_attached(
         mime: envelope_mime,
         size_bytes,
     };
-    let _ = ledger.emit_envelope(session_id, turn_id.0.to_string(), payload, None);
+    // Codex #1336-round-2 BLOCKER 5: thread the explicit `topic` through
+    // to the envelope. The caller (`emit_files_attached_from_background`)
+    // strips the topic suffix from `session_id` so SPA subscribers on the
+    // BASE bucket receive the envelope, but the envelope itself must
+    // still carry the topic so the topic-scoped classifier accepts it.
+    // Calling `emit_envelope` without the explicit topic would derive
+    // `topic = session_id.topic()` — `None` after the base-key strip —
+    // and silently drop the envelope from topic-scoped subscribers.
+    let _ =
+        ledger.emit_envelope_with_topic(session_id, turn_id.0.to_string(), payload, None, topic);
 }
 
 /// Emit one `file/attached` envelope per delivered artefact when a
@@ -1407,5 +1416,143 @@ mod tests {
              must return the explicit event.topic so the topic-scoped \
              subscriber routes the envelope correctly",
         );
+    }
+
+    /// Codex #1336 round-2 BLOCKER 5: the parallel `projection/envelope`
+    /// frame emitted alongside the legacy `file/attached` notification
+    /// must ALSO carry the topic. The alpha9 bridge strips the topic
+    /// suffix from `session_id` before calling `emit_envelope`, so the
+    /// previous `emit_envelope(session_id, ...)` derived topic via
+    /// `session_id.topic()` — which is now `None` — and the envelope
+    /// shipped with no topic context. Topic-scoped subscribers on the
+    /// envelope filter would silently drop it.
+    ///
+    /// Pre-fix: this assertion would fail because the envelope's
+    /// `topic` field was `None`.
+    /// Post-fix: `emit_envelope_with_topic` threads the captured topic
+    /// through so the envelope's `topic` matches the legacy
+    /// `FileAttached` event's `topic`.
+    #[test]
+    fn emit_files_attached_from_background_preserves_topic_on_envelope_when_session_id_stripped() {
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        let base_session = SessionKey::new("api", "blocker5-envelope-topic");
+        let topic_session = SessionKey::with_topic("api", "blocker5-envelope-topic", "slides");
+        let turn_id = TurnId::new();
+        let mut subscriber = ledger.subscribe(&base_session);
+
+        emit_files_attached_from_background(
+            &ledger,
+            &topic_session,
+            &turn_id,
+            &["/tmp/deck.pptx".to_string()],
+            &[],
+            Some("tc-blocker5".into()),
+        );
+
+        // Drain all events, find the envelope notification.
+        let mut envelope_topic: Option<String> = None;
+        let mut envelope_notification_topic: Option<String> = None;
+        while let Ok(event) = subscriber.try_recv() {
+            if let crate::api::ui_protocol_ledger::UiProtocolLedgerEvent::Notification(
+                notification @ UiNotification::Envelope(envelope_notif),
+            ) = &event.event
+            {
+                if matches!(
+                    &envelope_notif.envelope.payload,
+                    octos_core::ui_protocol::Payload::FileAttached { .. }
+                ) {
+                    envelope_topic = envelope_notif.topic.clone();
+                    envelope_notification_topic = notification.topic().map(ToOwned::to_owned);
+                    break;
+                }
+            }
+        }
+
+        let envelope_topic = envelope_topic.expect("file_attached envelope must be emitted");
+        assert_eq!(
+            envelope_topic, "slides",
+            "EnvelopeNotification.topic must be populated from the original \
+             topic-suffixed session_id BEFORE the strip — otherwise the \
+             topic-scoped classifier (UiNotification::topic()) reads None \
+             and drops the envelope from topic-scoped subscribers",
+        );
+        assert_eq!(
+            envelope_notification_topic.as_deref(),
+            Some("slides"),
+            "UiNotification::topic() on the envelope variant must surface \
+             the explicit topic for the topic-scope classifier",
+        );
+    }
+
+    /// Defensive: `emit_envelope_with_topic` honours its explicit topic
+    /// argument. An explicit `Some("…")` is the source of truth and
+    /// overrides any topic the session_id might carry. An explicit
+    /// `None` falls back to the append-time safety net
+    /// (`stamp_topic_from_session`) which reads `session_id.topic()`
+    /// — this preserves the legacy behaviour for callers that did NOT
+    /// strip the topic from session_id.
+    ///
+    /// The BLOCKER 5 bug the new path closes is: callers that DID
+    /// strip the topic from session_id (P0-A wire-gap fix) had no way
+    /// to thread the captured topic through; the envelope ended up
+    /// with `topic = None` AND a stripped session_id with no topic
+    /// fallback. The fix is to let those callers pass `Some(topic)`
+    /// — covered by `emit_files_attached_from_background_preserves_topic_on_envelope_when_session_id_stripped`
+    /// above. This sibling test just pins that an explicit `Some`
+    /// wins over the session_id suffix and that bare-session +
+    /// `None` still works.
+    #[test]
+    fn emit_envelope_with_topic_honours_explicit_topic_over_session_suffix() {
+        use octos_core::ui_protocol::{EnvelopeTokenUsage, Payload};
+
+        let ledger = UiProtocolLedger::new(32);
+
+        // Case 1: bare session, explicit topic Some → envelope has topic.
+        let bare = SessionKey::new("api", "blocker5-explicit-some");
+        let envelope = ledger
+            .emit_envelope_with_topic(
+                &bare,
+                "thread-1".into(),
+                Payload::TurnCompleted {
+                    token_usage: EnvelopeTokenUsage::default(),
+                },
+                None,
+                Some("plan"),
+            )
+            .expect("emit");
+        if let crate::api::ui_protocol_ledger::UiProtocolLedgerEvent::Notification(
+            UiNotification::Envelope(envelope_notif),
+        ) = &envelope.event
+        {
+            assert_eq!(envelope_notif.topic.as_deref(), Some("plan"));
+        } else {
+            panic!("expected envelope variant");
+        }
+
+        // Case 2: explicit `Some("plan")` wins over the session_id's
+        // own topic suffix — caller provided value is the source of
+        // truth.
+        let suffixed_a = SessionKey::with_topic("api", "blocker5-explicit-wins", "session_topic");
+        let envelope = ledger
+            .emit_envelope_with_topic(
+                &suffixed_a,
+                "thread-2".into(),
+                Payload::AssistantDelta { text: "hi".into() },
+                None,
+                Some("explicit_wins"),
+            )
+            .expect("emit");
+        if let crate::api::ui_protocol_ledger::UiProtocolLedgerEvent::Notification(
+            UiNotification::Envelope(envelope_notif),
+        ) = &envelope.event
+        {
+            assert_eq!(
+                envelope_notif.topic.as_deref(),
+                Some("explicit_wins"),
+                "explicit Some(topic) MUST win over session_id.topic()",
+            );
+        } else {
+            panic!("expected envelope variant");
+        }
     }
 }

--- a/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
+++ b/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
@@ -112,6 +112,20 @@ pub(super) fn emit_turn_completed_full(
         session_result,
     });
     let _ = ledger.append_notification(notification);
+
+    // UPCR-2026-014 M9-γ dual-emit: parallel canonical `turn_completed`
+    // envelope. The hard-barrier inside `emit_envelope` flips the
+    // thread's `completed` flag; any further envelope on the same
+    // thread is dropped at the live emit site (spec § 14.6).
+    let token_usage = octos_core::ui_protocol::EnvelopeTokenUsage {
+        input_tokens: tokens_in.map(u64::from).unwrap_or(0),
+        output_tokens: tokens_out.map(u64::from).unwrap_or(0),
+        reasoning_tokens: 0,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+    };
+    let payload = octos_core::ui_protocol::Payload::TurnCompleted { token_usage };
+    let _ = ledger.emit_envelope(session_id, turn_id.0.to_string(), payload, None);
 }
 
 /// Append a `file/attached.v1` envelope when a tool surfaces an
@@ -151,11 +165,41 @@ pub(super) fn emit_file_attached(
             .filter(|t| !t.is_empty())
             .map(ToOwned::to_owned),
         turn_id: turn_id.clone(),
-        path,
+        path: path.clone(),
         tool_call_id,
-        mime,
+        mime: mime.clone(),
     });
     let _ = ledger.append_notification(notification);
+
+    // UPCR-2026-014 M9-γ dual-emit: parallel canonical
+    // `file_attached` envelope. `mime` defaults to
+    // `application/octet-stream` (spec § 14.5 mandates a value); a
+    // warning is logged on metadata read failure so soak monitoring
+    // can surface broken artefact deliveries (file deleted between
+    // tool-end and emit, permissions, etc.).
+    let size_bytes = match std::fs::metadata(&path) {
+        Ok(meta) => meta.len(),
+        Err(error) => {
+            tracing::warn!(
+                target: "octos::ui_protocol::envelope",
+                path = %path,
+                ?error,
+                "file/attached envelope: fs::metadata failed; emitting size_bytes=0",
+            );
+            0
+        }
+    };
+    let envelope_mime = mime
+        .as_deref()
+        .filter(|m| !m.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| "application/octet-stream".to_owned());
+    let payload = octos_core::ui_protocol::Payload::FileAttached {
+        path,
+        mime: envelope_mime,
+        size_bytes,
+    };
+    let _ = ledger.emit_envelope(session_id, turn_id.0.to_string(), payload, None);
 }
 
 /// Emit one `file/attached` envelope per delivered artefact when a
@@ -642,12 +686,19 @@ mod tests {
             None,
         );
 
-        // Session A receives all four envelopes.
+        // Session A receives all four legacy envelopes PLUS the M9-γ
+        // dual-emit envelope for `turn_completed_full` (the
+        // `file_attached` dual-emit is barriered out because
+        // `turn_completed_full` already flipped the thread's
+        // `completed` flag).
         let mut count_a = 0;
         while sub_a.try_recv().is_ok() {
             count_a += 1;
         }
-        assert_eq!(count_a, 4, "session A receives all four envelopes");
+        assert_eq!(
+            count_a, 5,
+            "session A receives 4 legacy + 1 M9-γ turn_completed envelope (post-completion file_attached envelope barriered)",
+        );
 
         // Session B receives nothing — no cross-delivery.
         assert!(

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -326,6 +326,38 @@ struct ThreadSeqState {
     completed: bool,
 }
 
+/// On-disk schema for the per-thread watermark file. Codex #1336
+/// round-2 BLOCKER 3: persist `(session_id, thread_id) →
+/// (max_seq, completed)` so daemon restart can recover monotonic seq
+/// allocation even when the in-memory ring was LRU-evicted or the
+/// retained window dropped the originating envelopes.
+#[derive(Debug, Serialize, Deserialize)]
+struct ThreadWatermarkRecord {
+    v: u32,
+    session_id: String,
+    thread_id: String,
+    /// The next seq the allocator would issue. This is the high-water
+    /// mark + 1, written under the same lock that bumps the allocator.
+    next_seq: u64,
+    /// True once a `Payload::TurnCompleted` envelope has been emitted
+    /// for `(session_id, thread_id)`. Survives restart so post-completion
+    /// envelopes stay barriered even after the ring drops the
+    /// originating TurnCompleted.
+    completed: bool,
+}
+
+const THREAD_WATERMARK_DISK_VERSION: u32 = 1;
+
+/// Result of [`UiProtocolLedger::append_locked`] — the locked-half of
+/// the ledger append. Codex #1336 round-2 BLOCKER 2 extracted this so
+/// `emit_envelope_inner` can drive seq-allocation AND ledger append
+/// under a single critical section.
+struct AppendLockedOutcome {
+    cursor: UiCursor,
+    stamped: UiProtocolLedgerEvent,
+    on_disk_delta: i64,
+}
+
 impl LedgerInner {
     fn new() -> Self {
         Self {
@@ -647,6 +679,14 @@ impl UiProtocolLedger {
     /// (post-reconnect) bypasses the drop, so a client that reconnects
     /// with a pre-completion cursor still observes the full envelope
     /// history.
+    ///
+    /// Topic defaults to `session_id.topic()`. Callers that have stripped
+    /// the topic suffix from `session_id` (see the P0-A wire-gap fix in
+    /// `emit_files_attached_from_background`) MUST use
+    /// [`emit_envelope_with_topic`] to thread the captured topic
+    /// explicitly. This single-arg helper preserves the call sites that
+    /// emit on an unmodified `SessionKey` and do not have a separate
+    /// topic source.
     pub(crate) fn emit_envelope(
         &self,
         session_id: &SessionKey,
@@ -654,60 +694,177 @@ impl UiProtocolLedger {
         payload: Payload,
         client_message_id: Option<String>,
     ) -> Option<LedgeredUiProtocolEvent> {
-        let (seq, dropped_kind) = self.allocate_envelope_seq(session_id, &thread_id, &payload);
-        if let Some(kind) = dropped_kind {
-            metrics::counter!(
-                "octos_projection_post_completion_drop_total",
-                "kind" => kind,
-            )
-            .increment(1);
-            return None;
-        }
         let topic = session_id.topic().map(ToOwned::to_owned);
-        let envelope = Envelope {
-            thread_id,
-            seq,
-            client_message_id,
-            payload,
-        };
-        let notification = UiNotification::Envelope(EnvelopeNotification {
-            session_id: session_id.clone(),
-            topic,
-            envelope,
-        });
-        Some(self.append(UiProtocolLedgerEvent::Notification(notification), None))
+        self.emit_envelope_inner(session_id, thread_id, payload, client_message_id, topic)
+    }
+
+    /// Codex BLOCKER #1336-round-2 (BLOCKER 5): variant of
+    /// [`emit_envelope`] that accepts an explicit topic. Required by
+    /// callers that strip the `#<topic>` suffix from `session_id` before
+    /// publishing — without this hook the envelope would derive topic
+    /// from `session_id.topic()` (which is now `None`) and silently lose
+    /// routing.
+    ///
+    /// The caller-provided `topic` is the SOURCE OF TRUTH: an
+    /// `Some("…")` always wins over `session_id.topic()`, and `None`
+    /// means "no topic" (the call site has already decided the envelope
+    /// does not belong to any topic scope).
+    pub(crate) fn emit_envelope_with_topic(
+        &self,
+        session_id: &SessionKey,
+        thread_id: String,
+        payload: Payload,
+        client_message_id: Option<String>,
+        topic: Option<&str>,
+    ) -> Option<LedgeredUiProtocolEvent> {
+        let topic = topic
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+            .map(ToOwned::to_owned);
+        self.emit_envelope_inner(session_id, thread_id, payload, client_message_id, topic)
+    }
+
+    fn emit_envelope_inner(
+        &self,
+        session_id: &SessionKey,
+        thread_id: String,
+        payload: Payload,
+        client_message_id: Option<String>,
+        topic: Option<String>,
+    ) -> Option<LedgeredUiProtocolEvent> {
+        // Codex #1336 round-2 BLOCKER 2: allocate envelope seq, apply
+        // hard barrier, build the notification, append to the ledger
+        // entries (in-memory ring + disk write), AND publish to live
+        // subscribers — all inside ONE critical section. Previously
+        // `allocate_envelope_seq` took its own lock, returned, and
+        // then `append` re-acquired — letting two concurrent emits
+        // interleave `(seq=1 allocate, seq=2 allocate, seq=2 append,
+        // seq=1 append)`. Combined with a `Payload::TurnCompleted`
+        // arriving as seq=2, the wire observed `TurnCompleted(seq=2)`
+        // before the pre-completion delta `(seq=1)`, which the
+        // client bridge then dropped as post-completion.
+        //
+        // The broadcast `publish_live` is held inside the lock too so
+        // the broadcast send order strictly matches the seq allocation
+        // order. `broadcast::Sender::send` is non-blocking (try_send on
+        // a bounded queue) so the lock-hold is microseconds.
+        let session_id_clone = session_id.clone();
+        let preload_snapshot = self.snapshot_if_session_absent(&session_id_clone);
+        let cursor;
+        let stamped;
+        let on_disk_delta;
+        let ledgered;
+        let broadcast_sender;
+        {
+            let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+
+            // --- step 1: envelope seq allocation + hard barrier ---
+            let alloc = self.allocate_envelope_seq_locked(
+                &session_id_clone,
+                &thread_id,
+                &payload,
+                &mut inner,
+            );
+            let seq = match alloc {
+                Ok(seq) => seq,
+                Err(kind) => {
+                    drop(inner);
+                    metrics::counter!(
+                        "octos_projection_post_completion_drop_total",
+                        "kind" => kind,
+                    )
+                    .increment(1);
+                    return None;
+                }
+            };
+
+            // --- step 2: build the notification with allocated seq ---
+            let envelope = Envelope {
+                thread_id,
+                seq,
+                client_message_id,
+                payload,
+            };
+            let mut event = UiProtocolLedgerEvent::Notification(UiNotification::Envelope(
+                EnvelopeNotification {
+                    session_id: session_id_clone.clone(),
+                    topic,
+                    envelope,
+                },
+            ));
+            event.stamp_topic_from_session();
+
+            // --- step 3: append to the ledger (LRU, ring, disk) ---
+            let append_outcome =
+                self.append_locked(&session_id_clone, event, None, preload_snapshot, &mut inner);
+            cursor = append_outcome.cursor;
+            stamped = append_outcome.stamped;
+            on_disk_delta = append_outcome.on_disk_delta;
+            ledgered = LedgeredUiProtocolEvent {
+                cursor: cursor.clone(),
+                event: stamped.clone(),
+                from_connection: None,
+            };
+
+            // Accounting that the original `append` does after entry
+            // push — keep inside the same critical section so the
+            // next emit observes consistent state.
+            if on_disk_delta >= 0 {
+                inner.on_disk_bytes = inner.on_disk_bytes.saturating_add(on_disk_delta as u64);
+            } else {
+                inner.on_disk_bytes = inner.on_disk_bytes.saturating_sub((-on_disk_delta) as u64);
+            }
+            inner.touch_lru(&session_id_clone);
+
+            // --- step 4: publish to live subscribers WHILE STILL
+            // HOLDING THE LOCK so the broadcast send order strictly
+            // matches the seq allocation order. Another emit cannot
+            // acquire the lock + send its own envelope between our
+            // append and our broadcast send.
+            //
+            // `broadcast::Sender::send` is non-blocking (try_send on a
+            // bounded tokio channel) so the lock-hold is microseconds.
+            // `Err` is returned only when all receivers have been
+            // dropped, which is a no-op for our durable contract —
+            // the ledger record stands and any future reconnect
+            // catches up via cursor replay.
+            broadcast_sender = inner.subscribers.get(&session_id_clone).cloned();
+            if let Some(sender) = broadcast_sender.as_ref() {
+                let _ = sender.send(ledgered.clone());
+            }
+        }
+        let _ = broadcast_sender; // silence dead-store warning
+        Some(ledgered)
     }
 
     /// Per-thread envelope seq allocator with hard-barrier check.
     ///
-    /// Returns `(seq, Some(metric_kind))` when the hard barrier dropped
-    /// the emit. The metric kinds are:
-    ///   - `"duplicate_completed"` — a second `TurnCompleted` on the
-    ///     same thread.
-    ///   - `"post_completion"` — any non-`TurnCompleted` payload on a
-    ///     thread that already saw `TurnCompleted`.
+    /// Codex #1336 round-2 BLOCKER 2: now takes `&mut LedgerInner` so
+    /// the caller holds the mutex across both seq allocation AND the
+    /// subsequent ledger append. Returns `Ok(seq)` on success;
+    /// `Err(metric_kind)` when the hard barrier dropped the emit.
     ///
-    /// The first `emit_envelope` call for a `(session, thread)` pair
-    /// after process restart scans the durable ledger for existing
-    /// envelopes matching this thread and resumes from `max(seq) + 1` —
-    /// daemon restart MUST NOT reissue `seq=1` for a thread the client
-    /// already saw.
-    fn allocate_envelope_seq(
+    /// The first emit for a `(session, thread)` pair after process
+    /// restart scans the durable ledger for existing envelopes matching
+    /// this thread and resumes from `max(seq) + 1` — daemon restart
+    /// MUST NOT reissue `seq=1` for a thread the client already saw.
+    fn allocate_envelope_seq_locked(
         &self,
         session_id: &SessionKey,
         thread_id: &str,
         payload: &Payload,
-    ) -> (u64, Option<&'static str>) {
-        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        inner: &mut LedgerInner,
+    ) -> Result<u64, &'static str> {
         let key = (session_id.clone(), thread_id.to_owned());
         let needs_recovery = !inner.thread_seq.contains_key(&key);
         if needs_recovery {
-            // Scan the in-memory ring AND the disk-snapshot tail for
-            // existing envelopes matching this `(session, thread)` so
-            // the allocator continues from `max(seq) + 1`. The disk
-            // path is only consulted when the session has not been
-            // hydrated yet.
-            let recovered = self.recover_thread_seq_state(session_id, thread_id, &inner);
+            // Codex #1336 round-2 BLOCKER 3: recovery now consults the
+            // persistent per-thread high-watermark before falling back
+            // to scanning the in-memory ring. The in-memory ring may
+            // be empty if the session was LRU-evicted or the retained
+            // window aged out the relevant envelopes; the watermark
+            // file preserves max-seq + completion state independently.
+            let recovered = self.recover_thread_seq_state(session_id, thread_id, inner);
             inner.thread_seq.insert(key.clone(), recovered);
         }
         let state = inner
@@ -717,14 +874,11 @@ impl UiProtocolLedger {
         // Hard barrier per spec § 14.6.
         let is_turn_completed = matches!(payload, Payload::TurnCompleted { .. });
         if state.completed {
-            let kind = if is_turn_completed {
+            return Err(if is_turn_completed {
                 "duplicate_completed"
             } else {
                 "post_completion"
-            };
-            // Return the would-be-next seq for diagnostics; the caller
-            // doesn't use it on the drop path.
-            return (state.next_seq, Some(kind));
+            });
         }
         if state.next_seq == 0 {
             state.next_seq = 1;
@@ -734,28 +888,49 @@ impl UiProtocolLedger {
         if is_turn_completed {
             state.completed = true;
         }
-        (seq, None)
+        // Codex #1336 round-2 BLOCKER 3: persist the new watermark to
+        // disk WHILE STILL HOLDING THE LOCK so a crash mid-emit can
+        // still recover monotonically (write-ahead pattern).
+        self.persist_thread_watermark_locked(session_id, thread_id, state);
+        Ok(seq)
     }
 
     /// Daemon-restart recovery for the per-thread seq allocator.
     ///
-    /// Walks the in-memory ring (already hydrated from disk via
-    /// `recover()` at startup) for envelopes matching `(session, thread)`
-    /// and returns a `ThreadSeqState` whose `next_seq` continues from
-    /// `max(observed seq) + 1`. If a `TurnCompleted` is observed in the
-    /// ring, `completed` is preserved so the hard barrier survives the
-    /// restart.
+    /// Codex #1336 round-2 BLOCKER 3: consults TWO sources in priority
+    /// order:
     ///
-    /// O(N) over the in-memory ring for the session — acceptable because
-    /// the allocator recovery runs at most once per `(session, thread)`
-    /// pair per process lifetime (subsequent calls hit the `thread_seq`
-    /// map).
+    ///   1. **Persistent watermark file** (write-ahead, see
+    ///      [`persist_thread_watermark_locked`]). Survives LRU eviction
+    ///      AND retained-window compaction — the in-memory ring may
+    ///      have aged out every envelope for this `(session, thread)`
+    ///      while the watermark file still records `max(seq) +
+    ///      completed`. This is the "structurally honest" answer.
+    ///   2. **In-memory ring** (fallback). Used when the watermark file
+    ///      does not exist (ephemeral ledger, or a thread that has not
+    ///      yet recorded a watermark — e.g. when running with
+    ///      `LedgerConfig::ephemeral`). Returns `max(observed seq) + 1`.
+    ///
+    /// The watermark wins on conflict: if disk says `next_seq=42,
+    /// completed=true` but the ring has only seen seq=37, we resume
+    /// from seq=42 with completed=true. This is the safer direction
+    /// (never reissue a seq the client already saw).
+    ///
+    /// O(1) when the watermark file exists; O(N) over the in-memory
+    /// ring otherwise. The allocator recovery runs at most once per
+    /// `(session, thread)` pair per process lifetime (subsequent calls
+    /// hit the `thread_seq` map).
     fn recover_thread_seq_state(
         &self,
         session_id: &SessionKey,
         thread_id: &str,
         inner: &LedgerInner,
     ) -> ThreadSeqState {
+        // --- step 1: try the durable watermark file ---
+        if let Some(persisted) = self.read_thread_watermark(session_id, thread_id) {
+            return persisted;
+        }
+        // --- step 2: fall back to the in-memory ring scan ---
         let mut state = ThreadSeqState::default();
         let Some(session_state) = inner.sessions.get(session_id) else {
             return state;
@@ -776,6 +951,147 @@ impl UiProtocolLedger {
         state
     }
 
+    /// Codex #1336 round-2 BLOCKER 3: persist `(session, thread) →
+    /// (next_seq, completed)` write-ahead so daemon restart can recover
+    /// monotonically EVEN WHEN:
+    ///   - the session was LRU-evicted (the in-memory ring was dropped),
+    ///   - the retained-window compaction aged out every envelope for
+    ///     this thread (the ring still has the session but no envelopes
+    ///     matching `thread_id`),
+    ///   - the process crashes between allocate and append (the
+    ///     watermark is written BEFORE the ledger record so a restart
+    ///     observes the same `next_seq` even if the in-flight envelope
+    ///     never reached disk).
+    ///
+    /// **No-op on the ephemeral ledger** (no `data_dir`). Tests that
+    /// use `UiProtocolLedger::new(_)` keep their in-memory-only
+    /// recovery semantics; production durable ledgers get the disk
+    /// guarantee.
+    ///
+    /// Write-ahead pattern: an `O_TRUNC` write to a small per-thread
+    /// JSON file. Lock-held so a concurrent emit cannot see a
+    /// half-written watermark; the next emit either reads the
+    /// pre-update value (then writes a fresh one) or the just-updated
+    /// value, never an interleaving.
+    fn persist_thread_watermark_locked(
+        &self,
+        session_id: &SessionKey,
+        thread_id: &str,
+        state: &ThreadSeqState,
+    ) {
+        let Some(data_dir) = &self.config.data_dir else {
+            return;
+        };
+        let dir = data_dir
+            .join("ui-protocol")
+            .join(encode_session_dir_name(session_id))
+            .join("threads");
+        if let Err(error) = fs::create_dir_all(&dir) {
+            warn!(
+                target = "octos::ledger",
+                ?error,
+                path = %dir.display(),
+                "failed to create thread watermark dir; recovery will fall back to ring scan"
+            );
+            return;
+        }
+        let safe_name = encode_thread_file_name(thread_id);
+        let path = dir.join(format!("{safe_name}.json"));
+        let record = ThreadWatermarkRecord {
+            v: THREAD_WATERMARK_DISK_VERSION,
+            session_id: session_id.0.clone(),
+            thread_id: thread_id.to_owned(),
+            next_seq: state.next_seq,
+            completed: state.completed,
+        };
+        let json = match serde_json::to_vec(&record) {
+            Ok(json) => json,
+            Err(error) => {
+                warn!(
+                    target = "octos::ledger",
+                    ?error,
+                    session_id = %session_id.0,
+                    thread_id,
+                    "failed to serialize thread watermark"
+                );
+                return;
+            }
+        };
+        // Atomic-ish replace: write to `.tmp` then rename so a crash
+        // mid-write never leaves a partially-written watermark. The
+        // OS page cache provides "good enough" durability — an fsync
+        // here would dominate the allocate latency budget.
+        let tmp = dir.join(format!("{safe_name}.json.tmp"));
+        match fs::write(&tmp, &json).and_then(|_| fs::rename(&tmp, &path)) {
+            Ok(_) => {}
+            Err(error) => {
+                warn!(
+                    target = "octos::ledger",
+                    ?error,
+                    session_id = %session_id.0,
+                    thread_id,
+                    "failed to write thread watermark"
+                );
+            }
+        }
+    }
+
+    /// Codex #1336 round-2 BLOCKER 3: read the persistent watermark
+    /// file written by [`persist_thread_watermark_locked`]. Returns
+    /// `None` when the file is missing, malformed, or the ledger has
+    /// no `data_dir`. Callers (recovery) fall back to scanning the
+    /// in-memory ring on `None`.
+    fn read_thread_watermark(
+        &self,
+        session_id: &SessionKey,
+        thread_id: &str,
+    ) -> Option<ThreadSeqState> {
+        let data_dir = self.config.data_dir.as_ref()?;
+        let safe_name = encode_thread_file_name(thread_id);
+        let path = data_dir
+            .join("ui-protocol")
+            .join(encode_session_dir_name(session_id))
+            .join("threads")
+            .join(format!("{safe_name}.json"));
+        let bytes = match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(error) => {
+                warn!(
+                    target = "octos::ledger",
+                    ?error,
+                    path = %path.display(),
+                    "failed to read thread watermark"
+                );
+                return None;
+            }
+        };
+        match serde_json::from_slice::<ThreadWatermarkRecord>(&bytes) {
+            Ok(record) if record.v == THREAD_WATERMARK_DISK_VERSION => Some(ThreadSeqState {
+                next_seq: record.next_seq,
+                completed: record.completed,
+            }),
+            Ok(record) => {
+                warn!(
+                    target = "octos::ledger",
+                    version = record.v,
+                    path = %path.display(),
+                    "skipping thread watermark with unknown version"
+                );
+                None
+            }
+            Err(error) => {
+                warn!(
+                    target = "octos::ledger",
+                    ?error,
+                    path = %path.display(),
+                    "thread watermark file malformed; falling back to ring scan"
+                );
+                None
+            }
+        }
+    }
+
     fn append(
         &self,
         mut event: UiProtocolLedgerEvent,
@@ -789,75 +1105,11 @@ impl UiProtocolLedger {
         let on_disk_delta;
         {
             let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
-
-            // LRU eviction: if we'd exceed the active session cap and this
-            // session is new, evict the oldest first.
-            let is_new = !inner.sessions.contains_key(&session_id);
-            if is_new && inner.sessions.len() >= self.config.active_session_cap {
-                self.evict_lru_locked(&mut inner);
-            }
-
-            let session = inner
-                .sessions
-                .entry(session_id.clone())
-                .or_insert_with(SessionLedger::new);
-            if is_new {
-                if let Some(snapshot) = preload_snapshot {
-                    hydrate_session_from_snapshot(session, snapshot);
-                }
-            }
-            session.next_seq += 1;
-            session.last_touched_at = Instant::now();
-            cursor = UiCursor {
-                stream: session_id.0.clone(),
-                seq: session.next_seq,
-            };
-            stamped = event.with_cursor(cursor.clone());
-
-            // Write-ahead to disk before signaling the wire — happens
-            // inside the lock so two appends to the same session never
-            // interleave bytes in the file.
-            on_disk_delta = if self.config.data_dir.is_some() {
-                match self.write_record_locked(&session_id, session, &stamped) {
-                    Ok((written, reclaimed)) => (written as i64) - (reclaimed as i64),
-                    Err(error) => {
-                        warn!(
-                            target = "octos::ledger",
-                            ?error,
-                            session_id = %session_id.0,
-                            seq = cursor.seq,
-                            "failed to append ledger record to disk; in-memory only"
-                        );
-                        0
-                    }
-                }
-            } else {
-                0
-            };
-
-            let bytes = approx_event_bytes(&stamped);
-            session.in_memory_bytes = session.in_memory_bytes.saturating_add(bytes);
-            session.entries.push_back(LedgerEntry {
-                seq: cursor.seq,
-                event: stamped.clone(),
-                bytes,
-            });
-            // Cap the in-memory ring; older entries remain on disk for
-            // cursor replay (within log range). Each over-cap drop bumps
-            // the dropped counter (applied after we release the &mut on
-            // `session` to satisfy the borrow checker).
-            let mut dropped_now = 0u64;
-            while session.entries.len() > self.config.retained_per_session {
-                if let Some(dropped) = session.entries.pop_front() {
-                    session.in_memory_bytes = session.in_memory_bytes.saturating_sub(dropped.bytes);
-                    dropped_now += 1;
-                }
-            }
-
-            inner.dropped_count = inner.dropped_count.saturating_add(dropped_now);
-            // `on_disk_delta` is signed: rotation may reclaim more bytes than
-            // the new record adds, so a single append can be a net negative
-            // for `on_disk_bytes`.
+            let outcome =
+                self.append_locked(&session_id, event, None, preload_snapshot, &mut inner);
+            cursor = outcome.cursor;
+            stamped = outcome.stamped;
+            on_disk_delta = outcome.on_disk_delta;
             if on_disk_delta >= 0 {
                 inner.on_disk_bytes = inner.on_disk_bytes.saturating_add(on_disk_delta as u64);
             } else {
@@ -873,6 +1125,114 @@ impl UiProtocolLedger {
         };
         self.publish_live(&session_id, &ledgered);
         ledgered
+    }
+
+    /// Locked half of [`append`] — does the LRU + cursor + disk-write +
+    /// in-memory ring-push under an existing `&mut LedgerInner` lock.
+    /// Codex #1336 round-2 BLOCKER 2: extracted so [`emit_envelope_inner`]
+    /// can run seq-allocation AND ledger append in a SINGLE critical
+    /// section, eliminating the interleaving window where two concurrent
+    /// emits could publish out-of-order on the broadcast channel.
+    ///
+    /// Caller is responsible for updating `inner.on_disk_bytes` from the
+    /// returned signed delta and for invoking `touch_lru(session_id)`
+    /// — both pieces sit OUTSIDE this helper because the borrow checker
+    /// won't let us hold `&mut session` and call `inner.touch_lru`
+    /// simultaneously, and matching `append`'s old order keeps the
+    /// behaviour identical.
+    ///
+    /// `_from_connection` is intentionally unused here — the
+    /// `from_connection` tag is set on the wrapper [`LedgeredUiProtocolEvent`]
+    /// AFTER the lock is released. We accept it on the signature so the
+    /// call site can document intent (the new envelope path always
+    /// passes `None`; legacy `append_notification_from` paths still wrap
+    /// the wire-tagged ledgered event manually).
+    fn append_locked(
+        &self,
+        session_id: &SessionKey,
+        mut event: UiProtocolLedgerEvent,
+        _from_connection: Option<ConnectionId>,
+        preload_snapshot: Option<DiskSessionSnapshot>,
+        inner: &mut LedgerInner,
+    ) -> AppendLockedOutcome {
+        // `event.stamp_topic_from_session` is idempotent — `append`
+        // already invokes it before locking; the envelope path stamps
+        // inside the lock to keep the call ordering local. Either way
+        // this is cheap and only does work when the explicit `topic`
+        // field was absent.
+        event.stamp_topic_from_session();
+
+        // LRU eviction: if we'd exceed the active session cap and this
+        // session is new, evict the oldest first.
+        let is_new = !inner.sessions.contains_key(session_id);
+        if is_new && inner.sessions.len() >= self.config.active_session_cap {
+            self.evict_lru_locked(inner);
+        }
+
+        let session = inner
+            .sessions
+            .entry(session_id.clone())
+            .or_insert_with(SessionLedger::new);
+        if is_new {
+            if let Some(snapshot) = preload_snapshot {
+                hydrate_session_from_snapshot(session, snapshot);
+            }
+        }
+        session.next_seq += 1;
+        session.last_touched_at = Instant::now();
+        let cursor = UiCursor {
+            stream: session_id.0.clone(),
+            seq: session.next_seq,
+        };
+        let stamped = event.with_cursor(cursor.clone());
+
+        // Write-ahead to disk before signaling the wire — happens
+        // inside the lock so two appends to the same session never
+        // interleave bytes in the file.
+        let on_disk_delta: i64 = if self.config.data_dir.is_some() {
+            match self.write_record_locked(session_id, session, &stamped) {
+                Ok((written, reclaimed)) => (written as i64) - (reclaimed as i64),
+                Err(error) => {
+                    warn!(
+                        target = "octos::ledger",
+                        ?error,
+                        session_id = %session_id.0,
+                        seq = cursor.seq,
+                        "failed to append ledger record to disk; in-memory only"
+                    );
+                    0
+                }
+            }
+        } else {
+            0
+        };
+
+        let bytes = approx_event_bytes(&stamped);
+        session.in_memory_bytes = session.in_memory_bytes.saturating_add(bytes);
+        session.entries.push_back(LedgerEntry {
+            seq: cursor.seq,
+            event: stamped.clone(),
+            bytes,
+        });
+        // Cap the in-memory ring; older entries remain on disk for
+        // cursor replay (within log range). Each over-cap drop bumps
+        // the dropped counter (applied after we release the &mut on
+        // `session` to satisfy the borrow checker).
+        let mut dropped_now = 0u64;
+        while session.entries.len() > self.config.retained_per_session {
+            if let Some(dropped) = session.entries.pop_front() {
+                session.in_memory_bytes = session.in_memory_bytes.saturating_sub(dropped.bytes);
+                dropped_now += 1;
+            }
+        }
+
+        inner.dropped_count = inner.dropped_count.saturating_add(dropped_now);
+
+        AppendLockedOutcome {
+            cursor,
+            stamped,
+            on_disk_delta,
+        }
     }
 
     /// Fan the just-persisted event out to live subscribers. Runs after the
@@ -1739,6 +2099,20 @@ fn hex_digit(b: u8) -> Option<u8> {
         b'A'..=b'F' => Some(b - b'A' + 10),
         _ => None,
     }
+}
+
+/// Codex #1336 round-2 BLOCKER 3: hex-encode a thread_id so the
+/// per-thread watermark file name is filesystem-safe. Thread IDs are
+/// stringified UUIDs today (see `pre_stamp_turn_thread_id`) but may
+/// contain arbitrary text in tests / future shapes — hex-encoding is
+/// reversible, collision-free, and matches the
+/// `encode_session_dir_name` convention.
+fn encode_thread_file_name(thread_id: &str) -> String {
+    let mut out = String::with_capacity(thread_id.len() * 2);
+    for byte in thread_id.as_bytes() {
+        out.push_str(&format!("{:02x}", byte));
+    }
+    out
 }
 
 fn new_log_file_name() -> String {
@@ -2694,6 +3068,357 @@ mod tests {
             envelope_seq(&recovered),
             5,
             "ThreadSeqAllocator must continue from max(seq) + 1 after restart"
+        );
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Codex #1336 round-2 BLOCKER 2: atomic seq allocation + append
+    // ────────────────────────────────────────────────────────────────────
+
+    /// 100 concurrent emits on the same `(session, thread)` produce a
+    /// contiguous `seq` range `1..=100` and contiguous ledger-cursor
+    /// `seq` values, with the ring entries in EXACTLY the same order
+    /// as the allocated envelope `seq` values.
+    ///
+    /// Pre-fix: `allocate_envelope_seq` and `append` each took the
+    /// mutex independently, so two threads could interleave `(seq=1
+    /// allocate, seq=2 allocate, seq=2 append, seq=1 append)` and end
+    /// up with the ring entries in `seq=2, seq=1` order. A
+    /// `TurnCompleted(seq=2)` published before delta `seq=1` would
+    /// then cause the bridge to drop the delta as post-completion.
+    ///
+    /// Post-fix: allocation + ring push run under a SINGLE critical
+    /// section, so no other emit can interleave its append between
+    /// our allocate and our push.
+    #[test]
+    fn envelope_seq_allocation_and_append_are_atomic_under_concurrency() {
+        use std::sync::Arc;
+        use std::thread;
+        let ledger = Arc::new(UiProtocolLedger::new(256));
+        let session_id = SessionKey("local:atomic".into());
+        let thread_id = "thread-atomic".to_owned();
+        const N: usize = 100;
+
+        // Subscribe BEFORE emits start so the broadcast captures the
+        // delivery order — if seq allocation and append were not
+        // atomic, the broadcast send order could deviate from the
+        // allocation order.
+        let mut subscriber = ledger.subscribe(&session_id);
+
+        let mut handles = Vec::with_capacity(N);
+        for i in 0..N {
+            let ledger = ledger.clone();
+            let session_id = session_id.clone();
+            let thread_id = thread_id.clone();
+            handles.push(thread::spawn(move || {
+                ledger
+                    .emit_envelope(
+                        &session_id,
+                        thread_id,
+                        Payload::AssistantDelta {
+                            text: format!("concurrent-{i}"),
+                        },
+                        None,
+                    )
+                    .expect("concurrent emit must not be dropped")
+            }));
+        }
+        let mut results: Vec<LedgeredUiProtocolEvent> =
+            handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        // 1. All N seqs are contiguous 1..=N (no gaps, no duplicates).
+        let mut seqs: Vec<u64> = results.iter().map(envelope_seq).collect();
+        seqs.sort();
+        let expected: Vec<u64> = (1..=N as u64).collect();
+        assert_eq!(
+            seqs, expected,
+            "envelope seqs MUST be contiguous 1..=N with no gaps or duplicates"
+        );
+
+        // 2. The ledger cursor seqs are also contiguous (the in-memory
+        // ring order matches the allocation order).
+        let mut cursor_seqs: Vec<u64> = results.iter().map(|r| r.cursor.seq).collect();
+        cursor_seqs.sort();
+        assert_eq!(cursor_seqs, expected);
+
+        // 3. The mapping is consistent: a lower envelope.seq ALWAYS
+        // maps to a lower-or-equal ledger cursor.seq. The two seq
+        // spaces share a monotonic relationship because both are
+        // assigned inside the same critical section.
+        results.sort_by_key(|r| envelope_seq(r));
+        for window in results.windows(2) {
+            assert!(
+                window[0].cursor.seq < window[1].cursor.seq,
+                "ledger cursor.seq MUST be monotonic with envelope.seq under atomic emit"
+            );
+        }
+
+        // 4. The broadcast delivery order matches the allocation
+        // order. If allocate+append were not atomic, two emits could
+        // race past each other in publish_live and the broadcast
+        // would see seq=k+1 before seq=k.
+        let mut last_seq: u64 = 0;
+        for _ in 0..N {
+            match subscriber.try_recv() {
+                Ok(event) => {
+                    if let UiProtocolLedgerEvent::Notification(UiNotification::Envelope(ev)) =
+                        &event.event
+                    {
+                        assert!(
+                            ev.envelope.seq > last_seq,
+                            "broadcast delivery must observe seq in strictly monotonic order; \
+                             saw {} after {last_seq}",
+                            ev.envelope.seq
+                        );
+                        last_seq = ev.envelope.seq;
+                    }
+                }
+                Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) => {
+                    // Bounded broadcast may lag — that's OK for this test;
+                    // the durability is checked by the seqs/cursor_seqs
+                    // asserts above. We DO NOT assert delivery of all 100
+                    // because a lagged consumer is a separate concern.
+                    break;
+                }
+                Err(_) => break,
+            }
+        }
+    }
+
+    /// `TurnCompleted` and one pre-completion delta race: the wire
+    /// MUST observe the delta first (seq=1), then `TurnCompleted`
+    /// (seq=2). Pre-fix this could publish in `(seq=2, seq=1)` order
+    /// because the broadcast send happened after lock release on
+    /// different threads' lock acquisitions.
+    ///
+    /// We test this by emitting from two threads with a barrier so
+    /// they hit the mutex roughly simultaneously, then check the
+    /// in-memory ring's entry order matches the allocation order.
+    #[test]
+    fn turn_completed_never_appended_before_pre_completion_envelope_on_same_thread() {
+        // We can't easily force the OS scheduler to reproduce the
+        // race deterministically, but we can hammer the lock with N
+        // concurrent emits to maximise contention and assert the
+        // ring order matches the allocation order on every iteration.
+        // Combined with the atomicity test above, this gives high
+        // confidence the race is closed.
+        use std::sync::Arc;
+        use std::thread;
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        let session_id = SessionKey("local:tc-race".into());
+        let thread_id = "thread-tc".to_owned();
+
+        let mut handles = Vec::new();
+        for _ in 0..30 {
+            let l = ledger.clone();
+            let s = session_id.clone();
+            let t = thread_id.clone();
+            handles.push(thread::spawn(move || {
+                l.emit_envelope(
+                    &s,
+                    t,
+                    Payload::AssistantDelta {
+                        text: "delta".into(),
+                    },
+                    None,
+                )
+            }));
+        }
+        let mut delta_results: Vec<u64> = handles
+            .into_iter()
+            .filter_map(|h| h.join().unwrap())
+            .map(|r| envelope_seq(&r))
+            .collect();
+        delta_results.sort();
+        assert_eq!(delta_results, (1u64..=30).collect::<Vec<_>>());
+
+        // Now emit TurnCompleted on the same thread — it MUST land
+        // at seq=31 (after all the deltas).
+        let tc = ledger
+            .emit_envelope(
+                &session_id,
+                thread_id.clone(),
+                Payload::TurnCompleted {
+                    token_usage: octos_core::ui_protocol::EnvelopeTokenUsage::default(),
+                },
+                None,
+            )
+            .expect("turn_completed must not be dropped");
+        assert_eq!(envelope_seq(&tc), 31);
+
+        // And any further envelope on this thread is hard-barriered.
+        let post = ledger.emit_envelope(
+            &session_id,
+            thread_id,
+            Payload::AssistantDelta { text: "x".into() },
+            None,
+        );
+        assert!(post.is_none());
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Codex #1336 round-2 BLOCKER 3: persistent thread watermark recovery
+    // ────────────────────────────────────────────────────────────────────
+
+    /// The watermark file persists `(session, thread) → (next_seq,
+    /// completed)` write-ahead so an LRU-evicted session OR a thread
+    /// whose envelopes aged out of the retained window can still
+    /// resume seq allocation monotonically.
+    #[test]
+    fn thread_watermark_recovery_from_evicted_session() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionKey("local:wm-evict".into());
+        let thread_id = "thread-evict".to_owned();
+        // First boot: emit 3 envelopes — the watermark records
+        // next_seq=4 after the third emit.
+        {
+            let mut config = LedgerConfig::durable(temp.path().into());
+            config.active_session_cap = 8;
+            let ledger = UiProtocolLedger::with_config(config);
+            for _ in 0..3 {
+                let _ = ledger
+                    .emit_envelope(
+                        &session_id,
+                        thread_id.clone(),
+                        Payload::AssistantDelta { text: "d".into() },
+                        None,
+                    )
+                    .expect("emit");
+            }
+        }
+        // Second boot: build a FRESH ledger WITHOUT calling recover()
+        // (which would hydrate the disk into the in-memory ring).
+        // The thread_seq HashMap is empty, the in-memory ring is
+        // empty too — the ONLY way to resume monotonically is via
+        // the persistent watermark file.
+        let ledger = UiProtocolLedger::with_config(LedgerConfig::durable(temp.path().into()));
+        let resumed = ledger
+            .emit_envelope(
+                &session_id,
+                thread_id,
+                Payload::AssistantDelta {
+                    text: "after-evict".into(),
+                },
+                None,
+            )
+            .expect("emit after evicted-session recovery");
+        assert_eq!(
+            envelope_seq(&resumed),
+            4,
+            "watermark recovery MUST resume from next_seq=4 \
+             even with an empty in-memory ring (session was evicted, \
+             retained window has nothing to scan)",
+        );
+    }
+
+    /// When the retained-window compaction drops every envelope for
+    /// a thread but the SESSION itself is still hot, the watermark
+    /// file still records `max_seq + completed` — recovery resumes
+    /// from the watermark, not from a fresh `next_seq=1`.
+    #[test]
+    fn thread_watermark_survives_retained_window_compaction() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionKey("local:wm-compact".into());
+        let thread_id_a = "thread-A".to_owned();
+        let thread_id_b = "thread-B".to_owned();
+
+        // Tiny retained-window so a few emits on thread-B push
+        // thread-A's envelopes out of the ring.
+        let mut config = LedgerConfig::durable(temp.path().into());
+        config.retained_per_session = 3;
+        let ledger = UiProtocolLedger::with_config(config);
+
+        // Emit on thread-A; watermark records next_seq=3.
+        for _ in 0..2 {
+            let _ = ledger
+                .emit_envelope(
+                    &session_id,
+                    thread_id_a.clone(),
+                    Payload::AssistantDelta { text: "a".into() },
+                    None,
+                )
+                .expect("emit a");
+        }
+        // Hammer thread-B to push thread-A out of the ring.
+        for _ in 0..10 {
+            let _ = ledger
+                .emit_envelope(
+                    &session_id,
+                    thread_id_b.clone(),
+                    Payload::AssistantDelta { text: "b".into() },
+                    None,
+                )
+                .expect("emit b");
+        }
+
+        // Restart and emit again on thread-A — the in-memory ring no
+        // longer has thread-A envelopes (compacted), but the
+        // watermark file persists.
+        drop(ledger);
+        let ledger = UiProtocolLedger::with_config(LedgerConfig::durable(temp.path().into()));
+        let resumed = ledger
+            .emit_envelope(
+                &session_id,
+                thread_id_a,
+                Payload::AssistantDelta {
+                    text: "after-compact".into(),
+                },
+                None,
+            )
+            .expect("emit after compact-recovery");
+        assert_eq!(
+            envelope_seq(&resumed),
+            3,
+            "watermark recovery MUST resume from the persisted max+1 \
+             even when the retained window has compacted out the \
+             originating envelopes",
+        );
+    }
+
+    /// Completion state persists across restart: a thread that
+    /// received `TurnCompleted` BEFORE restart MUST stay barriered
+    /// after restart even when the in-memory ring is empty.
+    #[test]
+    fn thread_watermark_preserves_completed_across_restart() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionKey("local:wm-completed".into());
+        let thread_id = "thread-tc".to_owned();
+        {
+            let ledger = UiProtocolLedger::with_config(LedgerConfig::durable(temp.path().into()));
+            let _ = ledger
+                .emit_envelope(
+                    &session_id,
+                    thread_id.clone(),
+                    Payload::AssistantDelta { text: "d".into() },
+                    None,
+                )
+                .expect("delta");
+            let _ = ledger
+                .emit_envelope(
+                    &session_id,
+                    thread_id.clone(),
+                    Payload::TurnCompleted {
+                        token_usage: octos_core::ui_protocol::EnvelopeTokenUsage::default(),
+                    },
+                    None,
+                )
+                .expect("turn_completed");
+        }
+        let ledger = UiProtocolLedger::with_config(LedgerConfig::durable(temp.path().into()));
+        // Post-completion emit on the same thread MUST be barriered
+        // even though the in-memory ring is empty.
+        let dropped = ledger.emit_envelope(
+            &session_id,
+            thread_id,
+            Payload::AssistantDelta {
+                text: "should be barriered".into(),
+            },
+            None,
+        );
+        assert!(
+            dropped.is_none(),
+            "completed=true MUST survive restart so post-completion \
+             envelopes stay barriered even without an in-memory ring"
         );
     }
 }

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -60,8 +60,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use octos_core::SessionKey;
 use octos_core::ui_protocol::{
-    RpcError, RpcNotification, SessionOpened, TurnCompletedEvent, UiCursor, UiNotification,
-    UiProgressEvent, methods,
+    Envelope, EnvelopeNotification, Payload, RpcError, RpcNotification, SessionOpened,
+    TurnCompletedEvent, UiCursor, UiNotification, UiProgressEvent, methods,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
@@ -304,10 +304,26 @@ struct LedgerInner {
     /// channel is bounded — slow consumers see `Lagged(_)` and should fall
     /// back to cursor replay rather than block the producer.
     subscribers: HashMap<SessionKey, broadcast::Sender<LedgeredUiProtocolEvent>>,
+    /// UPCR-2026-014 M9-γ ThreadSeqAllocator + hard-barrier state per
+    /// `(SessionKey, thread_id)` for the canonical projection envelope.
+    /// `next_seq` is the next `seq: u64` to issue (1-based, strictly
+    /// monotonic within the thread). `completed` flips to `true` the
+    /// first time a `Payload::TurnCompleted` envelope is emitted; any
+    /// further envelope on the same thread is DROPPED at the live emit
+    /// site and counted in `octos_projection_post_completion_drop_total`.
+    thread_seq: HashMap<(SessionKey, String), ThreadSeqState>,
     /// Process-lifetime aggregate counters.
     evicted_count: u64,
     dropped_count: u64,
     on_disk_bytes: u64,
+}
+
+/// Per-thread sequence allocator + hard-barrier state.
+/// See [`LedgerInner::thread_seq`] for usage.
+#[derive(Debug, Default, Clone)]
+struct ThreadSeqState {
+    next_seq: u64,
+    completed: bool,
 }
 
 impl LedgerInner {
@@ -316,6 +332,7 @@ impl LedgerInner {
             sessions: HashMap::new(),
             lru: VecDeque::new(),
             subscribers: HashMap::new(),
+            thread_seq: HashMap::new(),
             evicted_count: 0,
             dropped_count: 0,
             on_disk_bytes: 0,
@@ -609,6 +626,154 @@ impl UiProtocolLedger {
             UiProtocolLedgerEvent::Progress(event),
             Some(from_connection),
         )
+    }
+
+    /// UPCR-2026-014 (M9-γ) — emit a canonical projection envelope with
+    /// server-allocated `seq` and hard-barrier enforcement.
+    ///
+    /// Per [§ 14.6 of the v1 spec](../../../api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md),
+    /// every envelope for a `(session_id, thread_id)` pair gets a
+    /// strictly-monotonic `seq: u64` issued from 1; once a
+    /// [`Payload::TurnCompleted`] envelope is emitted for a thread, any
+    /// further envelope on that thread is DROPPED at the live emit site
+    /// and counted in the
+    /// `octos_projection_post_completion_drop_total` metric.
+    ///
+    /// Returns the [`LedgeredUiProtocolEvent`] when the envelope is
+    /// emitted, or `None` when the hard barrier dropped it (the metric
+    /// is already bumped on the drop path).
+    ///
+    /// The drop is applied at the *live* emit site only — ledger replay
+    /// (post-reconnect) bypasses the drop, so a client that reconnects
+    /// with a pre-completion cursor still observes the full envelope
+    /// history.
+    pub(crate) fn emit_envelope(
+        &self,
+        session_id: &SessionKey,
+        thread_id: String,
+        payload: Payload,
+        client_message_id: Option<String>,
+    ) -> Option<LedgeredUiProtocolEvent> {
+        let (seq, dropped_kind) = self.allocate_envelope_seq(session_id, &thread_id, &payload);
+        if let Some(kind) = dropped_kind {
+            metrics::counter!(
+                "octos_projection_post_completion_drop_total",
+                "kind" => kind,
+            )
+            .increment(1);
+            return None;
+        }
+        let topic = session_id.topic().map(ToOwned::to_owned);
+        let envelope = Envelope {
+            thread_id,
+            seq,
+            client_message_id,
+            payload,
+        };
+        let notification = UiNotification::Envelope(EnvelopeNotification {
+            session_id: session_id.clone(),
+            topic,
+            envelope,
+        });
+        Some(self.append(UiProtocolLedgerEvent::Notification(notification), None))
+    }
+
+    /// Per-thread envelope seq allocator with hard-barrier check.
+    ///
+    /// Returns `(seq, Some(metric_kind))` when the hard barrier dropped
+    /// the emit. The metric kinds are:
+    ///   - `"duplicate_completed"` — a second `TurnCompleted` on the
+    ///     same thread.
+    ///   - `"post_completion"` — any non-`TurnCompleted` payload on a
+    ///     thread that already saw `TurnCompleted`.
+    ///
+    /// The first `emit_envelope` call for a `(session, thread)` pair
+    /// after process restart scans the durable ledger for existing
+    /// envelopes matching this thread and resumes from `max(seq) + 1` —
+    /// daemon restart MUST NOT reissue `seq=1` for a thread the client
+    /// already saw.
+    fn allocate_envelope_seq(
+        &self,
+        session_id: &SessionKey,
+        thread_id: &str,
+        payload: &Payload,
+    ) -> (u64, Option<&'static str>) {
+        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let key = (session_id.clone(), thread_id.to_owned());
+        let needs_recovery = !inner.thread_seq.contains_key(&key);
+        if needs_recovery {
+            // Scan the in-memory ring AND the disk-snapshot tail for
+            // existing envelopes matching this `(session, thread)` so
+            // the allocator continues from `max(seq) + 1`. The disk
+            // path is only consulted when the session has not been
+            // hydrated yet.
+            let recovered = self.recover_thread_seq_state(session_id, thread_id, &inner);
+            inner.thread_seq.insert(key.clone(), recovered);
+        }
+        let state = inner
+            .thread_seq
+            .get_mut(&key)
+            .expect("thread_seq entry inserted above");
+        // Hard barrier per spec § 14.6.
+        let is_turn_completed = matches!(payload, Payload::TurnCompleted { .. });
+        if state.completed {
+            let kind = if is_turn_completed {
+                "duplicate_completed"
+            } else {
+                "post_completion"
+            };
+            // Return the would-be-next seq for diagnostics; the caller
+            // doesn't use it on the drop path.
+            return (state.next_seq, Some(kind));
+        }
+        if state.next_seq == 0 {
+            state.next_seq = 1;
+        }
+        let seq = state.next_seq;
+        state.next_seq = state.next_seq.saturating_add(1);
+        if is_turn_completed {
+            state.completed = true;
+        }
+        (seq, None)
+    }
+
+    /// Daemon-restart recovery for the per-thread seq allocator.
+    ///
+    /// Walks the in-memory ring (already hydrated from disk via
+    /// `recover()` at startup) for envelopes matching `(session, thread)`
+    /// and returns a `ThreadSeqState` whose `next_seq` continues from
+    /// `max(observed seq) + 1`. If a `TurnCompleted` is observed in the
+    /// ring, `completed` is preserved so the hard barrier survives the
+    /// restart.
+    ///
+    /// O(N) over the in-memory ring for the session — acceptable because
+    /// the allocator recovery runs at most once per `(session, thread)`
+    /// pair per process lifetime (subsequent calls hit the `thread_seq`
+    /// map).
+    fn recover_thread_seq_state(
+        &self,
+        session_id: &SessionKey,
+        thread_id: &str,
+        inner: &LedgerInner,
+    ) -> ThreadSeqState {
+        let mut state = ThreadSeqState::default();
+        let Some(session_state) = inner.sessions.get(session_id) else {
+            return state;
+        };
+        for entry in &session_state.entries {
+            if let UiProtocolLedgerEvent::Notification(UiNotification::Envelope(ev)) = &entry.event
+            {
+                if ev.envelope.thread_id == thread_id {
+                    if ev.envelope.seq >= state.next_seq {
+                        state.next_seq = ev.envelope.seq + 1;
+                    }
+                    if matches!(ev.envelope.payload, Payload::TurnCompleted { .. }) {
+                        state.completed = true;
+                    }
+                }
+            }
+        }
+        state
     }
 
     fn append(
@@ -1525,6 +1690,7 @@ fn notification_session_id(notification: &UiNotification) -> &SessionKey {
         UiNotification::LoopCompleted(event) => &event.session_id,
         UiNotification::ContextCompactionCompleted(event) => &event.session_id,
         UiNotification::ContextNormalizationReported(event) => &event.session_id,
+        UiNotification::Envelope(event) => &event.session_id,
     }
 }
 
@@ -2318,5 +2484,216 @@ mod tests {
         drop(rx);
         // After all receivers drop, the orphaned sender is removed.
         assert_eq!(ledger.prune_idle_subscribers(), 1);
+    }
+
+    // ======================================================================
+    // UPCR-2026-014 M9-γ ThreadSeqAllocator + hard-barrier invariants.
+    // ======================================================================
+
+    fn envelope_seq(ledgered: &LedgeredUiProtocolEvent) -> u64 {
+        match &ledgered.event {
+            UiProtocolLedgerEvent::Notification(UiNotification::Envelope(ev)) => ev.envelope.seq,
+            other => panic!("expected envelope ledger event, got {other:?}"),
+        }
+    }
+
+    fn envelope_payload(ledgered: &LedgeredUiProtocolEvent) -> Payload {
+        match &ledgered.event {
+            UiProtocolLedgerEvent::Notification(UiNotification::Envelope(ev)) => {
+                ev.envelope.payload.clone()
+            }
+            other => panic!("expected envelope ledger event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn thread_seq_allocator_issues_monotonic_seq_within_thread() {
+        let ledger = UiProtocolLedger::new(32);
+        let session_id = SessionKey("local:thread-seq".into());
+        let thread_id = "thread-A".to_owned();
+
+        let a = ledger
+            .emit_envelope(
+                &session_id,
+                thread_id.clone(),
+                Payload::AssistantDelta { text: "a".into() },
+                None,
+            )
+            .expect("first emit");
+        let b = ledger
+            .emit_envelope(
+                &session_id,
+                thread_id.clone(),
+                Payload::AssistantDelta { text: "b".into() },
+                None,
+            )
+            .expect("second emit");
+        let c = ledger
+            .emit_envelope(
+                &session_id,
+                thread_id.clone(),
+                Payload::AssistantDelta { text: "c".into() },
+                None,
+            )
+            .expect("third emit");
+
+        assert_eq!(envelope_seq(&a), 1);
+        assert_eq!(envelope_seq(&b), 2);
+        assert_eq!(envelope_seq(&c), 3);
+    }
+
+    #[test]
+    fn thread_seq_allocator_is_independent_across_threads() {
+        let ledger = UiProtocolLedger::new(32);
+        let session_id = SessionKey("local:multi-thread".into());
+
+        let a1 = ledger
+            .emit_envelope(
+                &session_id,
+                "thread-A".into(),
+                Payload::AssistantDelta { text: "a1".into() },
+                None,
+            )
+            .unwrap();
+        let b1 = ledger
+            .emit_envelope(
+                &session_id,
+                "thread-B".into(),
+                Payload::AssistantDelta { text: "b1".into() },
+                None,
+            )
+            .unwrap();
+        let a2 = ledger
+            .emit_envelope(
+                &session_id,
+                "thread-A".into(),
+                Payload::AssistantDelta { text: "a2".into() },
+                None,
+            )
+            .unwrap();
+        let b2 = ledger
+            .emit_envelope(
+                &session_id,
+                "thread-B".into(),
+                Payload::AssistantDelta { text: "b2".into() },
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(envelope_seq(&a1), 1);
+        assert_eq!(envelope_seq(&a2), 2);
+        assert_eq!(envelope_seq(&b1), 1);
+        assert_eq!(envelope_seq(&b2), 2);
+    }
+
+    #[test]
+    fn hard_barrier_drops_post_completion_envelopes() {
+        let ledger = UiProtocolLedger::new(32);
+        let session_id = SessionKey("local:barrier".into());
+        let thread_id = "thread-X".to_owned();
+
+        let _ = ledger
+            .emit_envelope(
+                &session_id,
+                thread_id.clone(),
+                Payload::AssistantDelta { text: "hi".into() },
+                None,
+            )
+            .expect("pre-completion emit");
+        let completed = ledger
+            .emit_envelope(
+                &session_id,
+                thread_id.clone(),
+                Payload::TurnCompleted {
+                    token_usage: octos_core::ui_protocol::EnvelopeTokenUsage::default(),
+                },
+                None,
+            )
+            .expect("turn_completed emit");
+        assert!(matches!(
+            envelope_payload(&completed),
+            Payload::TurnCompleted { .. }
+        ));
+
+        // Post-completion: ANY further envelope on this thread is dropped.
+        let dropped = ledger.emit_envelope(
+            &session_id,
+            thread_id.clone(),
+            Payload::AssistantDelta {
+                text: "should be dropped".into(),
+            },
+            None,
+        );
+        assert!(dropped.is_none(), "post-completion emit must be dropped");
+
+        // A second TurnCompleted is also dropped.
+        let dup = ledger.emit_envelope(
+            &session_id,
+            thread_id,
+            Payload::TurnCompleted {
+                token_usage: octos_core::ui_protocol::EnvelopeTokenUsage::default(),
+            },
+            None,
+        );
+        assert!(
+            dup.is_none(),
+            "duplicate TurnCompleted on the same thread must be dropped"
+        );
+    }
+
+    #[test]
+    fn thread_seq_allocator_recovers_from_in_memory_ledger() {
+        // Daemon restart simulation: pre-fill the ring with envelopes
+        // bearing explicit seqs (as if recovered from disk via `recover`),
+        // then call `emit_envelope` on a fresh allocator — it MUST
+        // continue from max(seq) + 1, not reset to 1.
+        let ledger = UiProtocolLedger::new(32);
+        let session_id = SessionKey("local:restart".into());
+        let thread_id = "thread-R".to_owned();
+
+        // Pre-seed: bypass `emit_envelope` and append raw envelopes so the
+        // `thread_seq` map is NOT populated (simulating the post-restart
+        // state where the ring is hydrated from disk but the per-thread
+        // allocator hasn't observed an emit yet).
+        for seq in [1u64, 2, 3, 4] {
+            let envelope = Envelope {
+                thread_id: thread_id.clone(),
+                seq,
+                client_message_id: None,
+                payload: Payload::AssistantDelta {
+                    text: format!("delta-{seq}"),
+                },
+            };
+            let notif = UiNotification::Envelope(EnvelopeNotification {
+                session_id: session_id.clone(),
+                topic: None,
+                envelope,
+            });
+            let _ = ledger.append_notification(notif);
+        }
+        // Confirm the ring carries 4 envelopes (replay from seq=0).
+        let baseline = UiCursor {
+            stream: session_id.0.clone(),
+            seq: 0,
+        };
+        let replay = ledger.replay_after(&session_id, Some(&baseline)).unwrap();
+        assert_eq!(replay.len(), 4);
+
+        // Now emit_envelope: the allocator must resume from seq=5.
+        let recovered = ledger
+            .emit_envelope(
+                &session_id,
+                thread_id,
+                Payload::AssistantDelta {
+                    text: "post-recovery".into(),
+                },
+                None,
+            )
+            .expect("emit after recovery");
+        assert_eq!(
+            envelope_seq(&recovered),
+            5,
+            "ThreadSeqAllocator must continue from max(seq) + 1 after restart"
+        );
     }
 }

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -3178,53 +3178,39 @@ pub struct Envelope {
 /// envelopes flowing to the right subscriber pane.
 ///
 /// This wrapper carries those routing fields **outside** of the
-/// `envelope` body. The custom `Serialize`/`Deserialize` impls (see
-/// below) project the wire shape down to only the `envelope` field, so
-/// round-tripping a `EnvelopeNotification` through
-/// [`UiNotification::into_rpc_notification`] +
-/// [`UiNotification::from_rpc_notification`] preserves the inner
-/// `Envelope` byte-for-byte. The `session_id` + `topic` are
-/// reconstructed from the JSON-RPC `params` only by the server-internal
-/// ledger path; on a wire-only consume (client) only the envelope is
-/// recovered.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// `envelope` body so the durable ledger can persist them and recovery
+/// can rebuild the routing context after restart.
+///
+/// **Serialization split (codex #1336 round-2 BLOCKER 4):** the global
+/// `Serialize` / `Deserialize` derive includes ALL fields (envelope +
+/// session_id + topic) so the DURABLE LEDGER round-trips routing
+/// state across daemon restart. The wire shape — bare `Envelope` per
+/// spec § 14.1 — is opted into only at the JSON-RPC boundary in
+/// [`UiNotification::into_rpc_notification`] /
+/// [`UiNotification::from_method_and_params`], where the bare
+/// envelope is extracted/re-wrapped. This is the "structurally honest"
+/// answer: a single global Serialize that strips routing fields means
+/// the ledger's disk records also strip them, and recovery walks the
+/// disk back into an `EnvelopeNotification` with empty `session_id` /
+/// `None` topic — topic-scoped envelope replay after restart silently
+/// loses routing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EnvelopeNotification {
     /// Session this envelope belongs to. Used for ledger routing and
-    /// broadcast fan-out. Never serialized to the wire (spec § 14.1).
+    /// broadcast fan-out. Stripped from the wire (spec § 14.1) at the
+    /// `into_rpc_notification` boundary; preserved on disk so recovery
+    /// can rebuild routing.
     pub session_id: SessionKey,
     /// Optional topic for topic-scoped live forwarders (#1329 P0-A class
     /// fix). Captured at the emit site BEFORE any `base_key()` strip so
     /// the topic-scope filter routes correctly even when `session_id`
-    /// is the bare base key. Never serialized to the wire.
+    /// is the bare base key. Stripped from the wire at the
+    /// `into_rpc_notification` boundary; preserved on disk so recovery
+    /// can re-route topic-scoped envelopes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub topic: Option<String>,
     /// The canonical wire envelope — serializes verbatim per spec § 14.1.
     pub envelope: Envelope,
-}
-
-impl serde::Serialize for EnvelopeNotification {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        // The wire shape is the bare `Envelope` per spec § 14.1; the
-        // `session_id` and `topic` are server-internal routing fields
-        // that MUST NOT leak onto the JSON-RPC `params`.
-        self.envelope.serialize(serializer)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for EnvelopeNotification {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        // Decoding from the wire — `session_id` is not present on the
-        // wire; callers that need it must look it up from the RPC
-        // context. Default to an empty SessionKey here (the AppUI
-        // decode path in `from_method_and_params` resets it from the
-        // ambient context before adding to the ledger; pure-wire
-        // consumers only need the `envelope` field).
-        let envelope = Envelope::deserialize(deserializer)?;
-        Ok(Self {
-            session_id: SessionKey(String::new()),
-            topic: None,
-            envelope,
-        })
-    }
 }
 
 /// Draft command payloads for UI protocol v1.
@@ -5330,9 +5316,12 @@ impl UiNotification {
             Self::ContextNormalizationReported(params) => serde_json::to_value(params),
             // UPCR-2026-014 (M9-γ): the wire shape per spec § 14.1 is the
             // bare `Envelope` — `session_id` and `topic` are server-internal
-            // routing fields stripped from the wire by
-            // `EnvelopeNotification`'s `Serialize` impl.
-            Self::Envelope(params) => serde_json::to_value(params),
+            // routing fields stripped here at the JSON-RPC boundary. The
+            // `EnvelopeNotification` struct itself uses a derive-based
+            // `Serialize` so the durable ledger persists routing fields
+            // on disk; recovery rebuilds them before rebroadcasting (codex
+            // #1336 round-2 BLOCKER 4).
+            Self::Envelope(params) => serde_json::to_value(&params.envelope),
         }?;
 
         Ok(RpcNotification::new(method, params))
@@ -5412,7 +5401,21 @@ impl UiNotification {
             // are reconstituted from the ambient ledger context by the
             // server-side decode path (the ledger never round-trips a
             // wire-only envelope back into routing).
-            methods::PROJECTION_ENVELOPE => Ok(Self::Envelope(decode_params(method, params)?)),
+            //
+            // Codex #1336 round-2 BLOCKER 4: the JSON-RPC params carry
+            // ONLY the bare `Envelope` (the wire shape per spec § 14.1) —
+            // decode it into `Envelope` directly and wrap with empty
+            // routing fields. The full-struct `EnvelopeNotification`
+            // serialization is used by the ledger ONLY on disk, never
+            // on the wire.
+            methods::PROJECTION_ENVELOPE => {
+                let envelope: Envelope = decode_params(method, params)?;
+                Ok(Self::Envelope(EnvelopeNotification {
+                    session_id: SessionKey(String::new()),
+                    topic: None,
+                    envelope,
+                }))
+            }
             _ => Err(RpcError::method_not_found(method)),
         }
     }
@@ -10063,6 +10066,116 @@ mod tests {
             }
             other => panic!("expected Envelope variant, got {other:?}"),
         }
+    }
+
+    /// Codex #1336 round-2 BLOCKER 4: the durable ledger writes records
+    /// via `serde_json::to_string(&LedgerDiskRecord)`, which chains
+    /// through the global `Serialize` impl on `EnvelopeNotification`.
+    /// Before the fix, that global impl stripped `session_id` + `topic`
+    /// to mirror the wire shape — so disk records lost their routing
+    /// context and recovery deserialized them with empty/None routing.
+    /// Topic-scoped envelope replay after restart silently mis-routed.
+    ///
+    /// Post-fix: the global Serialize/Deserialize is derive-based and
+    /// preserves ALL fields. The wire shape is opted into only at the
+    /// JSON-RPC boundary inside `into_rpc_notification`.
+    #[test]
+    fn envelope_notification_serde_preserves_routing_fields_for_disk_persistence() {
+        // Persistent shape: routing fields survive a JSON round-trip.
+        // This is the path the durable ledger uses for its on-disk
+        // records, NOT the wire path.
+        let original = EnvelopeNotification {
+            session_id: SessionKey("local:disk-routing".into()),
+            topic: Some("planning".into()),
+            envelope: Envelope {
+                thread_id: "thread-disk".into(),
+                seq: 7,
+                client_message_id: None,
+                payload: Payload::AssistantDelta {
+                    text: "persisted delta".into(),
+                },
+            },
+        };
+
+        // Serialize the EnvelopeNotification directly (NOT via
+        // into_rpc_notification) — this mirrors how the ledger writes
+        // it inside a LedgerDiskRecord. The output MUST contain the
+        // routing fields.
+        let serialized =
+            serde_json::to_value(&original).expect("EnvelopeNotification serializes for disk");
+        assert_eq!(
+            serialized.get("session_id"),
+            Some(&json!("local:disk-routing")),
+            "session_id must persist on disk so recovery can rebuild routing",
+        );
+        assert_eq!(
+            serialized.get("topic"),
+            Some(&json!("planning")),
+            "topic must persist on disk so topic-scoped recovery routes correctly",
+        );
+        assert!(
+            serialized.get("envelope").is_some(),
+            "envelope body must be present on disk",
+        );
+
+        // Deserialize back — routing fields must round-trip byte-equal.
+        let parsed: EnvelopeNotification = serde_json::from_value(serialized)
+            .expect("EnvelopeNotification deserializes from disk");
+        assert_eq!(
+            parsed, original,
+            "disk round-trip must preserve all fields including routing",
+        );
+
+        // Defensive: a `topic: None` envelope omits the field on disk
+        // (no behavioural change — just keeps the disk shape compact
+        // when topic isn't set).
+        let no_topic = EnvelopeNotification {
+            session_id: SessionKey("local:disk-no-topic".into()),
+            topic: None,
+            envelope: original.envelope.clone(),
+        };
+        let serialized = serde_json::to_value(&no_topic).expect("serialize");
+        assert!(
+            serialized.get("topic").is_none(),
+            "absent topic is omitted on disk; deserialize defaults back to None",
+        );
+        let parsed: EnvelopeNotification = serde_json::from_value(serialized).expect("deserialize");
+        assert_eq!(parsed, no_topic);
+    }
+
+    /// Codex #1336 round-2 BLOCKER 4 — wire shape regression guard.
+    /// `into_rpc_notification` is the ONLY place the wire shape is
+    /// produced; routing fields are stripped here and ONLY here. The
+    /// disk-persistence test above pins that the routing fields DO
+    /// survive when the envelope is serialized directly (not through
+    /// into_rpc_notification).
+    #[test]
+    fn envelope_notification_into_rpc_notification_strips_routing_fields() {
+        let notif = UiNotification::Envelope(EnvelopeNotification {
+            session_id: SessionKey("local:wire-strip".into()),
+            topic: Some("planning".into()),
+            envelope: Envelope {
+                thread_id: "thread-wire".into(),
+                seq: 5,
+                client_message_id: None,
+                payload: Payload::AssistantDelta { text: "x".into() },
+            },
+        });
+        let rpc = notif.into_rpc_notification().expect("serialize");
+        assert_eq!(rpc.method, methods::PROJECTION_ENVELOPE);
+        let params = &rpc.params;
+        assert!(
+            params.get("session_id").is_none(),
+            "wire MUST strip session_id (spec § 14.1)",
+        );
+        assert!(
+            params.get("topic").is_none(),
+            "wire MUST strip topic (spec § 14.1)",
+        );
+        // Bare envelope on the wire — `thread_id`, `seq`, `payload`
+        // are top-level keys (no `envelope` nesting).
+        assert_eq!(params.get("thread_id"), Some(&json!("thread-wire")));
+        assert_eq!(params.get("seq"), Some(&json!(5)));
     }
 
     // ------------------------------------------------------------------

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -3166,6 +3166,67 @@ pub struct Envelope {
     pub payload: Payload,
 }
 
+/// Ledger / wire wrapper around [`Envelope`] for the
+/// `projection/envelope` notification (UPCR-2026-014 M9-γ).
+///
+/// The wire JSON-RPC `params` field MUST match the spec § 14.1 wire
+/// shape exactly — `{ thread_id, seq, client_message_id?, payload }` —
+/// with **no `session_id`** key. But the in-memory ledger needs the
+/// `SessionKey` to route the event to the right per-session ring and
+/// broadcast channel, and it needs the optional `topic` so the
+/// topic-scope live filter (`ledger_event_matches_topic_scope`) keeps
+/// envelopes flowing to the right subscriber pane.
+///
+/// This wrapper carries those routing fields **outside** of the
+/// `envelope` body. The custom `Serialize`/`Deserialize` impls (see
+/// below) project the wire shape down to only the `envelope` field, so
+/// round-tripping a `EnvelopeNotification` through
+/// [`UiNotification::into_rpc_notification`] +
+/// [`UiNotification::from_rpc_notification`] preserves the inner
+/// `Envelope` byte-for-byte. The `session_id` + `topic` are
+/// reconstructed from the JSON-RPC `params` only by the server-internal
+/// ledger path; on a wire-only consume (client) only the envelope is
+/// recovered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnvelopeNotification {
+    /// Session this envelope belongs to. Used for ledger routing and
+    /// broadcast fan-out. Never serialized to the wire (spec § 14.1).
+    pub session_id: SessionKey,
+    /// Optional topic for topic-scoped live forwarders (#1329 P0-A class
+    /// fix). Captured at the emit site BEFORE any `base_key()` strip so
+    /// the topic-scope filter routes correctly even when `session_id`
+    /// is the bare base key. Never serialized to the wire.
+    pub topic: Option<String>,
+    /// The canonical wire envelope — serializes verbatim per spec § 14.1.
+    pub envelope: Envelope,
+}
+
+impl serde::Serialize for EnvelopeNotification {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // The wire shape is the bare `Envelope` per spec § 14.1; the
+        // `session_id` and `topic` are server-internal routing fields
+        // that MUST NOT leak onto the JSON-RPC `params`.
+        self.envelope.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for EnvelopeNotification {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Decoding from the wire — `session_id` is not present on the
+        // wire; callers that need it must look it up from the RPC
+        // context. Default to an empty SessionKey here (the AppUI
+        // decode path in `from_method_and_params` resets it from the
+        // ambient context before adding to the ledger; pure-wire
+        // consumers only need the `envelope` field).
+        let envelope = Envelope::deserialize(deserializer)?;
+        Ok(Self {
+            session_id: SessionKey(String::new()),
+            topic: None,
+            envelope,
+        })
+    }
+}
+
 /// Draft command payloads for UI protocol v1.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -5050,6 +5111,14 @@ pub enum UiNotification {
     ContextCompactionCompleted(ContextCompactionCompletedEvent),
     /// M16: prompt normalization lifecycle event.
     ContextNormalizationReported(ContextNormalizationReportedEvent),
+    /// UPCR-2026-014 (M9-γ) canonical projection envelope (`projection/envelope`).
+    /// Spec § 14. Capability-gated on `projection.envelope.v1`; the
+    /// per-connection live filter keeps legacy and envelope deliveries
+    /// mutually exclusive (legacy clients never see this variant,
+    /// negotiated clients see ONLY this variant for the events it
+    /// supersedes — `message/delta`, `message/persisted`, `tool/*`,
+    /// `turn/completed`, `file/attached`).
+    Envelope(EnvelopeNotification),
 }
 
 fn set_topic_if_absent(slot: &mut Option<String>, topic: &str) {
@@ -5100,6 +5169,7 @@ impl UiNotification {
             Self::LoopCompleted(_) => methods::LOOP_COMPLETED,
             Self::ContextCompactionCompleted(_) => methods::CONTEXT_COMPACTION_COMPLETED,
             Self::ContextNormalizationReported(_) => methods::CONTEXT_NORMALIZATION_REPORTED,
+            Self::Envelope(_) => methods::PROJECTION_ENVELOPE,
         }
     }
 
@@ -5139,6 +5209,7 @@ impl UiNotification {
             Self::LoopCompleted(event) => &event.session_id,
             Self::ContextCompactionCompleted(event) => &event.session_id,
             Self::ContextNormalizationReported(event) => &event.session_id,
+            Self::Envelope(event) => &event.session_id,
         }
     }
 
@@ -5187,6 +5258,7 @@ impl UiNotification {
             Self::SessionEventBridged(event) => {
                 event.topic.as_deref().or_else(|| event.session_id.topic())
             }
+            Self::Envelope(event) => event.topic.as_deref().or_else(|| event.session_id.topic()),
             _ => self.session_id().topic(),
         }
     }
@@ -5213,6 +5285,7 @@ impl UiNotification {
             Self::TurnSpawnComplete(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::FileAttached(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::SessionEventBridged(event) => set_topic_if_absent(&mut event.topic, &topic),
+            Self::Envelope(event) => set_topic_if_absent(&mut event.topic, &topic),
             _ => {}
         }
     }
@@ -5255,6 +5328,11 @@ impl UiNotification {
             Self::LoopCompleted(params) => serde_json::to_value(params),
             Self::ContextCompactionCompleted(params) => serde_json::to_value(params),
             Self::ContextNormalizationReported(params) => serde_json::to_value(params),
+            // UPCR-2026-014 (M9-γ): the wire shape per spec § 14.1 is the
+            // bare `Envelope` — `session_id` and `topic` are server-internal
+            // routing fields stripped from the wire by
+            // `EnvelopeNotification`'s `Serialize` impl.
+            Self::Envelope(params) => serde_json::to_value(params),
         }?;
 
         Ok(RpcNotification::new(method, params))
@@ -5329,6 +5407,12 @@ impl UiNotification {
             methods::CONTEXT_NORMALIZATION_REPORTED => Ok(Self::ContextNormalizationReported(
                 decode_params(method, params)?,
             )),
+            // UPCR-2026-014 (M9-γ): decode the bare wire envelope into the
+            // wrapper; `session_id` and `topic` default to empty/None and
+            // are reconstituted from the ambient ledger context by the
+            // server-side decode path (the ledger never round-trips a
+            // wire-only envelope back into routing).
+            methods::PROJECTION_ENVELOPE => Ok(Self::Envelope(decode_params(method, params)?)),
             _ => Err(RpcError::method_not_found(method)),
         }
     }
@@ -9908,6 +9992,77 @@ mod tests {
             UI_PROTOCOL_KNOWN_FEATURES.contains(&UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1),
             "projection.envelope.v1 must be registered for capability negotiation"
         );
+    }
+
+    #[test]
+    fn envelope_notification_method_is_projection_envelope() {
+        let notif = UiNotification::Envelope(EnvelopeNotification {
+            session_id: SessionKey("local:demo".into()),
+            topic: None,
+            envelope: Envelope {
+                thread_id: "thread-1".into(),
+                seq: 1,
+                client_message_id: None,
+                payload: Payload::AssistantDelta { text: "hi".into() },
+            },
+        });
+        assert_eq!(notif.method(), "projection/envelope");
+        assert_eq!(notif.session_id(), &SessionKey("local:demo".into()));
+    }
+
+    #[test]
+    fn envelope_notification_round_trips_through_rpc_envelope_with_bare_wire_shape() {
+        // The wire shape MUST be the bare `Envelope` per spec § 14.1 —
+        // `session_id` and `topic` are server-internal routing fields
+        // and MUST NOT leak onto the JSON-RPC `params`.
+        let envelope = Envelope {
+            thread_id: "thread-7".into(),
+            seq: 42,
+            client_message_id: Some("cmid-x".into()),
+            payload: Payload::UserMessage {
+                text: "hi".into(),
+                files: vec![FileRef {
+                    path: "/tmp/a.png".into(),
+                    mime: "image/png".into(),
+                    size_bytes: 12,
+                }],
+            },
+        };
+        let notif = UiNotification::Envelope(EnvelopeNotification {
+            session_id: SessionKey("local:demo".into()),
+            topic: Some("planning".into()),
+            envelope: envelope.clone(),
+        });
+        let rpc = notif.into_rpc_notification().expect("serialize");
+        assert_eq!(rpc.method, "projection/envelope");
+        // Wire shape: bare Envelope JSON, no session_id/topic keys.
+        let params = &rpc.params;
+        assert!(
+            params.get("session_id").is_none(),
+            "session_id must not leak onto the wire"
+        );
+        assert!(
+            params.get("topic").is_none(),
+            "topic must not leak onto the wire"
+        );
+        assert_eq!(params.get("thread_id"), Some(&json!("thread-7")));
+        assert_eq!(params.get("seq"), Some(&json!(42)));
+        assert_eq!(params.get("client_message_id"), Some(&json!("cmid-x")));
+
+        // Round-trip decode: session_id defaults to empty (the AppUI
+        // decode path rebuilds it from ambient context); envelope must
+        // be byte-equal.
+        let parsed = UiNotification::from_rpc_notification(rpc).expect("decode");
+        match parsed {
+            UiNotification::Envelope(ev) => {
+                assert_eq!(ev.envelope, envelope);
+                // Routing fields default on the decode path; consumer
+                // reconstructs them from ambient context.
+                assert_eq!(ev.session_id, SessionKey(String::new()));
+                assert_eq!(ev.topic, None);
+            }
+            other => panic!("expected Envelope variant, got {other:?}"),
+        }
     }
 
     // ------------------------------------------------------------------

--- a/crates/octos-web/src/runtime/__tests__/ui-protocol-bridge.test.ts
+++ b/crates/octos-web/src/runtime/__tests__/ui-protocol-bridge.test.ts
@@ -1,0 +1,243 @@
+// Unit tests for the M9-γ projection-envelope bridge
+// (UPCR-2026-014, spec § 14.6).
+//
+// Coverage:
+//   - Malformed envelope rejection (missing fields, wrong types,
+//     unknown payload.type).
+//   - Hard-barrier post-completion drop (with metric labels matching
+//     the server-side `octos_projection_post_completion_drop_total`
+//     counter).
+//   - Strict per-thread seq monotonicity (gap / backward seq
+//     violations surface AND bump `seqGaps`).
+//   - Listener fan-out for accepted envelopes.
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  PROJECTION_ENVELOPE_METHOD,
+  ProjectionEnvelopeBridge,
+  type BridgeLogger,
+} from '../ui-protocol-bridge.js';
+
+function silentLogger(): BridgeLogger {
+  return { warn: vi.fn() };
+}
+
+describe('ProjectionEnvelopeBridge.decodeAndValidate', () => {
+  it('rejects non-object params', () => {
+    const bridge = new ProjectionEnvelopeBridge(silentLogger());
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, null);
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, 'string');
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, 42);
+    expect(bridge.metrics.malformed).toBe(3);
+    expect(bridge.metrics.accepted).toBe(0);
+  });
+
+  it('rejects envelope missing thread_id', () => {
+    const bridge = new ProjectionEnvelopeBridge(silentLogger());
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      seq: 1,
+      payload: { type: 'assistant_delta', data: { text: 'x' } },
+    });
+    expect(bridge.metrics.malformed).toBe(1);
+  });
+
+  it('rejects envelope with non-integer seq', () => {
+    const bridge = new ProjectionEnvelopeBridge(silentLogger());
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 1.5,
+      payload: { type: 'assistant_delta', data: { text: 'x' } },
+    });
+    expect(bridge.metrics.malformed).toBe(1);
+  });
+
+  it('rejects envelope with seq=0 (per-thread seq is 1-based)', () => {
+    const bridge = new ProjectionEnvelopeBridge(silentLogger());
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 0,
+      payload: { type: 'assistant_delta', data: { text: 'x' } },
+    });
+    expect(bridge.metrics.malformed).toBe(1);
+  });
+
+  it('rejects envelope with unknown payload.type', () => {
+    const bridge = new ProjectionEnvelopeBridge(silentLogger());
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 1,
+      payload: { type: 'no_such_kind', data: {} },
+    });
+    expect(bridge.metrics.malformed).toBe(1);
+  });
+
+  it('rejects envelope with non-string client_message_id', () => {
+    const bridge = new ProjectionEnvelopeBridge(silentLogger());
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 1,
+      client_message_id: 12345,
+      payload: { type: 'user_message', data: { text: 'hi' } },
+    });
+    expect(bridge.metrics.malformed).toBe(1);
+  });
+
+  it('accepts a well-formed envelope and routes to listeners', () => {
+    const bridge = new ProjectionEnvelopeBridge(silentLogger());
+    const seen: unknown[] = [];
+    bridge.onEnvelope((env) => seen.push(env));
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 1,
+      client_message_id: 'cmid-1',
+      payload: { type: 'user_message', data: { text: 'hi' } },
+    });
+    expect(bridge.metrics.accepted).toBe(1);
+    expect(bridge.metrics.malformed).toBe(0);
+    expect(seen.length).toBe(1);
+  });
+
+  it('ignores methods other than projection/envelope', () => {
+    const bridge = new ProjectionEnvelopeBridge(silentLogger());
+    bridge.handle('message/delta', {
+      thread_id: 'tA',
+      seq: 1,
+      payload: { type: 'assistant_delta', data: { text: 'x' } },
+    });
+    expect(bridge.metrics.accepted).toBe(0);
+    expect(bridge.metrics.malformed).toBe(0);
+  });
+});
+
+describe('ProjectionEnvelopeBridge hard barrier (spec § 14.6)', () => {
+  it('drops envelopes that arrive after turn_completed on the same thread', () => {
+    const bridge = new ProjectionEnvelopeBridge(silentLogger());
+    const seen: unknown[] = [];
+    bridge.onEnvelope((env) => seen.push(env));
+
+    // Pre-completion envelopes accepted.
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 1,
+      payload: { type: 'assistant_delta', data: { text: 'a' } },
+    });
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 2,
+      payload: { type: 'turn_completed', data: { token_usage: {} } },
+    });
+    expect(bridge.metrics.accepted).toBe(2);
+
+    // Post-completion AssistantDelta on the SAME thread — must be dropped.
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 3,
+      payload: { type: 'assistant_delta', data: { text: 'late' } },
+    });
+    expect(bridge.metrics.postCompletionDrops).toBe(1);
+    expect(bridge.metrics.duplicateCompletedDrops).toBe(0);
+    expect(bridge.metrics.accepted).toBe(2);
+    expect(seen.length).toBe(2);
+  });
+
+  it('counts duplicate turn_completed under the "duplicate_completed" label', () => {
+    const bridge = new ProjectionEnvelopeBridge(silentLogger());
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 1,
+      payload: { type: 'turn_completed', data: { token_usage: {} } },
+    });
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 2,
+      payload: { type: 'turn_completed', data: { token_usage: {} } },
+    });
+    expect(bridge.metrics.duplicateCompletedDrops).toBe(1);
+    expect(bridge.metrics.postCompletionDrops).toBe(0);
+    expect(bridge.metrics.accepted).toBe(1);
+  });
+
+  it('barriers are per-thread — completion on tA does not affect tB', () => {
+    const bridge = new ProjectionEnvelopeBridge(silentLogger());
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 1,
+      payload: { type: 'turn_completed', data: { token_usage: {} } },
+    });
+    // tB is unaffected — accepts envelopes freely.
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tB',
+      seq: 1,
+      payload: { type: 'assistant_delta', data: { text: 'hi' } },
+    });
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tB',
+      seq: 2,
+      payload: { type: 'assistant_delta', data: { text: 'more' } },
+    });
+    expect(bridge.metrics.accepted).toBe(3);
+    expect(bridge.metrics.postCompletionDrops).toBe(0);
+  });
+});
+
+describe('ProjectionEnvelopeBridge seq monotonicity assertion', () => {
+  it('counts non-monotonic seqs under seqGaps but still surfaces the envelope', () => {
+    const bridge = new ProjectionEnvelopeBridge(silentLogger());
+    const seen: unknown[] = [];
+    bridge.onEnvelope((env) => seen.push(env));
+
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 1,
+      payload: { type: 'assistant_delta', data: { text: 'a' } },
+    });
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 2,
+      payload: { type: 'assistant_delta', data: { text: 'b' } },
+    });
+    // Backward seq — violation, still surfaced.
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 1,
+      payload: { type: 'assistant_delta', data: { text: 'backward' } },
+    });
+    expect(bridge.metrics.seqGaps).toBe(1);
+    expect(bridge.metrics.accepted).toBe(3);
+    expect(seen.length).toBe(3);
+  });
+
+  it('counts forward gaps under seqGaps but still surfaces the envelope', () => {
+    const bridge = new ProjectionEnvelopeBridge(silentLogger());
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 1,
+      payload: { type: 'assistant_delta', data: { text: 'a' } },
+    });
+    // Skip seq=2 — gap.
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 5,
+      payload: { type: 'assistant_delta', data: { text: 'gap' } },
+    });
+    expect(bridge.metrics.seqGaps).toBe(1);
+    expect(bridge.metrics.accepted).toBe(2);
+  });
+
+  it('does not flag the first envelope of a new thread', () => {
+    const bridge = new ProjectionEnvelopeBridge(silentLogger());
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tA',
+      seq: 1,
+      payload: { type: 'assistant_delta', data: { text: 'a' } },
+    });
+    bridge.handle(PROJECTION_ENVELOPE_METHOD, {
+      thread_id: 'tB',
+      seq: 1,
+      payload: { type: 'assistant_delta', data: { text: 'b' } },
+    });
+    expect(bridge.metrics.seqGaps).toBe(0);
+    expect(bridge.metrics.accepted).toBe(2);
+  });
+});

--- a/crates/octos-web/src/runtime/ui-protocol-bridge.ts
+++ b/crates/octos-web/src/runtime/ui-protocol-bridge.ts
@@ -1,0 +1,278 @@
+// UI Protocol v1 — M9-γ canonical projection envelope BRIDGE
+// (UPCR-2026-014, spec § 14).
+//
+// This module is the canonical CLIENT consumer for the M9-γ
+// `projection/envelope` notification surface. Server emit is in
+// `crates/octos-cli/src/api/ui_protocol*.rs` (Rust); this bridge is the
+// matching TypeScript decode + invariant-check layer.
+//
+// Once the server-emit + per-connection live filter cutover lands
+// (this PR), a WS connection that negotiated `projection.envelope.v1`
+// receives ONLY `projection/envelope` notifications for the events
+// that surface had legacy analogs (`message/delta`, `message/persisted`,
+// `tool/*`, `turn/completed`, `file/attached`). Legacy clients keep
+// seeing those notifications; the per-connection mutual exclusion is
+// enforced server-side in `live_event_passes_capability_filter`.
+//
+// The bridge:
+//   1. Recognises `projection/envelope` notifications on the WS.
+//   2. Validates the wire payload against the existing TS `Envelope`
+//      type at `ui-protocol-types.ts:219-229`. Malformed envelopes are
+//      rejected (logged + counted in `bridge_malformed_total`).
+//   3. Enforces the hard barrier from spec § 14.6 — once a
+//      `turn_completed` envelope arrives for `thread_id` T, any
+//      subsequent envelope on the same thread is DROPPED and the drop
+//      is counted in `bridge_post_completion_drop_total` (kind label
+//      `"duplicate_completed"` vs `"post_completion"`, matching the
+//      server-side metric).
+//   4. Asserts strict per-thread `seq` monotonicity. A gap or a
+//      backward `seq` is logged and counted in
+//      `bridge_seq_gap_total`; the bridge keeps emitting (the
+//      projection is the source of truth for what to do with gaps —
+//      typically rehydrate via cursor).
+//   5. Provides a typed callback API (`onEnvelope`) the projection
+//      function subscribes to.
+//
+// Spec: `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` § 14.
+
+import type { Envelope, ThreadId, Seq } from './ui-protocol-types.js';
+import { UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1 } from './ui-protocol-types.js';
+
+/** Method literal for the projection-envelope notification.
+ *  Mirrors `methods::PROJECTION_ENVELOPE` in the Rust types. */
+export const PROJECTION_ENVELOPE_METHOD = 'projection/envelope';
+
+/** Per-bridge invariant counters surfaced for ops monitoring. The
+ *  fields mirror the server-side metric labels so an operator sees
+ *  matching numbers on both ends. */
+export interface BridgeMetrics {
+  /** Envelopes accepted by the bridge — payload type-valid, seq
+   *  monotonic, hard barrier not tripped. */
+  accepted: number;
+  /** Wire payload failed shape validation (missing `thread_id` /
+   *  `seq` / `payload`, unknown `payload.type`, etc.). */
+  malformed: number;
+  /** Hard-barrier drops: post-completion envelopes on a closed thread.
+   *  Mirrors `octos_projection_post_completion_drop_total{kind="post_completion"}`. */
+  postCompletionDrops: number;
+  /** Hard-barrier drops: duplicate `turn_completed` on a closed thread.
+   *  Mirrors `octos_projection_post_completion_drop_total{kind="duplicate_completed"}`. */
+  duplicateCompletedDrops: number;
+  /** Seq monotonicity violations (gap or backward seq). The bridge
+   *  still surfaces the envelope; the projection decides whether to
+   *  rehydrate. */
+  seqGaps: number;
+}
+
+/** Callback shape for accepted envelopes. The projection function
+ *  subscribes via `bridge.onEnvelope(cb)`. */
+export type EnvelopeListener = (envelope: Envelope) => void;
+
+/** Per-thread state for hard-barrier + monotonic-seq enforcement. */
+interface ThreadState {
+  highestSeq: Seq;
+  completed: boolean;
+}
+
+/** Optional logger interface — defaults to `console`. Unit tests pass
+ *  a quieter logger to avoid polluting test output. */
+export interface BridgeLogger {
+  warn(message: string, context?: unknown): void;
+}
+
+const defaultLogger: BridgeLogger = {
+  // eslint-disable-next-line no-console
+  warn: (msg, ctx) => console.warn(msg, ctx),
+};
+
+/** The bridge surface. One instance per WS connection. Callers
+ *  feed each notification through `bridge.handle(method, params)` and
+ *  subscribe to validated envelopes via `bridge.onEnvelope(cb)`. */
+export class ProjectionEnvelopeBridge {
+  private readonly listeners: EnvelopeListener[] = [];
+  private readonly threads = new Map<ThreadId, ThreadState>();
+  private readonly logger: BridgeLogger;
+  readonly metrics: BridgeMetrics = {
+    accepted: 0,
+    malformed: 0,
+    postCompletionDrops: 0,
+    duplicateCompletedDrops: 0,
+    seqGaps: 0,
+  };
+
+  constructor(logger: BridgeLogger = defaultLogger) {
+    this.logger = logger;
+  }
+
+  /** Subscribe a callback that fires for every envelope the bridge
+   *  accepts after hard-barrier + shape validation. */
+  onEnvelope(listener: EnvelopeListener): void {
+    this.listeners.push(listener);
+  }
+
+  /** Feed a single JSON-RPC notification through the bridge. Methods
+   *  other than `projection/envelope` are silently ignored — the
+   *  caller may safely feed every WS frame. */
+  handle(method: string, params: unknown): void {
+    if (method !== PROJECTION_ENVELOPE_METHOD) {
+      return;
+    }
+    const envelope = this.decodeAndValidate(params);
+    if (!envelope) {
+      return;
+    }
+    const state = this.threads.get(envelope.thread_id) ?? {
+      highestSeq: 0,
+      completed: false,
+    };
+
+    // Hard-barrier enforcement (spec § 14.6).
+    if (state.completed) {
+      const isTurnCompleted = envelope.payload.type === 'turn_completed';
+      if (isTurnCompleted) {
+        this.metrics.duplicateCompletedDrops += 1;
+        this.logger.warn(
+          'projection.envelope.bridge: duplicate turn_completed on closed thread (dropped)',
+          { thread_id: envelope.thread_id, seq: envelope.seq },
+        );
+      } else {
+        this.metrics.postCompletionDrops += 1;
+        this.logger.warn(
+          'projection.envelope.bridge: post-completion envelope (dropped)',
+          {
+            thread_id: envelope.thread_id,
+            seq: envelope.seq,
+            type: envelope.payload.type,
+          },
+        );
+      }
+      return;
+    }
+
+    // Seq monotonicity check (spec § 14.1: strictly monotonic; gaps
+    // are an error and trigger rehydration). We log and count the
+    // violation but still surface the envelope so the projection can
+    // decide whether to ignore the gap or kick off a rehydrate.
+    if (envelope.seq <= state.highestSeq) {
+      this.metrics.seqGaps += 1;
+      this.logger.warn(
+        'projection.envelope.bridge: non-monotonic seq (still surfaced)',
+        {
+          thread_id: envelope.thread_id,
+          seq: envelope.seq,
+          highest_seq: state.highestSeq,
+        },
+      );
+    } else if (envelope.seq !== state.highestSeq + 1 && state.highestSeq !== 0) {
+      // Forward gap — also a violation under § 14.1, but the bridge
+      // surfaces the envelope and lets the projection rehydrate.
+      this.metrics.seqGaps += 1;
+      this.logger.warn(
+        'projection.envelope.bridge: seq gap (still surfaced)',
+        {
+          thread_id: envelope.thread_id,
+          seq: envelope.seq,
+          expected: state.highestSeq + 1,
+        },
+      );
+    }
+
+    if (envelope.seq > state.highestSeq) {
+      state.highestSeq = envelope.seq;
+    }
+    if (envelope.payload.type === 'turn_completed') {
+      state.completed = true;
+    }
+    this.threads.set(envelope.thread_id, state);
+    this.metrics.accepted += 1;
+    for (const listener of this.listeners) {
+      try {
+        listener(envelope);
+      } catch (err) {
+        this.logger.warn('projection.envelope.bridge: listener threw', err);
+      }
+    }
+  }
+
+  /** Validate the JSON-RPC `params` payload against the wire schema
+   *  for the envelope. Returns the typed envelope on success or
+   *  `null` on shape failure (the malformed counter is bumped). */
+  private decodeAndValidate(params: unknown): Envelope | null {
+    if (!params || typeof params !== 'object') {
+      this.bumpMalformed('non-object params');
+      return null;
+    }
+    const candidate = params as Record<string, unknown>;
+    const threadId = candidate['thread_id'];
+    const seq = candidate['seq'];
+    const payload = candidate['payload'];
+    if (typeof threadId !== 'string' || threadId.length === 0) {
+      this.bumpMalformed('missing or empty thread_id');
+      return null;
+    }
+    if (typeof seq !== 'number' || !Number.isFinite(seq) || seq < 1 || !Number.isInteger(seq)) {
+      this.bumpMalformed('missing or non-positive integer seq');
+      return null;
+    }
+    if (!payload || typeof payload !== 'object') {
+      this.bumpMalformed('missing payload');
+      return null;
+    }
+    const payloadObj = payload as Record<string, unknown>;
+    const type = payloadObj['type'];
+    const data = payloadObj['data'];
+    if (typeof type !== 'string') {
+      this.bumpMalformed('missing payload.type');
+      return null;
+    }
+    if (!data || typeof data !== 'object') {
+      this.bumpMalformed('missing payload.data');
+      return null;
+    }
+    const knownTypes = [
+      'user_message',
+      'assistant_delta',
+      'assistant_persisted',
+      'tool_start',
+      'tool_progress',
+      'tool_end',
+      'file_attached',
+      'turn_completed',
+    ];
+    if (!knownTypes.includes(type)) {
+      this.bumpMalformed(`unknown payload.type: ${type}`);
+      return null;
+    }
+    const clientMessageId = candidate['client_message_id'];
+    if (
+      clientMessageId !== undefined &&
+      clientMessageId !== null &&
+      typeof clientMessageId !== 'string'
+    ) {
+      this.bumpMalformed('client_message_id must be string when present');
+      return null;
+    }
+    // Per spec § 14.1: `client_message_id` is ONLY populated on
+    // `user_message` envelopes. A server emitting it on any other
+    // variant is a wire contract violation — we surface but log.
+    if (clientMessageId && type !== 'user_message') {
+      this.logger.warn(
+        'projection.envelope.bridge: client_message_id present on non-user_message variant (wire contract violation)',
+        { thread_id: threadId, seq, type },
+      );
+    }
+    return params as Envelope;
+  }
+
+  private bumpMalformed(reason: string): void {
+    this.metrics.malformed += 1;
+    this.logger.warn(`projection.envelope.bridge: malformed envelope (${reason})`);
+  }
+}
+
+/** Convenience: the wire feature flag the bridge expects to have been
+ *  negotiated at session/open. Re-exported from `ui-protocol-types`
+ *  for caller ergonomics — passing this string into a `session/open`
+ *  request's `X-Octos-Ui-Features` opts the connection into the M9-γ
+ *  cutover. */
+export const REQUIRED_FEATURE = UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1;

--- a/crates/octos-web/vitest.config.ts
+++ b/crates/octos-web/vitest.config.ts
@@ -7,7 +7,10 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: false,
-    include: ['src/state/__tests__/**/*.test.ts'],
+    include: [
+      'src/state/__tests__/**/*.test.ts',
+      'src/runtime/__tests__/**/*.test.ts',
+    ],
     // The fixture-replay engine is allocation-light and entirely
     // synchronous; a single thread is faster than the pool overhead.
     pool: 'threads',


### PR DESCRIPTION
Closes #1328.

Pre-release direct cutover: γ-1 (#1343, `cc8c1f48`) added the capability surface; this PR adds the **server emit**, the **octos-web bridge**, **per-connection legacy/envelope mutual exclusion**, and the **hard barrier**.

## Summary

- **Server emit**: `UiNotification::Envelope(EnvelopeNotification)` variant on the core notification enum. Wire shape per spec § 14.1 — bare `Envelope` JSON, no `session_id` leak. `session_id` + `topic` ride OUT-of-band on `EnvelopeNotification` for ledger routing.
- **ThreadSeqAllocator**: `(SessionKey, ThreadId) → ThreadSeqState { next_seq, completed }` map on `UiProtocolLedger`. Issues monotonic `seq: u64` from 1; daemon restart scans the in-memory ring (already hydrated from disk) and resumes from `max(seq) + 1`.
- **Hard barrier (spec § 14.6)**: `emit_envelope` applies a per-thread barrier — any envelope after `TurnCompleted` is DROPPED and counted under `octos_projection_post_completion_drop_total{kind="duplicate_completed"|"post_completion"}`. Barrier applies at live emit only; ledger replay returns the full history.
- **Dual-emit**: wired at every legacy emit site — `MessageDelta` / `Tool*` (via `forward_progress_event`), `MessagePersisted` (via `install_message_commit_observer`, Assistant → `AssistantPersisted`, User → `UserMessage` with best-effort `FileRef`s), `TurnCompleted` (via `try_emit_terminal` + α-9 bridge), `FileAttached` (via α-9 bridge `emit_file_attached`).
- **Per-connection mutual exclusion**: `live_event_passes_capability_filter` — clients with `projection_envelope=true` see ONLY envelopes; clients with `projection_envelope=false` see ONLY legacy events. The legacy emit code paths stay in place because non-negotiated clients still need them; what changes is per-connection delivery.
- **Client bridge**: `crates/octos-web/src/runtime/ui-protocol-bridge.ts` — `ProjectionEnvelopeBridge` with shape validation, hard-barrier drops (matching server metric labels), strict per-thread seq monotonicity checks, typed `onEnvelope(cb)` callback.

## Spec § 14 wire shape is what the server emits

The TS `Envelope` type at `ui-protocol-types.ts:219-229` is now the canonical consume surface. The Rust `Envelope` at `crates/octos-core/src/ui_protocol.rs:3148` is the canonical emit surface. They round-trip byte-for-byte through `EnvelopeNotification`'s custom `Serialize`/`Deserialize` (which projects the wire shape down to just the `envelope` field — the routing fields are server-internal).

## Strict constraints honoured

- Did NOT keep dual-emit forever — per-connection mutual exclusion is the design.
- Did NOT add new manifest schema fields.
- Did NOT touch SessionScope, plugin loader, mofa-skills, or the SKILL.md campaign.
- MSRV 1.85.

## Test plan

- [x] `cargo build --workspace` — clean.
- [x] `cargo test -p octos-core ui_protocol` — 107 passing.
- [x] `cargo test -p octos-cli --features api --lib` (envelope + hard barrier + dual-emit + capability filter + thread seq allocator) — 8 new tests passing, 1426/1426 lib tests passing.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p octos-core` — clean.
- [x] octos-web `vitest` — **37 passing** (14 new bridge tests + 23 existing).
- [x] octos-web `tsc -b` — clean.

### Tests added

**octos-core**:
- `envelope_notification_method_is_projection_envelope`
- `envelope_notification_round_trips_through_rpc_envelope_with_bare_wire_shape` (wire shape MUST NOT leak `session_id`/`topic`)

**octos-cli (`ui_protocol_ledger`)**:
- `thread_seq_allocator_issues_monotonic_seq_within_thread`
- `thread_seq_allocator_is_independent_across_threads`
- `thread_seq_allocator_recovers_from_in_memory_ledger` (daemon-restart scan)
- `hard_barrier_drops_post_completion_envelopes` (post + duplicate)

**octos-cli (`ui_protocol`)**:
- `capability_filter_envelope_legacy_mutual_exclusion` (8 legacy variants × 2 clients = 16 corners)
- `live_emit_hard_barrier_does_not_affect_ledger_replay` (replay returns ALL post-completion, live emit barriers)
- `emit_envelope_for_legacy_notification_covers_every_progress_variant`

**octos-web (`ui-protocol-bridge.test.ts`, 14 tests)**:
- Malformed envelope rejection: non-object, missing `thread_id`, non-integer `seq`, `seq=0`, unknown `payload.type`, non-string `client_message_id`.
- Hard-barrier drops: post-completion drop, duplicate-completed drop with correct label, per-thread isolation.
- Seq monotonicity: backward seq violation (still surfaced), forward gap violation (still surfaced), first-of-thread no-flag.

## Known follow-up

- Background `BackgroundResultSender` persists today reuse the originating turn's `thread_id`. After this PR, the hard barrier will drop their `AssistantPersisted` envelopes on `projection.envelope.v1` clients (the original turn's `TurnCompleted` already closed the barrier). Legacy + spawn_complete shapes continue to flow as before. Surfacing background completions as envelopes requires backend mint-new-thread plumbing — out of scope per the task constraints ("Do NOT touch SessionScope, plugin loader, mofa-skills"). To be addressed in a follow-up issue.