### PR TITLE
fix(security): mark the configured LLM api_key_env as secret for subprocess tools

### DIFF
--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -46,6 +46,7 @@ pub mod steering;
 pub mod subagent_output;
 pub mod subagent_summary;
 mod subprocess_env;
+pub use subprocess_env::register_secret_env_names;
 pub mod summarizer;
 pub mod task_supervisor;
 pub mod tools;

--- a/crates/octos-agent/src/subprocess_env.rs
+++ b/crates/octos-agent/src/subprocess_env.rs
@@ -5,10 +5,52 @@
 //! inherit those raw secrets unless the tool explicitly allowlists them.
 
 use std::collections::HashSet;
+use std::sync::{LazyLock, RwLock};
 
 use tokio::process::Command;
 
 use crate::sandbox::BLOCKED_ENV_VARS;
+
+/// Exact env-var names known to hold a configured LLM provider API key.
+/// Populated at provider build time via [`register_secret_env_names`].
+///
+/// These are treated exactly like heuristic secrets ([`is_secret_env_name`]):
+/// stripped from the default subprocess environment, but still forwardable to a
+/// tool that explicitly allowlists them — the sanctioned path for skills that
+/// call LLMs (see `build_plugin_env`). The registry closes the gap where the
+/// NAME heuristic misses a custom `api_key_env` that doesn't look secret (e.g.
+/// `ANTHROPIC_CREDS`), so it can't be `echo`'d from the empty-allowlist shell
+/// tool / hooks / validators.
+static REGISTERED_SECRET_ENV: LazyLock<RwLock<HashSet<String>>> =
+    LazyLock::new(|| RwLock::new(HashSet::new()));
+
+/// Register env-var names (e.g. the resolved LLM `api_key_env`) that must
+/// always be stripped from subprocess environments. Idempotent; names are
+/// normalized (ASCII-uppercased). Safe to call repeatedly from provider
+/// construction.
+pub fn register_secret_env_names<I, S>(names: I)
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut set = REGISTERED_SECRET_ENV
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for name in names {
+        let normalized = normalize_env_name(name.as_ref());
+        if !normalized.is_empty() {
+            set.insert(normalized);
+        }
+    }
+}
+
+fn is_registered_secret_env_name(name: &str) -> bool {
+    let normalized = normalize_env_name(name);
+    REGISTERED_SECRET_ENV
+        .read()
+        .map(|set| set.contains(&normalized))
+        .unwrap_or(false)
+}
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct EnvAllowlist {
@@ -190,7 +232,10 @@ pub(crate) fn should_forward_env_name(name: &str, allowlist: &EnvAllowlist) -> b
     if is_injection_env_name(name) {
         return false;
     }
-    !is_secret_env_name(name) || allowlist.contains(name)
+    // Registered provider-key vars are treated like heuristic secrets: stripped
+    // by default, but still allowlistable (skills that call LLMs declare them).
+    let is_secret = is_secret_env_name(name) || is_registered_secret_env_name(name);
+    !is_secret || allowlist.contains(name)
 }
 
 pub(crate) fn sanitize_command_env(cmd: &mut Command, allowlist: &EnvAllowlist) {
@@ -247,6 +292,36 @@ mod tests {
         ] {
             assert!(!is_secret_env_name(name), "{name} should not be secret");
         }
+    }
+
+    #[test]
+    fn registered_secret_env_is_stripped_by_default_but_allowlistable() {
+        // A custom `api_key_env` whose NAME the heuristic does NOT flag.
+        let odd = "ZZ_PROVIDER_CREDS_FIXTURE";
+        assert!(
+            !is_secret_env_name(odd),
+            "fixture must be a name the heuristic does not flag"
+        );
+        // Before registration it would be forwarded (not secret-looking) — this
+        // is the gap: the shell tool could echo it.
+        assert!(should_forward_env_name(odd, &EnvAllowlist::empty()));
+
+        register_secret_env_names([odd]);
+
+        // After registration it is treated as a secret: stripped from the
+        // default (empty-allowlist) environment, so shell/hooks/validators
+        // can't echo it...
+        assert!(!should_forward_env_name(odd, &EnvAllowlist::empty()));
+        // (case-insensitive)
+        assert!(!should_forward_env_name(
+            "zz_provider_creds_fixture",
+            &EnvAllowlist::empty()
+        ));
+        // ...but a tool that declares it in its manifest allowlist may still
+        // receive it (the sanctioned path for skills that call LLMs).
+        let allowlisted = EnvAllowlist::from_names([odd]);
+        assert!(should_forward_env_name(odd, &allowlisted));
+        assert!(should_forward_env_name_strict(odd, &allowlisted));
     }
 
     #[test]

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -1131,6 +1131,24 @@ impl Config {
 
     /// Get the API key: auth store first, then environment variable.
     pub fn get_api_key(&self, provider: &str) -> Result<String> {
+        // Resolve the env var name we expect to hold this provider's key, and
+        // mark it as a secret FIRST — before any early return — so the
+        // configured key var is stripped from the default subprocess
+        // environment regardless of which resolution path (auth store /
+        // env_vars / keychain / process env) actually wins below. This also
+        // covers a custom `api_key_env` whose NAME does not look secret to the
+        // heuristic, so it can't be `echo`'d from the shell tool. Registered
+        // names are still allowlistable: a tool that declares the var in its
+        // manifest `env` list may receive it (the sanctioned path for skills
+        // that call LLMs). See `octos_agent::subprocess_env`.
+        let env_var = self.api_key_env.clone().unwrap_or_else(|| {
+            octos_llm::registry::lookup(provider)
+                .and_then(|e| e.api_key_env)
+                .map(String::from)
+                .unwrap_or_else(|| format!("{}_API_KEY", provider.to_uppercase()))
+        });
+        octos_agent::register_secret_env_names([env_var.as_str()]);
+
         // Check auth store first.
         if let Ok(store) = crate::auth::AuthStore::load() {
             if let Some(cred) = store.get(provider) {
@@ -1139,14 +1157,6 @@ impl Config {
                 }
             }
         }
-
-        // Resolve the env var name we expect to hold this provider's key.
-        let env_var = self.api_key_env.clone().unwrap_or_else(|| {
-            octos_llm::registry::lookup(provider)
-                .and_then(|e| e.api_key_env)
-                .map(String::from)
-                .unwrap_or_else(|| format!("{}_API_KEY", provider.to_uppercase()))
-        });
 
         if let Some(value) = self.env_vars.get(&env_var).and_then(|value| {
             crate::auth::keychain::resolve_value(&env_var, value).filter(|value| !value.is_empty())


### PR DESCRIPTION
## Problem

Subprocess env sanitisation (`subprocess_env::sanitize_command_env`) already strips secret-looking vars (`is_secret_env_name`: `*_KEY`, `*API_KEY*`, `*TOKEN*`, …) from every spawned tool, so `echo $ANTHROPIC_API_KEY` from the shell tool returns nothing. The gap: detection is **purely name-heuristic**, so a custom `api_key_env` that doesn't look secret (e.g. `ANTHROPIC_CREDS`) was forwarded to the empty-allowlist shell tool / hooks / validators and could be `echo`'d.

## Fix

- Exact-name registry `subprocess_env::register_secret_env_names`, populated at provider-build time with the resolved `api_key_env`.
- `Config::get_api_key` registers it **first, before any early return** (auth store / env_vars / keychain), so the name is marked regardless of which path resolves the key.
- Registered names are treated **exactly like heuristic secrets**: stripped from the default subprocess env, but **still allowlistable**. This is deliberate — `build_plugin_env` hands skills the provider key (e.g. mofa-slides needs `GEMINI_API_KEY`) via the manifest allowlist, so making registered names un-allowlistable would break those skills. The fix closes the shell-echo gap without touching the sanctioned skill-key path.

## Validation

- `subprocess_env` unit tests (incl. new odd-named + allowlistable regression) + the existing `shell_does_not_expose_configured_api_key_to_env_or_echo` regression pass; octos-cli builds; fmt/clippy clean.
- `codex review`: two findings (register-before-early-return; allowlistable not un-allowlistable) addressed; re-review clean.

(One unrelated `#[cfg(macos)]` firmlink path test fails environment-locally; this commit does not touch `tools/mod.rs`.)