### PR TITLE
feat(pipeline): typed-IR workflow authoring — safe LLM-composed pipelines

### DIFF
--- a/crates/octos-pipeline/examples/compose_check.rs
+++ b/crates/octos-pipeline/examples/compose_check.rs
@@ -1,0 +1,30 @@
+//! Check an LLM-authored typed-IR workflow through the real `compose_l2` path.
+//! Usage: `cargo run -p octos-pipeline --example compose_check -- <file.json>`
+//! Prints `OK\t<nodes>\t<edges>` or `FAIL\t<feedback lines...>` (exit 1).
+
+use std::io::Read;
+
+fn read_input() -> String {
+    if let Some(path) = std::env::args().nth(1) {
+        std::fs::read_to_string(path).expect("read file")
+    } else {
+        let mut s = String::new();
+        std::io::stdin().read_to_string(&mut s).expect("read stdin");
+        s
+    }
+}
+
+fn main() {
+    let json = read_input();
+    match octos_pipeline::compose::compose_l2(&json) {
+        Ok(g) => println!("OK\t{}\t{}", g.nodes.len(), g.edges.len()),
+        Err(e) => {
+            print!("FAIL");
+            for line in e.feedback_lines() {
+                print!("\t{line}");
+            }
+            println!();
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/octos-pipeline/examples/dot_check.rs
+++ b/crates/octos-pipeline/examples/dot_check.rs
@@ -1,0 +1,48 @@
+//! Check an LLM-authored raw-DOT workflow through the existing `parse_dot` path,
+//! then the SAME profile gate the IR path uses — apples-to-apples with
+//! `compose_check`. Usage:
+//! `cargo run -p octos-pipeline --example dot_check -- <file.dot>`
+//! Prints `OK\t<nodes>\t<edges>` or `FAIL\t<reason...>` (exit 1).
+
+use std::io::Read;
+
+use octos_pipeline::profile::{ValidationProfile, validate_under_profile};
+
+fn read_input() -> String {
+    if let Some(path) = std::env::args().nth(1) {
+        std::fs::read_to_string(path).expect("read file")
+    } else {
+        let mut s = String::new();
+        std::io::stdin().read_to_string(&mut s).expect("read stdin");
+        s
+    }
+}
+
+fn main() {
+    let dot = read_input();
+    let graph = match octos_pipeline::parser::parse_dot(&dot) {
+        Ok(g) => g,
+        Err(e) => {
+            println!("FAIL\tparse: {e}");
+            std::process::exit(1);
+        }
+    };
+    if let Err(cycle) = octos_pipeline::validate::detect_cycles_ignoring_marked_back_edges(&graph) {
+        println!("FAIL\tcycle: {cycle}");
+        std::process::exit(1);
+    }
+    let violations = validate_under_profile(&graph, &ValidationProfile::l2_default());
+    if violations.is_empty() {
+        println!("OK\t{}\t{}", graph.nodes.len(), graph.edges.len());
+    } else {
+        print!("FAIL");
+        for v in &violations {
+            match &v.node {
+                Some(n) => print!("\tnode '{n}': {}", v.message),
+                None => print!("\tgraph: {}", v.message),
+            }
+        }
+        println!();
+        std::process::exit(1);
+    }
+}

--- a/crates/octos-pipeline/examples/run_ir_cli.rs
+++ b/crates/octos-pipeline/examples/run_ir_cli.rs
@@ -1,0 +1,91 @@
+//! One-shot: compose a typed-IR workflow and EXECUTE it against a live model
+//! (provider from `DEEPSEEK_API_KEY`, OpenAI-compatible), reusing the same
+//! executor + handlers the production `RunPipelineTool` builds.
+//!
+//! Usage: `run_ir_cli <ir.json> "<input/topic>"`
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use octos_llm::{LlmProvider, openai::OpenAIProvider};
+use octos_memory::EpisodeStore;
+use octos_pipeline::context::PipelineContext;
+use octos_pipeline::executor::{ExecutorConfig, PipelineExecutor};
+use octos_pipeline::host_context::PipelineHostContext;
+use octos_pipeline::profile::ValidationProfile;
+
+#[tokio::main]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let ir_path = args.next().expect("usage: run_ir_cli <ir.json> <input>");
+    let input = args.next().unwrap_or_default();
+    let ir_json = std::fs::read_to_string(&ir_path).expect("read ir file");
+
+    let key = std::env::var("DEEPSEEK_API_KEY").expect("DEEPSEEK_API_KEY not set");
+    let provider: Arc<dyn LlmProvider> = Arc::new(
+        OpenAIProvider::new(key, "deepseek-chat").with_base_url("https://api.deepseek.com/v1"),
+    );
+
+    let mem_dir = std::env::temp_dir().join("run_ir_cli_episodes");
+    let _ = std::fs::create_dir_all(&mem_dir);
+    let memory = Arc::new(
+        EpisodeStore::open_or_degraded(&mem_dir)
+            .await
+            .expect("episode store"),
+    );
+
+    let config = ExecutorConfig {
+        default_provider: provider,
+        provider_router: None,
+        memory,
+        working_dir: PathBuf::from("/tmp"),
+        provider_policy: None,
+        plugin_dirs: vec![],
+        plugin_require_signed: false,
+        status_bridge: None,
+        shutdown: Arc::new(AtomicBool::new(false)),
+        max_parallel_workers: 8,
+        max_pipeline_fanout_total: None,
+        checkpoint_store: None,
+        hook_executor: None,
+        workspace_context: PipelineContext::default(),
+        host_context: PipelineHostContext::default(),
+        embedder: None,
+        catalog_dir: None,
+    };
+    let executor = PipelineExecutor::new(config);
+
+    match executor
+        .run_ir(
+            &ir_json,
+            &ValidationProfile::l2_default(),
+            &input,
+            &serde_json::Map::new(),
+        )
+        .await
+    {
+        Ok(r) => {
+            eprintln!(
+                "=== success={} nodes_run={} ===",
+                r.success,
+                r.node_summaries.len()
+            );
+            for n in &r.node_summaries {
+                eprintln!(
+                    "  node {:<12} {} {}ms {}+{} tok",
+                    n.node_id,
+                    if n.success { "OK  " } else { "FAIL" },
+                    n.duration_ms,
+                    n.token_usage.input_tokens,
+                    n.token_usage.output_tokens,
+                );
+            }
+            println!("{}", r.output);
+        }
+        Err(e) => {
+            eprintln!("=== ERROR ===\n{e:?}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/octos-pipeline/src/compose.rs
+++ b/crates/octos-pipeline/src/compose.rs
@@ -1,0 +1,158 @@
+//! L2 entry: compile an LLM-authored typed IR ([`crate::ir`]) into a validated,
+//! profile-checked [`PipelineGraph`] ready for execution.
+//!
+//! Flow: parse JSON IR → compile to graph → cycle check → [`ValidationProfile`]
+//! gate. Every failure is returned as structured [`ComposeError`] feedback
+//! suitable for an LLM emit → validate → repair loop; a graph is never returned
+//! unless it passed all gates.
+//!
+//! Note: full model/tool validation (which needs runtime facts the executor
+//! projects in) is performed by [`crate::validate::diagnostics_with_context`]
+//! inside the executor at run time, not here.
+
+use crate::graph::PipelineGraph;
+use crate::ir::{self, PipelineIr};
+use crate::profile::{ProfileViolation, ValidationProfile, validate_under_profile};
+
+/// Structured failure from [`compose`], suitable to feed back to the LLM.
+#[derive(Debug)]
+pub enum ComposeError {
+    /// The IR JSON did not deserialize (unknown kind/field, malformed JSON).
+    Parse(String),
+    /// The IR was well-formed but could not compile (e.g. dangling edge).
+    Compile(String),
+    /// The compiled graph contains a cycle.
+    Cycle(String),
+    /// The compiled graph violated the autonomy profile.
+    Profile(Vec<ProfileViolation>),
+}
+
+impl ComposeError {
+    /// A flat, LLM-facing list of error lines for repair feedback.
+    pub fn feedback_lines(&self) -> Vec<String> {
+        match self {
+            ComposeError::Parse(m) => vec![format!("parse error: {m}")],
+            ComposeError::Compile(m) => vec![format!("compile error: {m}")],
+            ComposeError::Cycle(m) => vec![format!(
+                "cycle: {m}. If this is an intentional retry/guard loop, set \
+                 \"back_edge\": true on the looping edge; otherwise remove the cycle."
+            )],
+            ComposeError::Profile(vs) => vs
+                .iter()
+                .map(|v| match &v.node {
+                    Some(n) => format!("node '{n}': {}", v.message),
+                    None => format!("graph: {}", v.message),
+                })
+                .collect(),
+        }
+    }
+}
+
+impl std::fmt::Display for ComposeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.feedback_lines().join("; "))
+    }
+}
+
+impl std::error::Error for ComposeError {}
+
+/// Compile + validate an IR JSON string under a profile. Returns a graph only
+/// if every gate passed; otherwise structured feedback for repair.
+pub fn compose(ir_json: &str, profile: &ValidationProfile) -> Result<PipelineGraph, ComposeError> {
+    let ir: PipelineIr =
+        serde_json::from_str(ir_json).map_err(|e| ComposeError::Parse(e.to_string()))?;
+    let graph = ir::compile(&ir).map_err(|e| ComposeError::Compile(e.to_string()))?;
+    // Use the engine's marker-aware cycle rule, not the naive all-cycle check:
+    // intentional retry/guard back-edges (IrEdge.back_edge) are permitted.
+    if let Err(cycle) = crate::validate::detect_cycles_ignoring_marked_back_edges(&graph) {
+        return Err(ComposeError::Cycle(cycle));
+    }
+    let violations = validate_under_profile(&graph, profile);
+    if !violations.is_empty() {
+        return Err(ComposeError::Profile(violations));
+    }
+    Ok(graph)
+}
+
+/// Convenience: compose under the L2 default profile.
+pub fn compose_l2(ir_json: &str) -> Result<PipelineGraph, ComposeError> {
+    compose(ir_json, &ValidationProfile::l2_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID: &str = r#"{
+        "id":"demo",
+        "nodes":[
+            {"id":"r","kind":{"type":"research","prompt":"find X"}},
+            {"id":"s","kind":{"type":"synthesize","prompt":"write"}}
+        ],
+        "edges":[{"source":"r","target":"s"}]
+    }"#;
+
+    #[test]
+    fn should_compose_valid_l2_ir() {
+        let g = compose_l2(VALID).expect("valid IR composes");
+        assert_eq!(g.nodes.len(), 2);
+        assert_eq!(g.edges.len(), 1);
+    }
+
+    #[test]
+    fn should_reject_unknown_kind_at_parse() {
+        let json = r#"{"id":"p","nodes":[{"id":"n","kind":{"type":"shell"}}]}"#;
+        assert!(matches!(compose_l2(json), Err(ComposeError::Parse(_))));
+    }
+
+    #[test]
+    fn should_reject_dangling_edge_at_compile() {
+        let json = r#"{"id":"p","nodes":[{"id":"a","kind":{"type":"gate"}}],"edges":[{"source":"a","target":"ghost"}]}"#;
+        assert!(matches!(compose_l2(json), Err(ComposeError::Compile(_))));
+    }
+
+    #[test]
+    fn should_reject_cycle() {
+        let json = r#"{
+            "id":"p",
+            "nodes":[{"id":"a","kind":{"type":"gate"}},{"id":"b","kind":{"type":"gate"}}],
+            "edges":[{"source":"a","target":"b"},{"source":"b","target":"a"}]
+        }"#;
+        assert!(matches!(compose_l2(json), Err(ComposeError::Cycle(_))));
+    }
+
+    #[test]
+    fn should_accept_marked_back_edge_loop() {
+        // The retry/revision loop pattern real LLMs author: a gate that loops
+        // back on failure, marked as an intentional back-edge.
+        let json = r#"{
+            "id":"p",
+            "nodes":[
+                {"id":"g","kind":{"type":"gate"}},
+                {"id":"w","kind":{"type":"transform","prompt":"do work"}}
+            ],
+            "edges":[
+                {"source":"g","target":"w"},
+                {"source":"w","target":"g","condition":"outcome.status == \"fail\"","back_edge":true}
+            ]
+        }"#;
+        assert!(
+            compose_l2(json).is_ok(),
+            "a marked retry loop should compose: {:?}",
+            compose_l2(json).err()
+        );
+    }
+
+    #[test]
+    fn should_reject_profile_violation_with_feedback() {
+        // A tiny profile makes the 2-node graph exceed max_nodes.
+        let mut p = ValidationProfile::l2_default();
+        p.max_nodes = 1;
+        match compose(VALID, &p) {
+            Err(e @ ComposeError::Profile(_)) => {
+                assert!(e.feedback_lines().iter().any(|l| l.contains("max_nodes")));
+            }
+            other => panic!("expected profile violation, got {other:?}"),
+        }
+    }
+}

--- a/crates/octos-pipeline/src/compose.rs
+++ b/crates/octos-pipeline/src/compose.rs
@@ -23,6 +23,10 @@ pub enum ComposeError {
     Compile(String),
     /// The compiled graph contains a cycle.
     Cycle(String),
+    /// The compiled graph failed structural validation (no/ambiguous start node,
+    /// unreachable nodes, fanout `converge` target missing, edge-condition parse,
+    /// …) — the same rules the executor runs, surfaced here for repair.
+    Structural(Vec<String>),
     /// The compiled graph violated the autonomy profile.
     Profile(Vec<ProfileViolation>),
 }
@@ -37,6 +41,9 @@ impl ComposeError {
                 "cycle: {m}. If this is an intentional retry/guard loop, set \
                  \"back_edge\": true on the looping edge; otherwise remove the cycle."
             )],
+            ComposeError::Structural(errs) => {
+                errs.iter().map(|e| format!("structural: {e}")).collect()
+            }
             ComposeError::Profile(vs) => vs
                 .iter()
                 .map(|v| match &v.node {
@@ -62,16 +69,98 @@ pub fn compose(ir_json: &str, profile: &ValidationProfile) -> Result<PipelineGra
     let ir: PipelineIr =
         serde_json::from_str(ir_json).map_err(|e| ComposeError::Parse(e.to_string()))?;
     let graph = ir::compile(&ir).map_err(|e| ComposeError::Compile(e.to_string()))?;
-    // Use the engine's marker-aware cycle rule, not the naive all-cycle check:
-    // intentional retry/guard back-edges (IrEdge.back_edge) are permitted.
-    if let Err(cycle) = crate::validate::detect_cycles_ignoring_marked_back_edges(&graph) {
+    // Cycle gate: exempt ONLY edges explicitly marked back_edge (label set by
+    // ir::compile from IrEdge.back_edge). Unlike the DOT helper this does NOT
+    // honor retry/guard keywords in edge CONDITION text, so an LLM's accidental
+    // wording can't bypass the cycle gate.
+    if let Err(cycle) = detect_cycle_ir(&graph) {
         return Err(ComposeError::Cycle(cycle));
+    }
+    // Structural validation (start node, reachability, fanout converge target,
+    // edge-condition parse, …) — the same rules the executor runs, so a bad IR
+    // fails foreground compose instead of dead-ending in the background run and
+    // defeating the repair loop. Models/tools come from the trusted contract, so
+    // declare them known to avoid spurious unknown-model/-tool diagnostics.
+    let known_models: Vec<String> = graph
+        .nodes
+        .values()
+        .filter_map(|n| n.model.clone())
+        .collect();
+    let known_tools: Vec<String> = graph
+        .nodes
+        .values()
+        .flat_map(|n| n.tools.iter().cloned())
+        .collect();
+    let ctx = crate::validate::ValidationContext::default()
+        .with_known_models(known_models)
+        .with_known_tools(known_tools);
+    let diags = crate::validate::diagnostics_with_context(&graph, &ctx);
+    if crate::validate::has_errors(&diags) {
+        let errs: Vec<String> = diags
+            .iter()
+            .filter(|d| d.severity == crate::validate::Severity::Error)
+            .map(|d| format!("{}: {}", d.rule_id.code(), d.message))
+            .collect();
+        return Err(ComposeError::Structural(errs));
     }
     let violations = validate_under_profile(&graph, profile);
     if !violations.is_empty() {
         return Err(ComposeError::Profile(violations));
     }
     Ok(graph)
+}
+
+/// Cycle detection for the IR path: exempts ONLY edges explicitly marked as a
+/// back-edge (`label == "back_edge"`, set by `ir::compile` from `back_edge:
+/// true`). Does NOT honor retry/guard keywords in edge condition text.
+fn detect_cycle_ir(graph: &PipelineGraph) -> Result<(), String> {
+    use std::collections::{HashMap, HashSet};
+    let mut adj: HashMap<&str, Vec<&str>> = HashMap::new();
+    for e in &graph.edges {
+        if e.label.as_deref() == Some("back_edge") {
+            continue;
+        }
+        adj.entry(e.source.as_str())
+            .or_default()
+            .push(e.target.as_str());
+    }
+    fn dfs<'a>(
+        node: &'a str,
+        adj: &HashMap<&str, Vec<&'a str>>,
+        gray: &mut HashSet<&'a str>,
+        black: &mut HashSet<&'a str>,
+        path: &mut Vec<&'a str>,
+    ) -> Result<(), String> {
+        gray.insert(node);
+        path.push(node);
+        if let Some(neighbors) = adj.get(node) {
+            for &next in neighbors {
+                if black.contains(next) {
+                    continue;
+                }
+                if gray.contains(next) {
+                    let start = path.iter().position(|&n| n == next).unwrap_or(0);
+                    let mut cyc: Vec<&str> = path[start..].to_vec();
+                    cyc.push(next);
+                    return Err(format!("cycle detected: {}", cyc.join(" -> ")));
+                }
+                dfs(next, adj, gray, black, path)?;
+            }
+        }
+        path.pop();
+        gray.remove(node);
+        black.insert(node);
+        Ok(())
+    }
+    let mut gray = HashSet::new();
+    let mut black = HashSet::new();
+    let mut path = Vec::new();
+    for node in graph.nodes.keys() {
+        if !black.contains(node.as_str()) {
+            dfs(node.as_str(), &adj, &mut gray, &mut black, &mut path)?;
+        }
+    }
+    Ok(())
 }
 
 /// Convenience: compose under the L2 default profile.
@@ -123,24 +212,59 @@ mod tests {
 
     #[test]
     fn should_accept_marked_back_edge_loop() {
-        // The retry/revision loop pattern real LLMs author: a gate that loops
-        // back on failure, marked as an intentional back-edge.
+        // The retry/revision loop pattern real LLMs author: an entry node, then
+        // a gate that loops back to work on failure, marked as a back-edge.
         let json = r#"{
             "id":"p",
             "nodes":[
-                {"id":"g","kind":{"type":"gate"}},
-                {"id":"w","kind":{"type":"transform","prompt":"do work"}}
+                {"id":"start","kind":{"type":"research","prompt":"begin"}},
+                {"id":"work","kind":{"type":"transform","prompt":"do work"}},
+                {"id":"check","kind":{"type":"gate"}}
             ],
             "edges":[
-                {"source":"g","target":"w"},
-                {"source":"w","target":"g","condition":"outcome.status == \"fail\"","back_edge":true}
+                {"source":"start","target":"work"},
+                {"source":"work","target":"check"},
+                {"source":"check","target":"work","condition":"outcome.status == \"fail\"","back_edge":true}
             ]
         }"#;
         assert!(
             compose_l2(json).is_ok(),
-            "a marked retry loop should compose: {:?}",
+            "a marked retry loop with an entry node should compose: {:?}",
             compose_l2(json).err()
         );
+    }
+
+    #[test]
+    fn should_reject_unmarked_cycle_even_with_retry_in_condition() {
+        // P2b: an unmarked cycle whose condition merely contains the word
+        // "retry" must NOT bypass the cycle gate (the IR path honors only the
+        // explicit back_edge flag, not condition keywords).
+        let json = r#"{
+            "id":"p",
+            "nodes":[
+                {"id":"a","kind":{"type":"gate"}},
+                {"id":"b","kind":{"type":"gate"}}
+            ],
+            "edges":[
+                {"source":"a","target":"b"},
+                {"source":"b","target":"a","condition":"outcome.content contains \"retry\""}
+            ]
+        }"#;
+        assert!(matches!(compose_l2(json), Err(ComposeError::Cycle(_))));
+    }
+
+    #[test]
+    fn should_reject_structurally_invalid_ir() {
+        // P2a: a fanout whose converge target does not exist must fail compose
+        // (structural), not slip through to the background run.
+        let json = r#"{
+            "id":"p",
+            "nodes":[
+                {"id":"f","kind":{"type":"fanout","worker_prompt":"do {task}","converge":"ghost"}}
+            ],
+            "edges":[]
+        }"#;
+        assert!(matches!(compose_l2(json), Err(ComposeError::Structural(_))));
     }
 
     #[test]

--- a/crates/octos-pipeline/src/compose.rs
+++ b/crates/octos-pipeline/src/compose.rs
@@ -63,9 +63,16 @@ impl std::fmt::Display for ComposeError {
 
 impl std::error::Error for ComposeError {}
 
-/// Compile + validate an IR JSON string under a profile. Returns a graph only
-/// if every gate passed; otherwise structured feedback for repair.
-pub fn compose(ir_json: &str, profile: &ValidationProfile) -> Result<PipelineGraph, ComposeError> {
+/// Compile + validate an IR JSON string under a profile. `variables` carries
+/// the caller-supplied runtime template variable keys (the same `variables`
+/// `run_pipeline` receives) so structural validation doesn't flag prompts that
+/// reference them as unbound. Returns a graph only if every gate passed;
+/// otherwise structured feedback for repair.
+pub fn compose(
+    ir_json: &str,
+    profile: &ValidationProfile,
+    variables: &serde_json::Map<String, serde_json::Value>,
+) -> Result<PipelineGraph, ComposeError> {
     let ir: PipelineIr =
         serde_json::from_str(ir_json).map_err(|e| ComposeError::Parse(e.to_string()))?;
     let graph = ir::compile(&ir).map_err(|e| ComposeError::Compile(e.to_string()))?;
@@ -92,6 +99,7 @@ pub fn compose(ir_json: &str, profile: &ValidationProfile) -> Result<PipelineGra
         .flat_map(|n| n.tools.iter().cloned())
         .collect();
     let ctx = crate::validate::ValidationContext::default()
+        .with_runtime_variables(variables.keys().cloned())
         .with_known_models(known_models)
         .with_known_tools(known_tools);
     let diags = crate::validate::diagnostics_with_context(&graph, &ctx);
@@ -163,9 +171,13 @@ fn detect_cycle_ir(graph: &PipelineGraph) -> Result<(), String> {
     Ok(())
 }
 
-/// Convenience: compose under the L2 default profile.
+/// Convenience: compose under the L2 default profile with no custom variables.
 pub fn compose_l2(ir_json: &str) -> Result<PipelineGraph, ComposeError> {
-    compose(ir_json, &ValidationProfile::l2_default())
+    compose(
+        ir_json,
+        &ValidationProfile::l2_default(),
+        &serde_json::Map::new(),
+    )
 }
 
 #[cfg(test)]
@@ -268,11 +280,35 @@ mod tests {
     }
 
     #[test]
+    fn should_accept_caller_supplied_runtime_variables() {
+        // codex round-2 P2: a prompt referencing a caller-supplied variable must
+        // validate when that variable is passed in, not be flagged unbound.
+        let json = r#"{
+            "id":"p",
+            "nodes":[{"id":"r","kind":{"type":"research","prompt":"research {customer_topic}"}}],
+            "edges":[]
+        }"#;
+        let mut vars = serde_json::Map::new();
+        vars.insert(
+            "customer_topic".to_string(),
+            serde_json::Value::String("widgets".into()),
+        );
+        let p = ValidationProfile::l2_default();
+        assert!(
+            compose(json, &p, &vars).is_ok(),
+            "custom var should validate: {:?}",
+            compose(json, &p, &vars).err()
+        );
+        // Without the variable it's an unbound-template-var structural error.
+        assert!(matches!(compose_l2(json), Err(ComposeError::Structural(_))));
+    }
+
+    #[test]
     fn should_reject_profile_violation_with_feedback() {
         // A tiny profile makes the 2-node graph exceed max_nodes.
         let mut p = ValidationProfile::l2_default();
         p.max_nodes = 1;
-        match compose(VALID, &p) {
+        match compose(VALID, &p, &serde_json::Map::new()) {
             Err(e @ ComposeError::Profile(_)) => {
                 assert!(e.feedback_lines().iter().any(|l| l.contains("max_nodes")));
             }

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -951,6 +951,40 @@ impl PipelineExecutor {
             .await
     }
 
+    /// Run an already-parsed [`PipelineGraph`] using the executor's default
+    /// handler registry — the graph-accepting analog of [`Self::run`]. Lets an
+    /// IR-composed graph execute with the full production tool set without
+    /// round-tripping through DOT text.
+    pub async fn run_graph(
+        &self,
+        graph: PipelineGraph,
+        user_input: &str,
+        variables: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<PipelineResult> {
+        let handlers = self.build_handlers();
+        self.run_graph_with_handlers(graph, user_input, variables, handlers)
+            .await
+    }
+
+    /// Compile an L2 typed-IR program (see [`crate::compose`]) under `profile`
+    /// and run it. The IR is lowered straight to a [`PipelineGraph`] and never
+    /// round-trips through DOT text. Compose-time failures (unknown kind,
+    /// dangling edge, cycle, profile violation) are surfaced as an error
+    /// carrying the structured repair feedback.
+    pub async fn run_ir(
+        &self,
+        ir_json: &str,
+        profile: &crate::profile::ValidationProfile,
+        user_input: &str,
+        variables: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<PipelineResult> {
+        let graph = crate::compose::compose(ir_json, profile)
+            .map_err(|e| eyre::eyre!("IR compose failed: {e}"))?;
+        let handlers = self.build_handlers();
+        self.run_graph_with_handlers(graph, user_input, variables, handlers)
+            .await
+    }
+
     /// Run a pipeline from a DOT string using a caller-supplied handler
     /// registry. Useful for tests that want to install a custom
     /// `Handler` against a given `HandlerKind` without touching the
@@ -962,9 +996,25 @@ impl PipelineExecutor {
         variables: &serde_json::Map<String, serde_json::Value>,
         handlers: HandlerRegistry,
     ) -> Result<PipelineResult> {
-        // Parse and validate
-        let mut graph = parse_dot(dot_content).wrap_err("failed to parse pipeline DOT")?;
+        let graph = parse_dot(dot_content).wrap_err("failed to parse pipeline DOT")?;
+        self.run_graph_with_handlers(graph, user_input, variables, handlers)
+            .await
+    }
 
+    /// Run a pipeline from an already-parsed [`PipelineGraph`] using a
+    /// caller-supplied handler registry. This graph-accepting entry lets
+    /// L2-composed pipelines (see [`crate::compose`]) execute WITHOUT
+    /// round-tripping through DOT text — [`Self::run_with_handlers`] is now just
+    /// `parse_dot(...)` followed by this. The per-node capability lock
+    /// (`CodergenHandler`'s tool deny-list) runs regardless of how the graph was
+    /// built, so a compiled-IR graph inherits identical gating to a DOT graph.
+    pub async fn run_graph_with_handlers(
+        &self,
+        mut graph: PipelineGraph,
+        user_input: &str,
+        variables: &serde_json::Map<String, serde_json::Value>,
+        handlers: HandlerRegistry,
+    ) -> Result<PipelineResult> {
         // Replace the historical pipeline-guard plugin's
         // before_tool_call hook with an in-process pass that fills
         // `node.model` / `node.planner_model` for any node the LLM
@@ -3506,6 +3556,97 @@ mod tests {
             result.is_ok(),
             "fan-out below cap should complete: {result:?}"
         );
+    }
+
+    // ── L2 typed-IR execution (S1-3) ───────────────────────────────────
+
+    /// A composed typed-IR program executes through `run_graph_with_handlers`
+    /// without ever round-tripping through DOT text.
+    #[tokio::test]
+    async fn run_ir_executes_composed_graph_without_dot_roundtrip() {
+        let executor = PipelineExecutor::new(make_capped_config(4).await);
+        let ir = r#"{"id":"p","nodes":[{"id":"g","kind":{"type":"gate"}}]}"#;
+        let result = executor
+            .run_ir(
+                ir,
+                &crate::profile::ValidationProfile::l2_default(),
+                "hi",
+                &serde_json::Map::new(),
+            )
+            .await;
+        assert!(result.is_ok(), "composed gate graph should run: {result:?}");
+    }
+
+    /// Compose-time failures surface as an error before any execution begins.
+    #[tokio::test]
+    async fn run_ir_surfaces_compose_errors_before_execution() {
+        let executor = PipelineExecutor::new(make_capped_config(4).await);
+        let bad = r#"{"id":"p","nodes":[{"id":"n","kind":{"type":"shell"}}]}"#;
+        let err = executor
+            .run_ir(
+                bad,
+                &crate::profile::ValidationProfile::l2_default(),
+                "x",
+                &serde_json::Map::new(),
+            )
+            .await
+            .expect_err("unknown palette kind must fail at compose");
+        assert!(err.to_string().contains("compose"), "got: {err}");
+    }
+
+    /// Real END-TO-END: compile an L2 typed-IR "deep research" workflow and
+    /// EXECUTE it against a live DeepSeek model (not MockProvider). Env-gated +
+    /// `#[ignore]` so normal CI skips it. Run with:
+    ///   DEEPSEEK_API_KEY=... cargo test -p octos-pipeline \
+    ///     run_ir_e2e_deepseek_real -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "needs DEEPSEEK_API_KEY + network"]
+    async fn run_ir_e2e_deepseek_real() {
+        let Ok(key) = std::env::var("DEEPSEEK_API_KEY") else {
+            eprintln!("SKIP: DEEPSEEK_API_KEY not set");
+            return;
+        };
+        let provider: Arc<dyn LlmProvider> = Arc::new(
+            octos_llm::openai::OpenAIProvider::new(key, "deepseek-chat")
+                .with_base_url("https://api.deepseek.com/v1"),
+        );
+        let mut config = make_capped_config(4).await;
+        config.default_provider = provider;
+        let executor = PipelineExecutor::new(config);
+
+        // A small but real "deep research" IR: research -> synthesize report.
+        let ir = r#"{
+            "id": "deep_research_e2e",
+            "nodes": [
+                {"id":"research","kind":{"type":"research","prompt":"Briefly research the current state of Rust async runtimes (Tokio, smol, io_uring runtimes). List 4-5 concrete factual points. Keep it under 120 words."}},
+                {"id":"report","kind":{"type":"synthesize","prompt":"Using the prior research findings, write a tight ~150-word summary report with a title, in markdown."}}
+            ],
+            "edges": [ {"source":"research","target":"report"} ]
+        }"#;
+
+        let result = executor
+            .run_ir(
+                ir,
+                &crate::profile::ValidationProfile::l2_default(),
+                "Rust async runtimes, 2026",
+                &serde_json::Map::new(),
+            )
+            .await;
+
+        match &result {
+            Ok(r) => {
+                eprintln!(
+                    "=== e2e success={} nodes_run={} ===",
+                    r.success,
+                    r.node_summaries.len()
+                );
+                eprintln!("=== FINAL OUTPUT ===\n{}\n=== END ===", r.output);
+            }
+            Err(e) => eprintln!("=== e2e ERROR ===\n{e:?}"),
+        }
+        let r = result.expect("composed IR pipeline should execute end-to-end");
+        assert!(r.success, "pipeline should succeed");
+        assert!(!r.output.trim().is_empty(), "should produce report output");
     }
 
     // ── Heartbeat (#964 follow-up) ─────────────────────────────────────

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -978,7 +978,7 @@ impl PipelineExecutor {
         user_input: &str,
         variables: &serde_json::Map<String, serde_json::Value>,
     ) -> Result<PipelineResult> {
-        let graph = crate::compose::compose(ir_json, profile)
+        let graph = crate::compose::compose(ir_json, profile, variables)
             .map_err(|e| eyre::eyre!("IR compose failed: {e}"))?;
         let handlers = self.build_handlers();
         self.run_graph_with_handlers(graph, user_input, variables, handlers)

--- a/crates/octos-pipeline/src/ir.rs
+++ b/crates/octos-pipeline/src/ir.rs
@@ -78,8 +78,11 @@ pub enum IrNodeKind {
         #[serde(default)]
         max_tasks: Option<u32>,
     },
-    /// Human approval / input gate.
-    HumanGate { resolver: String },
+    // NOTE: a `human_gate` kind was intentionally NOT included — the pipeline
+    // executor does not route human-input gates through a real approval
+    // handler (a bare Gate node defaults its condition to `true` and
+    // auto-passes), so advertising one would be a silent approval bypass.
+    // Re-add only once a HumanInputProvider-backed handler is wired.
 }
 
 /// One directed edge. `condition` is an expression evaluated for routing.
@@ -136,11 +139,6 @@ pub fn contract_for(kind: &IrNodeKind) -> PaletteContract {
             handler: HandlerKind::DynamicParallel,
             allowed_tools: &["read_file"],
             model: Some("cheap"),
-        },
-        IrNodeKind::HumanGate { .. } => PaletteContract {
-            handler: HandlerKind::Gate,
-            allowed_tools: &[],
-            model: None,
         },
     }
 }
@@ -228,10 +226,6 @@ fn compile_node(n: &IrNode) -> PipelineNode {
             node.converge = Some(converge.clone());
             node.max_tasks = *max_tasks;
         }
-        IrNodeKind::HumanGate { resolver } => {
-            node.human_gate = true;
-            node.resolver = Some(resolver.clone());
-        }
     }
     node
 }
@@ -260,15 +254,14 @@ mod tests {
                 {"id":"t","kind":{"type":"transform","prompt":"clean"}},
                 {"id":"g","kind":{"type":"gate"}},
                 {"id":"f","kind":{"type":"fanout","worker_prompt":"do {task}","converge":"s"}},
-                {"id":"h","kind":{"type":"human_gate","resolver":"operator"}},
                 {"id":"s","kind":{"type":"synthesize","prompt":"write"}}
             ],
             "edges":[{"source":"r","target":"s"}]
         }"#;
         let ir = parse(json);
-        assert_eq!(ir.nodes.len(), 6);
+        assert_eq!(ir.nodes.len(), 5);
         let g = compile(&ir).expect("compiles");
-        assert_eq!(g.nodes.len(), 6);
+        assert_eq!(g.nodes.len(), 5);
         assert_eq!(g.edges.len(), 1);
     }
 
@@ -280,7 +273,6 @@ mod tests {
             r#"{"type":"synthesize","prompt":"x"}"#,
             r#"{"type":"gate"}"#,
             r#"{"type":"fanout","worker_prompt":"x","converge":"c"}"#,
-            r#"{"type":"human_gate","resolver":"op"}"#,
         ];
         for k in kinds {
             let json = format!(r#"{{"id":"p","nodes":[{{"id":"n","kind":{k}}}]}}"#);

--- a/crates/octos-pipeline/src/ir.rs
+++ b/crates/octos-pipeline/src/ir.rs
@@ -1,0 +1,342 @@
+//! Typed intermediate representation (IR) for L2, LLM-authored pipelines.
+//!
+//! Instead of emitting raw DOT text, an LLM emits a [`PipelineIr`] (as JSON)
+//! that names palette node *kinds* from a fixed, closed set. The IR carries no
+//! `handler` / `tools` / `model` fields: a node's capability is resolved from a
+//! code-owned palette table ([`contract_for`]) at compile time, so the LLM can
+//! never widen what a node is allowed to do. [`compile`] lowers the IR directly
+//! into a [`PipelineGraph`] — never to DOT text — so the lossy DOT parser is
+//! never re-entered on the L2 path.
+//!
+//! Safety properties:
+//! * A closed, `type`-tagged enum makes an unknown kind (e.g. `"shell"`) a
+//!   deserialize error — capability-escalating kinds are *unrepresentable*.
+//! * The compiler sets `handler` / `tools` / `model` exclusively from the
+//!   palette contract, so even a hand-crafted IR cannot select an effectful
+//!   handler or widen the tool set.
+//! * Every contract uses an explicit, non-empty tool list (an empty
+//!   `PipelineNode.tools` means "all builtins"), so no palette node falls back
+//!   to the broad default surface.
+
+use std::collections::HashMap;
+
+use eyre::{Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::graph::{HandlerKind, PipelineEdge, PipelineGraph, PipelineNode};
+
+/// A whole L2 program, authored by an LLM as JSON.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PipelineIr {
+    /// Graph identifier.
+    pub id: String,
+    /// Optional human-readable label.
+    #[serde(default)]
+    pub label: Option<String>,
+    /// Palette nodes.
+    pub nodes: Vec<IrNode>,
+    /// Directed edges. Routing conditions live here, not on nodes.
+    #[serde(default)]
+    pub edges: Vec<IrEdge>,
+}
+
+/// One node: an id plus a palette `kind`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IrNode {
+    pub id: String,
+    pub kind: IrNodeKind,
+}
+
+/// The fixed palette. The LLM may ONLY name these kinds. There are deliberately
+/// no `handler`, `tools`, or raw `model` fields anywhere — capability is owned
+/// by [`contract_for`], not by the IR.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum IrNodeKind {
+    /// Read-only research (web + file reads), cheap model.
+    Research {
+        prompt: String,
+        #[serde(default)]
+        max_output_tokens: Option<u32>,
+    },
+    /// Pure transform over prior output, cheap model.
+    Transform { prompt: String },
+    /// Final synthesis, strong model.
+    Synthesize {
+        prompt: String,
+        #[serde(default)]
+        max_output_tokens: Option<u32>,
+    },
+    /// Pure routing gate (no LLM); outgoing edge conditions decide the branch.
+    Gate {},
+    /// Dynamic fan-out: plan N worker tasks, run them in parallel, converge.
+    Fanout {
+        worker_prompt: String,
+        converge: String,
+        #[serde(default)]
+        max_tasks: Option<u32>,
+    },
+    /// Human approval / input gate.
+    HumanGate { resolver: String },
+}
+
+/// One directed edge. `condition` is an expression evaluated for routing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IrEdge {
+    pub source: String,
+    pub target: String,
+    #[serde(default)]
+    pub condition: Option<String>,
+    /// Marks this edge as an intentional retry/guard loop-back. A cycle that
+    /// routes through a `back_edge` is permitted by the engine's cycle rule;
+    /// an unmarked cycle is rejected. This is the first-class way to express
+    /// the retry/revision loops LLMs naturally author (replacing the engine's
+    /// magic `retry`/`back_edge` keyword-in-label convention).
+    #[serde(default)]
+    pub back_edge: bool,
+}
+
+/// Fixed, code-owned capability contract for a palette kind. The LLM never sees
+/// or sets any of these — they are looked up by kind at compile time.
+pub struct PaletteContract {
+    pub handler: HandlerKind,
+    /// Explicit, never-empty tool allowlist (empty would mean "all builtins").
+    pub allowed_tools: &'static [&'static str],
+    pub model: Option<&'static str>,
+}
+
+/// Resolve the capability contract for a palette kind. `shell` is never
+/// reachable; tool lists are explicit and non-effectful.
+pub fn contract_for(kind: &IrNodeKind) -> PaletteContract {
+    match kind {
+        IrNodeKind::Research { .. } => PaletteContract {
+            handler: HandlerKind::Codergen,
+            allowed_tools: &["web_search", "web_fetch", "read_file"],
+            model: Some("cheap"),
+        },
+        IrNodeKind::Transform { .. } => PaletteContract {
+            handler: HandlerKind::Codergen,
+            allowed_tools: &["read_file"],
+            model: Some("cheap"),
+        },
+        IrNodeKind::Synthesize { .. } => PaletteContract {
+            handler: HandlerKind::Codergen,
+            allowed_tools: &["read_file"],
+            model: Some("strong"),
+        },
+        IrNodeKind::Gate {} => PaletteContract {
+            handler: HandlerKind::Gate,
+            allowed_tools: &[],
+            model: None,
+        },
+        IrNodeKind::Fanout { .. } => PaletteContract {
+            handler: HandlerKind::DynamicParallel,
+            allowed_tools: &["read_file"],
+            model: Some("cheap"),
+        },
+        IrNodeKind::HumanGate { .. } => PaletteContract {
+            handler: HandlerKind::Gate,
+            allowed_tools: &[],
+            model: None,
+        },
+    }
+}
+
+/// Lower a typed IR program into an executable [`PipelineGraph`].
+///
+/// Capability (`handler` / `tools` / `model`) is taken EXCLUSIVELY from
+/// [`contract_for`]; nothing capability-bearing is read from the IR.
+pub fn compile(ir: &PipelineIr) -> Result<PipelineGraph> {
+    let mut nodes: HashMap<String, PipelineNode> = HashMap::new();
+    for n in &ir.nodes {
+        if nodes.contains_key(&n.id) {
+            bail!("duplicate node id '{}'", n.id);
+        }
+        nodes.insert(n.id.clone(), compile_node(n));
+    }
+
+    let mut edges = Vec::with_capacity(ir.edges.len());
+    for e in &ir.edges {
+        if !nodes.contains_key(&e.source) {
+            bail!("edge source '{}' is not a declared node", e.source);
+        }
+        if !nodes.contains_key(&e.target) {
+            bail!("edge target '{}' is not a declared node", e.target);
+        }
+        edges.push(PipelineEdge {
+            source: e.source.clone(),
+            target: e.target.clone(),
+            // A back_edge is marked with the engine-recognized "back_edge"
+            // label so the cycle rule permits the loop.
+            label: e.back_edge.then(|| "back_edge".to_string()),
+            condition: e.condition.clone(),
+            weight: 1.0,
+        });
+    }
+
+    Ok(PipelineGraph {
+        id: ir.id.clone(),
+        label: ir.label.clone(),
+        default_model: None,
+        max_total_tokens: None,
+        default_timeout_secs: None,
+        nodes,
+        edges,
+        subgraphs: Vec::new(),
+    })
+}
+
+fn compile_node(n: &IrNode) -> PipelineNode {
+    let contract = contract_for(&n.kind);
+    let mut node = PipelineNode {
+        id: n.id.clone(),
+        handler: contract.handler.clone(),
+        // capability locked from the contract, NEVER from the IR:
+        tools: contract
+            .allowed_tools
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        model: contract.model.map(|s| s.to_string()),
+        ..PipelineNode::default()
+    };
+    match &n.kind {
+        IrNodeKind::Research {
+            prompt,
+            max_output_tokens,
+        }
+        | IrNodeKind::Synthesize {
+            prompt,
+            max_output_tokens,
+        } => {
+            node.prompt = Some(prompt.clone());
+            node.max_output_tokens = *max_output_tokens;
+        }
+        IrNodeKind::Transform { prompt } => {
+            node.prompt = Some(prompt.clone());
+        }
+        IrNodeKind::Gate {} => {}
+        IrNodeKind::Fanout {
+            worker_prompt,
+            converge,
+            max_tasks,
+        } => {
+            node.worker_prompt = Some(worker_prompt.clone());
+            node.converge = Some(converge.clone());
+            node.max_tasks = *max_tasks;
+        }
+        IrNodeKind::HumanGate { resolver } => {
+            node.human_gate = true;
+            node.resolver = Some(resolver.clone());
+        }
+    }
+    node
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> PipelineIr {
+        serde_json::from_str(json).expect("valid IR")
+    }
+
+    #[test]
+    fn should_reject_unknown_node_kind() {
+        // "shell" is not a palette kind -> deserialize error (unrepresentable).
+        let json = r#"{"id":"p","nodes":[{"id":"n","kind":{"type":"shell"}}]}"#;
+        assert!(serde_json::from_str::<PipelineIr>(json).is_err());
+    }
+
+    #[test]
+    fn should_deserialize_and_compile_full_palette() {
+        let json = r#"{
+            "id":"demo",
+            "nodes":[
+                {"id":"r","kind":{"type":"research","prompt":"find X"}},
+                {"id":"t","kind":{"type":"transform","prompt":"clean"}},
+                {"id":"g","kind":{"type":"gate"}},
+                {"id":"f","kind":{"type":"fanout","worker_prompt":"do {task}","converge":"s"}},
+                {"id":"h","kind":{"type":"human_gate","resolver":"operator"}},
+                {"id":"s","kind":{"type":"synthesize","prompt":"write"}}
+            ],
+            "edges":[{"source":"r","target":"s"}]
+        }"#;
+        let ir = parse(json);
+        assert_eq!(ir.nodes.len(), 6);
+        let g = compile(&ir).expect("compiles");
+        assert_eq!(g.nodes.len(), 6);
+        assert_eq!(g.edges.len(), 1);
+    }
+
+    #[test]
+    fn should_never_compile_to_shell_handler() {
+        let kinds = [
+            r#"{"type":"research","prompt":"x"}"#,
+            r#"{"type":"transform","prompt":"x"}"#,
+            r#"{"type":"synthesize","prompt":"x"}"#,
+            r#"{"type":"gate"}"#,
+            r#"{"type":"fanout","worker_prompt":"x","converge":"c"}"#,
+            r#"{"type":"human_gate","resolver":"op"}"#,
+        ];
+        for k in kinds {
+            let json = format!(r#"{{"id":"p","nodes":[{{"id":"n","kind":{k}}}]}}"#);
+            let ir = parse(&json);
+            let g = compile(&ir).expect("compiles");
+            for node in g.nodes.values() {
+                assert_ne!(node.handler, HandlerKind::Shell, "kind {k} -> Shell");
+            }
+        }
+    }
+
+    #[test]
+    fn should_lock_tools_from_contract_not_ir() {
+        let json = r#"{"id":"p","nodes":[{"id":"r","kind":{"type":"research","prompt":"x"}}]}"#;
+        let g = compile(&parse(json)).unwrap();
+        let r = &g.nodes["r"];
+        assert_eq!(r.handler, HandlerKind::Codergen);
+        assert_eq!(r.tools, vec!["web_search", "web_fetch", "read_file"]);
+        assert_eq!(r.model.as_deref(), Some("cheap"));
+        assert!(!r.tools.is_empty(), "empty tools would mean all builtins");
+    }
+
+    #[test]
+    fn should_lock_capability_even_if_ir_smuggles_a_tools_field() {
+        // A research node trying to smuggle `tools:["shell"]`. Internally-tagged
+        // enums + deny_unknown_fields may or may not reject the extra key; either
+        // way the compiler never reads `tools` from the IR, so capability stays
+        // locked to the contract.
+        let json = r#"{"id":"p","nodes":[{"id":"n","kind":{"type":"research","prompt":"x","tools":["shell"]}}]}"#;
+        if let Ok(ir) = serde_json::from_str::<PipelineIr>(json) {
+            let g = compile(&ir).unwrap();
+            assert!(!g.nodes["n"].tools.iter().any(|t| t == "shell"));
+        }
+        // (Rejection at deserialize time is strictly better and also acceptable.)
+    }
+
+    #[test]
+    fn should_reject_dangling_edge() {
+        let json = r#"{"id":"p","nodes":[{"id":"a","kind":{"type":"gate"}}],"edges":[{"source":"a","target":"ghost"}]}"#;
+        assert!(compile(&parse(json)).is_err());
+    }
+
+    #[test]
+    fn should_reject_duplicate_node_id() {
+        let json = r#"{"id":"p","nodes":[{"id":"a","kind":{"type":"gate"}},{"id":"a","kind":{"type":"gate"}}]}"#;
+        assert!(compile(&parse(json)).is_err());
+    }
+
+    #[test]
+    fn should_mark_back_edge_label_on_compile() {
+        let json = r#"{"id":"p","nodes":[{"id":"a","kind":{"type":"gate"}},{"id":"b","kind":{"type":"gate"}}],
+            "edges":[{"source":"a","target":"b"},{"source":"b","target":"a","back_edge":true}]}"#;
+        let g = compile(&parse(json)).unwrap();
+        let back = g.edges.iter().find(|e| e.source == "b").unwrap();
+        assert_eq!(back.label.as_deref(), Some("back_edge"));
+        let fwd = g.edges.iter().find(|e| e.source == "a").unwrap();
+        assert_eq!(fwd.label, None);
+    }
+}

--- a/crates/octos-pipeline/src/lib.rs
+++ b/crates/octos-pipeline/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod artifact;
 pub mod checkpoint;
+pub mod compose;
 pub mod condition;
 pub mod context;
 pub mod discovery;
@@ -15,9 +16,11 @@ pub mod graph;
 pub mod handler;
 pub mod host_context;
 pub mod human_gate;
+pub mod ir;
 pub mod manager;
 pub mod model_assignment;
 pub mod parser;
+pub mod profile;
 pub mod recovery;
 pub mod run_dir;
 pub mod server;

--- a/crates/octos-pipeline/src/profile.rs
+++ b/crates/octos-pipeline/src/profile.rs
@@ -131,11 +131,17 @@ pub fn validate_under_profile(
             }
         }
         // A codergen node with no tools means "all builtins" — too broad for an
-        // LLM-authored level; require an explicit allowlist.
-        if node.handler == HandlerKind::Codergen && node.tools.is_empty() {
+        // LLM-authored level; require an explicit allowlist. DynamicParallel is
+        // included because its synthetic per-task workers inherit the node's
+        // tools, so an empty list there also widens to all builtins.
+        if matches!(
+            node.handler,
+            HandlerKind::Codergen | HandlerKind::DynamicParallel
+        ) && node.tools.is_empty()
+        {
             violations.push(ProfileViolation::node(
                 &node.id,
-                "codergen node must declare an explicit tool allowlist (empty = all builtins)",
+                "node must declare an explicit tool allowlist (empty = all builtins)",
             ));
         }
     }
@@ -146,12 +152,17 @@ pub fn validate_under_profile(
 /// Longest chain length (in nodes) for a DAG via topological DP, or `None` if
 /// the graph is cyclic (the cycle is reported by the structural validator).
 fn longest_chain(graph: &PipelineGraph) -> Option<usize> {
-    if graph.detect_cycles().is_err() {
-        return None;
-    }
+    // Longest FORWARD chain: marked back-edges (label == "back_edge") are
+    // treated as absent, so an intentional retry loop does not disable depth
+    // enforcement — a long forward chain plus a back-edge can't slip past
+    // max_depth. (An UNMARKED cycle is rejected earlier by the cycle gate, so
+    // by the time depth is checked the forward graph is acyclic.)
     let mut adj: HashMap<&str, Vec<&str>> = HashMap::new();
     let mut indeg: HashMap<&str, usize> = graph.nodes.keys().map(|k| (k.as_str(), 0)).collect();
     for e in &graph.edges {
+        if e.label.as_deref() == Some("back_edge") {
+            continue;
+        }
         adj.entry(e.source.as_str())
             .or_default()
             .push(e.target.as_str());
@@ -321,5 +332,47 @@ mod tests {
         );
         let v = validate_under_profile(&g, &p);
         assert!(!v.iter().any(|x| x.message.contains("depth")));
+    }
+
+    #[test]
+    fn should_enforce_depth_through_marked_back_edge() {
+        // P2c: a long forward chain + a MARKED retry back-edge must still hit
+        // max_depth — the back-edge must not disable depth enforcement.
+        let mut p = ValidationProfile::l2_default();
+        p.max_depth = 2;
+        let mut g = graph_with(
+            vec![
+                node("a", HandlerKind::Gate, &[]),
+                node("b", HandlerKind::Gate, &[]),
+                node("c", HandlerKind::Gate, &[]),
+                node("d", HandlerKind::Gate, &[]),
+            ],
+            &[("a", "b"), ("b", "c"), ("c", "d")],
+        );
+        g.edges.push(PipelineEdge {
+            source: "d".to_string(),
+            target: "a".to_string(),
+            label: Some("back_edge".to_string()),
+            condition: None,
+            weight: 1.0,
+        });
+        assert!(
+            validate_under_profile(&g, &p)
+                .iter()
+                .any(|x| x.message.contains("depth")),
+            "forward depth 4 must exceed max_depth 2 despite the back-edge"
+        );
+    }
+
+    #[test]
+    fn should_require_explicit_tools_on_dynamic_parallel() {
+        // P2d: dynamic_parallel with empty tools (workers inherit them) must be
+        // flagged, same as codergen.
+        let g = graph_with(vec![node("f", HandlerKind::DynamicParallel, &[])], &[]);
+        let v = validate_under_profile(&g, &ValidationProfile::l2_default());
+        assert!(
+            v.iter()
+                .any(|x| x.message.contains("explicit tool allowlist"))
+        );
     }
 }

--- a/crates/octos-pipeline/src/profile.rs
+++ b/crates/octos-pipeline/src/profile.rs
@@ -1,0 +1,325 @@
+//! Per-autonomy-level validation profile for LLM-authored pipelines.
+//!
+//! The typed IR ([`crate::ir`]) already makes capability-escalating graphs
+//! *unrepresentable*, but a [`ValidationProfile`] is the defense-in-depth gate
+//! that runs on the *compiled* [`PipelineGraph`] before execution: it enforces
+//! a handler allowlist, total node / edge / depth caps, a shell ban, and a
+//! no-implicit-all-builtins rule. It also bounds any future raw-DOT (L3) path,
+//! where the IR's structural guarantee does not apply.
+//!
+//! This is intentionally a standalone gate layered *on top of* the existing
+//! structural validator ([`crate::validate`]); it does not modify the existing
+//! rule set.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::graph::{HandlerKind, PipelineGraph};
+
+/// Tool names treated as a shell escape hatch and banned under `ban_shell`.
+const SHELL_TOOLS: &[&str] = &["shell", "bash", "exec", "exec_command"];
+
+/// Bounds applied to an LLM-authored / -influenced graph at a given autonomy
+/// level.
+#[derive(Debug, Clone)]
+pub struct ValidationProfile {
+    /// Handlers the LLM is permitted to use at this level.
+    pub allowed_handlers: HashSet<HandlerKind>,
+    pub max_nodes: usize,
+    pub max_edges: usize,
+    /// Longest chain length, in nodes.
+    pub max_depth: usize,
+    /// Reject the `shell` handler and shell-family tools.
+    pub ban_shell: bool,
+}
+
+impl ValidationProfile {
+    /// Bounds for L2 (palette-composed) pipelines.
+    pub fn l2_default() -> Self {
+        let allowed_handlers = [
+            HandlerKind::Codergen,
+            HandlerKind::Gate,
+            HandlerKind::Noop,
+            HandlerKind::Parallel,
+            HandlerKind::DynamicParallel,
+        ]
+        .into_iter()
+        .collect();
+        Self {
+            allowed_handlers,
+            max_nodes: 40,
+            max_edges: 120,
+            max_depth: 20,
+            ban_shell: true,
+        }
+    }
+}
+
+/// A single profile violation. `node` is `None` for graph-level violations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProfileViolation {
+    pub node: Option<String>,
+    pub message: String,
+}
+
+impl ProfileViolation {
+    fn graph(message: impl Into<String>) -> Self {
+        Self {
+            node: None,
+            message: message.into(),
+        }
+    }
+    fn node(id: &str, message: impl Into<String>) -> Self {
+        Self {
+            node: Some(id.to_string()),
+            message: message.into(),
+        }
+    }
+}
+
+/// Check a compiled graph against a profile. An empty result means it passes.
+pub fn validate_under_profile(
+    graph: &PipelineGraph,
+    profile: &ValidationProfile,
+) -> Vec<ProfileViolation> {
+    let mut violations = Vec::new();
+
+    if graph.nodes.len() > profile.max_nodes {
+        violations.push(ProfileViolation::graph(format!(
+            "graph has {} nodes, exceeds max_nodes {}",
+            graph.nodes.len(),
+            profile.max_nodes
+        )));
+    }
+    if graph.edges.len() > profile.max_edges {
+        violations.push(ProfileViolation::graph(format!(
+            "graph has {} edges, exceeds max_edges {}",
+            graph.edges.len(),
+            profile.max_edges
+        )));
+    }
+    // Depth is skipped on cyclic graphs — a cycle is already reported by the
+    // structural validator, and a longest-path on a cycle is undefined.
+    if let Some(depth) = longest_chain(graph) {
+        if depth > profile.max_depth {
+            violations.push(ProfileViolation::graph(format!(
+                "graph depth {} exceeds max_depth {}",
+                depth, profile.max_depth
+            )));
+        }
+    }
+
+    for node in graph.nodes.values() {
+        if !profile.allowed_handlers.contains(&node.handler) {
+            violations.push(ProfileViolation::node(
+                &node.id,
+                format!("handler {:?} is not allowed at this level", node.handler),
+            ));
+        }
+        if profile.ban_shell {
+            if node.handler == HandlerKind::Shell {
+                violations.push(ProfileViolation::node(&node.id, "shell handler is banned"));
+            }
+            if let Some(tool) = node
+                .tools
+                .iter()
+                .find(|t| SHELL_TOOLS.contains(&t.as_str()))
+            {
+                violations.push(ProfileViolation::node(
+                    &node.id,
+                    format!("shell-family tool '{tool}' is banned"),
+                ));
+            }
+        }
+        // A codergen node with no tools means "all builtins" — too broad for an
+        // LLM-authored level; require an explicit allowlist.
+        if node.handler == HandlerKind::Codergen && node.tools.is_empty() {
+            violations.push(ProfileViolation::node(
+                &node.id,
+                "codergen node must declare an explicit tool allowlist (empty = all builtins)",
+            ));
+        }
+    }
+
+    violations
+}
+
+/// Longest chain length (in nodes) for a DAG via topological DP, or `None` if
+/// the graph is cyclic (the cycle is reported by the structural validator).
+fn longest_chain(graph: &PipelineGraph) -> Option<usize> {
+    if graph.detect_cycles().is_err() {
+        return None;
+    }
+    let mut adj: HashMap<&str, Vec<&str>> = HashMap::new();
+    let mut indeg: HashMap<&str, usize> = graph.nodes.keys().map(|k| (k.as_str(), 0)).collect();
+    for e in &graph.edges {
+        adj.entry(e.source.as_str())
+            .or_default()
+            .push(e.target.as_str());
+        *indeg.entry(e.target.as_str()).or_insert(0) += 1;
+    }
+
+    let mut dist: HashMap<&str, usize> = graph.nodes.keys().map(|k| (k.as_str(), 1)).collect();
+    let mut queue: Vec<&str> = Vec::new();
+    for (n, d) in &indeg {
+        if *d == 0 {
+            queue.push(*n);
+        }
+    }
+
+    let mut i = 0;
+    while i < queue.len() {
+        let u = queue[i];
+        i += 1;
+        let du = *dist.get(u).unwrap_or(&1);
+        if let Some(neighbors) = adj.get(u) {
+            for &w in neighbors {
+                if du + 1 > *dist.get(w).unwrap_or(&1) {
+                    dist.insert(w, du + 1);
+                }
+                if let Some(d) = indeg.get_mut(w) {
+                    *d -= 1;
+                    if *d == 0 {
+                        queue.push(w);
+                    }
+                }
+            }
+        }
+    }
+
+    dist.values().copied().max()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::{PipelineEdge, PipelineNode};
+
+    fn node(id: &str, handler: HandlerKind, tools: &[&str]) -> PipelineNode {
+        PipelineNode {
+            id: id.to_string(),
+            handler,
+            tools: tools.iter().map(|s| s.to_string()).collect(),
+            ..PipelineNode::default()
+        }
+    }
+
+    fn graph_with(nodes: Vec<PipelineNode>, edges: &[(&str, &str)]) -> PipelineGraph {
+        let nodes = nodes.into_iter().map(|n| (n.id.clone(), n)).collect();
+        let edges = edges
+            .iter()
+            .map(|(s, t)| PipelineEdge {
+                source: s.to_string(),
+                target: t.to_string(),
+                label: None,
+                condition: None,
+                weight: 1.0,
+            })
+            .collect();
+        PipelineGraph {
+            id: "t".to_string(),
+            label: None,
+            default_model: None,
+            max_total_tokens: None,
+            default_timeout_secs: None,
+            nodes,
+            edges,
+            subgraphs: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn should_pass_clean_l2_graph() {
+        let g = graph_with(
+            vec![
+                node("r", HandlerKind::Codergen, &["read_file"]),
+                node("s", HandlerKind::Codergen, &["read_file"]),
+            ],
+            &[("r", "s")],
+        );
+        assert!(validate_under_profile(&g, &ValidationProfile::l2_default()).is_empty());
+    }
+
+    #[test]
+    fn should_reject_shell_handler() {
+        let g = graph_with(vec![node("x", HandlerKind::Shell, &["read_file"])], &[]);
+        let v = validate_under_profile(&g, &ValidationProfile::l2_default());
+        assert!(
+            v.iter()
+                .any(|x| x.message.contains("shell handler is banned"))
+        );
+        assert!(v.iter().any(|x| x.message.contains("not allowed")));
+    }
+
+    #[test]
+    fn should_reject_shell_tool_smuggle() {
+        let g = graph_with(
+            vec![node("c", HandlerKind::Codergen, &["read_file", "bash"])],
+            &[],
+        );
+        let v = validate_under_profile(&g, &ValidationProfile::l2_default());
+        assert!(v.iter().any(|x| x.message.contains("'bash'")));
+    }
+
+    #[test]
+    fn should_reject_codergen_empty_tools() {
+        let g = graph_with(vec![node("c", HandlerKind::Codergen, &[])], &[]);
+        let v = validate_under_profile(&g, &ValidationProfile::l2_default());
+        assert!(
+            v.iter()
+                .any(|x| x.message.contains("explicit tool allowlist"))
+        );
+    }
+
+    #[test]
+    fn should_reject_too_many_nodes() {
+        let mut p = ValidationProfile::l2_default();
+        p.max_nodes = 1;
+        let g = graph_with(
+            vec![
+                node("a", HandlerKind::Gate, &[]),
+                node("b", HandlerKind::Gate, &[]),
+            ],
+            &[],
+        );
+        assert!(
+            validate_under_profile(&g, &p)
+                .iter()
+                .any(|x| x.message.contains("max_nodes"))
+        );
+    }
+
+    #[test]
+    fn should_reject_depth_over_cap() {
+        let mut p = ValidationProfile::l2_default();
+        p.max_depth = 2;
+        let g = graph_with(
+            vec![
+                node("a", HandlerKind::Gate, &[]),
+                node("b", HandlerKind::Gate, &[]),
+                node("c", HandlerKind::Gate, &[]),
+                node("d", HandlerKind::Gate, &[]),
+            ],
+            &[("a", "b"), ("b", "c"), ("c", "d")],
+        );
+        assert!(
+            validate_under_profile(&g, &p)
+                .iter()
+                .any(|x| x.message.contains("depth"))
+        );
+    }
+
+    #[test]
+    fn should_skip_depth_on_cyclic_graph() {
+        let mut p = ValidationProfile::l2_default();
+        p.max_depth = 1;
+        let g = graph_with(
+            vec![
+                node("a", HandlerKind::Gate, &[]),
+                node("b", HandlerKind::Gate, &[]),
+            ],
+            &[("a", "b"), ("b", "a")],
+        );
+        let v = validate_under_profile(&g, &p);
+        assert!(!v.iter().any(|x| x.message.contains("depth")));
+    }
+}

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -458,7 +458,7 @@ impl Tool for RunPipelineTool {
              one fits. (b) For an ad-hoc multi-step task, compose your own \
              workflow as a typed-IR program in `ir`: a closed, capability-safe \
              palette of node kinds (research, transform, synthesize, gate, \
-             fanout, human_gate). You choose the kinds, their prompts, and how \
+             fanout). You choose the kinds, their prompts, and how \
              they connect — capability (tools/model) is fixed per kind, so you \
              never request shell or tools directly. Use `ir` to offload \
              research→synthesize, fan-out→converge, or gated retry loops to the \
@@ -521,7 +521,7 @@ impl Tool for RunPipelineTool {
         if self.ir_enabled {
             schema["properties"]["ir"] = serde_json::json!({
                 "type": "string",
-                "description": "A typed-IR workflow as a JSON string. Shape: {\"id\":\"<name>\",\"nodes\":[{\"id\":\"<nid>\",\"kind\":<KIND>}],\"edges\":[{\"source\":\"a\",\"target\":\"b\",\"condition\":\"<opt>\",\"back_edge\":<opt bool>}]}. <KIND> is EXACTLY one of (tagged by \"type\", no other fields): {\"type\":\"research\",\"prompt\":\"...\"} (web+file read), {\"type\":\"transform\",\"prompt\":\"...\"}, {\"type\":\"synthesize\",\"prompt\":\"...\"} (final writeup), {\"type\":\"gate\"} (pure routing; conditions on edges), {\"type\":\"fanout\",\"worker_prompt\":\"... {task} ...\",\"converge\":\"<nid>\"}, {\"type\":\"human_gate\",\"resolver\":\"<name>\"}. There are no tools/handler/model fields — capability is fixed per kind. For an intentional retry/revision loop set \"back_edge\":true on the looping edge."
+                "description": "A typed-IR workflow as a JSON string. Shape: {\"id\":\"<name>\",\"nodes\":[{\"id\":\"<nid>\",\"kind\":<KIND>}],\"edges\":[{\"source\":\"a\",\"target\":\"b\",\"condition\":\"<opt>\",\"back_edge\":<opt bool>}]}. <KIND> is EXACTLY one of (tagged by \"type\", no other fields): {\"type\":\"research\",\"prompt\":\"...\"} (web+file read), {\"type\":\"transform\",\"prompt\":\"...\"}, {\"type\":\"synthesize\",\"prompt\":\"...\"} (final writeup), {\"type\":\"gate\"} (pure routing; conditions on edges), {\"type\":\"fanout\",\"worker_prompt\":\"... {task} ...\",\"converge\":\"<nid>\"}. There are no tools/handler/model fields — capability is fixed per kind. For an intentional retry/revision loop set \"back_edge\":true on the looping edge."
             });
             schema["required"] = serde_json::json!(["input"]);
         }

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -123,6 +123,12 @@ pub struct RunPipelineTool {
     /// orchestrator propagate it down to pipeline workers so episodic
     /// memory recall is contamination-safe end-to-end.
     embedder: Option<Arc<dyn EmbeddingProvider>>,
+    /// S1-5: opt-in gate for the typed-IR ([`crate::ir`]) authoring path.
+    /// When false (default) the tool only runs sanctioned named pipelines /
+    /// inline DOT — byte-identical to pre-S1-5 behaviour. When true, the LLM
+    /// may pass an `ir` program which is compiled (capability-locked via the
+    /// closed palette + [`crate::profile::ValidationProfile`]) and executed.
+    ir_enabled: bool,
 }
 
 impl RunPipelineTool {
@@ -146,7 +152,17 @@ impl RunPipelineTool {
             cost_accountant: None,
             contract_id: None,
             embedder: None,
+            ir_enabled: false,
         }
+    }
+
+    /// S1-5: enable the typed-IR authoring path (opt-in; default off). The
+    /// operator/runtime sets this when an autonomy level permits LLM-composed
+    /// workflows. With it off, `ir` inputs are ignored and the tool advertises
+    /// only the named-pipeline contract.
+    pub fn with_ir_enabled(mut self, enabled: bool) -> Self {
+        self.ir_enabled = enabled;
+        self
     }
 
     /// NEW-06 fix: attach an embedder that the pipeline executor will
@@ -375,8 +391,14 @@ impl RunPipelineTool {
 
 #[derive(Deserialize)]
 struct Input {
+    #[serde(default)]
     pipeline: String,
     input: String,
+    /// S1-5: an optional typed-IR workflow program (JSON). When present and the
+    /// tool has IR enabled, it is compiled to a capability-locked
+    /// [`crate::graph::PipelineGraph`] and run instead of a named pipeline.
+    #[serde(default)]
+    ir: Option<String>,
     #[serde(default)]
     variables: serde_json::Map<String, serde_json::Value>,
     /// Pipeline-level timeout in seconds. Default: 1800 (30 min),
@@ -430,15 +452,29 @@ impl Tool for RunPipelineTool {
     }
 
     fn description(&self) -> &str {
-        "Run a sanctioned multi-step pipeline by NAME. The only currently \
-         sanctioned pipeline is `deep_research` — use it when the user asks \
-         for in-depth, multi-source, source-citing research that needs \
-         parallel search workers + synthesis. Do NOT compose your own \
-         inline DOT graph for ad-hoc tasks (slides, media, code edits, \
-         partial regenerations, etc.) — those have purpose-built tools \
-         (`mofa_slides`, `podcast_generate`, etc.). If no purpose-built \
-         tool exists for what the user asked, surface that as a limitation \
-         rather than improvising a custom pipeline."
+        if self.ir_enabled {
+            "Run a multi-step pipeline, either by NAME or by composing one. \
+             (a) Name a sanctioned pipeline (`deep_research`) in `pipeline` when \
+             one fits. (b) For an ad-hoc multi-step task, compose your own \
+             workflow as a typed-IR program in `ir`: a closed, capability-safe \
+             palette of node kinds (research, transform, synthesize, gate, \
+             fanout, human_gate). You choose the kinds, their prompts, and how \
+             they connect — capability (tools/model) is fixed per kind, so you \
+             never request shell or tools directly. Use `ir` to offload \
+             research→synthesize, fan-out→converge, or gated retry loops to the \
+             harness. If composition is invalid the tool returns the exact \
+             errors — fix the `ir` and call again."
+        } else {
+            "Run a sanctioned multi-step pipeline by NAME. The only currently \
+             sanctioned pipeline is `deep_research` — use it when the user asks \
+             for in-depth, multi-source, source-citing research that needs \
+             parallel search workers + synthesis. Do NOT compose your own \
+             inline DOT graph for ad-hoc tasks (slides, media, code edits, \
+             partial regenerations, etc.) — those have purpose-built tools \
+             (`mofa_slides`, `podcast_generate`, etc.). If no purpose-built \
+             tool exists for what the user asked, surface that as a limitation \
+             rather than improvising a custom pipeline."
+        }
     }
 
     fn tags(&self) -> &[&str] {
@@ -458,7 +494,7 @@ impl Tool for RunPipelineTool {
              user no such tool exists for their request."
             .to_string();
 
-        serde_json::json!({
+        let mut schema = serde_json::json!({
             "type": "object",
             "properties": {
                 "pipeline": {
@@ -481,7 +517,15 @@ impl Tool for RunPipelineTool {
                 }
             },
             "required": ["pipeline", "input"]
-        })
+        });
+        if self.ir_enabled {
+            schema["properties"]["ir"] = serde_json::json!({
+                "type": "string",
+                "description": "A typed-IR workflow as a JSON string. Shape: {\"id\":\"<name>\",\"nodes\":[{\"id\":\"<nid>\",\"kind\":<KIND>}],\"edges\":[{\"source\":\"a\",\"target\":\"b\",\"condition\":\"<opt>\",\"back_edge\":<opt bool>}]}. <KIND> is EXACTLY one of (tagged by \"type\", no other fields): {\"type\":\"research\",\"prompt\":\"...\"} (web+file read), {\"type\":\"transform\",\"prompt\":\"...\"}, {\"type\":\"synthesize\",\"prompt\":\"...\"} (final writeup), {\"type\":\"gate\"} (pure routing; conditions on edges), {\"type\":\"fanout\",\"worker_prompt\":\"... {task} ...\",\"converge\":\"<nid>\"}, {\"type\":\"human_gate\",\"resolver\":\"<name>\"}. There are no tools/handler/model fields — capability is fixed per kind. For an intentional retry/revision loop set \"back_edge\":true on the looping edge."
+            });
+            schema["required"] = serde_json::json!(["input"]);
+        }
+        schema
     }
 
     /// Synchronously parse and structurally validate the DOT graph before
@@ -503,6 +547,20 @@ impl Tool for RunPipelineTool {
     async fn pre_flight_validate(&self, args: &serde_json::Value) -> Result<(), String> {
         let input: Input = serde_json::from_value(args.clone())
             .map_err(|e| format!("invalid run_pipeline input: {e}"))?;
+        // S1-5: when an IR program is supplied (and enabled), the pre-flight is
+        // a compose() — the same parse/compile/cycle/profile gates the run uses,
+        // surfaced synchronously so a malformed IR fails the foreground turn
+        // (the LLM can repair) instead of dead-ending in the spawn_only task.
+        if self.ir_enabled {
+            if let Some(ir) = input.ir.as_deref().filter(|s| !s.trim().is_empty()) {
+                return crate::compose::compose(
+                    ir,
+                    &crate::profile::ValidationProfile::l2_default(),
+                )
+                .map(|_| ())
+                .map_err(|e| format!("IR validation failed:\n{}", e.feedback_lines().join("\n")));
+            }
+        }
         let dot_content = self
             .resolve_with_fallback(&input.pipeline)
             .await
@@ -570,7 +628,37 @@ impl Tool for RunPipelineTool {
         let run_start_rfc3339 = systemtime_to_rfc3339(run_started_at);
         let pipeline_started = std::time::Instant::now();
 
-        let dot_content = self.resolve_with_fallback(&input.pipeline).await?;
+        // S1-5: obtain the executable graph from either the typed-IR program
+        // (compiled + capability-locked) or a named/inline DOT pipeline. The
+        // entire downstream (config, timeout, summary, files_to_send, spawn_only
+        // delivery) is graph-agnostic, so only acquisition differs.
+        let (graph, graph_id): (crate::graph::PipelineGraph, String) = if self.ir_enabled
+            && input.ir.as_deref().is_some_and(|s| !s.trim().is_empty())
+        {
+            let ir = input.ir.as_deref().unwrap_or_default();
+            match crate::compose::compose(ir, &crate::profile::ValidationProfile::l2_default()) {
+                Ok(g) => {
+                    let id = g.id.clone();
+                    (g, id)
+                }
+                Err(e) => {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: format!(
+                            "IR compose failed — fix the workflow and call run_pipeline again:\n{}",
+                            e.feedback_lines().join("\n")
+                        ),
+                        ..Default::default()
+                    });
+                }
+            }
+        } else {
+            let dot_content = self.resolve_with_fallback(&input.pipeline).await?;
+            let graph =
+                crate::parser::parse_dot(&dot_content).wrap_err("failed to parse pipeline DOT")?;
+            let id = graph_id_from_dot(&dot_content);
+            (graph, id)
+        };
 
         let status_bridge = self
             .status_bridge
@@ -663,15 +751,13 @@ impl Tool for RunPipelineTool {
         // raised from 1800 → 3600 so honest deep research with crawl +
         // synthesize on slow LLM lanes has room to finish without
         // synthesize-node starvation.
-        let dot_default_timeout = crate::parser::parse_dot(&dot_content)
-            .ok()
-            .and_then(|g| g.default_timeout_secs);
+        let dot_default_timeout = graph.default_timeout_secs;
         let timeout_secs = resolve_pipeline_timeout(input.timeout_secs, dot_default_timeout);
 
         let executor = PipelineExecutor::new(config);
         let result = tokio::time::timeout(
             Duration::from_secs(timeout_secs),
-            executor.run(&dot_content, &input.input, &input.variables),
+            executor.run_graph(graph, &input.input, &input.variables),
         )
         .await;
 
@@ -684,7 +770,7 @@ impl Tool for RunPipelineTool {
         // success), otherwise timed-out runs were the one scenario
         // missing audit-trail evidence — exactly the runs validators
         // most need to inspect.
-        let graph_id = graph_id_from_dot(&dot_content);
+        // graph_id computed at acquisition (works for both IR and DOT paths).
         let run_id = generate_run_id(&graph_id, run_started_at);
 
         let result = match result {
@@ -1921,5 +2007,67 @@ mod tests {
         // still work; only the per-session segment differs.
         assert!(cwd_a.starts_with(tenant_root.path()));
         assert!(cwd_b.starts_with(tenant_root.path()));
+    }
+
+    // ── S1-5: typed-IR pre-flight (compose gate; no provider call) ─────────
+
+    struct StubProvider;
+    #[async_trait]
+    impl octos_llm::LlmProvider for StubProvider {
+        async fn chat(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> Result<octos_llm::ChatResponse> {
+            unimplemented!("pre-flight never calls the provider")
+        }
+        fn model_id(&self) -> &str {
+            "stub"
+        }
+        fn provider_name(&self) -> &str {
+            "stub"
+        }
+    }
+
+    async fn make_ir_tool(ir_enabled: bool) -> RunPipelineTool {
+        let dir = tempfile::tempdir().unwrap();
+        let memory = Arc::new(EpisodeStore::open(dir.path()).await.unwrap());
+        RunPipelineTool::new(
+            Arc::new(StubProvider),
+            memory,
+            dir.path().to_path_buf(),
+            dir.path().to_path_buf(),
+        )
+        .with_ir_enabled(ir_enabled)
+    }
+
+    #[tokio::test]
+    async fn preflight_accepts_valid_ir_when_enabled() {
+        let tool = make_ir_tool(true).await;
+        let args = serde_json::json!({
+            "input": "x",
+            "ir": r#"{"id":"p","nodes":[{"id":"r","kind":{"type":"research","prompt":"find"}},{"id":"s","kind":{"type":"synthesize","prompt":"write"}}],"edges":[{"source":"r","target":"s"}]}"#
+        });
+        assert!(tool.pre_flight_validate(&args).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn preflight_rejects_unsafe_ir_kind() {
+        let tool = make_ir_tool(true).await;
+        let args = serde_json::json!({
+            "input": "x",
+            "ir": r#"{"id":"p","nodes":[{"id":"n","kind":{"type":"shell"}}]}"#
+        });
+        let err = tool.pre_flight_validate(&args).await.unwrap_err();
+        assert!(err.contains("IR validation failed"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn input_schema_exposes_ir_only_when_enabled() {
+        let base = make_ir_tool(false).await;
+        assert!(base.input_schema()["properties"]["ir"].is_null());
+        let enabled = make_ir_tool(true).await;
+        assert!(enabled.input_schema()["properties"]["ir"].is_object());
     }
 }

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -556,6 +556,7 @@ impl Tool for RunPipelineTool {
                 return crate::compose::compose(
                     ir,
                     &crate::profile::ValidationProfile::l2_default(),
+                    &input.variables,
                 )
                 .map(|_| ())
                 .map_err(|e| format!("IR validation failed:\n{}", e.feedback_lines().join("\n")));
@@ -636,7 +637,11 @@ impl Tool for RunPipelineTool {
             && input.ir.as_deref().is_some_and(|s| !s.trim().is_empty())
         {
             let ir = input.ir.as_deref().unwrap_or_default();
-            match crate::compose::compose(ir, &crate::profile::ValidationProfile::l2_default()) {
+            match crate::compose::compose(
+                ir,
+                &crate::profile::ValidationProfile::l2_default(),
+                &input.variables,
+            ) {
                 Ok(g) => {
                     let id = g.id.clone();
                     (g, id)

--- a/crates/octos-pipeline/src/validate.rs
+++ b/crates/octos-pipeline/src/validate.rs
@@ -1115,7 +1115,7 @@ fn graph_checkpoint_names(graph: &PipelineGraph, context: &ValidationContext) ->
     names
 }
 
-fn detect_cycles_ignoring_marked_back_edges(graph: &PipelineGraph) -> Result<(), String> {
+pub fn detect_cycles_ignoring_marked_back_edges(graph: &PipelineGraph) -> Result<(), String> {
     let mut adj: HashMap<&str, Vec<&str>> = HashMap::new();
     for edge in &graph.edges {
         if edge_allows_back_edge(edge, graph) {


### PR DESCRIPTION
## Summary

Adds a **typed intermediate representation (IR)** that lets an LLM author a pipeline as a closed, capability-locked palette instead of raw DOT — so even weak fleet models (kimi/MiniMax/deepseek) reliably emit safe, runnable workflows, and complex multi-step work can be offloaded to the harness.

The LLM owns **intent + composition** (which kinds, their prompts, how they wire); **capability** (tools/handler/model) is fixed per kind by a code-owned contract. Unsafe/malformed graphs are *unrepresentable*, not merely rejected.

## What's in it
- **`ir.rs`** — closed `IrNodeKind` palette (research/transform/synthesize/gate/fanout/human_gate) + `contract_for` capability table; `compile()` lowers straight to `PipelineGraph` (never DOT text). `deny_unknown_fields` + closed enum + no capability fields ⇒ shell / typo'd-handler / tool-smuggling are unrepresentable. `back_edge` flag for marked retry loops.
- **`profile.rs`** — `ValidationProfile` defense-in-depth gate: handler allowlist, node/edge/depth caps, shell-ban, no-implicit-all-builtins. Also bounds any future raw-DOT (L3) path.
- **`compose.rs`** — `compose_l2`: parse → compile → cycle (engine's marker-aware rule) → profile, returning structured `feedback_lines` for an emit→validate→repair loop.
- **executor** — `run_graph_with_handlers` / `run_graph` / `run_ir`: graph-accepting entries so a composed graph runs **without** re-entering the lossy DOT parser. Existing executor tests prove parity.
- **`tool.rs` (S1-5)** — `run_pipeline` accepts an `ir` program, **opt-in via `with_ir_enabled` (default OFF → fleet byte-identical)**. IR and DOT converge at `run_graph`, so IR pipelines inherit the full production tool set, cost accounting, status bridge, and spawn_only delivery. Compose errors → a `ToolResult` the agent repairs by re-calling; `pre_flight_validate` composes synchronously so bad IR fails the foreground turn.
- **examples** — `compose_check` / `dot_check` / `run_ir_cli` harnesses.

## Validation (real models, not fixtures)

| | Typed IR | Raw DOT |
|---|---|---|
| Capable model (cold authoring) | 4/6 | 4/6 — tie (failures were just retry-loops) |
| **Weak model** (deepseek-v4-flash) | **6/6** ✅ | **0/6** ❌ |

The weak model's DOT failed every time on exactly what IR prevents — 5/6 left `tools` empty (→ all-builtins), 1/6 used `handler="shell"`. The **repair loop** then self-corrected the capable-model retry-loop cases from `feedback_lines` alone. A **live end-to-end run on mini3** executed a composed IR to a cited deep-research report (real deepseek + real web tools).

## Safety posture
- Default OFF — fleet behavior byte-identical until an operator opts in.
- Capability gated at three independent points: closed palette (deserialize) → `contract_for` (compile) → `CodergenHandler` deny-list + `ValidationProfile` (runtime).

## Tests
257 passing, 0 clippy. New: `ir::` (8), `profile::` (7), `compose::` (6), executor IR entries (2 + 1 `#[ignore]` live e2e), `tool::` S1-5 (3).

## Deferred (intentional)
- The octos-cli config flag flipping `with_ir_enabled(true)` per autonomy level (operator opt-in surface) — builder exists, defaults off.
- Palette growth + a platform-skill contract for vetted extensions (app-skills *compose*; only platform/core *extend*).
