### PR TITLE
feat(agent): add opt-in verifier turn ledger

### DIFF
--- a/crates/octos-agent/src/agent/loop_compaction.rs
+++ b/crates/octos-agent/src/agent/loop_compaction.rs
@@ -54,9 +54,13 @@ pub(crate) fn prepare_conversation_messages(
 
 /// Prepare a task turn for the next model call.
 ///
-/// Task loops currently only need context trimming plus tool-call ID
-/// normalization.  Keeping this as a dedicated helper makes the task loop
-/// testable without the surrounding orchestration.
+/// Task loops need context trimming, system-message normalization, and
+/// tool-call ID normalization. The system-message pass matters once the
+/// opt-in verifier is enabled (#1365): the verifier appends a mid-transcript
+/// `System` note after assistant/tool rows, and providers that require a
+/// single leading system prompt would reject the next task request without
+/// this normalization (codex pre-merge P2). The chat path already runs it via
+/// `prepare_conversation_messages`; mirror it here.
 pub(crate) fn prepare_task_messages(
     agent: &Agent,
     messages: &mut Vec<Message>,
@@ -64,6 +68,9 @@ pub(crate) fn prepare_task_messages(
 ) {
     if agent.trim_to_context_window(messages) {
         turn.record_repair(LoopRepairReason::ContextTrimmed);
+    }
+    if normalize_system_messages(messages) {
+        turn.record_repair(LoopRepairReason::SystemMessagesNormalized);
     }
     if normalize_tool_call_ids(messages) {
         turn.record_repair(LoopRepairReason::ToolCallIdsNormalized);

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -17,6 +17,7 @@ use super::loop_compaction::{prepare_conversation_messages, prepare_task_message
 use super::loop_state::{LoopDecision, LoopRetryState, SHELL_SPIRAL_VARIANT};
 use super::message_repair::sanitize_tool_call_id;
 use super::turn_state::{LoopRetryReason, LoopTurnState};
+use super::verifier::{TurnLedger, ledger_entry_from_tool_result};
 use super::{Agent, ConversationResponse, TASK_REPORTER, TokenTracker};
 use crate::harness_errors::HarnessError;
 use crate::harness_events::write_event_to_sink;
@@ -788,6 +789,7 @@ impl Agent {
                 let mut retry_state =
                     PersistentRetryStateGuard::new(self.persistent_retry_state.clone());
                 let mut loop_detector = LoopDetector::new(12);
+                let mut turn_ledger = self.new_turn_ledger();
 
                 loop {
                     if let Some(stop) = turn.check_budget(self, activity.as_ref()) {
@@ -980,9 +982,23 @@ impl Agent {
 
                     match response.stop_reason {
                         StopReason::EndTurn | StopReason::StopSequence => {
+                            let content = response.content.clone().unwrap_or_default();
+                            if !self
+                                .verifier_allows_termination(
+                                    &mut messages,
+                                    turn_ledger.as_mut(),
+                                    &content,
+                                    iteration,
+                                    &mut turn,
+                                    tracker,
+                                )
+                                .await?
+                            {
+                                continue;
+                            }
                             self.emit_cost_update(turn.total_usage(), &response);
                             return Ok(ConversationResponse {
-                                content: response.content.unwrap_or_default(),
+                                content,
                                 reasoning_content: response.reasoning_content.clone(),
                                 provider_metadata: Some(
                                     self.llm.provider_metadata_for_index(response.provider_index),
@@ -1184,6 +1200,7 @@ impl Agent {
                                     Some(&mut iter_tool_success),
                                     Some(&mut turn_output_log),
                                     &mut loop_detector,
+                                    turn_ledger.as_mut(),
                                 )
                                 .await
                             {
@@ -1200,6 +1217,27 @@ impl Agent {
                                     }
                                 }
                             };
+
+                            if let Err(e) = self
+                                .maybe_run_verifier_after_tool_batch(
+                                    &mut messages,
+                                    turn_ledger.as_mut(),
+                                    iteration,
+                                    &mut turn,
+                                    tracker,
+                                )
+                                .await
+                            {
+                                match self.handle_loop_error_with_dispatch(
+                                    &e,
+                                    &mut retry_state,
+                                    iteration,
+                                    &mut messages,
+                                ) {
+                                    LoopErrorAction::Retry => continue,
+                                    LoopErrorAction::Bail => return Err(e),
+                                }
+                            }
 
                             let spiral_iteration = turn.iteration();
                             if let Some(outcome) = self.dispatch_shell_retry_recovery(
@@ -1338,6 +1376,23 @@ impl Agent {
                                         "tool invocation errored in spawn_only turn — suppressing synthesized 'Background work started' ack and letting the LLM react to the error"
                                     );
                                 } else {
+                                    let should_gate_spawn_ack = turn_ledger
+                                        .as_ref()
+                                        .is_some_and(TurnLedger::ready_gate_active);
+                                    if should_gate_spawn_ack
+                                        && !self
+                                            .verifier_allows_termination(
+                                                &mut messages,
+                                                turn_ledger.as_mut(),
+                                                "Background work started.",
+                                                iteration,
+                                                &mut turn,
+                                                tracker,
+                                            )
+                                            .await?
+                                    {
+                                        continue;
+                                    }
                                     self.emit_cost_update(turn.total_usage(), &response);
                                     // Post-spawn failure feedback loop
                                     // (feat/spawn-only-failure-feedback-loop):
@@ -1525,6 +1580,7 @@ impl Agent {
             // can run the no-progress soft check on tool results here too.
             // Matches the conversation-loop's window of 12.
             let mut loop_detector = LoopDetector::new(12);
+            let mut turn_ledger = self.new_turn_ledger();
             let config = self.chat_config();
 
             loop {
@@ -1634,6 +1690,20 @@ impl Agent {
                     StopReason::EndTurn | StopReason::StopSequence => {
                         let final_response =
                             response_with_max_token_fragments(&response, &max_token_fragments);
+                        let proposed = final_response.content.clone().unwrap_or_default();
+                        if !self
+                            .verifier_allows_termination(
+                                &mut messages,
+                                turn_ledger.as_mut(),
+                                &proposed,
+                                iteration,
+                                &mut turn,
+                                None,
+                            )
+                            .await?
+                        {
+                            continue;
+                        }
                         if self.config.save_episodes {
                             let summary = final_response.content.clone().unwrap_or_default();
                             let summary_truncated =
@@ -1776,6 +1846,27 @@ impl Agent {
                                 None,
                                 None,
                                 &mut loop_detector,
+                                turn_ledger.as_mut(),
+                            )
+                            .await
+                        {
+                            match self.handle_loop_error_with_dispatch(
+                                &e,
+                                &mut retry_state,
+                                iteration,
+                                &mut messages,
+                            ) {
+                                LoopErrorAction::Retry => continue,
+                                LoopErrorAction::Bail => return Err(e),
+                            }
+                        }
+                        if let Err(e) = self
+                            .maybe_run_verifier_after_tool_batch(
+                                &mut messages,
+                                turn_ledger.as_mut(),
+                                iteration,
+                                &mut turn,
+                                None,
                             )
                             .await
                         {
@@ -1938,6 +2029,7 @@ impl Agent {
         // appended to the matching Tool message's content and the
         // conversation continues.
         loop_detector: &mut LoopDetector,
+        turn_ledger: Option<&mut TurnLedger>,
     ) -> Result<ChatResponse> {
         // Sanitize tool_call_id characters: some providers (e.g. Moonshot/kimi)
         // generate IDs like "admin_view_sessions:11" which OpenAI rejects (only
@@ -2022,6 +2114,7 @@ impl Agent {
         if let Some(sink) = tool_structured_metadata {
             sink.extend(tool_metadata);
         }
+        let tool_success_for_ledger = tool_success.clone();
         if let Some(sink) = tool_success_by_id {
             sink.extend(tool_success);
         }
@@ -2048,6 +2141,12 @@ impl Agent {
                 .iter()
                 .map(|tc| (tc.id.as_str(), (tc.name.as_str(), &tc.arguments)))
                 .collect();
+            let success_by_id: HashMap<&str, bool> = tool_success_for_ledger
+                .iter()
+                .map(|(id, success)| (id.as_str(), *success))
+                .collect();
+            let stated_intent = response.content.as_deref();
+            let mut turn_ledger = turn_ledger;
             for message in merged.iter_mut() {
                 if message.role != MessageRole::Tool {
                     continue;
@@ -2058,8 +2157,25 @@ impl Agent {
                 let Some(&(name, args)) = id_to_call.get(id) else {
                     continue;
                 };
-                if let Some(hint) = loop_detector.record_result(name, args, &message.content) {
+                let result_before_hint = message.content.clone();
+                let repeating = if let Some(hint) =
+                    loop_detector.record_result(name, args, &result_before_hint)
+                {
                     message.content.push_str(&hint);
+                    true
+                } else {
+                    false
+                };
+                if let Some(ledger) = turn_ledger.as_deref_mut() {
+                    ledger.push_entry(ledger_entry_from_tool_result(
+                        turn.iteration(),
+                        stated_intent,
+                        name,
+                        args,
+                        success_by_id.get(id).copied(),
+                        &result_before_hint,
+                        repeating,
+                    ));
                 }
             }
         }
@@ -2736,16 +2852,370 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
     use std::sync::Mutex as StdMutex;
-    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
 
     use async_trait::async_trait;
     use octos_core::{AgentId, MessageRole, TaskContext, TaskKind, ToolCall};
     use octos_llm::{
         ChatResponse, LlmError, LlmErrorKind, LlmProvider, StopReason, TokenUsage as LlmTokenUsage,
+        ToolChoice,
     };
     use octos_memory::EpisodeStore;
 
     use crate::plugins::PluginTool;
+    use crate::{AgentConfig, AgentVerifierConfig};
+
+    fn tool_use(tool_calls: Vec<ToolCall>, input_tokens: u32, output_tokens: u32) -> ChatResponse {
+        ChatResponse {
+            content: None,
+            reasoning_content: None,
+            tool_calls,
+            stop_reason: StopReason::ToolUse,
+            usage: LlmTokenUsage {
+                input_tokens,
+                output_tokens,
+                ..Default::default()
+            },
+            provider_index: None,
+        }
+    }
+
+    fn end_turn(content: &str, input_tokens: u32, output_tokens: u32) -> ChatResponse {
+        ChatResponse {
+            content: Some(content.to_string()),
+            reasoning_content: None,
+            tool_calls: vec![],
+            stop_reason: StopReason::EndTurn,
+            usage: LlmTokenUsage {
+                input_tokens,
+                output_tokens,
+                ..Default::default()
+            },
+            provider_index: None,
+        }
+    }
+
+    struct ScriptedProvider {
+        responses: StdMutex<Vec<ChatResponse>>,
+    }
+
+    impl ScriptedProvider {
+        fn new(responses: Vec<ChatResponse>) -> Self {
+            Self {
+                responses: StdMutex::new(responses.into_iter().rev().collect()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl LlmProvider for ScriptedProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &ChatConfig,
+        ) -> Result<ChatResponse> {
+            self.responses
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .pop()
+                .ok_or_else(|| eyre::eyre!("scripted provider exhausted"))
+        }
+
+        fn model_id(&self) -> &str {
+            "planner-test"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    struct StaticResultTool {
+        name: &'static str,
+        output: &'static str,
+        success: bool,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl StaticResultTool {
+        fn new(
+            name: &'static str,
+            output: &'static str,
+            success: bool,
+            calls: Arc<AtomicUsize>,
+        ) -> Self {
+            Self {
+                name,
+                output,
+                success,
+                calls,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Tool for StaticResultTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn description(&self) -> &str {
+            "test tool for verifier loop tests"
+        }
+
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+
+        async fn execute(&self, _args: &serde_json::Value) -> Result<ToolResult> {
+            self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+            Ok(ToolResult {
+                output: self.output.to_string(),
+                success: self.success,
+                ..Default::default()
+            })
+        }
+    }
+
+    struct NoCallVerifier {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl LlmProvider for NoCallVerifier {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &ChatConfig,
+        ) -> Result<ChatResponse> {
+            self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+            eyre::bail!("verifier should have been skipped for quiet progress")
+        }
+
+        fn model_id(&self) -> &str {
+            "haiku-test"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock-verifier"
+        }
+    }
+
+    struct RepeatAwarePlanner {
+        calls: AtomicUsize,
+        saw_repeating_note: AtomicBool,
+    }
+
+    impl RepeatAwarePlanner {
+        fn new() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                saw_repeating_note: AtomicBool::new(false),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl LlmProvider for RepeatAwarePlanner {
+        async fn chat(
+            &self,
+            messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &ChatConfig,
+        ) -> Result<ChatResponse> {
+            let call = self.calls.fetch_add(1, AtomicOrdering::SeqCst) + 1;
+            let saw_repeating = messages.iter().any(|message| {
+                message.content.contains("[verifier]")
+                    && message.content.contains("verdict: Repeating")
+            });
+            if saw_repeating {
+                self.saw_repeating_note.store(true, AtomicOrdering::SeqCst);
+            }
+            let fix_ran = messages.iter().any(|message| {
+                message.role == MessageRole::Tool && message.content.contains("fixed style")
+            });
+            if fix_ran {
+                return Ok(end_turn("fixed answer", 12, 6));
+            }
+            if saw_repeating {
+                return Ok(tool_use(
+                    vec![ToolCall {
+                        id: "fix_call".into(),
+                        name: "fix_tool".into(),
+                        arguments: serde_json::json!({"path": "style.toml", "repair": true}),
+                        metadata: None,
+                    }],
+                    10,
+                    5,
+                ));
+            }
+            Ok(tool_use(
+                vec![ToolCall {
+                    id: format!("fail_call_{call}"),
+                    name: "fail_tool".into(),
+                    arguments: serde_json::json!({"path": "style.toml"}),
+                    metadata: None,
+                }],
+                10,
+                5,
+            ))
+        }
+
+        fn model_id(&self) -> &str {
+            "planner-test"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    struct LedgerDrivenVerifier {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl LlmProvider for LedgerDrivenVerifier {
+        async fn chat(
+            &self,
+            messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            config: &ChatConfig,
+        ) -> Result<ChatResponse> {
+            self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+            assert!(
+                matches!(config.tool_choice, ToolChoice::None),
+                "verifier call must not expose tools"
+            );
+            assert_eq!(
+                octos_llm::current_lane_context().lane,
+                Some(octos_llm::Lane::FastChat),
+                "verifier call should use the cheap fast-chat lane"
+            );
+            let prompt = messages
+                .iter()
+                .map(|message| message.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+            let verdict = if prompt.contains("tool=fix_tool") {
+                r#"{"verdict":"ReadyToAnswer"}"#
+            } else if prompt.contains("repeating=true") {
+                r#"{"verdict":"Repeating","error_class":"ContractFail"}"#
+            } else {
+                r#"{"verdict":"Insufficient","reason":"need a different action"}"#
+            };
+            Ok(ChatResponse {
+                content: Some(verdict.to_string()),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: StopReason::EndTurn,
+                usage: LlmTokenUsage {
+                    input_tokens: 3,
+                    output_tokens: 2,
+                    ..Default::default()
+                },
+                provider_index: None,
+            })
+        }
+
+        fn model_id(&self) -> &str {
+            "haiku-test"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock-verifier"
+        }
+    }
+
+    struct PrematureEndPlanner {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl LlmProvider for PrematureEndPlanner {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &ChatConfig,
+        ) -> Result<ChatResponse> {
+            let call = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+            if call == 0 {
+                return Ok(tool_use(
+                    vec![ToolCall {
+                        id: "fail_once".into(),
+                        name: "fail_tool".into(),
+                        arguments: serde_json::json!({"path": "style.toml"}),
+                        metadata: None,
+                    }],
+                    8,
+                    4,
+                ));
+            }
+            if call == 1 {
+                return Ok(end_turn("premature answer", 8, 4));
+            }
+            Ok(end_turn("ready answer", 8, 4))
+        }
+
+        fn model_id(&self) -> &str {
+            "planner-test"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    struct GateVerifier {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl LlmProvider for GateVerifier {
+        async fn chat(
+            &self,
+            messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &ChatConfig,
+        ) -> Result<ChatResponse> {
+            let call = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+            let prompt = messages
+                .iter()
+                .map(|message| message.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+            let verdict = if prompt.contains("Proposed answer:\nready answer") {
+                r#"{"verdict":"ReadyToAnswer"}"#
+            } else if call == 0 {
+                r#"{"verdict":"Blocked","reason":"tool failed"}"#
+            } else {
+                r#"{"verdict":"Insufficient","reason":"not ready yet"}"#
+            };
+            Ok(ChatResponse {
+                content: Some(verdict.to_string()),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: StopReason::EndTurn,
+                usage: LlmTokenUsage {
+                    input_tokens: 3,
+                    output_tokens: 2,
+                    ..Default::default()
+                },
+                provider_index: None,
+            })
+        }
+
+        fn model_id(&self) -> &str {
+            "haiku-test"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock-verifier"
+        }
+    }
     use crate::plugins::manifest::PluginToolDef;
     use crate::prompt_context::{
         PromptContextManager, PromptContextPhase, PromptContextReport, PromptContextRequest,
@@ -4860,6 +5330,168 @@ printf '{"output":"voice saved","success":true}\n'
             });
         }
         out
+    }
+
+    #[tokio::test]
+    async fn verifier_skips_quiet_successful_tool_batch_and_persists_ledger() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger_path = dir.path().join("turn_ledger.jsonl");
+        let planner: Arc<dyn LlmProvider> = Arc::new(ScriptedProvider::new(vec![
+            tool_use(
+                vec![ToolCall {
+                    id: "quiet_call".into(),
+                    name: "quiet_tool".into(),
+                    arguments: serde_json::json!({"path": "ok.txt"}),
+                    metadata: None,
+                }],
+                10,
+                5,
+            ),
+            end_turn("done", 10, 5),
+        ]));
+        let verifier = Arc::new(NoCallVerifier {
+            calls: AtomicUsize::new(0),
+        });
+        let mut tools = ToolRegistry::new();
+        tools.register(StaticResultTool::new(
+            "quiet_tool",
+            "healthy progress\n\nExit code: 0",
+            true,
+            Arc::new(AtomicUsize::new(0)),
+        ));
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let agent = Agent::new(AgentId::new("verifier-skip"), planner, tools, memory)
+            .with_config(AgentConfig {
+                save_episodes: false,
+                ..Default::default()
+            })
+            .with_verifier_config(
+                AgentVerifierConfig::with_provider(verifier.clone(), "haiku-test")
+                    .with_ledger_path(&ledger_path),
+            );
+
+        let response = agent
+            .process_message("do one safe thing", &[], vec![])
+            .await
+            .unwrap();
+
+        assert_eq!(response.content, "done");
+        assert_eq!(verifier.calls.load(AtomicOrdering::SeqCst), 0);
+        let persisted = std::fs::read_to_string(&ledger_path).expect("turn ledger persisted");
+        assert!(
+            persisted.contains("\"tool\":\"quiet_tool\""),
+            "quiet successful tool call should still be ledgered: {persisted}"
+        );
+    }
+
+    #[tokio::test]
+    async fn verifier_repeating_note_changes_next_planner_action() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger_path = dir.path().join("turn_ledger.jsonl");
+        let planner = Arc::new(RepeatAwarePlanner::new());
+        let verifier = Arc::new(LedgerDrivenVerifier {
+            calls: AtomicUsize::new(0),
+        });
+        let fail_calls = Arc::new(AtomicUsize::new(0));
+        let fix_calls = Arc::new(AtomicUsize::new(0));
+        let mut tools = ToolRegistry::new();
+        tools.register(StaticResultTool::new(
+            "fail_tool",
+            "[VALIDATION FAILED] style TOML is malformed",
+            false,
+            fail_calls.clone(),
+        ));
+        tools.register(StaticResultTool::new(
+            "fix_tool",
+            "fixed style\n\nExit code: 0",
+            true,
+            fix_calls.clone(),
+        ));
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let agent = Agent::new(
+            AgentId::new("verifier-repeat"),
+            planner.clone(),
+            tools,
+            memory,
+        )
+        .with_config(AgentConfig {
+            max_iterations: 12,
+            save_episodes: false,
+            ..Default::default()
+        })
+        .with_verifier_config(
+            AgentVerifierConfig::with_provider(verifier.clone(), "haiku-test")
+                .with_ledger_path(&ledger_path),
+        );
+
+        let response = agent
+            .process_message("repair the generated style", &[], vec![])
+            .await
+            .unwrap();
+
+        assert_eq!(response.content, "fixed answer");
+        assert!(
+            planner.saw_repeating_note.load(AtomicOrdering::SeqCst),
+            "planner must observe the injected Repeating verifier note"
+        );
+        assert_eq!(fail_calls.load(AtomicOrdering::SeqCst), 3);
+        assert_eq!(fix_calls.load(AtomicOrdering::SeqCst), 1);
+        assert!(
+            verifier.calls.load(AtomicOrdering::SeqCst) >= 4,
+            "verifier should classify failures and the ready gate"
+        );
+        let persisted = std::fs::read_to_string(&ledger_path).expect("turn ledger persisted");
+        assert!(persisted.contains("\"tool\":\"fail_tool\""));
+        assert!(persisted.contains("\"tool\":\"fix_tool\""));
+    }
+
+    #[tokio::test]
+    async fn verifier_ready_to_answer_gates_endturn_after_problem_signal() {
+        let dir = tempfile::tempdir().unwrap();
+        let planner = Arc::new(PrematureEndPlanner {
+            calls: AtomicUsize::new(0),
+        });
+        let verifier = Arc::new(GateVerifier {
+            calls: AtomicUsize::new(0),
+        });
+        let mut tools = ToolRegistry::new();
+        tools.register(StaticResultTool::new(
+            "fail_tool",
+            "[VALIDATION FAILED] artifact missing",
+            false,
+            Arc::new(AtomicUsize::new(0)),
+        ));
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let agent = Agent::new(
+            AgentId::new("verifier-gate"),
+            planner.clone(),
+            tools,
+            memory,
+        )
+        .with_config(AgentConfig {
+            max_iterations: 8,
+            save_episodes: false,
+            ..Default::default()
+        })
+        .with_verifier_config(AgentVerifierConfig::with_provider(
+            verifier.clone(),
+            "haiku-test",
+        ));
+
+        let response = agent
+            .process_message("try then answer too early", &[], vec![])
+            .await
+            .unwrap();
+
+        assert_eq!(response.content, "ready answer");
+        assert!(
+            planner.calls.load(AtomicOrdering::SeqCst) >= 3,
+            "premature EndTurn must be rejected until ReadyToAnswer"
+        );
+        assert!(
+            verifier.calls.load(AtomicOrdering::SeqCst) >= 3,
+            "failure classification plus two termination checks expected"
+        );
     }
 
     // ── is_productive_tool_message (M6.2) ───────────────────────────────

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -14,6 +14,7 @@ mod message_repair;
 pub mod realtime;
 mod streaming;
 mod turn_state;
+pub mod verifier;
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
@@ -29,6 +30,7 @@ use crate::progress::{ProgressReporter, SilentReporter};
 use crate::prompt_context::PromptContextManager;
 use crate::session::{SessionLimits, SessionUsage};
 use crate::tools::ToolRegistry;
+use verifier::AgentVerifierConfig;
 
 pub use realtime::RealtimeController;
 
@@ -286,6 +288,10 @@ pub struct Agent {
     /// pipeline workers, plugins, and shell to derive their CWD and
     /// path validation from this scope.
     pub(super) session_scope: Option<Arc<SessionScope>>,
+    /// Optional inference-time verifier plus structured TurnLedger. Absent
+    /// by default so legacy agent loops do not spend verifier calls or write
+    /// verifier sidecars unless a caller opts in explicitly.
+    pub(super) verifier_config: Option<AgentVerifierConfig>,
 }
 
 impl Agent {
@@ -330,6 +336,7 @@ impl Agent {
             sandbox_config: None,
             prompt_context_manager: None,
             session_scope: None,
+            verifier_config: None,
         }
     }
 
@@ -375,6 +382,7 @@ impl Agent {
             sandbox_config: None,
             prompt_context_manager: None,
             session_scope: None,
+            verifier_config: None,
         }
     }
 

--- a/crates/octos-agent/src/agent/verifier.rs
+++ b/crates/octos-agent/src/agent/verifier.rs
@@ -1,0 +1,744 @@
+//! Optional inference-time verifier and compact structured turn ledger.
+//!
+//! The verifier is deliberately opt-in. When no [`AgentVerifierConfig`] is
+//! attached to an [`Agent`](super::Agent), the hot loop keeps the legacy
+//! EndTurn/tool-use behaviour and does not write a sidecar ledger.
+
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use eyre::Result;
+use octos_core::{Message, MessageRole};
+use octos_llm::{ChatConfig, Lane, LaneContext, LlmProvider, ResponseFormat, ToolChoice};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tracing::warn;
+
+use super::Agent;
+use super::turn_state::LoopTurnState;
+use crate::TokenTracker;
+
+pub const TURN_LEDGER_SCHEMA_VERSION: u32 = 1;
+const MAX_LEDGER_ENTRIES_IN_MEMORY: usize = 64;
+const VERIFIER_MAX_TOKENS: u32 = 512;
+
+/// Opt-in verifier runtime configuration.
+///
+/// Production callers should pass a cheap/fast provider here. Tests use this
+/// to prove verifier calls are separated from the primary planner provider.
+#[derive(Clone)]
+pub struct AgentVerifierConfig {
+    pub enabled: bool,
+    pub provider: Arc<dyn LlmProvider>,
+    pub model_label: String,
+    pub lane_context: LaneContext,
+    pub ledger_path: Option<PathBuf>,
+    pub max_quiet_turns: u32,
+}
+
+impl AgentVerifierConfig {
+    pub fn with_provider(provider: Arc<dyn LlmProvider>, model_label: impl Into<String>) -> Self {
+        Self {
+            enabled: true,
+            provider,
+            model_label: model_label.into(),
+            lane_context: LaneContext {
+                lane: Some(Lane::FastChat),
+                config: None,
+            },
+            ledger_path: None,
+            max_quiet_turns: 0,
+        }
+    }
+
+    pub fn with_ledger_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.ledger_path = Some(path.into());
+        self
+    }
+
+    pub fn with_max_quiet_turns(mut self, turns: u32) -> Self {
+        self.max_quiet_turns = turns;
+        self
+    }
+
+    pub fn with_lane_context(mut self, lane_context: LaneContext) -> Self {
+        self.lane_context = lane_context;
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnOutcome {
+    Ok,
+    Err,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorClass {
+    ToolError,
+    ContractFail,
+    Timeout,
+    BadArgs,
+    PolicyDenied,
+    HookDenied,
+    SessionLimit,
+    Panic,
+    Unknown,
+}
+
+impl ErrorClass {
+    fn as_verifier_label(self) -> &'static str {
+        match self {
+            Self::ToolError => "ToolError",
+            Self::ContractFail => "ContractFail",
+            Self::Timeout => "Timeout",
+            Self::BadArgs => "BadArgs",
+            Self::PolicyDenied => "PolicyDenied",
+            Self::HookDenied => "HookDenied",
+            Self::SessionLimit => "SessionLimit",
+            Self::Panic => "Panic",
+            Self::Unknown => "Unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnLedgerEntry {
+    pub schema_version: u32,
+    pub turn: u32,
+    pub stated_intent: String,
+    pub tool: String,
+    pub args_fingerprint: u64,
+    pub outcome: TurnOutcome,
+    pub error_class: Option<ErrorClass>,
+    pub result_digest: String,
+    pub repeating: bool,
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "verdict", rename_all = "snake_case")]
+pub enum VerifierVerdict {
+    Progressing,
+    Insufficient { reason: String },
+    Repeating { error_class: ErrorClass },
+    Blocked { reason: String },
+    ReadyToAnswer,
+}
+
+impl VerifierVerdict {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Progressing => "Progressing",
+            Self::Insufficient { .. } => "Insufficient",
+            Self::Repeating { .. } => "Repeating",
+            Self::Blocked { .. } => "Blocked",
+            Self::ReadyToAnswer => "ReadyToAnswer",
+        }
+    }
+
+    fn detail(&self) -> Option<String> {
+        match self {
+            Self::Insufficient { reason } | Self::Blocked { reason } => Some(reason.clone()),
+            Self::Repeating { error_class } => {
+                Some(format!("error_class={}", error_class.as_verifier_label()))
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn ready_to_answer(&self) -> bool {
+        matches!(self, Self::ReadyToAnswer)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerifierRecord {
+    pub schema_version: u32,
+    pub turn: u32,
+    pub verdict: VerifierVerdict,
+    pub model: String,
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug)]
+pub(crate) struct TurnLedger {
+    entries: VecDeque<TurnLedgerEntry>,
+    latest_verdict: Option<VerifierVerdict>,
+    last_verified_turn: Option<u32>,
+    path: Option<PathBuf>,
+    write_error_logged: bool,
+}
+
+impl TurnLedger {
+    pub(crate) fn new(path: Option<PathBuf>) -> Self {
+        Self {
+            entries: VecDeque::with_capacity(MAX_LEDGER_ENTRIES_IN_MEMORY),
+            latest_verdict: None,
+            last_verified_turn: None,
+            path,
+            write_error_logged: false,
+        }
+    }
+
+    pub(crate) fn push_entry(&mut self, entry: TurnLedgerEntry) {
+        self.append_jsonl(&entry);
+        self.entries.push_back(entry);
+        while self.entries.len() > MAX_LEDGER_ENTRIES_IN_MEMORY {
+            self.entries.pop_front();
+        }
+    }
+
+    pub(crate) fn record_verdict(&mut self, turn: u32, verdict: VerifierVerdict, model: &str) {
+        let record = VerifierRecord {
+            schema_version: TURN_LEDGER_SCHEMA_VERSION,
+            turn,
+            verdict: verdict.clone(),
+            model: model.to_string(),
+            timestamp: chrono::Utc::now(),
+        };
+        self.append_jsonl(&record);
+        self.latest_verdict = Some(verdict);
+        self.last_verified_turn = Some(turn);
+    }
+
+    pub(crate) fn latest_verdict(&self) -> Option<&VerifierVerdict> {
+        self.latest_verdict.as_ref()
+    }
+
+    pub(crate) fn should_verify_after_tool_batch(&self, max_quiet_turns: u32) -> bool {
+        let Some(latest) = self.entries.back() else {
+            return false;
+        };
+        if latest.repeating || latest.outcome == TurnOutcome::Err {
+            return true;
+        }
+        if max_quiet_turns == 0 {
+            return false;
+        }
+        match self.last_verified_turn {
+            Some(last) => latest.turn.saturating_sub(last) >= max_quiet_turns,
+            None => latest.turn >= max_quiet_turns,
+        }
+    }
+
+    pub(crate) fn ready_gate_active(&self) -> bool {
+        self.latest_verdict
+            .as_ref()
+            .is_some_and(|verdict| !verdict.ready_to_answer())
+    }
+
+    pub(crate) fn recent_view(&self, limit: usize) -> String {
+        let start = self.entries.len().saturating_sub(limit);
+        self.entries
+            .iter()
+            .skip(start)
+            .map(|entry| {
+                let error = entry
+                    .error_class
+                    .map(|class| class.as_verifier_label())
+                    .unwrap_or("-");
+                format!(
+                    "- turn={} tool={} outcome={:?} error={} repeating={} args={} result={}",
+                    entry.turn,
+                    entry.tool,
+                    entry.outcome,
+                    error,
+                    entry.repeating,
+                    entry.args_fingerprint,
+                    entry.result_digest
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn append_jsonl<T: Serialize>(&mut self, row: &T) {
+        let Some(path) = self.path.clone() else {
+            return;
+        };
+        if let Some(parent) = path.parent() {
+            if let Err(error) = std::fs::create_dir_all(parent) {
+                self.log_write_error(&path, error);
+                return;
+            }
+        }
+        let line = match serde_json::to_string(row) {
+            Ok(line) => line,
+            Err(error) => {
+                self.log_write_error(&path, error);
+                return;
+            }
+        };
+        let mut line = line;
+        line.push('\n');
+        if let Err(error) = append_line(&path, &line) {
+            self.log_write_error(&path, error);
+        }
+    }
+
+    fn log_write_error(&mut self, path: &std::path::Path, error: impl std::fmt::Display) {
+        if !self.write_error_logged {
+            warn!(
+                path = %path.display(),
+                error = %error,
+                "failed to append turn ledger sidecar; continuing without durable verifier ledger"
+            );
+            self.write_error_logged = true;
+        }
+    }
+}
+
+fn append_line(path: &std::path::Path, line: &str) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    file.write_all(line.as_bytes())
+}
+
+pub(crate) fn ledger_entry_from_tool_result(
+    turn: u32,
+    stated_intent: Option<&str>,
+    tool: &str,
+    args: &serde_json::Value,
+    success: Option<bool>,
+    result: &str,
+    repeating: bool,
+) -> TurnLedgerEntry {
+    let error_class = classify_tool_result(success, result);
+    TurnLedgerEntry {
+        schema_version: TURN_LEDGER_SCHEMA_VERSION,
+        turn,
+        stated_intent: compact_intent(stated_intent.unwrap_or_default()),
+        tool: tool.to_string(),
+        args_fingerprint: fingerprint_args(args),
+        outcome: if error_class.is_some() {
+            TurnOutcome::Err
+        } else {
+            TurnOutcome::Ok
+        },
+        error_class,
+        result_digest: digest_result(result),
+        repeating,
+        timestamp: chrono::Utc::now(),
+    }
+}
+
+fn compact_intent(intent: &str) -> String {
+    let trimmed = intent.trim();
+    if trimmed.is_empty() {
+        return "(not stated)".to_string();
+    }
+    octos_core::truncated_utf8(trimmed, 160, "...")
+}
+
+fn classify_tool_result(success: Option<bool>, result: &str) -> Option<ErrorClass> {
+    if success == Some(true) {
+        return None;
+    }
+    let trimmed = result.trim_start();
+    if trimmed.is_empty() && success != Some(false) {
+        return None;
+    }
+    if trimmed.starts_with("[VALIDATION FAILED]") || trimmed.contains("workspace contract") {
+        return Some(ErrorClass::ContractFail);
+    }
+    if trimmed.starts_with("[POLICY DENIED]") {
+        return Some(ErrorClass::PolicyDenied);
+    }
+    if trimmed.starts_with("[HOOK DENIED]") {
+        return Some(ErrorClass::HookDenied);
+    }
+    if trimmed.starts_with("[SESSION LIMIT]") {
+        return Some(ErrorClass::SessionLimit);
+    }
+    if trimmed.contains("timed out") || trimmed.contains("timeout") {
+        return Some(ErrorClass::Timeout);
+    }
+    if trimmed.contains("malformed")
+        || trimmed.contains("invalid")
+        || trimmed.contains("bad argument")
+        || trimmed.contains("BadArgs")
+    {
+        return Some(ErrorClass::BadArgs);
+    }
+    if trimmed.starts_with("Tool '") && trimmed.contains("panicked") {
+        return Some(ErrorClass::Panic);
+    }
+    if success == Some(false) || trimmed.starts_with("Error:") {
+        return Some(ErrorClass::ToolError);
+    }
+    None
+}
+
+fn fingerprint_args(args: &serde_json::Value) -> u64 {
+    let digest = Sha256::digest(normalized_json(args).as_bytes());
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&digest[..8]);
+    u64::from_be_bytes(bytes)
+}
+
+fn digest_result(result: &str) -> String {
+    let digest = Sha256::digest(result.as_bytes());
+    digest
+        .iter()
+        .take(8)
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn normalized_json(value: &serde_json::Value) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| value.to_string())
+}
+
+impl Agent {
+    pub fn with_verifier_config(mut self, config: AgentVerifierConfig) -> Self {
+        self.verifier_config = config.enabled.then_some(config);
+        self
+    }
+
+    pub(super) fn new_turn_ledger(&self) -> Option<TurnLedger> {
+        self.verifier_config
+            .as_ref()
+            .filter(|config| config.enabled)
+            .map(|config| TurnLedger::new(config.ledger_path.clone()))
+    }
+
+    pub(super) async fn maybe_run_verifier_after_tool_batch(
+        &self,
+        messages: &mut Vec<Message>,
+        ledger: Option<&mut TurnLedger>,
+        iteration: u32,
+        turn: &mut LoopTurnState,
+        tracker: Option<&TokenTracker>,
+    ) -> Result<()> {
+        let Some(config) = self
+            .verifier_config
+            .as_ref()
+            .filter(|config| config.enabled)
+        else {
+            return Ok(());
+        };
+        let Some(ledger) = ledger else {
+            return Ok(());
+        };
+        if !ledger.should_verify_after_tool_batch(config.max_quiet_turns) {
+            return Ok(());
+        }
+        let verdict = self
+            .run_verifier(config, ledger, None, iteration, turn, tracker)
+            .await?;
+        inject_verifier_note(messages, ledger, &verdict);
+        Ok(())
+    }
+
+    pub(super) async fn verifier_allows_termination(
+        &self,
+        messages: &mut Vec<Message>,
+        ledger: Option<&mut TurnLedger>,
+        proposed_answer: &str,
+        iteration: u32,
+        turn: &mut LoopTurnState,
+        tracker: Option<&TokenTracker>,
+    ) -> Result<bool> {
+        let Some(config) = self
+            .verifier_config
+            .as_ref()
+            .filter(|config| config.enabled)
+        else {
+            return Ok(true);
+        };
+        let Some(ledger) = ledger else {
+            return Ok(true);
+        };
+        if ledger
+            .latest_verdict()
+            .is_some_and(VerifierVerdict::ready_to_answer)
+        {
+            return Ok(true);
+        }
+        if !ledger.ready_gate_active() {
+            return Ok(true);
+        }
+        let verdict = self
+            .run_verifier(
+                config,
+                ledger,
+                Some(proposed_answer),
+                iteration,
+                turn,
+                tracker,
+            )
+            .await?;
+        let ready = verdict.ready_to_answer();
+        if !ready {
+            inject_verifier_note(messages, ledger, &verdict);
+        }
+        Ok(ready)
+    }
+
+    async fn run_verifier(
+        &self,
+        config: &AgentVerifierConfig,
+        ledger: &mut TurnLedger,
+        proposed_answer: Option<&str>,
+        iteration: u32,
+        turn: &mut LoopTurnState,
+        tracker: Option<&TokenTracker>,
+    ) -> Result<VerifierVerdict> {
+        let prompt = verifier_prompt(ledger, proposed_answer);
+        let messages = vec![
+            Message {
+                role: MessageRole::System,
+                content: "You are the Octos verifier. Return only the requested JSON verdict."
+                    .to_string(),
+                media: vec![],
+                tool_calls: None,
+                tool_call_id: None,
+                reasoning_content: None,
+                client_message_id: None,
+                thread_id: None,
+                timestamp: chrono::Utc::now(),
+            },
+            Message {
+                role: MessageRole::User,
+                content: prompt,
+                media: vec![],
+                tool_calls: None,
+                tool_call_id: None,
+                reasoning_content: None,
+                client_message_id: None,
+                thread_id: None,
+                timestamp: chrono::Utc::now(),
+            },
+        ];
+        let verifier_config = ChatConfig {
+            max_tokens: Some(VERIFIER_MAX_TOKENS),
+            temperature: Some(0.0),
+            tool_choice: ToolChoice::None,
+            response_format: Some(ResponseFormat::JsonSchema {
+                name: "octos_verifier_verdict".to_string(),
+                schema: verifier_schema(),
+                strict: true,
+            }),
+            ..Default::default()
+        };
+        let response = octos_llm::with_lane_context(
+            config.lane_context.clone(),
+            config.provider.chat(&messages, &[], &verifier_config),
+        )
+        .await?;
+        turn.record_usage(
+            response.usage.input_tokens,
+            response.usage.output_tokens,
+            tracker,
+        );
+        let content = response.content.unwrap_or_default();
+        let verdict = parse_verifier_verdict(&content).unwrap_or_else(|| {
+            warn!(
+                model = %config.model_label,
+                response = %content,
+                "verifier returned unparsable verdict; treating as insufficient"
+            );
+            VerifierVerdict::Insufficient {
+                reason: "verifier returned an unparsable verdict".to_string(),
+            }
+        });
+        ledger.record_verdict(iteration, verdict.clone(), &config.model_label);
+        Ok(verdict)
+    }
+}
+
+fn verifier_prompt(ledger: &TurnLedger, proposed_answer: Option<&str>) -> String {
+    let answer = proposed_answer
+        .filter(|answer| !answer.trim().is_empty())
+        .map(|answer| {
+            format!(
+                "\n\nProposed answer:\n{}",
+                octos_core::truncated_utf8(answer, 1200, "...")
+            )
+        })
+        .unwrap_or_default();
+    format!(
+        "Classify the agent state using the recent TurnLedger. Prefer Repeating \
+         when the ledger marks repeated failing identical tool results. Prefer \
+         ReadyToAnswer only when the proposed answer is sufficient or the ledger \
+         shows enough progress to answer.\n\nRecent TurnLedger:\n{}\n{}\n\n\
+         Return JSON only, one of:\n\
+         {{\"verdict\":\"Progressing\"}}\n\
+         {{\"verdict\":\"Insufficient\",\"reason\":\"...\"}}\n\
+         {{\"verdict\":\"Repeating\",\"error_class\":\"ContractFail\"}}\n\
+         {{\"verdict\":\"Blocked\",\"reason\":\"...\"}}\n\
+         {{\"verdict\":\"ReadyToAnswer\"}}",
+        ledger.recent_view(5),
+        answer
+    )
+}
+
+fn inject_verifier_note(
+    messages: &mut Vec<Message>,
+    ledger: &TurnLedger,
+    verdict: &VerifierVerdict,
+) {
+    let mut content = format!(
+        "[verifier]\nverdict: {}\nrecent_turn_ledger:\n{}",
+        verdict.label(),
+        ledger.recent_view(5)
+    );
+    if let Some(detail) = verdict.detail() {
+        content.push_str("\nreason: ");
+        content.push_str(&detail);
+    }
+    content.push_str(
+        "\nplanner_instruction: condition the next action on this structured verdict; \
+         if Repeating, change tool, arguments, or strategy instead of replaying the same call.",
+    );
+    messages.push(Message {
+        role: MessageRole::System,
+        content,
+        media: vec![],
+        tool_calls: None,
+        tool_call_id: None,
+        reasoning_content: None,
+        client_message_id: None,
+        thread_id: None,
+        timestamp: chrono::Utc::now(),
+    });
+}
+
+fn parse_verifier_verdict(content: &str) -> Option<VerifierVerdict> {
+    let value: serde_json::Value = serde_json::from_str(content.trim()).ok()?;
+    let verdict = value.get("verdict")?.as_str()?;
+    match normalize_label(verdict).as_str() {
+        "progressing" => Some(VerifierVerdict::Progressing),
+        "insufficient" => Some(VerifierVerdict::Insufficient {
+            reason: value
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("insufficient progress")
+                .to_string(),
+        }),
+        "repeating" => Some(VerifierVerdict::Repeating {
+            error_class: parse_error_class(
+                value
+                    .get("error_class")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Unknown"),
+            ),
+        }),
+        "blocked" => Some(VerifierVerdict::Blocked {
+            reason: value
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("blocked")
+                .to_string(),
+        }),
+        "readytoanswer" | "ready_to_answer" => Some(VerifierVerdict::ReadyToAnswer),
+        _ => None,
+    }
+}
+
+fn parse_error_class(raw: &str) -> ErrorClass {
+    match normalize_label(raw).as_str() {
+        "toolerror" | "tool_error" => ErrorClass::ToolError,
+        "contractfail" | "contract_fail" => ErrorClass::ContractFail,
+        "timeout" => ErrorClass::Timeout,
+        "badargs" | "bad_args" => ErrorClass::BadArgs,
+        "policydenied" | "policy_denied" => ErrorClass::PolicyDenied,
+        "hookdenied" | "hook_denied" => ErrorClass::HookDenied,
+        "sessionlimit" | "session_limit" => ErrorClass::SessionLimit,
+        "panic" => ErrorClass::Panic,
+        _ => ErrorClass::Unknown,
+    }
+}
+
+fn normalize_label(raw: &str) -> String {
+    raw.chars()
+        .filter(|ch| *ch != '-' && !ch.is_whitespace())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn verifier_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "verdict": {
+                "type": "string",
+                "enum": ["Progressing", "Insufficient", "Repeating", "Blocked", "ReadyToAnswer"]
+            },
+            "reason": { "type": "string" },
+            "error_class": {
+                "type": "string",
+                "enum": [
+                    "ToolError",
+                    "ContractFail",
+                    "Timeout",
+                    "BadArgs",
+                    "PolicyDenied",
+                    "HookDenied",
+                    "SessionLimit",
+                    "Panic",
+                    "Unknown"
+                ]
+            }
+        },
+        "required": ["verdict"],
+        "additionalProperties": false
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn ledger_marks_repeating_only_when_caller_reports_repeating() {
+        let first = ledger_entry_from_tool_result(
+            1,
+            Some("check"),
+            "check_workspace_contract",
+            &json!({"path": "."}),
+            Some(true),
+            "running",
+            false,
+        );
+        let second = ledger_entry_from_tool_result(
+            2,
+            Some("check"),
+            "check_workspace_contract",
+            &json!({"path": "."}),
+            Some(true),
+            "completed",
+            false,
+        );
+
+        assert!(!first.repeating);
+        assert!(!second.repeating);
+        assert_eq!(first.outcome, TurnOutcome::Ok);
+        assert_eq!(second.outcome, TurnOutcome::Ok);
+        assert_ne!(first.result_digest, second.result_digest);
+    }
+
+    #[test]
+    fn parser_accepts_ready_and_repeating_verdicts() {
+        assert_eq!(
+            parse_verifier_verdict(r#"{"verdict":"ReadyToAnswer"}"#),
+            Some(VerifierVerdict::ReadyToAnswer)
+        );
+        assert_eq!(
+            parse_verifier_verdict(r#"{"verdict":"Repeating","error_class":"ContractFail"}"#),
+            Some(VerifierVerdict::Repeating {
+                error_class: ErrorClass::ContractFail
+            })
+        );
+    }
+}

--- a/crates/octos-agent/src/agent/verifier.rs
+++ b/crates/octos-agent/src/agent/verifier.rs
@@ -213,7 +213,22 @@ impl TurnLedger {
         let Some(latest) = self.entries.back() else {
             return false;
         };
-        if latest.repeating || latest.outcome == TurnOutcome::Err {
+        // codex pre-merge P2: a single LLM response can execute MULTIPLE tools,
+        // appending several entries. Checking only `entries.back()` misses a
+        // failure/repeat in an EARLIER result of the batch when a later result
+        // succeeds — so with the default `max_quiet_turns == 0` the verifier
+        // never classifies the failure and a premature EndTurn bypasses it.
+        // Scan every UNVERIFIED entry (turn beyond `last_verified_turn`) for a
+        // problem signal.
+        let problem_in_unverified = self
+            .entries
+            .iter()
+            .filter(|e| match self.last_verified_turn {
+                Some(last) => e.turn > last,
+                None => true,
+            })
+            .any(|e| e.repeating || e.outcome == TurnOutcome::Err);
+        if problem_in_unverified {
             return true;
         }
         if max_quiet_turns == 0 {
@@ -726,6 +741,73 @@ mod tests {
         assert_eq!(first.outcome, TurnOutcome::Ok);
         assert_eq!(second.outcome, TurnOutcome::Ok);
         assert_ne!(first.result_digest, second.result_digest);
+    }
+
+    #[test]
+    fn should_verify_detects_failure_earlier_in_multi_tool_batch() {
+        // codex pre-merge P2: a multi-tool batch can have an EARLIER failure
+        // and a LATER success. With max_quiet_turns == 0, checking only the
+        // last entry would return false and skip verification. Scanning all
+        // unverified entries must catch the earlier failure.
+        let mut ledger = TurnLedger::new(None);
+        // turn 1: FAILED tool result
+        ledger.push_entry(ledger_entry_from_tool_result(
+            1,
+            Some("do thing"),
+            "check_workspace_contract",
+            &json!({"path": "."}),
+            Some(false),
+            "Error: contract failed",
+            false,
+        ));
+        // turn 1 (same batch): SUCCESSFUL tool result (the back() entry)
+        ledger.push_entry(ledger_entry_from_tool_result(
+            1,
+            Some("do other thing"),
+            "read_file",
+            &json!({"path": "ok.txt"}),
+            Some(true),
+            "file contents",
+            false,
+        ));
+        assert!(
+            matches!(
+                ledger.entries.back().map(|e| e.outcome),
+                Some(TurnOutcome::Ok)
+            ),
+            "test setup: the LAST entry must be a success (the trap)"
+        );
+        assert!(
+            ledger.should_verify_after_tool_batch(0),
+            "an earlier failure in the batch must trigger verification even though the last entry succeeded",
+        );
+    }
+
+    #[test]
+    fn should_verify_false_when_all_unverified_entries_succeed() {
+        let mut ledger = TurnLedger::new(None);
+        ledger.push_entry(ledger_entry_from_tool_result(
+            1,
+            Some("a"),
+            "read_file",
+            &json!({"path": "a"}),
+            Some(true),
+            "ok",
+            false,
+        ));
+        ledger.push_entry(ledger_entry_from_tool_result(
+            1,
+            Some("b"),
+            "read_file",
+            &json!({"path": "b"}),
+            Some(true),
+            "ok2",
+            false,
+        ));
+        assert!(
+            !ledger.should_verify_after_tool_batch(0),
+            "all-success batch with max_quiet_turns=0 must NOT trigger verification",
+        );
     }
 
     #[test]

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -78,6 +78,10 @@ pub use agent::{
         AgentError, Heartbeat, HeartbeatState, RealtimeConfig, RealtimeHookEnricher,
         SensorContextInjector, SensorSnapshot, SensorSource,
     },
+    verifier::{
+        AgentVerifierConfig, ErrorClass, TURN_LEDGER_SCHEMA_VERSION, TurnLedgerEntry, TurnOutcome,
+        VerifierVerdict,
+    },
 };
 pub use compaction_tiered::{
     ApiMicroCompactionConfig, DEFAULT_TIER1_MAX_AGE_TURNS, DEFAULT_TIER1_MAX_SIZE_BYTES_PER_RESULT,

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -22,10 +22,10 @@ use octos_agent::tools::{
     ReadTaskOutputTool, SendFileTool, SpawnTool, ToolPolicy, ToolRegistry,
 };
 use octos_agent::{
-    Agent, AgentConfig, CompactionSummarizerKind, HookContext, HookExecutor, HookPayload,
-    HookResult, LoopRetryState, PromptContextManager, PromptContextPhase, PromptContextReport,
-    PromptContextRequest, TaskSupervisor, TokenTracker, TurnAttachmentContext, WorkspacePolicy,
-    read_workspace_policy, workspace_policy_path, write_workspace_policy,
+    Agent, AgentConfig, AgentVerifierConfig, CompactionSummarizerKind, HookContext, HookExecutor,
+    HookPayload, HookResult, LoopRetryState, PromptContextManager, PromptContextPhase,
+    PromptContextReport, PromptContextRequest, TaskSupervisor, TokenTracker, TurnAttachmentContext,
+    WorkspacePolicy, read_workspace_policy, workspace_policy_path, write_workspace_policy,
 };
 use octos_bus::{
     ActiveSessionStore, SessionHandle, SessionManager,
@@ -174,6 +174,22 @@ fn retry_state_sidecar_path(
     data_dir: &std::path::Path,
     session_key: &SessionKey,
 ) -> std::path::PathBuf {
+    hashed_session_sidecar_path(data_dir, session_key, "retry_state", "json")
+}
+
+fn turn_ledger_sidecar_path(
+    data_dir: &std::path::Path,
+    session_key: &SessionKey,
+) -> std::path::PathBuf {
+    hashed_session_sidecar_path(data_dir, session_key, "turn_ledger", "jsonl")
+}
+
+fn hashed_session_sidecar_path(
+    data_dir: &std::path::Path,
+    session_key: &SessionKey,
+    prefix: &str,
+    extension: &str,
+) -> std::path::PathBuf {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(session_key.0.as_bytes());
@@ -187,7 +203,15 @@ fn retry_state_sidecar_path(
     let short = &hex[..16];
     data_dir
         .join("sessions")
-        .join(format!("retry_state_{short}.json"))
+        .join(format!("{prefix}_{short}.{extension}"))
+}
+
+fn verifier_flag_enabled() -> bool {
+    verifier_flag_value_enabled(std::env::var("OCTOS_AGENT_VERIFIER").ok().as_deref())
+}
+
+fn verifier_flag_value_enabled(value: Option<&str>) -> bool {
+    value.is_some_and(|value| matches!(value, "1" | "true" | "TRUE" | "on" | "ON"))
 }
 
 /// Review A F-015: read a session's persistent `LoopRetryState` from disk.
@@ -3332,6 +3356,15 @@ impl ActorFactory {
         let retry_state_initial = load_retry_state(&retry_state_path);
         let persistent_retry_state = Arc::new(StdMutex::new(retry_state_initial));
         agent = agent.with_persistent_retry_state(persistent_retry_state.clone());
+
+        if verifier_flag_enabled() {
+            let model_label = std::env::var("OCTOS_AGENT_VERIFIER_MODEL")
+                .unwrap_or_else(|_| "session-cheap-verifier".to_string());
+            agent = agent.with_verifier_config(
+                AgentVerifierConfig::with_provider(self.llm_for_compaction.clone(), model_label)
+                    .with_ledger_path(turn_ledger_sidecar_path(&self.data_dir, &session_key)),
+            );
+        }
 
         // Wire the activate_tools back-reference now that tools are in Arc
         agent.wire_activate_tools();
@@ -8394,6 +8427,35 @@ mod tests {
             thread_id: None,
             timestamp: chrono::Utc::now(),
         }
+    }
+
+    #[test]
+    fn verifier_flag_parser_is_default_off_and_accepts_explicit_on_values() {
+        assert!(!verifier_flag_value_enabled(None));
+        assert!(!verifier_flag_value_enabled(Some("false")));
+        assert!(!verifier_flag_value_enabled(Some("0")));
+        assert!(verifier_flag_value_enabled(Some("1")));
+        assert!(verifier_flag_value_enabled(Some("true")));
+        assert!(verifier_flag_value_enabled(Some("TRUE")));
+        assert!(verifier_flag_value_enabled(Some("on")));
+        assert!(verifier_flag_value_enabled(Some("ON")));
+    }
+
+    #[test]
+    fn turn_ledger_sidecar_uses_session_hash_jsonl_name() {
+        let session_key = SessionKey::new("api", "verifier-sidecar-test");
+        let path = turn_ledger_sidecar_path(std::path::Path::new("/tmp/octos"), &session_key);
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("sidecar path has file name");
+
+        assert!(
+            path.parent()
+                .is_some_and(|parent| parent.ends_with("sessions"))
+        );
+        assert!(file_name.starts_with("turn_ledger_"));
+        assert!(file_name.ends_with(".jsonl"));
     }
 
     /// #1020 / M17-B — the production session-actor delegate factory


### PR DESCRIPTION
## Summary
- Add opt-in `AgentVerifierConfig` plus a persisted JSONL `TurnLedger` sidecar for tool-result progress/error records.
- Run the verifier only after plausible problem batches, route it through the cheap `FastChat` lane with tools disabled, and inject `[verifier]` structured notes for the next planner turn.
- Gate termination on `ReadyToAnswer` once the verifier has observed a problem signal, including the spawn_only synthesized ack path.
- Wire the feature behind `OCTOS_AGENT_VERIFIER` in the session actor, default off, with `OCTOS_AGENT_VERIFIER_MODEL` for ledger labeling.

Closes #1365

## Current-main refresh
- Refreshed onto `origin/main` `4adbe05fff212cb85d1f0a6d6225da0713446016`.
- Head: `11c9c999f096f3548aa8c19696bdfc36b7824576`.
- Isolated checkout: `/Users/yuechen/home/octos/target/octos-1375-refresh-current.ebyIJL/octos`.
- Environment: Darwin arm64; `rustc 1.95.0`; `cargo 1.95.0`.
- Remote branch was updated with an exact `--force-with-lease` from old head `4d8781de74457759568f93228359ec99bd010f1a`.

## Acceptance coverage
- Default-off config flag: `OCTOS_AGENT_VERIFIER` parser test covers disabled/default and explicit on values.
- Cheap verifier lane: verifier calls run under `Lane::FastChat`, with `ToolChoice::None`, asserted by the scripted verifier test.
- Durable structured memory: `TurnLedger` appends JSONL entries/verdicts to the session sidecar, with CLI sidecar path and persisted ledger tests.
- Cost guard: quiet successful tool batch writes the ledger but makes zero verifier calls.
- Repeating correction path: scripted planner observes `[verifier] verdict: Repeating` and switches from repeated failing tool calls to a different repair tool.
- Ready gate: premature `EndTurn` is rejected until verifier returns `ReadyToAnswer`.
- Falsification path: quiet progress does not call the verifier and ledger repeating stays false unless the no-progress detector reports repeating.

## Validation
- `git diff --check origin/main...HEAD` passed.
- `cargo fmt --all -- --check` passed.
- `CARGO_TARGET_DIR=/private/tmp/octos-1375-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-agent verifier -- --nocapture` passed: 5/5 focused verifier tests.
- `CARGO_TARGET_DIR=/private/tmp/octos-1375-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli verifier -- --nocapture` passed: verifier flag test plus PKCE verifier filter match, 2/2.
- `CARGO_TARGET_DIR=/private/tmp/octos-1375-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli turn_ledger_sidecar -- --nocapture` passed: 1/1.
- `CARGO_TARGET_DIR=/private/tmp/octos-1375-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-agent --lib -- --skip sandbox::macos::tests::test_macos_sandbox_allows_write_inside_cwd --skip sandbox::macos::tests::test_macos_sandbox_restricts_read_paths --skip tools::send_file::tests::test_base_dir_blocks_non_tmp_outside_path` passed: 1829 passed, 3 ignored, 3 filtered by the explicit sandbox-only skip list.
- `CARGO_TARGET_DIR=/private/tmp/octos-1375-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p octos-cli` passed.
- `CARGO_TARGET_DIR=/private/tmp/octos-1375-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings` passed.
- `git ls-files --others --exclude-standard` was empty in the isolated checkout.

## CI / merge status
- GitHub CI is green on refreshed head `11c9c999f096f3548aa8c19696bdfc36b7824576`: https://github.com/octos-org/octos/actions/runs/26789484396.
- Required successful checks include `check`, `check-matrix`, `test-octos-cli`, `test-octos-agent (lib)`, `test-octos-agent (integration)`, `dashboard`, `swarm-app`, `typos`, and `reject blocked author/committer emails`.
- Optional expansion jobs were skipped by workflow rules.
- Merge status is `MERGEABLE`, but branch protection remains blocked by required review: `mergeStateStatus=BLOCKED`, `reviewDecision=REVIEW_REQUIRED`.
