### PR TITLE
fix(ledger): rename outer discriminator to record_kind

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -123,10 +123,14 @@ impl LedgerConfig {
 
 /// Anything that can sit in the ledger ring.
 ///
-/// Serialized with an outer `envelope` tag distinct from `UiNotification`'s
-/// own `kind` tag so the two enums round-trip cleanly when nested.
+/// Serialized with an outer `record_kind` tag. The earlier name `"envelope"`
+/// collided with `EnvelopeNotification.envelope` once internally-tagged
+/// `UiNotification` flattened its variant data alongside the outer tag —
+/// serde produced two `"envelope"` keys in the same object and rejected
+/// the record on replay (`duplicate field 'envelope'`). `record_kind` is
+/// disjoint from every flattened inner field name on both branches.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "envelope", rename_all = "snake_case")]
+#[serde(tag = "record_kind", rename_all = "snake_case")]
 pub(crate) enum UiProtocolLedgerEvent {
     Notification(UiNotification),
     Progress(UiProgressEvent),
@@ -3420,5 +3424,40 @@ mod tests {
             "completed=true MUST survive restart so post-completion \
              envelopes stay barriered even without an in-memory ring"
         );
+    }
+
+    #[test]
+    fn envelope_notification_round_trips_through_ledger_wrapper() {
+        // On mini3 we saw 5 ledger records dropped on replay with
+        //   error=Error("duplicate field `envelope`", ...)
+        // because the outer `tag = "envelope"` discriminator flattened
+        // alongside `EnvelopeNotification.envelope` and produced two
+        // identical keys in the same JSON object. The wider standalone
+        // round-trip test for `EnvelopeNotification` in octos-core missed
+        // this — only the ledger wrapper exhibits the collision.
+        let session = SessionKey("local:envelope-round-trip".into());
+        let event = UiProtocolLedgerEvent::Notification(UiNotification::Envelope(
+            EnvelopeNotification {
+                session_id: session.clone(),
+                topic: Some("planning".into()),
+                envelope: Envelope {
+                    thread_id: "round-trip-thread".into(),
+                    seq: 7,
+                    client_message_id: None,
+                    payload: Payload::AssistantDelta {
+                        text: "round-trip me".into(),
+                    },
+                },
+            },
+        ));
+
+        let serialized = serde_json::to_string(&event).expect("ledger event serializes");
+        assert!(
+            !serialized.contains("\"envelope\":\"notification\""),
+            "outer ledger discriminator must NOT be named `envelope` — got {serialized}"
+        );
+        let parsed: UiProtocolLedgerEvent = serde_json::from_str(&serialized)
+            .unwrap_or_else(|e| panic!("ledger replay MUST succeed: {e}; payload={serialized}"));
+        assert_eq!(parsed, event, "round-trip must be field-equal");
     }
 }


### PR DESCRIPTION
## Summary

- `UiProtocolLedgerEvent` used `#[serde(tag = "envelope")]` for its outer enum, while `UiNotification::Envelope(EnvelopeNotification)` carries a struct field also named `envelope`. The flattened JSON produces two `envelope` keys; serde rejects on replay with `duplicate field 'envelope'`.
- Observed live on **mini3**: 5 records dropped from a slides-session ledger right after the round-24 daemon boot.
- Renames the outer tag to `record_kind` (disjoint from any flattened inner field). **Disk format only** — the wire path via `into_rpc_notification` extracts the bare `Envelope` and is unaffected.
- Old on-disk records were already being dropped by the old code; no migration regression.

## Why the existing test missed it

`crates/octos-core/src/ui_protocol.rs:10100+` round-trips `EnvelopeNotification` *standalone* — its serialized object has only one `envelope` key (the inner field). The collision only surfaces when wrapped in `UiProtocolLedgerEvent`, which the new test now does.

## Sample broken record (from mini3)

```json
{"v":1,"seq":5,"event":{"envelope":"notification","kind":"envelope","session_id":"slides-...","topic":"slides untitled-deck-...","envelope":{"thread_id":"...","seq":1,"payload":{...}}}}
```

Note the two `"envelope"` keys at the same nesting level.

## Test plan

- [x] New regression test passes: `cargo test -p octos-cli --features api --lib through_ledger_wrapper`
- [x] Full ledger suite: 32 passed
- [ ] Deploy to mini3 + verify no fresh `duplicate field 'envelope'` warnings in subsequent slides sessions