### PR TITLE
Persist usage analytics

### DIFF
--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -84,7 +84,7 @@ lettre = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 teloxide = { workspace = true, optional = true }
 sysinfo = { version = "0.34", optional = true }
-redb = { workspace = true, optional = true }
+redb.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 # O_NOFOLLOW for the symlink-safe preview file serve in
@@ -114,7 +114,7 @@ default = []
 # handlers and the admin dashboard's Matrix invite UI reference matrix-only
 # types (e.g. `octos_bus::MatrixInviteStore`), so the API cannot compile
 # without it.
-api = ["dep:axum", "dep:tower-http", "dep:futures", "dep:rust-embed", "dep:metrics-exporter-prometheus", "dep:lettre", "dep:rand", "dep:sysinfo", "dep:subtle", "dep:redb", "octos-bus/api", "matrix"]
+api = ["dep:axum", "dep:tower-http", "dep:futures", "dep:rust-embed", "dep:metrics-exporter-prometheus", "dep:lettre", "dep:rand", "dep:sysinfo", "dep:subtle", "octos-bus/api", "matrix"]
 admin-bot = ["dep:teloxide", "dep:futures", "api"]
 telegram = ["octos-bus/telegram"]
 discord = ["octos-bus/discord"]

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -3099,7 +3099,7 @@ pub(crate) fn is_authorized_for_profile(
 ///
 /// For regular users, returns their user ID. For admin token, returns the admin's own profile ID
 /// (auto-creating the admin profile if it doesn't exist yet).
-fn resolve_my_profile_id(
+pub(crate) fn resolve_my_profile_id(
     identity: &AuthIdentity,
     ps: &crate::profiles::ProfileStore,
     state: &AppState,

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -49,6 +49,7 @@ mod ui_protocol_reasoning_effort;
 mod ui_protocol_sanitize;
 mod ui_protocol_scope;
 mod ui_protocol_task_output;
+pub mod usage;
 pub mod user_admin;
 pub(crate) mod voice_turn;
 pub mod voices;

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -26,6 +26,7 @@ use super::solo_auth;
 use super::static_files;
 use super::swarm as swarm_api;
 use super::ui_protocol;
+use super::usage;
 use super::user_admin;
 use super::webhook_proxy;
 use crate::user_store::UserRole;
@@ -279,6 +280,11 @@ pub fn build_router(state: Arc<AppState>) -> Router {
             "/api/my/profile/metrics",
             get(auth_handlers::my_provider_metrics),
         )
+        .route("/api/my/usage", get(usage::my_usage))
+        .route(
+            "/api/my/usage/sessions/{session_id}",
+            get(usage::my_session_usage),
+        )
         .route(
             "/api/my/profile/skills",
             get(auth_handlers::my_profile_skills),
@@ -376,6 +382,15 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route(
             "/api/admin/profiles/{id}/metrics",
             get(admin::provider_metrics),
+        )
+        .route("/api/admin/usage", get(usage::admin_usage))
+        .route(
+            "/api/admin/profiles/{id}/usage",
+            get(usage::admin_profile_usage),
+        )
+        .route(
+            "/api/admin/profiles/{id}/usage/sessions/{session_id}",
+            get(usage::admin_profile_session_usage),
         )
         .route(
             "/api/admin/profiles/{id}/whatsapp/qr",

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -68,6 +68,7 @@ use octos_core::ui_protocol::{
 use octos_core::{
     AgentId, InboundMessage, MAIN_PROFILE_ID, Message, MessageRole, SessionKey, TaskId,
 };
+use octos_llm::pricing::model_pricing;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufWriter};
@@ -118,6 +119,7 @@ use crate::context_manager::{
     CompactContextPolicy, ContextCompactionRecord, ContextManager, ForkPolicy, PromptBuildPolicy,
     PromptFrame, load_or_rebuild_context_manager, persist_context_manager_snapshot,
 };
+use crate::usage_ledger::{PersistentUsageLedger, USAGE_LEDGER_FILE, UsageCostSource, UsageEvent};
 use crate::user_store::UserRole;
 
 const MAX_DIFF_PREVIEW_BYTES: usize = 256 * 1024;
@@ -17009,6 +17011,23 @@ async fn run_standalone_turn(
             return;
         }
     };
+    let usage_profile_id = active_profile_id
+        .clone()
+        .or_else(|| session_id.profile_id().map(ToOwned::to_owned))
+        .unwrap_or_else(|| profile_runtime.profile_id.clone());
+    let usage_ledger = match PersistentUsageLedger::open(&session_runtime.profile.data_dir).await {
+        Ok(ledger) => Some(Arc::new(ledger)),
+        Err(error) => {
+            warn!(
+                session = %session_id.0,
+                profile_id = %usage_profile_id,
+                path = %session_runtime.profile.data_dir.join(USAGE_LEDGER_FILE).display(),
+                error = %error,
+                "usage ledger unavailable; continuing turn without durable usage record"
+            );
+            None
+        }
+    };
 
     // Source the per-session primitives from the SessionRuntime.
     //
@@ -18212,6 +18231,10 @@ async fn run_standalone_turn(
     let turn_thread_id_for_done = turn_thread_id_for_persist.clone();
     let context_manager_for_result = context_manager.clone();
     let context_data_dir_for_result = session_runtime.profile.data_dir.clone();
+    let usage_ledger_for_result = usage_ledger.clone();
+    let usage_profile_id_for_result = usage_profile_id.clone();
+    let usage_session_id_for_result = session_id.to_string();
+    let usage_run_id_for_result = turn_id.0.to_string();
     // UPCR-2026-015 (M9-β-1): pull the pre-uploaded media paths off
     // the params and feed them to the agent loop. `process_message`
     // already accepts a `Vec<String>` of paths (used by the
@@ -18884,6 +18907,59 @@ async fn run_standalone_turn(
                     None
                 };
                 let _ = final_reply_tx.send(final_send);
+                if let Some(usage_ledger) = usage_ledger_for_result.as_ref() {
+                    let provider_metadata = response.provider_metadata.clone();
+                    let provider = provider_metadata
+                        .as_ref()
+                        .map(|meta| meta.provider.clone())
+                        .or_else(|| {
+                            let provider = request_agent.provider_name();
+                            (!provider.is_empty()).then(|| provider.to_string())
+                        });
+                    let model = provider_metadata
+                        .as_ref()
+                        .map(|meta| meta.model.clone())
+                        .or_else(|| {
+                            let model = request_agent.model_id();
+                            (!model.is_empty()).then(|| model.to_string())
+                        });
+                    let estimated_cost_usd =
+                        model.as_deref().and_then(model_pricing).map(|pricing| {
+                            pricing.cost(
+                                response.token_usage.input_tokens,
+                                response.token_usage.output_tokens,
+                            )
+                        });
+                    let cost_source = if estimated_cost_usd.is_some() {
+                        UsageCostSource::CatalogEstimate
+                    } else {
+                        UsageCostSource::Unavailable
+                    };
+                    let event = UsageEvent::completed_run(
+                        usage_profile_id_for_result.clone(),
+                        usage_session_id_for_result.clone(),
+                        usage_run_id_for_result.clone(),
+                        provider,
+                        model,
+                        provider_metadata
+                            .as_ref()
+                            .and_then(|meta| meta.endpoint.clone()),
+                        u64::from(response.token_usage.input_tokens),
+                        u64::from(response.token_usage.output_tokens),
+                        estimated_cost_usd,
+                        cost_source,
+                        "appui",
+                        None,
+                    );
+                    if let Err(error) = usage_ledger.record(event).await {
+                        warn!(
+                            session = %usage_session_id_for_result,
+                            run = %usage_run_id_for_result,
+                            error = %error,
+                            "failed to record AppUI usage event"
+                        );
+                    }
+                }
                 // Issue #1332: include `message_id` so the consumer
                 // can build `TurnSessionResult` for the
                 // `turn/completed` lifecycle envelope. Absent when no

--- a/crates/octos-cli/src/api/usage.rs
+++ b/crates/octos-cli/src/api/usage.rs
@@ -1,0 +1,252 @@
+//! Usage analytics API handlers.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path as AxumPath, Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use super::AppState;
+use super::auth_handlers;
+use super::router::AuthIdentity;
+use crate::profiles::ProfileStore;
+use crate::usage_ledger::{PersistentUsageLedger, UsageAnalytics, UsageQuery};
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct UsageApiQuery {
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub from: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub to: Option<DateTime<Utc>>,
+}
+
+impl UsageApiQuery {
+    fn into_ledger_query(self, profile_id: Option<String>) -> UsageQuery {
+        UsageQuery {
+            profile_id,
+            session_id: self.session_id,
+            from: self.from,
+            to: self.to,
+        }
+    }
+}
+
+pub async fn my_usage(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::Extension(identity): axum::Extension<AuthIdentity>,
+    Query(query): Query<UsageApiQuery>,
+) -> Result<Json<UsageAnalytics>, StatusCode> {
+    let (profile_id, data_dir) = resolve_my_usage_profile(&state, &headers, &identity)?;
+    usage_for_data_dir(&data_dir, query.into_ledger_query(Some(profile_id)))
+        .await
+        .map(Json)
+}
+
+pub async fn my_session_usage(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::Extension(identity): axum::Extension<AuthIdentity>,
+    AxumPath(session_id): AxumPath<String>,
+    Query(query): Query<UsageApiQuery>,
+) -> Result<Json<UsageAnalytics>, StatusCode> {
+    let (profile_id, data_dir) = resolve_my_usage_profile(&state, &headers, &identity)?;
+    let mut query = query.into_ledger_query(Some(profile_id));
+    query.session_id = Some(session_id);
+    usage_for_data_dir(&data_dir, query).await.map(Json)
+}
+
+pub async fn admin_usage(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<UsageApiQuery>,
+) -> Result<Json<UsageAnalytics>, StatusCode> {
+    let store = state
+        .profile_store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    aggregate_profiles_usage(store, query).await.map(Json)
+}
+
+pub async fn admin_profile_usage(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+    Query(query): Query<UsageApiQuery>,
+) -> Result<Json<UsageAnalytics>, StatusCode> {
+    let store = state
+        .profile_store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let data_dir = resolve_profile_data_dir(store, &id)?;
+    usage_for_data_dir(&data_dir, query.into_ledger_query(Some(id)))
+        .await
+        .map(Json)
+}
+
+pub async fn admin_profile_session_usage(
+    State(state): State<Arc<AppState>>,
+    AxumPath((id, session_id)): AxumPath<(String, String)>,
+    Query(query): Query<UsageApiQuery>,
+) -> Result<Json<UsageAnalytics>, StatusCode> {
+    let store = state
+        .profile_store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let data_dir = resolve_profile_data_dir(store, &id)?;
+    let mut query = query.into_ledger_query(Some(id));
+    query.session_id = Some(session_id);
+    usage_for_data_dir(&data_dir, query).await.map(Json)
+}
+
+pub(crate) async fn usage_for_data_dir(
+    data_dir: &Path,
+    query: UsageQuery,
+) -> Result<UsageAnalytics, StatusCode> {
+    let ledger = PersistentUsageLedger::open(data_dir)
+        .await
+        .map_err(|error| {
+            tracing::warn!(data_dir = %data_dir.display(), error = %error, "failed to open usage ledger");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    ledger.analytics(query).await.map_err(|error| {
+        tracing::warn!(data_dir = %data_dir.display(), error = %error, "failed to read usage analytics");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })
+}
+
+pub(crate) async fn aggregate_profiles_usage(
+    store: &ProfileStore,
+    query: UsageApiQuery,
+) -> Result<UsageAnalytics, StatusCode> {
+    let profiles = store
+        .list()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let mut aggregate = UsageAnalytics::default();
+    for profile in profiles {
+        let data_dir = store.resolve_data_dir(&profile);
+        let analytics = usage_for_data_dir(
+            &data_dir,
+            query.clone().into_ledger_query(Some(profile.id.clone())),
+        )
+        .await?;
+        aggregate.merge(analytics);
+    }
+    Ok(aggregate)
+}
+
+fn resolve_my_usage_profile(
+    state: &AppState,
+    headers: &HeaderMap,
+    identity: &AuthIdentity,
+) -> Result<(String, std::path::PathBuf), StatusCode> {
+    let store = state
+        .profile_store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let profile_id = auth_handlers::resolve_my_profile_id(identity, store, state, headers)?;
+    let data_dir = resolve_profile_data_dir(store, &profile_id)?;
+    Ok((profile_id, data_dir))
+}
+
+fn resolve_profile_data_dir(
+    store: &ProfileStore,
+    id: &str,
+) -> Result<std::path::PathBuf, StatusCode> {
+    let profile = store
+        .get(id)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
+    Ok(store.resolve_data_dir(&profile))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::profiles::{ProfileConfig, UserProfile};
+    use crate::usage_ledger::{UsageCostSource, UsageEvent};
+
+    fn profile(id: &str) -> UserProfile {
+        UserProfile {
+            id: id.to_string(),
+            name: id.to_string(),
+            public_subdomain: None,
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            config: ProfileConfig::default(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn usage(profile_id: &str, session_id: &str, input_tokens: u64) -> UsageEvent {
+        UsageEvent::completed_run(
+            profile_id,
+            session_id,
+            format!("run-{session_id}"),
+            Some("openai".to_string()),
+            Some("gpt-4.1".to_string()),
+            None,
+            input_tokens,
+            7,
+            Some(0.01),
+            UsageCostSource::CatalogEstimate,
+            "appui",
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn aggregate_profiles_usage_reads_every_profile_ledger() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ProfileStore::open(dir.path()).unwrap();
+        store.save(&profile("alpha")).unwrap();
+        store.save(&profile("beta")).unwrap();
+
+        for id in ["alpha", "beta"] {
+            let profile = store.get(id).unwrap().unwrap();
+            let ledger = PersistentUsageLedger::open(store.resolve_data_dir(&profile))
+                .await
+                .unwrap();
+            ledger
+                .record(usage(id, &format!("{id}-session"), 10))
+                .await
+                .unwrap();
+        }
+
+        let analytics = aggregate_profiles_usage(&store, UsageApiQuery::default())
+            .await
+            .unwrap();
+        assert_eq!(analytics.totals.run_count, 2);
+        assert_eq!(analytics.totals.input_tokens, 20);
+        assert_eq!(analytics.by_profile.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn data_dir_usage_query_filters_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = PersistentUsageLedger::open(dir.path()).await.unwrap();
+        ledger.record(usage("alpha", "one", 10)).await.unwrap();
+        ledger.record(usage("alpha", "two", 20)).await.unwrap();
+        drop(ledger);
+
+        let analytics = usage_for_data_dir(
+            dir.path(),
+            UsageQuery {
+                profile_id: Some("alpha".to_string()),
+                session_id: Some("two".to_string()),
+                from: None,
+                to: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(analytics.totals.run_count, 1);
+        assert_eq!(analytics.totals.input_tokens, 20);
+    }
+}

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -1282,6 +1282,11 @@ impl GatewayRuntime {
         let subagent_output_router = Arc::new(octos_agent::SubAgentOutputRouter::new(
             data_dir.join("subagent-outputs"),
         ));
+        let usage_ledger = Arc::new(
+            crate::usage_ledger::PersistentUsageLedger::open(&data_dir)
+                .await
+                .wrap_err("failed to open usage ledger")?,
+        );
 
         // Build ActorFactory with all shared resources
         let actor_factory = ActorFactory {
@@ -1293,6 +1298,7 @@ impl GatewayRuntime {
             hooks,
             hook_context_template,
             data_dir: data_dir.clone(),
+            usage_ledger: Some(usage_ledger.clone()),
             session_mgr: session_mgr.clone(),
             out_tx: out_tx.clone(),
             spawn_inbound_tx,

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -919,6 +919,10 @@ impl ProfileActorFactoryBuilder {
         } else {
             Some(Arc::new(HookExecutor::new(all_hooks)))
         };
+        let usage_ledger = Arc::new(
+            crate::usage_ledger::PersistentUsageLedger::open_sync(&profile_data_dir)
+                .wrap_err("failed to open profile usage ledger")?,
+        );
 
         Ok(ActorFactory {
             agent_config: self.agent_config.clone(),
@@ -932,6 +936,7 @@ impl ProfileActorFactoryBuilder {
                 profile_id: Some(profile_id.to_string()),
             }),
             data_dir: profile_data_dir,
+            usage_ledger: Some(usage_ledger),
             session_mgr: self.session_mgr.clone(),
             out_tx: self.out_tx.clone(),
             spawn_inbound_tx: self.spawn_inbound_tx.clone(),

--- a/crates/octos-cli/src/lib.rs
+++ b/crates/octos-cli/src/lib.rs
@@ -49,6 +49,7 @@ pub mod tenant;
 pub mod tools;
 #[cfg(feature = "api")]
 pub mod updater;
+pub mod usage_ledger;
 #[cfg(feature = "api")]
 pub mod user_store;
 pub mod workflow_runtime;

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -23,11 +23,12 @@ use octos_agent::tools::{
 };
 use octos_agent::{
     Agent, AgentConfig, AgentVerifierConfig, ApprovalDecision, ApprovalRequestEnvelope,
-    ApprovalResponsePayload, ApprovalTimeoutBehavior, CompactionSummarizerKind, HookContext,
-    HookExecutor, HookPayload, HookResult, HumanPendingApprovalStore, LoopRetryState,
-    PendingApproval, PendingApprovalDraft, PromptContextManager, PromptContextPhase,
-    PromptContextReport, PromptContextRequest, TaskSupervisor, TokenTracker, TurnAttachmentContext,
-    WorkspacePolicy, read_workspace_policy, workspace_policy_path, write_workspace_policy,
+    ApprovalResponsePayload, ApprovalTimeoutBehavior, CompactionSummarizerKind,
+    ConversationResponse, HookContext, HookExecutor, HookPayload, HookResult,
+    HumanPendingApprovalStore, LoopRetryState, PendingApproval, PendingApprovalDraft,
+    PromptContextManager, PromptContextPhase, PromptContextReport, PromptContextRequest,
+    TaskSupervisor, TokenTracker, TurnAttachmentContext, WorkspacePolicy, read_workspace_policy,
+    workspace_policy_path, write_workspace_policy,
 };
 use octos_bus::{
     ActiveSessionStore, SessionHandle, SessionManager,
@@ -63,6 +64,7 @@ use crate::context_manager::{
 };
 use crate::cron_tool::CronTool;
 use crate::status_layers::{StatusComposer, UserStatusConfig};
+use crate::usage_ledger::{PersistentUsageLedger, UsageCostSource, UsageEvent};
 use crate::workflow_runtime::{WorkflowInstance, WorkflowKind};
 
 /// Parameters for dispatching an inbound message to a session actor.
@@ -2644,6 +2646,8 @@ pub struct ActorFactory {
     pub hook_context_template: Option<HookContext>,
     /// Data directory for creating per-actor SessionHandle instances.
     pub data_dir: std::path::PathBuf,
+    /// Durable per-profile usage ledger for completed LLM runs.
+    pub usage_ledger: Option<Arc<PersistentUsageLedger>>,
     /// Shared SessionManager for admin operations (/sessions, /new, /delete).
     /// NOT used by actors — only by the gateway main loop.
     pub session_mgr: Arc<Mutex<SessionManager>>,
@@ -3709,6 +3713,7 @@ impl ActorFactory {
             sender_user_id: sender_user_id.clone(),
             user_status_config,
             data_dir: self.data_dir.clone(),
+            usage_ledger: self.usage_ledger.clone(),
             max_history: self.max_history.clone(),
             idle_timeout: self.idle_timeout,
             session_timeout: self.session_timeout,
@@ -3720,6 +3725,11 @@ impl ActorFactory {
             adaptive_router: self.adaptive_router.clone(),
             lane_routing: self.lane_routing.clone(),
             memory_store: self.memory_store.clone(),
+            usage_profile_id: self
+                .profile_id
+                .clone()
+                .or_else(|| session_key.profile_id().map(ToOwned::to_owned))
+                .unwrap_or_else(|| MAIN_PROFILE_ID.to_string()),
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: self.active_sessions.clone(),
@@ -4190,6 +4200,11 @@ struct SessionActor {
     user_status_config: UserStatusConfig,
     /// Data directory for persisting user configs.
     data_dir: std::path::PathBuf,
+    /// Durable per-profile usage ledger. `None` only in tests or if startup
+    /// deliberately omitted usage accounting.
+    usage_ledger: Option<Arc<PersistentUsageLedger>>,
+    /// Profile/account id used for usage analytics rollups.
+    usage_profile_id: String,
     max_history: Arc<std::sync::atomic::AtomicUsize>,
 
     idle_timeout: Duration,
@@ -4280,6 +4295,71 @@ struct SessionActor {
 }
 
 impl SessionActor {
+    async fn record_usage_event(
+        &self,
+        response: &ConversationResponse,
+        run_id: Option<&str>,
+        attribution: Option<&str>,
+    ) {
+        let Some(usage_ledger) = self.usage_ledger.as_ref() else {
+            return;
+        };
+        let provider_metadata = response.provider_metadata.clone();
+        let provider = provider_metadata
+            .as_ref()
+            .map(|meta| meta.provider.clone())
+            .or_else(|| {
+                let provider = self.agent.provider_name();
+                (!provider.is_empty()).then(|| provider.to_string())
+            });
+        let model = provider_metadata
+            .as_ref()
+            .map(|meta| meta.model.clone())
+            .or_else(|| {
+                let model = self.agent.model_id();
+                (!model.is_empty()).then(|| model.to_string())
+            });
+        let estimated_cost_usd = model.as_deref().and_then(model_pricing).map(|pricing| {
+            pricing.cost(
+                response.token_usage.input_tokens,
+                response.token_usage.output_tokens,
+            )
+        });
+        let cost_source = if estimated_cost_usd.is_some() {
+            UsageCostSource::CatalogEstimate
+        } else {
+            UsageCostSource::Unavailable
+        };
+        let run_id = run_id
+            .filter(|id| !id.is_empty())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| uuid::Uuid::now_v7().to_string());
+        let event = UsageEvent::completed_run(
+            self.usage_profile_id.clone(),
+            self.session_key.to_string(),
+            run_id.clone(),
+            provider,
+            model,
+            provider_metadata
+                .as_ref()
+                .and_then(|meta| meta.endpoint.clone()),
+            u64::from(response.token_usage.input_tokens),
+            u64::from(response.token_usage.output_tokens),
+            estimated_cost_usd,
+            cost_source,
+            self.channel.clone(),
+            attribution.map(ToOwned::to_owned),
+        );
+        if let Err(error) = usage_ledger.record(event).await {
+            warn!(
+                session = %self.session_key,
+                run = %run_id,
+                error = %error,
+                "failed to record gateway usage event"
+            );
+        }
+    }
+
     async fn emit_hook_payload(&self, payload: HookPayload) {
         let Some(hooks) = self.hooks.as_ref() else {
             return;
@@ -7494,6 +7574,8 @@ impl SessionActor {
                 let session_cost = model_id.as_deref().and_then(model_pricing).map(|pricing| {
                     pricing.cost(cr.token_usage.input_tokens, cr.token_usage.output_tokens)
                 });
+                self.record_usage_event(cr, client_message_id.as_deref(), None)
+                    .await;
                 // Bug 3 / W1.G4 cost panel — collect per-node cost rows that
                 // tools (today: `run_pipeline`) surfaced through their
                 // `ToolResult.structured_metadata` side-channel. Without this
@@ -8915,6 +8997,10 @@ impl SessionActor {
         } else {
             None
         };
+        if let Ok(Ok(ref cr)) = result {
+            self.record_usage_event(cr, client_message_id.as_deref(), None)
+                .await;
+        }
 
         match result {
             Ok(Ok(conv_response)) => {
@@ -11139,6 +11225,8 @@ mod tests {
             sender_user_id: None,
             user_status_config: UserStatusConfig::default(),
             data_dir: dir.path().to_path_buf(),
+            usage_ledger: None,
+            usage_profile_id: "test-profile".to_string(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
             session_timeout: Duration::from_secs(120),
@@ -11217,6 +11305,8 @@ mod tests {
             sender_user_id: None,
             user_status_config: UserStatusConfig::default(),
             data_dir: dir.path().to_path_buf(),
+            usage_ledger: None,
+            usage_profile_id: "test-profile".to_string(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
             session_timeout,
@@ -11376,6 +11466,8 @@ mod tests {
             sender_user_id: None,
             user_status_config: UserStatusConfig::default(),
             data_dir: dir.path().to_path_buf(),
+            usage_ledger: None,
+            usage_profile_id: "test-profile".to_string(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
             session_timeout: Duration::from_secs(120),
@@ -11507,6 +11599,8 @@ mod tests {
             sender_user_id: None,
             user_status_config: UserStatusConfig::default(),
             data_dir: dir.path().to_path_buf(),
+            usage_ledger: None,
+            usage_profile_id: "test-profile".to_string(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
             session_timeout: Duration::from_secs(120),
@@ -11634,6 +11728,8 @@ mod tests {
             sender_user_id: None,
             user_status_config: UserStatusConfig::default(),
             data_dir: dir.path().to_path_buf(),
+            usage_ledger: None,
+            usage_profile_id: "test-profile".to_string(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
             session_timeout: Duration::from_secs(120),
@@ -11733,6 +11829,8 @@ mod tests {
             sender_user_id: None,
             user_status_config: UserStatusConfig::default(),
             data_dir: dir.path().to_path_buf(),
+            usage_ledger: None,
+            usage_profile_id: "test-profile".to_string(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
             session_timeout: Duration::from_secs(120),
@@ -11831,6 +11929,8 @@ mod tests {
             sender_user_id: None,
             user_status_config: UserStatusConfig::default(),
             data_dir: std::path::PathBuf::from("/tmp"),
+            usage_ledger: None,
+            usage_profile_id: "test-profile".to_string(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
             session_timeout: Duration::from_secs(120),
@@ -14335,6 +14435,7 @@ mod tests {
             hooks: None,
             hook_context_template: None,
             data_dir: dir.path().to_path_buf(),
+            usage_ledger: None,
             session_mgr,
             out_tx: out_tx.clone(),
             spawn_inbound_tx: spawn_tx,
@@ -17276,6 +17377,8 @@ mod tests {
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
             consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
+            usage_ledger: None,
+            usage_profile_id: "test-profile".to_string(),
         };
 
         let handle = tokio::spawn(actor.run());

--- a/crates/octos-cli/src/usage_ledger.rs
+++ b/crates/octos-cli/src/usage_ledger.rs
@@ -1,0 +1,701 @@
+//! Durable session usage ledger for profile-level token and cost analytics.
+//!
+//! One row is written for each completed LLM run. The ledger lives under the
+//! profile data directory so session totals and provider/model rollups survive
+//! browser refreshes, reconnects, and daemon restarts.
+//!
+//! Schema versioning is explicit on every event. Version 1 stores raw usage
+//! events plus profile/session indexes; older rows without `schema_version`
+//! are treated as version 1 during reads so a future backfill can import legacy
+//! observations idempotently before a migration tightens the schema.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use eyre::{Result, WrapErr};
+use redb::{Database, ReadableTable, TableDefinition};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+use uuid::Uuid;
+
+pub const USAGE_LEDGER_FILE: &str = "usage_ledger.redb";
+pub const USAGE_EVENT_SCHEMA_VERSION: u32 = 1;
+
+const USAGE_EVENTS_TABLE: TableDefinition<'static, &str, &str> =
+    TableDefinition::new("usage_events");
+const USAGE_PROFILE_INDEX_TABLE: TableDefinition<'static, &str, &str> =
+    TableDefinition::new("usage_profile_index");
+const USAGE_SESSION_INDEX_TABLE: TableDefinition<'static, &str, &str> =
+    TableDefinition::new("usage_session_index");
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageCostSource {
+    CatalogEstimate,
+    ProviderReported,
+    #[default]
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UsageEvent {
+    #[serde(default = "default_usage_event_schema_version")]
+    pub schema_version: u32,
+    pub event_id: String,
+    pub timestamp: DateTime<Utc>,
+    pub profile_id: String,
+    pub session_id: String,
+    pub run_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimated_cost_usd: Option<f64>,
+    #[serde(default)]
+    pub cost_source: UsageCostSource,
+    #[serde(default = "default_usage_channel")]
+    pub channel: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attribution: Option<String>,
+}
+
+impl UsageEvent {
+    #[allow(clippy::too_many_arguments)]
+    pub fn completed_run(
+        profile_id: impl Into<String>,
+        session_id: impl Into<String>,
+        run_id: impl Into<String>,
+        provider: Option<String>,
+        model: Option<String>,
+        base_url: Option<String>,
+        input_tokens: u64,
+        output_tokens: u64,
+        estimated_cost_usd: Option<f64>,
+        cost_source: UsageCostSource,
+        channel: impl Into<String>,
+        attribution: Option<String>,
+    ) -> Self {
+        Self {
+            schema_version: USAGE_EVENT_SCHEMA_VERSION,
+            event_id: Uuid::now_v7().to_string(),
+            timestamp: Utc::now(),
+            profile_id: profile_id.into(),
+            session_id: session_id.into(),
+            run_id: run_id.into(),
+            provider,
+            model,
+            base_url,
+            input_tokens,
+            output_tokens,
+            estimated_cost_usd,
+            cost_source,
+            channel: channel.into(),
+            attribution,
+        }
+    }
+}
+
+fn default_usage_event_schema_version() -> u32 {
+    USAGE_EVENT_SCHEMA_VERSION
+}
+
+fn default_usage_channel() -> String {
+    "unknown".to_string()
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct UsageTotals {
+    pub run_count: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub estimated_cost_usd: f64,
+}
+
+impl UsageTotals {
+    pub fn add_event(&mut self, event: &UsageEvent) {
+        self.run_count = self.run_count.saturating_add(1);
+        self.input_tokens = self.input_tokens.saturating_add(event.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(event.output_tokens);
+        if let Some(cost) = event.estimated_cost_usd {
+            self.estimated_cost_usd += cost;
+        }
+    }
+
+    pub fn merge(&mut self, other: &UsageTotals) {
+        self.run_count = self.run_count.saturating_add(other.run_count);
+        self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
+        self.estimated_cost_usd += other.estimated_cost_usd;
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UsageRollup {
+    pub key: String,
+    pub totals: UsageTotals,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct UsageAnalytics {
+    pub totals: UsageTotals,
+    pub by_day: Vec<UsageRollup>,
+    pub by_month: Vec<UsageRollup>,
+    pub by_profile: Vec<UsageRollup>,
+    pub by_provider: Vec<UsageRollup>,
+    pub by_model: Vec<UsageRollup>,
+    pub by_channel: Vec<UsageRollup>,
+}
+
+impl UsageAnalytics {
+    pub fn from_events(events: &[UsageEvent]) -> Self {
+        let mut analytics = Self::default();
+        let mut by_day = BTreeMap::<String, UsageTotals>::new();
+        let mut by_month = BTreeMap::<String, UsageTotals>::new();
+        let mut by_profile = BTreeMap::<String, UsageTotals>::new();
+        let mut by_provider = BTreeMap::<String, UsageTotals>::new();
+        let mut by_model = BTreeMap::<String, UsageTotals>::new();
+        let mut by_channel = BTreeMap::<String, UsageTotals>::new();
+
+        for event in events {
+            analytics.totals.add_event(event);
+            add_rollup(
+                &mut by_day,
+                event.timestamp.format("%Y-%m-%d").to_string(),
+                event,
+            );
+            add_rollup(
+                &mut by_month,
+                event.timestamp.format("%Y-%m").to_string(),
+                event,
+            );
+            add_rollup(&mut by_profile, event.profile_id.clone(), event);
+            add_rollup(
+                &mut by_provider,
+                event
+                    .provider
+                    .clone()
+                    .unwrap_or_else(|| "unknown".to_string()),
+                event,
+            );
+            add_rollup(
+                &mut by_model,
+                event.model.clone().unwrap_or_else(|| "unknown".to_string()),
+                event,
+            );
+            add_rollup(&mut by_channel, event.channel.clone(), event);
+        }
+
+        analytics.by_day = map_rollups(by_day);
+        analytics.by_month = map_rollups(by_month);
+        analytics.by_profile = map_rollups(by_profile);
+        analytics.by_provider = map_rollups(by_provider);
+        analytics.by_model = map_rollups(by_model);
+        analytics.by_channel = map_rollups(by_channel);
+        analytics
+    }
+
+    pub fn merge(&mut self, other: UsageAnalytics) {
+        self.totals.merge(&other.totals);
+        merge_rollups(&mut self.by_day, other.by_day);
+        merge_rollups(&mut self.by_month, other.by_month);
+        merge_rollups(&mut self.by_profile, other.by_profile);
+        merge_rollups(&mut self.by_provider, other.by_provider);
+        merge_rollups(&mut self.by_model, other.by_model);
+        merge_rollups(&mut self.by_channel, other.by_channel);
+    }
+}
+
+fn add_rollup(map: &mut BTreeMap<String, UsageTotals>, key: String, event: &UsageEvent) {
+    map.entry(key).or_default().add_event(event);
+}
+
+fn map_rollups(map: BTreeMap<String, UsageTotals>) -> Vec<UsageRollup> {
+    map.into_iter()
+        .map(|(key, totals)| UsageRollup { key, totals })
+        .collect()
+}
+
+fn merge_rollups(target: &mut Vec<UsageRollup>, incoming: Vec<UsageRollup>) {
+    let mut merged = BTreeMap::<String, UsageTotals>::new();
+    for rollup in target.drain(..).chain(incoming) {
+        merged.entry(rollup.key).or_default().merge(&rollup.totals);
+    }
+    *target = map_rollups(merged);
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct UsageQuery {
+    #[serde(default)]
+    pub profile_id: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub from: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub to: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UsageBackfillReport {
+    pub imported: u64,
+    pub skipped_duplicates: u64,
+}
+
+#[derive(Clone)]
+pub struct PersistentUsageLedger {
+    path: PathBuf,
+}
+
+impl PersistentUsageLedger {
+    pub fn open_sync(data_dir: impl AsRef<Path>) -> Result<Self> {
+        let data_dir = data_dir.as_ref();
+        std::fs::create_dir_all(data_dir).wrap_err("failed to create usage ledger directory")?;
+        let db_path = data_dir.join(USAGE_LEDGER_FILE);
+        debug!(path = %db_path.display(), "prepared usage ledger");
+        Ok(Self { path: db_path })
+    }
+
+    pub async fn open(data_dir: impl AsRef<Path>) -> Result<Self> {
+        let data_dir = data_dir.as_ref().to_path_buf();
+        tokio::task::spawn_blocking(move || Self::open_sync(data_dir)).await?
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub async fn record(&self, event: UsageEvent) -> Result<()> {
+        let db_path = self.path.clone();
+        tokio::task::spawn_blocking(move || {
+            let db = Self::open_database(&db_path)?;
+            let body = serde_json::to_string(&event).wrap_err("failed to serialize usage event")?;
+            let write_txn = db.begin_write()?;
+            {
+                let mut table = write_txn.open_table(USAGE_EVENTS_TABLE)?;
+                table.insert(event.event_id.as_str(), body.as_str())?;
+            }
+            Self::append_index(
+                &write_txn,
+                USAGE_PROFILE_INDEX_TABLE,
+                &event.profile_id,
+                &event.event_id,
+            )?;
+            Self::append_index(
+                &write_txn,
+                USAGE_SESSION_INDEX_TABLE,
+                &event.session_id,
+                &event.event_id,
+            )?;
+            write_txn.commit()?;
+            Ok::<_, eyre::Report>(())
+        })
+        .await??;
+        Ok(())
+    }
+
+    pub async fn backfill_events(&self, events: Vec<UsageEvent>) -> Result<UsageBackfillReport> {
+        let db_path = self.path.clone();
+        tokio::task::spawn_blocking(move || {
+            let db = Self::open_database(&db_path)?;
+            let write_txn = db.begin_write()?;
+            let mut imported_events = Vec::new();
+            let mut skipped_duplicates = 0_u64;
+            {
+                let mut table = write_txn.open_table(USAGE_EVENTS_TABLE)?;
+                for event in events {
+                    if table.get(event.event_id.as_str())?.is_some() {
+                        skipped_duplicates = skipped_duplicates.saturating_add(1);
+                        continue;
+                    }
+                    let body = serde_json::to_string(&event)
+                        .wrap_err("failed to serialize usage event")?;
+                    table.insert(event.event_id.as_str(), body.as_str())?;
+                    imported_events.push(event);
+                }
+            }
+            for event in &imported_events {
+                Self::append_index(
+                    &write_txn,
+                    USAGE_PROFILE_INDEX_TABLE,
+                    &event.profile_id,
+                    &event.event_id,
+                )?;
+                Self::append_index(
+                    &write_txn,
+                    USAGE_SESSION_INDEX_TABLE,
+                    &event.session_id,
+                    &event.event_id,
+                )?;
+            }
+            write_txn.commit()?;
+            Ok::<_, eyre::Report>(UsageBackfillReport {
+                imported: imported_events.len() as u64,
+                skipped_duplicates,
+            })
+        })
+        .await?
+    }
+
+    pub async fn list_all(&self) -> Result<Vec<UsageEvent>> {
+        let db_path = self.path.clone();
+        tokio::task::spawn_blocking(move || {
+            let db = Self::open_database(&db_path)?;
+            let read_txn = db.begin_read()?;
+            Self::load_all(&read_txn)
+        })
+        .await?
+    }
+
+    pub async fn list_for_profile(&self, profile_id: &str) -> Result<Vec<UsageEvent>> {
+        self.list_by_index(USAGE_PROFILE_INDEX_TABLE, profile_id)
+            .await
+    }
+
+    pub async fn list_for_session(&self, session_id: &str) -> Result<Vec<UsageEvent>> {
+        self.list_by_index(USAGE_SESSION_INDEX_TABLE, session_id)
+            .await
+    }
+
+    pub async fn analytics(&self, query: UsageQuery) -> Result<UsageAnalytics> {
+        let mut events = if let Some(session_id) = query.session_id.as_deref() {
+            self.list_for_session(session_id).await?
+        } else if let Some(profile_id) = query.profile_id.as_deref() {
+            self.list_for_profile(profile_id).await?
+        } else {
+            self.list_all().await?
+        };
+        events.retain(|event| event_matches_query(event, &query));
+        events.sort_by(|a, b| {
+            a.timestamp
+                .cmp(&b.timestamp)
+                .then_with(|| a.event_id.cmp(&b.event_id))
+        });
+        Ok(UsageAnalytics::from_events(&events))
+    }
+
+    pub async fn session_totals(&self, session_id: &str) -> Result<UsageTotals> {
+        let events = self.list_for_session(session_id).await?;
+        Ok(UsageAnalytics::from_events(&events).totals)
+    }
+
+    fn open_database(db_path: &Path) -> Result<Database> {
+        let db = Database::create(db_path).wrap_err("failed to open usage ledger database")?;
+        let write_txn = db.begin_write()?;
+        {
+            let _ = write_txn.open_table(USAGE_EVENTS_TABLE)?;
+            let _ = write_txn.open_table(USAGE_PROFILE_INDEX_TABLE)?;
+            let _ = write_txn.open_table(USAGE_SESSION_INDEX_TABLE)?;
+        }
+        write_txn.commit()?;
+        Ok(db)
+    }
+
+    fn append_index(
+        txn: &redb::WriteTransaction,
+        table: TableDefinition<'static, &'static str, &'static str>,
+        key: &str,
+        event_id: &str,
+    ) -> Result<()> {
+        let mut table = txn.open_table(table)?;
+        let mut ids: Vec<String> = table
+            .get(key)?
+            .map(|value| serde_json::from_str(value.value()).unwrap_or_default())
+            .unwrap_or_default();
+        if !ids.iter().any(|id| id == event_id) {
+            ids.push(event_id.to_string());
+        }
+        let ids_json =
+            serde_json::to_string(&ids).wrap_err("failed to serialize usage index entry")?;
+        table.insert(key, ids_json.as_str())?;
+        Ok(())
+    }
+
+    fn load_by_ids(txn: &redb::ReadTransaction, ids: &[String]) -> Result<Vec<UsageEvent>> {
+        let table = txn.open_table(USAGE_EVENTS_TABLE)?;
+        let mut events = Vec::with_capacity(ids.len());
+        for id in ids {
+            if let Some(json) = table.get(id.as_str())? {
+                match serde_json::from_str::<UsageEvent>(json.value()) {
+                    Ok(event) => events.push(event),
+                    Err(error) => {
+                        warn!(event_id = id.as_str(), error = %error, "skipping corrupt usage row");
+                    }
+                }
+            }
+        }
+        Ok(events)
+    }
+
+    fn load_all(txn: &redb::ReadTransaction) -> Result<Vec<UsageEvent>> {
+        let table = txn.open_table(USAGE_EVENTS_TABLE)?;
+        let mut events = Vec::new();
+        for entry in table.iter()? {
+            let (id, json) = entry?;
+            match serde_json::from_str::<UsageEvent>(json.value()) {
+                Ok(event) => events.push(event),
+                Err(error) => {
+                    warn!(event_id = id.value(), error = %error, "skipping corrupt usage row");
+                }
+            }
+        }
+        Ok(events)
+    }
+
+    async fn list_by_index(
+        &self,
+        table: TableDefinition<'static, &'static str, &'static str>,
+        key: &str,
+    ) -> Result<Vec<UsageEvent>> {
+        let db_path = self.path.clone();
+        let key = key.to_string();
+        tokio::task::spawn_blocking(move || {
+            let db = Self::open_database(&db_path)?;
+            let read_txn = db.begin_read()?;
+            let index = read_txn.open_table(table)?;
+            let ids: Vec<String> = index
+                .get(key.as_str())?
+                .map(|value| serde_json::from_str(value.value()).unwrap_or_default())
+                .unwrap_or_default();
+            drop(index);
+            Self::load_by_ids(&read_txn, &ids)
+        })
+        .await?
+    }
+}
+
+fn event_matches_query(event: &UsageEvent, query: &UsageQuery) -> bool {
+    if let Some(profile_id) = query.profile_id.as_deref()
+        && event.profile_id != profile_id
+    {
+        return false;
+    }
+    if let Some(session_id) = query.session_id.as_deref()
+        && event.session_id != session_id
+    {
+        return false;
+    }
+    if let Some(from) = query.from
+        && event.timestamp < from
+    {
+        return false;
+    }
+    if let Some(to) = query.to
+        && event.timestamp > to
+    {
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::too_many_arguments)]
+    fn event(
+        profile_id: &str,
+        session_id: &str,
+        run_id: &str,
+        provider: &str,
+        model: &str,
+        day: &str,
+        input_tokens: u64,
+        output_tokens: u64,
+        cost: f64,
+        channel: &str,
+    ) -> UsageEvent {
+        let mut event = UsageEvent::completed_run(
+            profile_id,
+            session_id,
+            run_id,
+            Some(provider.to_string()),
+            Some(model.to_string()),
+            Some("https://example.invalid/v1".to_string()),
+            input_tokens,
+            output_tokens,
+            Some(cost),
+            UsageCostSource::CatalogEstimate,
+            channel,
+            None,
+        );
+        event.timestamp = DateTime::parse_from_rfc3339(&format!("{day}T12:00:00Z"))
+            .unwrap()
+            .with_timezone(&Utc);
+        event
+    }
+
+    #[tokio::test]
+    async fn usage_events_survive_reopen_and_roll_up_session_totals() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = PersistentUsageLedger::open(dir.path()).await.unwrap();
+        ledger
+            .record(event(
+                "profile-a",
+                "session-a",
+                "run-1",
+                "openai",
+                "gpt-4.1",
+                "2026-05-30",
+                100,
+                40,
+                0.012,
+                "appui",
+            ))
+            .await
+            .unwrap();
+        ledger
+            .record(event(
+                "profile-a",
+                "session-a",
+                "run-2",
+                "openai",
+                "gpt-4.1",
+                "2026-05-30",
+                10,
+                5,
+                0.001,
+                "appui",
+            ))
+            .await
+            .unwrap();
+        drop(ledger);
+
+        let reopened = PersistentUsageLedger::open(dir.path()).await.unwrap();
+        let totals = reopened.session_totals("session-a").await.unwrap();
+        assert_eq!(totals.run_count, 2);
+        assert_eq!(totals.input_tokens, 110);
+        assert_eq!(totals.output_tokens, 45);
+        assert!((totals.estimated_cost_usd - 0.013).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn analytics_group_by_time_profile_provider_model_and_channel() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = PersistentUsageLedger::open(dir.path()).await.unwrap();
+        for event in [
+            event(
+                "profile-a",
+                "session-a",
+                "run-1",
+                "openai",
+                "gpt-4.1",
+                "2026-05-01",
+                100,
+                50,
+                0.01,
+                "appui",
+            ),
+            event(
+                "profile-a",
+                "session-b",
+                "run-2",
+                "anthropic",
+                "claude-sonnet-4",
+                "2026-05-31",
+                40,
+                10,
+                0.02,
+                "matrix",
+            ),
+            event(
+                "profile-b",
+                "session-c",
+                "run-3",
+                "openai",
+                "gpt-4.1",
+                "2026-06-01",
+                25,
+                5,
+                0.03,
+                "appui",
+            ),
+        ] {
+            ledger.record(event).await.unwrap();
+        }
+
+        let analytics = ledger.analytics(UsageQuery::default()).await.unwrap();
+        assert_eq!(analytics.totals.run_count, 3);
+        assert_eq!(rollup(&analytics.by_month, "2026-05").run_count, 2);
+        assert_eq!(rollup(&analytics.by_day, "2026-06-01").input_tokens, 25);
+        assert_eq!(rollup(&analytics.by_profile, "profile-a").run_count, 2);
+        assert_eq!(rollup(&analytics.by_provider, "openai").run_count, 2);
+        assert_eq!(rollup(&analytics.by_model, "gpt-4.1").output_tokens, 55);
+        assert_eq!(rollup(&analytics.by_channel, "appui").run_count, 2);
+    }
+
+    #[tokio::test]
+    async fn backfill_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = PersistentUsageLedger::open(dir.path()).await.unwrap();
+        let mut legacy = event(
+            "profile-a",
+            "session-a",
+            "legacy-run",
+            "openai",
+            "gpt-4.1",
+            "2026-05-30",
+            12,
+            7,
+            0.004,
+            "backfill",
+        );
+        legacy.event_id = "legacy-event".to_string();
+
+        let first = ledger.backfill_events(vec![legacy.clone()]).await.unwrap();
+        let second = ledger.backfill_events(vec![legacy]).await.unwrap();
+
+        assert_eq!(first.imported, 1);
+        assert_eq!(first.skipped_duplicates, 0);
+        assert_eq!(second.imported, 0);
+        assert_eq!(second.skipped_duplicates, 1);
+        assert_eq!(
+            ledger.session_totals("session-a").await.unwrap().run_count,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_rows_without_schema_version_still_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join(USAGE_LEDGER_FILE);
+        let db = Database::create(&db_path).unwrap();
+        let tx = db.begin_write().unwrap();
+        {
+            let mut events = tx.open_table(USAGE_EVENTS_TABLE).unwrap();
+            events
+                .insert(
+                    "legacy",
+                    r#"{"event_id":"legacy","timestamp":"2026-05-30T12:00:00Z","profile_id":"profile-a","session_id":"session-a","run_id":"run-1","provider":"openai","model":"gpt-4.1","input_tokens":3,"output_tokens":4,"estimated_cost_usd":0.01,"cost_source":"catalog_estimate","channel":"appui"}"#,
+                )
+                .unwrap();
+            let mut sessions = tx.open_table(USAGE_SESSION_INDEX_TABLE).unwrap();
+            sessions.insert("session-a", r#"["legacy"]"#).unwrap();
+            let mut profiles = tx.open_table(USAGE_PROFILE_INDEX_TABLE).unwrap();
+            profiles.insert("profile-a", r#"["legacy"]"#).unwrap();
+        }
+        tx.commit().unwrap();
+        drop(db);
+
+        let ledger = PersistentUsageLedger::open(dir.path()).await.unwrap();
+        let events = ledger.list_for_session("session-a").await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].schema_version, USAGE_EVENT_SCHEMA_VERSION);
+        assert_eq!(events[0].input_tokens, 3);
+    }
+
+    fn rollup<'a>(rollups: &'a [UsageRollup], key: &str) -> &'a UsageTotals {
+        &rollups
+            .iter()
+            .find(|rollup| rollup.key == key)
+            .unwrap()
+            .totals
+    }
+}

--- a/crates/octos-web/src/runtime/__tests__/usage-api.test.ts
+++ b/crates/octos-web/src/runtime/__tests__/usage-api.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { UsageApiClient, type UsageAnalytics } from '../usage-api.js';
+
+const emptyUsage: UsageAnalytics = {
+  totals: {
+    run_count: 0,
+    input_tokens: 0,
+    output_tokens: 0,
+    estimated_cost_usd: 0,
+  },
+  by_day: [],
+  by_month: [],
+  by_profile: [],
+  by_provider: [],
+  by_model: [],
+  by_channel: [],
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  };
+}
+
+describe('UsageApiClient', () => {
+  it('loads own session totals from the persistent usage API', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(emptyUsage));
+    const client = new UsageApiClient({
+      baseUrl: 'https://octos.example/',
+      token: 'session-token',
+      fetchImpl,
+    });
+
+    await client.mySessionUsage('session/a b', {
+      from: '2026-05-01T00:00:00Z',
+      to: new Date('2026-06-01T00:00:00Z'),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://octos.example/api/my/usage/sessions/session%2Fa%20b?from=2026-05-01T00%3A00%3A00Z&to=2026-06-01T00%3A00%3A00.000Z',
+      {
+        headers: {
+          Accept: 'application/json',
+          Authorization: 'Bearer session-token',
+        },
+      },
+    );
+  });
+
+  it('queries admin aggregate usage with optional session filters', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(emptyUsage));
+    const client = new UsageApiClient({ fetchImpl });
+
+    await client.adminUsage({ sessionId: 'thread-1' });
+
+    expect(fetchImpl).toHaveBeenCalledWith('/api/admin/usage?session_id=thread-1', {
+      headers: { Accept: 'application/json' },
+    });
+  });
+
+  it('raises typed errors for non-2xx responses', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ error: 'forbidden' }, 403));
+    const client = new UsageApiClient({ fetchImpl });
+
+    await expect(client.myUsage()).rejects.toMatchObject({
+      name: 'UsageApiError',
+      status: 403,
+    });
+  });
+});

--- a/crates/octos-web/src/runtime/usage-api.ts
+++ b/crates/octos-web/src/runtime/usage-api.ts
@@ -1,0 +1,146 @@
+// Typed client for persistent usage analytics.
+//
+// These endpoints read the backend ledger added for durable session totals,
+// so chat surfaces can load accumulated usage after refresh, reconnect, or a
+// server restart instead of trusting only the latest turn_completed envelope.
+
+export type UsageCostSource = 'catalog_estimate' | 'provider_reported' | 'unavailable';
+
+export interface UsageTotals {
+  run_count: number;
+  input_tokens: number;
+  output_tokens: number;
+  estimated_cost_usd: number;
+}
+
+export interface UsageRollup {
+  key: string;
+  totals: UsageTotals;
+}
+
+export interface UsageAnalytics {
+  totals: UsageTotals;
+  by_day: UsageRollup[];
+  by_month: UsageRollup[];
+  by_profile: UsageRollup[];
+  by_provider: UsageRollup[];
+  by_model: UsageRollup[];
+  by_channel: UsageRollup[];
+}
+
+export interface UsageQueryParams {
+  sessionId?: string;
+  from?: string | Date;
+  to?: string | Date;
+}
+
+type UsageFetchResponse = {
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+  json(): Promise<unknown>;
+};
+
+type UsageFetch = (
+  input: string,
+  init?: { headers?: Record<string, string> },
+) => Promise<UsageFetchResponse>;
+
+export interface UsageApiClientOptions {
+  baseUrl?: string;
+  token?: string;
+  fetchImpl?: UsageFetch;
+}
+
+export class UsageApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message || `HTTP ${status}`);
+    this.name = 'UsageApiError';
+    this.status = status;
+  }
+}
+
+export class UsageApiClient {
+  private readonly baseUrl: string;
+  private readonly token?: string;
+  private readonly fetchImpl: UsageFetch;
+
+  constructor(options: UsageApiClientOptions = {}) {
+    this.baseUrl = (options.baseUrl ?? '').replace(/\/+$/, '');
+    this.token = options.token;
+    this.fetchImpl = options.fetchImpl ?? defaultFetch();
+  }
+
+  myUsage(query: UsageQueryParams = {}): Promise<UsageAnalytics> {
+    return this.get(`/api/my/usage${queryString(query)}`);
+  }
+
+  mySessionUsage(sessionId: string, query: Omit<UsageQueryParams, 'sessionId'> = {}) {
+    return this.get(
+      `/api/my/usage/sessions/${encodeURIComponent(sessionId)}${queryString(query)}`,
+    );
+  }
+
+  adminUsage(query: UsageQueryParams = {}): Promise<UsageAnalytics> {
+    return this.get(`/api/admin/usage${queryString(query)}`);
+  }
+
+  adminProfileUsage(profileId: string, query: UsageQueryParams = {}) {
+    return this.get(
+      `/api/admin/profiles/${encodeURIComponent(profileId)}/usage${queryString(query)}`,
+    );
+  }
+
+  adminProfileSessionUsage(
+    profileId: string,
+    sessionId: string,
+    query: Omit<UsageQueryParams, 'sessionId'> = {},
+  ) {
+    return this.get(
+      `/api/admin/profiles/${encodeURIComponent(profileId)}/usage/sessions/${encodeURIComponent(
+        sessionId,
+      )}${queryString(query)}`,
+    );
+  }
+
+  private async get(path: string): Promise<UsageAnalytics> {
+    const headers: Record<string, string> = { Accept: 'application/json' };
+    if (this.token) {
+      headers.Authorization = `Bearer ${this.token}`;
+    }
+    const response = await this.fetchImpl(`${this.baseUrl}${path}`, { headers });
+    if (!response.ok) {
+      throw new UsageApiError(response.status, await response.text());
+    }
+    return (await response.json()) as UsageAnalytics;
+  }
+}
+
+function defaultFetch(): UsageFetch {
+  const fetchImpl = globalThis.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw new UsageApiError(0, 'global fetch is unavailable');
+  }
+  return fetchImpl as unknown as UsageFetch;
+}
+
+function queryString(query: UsageQueryParams): string {
+  const params = new URLSearchParams();
+  if (query.sessionId) {
+    params.set('session_id', query.sessionId);
+  }
+  if (query.from) {
+    params.set('from', timestampParam(query.from));
+  }
+  if (query.to) {
+    params.set('to', timestampParam(query.to));
+  }
+  const encoded = params.toString();
+  return encoded ? `?${encoded}` : '';
+}
+
+function timestampParam(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : value;
+}

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -20,6 +20,8 @@ import type {
   SystemMetrics,
   PurgeReport,
   AdminAuditResponse,
+  UsageAnalytics,
+  UsageQueryParams,
 } from './types'
 
 const BASE = '/api/admin'
@@ -152,6 +154,15 @@ function queryPath(path: string, params: Record<string, string | number | undefi
   return suffix ? `${path}?${suffix}` : path
 }
 
+function usageQuery(query?: UsageQueryParams): string {
+  const params = new URLSearchParams()
+  if (query?.session_id) params.set('session_id', query.session_id)
+  if (query?.from) params.set('from', query.from)
+  if (query?.to) params.set('to', query.to)
+  const encoded = params.toString()
+  return encoded ? `?${encoded}` : ''
+}
+
 // ── Admin API (existing) ────────────────────────────────────────────
 
 export const api = {
@@ -223,6 +234,17 @@ export const api = {
 
   providerMetrics: (id: string) =>
     request<SharedMetrics | null>(`/profiles/${id}/metrics`),
+
+  usage: (query?: UsageQueryParams) =>
+    request<UsageAnalytics>(`/usage${usageQuery(query)}`),
+
+  profileUsage: (id: string, query?: UsageQueryParams) =>
+    request<UsageAnalytics>(`/profiles/${id}/usage${usageQuery(query)}`),
+
+  profileSessionUsage: (id: string, sessionId: string, query?: Omit<UsageQueryParams, 'session_id'>) =>
+    request<UsageAnalytics>(
+      `/profiles/${id}/usage/sessions/${encodeURIComponent(sessionId)}${usageQuery(query)}`,
+    ),
 
   // Sub-account management
   listSubAccounts: (parentId: string) =>
@@ -512,6 +534,14 @@ export const myApi = {
 
   providerMetrics: () =>
     authedRequest<SharedMetrics | null>('/my/profile/metrics'),
+
+  usage: (query?: UsageQueryParams) =>
+    authedRequest<UsageAnalytics>(`/my/usage${usageQuery(query)}`),
+
+  sessionUsage: (sessionId: string, query?: Omit<UsageQueryParams, 'session_id'>) =>
+    authedRequest<UsageAnalytics>(
+      `/my/usage/sessions/${encodeURIComponent(sessionId)}${usageQuery(query)}`,
+    ),
 
   listProfileSkills: () =>
     authedRequest<{ skills: { name: string; version: string | null; tool_count: number; source_repo: string | null }[] }>(

--- a/dashboard/src/pages/profile/HomePage.tsx
+++ b/dashboard/src/pages/profile/HomePage.tsx
@@ -6,7 +6,7 @@ import GatewayControls from '../../components/GatewayControls'
 import ConfirmDialog from '../../components/ConfirmDialog'
 import StatusBadge from '../../components/StatusBadge'
 import { CHANNEL_COLORS, CHANNEL_LABELS } from '../../types'
-import type { ProfileResponse } from '../../types'
+import type { ProfileResponse, UsageAnalytics, UsageRollup } from '../../types'
 import { api, myApi, systemApi } from '../../api'
 import { useToast } from '../../components/Toast'
 
@@ -40,6 +40,9 @@ export default function HomePage() {
   const [newSubdomain, setNewSubdomain] = useState('')
   const [newSubEmail, setNewSubEmail] = useState('')
   const [createSubLoading, setCreateSubLoading] = useState(false)
+  const [usage, setUsage] = useState<UsageAnalytics | null>(null)
+  const [usageLoading, setUsageLoading] = useState(false)
+  const [usageError, setUsageError] = useState<string | null>(null)
   // Public base domain advertised by the server — drives the preview
   // URL so mini2/3/5 render `*.bot./*.octos./*.ocean.ominix.io` instead
   // of mini1's `*.crew.ominix.io`. Falls back to `DEFAULT_BASE_DOMAIN`
@@ -64,6 +67,40 @@ export default function HomePage() {
   useEffect(() => {
     loadSubAccounts()
   }, [loadSubAccounts])
+
+  useEffect(() => {
+    let cancelled = false
+    if (!profileId || (!isOwn && !isAdmin)) {
+      setUsage(null)
+      setUsageError(null)
+      setUsageLoading(false)
+      return () => {
+        cancelled = true
+      }
+    }
+
+    setUsageLoading(true)
+    setUsageError(null)
+    const request = isOwn ? myApi.usage() : api.profileUsage(profileId)
+    request
+      .then((nextUsage) => {
+        if (cancelled) return
+        setUsage(nextUsage)
+      })
+      .catch((error: any) => {
+        if (cancelled) return
+        setUsage(null)
+        setUsageError(error?.message || 'Failed to load usage')
+      })
+      .finally(() => {
+        if (cancelled) return
+        setUsageLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [profileId, isOwn, isAdmin])
 
   useEffect(() => {
     let cancelled = false
@@ -202,7 +239,7 @@ export default function HomePage() {
         </div>
       )}
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
         {/* Gateway Controls */}
         <GatewayControls
           status={status || { running: false, pid: null, started_at: null, uptime_secs: null }}
@@ -256,6 +293,12 @@ export default function HomePage() {
             </div>
           )}
         </div>
+
+        <UsagePanel
+          usage={usage}
+          loading={usageLoading}
+          error={usageError}
+        />
       </div>
 
       {/* Profile Settings */}
@@ -569,6 +612,83 @@ function InfoRow({ label, value }: { label: string; value: string }) {
       <dd className="text-gray-300">{value}</dd>
     </div>
   )
+}
+
+function UsagePanel({
+  usage,
+  loading,
+  error,
+}: {
+  usage: UsageAnalytics | null
+  loading: boolean
+  error: string | null
+}) {
+  const totals = usage?.totals
+  const totalTokens = (totals?.input_tokens || 0) + (totals?.output_tokens || 0)
+  const topProvider = topRollup(usage?.by_provider)
+  const topModel = topRollup(usage?.by_model)
+  const topChannel = topRollup(usage?.by_channel)
+
+  return (
+    <div className="bg-surface rounded-xl border border-gray-700/50 p-5 min-h-[220px]">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-semibold text-white">Usage</h3>
+        {loading && (
+          <div className="animate-spin w-4 h-4 border-2 border-accent border-t-transparent rounded-full" />
+        )}
+      </div>
+
+      {error ? (
+        <p className="text-sm text-red-300">{error}</p>
+      ) : (
+        <div className="space-y-4">
+          <div className="grid grid-cols-3 gap-2">
+            <UsageMetric label="Runs" value={String(totals?.run_count || 0)} />
+            <UsageMetric label="Tokens" value={formatTokens(totalTokens)} />
+            <UsageMetric label="Cost" value={formatCost(totals?.estimated_cost_usd || 0)} />
+          </div>
+
+          <dl className="space-y-3 text-xs">
+            <InfoRow label="Input" value={formatTokens(totals?.input_tokens || 0)} />
+            <InfoRow label="Output" value={formatTokens(totals?.output_tokens || 0)} />
+            <InfoRow label="Provider" value={topProvider} />
+            <InfoRow label="Model" value={topModel} />
+            <InfoRow label="Channel" value={topChannel} />
+          </dl>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function UsageMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg bg-white/[0.03] border border-gray-700/40 px-3 py-2 min-w-0">
+      <div className="text-[10px] uppercase text-gray-500 truncate">{label}</div>
+      <div className="text-sm font-semibold text-gray-100 truncate" title={value}>
+        {value}
+      </div>
+    </div>
+  )
+}
+
+function topRollup(rollups: UsageRollup[] | undefined): string {
+  if (!rollups || rollups.length === 0) return 'None'
+  return [...rollups]
+    .sort((a, b) => b.totals.run_count - a.totals.run_count || a.key.localeCompare(b.key))[0]
+    .key
+}
+
+function formatTokens(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`
+  return String(value)
+}
+
+function formatCost(value: number): string {
+  if (value === 0) return '$0.00'
+  if (value < 0.01) return `$${value.toFixed(4)}`
+  return `$${value.toFixed(2)}`
 }
 
 function formatUptime(secs: number | null): string {

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -366,6 +366,36 @@ export interface SharedMetrics {
   providers: SharedProviderMetrics[]
 }
 
+// ── Persistent Usage Analytics ──────────────────────────────────────
+
+export interface UsageTotals {
+  run_count: number
+  input_tokens: number
+  output_tokens: number
+  estimated_cost_usd: number
+}
+
+export interface UsageRollup {
+  key: string
+  totals: UsageTotals
+}
+
+export interface UsageAnalytics {
+  totals: UsageTotals
+  by_day: UsageRollup[]
+  by_month: UsageRollup[]
+  by_profile: UsageRollup[]
+  by_provider: UsageRollup[]
+  by_model: UsageRollup[]
+  by_channel: UsageRollup[]
+}
+
+export interface UsageQueryParams {
+  session_id?: string
+  from?: string
+  to?: string
+}
+
 // ── Admin Bot Config (legacy, kept for backwards compat) ─────────────
 
 export interface AdminBotConfig {


### PR DESCRIPTION
## Summary
- add a durable redb-backed usage ledger with versioned usage events, profile/session indexes, idempotent backfill, and restart-safe analytics rollups
- record completed AppUI and gateway LLM runs with provider/model/base URL, token counts, estimated catalog cost, channel, and profile/session attribution
- expose user/admin usage APIs plus typed dashboard and octos-web clients for accumulated totals
- show persistent profile usage totals in the dashboard profile overview for `/my` and admin profile views
- include rustfmt-only cleanup required by the workspace formatting gate

Closes #321

## Current-main refresh
- Refreshed onto `origin/main` `f6936c452389c5172496ee0c3e13393956086d92`.
- Head: `be6972a4c458c22997324526f0dc09564e95c375`.
- Isolated checkout: `/Users/yuechen/home/octos/target/octos-1376-f693.xDDgXH/octos`.
- Environment: Darwin arm64; `rustc 1.95.0`; `cargo 1.95.0`; Node `v24.10.0`; npm `11.6.0`.
- Refresh conflict resolved only in `crates/octos-cli/src/session_actor.rs`, preserving current-main `AgentVerifierConfig` while keeping the PR's `ConversationResponse` import.

## Validation
- `git status --short --branch` showed a clean isolated checkout at push time.
- `git ls-files --others --exclude-standard` was empty at push time.
- `git diff --check origin/main...HEAD` passed.
- `cargo fmt --all -- --check` passed.
- `typos` on touched files passed.
- `CARGO_TARGET_DIR=/private/tmp/octos-1376-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo build -p octos-cli --features api --bin octos` passed.
- `CARGO_TARGET_DIR=/private/tmp/octos-1376-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api usage -- --nocapture` passed: 8 matching tests passed, including `usage_ledger` and `api::usage` coverage.
- `CARGO_TARGET_DIR=/private/tmp/octos-1376-f693-clippy-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings` passed.
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1376-f693 npm --prefix crates/octos-web ci` installed from the checked-in lockfile.
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1376-f693 npm --prefix crates/octos-web test` passed: 4 files, 40 tests.
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1376-f693 npm --prefix crates/octos-web run typecheck` passed.
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1376-f693 npm --prefix dashboard ci` installed from the checked-in lockfile.
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1376-f693 npm --prefix dashboard run typecheck` passed.
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1376-f693 npm --prefix dashboard test` passed: 6 files, 32 tests.
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1376-f693 npm --prefix dashboard run build` passed; generated embedded admin assets were not tracked.

## CI / merge status
- GitHub CI is green on refreshed head `be6972a4c458c22997324526f0dc09564e95c375`.
- Merge is branch-protection blocked by required review: `reviewDecision=REVIEW_REQUIRED`, `mergeStateStatus=BLOCKED`.

