### PR TITLE
fix(cli): protect init defaults from overwrite

### DIFF
--- a/crates/octos-cli/src/commands/init.rs
+++ b/crates/octos-cli/src/commands/init.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use clap::Args;
 use colored::Colorize;
-use eyre::{Result, WrapErr};
+use eyre::{Result, WrapErr, eyre};
 use serde_json::json;
 
 use super::Executable;
@@ -147,6 +147,10 @@ pub struct InitCommand {
     /// Skip interactive prompts and use defaults.
     #[arg(long)]
     pub defaults: bool,
+
+    /// Overwrite an existing config without prompting.
+    #[arg(long)]
+    pub force: bool,
 }
 
 impl Executable for InitCommand {
@@ -167,7 +171,13 @@ impl Executable for InitCommand {
                 "Config already exists:".yellow(),
                 config_path.display()
             );
-            if !self.defaults {
+            if self.defaults && !self.force {
+                return Err(eyre!(
+                    "Config already exists at {}. Re-run with --force to overwrite it.",
+                    config_path.display()
+                ));
+            }
+            if !self.defaults && !self.force {
                 print!("Overwrite? [y/N] ");
                 io::stdout().flush()?;
 
@@ -177,6 +187,12 @@ impl Executable for InitCommand {
                     println!("Aborted.");
                     return Ok(());
                 }
+            }
+            if self.force {
+                println!(
+                    "{}",
+                    "Overwriting existing config because --force was set.".yellow()
+                );
             }
         }
 

--- a/crates/octos-cli/tests/cli_tests.rs
+++ b/crates/octos-cli/tests/cli_tests.rs
@@ -66,6 +66,7 @@ fn test_init_help() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Initialize"));
     assert!(stdout.contains("--defaults"));
+    assert!(stdout.contains("--force"));
 }
 
 #[test]
@@ -205,6 +206,58 @@ fn test_init_defaults_uses_octos_home_when_cwd_not_provided() {
     let content = std::fs::read_to_string(&home_config).unwrap();
     assert!(content.contains("openai"));
     assert!(content.contains("gpt-4.1-mini"));
+}
+
+#[test]
+fn test_init_defaults_refuses_to_overwrite_existing_config() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let octos_dir = temp_dir.path().join(".octos");
+    std::fs::create_dir_all(&octos_dir).unwrap();
+    let config_path = octos_dir.join("config.json");
+    let original = r#"{"provider":"sentinel","model":"keep-me"}"#;
+    std::fs::write(&config_path, original).unwrap();
+
+    let mut cmd = Command::new(octos_binary());
+    clear_provider_env(&mut cmd);
+    let output = cmd
+        .env("OPENAI_API_KEY", "test-openai-key")
+        .args(["init", "--defaults", "--cwd"])
+        .arg(temp_dir.path())
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Config already exists"));
+    assert_eq!(std::fs::read_to_string(&config_path).unwrap(), original);
+}
+
+#[test]
+fn test_init_defaults_force_overwrites_existing_config() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let octos_dir = temp_dir.path().join(".octos");
+    std::fs::create_dir_all(&octos_dir).unwrap();
+    let config_path = octos_dir.join("config.json");
+    std::fs::write(
+        &config_path,
+        r#"{"provider":"sentinel","model":"replace-me"}"#,
+    )
+    .unwrap();
+
+    let mut cmd = Command::new(octos_binary());
+    clear_provider_env(&mut cmd);
+    let output = cmd
+        .env("OPENAI_API_KEY", "test-openai-key")
+        .args(["init", "--defaults", "--force", "--cwd"])
+        .arg(temp_dir.path())
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(output.status.success());
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    assert!(content.contains("openai"));
+    assert!(content.contains("gpt-4.1-mini"));
+    assert!(!content.contains("sentinel"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add `octos init --force` as the explicit non-interactive overwrite path.
- Make `octos init --defaults` fail closed when `config.json` already exists and `--force` is not set.
- Add CLI regressions proving the existing config remains unchanged without `--force` and is overwritten only with `--force`.

Closes #290

## Current-main refresh

- Refreshed onto `origin/main` `f6936c452389c5172496ee0c3e13393956086d92`.
- Refreshed head: `56d6016d1ac63714f27dddbdf9d19fe51f4ceceb`.
- Isolated checkout: `/private/tmp/octos-1353-f693.NZnvXD/octos`.
- Root dirty checkout was left untouched.
- Environment: Darwin arm64; `rustc 1.95.0`; `cargo 1.95.0`; Node `v24.10.0`; npm `11.6.0`.

## Diff shape

Only these files changed:

- `crates/octos-cli/src/commands/init.rs`
- `crates/octos-cli/tests/cli_tests.rs`

No generated artifacts are included.

## Local validation

Passed locally:

- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`
- `rustfmt --check crates/octos-cli/src/commands/init.rs crates/octos-cli/tests/cli_tests.rs`
- `typos crates/octos-cli/src/commands/init.rs crates/octos-cli/tests/cli_tests.rs`
- `CARGO_TARGET_DIR=/private/tmp/octos-1353-f693-target-cli CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --test cli_tests test_init -- --nocapture` -> 5 passed, including overwrite refusal and explicit `--force` overwrite coverage
- `CARGO_TARGET_DIR=/private/tmp/octos-1353-f693-target-cli CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --test cli_tests -- --nocapture` -> 19 passed, 3 ignored
- `CARGO_TARGET_DIR=/private/tmp/octos-1353-f693-target-check CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p octos-cli --no-default-features`
- `CARGO_TARGET_DIR=/private/tmp/octos-1353-f693-target-clippy CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -p octos-cli --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/private/tmp/octos-1353-f693-target-clippy CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings`
- `git ls-files --others --exclude-standard` -> empty in the isolated checkout

## CI / merge status

GitHub CI is green on refreshed head `56d6016d1ac63714f27dddbdf9d19fe51f4ceceb`: `check`, `check-matrix`, `dashboard`, `reject blocked author/committer emails`, `swarm-app`, `test-octos-agent (integration)`, `test-octos-agent (lib)`, `test-octos-cli`, and `typos` passed. Optional expansion jobs were skipped as expected.

Current merge gate: `BLOCKED` / `REVIEW_REQUIRED`.
