### PR TITLE
fix: format and lint current Rust regression tests

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -171,12 +171,12 @@ pub(super) fn satisfied_completion_content(output_files: &[String], tool_output:
 /// Empirical validation (llm-benchmark replay of mini3 session
 /// slides-1780013669236-8w2ime, the production failure that motivated
 /// this fix):
-///   - kimi-k2.5 + only `check_workspace_contract`:
-///     loop rate 5/5 → 3/5 with this block (40% break out)
-///   - kimi-k2.5 + check + read_file + list_dir:
-///     no consistent change (within noise)
-///   - claude-opus-4.7:
-///     already 0/5 loops in both arms; block has no effect on Opus
+/// - kimi-k2.5 + only `check_workspace_contract`:
+///   loop rate 5/5 → 3/5 with this block (40% break out)
+/// - kimi-k2.5 + check + read_file + list_dir:
+///   no consistent change (within noise)
+/// - claude-opus-4.7:
+///   already 0/5 loops in both arms; block has no effect on Opus
 ///
 /// The block follows hermes-agent's prompt-time-injection pattern (in
 /// `agent/prompt_builder.py`), but applied universally rather than


### PR DESCRIPTION
## Summary
- Refresh #1359 onto current `origin/main` and preserve the mechanical rustfmt/clippy-cleanup intent.
- Most of the original five-file formatting/lint diff is already present on current main; the remaining refreshed diff is limited to rustdoc bullet formatting in `crates/octos-agent/src/agent/execution.rs`.
- No behavior changes and no closing issue reference.

Refs #1358

## Current-main refresh
- Base: current `origin/main` / GitHub `main` `f6936c452389c5172496ee0c3e13393956086d92`.
- Old head: `31a6e2b461f61723847dbd8deaab864c16f4a2da`.
- Refreshed head: `48349d0f8d3d44f0e772032b060689779eaf8642`.
- Isolated checkout: `/Users/yuechen/home/octos/target/octos-1359-f693.1H35Vo/octos`; root dirty checkout left untouched.
- Environment: Darwin arm64; `rustc 1.95.0`; `cargo 1.95.0`; build targets under `/private/tmp`.
- Conflict resolution: kept current-main `result_before_hint` ledger behavior in `loop_runner.rs`; after replay, that file no longer differs from current main.

## Validation
Passed locally:
- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`
- `typos crates/octos-agent/src/agent/execution.rs`
- `CARGO_TARGET_DIR=/private/tmp/octos-1359-f693-agent-test-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-agent --lib record_result -- --nocapture` passed: 5/5.
- `CARGO_TARGET_DIR=/private/tmp/octos-1359-f693-clippy-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings` passed.
- `git ls-files --others --exclude-standard` was empty in the isolated checkout.

## CI / merge status
- GitHub CI is green on refreshed head `48349d0f8d3d44f0e772032b060689779eaf8642`.
- Merge is expected to remain branch-protection blocked by required review.

