### PR TITLE
feat(auth): no-password solo login for local single-user installs

### DIFF
--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -581,6 +581,10 @@ pub async fn auth_status(
             .as_ref()
             .map(|m| m.allow_self_registration())
             .unwrap_or(false),
+        // Advertise solo only when supported — which now requires the
+        // explicit opt-in (a hosted Local-mode fleet daemon behind Caddy never
+        // sets it), so the SPA never offers the no-password path there. See
+        // `supports_local_solo_profile_create` / `crate::api::solo_auth`.
         local_solo_enabled: crate::api::ui_protocol::supports_local_solo_profile_create(&state),
         scoped_profile,
     }))
@@ -2395,6 +2399,7 @@ mod tests {
         ));
         let state = AppState {
             auth_token: Some("bootstrap-token".into()),
+            solo_login_enabled: true,
             admin_token_store: Arc::new(crate::admin_token_store::AdminTokenStore::new(dir.path())),
             setup_state_store: Arc::new(crate::setup_state_store::SetupStateStore::new(dir.path())),
             metrics_handle: None,

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -366,6 +366,14 @@ pub struct AuthStatusResponse {
     pub email_login_enabled: bool,
     pub admin_token_login_enabled: bool,
     pub allow_self_registration: bool,
+    /// True when this host advertises the no-password solo login path
+    /// (`POST /api/auth/solo` / `/api/auth/solo/create`): a Local-mode
+    /// deployment with profile + user stores. The SPA reads this to show
+    /// the "continue without a password" affordance. Mirrors the TUI's
+    /// `profile/local/create` capability gate (`supports_local_solo_profile_create`).
+    /// The flag does NOT mean auth is bypassed — the endpoints still
+    /// enforce a loopback peer at request time.
+    pub local_solo_enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scoped_profile: Option<ScopedAuthTarget>,
 }
@@ -573,6 +581,7 @@ pub async fn auth_status(
             .as_ref()
             .map(|m| m.allow_self_registration())
             .unwrap_or(false),
+        local_solo_enabled: crate::api::ui_protocol::supports_local_solo_profile_create(&state),
         scoped_profile,
     }))
 }
@@ -2396,6 +2405,34 @@ mod tests {
             ..AppState::empty_for_tests()
         };
         (dir, state, user_store, profile_store)
+    }
+
+    #[tokio::test]
+    async fn auth_status_advertises_local_solo_enabled_in_local_mode() {
+        // Local deployment + profile/user stores ⇒ the no-password solo
+        // login path is available, so /api/auth/status must advertise it.
+        let (_dir, state, _user_store, _profile_store) = temp_app_state();
+        assert_eq!(state.deployment_mode, crate::config::DeploymentMode::Local);
+        let Json(status) = auth_status(State(Arc::new(state)), HeaderMap::new())
+            .await
+            .unwrap();
+        assert!(status.local_solo_enabled);
+    }
+
+    #[tokio::test]
+    async fn auth_status_hides_local_solo_in_tenant_mode() {
+        // Tenant/cloud hosts are multi-tenant; the solo path must never be
+        // advertised there (defense-in-depth alongside the request-time
+        // loopback gate enforced by the handlers themselves).
+        let (_dir, state, _user_store, _profile_store) = temp_app_state();
+        let state = AppState {
+            deployment_mode: crate::config::DeploymentMode::Tenant,
+            ..state
+        };
+        let Json(status) = auth_status(State(Arc::new(state)), HeaderMap::new())
+            .await
+            .unwrap();
+        assert!(!status.local_solo_enabled);
     }
 
     fn scoped_host_headers(host: &str) -> HeaderMap {

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -227,7 +227,7 @@ fn resolve_root_login_target(state: &AppState, email: &str) -> Option<RootLoginT
     }
 }
 
-fn is_login_ready_email(email: &str) -> bool {
+pub(crate) fn is_login_ready_email(email: &str) -> bool {
     let normalized = email.trim().to_lowercase();
     !normalized.is_empty() && normalized != ADMIN_PLACEHOLDER_EMAIL
 }

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -242,6 +242,16 @@ pub struct AppState {
     pub frps_port: Option<u16>,
     /// Deployment mode (local, tenant, or cloud).
     pub deployment_mode: crate::config::DeploymentMode,
+    /// Opt-in for the no-password "solo" REST login (`/api/auth/solo*`).
+    /// OFF by default; set by `octos serve --solo` / `OCTOS_SOLO_LOGIN=1`.
+    ///
+    /// SECURITY: `deployment_mode == Local` is NOT sufficient to enable solo
+    /// login. A hosted fleet daemon runs Local mode behind a Caddy reverse
+    /// proxy, so every request reaches the daemon over loopback and would
+    /// otherwise pass the loopback guard. This explicit opt-in (which fleet
+    /// configs never set) is the primary defence; the handlers additionally
+    /// reject any request carrying proxy-forwarding headers.
+    pub solo_login_enabled: bool,
     /// Whether the admin shell endpoint is enabled (default: false).
     pub allow_admin_shell: bool,
     /// Content catalog manager for per-profile file indexing.
@@ -352,6 +362,7 @@ impl AppState {
             frps_server: None,
             frps_port: None,
             deployment_mode: crate::config::DeploymentMode::Local,
+            solo_login_enabled: false,
             allow_admin_shell: false,
             content_catalog_mgr: None,
             swarm_state: None,

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -23,6 +23,7 @@ pub mod preview;
 pub mod preview_tokens;
 pub mod purge;
 mod router;
+pub(crate) mod solo_auth;
 pub(crate) mod specialist_runner;
 mod static_files;
 pub(crate) mod supervisor_store;

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -19,6 +19,7 @@ use super::frps_plugin;
 use super::handlers;
 use super::metrics;
 use super::purge;
+use super::solo_auth;
 use super::static_files;
 use super::swarm as swarm_api;
 use super::ui_protocol;
@@ -86,10 +87,17 @@ pub fn build_router(state: Arc<AppState>) -> Router {
     };
 
     // Public auth endpoints (no auth required)
+    //
+    // `/api/auth/solo*` are the no-password solo login routes. They are
+    // public by design — no credential exists yet on a fresh local install
+    // — and fail closed inside the handlers (`solo_auth::solo_login_allowed`)
+    // unless the host is Local-solo AND the peer is loopback.
     let auth_api = Router::new()
         .route("/api/auth/status", get(auth_handlers::auth_status))
         .route("/api/auth/send-code", post(auth_handlers::send_code))
         .route("/api/auth/verify", post(auth_handlers::verify))
+        .route("/api/auth/solo", post(solo_auth::solo_login))
+        .route("/api/auth/solo/create", post(solo_auth::solo_create))
         .route("/api/auth/logout", post(auth_handlers::logout));
 
     // Chat + status API (existing)

--- a/crates/octos-cli/src/api/solo_auth.rs
+++ b/crates/octos-cli/src/api/solo_auth.rs
@@ -32,7 +32,7 @@ use octos_core::ui_protocol::{
 };
 
 use super::AppState;
-use super::auth_handlers::is_top_level_profile_id;
+use super::auth_handlers::{is_login_ready_email, is_top_level_profile_id};
 use super::ui_protocol::{create_or_get_local_solo_profile, supports_local_solo_profile_create};
 use crate::user_store::{User, UserRole};
 
@@ -81,11 +81,18 @@ fn rpc_error_to_status(err: &RpcError) -> StatusCode {
 /// Resolve the local solo owner. In solo mode there is normally exactly one
 /// top-level user; if several exist (e.g. repeated `solo/create` with
 /// different usernames) the most recently created wins so a fresh onboard
-/// takes effect. Sub-accounts are excluded.
+/// takes effect.
+///
+/// Sub-accounts and the bootstrap `admin` placeholder are excluded. The
+/// placeholder (email `admin@localhost`) is created by `ensure_admin_user`
+/// on a bare admin-token `/me` call; it is NOT a solo owner, so matching it
+/// here would mint an admin session instead of the documented first-run 404.
+/// `is_login_ready_email` rejects it (and any empty/placeholder email),
+/// leaving only genuine solo profiles created via `profile/local/create`.
 fn resolve_solo_user(state: &AppState) -> Option<User> {
     let store = state.user_store.as_ref()?;
     let mut users: Vec<User> = store.list().ok()?;
-    users.retain(|u| is_top_level_profile_id(state, &u.id));
+    users.retain(|u| is_top_level_profile_id(state, &u.id) && is_login_ready_email(&u.email));
     users.into_iter().max_by_key(|u| u.created_at)
 }
 
@@ -236,6 +243,34 @@ mod tests {
         let err = solo_login(State(state), loopback())
             .await
             .expect_err("no solo profile yet → 404 so the SPA shows the create form");
+        assert_eq!(err, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn solo_login_404_ignores_admin_placeholder() {
+        // A bare admin-token `/me` call can create the disabled `admin`
+        // placeholder (email admin@localhost) as a top-level user. That is
+        // NOT a solo owner — solo_login must still 404 so the SPA shows the
+        // create form rather than minting an admin session.
+        let dir = tempfile::tempdir().unwrap();
+        let state = solo_state(dir.path());
+        state
+            .user_store
+            .as_ref()
+            .unwrap()
+            .save(&User {
+                id: "admin".into(),
+                email: "admin@localhost".into(),
+                name: "Admin".into(),
+                role: UserRole::Admin,
+                created_at: chrono::Utc::now(),
+                last_login_at: None,
+            })
+            .unwrap();
+
+        let err = solo_login(State(state), loopback())
+            .await
+            .expect_err("the admin placeholder is not a solo owner");
         assert_eq!(err, StatusCode::NOT_FOUND);
     }
 

--- a/crates/octos-cli/src/api/solo_auth.rs
+++ b/crates/octos-cli/src/api/solo_auth.rs
@@ -1,0 +1,334 @@
+//! No-password "solo" login for local single-user installs.
+//!
+//! In `DeploymentMode::Local` the dashboard is a single-operator tool on a
+//! loopback-only host, so forcing an admin-token / OTP login adds friction
+//! with no security benefit. These endpoints mirror the TUI's solo
+//! onboarding (`profile/local/create` is the login primitive): the SPA can
+//! create a local profile and/or obtain a session token without a password.
+//!
+//! ## Security model — fail closed
+//!
+//! Both handlers gate on [`solo_login_allowed`], which requires BOTH:
+//!   1. [`supports_local_solo_profile_create`] — `deployment_mode == Local`
+//!      with profile + user stores present, AND
+//!   2. a loopback request peer (`ConnectInfo` IP `is_loopback()`).
+//!
+//! Local mode binds `127.0.0.1` and runs no reverse proxy (proxies are a
+//! tenant/cloud concern), so a loopback peer here is a genuine local client
+//! — the same loopback-⇒-trusted model the codebase already uses for
+//! `X-Profile-Id` (`router::is_trusted_proxy_addr`). Tenant/cloud hosts,
+//! which DO terminate proxies over loopback, are excluded by gate (1), so
+//! the proxy-spoofing path can never reach these handlers.
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+
+use axum::extract::{ConnectInfo, Json, State};
+use axum::http::StatusCode;
+use serde::Serialize;
+
+use octos_core::ui_protocol::{
+    ProfileLocalCreateParams, ProfileLocalCreateResult, RpcError, rpc_error_codes,
+};
+
+use super::AppState;
+use super::auth_handlers::is_top_level_profile_id;
+use super::ui_protocol::{create_or_get_local_solo_profile, supports_local_solo_profile_create};
+use crate::user_store::{User, UserRole};
+
+/// `POST /api/auth/solo/create` response: the created/looked-up local
+/// profile plus a freshly minted session token. Flattened so the SPA sees
+/// the same shape it would from `profile/local/create`, with `token` added.
+#[derive(Debug, Serialize)]
+pub struct SoloCreateResponse {
+    #[serde(flatten)]
+    pub result: ProfileLocalCreateResult,
+    pub token: String,
+}
+
+/// `POST /api/auth/solo` response: a session token for the existing local
+/// solo owner.
+#[derive(Debug, Serialize)]
+pub struct SoloLoginResponse {
+    pub token: String,
+    pub user: User,
+}
+
+/// The one security-critical check in the solo path. See the module docs.
+/// Returns `Ok(())` only for a Local-solo host reached over loopback;
+/// everything else is `403`.
+fn solo_login_allowed(state: &AppState, remote_ip: Option<IpAddr>) -> Result<(), StatusCode> {
+    if !supports_local_solo_profile_create(state) {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    match remote_ip {
+        Some(ip) if ip.is_loopback() => Ok(()),
+        _ => Err(StatusCode::FORBIDDEN),
+    }
+}
+
+/// Map the RPC error from the shared profile-creation logic onto an HTTP
+/// status. Validation failures are the caller's fault (400); the unsupported
+/// gate is a policy refusal (403); anything else is a server fault (500).
+fn rpc_error_to_status(err: &RpcError) -> StatusCode {
+    match err.code {
+        rpc_error_codes::INVALID_PARAMS => StatusCode::BAD_REQUEST,
+        rpc_error_codes::PERMISSION_DENIED => StatusCode::FORBIDDEN,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+/// Resolve the local solo owner. In solo mode there is normally exactly one
+/// top-level user; if several exist (e.g. repeated `solo/create` with
+/// different usernames) the most recently created wins so a fresh onboard
+/// takes effect. Sub-accounts are excluded.
+fn resolve_solo_user(state: &AppState) -> Option<User> {
+    let store = state.user_store.as_ref()?;
+    let mut users: Vec<User> = store.list().ok()?;
+    users.retain(|u| is_top_level_profile_id(state, &u.id));
+    users.into_iter().max_by_key(|u| u.created_at)
+}
+
+/// Mint a session token for `user_id`. `validate_session` re-reads the live
+/// role from the store, so `role` here is non-authoritative.
+async fn mint_solo_session(
+    state: &AppState,
+    user_id: &str,
+    role: UserRole,
+) -> Result<String, StatusCode> {
+    let auth_manager = state
+        .auth_manager
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    auth_manager
+        .create_session_for_user(user_id, role)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+/// `POST /api/auth/solo/create` — onboard a local profile AND log in.
+///
+/// Public route (no auth middleware): the whole point is that no credential
+/// exists yet. Gated at request time by [`solo_login_allowed`].
+pub async fn solo_create(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    Json(params): Json<ProfileLocalCreateParams>,
+) -> Result<Json<SoloCreateResponse>, StatusCode> {
+    solo_login_allowed(&state, Some(addr.ip()))?;
+    let result = create_or_get_local_solo_profile(&state, params)
+        .map_err(|err| rpc_error_to_status(&err))?;
+    // The local solo owner is created with the Admin role
+    // (see `create_or_get_local_solo_profile`).
+    let token = mint_solo_session(&state, &result.user_id, UserRole::Admin).await?;
+    Ok(Json(SoloCreateResponse { result, token }))
+}
+
+/// `POST /api/auth/solo` — re-login for the existing local solo owner.
+///
+/// `404` when no solo profile exists yet (the SPA then shows the create
+/// form). Gated by [`solo_login_allowed`].
+pub async fn solo_login(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+) -> Result<Json<SoloLoginResponse>, StatusCode> {
+    solo_login_allowed(&state, Some(addr.ip()))?;
+    let user = resolve_solo_user(&state).ok_or(StatusCode::NOT_FOUND)?;
+    let token = mint_solo_session(&state, &user.id, user.role.clone()).await?;
+    Ok(Json(SoloLoginResponse { token, user }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::DeploymentMode;
+    use crate::otp::AuthManager;
+    use crate::profiles::ProfileStore;
+    use crate::user_store::UserStore;
+    use std::path::Path;
+
+    fn solo_state_in_mode(dir: &Path, mode: DeploymentMode) -> Arc<AppState> {
+        let user_store = Arc::new(UserStore::open(dir).unwrap());
+        let auth_manager = Arc::new(AuthManager::new(None, user_store.clone()));
+        Arc::new(AppState {
+            profile_store: Some(Arc::new(ProfileStore::open(dir).unwrap())),
+            user_store: Some(user_store),
+            auth_manager: Some(auth_manager),
+            deployment_mode: mode,
+            ..AppState::empty_for_tests()
+        })
+    }
+
+    fn solo_state(dir: &Path) -> Arc<AppState> {
+        solo_state_in_mode(dir, DeploymentMode::Local)
+    }
+
+    fn loopback() -> ConnectInfo<SocketAddr> {
+        ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 40000)))
+    }
+
+    fn remote() -> ConnectInfo<SocketAddr> {
+        ConnectInfo(SocketAddr::from(([8, 8, 8, 8], 40000)))
+    }
+
+    fn params(name: &str, username: &str, email: &str) -> ProfileLocalCreateParams {
+        ProfileLocalCreateParams {
+            name: name.into(),
+            username: username.into(),
+            email: email.into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn solo_create_returns_profile_and_token_when_local_and_loopback() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = solo_state(dir.path());
+
+        let Json(resp) = solo_create(
+            State(state.clone()),
+            loopback(),
+            Json(params("Ada Lovelace", "ada", "ada@example.com")),
+        )
+        .await
+        .expect("solo create should succeed on a local loopback host");
+
+        assert!(resp.result.created, "first create should report created");
+        assert_eq!(resp.result.runtime_mode, "solo");
+        assert_eq!(resp.result.user_id, "ada");
+        assert!(!resp.token.is_empty());
+
+        // The minted token must validate through the normal session path.
+        let mgr = state.auth_manager.as_ref().unwrap();
+        let (user_id, role) = mgr.validate_session(&resp.token).await.unwrap();
+        assert_eq!(user_id, "ada");
+        assert_eq!(role, UserRole::Admin);
+    }
+
+    #[tokio::test]
+    async fn solo_login_returns_token_when_profile_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = solo_state(dir.path());
+
+        // Seed via create, then re-login.
+        let _ = solo_create(
+            State(state.clone()),
+            loopback(),
+            Json(params("Ada", "ada", "ada@example.com")),
+        )
+        .await
+        .unwrap();
+
+        let Json(resp) = solo_login(State(state.clone()), loopback())
+            .await
+            .expect("solo login should succeed once a profile exists");
+
+        assert_eq!(resp.user.id, "ada");
+        let mgr = state.auth_manager.as_ref().unwrap();
+        let (user_id, _) = mgr.validate_session(&resp.token).await.unwrap();
+        assert_eq!(user_id, "ada");
+    }
+
+    #[tokio::test]
+    async fn solo_login_404_when_no_profile_yet() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = solo_state(dir.path());
+
+        let err = solo_login(State(state), loopback())
+            .await
+            .expect_err("no solo profile yet → 404 so the SPA shows the create form");
+        assert_eq!(err, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn solo_create_403_when_not_local_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = solo_state_in_mode(dir.path(), DeploymentMode::Tenant);
+
+        let err = solo_create(
+            State(state),
+            loopback(),
+            Json(params("Ada", "ada", "ada@example.com")),
+        )
+        .await
+        .expect_err("solo create must be refused on a tenant host");
+        assert_eq!(err, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn solo_create_403_when_peer_not_loopback() {
+        // Security: even in Local mode, a non-loopback peer must be refused.
+        let dir = tempfile::tempdir().unwrap();
+        let state = solo_state(dir.path());
+
+        let err = solo_create(
+            State(state),
+            remote(),
+            Json(params("Ada", "ada", "ada@example.com")),
+        )
+        .await
+        .expect_err("non-loopback peer must be refused");
+        assert_eq!(err, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn solo_login_403_when_peer_not_loopback() {
+        // Security: a fully-valid would-be login is still blocked off-loopback,
+        // proving the guard (not a missing profile) is what refuses it.
+        let dir = tempfile::tempdir().unwrap();
+        let state = solo_state(dir.path());
+        let _ = solo_create(
+            State(state.clone()),
+            loopback(),
+            Json(params("Ada", "ada", "ada@example.com")),
+        )
+        .await
+        .unwrap();
+
+        let err = solo_login(State(state), remote())
+            .await
+            .expect_err("non-loopback peer must be refused even with a valid profile");
+        assert_eq!(err, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn solo_create_400_on_invalid_username() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = solo_state(dir.path());
+
+        let err = solo_create(
+            State(state),
+            loopback(),
+            Json(params("Ada", "has space", "ada@example.com")),
+        )
+        .await
+        .expect_err("an invalid username must surface as a 400");
+        assert_eq!(err, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn solo_create_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = solo_state(dir.path());
+
+        let Json(first) = solo_create(
+            State(state.clone()),
+            loopback(),
+            Json(params("Ada", "ada", "ada@example.com")),
+        )
+        .await
+        .unwrap();
+        assert!(first.result.created);
+
+        let Json(second) = solo_create(
+            State(state.clone()),
+            loopback(),
+            Json(params("Ada", "ada", "ada@example.com")),
+        )
+        .await
+        .unwrap();
+        assert!(
+            !second.result.created,
+            "re-running create for the same owner is a no-op create"
+        );
+    }
+}

--- a/crates/octos-cli/src/api/solo_auth.rs
+++ b/crates/octos-cli/src/api/solo_auth.rs
@@ -1,30 +1,36 @@
 //! No-password "solo" login for local single-user installs.
 //!
-//! In `DeploymentMode::Local` the dashboard is a single-operator tool on a
-//! loopback-only host, so forcing an admin-token / OTP login adds friction
-//! with no security benefit. These endpoints mirror the TUI's solo
-//! onboarding (`profile/local/create` is the login primitive): the SPA can
-//! create a local profile and/or obtain a session token without a password.
+//! The dashboard normally needs an admin-token / OTP login. On a genuine
+//! single-user local box that is pure friction, so these endpoints let the
+//! SPA create a local profile and/or obtain a session token without a
+//! password — mirroring the TUI's solo onboarding (`profile/local/create`
+//! is the login primitive).
 //!
 //! ## Security model — fail closed
 //!
-//! Both handlers gate on [`solo_login_allowed`], which requires BOTH:
-//!   1. [`supports_local_solo_profile_create`] — `deployment_mode == Local`
-//!      with profile + user stores present, AND
-//!   2. a loopback request peer (`ConnectInfo` IP `is_loopback()`).
+//! Both handlers gate on [`solo_login_allowed`], which requires ALL of:
+//!   1. [`supports_local_solo_profile_create`] — which itself requires the
+//!      explicit operator **opt-in** (`octos serve --solo` /
+//!      `OCTOS_SOLO_LOGIN=1`) AND `deployment_mode == Local` with profile +
+//!      user stores. The opt-in lives on the shared predicate so it gates the
+//!      WS `profile/local/create` path too, not just these REST endpoints.
+//!   2. a loopback request peer (`ConnectInfo` IP `is_loopback()`), AND
+//!   3. NO reverse-proxy headers on the request.
 //!
-//! Local mode binds `127.0.0.1` and runs no reverse proxy (proxies are a
-//! tenant/cloud concern), so a loopback peer here is a genuine local client
-//! — the same loopback-⇒-trusted model the codebase already uses for
-//! `X-Profile-Id` (`router::is_trusted_proxy_addr`). Tenant/cloud hosts,
-//! which DO terminate proxies over loopback, are excluded by gate (1), so
-//! the proxy-spoofing path can never reach these handlers.
+//! The opt-in is the primary defence and exists because `deployment_mode ==
+//! Local` is NOT a safe proxy for "single-user box". A hosted fleet daemon
+//! runs Local mode behind a Caddy reverse proxy, so every external request
+//! reaches the daemon over loopback and would pass gate (2) — the codebase
+//! itself notes "loopback ⇒ trusted [proxy]" in `router::is_trusted_proxy_addr`.
+//! The opt-in (which fleet configs never set) plus gate (3) — rejecting any
+//! request that carries `X-Forwarded-*` / `X-Real-IP` / `Forwarded` — ensure a
+//! proxied request can never launder itself through the loopback check.
 
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
 use axum::extract::{ConnectInfo, Json, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use serde::Serialize;
 
 use octos_core::ui_protocol::{
@@ -54,17 +60,42 @@ pub struct SoloLoginResponse {
     pub user: User,
 }
 
-/// The one security-critical check in the solo path. See the module docs.
-/// Returns `Ok(())` only for a Local-solo host reached over loopback;
-/// everything else is `403`.
-fn solo_login_allowed(state: &AppState, remote_ip: Option<IpAddr>) -> Result<(), StatusCode> {
+/// Headers a reverse proxy sets but a direct local client does not. Their
+/// presence means the request was forwarded (e.g. by the Caddy that fronts
+/// the fleet), so it must never satisfy the loopback check.
+const PROXY_HEADERS: &[&str] = &[
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "x-real-ip",
+    "forwarded",
+];
+
+fn is_proxied(headers: &HeaderMap) -> bool {
+    PROXY_HEADERS.iter().any(|h| headers.contains_key(*h))
+}
+
+/// The security gate for the solo path. See the module docs for the full
+/// rationale. Returns `Ok(())` only when the operator opted in, the host is
+/// Local with stores, the peer is loopback, AND the request is not proxied.
+fn solo_login_allowed(
+    state: &AppState,
+    remote_ip: Option<IpAddr>,
+    headers: &HeaderMap,
+) -> Result<(), StatusCode> {
+    // (1)+(2) Opt-in (folded into supports_local_solo_profile_create) AND
+    // Local mode with profile/user stores. The opt-in is the primary defence
+    // — a hosted fleet daemon never sets it.
     if !supports_local_solo_profile_create(state) {
         return Err(StatusCode::FORBIDDEN);
     }
-    match remote_ip {
-        Some(ip) if ip.is_loopback() => Ok(()),
-        _ => Err(StatusCode::FORBIDDEN),
+    // (3) Loopback peer AND (4) not proxied — a forwarded request from Caddy
+    // arrives over loopback but carries proxy headers; reject it.
+    let loopback = remote_ip.map(|ip| ip.is_loopback()).unwrap_or(false);
+    if !loopback || is_proxied(headers) {
+        return Err(StatusCode::FORBIDDEN);
     }
+    Ok(())
 }
 
 /// Map the RPC error from the shared profile-creation logic onto an HTTP
@@ -120,9 +151,10 @@ async fn mint_solo_session(
 pub async fn solo_create(
     State(state): State<Arc<AppState>>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
     Json(params): Json<ProfileLocalCreateParams>,
 ) -> Result<Json<SoloCreateResponse>, StatusCode> {
-    solo_login_allowed(&state, Some(addr.ip()))?;
+    solo_login_allowed(&state, Some(addr.ip()), &headers)?;
     let result = create_or_get_local_solo_profile(&state, params)
         .map_err(|err| rpc_error_to_status(&err))?;
     // The local solo owner is created with the Admin role
@@ -138,8 +170,9 @@ pub async fn solo_create(
 pub async fn solo_login(
     State(state): State<Arc<AppState>>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
 ) -> Result<Json<SoloLoginResponse>, StatusCode> {
-    solo_login_allowed(&state, Some(addr.ip()))?;
+    solo_login_allowed(&state, Some(addr.ip()), &headers)?;
     let user = resolve_solo_user(&state).ok_or(StatusCode::NOT_FOUND)?;
     let token = mint_solo_session(&state, &user.id, user.role.clone()).await?;
     Ok(Json(SoloLoginResponse { token, user }))
@@ -154,7 +187,7 @@ mod tests {
     use crate::user_store::UserStore;
     use std::path::Path;
 
-    fn solo_state_in_mode(dir: &Path, mode: DeploymentMode) -> Arc<AppState> {
+    fn solo_state_full(dir: &Path, mode: DeploymentMode, opt_in: bool) -> Arc<AppState> {
         let user_store = Arc::new(UserStore::open(dir).unwrap());
         let auth_manager = Arc::new(AuthManager::new(None, user_store.clone()));
         Arc::new(AppState {
@@ -162,12 +195,17 @@ mod tests {
             user_store: Some(user_store),
             auth_manager: Some(auth_manager),
             deployment_mode: mode,
+            solo_login_enabled: opt_in,
             ..AppState::empty_for_tests()
         })
     }
 
     fn solo_state(dir: &Path) -> Arc<AppState> {
-        solo_state_in_mode(dir, DeploymentMode::Local)
+        solo_state_full(dir, DeploymentMode::Local, true)
+    }
+
+    fn solo_state_in_mode(dir: &Path, mode: DeploymentMode) -> Arc<AppState> {
+        solo_state_full(dir, mode, true)
     }
 
     fn loopback() -> ConnectInfo<SocketAddr> {
@@ -176,6 +214,17 @@ mod tests {
 
     fn remote() -> ConnectInfo<SocketAddr> {
         ConnectInfo(SocketAddr::from(([8, 8, 8, 8], 40000)))
+    }
+
+    fn no_headers() -> HeaderMap {
+        HeaderMap::new()
+    }
+
+    fn proxied_headers() -> HeaderMap {
+        // What Caddy (or any reverse proxy) adds in front of the daemon.
+        let mut h = HeaderMap::new();
+        h.insert("x-forwarded-for", "203.0.113.7".parse().unwrap());
+        h
     }
 
     fn params(name: &str, username: &str, email: &str) -> ProfileLocalCreateParams {
@@ -194,6 +243,7 @@ mod tests {
         let Json(resp) = solo_create(
             State(state.clone()),
             loopback(),
+            no_headers(),
             Json(params("Ada Lovelace", "ada", "ada@example.com")),
         )
         .await
@@ -220,12 +270,13 @@ mod tests {
         let _ = solo_create(
             State(state.clone()),
             loopback(),
+            no_headers(),
             Json(params("Ada", "ada", "ada@example.com")),
         )
         .await
         .unwrap();
 
-        let Json(resp) = solo_login(State(state.clone()), loopback())
+        let Json(resp) = solo_login(State(state.clone()), loopback(), no_headers())
             .await
             .expect("solo login should succeed once a profile exists");
 
@@ -240,7 +291,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let state = solo_state(dir.path());
 
-        let err = solo_login(State(state), loopback())
+        let err = solo_login(State(state), loopback(), no_headers())
             .await
             .expect_err("no solo profile yet → 404 so the SPA shows the create form");
         assert_eq!(err, StatusCode::NOT_FOUND);
@@ -268,10 +319,67 @@ mod tests {
             })
             .unwrap();
 
-        let err = solo_login(State(state), loopback())
+        let err = solo_login(State(state), loopback(), no_headers())
             .await
             .expect_err("the admin placeholder is not a solo owner");
         assert_eq!(err, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn solo_create_403_when_opt_in_disabled() {
+        // SECURITY: without the explicit operator opt-in, the solo endpoints
+        // must be refused even on a Local loopback host. This is the guard
+        // that keeps the Caddy-fronted fleet (which runs Local mode) safe.
+        let dir = tempfile::tempdir().unwrap();
+        let state = solo_state_full(dir.path(), DeploymentMode::Local, false);
+
+        let err = solo_create(
+            State(state),
+            loopback(),
+            no_headers(),
+            Json(params("Ada", "ada", "ada@example.com")),
+        )
+        .await
+        .expect_err("solo must be refused unless explicitly opted in");
+        assert_eq!(err, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn solo_create_403_when_proxied() {
+        // SECURITY: a reverse proxy reaches the daemon over loopback but sets
+        // forwarding headers. Such a request must be refused even with the
+        // opt-in on, so the loopback check cannot be laundered through Caddy.
+        let dir = tempfile::tempdir().unwrap();
+        let state = solo_state(dir.path());
+
+        let err = solo_create(
+            State(state),
+            loopback(),
+            proxied_headers(),
+            Json(params("Ada", "ada", "ada@example.com")),
+        )
+        .await
+        .expect_err("a proxied (X-Forwarded-For) request must be refused");
+        assert_eq!(err, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn solo_login_403_when_proxied() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = solo_state(dir.path());
+        let _ = solo_create(
+            State(state.clone()),
+            loopback(),
+            no_headers(),
+            Json(params("Ada", "ada", "ada@example.com")),
+        )
+        .await
+        .unwrap();
+
+        let err = solo_login(State(state), loopback(), proxied_headers())
+            .await
+            .expect_err("a proxied login must be refused even with a valid profile");
+        assert_eq!(err, StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]
@@ -282,6 +390,7 @@ mod tests {
         let err = solo_create(
             State(state),
             loopback(),
+            no_headers(),
             Json(params("Ada", "ada", "ada@example.com")),
         )
         .await
@@ -298,6 +407,7 @@ mod tests {
         let err = solo_create(
             State(state),
             remote(),
+            no_headers(),
             Json(params("Ada", "ada", "ada@example.com")),
         )
         .await
@@ -314,12 +424,13 @@ mod tests {
         let _ = solo_create(
             State(state.clone()),
             loopback(),
+            no_headers(),
             Json(params("Ada", "ada", "ada@example.com")),
         )
         .await
         .unwrap();
 
-        let err = solo_login(State(state), remote())
+        let err = solo_login(State(state), remote(), no_headers())
             .await
             .expect_err("non-loopback peer must be refused even with a valid profile");
         assert_eq!(err, StatusCode::FORBIDDEN);
@@ -333,6 +444,7 @@ mod tests {
         let err = solo_create(
             State(state),
             loopback(),
+            no_headers(),
             Json(params("Ada", "has space", "ada@example.com")),
         )
         .await
@@ -348,6 +460,7 @@ mod tests {
         let Json(first) = solo_create(
             State(state.clone()),
             loopback(),
+            no_headers(),
             Json(params("Ada", "ada", "ada@example.com")),
         )
         .await
@@ -357,6 +470,7 @@ mod tests {
         let Json(second) = solo_create(
             State(state.clone()),
             loopback(),
+            no_headers(),
             Json(params("Ada", "ada", "ada@example.com")),
         )
         .await

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -4988,8 +4988,19 @@ fn raw_profile_id(params: &RawProfileParams, connection_profile_id: Option<&str>
         .unwrap_or_else(|| MAIN_PROFILE_ID.to_string())
 }
 
-fn supports_local_solo_profile_create(state: &AppState) -> bool {
-    state.deployment_mode == crate::config::DeploymentMode::Local
+/// Whether the no-password local-solo profile primitive is available — both
+/// the `profile/local/create` WS method (TUI onboarding) and the
+/// `/api/auth/solo*` REST endpoints (dashboard).
+///
+/// SECURITY: this requires the explicit `solo_login_enabled` opt-in, NOT just
+/// Local mode. The hosted fleet runs Local mode behind a Caddy reverse proxy,
+/// so a proxied client reaches the daemon over loopback; without this gate it
+/// could create a top-level Admin user over EITHER transport. Fleet configs
+/// never set the opt-in, so solo stays off there; a genuine solo install runs
+/// `octos serve --solo` / `OCTOS_SOLO_LOGIN=1`.
+pub(crate) fn supports_local_solo_profile_create(state: &AppState) -> bool {
+    state.solo_login_enabled
+        && state.deployment_mode == crate::config::DeploymentMode::Local
         && state.profile_store.is_some()
         && state.user_store.is_some()
 }
@@ -5231,7 +5242,7 @@ fn ensure_existing_local_profile_matches(
     Ok(())
 }
 
-fn create_or_get_local_solo_profile(
+pub(crate) fn create_or_get_local_solo_profile(
     state: &AppState,
     params: octos_core::ui_protocol::ProfileLocalCreateParams,
 ) -> Result<octos_core::ui_protocol::ProfileLocalCreateResult, RpcError> {
@@ -19227,6 +19238,9 @@ mod tests {
             profile_store: Some(Arc::new(crate::profiles::ProfileStore::open(dir).unwrap())),
             user_store: Some(Arc::new(crate::user_store::UserStore::open(dir).unwrap())),
             deployment_mode: crate::config::DeploymentMode::Local,
+            // Solo profile creation is opt-in; the TUI/WS tests exercise the
+            // supported path, so enable it here.
+            solo_login_enabled: true,
             ..AppState::empty_for_tests()
         }
     }

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -246,6 +246,15 @@ pub struct ServeCommand {
     #[arg(long)]
     pub auth_token: Option<String>,
 
+    /// Enable the no-password "solo" login (`POST /api/auth/solo*`) for a
+    /// local single-user install. OFF by default. Only honoured for direct
+    /// loopback requests on a Local-mode host with profile/user stores, and
+    /// never when the request carries reverse-proxy headers. Also settable
+    /// via `OCTOS_SOLO_LOGIN=1`. Do NOT set on a host fronted by a reverse
+    /// proxy (e.g. the Caddy-fronted fleet) — see `api::solo_auth`.
+    #[arg(long)]
+    pub solo: bool,
+
     /// Disable automatic retry on transient errors.
     #[arg(long)]
     pub no_retry: bool,
@@ -634,6 +643,10 @@ impl ServeCommand {
                 .or_else(|| std::env::var("FRPS_SERVER").ok()),
             frps_port: std::env::var("FRPS_PORT").ok().and_then(|p| p.parse().ok()),
             deployment_mode: config.mode.clone(),
+            solo_login_enabled: self.solo
+                || std::env::var("OCTOS_SOLO_LOGIN")
+                    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                    .unwrap_or(false),
             allow_admin_shell: config.allow_admin_shell,
             content_catalog_mgr: Some(Arc::new(
                 crate::content_catalog::ContentCatalogManager::new(profile_store.clone()),

--- a/crates/octos-cli/src/otp.rs
+++ b/crates/octos-cli/src/otp.rs
@@ -559,6 +559,12 @@ impl AuthManager {
     /// cannot escalate privileges.
     pub async fn create_session_for_user(&self, user_id: &str, role: UserRole) -> Result<String> {
         let now = Utc::now();
+        // Record the login on the user, matching the OTP paths, so admin /
+        // user audit views show an accurate last_login_at after a solo login.
+        if let Some(mut user) = self.user_store.get(user_id)? {
+            user.last_login_at = Some(now);
+            self.user_store.save(&user)?;
+        }
         let token = generate_session_token();
         let session = ActiveSession {
             user_id: user_id.to_owned(),

--- a/crates/octos-cli/src/otp.rs
+++ b/crates/octos-cli/src/otp.rs
@@ -547,6 +547,37 @@ impl AuthManager {
         Ok(Some(token))
     }
 
+    /// Mint a session token for a known user WITHOUT an OTP challenge.
+    ///
+    /// This backs the loopback-only solo (no-password) login path. It performs
+    /// NO authorization of its own — the caller is responsible for gating
+    /// (`deployment_mode == Local` AND a loopback peer). Treat a call to this
+    /// as "the caller has already proven this is a local solo box."
+    ///
+    /// `user_id`/`role` are recorded on the session as-is; `validate_session`
+    /// later re-reads the live role from the user store, so a stale role here
+    /// cannot escalate privileges.
+    pub async fn create_session_for_user(&self, user_id: &str, role: UserRole) -> Result<String> {
+        let now = Utc::now();
+        let token = generate_session_token();
+        let session = ActiveSession {
+            user_id: user_id.to_owned(),
+            role,
+            created_at: now,
+            expires_at: now + Duration::hours(self.session_expiry_hours as i64),
+        };
+
+        {
+            let mut sessions = self.sessions.write().await;
+            sessions.insert(token.clone(), session);
+            if let Some(ref path) = self.sessions_path {
+                Self::persist_sessions_blocking(&sessions, path);
+            }
+        }
+
+        Ok(token)
+    }
+
     /// Validate a session token. Returns (user_id, role) if valid.
     /// Re-reads user role from disk to reflect role changes / deletions.
     pub async fn validate_session(&self, token: &str) -> Option<(String, UserRole)> {
@@ -931,6 +962,35 @@ mod tests {
         // Revoke
         mgr.revoke_session(&token).await;
         assert!(mgr.validate_session(&token).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn create_session_for_user_mints_validatable_session() {
+        // The solo (no-password) login path mints a session directly, with
+        // no OTP exchange. The minted token must validate exactly like an
+        // OTP-issued one so the rest of the auth pipeline is unchanged.
+        let dir = tempfile::tempdir().unwrap();
+        let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
+        user_store
+            .save(&crate::user_store::User {
+                id: "ada".into(),
+                email: "ada@example.com".into(),
+                name: "Ada".into(),
+                role: UserRole::Admin,
+                created_at: Utc::now(),
+                last_login_at: None,
+            })
+            .unwrap();
+
+        let mgr = AuthManager::new(None, user_store);
+        let token = mgr
+            .create_session_for_user("ada", UserRole::Admin)
+            .await
+            .unwrap();
+
+        let (user_id, role) = mgr.validate_session(&token).await.unwrap();
+        assert_eq!(user_id, "ada");
+        assert_eq!(role, UserRole::Admin);
     }
 
     #[tokio::test]

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -8,6 +8,9 @@ import type {
   OtpSendResponse,
   OtpVerifyResponse,
   MeResponse,
+  AuthStatusResponse,
+  SoloLoginResult,
+  SoloCreateResult,
   User,
   AllowlistEntry,
   SharedMetrics,
@@ -388,6 +391,21 @@ export const authApi = {
     }),
 
   me: () => authedRequest<MeResponse>('/auth/me'),
+
+  // Public login configuration — which login modes to render.
+  status: () => publicRequest<AuthStatusResponse>('/auth/status'),
+
+  // No-password solo login (Local-mode host, loopback peer). `soloLogin`
+  // re-logs the existing owner (404 when none exists yet); `soloCreate`
+  // onboards a local profile and logs in atomically.
+  soloLogin: () =>
+    publicRequest<SoloLoginResult>('/auth/solo', { method: 'POST' }),
+
+  soloCreate: (body: { name: string; username: string; email: string }) =>
+    publicRequest<SoloCreateResult>('/auth/solo/create', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
 
   logout: () =>
     authedRequest<ActionResponse>('/auth/logout', { method: 'POST' }),

--- a/dashboard/src/components/BootstrapGate.test.tsx
+++ b/dashboard/src/components/BootstrapGate.test.tsx
@@ -153,6 +153,24 @@ describe('BootstrapGate', () => {
     expect(screen.queryByTestId('welcome')).not.toBeInTheDocument()
   })
 
+  it('still forces rotation on a solo-capable host that also exposes admin-token login', async () => {
+    // local_solo_enabled is true for any Local host with stores, but if an
+    // admin token is also configured (admin_token_login_enabled) there is a
+    // live bootstrap token to rotate — the gate must NOT be bypassed.
+    mockGetTokenStatus.mockResolvedValue({ rotated: false })
+    mockGetSetupState.mockResolvedValue({
+      wizard_completed_at: null,
+      wizard_skipped: false,
+      wizard_last_step_reached: 0,
+    })
+    mockAuthStatus.mockResolvedValue({
+      local_solo_enabled: true,
+      admin_token_login_enabled: true,
+    })
+    renderAt('/')
+    await waitFor(() => expect(screen.getByTestId('welcome')).toBeInTheDocument())
+  })
+
   it('bypasses the gate for non-admin users', async () => {
     isAdminMock = false
     renderAt('/')

--- a/dashboard/src/components/BootstrapGate.test.tsx
+++ b/dashboard/src/components/BootstrapGate.test.tsx
@@ -18,6 +18,7 @@ import { ApiError } from '../api'
 
 const mockGetTokenStatus = vi.fn()
 const mockGetSetupState = vi.fn()
+const mockAuthStatus = vi.fn()
 
 vi.mock('../api', async () => {
   const actual = await vi.importActual<typeof import('../api')>('../api')
@@ -27,6 +28,7 @@ vi.mock('../api', async () => {
       getTokenStatus: () => mockGetTokenStatus(),
       getSetupState: () => mockGetSetupState(),
     },
+    authApi: { ...actual.authApi, status: () => mockAuthStatus() },
   }
 })
 
@@ -62,6 +64,9 @@ beforeEach(() => {
   isAdminMock = true
   mockGetTokenStatus.mockReset()
   mockGetSetupState.mockReset()
+  mockAuthStatus.mockReset()
+  // Default: a non-solo host, so existing rotate-wizard behaviour is unchanged.
+  mockAuthStatus.mockResolvedValue({ local_solo_enabled: false })
 })
 
 afterEach(() => {
@@ -131,6 +136,21 @@ describe('BootstrapGate', () => {
     mockGetSetupState.mockRejectedValue(new ApiError(500, 'server error'))
     renderAt('/')
     await waitFor(() => expect(screen.getByTestId('welcome')).toBeInTheDocument())
+  })
+
+  it('renders children on a solo host even when the token is not rotated', async () => {
+    // No-password solo hosts have nothing to rotate; the gate must not push
+    // the freshly solo-logged-in admin into the rotate-token wizard.
+    mockGetTokenStatus.mockResolvedValue({ rotated: false })
+    mockGetSetupState.mockResolvedValue({
+      wizard_completed_at: null,
+      wizard_skipped: false,
+      wizard_last_step_reached: 0,
+    })
+    mockAuthStatus.mockResolvedValue({ local_solo_enabled: true })
+    renderAt('/')
+    await waitFor(() => expect(screen.getByTestId('children')).toBeInTheDocument())
+    expect(screen.queryByTestId('welcome')).not.toBeInTheDocument()
   })
 
   it('bypasses the gate for non-admin users', async () => {

--- a/dashboard/src/components/BootstrapGate.tsx
+++ b/dashboard/src/components/BootstrapGate.tsx
@@ -51,11 +51,14 @@ export default function BootstrapGate({ children }: { children: React.ReactNode 
       }
 
       // Solo hosts have no password to rotate — the no-password solo login
-      // IS the setup. Never force the rotate-token wizard there (it stays
-      // reachable from the sidebar for anyone who wants it).
+      // IS the setup, so don't force the rotate-token wizard there (it stays
+      // reachable from the sidebar). But a Local host that ALSO exposes
+      // admin-token login still has a live bootstrap token that must be
+      // rotated, so only bypass when admin-token login is absent.
       if (
         authStatusRes.status === 'fulfilled' &&
-        authStatusRes.value.local_solo_enabled
+        authStatusRes.value.local_solo_enabled &&
+        !authStatusRes.value.admin_token_login_enabled
       ) {
         setDecision({ redirectTo: null, path: location.pathname })
         return

--- a/dashboard/src/components/BootstrapGate.tsx
+++ b/dashboard/src/components/BootstrapGate.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
-import { ApiError, api } from '../api'
+import { ApiError, api, authApi } from '../api'
 import { useAuth } from '../contexts/AuthContext'
 
 // Result of the bootstrap check.
@@ -28,40 +28,54 @@ export default function BootstrapGate({ children }: { children: React.ReactNode 
     }
     let cancelled = false
 
-    // Probe both endpoints in parallel. If either auth check fails (401/403)
-    // we bow out — AuthGuard upstream will redirect to /login. Other errors
-    // (5xx, network) fall through to the conservative "not rotated" branch
-    // so a misconfigured server still surfaces the wizard.
-    Promise.allSettled([api.getTokenStatus(), api.getSetupState()]).then(
-      ([statusRes, stateRes]) => {
-        if (cancelled) return
+    // Probe in parallel. If either admin auth check fails (401/403) we bow
+    // out — AuthGuard upstream will redirect to /login. Other errors (5xx,
+    // network) fall through to the conservative "not rotated" branch so a
+    // misconfigured server still surfaces the wizard. `authApi.status()` is
+    // public and tells us whether this is a no-password solo host.
+    Promise.allSettled([
+      api.getTokenStatus(),
+      api.getSetupState(),
+      authApi.status(),
+    ]).then(([statusRes, stateRes, authStatusRes]) => {
+      if (cancelled) return
 
-        const authFailed =
-          (statusRes.status === 'rejected' && ApiError.isAuthError(statusRes.reason)) ||
-          (stateRes.status === 'rejected' && ApiError.isAuthError(stateRes.reason))
-        if (authFailed) {
-          // Let AuthGuard handle the redirect. Render children so the
-          // unauthenticated path is invisible (no setup chrome flashes).
-          setDecision({ redirectTo: null, path: location.pathname })
-          return
-        }
+      const authFailed =
+        (statusRes.status === 'rejected' && ApiError.isAuthError(statusRes.reason)) ||
+        (stateRes.status === 'rejected' && ApiError.isAuthError(stateRes.reason))
+      if (authFailed) {
+        // Let AuthGuard handle the redirect. Render children so the
+        // unauthenticated path is invisible (no setup chrome flashes).
+        setDecision({ redirectTo: null, path: location.pathname })
+        return
+      }
 
-        const rotated =
-          statusRes.status === 'fulfilled' ? statusRes.value.rotated : false
-        const wizardCompleted =
-          stateRes.status === 'fulfilled' && stateRes.value.wizard_completed_at != null
+      // Solo hosts have no password to rotate — the no-password solo login
+      // IS the setup. Never force the rotate-token wizard there (it stays
+      // reachable from the sidebar for anyone who wants it).
+      if (
+        authStatusRes.status === 'fulfilled' &&
+        authStatusRes.value.local_solo_enabled
+      ) {
+        setDecision({ redirectTo: null, path: location.pathname })
+        return
+      }
 
-        if (rotated) {
-          setDecision({ redirectTo: null, path: location.pathname })
-          return
-        }
+      const rotated =
+        statusRes.status === 'fulfilled' ? statusRes.value.rotated : false
+      const wizardCompleted =
+        stateRes.status === 'fulfilled' && stateRes.value.wizard_completed_at != null
 
-        // Token not rotated. Skip the welcome step when the operator has
-        // already completed the wizard once (re-rotation case).
-        const target = wizardCompleted ? '/setup/rotate-token' : '/setup/welcome'
-        setDecision({ redirectTo: target, path: location.pathname })
-      },
-    )
+      if (rotated) {
+        setDecision({ redirectTo: null, path: location.pathname })
+        return
+      }
+
+      // Token not rotated. Skip the welcome step when the operator has
+      // already completed the wizard once (re-rotation case).
+      const target = wizardCompleted ? '/setup/rotate-token' : '/setup/welcome'
+      setDecision({ redirectTo: target, path: location.pathname })
+    })
 
     return () => {
       cancelled = true

--- a/dashboard/src/components/SoloProfileForm.test.tsx
+++ b/dashboard/src/components/SoloProfileForm.test.tsx
@@ -1,0 +1,97 @@
+// Tests for SoloProfileForm — the no-password local onboarding form.
+// Validation mirrors the server validators; the form must keep submit
+// disabled until name/username/email are valid, send trimmed values, and
+// surface a server rejection.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import SoloProfileForm from './SoloProfileForm'
+
+const soloCreate = vi.fn()
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ soloCreate }),
+}))
+
+beforeEach(() => {
+  soloCreate.mockReset()
+})
+
+function renderForm(onDone?: () => void) {
+  return render(
+    <MemoryRouter>
+      <SoloProfileForm onDone={onDone} />
+    </MemoryRouter>,
+  )
+}
+
+describe('SoloProfileForm', () => {
+  it('keeps submit disabled until name, username and email are valid', async () => {
+    const user = userEvent.setup()
+    renderForm()
+    const submit = screen.getByTestId('solo-submit')
+    expect(submit).toBeDisabled()
+
+    await user.type(screen.getByTestId('solo-name'), 'Ada Lovelace')
+    await user.type(screen.getByTestId('solo-username'), 'ada')
+    expect(submit).toBeDisabled() // email still missing
+
+    await user.type(screen.getByTestId('solo-email'), 'ada@example.com')
+    expect(submit).toBeEnabled()
+  })
+
+  it('rejects a username containing spaces', async () => {
+    const user = userEvent.setup()
+    renderForm()
+    await user.type(screen.getByTestId('solo-name'), 'Ada')
+    await user.type(screen.getByTestId('solo-username'), 'has space')
+    await user.type(screen.getByTestId('solo-email'), 'ada@example.com')
+    expect(screen.getByTestId('solo-submit')).toBeDisabled()
+  })
+
+  it('rejects an email with no @', async () => {
+    const user = userEvent.setup()
+    renderForm()
+    await user.type(screen.getByTestId('solo-name'), 'Ada')
+    await user.type(screen.getByTestId('solo-username'), 'ada')
+    await user.type(screen.getByTestId('solo-email'), 'not-an-email')
+    expect(screen.getByTestId('solo-submit')).toBeDisabled()
+  })
+
+  it('submits trimmed values and calls onDone on success', async () => {
+    const user = userEvent.setup()
+    soloCreate.mockResolvedValue(undefined)
+    const onDone = vi.fn()
+    renderForm(onDone)
+
+    await user.type(screen.getByTestId('solo-name'), '  Ada Lovelace ')
+    await user.type(screen.getByTestId('solo-username'), ' ada ')
+    await user.type(screen.getByTestId('solo-email'), ' ada@example.com ')
+    await user.click(screen.getByTestId('solo-submit'))
+
+    await waitFor(() =>
+      expect(soloCreate).toHaveBeenCalledWith({
+        name: 'Ada Lovelace',
+        username: 'ada',
+        email: 'ada@example.com',
+      }),
+    )
+    await waitFor(() => expect(onDone).toHaveBeenCalled())
+  })
+
+  it('surfaces a server rejection', async () => {
+    const user = userEvent.setup()
+    soloCreate.mockRejectedValue(new Error('username taken'))
+    renderForm()
+
+    await user.type(screen.getByTestId('solo-name'), 'Ada')
+    await user.type(screen.getByTestId('solo-username'), 'ada')
+    await user.type(screen.getByTestId('solo-email'), 'ada@example.com')
+    await user.click(screen.getByTestId('solo-submit'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('solo-error')).toHaveTextContent('username taken'),
+    )
+  })
+})

--- a/dashboard/src/components/SoloProfileForm.tsx
+++ b/dashboard/src/components/SoloProfileForm.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+
+// Client-side mirror of the server validators in `crate::api::ui_protocol`
+// (`validate_local_name`, `normalize_local_username`, `validate_local_email`).
+// These are a UX nicety only — the server remains authoritative and any
+// rejection it returns is surfaced verbatim below the form.
+const USERNAME_RE = /^[A-Za-z0-9._-]+$/
+const EMAIL_RE = /^[^\s@]+@[^\s@]+$/
+
+/**
+ * The solo onboarding form: full name / username / email → `soloCreate`.
+ * Shared by the login page (first run) and reusable elsewhere. On success
+ * it calls `onDone` if provided, otherwise navigates to `/`.
+ */
+export default function SoloProfileForm({ onDone }: { onDone?: () => void }) {
+  const { soloCreate } = useAuth()
+  const navigate = useNavigate()
+  const [name, setName] = useState('')
+  const [username, setUsername] = useState('')
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const nameOk = name.trim().length > 0 && name.trim().length <= 128
+  const usernameOk =
+    username.trim().length > 0 &&
+    username.trim().length <= 64 &&
+    USERNAME_RE.test(username.trim())
+  const emailOk = EMAIL_RE.test(email.trim())
+  const canSubmit = nameOk && usernameOk && emailOk && !submitting
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canSubmit) return
+    setError('')
+    setSubmitting(true)
+    try {
+      await soloCreate({
+        name: name.trim(),
+        username: username.trim(),
+        email: email.trim(),
+      })
+      if (onDone) onDone()
+      else navigate('/', { replace: true })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not create profile')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} data-testid="solo-profile-form">
+      <p className="text-sm text-gray-400 mb-4">
+        Create a local profile. It stays on this machine — no email code is sent.
+      </p>
+
+      <label className="block text-sm font-medium text-gray-300 mb-1" htmlFor="solo-name">
+        Full name
+      </label>
+      <input
+        id="solo-name"
+        data-testid="solo-name"
+        className="input w-full mb-3"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        autoFocus
+        disabled={submitting}
+      />
+
+      <label className="block text-sm font-medium text-gray-300 mb-1" htmlFor="solo-username">
+        Username
+      </label>
+      <input
+        id="solo-username"
+        data-testid="solo-username"
+        className="input w-full mb-1 font-mono"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        disabled={submitting}
+      />
+      <p className="text-xs text-gray-600 mb-3">
+        Letters, digits, dot, hyphen or underscore.
+      </p>
+
+      <label className="block text-sm font-medium text-gray-300 mb-1" htmlFor="solo-email">
+        Email
+      </label>
+      <input
+        id="solo-email"
+        data-testid="solo-email"
+        type="email"
+        className="input w-full mb-4"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        disabled={submitting}
+      />
+
+      {error && (
+        <p data-testid="solo-error" className="text-sm text-red-400 mb-3">
+          {error}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        data-testid="solo-submit"
+        disabled={!canSubmit}
+        className="w-full px-4 py-2.5 text-sm font-medium rounded-lg bg-accent text-white hover:bg-accent-light transition disabled:opacity-50"
+      >
+        {submitting ? 'Creating…' : 'Create profile & continue'}
+      </button>
+    </form>
+  )
+}

--- a/dashboard/src/contexts/AuthContext.test.tsx
+++ b/dashboard/src/contexts/AuthContext.test.tsx
@@ -1,0 +1,107 @@
+// Tests for the no-password solo paths on AuthContext.
+//
+// soloCreate must establish an authenticated principal even when the
+// follow-up /me refresh fails — otherwise AuthGuard would bounce the
+// freshly-created operator back to /login with no error.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { AuthProvider, useAuth } from './AuthContext'
+
+const mockMe = vi.fn()
+const mockSoloCreate = vi.fn()
+
+vi.mock('../api', async () => {
+  const actual = await vi.importActual<typeof import('../api')>('../api')
+  return {
+    ...actual,
+    authApi: {
+      ...actual.authApi,
+      me: () => mockMe(),
+      soloCreate: (b: unknown) => mockSoloCreate(b),
+    },
+  }
+})
+
+function Consumer() {
+  const { user, soloCreate } = useAuth()
+  return (
+    <div>
+      <button
+        data-testid="go"
+        onClick={() =>
+          void soloCreate({ name: 'Ada', username: 'ada', email: 'ada@example.com' })
+        }
+      >
+        go
+      </button>
+      <span data-testid="uid">{user?.id ?? 'none'}</span>
+      <span data-testid="uname">{user?.name ?? ''}</span>
+    </div>
+  )
+}
+
+function renderProvider() {
+  return render(
+    <MemoryRouter>
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+const CREATE_RESULT = {
+  profile_id: 'ada',
+  user_id: 'ada',
+  name: 'Ada',
+  username: 'ada',
+  email: 'ada@example.com',
+  created: true,
+  runtime_mode: 'solo',
+  token: 'tok123',
+}
+
+beforeEach(() => {
+  mockMe.mockReset()
+  mockSoloCreate.mockReset()
+  localStorage.clear()
+})
+
+describe('AuthContext soloCreate', () => {
+  it('sets the user from the create result even when /me fails', async () => {
+    mockSoloCreate.mockResolvedValue(CREATE_RESULT)
+    mockMe.mockRejectedValue(new Error('me unreachable'))
+    const user = userEvent.setup()
+    renderProvider()
+
+    await user.click(screen.getByTestId('go'))
+
+    await waitFor(() => expect(screen.getByTestId('uid')).toHaveTextContent('ada'))
+    expect(localStorage.getItem('octos_session_token')).toBe('tok123')
+  })
+
+  it('refines the user from /me when it succeeds', async () => {
+    mockSoloCreate.mockResolvedValue(CREATE_RESULT)
+    mockMe.mockResolvedValue({
+      user: {
+        id: 'ada',
+        email: 'ada@example.com',
+        name: 'Ada Lovelace',
+        role: 'admin',
+        created_at: '2026-01-01T00:00:00Z',
+        last_login_at: null,
+      },
+      profile: null,
+      scoped_profile: null,
+    })
+    const user = userEvent.setup()
+    renderProvider()
+
+    await user.click(screen.getByTestId('go'))
+
+    await waitFor(() => expect(screen.getByTestId('uname')).toHaveTextContent('Ada Lovelace'))
+  })
+})

--- a/dashboard/src/contexts/AuthContext.tsx
+++ b/dashboard/src/contexts/AuthContext.tsx
@@ -121,14 +121,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const res = await authApi.soloCreate(body)
       localStorage.setItem('octos_session_token', res.token)
       setToken(res.token)
-      // soloCreate returns the profile fields + token but not a full User;
-      // fetch the canonical principal via /me now that the token is live.
+      // Establish the principal directly from the create result so AuthGuard
+      // always has a user — even if the follow-up /me refresh fails (which
+      // would otherwise bounce the operator back to /login with no error).
+      // The local solo owner is created with the admin role server-side.
+      setUser({
+        id: res.user_id,
+        email: res.email,
+        name: res.name,
+        role: 'admin',
+        created_at: new Date().toISOString(),
+        last_login_at: null,
+      })
+      // Refine with the canonical principal + tenant scope when reachable.
       try {
         const me = await authApi.me()
         setUser(me.user)
         setScopedProfile(me.scoped_profile ?? null)
       } catch {
-        // best-effort
+        // best-effort refine — the create-derived user already unblocks the guard
       }
     },
     [],

--- a/dashboard/src/contexts/AuthContext.tsx
+++ b/dashboard/src/contexts/AuthContext.tsx
@@ -17,6 +17,12 @@ interface AuthContextValue {
   sendOtp: (email: string) => Promise<{ ok: boolean; message?: string }>
   verifyOtp: (email: string, code: string) => Promise<boolean>
   loginWithToken: (token: string) => Promise<boolean>
+  /** No-password solo re-login for the existing local owner. Rejects with
+   *  an `ApiError(404)` when no solo profile exists yet — the caller then
+   *  shows the create form. */
+  soloLogin: () => Promise<void>
+  /** Onboard a local profile AND log in (no password). */
+  soloCreate: (body: { name: string; username: string; email: string }) => Promise<void>
   swapToken: (newToken: string) => void
   logout: () => Promise<void>
 }
@@ -94,6 +100,40 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, [])
 
+  // No-password solo login. The server only honours these on a Local-mode
+  // host reached over loopback (see `crate::api::solo_auth`); off-loopback
+  // they 403, so the SPA can never land a session it shouldn't.
+  const soloLogin = useCallback(async () => {
+    const res = await authApi.soloLogin()
+    localStorage.setItem('octos_session_token', res.token)
+    setToken(res.token)
+    setUser(res.user)
+    try {
+      const me = await authApi.me()
+      setScopedProfile(me.scoped_profile ?? null)
+    } catch {
+      // best-effort scope refresh
+    }
+  }, [])
+
+  const soloCreate = useCallback(
+    async (body: { name: string; username: string; email: string }) => {
+      const res = await authApi.soloCreate(body)
+      localStorage.setItem('octos_session_token', res.token)
+      setToken(res.token)
+      // soloCreate returns the profile fields + token but not a full User;
+      // fetch the canonical principal via /me now that the token is live.
+      try {
+        const me = await authApi.me()
+        setUser(me.user)
+        setScopedProfile(me.scoped_profile ?? null)
+      } catch {
+        // best-effort
+      }
+    },
+    [],
+  )
+
   const swapToken = useCallback((newToken: string) => {
     localStorage.setItem('octos_auth_token', newToken)
     setToken(newToken)
@@ -114,7 +154,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   return (
     <AuthContext.Provider
-      value={{ user, token, isAdmin, scopedProfile, loading, sendOtp, verifyOtp, loginWithToken, swapToken, logout }}
+      value={{ user, token, isAdmin, scopedProfile, loading, sendOtp, verifyOtp, loginWithToken, soloLogin, soloCreate, swapToken, logout }}
     >
       {children}
     </AuthContext.Provider>

--- a/dashboard/src/pages/LoginPage.test.tsx
+++ b/dashboard/src/pages/LoginPage.test.tsx
@@ -1,0 +1,94 @@
+// Tests for the no-password "solo" affordance on the dashboard login page.
+//
+// The page must:
+//   * Offer "Continue without a password" only when /api/auth/status reports
+//     local_solo_enabled.
+//   * Re-login the existing owner via soloLogin → navigate home.
+//   * Drop into the create form when soloLogin 404s (no profile yet).
+//   * Never show the affordance on a non-solo host.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import LoginPage from './LoginPage'
+import { ApiError } from '../api'
+
+const mockStatus = vi.fn()
+const soloLogin = vi.fn()
+const soloCreate = vi.fn()
+
+vi.mock('../api', async () => {
+  const actual = await vi.importActual<typeof import('../api')>('../api')
+  return {
+    ...actual,
+    authApi: { ...actual.authApi, status: () => mockStatus() },
+  }
+})
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: null,
+    sendOtp: vi.fn(),
+    verifyOtp: vi.fn(),
+    loginWithToken: vi.fn(),
+    soloLogin,
+    soloCreate,
+  }),
+}))
+
+beforeEach(() => {
+  mockStatus.mockReset()
+  soloLogin.mockReset()
+  soloCreate.mockReset()
+})
+
+function renderLogin() {
+  return render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/" element={<div data-testid="home">home</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('LoginPage solo affordance', () => {
+  it('shows the solo button when local_solo_enabled is true', async () => {
+    mockStatus.mockResolvedValue({ local_solo_enabled: true })
+    renderLogin()
+    await waitFor(() =>
+      expect(screen.getByTestId('solo-continue')).toBeInTheDocument(),
+    )
+  })
+
+  it('hides the solo button when local_solo_enabled is false', async () => {
+    mockStatus.mockResolvedValue({ local_solo_enabled: false })
+    renderLogin()
+    // The email form is always present; wait for it, then assert no solo button.
+    await waitFor(() => expect(screen.getByText('Email address')).toBeInTheDocument())
+    expect(screen.queryByTestId('solo-continue')).not.toBeInTheDocument()
+  })
+
+  it('logs in the existing owner and navigates home', async () => {
+    mockStatus.mockResolvedValue({ local_solo_enabled: true })
+    soloLogin.mockResolvedValue(undefined)
+    const user = userEvent.setup()
+    renderLogin()
+    await user.click(await screen.findByTestId('solo-continue'))
+    await waitFor(() => expect(soloLogin).toHaveBeenCalled())
+    await waitFor(() => expect(screen.getByTestId('home')).toBeInTheDocument())
+  })
+
+  it('drops into the create form when no profile exists yet (404)', async () => {
+    mockStatus.mockResolvedValue({ local_solo_enabled: true })
+    soloLogin.mockRejectedValue(new ApiError(404, 'no solo profile'))
+    const user = userEvent.setup()
+    renderLogin()
+    await user.click(await screen.findByTestId('solo-continue'))
+    await waitFor(() =>
+      expect(screen.getByTestId('solo-profile-form')).toBeInTheDocument(),
+    )
+  })
+})

--- a/dashboard/src/pages/LoginPage.tsx
+++ b/dashboard/src/pages/LoginPage.tsx
@@ -1,11 +1,14 @@
 import { useState, useRef, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
+import { authApi, ApiError } from '../api'
+import SoloProfileForm from '../components/SoloProfileForm'
 
 export default function LoginPage() {
-  const { user, sendOtp, verifyOtp, loginWithToken } = useAuth()
+  const { user, sendOtp, verifyOtp, loginWithToken, soloLogin } = useAuth()
   const navigate = useNavigate()
-  const [step, setStep] = useState<'email' | 'code' | 'token'>('email')
+  const [step, setStep] = useState<'email' | 'code' | 'token' | 'solo'>('email')
+  const [soloEnabled, setSoloEnabled] = useState(false)
   const [email, setEmail] = useState('')
   const [code, setCode] = useState(['', '', '', '', '', ''])
   const [adminToken, setAdminToken] = useState('')
@@ -18,6 +21,34 @@ export default function LoginPage() {
   useEffect(() => {
     if (user) navigate('/', { replace: true })
   }, [user, navigate])
+
+  // Probe public login config to decide whether to offer the no-password
+  // solo path. Failure leaves solo hidden — the OTP / token forms still work.
+  useEffect(() => {
+    authApi
+      .status()
+      .then((s) => setSoloEnabled(s.local_solo_enabled))
+      .catch(() => {})
+  }, [])
+
+  const handleSoloContinue = async () => {
+    setError('')
+    setLoading(true)
+    try {
+      // Re-login the existing local owner. First run (no profile yet) comes
+      // back as 404 → drop into the create form.
+      await soloLogin()
+      navigate('/', { replace: true })
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 404) {
+        setStep('solo')
+      } else {
+        setError(e instanceof Error ? e.message : 'Solo login failed')
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
 
   const handleSendCode = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -125,7 +156,21 @@ export default function LoginPage() {
         </div>
 
         <div className="bg-surface rounded-xl border border-gray-700/50 p-6">
-          {step === 'token' ? (
+          {step === 'solo' ? (
+            <div>
+              <SoloProfileForm onDone={() => navigate('/', { replace: true })} />
+              <button
+                type="button"
+                onClick={() => {
+                  setStep('email')
+                  setError('')
+                }}
+                className="mt-3 w-full text-sm text-gray-500 hover:text-gray-300 transition"
+              >
+                Back
+              </button>
+            </div>
+          ) : step === 'token' ? (
             <form onSubmit={handleTokenLogin}>
               <label
                 htmlFor="admin-token"
@@ -165,7 +210,29 @@ export default function LoginPage() {
               </button>
             </form>
           ) : step === 'email' ? (
-            <form onSubmit={handleSendCode}>
+            <>
+              {soloEnabled && (
+                <div className="mb-6">
+                  <button
+                    type="button"
+                    data-testid="solo-continue"
+                    onClick={handleSoloContinue}
+                    disabled={loading}
+                    className="w-full px-4 py-2.5 text-sm font-medium rounded-lg bg-accent text-white hover:bg-accent-light transition disabled:opacity-50"
+                  >
+                    {loading ? 'Continuing…' : 'Continue without a password'}
+                  </button>
+                  <p className="mt-2 text-center text-xs text-gray-600">
+                    Solo mode — local, single-user, stays on this machine.
+                  </p>
+                  <div className="my-4 flex items-center gap-3 text-xs text-gray-600">
+                    <span className="h-px flex-1 bg-gray-700/50" />
+                    or sign in with email
+                    <span className="h-px flex-1 bg-gray-700/50" />
+                  </div>
+                </div>
+              )}
+              <form onSubmit={handleSendCode}>
               <label
                 htmlFor="login-email"
                 className="block text-sm font-medium text-gray-300 mb-2"
@@ -193,7 +260,8 @@ export default function LoginPage() {
               >
                 {loading ? 'Sending...' : 'Send verification code'}
               </button>
-            </form>
+              </form>
+            </>
           ) : (
             <div>
               <p className="text-sm text-gray-400 mb-1">
@@ -251,7 +319,7 @@ export default function LoginPage() {
         </div>
 
         {/* Toggle between email and token login */}
-        {step !== 'code' && step !== 'token' && (
+        {step !== 'code' && step !== 'token' && step !== 'solo' && (
           <div className="text-center mt-4">
             <button
               type="button"

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -269,6 +269,39 @@ export interface MeResponse {
   scoped_profile?: ScopedAuthTarget | null
 }
 
+/// Public login configuration from `GET /api/auth/status`. Drives which
+/// login affordances the page renders. `local_solo_enabled` is the
+/// no-password solo path (Local-mode host with stores); see
+/// `crate::api::solo_auth`.
+export interface AuthStatusResponse {
+  bootstrap_mode: boolean
+  email_login_enabled: boolean
+  admin_token_login_enabled: boolean
+  allow_self_registration: boolean
+  local_solo_enabled: boolean
+  scoped_profile?: ScopedAuthTarget | null
+}
+
+/// `POST /api/auth/solo` — re-login for the existing local solo owner.
+export interface SoloLoginResult {
+  token: string
+  user: User
+}
+
+/// `POST /api/auth/solo/create` — create the local profile AND log in.
+/// Mirrors the server `ProfileLocalCreateResult` shape plus a session
+/// `token`.
+export interface SoloCreateResult {
+  profile_id: string
+  user_id: string
+  name: string
+  username: string
+  email: string
+  created: boolean
+  runtime_mode: string
+  token: string
+}
+
 export interface BridgeQrInfo {
   qr: string | null
   status: 'waiting' | 'connected' | 'disconnected' | 'logged_out'

--- a/e2e/matrix/run.mjs
+++ b/e2e/matrix/run.mjs
@@ -548,7 +548,11 @@ export class StdioClient {
     this.nextSeq = 0;
     this.child = spawn(
       octosBin,
-      ['serve', '--stdio', '--data-dir', dataDir, '--cwd', workspace],
+      // `--solo` opts into the no-password local-solo gate so the matrix's
+      // `profile/local/create` onboarding scenarios are advertised/executed.
+      // Solo is OFF by default (see `api::solo_auth`); harmless for non-solo
+      // scenarios.
+      ['serve', '--stdio', '--solo', '--data-dir', dataDir, '--cwd', workspace],
       {
         cwd: repoRoot,
         env: {

--- a/e2e/tests/solo-login.spec.ts
+++ b/e2e/tests/solo-login.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Real-browser UX test for the no-password "solo" login on the admin
+ * dashboard. Drives the full first-run path:
+ *
+ *   /admin/  → (no token) login page → "Continue without a password"
+ *   → soloLogin 404 (no profile yet) → solo profile form
+ *   → fill name/username/email → soloCreate → token minted
+ *   → BootstrapGate sees a solo host → lands in the dashboard (NOT the
+ *     rotate-token wizard).
+ *
+ * Prereqs (started out-of-band by the runner):
+ *   - `octos serve --port 8080` with a FRESH data dir (Local mode → solo).
+ *   - `vite dev` on :5173 serving the dashboard at /admin/, proxying /api
+ *     to :8080. Set OCTOS_TEST_URL=http://localhost:5173.
+ */
+test('solo no-password login creates a local profile and enters the dashboard', async ({
+  page,
+}) => {
+  await page.goto('/admin/');
+
+  // Unauthenticated → login page. The solo affordance appears once the
+  // public /api/auth/status probe resolves with local_solo_enabled.
+  const solo = page.getByTestId('solo-continue');
+  await expect(solo).toBeVisible();
+  await solo.click();
+
+  // First run: no profile yet, so soloLogin 404s and we get the create form.
+  await expect(page.getByTestId('solo-profile-form')).toBeVisible();
+
+  await page.getByTestId('solo-name').fill('Ada Lovelace');
+  await page.getByTestId('solo-username').fill('ada');
+  await page.getByTestId('solo-email').fill('ada@example.com');
+  await page.getByTestId('solo-submit').click();
+
+  // Lands in the authenticated dashboard (home), not the setup wizard.
+  await expect(page).toHaveURL(/\/admin\/?(\?.*)?$/);
+  await expect(page.getByText('All Profiles')).toBeVisible();
+  await expect(page.getByText('ada@example.com')).toBeVisible();
+
+  // Must NOT have been hijacked into the rotate-token / welcome wizard.
+  await expect(page.getByText('Two quick steps')).toHaveCount(0);
+  await expect(page).not.toHaveURL(/\/setup\//);
+});

--- a/e2e/tests/solo-login.spec.ts
+++ b/e2e/tests/solo-login.spec.ts
@@ -11,7 +11,9 @@ import { test, expect } from '@playwright/test';
  *     rotate-token wizard).
  *
  * Prereqs (started out-of-band by the runner):
- *   - `octos serve --port 8080` with a FRESH data dir (Local mode → solo).
+ *   - `octos serve --solo --port 8080` with a FRESH data dir. The `--solo`
+ *     opt-in is REQUIRED — solo login is OFF by default and must never be
+ *     enabled on a proxy-fronted host (see `api::solo_auth`).
  *   - `vite dev` on :5173 serving the dashboard at /admin/, proxying /api
  *     to :8080. Set OCTOS_TEST_URL=http://localhost:5173.
  */

--- a/scripts/m12-solo-appui-soak.sh
+++ b/scripts/m12-solo-appui-soak.sh
@@ -19,6 +19,10 @@ auth_token="${OCTOS_M12_SOAK_AUTH_TOKEN:-octos-m12-solo-soak-token}"
 profile_id="${OCTOS_M12_SOAK_PROFILE:-m12solo}"
 session_id="${OCTOS_M12_SOAK_SESSION:-$profile_id:local:m12-solo#$run_id}"
 serve_args="${OCTOS_M12_SOAK_SERVE_ARGS:-}"
+# The no-password local-solo gate is opt-in (OFF by default; see
+# `api::solo_auth`). This soak intentionally exercises solo onboarding, so opt
+# in for both the WS and stdio serve launches below.
+export OCTOS_SOLO_LOGIN=1
 strict="${OCTOS_M12_SOAK_STRICT:-0}"
 tenant_negative="${OCTOS_M12_SOAK_TENANT_NEGATIVE:-0}"
 api_key_env="${OCTOS_M12_SOAK_API_KEY_ENV:-OPENAI_API_KEY}"


### PR DESCRIPTION
## Summary

Adds a no-password **solo login** for local single-user installs — the dashboard equivalent of octos-tui's solo onboarding. On an opted-in Local host, the operator can create a local profile (name / username / email) and enter the dashboard without an admin token or OTP.

- **Backend** (`api/solo_auth.rs`): public `POST /api/auth/solo` (re-login) and `POST /api/auth/solo/create` (onboard + login); `/api/auth/status` advertises `local_solo_enabled`. Reuses the existing `create_or_get_local_solo_profile` primitive; `AuthManager::create_session_for_user` mints a session with no OTP.
- **Dashboard**: "Continue without a password" on the login page → `SoloProfileForm`; `BootstrapGate` is solo-aware so a solo login isn't forced into the rotate-token wizard.

## Security (fail closed)

`deployment_mode == Local` is **not** a safe signal — the hosted fleet runs Local mode behind a Caddy proxy, so every request reaches the daemon over loopback. The solo path is therefore gated on:
1. an explicit **opt-in** (`octos serve --solo` / `OCTOS_SOLO_LOGIN=1`, OFF by default), folded into the shared `supports_local_solo_profile_create` predicate so it covers **both** the WS `profile/local/create` (TUI) and the REST endpoints;
2. a **loopback** peer; and
3. **rejection of any proxied request** (`X-Forwarded-*` / `X-Real-IP` / `Forwarded`).

Fleet configs never set the opt-in, so solo stays off there.

## Validation

- Rust lib suite green; dashboard vitest 32/32; fmt + clippy clean.
- Reviewed with `codex review` per commit; all findings fixed (incl. a P1 — the opt-in was extended to the WS path).
- **Real browser soak on mini1** (arm64 / macOS 15.7.4, dedicated `--solo` loopback instance, no Caddy): create flow 10/10, returning-login 20/20 serialized; security gate 4/4 — `--solo` advertises solo, **proxied `solo/create` → 403**, default-off without `--solo`, solo login off by default → 403.

## Notes

- Solo onboarding harnesses (`e2e/matrix/run.mjs`, `scripts/m12-solo-appui-soak.sh`) now pass `--solo` since the gate is opt-in.