### PR TITLE
fix(tools): decode up/ upload handles in scoped session resolver (#1367)

### DIFF
--- a/crates/octos-agent/src/tools/grep_tool.rs
+++ b/crates/octos-agent/src/tools/grep_tool.rs
@@ -223,6 +223,10 @@ fn run_grep(
     context: usize,
     ignore_case: bool,
 ) -> Result<(Vec<String>, usize)> {
+    // Canonical form of the resolved search root. Used by the per-entry scope
+    // guard to exempt the legitimately-rooted upload file (see below).
+    let canonical_search_root = octos_core::canonicalize_lossy(&search_root);
+
     // Compile regex.
     let regex_pattern = if ignore_case {
         format!("(?i){}", pattern_str)
@@ -265,11 +269,34 @@ fn run_grep(
         // closes the symlink-loop escape: a symlink inside the
         // skill_dir pointing at `/etc` would otherwise let the walker
         // read passwd; canonicalize-then-classify rejects it.
+        //
+        // EXCEPT the file the search was explicitly rooted at: when `path` was
+        // an upload handle (`up/...`), `search_root` is the resolved
+        // upload-tmpdir file, which classifies OutOfScope because uploads live
+        // outside any SessionScope (see `resolve_for_scope`). Without an
+        // exemption grep would resolve the handle then silently report "No
+        // matches". We exempt ONLY entries whose canonical path is contained in
+        // the canonical search root — i.e. the upload file the caller actually
+        // asked to search.
+        //
+        // SECURITY: keying the exemption on containment in `search_root` (not
+        // on "is under the global upload tmpdir") is what makes it leak-proof.
+        // A symlink whose target is a SIBLING upload, `/etc/passwd`, or any
+        // other tenant's file canonicalises OUTSIDE `search_root`, so it is not
+        // exempt and stays dropped — even when the workspace itself is nested
+        // under the upload tmpdir. For a normal workspace walk `search_root` is
+        // the in-scope workspace, so its files never classify OutOfScope and
+        // this exemption is inert.
+        // `&&` short-circuits, so the second `canonicalize_lossy` runs ONLY for
+        // the rare OutOfScope entry (almost never during a normal workspace
+        // walk) — `classify_canonical_path` already canonicalised once, so we
+        // don't pay a second stat per in-scope file.
         if let Some(scope) = scope.as_ref() {
             if matches!(
                 scope.classify_canonical_path(path),
                 PathClassification::OutOfScope
-            ) {
+            ) && !octos_core::canonicalize_lossy(path).starts_with(&canonical_search_root)
+            {
                 continue;
             }
         }
@@ -570,6 +597,103 @@ mod tests {
         assert!(
             result.output.contains("outside session scope"),
             "expected scope rejection, got: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn grep_searches_resolved_upload_handle_contents() {
+        // codex #1367 P2: an uploaded file lives in the upload tmpdir, which
+        // is OUTSIDE the SessionScope. Once `resolve_for_scope` decodes the
+        // `up/...` handle to the real upload path, grep's per-entry OutOfScope
+        // filter must NOT drop it — otherwise grep resolves the handle then
+        // silently returns "No matches" for a file the user uploaded.
+        let upload_root = octos_bus::file_handle::temp_upload_root();
+        std::fs::create_dir_all(&upload_root).unwrap();
+        let uploaded = upload_root.join(format!("g-{}-insight.md", std::process::id()));
+        std::fs::write(
+            &uploaded,
+            "# strategy insight\nNEEDLE marks the spot in the uploaded report\n",
+        )
+        .unwrap();
+        let handle =
+            octos_bus::file_handle::encode_tmp_upload_handle(&uploaded, Some("insight.md"))
+                .expect("encode upload handle");
+
+        // Workspace is unrelated to the upload tmpdir.
+        let workspace = tempfile::tempdir().unwrap();
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![]).unwrap();
+
+        let tool = GrepTool::new(workspace.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "pattern": "NEEDLE",
+                    "path": handle,
+                }),
+            )
+            .await
+            .unwrap();
+
+        let _ = std::fs::remove_file(&uploaded);
+
+        // Assert on REAL match output, not the echoed pattern: the no-match
+        // message is `No matches found for pattern: NEEDLE` (which contains the
+        // pattern), so checking for "NEEDLE" alone would pass even when the
+        // file was dropped. The match line carries the surrounding text, which
+        // the no-match message never does.
+        assert!(result.success, "expected success, got: {}", result.output);
+        assert!(
+            result.output.starts_with("Found ")
+                && result
+                    .output
+                    .contains("marks the spot in the uploaded report"),
+            "grep must surface the uploaded file's matched line, got: {}",
+            result.output
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn grep_does_not_follow_workspace_symlink_into_upload_root() {
+        // codex #1367 round-2 P1: the upload-root exemption must apply ONLY
+        // when the search is explicitly rooted at an upload handle. A workspace
+        // symlink whose target sits under the GLOBAL upload tmpdir must still be
+        // dropped — otherwise a scoped session could read arbitrary uploads
+        // (other tenants' files) by planting a symlink in its own workspace.
+        let upload_root = octos_bus::file_handle::temp_upload_root();
+        std::fs::create_dir_all(&upload_root).unwrap();
+        let secret = upload_root.join(format!("s-{}-secret.md", std::process::id()));
+        std::fs::write(
+            &secret,
+            "TENANT_SECRET must never leak via a workspace symlink\n",
+        )
+        .unwrap();
+
+        let workspace = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(&secret, workspace.path().join("leak.md")).unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![]).unwrap();
+        let tool = GrepTool::new(workspace.path());
+        let ctx = ctx_with_scope(scope);
+
+        // Search the WORKSPACE (not the upload handle): rooted_in_upload=false,
+        // so the exemption must not fire and the symlink target stays dropped.
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({ "pattern": "TENANT_SECRET" }))
+            .await
+            .unwrap();
+
+        let _ = std::fs::remove_file(&secret);
+
+        assert!(
+            !result
+                .output
+                .contains("must never leak via a workspace symlink"),
+            "scoped grep must NOT follow a workspace symlink into the upload tmpdir, got: {}",
             result.output
         );
     }

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -869,6 +869,59 @@ fn resolve_for_scope(
     user_path: &str,
     for_write: bool,
 ) -> Result<PathBuf, &'static str> {
+    // Upload handles (`up/<base64>/<name>`) are opaque references to a file in
+    // the authenticated upload tmpdir — NOT workspace-relative paths. Without
+    // this short-circuit the join+classify logic below treats them as
+    // `<workspace>/up/<base64>/<name>` (lexically InWorkspace) and the file is
+    // never found, so every scoped (SPA web-/slides-/site-) session is unable
+    // to read ANY uploaded file. Decode via the unified resolver (which
+    // canonicalizes under the upload root, firmlink-safe), matching the legacy
+    // `resolve_path`.
+    //
+    // SECURITY: only trust this short-circuit when the resolver actually
+    // landed in the upload tmpdir (`ToolPathScope::UploadTmpdir`). A path that
+    // merely *starts with* `up/` but is not a valid handle (e.g.
+    // `up/link/secret.txt`) decode-fails and `resolve_tool_path` falls back to
+    // `ToolPathScope::Workspace`, returning the LEXICAL `<workspace>/up/...`
+    // form. Returning that here would skip the canonical ancestor-symlink guard
+    // in `classify_canonical_path` below — and `read_no_follow` only protects
+    // the leaf component, so a symlinked `workspace/up` would reopen a scoped
+    // read escape. Such paths therefore fall through to the normal resolver.
+    // Uploads are read sources, so writes to a resolved upload handle are
+    // refused. The `pf/` profile handle needs a profile root that
+    // `SessionScope` does not currently expose; tracked as a follow-up
+    // (issue #1367).
+    if user_path.starts_with("up/") {
+        match octos_bus::file_handle::resolve_tool_path(scope.workspace(), None, user_path) {
+            Ok(resolved)
+                if resolved.scope == octos_bus::file_handle::ToolPathScope::UploadTmpdir =>
+            {
+                return if for_write {
+                    Err("Writes to uploaded files are not permitted")
+                } else {
+                    Ok(resolved.absolute)
+                };
+            }
+            _ => {
+                // If the value DECODES as an upload handle it is unambiguously an
+                // upload reference: never fall through to the workspace resolver
+                // (which would let `write_file` create `<workspace>/up/<payload>/
+                // <name>`, or a read silently hit an unrelated workspace file with
+                // the same literal path). The temp file may have been deleted or
+                // no longer canonicalises under the upload root — report it as a
+                // missing upload rather than masking it as a workspace path.
+                if matches!(
+                    octos_bus::file_handle::decode_file_handle(user_path),
+                    Some(octos_bus::file_handle::FileHandleScope::TempUpload(_))
+                ) {
+                    return Err("Uploaded file not found");
+                }
+                // A value that merely starts with `up/` but does NOT decode as a
+                // handle (e.g. a real workspace path) falls through to the scoped
+                // resolver, where the canonical containment guard still applies.
+            }
+        }
+    }
     let candidate = PathBuf::from(user_path);
     let absolute = if candidate.is_absolute() {
         candidate
@@ -1433,6 +1486,112 @@ mod path_tests {
         // The lexical absolute form passes through unchanged
         // (canonicalisation is only used for classification).
         assert_eq!(resolved, skill_file);
+    }
+
+    /// Regression (issue #1367): a SCOPED session must resolve an
+    /// `up/<base64>/<name>` upload handle to the real file under the upload
+    /// tmpdir — NOT treat it as a workspace-relative `<workspace>/up/...`
+    /// path. Every SPA (web-/slides-/site-) session is scoped, so before this
+    /// fix uploaded attachments were unreadable ("File not found: up/...").
+    /// The pre-existing scope tests never exercised a handle — that gap is
+    /// what let the bug ship.
+    #[test]
+    fn scoped_session_resolves_upload_handle_to_tmpdir_not_workspace() {
+        let upload_root = octos_bus::file_handle::temp_upload_root();
+        std::fs::create_dir_all(&upload_root).expect("upload tmpdir creatable");
+        let uploaded = upload_root.join(format!("u-{}-report.md", std::process::id()));
+        std::fs::write(&uploaded, b"# strategy insight report\n").unwrap();
+        let handle = octos_bus::file_handle::encode_tmp_upload_handle(&uploaded, Some("report.md"))
+            .expect("encode upload handle");
+        assert!(
+            handle.starts_with("up/"),
+            "expected an up/ handle, got {handle}"
+        );
+
+        let workspace = tempfile::tempdir().expect("workspace tmpdir");
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![]).unwrap();
+
+        // READ resolves to the real upload file (under the canonical upload
+        // root), NOT under the workspace.
+        let resolved = resolve_path_for_session_scope_read(&scope, &handle)
+            .expect("scoped session must resolve an up/ upload handle");
+        let canon_root = std::fs::canonicalize(&upload_root).unwrap_or(upload_root.clone());
+        assert!(
+            resolved.starts_with(&canon_root),
+            "resolved {} must be under the upload root {}, not joined onto the workspace",
+            resolved.display(),
+            canon_root.display()
+        );
+        assert!(
+            !resolved.starts_with(workspace.path()),
+            "must NOT resolve the upload handle under the workspace"
+        );
+
+        // Uploads are read sources — writes via the handle are refused.
+        assert!(
+            resolve_path_for_session_scope_write(&scope, &handle).is_err(),
+            "writes to an upload handle must be refused"
+        );
+
+        let _ = std::fs::remove_file(&uploaded);
+    }
+
+    /// SECURITY (codex #1367 P1): a path that merely *starts with* `up/` but
+    /// is NOT a valid upload handle must NOT bypass the canonical
+    /// ancestor-symlink guard. `up/secret.txt` ("secret.txt" isn't valid
+    /// base64 → decode fails → `resolve_tool_path` falls back to
+    /// `ToolPathScope::Workspace`, returning the LEXICAL `<workspace>/up/...`).
+    /// The short-circuit must reject the Workspace fallback and let the path
+    /// fall through to `classify_canonical_path`, which canonicalises through
+    /// the `up` symlink and refuses the escape — instead of leaking a lexical
+    /// path whose only protection (`O_NOFOLLOW`) guards the leaf, not the `up`
+    /// ancestor.
+    #[test]
+    #[cfg(unix)]
+    fn scoped_session_does_not_trust_non_handle_up_prefix_via_symlink() {
+        let workspace = tempfile::tempdir().expect("workspace tmpdir");
+        let outside = tempfile::tempdir().expect("out-of-scope tmpdir");
+        std::fs::write(outside.path().join("secret.txt"), b"top secret\n").unwrap();
+        // workspace/up -> <outside>: an ancestor symlink escaping the scope.
+        std::os::unix::fs::symlink(outside.path(), workspace.path().join("up")).unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![]).unwrap();
+
+        let resolved = resolve_path_for_session_scope_read(&scope, "up/secret.txt");
+        assert!(
+            resolved.is_err(),
+            "a non-handle up/ path through an ancestor symlink must be refused, got {resolved:?}"
+        );
+    }
+
+    /// codex #1367 round-4 P2: a value that DECODES as an upload handle but
+    /// whose temp file is gone (deleted / no longer canonicalises under the
+    /// upload root) must report a missing upload — NOT fall through to the
+    /// workspace resolver, which would let `write_file` create
+    /// `<workspace>/up/<payload>/<name>` or a read silently hit an unrelated
+    /// same-named workspace file.
+    #[test]
+    fn scoped_session_rejects_decoded_but_missing_upload_handle() {
+        let upload_root = octos_bus::file_handle::temp_upload_root();
+        std::fs::create_dir_all(&upload_root).unwrap();
+        let uploaded = upload_root.join(format!("m-{}-gone.md", std::process::id()));
+        std::fs::write(&uploaded, b"temp\n").unwrap();
+        let handle = octos_bus::file_handle::encode_tmp_upload_handle(&uploaded, Some("gone.md"))
+            .expect("encode upload handle");
+        // Delete the upload so the handle still DECODES but no longer resolves.
+        std::fs::remove_file(&uploaded).unwrap();
+
+        let workspace = tempfile::tempdir().expect("workspace tmpdir");
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![]).unwrap();
+
+        assert!(
+            resolve_path_for_session_scope_read(&scope, &handle).is_err(),
+            "a decoded-but-missing upload handle must error, not resolve to a workspace path"
+        );
+        assert!(
+            resolve_path_for_session_scope_write(&scope, &handle).is_err(),
+            "write to a missing upload handle must error"
+        );
     }
 
     /// PR-A core invariant: write attempts inside a registered


### PR DESCRIPTION
## Problem

In every **scoped** session (SPA web-/slides-/site-), the file tools' resolver `resolve_for_scope` joined an `up/<base64>/<name>` upload handle onto the workspace (`<workspace>/up/...`) and never found it — so the agent could not read **any** uploaded file of any type (`File not found: up/...`). The legacy unscoped `resolve_path` decoded handles correctly; the scoped path did not (a documented `TODO(phase3b)` regression). This is the root cause behind "uploaded file can't be found" on the fleet.

## Fix

Short-circuit `up/` handles in `resolve_for_scope` to the unified `octos_bus::file_handle::resolve_tool_path` (decodes + canonicalizes under the upload tmpdir, firmlink-safe), read-only since uploads are read sources. **One site fixes all five scoped file tools** (read/write/edit/list/grep) — structural, not per-tool.

## Codex review (4 rounds, all findings addressed)

- **R1 P1** (security): only trust the short-circuit when the resolver returns `UploadTmpdir`; a non-handle `up/...` falls through to the canonical ancestor-symlink guard (`read_no_follow` only protects the leaf).
- **R1 P2** (grep): scoped grep over an upload handle no longer reports "No matches".
- **R2/R3** (security): the grep exemption keys on **canonical containment in the resolved `search_root`** — a symlink to a sibling upload / other tenant / `/etc/passwd` canonicalizes outside `search_root` and stays dropped, even when the workspace is nested under the upload tmpdir. (Replaced an earlier path-based gate that misfired.)
- **R4 P2**: a decoded-but-missing handle reports a missing upload instead of falling through to the workspace resolver.
- **R4 P3**: grep canonicalizes a second time only for the rare OutOfScope entry (`&&` short-circuit).

## Tests

Five regression tests, all **falsification-verified in both directions**: happy-path resolve, round-1 non-handle symlink escape, grep-on-upload, workspace-symlink-into-uploads cross-tenant leak, decoded-but-missing handle. fmt + clippy clean; `file_handle.rs` nets to zero.

## Known follow-up (tracked, not in this PR)

Upload handles aren't bound to a session — a scoped session that knows another session's handle could read it (pre-existing; low practical exploitability with uuid-v7 handles). Decision was to ship the decode fix and track the isolation hardening separately: **#1369**.

Fixes #1367.

🤖 Generated with [Claude Code](https://claude.com/claude-code)