### PR TITLE
fix(tools): explicit all_ready + summary signal on check_workspace_contract

### DIFF
--- a/crates/octos-agent/src/tools/check_workspace_contract.rs
+++ b/crates/octos-agent/src/tools/check_workspace_contract.rs
@@ -55,7 +55,7 @@ impl Tool for CheckWorkspaceContractTool {
     }
 
     fn description(&self) -> &str {
-        "Inspect workspace contract state for the current workspace. Use this to answer whether a slides/site deliverable is actually ready, which required checks failed, which artifacts exist, and what revision is currently present. Task state tells you what happened in execution; workspace state tells you what is true about the deliverable."
+        "Inspect workspace contract state for the current workspace. Use this to answer whether a slides/site deliverable is actually ready, which required checks failed, which artifacts exist, and what revision is currently present. Task state tells you what happened in execution; workspace state tells you what is true about the deliverable. The output includes a top-level `all_ready: bool` — when true, the deliverable is COMPLETE and you should finish the turn rather than re-poll."
     }
 
     fn tags(&self) -> &[&str] {
@@ -106,11 +106,36 @@ impl Tool for CheckWorkspaceContractTool {
             contracts.retain(|status| !status.ready);
         }
 
+        let repo_count = contracts.len();
+        let ready_count = contracts.iter().filter(|status| status.ready).count();
+        // `all_ready` is the explicit termination signal for the LLM. When this
+        // is `true`, the deliverable is satisfied and there is no reason to
+        // re-poll — every artifact under the contract is present and every
+        // required validator passed. Without this flag the LLM had to derive
+        // the answer from a 4 KB nested artifact tree, which on degraded
+        // models (kimi @ 44 tools, ~110 KB prompt) collapsed into a tight
+        // re-call loop the runtime had to break with LOOP DETECTED.
+        let all_ready = repo_count > 0 && ready_count == repo_count;
+        let summary = if repo_count == 0 {
+            "No workspace contracts match the selector.".to_string()
+        } else if all_ready {
+            format!(
+                "All {repo_count} contract(s) satisfied — every required artifact is present and every validator passed. The deliverable is COMPLETE; do not re-poll, finish the turn."
+            )
+        } else {
+            let not_ready = repo_count - ready_count;
+            format!(
+                "{ready_count}/{repo_count} contract(s) satisfied; {not_ready} not yet ready — inspect `contracts[].ready_state` for what's missing."
+            )
+        };
+
         let output = json!({
             "workspace_root": self.base_dir,
             "requested_project": input.project,
-            "repo_count": contracts.len(),
-            "ready_count": contracts.iter().filter(|status| status.ready).count(),
+            "all_ready": all_ready,
+            "summary": summary,
+            "repo_count": repo_count,
+            "ready_count": ready_count,
             "contracts": contracts,
         });
 
@@ -207,6 +232,15 @@ mod tests {
         let payload: serde_json::Value = serde_json::from_str(&result.output).unwrap();
         assert_eq!(payload["repo_count"], 1);
         assert_eq!(payload["ready_count"], 1);
+        assert_eq!(payload["all_ready"], true);
+        assert!(
+            payload["summary"]
+                .as_str()
+                .map(|s| s.contains("COMPLETE") && s.contains("do not re-poll"))
+                .unwrap_or(false),
+            "summary must give the LLM an explicit termination signal: {}",
+            payload["summary"]
+        );
         assert_eq!(payload["contracts"][0]["repo_label"], "slides/demo");
         assert_eq!(payload["contracts"][0]["ready"], true);
         assert_eq!(payload["contracts"][0]["artifacts"][0]["name"], "deck");


### PR DESCRIPTION
## Summary

Live mini3 soak (session `slides-1780013669236-8w2ime`) hit a 5-iteration loop on `check_workspace_contract`. The loop detector caught it at iter 4 (\"[LOOP DETECTED] The agent kept calling the same tool with the same arguments...\") and terminated the turn at iter 5.

Root cause is dual:
1. **Tool count 44 + ~110 KB prompt → kimi falls into a fixed-point attractor** that re-emits the safest-looking tool name with empty args. Already flagged by the runtime: `WARN high tool count may cause empty responses with some models; tools=44`.
2. **`check_workspace_contract` gave the LLM no top-level termination signal** — the 4 KB output had every artifact marked `\"present\": true` and `repo_count == ready_count`, but the LLM had to walk the tree to derive that. On a degraded model, it kept re-polling instead.

This PR closes (2). (1) is tracked separately — needs per-topic `tool_policy` infrastructure (extend `tool_policy_by_provider` to `tool_policy_by_topic`), not a leaf-tool change.

## What changes

```diff
+ "all_ready": true,
+ "summary": "All 1 contract(s) satisfied — every required artifact is present and every validator passed. The deliverable is COMPLETE; do not re-poll, finish the turn.",
  "workspace_root": "...",
  "requested_project": "slides/...",
  "repo_count": 1,
  "ready_count": 1,
  "contracts": [ ... existing tree ... ]
```

Tool `description()` updated to mention `all_ready` so the LLM sees the contract at session-start.

## Test plan

- [x] `cargo test -p octos-agent --lib check_workspace_contract` — 3/3 pass
- [x] New assertion verifies the summary contains both \"COMPLETE\" and \"do not re-poll\" — the explicit termination signal
- [ ] Deploy to mini3, observe that the LLM stops looping on this tool

## Out of scope

Per-topic tool policy (44 → ~15 tools for slides sessions) — separate PR.