### PR TITLE
fix(pipeline+agent): close run_pipeline misroute + no-embedder recall contamination

### DIFF
--- a/crates/octos-agent/src/agent/memory.rs
+++ b/crates/octos-agent/src/agent/memory.rs
@@ -52,6 +52,27 @@ pub const MIN_EPISODE_SIMILARITY: f32 = 0.55;
 /// also re-checks the floor as defense in depth.
 const RELEVANT_EXPERIENCES_INJECT_LIMIT: usize = 6;
 
+/// Neutral, non-misattributing log line emitted when this agent runs
+/// without an embedder configured and therefore skips episodic recall.
+///
+/// **Why this exists (the misdiagnostic-WARN fix).** The previous
+/// no-embedder branch logged at `warn!` and told the operator to
+/// "investigate the `RunPipelineTool::with_embedder` wiring (NEW-06)".
+/// That advice is wrong for the common case: on a host with no embedder
+/// configured at all (the soak hosts), `create_embedder()` returns
+/// `None` and `self.embedder` is legitimately `None` — the wiring is
+/// fine, there is simply nothing to propagate. The only state knowable
+/// at this call site is "this agent has no embedder" (`self.embedder`
+/// is `None`); we cannot distinguish "never had one" from "had a parent
+/// embedder but lost it in the worker" here, because a worker that lost
+/// its embedder also just presents as `embedder == None`. Since we
+/// cannot tell them apart, we must NOT assert the wiring is broken —
+/// that misdirected an operator into chasing a non-bug. So the message
+/// is downgraded to a neutral `debug!`, with no NEW-06 / wiring
+/// attribution.
+const NO_EMBEDDER_RECALL_SKIPPED_MSG: &str =
+    "memory recall: no embedder configured; skipping episodic recall (no cross-task injection)";
+
 impl Agent {
     pub(super) async fn build_initial_messages(&self, task: &Task) -> Vec<Message> {
         let mut messages = vec![Message {
@@ -159,64 +180,38 @@ impl Agent {
                     });
                 }
             }
-        } else if let Ok(episodes) = self
-            .memory
-            .find_relevant_filtered(
-                &task.context.working_dir,
-                &query,
-                3,
-                // NEW-06 defense-in-depth: apply the modality-aware
-                // similarity gate to the no-embedder fallback path too.
-                // The primary fix is propagating the parent embedder
-                // to pipeline workers via `RunPipelineTool::with_embedder`
-                // (crates/octos-pipeline/src/tool.rs); this is the
-                // belt-and-suspenders rail for the case where a worker
-                // still ends up here (embedder construction failed, an
-                // older call site not yet updated, etc.).
-                Some(MIN_EPISODE_SIMILARITY),
-            )
-            .await
-        {
-            // CWD-scoped fallback path. No scoring infrastructure here;
-            // the cwd filter + keyword match already constrain results.
-            // Inject only when there's something to inject (no empty header).
+        } else {
+            // No-embedder path. Contamination guard (NEW-06 follow-up,
+            // option (a)): when there is NO embedder we skip episodic
+            // recall ENTIRELY rather than injecting BM25-only,
+            // same-workspace matches.
             //
-            // NEW-06 diagnostic: ALSO log on the no-embedder path so we
-            // can detect contamination here too. The round-3 root
-            // cause was that pipeline workers fell through to THIS
-            // branch because their parent agent's embedder wasn't
-            // propagated. The wiring fix lives in
-            // crates/octos-pipeline (RunPipelineTool::with_embedder ->
-            // CodergenHandler -> worker Agent::with_embedder); this
-            // log gives us evidence when a worker still ends up here
-            // despite the fix (e.g. embedder failed to construct).
-            if !episodes.is_empty() {
-                let ids: Vec<String> = episodes.iter().map(|e| e.id.clone()).collect();
-                warn!(
-                    caller = "agent_memory_cwd_fallback",
-                    agent = %self.id,
-                    cwd = %task.context.working_dir.display(),
-                    query_len = query.len(),
-                    injected = episodes.len(),
-                    episodes = ?ids,
-                    "memory recall: no-embedder CWD fallback (no similarity gate). \
-                     If this agent is a pipeline worker, the parent embedder did NOT \
-                     propagate — investigate the RunPipelineTool::with_embedder wiring \
-                     (NEW-06)."
-                );
-                let content = render_relevant_experiences(&episodes);
-                messages.push(Message {
-                    role: MessageRole::System,
-                    content,
-                    media: vec![],
-                    tool_calls: None,
-                    tool_call_id: None,
-                    reasoning_content: None,
-                    client_message_id: None,
-                    thread_id: None,
-                    timestamp: chrono::Utc::now(),
-                });
-            }
+            // Rationale for option (a) over raising the floor (option b):
+            // without an embedder the only signal is BM25 keyword overlap
+            // scoped to the working directory. On the soak hosts every
+            // task shares ONE workspace, so a prior *unrelated* episode
+            // that merely shares vocabulary (the "Jingkang Incident"
+            // research doc recalled into a code-review run) can clear any
+            // BM25 floor and get injected into a fresh, unrelated context.
+            // BM25-only same-workspace recall has no reliable way to
+            // distinguish on-task from cross-task here, so there is no
+            // safe value in injecting it at all — skipping is the
+            // least-invasive correct fix. Embedder-backed recall (the
+            // `if let Some(embedder)` arm above) keeps the modality-aware
+            // similarity gate and is unaffected.
+            //
+            // The log is deliberately neutral (`debug!`, no NEW-06 /
+            // `with_embedder` wiring attribution): the only knowable state
+            // here is "this agent has no embedder", which is the expected
+            // condition on an unconfigured host, not evidence of a wiring
+            // bug. See `NO_EMBEDDER_RECALL_SKIPPED_MSG`.
+            tracing::debug!(
+                caller = "agent_memory_no_embedder",
+                agent = %self.id,
+                cwd = %task.context.working_dir.display(),
+                query_len = query.len(),
+                "{NO_EMBEDDER_RECALL_SKIPPED_MSG}"
+            );
         }
 
         // Add the task as user message
@@ -283,13 +278,6 @@ fn format_relevant_experiences(scored: &[(Episode, HybridScore)]) -> Option<Stri
         return None;
     }
     Some(render_relevant_experiences_iter(filtered.into_iter()))
-}
-
-/// Render a slice of episodes (no scores) into the "Relevant Past
-/// Experiences" system message body. Used by the cwd-scoped fallback path
-/// where scores aren't available; the cwd filter constrains noise instead.
-fn render_relevant_experiences(episodes: &[Episode]) -> String {
-    render_relevant_experiences_iter(episodes.iter())
 }
 
 fn render_relevant_experiences_iter<'a, I>(iter: I) -> String
@@ -598,6 +586,151 @@ mod tests {
             assert!(
                 !rendered.contains(&needle),
                 "expected rank '{needle}' to be truncated past the inject limit ({RELEVANT_EXPERIENCES_INJECT_LIMIT})"
+            );
+        }
+    }
+
+    // ---- Fix #1: the no-embedder log must not misattribute to wiring ----
+
+    /// The neutral no-embedder log line must NOT tell the operator to
+    /// investigate the `RunPipelineTool::with_embedder` wiring (the prior
+    /// misdiagnostic WARN). The only state knowable on that path is
+    /// "this agent has no embedder", which is the expected condition on
+    /// an unconfigured host — not evidence of a wiring bug — so the
+    /// message must carry no NEW-06 / `with_embedder` blame.
+    #[test]
+    fn no_embedder_log_message_does_not_misattribute_to_wiring() {
+        let msg = NO_EMBEDDER_RECALL_SKIPPED_MSG.to_ascii_lowercase();
+        assert!(
+            !msg.contains("with_embedder"),
+            "no-embedder log must not blame RunPipelineTool::with_embedder wiring: {NO_EMBEDDER_RECALL_SKIPPED_MSG}"
+        );
+        assert!(
+            !msg.contains("new-06"),
+            "no-embedder log must not reference the NEW-06 wiring investigation: {NO_EMBEDDER_RECALL_SKIPPED_MSG}"
+        );
+        assert!(
+            !msg.contains("propagate") && !msg.contains("investigate"),
+            "no-embedder log must not direct the operator to investigate embedder propagation: {NO_EMBEDDER_RECALL_SKIPPED_MSG}"
+        );
+        // And it should still say *something* useful about why recall was skipped.
+        assert!(
+            msg.contains("embedder") && msg.contains("skip"),
+            "no-embedder log should still explain that recall was skipped because no embedder is configured: {NO_EMBEDDER_RECALL_SKIPPED_MSG}"
+        );
+    }
+
+    // ---- Fix #3 (option a): no-embedder recall injects nothing ----
+
+    /// A stub provider that immediately ends the turn — enough to let us
+    /// drive `build_initial_messages` through `Agent`.
+    struct EndTurnProvider;
+
+    #[async_trait::async_trait]
+    impl octos_llm::LlmProvider for EndTurnProvider {
+        async fn chat(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            Ok(octos_llm::ChatResponse {
+                content: Some(String::new()),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: octos_llm::TokenUsage::default(),
+                provider_index: None,
+            })
+        }
+        fn model_id(&self) -> &str {
+            "test-model"
+        }
+        fn provider_name(&self) -> &str {
+            "test"
+        }
+    }
+
+    /// Contamination guard (the "Jingkang artifact" bug). On a host with
+    /// NO embedder configured, a prior *unrelated* episode that merely
+    /// shares vocabulary with the current task — and lives in the SAME
+    /// workspace (so the old cwd filter would have admitted it) — must
+    /// NOT be injected into the fresh task's prompt.
+    ///
+    /// Pre-fix: `build_initial_messages` fell into the no-embedder branch,
+    /// ran a BM25-only same-cwd recall, and injected the shared-vocab
+    /// episode as a "Relevant Past Experience" — exactly how a stale
+    /// "Jingkang Incident" research doc leaked into a code-review run.
+    /// Post-fix (option a): the no-embedder branch skips recall entirely,
+    /// so no "Relevant Past Experiences" message is produced.
+    #[tokio::test]
+    async fn no_embedder_path_does_not_inject_shared_vocab_episode() {
+        use crate::{Agent, tools::ToolRegistry};
+        use octos_core::{TaskContext, TaskKind};
+        use octos_memory::EpisodeStore;
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().to_path_buf();
+
+        let memory = Arc::new(EpisodeStore::open(workspace.join("memory")).await.unwrap());
+
+        // A prior, unrelated episode that shares vocabulary ("history",
+        // "incident", "report") with a code-review-style query, stored in
+        // the SAME workspace so a cwd-scoped BM25 recall WOULD have matched
+        // it. This stands in for the stale "Jingkang Incident" history doc.
+        let contaminating = Episode::new(
+            TaskId::new(),
+            AgentId::new("prior-task"),
+            workspace.clone(),
+            "Researched the Jingkang Incident history report and synthesized a timeline"
+                .to_string(),
+            EpisodeOutcome::Success,
+        );
+        memory.store(contaminating).await.unwrap();
+
+        // Sanity: the store CAN find it by shared vocabulary in this cwd
+        // (proving the contamination vector is real and the guard, not a
+        // cwd/keyword miss, is what closes it).
+        let hits = memory
+            .find_relevant(&workspace, "review the incident history report", 5)
+            .await
+            .unwrap();
+        assert!(
+            hits.iter().any(|e| e.summary.contains("Jingkang")),
+            "precondition: the shared-vocab episode is recallable by BM25 in this cwd"
+        );
+
+        // Agent::new defaults embedder=None — the no-embedder path.
+        let provider: Arc<dyn octos_llm::LlmProvider> = Arc::new(EndTurnProvider);
+        let tools = ToolRegistry::with_builtins(&workspace);
+        let agent = Agent::new(AgentId::new("reviewer"), provider, tools, memory);
+
+        let task = octos_core::Task::new(
+            TaskKind::Custom {
+                name: "review the incident history report".to_string(),
+                params: serde_json::Value::Null,
+            },
+            TaskContext {
+                working_dir: workspace.clone(),
+                ..Default::default()
+            },
+        );
+
+        let messages = agent.build_initial_messages(&task).await;
+
+        // No message may carry the stale episode or a "Relevant Past
+        // Experiences" header — recall is skipped entirely on this path.
+        for m in &messages {
+            assert!(
+                !m.content.contains("Jingkang"),
+                "no-embedder path injected the stale cross-task episode: {:?}",
+                m.content
+            );
+            assert!(
+                !m.content.contains("Relevant Past Experiences"),
+                "no-embedder path must not inject any past-experience block: {:?}",
+                m.content
             );
         }
     }

--- a/crates/octos-agent/src/agent/memory.rs
+++ b/crates/octos-agent/src/agent/memory.rs
@@ -99,11 +99,13 @@ impl Agent {
             octos_core::TaskKind::Custom { name, .. } => name.clone(),
         };
 
-        // Hybrid (embedding-aware) path returns scored matches so we can
-        // filter out below-threshold noise that would otherwise contaminate
-        // unrelated sessions. The cwd-scoped `find_relevant` fallback is
-        // already filtered by working directory and keyword overlap, so it
-        // doesn't need the score gate.
+        // Episodic recall requires an embedder. The hybrid (embedding-aware)
+        // path returns scored matches so we can filter out below-threshold
+        // noise that would otherwise contaminate unrelated sessions. WITHOUT
+        // an embedder we SKIP recall entirely (the `else` below): BM25-only
+        // keyword overlap within a single shared workspace can't discriminate
+        // on-task from cross-task episodes, so injecting it leaks stale,
+        // unrelated memory into the prompt.
         if let Some(ref embedder) = self.embedder {
             // Push the modality-aware similarity floor down into the
             // index via `_filtered`. The floor is applied to every

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -358,9 +358,10 @@ pub struct ExecutorConfig {
     /// node worker [`octos_agent::Agent`] so episodic memory recall
     /// stays on the contamination-safe hybrid scored + filtered path.
     ///
-    /// `None` keeps the legacy unfiltered cwd-only fallback in
-    /// `EpisodeStore::find_relevant` — identical to pre-fix behaviour
-    /// for callers that don't propagate the orchestrator's embedder.
+    /// `None` means per-node workers SKIP episodic recall entirely (the
+    /// no-embedder branch in `octos_agent::agent::memory`) — BM25-only cwd
+    /// recall can't separate cross-task episodes, so injecting it would leak
+    /// stale unrelated memory; skipping is the contamination-safe choice.
     pub embedder: Option<Arc<dyn octos_llm::EmbeddingProvider>>,
     /// Phase 2-A — directory used to load `pipeline_models.json` and
     /// `model_catalog.json` for per-node model assignment, plus to

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -529,14 +529,22 @@ impl Tool for RunPipelineTool {
 
     fn description(&self) -> &str {
         "Run a sanctioned multi-step pipeline by NAME. The only currently \
-         sanctioned pipeline is `deep_research` — use it when the user asks \
-         for in-depth, multi-source, source-citing research that needs \
-         parallel search workers + synthesis. Do NOT compose your own \
-         inline DOT graph for ad-hoc tasks (slides, media, code edits, \
-         partial regenerations, etc.) — those have purpose-built tools \
-         (`mofa_slides`, `podcast_generate`, etc.). If no purpose-built \
+         sanctioned pipeline is `deep_research`, which performs MULTI-SOURCE \
+         WEB-RESEARCH SYNTHESIS: it fans out parallel web-search workers and \
+         synthesizes a source-citing report. Use it ONLY when the user asks \
+         for in-depth, multi-source research drawn from the open web. \
+         deep_research MUST NOT be used for code review, local-codebase \
+         analysis, debugging, or anything answerable from the files already \
+         in the working directory — it has no access to your repository and \
+         will fabricate or recall unrelated material. For those tasks do NOT \
+         call run_pipeline at all; answer directly with the local tools \
+         (`read_file`, `grep`, `glob`, `list_dir`, `shell`). Likewise do NOT \
+         compose your own inline DOT graph for ad-hoc tasks (slides, media, \
+         code edits, partial regenerations, etc.) — those have purpose-built \
+         tools (`mofa_slides`, `podcast_generate`, etc.). If no purpose-built \
          tool exists for what the user asked, surface that as a limitation \
-         rather than improvising a custom pipeline."
+         rather than improvising a custom pipeline or force-fitting \
+         deep_research."
     }
 
     fn tags(&self) -> &[&str] {
@@ -545,15 +553,21 @@ impl Tool for RunPipelineTool {
 
     fn input_schema(&self) -> serde_json::Value {
         let pipeline_desc = "Name of the sanctioned pipeline to run. The only currently \
-             sanctioned name is `deep_research`. Do NOT pass an inline \
-             DOT graph here — inline DOT was the legacy free-form \
-             contract; the executor still accepts it for operator \
-             debugging but agent-driven runs MUST use the name form. If \
-             you find yourself wanting to compose your own DOT, the \
-             correct response is to use the purpose-built tool for that \
-             domain (`mofa_slides` for slides, `podcast_generate` for \
-             podcasts, `voice_synthesize` for TTS, etc.), or tell the \
-             user no such tool exists for their request."
+             sanctioned name is `deep_research`, which is for MULTI-SOURCE \
+             WEB-RESEARCH SYNTHESIS ONLY (parallel web-search workers + a \
+             cited synthesis). `deep_research` MUST NOT be selected for code \
+             review, local-codebase analysis, debugging, or any task \
+             answerable from the working directory — those are NOT web \
+             research; answer them directly with the local file/shell tools \
+             (`read_file`, `grep`, `glob`, `list_dir`, `shell`) instead of \
+             calling run_pipeline. Do NOT pass an inline DOT graph here — \
+             inline DOT was the legacy free-form contract; the executor \
+             still accepts it for operator debugging but agent-driven runs \
+             MUST use the name form. If you find yourself wanting to compose \
+             your own DOT, the correct response is to use the purpose-built \
+             tool for that domain (`mofa_slides` for slides, \
+             `podcast_generate` for podcasts, `voice_synthesize` for TTS, \
+             etc.), or tell the user no such tool exists for their request."
             .to_string();
 
         // Gap 4.1: advertise the LIVE discovery list, not a hard-coded

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -120,14 +120,14 @@ pub struct RunPipelineTool {
     contract_id: Option<String>,
     /// NEW-06 fix: optional embedder for hybrid memory search.
     ///
-    /// Without this set, worker `Agent` instances spawned per pipeline
-    /// node fall through to the unfiltered cwd-only fallback path in
-    /// `EpisodeStore::find_relevant` — which only does keyword overlap
-    /// plus CWD filtering, NOT the modality-aware similarity gate in
-    /// [`octos_agent::agent::memory::MIN_EPISODE_SIMILARITY`]. The
-    /// gateway / serve runtimes own the embedder; this lets the
-    /// orchestrator propagate it down to pipeline workers so episodic
-    /// memory recall is contamination-safe end-to-end.
+    /// Without this set, worker `Agent` instances spawned per pipeline node
+    /// SKIP episodic memory recall entirely (the no-embedder branch in
+    /// `octos_agent::agent::memory`): BM25-only keyword recall within a single
+    /// shared workspace can't discriminate on-task from cross-task episodes, so
+    /// it would leak stale unrelated memory. The gateway / serve runtimes own
+    /// the embedder; this lets the orchestrator propagate it down to pipeline
+    /// workers so episodic memory recall is available AND contamination-safe
+    /// end-to-end.
     embedder: Option<Arc<dyn EmbeddingProvider>>,
 }
 

--- a/crates/octos-pipeline/tests/dynamic_pipeline_enum.rs
+++ b/crates/octos-pipeline/tests/dynamic_pipeline_enum.rs
@@ -647,3 +647,72 @@ async fn bootstrap_then_discover_deep_research_end_to_end() {
         .await
         .expect("bootstrapped deep_research must pass pre_flight_validate");
 }
+
+/// Routing guidance ("Jingkang artifact" routing-collapse fix). The tool
+/// exposes exactly one pipeline (`deep_research`), and the agent force-fit a
+/// CODE-REVIEW task onto it — the web-research-synthesis pipeline then ran
+/// over a shared workspace and recalled a stale unrelated research artifact.
+///
+/// We cannot reliably classify intent in code without a brittle classifier,
+/// so the enforcement is a STRONG description/schema guardrail: both the
+/// tool `description()` and the `pipeline` arg's enum-doc must state in plain
+/// terms that `deep_research` is for multi-source WEB-research synthesis ONLY
+/// and MUST NOT be used for code review / local-codebase analysis / anything
+/// answerable from the working directory (those use the direct
+/// file/shell/grep/read tools). This test pins that guidance so it cannot
+/// silently regress.
+#[tokio::test]
+async fn run_pipeline_guidance_steers_code_review_away_from_deep_research() {
+    let working = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+    let tool = make_tool_with_data(working.path(), data.path()).await;
+
+    let description = tool.description().to_ascii_lowercase();
+    let schema = tool.input_schema();
+    let pipeline_desc = schema["properties"]["pipeline"]["description"]
+        .as_str()
+        .expect("pipeline arg must carry a description")
+        .to_ascii_lowercase();
+
+    // The two surfaces the model actually reads when deciding to call.
+    let combined = format!("{description}\n{pipeline_desc}");
+
+    // 1. It must scope deep_research to multi-source WEB research synthesis.
+    assert!(
+        combined.contains("web") && combined.contains("research"),
+        "guidance must scope deep_research to web-research synthesis; got:\n{combined}"
+    );
+
+    // 2. It must explicitly steer code review away.
+    assert!(
+        combined.contains("code review") || combined.contains("code-review"),
+        "guidance must explicitly mention code review as a NON-use; got:\n{combined}"
+    );
+
+    // 3. It must explicitly steer local-codebase / working-directory tasks away.
+    assert!(
+        combined.contains("local") || combined.contains("codebase"),
+        "guidance must mention local-codebase analysis as a NON-use; got:\n{combined}"
+    );
+    assert!(
+        combined.contains("working directory") || combined.contains("working-directory"),
+        "guidance must mention working-directory-answerable tasks as a NON-use; got:\n{combined}"
+    );
+
+    // 4. It must point such tasks at the direct file/shell tools instead.
+    let names_direct_tools = ["read_file", "read", "grep", "shell", "list_dir"]
+        .iter()
+        .any(|t| combined.contains(t));
+    assert!(
+        names_direct_tools,
+        "guidance must redirect code-review / local tasks to the direct \
+         file/shell/grep/read tools; got:\n{combined}"
+    );
+
+    // 5. A clear MUST NOT / do-not prohibition (not merely a soft hint).
+    assert!(
+        combined.contains("must not") || combined.contains("do not use"),
+        "guidance must carry a strong prohibition (MUST NOT / do not use), not \
+         a soft suggestion; got:\n{combined}"
+    );
+}


### PR DESCRIPTION
Fixes the soak bug where a CODE-REVIEW prompt produced a stale unrelated 'Jingkang Incident' history artifact. Root cause was two compounding contract gaps (NOT a missing embedder-wiring fix — that wiring is fine; the WARN was misdiagnostic).

## Fixes
1. **No-embedder recall contamination (load-bearing)** — on the no-embedder path, SKIP episodic recall entirely (`octos-agent/src/agent/memory.rs`). BM25-only keyword recall within one shared workspace can't discriminate on-task vs cross-task episodes, so a prior unrelated episode (the Jingkang research doc) leaked into a fresh run. The embedder-present hybrid scored+filtered path is unchanged. Test: a same-workspace 'Jingkang' episode is recallable but NOT injected on the no-embedder path.
2. **Misdiagnostic WARN** — the no-embedder branch told operators to 'investigate RunPipelineTool::with_embedder wiring (NEW-06)', but the only knowable state there is `embedder.is_none()` (expected on an unconfigured host). Downgraded to a neutral `debug!` with no wiring misattribution. Test asserts no misleading text.
3. **run_pipeline routing guidance (description-only)** — `run_pipeline`/`deep_research` description now states it's MULTI-SOURCE WEB-RESEARCH SYNTHESIS only, not for code review / local-codebase tasks (those use the direct file/shell/grep tools). No brittle intent classifier added. Test RED-verified against the old description.
4. Doc cleanup: updated the no-embedder comments (tool.rs/executor.rs/memory.rs) to match the recall-skip behavior.

codex-reviewed: SHIP, no DO-NOT-SHIP. Build/test/fmt/clippy clean (only the known env tmpdir flake). Follow-up noted by codex: spawn/delegate children also get no embedder so they now skip recall too — propagating the embedder to them is a reasonable future improvement.