### PR TITLE
test(deploy): restore deploy dry-run harness

### DIFF
--- a/scripts/cloud-host-deploy.sh
+++ b/scripts/cloud-host-deploy.sh
@@ -19,7 +19,7 @@ VERSION="latest"
 PREFIX="${OCTOS_PREFIX:-$HOME/.octos/bin}"
 DATA_DIR="${OCTOS_HOME:-$HOME/.octos}"
 PORT="8080"
-AUTH_TOKEN=""
+AUTH_TOKEN="${AUTH_TOKEN:-}"
 FRPS_TOKEN="${FRPS_TOKEN:-}"
 TUNNEL_DOMAIN="${TUNNEL_DOMAIN:-}"
 FRPS_SERVER="${FRPS_SERVER:-}"
@@ -137,7 +137,7 @@ Options:
   --no-smtp              Disable SMTP for dashboard OTP emails
   --install-deps         Forward to install.sh to install missing runtime deps
   --uninstall            Remove octos serve, frps, and Caddy host services/config
-  --purge                Delete the data dir only (preserves bootstrap state)
+  --purge                Delete the data dir and bootstrap state
   --non-interactive      Fail instead of prompting for missing values
   --dry-run              Write config files but print commands instead of executing them
 
@@ -674,6 +674,7 @@ run_host_purge() {
     fi
 
     section "Purging local state"
+    run_cmd_best_effort sudo rm -f "$STATE_FILE"
     run_cmd_best_effort sudo rm -rf "$DATA_DIR"
 
     section "Complete"
@@ -684,7 +685,7 @@ run_host_purge() {
         echo "    Preserved installed services and binaries."
     fi
     echo "    Purged data dir:    $DATA_DIR"
-    echo "    Preserved bootstrap state: $STATE_FILE"
+    echo "    Purged bootstrap state: $STATE_FILE"
 }
 
 run_host_uninstall() {

--- a/scripts/local-tenant-deploy.sh
+++ b/scripts/local-tenant-deploy.sh
@@ -581,7 +581,7 @@ if [ -n "$CLI_FEATURES" ] && [ "$SKIP_TUNNEL" = false ]; then
 
     if [ -z "$FRPS_TOKEN" ]; then
         echo ""
-        echo "    Enter the per-tenant tunnel token issued by your cloud operator"
+        echo "    Enter the shared frps auth token from your operator or cloud host"
         echo "    (registered in the cloud node's tenant store; written to metadatas.token):"
         printf "    > "
         read -r FRPS_TOKEN < /dev/tty


### PR DESCRIPTION
## Summary
- Make `cloud-host-deploy.sh --purge` remove the bootstrap state file in dry-run/live command output, matching the deploy harness expectation.
- Preserve explicit `AUTH_TOKEN=...` environment overrides for cloud-host redeploys while keeping existing config-token preservation when no token is supplied.
- Align the local tenant tunnel prompt with the shared frps token source wording checked by the deploy harness.
- Refreshed onto current GitHub `main` `4adbe05fff212cb85d1f0a6d6225da0713446016`; refreshed head is `54b6ddfcc4f903e30ca418a6e2e9253386b16cba`.
- Dropped stale unrelated #1322/#1359 support commits; the diff is now only the deploy harness script fix.

Refs #237. This is validation-enabling only; #237 still needs a Linux bare-metal/VM deploy transcript and target OS matrix before closure.

## Validation
Environment: isolated clone `/Users/yuechen/home/octos/target/octos-1351-refresh-current`; root checkout left untouched.

Passed:
- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`
- `bash -n scripts/install.sh scripts/cloud-host-deploy.sh scripts/local-tenant-deploy.sh scripts/octos-doctor.sh scripts/build-local-bundle.sh`
- `bash scripts/test-cloud-host-deploy.sh` -> cloud deploy tests passed
- `bash scripts/test-local-tenant-deploy.sh` -> local tenant deploy tests passed
- `git ls-files --others --exclude-standard` -> empty

No generated artifacts are included.

## CI / merge status
- GitHub CI is green on head `54b6ddfcc4f903e30ca418a6e2e9253386b16cba`: `check`, `test-octos-cli`, `test-octos-agent (lib)`, `test-octos-agent (integration)`, `dashboard`, `swarm-app`, `check-matrix`, `typos`, and author-email passed. Optional platform/e2e/security expansion jobs were skipped by workflow conditions.
- Current GitHub state remains `MERGEABLE` but branch-protection blocked by required review (`BLOCKED` / `REVIEW_REQUIRED`).
- This PR remains `Refs #237`, not `Closes #237`; Linux bare-metal/VM deploy transcript evidence and a target OS matrix are still required before closure.
