### PR TITLE
fix(tools): bind upload handles to session scope

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -23,10 +23,11 @@
 //! tools still serializes the whole batch. An optimised "run Safe in parallel,
 //! then Exclusive in order" pipeline is explicitly deferred (see the M8.8 spec).
 
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use eyre::Result;
-use octos_core::{Message, MessageRole, TokenUsage};
+use octos_core::{Message, MessageRole, SessionScope, TokenUsage};
 use octos_llm::ChatResponse;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
@@ -67,6 +68,16 @@ fn should_auto_send_tool_files(
     tool_name: &str,
 ) -> bool {
     !(suppress_auto_send_files || explicit_send_file_requested && tool_name != "send_file")
+}
+
+pub(super) fn session_scope_for_messages(
+    scope: &Option<Arc<SessionScope>>,
+    messages: &[Message],
+) -> Option<Arc<SessionScope>> {
+    scope.as_ref().map(|scope| {
+        let handles = messages.iter().flat_map(|message| message.media.iter());
+        Arc::new(scope.as_ref().clone().with_attached_upload_handles(handles))
+    })
 }
 
 /// Issue #896 — spawn_only filename propagation (Layer 1).
@@ -171,12 +182,12 @@ pub(super) fn satisfied_completion_content(output_files: &[String], tool_output:
 /// Empirical validation (llm-benchmark replay of mini3 session
 /// slides-1780013669236-8w2ime, the production failure that motivated
 /// this fix):
-///   - kimi-k2.5 + only `check_workspace_contract`:
-///       loop rate 5/5 → 3/5 with this block (40% break out)
-///   - kimi-k2.5 + check + read_file + list_dir:
-///       no consistent change (within noise)
-///   - claude-opus-4.7:
-///       already 0/5 loops in both arms; block has no effect on Opus
+/// - kimi-k2.5 + only `check_workspace_contract`:
+///   loop rate 5/5 → 3/5 with this block (40% break out)
+/// - kimi-k2.5 + check + read_file + list_dir:
+///   no consistent change (within noise)
+/// - claude-opus-4.7:
+///   already 0/5 loops in both arms; block has no effect on Opus
 ///
 /// The block follows hermes-agent's prompt-time-injection pattern (in
 /// `agent/prompt_builder.py`), but applied universally rather than
@@ -229,6 +240,7 @@ impl Agent {
         tool_call: &octos_core::ToolCall,
         explicit_send_file_requested: bool,
         turn_attachment_ctx: &crate::tools::TurnAttachmentContext,
+        session_scope: Option<Arc<SessionScope>>,
     ) -> JoinHandle<ToolCallResult> {
         // Clone Arc-wrapped fields so the spawned task is 'static
         let tools = self.tools.clone();
@@ -274,12 +286,11 @@ impl Agent {
         // `ctx.spawn_depth` and refuses further nesting at the cap.
         let spawn_depth = self.spawn_depth;
         // Phase 1 of the SessionScope migration (PR #1198 follow-up):
-        // snapshot the agent's `session_scope` so the foreground and
-        // spawn_only `ToolContext` builders below thread it onto every
-        // tool call. `None` keeps pre-Phase-1 behaviour; downstream
-        // consumers (pipeline workers, file tools, plugins) come online
-        // in Phase 2.
-        let session_scope = self.session_scope.clone();
+        // snapshot the effective per-turn `session_scope` so the
+        // foreground and spawn_only `ToolContext` builders below thread it
+        // onto every tool call. The caller layers current/history upload
+        // media onto the scope before dispatch so multi-tenant upload
+        // handles remain session-bound.
 
         tokio::spawn(async move {
             let tool_start = Instant::now();
@@ -1655,6 +1666,7 @@ impl Agent {
     pub(super) async fn execute_tools(
         &self,
         response: &ChatResponse,
+        session_scope: Option<Arc<SessionScope>>,
     ) -> Result<(
         Vec<Message>,
         Vec<std::path::PathBuf>,
@@ -1727,6 +1739,7 @@ impl Agent {
                 response,
                 explicit_send_file_requested,
                 &turn_attachment_ctx,
+                session_scope,
                 tool_timeout,
                 tool_timeout_secs,
             )
@@ -1742,6 +1755,7 @@ impl Agent {
                         tool_call,
                         explicit_send_file_requested,
                         &turn_attachment_ctx,
+                        session_scope.clone(),
                     )
                 })
                 .collect();
@@ -1879,6 +1893,7 @@ impl Agent {
         response: &ChatResponse,
         explicit_send_file_requested: bool,
         turn_attachment_ctx: &crate::tools::TurnAttachmentContext,
+        session_scope: Option<Arc<SessionScope>>,
         tool_timeout: Duration,
         tool_timeout_secs: u64,
     ) -> Vec<ToolCallResult> {
@@ -1898,8 +1913,12 @@ impl Agent {
                 continue;
             }
 
-            let handle =
-                self.spawn_tool_task(tool_call, explicit_send_file_requested, turn_attachment_ctx);
+            let handle = self.spawn_tool_task(
+                tool_call,
+                explicit_send_file_requested,
+                turn_attachment_ctx,
+                session_scope.clone(),
+            );
 
             let outcome = match tokio::time::timeout(tool_timeout, handle).await {
                 Ok(Ok(r)) => r,
@@ -2009,8 +2028,24 @@ fn panic_result(tool_call: &octos_core::ToolCall, reason: &str) -> ToolCallResul
 mod tests {
     use super::{
         build_spawn_only_produced_files_message, relativize_workspace_path,
-        satisfied_completion_content, should_auto_send_tool_files,
+        satisfied_completion_content, session_scope_for_messages, should_auto_send_tool_files,
     };
+    use octos_core::{Message, MessageRole, SessionScope};
+    use std::sync::Arc;
+
+    fn message_with_media(media: Vec<&str>) -> Message {
+        Message {
+            role: MessageRole::User,
+            content: String::new(),
+            media: media.into_iter().map(str::to_string).collect(),
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: None,
+            timestamp: chrono::Utc::now(),
+        }
+    }
 
     #[test]
     fn explicit_send_file_turn_suppresses_plugin_auto_send_for_other_tools() {
@@ -2021,6 +2056,29 @@ mod tests {
     #[test]
     fn auto_send_respects_global_suppression_flag() {
         assert!(!should_auto_send_tool_files(true, false, "mofa_slides"));
+    }
+
+    #[test]
+    fn session_scope_for_messages_collects_upload_handles_from_media_history() {
+        let tenant = tempfile::tempdir().unwrap();
+        let scope = Some(Arc::new(
+            SessionScope::multi_tenant_with_default_zones(
+                tenant.path().to_path_buf(),
+                "dspfac".into(),
+                "web-1".into(),
+            )
+            .unwrap(),
+        ));
+        let messages = vec![
+            message_with_media(vec!["up/current-payload/current.md", "workspace/file.md"]),
+            message_with_media(vec!["up/history-payload/history.md"]),
+        ];
+
+        let scoped = session_scope_for_messages(&scope, &messages).unwrap();
+
+        assert!(scoped.allows_upload_handle("up/current-payload"));
+        assert!(scoped.allows_upload_handle("up/history-payload/renamed.md"));
+        assert!(!scoped.allows_upload_handle("up/foreign-payload/foreign.md"));
     }
 
     #[test]

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -2000,6 +2000,8 @@ impl Agent {
         // from content prefixes (which missed shell timeouts, sandbox
         // path rejections, browser nav failures, etc.).
         let mut tool_success: Vec<(String, bool)> = Vec::new();
+        let session_scope =
+            super::execution::session_scope_for_messages(&self.session_scope, messages);
         for batch in tool_batches {
             let mut batch_response = limited_response.clone();
             batch_response.tool_calls = batch.to_vec();
@@ -2010,7 +2012,9 @@ impl Agent {
                 batch_tokens,
                 batch_metadata,
                 batch_success,
-            ) = self.execute_tools(&batch_response).await?;
+            ) = self
+                .execute_tools(&batch_response, session_scope.clone())
+                .await?;
             tool_messages.extend(batch_messages);
             tool_files.extend(batch_files);
             tool_send_files.extend(batch_send_files);
@@ -2058,9 +2062,7 @@ impl Agent {
                 let Some(&(name, args)) = id_to_call.get(id) else {
                     continue;
                 };
-                if let Some(hint) =
-                    loop_detector.record_result(name, args, &message.content)
-                {
+                if let Some(hint) = loop_detector.record_result(name, args, &message.content) {
                     message.content.push_str(&hint);
                 }
             }

--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -851,7 +851,7 @@ mod tests {
              see docs/STREAMING-TRANSACTIONAL-BOUNDARY-ADR.md"
         );
         // Sanity: must be larger than legacy 30s value.
-        assert!(super::STREAM_INTER_CHUNK_IDLE_TIMEOUT_SECS > 30);
+        const { assert!(super::STREAM_INTER_CHUNK_IDLE_TIMEOUT_SECS > 30) };
     }
 
     // Use Duration in a sanity check to make sure the constant is usable.

--- a/crates/octos-agent/src/loop_detect.rs
+++ b/crates/octos-agent/src/loop_detect.rs
@@ -247,7 +247,10 @@ mod tests {
         assert!(d.record_result("check", &args, result).is_none());
         assert!(d.record_result("check", &args, result).is_none());
         let hint = d.record_result("check", &args, result);
-        assert!(hint.is_some(), "expected NO PROGRESS hint after 3 identical");
+        assert!(
+            hint.is_some(),
+            "expected NO PROGRESS hint after 3 identical"
+        );
         assert!(hint.unwrap().contains("NO PROGRESS"));
     }
 

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -892,6 +892,13 @@ fn resolve_for_scope(
     // `SessionScope` does not currently expose; tracked as a follow-up
     // (issue #1367).
     if user_path.starts_with("up/") {
+        let decoded_upload_handle = matches!(
+            octos_bus::file_handle::decode_file_handle(user_path),
+            Some(octos_bus::file_handle::FileHandleScope::TempUpload(_))
+        );
+        if decoded_upload_handle && !scope.allows_upload_handle(user_path) {
+            return Err("Uploaded file is not attached to this session");
+        }
         match octos_bus::file_handle::resolve_tool_path(scope.workspace(), None, user_path) {
             Ok(resolved)
                 if resolved.scope == octos_bus::file_handle::ToolPathScope::UploadTmpdir =>
@@ -910,10 +917,7 @@ fn resolve_for_scope(
                 // the same literal path). The temp file may have been deleted or
                 // no longer canonicalises under the upload root — report it as a
                 // missing upload rather than masking it as a workspace path.
-                if matches!(
-                    octos_bus::file_handle::decode_file_handle(user_path),
-                    Some(octos_bus::file_handle::FileHandleScope::TempUpload(_))
-                ) {
+                if decoded_upload_handle {
                     return Err("Uploaded file not found");
                 }
                 // A value that merely starts with `up/` but does NOT decode as a
@@ -1532,6 +1536,56 @@ mod path_tests {
             resolve_path_for_session_scope_write(&scope, &handle).is_err(),
             "writes to an upload handle must be refused"
         );
+
+        let _ = std::fs::remove_file(&uploaded);
+    }
+
+    #[test]
+    fn multi_tenant_session_rejects_unattached_upload_handle() {
+        let upload_root = octos_bus::file_handle::temp_upload_root();
+        std::fs::create_dir_all(&upload_root).expect("upload tmpdir creatable");
+        let uploaded = upload_root.join(format!("mt-{}-foreign.md", std::process::id()));
+        std::fs::write(&uploaded, b"foreign session upload\n").unwrap();
+        let handle =
+            octos_bus::file_handle::encode_tmp_upload_handle(&uploaded, Some("foreign.md"))
+                .expect("encode upload handle");
+
+        let tenant = tempfile::tempdir().expect("tenant data dir");
+        let scope = SessionScope::multi_tenant_with_default_zones(
+            tenant.path().to_path_buf(),
+            "dspfac".into(),
+            "web-b".into(),
+        )
+        .unwrap();
+
+        let err = resolve_path_for_session_scope_read(&scope, &handle)
+            .expect_err("foreign upload handle must be rejected");
+        assert_eq!(err, "Uploaded file is not attached to this session");
+
+        let _ = std::fs::remove_file(&uploaded);
+    }
+
+    #[test]
+    fn multi_tenant_session_resolves_attached_upload_handle() {
+        let upload_root = octos_bus::file_handle::temp_upload_root();
+        std::fs::create_dir_all(&upload_root).expect("upload tmpdir creatable");
+        let uploaded = upload_root.join(format!("mt-{}-own.md", std::process::id()));
+        std::fs::write(&uploaded, b"own session upload\n").unwrap();
+        let handle = octos_bus::file_handle::encode_tmp_upload_handle(&uploaded, Some("own.md"))
+            .expect("encode upload handle");
+
+        let tenant = tempfile::tempdir().expect("tenant data dir");
+        let scope = SessionScope::multi_tenant_with_default_zones(
+            tenant.path().to_path_buf(),
+            "dspfac".into(),
+            "web-a".into(),
+        )
+        .unwrap()
+        .with_attached_upload_handles([handle.as_str()]);
+
+        let resolved = resolve_path_for_session_scope_read(&scope, &handle)
+            .expect("attached upload handle must resolve");
+        assert_eq!(resolved, std::fs::canonicalize(&uploaded).unwrap());
 
         let _ = std::fs::remove_file(&uploaded);
     }

--- a/crates/octos-agent/src/tools/read_file.rs
+++ b/crates/octos-agent/src/tools/read_file.rs
@@ -651,6 +651,72 @@ mod tests {
         assert!(result.output.contains("shared notes"));
     }
 
+    #[tokio::test]
+    async fn read_file_refuses_multi_tenant_upload_handle_not_attached_to_session() {
+        let upload_root = octos_bus::file_handle::temp_upload_root();
+        std::fs::create_dir_all(&upload_root).unwrap();
+        let uploaded = upload_root.join(format!("read-{}-foreign.txt", std::process::id()));
+        std::fs::write(&uploaded, "foreign upload\n").unwrap();
+        let handle =
+            octos_bus::file_handle::encode_tmp_upload_handle(&uploaded, Some("foreign.txt"))
+                .unwrap();
+
+        let data_dir = tempfile::tempdir().unwrap();
+        let scope = SessionScope::multi_tenant_with_default_zones(
+            data_dir.path().to_path_buf(),
+            "dspfac".into(),
+            "web-b".into(),
+        )
+        .unwrap();
+        let tool = ReadFileTool::new(scope.workspace());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"path": handle}))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(
+            result.output.contains("not attached to this session"),
+            "expected upload attachment rejection, got: {}",
+            result.output
+        );
+
+        let _ = std::fs::remove_file(&uploaded);
+    }
+
+    #[tokio::test]
+    async fn read_file_allows_multi_tenant_upload_handle_attached_to_session() {
+        let upload_root = octos_bus::file_handle::temp_upload_root();
+        std::fs::create_dir_all(&upload_root).unwrap();
+        let uploaded = upload_root.join(format!("read-{}-own.txt", std::process::id()));
+        std::fs::write(&uploaded, "own upload\n").unwrap();
+        let handle =
+            octos_bus::file_handle::encode_tmp_upload_handle(&uploaded, Some("own.txt")).unwrap();
+
+        let data_dir = tempfile::tempdir().unwrap();
+        let scope = SessionScope::multi_tenant_with_default_zones(
+            data_dir.path().to_path_buf(),
+            "dspfac".into(),
+            "web-a".into(),
+        )
+        .unwrap()
+        .with_attached_upload_handles([handle.as_str()]);
+        let tool = ReadFileTool::new(scope.workspace());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"path": handle}))
+            .await
+            .unwrap();
+
+        assert!(result.success, "expected success, got: {}", result.output);
+        assert!(result.output.contains("own upload"));
+
+        let _ = std::fs::remove_file(&uploaded);
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn read_file_refuses_ancestor_symlink_escape() {

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -3436,8 +3436,8 @@ mod tests {
         // round-trip test for `EnvelopeNotification` in octos-core missed
         // this — only the ledger wrapper exhibits the collision.
         let session = SessionKey("local:envelope-round-trip".into());
-        let event = UiProtocolLedgerEvent::Notification(UiNotification::Envelope(
-            EnvelopeNotification {
+        let event =
+            UiProtocolLedgerEvent::Notification(UiNotification::Envelope(EnvelopeNotification {
                 session_id: session.clone(),
                 topic: Some("planning".into()),
                 envelope: Envelope {
@@ -3448,8 +3448,7 @@ mod tests {
                         text: "round-trip me".into(),
                     },
                 },
-            },
-        ));
+            }));
 
         let serialized = serde_json::to_string(&event).expect("ledger event serializes");
         assert!(

--- a/crates/octos-core/src/session_scope.rs
+++ b/crates/octos-core/src/session_scope.rs
@@ -403,6 +403,12 @@ pub struct SessionScope {
     /// higher-priority classifications even when a skill_dir happens
     /// to live inside them.
     skill_read_zones: Vec<PathBuf>,
+    /// Upload handles that were explicitly attached to this session
+    /// through current or historical message media. This is deliberately
+    /// not serialized into diagnostics: handles are bearer references to
+    /// process-global upload tmpdir entries.
+    #[serde(skip_serializing)]
+    attached_upload_handles: Vec<String>,
 }
 
 /// Canonical names of shared zones under `<root>` for the dspfac /
@@ -480,6 +486,7 @@ impl SessionScope {
                 shared_zones,
             },
             skill_read_zones: Vec::new(),
+            attached_upload_handles: Vec::new(),
         })
     }
 
@@ -520,6 +527,7 @@ impl SessionScope {
             root: cwd,
             mode: ScopeMode::Solo { granted_dirs },
             skill_read_zones: Vec::new(),
+            attached_upload_handles: Vec::new(),
         })
     }
 
@@ -550,6 +558,55 @@ impl SessionScope {
     /// reach. See the `skill_read_zones` field doc on [`SessionScope`].
     pub fn skill_read_zones(&self) -> &[PathBuf] {
         &self.skill_read_zones
+    }
+
+    /// Return upload handles that were explicitly attached to this
+    /// session's current or historical user-visible media.
+    pub fn attached_upload_handles(&self) -> &[String] {
+        &self.attached_upload_handles
+    }
+
+    /// Return a new `SessionScope` with the attached-upload allowlist
+    /// replaced by `handles`.
+    ///
+    /// Handles are normalized to the opaque identity portion
+    /// (`up/<payload>`) so callers may pass either the full
+    /// `up/<payload>/<display-name>` form or the shorter form that LLMs
+    /// often retain. Non-upload values are ignored.
+    pub fn with_attached_upload_handles<I, S>(mut self, handles: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut normalized = Vec::new();
+        for handle in handles {
+            let Some(key) = upload_handle_key(handle.as_ref()) else {
+                continue;
+            };
+            if !normalized.iter().any(|existing| existing == &key) {
+                normalized.push(key);
+            }
+        }
+        self.attached_upload_handles = normalized;
+        self
+    }
+
+    /// Whether this scope may resolve the given upload handle.
+    ///
+    /// Multi-tenant sessions must have explicitly attached the handle in
+    /// the current turn or conversation history. Solo mode keeps the
+    /// historical developer-CWD behavior: upload handles are not a tenant
+    /// boundary there, so no allowlist is required.
+    pub fn allows_upload_handle(&self, handle: &str) -> bool {
+        let Some(key) = upload_handle_key(handle) else {
+            return false;
+        };
+        if !matches!(self.mode, ScopeMode::MultiTenant { .. }) {
+            return true;
+        }
+        self.attached_upload_handles
+            .iter()
+            .any(|allowed| allowed == &key)
     }
 
     /// Return a new `SessionScope` with `skill_read_zones` replacing
@@ -729,6 +786,14 @@ impl SessionScope {
     }
 }
 
+fn upload_handle_key(handle: &str) -> Option<String> {
+    let mut parts = handle.split('/');
+    match (parts.next(), parts.next()) {
+        (Some("up"), Some(payload)) if !payload.is_empty() => Some(format!("up/{payload}")),
+        _ => None,
+    }
+}
+
 /// Canonicalise a path, walking ancestors when the leaf doesn't exist
 /// yet (writes targeting new files inside an existing directory).
 /// Mirrors `octos_agent::tools::canonicalize_lossy` (and
@@ -881,6 +946,26 @@ mod tests {
         assert_eq!(scope.root(), cwd);
         assert_eq!(scope.workspace(), cwd);
         assert!(scope.shared_zones().is_empty());
+    }
+
+    #[test]
+    fn multi_tenant_upload_handles_require_explicit_attachment() {
+        let data = abs("/octos/profiles/dspfac/data");
+        let scope = mt_default(&data, "web-1")
+            .with_attached_upload_handles(["up/abc123/report.md", "not-an-upload"]);
+
+        assert_eq!(scope.attached_upload_handles(), &["up/abc123".to_string()]);
+        assert!(scope.allows_upload_handle("up/abc123"));
+        assert!(scope.allows_upload_handle("up/abc123/renamed.md"));
+        assert!(!scope.allows_upload_handle("up/other/report.md"));
+    }
+
+    #[test]
+    fn solo_upload_handles_do_not_require_attachment_allowlist() {
+        let cwd = abs("/home/yc/my-project");
+        let scope = SessionScope::solo(cwd, vec![]).unwrap();
+
+        assert!(scope.allows_upload_handle("up/other/report.md"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add a non-serialized attached-upload allowlist to `SessionScope`.
- Derive the allowlist from current and historical `Message.media` before tool dispatch.
- Refuse decoded `up/` handles in multi-tenant scoped sessions unless the handle was attached to that session, while preserving solo and same-session upload reads.
- Include minimal current-main rustfmt/clippy cleanup needed for validation.

Closes #1369

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `git ls-files --others --exclude-standard`
- `CARGO_TARGET_DIR=/private/tmp/octos-1369-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-core upload_handles -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/octos-1369-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-agent upload_handle -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/octos-1369-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-core -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/octos-1369-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings`

## Local Full-Agent Test Note

Attempted `cargo test -p octos-core -p octos-agent -- --nocapture`. `octos-core` was later run separately and passed. The `octos-agent` full run had three local environment failures unrelated to this change:

- `sandbox::macos::tests::test_macos_sandbox_allows_write_inside_cwd`: `sandbox-exec: sandbox_apply: Operation not permitted`
- `sandbox::macos::tests::test_macos_sandbox_restricts_read_paths`: creating `$HOME/.sandbox_test_tmp` denied by the Codex filesystem sandbox
- `tools::send_file::tests::test_base_dir_blocks_non_tmp_outside_path`: creating a tempdir under `/Users/yuechen` denied by the Codex filesystem sandbox

The focused upload/session regressions passed, and workspace clippy passed.
