### PR TITLE
fix(uploads): close #1377 cross-tenant upload isolation (serve + gateway + slides input-path)

### DIFF
--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -1456,6 +1456,71 @@ fn rescue_workspace_input_existence(
     }
 }
 
+/// Lexically test whether `candidate` stays within `root` after
+/// collapsing `.`/`..` components, WITHOUT touching the filesystem.
+///
+/// Used by the plugin input-path subdir rescue to refuse a
+/// workspace-relative candidate that would climb out of the workspace
+/// root (defence in depth — the caller already rejected raw `..` input,
+/// but the `skill-output/`-stripped form is re-derived and re-checked
+/// here). A `..` that pops above `root` makes the running depth go
+/// negative → not within.
+fn lexically_within(root: &std::path::Path, candidate: &std::path::Path) -> bool {
+    let Ok(rel) = candidate.strip_prefix(root) else {
+        return false; // not even lexically prefixed by root
+    };
+    let mut depth: i32 = 0;
+    for comp in rel.components() {
+        match comp {
+            std::path::Component::ParentDir => {
+                depth -= 1;
+                if depth < 0 {
+                    return false;
+                }
+            }
+            std::path::Component::Normal(_) => depth += 1,
+            // CurDir / RootDir / Prefix: ignore (RootDir/Prefix can't
+            // appear in a relative strip result; CurDir is a no-op).
+            _ => {}
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod subdir_rescue_tests {
+    use super::lexically_within;
+    use std::path::Path;
+
+    #[test]
+    fn lexically_within_accepts_subdir_paths() {
+        let root = Path::new("/ws");
+        assert!(lexically_within(
+            root,
+            Path::new("/ws/slides/deck/script.js")
+        ));
+        assert!(lexically_within(root, Path::new("/ws/file.txt")));
+        assert!(lexically_within(root, Path::new("/ws"))); // root itself
+    }
+
+    #[test]
+    fn lexically_within_rejects_escapes_and_foreign_roots() {
+        let root = Path::new("/ws");
+        // climbs above root
+        assert!(!lexically_within(root, Path::new("/ws/../etc/passwd")));
+        assert!(!lexically_within(root, Path::new("/ws/a/../../etc")));
+        // not under root at all
+        assert!(!lexically_within(root, Path::new("/etc/passwd")));
+    }
+
+    #[test]
+    fn lexically_within_allows_interior_parent_that_stays_within() {
+        let root = Path::new("/ws");
+        // dips into a subdir then back up — net still inside
+        assert!(lexically_within(root, Path::new("/ws/a/b/../c")));
+    }
+}
+
 /// Resolve a plugin tool's input path (`audio_path` / `file_path` /
 /// `input` / `script_path` / `video_path` / `text_path` / per-slide
 /// `source_image`) to an absolute on-disk string.
@@ -1591,6 +1656,72 @@ fn resolve_plugin_input_path(
     // doesn't fix the adversarial race.
     if work_dir.file_name().and_then(|s| s.to_str()) == Some("skill-output") {
         if let Some(parent) = work_dir.parent() {
+            // #1377 slides fix: BEFORE the basename-only rescue, try the
+            // FULL workspace-relative path under the workspace root. The
+            // basename rescue below only finds a file at `<workspace>/
+            // <basename>`, so a SUBDIR-prefixed input like
+            // `slides/<deck>/script.js` (the documented mofa-slides
+            // `input:` form, written by `write_file` against the workspace
+            // ROOT) never resolves — the work_dir is chrooted to
+            // `<workspace>/skill-output/`, so `work_dir.join(raw_path)`
+            // probes `<workspace>/skill-output/slides/...` and misses.
+            // Without this the agent's safe `input:` mode fails with
+            // `os error 2` and it falls back to partial inline `slides`
+            // arrays that overwrite earlier slides (position-based
+            // filenames). Probe `raw_path` and its `skill-output/`-
+            // stripped form against the workspace root, guarded by the
+            // same symlink/regular-file check as the basename rescue PLUS
+            // a lexical-containment check (raw `..` already returned Err
+            // at this fn's entry; this rejects any candidate that still
+            // escapes the workspace root after normalisation).
+            let workspace_root = parent;
+            for rel in [Some(raw_path), stripped.as_deref()].into_iter().flatten() {
+                let candidate = workspace_root.join(rel);
+                // Lexical containment: the normalised candidate must stay
+                // under the workspace root. `lexically_within` collapses
+                // `.`/`..` without touching disk; a candidate that climbs
+                // out (despite the entry `..` guard, e.g. via the stripped
+                // form) is refused.
+                if !lexically_within(workspace_root, &candidate) {
+                    continue;
+                }
+                // Guard 1 (final component): reject if the candidate's LEAF
+                // is a symlink or non-regular file. `symlink_metadata` does
+                // NOT follow the final component, so a `script.js -> …`
+                // symlink at the candidate path is refused regardless of its
+                // target — matching the basename rescue's target-agnostic,
+                // TOCTOU-resistant posture.
+                let leaf_is_regular_file = std::fs::symlink_metadata(&candidate)
+                    .map(|m| m.file_type().is_file())
+                    .unwrap_or(false);
+                if !leaf_is_regular_file {
+                    continue;
+                }
+                // Guard 2 (ancestors — codex round-1 P1): unlike the basename
+                // rescue (single component), this candidate carries SUBDIR
+                // components, so a symlinked ANCESTOR (`<workspace>/slides ->
+                // /etc`) could let `slides/passwd` escape — `symlink_metadata`
+                // above only checks the LEAF, and it traverses symlinked
+                // parents. Canonicalize the full candidate (resolves every
+                // ancestor symlink) and require it to stay under the canonical
+                // workspace root.
+                let (Ok(canon), Ok(canon_root)) = (
+                    std::fs::canonicalize(&candidate),
+                    std::fs::canonicalize(workspace_root),
+                ) else {
+                    continue;
+                };
+                if !canon.starts_with(&canon_root) {
+                    continue; // a symlinked ancestor escaped the workspace
+                }
+                // Both guards passed: return the LEXICAL candidate (not
+                // `canon`). Containment is proven, so the lexical path names
+                // the same in-workspace file, and the legacy resolver
+                // contract is to return the workspace-relative lexical form
+                // (callers/tests rely on it; canonicalize would also rewrite
+                // macOS `/var`->`/private/var`).
+                return Ok(candidate.to_string_lossy().into_owned());
+            }
             if let Some(basename) = std::path::Path::new(raw_path).file_name() {
                 let candidate = parent.join(basename);
                 // Reject symlinks AND non-regular files (directories,
@@ -3310,6 +3441,60 @@ mod tests {
         );
         // Defense in depth.
         let _ = bait;
+    }
+
+    #[test]
+    fn subdir_rescue_resolves_workspace_relative_script() {
+        // #1377 slides fix: a SUBDIR-prefixed input (`slides/<deck>/script.js`)
+        // written at the workspace ROOT must resolve when work_dir is
+        // chrooted to `<workspace>/skill-output/`. Before the fix only the
+        // basename was probed at the root, so this missed and the agent fell
+        // back to the overwrite-prone inline-array mode.
+        let workspace = tempfile::tempdir().unwrap();
+        let skill_output = workspace.path().join("skill-output");
+        std::fs::create_dir_all(&skill_output).unwrap();
+        let deck_dir = workspace.path().join("slides").join("deck");
+        std::fs::create_dir_all(&deck_dir).unwrap();
+        let script = deck_dir.join("script.js");
+        std::fs::write(&script, "module.exports = []").unwrap();
+
+        let resolved = resolve_plugin_input_path("slides/deck/script.js", &skill_output)
+            .expect("subdir-prefixed workspace-relative input must resolve");
+        assert_eq!(
+            std::fs::canonicalize(&resolved).unwrap(),
+            std::fs::canonicalize(&script).unwrap(),
+            "must resolve to the real workspace-root script",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn subdir_rescue_rejects_symlinked_ancestor_escape() {
+        // Codex round-1 P1: the full-path rescue carries SUBDIR components,
+        // so a symlinked ANCESTOR (`<workspace>/slides -> /etc`) could let
+        // `slides/passwd` escape — `symlink_metadata` only checks the final
+        // component. The canonical-containment guard must reject it.
+        let workspace = tempfile::tempdir().unwrap();
+        let skill_output = workspace.path().join("skill-output");
+        std::fs::create_dir_all(&skill_output).unwrap();
+        // `<workspace>/slides` is a symlink to /etc (an ancestor of the input).
+        let bait_dir = workspace.path().join("slides");
+        std::os::unix::fs::symlink("/etc", &bait_dir).unwrap();
+
+        let resolved = resolve_plugin_input_path("slides/passwd", &skill_output)
+            .expect("resolver still returns a (contained) fallback path, not the escape");
+        let resolved_path = std::path::Path::new(&resolved);
+        assert!(
+            !resolved_path.starts_with("/etc"),
+            "rescue must not resolve through a symlinked ancestor into /etc: {resolved}",
+        );
+        // Falls through to a contained path (skill-output basename join, or
+        // the lexical fallback) — never the escaped /etc/passwd.
+        assert!(
+            resolved_path.starts_with(workspace.path()),
+            "resolved path must stay within the workspace: {resolved}",
+        );
+        let _ = bait_dir;
     }
 
     #[cfg(unix)]

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -892,6 +892,23 @@ fn resolve_for_scope(
     // `SessionScope` does not currently expose; tracked as a follow-up
     // (issue #1367).
     if user_path.starts_with("up/") {
+        // #1377 tenant isolation: in a multi-tenant (scoped) session, uploads
+        // are materialized into `<workspace>/uploads/` at turn start and read
+        // by that workspace path. Refuse global `up/` handle resolution here so
+        // a scoped session cannot reach the process-global upload tmpdir (and
+        // thus another tenant's uploads) by handle. Solo sessions (CLI
+        // `octos chat`) keep resolving handles for back-compat.
+        if scope.tenant_id().is_some()
+            && matches!(
+                octos_bus::file_handle::decode_file_handle(user_path),
+                Some(octos_bus::file_handle::FileHandleScope::TempUpload(_))
+            )
+        {
+            return Err(
+                "Uploaded file not found; uploaded files are under uploads/ — \
+                 read with read_file(\"uploads/<name>\")",
+            );
+        }
         match octos_bus::file_handle::resolve_tool_path(scope.workspace(), None, user_path) {
             Ok(resolved)
                 if resolved.scope == octos_bus::file_handle::ToolPathScope::UploadTmpdir =>
@@ -1640,6 +1657,43 @@ mod path_tests {
             resolve_path_for_session_scope_write(&scope, &handle).is_err(),
             "write to a missing upload handle must error"
         );
+    }
+
+    /// #1377 tenant isolation: a multi-tenant (scoped) session must NOT resolve
+    /// a global `up/` upload handle — uploads are materialized into `uploads/`
+    /// and read by that workspace path. (Solo sessions keep resolving handles;
+    /// covered by `scoped_session_resolves_upload_handle_to_tmpdir_not_workspace`.)
+    #[test]
+    fn multi_tenant_session_refuses_global_up_handle_but_reads_uploads_dir() {
+        let data = tempfile::tempdir().expect("profile data dir");
+        let scope = SessionScope::multi_tenant_with_default_zones(
+            data.path().to_path_buf(),
+            "tenant-a".into(),
+            "web-x".into(),
+        )
+        .unwrap();
+        // Create the workspace so canonicalize is firmlink-consistent on macOS.
+        std::fs::create_dir_all(scope.workspace()).unwrap();
+
+        // A valid up/ handle (which a solo session WOULD resolve under the
+        // global tmpdir) is refused for a multi-tenant session.
+        let upload_root = octos_bus::file_handle::temp_upload_root();
+        std::fs::create_dir_all(&upload_root).unwrap();
+        let uploaded = upload_root.join(format!("mt-{}-secret.md", std::process::id()));
+        std::fs::write(&uploaded, b"tenant secret\n").unwrap();
+        let handle =
+            octos_bus::file_handle::encode_tmp_upload_handle(&uploaded, Some("secret.md")).unwrap();
+        let resolved = resolve_path_for_session_scope_read(&scope, &handle);
+        let _ = std::fs::remove_file(&uploaded);
+        assert!(
+            resolved.is_err(),
+            "a multi-tenant session must refuse a global up/ handle, got {resolved:?}"
+        );
+
+        // ...but the materialized workspace path resolves InWorkspace.
+        let ok = resolve_path_for_session_scope_read(&scope, "uploads/secret.md")
+            .expect("uploads/<name> must resolve in the workspace");
+        assert!(ok.starts_with(scope.workspace().join("uploads")));
     }
 
     /// Interim guard (#1378): the upload-handle namespace is detected for

--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -2488,9 +2488,68 @@ async fn handle_file_download(
     }
 }
 
+/// Query params for `POST /upload`. `target_profile_id` lets a cross-profile
+/// routing client stamp the upload with the same tenant it will route the
+/// subsequent `/chat` to (#1377 codex round-5 P2); absent for the common
+/// single-profile case.
+#[derive(Debug, Default, serde::Deserialize)]
+struct UploadQuery {
+    #[serde(default)]
+    target_profile_id: Option<String>,
+}
+
 /// POST /upload — upload files for use in chat media field.
-async fn handle_upload(mut multipart: axum::extract::Multipart) -> Response {
-    let upload_dir = std::env::temp_dir().join("octos-uploads");
+///
+/// #1377: stores uploads under `octos-uploads/<tenant>/<name>` where the
+/// tenant is the gateway's resolved profile (the same layout the `octos serve`
+/// handler uses), so the resolved `up/` handle carries the owning tenant and
+/// the cross-tenant ownership gate (`upload_owned_by_tenant`) can enforce
+/// isolation. A gateway with no profile (single-tenant / main) stores flat,
+/// preserving the previous behaviour.
+async fn handle_upload(
+    State(state): State<ApiState>,
+    axum::extract::Query(query): axum::extract::Query<UploadQuery>,
+    mut multipart: axum::extract::Multipart,
+) -> Response {
+    let upload_root = std::env::temp_dir().join("octos-uploads");
+    // #1377: stamp the upload with the OWNING tenant so the resolved handle
+    // matches what the subsequent `/chat` filters against. When the client
+    // routes cross-profile it passes `?target_profile_id=<p>` (the same value
+    // it sends on `/chat`); otherwise fall back to the gateway's own profile,
+    // then to `_main` (codex round-7 P1: a gateway is a multi-tenant context,
+    // so uploads are ALWAYS tenant-stamped — never flat — otherwise the
+    // main/admin route would accept any tenant's handles). The target is
+    // charset-guarded (lowercase alnum + `-`, the profile-id alphabet) so it
+    // cannot inject a path component or `..`; an invalid/empty value falls
+    // back to the gateway profile / `_main`.
+    let tenant = query
+        .target_profile_id
+        .as_deref()
+        .filter(|t| {
+            !t.is_empty()
+                && t.bytes()
+                    .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+        })
+        .map(str::to_string)
+        .or_else(|| state.profile_id.clone())
+        .unwrap_or_else(|| octos_core::MAIN_PROFILE_ID.to_string());
+    let upload_dir = upload_root.join(&tenant);
+    // codex round-7 P2: a LEGACY flat upload named exactly like a profile id
+    // (`octos-uploads/<tenant>`) would block `create_dir_all` and 500 every
+    // upload for that tenant. Such a flat file is a pre-migration artifact in
+    // the ephemeral temp dir that the new layout treats as un-owned (dropped
+    // by the filter) anyway, so clear it to make room for the tenant dir.
+    if tokio::fs::metadata(&upload_dir)
+        .await
+        .map(|m| m.is_file())
+        .unwrap_or(false)
+    {
+        warn!(
+            tenant = %tenant,
+            "removing legacy flat upload colliding with tenant directory"
+        );
+        let _ = tokio::fs::remove_file(&upload_dir).await;
+    }
     if let Err(e) = tokio::fs::create_dir_all(&upload_dir).await {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -2452,6 +2452,36 @@ async fn handle_file_download(
         return (StatusCode::FORBIDDEN, "access denied").into_response();
     };
 
+    // #1377 (codex pre-merge P1): the download route resolves `up/` handles
+    // against the PROCESS-GLOBAL upload root, so without an ownership check a
+    // leaked/guessable `up/<other-tenant>/...` handle would let one tenant
+    // download another's upload — the download-side twin of the upload-in gap
+    // this PR closes.
+    //
+    // AUTHZ uses ONLY the server-trusted gateway tenant (`state.profile_id`,
+    // fixed at startup), NEVER a request-supplied value. The gateway HTTP
+    // layer has no per-request tenant authentication, so trusting a
+    // `?target_profile_id` here would let an attacker name the foreign tenant
+    // and pass the check (codex pre-merge P1 round-2). `_main` fallback keeps
+    // a no-profile gateway gated (never None -> never skipped).
+    //
+    // Consequence: a cross-profile-ROUTED upload (stamped with a
+    // `target_profile_id` other than the gateway profile) is NOT downloadable
+    // through this raw `up/` route — the gateway cannot authenticate the
+    // caller as that tenant, so it must refuse. The agent still reaches such a
+    // file via the materialized workspace copy (`uploads/<name>`); only the
+    // un-authenticatable raw-handle download is closed. Workspace/profile
+    // files (not under the upload root) are unaffected.
+    if crate::file_handle::is_under_upload_root(&canonical) {
+        let tenant = state
+            .profile_id
+            .clone()
+            .unwrap_or_else(|| octos_core::MAIN_PROFILE_ID.to_string());
+        if !crate::file_handle::upload_owned_by_tenant(&canonical, Some(&tenant)) {
+            return (StatusCode::FORBIDDEN, "access denied").into_response();
+        }
+    }
+
     match tokio::fs::read(&canonical).await {
         Ok(bytes) => {
             let filename = canonical
@@ -2498,6 +2528,29 @@ struct UploadQuery {
     target_profile_id: Option<String>,
 }
 
+/// The effective OWNING tenant an `/upload` is STAMPED with (#1377): a
+/// charset-guarded `?target_profile_id` (cross-profile routing), else the
+/// gateway's own profile, else `_main`. NEVER `None`.
+///
+/// NOTE: this is the UPLOAD-STAMP tenant, used only for where to STORE the
+/// file. It is NOT an authorization signal — `target_profile_id` is
+/// request-supplied. The `/files` download gate authorizes against the
+/// server-trusted `state.profile_id` ONLY (see `handle_file_download`).
+fn effective_upload_tenant(
+    target_profile_id: Option<&str>,
+    gateway_profile_id: Option<&str>,
+) -> String {
+    target_profile_id
+        .filter(|t| {
+            !t.is_empty()
+                && t.bytes()
+                    .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+        })
+        .map(str::to_string)
+        .or_else(|| gateway_profile_id.map(str::to_string))
+        .unwrap_or_else(|| octos_core::MAIN_PROFILE_ID.to_string())
+}
+
 /// POST /upload — upload files for use in chat media field.
 ///
 /// #1377: stores uploads under `octos-uploads/<tenant>/<name>` where the
@@ -2522,17 +2575,10 @@ async fn handle_upload(
     // charset-guarded (lowercase alnum + `-`, the profile-id alphabet) so it
     // cannot inject a path component or `..`; an invalid/empty value falls
     // back to the gateway profile / `_main`.
-    let tenant = query
-        .target_profile_id
-        .as_deref()
-        .filter(|t| {
-            !t.is_empty()
-                && t.bytes()
-                    .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
-        })
-        .map(str::to_string)
-        .or_else(|| state.profile_id.clone())
-        .unwrap_or_else(|| octos_core::MAIN_PROFILE_ID.to_string());
+    let tenant = effective_upload_tenant(
+        query.target_profile_id.as_deref(),
+        state.profile_id.as_deref(),
+    );
     let upload_dir = upload_root.join(&tenant);
     // codex round-7 P2: a LEGACY flat upload named exactly like a profile id
     // (`octos-uploads/<tenant>`) would block `create_dir_all` and 500 every
@@ -2751,6 +2797,38 @@ mod tests {
     use axum::http::Request;
     use std::path::Path;
     use tower::util::ServiceExt;
+
+    #[test]
+    fn effective_upload_tenant_is_never_none_and_matches_upload_stamp() {
+        // Cross-profile target (charset-valid) wins.
+        assert_eq!(
+            effective_upload_tenant(Some("dspfac--lbc-bot"), Some("dspfac")),
+            "dspfac--lbc-bot"
+        );
+        // Invalid target (path-injection / uppercase / empty) is ignored,
+        // falls back to the gateway profile.
+        assert_eq!(
+            effective_upload_tenant(Some("../etc"), Some("dspfac")),
+            "dspfac"
+        );
+        assert_eq!(effective_upload_tenant(Some(""), Some("dspfac")), "dspfac");
+        assert_eq!(
+            effective_upload_tenant(Some("Dspfac"), Some("dspfac")),
+            "dspfac"
+        );
+        // No target -> gateway profile.
+        assert_eq!(effective_upload_tenant(None, Some("dspfac")), "dspfac");
+        // No target AND no gateway profile (main/admin gateway) -> `_main`,
+        // NEVER None — so the download gate actually fires (codex pre-merge P1).
+        assert_eq!(
+            effective_upload_tenant(None, None),
+            octos_core::MAIN_PROFILE_ID
+        );
+        assert_eq!(
+            effective_upload_tenant(Some(""), None),
+            octos_core::MAIN_PROFILE_ID
+        );
+    }
 
     const TEST_PROFILE_ID: &str = "dspfac";
 

--- a/crates/octos-bus/src/file_handle.rs
+++ b/crates/octos-bus/src/file_handle.rs
@@ -535,6 +535,15 @@ enum MaterializeOutcome {
 /// Callers pass a path that is ALREADY resolved (e.g. via
 /// [`resolve_upload_reference`]); a path outside the upload root yields `false`
 /// for a multi-tenant caller, so non-upload paths must be screened separately.
+/// Whether a RESOLVED path lives under the process-global upload tmpdir
+/// root (`octos-uploads`). Callers use this to decide whether the tenant
+/// ownership rule ([`upload_owned_by_tenant`]) even applies: a workspace or
+/// profile file is NOT under the upload root and must not be subjected to
+/// the upload-ownership check (it would be falsely denied).
+pub fn is_under_upload_root(resolved: &Path) -> bool {
+    resolved.starts_with(canonical_root(&temp_upload_root()))
+}
+
 pub fn upload_owned_by_tenant(resolved: &Path, tenant_id: Option<&str>) -> bool {
     let Some(tenant) = tenant_id else {
         return true; // single-tenant: ownership check does not apply
@@ -705,6 +714,21 @@ mod tests {
             out_b[0]
         );
         assert!(ws_b.path().join(&out_b[0]).is_file());
+    }
+
+    #[test]
+    fn is_under_upload_root_distinguishes_upload_from_other_paths() {
+        let root = canonical_root(&temp_upload_root());
+        // Upload-root paths (any tenant / flat) are "under" the root — the
+        // download gate then applies the ownership check to these.
+        assert!(is_under_upload_root(&root.join("dspfac/uuid_doc.md")));
+        assert!(is_under_upload_root(&root.join("flat.md")));
+        // Workspace / profile / external paths are NOT under the upload root,
+        // so the download gate leaves them alone (no false denial).
+        assert!(!is_under_upload_root(std::path::Path::new(
+            "/some/profile/data/users/web-1/workspace/out.pptx"
+        )));
+        assert!(!is_under_upload_root(std::path::Path::new("/etc/passwd")));
     }
 
     #[test]

--- a/crates/octos-bus/src/file_handle.rs
+++ b/crates/octos-bus/src/file_handle.rs
@@ -450,9 +450,347 @@ fn sanitize_display_name(name: &str) -> String {
     }
 }
 
+/// Materialize turn-attached upload references into `<workspace>/uploads/` so
+/// they become first-class, browsable session files (#1377). Returns the media
+/// list rewritten for the model and for persistence:
+///
+/// - A **non-image** upload handle / tmpdir reference is COPIED into
+///   `<workspace>/uploads/<name>` and rewritten to the workspace-relative
+///   string `uploads/<name>`, so `read_file`/`grep`/`list_dir`/`glob` all work
+///   by normal filesystem semantics — and global `up/` resolution can be
+///   refused for scoped sessions (tenant isolation) without losing access.
+/// - **Images** pass through UNCHANGED: they're consumed by the vision encoder
+///   via `std::fs::read` on their path (never via `read_file`), so the model
+///   never browses them and materializing would only risk the vision path.
+///   (Image materialization is a tracked follow-up.)
+/// - Anything that does NOT resolve to a staged upload — an already
+///   workspace-relative path (e.g. a re-referenced prior-turn `uploads/x`) or
+///   an unknown string — is passed through unchanged (idempotent across turns).
+///
+/// Copy is collision-safe (`uploads/<uuid>-<name>` on a name clash; never
+/// overwrites), symlink-safe (refuses a symlinked `uploads/` dir or an existing
+/// `uploads/<name>` entry), and atomic (temp file + rename). The source has
+/// already been canonicalized under the upload tmpdir by
+/// `resolve_upload_reference`, so symlink escapes on the source are excluded.
+/// The original (sanitized) display name from an `up/<base64>/<display>`
+/// handle, if present. `None` for the 2-segment `up/<base64>` form or a
+/// non-handle string. base64 uses URL-safe alphabet (no `/`), so the display is
+/// the segment after the second `/`.
+fn handle_display_name(entry: &str) -> Option<String> {
+    let display = entry.strip_prefix("up/")?.split_once('/')?.1;
+    if display.is_empty() {
+        return None;
+    }
+    Some(sanitize_display_name(display))
+}
+
+pub fn materialize_turn_uploads(
+    workspace_root: &Path,
+    tenant_id: Option<&str>,
+    media: &[String],
+) -> Vec<String> {
+    let uploads_dir = workspace_root.join("uploads");
+    media
+        .iter()
+        .filter_map(
+            |entry| match materialize_one(&uploads_dir, tenant_id, entry) {
+                MaterializeOutcome::Rewritten(path) => Some(path),
+                MaterializeOutcome::Passthrough => Some(entry.clone()),
+                // Foreign / cross-tenant: DROP the entry entirely. Passing the
+                // original handle through would let a no-`SessionScope` session
+                // (profile-qualified / cwd-hinted) read it via the legacy
+                // `resolve_path` fallback, bypassing the tenant gate (codex P1).
+                MaterializeOutcome::DropForeign => None,
+            },
+        )
+        .collect()
+}
+
+enum MaterializeOutcome {
+    /// Copied into the workspace; use this `uploads/<name>` path.
+    Rewritten(String),
+    /// Not a staged upload to rewrite (image / already-workspace / unknown /
+    /// I/O refusal) — keep the original media string unchanged.
+    Passthrough,
+    /// A staged upload owned by ANOTHER tenant — remove it from the media set.
+    DropForeign,
+}
+
+/// Copy one upload reference into `uploads_dir`. See [`MaterializeOutcome`].
+fn materialize_one(uploads_dir: &Path, tenant_id: Option<&str>, entry: &str) -> MaterializeOutcome {
+    let Some(src) = resolve_upload_reference(entry) else {
+        return MaterializeOutcome::Passthrough; // not a staged upload (workspace path / external / unknown)
+    };
+
+    // #1377 tenant isolation: uploads are stored under
+    // `octos-uploads/<tenant>/<uuid>_<name>`, so the FIRST path component of the
+    // resolved file (relative to the upload root) is the owning tenant. In a
+    // multi-tenant session only keep a file owned by THIS tenant; a file owned by
+    // another tenant — whether referenced by `up/` handle, a raw absolute/relative
+    // tmpdir path, OR an image path (which would otherwise reach the vision
+    // encoder via std::fs::read) — is DROPPED. Checking the RESOLVED path covers
+    // ALL of these (codex round-6 P1.3 + round-7 image P1). A flat legacy file
+    // (no tenant component) is also dropped. Solo sessions (`tenant_id == None`,
+    // CLI `octos chat`) skip the check (single-tenant).
+    if let Some(tenant) = tenant_id {
+        let owned = src
+            .strip_prefix(canonical_root(&temp_upload_root()))
+            .ok()
+            .and_then(|rel| rel.components().next())
+            .map(|c| matches!(c, Component::Normal(s) if s.to_str() == Some(tenant)))
+            .unwrap_or(false);
+        if !owned {
+            return MaterializeOutcome::DropForeign;
+        }
+    }
+
+    // Owned image: keep it on the vision path (the encoder reads it directly via
+    // std::fs::read) — don't copy into `uploads/`. Rewrite to the resolved
+    // ABSOLUTE path so the encoder can read it (a bare `up/` handle isn't a real
+    // file path). A non-tmpdir image (workspace/external) already returned
+    // Passthrough above via `resolve_upload_reference` == None.
+    if crate::media::is_image(entry) {
+        return match src.to_str() {
+            Some(abs) => MaterializeOutcome::Rewritten(abs.to_string()),
+            None => MaterializeOutcome::Passthrough,
+        };
+    }
+
+    // From here the file is OWNED by this tenant (or solo) — an I/O refusal
+    // returns Passthrough (keep the original handle; never re-expose a foreign
+    // file, which was already DropForeign'd above).
+    // Never write through a symlinked `uploads/` directory.
+    if let Ok(meta) = std::fs::symlink_metadata(uploads_dir) {
+        if meta.file_type().is_symlink() {
+            return MaterializeOutcome::Passthrough;
+        }
+    }
+    if std::fs::create_dir_all(uploads_dir).is_err() {
+        return MaterializeOutcome::Passthrough;
+    }
+
+    // Prefer the original display name carried in the `up/<base64>/<display>`
+    // handle — the upload endpoint stores the file on disk as `<uuid>_<name>`,
+    // so `src.file_name()` would leak the uuid into the workspace path the model
+    // sees. Fall back to the source basename for non-handle references.
+    let base = handle_display_name(entry).unwrap_or_else(|| {
+        sanitize_display_name(src.file_name().and_then(|n| n.to_str()).unwrap_or("file"))
+    });
+    // Stage the bytes in a private temp file, then publish via `hard_link`,
+    // which is atomic AND fails (rather than replacing, the way `rename` does)
+    // if the destination already exists. This makes concurrent turns
+    // materializing the same display name safe: at most one wins each name; the
+    // loser observes `AlreadyExists` and falls back to a uuid-prefixed name. A
+    // bare existence pre-check + `rename` would let two turns both pick
+    // `uploads/<name>` and clobber each other (codex #1377 P2).
+    let tmp = uploads_dir.join(format!(".{}.{base}.tmp", uuid::Uuid::now_v7()));
+    if std::fs::copy(&src, &tmp).is_err() {
+        return MaterializeOutcome::Passthrough;
+    }
+    let published = {
+        let first = uploads_dir.join(&base);
+        match std::fs::hard_link(&tmp, &first) {
+            Ok(()) => Some(base.clone()),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                let unique = format!("{}-{base}", uuid::Uuid::now_v7());
+                std::fs::hard_link(&tmp, uploads_dir.join(&unique))
+                    .ok()
+                    .map(|()| unique)
+            }
+            Err(_) => None,
+        }
+    };
+    let _ = std::fs::remove_file(&tmp);
+    match published {
+        Some(name) => MaterializeOutcome::Rewritten(format!("uploads/{name}")),
+        None => MaterializeOutcome::Passthrough,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Create a real file under the upload tmpdir (flat, legacy layout) and
+    /// return its `up/` handle.
+    fn stage_upload(name: &str, body: &[u8]) -> (PathBuf, String) {
+        let root = temp_upload_root();
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join(format!("{}_{name}", uuid::Uuid::now_v7()));
+        std::fs::write(&path, body).unwrap();
+        let handle = encode_tmp_upload_handle(&path, Some(name)).expect("encode handle");
+        (path, handle)
+    }
+
+    /// Create a real file under the per-tenant upload layout
+    /// (`octos-uploads/<tenant>/<uuid>_<name>`) and return its `up/` handle
+    /// (whose decoded relative path therefore begins with `<tenant>`).
+    fn stage_tenant_upload(tenant: &str, name: &str, body: &[u8]) -> (PathBuf, String) {
+        let dir = temp_upload_root().join(tenant);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(format!("{}_{name}", uuid::Uuid::now_v7()));
+        std::fs::write(&path, body).unwrap();
+        let handle = encode_tmp_upload_handle(&path, Some(name)).expect("encode handle");
+        (path, handle)
+    }
+
+    #[test]
+    fn materialize_matching_tenant_materializes_mismatch_and_flat_dropped() {
+        let ws = tempfile::tempdir().unwrap();
+        let (_a, h_a) = stage_tenant_upload("tenant-a", "owned.md", b"mine");
+        let (_b, h_b) = stage_tenant_upload("tenant-b", "foreign.md", b"theirs");
+        let (_f, h_flat) = stage_upload("legacy.md", b"flat");
+
+        // Session belongs to tenant-a.
+        let out = materialize_turn_uploads(ws.path(), Some("tenant-a"), &[h_a, h_b, h_flat]);
+
+        // tenant-a's own upload → materialized; the others (another tenant + a
+        // flat legacy handle) → DROPPED entirely (removed from the media set,
+        // not passed through — so a no-scope session can't reach them via the
+        // legacy resolver), and never copied into the workspace.
+        assert_eq!(out, vec!["uploads/owned.md".to_string()]);
+        assert!(ws.path().join("uploads/owned.md").is_file());
+        assert!(!ws.path().join("uploads/foreign.md").exists());
+        assert!(!ws.path().join("uploads/legacy.md").exists());
+    }
+
+    #[test]
+    fn materialize_rejects_raw_tmpdir_path_bypass() {
+        // codex round-5 P1.3: a client can submit a raw absolute path under
+        // another tenant's upload dir (NOT an up/ handle, so decode returns
+        // None). The check on the RESOLVED path must still drop it.
+        let ws = tempfile::tempdir().unwrap();
+        let (abs_src, _handle) = stage_tenant_upload("tenant-b", "secret.md", b"theirs");
+        let raw_abs = abs_src.to_string_lossy().into_owned();
+
+        let out = materialize_turn_uploads(ws.path(), Some("tenant-a"), &[raw_abs.clone()]);
+        assert!(
+            out.is_empty(),
+            "raw cross-tenant tmpdir path must be DROPPED, got: {out:?}"
+        );
+        assert!(!ws.path().join("uploads/secret.md").exists());
+
+        // The owner (tenant-b) CAN materialize the same raw path. (A raw path
+        // carries no `up/` display name, so the workspace copy keeps the on-disk
+        // `<uuid>_secret.md` basename — that's fine; the point is it materializes.)
+        let ws_b = tempfile::tempdir().unwrap();
+        let out_b = materialize_turn_uploads(ws_b.path(), Some("tenant-b"), &[raw_abs]);
+        assert!(
+            out_b[0].starts_with("uploads/") && out_b[0].ends_with("secret.md"),
+            "owner's raw path should materialize, got: {}",
+            out_b[0]
+        );
+        assert!(ws_b.path().join(&out_b[0]).is_file());
+    }
+
+    #[test]
+    fn materialize_solo_session_ignores_tenant_check() {
+        // tenant_id == None (CLI `octos chat`): no tenant gate — a flat handle
+        // still materializes (back-compat).
+        let ws = tempfile::tempdir().unwrap();
+        let (_f, h_flat) = stage_upload("notes.md", b"solo");
+        let out = materialize_turn_uploads(ws.path(), None, std::slice::from_ref(&h_flat));
+        assert_eq!(out[0], "uploads/notes.md");
+        assert!(ws.path().join("uploads/notes.md").is_file());
+    }
+
+    #[test]
+    fn materialize_copies_non_image_upload_into_workspace_uploads() {
+        let ws = tempfile::tempdir().unwrap();
+        let (src, handle) = stage_upload("report.md", b"# strategy\n");
+
+        let out = materialize_turn_uploads(ws.path(), None, &[handle]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0], "uploads/report.md", "rewritten to workspace path");
+        let dest = ws.path().join("uploads/report.md");
+        assert!(dest.is_file(), "file copied into <workspace>/uploads/");
+        assert_eq!(std::fs::read(&dest).unwrap(), b"# strategy\n");
+        let _ = std::fs::remove_file(&src);
+    }
+
+    #[test]
+    fn materialize_keeps_owned_image_on_vision_path_as_absolute() {
+        let ws = tempfile::tempdir().unwrap();
+        let (src, handle) = stage_upload("photo.png", b"\x89PNG\r\n");
+        // Solo (no tenant): image is NOT copied into uploads/, but is rewritten
+        // to its resolved ABSOLUTE path so the vision encoder can `std::fs::read`
+        // it (a bare `up/` handle isn't a real file path).
+        let out = materialize_turn_uploads(ws.path(), None, std::slice::from_ref(&handle));
+        assert_eq!(
+            out[0],
+            std::fs::canonicalize(&src).unwrap().to_string_lossy(),
+            "owned image → resolved absolute path"
+        );
+        assert!(
+            !ws.path().join("uploads").exists(),
+            "no uploads/ dir created for an image-only turn"
+        );
+        let _ = std::fs::remove_file(&src);
+    }
+
+    #[test]
+    fn materialize_drops_foreign_image() {
+        // codex round-7 P1: a raw image path under ANOTHER tenant's upload dir
+        // must be DROPPED, not passed through to the vision encoder.
+        let ws = tempfile::tempdir().unwrap();
+        let (src, _h) = stage_tenant_upload("tenant-b", "secret.png", b"\x89PNG\r\n");
+        let raw_abs = src.to_string_lossy().into_owned();
+        let out = materialize_turn_uploads(ws.path(), Some("tenant-a"), &[raw_abs]);
+        assert!(
+            out.is_empty(),
+            "foreign image must be dropped, got: {out:?}"
+        );
+        let _ = std::fs::remove_file(&src);
+    }
+
+    #[test]
+    fn materialize_passes_through_non_upload_paths() {
+        let ws = tempfile::tempdir().unwrap();
+        // Already a workspace-relative path (e.g. a re-referenced prior turn) —
+        // resolve_upload_reference returns None → passthrough (idempotent).
+        let out = materialize_turn_uploads(
+            ws.path(),
+            None,
+            &["uploads/report.md".to_string(), "notes.txt".to_string()],
+        );
+        assert_eq!(out, vec!["uploads/report.md", "notes.txt"]);
+    }
+
+    #[test]
+    fn materialize_never_overwrites_on_name_collision() {
+        let ws = tempfile::tempdir().unwrap();
+        let (s1, h1) = stage_upload("dup.md", b"first");
+        let (s2, h2) = stage_upload("dup.md", b"second");
+        let out = materialize_turn_uploads(ws.path(), None, &[h1, h2]);
+        assert_eq!(out[0], "uploads/dup.md");
+        assert_ne!(out[1], "uploads/dup.md", "collision gets a unique suffix");
+        assert!(out[1].starts_with("uploads/") && out[1].ends_with("-dup.md"));
+        // Both files exist with their own content (no clobber).
+        assert_eq!(std::fs::read(ws.path().join(&out[0])).unwrap(), b"first");
+        assert_eq!(std::fs::read(ws.path().join(&out[1])).unwrap(), b"second");
+        let _ = std::fs::remove_file(&s1);
+        let _ = std::fs::remove_file(&s2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn materialize_refuses_symlinked_uploads_dir() {
+        let ws = tempfile::tempdir().unwrap();
+        let elsewhere = tempfile::tempdir().unwrap();
+        // `uploads` is a symlink pointing outside the workspace.
+        std::os::unix::fs::symlink(elsewhere.path(), ws.path().join("uploads")).unwrap();
+        let (src, handle) = stage_upload("x.md", b"data");
+        let out = materialize_turn_uploads(ws.path(), None, std::slice::from_ref(&handle));
+        assert_eq!(
+            out[0], handle,
+            "must NOT write through a symlinked uploads/ dir"
+        );
+        assert!(
+            !elsewhere.path().join("x.md").exists(),
+            "no file written through the symlink"
+        );
+        let _ = std::fs::remove_file(&src);
+    }
 
     #[test]
     fn profile_handle_round_trips() {

--- a/crates/octos-bus/src/file_handle.rs
+++ b/crates/octos-bus/src/file_handle.rs
@@ -696,7 +696,8 @@ mod tests {
         let (abs_src, _handle) = stage_tenant_upload("tenant-b", "secret.md", b"theirs");
         let raw_abs = abs_src.to_string_lossy().into_owned();
 
-        let out = materialize_turn_uploads(ws.path(), Some("tenant-a"), &[raw_abs.clone()]);
+        let out =
+            materialize_turn_uploads(ws.path(), Some("tenant-a"), std::slice::from_ref(&raw_abs));
         assert!(
             out.is_empty(),
             "raw cross-tenant tmpdir path must be DROPPED, got: {out:?}"

--- a/crates/octos-bus/src/file_handle.rs
+++ b/crates/octos-bus/src/file_handle.rs
@@ -517,31 +517,55 @@ enum MaterializeOutcome {
 }
 
 /// Copy one upload reference into `uploads_dir`. See [`MaterializeOutcome`].
+/// Whether a RESOLVED upload-tmpdir path is owned by `tenant_id`.
+///
+/// Uploads are stored as `octos-uploads/<tenant>/<uuid>_<name>`, so the FIRST
+/// path component of the resolved file (relative to the canonical upload root)
+/// is the owning tenant. This is the single tenant-ownership predicate shared by
+/// every upload-into-workspace path so the isolation rule cannot drift between
+/// them (the serve `materialize_one` and the gateway/actor
+/// `copy_media_to_workspace`):
+///
+/// - `tenant_id == Some(t)` → owned only if the resolved file's first component
+///   under the upload root equals `t`. A file owned by ANOTHER tenant — by `up/`
+///   handle, a raw absolute/relative tmpdir path, OR an image path — is NOT
+///   owned. A flat legacy file (no tenant component) is NOT owned either.
+/// - `tenant_id == None` (solo / CLI `octos chat`, single-tenant) → always owned.
+///
+/// Callers pass a path that is ALREADY resolved (e.g. via
+/// [`resolve_upload_reference`]); a path outside the upload root yields `false`
+/// for a multi-tenant caller, so non-upload paths must be screened separately.
+pub fn upload_owned_by_tenant(resolved: &Path, tenant_id: Option<&str>) -> bool {
+    let Some(tenant) = tenant_id else {
+        return true; // single-tenant: ownership check does not apply
+    };
+    let Ok(rel) = resolved.strip_prefix(canonical_root(&temp_upload_root())) else {
+        return false; // outside the upload root entirely
+    };
+    let mut comps = rel.components();
+    let first_is_tenant =
+        matches!(comps.next(), Some(Component::Normal(s)) if s.to_str() == Some(tenant));
+    // Require at least one MORE component after the tenant directory. A flat
+    // file resolved at `octos-uploads/<tenant>` (the legacy flat `/upload`
+    // path can create a file named exactly like the tenant) has the tenant as
+    // its ONLY component — that is NOT a `<tenant>/<file>` layout and must not
+    // be treated as owned (codex P2). `<tenant>/<file>` → owned.
+    first_is_tenant && comps.next().is_some()
+}
+
 fn materialize_one(uploads_dir: &Path, tenant_id: Option<&str>, entry: &str) -> MaterializeOutcome {
     let Some(src) = resolve_upload_reference(entry) else {
         return MaterializeOutcome::Passthrough; // not a staged upload (workspace path / external / unknown)
     };
 
-    // #1377 tenant isolation: uploads are stored under
-    // `octos-uploads/<tenant>/<uuid>_<name>`, so the FIRST path component of the
-    // resolved file (relative to the upload root) is the owning tenant. In a
-    // multi-tenant session only keep a file owned by THIS tenant; a file owned by
-    // another tenant — whether referenced by `up/` handle, a raw absolute/relative
-    // tmpdir path, OR an image path (which would otherwise reach the vision
-    // encoder via std::fs::read) — is DROPPED. Checking the RESOLVED path covers
-    // ALL of these (codex round-6 P1.3 + round-7 image P1). A flat legacy file
-    // (no tenant component) is also dropped. Solo sessions (`tenant_id == None`,
-    // CLI `octos chat`) skip the check (single-tenant).
-    if let Some(tenant) = tenant_id {
-        let owned = src
-            .strip_prefix(canonical_root(&temp_upload_root()))
-            .ok()
-            .and_then(|rel| rel.components().next())
-            .map(|c| matches!(c, Component::Normal(s) if s.to_str() == Some(tenant)))
-            .unwrap_or(false);
-        if !owned {
-            return MaterializeOutcome::DropForeign;
-        }
+    // #1377 tenant isolation: in a multi-tenant session only keep a file owned by
+    // THIS tenant; a file owned by another tenant — whether referenced by `up/`
+    // handle, a raw absolute/relative tmpdir path, OR an image path (which would
+    // otherwise reach the vision encoder via std::fs::read) — is DROPPED. Checking
+    // the RESOLVED path covers ALL of these (codex round-6 P1.3 + round-7 image
+    // P1). Solo sessions (`tenant_id == None`, CLI `octos chat`) skip the check.
+    if !upload_owned_by_tenant(&src, tenant_id) {
+        return MaterializeOutcome::DropForeign;
     }
 
     // Owned image: keep it on the vision path (the encoder reads it directly via
@@ -681,6 +705,38 @@ mod tests {
             out_b[0]
         );
         assert!(ws_b.path().join(&out_b[0]).is_file());
+    }
+
+    #[test]
+    fn upload_owned_by_tenant_keys_off_first_component_under_root() {
+        // The shared predicate used by BOTH the serve materializer and the
+        // gateway/actor `copy_media_to_workspace`. Ownership = the resolved
+        // file's first path component (under the canonical upload root)
+        // equals the tenant.
+        let root = canonical_root(&temp_upload_root());
+        let owned = root.join("dspfac").join("uuid_doc.md");
+        let foreign = root.join("acme").join("uuid_doc.md");
+        let flat = root.join("legacy_no_tenant.md");
+        // Flat file named EXACTLY like the tenant (legacy flat `/upload`): the
+        // tenant is its only component, so it must NOT be owned (codex P2).
+        let flat_named_as_tenant = root.join("dspfac");
+        let outside = PathBuf::from("/etc/passwd");
+
+        // Multi-tenant: only `<tenant>/<file>` is owned.
+        assert!(upload_owned_by_tenant(&owned, Some("dspfac")));
+        assert!(!upload_owned_by_tenant(&foreign, Some("dspfac")));
+        // Flat files (no tenant subdir) and paths outside the upload root are
+        // NOT owned — all dropped by the materializer / copy path.
+        assert!(!upload_owned_by_tenant(&flat, Some("dspfac")));
+        assert!(!upload_owned_by_tenant(
+            &flat_named_as_tenant,
+            Some("dspfac")
+        ));
+        assert!(!upload_owned_by_tenant(&outside, Some("dspfac")));
+
+        // Solo (tenant_id == None, CLI `octos chat`): ownership check skipped.
+        assert!(upload_owned_by_tenant(&foreign, None));
+        assert!(upload_owned_by_tenant(&outside, None));
     }
 
     #[test]

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -61,9 +61,160 @@ pub(crate) fn response_path_for_profile_file(
 fn resolve_scoped_download_path(
     base_dir: &std::path::Path,
     request_path: &str,
+    auth_profile: Option<&str>,
+    session_workspace: Option<&std::path::Path>,
 ) -> Option<std::path::PathBuf> {
-    resolve_scoped_file_handle(base_dir, request_path)
+    if let Some(resolved) = resolve_scoped_file_handle(base_dir, request_path)
         .or_else(|| resolve_legacy_file_request(base_dir, request_path))
+    {
+        // SECURITY (#1377 round-6 P1.2): `up/` handles + raw tmpdir refs resolve
+        // against the PROCESS-GLOBAL upload root regardless of `base_dir`, so a
+        // requester who obtains another tenant's handle could otherwise download
+        // it. Now that uploads are stored under `octos-uploads/<profile>/…`,
+        // refuse an upload-tmpdir result whose owning tenant != the authenticated
+        // requester. Non-upload results (profile files already scoped to
+        // `base_dir`) are unaffected.
+        if let Some(owner) = upload_tmpdir_tenant(&resolved) {
+            if auth_profile != Some(owner.as_str()) {
+                return None;
+            }
+        }
+        return Some(resolved);
+    }
+    // #1377: uploaded files are materialized into the per-session workspace
+    // (`<workspace>/uploads/<name>`) and the user-message `FileRef` carries that
+    // workspace-relative path. Serve it from the resolved session workspace (the
+    // caller passes the SAME root the turn materialized into).
+    resolve_within_workspace(session_workspace?, request_path)
+}
+
+/// If `p` is contained under the process-global upload tmpdir, return its owning
+/// tenant (the first path component, since uploads live at
+/// `octos-uploads/<tenant>/<uuid>_<name>`). `None` for any path NOT under the
+/// upload root (e.g. a profile file already scoped to its tenant `base_dir`).
+fn upload_tmpdir_tenant(p: &std::path::Path) -> Option<String> {
+    let root = std::fs::canonicalize(octos_bus::file_handle::temp_upload_root()).ok()?;
+    let canon = std::fs::canonicalize(p).ok()?;
+    match canon.strip_prefix(&root).ok()?.components().next()? {
+        std::path::Component::Normal(s) => s.to_str().map(str::to_string),
+        _ => None,
+    }
+}
+
+/// Resolve a workspace-relative download path (e.g. `uploads/<name>`) under
+/// `workspace_root`. Canonical containment + traversal guards keep it inside
+/// that workspace.
+fn resolve_within_workspace(
+    workspace_root: &std::path::Path,
+    request_path: &str,
+) -> Option<std::path::PathBuf> {
+    let rel = std::path::Path::new(request_path);
+    if rel.is_absolute()
+        || rel
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return None;
+    }
+    let candidate = std::fs::canonicalize(workspace_root.join(rel)).ok()?;
+    let canon_ws = std::fs::canonicalize(workspace_root).ok()?;
+    (candidate.is_file() && candidate.starts_with(&canon_ws)).then_some(candidate)
+}
+
+/// Resolve the workspace root for a download request's owning session, matching
+/// EXACTLY where the turn materialized uploads (#1377). `data_dir` is the
+/// authenticated caller's profile/tenant root, so this only reaches that
+/// tenant's own sessions.
+///
+/// Primary: the in-memory open-session map (`session_workspace_root_for_state`),
+/// which holds the exact `workspace_root` the turn used — correct for every
+/// session shape, including `base_key()`-encoded and cwd-hinted workspaces.
+/// Fallback (evicted session): the canonical multi-tenant layout
+/// `<data>/users/<encode_path_component(base_key)>/workspace` (mirrors the
+/// workspace construction in `ui_protocol.rs`).
+///
+/// SECURITY: the open-session map is process-GLOBAL across tenants, so a map
+/// hit is trusted ONLY when its workspace is contained under the authenticated
+/// `data_dir` (this tenant's root). A foreign session id therefore can't
+/// surface another tenant's workspace; it falls through to the tenant-scoped
+/// reconstruction, which (for a foreign session) won't exist under this
+/// `data_dir` and resolves to a 404 — never a cross-tenant read (codex #1377
+/// round-3/8 P1).
+///
+/// KNOWN LIMITATION: a session opened with an approved `cwd` OUTSIDE the data
+/// dir (desktop/AppUI custom workspaces — NOT the hosted `<data>/users/...`
+/// fleet layout) materialises uploads into that external repo, which this
+/// containment rule won't serve via `/api/files`. Soundly serving those needs a
+/// session→owning-profile binding the workspace map does not carry; a generic
+/// cwd-safety re-check is NOT an ownership proof (it would reopen the
+/// cross-tenant read — codex round-8 P1). Tracked as a follow-up.
+fn resolve_session_workspace_root(
+    state: &AppState,
+    data_dir: &std::path::Path,
+    session_id: &str,
+) -> Option<std::path::PathBuf> {
+    if session_id.is_empty() {
+        return None;
+    }
+    let key = octos_core::SessionKey(session_id.to_string());
+    if let Some(ws) = crate::api::ui_protocol::session_workspace_root_for_state(state, &key) {
+        if map_workspace_belongs_to_tenant(&ws, data_dir) {
+            return Some(ws);
+        }
+        // Outside this tenant's data dir → not provably owned by the requester.
+        // Ignore the global map entry and fall through to the tenant-scoped
+        // reconstruction below.
+    }
+    let base = session_id.split('#').next().unwrap_or(session_id);
+    if base.is_empty() || base.contains('/') || base.contains('\\') || base.contains("..") {
+        return None;
+    }
+    let encoded = octos_bus::session::encode_path_component(base);
+    Some(data_dir.join("users").join(encoded).join("workspace"))
+}
+
+/// True when `ws` (a global-map workspace root) is contained under the
+/// authenticated tenant's `data_dir`. Canonicalizes both sides; fails closed if
+/// either can't be canonicalized.
+fn map_workspace_belongs_to_tenant(ws: &std::path::Path, data_dir: &std::path::Path) -> bool {
+    match (std::fs::canonicalize(ws), std::fs::canonicalize(data_dir)) {
+        (Ok(w), Ok(d)) => w.starts_with(&d),
+        _ => false,
+    }
+}
+
+/// The authenticated requester's owning profile id, derived the SAME way the WS
+/// session derives its tenant (routed header OR authenticated identity), so a
+/// download's tenant check matches the upload's stamp. Admin-without-routing →
+/// `MAIN_PROFILE_ID` (admin runs default sessions as `_main`). `None` when it
+/// can't be resolved — download callers then fail closed. Used by `/api/files`.
+fn request_owner_profile(
+    state: &AppState,
+    headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
+) -> Option<String> {
+    let header_profile_id = routed_profile_id_from_headers(state, headers);
+    let identity_profile_id = match identity {
+        Some(AuthIdentity::User { id, .. }) => Some(id.as_str()),
+        Some(AuthIdentity::Admin) => Some(ADMIN_PROFILE_ID),
+        None => None,
+    };
+    let pid = if identity.is_none() && header_profile_id.is_none() {
+        MAIN_PROFILE_ID.to_string()
+    } else {
+        decide_resolved_profile_id(
+            state,
+            identity,
+            header_profile_id.as_deref(),
+            identity_profile_id,
+        )
+        .ok()?
+    };
+    Some(if pid == ADMIN_PROFILE_ID {
+        MAIN_PROFILE_ID.to_string()
+    } else {
+        pid
+    })
 }
 
 fn request_host(headers: &HeaderMap) -> Option<String> {
@@ -1435,11 +1586,51 @@ pub async fn delete_session(
 /// Accepts multipart/form-data with one or more `file` fields.
 /// Returns JSON array of server-side upload handles.
 pub async fn upload(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    identity: Option<Extension<AuthIdentity>>,
     mut multipart: axum::extract::Multipart,
 ) -> Result<Json<Vec<String>>, (StatusCode, String)> {
-    // Determine upload directory
-    let upload_dir = std::env::temp_dir().join("octos-uploads");
+    // #1377 tenant isolation: stamp the upload with the OWNING profile so the
+    // turn-start materializer can verify ownership (`octos-uploads/<profile>/…`).
+    // The id MUST equal the session's `tenant_id` (both `profile.id`), so it is
+    // resolved IDENTITY-AWARE exactly like the session's profile — NOT from the
+    // routing header alone: an OTP/bearer user on the bare host has no routed
+    // header but their session is scoped to their own profile, so a header-only
+    // `_main` fallback would mis-stamp the upload and make it unreadable (codex
+    // round-5 P1). Cross-tenant `X-Profile-Id` → 403; truly unauthenticated
+    // (no identity, no header) → `MAIN_PROFILE_ID` (the default profile's tenant).
+    let identity_ref = identity.as_ref().map(|ext| &ext.0);
+    let header_profile_id = routed_profile_id_from_headers(&state, &headers);
+    let identity_profile_id = match identity_ref {
+        Some(AuthIdentity::User { id, .. }) => Some(id.as_str()),
+        Some(AuthIdentity::Admin) => Some(ADMIN_PROFILE_ID),
+        None => None,
+    };
+    let resolved_profile_id = if identity_ref.is_none() && header_profile_id.is_none() {
+        MAIN_PROFILE_ID.to_string()
+    } else {
+        decide_resolved_profile_id(
+            &state,
+            identity_ref,
+            header_profile_id.as_deref(),
+            identity_profile_id,
+        )
+        .map_err(|_| (StatusCode::FORBIDDEN, "forbidden".to_string()))?
+    };
+    // An admin token with NO tenant routing runs its WS session under the
+    // default profile (`MAIN_PROFILE_ID`), not under `admin`. Stamp the upload
+    // the same way so the materializer doesn't treat the admin's own upload as
+    // foreign (codex round-6 P2). Admin acting AS a tenant carries a header,
+    // which resolves to that tenant above (not `admin`).
+    let profile_id = if resolved_profile_id == ADMIN_PROFILE_ID {
+        MAIN_PROFILE_ID.to_string()
+    } else {
+        resolved_profile_id
+    };
+
+    // Determine upload directory (per-tenant subdir).
+    let upload_dir = std::env::temp_dir().join("octos-uploads").join(&profile_id);
     tokio::fs::create_dir_all(&upload_dir).await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1703,7 +1894,19 @@ pub async fn serve_file_by_query(
         Ok(data_dir) => data_dir,
         Err(response) => return response,
     };
-    serve_file_impl(&data_dir, filename).await
+    // #1377: the authenticated requester's profile gates upload-tmpdir downloads
+    // (no cross-tenant) and authorizes a session-relative `uploads/<name>` path.
+    let auth_profile = request_owner_profile(&state, &headers, identity);
+    let session_ws = params
+        .get("session")
+        .and_then(|s| resolve_session_workspace_root(&state, &data_dir, s));
+    serve_file_impl(
+        &data_dir,
+        filename,
+        auth_profile.as_deref(),
+        session_ws.as_deref(),
+    )
+    .await
 }
 
 /// GET /api/files/:filename -- serve uploaded files and pipeline report files.
@@ -1712,17 +1915,35 @@ pub async fn serve_file(
     headers: HeaderMap,
     identity: Option<Extension<AuthIdentity>>,
     axum::extract::Path(filename): axum::extract::Path<String>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
 ) -> Response {
     let identity = identity.as_ref().map(|ext| &ext.0);
     let data_dir = match resolve_file_access_data_dir(&state, &headers, identity).await {
         Ok(data_dir) => data_dir,
         Err(response) => return response,
     };
-    serve_file_impl(&data_dir, &filename).await
+    let auth_profile = request_owner_profile(&state, &headers, identity);
+    let session_ws = params
+        .get("session")
+        .and_then(|s| resolve_session_workspace_root(&state, &data_dir, s));
+    serve_file_impl(
+        &data_dir,
+        &filename,
+        auth_profile.as_deref(),
+        session_ws.as_deref(),
+    )
+    .await
 }
 
-async fn serve_file_impl(data_dir: &std::path::Path, filename: &str) -> Response {
-    let Some(path) = resolve_scoped_download_path(data_dir, filename) else {
+async fn serve_file_impl(
+    data_dir: &std::path::Path,
+    filename: &str,
+    auth_profile: Option<&str>,
+    session_workspace: Option<&std::path::Path>,
+) -> Response {
+    let Some(path) =
+        resolve_scoped_download_path(data_dir, filename, auth_profile, session_workspace)
+    else {
         return (StatusCode::FORBIDDEN, "access denied").into_response();
     };
 
@@ -4268,8 +4489,104 @@ mod tests {
         std::fs::write(&other_file, b"secret").unwrap();
 
         assert!(
-            resolve_scoped_download_path(current.path(), &other_file.to_string_lossy()).is_none()
+            resolve_scoped_download_path(current.path(), &other_file.to_string_lossy(), None, None)
+                .is_none()
         );
+    }
+
+    #[test]
+    fn resolve_scoped_download_path_serves_session_workspace_upload() {
+        // #1377: `uploads/<name>` resolves under the resolved session workspace.
+        let data = tempfile::tempdir().unwrap();
+        let ws = data.path().join("users/web-abc/workspace");
+        std::fs::create_dir_all(ws.join("uploads")).unwrap();
+        std::fs::write(ws.join("uploads/report.md"), b"hi").unwrap();
+
+        // With the owning session workspace → resolves to the workspace file.
+        // (auth_profile is irrelevant for a workspace-relative path — only
+        // upload-tmpdir results are tenant-gated.)
+        let ok = resolve_scoped_download_path(
+            data.path(),
+            "uploads/report.md",
+            None,
+            Some(ws.as_path()),
+        );
+        assert_eq!(
+            ok,
+            Some(std::fs::canonicalize(ws.join("uploads/report.md")).unwrap())
+        );
+
+        // Without a session workspace → not resolvable (no session context).
+        assert!(
+            resolve_scoped_download_path(data.path(), "uploads/report.md", None, None).is_none()
+        );
+        // Traversal is refused even with a workspace.
+        assert!(
+            resolve_scoped_download_path(data.path(), "../../etc/passwd", None, Some(ws.as_path()))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn resolve_scoped_download_path_gates_cross_tenant_upload_handle() {
+        // codex round-6 P1.2: a download for an upload-tmpdir file owned by
+        // another tenant is refused; the owner gets it.
+        let data = tempfile::tempdir().unwrap();
+        let upload_root = octos_bus::file_handle::temp_upload_root().join("tenant-b");
+        std::fs::create_dir_all(&upload_root).unwrap();
+        let f = upload_root.join(format!("u-{}-secret.md", std::process::id()));
+        std::fs::write(&f, b"theirs").unwrap();
+        let handle =
+            octos_bus::file_handle::encode_tmp_upload_handle(&f, Some("secret.md")).unwrap();
+
+        // Requester is tenant-a → refused.
+        assert!(
+            resolve_scoped_download_path(data.path(), &handle, Some("tenant-a"), None).is_none(),
+            "cross-tenant upload download must be refused"
+        );
+        // Owner tenant-b → served.
+        assert!(
+            resolve_scoped_download_path(data.path(), &handle, Some("tenant-b"), None).is_some(),
+            "the owning tenant must be able to download its upload"
+        );
+        let _ = std::fs::remove_file(&f);
+    }
+
+    #[test]
+    fn resolve_session_workspace_root_falls_back_to_base_key_layout() {
+        // #1377: an evicted (not-in-map) session resolves to the canonical
+        // `<data>/users/<encode(base_key)>/workspace`, with the topic stripped.
+        let data = tempfile::tempdir().unwrap();
+        let state = AppState::empty_for_tests();
+        // Topic-suffixed key → workspace dir uses base_key (topic stripped).
+        let ws = resolve_session_workspace_root(&state, data.path(), "slides-xyz#deck-1").unwrap();
+        let expected_base = octos_bus::session::encode_path_component("slides-xyz");
+        assert_eq!(
+            ws,
+            data.path()
+                .join("users")
+                .join(expected_base)
+                .join("workspace")
+        );
+        // Empty session id → None.
+        assert!(resolve_session_workspace_root(&state, data.path(), "").is_none());
+    }
+
+    #[test]
+    fn map_workspace_must_be_under_authenticated_tenant() {
+        // codex #1377 round-3 P1: a global-map workspace from ANOTHER tenant must
+        // not be trusted by the session-aware download path.
+        let tenant_a = tempfile::tempdir().unwrap();
+        let tenant_b = tempfile::tempdir().unwrap();
+        let a_ws = tenant_a.path().join("users/web-a/workspace");
+        std::fs::create_dir_all(&a_ws).unwrap();
+        let b_ws = tenant_b.path().join("users/web-b/workspace");
+        std::fs::create_dir_all(&b_ws).unwrap();
+
+        // A's workspace is under A's data dir → trusted.
+        assert!(map_workspace_belongs_to_tenant(&a_ws, tenant_a.path()));
+        // B's workspace is NOT under A's data dir → rejected (no cross-tenant).
+        assert!(!map_workspace_belongs_to_tenant(&b_ws, tenant_a.path()));
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -8717,7 +8717,10 @@ pub(crate) async fn resolve_sessions_for_lookup(
     state.sessions.clone()
 }
 
-fn session_workspace_root_for_state(state: &AppState, session_id: &SessionKey) -> Option<PathBuf> {
+pub(crate) fn session_workspace_root_for_state(
+    state: &AppState,
+    session_id: &SessionKey,
+) -> Option<PathBuf> {
     // M11-F: read-through view on `session_workspaces()` only. The
     // legacy `state.agent.tool_registry().workspace_root()` fallback
     // was deleted alongside `state.agent`; the cached
@@ -16560,11 +16563,29 @@ async fn run_standalone_turn(
     // the WS transport. The legacy `rewrite_for` field is logged at
     // debug level for now; durable in-place rewrites land in a
     // follow-up that touches the per-session ledger replace path.
-    let turn_media_paths: Vec<String> = params
+    // #1377: materialize non-image uploads into `<workspace>/uploads/` so the
+    // agent reads them as ordinary workspace files (read_file/grep/list_dir/glob
+    // all work) and global `up/` resolution can be refused for tenant isolation.
+    // Images pass through unchanged (vision reads them directly). The persisted
+    // user-row media (set from this list inside the agent loop) therefore stores
+    // `uploads/<name>` so the `up/` handle never resurfaces in later turns; the
+    // client-facing `UserMessage` envelope keeps the original handle for display.
+    let raw_media: Vec<String> = params
         .media
         .iter()
         .map(|file_ref| file_ref.path.clone())
         .collect();
+    let turn_media_paths: Vec<String> = octos_bus::file_handle::materialize_turn_uploads(
+        &session_runtime.workspace_root,
+        // #1377: bind to the session's OWNING TENANT so the materializer only
+        // copies uploads owned by this tenant (cross-tenant handles dropped).
+        // Use the runtime's profile id — NOT `scope.tenant_id()` — because
+        // profile-qualified AppUI sessions (`:`-keyed) run under a profile but
+        // may have no attached `SessionScope`; deriving the tenant only from the
+        // scope would skip the ownership check for them (codex round-5 P1).
+        Some(session_runtime.profile.profile_id.as_str()),
+        &raw_media,
+    );
     if let Some(rewrite_for) = params.rewrite_for.as_deref() {
         tracing::debug!(
             session = %session_id.0,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -16459,69 +16459,39 @@ async fn run_standalone_turn(
         if scope.workspace() == session_runtime.workspace_root.as_path() {
             request_agent = request_agent.with_session_scope(scope.clone());
         } else {
-            // Phase 3-A codex round-4 (rolling back rounds 2/3): for
-            // hint sessions (the workspace mismatch case), do NOT
-            // propagate any SessionScope onto the per-turn agent —
-            // keep them on the pre-Phase-3-A `session_scope: None`
-            // path. Rationale + history:
+            // #1377 Phase-3-B: this branch is now a DEFENSIVE FALLBACK
+            // that should be unreachable. `SessionRuntime::bootstrap`
+            // now roots the scope at the session's REAL `workspace_root`
+            // for every shape — channel-prefixed (`:`) ids via the
+            // encoded-path workspace, and coding-agent `workspace_hint`
+            // sessions via a repo-rooted scope (root == workspace) — so
+            // `scope.workspace() == session_runtime.workspace_root`
+            // holds by construction and the `if` branch above fires.
             //
-            // - Round-2 synthesized a workspace-rooted solo scope so
-            //   the Phase-2 consumers' boundary check would kick in,
-            //   addressing codex round-1's plugin path-escape concern.
-            //   But that introduced an upload-handle regression
-            //   (codex round-2 P2): the new scope-aware resolver
-            //   classified `up/...` and absolute upload-tmpdir paths
-            //   as OutOfScope, breaking attachment resolution.
-            // - Round-3 added `temp_upload_root()` as a granted_dir to
-            //   close the absolute-path arm, but codex round-3 P2
-            //   showed two remaining gaps the scoped resolver still
-            //   can't handle: (a) `up/...` handles are not decoded by
-            //   `resolve_path_for_session_scope_*` (they're treated as
-            //   workspace-relative `<workspace>/up/...`); (b) on macOS
-            //   the canonical upload root is `/private/var/folders/...`
-            //   while `temp_upload_root()` returns `/var/folders/...`
-            //   — the plugin tool's LEXICAL classifier doesn't follow
-            //   firmlinks, so canonical paths and decoded handles
-            //   remain OutOfScope.
+            // The earlier rounds deliberately skipped propagation for
+            // the workspace-mismatch (hint) case because the scoped
+            // resolver misclassified `up/...` handles and absolute
+            // upload-tmpdir paths as OutOfScope. That blocker is gone:
+            // uploads are now materialized into `<workspace>/uploads/`
+            // at turn start and read by their workspace-relative path,
+            // so there are no raw `up/` handles left for the scoped
+            // resolver to misclassify (a pasted foreign `up/` handle is
+            // instead REFUSED by the tenant-ownership gate — the goal).
             //
-            // Both of those gaps are properly addressed in `octos-bus`
-            // (handle decoding) and `octos-agent` plugins (canonical
-            // classification) — i.e. Phase-2 consumer changes that the
-            // user explicitly bounded out of this PR ("stay in
-            // plumbing — additive scope propagation only"). Until a
-            // follow-up Phase 3-B PR closes those, the safer landing
-            // for THIS PR is to leave hint sessions on their
-            // pre-existing legacy (None) behaviour: handle resolution
-            // works through `resolve_tool_path` as before; the
-            // pre-existing plugin path-escape risk codex round-1
-            // surfaced is NEITHER introduced NOR closed by this PR
-            // (it's pre-existing — Phase-2 PRs are the right place to
-            // close it via either a bootstrap-side scope rebuild for
-            // hint sessions or scope-aware handle decoding).
-            //
-            // Default-layout sessions (the common mini5 NEW-06 path)
-            // still get full propagation through the `if` branch
-            // above. This gate ONLY skips for hint sessions whose
-            // cached scope was built under the canonical
-            // `<data>/users/<id>/workspace` layout while
-            // workspace_root tracks a caller-supplied repo path.
-            //
-            // TODO(phase3b): reconcile `SessionRuntime::bootstrap`'s
-            // SessionScope construction with `workspace_hint` (build
-            // `SessionScope::solo` from workspace_root for hint
-            // sessions, with `temp_upload_root` granted and canonical
-            // upload root pre-resolved) so this skip branch becomes
-            // unreachable and hint sessions also benefit from the
-            // Phase-2 consumer boundary checks.
-            tracing::debug!(
+            // If we ever DO land here (a scope whose workspace does not
+            // match the turn's workspace_root), propagating it would
+            // misresolve relative paths against the wrong directory, so
+            // the safe action is still to skip and fall back to the
+            // legacy resolver. Log at warn so the unexpected mismatch is
+            // visible rather than silent.
+            tracing::warn!(
                 session = %session_id.0,
                 turn = %turn_id.0,
                 scope_workspace = %scope.workspace().display(),
                 runtime_workspace = %session_runtime.workspace_root.display(),
-                "skipping SessionScope propagation onto per-turn agent: \
-                 scope workspace does not match SessionRuntime.workspace_root \
-                 (likely a coding-agent hint session); falling back to \
-                 legacy unread-scope behaviour pending phase3b resolver work"
+                "SessionScope workspace does not match SessionRuntime.workspace_root; \
+                 NOT propagating (bootstrap should root every scope at workspace_root — \
+                 this branch is expected to be unreachable post-#1377 Phase-3-B)"
             );
         }
     }

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -1643,25 +1643,12 @@ impl GatewayRuntime {
                 }
             }
 
-            // Transcribe audio, separate images, and tag voice metadata.
-            let media_result = message_preprocessing::process_media(
-                &mut inbound,
-                self.asr_binary.as_deref(),
-                self.asr_language.as_deref(),
-                &self.channel_mgr,
-            )
-            .await;
-            let image_media = media_result.image_media;
-            let attachment_media = media_result.attachment_media;
-            let attachment_prompt = media_result.attachment_prompt;
-
-            // Route cron-triggered messages to their target channel
-            let (reply_channel, reply_chat_id) = message_preprocessing::resolve_reply_target(
-                &inbound,
-                &self.default_cron_channel,
-                &self.default_cron_chat_id,
-            );
-
+            // #1377 codex round-6 P1: resolve routing (incl. profile-factory
+            // build, which resets `dispatch_profile_id` to None on failure)
+            // BEFORE media preprocessing, so the isolation tenant reflects the
+            // FINAL dispatch decision. Otherwise a `target`-stamped upload
+            // could be transcribed as the target tenant yet then routed to a
+            // different (fallback) actor — a cross-session mismatch.
             let target_profile = inbound
                 .metadata
                 .get("target_profile_id")
@@ -1693,9 +1680,68 @@ impl GatewayRuntime {
                     }
                 }
             }
-
             // Update dispatcher's profile ID for this message.
             self.session_dispatcher.dispatch_profile_id = dispatch_profile_id.clone();
+
+            // ISOLATION tenant = the FINAL dispatch profile (after any
+            // fallback-to-None above), or the gateway's own profile, or
+            // `_main` as a last resort. A gateway is a multi-tenant context,
+            // so the tenant is NEVER None — otherwise the upload gates treat
+            // `None` as solo and skip ownership checks, letting the main/admin
+            // gateway accept any tenant's `up/` handles (codex round-7 P1).
+            // `_main` matches the serve handler's resolved main tenant.
+            let isolation_tenant: Option<String> = dispatch_profile_id
+                .clone()
+                .or_else(|| self.profile_id.clone())
+                .or_else(|| Some(octos_core::MAIN_PROFILE_ID.to_string()));
+
+            // Drop cross-tenant uploads from `inbound.media` BEFORE
+            // `process_media` resolves images or transcribes audio — a foreign
+            // `up/.../voice.ogg` would otherwise be transcribed into the
+            // message content before any later filter, which dropping the path
+            // cannot undo (codex round-3 P1).
+            if let Some(tenant) = isolation_tenant.as_deref() {
+                inbound.media.retain(|entry| {
+                    match octos_bus::file_handle::resolve_upload_reference(entry) {
+                        Some(resolved) => {
+                            let owned = octos_bus::file_handle::upload_owned_by_tenant(
+                                &resolved,
+                                Some(tenant),
+                            );
+                            if !owned {
+                                tracing::warn!(
+                                    tenant = %tenant,
+                                    "dropping cross-tenant upload from inbound media before preprocessing",
+                                );
+                            }
+                            owned
+                        }
+                        None => true, // not a staged upload — keep (workspace / external)
+                    }
+                });
+            }
+
+            // Transcribe audio, separate images, and tag voice metadata.
+            let media_result = message_preprocessing::process_media(
+                &mut inbound,
+                self.asr_binary.as_deref(),
+                self.asr_language.as_deref(),
+                &self.channel_mgr,
+            )
+            .await;
+            let image_media = media_result.image_media;
+            let attachment_media = media_result.attachment_media;
+            let attachment_prompt = media_result.attachment_prompt;
+
+            // Route cron-triggered messages to their target channel
+            let (reply_channel, reply_chat_id) = message_preprocessing::resolve_reply_target(
+                &inbound,
+                &self.default_cron_channel,
+                &self.default_cron_chat_id,
+            );
+
+            // (routing + `dispatch_profile_id` + isolation_tenant were resolved
+            // BEFORE media preprocessing above — codex round-6 P1.)
 
             // Resolve session key with the current profile-scoped base key only.
             let base_session_key = build_profiled_session_key(
@@ -1945,6 +1991,9 @@ impl GatewayRuntime {
                     reply_chat_id: &reply_chat_id,
                     status_indicator,
                     profile_id: dispatch_profile_id.as_deref(),
+                    // #1377 P1.2: ISOLATION tenant (never None on a profiled
+                    // gateway), decoupled from the routing `profile_id`.
+                    tenant_id: isolation_tenant.as_deref(),
                     system_prompt_override: prompt_override,
                     sender_user_id: dispatch_sender_uid,
                 })

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -560,7 +560,7 @@ fn resolve_session_max_iterations(configured: Option<u32>) -> u32 {
 /// `-` is lossless for the field's only purpose (diagnostics/logging)
 /// while guaranteeing the constructor's `is_safe_session_id` check
 /// passes.
-fn sanitize_scope_session_id(raw: &str) -> String {
+pub(crate) fn sanitize_scope_session_id(raw: &str) -> String {
     let mut out: String = raw
         .chars()
         .map(|c| {

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -16,7 +16,9 @@ use octos_agent::{
     SubAgentOutputRouter, ToolRegistry,
 };
 use octos_bus::SessionManager;
-use octos_core::{AgentId, SessionKey, SessionScope, is_safe_session_id};
+use octos_core::{
+    AgentId, DEFAULT_MULTI_TENANT_SHARED_ZONE_NAMES, SessionKey, SessionScope, is_safe_session_id,
+};
 
 use super::ProfileRuntime;
 
@@ -299,92 +301,127 @@ impl SessionRuntime {
         ));
         let file_state_cache = Arc::new(FileStateCache::new());
 
-        // Phase 1 of the SessionScope migration (PR #1198 follow-up):
-        // construct the multi-tenant filesystem contract for this
-        // session and stash it on the agent. The session id must
-        // satisfy [`is_safe_session_id`] (SPA `web-/slides-/site-`
-        // shapes pass; channel-prefixed `api:...` shapes do not). For
-        // unsafe shapes we leave the scope unset — Phase 1 is
-        // additive, no consumer reads the field yet. Phase 3 will
-        // migrate `api_session_workspace_dirs` and the related
-        // bespoke validators onto this contract; that's when the
-        // workspace shape mismatch between `SessionScope.workspace`
-        // (`<data>/users/<id>/workspace`) and the legacy encoded path
-        // (`<data>/users/<encoded id>/workspace` when the id has
-        // chars `is_safe_session_id` rejects) gets reconciled.
+        // SessionScope construction (#1377 Phase-3-B reconciliation).
+        //
+        // Bind a tenant-scoped filesystem contract to EVERY serve session
+        // and root it at the session's REAL `workspace_root` — not the
+        // canonical `<data>/users/<id>/workspace` derivation. This closes
+        // the round-9 cross-tenant gap: previously, channel-prefixed (`:`)
+        // and coding-agent `workspace_hint` sessions were left with
+        // `session_scope: None`, so their per-turn agent ran the unscoped
+        // legacy resolver, which decodes a process-global `up/` upload
+        // handle with NO tenant check (another tenant's pasted handle
+        // would resolve). A tenant-bound scope routes those sessions
+        // through the gated `resolve_for_scope` instead, where the
+        // upload-ownership gate fires.
+        //
+        // Why this is now safe (the Phase-3-A blockers are resolved): the
+        // earlier rounds left these sessions unscoped because the scoped
+        // resolver misclassified `up/...` handles and absolute upload-
+        // tmpdir paths as OutOfScope. Uploads are now MATERIALIZED into
+        // `<workspace>/uploads/` at turn start and read by their
+        // workspace-relative path, so the scoped resolver sees a real
+        // InWorkspace file — there are no raw `up/` handles left to
+        // misclassify. The legacy resolver already confined absolute
+        // paths to {workspace, upload-tmpdir, profile-root}, so the only
+        // behavioural delta for newly-scoped sessions is losing raw
+        // absolute upload-tmpdir reads (replaced by materialized uploads)
+        // and `pf/` profile-handle reads (tracked: #1367).
+        //
+        // Root selection respects the SessionScope WorkspaceEscapesRoot
+        // invariant: canonical/encoded sessions whose workspace lives
+        // under the profile data dir keep `root = data_dir` + the
+        // standard research/skills shared zones; coding-agent hint
+        // sessions whose repo is OUTSIDE the data dir root the scope AT
+        // the repo (`root == workspace`) with no shared zones.
         let session_id_raw = session_key.base_key().to_string();
-        let session_scope = if is_safe_session_id(&session_id_raw) {
-            match SessionScope::multi_tenant_with_default_zones(
-                profile.data_dir.clone(),
+        // The scope's session-id field is informational only
+        // (classification keys off `workspace`, never this id), but it
+        // must satisfy `is_safe_session_id`; collapse the `:` of
+        // channel-prefixed shapes (and any other out-of-alphabet byte).
+        let scope_session_id = sanitize_scope_session_id(&session_id_raw);
+        let workspace_under_data = workspace_root.starts_with(&profile.data_dir);
+        let scope_root = if workspace_under_data {
+            profile.data_dir.clone()
+        } else {
+            workspace_root.clone()
+        };
+        let scope_zones: Vec<PathBuf> = if workspace_under_data {
+            DEFAULT_MULTI_TENANT_SHARED_ZONE_NAMES
+                .iter()
+                .map(|name| profile.data_dir.join(name))
+                .collect()
+        } else {
+            Vec::new()
+        };
+        // Closure so the skill-zone-rejected fallback can rebuild the
+        // identical scope without re-deriving every input.
+        let build_scope = || {
+            SessionScope::multi_tenant_at_workspace(
+                scope_root.clone(),
+                workspace_root.clone(),
                 profile.profile_id.clone(),
-                session_id_raw.clone(),
-            ) {
+                scope_session_id.clone(),
+                scope_zones.clone(),
+            )
+        };
+        let session_scope = if permissions.filesystem_scope.is_host() {
+            // Codex round-10 P1: a `danger_full_access` session resolves
+            // to `FilesystemScope::Host` — file tools are deliberately
+            // allowed to target absolute host paths outside the workspace,
+            // and the sandbox is disabled. But the file tools PREFER an
+            // attached `ctx.session_scope` over their `filesystem_scope`,
+            // so attaching a scope here would silently re-fence a session
+            // the operator explicitly granted host access. Host access is
+            // a Solo-runtime single-user escape hatch, not a multi-tenant
+            // isolation context, so the cross-tenant upload gate does not
+            // apply. Leave the scope unset to honour the Host permission.
+            tracing::debug!(
+                profile_id = %profile.profile_id,
+                session = %session_key,
+                "skipping SessionScope: permissions grant Host filesystem access \
+                 (danger_full_access) — file tools must keep their host reach",
+            );
+            None
+        } else {
+            match build_scope() {
                 Ok(scope) => {
-                    // PR-A: thread the per-profile plugin install
-                    // directories through to the scope so file tools
-                    // (`read_file` today, glob/grep/list_dir in
-                    // PR-B) can reach the SKILL.md content the
-                    // agent's system prompt references.
-                    //
-                    // Codex round-2 BLOCKER 2 (PR #1327 review): SKIP
-                    // dirs that fail canonicalize (fail-closed). A
-                    // missing dir has no readable SKILL content yet,
-                    // so dropping it is the safe fallback. Keeping the
-                    // raw path was a fail-open vulnerability: if the
-                    // raw path is later created/replaced as a symlink
-                    // to `/etc`, `classify_canonical_path` would
-                    // canonicalize both candidate and zone root to
-                    // `/etc` and allow reads as `InSkillDir`. The
-                    // shared helper logs a warning per skip.
+                    // PR-A: thread the per-profile plugin install directories
+                    // through so file tools can reach the SKILL.md content the
+                    // system prompt references. Codex round-2 BLOCKER 2: SKIP
+                    // dirs that fail canonicalize (fail-closed) — a raw path
+                    // later replaced by a symlink to `/etc` would otherwise be
+                    // legitimised as `InSkillDir`.
                     let skill_dirs =
                         octos_core::canonicalize_skill_read_zones(&profile.plugin_dirs);
-                    let scope = scope
-                        .with_skill_read_zones(skill_dirs)
-                        .unwrap_or_else(|err| {
-                            tracing::warn!(
-                                profile_id = %profile.profile_id,
-                                session = %session_key,
-                                error = %err,
-                                "with_skill_read_zones rejected one or more plugin_dirs; \
-                                 continuing without skill_read_zones (read_file may not reach SKILL.md references)",
-                            );
-                            // Reconstruct the scope without skill
-                            // zones — non-fatal additive feature.
-                            SessionScope::multi_tenant_with_default_zones(
-                                profile.data_dir.clone(),
-                                profile.profile_id.clone(),
-                                session_id_raw.clone(),
-                            )
-                            .expect("scope was buildable above; rebuilding with the same inputs must succeed")
-                        });
+                    let scope = scope.with_skill_read_zones(skill_dirs).unwrap_or_else(|err| {
+                        tracing::warn!(
+                            profile_id = %profile.profile_id,
+                            session = %session_key,
+                            error = %err,
+                            "with_skill_read_zones rejected one or more plugin_dirs; \
+                             continuing without skill_read_zones (read_file may not reach SKILL.md references)",
+                        );
+                        build_scope().expect(
+                            "scope was buildable above; rebuilding with the same inputs must succeed",
+                        )
+                    });
                     Some(Arc::new(scope))
                 }
                 Err(err) => {
+                    // A scope that cannot be built (e.g. a non-absolute hint
+                    // workspace) falls back to the unscoped legacy resolver —
+                    // a no-regression degrade, not a hard failure.
                     tracing::warn!(
                         profile_id = %profile.profile_id,
                         session = %session_key,
+                        workspace_root = %workspace_root.display(),
                         error = %err,
-                        "SessionScope construction failed; bootstrap continues without scope (Phase 1 additive)",
+                        "SessionScope construction failed; bootstrap continues without scope (legacy resolver path)",
                     );
                     None
                 }
             }
-        } else {
-            // Codex review note (Phase-1 LOW): channel-prefixed legacy
-            // session ids (`api:web-1234`, `telegram:12345`, etc.) fail
-            // `is_safe_session_id` by design — the SessionScope on-disk
-            // layout uses the raw id, while gateway/legacy paths
-            // percent-encode the `:` before joining. Phase 3 will route
-            // every shape through the scope contract; until then, log
-            // the skip at `debug!` (not `warn!`) since this is the
-            // expected path for non-SPA channels and we don't want
-            // gateway sessions to spam warn lines.
-            tracing::debug!(
-                profile_id = %profile.profile_id,
-                session = %session_key,
-                "skipping SessionScope construction: session id outside is_safe_session_id alphabet (Phase 1 expected for channel-prefixed shapes)",
-            );
-            None
         };
 
         let mut agent = Agent::new_shared(
@@ -514,6 +551,38 @@ fn resolve_session_max_iterations(configured: Option<u32>) -> u32 {
 /// `api/handlers.rs::api_session_workspace_dirs` so an existing
 /// session can transparently pick up the new code path without
 /// losing its workspace.
+/// Map a raw session base-key into the [`is_safe_session_id`] alphabet
+/// for use as a [`SessionScope`]'s INFORMATIONAL session-id field.
+///
+/// Channel-prefixed ids (`api:web-1234`) carry a `:` that the scope's id
+/// field rejects. Scope path classification keys off the explicit
+/// workspace, never this id, so collapsing every out-of-alphabet byte to
+/// `-` is lossless for the field's only purpose (diagnostics/logging)
+/// while guaranteeing the constructor's `is_safe_session_id` check
+/// passes.
+fn sanitize_scope_session_id(raw: &str) -> String {
+    let mut out: String = raw
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '#') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    // `is_safe_session_id` also rejects empty / "." / "..". The map above
+    // already turns every `.` into `-`, so only the empty case remains.
+    if out.is_empty() {
+        out.push('-');
+    }
+    debug_assert!(
+        is_safe_session_id(&out),
+        "sanitize_scope_session_id must yield an is_safe_session_id-valid id: {out:?}",
+    );
+    out
+}
+
 fn resolve_workspace_root(
     profile: &ProfileRuntime,
     session_key: &SessionKey,
@@ -719,6 +788,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bootstrap_roots_scope_at_repo_for_workspace_hint_session() {
+        // #1377 Phase-3-B: a coding-agent `workspace_hint` session whose
+        // repo lives OUTSIDE the profile data dir gets a tenant scope
+        // rooted AT the repo (root == workspace, no shared zones). This
+        // (a) keeps the per-turn agent tenant-bound so the `up/` upload
+        // gate fires, and (b) makes scope.workspace() == workspace_root so
+        // the WS per-turn handler propagates it instead of skipping to the
+        // unscoped legacy resolver (the old Phase-3-A mismatch branch).
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir.clone()).await;
+
+        // Repo hint is a sibling of the data dir -> NOT under it.
+        let repo = tmp.path().join("some-repo");
+        let key = SessionKey::new("appui", "coding-1");
+        let rt = SessionRuntime::bootstrap(&profile, key, Some(repo.clone()))
+            .await
+            .expect("bootstrap with workspace hint");
+
+        assert_eq!(rt.workspace_root, repo);
+        assert!(
+            !repo.starts_with(&data_dir),
+            "test setup: repo must be outside data dir"
+        );
+
+        let scope = rt
+            .agent
+            .session_scope()
+            .expect("hint session now carries a tenant scope")
+            .clone();
+        assert_eq!(scope.tenant_id(), Some(profile.profile_id.as_str()));
+        // root == workspace == repo; no shared zones (repo is out-of-tree).
+        assert_eq!(scope.workspace(), repo.as_path());
+        assert_eq!(scope.root(), repo.as_path());
+        assert!(scope.shared_zones().is_empty());
+        // Critical for propagation: scope.workspace() == workspace_root.
+        assert_eq!(scope.workspace(), rt.workspace_root.as_path());
+    }
+
+    #[tokio::test]
     async fn bootstrap_without_hint_writes_default_policy() {
         let tmp = TempDir::new().unwrap();
         let data_dir = tmp.path().join("profile-data");
@@ -785,53 +894,57 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bootstrap_leaves_session_scope_unset_for_unsafe_session_id() {
-        // Phase 1 contract: when the session_id contains characters
-        // outside the `is_safe_session_id` alphabet (e.g. the legacy
-        // `channel:chat_id` shape with `:`), bootstrap MUST NOT panic
-        // — it leaves the scope unset and the agent keeps pre-Phase-1
-        // behaviour. Phase 3 reconciles the encoded-path-vs-bare-id
-        // mismatch by routing every legitimate id through the scope
-        // contract.
+    async fn bootstrap_attaches_tenant_scope_for_channel_prefixed_session_id() {
+        // #1377 Phase-3-B reconciliation: channel-prefixed (`:`) session
+        // ids previously left `session_scope` unset, dropping the per-turn
+        // agent onto the unscoped legacy resolver (which decodes a
+        // process-global `up/` upload handle with NO tenant check). The
+        // scope is now bound to the REAL (percent-encoded) workspace path
+        // — not a path re-derived from the raw id — so the upload-
+        // ownership gate in `resolve_for_scope` applies.
         let tmp = TempDir::new().unwrap();
         let data_dir = tmp.path().join("profile-data");
         let profile = make_profile(data_dir.clone()).await;
 
-        // SessionKey with a `:` channel prefix — fails is_safe_session_id.
+        // SessionKey with a `:` channel prefix — outside is_safe_session_id.
         let key = SessionKey::new("api", "web-1234");
         let rt = SessionRuntime::bootstrap(&profile, key, None)
             .await
-            .expect("bootstrap must succeed even when scope can't be built");
+            .expect("bootstrap must succeed for channel-prefixed id");
 
-        assert!(
-            rt.agent.session_scope().is_none(),
-            "channel-prefixed session ids must not produce a scope in Phase 1",
-        );
+        let scope = rt
+            .agent
+            .session_scope()
+            .expect("channel-prefixed id now yields a tenant-bound scope")
+            .clone();
+        // Tenant binding present -> the resolver's `up/` ownership gate fires.
+        assert_eq!(scope.tenant_id(), Some(profile.profile_id.as_str()));
+        assert_eq!(scope.root(), data_dir.as_path());
+        // Workspace is the real on-disk (percent-encoded) path and matches
+        // the runtime's workspace_root, so per-turn propagation attaches it.
+        assert_eq!(scope.workspace(), rt.workspace_root.as_path());
+        assert!(rt.workspace_root.starts_with(&data_dir));
     }
 
-    /// Phase 3-A design-pin (Phase 1 follow-up — gap #3 from codex
-    /// review of Phase 2-C): the `else` branch at
-    /// `SessionRuntime::bootstrap` (around `is_safe_session_id` check)
-    /// deliberately leaves `session_scope` unset for channel-prefixed
-    /// legacy session ids like `api:web-1234`, `telegram:12345`,
-    /// `discord:guild#chan`. This is INTENTIONAL: the SessionScope
-    /// on-disk layout uses the raw id while gateway/legacy paths
-    /// percent-encode the `:`, so the workspace shapes are not yet
-    /// reconciled until Phase 3 routes every shape through the scope
-    /// contract. This test exists explicitly to PIN that design
-    /// decision so a future "just construct a scope for every id"
-    /// refactor cannot silently flip it without re-reading the
-    /// rationale in the comment at the unsafe-id branch.
+    /// #1377 Phase-3-B reconciliation (formerly a Phase-3-A design-pin
+    /// asserting these stay unscoped). The old pin required "reconciling
+    /// the encoded-vs-raw workspace path mismatch first" before building
+    /// a scope for channel-prefixed ids — that reconciliation is now
+    /// done: [`SessionScope::multi_tenant_at_workspace`] binds the scope
+    /// to the REAL encoded `workspace_root` rather than re-deriving a
+    /// path from the raw id. So every channel-prefixed legacy session now
+    /// carries a tenant-bound scope and routes through the gated
+    /// resolver, closing the cross-tenant `up/` upload gap. This test
+    /// PINS the new contract.
     #[tokio::test]
-    async fn unsafe_session_id_session_intentionally_has_none_scope() {
+    async fn channel_prefixed_session_ids_get_tenant_scope() {
         let tmp = TempDir::new().unwrap();
         let data_dir = tmp.path().join("profile-data");
         let profile = make_profile(data_dir.clone()).await;
 
-        // Three flavours of channel-prefixed legacy ids that historically
-        // satisfied the gateway dispatcher but fail `is_safe_session_id`
-        // (the `:` character is rejected). Each must succeed at bootstrap
-        // and yield `agent.session_scope() == None`.
+        // Three flavours of channel-prefixed legacy ids that fail
+        // `is_safe_session_id` (the `:` is rejected). Each must succeed at
+        // bootstrap and now yield a tenant-bound scope.
         let cases = ["api:web-1234", "telegram:12345", "discord:guild#chan"];
         for raw in cases {
             // Split on `:` to round-trip through SessionKey::new's
@@ -843,10 +956,21 @@ mod tests {
             let rt = SessionRuntime::bootstrap(&profile, key.clone(), None)
                 .await
                 .expect("bootstrap must succeed for legacy channel id");
-            assert!(
-                rt.agent.session_scope().is_none(),
-                "design pin: unsafe session id {raw:?} (key={key:?}) must leave session_scope unset; \
-                 changing this requires reconciling the encoded-vs-raw workspace path mismatch first",
+            let scope = rt.agent.session_scope().unwrap_or_else(|| {
+                panic!(
+                    "channel-prefixed id {raw:?} (key={key:?}) must now carry a tenant scope \
+                     (reconciliation done: scope bound to the real encoded workspace_root)"
+                )
+            });
+            assert_eq!(
+                scope.tenant_id(),
+                Some(profile.profile_id.as_str()),
+                "scope for {raw:?} must be tenant-bound so the upload-ownership gate fires",
+            );
+            assert_eq!(
+                scope.workspace(),
+                rt.workspace_root.as_path(),
+                "scope for {raw:?} must be rooted at the real workspace_root",
             );
         }
     }
@@ -933,49 +1057,34 @@ mod tests {
         assert_eq!(turn_scope.root(), data_dir.as_path());
     }
 
-    /// Phase 3-A codex round-4 regression-pin: when a coding-agent UI
-    /// opens a session with an explicit `cwd` hint, the cached
-    /// `SessionRuntime` honours the hint for `workspace_root` and the
-    /// rebound tool registry, but `bootstrap` still builds the
-    /// `SessionScope` from the canonical `<data>/users/<id>/workspace`
-    /// layout — so the cached scope's workspace does NOT match the
-    /// runtime's. The WS turn handler MUST skip propagation in this
-    /// case and leave the per-turn agent's `session_scope` as None
-    /// so hint sessions stay on their pre-Phase-3-A (legacy) behaviour.
+    /// #1377 Phase-3-B (formerly the Phase-3-A round-4 skip-pin): when a
+    /// coding-agent UI opens a session with an explicit `cwd` hint, the
+    /// cached `SessionRuntime` honours the hint for `workspace_root`, and
+    /// bootstrap NOW roots the `SessionScope` at that same
+    /// `workspace_root` (repo-rooted, root == workspace). So the cached
+    /// scope's workspace MATCHES the runtime's, and the WS turn handler
+    /// PROPAGATES it onto the per-turn agent — making the agent
+    /// tenant-bound so the `up/` upload-ownership gate fires.
     ///
-    /// Why skip rather than synthesize? Rounds 2 and 3 of this fix
-    /// tried synthesizing a workspace-rooted solo scope (round-2 with
-    /// empty grants, round-3 with `temp_upload_root` granted), but
-    /// each surfaced further regressions:
-    /// - The scope-aware resolver does not decode `up/...` handles
-    ///   (codex round-3 P2.a) — it treats them as workspace-relative
-    ///   `<workspace>/up/...`, so attachment resolution breaks.
-    /// - The plugin tool's classifier uses lexical (not canonical)
-    ///   classification (codex round-3 P2.b), so on macOS the
-    ///   `/var/folders/...` raw form and the `/private/var/folders/...`
-    ///   canonical form mismatch — granting one doesn't cover the
-    ///   other.
+    /// Earlier rounds skipped propagation here because bootstrap built
+    /// the scope from the canonical `<data>/users/<id>/workspace` layout
+    /// (a workspace mismatch) and the scoped resolver misclassified
+    /// `up/...` handles. Both are resolved: bootstrap reconciles the
+    /// workspace, and uploads are materialized into `<workspace>/uploads/`
+    /// so no raw `up/` handle reaches the scoped resolver.
     ///
-    /// Both of those are Phase-2 consumer changes the user explicitly
-    /// bounded out of this PR ("stay in plumbing — additive scope
-    /// propagation only"). The minimal-blast-radius landing is to
-    /// SKIP propagation for hint sessions and document the deferral
-    /// via a `TODO(phase3b)` at the call site.
-    ///
-    /// This test mirrors the round-4 rebuild and confirms hint
-    /// sessions keep their pre-Phase-3-A `session_scope: None`
-    /// behaviour byte-for-byte.
+    /// This test mirrors the WS turn rebuild and confirms hint sessions
+    /// now carry a propagated, workspace-matched scope.
     #[tokio::test]
-    async fn ui_protocol_ws_turn_agent_skips_session_scope_on_workspace_hint() {
+    async fn ui_protocol_ws_turn_agent_propagates_session_scope_on_workspace_hint() {
         use octos_agent::Agent;
 
         let tmp = TempDir::new().unwrap();
         let data_dir = tmp.path().join("profile-data");
         let profile = make_profile(data_dir.clone()).await;
 
-        // A safe SPA-shape session id (so bootstrap DOES build a
-        // scope under the default layout) PLUS a hint pointing at a
-        // different repo path — i.e. the coding-agent UI flow.
+        // A safe SPA-shape session id PLUS a hint pointing at a different
+        // repo path — i.e. the coding-agent UI flow.
         let session_id = "web-1779574360681-hintsx";
         let key = SessionKey(session_id.to_string());
         let hint_repo = tmp.path().join("coding-agent-repo");
@@ -984,14 +1093,13 @@ mod tests {
             .await
             .expect("bootstrap session runtime with workspace hint");
 
-        // Pre-condition: workspace_root tracks the HINT, but the cached
-        // scope was built from the default `<data>/users/<id>/workspace`
-        // layout (Phase-1 bootstrap behaviour we deliberately leave
-        // unchanged on this PR).
+        // Pre-condition: workspace_root honours the hint AND the cached
+        // scope is now rooted at that same workspace_root (the #1377
+        // reconciliation), so they match by construction.
         let runtime_scope = rt
             .agent
             .session_scope()
-            .expect("safe session id always yields a SessionScope")
+            .expect("hint session yields a tenant-bound SessionScope")
             .clone();
         let canonical_workspace = std::fs::canonicalize(&hint_repo).unwrap();
         let runtime_workspace_canonical = std::fs::canonicalize(&rt.workspace_root).unwrap();
@@ -999,16 +1107,19 @@ mod tests {
             runtime_workspace_canonical, canonical_workspace,
             "workspace_root must honour the hint"
         );
-        assert_ne!(
+        assert_eq!(
             runtime_scope.workspace(),
             rt.workspace_root.as_path(),
-            "Phase 1 design: scope still uses default <data>/users/<id>/workspace \
-             — this is the mismatch the round-4 skip at ui_protocol.rs guards against"
+            "#1377: bootstrap now roots the scope at the hint workspace_root",
+        );
+        assert_eq!(
+            runtime_scope.tenant_id(),
+            Some(profile.profile_id.as_str()),
+            "hint-session scope must be tenant-bound so the upload gate fires",
         );
 
-        // Mirror the WS turn handler's per-turn rebuild WITH the
-        // round-4 skip gate: when the cached scope's workspace doesn't
-        // match the runtime's workspace_root, skip propagation.
+        // Mirror the WS turn handler's per-turn rebuild + propagation
+        // gate: the workspaces match, so the scope IS propagated.
         let tools = Arc::new(rt.tools.snapshot_excluding(&[]));
         let mut request_agent = Agent::new_shared(
             AgentId::new(format!("ui-protocol-{}", uuid::Uuid::now_v7())),
@@ -1020,18 +1131,13 @@ mod tests {
             if scope.workspace() == rt.workspace_root.as_path() {
                 request_agent = request_agent.with_session_scope(scope.clone());
             }
-            // else: skip — see api/ui_protocol.rs round-4 comment for
-            // the full trade-off matrix; deferred to phase3b.
         }
 
-        assert!(
-            request_agent.session_scope().is_none(),
-            "per-turn agent must skip the mismatched scope when the session was \
-             opened with a workspace hint — hint sessions keep their pre-Phase-3-A \
-             `session_scope: None` behaviour byte-for-byte (Phase 3-B PR will revisit \
-             once the scope-aware resolver handles `up/...` decoding and canonical \
-             classification)",
+        let turn_scope = request_agent.session_scope().expect(
+            "per-turn agent must now carry the propagated, workspace-matched scope for \
+             a workspace-hint session (#1377 Phase-3-B reconciliation)",
         );
+        assert!(Arc::ptr_eq(turn_scope, &runtime_scope));
     }
 
     #[tokio::test]
@@ -1511,6 +1617,16 @@ mod tests {
         assert_eq!(
             rt.permissions.permission_profile,
             PermissionProfile::DangerFullAccess
+        );
+        // Codex round-10 P1: a Host (danger_full_access) session must NOT
+        // carry a SessionScope, or the file tools would prefer it over the
+        // Host filesystem_scope and silently re-fence the operator-granted
+        // host access. This session is `:`-keyed AND hinted — exactly the
+        // shapes #1377 newly scopes — so the assertion proves the Host gate
+        // wins over scope attachment.
+        assert!(
+            rt.agent.session_scope().is_none(),
+            "Host (danger_full_access) sessions must not carry a SessionScope",
         );
         assert!(!rt.sandbox.enabled);
         assert_eq!(rt.sandbox.mode, SandboxMode::None);

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -340,16 +340,39 @@ impl SessionRuntime {
         // must satisfy `is_safe_session_id`; collapse the `:` of
         // channel-prefixed shapes (and any other out-of-alphabet byte).
         let scope_session_id = sanitize_scope_session_id(&session_id_raw);
-        let workspace_under_data = workspace_root.starts_with(&profile.data_dir);
+        // #1377 (codex pre-merge P2): decide in-profile membership by comparing
+        // CANONICAL forms (firmlink-safe: macOS `/var` vs `/private/var`), but
+        // pick the `scope_root` that is an actual PREFIX of `workspace_root`.
+        // `workspace_root` is canonical for hint sessions (the `..`/symlink fix
+        // above) but RAW for the common no-hint case (it is built but not yet
+        // created on disk when `resolve_workspace_root` runs, so it can't be
+        // canonicalized there). Comparing a canonical workspace to a raw
+        // data_dir (or vice-versa) would misclassify; comparing canonical
+        // forms is correct, and rooting at whichever data_dir form prefixes
+        // the actual `workspace_root` keeps `scope.classify_*` containment
+        // intact for both shapes. `canonicalize` falls back to the raw path
+        // when the dir is absent.
+        let raw_data_dir = profile.data_dir.clone();
+        let canon_data_dir =
+            std::fs::canonicalize(&raw_data_dir).unwrap_or_else(|_| raw_data_dir.clone());
+        let canon_ws =
+            std::fs::canonicalize(&workspace_root).unwrap_or_else(|_| workspace_root.clone());
+        let workspace_under_data = canon_ws.starts_with(&canon_data_dir);
+        // Use the data_dir form that actually prefixes workspace_root so the
+        // scope's root is a true ancestor (raw-vs-raw for no-hint, else canon).
         let scope_root = if workspace_under_data {
-            profile.data_dir.clone()
+            if workspace_root.starts_with(&raw_data_dir) {
+                raw_data_dir.clone()
+            } else {
+                canon_data_dir.clone()
+            }
         } else {
             workspace_root.clone()
         };
         let scope_zones: Vec<PathBuf> = if workspace_under_data {
             DEFAULT_MULTI_TENANT_SHARED_ZONE_NAMES
                 .iter()
-                .map(|name| profile.data_dir.join(name))
+                .map(|name| scope_root.join(name))
                 .collect()
         } else {
             Vec::new()
@@ -589,7 +612,14 @@ fn resolve_workspace_root(
     workspace_hint: Option<PathBuf>,
 ) -> Result<PathBuf> {
     if let Some(hint) = workspace_hint {
-        return validate_workspace_hint(&hint).map(|_| hint);
+        // #1377 (codex pre-merge P1): return the CANONICAL hint, not the raw
+        // one. A raw hint carrying `..` (or symlinked ancestors) would flow
+        // into `workspace_root`, and `SessionScope::multi_tenant_at_workspace`
+        // rejects `..` — leaving the session UNSCOPED and back on the legacy
+        // resolver that decodes global `up/` handles with no tenant check.
+        // Canonicalizing collapses `..` and resolves symlinks so the scope is
+        // always built and the upload-ownership gate applies.
+        return validate_workspace_hint(&hint);
     }
 
     let encoded_base = octos_bus::session::encode_path_component(session_key.base_key());
@@ -614,7 +644,7 @@ fn resolve_workspace_root(
 /// `api/ui_protocol.rs::validate_session_workspace_allowed` and this
 /// function can call. Today the two paths must stay synchronized by
 /// inspection.
-fn validate_workspace_hint(hint: &Path) -> Result<()> {
+fn validate_workspace_hint(hint: &Path) -> Result<PathBuf> {
     // The hint must canonicalize (so we reject symlink traps and
     // nonexistent paths early). Callers that want to *create* a
     // workspace should pre-create the directory before passing the
@@ -650,7 +680,9 @@ fn validate_workspace_hint(hint: &Path) -> Result<()> {
         }
     }
 
-    Ok(())
+    // Return the CANONICAL path (collapses `..`, resolves symlinks) so the
+    // caller roots the session scope at a normalized workspace_root.
+    Ok(canonical)
 }
 
 #[cfg(test)]
@@ -802,14 +834,20 @@ mod tests {
 
         // Repo hint is a sibling of the data dir -> NOT under it.
         let repo = tmp.path().join("some-repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        // #1377 (codex pre-merge P1): the hint is now CANONICALIZED before it
+        // becomes workspace_root (so a `..`/symlinked hint can't slip through
+        // unscoped). Compare against the canonical form (`/tmp`->`/private/tmp`
+        // on macOS).
+        let repo_canon = std::fs::canonicalize(&repo).unwrap();
         let key = SessionKey::new("appui", "coding-1");
         let rt = SessionRuntime::bootstrap(&profile, key, Some(repo.clone()))
             .await
             .expect("bootstrap with workspace hint");
 
-        assert_eq!(rt.workspace_root, repo);
+        assert_eq!(rt.workspace_root, repo_canon);
         assert!(
-            !repo.starts_with(&data_dir),
+            !repo_canon.starts_with(&data_dir),
             "test setup: repo must be outside data dir"
         );
 
@@ -819,9 +857,9 @@ mod tests {
             .expect("hint session now carries a tenant scope")
             .clone();
         assert_eq!(scope.tenant_id(), Some(profile.profile_id.as_str()));
-        // root == workspace == repo; no shared zones (repo is out-of-tree).
-        assert_eq!(scope.workspace(), repo.as_path());
-        assert_eq!(scope.root(), repo.as_path());
+        // root == workspace == canonical repo; no shared zones (out-of-tree).
+        assert_eq!(scope.workspace(), repo_canon.as_path());
+        assert_eq!(scope.root(), repo_canon.as_path());
         assert!(scope.shared_zones().is_empty());
         // Critical for propagation: scope.workspace() == workspace_root.
         assert_eq!(scope.workspace(), rt.workspace_root.as_path());
@@ -919,9 +957,12 @@ mod tests {
             .clone();
         // Tenant binding present -> the resolver's `up/` ownership gate fires.
         assert_eq!(scope.tenant_id(), Some(profile.profile_id.as_str()));
+        // No-hint session: workspace_root is the raw `<data>/users/<enc>/
+        // workspace` path, so scope.root() stays the raw data_dir (the form
+        // that prefixes workspace_root).
         assert_eq!(scope.root(), data_dir.as_path());
-        // Workspace is the real on-disk (percent-encoded) path and matches
-        // the runtime's workspace_root, so per-turn propagation attaches it.
+        // Workspace matches the runtime's workspace_root, so per-turn
+        // propagation attaches it.
         assert_eq!(scope.workspace(), rt.workspace_root.as_path());
         assert!(rt.workspace_root.starts_with(&data_dir));
     }

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -37,7 +37,7 @@ use octos_bus::{
 use octos_core::AgentId;
 use octos_core::{
     InboundMessage, MAIN_PROFILE_ID, METADATA_SENDER_USER_ID, Message, MessageRole,
-    OutboundMessage, SessionKey, SessionScope, is_safe_session_id,
+    OutboundMessage, SessionKey, SessionScope,
 };
 use octos_llm::{
     AdaptiveMode, AdaptiveRouter, EmbeddingProvider, FailoverEvent, LlmProvider, ProviderRouter,
@@ -74,6 +74,11 @@ pub struct DispatchParams<'a> {
     pub reply_chat_id: &'a str,
     pub status_indicator: Option<Arc<StatusComposer>>,
     pub profile_id: Option<&'a str>,
+    /// Owning tenant for upload isolation (#1377 P1.2). Decoupled from
+    /// `profile_id` (routing): on a profiled gateway this falls back to the
+    /// gateway's own profile, so it is never `None` even when `profile_id`
+    /// is (unknown `target_profile_id`), preventing an unscoped bypass.
+    pub tenant_id: Option<&'a str>,
     pub system_prompt_override: Option<String>,
     pub sender_user_id: Option<String>,
 }
@@ -87,6 +92,12 @@ struct SpawnParams<'a> {
     status_indicator: Option<Arc<StatusComposer>>,
     system_prompt_override: Option<String>,
     sender_user_id: Option<String>,
+    /// Resolved DISPATCH profile = the authoritative owning tenant for this
+    /// actor (#1377 codex P1.2). NOT the top-level factory's `profile_id`,
+    /// which is `None` for the current-profile gateway — `resolve_dispatch_
+    /// profile_id` falls back to the current gateway profile, so this is
+    /// `Some(profile)` on a single-profile deploy (e.g. the dspfac fleet).
+    tenant_id: Option<String>,
 }
 
 /// Parameters for the outbound message forwarder task.
@@ -2102,6 +2113,7 @@ impl ActorRegistry {
             reply_chat_id,
             status_indicator,
             profile_id,
+            tenant_id,
             system_prompt_override,
             sender_user_id,
         } = params;
@@ -2125,6 +2137,10 @@ impl ActorRegistry {
                 status_indicator: status_indicator.clone(),
                 system_prompt_override: system_prompt_override.clone(),
                 sender_user_id: sender_user_id.clone(),
+                // #1377 P1.2: the ISOLATION tenant (falls back to the gateway
+                // profile; never None on a profiled gateway), not the routing
+                // profile_id which is None for the current-profile gateway.
+                tenant_id: tenant_id.map(|s| s.to_string()),
             });
             self.actors.insert(
                 key_str.clone(),
@@ -2191,6 +2207,8 @@ impl ActorRegistry {
                     status_indicator,
                     system_prompt_override: prompt_override.clone(),
                     sender_user_id: uid_override.clone(),
+                    // #1377 P1.2: isolation tenant (gateway-profile fallback).
+                    tenant_id: tenant_id.map(|s| s.to_string()),
                 });
                 let _ = tx.send(actor_msg).await;
                 self.actors.insert(
@@ -2453,17 +2471,19 @@ impl ToolRegistryFactory for SnapshotToolRegistryFactory {
 /// `ActorFactory::spawn` so the wiring can be unit-tested without
 /// having to drive an entire actor through a tokio mpsc channel.
 ///
-/// Returns `Some(scope)` when:
-/// - `profile_id` is `Some` (per-profile actors created by
-///   `ProfileFactory::build` always supply it; the admin / test
-///   ActorFactory leaves it `None`), AND
-/// - `session_key.base_key()` satisfies [`is_safe_session_id`] (SPA
-///   `web-/slides-/site-` shapes pass; channel-prefixed `api:...`
-///   shapes do not — those route through the legacy resolver).
+/// Returns `Some(scope)` when `profile_id` is `Some` (per-profile actors
+/// created by `ProfileFactory::build` always supply it; the admin / test
+/// ActorFactory leaves it `None`). The scope is rooted at the session's
+/// REAL on-disk workspace (`<data>/users/<encoded base_key>/workspace`),
+/// so BOTH SPA `web-/slides-/site-` shapes AND channel-prefixed `api:...`
+/// shapes get a tenant-bound scope (#1377 Phase-3-B — the gateway/actor
+/// sibling of the serve `SessionRuntime` fix). Channel-prefixed ids used
+/// to skip scope construction and fall onto the unscoped legacy resolver
+/// (which decodes process-global `up/` upload handles with no tenant
+/// check); rooting at the encoded workspace closes that gap.
 ///
-/// Returns `None` (= legacy resolver) for the admin path, the
-/// channel-prefixed shapes, or when the scope builder rejects the
-/// inputs entirely.
+/// Returns `None` (= legacy resolver) only for the admin path (no
+/// `profile_id`) or when the scope builder rejects the inputs entirely.
 ///
 /// Fail-closed canonicalisation per round-2 BLOCKER 2: any
 /// `plugin_dir` that fails canonicalize is dropped (logged at `warn`).
@@ -2482,20 +2502,36 @@ pub(crate) fn build_gateway_session_scope(
         );
         return None;
     };
-    if !is_safe_session_id(&session_id_raw) {
-        tracing::debug!(
-            profile_id = %profile_id,
-            session = %session_key,
-            "ActorFactory::spawn skipping SessionScope: session id outside is_safe_session_id alphabet \
-             (legacy channel-prefixed shape)",
-        );
-        return None;
-    }
-    match SessionScope::multi_tenant_with_default_zones(
-        data_dir.to_path_buf(),
-        profile_id.to_string(),
-        session_id_raw.clone(),
-    ) {
+
+    // #1377 Phase-3-B (gateway/actor sibling of the serve `SessionRuntime`
+    // fix): bind the scope to the session's REAL on-disk workspace —
+    // `<data>/users/<encoded base_key>/workspace`, the SAME path the actor
+    // computes for `user_workspace` — rather than re-deriving it from the
+    // raw id. This closes the channel-prefixed (`:`) gap: those ids fail
+    // `is_safe_session_id`, so the old `multi_tenant_with_default_zones`
+    // (which uses the raw id and percent-encoding-mismatched path) skipped
+    // them, leaving actor file tools on the unscoped legacy resolver that
+    // decodes process-global `up/` handles with no tenant check. The
+    // workspace path is the encoded form, so it matches the actor and the
+    // tenant-ownership gate in `resolve_for_scope` now applies. Safe-id
+    // sessions get a byte-identical scope (encode == raw, sanitize == raw).
+    let encoded_base = octos_bus::session::encode_path_component(&session_id_raw);
+    let workspace = data_dir.join("users").join(&encoded_base).join("workspace");
+    let scope_session_id = crate::runtime::session::sanitize_scope_session_id(&session_id_raw);
+    let shared_zones: Vec<std::path::PathBuf> = octos_core::DEFAULT_MULTI_TENANT_SHARED_ZONE_NAMES
+        .iter()
+        .map(|name| data_dir.join(name))
+        .collect();
+    let build = || {
+        SessionScope::multi_tenant_at_workspace(
+            data_dir.to_path_buf(),
+            workspace.clone(),
+            profile_id.to_string(),
+            scope_session_id.clone(),
+            shared_zones.clone(),
+        )
+    };
+    match build() {
         Ok(scope) => {
             // Round-2 BLOCKER 2: fail-closed canonicalisation. Drop
             // any plugin dir that can't be canonicalised so a later
@@ -2511,13 +2547,7 @@ pub(crate) fn build_gateway_session_scope(
                         "ActorFactory::spawn with_skill_read_zones rejected one or more plugin_dirs; \
                          attaching scope without skill_read_zones",
                     );
-                    SessionScope::multi_tenant_with_default_zones(
-                        data_dir.to_path_buf(),
-                        profile_id.to_string(),
-                        session_id_raw,
-                    )
-                    .map(Arc::new)
-                    .ok()
+                    build().map(Arc::new).ok()
                 }
             }
         }
@@ -2545,6 +2575,7 @@ impl ActorFactory {
             status_indicator,
             system_prompt_override,
             sender_user_id,
+            tenant_id,
         } = params;
         let (tx, rx) = mpsc::channel(ACTOR_INBOX_SIZE);
 
@@ -3235,7 +3266,9 @@ impl ActorFactory {
         // and could not reach the per-profile skill_dirs the
         // SKILL.md auto-inject teaches the agent to use.
         let session_scope_arc = build_gateway_session_scope(
-            self.profile_id.as_deref(),
+            // #1377 P1.2: use the DISPATCH tenant (the top-level factory's
+            // `profile_id` is None for the current-profile gateway).
+            tenant_id.as_deref(),
             &self.data_dir,
             &session_key,
             &self.plugin_dirs,
@@ -3310,6 +3343,7 @@ impl ActorFactory {
             session_key: session_key.clone(),
             channel: channel.to_string(),
             chat_id: chat_id.to_string(),
+            tenant_id,
             inbox: rx,
             agent: Arc::new(agent),
             hooks: self.hooks.clone(),
@@ -3771,6 +3805,12 @@ struct SessionActor {
     session_key: SessionKey,
     channel: String,
     chat_id: String,
+
+    /// Owning tenant (the spawning factory's `profile_id`), or `None` for the
+    /// admin/test/single-tenant path. #1377: used to drop cross-tenant uploads
+    /// in `copy_media_to_workspace` — the authoritative tenant, matching the id
+    /// `build_gateway_session_scope` binds onto the agent's `SessionScope`.
+    tenant_id: Option<String>,
 
     inbox: mpsc::Receiver<ActorMessage>,
 
@@ -4450,6 +4490,18 @@ impl SessionActor {
                                     attachment_prompt,
                                 )
                                 .await;
+
+                            // #1377 codex P1.1: drop cross-tenant uploads from the
+                            // fully-merged media set (this turn + any drained queued
+                            // turns) BEFORE vision encoding / ASR / workspace copy —
+                            // `drain_queue` only concatenates media strings, so this
+                            // is the single point where ALL inbound media is present
+                            // yet still unread. A foreign image handle would otherwise
+                            // reach the vision encoder, and foreign audio the ASR, via
+                            // `process_inbound*` below.
+                            let final_media = self.drop_foreign_uploads(final_media);
+                            let final_attachment_media =
+                                self.drop_foreign_uploads(final_attachment_media);
 
                             // Copy non-image attachments into the agent workspace so
                             // tools can resolve them by filename without path hints.
@@ -5598,19 +5650,75 @@ impl SessionActor {
     /// Copy media files from their original location (e.g. profile media_dir)
     /// into the agent's sandboxed `user_workspace` so that `read_file` and
     /// other cwd-bound tools can access them.  Returns the updated paths.
+    /// Drop any staged upload in `media` NOT owned by this actor's tenant.
+    ///
+    /// #1377 codex P1.1: this runs on the RAW merged media set (image +
+    /// attachment) the moment a turn is assembled — BEFORE vision encoding,
+    /// ASR transcription, or the workspace copy — because a foreign image
+    /// handle is read directly by the vision encoder and audio is transcribed
+    /// before `copy_media_to_workspace`. Non-upload entries (workspace /
+    /// external paths, which `resolve_upload_reference` returns `None` for)
+    /// are kept unchanged. Solo sessions (`tenant_id == None`) keep everything.
+    fn drop_foreign_uploads(&self, media: Vec<String>) -> Vec<String> {
+        media
+            .into_iter()
+            .filter(|entry| {
+                match octos_bus::file_handle::resolve_upload_reference(entry) {
+                    Some(resolved) => {
+                        let owned = octos_bus::file_handle::upload_owned_by_tenant(
+                            &resolved,
+                            self.tenant_id.as_deref(),
+                        );
+                        if !owned {
+                            warn!(
+                                session = %self.session_key,
+                                "dropping cross-tenant upload from inbound media \
+                                 (staged file not owned by this tenant)",
+                            );
+                        }
+                        owned
+                    }
+                    None => true, // not a staged upload — keep (workspace / external)
+                }
+            })
+            .collect()
+    }
+
     fn copy_media_to_workspace(&self, media: Vec<String>) -> Vec<String> {
         media
             .into_iter()
-            .map(|path| {
-                let resolved = octos_bus::file_handle::resolve_upload_reference(&path)
-                    .map(|candidate| candidate.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| path.clone());
+            .filter_map(|path| {
+                // #1377 tenant isolation (gateway/actor analog of the serve
+                // `materialize_turn_uploads` ownership check): a media entry may
+                // reference a STAGED upload (`up/` handle or upload-tmpdir path).
+                // Resolve it and, in a multi-tenant session, DROP any upload
+                // owned by ANOTHER tenant before copying it into this session's
+                // workspace — otherwise a pasted foreign handle would copy
+                // another tenant's file in. Non-upload entries (workspace /
+                // external paths) resolve to `None` and are kept unchanged.
+                let resolved = match octos_bus::file_handle::resolve_upload_reference(&path) {
+                    Some(candidate) => {
+                        if !octos_bus::file_handle::upload_owned_by_tenant(
+                            &candidate,
+                            self.tenant_id.as_deref(),
+                        ) {
+                            warn!(
+                                session = %self.session_key,
+                                "dropping cross-tenant upload from media set \
+                                 (staged file not owned by this tenant)",
+                            );
+                            return None;
+                        }
+                        candidate.to_string_lossy().into_owned()
+                    }
+                    None => path.clone(),
+                };
                 let src = std::path::Path::new(&resolved);
                 if !src.exists() {
-                    return resolved;
+                    return Some(resolved);
                 }
                 let Some(filename) = src.file_name() else {
-                    return resolved;
+                    return Some(resolved);
                 };
                 let dest = self.user_workspace.join(filename);
                 match std::fs::copy(src, &dest) {
@@ -5621,7 +5729,7 @@ impl SessionActor {
                             dest = %dest.display(),
                             "copied media file to workspace"
                         );
-                        dest.to_string_lossy().into_owned()
+                        Some(dest.to_string_lossy().into_owned())
                     }
                     Err(e) => {
                         warn!(
@@ -5630,7 +5738,7 @@ impl SessionActor {
                             error = %e,
                             "failed to copy media to workspace, using original path"
                         );
-                        resolved
+                        Some(resolved)
                     }
                 }
             })
@@ -9889,6 +9997,7 @@ mod tests {
             session_key: SessionKey::new("cli", "test"),
             channel: "cli".to_string(),
             chat_id: "test".to_string(),
+            tenant_id: None,
             inbox: inbox_rx,
             agent: Arc::new(agent),
             hooks: None,
@@ -9960,6 +10069,7 @@ mod tests {
             session_key: SessionKey::new("cli", "test"),
             channel: "cli".to_string(),
             chat_id: "test".to_string(),
+            tenant_id: None,
             inbox: inbox_rx,
             agent: Arc::new(agent),
             hooks: None,
@@ -10109,6 +10219,7 @@ mod tests {
             session_key: SessionKey::new("cli", "test"),
             channel: "cli".to_string(),
             chat_id: "test".to_string(),
+            tenant_id: None,
             inbox: inbox_rx,
             agent: Arc::new(agent),
             hooks: Some(hooks),
@@ -10233,6 +10344,7 @@ mod tests {
             session_key: SessionKey::new("cli", "test"),
             channel: "cli".to_string(),
             chat_id: "test".to_string(),
+            tenant_id: None,
             inbox: inbox_rx,
             agent: Arc::new(agent),
             hooks: Some(hooks),
@@ -10356,6 +10468,7 @@ mod tests {
             session_key: SessionKey::new("cli", "test"),
             channel: "cli".to_string(),
             chat_id: "test".to_string(),
+            tenant_id: None,
             inbox: inbox_rx,
             agent: Arc::new(agent),
             hooks: None,
@@ -10448,6 +10561,7 @@ mod tests {
             session_key: SessionKey::new("cli", "test"),
             channel: "cli".to_string(),
             chat_id: "test".to_string(),
+            tenant_id: None,
             inbox: inbox_rx,
             agent: Arc::new(agent),
             hooks: None,
@@ -10542,6 +10656,7 @@ mod tests {
             session_key: session_key.clone(),
             channel: reply_channel.to_string(),
             chat_id: "test-api-chat".to_string(),
+            tenant_id: None,
             inbox: inbox_rx,
             agent: Arc::new(agent),
             hooks: None,
@@ -13003,6 +13118,7 @@ mod tests {
                 reply_chat_id: "!room:localhost",
                 status_indicator: None,
                 profile_id: Some("weather"),
+                tenant_id: Some("weather"),
                 system_prompt_override: Some("You are a weather bot".to_string()),
                 sender_user_id: Some("@octos_weather:localhost".to_string()),
             })
@@ -13045,6 +13161,7 @@ mod tests {
                 reply_chat_id: "!room:localhost",
                 status_indicator: None,
                 profile_id: None,
+                tenant_id: None,
                 system_prompt_override: None,
                 sender_user_id: None,
             })
@@ -13087,6 +13204,7 @@ mod tests {
                 reply_chat_id: "!room:localhost",
                 status_indicator: None,
                 profile_id: Some("weather"),
+                tenant_id: Some("weather"),
                 system_prompt_override: None,
                 sender_user_id: None,
             })
@@ -13113,6 +13231,7 @@ mod tests {
                 reply_chat_id: "!room:localhost",
                 status_indicator: None,
                 profile_id: None,
+                tenant_id: None,
                 system_prompt_override: None,
                 sender_user_id: None,
             })
@@ -13162,6 +13281,7 @@ mod tests {
                 reply_chat_id: "!room:localhost",
                 status_indicator: None,
                 profile_id: Some("weather"),
+                tenant_id: Some("weather"),
                 system_prompt_override: None,
                 sender_user_id: Some("@octos_weather:localhost".to_string()),
             })
@@ -15270,26 +15390,32 @@ mod tests {
     }
 
     #[test]
-    fn build_gateway_session_scope_returns_none_for_unsafe_session_id() {
-        // Channel-prefixed legacy shapes (`api:web-1234`,
-        // `telegram:12345`, etc.) produce a `base_key()` containing
-        // `:`, which fails `is_safe_session_id`. We MUST route those
-        // through the legacy resolver (= None) rather than building a
-        // scope against the unsafe id.
+    fn build_gateway_session_scope_binds_tenant_for_unsafe_session_id() {
+        // #1377 Phase-3-B: channel-prefixed legacy shapes (`api:web-1234`,
+        // `telegram:12345`, etc.) produce a `base_key()` containing `:`,
+        // which fails `is_safe_session_id`. These USED to skip scope
+        // construction (None), dropping actor file tools onto the unscoped
+        // legacy resolver that decodes process-global `up/` handles with no
+        // tenant check. They now get a tenant-bound scope rooted at the
+        // session's real (percent-encoded) workspace, so the upload gate
+        // applies — the gateway/actor sibling of the serve fix.
         let tmp = tempfile::TempDir::new().unwrap();
         let session_key = SessionKey::new("telegram", "12345");
-        // Sanity: pin the regression — channel-prefixed shape really
-        // fails the safe-id check.
+        // Sanity: pin that this really is a channel-prefixed (unsafe) shape.
         assert!(
             !octos_core::is_safe_session_id(session_key.base_key()),
             "this test relies on channel-prefixed keys failing is_safe_session_id; \
              update the test if SessionKey's representation changes",
         );
 
-        let scope = build_gateway_session_scope(Some("dspfac"), tmp.path(), &session_key, &[]);
-        assert!(
-            scope.is_none(),
-            "unsafe session id must skip scope (legacy resolver path)",
+        let scope = build_gateway_session_scope(Some("dspfac"), tmp.path(), &session_key, &[])
+            .expect("channel-prefixed id now yields a tenant-bound scope");
+        assert_eq!(scope.tenant_id(), Some("dspfac"));
+        // Workspace is the real encoded on-disk path under the data dir.
+        let encoded = octos_bus::session::encode_path_component(session_key.base_key());
+        assert_eq!(
+            scope.workspace(),
+            tmp.path().join("users").join(&encoded).join("workspace"),
         );
     }
 

--- a/crates/octos-core/src/session_scope.rs
+++ b/crates/octos-core/src/session_scope.rs
@@ -546,6 +546,17 @@ impl SessionScope {
         &self.mode
     }
 
+    /// The tenant (profile) id this scope belongs to — `Some` for a
+    /// multi-tenant session, `None` for a solo session. Used to bind
+    /// uploaded files to a tenant and to refuse cross-tenant `up/`
+    /// handle resolution (#1377).
+    pub fn tenant_id(&self) -> Option<&str> {
+        match &self.mode {
+            ScopeMode::MultiTenant { tenant_id, .. } => Some(tenant_id.as_str()),
+            ScopeMode::Solo { .. } => None,
+        }
+    }
+
     /// Return the read-only plugin skill directories the agent may
     /// reach. See the `skill_read_zones` field doc on [`SessionScope`].
     pub fn skill_read_zones(&self) -> &[PathBuf] {
@@ -856,6 +867,15 @@ mod tests {
             session.into(),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn tenant_id_some_for_multi_tenant_none_for_solo() {
+        let data = abs("/octos/profiles/dspfac/data");
+        let mt = mt_default(&data, "web-x");
+        assert_eq!(mt.tenant_id(), Some("dspfac"));
+        let solo = SessionScope::solo(abs("/ws"), vec![]).unwrap();
+        assert_eq!(solo.tenant_id(), None);
     }
 
     #[test]

--- a/crates/octos-core/src/session_scope.rs
+++ b/crates/octos-core/src/session_scope.rs
@@ -499,6 +499,119 @@ impl SessionScope {
         Self::multi_tenant(profile_data_dir, tenant_id, session_id, shared_zones)
     }
 
+    /// Construct a multi-tenant scope bound to an EXPLICIT `workspace`
+    /// directory rather than the canonical
+    /// `<root>/users/<session_id>/workspace` layout that
+    /// [`Self::multi_tenant`] derives.
+    ///
+    /// Use this when the session's real on-disk workspace does not match
+    /// the canonical derivation:
+    ///
+    /// - **coding-agent `workspace_hint` sessions** rooted at a
+    ///   caller-supplied repo. The repo lives OUTSIDE the profile data
+    ///   dir, so pass `profile_data_dir == workspace` (root the scope at
+    ///   the repo itself) and `shared_zones == []` — there is no valid
+    ///   `<root>/research` zone to grant.
+    /// - **channel-prefixed session ids** (`api:web-1234`, …) whose `:`
+    ///   the on-disk path percent-encodes. Pass the profile data dir as
+    ///   `profile_data_dir` and the encoded
+    ///   `<data>/users/<encoded>/workspace` as `workspace` (it IS under
+    ///   the data dir), with the usual shared zones.
+    ///
+    /// `session_id` is recorded for diagnostics only — classification
+    /// keys off `workspace` + `shared_zones`, never `session_id` — but it
+    /// must still satisfy [`is_safe_session_id`] (callers sanitize the
+    /// `:` first). The tenant binding applies regardless, so the agent
+    /// resolver's upload-ownership gate fires for `up/` handles in these
+    /// sessions (#1377): an unscoped session would decode a global `up/`
+    /// handle with no tenant check, but a tenant-bound scope routes
+    /// through the gated resolver.
+    ///
+    /// Validates that `profile_data_dir` and `workspace` are absolute,
+    /// that `workspace` does not escape `profile_data_dir` (equal is
+    /// allowed — the coding-agent root-at-repo case), that the tenant id
+    /// is non-empty, that `session_id` is safe, and that every shared
+    /// zone is a strict subdir of root that does not overlap the
+    /// per-session `users/` subtree (codex round-2 P2 isolation guard).
+    pub fn multi_tenant_at_workspace(
+        profile_data_dir: PathBuf,
+        workspace: PathBuf,
+        tenant_id: String,
+        session_id: String,
+        shared_zones: Vec<PathBuf>,
+    ) -> Result<Self, SessionScopeError> {
+        if !profile_data_dir.is_absolute() {
+            return Err(SessionScopeError::RootNotAbsolute(profile_data_dir));
+        }
+        if !workspace.is_absolute() {
+            // An absolute workspace is required for the same reason as an
+            // absolute root: so the scope cannot be reinterpreted against
+            // a different CWD. Reuse `RootNotAbsolute` — there is no
+            // separate workspace-absoluteness variant and the message is
+            // accurate (workspace is the scope's effective root here).
+            return Err(SessionScopeError::RootNotAbsolute(workspace));
+        }
+        // Reject `..` components BEFORE the lexical containment check
+        // below. `Path::starts_with` is purely lexical, so a workspace
+        // like `<root>/../escapes` lexically "starts with" <root> yet
+        // canonicalizes OUTSIDE it — and the scoped resolver canonicalizes
+        // `scope.workspace()`, which would then classify the escaped
+        // directory as `InWorkspace`, defeating the WorkspaceEscapesRoot
+        // guarantee (codex round-11 P2). Canonical/derived workspaces
+        // never contain `..`, so rejecting is a safe degrade (the bootstrap
+        // caller falls back to an unscoped session). Check `root` too —
+        // a `..` in the root would make the containment compare meaningless.
+        if workspace
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+            || profile_data_dir
+                .components()
+                .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            return Err(SessionScopeError::WorkspaceEscapesRoot {
+                root: profile_data_dir,
+                workspace,
+            });
+        }
+        if !workspace.starts_with(&profile_data_dir) {
+            return Err(SessionScopeError::WorkspaceEscapesRoot {
+                root: profile_data_dir,
+                workspace,
+            });
+        }
+        if tenant_id.is_empty() {
+            return Err(SessionScopeError::EmptyTenantId);
+        }
+        if !is_safe_session_id(&session_id) {
+            return Err(SessionScopeError::UnsafeSessionId(session_id));
+        }
+        let users_subtree = profile_data_dir.join(MULTI_TENANT_USERS_DIR_NAME);
+        for zone in &shared_zones {
+            if zone == &profile_data_dir || !zone.starts_with(&profile_data_dir) {
+                return Err(SessionScopeError::SharedZoneNotStrictSubdir {
+                    root: profile_data_dir.clone(),
+                    zone: zone.clone(),
+                });
+            }
+            if zone == &users_subtree || zone.starts_with(&users_subtree) {
+                return Err(SessionScopeError::SharedZoneOverlapsUsersSubtree {
+                    users_subtree: users_subtree.clone(),
+                    zone: zone.clone(),
+                });
+            }
+        }
+        Ok(Self {
+            workspace,
+            root: profile_data_dir,
+            mode: ScopeMode::MultiTenant {
+                tenant_id,
+                session_id,
+                shared_zones,
+            },
+            skill_read_zones: Vec::new(),
+        })
+    }
+
     /// Construct a solo scope from the user's CWD. Workspace == root
     /// (one CWD per process); no shared zones (cross-session
     /// continuity is the user's project files in their CWD, not a
@@ -876,6 +989,107 @@ mod tests {
         assert_eq!(mt.tenant_id(), Some("dspfac"));
         let solo = SessionScope::solo(abs("/ws"), vec![]).unwrap();
         assert_eq!(solo.tenant_id(), None);
+    }
+
+    #[test]
+    fn multi_tenant_at_workspace_accepts_encoded_under_data_layout() {
+        // Channel-prefixed `:` session: the on-disk workspace lives under
+        // the profile data dir (percent-encoded path), so root stays at
+        // the data dir and the standard shared zones apply.
+        let data = abs("/octos/profiles/dspfac/data");
+        let workspace = data.join("users/api%3Aweb-1234/workspace");
+        let scope = SessionScope::multi_tenant_at_workspace(
+            data.clone(),
+            workspace.clone(),
+            "dspfac".into(),
+            "api-web-1234".into(),
+            vec![data.join("research"), data.join("skills")],
+        )
+        .expect("encoded workspace under data dir is valid");
+        assert_eq!(scope.root(), data);
+        assert_eq!(scope.workspace(), workspace.as_path());
+        // Tenant binding present -> the agent resolver's upload gate fires.
+        assert_eq!(scope.tenant_id(), Some("dspfac"));
+        // A workspace-relative path classifies InWorkspace; arbitrary
+        // absolute paths outside the scope stay OutOfScope.
+        assert!(matches!(
+            scope.classify_canonical_path(&workspace.join("uploads/a.md")),
+            PathClassification::InWorkspace
+        ));
+    }
+
+    #[test]
+    fn multi_tenant_at_workspace_roots_at_repo_for_coding_hint() {
+        // Coding-agent hint session: the repo lives OUTSIDE the profile
+        // data dir, so the caller roots the scope at the repo itself
+        // (workspace == root) with no shared zones. workspace.starts_with
+        // (root) holds via equality, so the WorkspaceEscapesRoot guard
+        // does not trip.
+        // Use a path under `/octos` (guaranteed not to exist and not a
+        // macOS automount like `/home`) so `canonicalize_lossy` treats
+        // candidate + workspace identically.
+        let repo = abs("/octos/repos/some-repo");
+        let scope = SessionScope::multi_tenant_at_workspace(
+            repo.clone(),
+            repo.clone(),
+            "dspfac".into(),
+            "appui-1234".into(),
+            vec![],
+        )
+        .expect("repo-rooted hint scope is valid");
+        assert_eq!(scope.root(), repo);
+        assert_eq!(scope.workspace(), repo);
+        assert_eq!(scope.tenant_id(), Some("dspfac"));
+        assert!(matches!(
+            scope.classify_canonical_path(&repo.join("src/main.rs")),
+            PathClassification::InWorkspace
+        ));
+    }
+
+    #[test]
+    fn multi_tenant_at_workspace_rejects_workspace_escaping_root() {
+        // A workspace that is neither under nor equal to root is a
+        // contract violation (the caller must root at the repo for the
+        // out-of-tree case, not leave root at the data dir).
+        let data = abs("/octos/profiles/dspfac/data");
+        let escaped = abs("/home/yc/outside");
+        let err = SessionScope::multi_tenant_at_workspace(
+            data,
+            escaped,
+            "dspfac".into(),
+            "x".into(),
+            vec![],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            SessionScopeError::WorkspaceEscapesRoot { .. }
+        ));
+    }
+
+    #[test]
+    fn multi_tenant_at_workspace_rejects_parent_dir_escape() {
+        // codex round-11 P2: a workspace that lexically `starts_with` root
+        // but contains `..` canonicalizes OUTSIDE root. `Path::starts_with`
+        // would accept it, so the `..` guard must reject it first.
+        let data = abs("/octos/profiles/dspfac/data");
+        let escaping = data.join("../escapes"); // lexically starts_with data
+        assert!(
+            escaping.starts_with(&data),
+            "test premise: the escaping path lexically starts_with root",
+        );
+        let err = SessionScope::multi_tenant_at_workspace(
+            data,
+            escaping,
+            "dspfac".into(),
+            "x".into(),
+            vec![],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            SessionScopeError::WorkspaceEscapesRoot { .. }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1377. Closes #1369. Also supersedes #1373 (#1369 — competing upload-scope fix; this PR covers that goal end-to-end and is live-verified).

## Scope (5 commits, off latest main, codex-clean, verified on mini3)
1. **`78cbd793`** — plugin subdir-prefixed input-path rescue (fixes the mofa-slides overwrite bug: `input: slides/<deck>/script.js` now resolves, so the agent stops falling back to the partial-array mode that clobbered slides 1-3).
2. **`19375cc2`** — materialize uploads into `<workspace>/uploads/` + per-tenant binding.
3. **`bf3e0c69`** — tenant-bind unscoped serve sessions (channel-prefixed `:` + workspace-hint) so the `up/` ownership gate fires.
4. **`7ee536f5`** — close the gateway/actor sibling: per-tenant `ApiChannel /upload` storage, pre-ASR/vision media filter, scope-binding, dispatch-tenant threading.
5. **`d6dad6c5`** — pre-merge hardening: gate `GET /files` downloads on the server-trusted tenant; canonicalize workspace hints; firmlink-safe in-profile scope-root selection.

## Cross-tenant isolation — LIVE-VERIFIED on mini3 (gateway 9401)
- Upload as tenant A (`dspfac`) → stored `octos-uploads/dspfac/...`; tenant B (`dspfac--lbc-bot`) → `octos-uploads/dspfac--lbc-bot/...` (per-tenant storage confirmed on disk).
- **ATTACK** (B chat carrying A's handle) → `NO_FILE_RECEIVED` (dropped pre-agent).
- **CONTROL** (B reads its own handle) → `read_file` → `hello-from-tenant-B` (legit uploads unaffected).
- **ATTACK 2** (B `read_file`s A's handle directly) → `Uploaded file not found` (scope gate refused).

## Review
- **codex pre-merge gate**: all commits reviewed; 2 genuine residuals found (download-route ungated; raw workspace hint) + 1 self-introduced flaw (download gate trusting a request param) — all fixed; final commit codex-clean.
- octos-bus 283 (--features api) + octos-cli lib 1471 + octos-agent plugins 108 tests pass; fmt/clippy clean.

## Not included (tracked follow-ups)
- Web download chip session-context (`01eeabc`, separate).
- `pf/` profile-handle reads for newly-scoped sessions (#1367).
- A cross-profile-routed upload is not downloadable via the raw `up/` GET route (the gateway can't authenticate the caller as the target tenant); the agent reaches it via the materialized workspace copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)