### PR TITLE
fix(agent): wire set_on_failure_signal on WS run_standalone_turn path (#1324 follow-up)

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -22,7 +22,7 @@ use super::supervisor_store::{
 };
 use chrono::Utc;
 use octos_agent::tools::mcp_agent::DispatchContextContract;
-use octos_agent::{Agent, AgentConfig, RoleTemplate, ToolRegistry};
+use octos_agent::{Agent, AgentConfig, RoleTemplate, SpawnOnlyFailureSignal, ToolRegistry};
 use octos_core::ui_protocol::{
     OutputCursor, RpcError, autonomy_error_kinds as kinds, methods, rpc_error_codes,
 };
@@ -79,6 +79,25 @@ const GOAL_COMPLETE_SENTINELS: &[&str] = &[
 const NATIVE_SPECIALIST_BACKEND_KIND: &str = "native";
 const NATIVE_SPECIALIST_SUMMARY_ARTIFACT_ID: &str = "summary";
 const NATIVE_SPECIALIST_ARTIFACT_CONTENT_MAX_BYTES: usize = 256 * 1024;
+
+/// #1324 follow-up — kind label for the `External(_)` master continuation
+/// reason used to re-inject a `SpawnOnlyFailureSignal` as a synthetic
+/// recovery turn on the WS / standalone-turn path. The gateway path drives
+/// recovery through `ActorMessage::RecoveryHint` directly into the actor
+/// inbox; on the WS path the closest equivalent is the global master
+/// continuation queue (drained on the connection's tick).
+pub(crate) const SPAWN_ONLY_FAILURE_EXTERNAL_KIND: &str = "spawn_only_failure";
+const SPAWN_ONLY_FAILURE_META_TASK_ID: &str = "task_id";
+const SPAWN_ONLY_FAILURE_META_TOOL_NAME: &str = "tool_name";
+const SPAWN_ONLY_FAILURE_META_ERROR_MESSAGE: &str = "error_message";
+const SPAWN_ONLY_FAILURE_META_TOOL_INPUT: &str = "tool_input";
+const SPAWN_ONLY_FAILURE_META_ALTERNATIVES: &str = "suggested_alternatives";
+const SPAWN_ONLY_FAILURE_META_ORIGINATING_CMID: &str = "originating_client_message_id";
+/// Synthetic "group" id stamped onto spawn_only failure continuations so
+/// the `External` enqueue path passes the scheduler's required field.
+/// Distinct from `coding-autonomy` (loops/goals) so operators can filter
+/// the persisted queue by group when triaging recovery turns.
+const SPAWN_ONLY_FAILURE_GROUP: &str = "spawn-only-failure-recovery";
 
 #[derive(Debug, Clone)]
 pub(crate) struct AgentListRequest {
@@ -1468,6 +1487,80 @@ impl InProcessAgentOrchestrator {
         enqueue_goal_continuation_with_idle(&mut state, session_id, profile_id, &goal, idle_state)
             .map(|outcome| matches!(outcome, MasterContinuationEnqueueOutcome::Queued(_)))
             .unwrap_or(false)
+    }
+
+    /// PR #1324 follow-up — enqueue a synthetic recovery continuation for a
+    /// failed `spawn_only` task.
+    ///
+    /// The gateway path drives recovery through
+    /// [`ActorMessage::RecoveryHint`] directly into the session actor's
+    /// inbox (see `session_actor.rs::SessionActor::spawn` for the wiring).
+    /// The WS / `run_standalone_turn` path has no equivalent inbox: the
+    /// per-turn registry's `TaskSupervisor` outlives the turn (background
+    /// tokio::spawn tasks may fail AFTER the turn terminates), and the
+    /// WS connection itself may have closed before the failure surfaces.
+    /// The closest survivor is the in-process master continuation queue
+    /// (drained on every `appui_continuation_tick`), so we enqueue an
+    /// `External("spawn_only_failure")` request carrying the recovery
+    /// fields in metadata. `master_continuation_prompt` recognises the
+    /// kind and renders the same `[system-internal] Your previous ...`
+    /// body that `build_recovery_prompt` produces on the gateway path.
+    ///
+    /// The dedupe key is keyed on `task_id` so repeated `mark_failed`
+    /// calls (live + cascade-fail, idempotent re-marks) collapse onto a
+    /// single queued continuation.
+    pub(crate) fn enqueue_spawn_only_failure_continuation(
+        &self,
+        session_id: &SessionKey,
+        profile_id: &str,
+        signal: &SpawnOnlyFailureSignal,
+    ) -> MasterContinuationEnqueueOutcome {
+        let mut request = MasterContinuationRequest::new(
+            SPAWN_ONLY_FAILURE_GROUP,
+            session_id.to_string(),
+            profile_id.to_owned(),
+            MasterContinuationReason::External(SPAWN_ONLY_FAILURE_EXTERNAL_KIND.to_owned()),
+            SystemTime::now(),
+        )
+        .with_metadata(SPAWN_ONLY_FAILURE_META_TASK_ID, signal.task_id.clone())
+        .with_metadata(SPAWN_ONLY_FAILURE_META_TOOL_NAME, signal.tool_name.clone())
+        .with_metadata(
+            SPAWN_ONLY_FAILURE_META_ERROR_MESSAGE,
+            signal.error_message.clone(),
+        )
+        .with_dedupe_key(format!(
+            "external/{kind}/{session}/{task}",
+            kind = SPAWN_ONLY_FAILURE_EXTERNAL_KIND,
+            session = session_id,
+            task = signal.task_id,
+        ));
+        if !signal.tool_input.is_null() {
+            request = request.with_metadata(
+                SPAWN_ONLY_FAILURE_META_TOOL_INPUT,
+                serde_json::to_string(&signal.tool_input).unwrap_or_else(|_| "{}".to_owned()),
+            );
+        }
+        if !signal.suggested_alternatives.is_empty() {
+            // Comma-separated list; the renderer in `master_continuation_prompt`
+            // parses it back into a bullet block. We deliberately use a
+            // separator (`,`) that the existing `parse_alternatives`
+            // splitter does NOT recognise so an alternative containing
+            // `, ` isn't mis-split — alternatives are joined as supplied
+            // and rendered verbatim in the prompt.
+            request = request.with_metadata(
+                SPAWN_ONLY_FAILURE_META_ALTERNATIVES,
+                signal.suggested_alternatives.join("\u{001f}"),
+            );
+        }
+        if let Some(cmid) = signal
+            .originating_client_message_id
+            .as_ref()
+            .filter(|cmid| !cmid.is_empty())
+        {
+            request = request.with_metadata(SPAWN_ONLY_FAILURE_META_ORIGINATING_CMID, cmid.clone());
+        }
+        let mut state = self.state();
+        enqueue_and_persist_continuation(&mut state, request)
     }
 
     /// #979 / M15-C2 — flip the goal to `complete` when the model
@@ -4292,11 +4385,64 @@ pub(crate) fn master_continuation_prompt(continuation: &QueuedMasterContinuation
                 "[system-internal]\nThe active goal exhausted its continuation budget. This is the final wrap-up turn.\n\nGoal: {goal_id}\nMetadata:\n{metadata}\n\n{directive}",
             )
         }
+        MasterContinuationReason::External(kind) if kind == SPAWN_ONLY_FAILURE_EXTERNAL_KIND => {
+            render_spawn_only_failure_recovery_prompt(continuation)
+        }
         MasterContinuationReason::External(kind) => format!(
             "[system-internal]\nAn external master continuation was requested.\n\nKind: {kind}\nGroup: {group}\nMetadata:\n{metadata}\n\nHandle the continuation conservatively and summarize the visible state for the user.",
             group = continuation.group_id.as_str(),
         ),
     }
+}
+
+/// PR #1324 follow-up — render the spawn_only post-spawn failure recovery
+/// prompt from a queued continuation's metadata. Mirrors the
+/// `build_recovery_prompt` helper in `session_actor.rs` that the gateway
+/// path uses on the `ActorMessage::RecoveryHint` inbox, so the LLM sees
+/// the same `[system-internal] Your previous ...` body regardless of
+/// which path delivered the recovery turn.
+fn render_spawn_only_failure_recovery_prompt(continuation: &QueuedMasterContinuation) -> String {
+    let tool_name = continuation
+        .metadata
+        .get(SPAWN_ONLY_FAILURE_META_TOOL_NAME)
+        .map(String::as_str)
+        .unwrap_or("unknown");
+    let error_message = continuation
+        .metadata
+        .get(SPAWN_ONLY_FAILURE_META_ERROR_MESSAGE)
+        .map(String::as_str)
+        .unwrap_or("");
+    let input_block = continuation
+        .metadata
+        .get(SPAWN_ONLY_FAILURE_META_TOOL_INPUT)
+        .map(|input| format!("\nOriginal input: {input}"))
+        .unwrap_or_default();
+    let alternatives_block = continuation
+        .metadata
+        .get(SPAWN_ONLY_FAILURE_META_ALTERNATIVES)
+        .map(|joined| {
+            let list = joined
+                .split('\u{001f}')
+                .filter(|alt| !alt.is_empty())
+                .map(|alt| format!("- {alt}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            if list.is_empty() {
+                String::new()
+            } else {
+                format!("\nDetected alternatives:\n{list}\n")
+            }
+        })
+        .unwrap_or_default();
+    format!(
+        "[system-internal] Your previous `{tool}` call failed.\n\
+         Error: {err}{input}{alts}\n\
+         Respond to the user with a path forward — offer the alternatives, or try the safest one yourself if appropriate. Do not just report failure.",
+        tool = tool_name,
+        err = error_message,
+        input = input_block,
+        alts = alternatives_block,
+    )
 }
 
 fn master_continuation_reason_wire_name(reason: &MasterContinuationReason) -> String {

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -15490,6 +15490,55 @@ async fn run_standalone_turn(
         let bg_turn_id = turn_id.clone();
         let task_state_path = ui_protocol_task_output::task_state_path(&bg_data_dir, &session_id);
         let task_supervisor = tool_registry.supervisor();
+        // PR #1324 follow-up (L3 WS coverage gap): wire the spawn_only
+        // post-spawn failure signal BEFORE `enable_persistence` so the
+        // orphan-task sweep at `task_supervisor.rs:1164-1166` —
+        // which can `mark_failed` resurrected tasks — does NOT
+        // silently drop the recovery turn. The gateway path drives
+        // recovery through `ActorMessage::RecoveryHint` directly into
+        // the session actor's inbox; the WS turn handler has no
+        // actor, so we re-inject the failure into the global master
+        // continuation queue (drained on every
+        // `appui_continuation_tick`). `default_agent_orchestrator()`
+        // is a process-wide singleton, so the callback survives both
+        // the per-turn `tool_registry` drop AND a closed WS
+        // connection — on next subscribe, the queued
+        // `External("spawn_only_failure")` continuation fires and
+        // `master_continuation_prompt` renders the recovery body.
+        //
+        // The per-connection drain filter
+        // (`maybe_spawn_appui_master_continuation_runner`) takes
+        // exactly one continuation per session per tick, so the
+        // dedupe key on the request collapses repeated `mark_failed`
+        // calls onto one recovery turn even if `notify_failure`
+        // re-fires through a sibling path.
+        let failure_session_id = session_id.clone();
+        let failure_profile_id = active_profile_id
+            .clone()
+            .or_else(|| routed_profile_id.clone())
+            .unwrap_or_else(|| MAIN_PROFILE_ID.to_owned());
+        task_supervisor.set_on_failure_signal(move |signal| {
+            let outcome = default_agent_orchestrator().enqueue_spawn_only_failure_continuation(
+                &failure_session_id,
+                &failure_profile_id,
+                signal,
+            );
+            if outcome.is_duplicate() {
+                debug!(
+                    session = %failure_session_id,
+                    task_id = %signal.task_id,
+                    tool = %signal.tool_name,
+                    "spawn_only failure recovery continuation suppressed (duplicate dedupe key)"
+                );
+            } else {
+                info!(
+                    session = %failure_session_id,
+                    task_id = %signal.task_id,
+                    tool = %signal.tool_name,
+                    "spawn_only failure recovery continuation queued (WS path)"
+                );
+            }
+        });
         if let Err(error) = task_supervisor.enable_persistence(task_state_path.clone()) {
             warn!(
                 session_id = %session_id.0,
@@ -22512,6 +22561,238 @@ ignore = []
         assert_eq!(tasks[0]["id"], task_id);
         assert_eq!(tasks[0]["tool_name"], "podcast_generate");
         assert_eq!(tasks[0]["status"], "running");
+    }
+
+    /// PR #1324 follow-up — pin that wiring `set_on_failure_signal` on a
+    /// per-turn `TaskSupervisor` (the way `run_standalone_turn` does
+    /// after this fix) routes a `SpawnOnlyFailureSignal` through to the
+    /// global master continuation queue. Pre-fix, the WS path created a
+    /// fresh `Arc::new(TaskSupervisor::new())` via
+    /// `snapshot_excluding(&[])` whose `on_failure` slot was `None` —
+    /// `invoke_failure_callback` silently no-op'd and the LLM never saw
+    /// the post-spawn failure → never retried.
+    ///
+    /// The test drives the canonical post-ack failure path:
+    ///   1. `register_with_input_and_cmid` + `mark_synth_ack_emitted`
+    ///      mirrors what `execution.rs::spawn_only` does when the LLM
+    ///      sees the synthetic ack tool result.
+    ///   2. `mark_failed` fires `notify_failure`. With a non-empty
+    ///      `tool_call_id` AND ack already recorded, the
+    ///      `notify_failure` path calls `invoke_failure_callback`
+    ///      synchronously inside `mark_failed`.
+    ///   3. The callback wired here mirrors the production wiring at
+    ///      `run_standalone_turn`: it enqueues a
+    ///      `MasterContinuationReason::External("spawn_only_failure")`
+    ///      continuation against the `default_agent_orchestrator()`.
+    ///   4. The pending continuation count + prompt body are asserted.
+    #[tokio::test(flavor = "current_thread")]
+    async fn ws_turn_supervisor_routes_spawn_only_failure_to_master_continuation_queue() {
+        // Use a profile_id distinct from MAIN_PROFILE_ID so this test
+        // does not contaminate sibling tests that drive the
+        // `default_agent_orchestrator()` static under the main profile
+        // (e.g. `appui_due_fixed_loop_tick_drains_internal_continuation_turn`).
+        // The drain path filters by profile, so queueing under a
+        // unique profile keeps the queue local to this test.
+        //
+        // We do NOT call `clear_default_agent_orchestrator_for_test()`
+        // at start either — it wipes the entire process-wide
+        // orchestrator, including state created by sibling tests
+        // running in parallel under their own profiles. The
+        // session-scoped assertions below filter by our unique
+        // session_id + profile_id, so prior state on other keys is
+        // invisible.
+        let session_id = SessionKey("web:tester#l3-recovery".to_owned());
+        let profile_id = "test-l3-recovery-isolate".to_owned();
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        // Mirror the WS path: per-turn registry built from snapshot.
+        let parent = octos_agent::ToolRegistry::with_builtins(temp.path());
+        let mut tool_registry = parent.snapshot_excluding(&[]);
+        tool_registry.set_session_key(session_id.to_string());
+        let task_supervisor = tool_registry.supervisor();
+
+        // Wire `set_on_failure_signal` exactly the way
+        // `run_standalone_turn` does after the PR #1324 follow-up. The
+        // callback is invoked inline from `mark_failed` /
+        // `notify_failure`, so a synchronous enqueue against the
+        // process-wide orchestrator singleton is observable on the next
+        // `pending_continuation_count_for_test()` read.
+        let cb_session = session_id.clone();
+        let cb_profile = profile_id.clone();
+        task_supervisor.set_on_failure_signal(move |signal| {
+            let _ = default_agent_orchestrator().enqueue_spawn_only_failure_continuation(
+                &cb_session,
+                &cb_profile,
+                signal,
+            );
+        });
+
+        // Background spawn_only task: register + mark synth-ack + run +
+        // fail. This is the canonical production sequence in
+        // `execution.rs::spawn_only` for a task that succeeds at
+        // dispatch but fails AFTER the LLM has already moved on
+        // (e.g. mofa_slides plugin process crashes mid-render).
+        let task_id = task_supervisor.register_with_input_and_cmid(
+            "mofa_slides",
+            "call-l3-recovery",
+            Some(&session_id.0),
+            Some(serde_json::json!({"topic": "rust"})),
+            Some("user-cmid-42".to_owned()),
+        );
+        task_supervisor.mark_synth_ack_emitted("call-l3-recovery");
+        task_supervisor.mark_running(&task_id);
+        task_supervisor.mark_failed(
+            &task_id,
+            "puer-woodblock-style: plugin exited 137 (sigkill)".to_string(),
+        );
+
+        // The callback should have enqueued exactly one external
+        // spawn_only_failure continuation against the global
+        // orchestrator.
+        assert_eq!(
+            default_agent_orchestrator()
+                .pending_continuation_count_for_session_for_test(&session_id, &profile_id,),
+            1,
+            "WS-path failure signal must reach the master continuation queue",
+        );
+
+        // The prompt body MUST surface the tool name + error message so
+        // the LLM has actionable context. We assert the structural
+        // pieces (the exact wording is owned by
+        // `render_spawn_only_failure_recovery_prompt` and tested
+        // separately at unit scope).
+        let drained = default_agent_orchestrator().drain_ready_continuations_for_session(
+            &session_id,
+            &profile_id,
+            crate::api::master_continuation_scheduler::MasterContinuationRuntimeState::idle(),
+            1,
+        );
+        assert_eq!(drained.len(), 1, "exactly one continuation must drain");
+        let prompt = master_continuation_prompt(&drained[0]);
+        assert!(
+            prompt.contains("[system-internal]") && prompt.contains("mofa_slides"),
+            "recovery prompt must mark itself system-internal and surface \
+             the failing tool name; got: {prompt}",
+        );
+        assert!(
+            prompt.contains("puer-woodblock-style"),
+            "recovery prompt must surface the underlying error so the \
+             LLM can pick an alternative; got: {prompt}",
+        );
+
+        // The per-turn registry's supervisor holds an `Arc` clone the
+        // failure callback captures; drop the registry to release the
+        // callback before the test function returns. We deliberately
+        // do NOT call `clear_default_agent_orchestrator_for_test()`
+        // at end — that would wipe queue entries created by sibling
+        // tests running in parallel under the shared static.
+        drop(tool_registry);
+    }
+
+    /// Regression: a `mark_failed` driven by the orphan-task sweep
+    /// during `enable_persistence` (`task_supervisor.rs:1164-1166`)
+    /// MUST reach the recovery callback. This pins the wiring order
+    /// the PR #1324 follow-up established: `set_on_failure_signal`
+    /// runs BEFORE `enable_persistence`, otherwise the orphan sweep's
+    /// `mark_failed` hits an `on_failure: None` slot and the recovery
+    /// turn for the resurrected task is silently dropped.
+    ///
+    /// Reproducer: a single supervisor with an in-memory non-terminal
+    /// task plus a recorded synth-ack. Calling `enable_persistence`
+    /// AFTER both states are established sweeps the task into the
+    /// `Failed` runtime state and — because the ack IS recorded —
+    /// `notify_failure` lands on the "ack already recorded" arm,
+    /// which fires `invoke_failure_callback` synchronously inside
+    /// `mark_failed`. With the corrected wiring order (callback
+    /// before persistence), the recovery callback fires and the
+    /// orchestrator's queue gains exactly one continuation. With
+    /// the pre-fix order (callback after persistence), the callback
+    /// is `None` at the moment `mark_failed` runs and the failure
+    /// is silently dropped — `pending_continuation_count` stays at 0.
+    ///
+    /// The test deliberately exercises only the live in-memory
+    /// orphan-sweep path. The persisted-ledger path (Phase 1 / Phase 2
+    /// across a supervisor drop) sweeps the task into the same
+    /// `Failed` state but lands on the stash arm of `notify_failure`
+    /// — the ack-set is not persisted, so a fresh supervisor sees no
+    /// ack on the replayed task. That stash-arm path is covered by
+    /// the unit tests in `task_supervisor::tests`; what this test
+    /// pins is the WIRING ORDER on a single supervisor.
+    #[tokio::test(flavor = "current_thread")]
+    async fn ws_turn_supervisor_orphan_sweep_failures_reach_recovery_callback() {
+        // Use a profile_id distinct from MAIN_PROFILE_ID so this test
+        // does not contaminate sibling tests that drain the
+        // `default_agent_orchestrator()` static under the main profile.
+        // (See the companion routes test for the rationale on why we
+        // do not call `clear_default_agent_orchestrator_for_test()`.)
+        let session_id = SessionKey("web:tester#l3-orphan".to_owned());
+        let profile_id = "test-l3-orphan-isolate".to_owned();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let ledger_path = temp.path().join("task_ledger.jsonl");
+
+        // Build a per-turn registry exactly like the WS path.
+        let parent = octos_agent::ToolRegistry::with_builtins(temp.path());
+        let mut tool_registry = parent.snapshot_excluding(&[]);
+        tool_registry.set_session_key(session_id.to_string());
+        let task_supervisor = tool_registry.supervisor();
+
+        // Pre-populate a non-terminal task + record its synth-ack. The
+        // ack-set is in-memory only (not persisted), so this scenario
+        // requires building both states on the same supervisor: a
+        // fresh supervisor reloading from disk would not see the ack.
+        let task_id = task_supervisor.register_with_input_and_cmid(
+            "mofa_slides",
+            "call-orphan-1",
+            Some(&session_id.0),
+            Some(serde_json::json!({"topic": "rust"})),
+            Some("user-cmid-orphan".to_owned()),
+        );
+        task_supervisor.mark_synth_ack_emitted("call-orphan-1");
+        task_supervisor.mark_running(&task_id);
+
+        // Wire the failure callback BEFORE enable_persistence — the
+        // PR #1324 follow-up wiring order. The callback enqueues
+        // against the global orchestrator, same as production at
+        // `run_standalone_turn`.
+        let cb_session = session_id.clone();
+        let cb_profile = profile_id.clone();
+        task_supervisor.set_on_failure_signal(move |signal| {
+            let _ = default_agent_orchestrator().enqueue_spawn_only_failure_continuation(
+                &cb_session,
+                &cb_profile,
+                signal,
+            );
+        });
+
+        // enable_persistence runs the orphan sweep over the in-memory
+        // map. The `mark_running` task is non-terminal, so the sweep
+        // `mark_failed`'s it. `notify_failure` finds the ack already
+        // recorded (from the `mark_synth_ack_emitted` call above) and
+        // takes the "ack already recorded" arm — which invokes
+        // `invoke_failure_callback` synchronously inside
+        // `mark_failed`. Pre-fix wiring (callback AFTER
+        // enable_persistence) would observe `on_failure: None` here
+        // and silently drop the recovery; the corrected order surfaces
+        // it on the orchestrator queue.
+        task_supervisor
+            .enable_persistence(&ledger_path)
+            .expect("enable_persistence on per-turn supervisor");
+
+        let reaped = task_supervisor
+            .get_task(&task_id)
+            .expect("orphaned task must still be tracked after sweep");
+        assert_eq!(reaped.status, octos_agent::TaskStatus::Failed);
+
+        assert_eq!(
+            default_agent_orchestrator()
+                .pending_continuation_count_for_session_for_test(&session_id, &profile_id,),
+            1,
+            "orphan-sweep failure (ack-recorded arm) must reach the \
+             recovery callback when `set_on_failure_signal` is wired \
+             BEFORE `enable_persistence` (PR #1324 follow-up ordering)",
+        );
+
+        drop(tool_registry);
     }
 
     #[test]

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -2774,6 +2774,33 @@ impl ActorFactory {
             .tool_registry_factory
             .create_registry_for_workspace(&user_workspace, user_sandbox);
         let supervisor = tools.supervisor();
+        // Wire supervisor on_failure_signal callback (M8.9) BEFORE
+        // `enable_persistence`. The orphan-task sweep at
+        // `task_supervisor.rs:1164-1166` can `mark_failed` resurrected
+        // tasks during `enable_persistence`, which fires the failure
+        // callback synchronously via `notify_failure`. Wiring this
+        // AFTER `enable_persistence` (pre-#1324-followup ordering) made
+        // those orphan-sweep failures silently dropped — `on_failure`
+        // was still `None` and `invoke_failure_callback` no-op'd. The
+        // PR #1324 follow-up reorders both this gateway path and the
+        // WS `run_standalone_turn` path to wire the callback first so
+        // every failure path — orphan-sweep, live `mark_failed`,
+        // cascade-fail — reaches the recovery inbox.
+        let recovery_tx = tx.clone();
+        supervisor.set_on_failure_signal(move |signal| {
+            let prompt = build_recovery_prompt(signal);
+            let _ = recovery_tx.try_send(ActorMessage::RecoveryHint {
+                task_id: signal.task_id.clone(),
+                tool_name: signal.tool_name.clone(),
+                prompt,
+                // Issue #738 fix: forward the originating user turn's
+                // cmid into the recovery hint so the synthetic
+                // InboundMessage stamps `client_message_id` into its
+                // metadata and `process_inbound` reuses it instead of
+                // minting an orphan UUIDv7.
+                originating_client_message_id: signal.originating_client_message_id.clone(),
+            });
+        });
         if let Err(error) = supervisor.enable_persistence(&task_state_path) {
             warn!(
                 session = %session_key,
@@ -3000,26 +3027,11 @@ impl ActorFactory {
             forward_task_status_to_actor_inbox(&status_tx, &task_data_dir, task);
         });
 
-        // Wire supervisor on_failure_signal callback (M8.9): when a
-        // spawn_only task transitions to Failed, enqueue a synthetic
-        // recovery turn so the LLM can offer alternatives or take a
-        // recovery action instead of leaving the user with only a
-        // terminal failure notification.
-        let recovery_tx = tx.clone();
-        supervisor.set_on_failure_signal(move |signal| {
-            let prompt = build_recovery_prompt(signal);
-            let _ = recovery_tx.try_send(ActorMessage::RecoveryHint {
-                task_id: signal.task_id.clone(),
-                tool_name: signal.tool_name.clone(),
-                prompt,
-                // Issue #738 fix: forward the originating user turn's
-                // cmid into the recovery hint so the synthetic
-                // InboundMessage stamps `client_message_id` into its
-                // metadata and `process_inbound` reuses it instead of
-                // minting an orphan UUIDv7.
-                originating_client_message_id: signal.originating_client_message_id.clone(),
-            });
-        });
+        // (PR #1324 follow-up moved the `set_on_failure_signal` wiring
+        // to immediately after `let supervisor = tools.supervisor();`
+        // above so the orphan-task sweep that runs during
+        // `enable_persistence` reaches the recovery inbox instead of
+        // hitting an `on_failure: None` callback slot.)
 
         let cron_tool_ref = if let Some(ref cron_service) = self.cron_service {
             let cron_tool = Arc::new(CronTool::with_context(


### PR DESCRIPTION
## Summary

PR #1324 (L3 post-spawn failure feedback) wired `set_on_failure_signal` only on the gateway `ActorFactory::spawn` path. The WS `run_standalone_turn` path uses a per-turn `TaskSupervisor` created by `snapshot_excluding(&[])` whose `on_failure: None`. mofa_slides background failures via WS triggered `notify_failure` → silent drop in `invoke_failure_callback` → LLM never saw the retry signal.

**Empirical trigger**: puer-woodblock-style failure on mini3 (round-23 fleet deploy) did NOT cause the LLM to attempt a retry. Deep-trace identified the WS-path coverage gap.

## Fix

- Wire `set_on_failure_signal` BEFORE `enable_persistence` on the WS path (`crates/octos-cli/src/api/ui_protocol.rs:15520`) so the orphan-task sweep at `task_supervisor.rs:1164-1166` also reaches the recovery inbox. The callback enqueues a `MasterContinuationReason::External("spawn_only_failure")` request against the process-wide `default_agent_orchestrator()`; the per-connection drain (`appui_continuation_tick` → `drain_appui_due_master_continuations`) picks it up on the next tick — surviving the per-turn `tool_registry` drop AND a closed WS connection.
- Add `InProcessAgentOrchestrator::enqueue_spawn_only_failure_continuation` + extend `master_continuation_prompt` to render the `spawn_only_failure` External kind using the same body shape as `build_recovery_prompt` on the gateway side.
- Reorder the gateway path's existing `set_on_failure_signal` wiring (`session_actor.rs:2790`) to also run BEFORE `enable_persistence` (the same latent hazard at line 2776 vs old line 3009).

## Test plan

- [x] `cargo test -p octos-cli --features api --lib api::ui_protocol::tests::ws_turn_supervisor` — 2/2 new tests pass; the canonical live-failure path AND the orphan-sweep ack-recorded-arm wiring-order regression both reach the queue.
- [x] `cargo test -p octos-agent` — 16/16 pass.
- [x] `cargo clippy --workspace --no-deps -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo build --workspace` clean.
- [x] Full `cargo test -p octos-cli --features api --lib` suite: 1443 pass (intermittent pre-existing flakiness in two timing-sensitive tests — `background_failure_recovery_capped_at_max_retries` + `router_failover_debounce_collapses_burst` — verified on main branch with same 2/5 flake rate, unrelated to this change).

## Strict constraints respected

- No `TaskSupervisor` semantics change.
- No new manifest fields.
- Additive wiring only — gateway path's `set_on_failure_signal` callback body is byte-identical, only the position changed.