### PR TITLE
feat(pipeline): add pre-execution graph type-checker

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -172,11 +172,11 @@ pub(super) fn satisfied_completion_content(output_files: &[String], tool_output:
 /// slides-1780013669236-8w2ime, the production failure that motivated
 /// this fix):
 ///   - kimi-k2.5 + only `check_workspace_contract`:
-///       loop rate 5/5 → 3/5 with this block (40% break out)
+///     loop rate 5/5 → 3/5 with this block (40% break out)
 ///   - kimi-k2.5 + check + read_file + list_dir:
-///       no consistent change (within noise)
+///     no consistent change (within noise)
 ///   - claude-opus-4.7:
-///       already 0/5 loops in both arms; block has no effect on Opus
+///     already 0/5 loops in both arms; block has no effect on Opus
 ///
 /// The block follows hermes-agent's prompt-time-injection pattern (in
 /// `agent/prompt_builder.py`), but applied universally rather than

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -2058,9 +2058,7 @@ impl Agent {
                 let Some(&(name, args)) = id_to_call.get(id) else {
                     continue;
                 };
-                if let Some(hint) =
-                    loop_detector.record_result(name, args, &message.content)
-                {
+                if let Some(hint) = loop_detector.record_result(name, args, &message.content) {
                     message.content.push_str(&hint);
                 }
             }

--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -851,7 +851,8 @@ mod tests {
              see docs/STREAMING-TRANSACTIONAL-BOUNDARY-ADR.md"
         );
         // Sanity: must be larger than legacy 30s value.
-        assert!(super::STREAM_INTER_CHUNK_IDLE_TIMEOUT_SECS > 30);
+        let timeout_secs = super::STREAM_INTER_CHUNK_IDLE_TIMEOUT_SECS;
+        assert!(timeout_secs > 30);
     }
 
     // Use Duration in a sanity check to make sure the constant is usable.

--- a/crates/octos-agent/src/loop_detect.rs
+++ b/crates/octos-agent/src/loop_detect.rs
@@ -247,7 +247,10 @@ mod tests {
         assert!(d.record_result("check", &args, result).is_none());
         assert!(d.record_result("check", &args, result).is_none());
         let hint = d.record_result("check", &args, result);
-        assert!(hint.is_some(), "expected NO PROGRESS hint after 3 identical");
+        assert!(
+            hint.is_some(),
+            "expected NO PROGRESS hint after 3 identical"
+        );
         assert!(hint.unwrap().contains("NO PROGRESS"));
     }
 

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -3436,8 +3436,8 @@ mod tests {
         // round-trip test for `EnvelopeNotification` in octos-core missed
         // this — only the ledger wrapper exhibits the collision.
         let session = SessionKey("local:envelope-round-trip".into());
-        let event = UiProtocolLedgerEvent::Notification(UiNotification::Envelope(
-            EnvelopeNotification {
+        let event =
+            UiProtocolLedgerEvent::Notification(UiNotification::Envelope(EnvelopeNotification {
                 session_id: session.clone(),
                 topic: Some("planning".into()),
                 envelope: Envelope {
@@ -3448,8 +3448,7 @@ mod tests {
                         text: "round-trip me".into(),
                     },
                 },
-            },
-        ));
+            }));
 
         let serialized = serde_json::to_string(&event).expect("ledger event serializes");
         assert!(

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -994,6 +994,15 @@ impl PipelineExecutor {
             .as_deref()
             .unwrap_or(&self.config.working_dir);
         crate::model_assignment::assign_from_catalog_dir(&mut graph, catalog_dir);
+        let known_models = crate::model_assignment::known_model_keys_from_catalog_dir(catalog_dir);
+        let mut validation_context = if known_models.is_empty() {
+            validate::ValidationContext::default()
+        } else {
+            validate::ValidationContext::default().with_known_models(known_models)
+        };
+        validation_context
+            .runtime_channels
+            .extend(variables.keys().cloned());
 
         // ── Pipeline start: log graph structure ──
         let node_summary: Vec<String> = graph
@@ -1021,7 +1030,7 @@ impl PipelineExecutor {
             edge_summary.join("\n")
         );
 
-        let diags = validate::validate(&graph);
+        let diags = validate::validate_with_context(&graph, &validation_context);
 
         for diag in &diags {
             match diag.severity {
@@ -3183,6 +3192,97 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let dir = Box::leak(Box::new(dir));
         EpisodeStore::open(dir.path()).await.unwrap()
+    }
+
+    struct CountingHandler {
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::handler::Handler for CountingHandler {
+        async fn execute(&self, node: &PipelineNode, _ctx: &HandlerContext) -> Result<NodeOutcome> {
+            self.calls
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Ok(NodeOutcome {
+                node_id: node.id.clone(),
+                status: OutcomeStatus::Pass,
+                content: "called".to_string(),
+                token_usage: TokenUsage::default(),
+                files_modified: vec![],
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn validation_errors_stop_before_handler_dispatch() {
+        let executor = PipelineExecutor::new(make_capped_config(8).await);
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut handlers = HandlerRegistry::new();
+        handlers.register(
+            HandlerKind::Codergen,
+            Arc::new(CountingHandler {
+                calls: calls.clone(),
+            }),
+        );
+
+        let result = executor
+            .run_with_handlers(
+                r#"
+                digraph invalid {
+                    start [handler="codergen", prompt="Use {missing_binding}"]
+                }
+                "#,
+                "input",
+                &serde_json::Map::new(),
+                handlers,
+            )
+            .await;
+
+        let err = result.expect_err("invalid template binding must fail before execution");
+        assert!(
+            err.to_string().contains("rule 16"),
+            "error should include the template-binding validation rule: {err}"
+        );
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::Relaxed),
+            0,
+            "handler must not dispatch after validation errors"
+        );
+    }
+
+    #[tokio::test]
+    async fn validation_accepts_runtime_variable_bindings() {
+        let executor = PipelineExecutor::new(make_capped_config(8).await);
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut handlers = HandlerRegistry::new();
+        handlers.register(
+            HandlerKind::Codergen,
+            Arc::new(CountingHandler {
+                calls: calls.clone(),
+            }),
+        );
+        let variables = serde_json::json!({ "topic": "pipeline validation" });
+        let variables = variables.as_object().unwrap();
+
+        let result = executor
+            .run_with_handlers(
+                r#"
+                digraph valid {
+                    start [handler="codergen", prompt="Use {topic}"]
+                }
+                "#,
+                "input",
+                variables,
+                handlers,
+            )
+            .await;
+
+        result.expect("runtime variables should satisfy template binding");
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "handler should dispatch after runtime variable binding validates"
+        );
     }
 
     #[test]

--- a/crates/octos-pipeline/src/graph.rs
+++ b/crates/octos-pipeline/src/graph.rs
@@ -158,6 +158,12 @@ pub struct PipelineNode {
     /// An empty list means no checkpoint is written for this node.
     #[serde(default)]
     pub checkpoints: Vec<MissionCheckpoint>,
+    /// Marks this gate as requiring external human/operator resolution.
+    #[serde(default)]
+    pub human_gate: bool,
+    /// Resolver/channel name used when `human_gate` is true.
+    #[serde(default)]
+    pub human_resolver: Option<String>,
 }
 
 impl Default for PipelineNode {
@@ -183,6 +189,8 @@ impl Default for PipelineNode {
             deadline_action: None,
             continue_on_error: false,
             checkpoints: Vec::new(),
+            human_gate: false,
+            human_resolver: None,
         }
     }
 }

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -1267,6 +1267,8 @@ mod tests {
             deadline_action: None,
             continue_on_error: false,
             checkpoints: vec![],
+            human_gate: false,
+            human_resolver: None,
         };
 
         let outcome = GateHandler
@@ -1336,6 +1338,8 @@ mod tests {
             deadline_action: None,
             continue_on_error: false,
             checkpoints: vec![],
+            human_gate: false,
+            human_resolver: None,
         };
 
         let outcome = GateHandler.execute(&gate, &ctx).await.unwrap();
@@ -1389,6 +1393,8 @@ mod tests {
             deadline_action: None,
             continue_on_error: false,
             checkpoints: vec![],
+            human_gate: false,
+            human_resolver: None,
         };
 
         let outcome = GateHandler.execute(&gate, &ctx).await.unwrap();
@@ -1452,6 +1458,8 @@ mod tests {
             deadline_action: None,
             continue_on_error: false,
             checkpoints: vec![],
+            human_gate: false,
+            human_resolver: None,
         };
 
         let outcome = GateHandler.execute(&gate, &ctx).await.unwrap();
@@ -1515,6 +1523,8 @@ mod tests {
             deadline_action: None,
             continue_on_error: false,
             checkpoints: vec![],
+            human_gate: false,
+            human_resolver: None,
         };
 
         let outcome = GateHandler.execute(&gate, &ctx).await.unwrap();
@@ -1576,6 +1586,8 @@ mod tests {
             deadline_action: None,
             continue_on_error: false,
             checkpoints: vec![],
+            human_gate: false,
+            human_resolver: None,
         };
 
         let outcome = GateHandler.execute(&gate, &ctx).await.unwrap();

--- a/crates/octos-pipeline/src/lib.rs
+++ b/crates/octos-pipeline/src/lib.rs
@@ -59,4 +59,7 @@ pub use server::{
 pub use stylesheet::{ModelStylesheet, ResolvedStyle, StyleRule};
 pub use thread::{Thread, ThreadRegistry};
 pub use tool::RunPipelineTool;
-pub use validate::{LintDiagnostic, Severity, validate};
+pub use validate::{
+    GraphLocation, LintDiagnostic, PipelineDiagnostic, RuleId, Severity, ValidationContext,
+    validate, validate_result, validate_with_context,
+};

--- a/crates/octos-pipeline/src/model_assignment.rs
+++ b/crates/octos-pipeline/src/model_assignment.rs
@@ -40,6 +40,7 @@
 //! PID + nanos seeded round-robin start indices keep concurrent
 //! pipelines from herd-routing to the same model on every call.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use serde::Deserialize;
@@ -146,6 +147,24 @@ pub fn assign_from_catalog_dir(graph: &mut PipelineGraph, data_dir: &Path) {
     };
 
     assign_to_graph(graph, &pools);
+}
+
+/// Return every model key advertised by the profile/system pipeline catalog.
+///
+/// The validator uses this as its pure, data-driven source of truth after
+/// DOT parsing and model assignment. Missing or malformed catalogs return an
+/// empty set so callers can skip catalog-backed model validation rather than
+/// rejecting legacy/offline runs.
+pub fn known_model_keys_from_catalog_dir(data_dir: &Path) -> HashSet<String> {
+    load_catalog(data_dir)
+        .map(|catalog| {
+            catalog
+                .models
+                .into_iter()
+                .map(|entry| entry.model_key().to_string())
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Test-friendly entry point that takes pre-built pools directly so we

--- a/crates/octos-pipeline/src/parser.rs
+++ b/crates/octos-pipeline/src/parser.rs
@@ -554,6 +554,10 @@ fn build_node(id: &str, attrs: &HashMap<String, String>) -> PipelineNode {
         .get("deadline_action")
         .and_then(|s| parse_deadline_action(s));
     let checkpoints = parse_checkpoints(attrs);
+    let human_gate = attrs
+        .get("human_gate")
+        .and_then(|s| parse_bool(s))
+        .unwrap_or(false);
 
     PipelineNode {
         id: id.to_string(),
@@ -587,6 +591,11 @@ fn build_node(id: &str, attrs: &HashMap<String, String>) -> PipelineNode {
             .and_then(|s| parse_bool(s))
             .unwrap_or(false),
         checkpoints,
+        human_gate,
+        human_resolver: attrs
+            .get("human_resolver")
+            .or_else(|| attrs.get("resolver"))
+            .cloned(),
     }
 }
 
@@ -843,6 +852,20 @@ mod tests {
 
         let graph = parse_dot(dot).unwrap();
         assert!(graph.nodes["review"].goal_gate);
+    }
+
+    #[test]
+    fn test_parse_human_gate_resolver() {
+        let dot = r#"
+            digraph test {
+                approve [handler="gate", human_gate="true", resolver="operator"]
+            }
+        "#;
+
+        let graph = parse_dot(dot).unwrap();
+        let node = &graph.nodes["approve"];
+        assert!(node.human_gate);
+        assert_eq!(node.human_resolver.as_deref(), Some("operator"));
     }
 
     #[test]

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -509,7 +509,9 @@ impl Tool for RunPipelineTool {
             .map_err(|e| format!("failed to resolve pipeline DOT: {e}"))?;
         let graph = crate::parser::parse_dot(&dot_content)
             .map_err(|e| format!("failed to parse pipeline DOT: {e}"))?;
-        let diags = crate::validate::validate(&graph);
+        let validation_context = crate::validate::ValidationContext::default()
+            .with_runtime_channels(input.variables.keys().cloned());
+        let diags = crate::validate::validate_with_context(&graph, &validation_context);
         if crate::validate::has_errors(&diags) {
             let errors: Vec<_> = diags
                 .iter()

--- a/crates/octos-pipeline/src/validate.rs
+++ b/crates/octos-pipeline/src/validate.rs
@@ -1,17 +1,30 @@
-//! Graph validation (lint rules) for pipelines.
+//! Graph validation (lint/type-check rules) for pipelines.
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use octos_agent::tools::policy::TOOL_GROUPS;
+
 use crate::condition;
-use crate::graph::{HandlerKind, PipelineGraph};
+use crate::graph::{HandlerKind, PipelineEdge, PipelineGraph, PipelineNode};
+
+/// Default static fan-out cap used by the pre-execution validator.
+pub const DEFAULT_STATIC_FANOUT_LIMIT: usize = 50;
 
 /// A validation diagnostic.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LintDiagnostic {
+    /// Backward-compatible numeric rule identifier.
     pub rule: u32,
+    /// Stable typed rule identifier.
+    pub rule_id: RuleId,
     pub severity: Severity,
+    pub location: GraphLocation,
     pub message: String,
+    pub fix_hint: Option<String>,
 }
+
+/// New typed diagnostic name requested by the pre-execution checker contract.
+pub type PipelineDiagnostic = LintDiagnostic;
 
 /// Diagnostic severity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -20,12 +33,110 @@ pub enum Severity {
     Warning,
 }
 
-/// Validate a pipeline graph against all lint rules.
+/// Location attached to a pipeline diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GraphLocation {
+    Graph,
+    Node(String),
+    Edge { source: String, target: String },
+}
+
+/// Stable identifiers for validation rules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RuleId {
+    StartNode,
+    UnreachableNode,
+    EdgeTargetExists,
+    SelfLoop,
+    GoalGateEdges,
+    ConditionParses,
+    KnownHandler,
+    PromptRequired,
+    DuplicateEdge,
+    PositiveWeight,
+    AtLeastOneNode,
+    EdgeSourceExists,
+    ParallelConverge,
+    DynamicParallel,
+    Dag,
+    TemplateBinding,
+    EdgeReferenced,
+    KnownModel,
+    KnownToolPolicy,
+    FanoutBound,
+    HumanGateResolver,
+    DanglingReference,
+}
+
+/// Context used for validation checks that depend on runtime/catalog state.
+#[derive(Debug, Clone)]
+pub struct ValidationContext {
+    /// Provider/model catalog keys. `None` skips model-existence validation.
+    pub known_models: Option<HashSet<String>>,
+    /// Known tool names. `None` skips tool-name validation, but group names
+    /// are still checked against `TOOL_GROUPS`.
+    pub known_tools: Option<HashSet<String>>,
+    /// Runtime template channels that are valid without an upstream node.
+    pub runtime_channels: HashSet<String>,
+    /// Artifact names declared outside the DOT graph.
+    pub known_artifacts: HashSet<String>,
+    /// Static per-node fan-out cap.
+    pub fanout_limit: usize,
+}
+
+impl Default for ValidationContext {
+    fn default() -> Self {
+        Self {
+            known_models: None,
+            known_tools: Some(default_known_tools()),
+            runtime_channels: default_runtime_channels(),
+            known_artifacts: HashSet::new(),
+            fanout_limit: DEFAULT_STATIC_FANOUT_LIMIT,
+        }
+    }
+}
+
+impl ValidationContext {
+    pub fn with_known_models(mut self, models: HashSet<String>) -> Self {
+        self.known_models = Some(models);
+        self
+    }
+
+    pub fn with_known_artifacts<I, S>(mut self, artifacts: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.known_artifacts = artifacts.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn with_runtime_channels<I, S>(mut self, channels: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.runtime_channels
+            .extend(channels.into_iter().map(Into::into));
+        self
+    }
+}
+
+/// Validate a pipeline graph against all lint/type-check rules.
 ///
-/// Returns a list of diagnostics. If any are `Error` severity,
-/// the graph should not be executed.
-pub fn validate(graph: &PipelineGraph) -> Vec<LintDiagnostic> {
+/// Returns a list of diagnostics. If any are `Error` severity, the graph
+/// should not be executed.
+pub fn validate(graph: &PipelineGraph) -> Vec<PipelineDiagnostic> {
+    validate_with_context(graph, &ValidationContext::default())
+}
+
+/// Validate a pipeline graph with caller-supplied catalog/runtime facts.
+pub fn validate_with_context(
+    graph: &PipelineGraph,
+    context: &ValidationContext,
+) -> Vec<PipelineDiagnostic> {
     let mut diags = Vec::new();
+    rule_11_at_least_one_node(graph, &mut diags);
     rule_01_start_node(graph, &mut diags);
     rule_02_unreachable_nodes(graph, &mut diags);
     rule_03_edge_targets_exist(graph, &mut diags);
@@ -36,16 +147,32 @@ pub fn validate(graph: &PipelineGraph) -> Vec<LintDiagnostic> {
     rule_08_prompt_required(graph, &mut diags);
     rule_09_no_duplicate_edges(graph, &mut diags);
     rule_10_positive_weight(graph, &mut diags);
-    rule_11_at_least_one_node(graph, &mut diags);
     rule_12_edge_sources_exist(graph, &mut diags);
     rule_13_parallel_converge(graph, &mut diags);
     rule_14_dynamic_parallel(graph, &mut diags);
     rule_15_no_cycles(graph, &mut diags);
+    rule_16_template_bindings(graph, context, &mut diags);
+    rule_17_edge_referenced(graph, &mut diags);
+    rule_18_known_models(graph, context, &mut diags);
+    rule_19_known_tools(graph, context, &mut diags);
+    rule_20_fanout_bound(graph, context, &mut diags);
+    rule_21_human_gate_resolver(graph, &mut diags);
+    rule_22_dangling_refs(graph, context, &mut diags);
     diags
 }
 
+/// Result-oriented validation entry point.
+pub fn validate_result(graph: &PipelineGraph) -> Result<(), Vec<PipelineDiagnostic>> {
+    let diags = validate(graph);
+    if has_errors(&diags) {
+        Err(diags)
+    } else {
+        Ok(())
+    }
+}
+
 /// Check if any diagnostics are errors.
-pub fn has_errors(diags: &[LintDiagnostic]) -> bool {
+pub fn has_errors(diags: &[PipelineDiagnostic]) -> bool {
     diags.iter().any(|d| d.severity == Severity::Error)
 }
 
@@ -60,7 +187,7 @@ pub fn find_start_node(graph: &PipelineGraph) -> Option<String> {
         .nodes
         .keys()
         .filter(|id| !incoming.contains(id.as_str()))
-        .map(|s| s.as_str())
+        .map(String::as_str)
         .collect();
 
     if sources.len() == 1 {
@@ -70,41 +197,102 @@ pub fn find_start_node(graph: &PipelineGraph) -> Option<String> {
     }
 }
 
-// ---- Individual rules ----
-
-fn rule_01_start_node(graph: &PipelineGraph, diags: &mut Vec<LintDiagnostic>) {
-    if find_start_node(graph).is_none() {
-        let incoming: HashSet<&str> = graph.edges.iter().map(|e| e.target.as_str()).collect();
-        let sources: Vec<&str> = graph
-            .nodes
-            .keys()
-            .filter(|id| !incoming.contains(id.as_str()))
-            .map(|s| s.as_str())
-            .collect();
-
-        diags.push(LintDiagnostic {
-            rule: 1,
-            severity: Severity::Error,
-            message: if sources.is_empty() {
-                "no start node found (all nodes have incoming edges)".into()
-            } else {
-                format!(
-                    "ambiguous start: {} nodes with no incoming edges: {}",
-                    sources.len(),
-                    sources.join(", ")
-                )
-            },
-        });
+fn diagnostic(
+    rule: u32,
+    rule_id: RuleId,
+    severity: Severity,
+    location: GraphLocation,
+    message: impl Into<String>,
+    fix_hint: impl Into<Option<String>>,
+) -> PipelineDiagnostic {
+    PipelineDiagnostic {
+        rule,
+        rule_id,
+        severity,
+        location,
+        message: message.into(),
+        fix_hint: fix_hint.into(),
     }
 }
 
-fn rule_02_unreachable_nodes(graph: &PipelineGraph, diags: &mut Vec<LintDiagnostic>) {
+fn node_diag(
+    rule: u32,
+    rule_id: RuleId,
+    severity: Severity,
+    node_id: &str,
+    message: impl Into<String>,
+    fix_hint: impl Into<Option<String>>,
+) -> PipelineDiagnostic {
+    diagnostic(
+        rule,
+        rule_id,
+        severity,
+        GraphLocation::Node(node_id.to_string()),
+        message,
+        fix_hint,
+    )
+}
+
+fn edge_diag(
+    rule: u32,
+    rule_id: RuleId,
+    severity: Severity,
+    edge: &PipelineEdge,
+    message: impl Into<String>,
+    fix_hint: impl Into<Option<String>>,
+) -> PipelineDiagnostic {
+    diagnostic(
+        rule,
+        rule_id,
+        severity,
+        GraphLocation::Edge {
+            source: edge.source.clone(),
+            target: edge.target.clone(),
+        },
+        message,
+        fix_hint,
+    )
+}
+
+// ---- Individual rules ----
+
+fn rule_01_start_node(graph: &PipelineGraph, diags: &mut Vec<PipelineDiagnostic>) {
+    if find_start_node(graph).is_some() {
+        return;
+    }
+
+    let incoming: HashSet<&str> = graph.edges.iter().map(|e| e.target.as_str()).collect();
+    let sources: Vec<&str> = graph
+        .nodes
+        .keys()
+        .filter(|id| !incoming.contains(id.as_str()))
+        .map(String::as_str)
+        .collect();
+
+    diags.push(diagnostic(
+        1,
+        RuleId::StartNode,
+        Severity::Error,
+        GraphLocation::Graph,
+        if sources.is_empty() {
+            "no start node found (all nodes have incoming edges)".to_string()
+        } else {
+            format!(
+                "ambiguous start: {} nodes with no incoming edges: {}",
+                sources.len(),
+                sources.join(", ")
+            )
+        },
+        Some("Add a single `start` node or connect all roots behind one source node.".to_string()),
+    ));
+}
+
+fn rule_02_unreachable_nodes(graph: &PipelineGraph, diags: &mut Vec<PipelineDiagnostic>) {
     let start = match find_start_node(graph) {
         Some(s) => s,
-        None => return, // can't check reachability without a start node
+        None => return,
     };
 
-    // Build adjacency list
     let mut adj: HashMap<&str, Vec<&str>> = HashMap::new();
     for edge in &graph.edges {
         adj.entry(edge.source.as_str())
@@ -112,7 +300,6 @@ fn rule_02_unreachable_nodes(graph: &PipelineGraph, diags: &mut Vec<LintDiagnost
             .push(edge.target.as_str());
     }
 
-    // BFS from start
     let mut visited = HashSet::new();
     let mut queue = VecDeque::new();
     visited.insert(start.as_str());
@@ -130,245 +317,854 @@ fn rule_02_unreachable_nodes(graph: &PipelineGraph, diags: &mut Vec<LintDiagnost
 
     for id in graph.nodes.keys() {
         if !visited.contains(id.as_str()) {
-            diags.push(LintDiagnostic {
-                rule: 2,
-                severity: Severity::Warning,
-                message: format!("node '{id}' is unreachable from start"),
-            });
+            diags.push(node_diag(
+                2,
+                RuleId::UnreachableNode,
+                Severity::Error,
+                id,
+                format!("node '{id}' is an orphan and is unreachable from start"),
+                Some("Connect the node from the start component or remove it.".to_string()),
+            ));
         }
     }
 }
 
-fn rule_03_edge_targets_exist(graph: &PipelineGraph, diags: &mut Vec<LintDiagnostic>) {
+fn rule_03_edge_targets_exist(graph: &PipelineGraph, diags: &mut Vec<PipelineDiagnostic>) {
     for edge in &graph.edges {
         if !graph.nodes.contains_key(&edge.target) {
-            diags.push(LintDiagnostic {
-                rule: 3,
-                severity: Severity::Error,
-                message: format!("edge target '{}' does not exist", edge.target),
-            });
+            diags.push(edge_diag(
+                3,
+                RuleId::EdgeTargetExists,
+                Severity::Error,
+                edge,
+                format!("edge target '{}' does not exist", edge.target),
+                Some("Declare the target node or remove this edge.".to_string()),
+            ));
         }
     }
 }
 
-fn rule_04_no_self_loops(graph: &PipelineGraph, diags: &mut Vec<LintDiagnostic>) {
+fn rule_04_no_self_loops(graph: &PipelineGraph, diags: &mut Vec<PipelineDiagnostic>) {
     for edge in &graph.edges {
-        if edge.source == edge.target {
-            let node = graph.nodes.get(&edge.source);
-            let is_retry = node.is_some_and(|n| n.max_retries > 0);
-            if !is_retry {
-                diags.push(LintDiagnostic {
-                    rule: 4,
-                    severity: Severity::Warning,
-                    message: format!("self-loop on '{}' without max_retries > 0", edge.source),
-                });
-            }
+        if edge.source != edge.target {
+            continue;
+        }
+        let node = graph.nodes.get(&edge.source);
+        let is_retry = node.is_some_and(|n| n.max_retries > 0) || is_retry_or_guard_edge(edge);
+        if !is_retry {
+            diags.push(edge_diag(
+                4,
+                RuleId::SelfLoop,
+                Severity::Warning,
+                edge,
+                format!(
+                    "self-loop on '{}' without max_retries or retry marker",
+                    edge.source
+                ),
+                Some(
+                    "Set `max_retries`, label the edge `retry`, or remove the self-loop."
+                        .to_string(),
+                ),
+            ));
         }
     }
 }
 
-fn rule_05_goal_gate_edges(graph: &PipelineGraph, diags: &mut Vec<LintDiagnostic>) {
+fn rule_05_goal_gate_edges(graph: &PipelineGraph, diags: &mut Vec<PipelineDiagnostic>) {
     for node in graph.nodes.values() {
-        if node.goal_gate {
-            let has_outgoing = graph.edges.iter().any(|e| e.source == node.id);
-            if !has_outgoing {
-                diags.push(LintDiagnostic {
-                    rule: 5,
-                    severity: Severity::Warning,
-                    message: format!(
-                        "goal_gate node '{}' has no outgoing edges (will always terminate)",
-                        node.id
-                    ),
-                });
-            }
+        if !node.goal_gate {
+            continue;
+        }
+        let has_outgoing = graph.edges.iter().any(|e| e.source == node.id);
+        if !has_outgoing {
+            diags.push(node_diag(
+                5,
+                RuleId::GoalGateEdges,
+                Severity::Warning,
+                &node.id,
+                format!(
+                    "goal_gate node '{}' has no outgoing edges (will always terminate)",
+                    node.id
+                ),
+                Some("Add explicit success/failure edges if later work should run.".to_string()),
+            ));
         }
     }
 }
 
-fn rule_06_conditions_parse(graph: &PipelineGraph, diags: &mut Vec<LintDiagnostic>) {
+fn rule_06_conditions_parse(graph: &PipelineGraph, diags: &mut Vec<PipelineDiagnostic>) {
     for edge in &graph.edges {
-        if let Some(ref cond) = edge.condition {
-            if let Err(e) = condition::parse_condition(cond) {
-                diags.push(LintDiagnostic {
-                    rule: 6,
-                    severity: Severity::Error,
-                    message: format!(
-                        "edge {} -> {}: invalid condition '{}': {}",
-                        edge.source, edge.target, cond, e
-                    ),
-                });
-            }
+        let Some(cond) = edge.condition.as_ref() else {
+            continue;
+        };
+        if let Err(e) = condition::parse_condition(cond) {
+            diags.push(edge_diag(
+                6,
+                RuleId::ConditionParses,
+                Severity::Error,
+                edge,
+                format!(
+                    "edge {} -> {}: invalid condition '{}': {}",
+                    edge.source, edge.target, cond, e
+                ),
+                Some(
+                    "Use supported condition syntax such as `outcome.status == \"pass\"`."
+                        .to_string(),
+                ),
+            ));
         }
     }
 }
 
-fn rule_07_known_handler(graph: &PipelineGraph, diags: &mut Vec<LintDiagnostic>) {
-    // HandlerKind is an enum, so if it parsed successfully it's known.
-    // This rule catches the case where the parser couldn't identify the handler
-    // and defaulted to Codergen — but since we default, this is always ok.
-    // Keep as a placeholder for future custom handlers.
-    let _ = (graph, diags);
+fn rule_07_known_handler(_graph: &PipelineGraph, _diags: &mut Vec<PipelineDiagnostic>) {
+    // HandlerKind is an enum. If parsing succeeded the handler is known; if it
+    // failed, the parser fell back to Codergen for backward compatibility.
 }
 
-fn rule_08_prompt_required(graph: &PipelineGraph, diags: &mut Vec<LintDiagnostic>) {
+fn rule_08_prompt_required(graph: &PipelineGraph, diags: &mut Vec<PipelineDiagnostic>) {
     for node in graph.nodes.values() {
         if node.handler == HandlerKind::Codergen && node.prompt.is_none() {
-            diags.push(LintDiagnostic {
-                rule: 8,
-                severity: Severity::Warning,
-                message: format!(
+            diags.push(node_diag(
+                8,
+                RuleId::PromptRequired,
+                Severity::Warning,
+                &node.id,
+                format!(
                     "codergen node '{}' has no prompt (will use default worker prompt)",
                     node.id
                 ),
-            });
+                Some("Add a `prompt` attribute describing this node's task.".to_string()),
+            ));
         }
     }
 }
 
-fn rule_09_no_duplicate_edges(graph: &PipelineGraph, diags: &mut Vec<LintDiagnostic>) {
+fn rule_09_no_duplicate_edges(graph: &PipelineGraph, diags: &mut Vec<PipelineDiagnostic>) {
     let mut seen = HashSet::new();
     for edge in &graph.edges {
         let key = (&edge.source, &edge.target);
         if !seen.insert(key) {
-            diags.push(LintDiagnostic {
-                rule: 9,
-                severity: Severity::Warning,
-                message: format!("duplicate edge from '{}' to '{}'", edge.source, edge.target),
-            });
+            diags.push(edge_diag(
+                9,
+                RuleId::DuplicateEdge,
+                Severity::Warning,
+                edge,
+                format!("duplicate edge from '{}' to '{}'", edge.source, edge.target),
+                Some(
+                    "Remove the duplicate or make the conditions mutually meaningful.".to_string(),
+                ),
+            ));
         }
     }
 }
 
-fn rule_10_positive_weight(graph: &PipelineGraph, diags: &mut Vec<LintDiagnostic>) {
+fn rule_10_positive_weight(graph: &PipelineGraph, diags: &mut Vec<PipelineDiagnostic>) {
     for edge in &graph.edges {
         if edge.weight <= 0.0 {
-            diags.push(LintDiagnostic {
-                rule: 10,
-                severity: Severity::Error,
-                message: format!(
+            diags.push(edge_diag(
+                10,
+                RuleId::PositiveWeight,
+                Severity::Error,
+                edge,
+                format!(
                     "edge {} -> {}: weight must be positive, got {}",
                     edge.source, edge.target, edge.weight
                 ),
-            });
+                Some("Use a positive weight or omit the attribute for the default.".to_string()),
+            ));
         }
     }
 }
 
-fn rule_11_at_least_one_node(graph: &PipelineGraph, diags: &mut Vec<LintDiagnostic>) {
+fn rule_11_at_least_one_node(graph: &PipelineGraph, diags: &mut Vec<PipelineDiagnostic>) {
     if graph.nodes.is_empty() {
-        diags.push(LintDiagnostic {
-            rule: 11,
-            severity: Severity::Error,
-            message: "graph has no nodes".into(),
-        });
+        diags.push(diagnostic(
+            11,
+            RuleId::AtLeastOneNode,
+            Severity::Error,
+            GraphLocation::Graph,
+            "graph has no nodes",
+            Some("Declare at least one node.".to_string()),
+        ));
     }
 }
 
-fn rule_12_edge_sources_exist(graph: &PipelineGraph, diags: &mut Vec<LintDiagnostic>) {
+fn rule_12_edge_sources_exist(graph: &PipelineGraph, diags: &mut Vec<PipelineDiagnostic>) {
     for edge in &graph.edges {
         if !graph.nodes.contains_key(&edge.source) {
-            diags.push(LintDiagnostic {
-                rule: 12,
-                severity: Severity::Error,
-                message: format!("edge source '{}' does not exist", edge.source),
-            });
+            diags.push(edge_diag(
+                12,
+                RuleId::EdgeSourceExists,
+                Severity::Error,
+                edge,
+                format!("edge source '{}' does not exist", edge.source),
+                Some("Declare the source node or remove this edge.".to_string()),
+            ));
         }
     }
 }
 
-fn rule_13_parallel_converge(graph: &PipelineGraph, diags: &mut Vec<LintDiagnostic>) {
+fn rule_13_parallel_converge(graph: &PipelineGraph, diags: &mut Vec<PipelineDiagnostic>) {
     for node in graph.nodes.values() {
         if node.handler != HandlerKind::Parallel {
             continue;
         }
 
-        // Must have converge attribute
         match &node.converge {
-            None => {
-                diags.push(LintDiagnostic {
-                    rule: 13,
-                    severity: Severity::Error,
-                    message: format!("parallel node '{}' missing converge attribute", node.id),
-                });
-            }
-            Some(target) if !graph.nodes.contains_key(target) => {
-                diags.push(LintDiagnostic {
-                    rule: 13,
-                    severity: Severity::Error,
-                    message: format!(
-                        "parallel node '{}' converge target '{}' does not exist",
-                        node.id, target
-                    ),
-                });
-            }
+            None => diags.push(node_diag(
+                13,
+                RuleId::ParallelConverge,
+                Severity::Error,
+                &node.id,
+                format!("parallel node '{}' missing converge attribute", node.id),
+                Some("Set `converge` to the node that joins branch outputs.".to_string()),
+            )),
+            Some(target) if !graph.nodes.contains_key(target) => diags.push(node_diag(
+                13,
+                RuleId::ParallelConverge,
+                Severity::Error,
+                &node.id,
+                format!(
+                    "parallel node '{}' converge target '{}' does not exist",
+                    node.id, target
+                ),
+                Some("Declare the converge target node.".to_string()),
+            )),
             _ => {}
         }
 
-        // Must have outgoing edges (otherwise nothing to parallelize)
         let has_targets = graph.edges.iter().any(|e| e.source == node.id);
         if !has_targets {
-            diags.push(LintDiagnostic {
-                rule: 13,
-                severity: Severity::Warning,
-                message: format!("parallel node '{}' has no outgoing edges", node.id),
-            });
+            diags.push(node_diag(
+                13,
+                RuleId::ParallelConverge,
+                Severity::Warning,
+                &node.id,
+                format!("parallel node '{}' has no outgoing edges", node.id),
+                Some("Add branch edges or change the handler kind.".to_string()),
+            ));
         }
     }
 }
 
-fn rule_15_no_cycles(graph: &PipelineGraph, diags: &mut Vec<LintDiagnostic>) {
-    if let Err(cycle_path) = graph.detect_cycles() {
-        diags.push(LintDiagnostic {
-            rule: 15,
-            severity: Severity::Error,
-            message: cycle_path,
-        });
-    }
-}
-
-fn rule_14_dynamic_parallel(graph: &PipelineGraph, diags: &mut Vec<LintDiagnostic>) {
+fn rule_14_dynamic_parallel(graph: &PipelineGraph, diags: &mut Vec<PipelineDiagnostic>) {
     for node in graph.nodes.values() {
         if node.handler != HandlerKind::DynamicParallel {
             continue;
         }
 
-        // Must have converge attribute
         match &node.converge {
-            None => {
-                diags.push(LintDiagnostic {
-                    rule: 14,
-                    severity: Severity::Error,
-                    message: format!(
-                        "dynamic_parallel node '{}' missing converge attribute",
-                        node.id
-                    ),
-                });
-            }
-            Some(target) if !graph.nodes.contains_key(target) => {
-                diags.push(LintDiagnostic {
-                    rule: 14,
-                    severity: Severity::Error,
-                    message: format!(
-                        "dynamic_parallel node '{}' converge target '{}' does not exist",
-                        node.id, target
-                    ),
-                });
-            }
+            None => diags.push(node_diag(
+                14,
+                RuleId::DynamicParallel,
+                Severity::Error,
+                &node.id,
+                format!(
+                    "dynamic_parallel node '{}' missing converge attribute",
+                    node.id
+                ),
+                Some("Set `converge` to the node that joins dynamic worker outputs.".to_string()),
+            )),
+            Some(target) if !graph.nodes.contains_key(target) => diags.push(node_diag(
+                14,
+                RuleId::DynamicParallel,
+                Severity::Error,
+                &node.id,
+                format!(
+                    "dynamic_parallel node '{}' converge target '{}' does not exist",
+                    node.id, target
+                ),
+                Some("Declare the converge target node.".to_string()),
+            )),
             _ => {}
         }
 
-        // Warn if no prompt (planning prompt)
         if node.prompt.is_none() {
-            diags.push(LintDiagnostic {
-                rule: 14,
-                severity: Severity::Warning,
-                message: format!(
+            diags.push(node_diag(
+                14,
+                RuleId::DynamicParallel,
+                Severity::Warning,
+                &node.id,
+                format!(
                     "dynamic_parallel node '{}' has no prompt (will use default planning prompt)",
                     node.id
                 ),
-            });
+                Some("Add a planning `prompt` for deterministic task generation.".to_string()),
+            ));
         }
     }
+}
+
+fn rule_15_no_cycles(graph: &PipelineGraph, diags: &mut Vec<PipelineDiagnostic>) {
+    if let Some(cycle_path) = detect_unmarked_cycle(graph) {
+        diags.push(diagnostic(
+            15,
+            RuleId::Dag,
+            Severity::Error,
+            GraphLocation::Graph,
+            format!("cycle detected: {}", cycle_path.join(" -> ")),
+            Some(
+                "Break the cycle or mark the back-edge as `label=\"retry\"`/`label=\"guard\"`."
+                    .to_string(),
+            ),
+        ));
+    }
+}
+
+fn rule_16_template_bindings(
+    graph: &PipelineGraph,
+    context: &ValidationContext,
+    diags: &mut Vec<PipelineDiagnostic>,
+) {
+    let upstream = transitive_upstream_by_node(graph);
+    for node in graph.nodes.values() {
+        for (field, template) in node_templates(node) {
+            for var in template_variables(template) {
+                if template_var_resolves(graph, context, &upstream, node, &var) {
+                    continue;
+                }
+                diags.push(node_diag(
+                    16,
+                    RuleId::TemplateBinding,
+                    Severity::Error,
+                    &node.id,
+                    format!(
+                        "node '{}' {} references unbound template variable '{{{}}}'",
+                        node.id, field, var
+                    ),
+                    Some(
+                        "Use `{input}`, a runtime channel, a declared artifact/checkpoint, or an upstream node id.".to_string(),
+                    ),
+                ));
+            }
+        }
+    }
+}
+
+fn rule_17_edge_referenced(graph: &PipelineGraph, diags: &mut Vec<PipelineDiagnostic>) {
+    for edge in &graph.edges {
+        let Some(target) = graph.nodes.get(&edge.target) else {
+            continue;
+        };
+        let consumed = node_templates(target)
+            .any(|(_, template)| template_references_source(template, &edge.source));
+        if !consumed {
+            diags.push(edge_diag(
+                17,
+                RuleId::EdgeReferenced,
+                Severity::Warning,
+                edge,
+                format!(
+                    "edge {} -> {} is declared but target template never references '{}'",
+                    edge.source, edge.target, edge.source
+                ),
+                Some(format!(
+                    "Reference `{{{}}}` in node '{}' or remove the dead data edge.",
+                    edge.source, edge.target
+                )),
+            ));
+        }
+    }
+}
+
+fn rule_18_known_models(
+    graph: &PipelineGraph,
+    context: &ValidationContext,
+    diags: &mut Vec<PipelineDiagnostic>,
+) {
+    let Some(known_models) = context.known_models.as_ref() else {
+        return;
+    };
+    if known_models.is_empty() {
+        return;
+    }
+
+    if let Some(model) = graph.default_model.as_deref() {
+        check_model_value(
+            model,
+            known_models,
+            GraphLocation::Graph,
+            "graph default_model",
+            diags,
+        );
+    }
+
+    for node in graph.nodes.values() {
+        if let Some(model) = node.model.as_deref() {
+            check_model_value(
+                model,
+                known_models,
+                GraphLocation::Node(node.id.clone()),
+                "model",
+                diags,
+            );
+        }
+        if let Some(model) = node.planner_model.as_deref() {
+            check_model_value(
+                model,
+                known_models,
+                GraphLocation::Node(node.id.clone()),
+                "planner_model",
+                diags,
+            );
+        }
+    }
+}
+
+fn rule_19_known_tools(
+    graph: &PipelineGraph,
+    context: &ValidationContext,
+    diags: &mut Vec<PipelineDiagnostic>,
+) {
+    let known_groups: HashSet<&str> = TOOL_GROUPS.iter().map(|g| g.name).collect();
+    for node in graph.nodes.values() {
+        for tool in &node.tools {
+            if tool.is_empty() {
+                continue;
+            }
+            if tool.starts_with("group:") {
+                if !known_groups.contains(tool.as_str()) && !tool.starts_with("group:robot:") {
+                    diags.push(node_diag(
+                        19,
+                        RuleId::KnownToolPolicy,
+                        Severity::Error,
+                        &node.id,
+                        format!("node '{}' references unknown tool group '{}'", node.id, tool),
+                        Some("Use a known group such as `group:fs`, `group:runtime`, `group:search`, `group:web`, or `group:sessions`.".to_string()),
+                    ));
+                }
+                continue;
+            }
+
+            let Some(known_tools) = context.known_tools.as_ref() else {
+                continue;
+            };
+            if !known_tools.contains(tool) {
+                diags.push(node_diag(
+                    19,
+                    RuleId::KnownToolPolicy,
+                    Severity::Error,
+                    &node.id,
+                    format!("node '{}' references unknown tool '{}'", node.id, tool),
+                    Some(
+                        "Use a registered tool name or a known `group:*` policy group.".to_string(),
+                    ),
+                ));
+            }
+        }
+    }
+}
+
+fn rule_20_fanout_bound(
+    graph: &PipelineGraph,
+    context: &ValidationContext,
+    diags: &mut Vec<PipelineDiagnostic>,
+) {
+    let mut outgoing: HashMap<&str, usize> = HashMap::new();
+    for edge in &graph.edges {
+        *outgoing.entry(edge.source.as_str()).or_default() += 1;
+    }
+
+    for (node_id, degree) in outgoing {
+        if degree > context.fanout_limit {
+            diags.push(node_diag(
+                20,
+                RuleId::FanoutBound,
+                Severity::Error,
+                node_id,
+                format!(
+                    "node '{node_id}' fan-out degree {degree} exceeds cap {}",
+                    context.fanout_limit
+                ),
+                Some("Reduce outgoing edges or split the fan-out into bounded stages.".to_string()),
+            ));
+        }
+    }
+
+    for node in graph.nodes.values() {
+        let Some(max_tasks) = node.max_tasks else {
+            continue;
+        };
+        if usize::try_from(max_tasks).unwrap_or(usize::MAX) > context.fanout_limit {
+            diags.push(node_diag(
+                20,
+                RuleId::FanoutBound,
+                Severity::Error,
+                &node.id,
+                format!(
+                    "node '{}' max_tasks {} exceeds cap {}",
+                    node.id, max_tasks, context.fanout_limit
+                ),
+                Some("Lower `max_tasks` or raise the validator cap explicitly.".to_string()),
+            ));
+        }
+    }
+}
+
+fn rule_21_human_gate_resolver(graph: &PipelineGraph, diags: &mut Vec<PipelineDiagnostic>) {
+    for node in graph.nodes.values() {
+        if node.human_gate && node.human_resolver.as_deref().is_none_or(str::is_empty) {
+            diags.push(node_diag(
+                21,
+                RuleId::HumanGateResolver,
+                Severity::Error,
+                &node.id,
+                format!("human-gate node '{}' has no resolver configured", node.id),
+                Some("Set `human_resolver` or `resolver` on the gate node.".to_string()),
+            ));
+        }
+    }
+}
+
+fn rule_22_dangling_refs(
+    graph: &PipelineGraph,
+    context: &ValidationContext,
+    diags: &mut Vec<PipelineDiagnostic>,
+) {
+    let checkpoints: HashSet<&str> = graph
+        .nodes
+        .values()
+        .flat_map(|node| {
+            node.checkpoints
+                .iter()
+                .map(|checkpoint| checkpoint.name.as_str())
+        })
+        .collect();
+
+    for node in graph.nodes.values() {
+        for (field, template) in node_templates(node) {
+            for var in template_variables(template) {
+                if let Some(name) = var
+                    .strip_prefix("artifact:")
+                    .or_else(|| var.strip_prefix("artifact."))
+                {
+                    if !context.known_artifacts.contains(name) {
+                        diags.push(node_diag(
+                            22,
+                            RuleId::DanglingReference,
+                            Severity::Error,
+                            &node.id,
+                            format!(
+                                "node '{}' {} references unknown artifact '{}'",
+                                node.id, field, name
+                            ),
+                            Some(
+                                "Declare the artifact in validation context or fix the reference."
+                                    .to_string(),
+                            ),
+                        ));
+                    }
+                }
+                if let Some(name) = var
+                    .strip_prefix("checkpoint:")
+                    .or_else(|| var.strip_prefix("checkpoint."))
+                {
+                    if !checkpoints.contains(name) {
+                        diags.push(node_diag(
+                            22,
+                            RuleId::DanglingReference,
+                            Severity::Error,
+                            &node.id,
+                            format!(
+                                "node '{}' {} references unknown checkpoint '{}'",
+                                node.id, field, name
+                            ),
+                            Some("Declare `checkpoint=\"...\"` on an upstream node or fix the reference.".to_string()),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn check_model_value(
+    value: &str,
+    known_models: &HashSet<String>,
+    location: GraphLocation,
+    field_name: &str,
+    diags: &mut Vec<PipelineDiagnostic>,
+) {
+    for model in value.split(',').map(str::trim).filter(|m| !m.is_empty()) {
+        if known_models.contains(model) {
+            continue;
+        }
+        diags.push(diagnostic(
+            18,
+            RuleId::KnownModel,
+            Severity::Error,
+            location.clone(),
+            format!("{field_name} references unknown model '{model}'"),
+            Some("Use a model key present in the provider catalog/model stylesheet.".to_string()),
+        ));
+    }
+}
+
+fn node_templates(node: &PipelineNode) -> impl Iterator<Item = (&'static str, &str)> {
+    node.prompt
+        .as_deref()
+        .map(|prompt| ("prompt", prompt))
+        .into_iter()
+        .chain(
+            node.worker_prompt
+                .as_deref()
+                .map(|prompt| ("worker_prompt", prompt)),
+        )
+}
+
+fn template_variables(template: &str) -> Vec<String> {
+    let mut vars = Vec::new();
+    let mut rest = template;
+    while let Some(start) = rest.find('{') {
+        rest = &rest[start + 1..];
+        if rest.starts_with('{') {
+            rest = &rest[1..];
+            continue;
+        }
+        let Some(end) = rest.find('}') else {
+            break;
+        };
+        let candidate = &rest[..end];
+        rest = &rest[end + 1..];
+        if is_template_identifier(candidate) {
+            vars.push(candidate.to_string());
+        }
+    }
+    vars.sort();
+    vars.dedup();
+    vars
+}
+
+fn is_template_identifier(candidate: &str) -> bool {
+    let mut chars = candidate.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | ':' | '/'))
+}
+
+fn template_references_source(template: &str, source: &str) -> bool {
+    template_variables(template).iter().any(|var| {
+        var == source
+            || var
+                .strip_prefix(source)
+                .is_some_and(|rest| matches!(rest, ".output" | ":output"))
+    })
+}
+
+fn template_var_resolves(
+    graph: &PipelineGraph,
+    context: &ValidationContext,
+    upstream: &HashMap<String, HashSet<String>>,
+    node: &PipelineNode,
+    var: &str,
+) -> bool {
+    if context.runtime_channels.contains(var) {
+        return true;
+    }
+    if var == "task" && node.handler == HandlerKind::DynamicParallel {
+        return true;
+    }
+    if var
+        .strip_prefix("artifact:")
+        .or_else(|| var.strip_prefix("artifact."))
+        .is_some_and(|name| context.known_artifacts.contains(name))
+    {
+        return true;
+    }
+    if var
+        .strip_prefix("checkpoint:")
+        .or_else(|| var.strip_prefix("checkpoint."))
+        .is_some()
+    {
+        return graph
+            .nodes
+            .values()
+            .flat_map(|n| n.checkpoints.iter())
+            .any(|checkpoint| {
+                var.ends_with(checkpoint.name.as_str()) && !checkpoint.name.is_empty()
+            });
+    }
+    let normalized = var
+        .strip_suffix(".output")
+        .or_else(|| var.strip_suffix(":output"))
+        .unwrap_or(var);
+    upstream
+        .get(&node.id)
+        .is_some_and(|nodes| nodes.contains(normalized))
+}
+
+fn transitive_upstream_by_node(graph: &PipelineGraph) -> HashMap<String, HashSet<String>> {
+    let mut reverse: HashMap<&str, Vec<&str>> = HashMap::new();
+    for edge in &graph.edges {
+        reverse
+            .entry(edge.target.as_str())
+            .or_default()
+            .push(edge.source.as_str());
+    }
+
+    graph
+        .nodes
+        .keys()
+        .map(|node_id| {
+            let mut seen = HashSet::new();
+            let mut queue: VecDeque<&str> = reverse
+                .get(node_id.as_str())
+                .cloned()
+                .unwrap_or_default()
+                .into();
+            while let Some(next) = queue.pop_front() {
+                if !seen.insert(next.to_string()) {
+                    continue;
+                }
+                if let Some(parents) = reverse.get(next) {
+                    for parent in parents {
+                        queue.push_back(parent);
+                    }
+                }
+            }
+            (node_id.clone(), seen)
+        })
+        .collect()
+}
+
+fn detect_unmarked_cycle(graph: &PipelineGraph) -> Option<Vec<String>> {
+    let mut adj: HashMap<&str, Vec<&str>> = HashMap::new();
+    for edge in &graph.edges {
+        if is_retry_or_guard_edge(edge) {
+            continue;
+        }
+        adj.entry(edge.source.as_str())
+            .or_default()
+            .push(edge.target.as_str());
+    }
+
+    let mut white: HashSet<&str> = graph.nodes.keys().map(String::as_str).collect();
+    let mut gray: HashSet<&str> = HashSet::new();
+    let mut black: HashSet<&str> = HashSet::new();
+    let mut path: Vec<&str> = Vec::new();
+
+    fn dfs<'a>(
+        node: &'a str,
+        adj: &HashMap<&str, Vec<&'a str>>,
+        white: &mut HashSet<&'a str>,
+        gray: &mut HashSet<&'a str>,
+        black: &mut HashSet<&'a str>,
+        path: &mut Vec<&'a str>,
+    ) -> Option<Vec<String>> {
+        white.remove(node);
+        gray.insert(node);
+        path.push(node);
+
+        if let Some(neighbors) = adj.get(node) {
+            for &next in neighbors {
+                if black.contains(next) {
+                    continue;
+                }
+                if gray.contains(next) {
+                    let cycle_start = path.iter().position(|&n| n == next).unwrap_or(0);
+                    let mut cycle: Vec<String> = path[cycle_start..]
+                        .iter()
+                        .map(|n| (*n).to_string())
+                        .collect();
+                    cycle.push(next.to_string());
+                    return Some(cycle);
+                }
+                if let Some(cycle) = dfs(next, adj, white, gray, black, path) {
+                    return Some(cycle);
+                }
+            }
+        }
+
+        path.pop();
+        gray.remove(node);
+        black.insert(node);
+        None
+    }
+
+    let all_nodes: Vec<&str> = graph.nodes.keys().map(String::as_str).collect();
+    for node in all_nodes {
+        if white.contains(node) {
+            if let Some(cycle) = dfs(node, &adj, &mut white, &mut gray, &mut black, &mut path) {
+                return Some(cycle);
+            }
+        }
+    }
+    None
+}
+
+fn is_retry_or_guard_edge(edge: &PipelineEdge) -> bool {
+    let label = edge
+        .label
+        .as_deref()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let condition = edge
+        .condition
+        .as_deref()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    label.contains("retry")
+        || label.contains("guard")
+        || condition.contains("retry")
+        || condition.contains("guard")
+}
+
+fn default_runtime_channels() -> HashSet<String> {
+    [
+        "input",
+        "user_input",
+        "outcome",
+        "context",
+        "workspace",
+        "files",
+        "artifacts",
+        "previous",
+        "task",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
+}
+
+fn default_known_tools() -> HashSet<String> {
+    let mut tools: HashSet<String> = TOOL_GROUPS
+        .iter()
+        .flat_map(|group| group.tools.iter().copied())
+        .map(str::to_string)
+        .collect();
+    tools.extend(
+        [
+            "apply_patch",
+            "bash",
+            "browser",
+            "deep_search",
+            "delegate",
+            "diff_edit",
+            "edit_file",
+            "exec_command",
+            "glob",
+            "grep",
+            "list_dir",
+            "manage_skills",
+            "read_file",
+            "search",
+            "shell",
+            "spawn",
+            "spawn_agent",
+            "synthesize_research",
+            "web_fetch",
+            "web_search",
+            "write_file",
+            "write_stdin",
+        ]
+        .into_iter()
+        .map(str::to_string),
+    );
+    tools
 }
 
 #[cfg(test)]
@@ -376,12 +1172,24 @@ mod tests {
     use super::*;
     use crate::parser::parse_dot;
 
+    fn assert_rule(diags: &[PipelineDiagnostic], rule_id: RuleId) {
+        assert!(
+            diags.iter().any(|d| d.rule_id == rule_id),
+            "expected {rule_id:?} in {diags:?}"
+        );
+    }
+
+    fn known_models(names: &[&str]) -> ValidationContext {
+        ValidationContext::default()
+            .with_known_models(names.iter().map(|name| (*name).to_string()).collect())
+    }
+
     #[test]
     fn test_valid_graph() {
         let dot = r#"
             digraph test {
-                start [prompt="Begin"]
-                finish [prompt="End"]
+                start [prompt="Begin with {input}", tools="read_file"]
+                finish [prompt="End using {start}", tools="write_file"]
                 start -> finish
             }
         "#;
@@ -403,11 +1211,11 @@ mod tests {
         let graph = parse_dot(dot).unwrap();
         let diags = validate(&graph);
         assert!(has_errors(&diags));
-        assert!(diags.iter().any(|d| d.rule == 1));
+        assert_rule(&diags, RuleId::StartNode);
     }
 
     #[test]
-    fn test_unreachable_node() {
+    fn test_unreachable_node_is_error() {
         let dot = r#"
             digraph test {
                 start [prompt="Begin"]
@@ -418,10 +1226,298 @@ mod tests {
         "#;
         let graph = parse_dot(dot).unwrap();
         let diags = validate(&graph);
+        assert!(has_errors(&diags));
+        assert_rule(&diags, RuleId::UnreachableNode);
         assert!(
             diags
                 .iter()
-                .any(|d| d.rule == 2 && d.message.contains("orphan"))
+                .any(|d| d.location == GraphLocation::Node("orphan".into()))
+        );
+    }
+
+    #[test]
+    fn template_binding_rejects_unbound_variable() {
+        let graph = parse_dot(
+            r#"
+            digraph test {
+                start [prompt="Use {missing}"]
+            }
+        "#,
+        )
+        .unwrap();
+        let diags = validate(&graph);
+        assert!(has_errors(&diags));
+        assert_rule(&diags, RuleId::TemplateBinding);
+        assert!(diags.iter().any(|d| d.fix_hint.is_some()));
+    }
+
+    #[test]
+    fn template_binding_accepts_input_runtime_artifact_and_upstream() {
+        let graph = parse_dot(
+            r#"
+            digraph test {
+                start [prompt="Use {input} and {topic} and {artifact:deck}"]
+                analyze [prompt="Analyze {start.output} with {context}"]
+                start -> analyze
+            }
+        "#,
+        )
+        .unwrap();
+        let ctx = ValidationContext::default()
+            .with_known_artifacts(["deck"])
+            .with_runtime_channels(["topic"]);
+        let diags = validate_with_context(&graph, &ctx);
+        assert!(!has_errors(&diags), "unexpected errors: {diags:?}");
+    }
+
+    #[test]
+    fn dead_edge_warns_when_target_template_does_not_consume_source() {
+        let graph = parse_dot(
+            r#"
+            digraph test {
+                start [prompt="Use {input}"]
+                finish [prompt="Ignore predecessor"]
+                start -> finish
+            }
+        "#,
+        )
+        .unwrap();
+        let diags = validate(&graph);
+        assert!(!has_errors(&diags), "dead edge should warn only: {diags:?}");
+        assert_rule(&diags, RuleId::EdgeReferenced);
+    }
+
+    #[test]
+    fn edge_reference_passes_when_target_template_consumes_source() {
+        let graph = parse_dot(
+            r#"
+            digraph test {
+                start [prompt="Use {input}"]
+                finish [prompt="Use {start}"]
+                start -> finish
+            }
+        "#,
+        )
+        .unwrap();
+        let diags = validate(&graph);
+        assert!(
+            !diags.iter().any(|d| d.rule_id == RuleId::EdgeReferenced),
+            "edge should be consumed: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn cycle_without_retry_marker_is_error() {
+        let graph = parse_dot(
+            r#"
+            digraph test {
+                start [prompt="A"]
+                b [prompt="B"]
+                start -> b
+                b -> start
+            }
+        "#,
+        )
+        .unwrap();
+        let diags = validate(&graph);
+        assert!(has_errors(&diags));
+        assert_rule(&diags, RuleId::Dag);
+    }
+
+    #[test]
+    fn cycle_with_retry_marker_is_allowed() {
+        let graph = parse_dot(
+            r#"
+            digraph test {
+                start [prompt="A"]
+                b [prompt="B"]
+                start -> b
+                b -> start [label="retry"]
+            }
+        "#,
+        )
+        .unwrap();
+        let diags = validate(&graph);
+        assert!(
+            !diags.iter().any(|d| d.rule_id == RuleId::Dag),
+            "retry back-edge should be ignored by DAG check: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn model_catalog_rejects_unknown_model() {
+        let graph = parse_dot(
+            r#"
+            digraph test {
+                start [model="missing-model", prompt="A"]
+            }
+        "#,
+        )
+        .unwrap();
+        let diags = validate_with_context(&graph, &known_models(&["known-model"]));
+        assert!(has_errors(&diags));
+        assert_rule(&diags, RuleId::KnownModel);
+    }
+
+    #[test]
+    fn model_catalog_accepts_known_model_pool() {
+        let graph = parse_dot(
+            r#"
+            digraph test {
+                start [handler="dynamic_parallel", model="fast-a,fast-b", planner_model="strong-a", converge="merge", prompt="Plan"]
+                merge [handler="noop"]
+                start -> merge
+            }
+        "#,
+        )
+        .unwrap();
+        let diags = validate_with_context(&graph, &known_models(&["fast-a", "fast-b", "strong-a"]));
+        assert!(
+            !diags.iter().any(|d| d.rule_id == RuleId::KnownModel),
+            "known model pool should pass: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn tool_policy_rejects_unknown_tool_and_group() {
+        let graph = parse_dot(
+            r#"
+            digraph test {
+                start [prompt="A", tools="read_file,not_a_tool,group:nope"]
+            }
+        "#,
+        )
+        .unwrap();
+        let diags = validate(&graph);
+        assert!(has_errors(&diags));
+        assert_eq!(
+            diags
+                .iter()
+                .filter(|d| d.rule_id == RuleId::KnownToolPolicy)
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn tool_policy_accepts_known_tool_and_group() {
+        let graph = parse_dot(
+            r#"
+            digraph test {
+                start [prompt="A", tools="read_file,group:search"]
+            }
+        "#,
+        )
+        .unwrap();
+        let diags = validate(&graph);
+        assert!(
+            !diags.iter().any(|d| d.rule_id == RuleId::KnownToolPolicy),
+            "known tool/group should pass: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn fanout_over_cap_is_error() {
+        let dot = format!(
+            "digraph test {{ start [prompt=\"A\"] {} }}",
+            (0..51)
+                .map(|i| format!("start -> n{i}; n{i} [prompt=\"N\"]"))
+                .collect::<Vec<_>>()
+                .join("; ")
+        );
+        let graph = parse_dot(&dot).unwrap();
+        let diags = validate(&graph);
+        assert!(has_errors(&diags));
+        assert_rule(&diags, RuleId::FanoutBound);
+    }
+
+    #[test]
+    fn fanout_at_cap_is_allowed() {
+        let dot = format!(
+            "digraph test {{ start [prompt=\"A\"] {} }}",
+            (0..50)
+                .map(|i| format!("start -> n{i}; n{i} [prompt=\"{{start}}\"]"))
+                .collect::<Vec<_>>()
+                .join("; ")
+        );
+        let graph = parse_dot(&dot).unwrap();
+        let diags = validate(&graph);
+        assert!(
+            !diags.iter().any(|d| d.rule_id == RuleId::FanoutBound),
+            "cap-sized fanout should pass: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn human_gate_requires_resolver() {
+        let graph = parse_dot(
+            r#"
+            digraph test {
+                start [handler="gate", human_gate="true", prompt="approve"]
+            }
+        "#,
+        )
+        .unwrap();
+        let diags = validate(&graph);
+        assert!(has_errors(&diags));
+        assert_rule(&diags, RuleId::HumanGateResolver);
+    }
+
+    #[test]
+    fn human_gate_with_resolver_passes() {
+        let graph = parse_dot(
+            r#"
+            digraph test {
+                start [handler="gate", human_gate="true", resolver="operator", prompt="approve"]
+            }
+        "#,
+        )
+        .unwrap();
+        let diags = validate(&graph);
+        assert!(
+            !diags.iter().any(|d| d.rule_id == RuleId::HumanGateResolver),
+            "resolver should satisfy human gate: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn dangling_artifact_and_checkpoint_refs_are_errors() {
+        let graph = parse_dot(
+            r#"
+            digraph test {
+                start [prompt="Use {artifact:deck} and {checkpoint:post_search}"]
+            }
+        "#,
+        )
+        .unwrap();
+        let diags = validate(&graph);
+        assert!(has_errors(&diags));
+        assert_eq!(
+            diags
+                .iter()
+                .filter(|d| d.rule_id == RuleId::DanglingReference)
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn declared_artifact_and_checkpoint_refs_pass() {
+        let graph = parse_dot(
+            r#"
+            digraph test {
+                start [prompt="Seed", checkpoint="post_search"]
+                finish [prompt="Use {artifact:deck} and {checkpoint:post_search} and {start}"]
+                start -> finish
+            }
+        "#,
+        )
+        .unwrap();
+        let ctx = ValidationContext::default().with_known_artifacts(["deck"]);
+        let diags = validate_with_context(&graph, &ctx);
+        assert!(
+            !diags.iter().any(|d| d.rule_id == RuleId::DanglingReference),
+            "declared references should pass: {diags:?}"
         );
     }
 
@@ -429,50 +1525,27 @@ mod tests {
     fn test_parallel_missing_converge() {
         let dot = r#"
             digraph test {
-                fan [handler="parallel"]
+                start [handler="parallel"]
                 a [prompt="A"]
-                fan -> a
+                start -> a
             }
         "#;
         let graph = parse_dot(dot).unwrap();
         let diags = validate(&graph);
         assert!(has_errors(&diags));
-        assert!(
-            diags
-                .iter()
-                .any(|d| d.rule == 13 && d.message.contains("missing converge"))
-        );
-    }
-
-    #[test]
-    fn test_parallel_converge_not_found() {
-        let dot = r#"
-            digraph test {
-                fan [handler="parallel", converge="nonexistent"]
-                a [prompt="A"]
-                fan -> a
-            }
-        "#;
-        let graph = parse_dot(dot).unwrap();
-        let diags = validate(&graph);
-        assert!(has_errors(&diags));
-        assert!(
-            diags
-                .iter()
-                .any(|d| d.rule == 13 && d.message.contains("does not exist"))
-        );
+        assert_rule(&diags, RuleId::ParallelConverge);
     }
 
     #[test]
     fn test_parallel_valid() {
         let dot = r#"
             digraph test {
-                fan [handler="parallel", converge="merge"]
+                start [handler="parallel", converge="merge"]
                 a [prompt="A"]
                 b [prompt="B"]
-                merge [prompt="Merge"]
-                fan -> a
-                fan -> b
+                merge [prompt="Merge {a} {b}"]
+                start -> a
+                start -> b
                 a -> merge
                 b -> merge
             }
@@ -486,60 +1559,37 @@ mod tests {
     fn test_positive_weight() {
         let dot = r#"
             digraph test {
-                a -> b [weight="0"]
+                start -> b [weight="0"]
             }
         "#;
         let graph = parse_dot(dot).unwrap();
         let diags = validate(&graph);
         assert!(has_errors(&diags));
-        assert!(diags.iter().any(|d| d.rule == 10));
+        assert_rule(&diags, RuleId::PositiveWeight);
     }
 
     #[test]
     fn test_dynamic_parallel_missing_converge() {
         let dot = r#"
             digraph test {
-                plan [handler="dynamic_parallel", prompt="Plan"]
+                start [handler="dynamic_parallel", prompt="Plan"]
                 next [prompt="Next"]
-                plan -> next
+                start -> next
             }
         "#;
         let graph = parse_dot(dot).unwrap();
         let diags = validate(&graph);
         assert!(has_errors(&diags));
-        assert!(
-            diags
-                .iter()
-                .any(|d| d.rule == 14 && d.message.contains("missing converge"))
-        );
-    }
-
-    #[test]
-    fn test_dynamic_parallel_converge_not_found() {
-        let dot = r#"
-            digraph test {
-                plan [handler="dynamic_parallel", converge="nonexistent", prompt="Plan"]
-                next [prompt="Next"]
-                plan -> next
-            }
-        "#;
-        let graph = parse_dot(dot).unwrap();
-        let diags = validate(&graph);
-        assert!(has_errors(&diags));
-        assert!(
-            diags
-                .iter()
-                .any(|d| d.rule == 14 && d.message.contains("does not exist"))
-        );
+        assert_rule(&diags, RuleId::DynamicParallel);
     }
 
     #[test]
     fn test_dynamic_parallel_no_prompt_warning() {
         let dot = r#"
             digraph test {
-                plan [handler="dynamic_parallel", converge="analyze"]
-                analyze [prompt="Analyze"]
-                plan -> analyze
+                start [handler="dynamic_parallel", converge="analyze"]
+                analyze [prompt="Analyze {start}"]
+                start -> analyze
             }
         "#;
         let graph = parse_dot(dot).unwrap();
@@ -548,25 +1598,7 @@ mod tests {
         assert!(
             diags
                 .iter()
-                .any(|d| d.rule == 14 && d.message.contains("no prompt"))
+                .any(|d| d.rule_id == RuleId::DynamicParallel && d.severity == Severity::Warning)
         );
-    }
-
-    #[test]
-    fn test_dynamic_parallel_valid() {
-        let dot = r#"
-            digraph test {
-                plan [handler="dynamic_parallel", converge="analyze", prompt="Generate angles"]
-                analyze [prompt="Cross-reference"]
-                synthesize [prompt="Write report", goal_gate="true"]
-                plan -> analyze
-                analyze -> synthesize
-            }
-        "#;
-        let graph = parse_dot(dot).unwrap();
-        let diags = validate(&graph);
-        assert!(!has_errors(&diags), "unexpected errors: {diags:?}");
-        // No warnings about rule 14
-        assert!(!diags.iter().any(|d| d.rule == 14));
     }
 }

--- a/crates/octos-pipeline/tests/pre_flight_validation.rs
+++ b/crates/octos-pipeline/tests/pre_flight_validation.rs
@@ -112,6 +112,24 @@ async fn pre_flight_accepts_well_formed_dot() {
 }
 
 #[tokio::test]
+async fn pre_flight_accepts_declared_runtime_variables() {
+    let (tool, _working, _data) = make_tool().await;
+    let args = serde_json::json!({
+        "pipeline": "digraph ok {\n\
+            start [handler=Codergen, prompt=\"Use {topic}\"];\n\
+        }",
+        "input": "anything",
+        "variables": { "topic": "pipeline validation" },
+    });
+    let result = tool.pre_flight_validate(&args).await;
+    assert!(
+        result.is_ok(),
+        "declared variables must satisfy pre-flight template binding; got Err: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
 async fn pre_flight_rejects_malformed_json_args() {
     let (tool, _working, _data) = make_tool().await;
     let args = serde_json::json!({ "pipeline": "digraph x { a; }" }); // missing required `input`


### PR DESCRIPTION
## Summary
- add typed pipeline diagnostics and a pure validation context for pre-execution graph checks
- validate template bindings, dead edges, reachability/DAG, catalog models, tool policy, fanout caps, human gate resolvers, and artifact/checkpoint references
- wire validation into run_pipeline pre-flight and executor startup so Error diagnostics stop before handler dispatch; runtime variables remain valid bindings
- include support-only current-main rustfmt/clippy cleanup needed for broad -D warnings

Closes #1366

## Validation
- cargo fmt --all -- --check
- git diff --check origin/main..HEAD
- git ls-files --others --exclude-standard  # empty
- CARGO_TARGET_DIR=/private/tmp/octos-1366-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-pipeline -- --nocapture
- CARGO_TARGET_DIR=/private/tmp/octos-1366-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings

Base verified after rebase: origin/main 38eb28a413400cd908ac47cc415f9b10b90b4470