### PR TITLE
feat: add Linux Landlock seccomp sandbox

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -30,12 +30,16 @@ jobs:
           echo "OCTOS_GIT_HASH=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
           echo "OCTOS_BUILD_DATE=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
 
-      - name: Build octos CLI
-        run: cargo build --release -p octos-cli --features "api,telegram,discord,feishu,twilio,wecom,wecom-bot,audio_mp3"
+      - name: Build octos CLI and sandbox helper
+        run: |
+          cargo build --release -p octos-cli --features "api,telegram,discord,feishu,twilio,wecom,wecom-bot,audio_mp3"
+          cargo build --release -p octos-sandbox
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: octos-linux-x86_64
-          path: target/release/octos
+          path: |
+            target/release/octos
+            target/release/octos-sandbox
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,7 @@ jobs:
       CARGO_BUILD_JOBS: "1"
       CARGO_PROFILE_TEST_DEBUG: line-tables-only
       CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      RUST_TEST_THREADS: "1"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -805,4 +806,4 @@ jobs:
         if: steps.changes.outputs.run == 'true'
         run: |
           echo "Running 24 security integration tests on macOS (sandbox-exec SBPL)"
-          cargo test -p crew-agent --test security_sandbox -- --nocapture
+          cargo test -p octos-agent --test security_sandbox -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,9 @@ jobs:
       - name: Test octos-plugin
         run: cargo test -p octos-plugin
 
+      - name: Test octos-sandbox
+        run: cargo test -p octos-sandbox
+
       # RFC-2 (issue #1291): validate every bundled `crates/app-skills/*/manifest.json`
       # against the strict octos JSON schema validator. A failure here means a
       # bundled skill ships a manifest shape that strict LLM-provider validators
@@ -400,6 +403,8 @@ jobs:
         run: cargo test -p octos-pipeline
       - name: Test octos-plugin
         run: cargo test -p octos-plugin
+      - name: Test octos-sandbox
+        run: cargo test -p octos-sandbox
       - name: Test octos-swarm
         run: cargo test -p octos-swarm
       - name: Test octos-agent (lib)
@@ -456,6 +461,8 @@ jobs:
         run: cargo test -p octos-pipeline
       - name: Test octos-plugin
         run: cargo test -p octos-plugin
+      - name: Test octos-sandbox
+        run: cargo test -p octos-sandbox
       - name: Test octos-swarm
         run: cargo test -p octos-swarm
       - name: Test octos-agent (lib)
@@ -507,6 +514,8 @@ jobs:
         run: cargo test -p octos-pipeline
       - name: Test octos-plugin
         run: cargo test -p octos-plugin
+      - name: Test octos-sandbox
+        run: cargo test -p octos-sandbox
       - name: Test octos-swarm
         run: cargo test -p octos-swarm
       - name: Test octos-agent (lib)
@@ -550,12 +559,13 @@ jobs:
           git submodule update --init octos-web
           bash scripts/build-web-app.sh
           cargo build --release -p octos-cli --features ${{ env.FEATURES }}
+          cargo build --release -p octos-sandbox
           cargo build --release ${{ env.SKILL_CRATES }}
 
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-aarch64-apple-darwin.tar.gz *
@@ -589,12 +599,13 @@ jobs:
           git submodule update --init octos-web
           bash scripts/build-web-app.sh
           cargo build --release -p octos-cli --features ${{ env.FEATURES }}
+          cargo build --release -p octos-sandbox
           cargo build --release ${{ env.SKILL_CRATES }}
 
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-x86_64-unknown-linux-gnu.tar.gz *
@@ -630,12 +641,13 @@ jobs:
           git submodule update --init octos-web
           bash scripts/build-web-app.sh
           cargo build --release -p octos-cli --features ${{ env.FEATURES }}
+          cargo build --release -p octos-sandbox
           cargo build --release ${{ env.SKILL_CRATES }}
 
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-aarch64-unknown-linux-gnu.tar.gz *
@@ -671,13 +683,14 @@ jobs:
           git submodule update --init octos-web
           bash scripts/build-web-app.sh
           cargo build --release -p octos-cli --features ${{ env.FEATURES }}
+          cargo build --release -p octos-sandbox
           cargo build --release ${{ env.SKILL_CRATES }}
 
       - name: Bundle
         shell: bash
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/${b}.exe" dist/ 2>/dev/null || true
           done
           cd dist && 7z a ../octos-bundle-x86_64-pc-windows-msvc.zip *

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -63,8 +63,10 @@ jobs:
           git submodule update --init octos-web
           bash scripts/build-web-app.sh
 
-      - name: Build octos CLI
-        run: cargo build --release -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3"
+      - name: Build octos CLI and sandbox helper
+        run: |
+          cargo build --release -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3"
+          cargo build --release -p octos-sandbox
 
       - name: Build app-skill binaries
         run: cargo build --release -p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather
@@ -72,7 +74,7 @@ jobs:
       - name: Bundle release tarball
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-aarch64-apple-darwin.tar.gz *

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,12 +52,13 @@ jobs:
       - name: Build
         run: |
           cargo build --release -p octos-cli --features ${{ env.FEATURES }}
+          cargo build --release -p octos-sandbox
           cargo build --release ${{ env.SKILL_CRATES }}
 
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-aarch64-apple-darwin.tar.gz *
@@ -95,12 +96,13 @@ jobs:
       - name: Build
         run: |
           cargo build --release -p octos-cli --features ${{ env.FEATURES }}
+          cargo build --release -p octos-sandbox
           cargo build --release ${{ env.SKILL_CRATES }}
 
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-x86_64-unknown-linux-gnu.tar.gz *
@@ -140,12 +142,13 @@ jobs:
       - name: Build
         run: |
           cargo build --release -p octos-cli --features ${{ env.FEATURES }}
+          cargo build --release -p octos-sandbox
           cargo build --release ${{ env.SKILL_CRATES }}
 
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-aarch64-unknown-linux-gnu.tar.gz *
@@ -187,13 +190,14 @@ jobs:
       - name: Build
         run: |
           cargo build --release -p octos-cli --features ${{ env.FEATURES }}
+          cargo build --release -p octos-sandbox
           cargo build --release ${{ env.SKILL_CRATES }}
 
       - name: Bundle
         shell: bash
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/${b}.exe" dist/ 2>/dev/null || true
           done
           cd dist && 7z a ../octos-bundle-x86_64-pc-windows-msvc.zip *

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,6 +1333,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_filter"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3160,6 +3180,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "landlock"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3196,9 +3227,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -4030,7 +4061,10 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "eyre",
+ "landlock",
+ "libc",
  "rappct",
+ "seccompiler",
  "windows 0.62.2",
 ]
 
@@ -5156,6 +5190,15 @@ dependencies = [
  "precomputed-hash",
  "selectors",
  "tendril",
+]
+
+[[package]]
+name = "seccompiler"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ octos-agent (agent loop, tool registry, MCP, hooks, three-tier compaction,
    ├─ octos-memory    (long-term + episodic + HNSW vector + BM25 hybrid search)
    ├─ octos-pipeline  (DOT-graph workflows, per-node model, bounded fan-out)
    ├─ octos-plugin    (skill manifest, discovery, gating, lifecycle, protocol v2)
-   ├─ octos-sandbox   (Windows AppContainer helper binary)
+   ├─ octos-sandbox   (platform sandbox helper binary)
    ├─ octos-swarm     (PM/swarm dispatcher, ledger, topology, validator gate)
    └─ octos-core      (Task, Message, Error types — no internal deps)
 

--- a/crates/app-skills/account-manager/src/main.rs
+++ b/crates/app-skills/account-manager/src/main.rs
@@ -101,7 +101,7 @@ struct Input {
     /// Toggle sandbox: true = on, false = off
     #[serde(default)]
     sandbox: Option<bool>,
-    /// Sandbox mode override: "auto", "macos", "docker", "bwrap"
+    /// Sandbox mode override: "auto", "macos", "docker", "bwrap", "landlock", "appcontainer"
     #[serde(default)]
     sandbox_mode: Option<String>,
     /// Allow network inside sandbox

--- a/crates/octos-agent/src/role_template.rs
+++ b/crates/octos-agent/src/role_template.rs
@@ -215,7 +215,7 @@ pub struct RoleTemplate {
     pub allowed_tools: &'static [&'static str],
     /// Default sandbox mode the role suggests. One of `SANDBOX_AUTO`
     /// or `SANDBOX_NONE`. Templates intentionally do not advertise
-    /// "bwrap" / "docker" — backend selection is environment-driven.
+    /// specific backends — backend selection is environment-driven.
     pub default_sandbox_mode: &'static str,
     /// Default approval policy the role suggests. One of
     /// `APPROVAL_ASK` or `APPROVAL_NEVER`.

--- a/crates/octos-agent/src/sandbox/landlock.rs
+++ b/crates/octos-agent/src/sandbox/landlock.rs
@@ -25,7 +25,11 @@ impl Sandbox for LinuxContainerSandbox {
             tracing::error!("octos-sandbox helper not found, refusing unsandboxed Linux command");
             let mut cmd = Command::new("sh");
             cmd.arg("-c")
-                .arg("echo 'sandbox error: octos-sandbox helper not found' >&2; exit 1");
+                .arg("echo 'sandbox error: octos-sandbox helper not found' >&2; exit 1")
+                .current_dir(cwd);
+            for var in BLOCKED_ENV_VARS {
+                cmd.env_remove(var);
+            }
             return cmd;
         };
 

--- a/crates/octos-agent/src/sandbox/landlock.rs
+++ b/crates/octos-agent/src/sandbox/landlock.rs
@@ -1,0 +1,106 @@
+//! Linux container sandbox using the octos-sandbox Landlock/seccomp helper.
+
+use std::path::Path;
+
+use tokio::process::Command;
+
+use super::{BLOCKED_ENV_VARS, Sandbox, find_sandbox_helper_path};
+
+/// Linux sandbox for unprivileged containers.
+///
+/// Delegates enforcement to the `octos-sandbox` helper so Landlock and
+/// seccomp setup happens in the helper process before it `exec`s the shell.
+pub struct LinuxContainerSandbox {
+    /// Allow network access inside the sandbox.
+    pub allow_network: bool,
+    /// Additional paths to grant read access to.
+    pub read_allow_paths: Vec<String>,
+    /// Optional profile label, currently accepted for parity with other helpers.
+    pub profile_name: Option<String>,
+}
+
+impl Sandbox for LinuxContainerSandbox {
+    fn wrap_command(&self, shell_command: &str, cwd: &Path) -> Command {
+        let Some(helper_path) = find_sandbox_helper_path() else {
+            tracing::error!("octos-sandbox helper not found, refusing unsandboxed Linux command");
+            let mut cmd = Command::new("sh");
+            cmd.arg("-c")
+                .arg("echo 'sandbox error: octos-sandbox helper not found' >&2; exit 1");
+            return cmd;
+        };
+
+        let mut cmd = Command::new(helper_path);
+        cmd.arg("--profile")
+            .arg(self.profile_name.as_deref().unwrap_or("octos.linux"))
+            .arg("--cwd")
+            .arg(cwd);
+
+        for path in &self.read_allow_paths {
+            if Path::new(path).exists() {
+                cmd.arg("--allow-read").arg(path);
+            }
+        }
+
+        if self.allow_network {
+            cmd.arg("--allow-network");
+        }
+
+        cmd.arg("--").arg("sh").arg("-c").arg(shell_command);
+        cmd.current_dir(cwd);
+
+        for var in BLOCKED_ENV_VARS {
+            cmd.env_remove(var);
+        }
+
+        cmd
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linux_container_sandbox_uses_helper_or_fails_closed() {
+        let sandbox = LinuxContainerSandbox {
+            allow_network: false,
+            read_allow_paths: vec!["/usr".to_string()],
+            profile_name: Some("octos.test".to_string()),
+        };
+        let cmd = sandbox.wrap_command("echo hello", Path::new("/tmp"));
+        let prog = cmd.as_std().get_program().to_string_lossy().to_string();
+
+        assert!(
+            prog.contains("octos-sandbox") || prog == "sh",
+            "expected octos-sandbox helper or fail-closed shell, got {prog}"
+        );
+    }
+
+    #[test]
+    fn linux_container_sandbox_removes_injection_env() {
+        let sandbox = LinuxContainerSandbox {
+            allow_network: true,
+            read_allow_paths: vec![],
+            profile_name: None,
+        };
+        let cmd = sandbox.wrap_command("echo hello", Path::new("/tmp"));
+        let removed: Vec<String> = cmd
+            .as_std()
+            .get_envs()
+            .filter_map(|(key, value)| {
+                if value.is_none() {
+                    Some(key.to_string_lossy().to_string())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for var in BLOCKED_ENV_VARS {
+            assert!(
+                removed.iter().any(|removed| removed == *var),
+                "Linux container sandbox should env_remove {var}"
+            );
+        }
+    }
+}

--- a/crates/octos-agent/src/sandbox/mod.rs
+++ b/crates/octos-agent/src/sandbox/mod.rs
@@ -1,16 +1,20 @@
 //! Sandboxing for shell command execution.
 //!
-//! Provides platform-specific isolation: bubblewrap on Linux,
-//! sandbox-exec on macOS, or no sandbox (pass-through).
+//! Provides platform-specific isolation: bubblewrap or Landlock/seccomp on Linux,
+//! sandbox-exec on macOS, AppContainer on Windows, or no sandbox (pass-through).
 
 mod bwrap;
 mod docker;
+#[cfg(target_os = "linux")]
+mod landlock;
 mod macos;
 #[cfg(windows)]
 mod windows;
 
 pub use bwrap::BwrapSandbox;
 pub use docker::DockerSandbox;
+#[cfg(target_os = "linux")]
+pub use landlock::LinuxContainerSandbox;
 pub use macos::MacosSandbox;
 #[cfg(windows)]
 pub use windows::AppContainerSandbox;
@@ -186,6 +190,8 @@ pub enum SandboxMode {
     Auto,
     /// Linux bubblewrap.
     Bwrap,
+    /// Linux container sandbox using Landlock filesystem rules plus seccomp.
+    Landlock,
     /// macOS sandbox-exec.
     Macos,
     /// Docker container isolation.
@@ -235,6 +241,23 @@ pub fn create_sandbox(config: &SandboxConfig) -> Box<dyn Sandbox> {
         SandboxMode::Bwrap => Box::new(BwrapSandbox {
             allow_network: config.allow_network,
         }),
+        SandboxMode::Landlock => {
+            #[cfg(target_os = "linux")]
+            {
+                Box::new(LinuxContainerSandbox {
+                    allow_network: config.allow_network,
+                    read_allow_paths: config.read_allow_paths.clone(),
+                    profile_name: config.profile_name.clone(),
+                })
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                tracing::warn!(
+                    "Landlock/seccomp is only available on Linux, falling back to NoSandbox"
+                );
+                Box::new(NoSandbox)
+            }
+        }
         SandboxMode::Macos => Box::new(MacosSandbox {
             allow_network: config.allow_network,
             read_allow_paths: config.read_allow_paths.clone(),
@@ -260,56 +283,135 @@ pub fn create_sandbox(config: &SandboxConfig) -> Box<dyn Sandbox> {
                 Box::new(NoSandbox)
             }
         }
-        SandboxMode::Auto => {
-            if cfg!(target_os = "linux") && which_exists("bwrap") {
-                Box::new(BwrapSandbox {
-                    allow_network: config.allow_network,
-                })
-            } else if cfg!(target_os = "macos") && which_exists("sandbox-exec") {
-                Box::new(MacosSandbox {
-                    allow_network: config.allow_network,
-                    read_allow_paths: config.read_allow_paths.clone(),
-                })
-            } else if cfg!(target_os = "windows") && has_sandbox_helper() {
-                #[cfg(windows)]
-                {
-                    Box::new(AppContainerSandbox {
-                        allow_network: config.allow_network,
-                        read_allow_paths: config.read_allow_paths.clone(),
-                        profile_name: config.profile_name.clone(),
-                    })
-                }
-                #[cfg(not(windows))]
-                {
-                    Box::new(NoSandbox)
-                }
-            } else if which_exists("docker") {
-                Box::new(DockerSandbox {
-                    config: config.docker.clone(),
-                    allow_network: config.allow_network,
-                })
-            } else {
-                tracing::warn!(
-                    "no sandbox backend found (bwrap, sandbox-exec, docker, or AppContainer). \
-                     Shell commands will run WITHOUT isolation. \
-                     Install a sandbox backend or set sandbox.enabled = false to silence this warning."
-                );
-                Box::new(NoSandbox)
-            }
-        }
+        SandboxMode::Auto => create_auto_sandbox(config),
     }
 }
 
+fn create_auto_sandbox(config: &SandboxConfig) -> Box<dyn Sandbox> {
+    #[cfg(target_os = "macos")]
+    {
+        if which_exists("sandbox-exec") {
+            return Box::new(MacosSandbox {
+                allow_network: config.allow_network,
+                read_allow_paths: config.read_allow_paths.clone(),
+            });
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if bwrap_works() {
+            return Box::new(BwrapSandbox {
+                allow_network: config.allow_network,
+            });
+        }
+        if linux_container_sandbox_available() {
+            return Box::new(LinuxContainerSandbox {
+                allow_network: config.allow_network,
+                read_allow_paths: config.read_allow_paths.clone(),
+                profile_name: config.profile_name.clone(),
+            });
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if has_sandbox_helper() {
+            return Box::new(AppContainerSandbox {
+                allow_network: config.allow_network,
+                read_allow_paths: config.read_allow_paths.clone(),
+                profile_name: config.profile_name.clone(),
+            });
+        }
+    }
+
+    if which_exists("docker") {
+        Box::new(DockerSandbox {
+            config: config.docker.clone(),
+            allow_network: config.allow_network,
+        })
+    } else {
+        tracing::warn!(
+            "no sandbox backend found (bwrap, Landlock/seccomp, sandbox-exec, docker, or AppContainer). \
+             Shell commands will run WITHOUT isolation. \
+             Install a sandbox backend or set sandbox.enabled = false to silence this warning."
+        );
+        Box::new(NoSandbox)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn bwrap_works() -> bool {
+    if !which_exists("bwrap") {
+        return false;
+    }
+
+    let mut cmd = std::process::Command::new("bwrap");
+    for dir in ["/usr", "/lib", "/lib64", "/bin", "/sbin", "/etc"] {
+        if Path::new(dir).exists() {
+            cmd.arg("--ro-bind").arg(dir).arg(dir);
+        }
+    }
+    cmd.arg("--dev")
+        .arg("/dev")
+        .arg("--proc")
+        .arg("/proc")
+        .arg("--tmpfs")
+        .arg("/tmp")
+        .arg("--die-with-parent")
+        .arg("--")
+        .arg(if Path::new("/bin/true").exists() {
+            "/bin/true"
+        } else {
+            "/usr/bin/true"
+        })
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "linux")]
+fn linux_container_sandbox_available() -> bool {
+    find_sandbox_helper_path()
+        .and_then(|helper| {
+            std::process::Command::new(helper)
+                .arg("--probe-linux")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .ok()
+        })
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
 /// Check if the octos-sandbox helper binary is available.
+#[cfg(windows)]
 fn has_sandbox_helper() -> bool {
+    find_sandbox_helper_path().is_some()
+}
+
+#[cfg(any(windows, target_os = "linux"))]
+fn find_sandbox_helper_path() -> Option<String> {
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
-            if dir.join("octos-sandbox.exe").exists() || dir.join("octos-sandbox").exists() {
-                return true;
+            let helper = if cfg!(windows) {
+                dir.join("octos-sandbox.exe")
+            } else {
+                dir.join("octos-sandbox")
+            };
+            if helper.exists() {
+                return Some(helper.to_string_lossy().into_owned());
             }
         }
     }
-    which_exists("octos-sandbox")
+    if which_exists("octos-sandbox") {
+        Some("octos-sandbox".to_string())
+    } else {
+        None
+    }
 }
 
 /// Check if a binary exists on PATH.
@@ -367,6 +469,7 @@ mod tests {
         let modes = [
             (SandboxMode::Auto, "\"auto\""),
             (SandboxMode::Bwrap, "\"bwrap\""),
+            (SandboxMode::Landlock, "\"landlock\""),
             (SandboxMode::Macos, "\"macos\""),
             (SandboxMode::Docker, "\"docker\""),
             (SandboxMode::AppContainer, "\"appcontainer\""),

--- a/crates/octos-cli/src/commands/gateway/account_handler.rs
+++ b/crates/octos-cli/src/commands/gateway/account_handler.rs
@@ -348,10 +348,11 @@ fn handle_account_update(
                     "macos" => octos_agent::SandboxMode::Macos,
                     "docker" => octos_agent::SandboxMode::Docker,
                     "bwrap" => octos_agent::SandboxMode::Bwrap,
+                    "landlock" => octos_agent::SandboxMode::Landlock,
                     "appcontainer" => octos_agent::SandboxMode::AppContainer,
                     _ => {
                         return format!(
-                            "Invalid sandbox mode: {val}\nValid modes: auto, macos, docker, bwrap, appcontainer"
+                            "Invalid sandbox mode: {val}\nValid modes: auto, macos, docker, bwrap, landlock, appcontainer"
                         );
                     }
                 };
@@ -459,7 +460,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn account_update_invalid_mode_message_lists_appcontainer() {
+    async fn account_update_persists_landlock_sandbox_mode() {
+        let (_dir, store, sub_id) = create_store_with_sub_account();
+        let profile_store = Some(store.clone());
+
+        let response = handle_account_command(
+            &format!("update {sub_id} sandbox=true sandbox-mode=landlock"),
+            Some("parent"),
+            &profile_store,
+        )
+        .await;
+
+        assert!(
+            response.contains("Updated sub-account"),
+            "unexpected response: {response}"
+        );
+
+        let updated = store.get(&sub_id).expect("load sub").expect("sub exists");
+        assert_eq!(
+            updated.config.sandbox.mode,
+            octos_agent::SandboxMode::Landlock
+        );
+        assert!(updated.config.sandbox.enabled);
+    }
+
+    #[tokio::test]
+    async fn account_update_invalid_mode_message_lists_landlock_and_appcontainer() {
         let (_dir, store, sub_id) = create_store_with_sub_account();
         let profile_store = Some(store);
 
@@ -470,6 +496,8 @@ mod tests {
         )
         .await;
 
-        assert!(response.contains("Valid modes: auto, macos, docker, bwrap, appcontainer"));
+        assert!(
+            response.contains("Valid modes: auto, macos, docker, bwrap, landlock, appcontainer")
+        );
     }
 }

--- a/crates/octos-sandbox/Cargo.toml
+++ b/crates/octos-sandbox/Cargo.toml
@@ -3,7 +3,7 @@ name = "octos-sandbox"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.85.0"
-description = "AppContainer sandbox helper for octos on Windows"
+description = "Platform sandbox helper for octos"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
@@ -15,6 +15,11 @@ windows = { version = "0.62", features = [
     "Win32_System_Threading",
     "Win32_Security",
 ] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+landlock = "0.4.5"
+libc.workspace = true
+seccompiler = "0.5.0"
 
 [lints]
 workspace = true

--- a/crates/octos-sandbox/src/main.rs
+++ b/crates/octos-sandbox/src/main.rs
@@ -1,28 +1,52 @@
-//! octos-sandbox: AppContainer helper binary for Windows.
+//! octos-sandbox: platform sandbox helper binary.
 //!
-//! Creates/reuses an AppContainer profile and launches a command inside it
-//! with restricted filesystem and network access.
+//! On Windows, creates/reuses an AppContainer profile and launches a command
+//! inside it with restricted filesystem and network access. On Linux, applies
+//! a Landlock filesystem policy plus a seccomp denylist before execing the
+//! command.
 //!
 //! Usage:
 //!   octos-sandbox --profile octos.dspfac --cwd C:\work \
 //!     --allow-read C:\tools --allow-network \
 //!     -- cmd /C "echo hello"
 //!
-//! On non-Windows platforms, this binary is a no-op passthrough.
+//! On other platforms, this binary is a no-op passthrough.
 
 use clap::Parser;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+#[cfg(target_os = "linux")]
+const BLOCKED_ENV_VARS: &[&str] = &[
+    "LD_PRELOAD",
+    "LD_LIBRARY_PATH",
+    "LD_AUDIT",
+    "DYLD_INSERT_LIBRARIES",
+    "DYLD_LIBRARY_PATH",
+    "DYLD_FRAMEWORK_PATH",
+    "DYLD_FALLBACK_LIBRARY_PATH",
+    "DYLD_VERSIONED_LIBRARY_PATH",
+    "NODE_OPTIONS",
+    "PYTHONSTARTUP",
+    "PYTHONPATH",
+    "PERL5OPT",
+    "RUBYOPT",
+    "RUBYLIB",
+    "JAVA_TOOL_OPTIONS",
+    "BASH_ENV",
+    "ENV",
+    "ZDOTDIR",
+];
+
 #[derive(Parser, Debug)]
-#[command(name = "octos-sandbox", about = "AppContainer sandbox helper")]
+#[command(name = "octos-sandbox", about = "platform sandbox helper")]
 struct Args {
     /// AppContainer profile name (e.g. "octos.dspfac").
-    #[arg(long)]
+    #[arg(long, default_value = "octos.default")]
     profile: String,
 
     /// Working directory (granted read-write access).
-    #[arg(long)]
+    #[arg(long, default_value = ".")]
     cwd: PathBuf,
 
     /// Paths to grant read-only access to (repeatable).
@@ -33,8 +57,12 @@ struct Args {
     #[arg(long)]
     allow_network: bool,
 
+    /// Probe whether the Linux Landlock/seccomp sandbox can be enforced.
+    #[arg(long)]
+    probe_linux: bool,
+
     /// Command and arguments to run inside the sandbox.
-    #[arg(last = true, required = true)]
+    #[arg(last = true)]
     command: Vec<String>,
 }
 
@@ -52,7 +80,28 @@ fn main() -> ExitCode {
         }
     }
 
-    #[cfg(not(windows))]
+    #[cfg(target_os = "linux")]
+    {
+        if args.probe_linux {
+            return match probe_linux() {
+                Ok(()) => ExitCode::SUCCESS,
+                Err(e) => {
+                    eprintln!("octos-sandbox probe error: {e}");
+                    ExitCode::from(1)
+                }
+            };
+        }
+
+        match run_linux_sandboxed(&args) {
+            Ok(code) => ExitCode::from(code),
+            Err(e) => {
+                eprintln!("octos-sandbox error: {e}");
+                ExitCode::from(1)
+            }
+        }
+    }
+
+    #[cfg(all(not(windows), not(target_os = "linux")))]
     {
         // Non-Windows: passthrough — just exec the command directly
         match run_passthrough(&args) {
@@ -65,7 +114,7 @@ fn main() -> ExitCode {
     }
 }
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), not(target_os = "linux")))]
 fn run_passthrough(args: &Args) -> eyre::Result<u8> {
     use std::process::Command;
 
@@ -80,6 +129,153 @@ fn run_passthrough(args: &Args) -> eyre::Result<u8> {
         .status()?;
 
     Ok(status.code().unwrap_or(1) as u8)
+}
+
+#[cfg(target_os = "linux")]
+fn probe_linux() -> eyre::Result<()> {
+    apply_linux_landlock(&std::env::current_dir()?, &[])?;
+    apply_linux_seccomp(false)?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn run_linux_sandboxed(args: &Args) -> eyre::Result<u8> {
+    use eyre::WrapErr;
+    use std::os::unix::process::CommandExt;
+    use std::process::Command;
+
+    let (prog, cmd_args) = args
+        .command
+        .split_first()
+        .ok_or_else(|| eyre::eyre!("no command specified"))?;
+
+    let mut command = Command::new(prog);
+    command.args(cmd_args).current_dir(&args.cwd);
+    for var in BLOCKED_ENV_VARS {
+        command.env_remove(var);
+    }
+
+    apply_linux_landlock(&args.cwd, &args.allow_read)
+        .wrap_err("failed to apply Landlock policy")?;
+    apply_linux_seccomp(args.allow_network).wrap_err("failed to apply seccomp policy")?;
+
+    Err(command.exec().into())
+}
+
+#[cfg(target_os = "linux")]
+fn apply_linux_landlock(cwd: &std::path::Path, extra_read_paths: &[PathBuf]) -> eyre::Result<()> {
+    use eyre::{WrapErr, bail};
+    use landlock::{
+        ABI, Access, AccessFs, Ruleset, RulesetAttr, RulesetCreatedAttr, RulesetStatus,
+        make_bitflags, path_beneath_rules,
+    };
+
+    const SYSTEM_READ_PATHS: &[&str] = &[
+        "/usr",
+        "/bin",
+        "/sbin",
+        "/lib",
+        "/lib64",
+        "/etc",
+        "/dev/urandom",
+        "/dev/random",
+    ];
+    const SYSTEM_EXEC_PATHS: &[&str] = &["/usr/bin", "/bin"];
+    const SYSTEM_WRITE_PATHS: &[&str] = &["/tmp", "/var/tmp", "/dev/null"];
+
+    let abi = ABI::V1;
+    let read_access = make_bitflags!(AccessFs::{ReadFile | ReadDir});
+    let exec_access = read_access | AccessFs::Execute;
+    let write_access = read_access | AccessFs::from_write(abi);
+
+    let cwd = cwd
+        .canonicalize()
+        .wrap_err_with(|| format!("failed to canonicalize cwd {}", cwd.display()))?;
+
+    let mut created = Ruleset::default()
+        .handle_access(AccessFs::from_all(abi))?
+        .create()?
+        .add_rules(path_beneath_rules(SYSTEM_READ_PATHS, read_access))?
+        .add_rules(path_beneath_rules(SYSTEM_EXEC_PATHS, exec_access))?
+        .add_rules(path_beneath_rules(SYSTEM_WRITE_PATHS, write_access))?
+        .add_rules(path_beneath_rules([cwd.as_path()], write_access))?;
+
+    for path in extra_read_paths {
+        created = created.add_rules(path_beneath_rules([path.as_path()], read_access))?;
+    }
+
+    let status = created.restrict_self()?;
+    if status.ruleset != RulesetStatus::FullyEnforced {
+        bail!(
+            "Landlock ruleset was not fully enforced: {:?}",
+            status.ruleset
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn apply_linux_seccomp(allow_network: bool) -> eyre::Result<()> {
+    use eyre::WrapErr;
+    use seccompiler::{
+        BpfProgram, SeccompAction, SeccompCmpArgLen, SeccompCmpOp, SeccompCondition, SeccompFilter,
+        SeccompRule,
+    };
+    use std::collections::BTreeMap;
+    use std::convert::TryInto;
+
+    let mut rules: BTreeMap<i64, Vec<SeccompRule>> = blocked_syscalls()
+        .into_iter()
+        .map(|syscall| (syscall, Vec::new()))
+        .collect();
+
+    if !allow_network {
+        let internet_socket_rules = vec![
+            SeccompRule::new(vec![SeccompCondition::new(
+                0,
+                SeccompCmpArgLen::Dword,
+                SeccompCmpOp::Eq,
+                libc::AF_INET as u64,
+            )?])?,
+            SeccompRule::new(vec![SeccompCondition::new(
+                0,
+                SeccompCmpArgLen::Dword,
+                SeccompCmpOp::Eq,
+                libc::AF_INET6 as u64,
+            )?])?,
+        ];
+        rules.insert(libc::SYS_socket, internet_socket_rules);
+    }
+
+    let filter: BpfProgram = SeccompFilter::new(
+        rules,
+        SeccompAction::Allow,
+        SeccompAction::Errno(libc::EPERM as u32),
+        std::env::consts::ARCH.try_into()?,
+    )?
+    .try_into()?;
+
+    seccompiler::apply_filter(&filter).wrap_err("seccomp filter installation failed")?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn blocked_syscalls() -> Vec<i64> {
+    vec![
+        libc::SYS_bpf,
+        libc::SYS_finit_module,
+        libc::SYS_init_module,
+        libc::SYS_kexec_load,
+        libc::SYS_mount,
+        libc::SYS_open_by_handle_at,
+        libc::SYS_perf_event_open,
+        libc::SYS_pivot_root,
+        libc::SYS_ptrace,
+        libc::SYS_reboot,
+        libc::SYS_umount2,
+        libc::SYS_userfaultfd,
+    ]
 }
 
 #[cfg(windows)]

--- a/crates/octos-sandbox/src/main.rs
+++ b/crates/octos-sandbox/src/main.rs
@@ -180,7 +180,16 @@ fn apply_linux_landlock(cwd: &std::path::Path, extra_read_paths: &[PathBuf]) -> 
         "/dev/urandom",
         "/dev/random",
     ];
-    const SYSTEM_EXEC_PATHS: &[&str] = &["/usr/bin", "/bin"];
+    const SYSTEM_EXEC_PATHS: &[&str] = &[
+        "/usr/bin",
+        "/bin",
+        // Dynamically linked binaries need execute access to their ELF
+        // interpreter, which commonly lives below one of these directories.
+        "/usr/lib",
+        "/usr/lib64",
+        "/lib",
+        "/lib64",
+    ];
     const SYSTEM_WRITE_PATHS: &[&str] = &["/tmp", "/var/tmp", "/dev/null"];
 
     let abi = ABI::V1;

--- a/crates/octos-sandbox/tests/linux_sandbox.rs
+++ b/crates/octos-sandbox/tests/linux_sandbox.rs
@@ -1,0 +1,115 @@
+#![cfg(target_os = "linux")]
+
+use std::process::Command;
+
+fn helper() -> &'static str {
+    env!("CARGO_BIN_EXE_octos-sandbox")
+}
+
+fn require_linux_sandbox_supported() {
+    let output = Command::new(helper())
+        .arg("--probe-linux")
+        .output()
+        .expect("octos-sandbox probe should run");
+    assert!(
+        output.status.success(),
+        "Linux Landlock/seccomp probe failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn linux_probe_succeeds_when_kernel_supports_landlock_seccomp() {
+    require_linux_sandbox_supported();
+}
+
+#[test]
+fn linux_sandbox_allows_cwd_write_and_blocks_sibling_write() {
+    require_linux_sandbox_supported();
+
+    let root = std::env::current_dir()
+        .unwrap()
+        .join("target")
+        .join(format!("linux-sandbox-test-{}", std::process::id()));
+    let work = root.join("work");
+    let outside = root.join("outside");
+    std::fs::create_dir_all(&work).unwrap();
+    std::fs::create_dir_all(&outside).unwrap();
+
+    let inside_file = work.join("inside.txt");
+    let outside_file = outside.join("escape.txt");
+    let script = format!(
+        "echo ok > '{}' && if echo bad > '{}'; then exit 42; else test ! -e '{}'; fi",
+        inside_file.display(),
+        outside_file.display(),
+        outside_file.display(),
+    );
+
+    let status = Command::new(helper())
+        .arg("--cwd")
+        .arg(&work)
+        .arg("--")
+        .arg("sh")
+        .arg("-c")
+        .arg(script)
+        .status()
+        .expect("octos-sandbox command should run");
+
+    assert!(status.success(), "sandboxed command should pass");
+    assert_eq!(std::fs::read_to_string(&inside_file).unwrap(), "ok\n");
+    assert!(
+        !outside_file.exists(),
+        "Landlock should block writes outside cwd and /tmp"
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn linux_sandbox_blocks_internet_socket_when_network_disabled() {
+    require_linux_sandbox_supported();
+
+    let Some(python_path) = ["/usr/bin/python3", "/bin/python3"]
+        .into_iter()
+        .find(|path| std::path::Path::new(path).exists())
+    else {
+        eprintln!("SKIP: python3 not available in allowed exec dirs");
+        return;
+    };
+
+    let work = std::env::current_dir()
+        .unwrap()
+        .join("target")
+        .join(format!("linux-sandbox-net-test-{}", std::process::id()));
+    std::fs::create_dir_all(&work).unwrap();
+
+    let script = r#"
+import errno
+import socket
+import sys
+
+try:
+    socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+except OSError as exc:
+    sys.exit(0 if exc.errno == errno.EPERM else 2)
+else:
+    sys.exit(42)
+"#;
+
+    let status = Command::new(helper())
+        .arg("--cwd")
+        .arg(&work)
+        .arg("--")
+        .arg(python_path)
+        .arg("-c")
+        .arg(script)
+        .status()
+        .expect("octos-sandbox network test should run");
+
+    assert!(
+        status.success(),
+        "seccomp should deny AF_INET sockets with EPERM"
+    );
+
+    let _ = std::fs::remove_dir_all(work);
+}

--- a/scripts/build-local-bundle.sh
+++ b/scripts/build-local-bundle.sh
@@ -112,7 +112,7 @@ fi
 # ── Bundle (same binary list as .github/workflows/ci.yml:179-182) ────
 TARBALL="octos-bundle-${TRIPLE}.tar.gz"
 rm -rf dist && mkdir dist
-for b in octos news_fetch deep-search deep_crawl send_email account_manager \
+for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager \
          voice clock weather; do
     cp "target/release/$b" dist/ 2>/dev/null || true
 done

--- a/scripts/milestone-ci.sh
+++ b/scripts/milestone-ci.sh
@@ -78,6 +78,7 @@ run_workspace_all_features() {
 
 run_release_bundle() {
   cargo build --release -p octos-cli --features "$FEATURES"
+  cargo build --release -p octos-sandbox
   # shellcheck disable=SC2086
   cargo build --release ${SKILL_CRATES}
 }


### PR DESCRIPTION
Closes #235

## Summary

- Adds a Linux `Landlock` sandbox mode backed by the `octos-sandbox` helper, with Landlock filesystem restrictions and a seccomp denylist before command exec.
- Updates auto-detection so Linux tries working `bwrap`, then probes Landlock/seccomp, then Docker, then `NoSandbox`.
- Adds Linux integration tests for helper probing, cwd write confinement, sibling write denial, and AF_INET socket denial.
- Ships `octos-sandbox` in release/local bundles and accepts `sandbox-mode=landlock` through the gateway account update path.
- Carries current-main CI unblockers only: the Rustdoc `doc_lazy_continuation` paragraph break, the test-only `cli_agent_adapter` temp-script race fix from #1322, and `RUST_TEST_THREADS=1` for the already-sharded `octos-agent` CI job after repeated runner shutdowns. No additional issue is closed by those commits.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `git diff --cached --check`
- `CARGO_HOME=/private/tmp/octos-235-cargo-home CARGO_TARGET_DIR=/private/tmp/octos-235-target CARGO_INCREMENTAL=0 cargo test -p octos-sandbox`
- `CARGO_HOME=/private/tmp/octos-235-cargo-home CARGO_TARGET_DIR=/private/tmp/octos-235-linux-target CARGO_INCREMENTAL=0 cargo check -p octos-sandbox --target x86_64-unknown-linux-gnu`
- `CARGO_HOME=/private/tmp/octos-235-cargo-home CARGO_TARGET_DIR=/private/tmp/octos-235-linux-target CARGO_INCREMENTAL=0 cargo check -p octos-sandbox --tests --target x86_64-unknown-linux-gnu`
- `CARGO_HOME=/private/tmp/octos-235-cargo-home CARGO_TARGET_DIR=/private/tmp/octos-235-linux-target CARGO_INCREMENTAL=0 cargo clippy -p octos-sandbox --tests --target x86_64-unknown-linux-gnu -- -D warnings`
- `CARGO_HOME=/private/tmp/octos-235-cargo-home CARGO_TARGET_DIR=/private/tmp/octos-235-target CARGO_INCREMENTAL=0 cargo clippy -p octos-sandbox --all-targets -- -D warnings`
- `CARGO_HOME=/private/tmp/octos-235-cargo-home CARGO_TARGET_DIR=/private/tmp/octos-235-target CARGO_INCREMENTAL=0 cargo test -p octos-agent sandbox::tests::test_sandbox_mode_serde_roundtrip --lib`
- `CARGO_HOME=/private/tmp/octos-235-cargo-home CARGO_TARGET_DIR=/private/tmp/octos-235-target CARGO_INCREMENTAL=0 cargo test -p octos-cli account_update_ --lib`
- `CARGO_HOME=/private/tmp/octos-235-cargo-home CARGO_TARGET_DIR=/private/tmp/octos-235-target CARGO_INCREMENTAL=0 cargo clippy -p octos-agent --lib -- -D warnings`
- `CARGO_HOME=/private/tmp/octos-235-cargo-home CARGO_TARGET_DIR=/private/tmp/octos-235-target CARGO_INCREMENTAL=0 cargo clippy -p octos-cli --lib -- -D warnings`
- `CARGO_HOME=/private/tmp/octos-235-cargo-home CARGO_TARGET_DIR=/private/tmp/octos-235-target CARGO_INCREMENTAL=0 cargo test -p octos-cli --features api cli_agent_adapter::tests:: -- --nocapture`
- `git diff --check` after the CI-thread hardening commit

GitHub CI is green on current head `c240bce0e0d1182cf7df7f32603227c21fec5ff8`, including `check`, `check-matrix`, `dashboard`, `swarm-app`, `test-octos-agent (lib)`, `test-octos-agent (integration)`, `test-octos-cli`, `typos`, `e2e-tool-regression`, `security`, and author-email. The earlier Linux `check` evidence on `127862dd` included `cargo test -p octos-sandbox`, proving the Linux-only Landlock/seccomp runtime tests after the dynamic-loader execute-access fix. Merge remains branch-protection blocked by required review (`REVIEW_REQUIRED`).

