### PR TITLE
fix(agent): synthesize tool_call_id when provider streams none (spawn_only recovery)

### DIFF
--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -281,10 +281,25 @@ impl Agent {
         // PR — with the boundary in place they were treating symptoms of
         // the missing invariant, not addressing it.
         let mut parsed_tool_calls: Vec<octos_core::ToolCall> = Vec::with_capacity(tool_calls.len());
-        for (id, name, args, metadata) in tool_calls {
+        for (index, (id, name, args, metadata)) in tool_calls.into_iter().enumerate() {
             if name.is_empty() {
                 continue;
             }
+            // Some OpenAI-compatible providers (kimi / MiniMax via wisemodel)
+            // stream tool calls with no `id`. An empty tool_call_id is not
+            // cosmetic: it silently disables spawn_only failure-recovery
+            // downstream — `TaskSupervisor::notify_failure` returns early on
+            // an empty id (it can't key the synth-ack lookup), so a failed
+            // background skill never routes a recovery turn back to the LLM
+            // and the model can't fix its own bad input. Mint a stable,
+            // per-response-unique positional id (matching the Gemini
+            // provider's `call_{n}` convention) so a non-empty id always
+            // reaches the agent loop.
+            let id = if id.is_empty() {
+                format!("call_{index}")
+            } else {
+                id
+            };
             match serde_json::from_str(&args) {
                 Ok(arguments) => parsed_tool_calls.push(octos_core::ToolCall {
                     id,
@@ -577,6 +592,53 @@ mod tests {
             elapsed < std::time::Duration::from_secs(5),
             "idle timeout took {elapsed:?} — wait_for_shutdown safety guard likely fired \
              before the 1s timeout, which means the test passes by accident"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_synthesizes_tool_call_id_when_provider_omits_it() {
+        // Regression (mofa_slides slides-1780072199773-2htqt1, mini3,
+        // 2026-05-29): kimi / MiniMax via wisemodel stream tool calls with
+        // NO `id` field. An empty tool_call_id silently disables spawn_only
+        // failure-recovery downstream — `TaskSupervisor::notify_failure`
+        // returns early on an empty id (it can't key the synth-ack lookup),
+        // so a failed background skill never routes a recovery turn back to
+        // the LLM and the model can't fix its own bad input. The streaming
+        // assembler must mint a stable, unique positional id (matching the
+        // Gemini provider's `call_{n}` convention) so a non-empty id always
+        // reaches the agent loop.
+        let (agent, _dir) = build_test_agent().await;
+
+        let stream = into_chat_stream(vec![
+            StreamEvent::ToolCallDelta {
+                index: 0,
+                id: None,
+                name: Some("mofa_slides".to_string()),
+                arguments_delta: r#"{"deck":"x"}"#.to_string(),
+            },
+            StreamEvent::ToolCallDelta {
+                index: 1,
+                id: None,
+                name: Some("glob".to_string()),
+                arguments_delta: r#"{"pattern":"*.toml"}"#.to_string(),
+            },
+            StreamEvent::Usage(LlmTokenUsage::default()),
+            StreamEvent::Done(StopReason::ToolUse),
+        ]);
+
+        let (resp, _streamed) = agent
+            .consume_stream_with_input_estimate(stream, 1, 100)
+            .await
+            .expect("clean tool-use stream must assemble into a ChatResponse");
+
+        assert_eq!(resp.tool_calls.len(), 2);
+        assert!(
+            !resp.tool_calls[0].id.is_empty() && !resp.tool_calls[1].id.is_empty(),
+            "empty provider tool_call ids must be synthesized, not passed through"
+        );
+        assert_ne!(
+            resp.tool_calls[0].id, resp.tool_calls[1].id,
+            "synthesized ids must be unique per tool call"
         );
     }
 

--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -1,6 +1,6 @@
 //! Stream consumption, shutdown handling, and cost reporting.
 
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use eyre::Result;
 use futures::StreamExt;
@@ -10,6 +10,14 @@ use tracing::warn;
 
 use super::Agent;
 use crate::progress::ProgressEvent;
+
+/// Process-global monotonic counter for synthesizing tool-call ids when a
+/// provider streams a tool call with no `id`. MUST be globally unique (not a
+/// per-response positional index): `TaskSupervisor`'s
+/// `synth_ack_emitted_tool_call_ids` set is long-lived per session, so a
+/// positional id reused across responses could match a stale ack and fire an
+/// unwarranted recovery turn (codex P2).
+static SYNTH_TOOL_CALL_SEQ: AtomicU64 = AtomicU64::new(0);
 
 /// Default inter-chunk idle timeout for SSE streams.
 ///
@@ -281,7 +289,7 @@ impl Agent {
         // PR — with the boundary in place they were treating symptoms of
         // the missing invariant, not addressing it.
         let mut parsed_tool_calls: Vec<octos_core::ToolCall> = Vec::with_capacity(tool_calls.len());
-        for (index, (id, name, args, metadata)) in tool_calls.into_iter().enumerate() {
+        for (id, name, args, metadata) in tool_calls.into_iter() {
             if name.is_empty() {
                 continue;
             }
@@ -291,12 +299,16 @@ impl Agent {
             // downstream — `TaskSupervisor::notify_failure` returns early on
             // an empty id (it can't key the synth-ack lookup), so a failed
             // background skill never routes a recovery turn back to the LLM
-            // and the model can't fix its own bad input. Mint a stable,
-            // per-response-unique positional id (matching the Gemini
-            // provider's `call_{n}` convention) so a non-empty id always
-            // reaches the agent loop.
+            // and the model can't fix its own bad input. Mint a PROCESS-UNIQUE
+            // id (monotonic counter, NOT a positional `call_{index}`): the
+            // supervisor's synth-ack set is long-lived per session, so a
+            // positional id reused across responses could match a stale ack
+            // and fire an unwarranted recovery turn (codex P2).
             let id = if id.is_empty() {
-                format!("call_{index}")
+                format!(
+                    "call_synth_{}",
+                    SYNTH_TOOL_CALL_SEQ.fetch_add(1, Ordering::Relaxed)
+                )
             } else {
                 id
             };
@@ -633,12 +645,44 @@ mod tests {
 
         assert_eq!(resp.tool_calls.len(), 2);
         assert!(
-            !resp.tool_calls[0].id.is_empty() && !resp.tool_calls[1].id.is_empty(),
-            "empty provider tool_call ids must be synthesized, not passed through"
+            resp.tool_calls
+                .iter()
+                .all(|tc| tc.id.starts_with("call_synth_")),
+            "empty provider tool_call ids must be synthesized, not passed through: {:?}",
+            resp.tool_calls.iter().map(|tc| &tc.id).collect::<Vec<_>>()
         );
         assert_ne!(
             resp.tool_calls[0].id, resp.tool_calls[1].id,
             "synthesized ids must be unique per tool call"
+        );
+
+        // codex P2: ids must be unique ACROSS responses too — the supervisor's
+        // synth-ack set is long-lived per session, so a positional `call_0`
+        // reused on a later turn could match a stale ack. A second assembly
+        // must produce a disjoint id set.
+        let first_ids: std::collections::HashSet<String> =
+            resp.tool_calls.iter().map(|tc| tc.id.clone()).collect();
+        let stream2 = into_chat_stream(vec![
+            StreamEvent::ToolCallDelta {
+                index: 0,
+                id: None,
+                name: Some("mofa_slides".to_string()),
+                arguments_delta: r#"{"deck":"y"}"#.to_string(),
+            },
+            StreamEvent::Usage(LlmTokenUsage::default()),
+            StreamEvent::Done(StopReason::ToolUse),
+        ]);
+        let (resp2, _) = agent
+            .consume_stream_with_input_estimate(stream2, 2, 100)
+            .await
+            .expect("second stream must assemble");
+        assert!(
+            resp2
+                .tool_calls
+                .iter()
+                .all(|tc| !first_ids.contains(&tc.id)),
+            "synthesized ids must not collide across responses (codex P2): first={first_ids:?} second={:?}",
+            resp2.tool_calls.iter().map(|tc| &tc.id).collect::<Vec<_>>()
         );
     }
 

--- a/crates/octos-agent/tests/spawn_only_empty_id_recovery.rs
+++ b/crates/octos-agent/tests/spawn_only_empty_id_recovery.rs
@@ -1,0 +1,215 @@
+//! Whole-chain regression: an ID-less provider (empty `tool_call_id`) must
+//! still route a spawn_only background FAILURE back as a recovery signal.
+//!
+//! Production context (session slides-1780072199773-2htqt1, mini3,
+//! 2026-05-29): kimi / MiniMax via wisemodel stream tool calls with no `id`.
+//! Before the streaming-layer id synthesis in `agent/streaming.rs`, the
+//! empty `tool_call_id` made `TaskSupervisor::notify_failure` skip the
+//! `SpawnOnlyFailureSignal`, so a failed background skill (e.g. `mofa_slides`
+//! parse-erroring on a TOML the model itself wrote) never routed a recovery
+//! turn back to the LLM and the model could not self-correct.
+//!
+//! This drives the REAL agent loop end to end — streaming assembly
+//! (id synthesis) -> spawn_only synth-ack -> background dispatch -> failure
+//! -> `notify_failure` -> `SpawnOnlyFailureSignal`. The `ScriptedLlm`'s
+//! `ChatResponse` carries an empty `tool_call_id`; the default `chat_stream`
+//! re-emits it as a `ToolCallDelta` consumed by `consume_stream_inner`, which
+//! is exactly where the synthesized `call_{index}` id is minted. The signal
+//! is what the session actor / WS path turns into a recovery turn (covered
+//! separately by `session_actor` tests for non-empty ids), so asserting the
+//! signal fires closes the empty-id gap.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use octos_agent::{Agent, AgentConfig, ReadTaskOutputTool, Tool, ToolRegistry, ToolResult};
+use octos_core::{AgentId, Message, ToolCall};
+use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, TokenUsage, ToolSpec};
+use octos_memory::EpisodeStore;
+use tempfile::TempDir;
+
+struct ScriptedLlm {
+    responses: Mutex<Vec<ChatResponse>>,
+}
+
+impl ScriptedLlm {
+    fn new(responses: Vec<ChatResponse>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for ScriptedLlm {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> eyre::Result<ChatResponse> {
+        let mut r = self.responses.lock().unwrap();
+        if r.is_empty() {
+            eyre::bail!("ScriptedLlm: no more responses");
+        }
+        Ok(r.remove(0))
+    }
+    fn context_window(&self) -> u32 {
+        128_000
+    }
+    fn model_id(&self) -> &str {
+        "empty-id-recovery-test"
+    }
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+/// A spawn_only probe whose background execution always fails — mirrors a
+/// `mofa_slides` run that hits a TOML parse error after being backgrounded.
+struct FailingSpawnOnlyTool;
+
+#[async_trait]
+impl Tool for FailingSpawnOnlyTool {
+    fn name(&self) -> &str {
+        "failing_probe"
+    }
+    fn description(&self) -> &str {
+        "spawn_only probe that always fails in the background"
+    }
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+    async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+        eyre::bail!("simulated TOML parse failure at line 40")
+    }
+}
+
+fn tool_use(calls: Vec<ToolCall>) -> ChatResponse {
+    ChatResponse {
+        content: None,
+        reasoning_content: None,
+        tool_calls: calls,
+        stop_reason: StopReason::ToolUse,
+        usage: TokenUsage {
+            input_tokens: 50,
+            output_tokens: 5,
+            ..Default::default()
+        },
+        provider_index: None,
+    }
+}
+
+fn end_turn(text: &str) -> ChatResponse {
+    ChatResponse {
+        content: Some(text.into()),
+        reasoning_content: None,
+        tool_calls: vec![],
+        stop_reason: StopReason::EndTurn,
+        usage: TokenUsage {
+            input_tokens: 5,
+            output_tokens: 5,
+            ..Default::default()
+        },
+        provider_index: None,
+    }
+}
+
+fn tc(id: &str, name: &str) -> ToolCall {
+    ToolCall {
+        id: id.into(),
+        name: name.into(),
+        arguments: serde_json::json!({}),
+        metadata: None,
+    }
+}
+
+#[tokio::test]
+async fn empty_id_spawn_only_failure_still_fires_recovery_signal() {
+    let memory_dir = TempDir::new().unwrap();
+
+    let mut tools = ToolRegistry::new();
+    tools.register(FailingSpawnOnlyTool);
+    tools.mark_spawn_only("failing_probe", None);
+
+    // The new task_handle envelope path is gated on `read_task_output` being
+    // registered (otherwise the legacy free-text ack is used). Wire it so the
+    // test exercises the production-shaped path.
+    let supervisor = tools.supervisor();
+    let workspace = memory_dir.path().join("ws");
+    std::fs::create_dir_all(&workspace).unwrap();
+    tools.register(ReadTaskOutputTool::new(
+        supervisor.clone(),
+        "test-session",
+        None,
+        workspace,
+    ));
+
+    // Capture (tool_name, error_message) for any SpawnOnlyFailureSignal the
+    // supervisor emits. This is the signal the session actor / WS path turns
+    // into a recovery turn.
+    let captured: Arc<Mutex<Vec<(String, String)>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = captured.clone();
+    supervisor.set_on_failure_signal(move |signal| {
+        sink.lock()
+            .unwrap()
+            .push((signal.tool_name.clone(), signal.error_message.clone()));
+    });
+
+    let memory = Arc::new(
+        EpisodeStore::open(memory_dir.path().join(".octos"))
+            .await
+            .unwrap(),
+    );
+
+    // Turn 1: the model calls the spawn_only tool with an EMPTY tool_call_id
+    // — the kimi / MiniMax via wisemodel regime. The default `chat_stream`
+    // re-emits it as a `ToolCallDelta`, and `consume_stream_inner` mints the
+    // synthesized `call_0` id. Turn 2 is a safety net (the foreground turn
+    // ends at the spawn_only ack).
+    let llm: Arc<dyn LlmProvider> = Arc::new(ScriptedLlm::new(vec![
+        tool_use(vec![tc("", "failing_probe")]),
+        end_turn("acknowledged the failure"),
+    ]));
+
+    let agent = Agent::new(AgentId::new("empty-id-recovery"), llm, tools, memory).with_config(
+        AgentConfig {
+            save_episodes: false,
+            suppress_auto_send_files: true,
+            ..Default::default()
+        },
+    );
+
+    let _ = agent
+        .process_message("kick the failing probe", &[], vec![])
+        .await
+        .expect("agent loop must not error");
+
+    // Let the detached background task fail and the signal propagate.
+    for _ in 0..100 {
+        if !captured.lock().unwrap().is_empty() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let signals = captured.lock().unwrap();
+    assert!(
+        !signals.is_empty(),
+        "spawn_only background failure must fire a recovery signal even when the \
+         provider emitted an EMPTY tool_call_id — the synthesized id must reach \
+         the supervisor's synth-ack lookup. (Empty here means notify_failure \
+         silently skipped and the model would never get a recovery turn.)"
+    );
+    assert_eq!(
+        signals[0].0, "failing_probe",
+        "signal must name the failed tool"
+    );
+    assert!(
+        signals[0].1.contains("simulated TOML parse failure"),
+        "signal must carry the background failure text; got: {}",
+        signals[0].1
+    );
+}


### PR DESCRIPTION
## Problem
ID-less OpenAI-compatible providers (kimi / MiniMax via wisemodel) stream tool calls with no `id`. The streaming assembler left it empty, silently disabling spawn_only failure-recovery: `TaskSupervisor::notify_failure` returns early on an empty `tool_call_id`, so a failed background skill (e.g. `mofa_slides` hitting a TOML parse error) dead-ended with no agent turn to fix it. Root-caused from prod session `slides-1780072199773-2htqt1` (mini3).

## Fix
Mint a process-unique id (`call_synth_{n}`, monotonic counter) where the agent loop assembles a streamed ChatResponse. NOT positional (supervisor synth-ack set is session-lived; a reused `call_0` could match a stale ack — codex P2, fixed).

## Verification
- Unit + whole-chain integration test, falsification-verified.
- Live A/B on mini3: forced `mofa_slides` TOML failure now drives a recovery turn; the original empty-id failure produced 0 continuations.
- codex review: clean.