### PR TITLE
fix(email): keep gateway replies flowing

### DIFF
--- a/crates/octos-bus/src/email_channel.rs
+++ b/crates/octos-bus/src/email_channel.rs
@@ -76,6 +76,11 @@ impl Channel for EmailChannel {
             .and_then(|v| v.as_str())
             .unwrap_or("Re: Message");
 
+        info!(
+            recipient = %msg.chat_id,
+            subject = %subject,
+            "smtp_send outbound email"
+        );
         smtp_send(&self.config, &msg.chat_id, subject, &msg.content).await
     }
 
@@ -183,14 +188,25 @@ async fn imap_poll(config: &EmailConfig, tx: &mpsc::Sender<InboundMessage>) -> R
     }
     // Stream dropped — session is free again.
 
-    // Mark all fetched as seen
-    session.store(&seq_set, "+FLAGS (\\Seen)").await.ok();
+    // Mark all fetched as seen.
+    if let Err(e) = session.store(&seq_set, "+FLAGS (\\Seen)").await {
+        warn!(error = %e, "IMAP STORE failed while marking messages seen");
+    }
     session.logout().await.ok();
 
     // Send parsed emails as inbound messages
     let mut count = 0;
     for (from, subject, text_body) in parsed_emails {
         let sender_email = extract_email_address(&from);
+
+        if should_skip_self_reply(&sender_email, &subject, config) {
+            info!(
+                sender = %sender_email,
+                subject = %subject,
+                "skipping self-sent email reply"
+            );
+            continue;
+        }
 
         let content = if subject.is_empty() {
             text_body
@@ -286,15 +302,54 @@ fn extract_text_body(mail: &mailparse::ParsedMail) -> Option<String> {
 fn extract_email_address(from: &str) -> String {
     if let Some(start) = from.rfind('<') {
         if let Some(end) = from[start..].find('>') {
-            return from[start + 1..start + end].to_string();
+            return from[start + 1..start + end].trim().to_string();
         }
     }
     from.trim().to_string()
 }
 
+fn canonical_email_address(value: &str) -> String {
+    extract_email_address(value).to_ascii_lowercase()
+}
+
+fn subject_is_reply(subject: &str) -> bool {
+    subject.trim_start().to_ascii_lowercase().starts_with("re:")
+}
+
+fn should_skip_self_reply(sender_email: &str, subject: &str, config: &EmailConfig) -> bool {
+    if !subject_is_reply(subject) {
+        return false;
+    }
+
+    let sender = canonical_email_address(sender_email);
+    if sender.is_empty() {
+        return false;
+    }
+
+    [config.from_address.as_str(), config.username.as_str()]
+        .into_iter()
+        .filter(|addr| !addr.trim().is_empty())
+        .any(|addr| canonical_email_address(addr) == sender)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_config(from_address: &str, username: &str) -> EmailConfig {
+        EmailConfig {
+            imap_host: "imap.example.com".into(),
+            imap_port: 993,
+            smtp_host: "smtp.example.com".into(),
+            smtp_port: 465,
+            username: username.into(),
+            password: "secret".into(),
+            from_address: from_address.into(),
+            poll_interval_secs: 30,
+            allowed_senders: vec![],
+            max_body_chars: 10_000,
+        }
+    }
 
     #[test]
     fn test_extract_email_address() {
@@ -310,5 +365,46 @@ mod tests {
             extract_email_address("<bob@example.com>"),
             "bob@example.com"
         );
+        assert_eq!(
+            extract_email_address("Bot < bot@example.com >"),
+            "bot@example.com"
+        );
+    }
+
+    #[test]
+    fn self_sent_reply_is_skipped_to_prevent_mail_loop() {
+        let config = test_config("Bot <bot@example.com>", "bot-login@example.com");
+
+        assert!(should_skip_self_reply(
+            "bot@example.com",
+            "Re: incoming question",
+            &config
+        ));
+        assert!(should_skip_self_reply(
+            "BOT@example.com",
+            "  re: incoming question",
+            &config
+        ));
+        assert!(should_skip_self_reply(
+            "bot-login@example.com",
+            "Re: via login address",
+            &config
+        ));
+    }
+
+    #[test]
+    fn non_self_or_non_reply_email_is_not_skipped() {
+        let config = test_config("bot@example.com", "bot-login@example.com");
+
+        assert!(!should_skip_self_reply(
+            "user@example.com",
+            "Re: incoming question",
+            &config
+        ));
+        assert!(!should_skip_self_reply(
+            "bot@example.com",
+            "New incoming question",
+            &config
+        ));
     }
 }

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -2131,6 +2131,7 @@ mod tests {
             media: vec![],
             metadata: serde_json::json!({}),
             message_id: None,
+            origin: octos_core::MessageOrigin::ExternalUser,
         }
     }
 

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -53,6 +53,49 @@ use super::matrix_integration::*;
 
 const PROFILE_PROMPT_CACHE_CAP: usize = 128;
 
+enum GatewayLoopEvent {
+    Wake,
+    Shutdown,
+    InboundClosed,
+    SessionDeleted(String),
+    Inbound(octos_core::InboundMessage),
+}
+
+async fn next_gateway_loop_event(
+    agent_handle: &mut octos_bus::AgentHandle,
+    session_delete_rx: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
+    shutdown: &AtomicBool,
+    shutdown_notify: &Notify,
+) -> GatewayLoopEvent {
+    if shutdown.load(Ordering::Acquire) {
+        return GatewayLoopEvent::Shutdown;
+    }
+
+    tokio::select! {
+        biased;
+        _ = shutdown_notify.notified() => {
+            if shutdown.load(Ordering::Acquire) {
+                GatewayLoopEvent::Shutdown
+            } else {
+                GatewayLoopEvent::Wake
+            }
+        }
+        session_id = session_delete_rx.recv() => {
+            if let Some(id) = session_id {
+                GatewayLoopEvent::SessionDeleted(id)
+            } else {
+                GatewayLoopEvent::Wake
+            }
+        }
+        inbound = agent_handle.recv_inbound() => {
+            match inbound {
+                Some(inbound) => GatewayLoopEvent::Inbound(inbound),
+                None => GatewayLoopEvent::InboundClosed,
+            }
+        }
+    }
+}
+
 // `discover_ominix_url` and `push_runtime_plugin_env` live in
 // `crate::skills_scope` so the `serve` plugin loader can reuse them.
 use crate::skills_scope::{discover_ominix_url, push_runtime_plugin_env};
@@ -1636,33 +1679,22 @@ impl GatewayRuntime {
             if self.shutdown.load(Ordering::Acquire) {
                 break;
             }
-            let shutdown_notified = shutdown_notify.notified();
-            tokio::pin!(shutdown_notified);
-            if self.shutdown.load(Ordering::Acquire) {
-                break;
-            }
-
-            let mut inbound = tokio::select! {
-                biased;
-                _ = &mut shutdown_notified => {
-                    if self.shutdown.load(Ordering::Acquire) {
-                        break;
-                    }
+            let mut inbound = match next_gateway_loop_event(
+                &mut self.agent_handle,
+                &mut self.session_delete_rx,
+                &self.shutdown,
+                &shutdown_notify,
+            )
+            .await
+            {
+                GatewayLoopEvent::Wake => continue,
+                GatewayLoopEvent::Shutdown | GatewayLoopEvent::InboundClosed => break,
+                GatewayLoopEvent::SessionDeleted(id) => {
+                    tracing::debug!(session = %id, "stopping actor for deleted session");
+                    self.actor_registry.remove_session(&id);
                     continue;
                 }
-                session_id = self.session_delete_rx.recv() => {
-                    if let Some(id) = session_id {
-                        tracing::debug!(session = %id, "stopping actor for deleted session");
-                        self.actor_registry.remove_session(&id);
-                    }
-                    continue;
-                }
-                inbound = self.agent_handle.recv_inbound() => {
-                    match inbound {
-                        Some(inbound) => inbound,
-                        None => break,
-                    }
-                }
+                GatewayLoopEvent::Inbound(inbound) => inbound,
             };
 
             if self.shutdown.load(Ordering::Acquire) {
@@ -2080,5 +2112,60 @@ impl GatewayRuntime {
         ch_result?;
         println!("{}", "Gateway stopped.".dimmed());
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use tokio::sync::mpsc;
+
+    fn make_inbound(content: &str) -> octos_core::InboundMessage {
+        octos_core::InboundMessage {
+            channel: "email".into(),
+            sender_id: "sender@example.com".into(),
+            chat_id: "sender@example.com".into(),
+            content: content.into(),
+            timestamp: Utc::now(),
+            media: vec![],
+            metadata: serde_json::json!({}),
+            message_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn notify_wake_does_not_starve_next_inbound_message() {
+        let (mut agent_handle, publisher) = octos_bus::create_bus();
+        let inbound_tx = publisher.inbound_sender();
+        let (_delete_tx, mut delete_rx) = mpsc::unbounded_channel();
+        let shutdown = AtomicBool::new(false);
+        let shutdown_notify = Notify::new();
+
+        shutdown_notify.notify_one();
+        match next_gateway_loop_event(
+            &mut agent_handle,
+            &mut delete_rx,
+            &shutdown,
+            &shutdown_notify,
+        )
+        .await
+        {
+            GatewayLoopEvent::Wake => {}
+            _ => panic!("expected a non-shutdown wake"),
+        }
+
+        inbound_tx.send(make_inbound("hello")).await.unwrap();
+        match next_gateway_loop_event(
+            &mut agent_handle,
+            &mut delete_rx,
+            &shutdown,
+            &shutdown_notify,
+        )
+        .await
+        {
+            GatewayLoopEvent::Inbound(inbound) => assert_eq!(inbound.content, "hello"),
+            _ => panic!("expected inbound message after wake"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Keep the gateway dispatch wait step fresh/testable so a non-shutdown `Notify` wake cannot starve the next inbound message.
- Add an email-channel regression guard for self-sent `Re:` replies so SMTP self-tests do not create reply loops.
- Surface SMTP send attempts and IMAP `STORE` failures in logs instead of leaving the outbound path silent.
- Refreshed the PR onto current `origin/main` `4adbe05fff212cb85d1f0a6d6225da0713446016`; refreshed head is `fbb75f0a53c9712454cbaf45da4adf2e97f888ce`.
- Dropped stale unrelated #1322/#1359 commits from this PR; the diff is now only `email_channel.rs` and `gateway_runtime.rs`.

Closes #1344

## Validation

- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/private/tmp/octos-1349-current-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli notify_wake_does_not_starve_next_inbound_message -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/octos-1349-current-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-bus --features email email_channel --lib -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/octos-1349-current-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-bus --features email --lib -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/octos-1349-current-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings`
- `git ls-files --others --exclude-standard` -> empty

Source was refreshed in isolated clone `target/octos-1349-refresh-current`; root dirty checkout was preserved.


## CI / merge status
- GitHub CI is green on refreshed head `fbb75f0a53c9712454cbaf45da4adf2e97f888ce`: `check`, `check-matrix`, `dashboard`, `swarm-app`, `test-octos-agent (lib)`, `test-octos-agent (integration)`, `test-octos-cli`, `typos`, and author-email passed. Optional expansion jobs were skipped by workflow policy.
- Merge remains branch-protection blocked by required review (`BLOCKED`, `REVIEW_REQUIRED`).
