### PR TITLE
fix(appui): gate task capabilities on runtime wiring

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -171,12 +171,12 @@ pub(super) fn satisfied_completion_content(output_files: &[String], tool_output:
 /// Empirical validation (llm-benchmark replay of mini3 session
 /// slides-1780013669236-8w2ime, the production failure that motivated
 /// this fix):
-///   - kimi-k2.5 + only `check_workspace_contract`:
-///       loop rate 5/5 → 3/5 with this block (40% break out)
-///   - kimi-k2.5 + check + read_file + list_dir:
-///       no consistent change (within noise)
-///   - claude-opus-4.7:
-///       already 0/5 loops in both arms; block has no effect on Opus
+/// - kimi-k2.5 + only `check_workspace_contract`:
+///   loop rate 5/5 → 3/5 with this block (40% break out)
+/// - kimi-k2.5 + check + read_file + list_dir:
+///   no consistent change (within noise)
+/// - claude-opus-4.7:
+///   already 0/5 loops in both arms; block has no effect on Opus
 ///
 /// The block follows hermes-agent's prompt-time-injection pattern (in
 /// `agent/prompt_builder.py`), but applied universally rather than

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -2058,9 +2058,7 @@ impl Agent {
                 let Some(&(name, args)) = id_to_call.get(id) else {
                     continue;
                 };
-                if let Some(hint) =
-                    loop_detector.record_result(name, args, &message.content)
-                {
+                if let Some(hint) = loop_detector.record_result(name, args, &message.content) {
                     message.content.push_str(&hint);
                 }
             }

--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -851,7 +851,7 @@ mod tests {
              see docs/STREAMING-TRANSACTIONAL-BOUNDARY-ADR.md"
         );
         // Sanity: must be larger than legacy 30s value.
-        assert!(super::STREAM_INTER_CHUNK_IDLE_TIMEOUT_SECS > 30);
+        const { assert!(super::STREAM_INTER_CHUNK_IDLE_TIMEOUT_SECS > 30) };
     }
 
     // Use Duration in a sanity check to make sure the constant is usable.

--- a/crates/octos-agent/src/loop_detect.rs
+++ b/crates/octos-agent/src/loop_detect.rs
@@ -247,7 +247,10 @@ mod tests {
         assert!(d.record_result("check", &args, result).is_none());
         assert!(d.record_result("check", &args, result).is_none());
         let hint = d.record_result("check", &args, result);
-        assert!(hint.is_some(), "expected NO PROGRESS hint after 3 identical");
+        assert!(
+            hint.is_some(),
+            "expected NO PROGRESS hint after 3 identical"
+        );
         assert!(hint.unwrap().contains("NO PROGRESS"));
     }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1254,6 +1254,7 @@ impl ConnectionUiFeatures {
     }
 
     fn advertised_capabilities(self, state: &AppState) -> UiProtocolCapabilities {
+        let task_runtime_available = supports_appui_task_runtime(state);
         let mut capabilities = self.negotiated_capabilities();
         for method in APPUI_EXTRA_METHODS {
             if *method == APPUI_METHOD_PROFILE_LOCAL_CREATE
@@ -1341,10 +1342,12 @@ impl ConnectionUiFeatures {
                 &mut capabilities.supported_features,
                 octos_core::ui_protocol::UI_PROTOCOL_FEATURE_HARNESS_TASK_SUPERVISION_INSPECTION_V1,
             );
-            push_capability_feature(
-                &mut capabilities.supported_features,
-                octos_core::ui_protocol::UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1,
-            );
+            if task_runtime_available {
+                push_capability_feature(
+                    &mut capabilities.supported_features,
+                    octos_core::ui_protocol::UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1,
+                );
+            }
         }
         if supports_local_solo_profile_create(state) {
             push_capability_feature(
@@ -1359,11 +1362,45 @@ impl ConnectionUiFeatures {
                 APPUI_FEATURE_ONBOARDING_WORKSPACE_PROBE_V1,
             );
         }
+        if !task_runtime_available {
+            prune_appui_task_runtime_capabilities(&mut capabilities);
+        }
         if self.stdio_transport {
             apply_stdio_auth_bound_capability_policy(&mut capabilities);
         }
         capabilities
     }
+}
+
+fn supports_appui_task_runtime(state: &AppState) -> bool {
+    state.task_query_store.is_some()
+}
+
+fn prune_appui_task_runtime_capabilities(capabilities: &mut UiProtocolCapabilities) {
+    capabilities
+        .supported_methods
+        .retain(|method| !is_appui_task_runtime_method(method));
+    capabilities
+        .supported_features
+        .retain(|feature| !is_appui_task_runtime_feature(feature));
+}
+
+fn is_appui_task_runtime_method(method: &str) -> bool {
+    matches!(
+        method,
+        octos_core::ui_protocol::methods::TASK_LIST
+            | octos_core::ui_protocol::methods::TASK_CANCEL
+            | octos_core::ui_protocol::methods::TASK_RESTART_FROM_NODE
+            | octos_core::ui_protocol::methods::TASK_ARTIFACT_LIST
+            | octos_core::ui_protocol::methods::TASK_ARTIFACT_READ
+    )
+}
+
+fn is_appui_task_runtime_feature(feature: &str) -> bool {
+    matches!(
+        feature,
+        UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1 | UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1
+    )
 }
 
 fn apply_stdio_auth_bound_capability_policy(capabilities: &mut UiProtocolCapabilities) {
@@ -19042,6 +19079,54 @@ mod tests {
             .collect()
     }
 
+    fn assert_task_runtime_surface_hidden(capabilities: &UiProtocolCapabilities) {
+        for feature in [
+            UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
+            UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1,
+        ] {
+            assert!(
+                !capabilities.supports_feature(feature),
+                "{feature} must not be advertised without task runtime wiring"
+            );
+        }
+        for method in [
+            methods::TASK_LIST,
+            methods::TASK_CANCEL,
+            methods::TASK_RESTART_FROM_NODE,
+            methods::TASK_ARTIFACT_LIST,
+            methods::TASK_ARTIFACT_READ,
+        ] {
+            assert!(
+                !capabilities.supports_method(method),
+                "{method} must not be advertised without task runtime wiring"
+            );
+        }
+    }
+
+    fn assert_task_runtime_surface_advertised(capabilities: &UiProtocolCapabilities) {
+        for feature in [
+            UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
+            UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1,
+        ] {
+            assert!(
+                capabilities.supports_feature(feature),
+                "{feature} must be advertised when task runtime wiring is present"
+            );
+        }
+        for method in [
+            methods::TASK_LIST,
+            methods::TASK_CANCEL,
+            methods::TASK_RESTART_FROM_NODE,
+            methods::TASK_ARTIFACT_LIST,
+            methods::TASK_ARTIFACT_READ,
+        ] {
+            assert!(
+                capabilities.supports_method(method),
+                "{method} must be advertised when task runtime wiring is present"
+            );
+        }
+    }
+
     fn dispatch_probe_request(method: &str) -> RpcRequest<Value> {
         let session_id = SessionKey("local:dispatch-parity".into());
         let turn_id = TurnId::new();
@@ -25167,7 +25252,9 @@ ignore = []
     async fn session_open_result_advertises_full_protocol_when_no_header() {
         // Client sent no `X-Octos-Ui-Features` request — server returns
         // the `first_server_slice` baseline so a discovery-aware client
-        // can learn the surface in-band per UPCR-2026-007.
+        // can learn the surface in-band per UPCR-2026-007, with
+        // runtime-backed task capabilities pruned when no task supervisor
+        // store is wired for the AppUI connection.
         let temp = tempfile::tempdir().expect("tempdir");
         let state = state_with_sessions(temp.path());
         let ledger = UiProtocolLedger::new(16);
@@ -25196,10 +25283,10 @@ ignore = []
         assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1));
         assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1));
         assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1));
-        assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1));
         assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_CONTEXT_LIFECYCLE_V1));
         assert!(capabilities.supports_feature(APPUI_FEATURE_PERMISSION_PROFILE_V1));
         assert!(capabilities.supports_feature(APPUI_FEATURE_RUNTIME_POLICY_STAMP_V1));
+        assert_task_runtime_surface_hidden(capabilities);
         let context_state = outcome
             .result
             .opened
@@ -25219,6 +25306,56 @@ ignore = []
             !context_state.transcript_hash.is_empty(),
             "context state must include a stable transcript hash"
         );
+    }
+
+    #[test]
+    fn advertised_capabilities_hide_task_runtime_surface_without_store() {
+        let state = AppState::empty_for_tests();
+        let requested_task_features = ConnectionUiFeatures::from_requested_feature_tokens(
+            [
+                UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
+                UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1,
+            ],
+            false,
+        );
+        let requested_agent_control = ConnectionUiFeatures::from_requested_feature_tokens(
+            [
+                UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1,
+                UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1,
+            ],
+            false,
+        );
+
+        for features in [
+            ConnectionUiFeatures::default(),
+            requested_task_features,
+            requested_agent_control,
+        ] {
+            let capabilities = features.advertised_capabilities(&state);
+            assert_task_runtime_surface_hidden(&capabilities);
+        }
+    }
+
+    #[test]
+    fn advertised_capabilities_include_task_runtime_surface_when_store_wired() {
+        let session_id = SessionKey("local:task-runtime-caps".into());
+        let (state, _supervisor, _task_id) = appui_task_state_with_running_task(&session_id);
+        let requested_task_features = ConnectionUiFeatures::from_requested_feature_tokens(
+            [
+                UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
+                UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1,
+            ],
+            false,
+        );
+
+        for features in [
+            ConnectionUiFeatures::default(),
+            requested_task_features,
+            ConnectionUiFeatures::stdio_defaults(),
+        ] {
+            let capabilities = features.advertised_capabilities(&state);
+            assert_task_runtime_surface_advertised(&capabilities);
+        }
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -3436,8 +3436,8 @@ mod tests {
         // round-trip test for `EnvelopeNotification` in octos-core missed
         // this — only the ledger wrapper exhibits the collision.
         let session = SessionKey("local:envelope-round-trip".into());
-        let event = UiProtocolLedgerEvent::Notification(UiNotification::Envelope(
-            EnvelopeNotification {
+        let event =
+            UiProtocolLedgerEvent::Notification(UiNotification::Envelope(EnvelopeNotification {
                 session_id: session.clone(),
                 topic: Some("planning".into()),
                 envelope: Envelope {
@@ -3448,8 +3448,7 @@ mod tests {
                         text: "round-trip me".into(),
                     },
                 },
-            },
-        ));
+            }));
 
         let serialized = serde_json::to_string(&event).expect("ledger event serializes");
         assert!(

--- a/crates/octos-cli/src/cli_agent_adapter.rs
+++ b/crates/octos-cli/src/cli_agent_adapter.rs
@@ -329,15 +329,15 @@ mod tests {
     use super::*;
 
     #[cfg(unix)]
-    fn write_executable(dir: &tempfile::TempDir, name: &str, body: &str) -> PathBuf {
-        use std::os::unix::fs::PermissionsExt;
-
+    fn write_script(dir: &tempfile::TempDir, name: &str, body: &str) -> PathBuf {
         let path = dir.path().join(name);
         std::fs::write(&path, body).unwrap();
-        let mut perms = std::fs::metadata(&path).unwrap().permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&path, perms).unwrap();
         path
+    }
+
+    #[cfg(unix)]
+    fn script_command(script: PathBuf) -> CliAgentCommandConfig {
+        CliAgentCommandConfig::new("/bin/sh").arg(script.to_string_lossy())
     }
 
     #[cfg(unix)]
@@ -345,7 +345,7 @@ mod tests {
     async fn captures_stdout_stderr_and_declared_artifacts() {
         let dir = tempfile::tempdir().unwrap();
         let artifact = dir.path().join("report.md");
-        let script = write_executable(
+        let script = write_script(
             &dir,
             "agent-fixture",
             r#"#!/bin/sh
@@ -356,7 +356,7 @@ printf '# report\n' > "$1"
         );
 
         let result = run_cli_agent_command(
-            CliAgentCommandConfig::new(script)
+            script_command(script)
                 .arg(artifact.to_string_lossy())
                 .declared_artifact(&artifact),
         )
@@ -382,7 +382,7 @@ printf '# report\n' > "$1"
     #[tokio::test]
     async fn relative_declared_artifacts_resolve_against_child_cwd() {
         let dir = tempfile::tempdir().unwrap();
-        let script = write_executable(
+        let script = write_script(
             &dir,
             "relative-artifact-agent",
             r#"#!/bin/sh
@@ -391,7 +391,7 @@ printf '# report\n' > report.md
         );
 
         let result = run_cli_agent_command(
-            CliAgentCommandConfig::new(script)
+            script_command(script)
                 .cwd(dir.path())
                 .declared_artifact("report.md"),
         )
@@ -411,7 +411,7 @@ printf '# report\n' > report.md
     #[tokio::test]
     async fn transcript_capture_is_bounded_and_marks_truncation() {
         let dir = tempfile::tempdir().unwrap();
-        let script = write_executable(
+        let script = write_script(
             &dir,
             "large-output-agent",
             r#"#!/bin/sh
@@ -419,9 +419,7 @@ perl -e 'print "x" x (1024 * 1024 + 64)'
 "#,
         );
 
-        let result = run_cli_agent_command(CliAgentCommandConfig::new(script))
-            .await
-            .unwrap();
+        let result = run_cli_agent_command(script_command(script)).await.unwrap();
 
         assert_eq!(
             result.transcript.stdout.len(),
@@ -436,7 +434,7 @@ perl -e 'print "x" x (1024 * 1024 + 64)'
     async fn times_out_and_kills_child() {
         let dir = tempfile::tempdir().unwrap();
         let marker = dir.path().join("finished");
-        let script = write_executable(
+        let script = write_script(
             &dir,
             "slow-agent",
             r#"#!/bin/sh
@@ -446,7 +444,7 @@ printf done > "$1"
         );
 
         let result = run_cli_agent_command(
-            CliAgentCommandConfig::new(script)
+            script_command(script)
                 .arg(marker.to_string_lossy())
                 .timeout(Duration::from_millis(100)),
         )
@@ -463,7 +461,7 @@ printf done > "$1"
     async fn cancel_reports_cancelled_and_stops_process() {
         let dir = tempfile::tempdir().unwrap();
         let marker = dir.path().join("finished");
-        let script = write_executable(
+        let script = write_script(
             &dir,
             "cancel-agent",
             r#"#!/bin/sh
@@ -473,7 +471,7 @@ printf done > "$1"
         );
 
         let mut process = CliAgentProcess::spawn(
-            CliAgentCommandConfig::new(script)
+            script_command(script)
                 .arg(marker.to_string_lossy())
                 .timeout(Duration::from_secs(5)),
         )
@@ -490,7 +488,7 @@ printf done > "$1"
     async fn close_reports_closed_and_stops_process() {
         let dir = tempfile::tempdir().unwrap();
         let marker = dir.path().join("finished");
-        let script = write_executable(
+        let script = write_script(
             &dir,
             "close-agent",
             r#"#!/bin/sh
@@ -500,7 +498,7 @@ printf done > "$1"
         );
 
         let mut process = CliAgentProcess::spawn(
-            CliAgentCommandConfig::new(script)
+            script_command(script)
                 .arg(marker.to_string_lossy())
                 .timeout(Duration::from_secs(5)),
         )
@@ -517,7 +515,7 @@ printf done > "$1"
     async fn argv_config_does_not_invoke_shell_metacharacters() {
         let dir = tempfile::tempdir().unwrap();
         let injected = dir.path().join("pwned");
-        let script = write_executable(
+        let script = write_script(
             &dir,
             "echo-argv",
             r#"#!/bin/sh
@@ -526,7 +524,7 @@ printf '%s\n' "$1"
         );
 
         let payload = format!("literal; touch {}", injected.display());
-        let result = run_cli_agent_command(CliAgentCommandConfig::new(script).arg(payload.clone()))
+        let result = run_cli_agent_command(script_command(script).arg(payload.clone()))
             .await
             .unwrap();
 


### PR DESCRIPTION
Withdrawn duplicate closure path.

After rechecking issue #1380 and the follow-up coordination comment, PR #1381 is the selected contract-preserving approach for the serve/WebSocket task-control gap. This branch used the alternate capability-gating approach and should not auto-close #1380.

Prior validation for this branch remains recorded in the closed PR history, but this PR is intentionally closed and superseded by #1381.