### PR TITLE
fix(agent): result-hash no-progress detector (OpenClaw-style)

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -1183,6 +1183,7 @@ impl Agent {
                                     Some(&mut tool_structured_metadata),
                                     Some(&mut iter_tool_success),
                                     Some(&mut turn_output_log),
+                                    &mut loop_detector,
                                 )
                                 .await
                             {
@@ -1520,6 +1521,10 @@ impl Agent {
             // the same session (the guard's `Drop` impl writes back).
             let mut retry_state =
                 PersistentRetryStateGuard::new(self.persistent_retry_state.clone());
+            // PR #1363: task-loop gets its own detector so handle_tool_use
+            // can run the no-progress soft check on tool results here too.
+            // Matches the conversation-loop's window of 12.
+            let mut loop_detector = LoopDetector::new(12);
             let config = self.chat_config();
 
             loop {
@@ -1770,6 +1775,7 @@ impl Agent {
                                 None,
                                 None,
                                 None,
+                                &mut loop_detector,
                             )
                             .await
                         {
@@ -1923,6 +1929,15 @@ impl Agent {
         // `TaskResult`, not `ConversationResponse`, so no log is
         // needed there).
         turn_output_log: Option<&mut Vec<Message>>,
+        // PR #1363 (this PR): the outer-scope LoopDetector. Hard cycle
+        // detection runs in the caller BEFORE this is invoked (so the
+        // turn can be terminated cleanly); the soft "no progress" hint
+        // — which augments the just-produced tool result — runs INSIDE
+        // this function because we need the actual result content. The
+        // soft check is non-terminating: if it fires, the hint is
+        // appended to the matching Tool message's content and the
+        // conversation continues.
+        loop_detector: &mut LoopDetector,
     ) -> Result<ChatResponse> {
         // Sanitize tool_call_id characters: some providers (e.g. Moonshot/kimi)
         // generate IDs like "admin_view_sessions:11" which OpenAI rejects (only
@@ -2011,12 +2026,45 @@ impl Agent {
             sink.extend(tool_success);
         }
 
-        let merged = merge_tool_messages_in_order(
+        let mut merged = merge_tool_messages_in_order(
             &response,
             &limited_response,
             tool_messages,
             blocked_messages,
         );
+
+        // PR #1363: OpenClaw-style no-progress check. For each Tool
+        // message we just produced, record `(tool_name, args, result)`
+        // in the result-aware ring. If the last 3 records match, append
+        // a soft NO_PROGRESS hint to that tool message's content so the
+        // LLM sees it on its next iteration. Distinguishes a stuck loop
+        // (identical (args, result) repeated) from a legitimate poll
+        // (same args, evolving result). Non-terminating — the hard
+        // cycle detector at the caller's pre-call site is the backstop.
+        {
+            use std::collections::HashMap;
+            let id_to_call: HashMap<&str, (&str, &serde_json::Value)> = response
+                .tool_calls
+                .iter()
+                .map(|tc| (tc.id.as_str(), (tc.name.as_str(), &tc.arguments)))
+                .collect();
+            for message in merged.iter_mut() {
+                if message.role != MessageRole::Tool {
+                    continue;
+                }
+                let Some(id) = message.tool_call_id.as_deref() else {
+                    continue;
+                };
+                let Some(&(name, args)) = id_to_call.get(id) else {
+                    continue;
+                };
+                if let Some(hint) =
+                    loop_detector.record_result(name, args, &message.content)
+                {
+                    message.content.push_str(&hint);
+                }
+            }
+        }
 
         // M6.2: record a productive-tool-call signal per merged Tool message
         // so the `LoopRetryState` grace-call path sees the loop making progress.

--- a/crates/octos-agent/src/loop_detect.rs
+++ b/crates/octos-agent/src/loop_detect.rs
@@ -7,10 +7,33 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
+/// Soft "no-progress" hint appended to a tool result when the same
+/// (name, args, result) triple has been seen 3 times in a row. The
+/// LLM sees this on its next iteration as part of the most recent
+/// tool result — it does not terminate the turn. Hard cycle detection
+/// (existing logic) catches anything that survives this nudge.
+///
+/// This is the OpenClaw lesson — distinguish "no progress" (same args
+/// AND same result) from legitimate polling (same args, different
+/// result over time). The production loop on mini3 session 8w2ime had
+/// kimi-k2.5 calling `check_workspace_contract` 5 times with the same
+/// args, all returning identical 4 KB trees. With result hashing, that
+/// fires at iter 3 — early enough to nudge before the hard cycle
+/// detector terminates the turn at iter 4. Legitimate polls like
+/// `check_background_tasks` (which return different statuses while a
+/// background job runs) are unaffected.
+pub const NO_PROGRESS_HINT: &str = "\n\n[NO PROGRESS] You have now called this tool 3 times in a row with identical arguments AND received identical results. Calling it again will produce the same result. To make progress, either switch to a different tool (read_file / list_dir / view_image for file content) or finish the turn with the information you already have.";
+
 /// Tracks tool call patterns and detects loops.
 pub struct LoopDetector {
-    /// Ring buffer of recent tool call signatures.
+    /// Ring buffer of recent tool call signatures (name + args).
+    /// Used by `record()` for hard cycle detection.
     signatures: Vec<u64>,
+    /// Ring buffer of recent (name + args + result) signatures.
+    /// Used by `record_result()` for the OpenClaw-style "no progress"
+    /// soft hint, which only fires when both args AND result repeat —
+    /// distinguishing stuck loops from legitimate polling.
+    result_signatures: Vec<u64>,
     /// Maximum window size to check for patterns.
     window: usize,
 }
@@ -20,6 +43,7 @@ impl LoopDetector {
     pub fn new(window: usize) -> Self {
         Self {
             signatures: Vec::with_capacity(window * 2),
+            result_signatures: Vec::with_capacity(window * 2),
             window,
         }
     }
@@ -67,6 +91,61 @@ impl LoopDetector {
         let args_str = args.to_string();
         args_str.hash(&mut hasher);
         hasher.finish()
+    }
+
+    /// Compute a signature hash for a tool call AND its result.
+    fn signature_with_result(name: &str, args: &serde_json::Value, result: &str) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        name.hash(&mut hasher);
+        let args_str = args.to_string();
+        args_str.hash(&mut hasher);
+        result.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// Record a tool call's RESULT after the tool has executed.
+    ///
+    /// Returns `Some(NO_PROGRESS_HINT)` when the last 3 records for
+    /// this `(name, args, result)` triple are identical — meaning the
+    /// LLM called the same tool with the same args 3 times in a row
+    /// AND got the same result each time. This is the "no progress"
+    /// signal that distinguishes stuck loops from legitimate polling.
+    ///
+    /// Fires at most once per "burst" — after firing, the result
+    /// signature ring is cleared so a 4th identical call does not
+    /// re-fire (the existing `record()` cycle detector picks up
+    /// anything that survives the soft nudge).
+    ///
+    /// Callers should append the returned hint to the tool result
+    /// message's content so the LLM sees it as part of its next-turn
+    /// context. Does NOT terminate the turn — that's the hard
+    /// detector's job.
+    pub fn record_result(
+        &mut self,
+        tool_name: &str,
+        args: &serde_json::Value,
+        result: &str,
+    ) -> Option<String> {
+        let sig = Self::signature_with_result(tool_name, args, result);
+        self.result_signatures.push(sig);
+
+        // Bound the ring buffer
+        if self.result_signatures.len() > self.window * 2 {
+            let drain_to = self.result_signatures.len() - self.window;
+            self.result_signatures.drain(..drain_to);
+        }
+
+        let len = self.result_signatures.len();
+        if len < 3 {
+            return None;
+        }
+        let last3 = &self.result_signatures[len - 3..];
+        if last3[0] == last3[1] && last3[1] == last3[2] {
+            // Fire once — clear so a 4th identical call won't re-fire.
+            self.result_signatures.clear();
+            return Some(NO_PROGRESS_HINT.to_string());
+        }
+        None
     }
 
     /// Check if the window contains a repeating pattern of the given cycle length.
@@ -147,5 +226,73 @@ mod tests {
         assert!(d.record("t", &b).is_none());
         let warning = d.record("t", &c);
         assert!(warning.is_some());
+    }
+
+    // ----- record_result tests (OpenClaw-style no-progress detection) -----
+
+    #[test]
+    fn record_result_quiet_for_first_two_calls() {
+        let mut d = LoopDetector::new(10);
+        let args = json!({"project": "slides/demo"});
+        let same_result = "{\"contracts\":[{\"ready\":true}]}";
+        assert!(d.record_result("check", &args, same_result).is_none());
+        assert!(d.record_result("check", &args, same_result).is_none());
+    }
+
+    #[test]
+    fn record_result_fires_after_three_identical_triples() {
+        let mut d = LoopDetector::new(10);
+        let args = json!({"project": "slides/demo"});
+        let result = "{\"contracts\":[{\"ready\":true}]}";
+        assert!(d.record_result("check", &args, result).is_none());
+        assert!(d.record_result("check", &args, result).is_none());
+        let hint = d.record_result("check", &args, result);
+        assert!(hint.is_some(), "expected NO PROGRESS hint after 3 identical");
+        assert!(hint.unwrap().contains("NO PROGRESS"));
+    }
+
+    #[test]
+    fn record_result_silent_when_result_changes_legitimate_poll() {
+        let mut d = LoopDetector::new(10);
+        let args = json!({});
+        // Same tool + args, but result evolves (polling case)
+        assert!(d.record_result("poll", &args, "running").is_none());
+        assert!(d.record_result("poll", &args, "running").is_none());
+        assert!(d.record_result("poll", &args, "completed").is_none());
+        // Even after switching back, two same + one different is not a streak of 3
+        assert!(d.record_result("poll", &args, "running").is_none());
+    }
+
+    #[test]
+    fn record_result_silent_when_args_change() {
+        let mut d = LoopDetector::new(10);
+        let result = "ok";
+        assert!(
+            d.record_result("read_file", &json!({"path": "a"}), result)
+                .is_none()
+        );
+        assert!(
+            d.record_result("read_file", &json!({"path": "b"}), result)
+                .is_none()
+        );
+        assert!(
+            d.record_result("read_file", &json!({"path": "c"}), result)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn record_result_fires_once_per_burst() {
+        let mut d = LoopDetector::new(10);
+        let args = json!({"x": 1});
+        let result = "same";
+        d.record_result("t", &args, result);
+        d.record_result("t", &args, result);
+        let first = d.record_result("t", &args, result);
+        assert!(first.is_some());
+        // 4th identical call should NOT re-fire — buffer was cleared.
+        // The hard cycle detector picks up anything that survives.
+        let second = d.record_result("t", &args, result);
+        assert!(second.is_none());
     }
 }


### PR DESCRIPTION
See commit message. Adopts OpenClaw's result-hashing pattern that codex and hermes both skip. Distinguishes stuck loops (same args + same result repeated) from legitimate polling (same args, evolving result). Fires soft hint at iter 3, complementary with the existing iter-4 hard cycle detector. 5 new unit tests + 13 total pass.