### PR TITLE
fix(tools): decode scoped upload handles

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -171,12 +171,12 @@ pub(super) fn satisfied_completion_content(output_files: &[String], tool_output:
 /// Empirical validation (llm-benchmark replay of mini3 session
 /// slides-1780013669236-8w2ime, the production failure that motivated
 /// this fix):
-///   - kimi-k2.5 + only `check_workspace_contract`:
-///     loop rate 5/5 → 3/5 with this block (40% break out)
-///   - kimi-k2.5 + check + read_file + list_dir:
-///     no consistent change (within noise)
-///   - claude-opus-4.7:
-///     already 0/5 loops in both arms; block has no effect on Opus
+/// - kimi-k2.5 + only `check_workspace_contract`:
+///   loop rate 5/5 → 3/5 with this block (40% break out)
+/// - kimi-k2.5 + check + read_file + list_dir:
+///   no consistent change (within noise)
+/// - claude-opus-4.7:
+///   already 0/5 loops in both arms; block has no effect on Opus
 ///
 /// The block follows hermes-agent's prompt-time-injection pattern (in
 /// `agent/prompt_builder.py`), but applied universally rather than

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -172,11 +172,11 @@ pub(super) fn satisfied_completion_content(output_files: &[String], tool_output:
 /// slides-1780013669236-8w2ime, the production failure that motivated
 /// this fix):
 ///   - kimi-k2.5 + only `check_workspace_contract`:
-///       loop rate 5/5 → 3/5 with this block (40% break out)
+///     loop rate 5/5 → 3/5 with this block (40% break out)
 ///   - kimi-k2.5 + check + read_file + list_dir:
-///       no consistent change (within noise)
+///     no consistent change (within noise)
 ///   - claude-opus-4.7:
-///       already 0/5 loops in both arms; block has no effect on Opus
+///     already 0/5 loops in both arms; block has no effect on Opus
 ///
 /// The block follows hermes-agent's prompt-time-injection pattern (in
 /// `agent/prompt_builder.py`), but applied universally rather than

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -2058,9 +2058,7 @@ impl Agent {
                 let Some(&(name, args)) = id_to_call.get(id) else {
                     continue;
                 };
-                if let Some(hint) =
-                    loop_detector.record_result(name, args, &message.content)
-                {
+                if let Some(hint) = loop_detector.record_result(name, args, &message.content) {
                     message.content.push_str(&hint);
                 }
             }

--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -851,7 +851,7 @@ mod tests {
              see docs/STREAMING-TRANSACTIONAL-BOUNDARY-ADR.md"
         );
         // Sanity: must be larger than legacy 30s value.
-        assert!(super::STREAM_INTER_CHUNK_IDLE_TIMEOUT_SECS > 30);
+        const { assert!(super::STREAM_INTER_CHUNK_IDLE_TIMEOUT_SECS > 30) };
     }
 
     // Use Duration in a sanity check to make sure the constant is usable.

--- a/crates/octos-agent/src/loop_detect.rs
+++ b/crates/octos-agent/src/loop_detect.rs
@@ -247,7 +247,10 @@ mod tests {
         assert!(d.record_result("check", &args, result).is_none());
         assert!(d.record_result("check", &args, result).is_none());
         let hint = d.record_result("check", &args, result);
-        assert!(hint.is_some(), "expected NO PROGRESS hint after 3 identical");
+        assert!(
+            hint.is_some(),
+            "expected NO PROGRESS hint after 3 identical"
+        );
         assert!(hint.unwrap().contains("NO PROGRESS"));
     }
 

--- a/crates/octos-agent/src/tools/grep_tool.rs
+++ b/crates/octos-agent/src/tools/grep_tool.rs
@@ -164,6 +164,15 @@ impl Tool for GrepTool {
             },
         };
 
+        // Whether the search root itself resolved under the upload tmpdir,
+        // i.e. the `path` input was an explicit `up/...` upload handle (the
+        // ONLY way `resolve_for_scope` yields an upload-tmpdir path — a plain
+        // workspace path that symlinks into uploads is refused at resolution as
+        // OutOfScope). This gates the per-entry upload exemption below so it
+        // CANNOT be reached during a normal workspace/skill walk.
+        let rooted_in_upload = ctx.session_scope.is_some()
+            && octos_bus::file_handle::is_within_upload_root(&search_root);
+
         let scope = ctx.session_scope.clone();
         let pattern_str = input.pattern.clone();
         let file_pattern = input.file_pattern.clone();
@@ -176,6 +185,7 @@ impl Tool for GrepTool {
             run_grep(
                 scope,
                 search_root,
+                rooted_in_upload,
                 pattern_str,
                 file_pattern,
                 limit,
@@ -217,6 +227,7 @@ impl Tool for GrepTool {
 fn run_grep(
     scope: Option<Arc<SessionScope>>,
     search_root: PathBuf,
+    rooted_in_upload: bool,
     pattern_str: String,
     file_pattern: Option<String>,
     limit: usize,
@@ -265,11 +276,31 @@ fn run_grep(
         // closes the symlink-loop escape: a symlink inside the
         // skill_dir pointing at `/etc` would otherwise let the walker
         // read passwd; canonicalize-then-classify rejects it.
+        //
+        // EXCEPT — only when the search was explicitly rooted at an upload
+        // handle (`rooted_in_upload`) — files under the authenticated upload
+        // tmpdir: `search_root` is then an upload-tmpdir file, which classifies
+        // OutOfScope (uploads live outside any SessionScope) yet is a
+        // first-class read source for scoped sessions (see `resolve_for_scope`).
+        // Without this grep would resolve the handle then silently report "No
+        // matches". `is_within_upload_root` canonicalises, so a symlink out of
+        // the upload root is still rejected.
+        //
+        // SECURITY: this exemption MUST be gated on `rooted_in_upload`. If it
+        // applied to every walked file, a workspace/skill-dir symlink pointing
+        // into the GLOBAL upload tmpdir would let a scoped session read
+        // arbitrary uploads (other tenants' files), bypassing the
+        // symlink-escape filter the other file tools enforce. During a normal
+        // workspace walk `rooted_in_upload` is false, so the strict OutOfScope
+        // drop is preserved.
         if let Some(scope) = scope.as_ref() {
-            if matches!(
+            let out_of_scope = matches!(
                 scope.classify_canonical_path(path),
                 PathClassification::OutOfScope
-            ) {
+            );
+            let exempt_upload =
+                rooted_in_upload && octos_bus::file_handle::is_within_upload_root(path);
+            if out_of_scope && !exempt_upload {
                 continue;
             }
         }
@@ -570,6 +601,103 @@ mod tests {
         assert!(
             result.output.contains("outside session scope"),
             "expected scope rejection, got: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn grep_searches_resolved_upload_handle_contents() {
+        // codex #1367 P2: an uploaded file lives in the upload tmpdir, which
+        // is OUTSIDE the SessionScope. Once `resolve_for_scope` decodes the
+        // `up/...` handle to the real upload path, grep's per-entry OutOfScope
+        // filter must NOT drop it — otherwise grep resolves the handle then
+        // silently returns "No matches" for a file the user uploaded.
+        let upload_root = octos_bus::file_handle::temp_upload_root();
+        std::fs::create_dir_all(&upload_root).unwrap();
+        let uploaded = upload_root.join(format!("g-{}-insight.md", std::process::id()));
+        std::fs::write(
+            &uploaded,
+            "# strategy insight\nNEEDLE marks the spot in the uploaded report\n",
+        )
+        .unwrap();
+        let handle =
+            octos_bus::file_handle::encode_tmp_upload_handle(&uploaded, Some("insight.md"))
+                .expect("encode upload handle");
+
+        // Workspace is unrelated to the upload tmpdir.
+        let workspace = tempfile::tempdir().unwrap();
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![]).unwrap();
+
+        let tool = GrepTool::new(workspace.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "pattern": "NEEDLE",
+                    "path": handle,
+                }),
+            )
+            .await
+            .unwrap();
+
+        let _ = std::fs::remove_file(&uploaded);
+
+        // Assert on REAL match output, not the echoed pattern: the no-match
+        // message is `No matches found for pattern: NEEDLE` (which contains the
+        // pattern), so checking for "NEEDLE" alone would pass even when the
+        // file was dropped. The match line carries the surrounding text, which
+        // the no-match message never does.
+        assert!(result.success, "expected success, got: {}", result.output);
+        assert!(
+            result.output.starts_with("Found ")
+                && result
+                    .output
+                    .contains("marks the spot in the uploaded report"),
+            "grep must surface the uploaded file's matched line, got: {}",
+            result.output
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn grep_does_not_follow_workspace_symlink_into_upload_root() {
+        // codex #1367 round-2 P1: the upload-root exemption must apply ONLY
+        // when the search is explicitly rooted at an upload handle. A workspace
+        // symlink whose target sits under the GLOBAL upload tmpdir must still be
+        // dropped — otherwise a scoped session could read arbitrary uploads
+        // (other tenants' files) by planting a symlink in its own workspace.
+        let upload_root = octos_bus::file_handle::temp_upload_root();
+        std::fs::create_dir_all(&upload_root).unwrap();
+        let secret = upload_root.join(format!("s-{}-secret.md", std::process::id()));
+        std::fs::write(
+            &secret,
+            "TENANT_SECRET must never leak via a workspace symlink\n",
+        )
+        .unwrap();
+
+        let workspace = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(&secret, workspace.path().join("leak.md")).unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![]).unwrap();
+        let tool = GrepTool::new(workspace.path());
+        let ctx = ctx_with_scope(scope);
+
+        // Search the WORKSPACE (not the upload handle): rooted_in_upload=false,
+        // so the exemption must not fire and the symlink target stays dropped.
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({ "pattern": "TENANT_SECRET" }))
+            .await
+            .unwrap();
+
+        let _ = std::fs::remove_file(&secret);
+
+        assert!(
+            !result
+                .output
+                .contains("must never leak via a workspace symlink"),
+            "scoped grep must NOT follow a workspace symlink into the upload tmpdir, got: {}",
             result.output
         );
     }

--- a/crates/octos-agent/src/tools/grep_tool.rs
+++ b/crates/octos-agent/src/tools/grep_tool.rs
@@ -164,15 +164,6 @@ impl Tool for GrepTool {
             },
         };
 
-        // Whether the search root itself resolved under the upload tmpdir,
-        // i.e. the `path` input was an explicit `up/...` upload handle (the
-        // ONLY way `resolve_for_scope` yields an upload-tmpdir path — a plain
-        // workspace path that symlinks into uploads is refused at resolution as
-        // OutOfScope). This gates the per-entry upload exemption below so it
-        // CANNOT be reached during a normal workspace/skill walk.
-        let rooted_in_upload = ctx.session_scope.is_some()
-            && octos_bus::file_handle::is_within_upload_root(&search_root);
-
         let scope = ctx.session_scope.clone();
         let pattern_str = input.pattern.clone();
         let file_pattern = input.file_pattern.clone();
@@ -185,7 +176,6 @@ impl Tool for GrepTool {
             run_grep(
                 scope,
                 search_root,
-                rooted_in_upload,
                 pattern_str,
                 file_pattern,
                 limit,
@@ -227,7 +217,6 @@ impl Tool for GrepTool {
 fn run_grep(
     scope: Option<Arc<SessionScope>>,
     search_root: PathBuf,
-    rooted_in_upload: bool,
     pattern_str: String,
     file_pattern: Option<String>,
     limit: usize,
@@ -253,6 +242,14 @@ fn run_grep(
         .hidden(false)
         .git_ignore(true)
         .build();
+    // Whether the search root itself resolved under the upload tmpdir, i.e. the
+    // `path` input was an explicit `up/...` upload handle (the ONLY way
+    // `resolve_for_scope` yields an upload-tmpdir path - a plain workspace path
+    // that symlinks into uploads is refused at resolution as OutOfScope). This
+    // gates the per-entry upload exemption below so it CANNOT be reached during
+    // a normal workspace/skill walk.
+    let rooted_in_upload =
+        scope.is_some() && octos_bus::file_handle::is_within_upload_root(&search_root);
 
     for entry in walker {
         if match_count >= limit {

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -869,6 +869,43 @@ fn resolve_for_scope(
     user_path: &str,
     for_write: bool,
 ) -> Result<PathBuf, &'static str> {
+    // Upload handles (`up/<base64>/<name>`) are opaque references to a file in
+    // the authenticated upload tmpdir — NOT workspace-relative paths. Without
+    // this short-circuit the join+classify logic below treats them as
+    // `<workspace>/up/<base64>/<name>` (lexically InWorkspace) and the file is
+    // never found, so every scoped (SPA web-/slides-/site-) session is unable
+    // to read ANY uploaded file. Decode via the unified resolver (which
+    // canonicalizes under the upload root, firmlink-safe), matching the legacy
+    // `resolve_path`.
+    //
+    // SECURITY: only trust this short-circuit when the resolver actually
+    // landed in the upload tmpdir (`ToolPathScope::UploadTmpdir`). A path that
+    // merely *starts with* `up/` but is not a valid handle (e.g.
+    // `up/link/secret.txt`) decode-fails and `resolve_tool_path` falls back to
+    // `ToolPathScope::Workspace`, returning the LEXICAL `<workspace>/up/...`
+    // form. Returning that here would skip the canonical ancestor-symlink guard
+    // in `classify_canonical_path` below — and `read_no_follow` only protects
+    // the leaf component, so a symlinked `workspace/up` would reopen a scoped
+    // read escape. Such paths therefore fall through to the normal resolver.
+    // Uploads are read sources, so writes to a resolved upload handle are
+    // refused. The `pf/` profile handle needs a profile root that
+    // `SessionScope` does not currently expose; tracked as a follow-up
+    // (issue #1367).
+    if user_path.starts_with("up/") {
+        if let Ok(resolved) =
+            octos_bus::file_handle::resolve_tool_path(scope.workspace(), None, user_path)
+        {
+            if resolved.scope == octos_bus::file_handle::ToolPathScope::UploadTmpdir {
+                return if for_write {
+                    Err("Writes to uploaded files are not permitted")
+                } else {
+                    Ok(resolved.absolute)
+                };
+            }
+        }
+        // Not a genuine upload handle (decode failed / fell back to Workspace):
+        // fall through so the canonical containment guard still applies.
+    }
     let candidate = PathBuf::from(user_path);
     let absolute = if candidate.is_absolute() {
         candidate
@@ -1433,6 +1470,82 @@ mod path_tests {
         // The lexical absolute form passes through unchanged
         // (canonicalisation is only used for classification).
         assert_eq!(resolved, skill_file);
+    }
+
+    /// Regression (issue #1367): a SCOPED session must resolve an
+    /// `up/<base64>/<name>` upload handle to the real file under the upload
+    /// tmpdir — NOT treat it as a workspace-relative `<workspace>/up/...`
+    /// path. Every SPA (web-/slides-/site-) session is scoped, so before this
+    /// fix uploaded attachments were unreadable ("File not found: up/...").
+    /// The pre-existing scope tests never exercised a handle — that gap is
+    /// what let the bug ship.
+    #[test]
+    fn scoped_session_resolves_upload_handle_to_tmpdir_not_workspace() {
+        let upload_root = octos_bus::file_handle::temp_upload_root();
+        std::fs::create_dir_all(&upload_root).expect("upload tmpdir creatable");
+        let uploaded = upload_root.join(format!("u-{}-report.md", std::process::id()));
+        std::fs::write(&uploaded, b"# strategy insight report\n").unwrap();
+        let handle = octos_bus::file_handle::encode_tmp_upload_handle(&uploaded, Some("report.md"))
+            .expect("encode upload handle");
+        assert!(
+            handle.starts_with("up/"),
+            "expected an up/ handle, got {handle}"
+        );
+
+        let workspace = tempfile::tempdir().expect("workspace tmpdir");
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![]).unwrap();
+
+        // READ resolves to the real upload file (under the canonical upload
+        // root), NOT under the workspace.
+        let resolved = resolve_path_for_session_scope_read(&scope, &handle)
+            .expect("scoped session must resolve an up/ upload handle");
+        let canon_root = std::fs::canonicalize(&upload_root).unwrap_or(upload_root.clone());
+        assert!(
+            resolved.starts_with(&canon_root),
+            "resolved {} must be under the upload root {}, not joined onto the workspace",
+            resolved.display(),
+            canon_root.display()
+        );
+        assert!(
+            !resolved.starts_with(workspace.path()),
+            "must NOT resolve the upload handle under the workspace"
+        );
+
+        // Uploads are read sources — writes via the handle are refused.
+        assert!(
+            resolve_path_for_session_scope_write(&scope, &handle).is_err(),
+            "writes to an upload handle must be refused"
+        );
+
+        let _ = std::fs::remove_file(&uploaded);
+    }
+
+    /// SECURITY (codex #1367 P1): a path that merely *starts with* `up/` but
+    /// is NOT a valid upload handle must NOT bypass the canonical
+    /// ancestor-symlink guard. `up/secret.txt` ("secret.txt" isn't valid
+    /// base64 → decode fails → `resolve_tool_path` falls back to
+    /// `ToolPathScope::Workspace`, returning the LEXICAL `<workspace>/up/...`).
+    /// The short-circuit must reject the Workspace fallback and let the path
+    /// fall through to `classify_canonical_path`, which canonicalises through
+    /// the `up` symlink and refuses the escape — instead of leaking a lexical
+    /// path whose only protection (`O_NOFOLLOW`) guards the leaf, not the `up`
+    /// ancestor.
+    #[test]
+    #[cfg(unix)]
+    fn scoped_session_does_not_trust_non_handle_up_prefix_via_symlink() {
+        let workspace = tempfile::tempdir().expect("workspace tmpdir");
+        let outside = tempfile::tempdir().expect("out-of-scope tmpdir");
+        std::fs::write(outside.path().join("secret.txt"), b"top secret\n").unwrap();
+        // workspace/up -> <outside>: an ancestor symlink escaping the scope.
+        std::os::unix::fs::symlink(outside.path(), workspace.path().join("up")).unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![]).unwrap();
+
+        let resolved = resolve_path_for_session_scope_read(&scope, "up/secret.txt");
+        assert!(
+            resolved.is_err(),
+            "a non-handle up/ path through an ancestor symlink must be refused, got {resolved:?}"
+        );
     }
 
     /// PR-A core invariant: write attempts inside a registered

--- a/crates/octos-bus/src/file_handle.rs
+++ b/crates/octos-bus/src/file_handle.rs
@@ -72,6 +72,18 @@ pub fn temp_upload_root() -> PathBuf {
     std::env::temp_dir().join("octos-uploads")
 }
 
+/// True when `path`'s canonical form lies inside the authenticated upload
+/// tmpdir (`octos-uploads`). Uploaded attachments live outside any
+/// [`crate::session`]/`SessionScope`, so walk-style tools (`grep`) that drop
+/// out-of-scope entries need this to recognise a resolved upload handle as a
+/// permitted read target. Canonicalising both sides keeps the macOS firmlink
+/// equivalence (`/var` vs `/private/var`) AND the symlink-escape guard intact:
+/// a symlink whose target is outside the upload root won't canonicalise back
+/// under it.
+pub fn is_within_upload_root(path: &Path) -> bool {
+    canonicalize_lossy(path).starts_with(canonical_root(&temp_upload_root()))
+}
+
 pub fn encode_profile_file_handle(base_dir: &Path, path: &Path) -> Option<String> {
     let relative = path
         .strip_prefix(base_dir)

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -3436,8 +3436,8 @@ mod tests {
         // round-trip test for `EnvelopeNotification` in octos-core missed
         // this — only the ledger wrapper exhibits the collision.
         let session = SessionKey("local:envelope-round-trip".into());
-        let event = UiProtocolLedgerEvent::Notification(UiNotification::Envelope(
-            EnvelopeNotification {
+        let event =
+            UiProtocolLedgerEvent::Notification(UiNotification::Envelope(EnvelopeNotification {
                 session_id: session.clone(),
                 topic: Some("planning".into()),
                 envelope: Envelope {
@@ -3448,8 +3448,7 @@ mod tests {
                         text: "round-trip me".into(),
                     },
                 },
-            },
-        ));
+            }));
 
         let serialized = serde_json::to_string(&event).expect("ledger event serializes");
         assert!(

--- a/crates/octos-cli/src/cli_agent_adapter.rs
+++ b/crates/octos-cli/src/cli_agent_adapter.rs
@@ -329,15 +329,15 @@ mod tests {
     use super::*;
 
     #[cfg(unix)]
-    fn write_executable(dir: &tempfile::TempDir, name: &str, body: &str) -> PathBuf {
-        use std::os::unix::fs::PermissionsExt;
-
+    fn write_script(dir: &tempfile::TempDir, name: &str, body: &str) -> PathBuf {
         let path = dir.path().join(name);
         std::fs::write(&path, body).unwrap();
-        let mut perms = std::fs::metadata(&path).unwrap().permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&path, perms).unwrap();
         path
+    }
+
+    #[cfg(unix)]
+    fn script_command(script: PathBuf) -> CliAgentCommandConfig {
+        CliAgentCommandConfig::new("/bin/sh").arg(script.to_string_lossy())
     }
 
     #[cfg(unix)]
@@ -345,7 +345,7 @@ mod tests {
     async fn captures_stdout_stderr_and_declared_artifacts() {
         let dir = tempfile::tempdir().unwrap();
         let artifact = dir.path().join("report.md");
-        let script = write_executable(
+        let script = write_script(
             &dir,
             "agent-fixture",
             r#"#!/bin/sh
@@ -356,7 +356,7 @@ printf '# report\n' > "$1"
         );
 
         let result = run_cli_agent_command(
-            CliAgentCommandConfig::new(script)
+            script_command(script)
                 .arg(artifact.to_string_lossy())
                 .declared_artifact(&artifact),
         )
@@ -382,7 +382,7 @@ printf '# report\n' > "$1"
     #[tokio::test]
     async fn relative_declared_artifacts_resolve_against_child_cwd() {
         let dir = tempfile::tempdir().unwrap();
-        let script = write_executable(
+        let script = write_script(
             &dir,
             "relative-artifact-agent",
             r#"#!/bin/sh
@@ -391,7 +391,7 @@ printf '# report\n' > report.md
         );
 
         let result = run_cli_agent_command(
-            CliAgentCommandConfig::new(script)
+            script_command(script)
                 .cwd(dir.path())
                 .declared_artifact("report.md"),
         )
@@ -411,7 +411,7 @@ printf '# report\n' > report.md
     #[tokio::test]
     async fn transcript_capture_is_bounded_and_marks_truncation() {
         let dir = tempfile::tempdir().unwrap();
-        let script = write_executable(
+        let script = write_script(
             &dir,
             "large-output-agent",
             r#"#!/bin/sh
@@ -419,9 +419,7 @@ perl -e 'print "x" x (1024 * 1024 + 64)'
 "#,
         );
 
-        let result = run_cli_agent_command(CliAgentCommandConfig::new(script))
-            .await
-            .unwrap();
+        let result = run_cli_agent_command(script_command(script)).await.unwrap();
 
         assert_eq!(
             result.transcript.stdout.len(),
@@ -436,7 +434,7 @@ perl -e 'print "x" x (1024 * 1024 + 64)'
     async fn times_out_and_kills_child() {
         let dir = tempfile::tempdir().unwrap();
         let marker = dir.path().join("finished");
-        let script = write_executable(
+        let script = write_script(
             &dir,
             "slow-agent",
             r#"#!/bin/sh
@@ -446,7 +444,7 @@ printf done > "$1"
         );
 
         let result = run_cli_agent_command(
-            CliAgentCommandConfig::new(script)
+            script_command(script)
                 .arg(marker.to_string_lossy())
                 .timeout(Duration::from_millis(100)),
         )
@@ -463,7 +461,7 @@ printf done > "$1"
     async fn cancel_reports_cancelled_and_stops_process() {
         let dir = tempfile::tempdir().unwrap();
         let marker = dir.path().join("finished");
-        let script = write_executable(
+        let script = write_script(
             &dir,
             "cancel-agent",
             r#"#!/bin/sh
@@ -473,7 +471,7 @@ printf done > "$1"
         );
 
         let mut process = CliAgentProcess::spawn(
-            CliAgentCommandConfig::new(script)
+            script_command(script)
                 .arg(marker.to_string_lossy())
                 .timeout(Duration::from_secs(5)),
         )
@@ -490,7 +488,7 @@ printf done > "$1"
     async fn close_reports_closed_and_stops_process() {
         let dir = tempfile::tempdir().unwrap();
         let marker = dir.path().join("finished");
-        let script = write_executable(
+        let script = write_script(
             &dir,
             "close-agent",
             r#"#!/bin/sh
@@ -500,7 +498,7 @@ printf done > "$1"
         );
 
         let mut process = CliAgentProcess::spawn(
-            CliAgentCommandConfig::new(script)
+            script_command(script)
                 .arg(marker.to_string_lossy())
                 .timeout(Duration::from_secs(5)),
         )
@@ -517,7 +515,7 @@ printf done > "$1"
     async fn argv_config_does_not_invoke_shell_metacharacters() {
         let dir = tempfile::tempdir().unwrap();
         let injected = dir.path().join("pwned");
-        let script = write_executable(
+        let script = write_script(
             &dir,
             "echo-argv",
             r#"#!/bin/sh
@@ -526,7 +524,7 @@ printf '%s\n' "$1"
         );
 
         let payload = format!("literal; touch {}", injected.display());
-        let result = run_cli_agent_command(CliAgentCommandConfig::new(script).arg(payload.clone()))
+        let result = run_cli_agent_command(script_command(script).arg(payload.clone()))
             .await
             .unwrap();
 


### PR DESCRIPTION
## Summary
- Decode `up/...` upload handles through the shared file-handle resolver before scoped file-tool containment checks.
- Keep uploaded files read-only for scoped sessions and fall back to normal scoped resolution for non-handle `up/` paths.
- Let scoped `grep` search a resolved upload handle without opening workspace symlink access to the global upload root.
- Include minimal current-main rustfmt/clippy cleanup required for strict CI.

Closes #1367

## Validation
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `CARGO_TARGET_DIR=/private/tmp/octos-1367-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-agent --lib upload -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/octos-1367-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-agent --lib tools::path_tests::scoped_session_does_not_trust_non_handle_up_prefix_via_symlink -- --exact --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/octos-1367-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-agent --lib tools::path_tests -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/octos-1367-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-bus file_handle -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/octos-1367-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/private/tmp/octos-1367-target CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api --lib cli_agent_adapter::tests:: -- --nocapture`
- `git ls-files --others --exclude-standard`