### PR TITLE
fix(runtime): honor configured max_iterations for sessions + spawned sub-agents

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -33170,6 +33170,7 @@ ignore = []
             plugin_env_template: Vec::new(),
             tool_policy: None,
             default_sandbox: sandbox,
+            max_iterations: None,
             tool_specs: Arc::new(base_tools),
             plugin_tool_names: Vec::new(),
             plugin_dirs: Vec::new(),

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -571,6 +571,7 @@ mod tests {
             plugin_env_template: Vec::new(),
             tool_policy: None,
             default_sandbox: sandbox,
+            max_iterations: None,
             tool_specs: Arc::new(base_tools),
             plugin_tool_names: Vec::new(),
             plugin_dirs: Vec::new(),

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -174,6 +174,13 @@ pub struct ProfileRuntime {
     /// this value.
     pub default_sandbox: SandboxConfig,
 
+    /// Configured agent iteration budget (`config.max_iterations`) that
+    /// sessions — and the sub-agents they spawn — inherit. `None` falls back
+    /// to [`AgentConfig`]'s default. Captured here so the session runtime
+    /// honors the configured value instead of a hardcoded cap (which silently
+    /// starved spawned sub-agents doing multi-step work).
+    pub max_iterations: Option<u32>,
+
     /// The base [`ToolRegistry`] template — builtins + plugins +
     /// MCP agents + the LRU pin set — but **NOT** workspace-bound.
     /// Sessions clone this and call `with_workspace_root` to obtain
@@ -968,6 +975,7 @@ impl ProfileRuntime {
             plugin_env_template,
             tool_policy: config.tool_policy.clone(),
             default_sandbox,
+            max_iterations: config.max_iterations,
             tool_specs: Arc::new(tools),
             plugin_tool_names: plugin_result.tool_names.clone(),
             plugin_dirs,

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -394,7 +394,11 @@ impl SessionRuntime {
             profile.memory.clone(),
         )
         .with_config(AgentConfig {
-            max_iterations: 20,
+            // Honor the configured `max_iterations` instead of a hardcoded cap.
+            // The previous fixed `20` ignored config AND propagated to spawned
+            // sub-agents (which inherit this config), starving multi-step
+            // background tasks that need more iterations.
+            max_iterations: resolve_session_max_iterations(profile.max_iterations),
             save_episodes: true,
             ..Default::default()
         })
@@ -492,6 +496,15 @@ fn bootstrap_session_policy(workspace_root: &Path) -> Result<()> {
         .wrap_err("failed to bootstrap session workspace policy")
 }
 
+/// Resolve the per-session agent iteration budget from the profile's
+/// configured `gateway.max_iterations`, falling back to the `AgentConfig`
+/// default when unset. Spawned sub-agents inherit the resulting config, so
+/// this is also the cap for background workers — `None` must not collapse to a
+/// small hardcoded value the way the previous fixed `20` did.
+fn resolve_session_max_iterations(configured: Option<u32>) -> u32 {
+    configured.unwrap_or_else(|| AgentConfig::default().max_iterations)
+}
+
 /// Resolve a per-session workspace root.
 ///
 /// Honors a caller-supplied `workspace_hint` (coding-agent flow) when
@@ -578,6 +591,24 @@ mod tests {
     use std::sync::Arc;
     use std::time::SystemTime;
 
+    #[test]
+    fn resolve_session_max_iterations_honors_config_else_default() {
+        // A configured gateway.max_iterations must be respected (the bug was a
+        // hardcoded 20 that ignored it and starved spawned sub-agents).
+        assert_eq!(resolve_session_max_iterations(Some(120)), 120);
+        assert_eq!(resolve_session_max_iterations(Some(5)), 5);
+        // Unset falls back to the AgentConfig default (50), not the old 20.
+        assert_eq!(
+            resolve_session_max_iterations(None),
+            AgentConfig::default().max_iterations
+        );
+        assert_ne!(
+            resolve_session_max_iterations(None),
+            20,
+            "unset must not collapse to the old hardcoded cap"
+        );
+    }
+
     use octos_agent::sandbox::create_sandbox;
     use octos_agent::workspace_contract::{SpawnTaskContractResult, enforce_spawn_task_contract};
     use octos_agent::workspace_policy::{
@@ -642,6 +673,7 @@ mod tests {
             plugin_env_template: Vec::new(),
             tool_policy: None,
             default_sandbox: sandbox,
+            max_iterations: None,
             tool_specs: Arc::new(base_tools),
             plugin_tool_names: Vec::new(),
             plugin_dirs: Vec::new(),
@@ -1122,6 +1154,7 @@ mod tests {
             plugin_env_template: Vec::new(),
             tool_policy: None,
             default_sandbox: sandbox,
+            max_iterations: None,
             tool_specs: Arc::new(base_tools),
             plugin_tool_names: Vec::new(),
             plugin_dirs: Vec::new(),
@@ -1174,6 +1207,7 @@ mod tests {
             plugin_env_template: Vec::new(),
             tool_policy: None,
             default_sandbox: sandbox,
+            max_iterations: None,
             tool_specs: Arc::new(base_tools),
             plugin_tool_names: Vec::new(),
             plugin_dirs: Vec::new(),
@@ -1254,6 +1288,7 @@ mod tests {
             plugin_env_template: Vec::new(),
             tool_policy: None,
             default_sandbox: sandbox,
+            max_iterations: None,
             tool_specs: Arc::new(base_tools),
             plugin_tool_names: Vec::new(),
             plugin_dirs: Vec::new(),

--- a/crates/octos-cli/tests/coding_multi_session.rs
+++ b/crates/octos-cli/tests/coding_multi_session.rs
@@ -205,6 +205,7 @@ async fn make_m11g_profile(profile_id: &str, data_dir: &std::path::Path) -> Arc<
         plugin_env_template: Vec::new(),
         tool_policy: None,
         default_sandbox: sandbox,
+        max_iterations: None,
         tool_specs: Arc::new(base_tools),
         plugin_tool_names: Vec::new(),
         plugin_dirs: Vec::new(),


### PR DESCRIPTION
## Why

The per-session agent (`runtime/session.rs`) was built with a **hardcoded** `AgentConfig { max_iterations: 20 }`. This:
1. **Silently ignored** the configurable `max_iterations` (`config.rs:99`).
2. **Propagated to spawned sub-agents** — they inherit the parent's `AgentConfig` via the spawn tool's `with_agent_config` → worker `with_config` — so every background worker was also capped at 20.

Observed live (DeepSeek session on a fleet mini): the agent spawned sub-agents to build a comparison site; the "Build an Astro static site" sub-agents needed more than 20 tool-call steps and **failed** with *"The agent did not complete within 20 iterations"* (`agent/budget.rs`). There was no way to raise the cap via config because the value was hardcoded — and 20 is even *below* the documented `AgentConfig` default of 50.

## What

- `ProfileRuntime` captures `config.max_iterations` at bootstrap (new `max_iterations: Option<u32>` field).
- `runtime/session.rs` resolves the budget via `resolve_session_max_iterations(profile.max_iterations)` → the configured value, falling back to `AgentConfig::default().max_iterations` (**50**) instead of the hardcoded **20**.
- Spawned sub-agents inherit the resolved config, so background workers are no longer starved, and operators can configure higher.

## Tests

`resolve_session_max_iterations_honors_config_else_default`: a configured value is respected; unset falls back to the `AgentConfig` default (50), never the old hardcoded 20. octos-cli builds + the test passes; fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)