### PR TITLE
feat(dashboard): show metrics freshness

### DIFF
--- a/dashboard/src/pages/ServerMetricsPage.test.tsx
+++ b/dashboard/src/pages/ServerMetricsPage.test.tsx
@@ -1,0 +1,88 @@
+import { act } from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ServerMetricsPage from './ServerMetricsPage'
+import type { SystemMetrics } from '../types'
+
+const mockSystemMetrics = vi.fn()
+
+vi.mock('../api', () => ({
+  api: {
+    systemMetrics: (opts?: { procs?: boolean }) => mockSystemMetrics(opts),
+  },
+}))
+
+const metrics: SystemMetrics = {
+  cpu: {
+    usage_percent: 12.5,
+    core_count: 8,
+    brand: 'Test CPU',
+  },
+  memory: {
+    total_bytes: 16 * 1024 * 1024 * 1024,
+    used_bytes: 8 * 1024 * 1024 * 1024,
+    available_bytes: 8 * 1024 * 1024 * 1024,
+  },
+  swap: {
+    total_bytes: 0,
+    used_bytes: 0,
+  },
+  disks: [],
+  top_processes: [],
+  platform: {
+    hostname: 'metrics-host',
+    os: 'Darwin',
+    os_version: '26.0',
+    uptime_secs: 3660,
+  },
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-05-28T12:00:00Z'))
+  mockSystemMetrics.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('ServerMetricsPage freshness indicator', () => {
+  it('shows how long ago metrics were successfully updated', async () => {
+    mockSystemMetrics.mockResolvedValue(metrics)
+
+    render(<ServerMetricsPage />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('Updated 0s ago')).toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+
+    expect(screen.getByText('Updated 3s ago')).toBeInTheDocument()
+  })
+
+  it('shows last successful update age after a refresh failure', async () => {
+    mockSystemMetrics
+      .mockResolvedValueOnce(metrics)
+      .mockRejectedValueOnce(new Error('network down'))
+
+    render(<ServerMetricsPage />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('Updated 0s ago')).toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000)
+    })
+
+    expect(screen.getByText(/Update failed: network down/)).toBeInTheDocument()
+    expect(screen.getByText(/Last successful update: 5s ago/)).toBeInTheDocument()
+    expect(screen.getByText('Updated 5s ago')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/pages/ServerMetricsPage.tsx
+++ b/dashboard/src/pages/ServerMetricsPage.tsx
@@ -23,6 +23,16 @@ function formatUptime(secs: number): string {
   return `${mins}m`
 }
 
+function formatAge(timestampMs: number, nowMs: number): string {
+  const elapsedSecs = Math.max(0, Math.floor((nowMs - timestampMs) / 1000))
+  if (elapsedSecs < 60) return `${elapsedSecs}s ago`
+  const elapsedMins = Math.floor(elapsedSecs / 60)
+  if (elapsedMins < 60) return `${elapsedMins}m ago`
+  const elapsedHours = Math.floor(elapsedMins / 60)
+  if (elapsedHours < 24) return `${elapsedHours}h ago`
+  return `${Math.floor(elapsedHours / 24)}d ago`
+}
+
 function cpuColor(pct: number): string {
   if (pct >= 80) return 'bg-red-500'
   if (pct >= 50) return 'bg-yellow-500'
@@ -84,6 +94,8 @@ export default function ServerMetricsPage() {
   const [metrics, setMetrics] = useState<SystemMetrics | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [live, setLive] = useState(true)
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null)
+  const [nowMs, setNowMs] = useState(() => Date.now())
   const [procSort, setProcSort] = useState<ProcSortKey>('memory_bytes')
   const [procDir, setProcDir] = useState<SortDir>('desc')
   const [procOpen, setProcOpen] = useState(false)
@@ -93,10 +105,14 @@ export default function ServerMetricsPage() {
   const fetchMetrics = async () => {
     try {
       const data = await api.systemMetrics({ procs: procOpenRef.current })
+      const fetchedAt = Date.now()
       setMetrics(data)
+      setLastUpdatedAt(fetchedAt)
+      setNowMs(fetchedAt)
       setError(null)
     } catch (e: any) {
-      setError(e.message)
+      setError(e?.message || 'Unknown error')
+      setNowMs(Date.now())
     }
   }
 
@@ -106,6 +122,11 @@ export default function ServerMetricsPage() {
     return () => {
       if (timerRef.current) clearInterval(timerRef.current)
     }
+  }, [])
+
+  useEffect(() => {
+    const clock = setInterval(() => setNowMs(Date.now()), 1000)
+    return () => clearInterval(clock)
   }, [])
 
   const toggleLive = () => {
@@ -164,29 +185,37 @@ export default function ServerMetricsPage() {
   const swapPercent = m.swap.total_bytes > 0
     ? (m.swap.used_bytes / m.swap.total_bytes) * 100
     : 0
+  const updatedAge = lastUpdatedAt === null ? null : formatAge(lastUpdatedAt, nowMs)
 
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-xl font-bold text-white">{m.platform.hostname || 'Server'}</h1>
           <p className="text-sm text-gray-500">
             {m.platform.os} {m.platform.os_version} &middot; up {formatUptime(m.platform.uptime_secs)}
           </p>
         </div>
-        <button
-          onClick={toggleLive}
-          className="flex items-center gap-2 px-3 py-1.5 text-xs font-medium rounded-lg border border-gray-700 hover:bg-white/5 transition"
-        >
-          <span className={`inline-block w-2 h-2 rounded-full ${live ? 'bg-green-500 animate-pulse' : 'bg-gray-600'}`} />
-          {live ? 'Live' : 'Paused'}
-        </button>
+        <div className="flex flex-wrap items-center gap-3">
+          {updatedAge && (
+            <span className="text-xs text-gray-500" aria-live="polite">
+              Updated {updatedAge}
+            </span>
+          )}
+          <button
+            onClick={toggleLive}
+            className="flex items-center gap-2 px-3 py-1.5 text-xs font-medium rounded-lg border border-gray-700 hover:bg-white/5 transition"
+          >
+            <span className={`inline-block w-2 h-2 rounded-full ${live ? 'bg-green-500 animate-pulse' : 'bg-gray-600'}`} />
+            {live ? 'Live' : 'Paused'}
+          </button>
+        </div>
       </div>
 
       {error && (
         <div className="text-xs text-yellow-500 bg-yellow-500/10 rounded-lg px-3 py-2">
-          Update failed: {error} (showing last known data)
+          Update failed: {error}. {updatedAge ? `Last successful update: ${updatedAge}.` : 'Showing last known data.'}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Closes #427.
Refs #1322.

- Adds an `Updated Xs ago` freshness label next to the ServerMetricsPage Live/Paused toggle.
- Tracks the last successful metrics fetch and includes the age in the non-blocking failure banner when refreshes fail.
- Adds focused React/Vitest regression coverage for freshness aging and stale-after-failure behavior.
- Carries the existing non-closing #1322 CLI test-race support fix because GitHub `test-octos-cli` previously reproduced `Text file busy (os error 26)` after a dashboard-only refresh.

## Current-main refresh

- Base: `origin/main` `4adbe05fff212cb85d1f0a6d6225da0713446016`.
- Head: `8cba86b66c9e828f940eb35d23101317d5433a65`.
- Isolated checkout: `/Users/yuechen/home/octos/target/octos-1352-refresh-current.CeBKZV/octos`.
- npm cache: `/private/tmp/octos-npm-cache-427-current-4adbe`.
- Dashboard build output: `/private/tmp/octos-427-dashboard-build-current-4adbe`.
- Cargo target: `/private/tmp/octos-1352-current-4adbe-target`.
- Environment: Darwin arm64; `rustc 1.95.0`; `cargo 1.95.0`; Node `v24.10.0`; npm `11.6.0`.

## Validation

Passed locally:

- `git diff --check origin/main...HEAD`.
- `cargo fmt --all -- --check`.
- `typos dashboard/src/pages/ServerMetricsPage.tsx dashboard/src/pages/ServerMetricsPage.test.tsx crates/octos-cli/src/cli_agent_adapter.rs`.
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-427-current-4adbe npm --prefix dashboard ci` completed with existing npm audit findings: 1 moderate, 2 high.
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-427-current-4adbe npm --prefix dashboard test -- ServerMetricsPage.test.tsx` passed: 1 file, 2 tests.
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-427-current-4adbe npm --prefix dashboard test` passed: 7 files, 34 tests.
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-427-current-4adbe npm --prefix dashboard run typecheck` passed.
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-427-current-4adbe VITE_OUT_DIR=/private/tmp/octos-427-dashboard-build-current-4adbe npm --prefix dashboard run build` passed.
- `CARGO_TARGET_DIR=/private/tmp/octos-1352-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api --lib cli_agent_adapter::tests:: -- --nocapture` passed: 8/8 tests.
- `CARGO_TARGET_DIR=/private/tmp/octos-1352-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --lib -- --nocapture` passed: 482 passed, 0 failed, 2 ignored.
- `CARGO_TARGET_DIR=/private/tmp/octos-1352-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings` passed.
- `git ls-files --others --exclude-standard` was empty in the isolated checkout after validation.

GitHub CI is green on refreshed head `8cba86b66c9e828f940eb35d23101317d5433a65`.

## Coordination

The closure behavior for #427 is limited to:

- `dashboard/src/pages/ServerMetricsPage.test.tsx`
- `dashboard/src/pages/ServerMetricsPage.tsx`

The carried CLI file is support-only for the required GitHub test gate:

- `crates/octos-cli/src/cli_agent_adapter.rs`

No generated artifacts are included. Merge remains branch-protection blocked by required review.
