### PR TITLE
fix(ledger): recover legacy envelope-tagged records + aggregate skip warnings

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol_diff.rs
+++ b/crates/octos-cli/src/api/ui_protocol_diff.rs
@@ -69,7 +69,7 @@ use octos_core::ui_protocol::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// A pending diff-preview entry. Carries both the parsed `DiffPreview` that
 /// is shipped to clients and a raw snapshot of the underlying diff bytes
@@ -220,6 +220,11 @@ struct StoreInner {
     dropped_count: u64,
     evicted_count: u64,
     recovery_loaded_count: u64,
+    /// Total diff-preview records skipped during recovery (unknown
+    /// version + genuinely-malformed + session-id mismatch). Surfaced so
+    /// operators/tests can observe the aggregated per-file skip volume
+    /// deterministically without depending on the tracing subscriber.
+    recovery_skipped_count: u64,
 }
 
 impl StoreInner {
@@ -233,6 +238,7 @@ impl StoreInner {
             dropped_count: 0,
             evicted_count: 0,
             recovery_loaded_count: 0,
+            recovery_skipped_count: 0,
         }
     }
 
@@ -378,6 +384,7 @@ impl PendingDiffPreviewStore {
         // re-inserts collapse: the latest write wins (matches the live
         // semantics of `insert_with_snapshot`).
         let mut loaded = 0usize;
+        let mut skipped_total = 0u64;
         let mut seen_ids: HashSet<PreviewId> = HashSet::new();
         for path in &log_files {
             let file = match File::open(path) {
@@ -393,6 +400,14 @@ impl PendingDiffPreviewStore {
                 }
             };
             let reader = BufReader::new(file);
+            // Aggregate skip counts per file: emit ONE summary `warn!`
+            // after the inner loop instead of one line per record per
+            // rescan. Recovery re-reads every log from byte 0, so
+            // per-record warnings multiply into log spam on corrupted or
+            // legacy logs. Per-record detail stays at `debug!`.
+            let mut skipped_unknown_version = 0u64;
+            let mut skipped_malformed = 0u64;
+            let mut skipped_session_mismatch = 0u64;
             for line_result in reader.lines() {
                 let line = match line_result {
                     Ok(line) => line,
@@ -413,7 +428,8 @@ impl PendingDiffPreviewStore {
                 let record = match serde_json::from_str::<DiffPreviewDiskRecord>(&line) {
                     Ok(record) if record.v == DIFF_PREVIEW_DISK_VERSION => record,
                     Ok(record) => {
-                        warn!(
+                        skipped_unknown_version += 1;
+                        debug!(
                             target = "octos::diff_preview",
                             version = record.v,
                             path = %path.display(),
@@ -422,7 +438,8 @@ impl PendingDiffPreviewStore {
                         continue;
                     }
                     Err(error) => {
-                        warn!(
+                        skipped_malformed += 1;
+                        debug!(
                             target = "octos::diff_preview",
                             ?error,
                             session_id = %session_id.0,
@@ -433,7 +450,8 @@ impl PendingDiffPreviewStore {
                     }
                 };
                 if record.preview.session_id != *session_id {
-                    warn!(
+                    skipped_session_mismatch += 1;
+                    debug!(
                         target = "octos::diff_preview",
                         record_session_id = %record.preview.session_id.0,
                         dir_session_id = %session_id.0,
@@ -452,12 +470,31 @@ impl PendingDiffPreviewStore {
                     loaded += 1;
                 }
             }
+            let skipped_in_file =
+                skipped_unknown_version + skipped_malformed + skipped_session_mismatch;
+            if skipped_in_file > 0 {
+                skipped_total = skipped_total.saturating_add(skipped_in_file);
+                warn!(
+                    target = "octos::diff_preview",
+                    session_id = %session_id.0,
+                    path = %path.display(),
+                    skipped = skipped_in_file,
+                    skipped_unknown_version,
+                    skipped_malformed,
+                    skipped_session_mismatch,
+                    "skipped diff-preview records during scan (aggregated)"
+                );
+            }
         }
 
-        if loaded > 0 {
+        if loaded > 0 || skipped_total > 0 {
             let mut inner = self.inner.lock().expect("diff preview store poisoned");
-            inner.on_disk_bytes = inner.on_disk_bytes.saturating_add(total_disk_bytes);
-            inner.touch_lru(session_id);
+            if loaded > 0 {
+                inner.on_disk_bytes = inner.on_disk_bytes.saturating_add(total_disk_bytes);
+                inner.touch_lru(session_id);
+            }
+            inner.recovery_skipped_count =
+                inner.recovery_skipped_count.saturating_add(skipped_total);
         }
         Ok(loaded)
     }
@@ -768,6 +805,7 @@ impl PendingDiffPreviewStore {
             sessions_evicted: inner.evicted_count,
             entries_dropped: inner.dropped_count,
             recovery_entries_loaded: inner.recovery_loaded_count,
+            recovery_records_skipped: inner.recovery_skipped_count,
             bytes_in_memory: in_memory_bytes,
             bytes_on_disk: inner.on_disk_bytes,
         }
@@ -820,6 +858,7 @@ pub(super) struct DiffPreviewMetrics {
     pub(super) sessions_evicted: u64,
     pub(super) entries_dropped: u64,
     pub(super) recovery_entries_loaded: u64,
+    pub(super) recovery_records_skipped: u64,
     pub(super) bytes_in_memory: usize,
     pub(super) bytes_on_disk: u64,
 }
@@ -1341,6 +1380,51 @@ diff --git a/src/lib.rs b/src/lib.rs
             })
             .expect("valid preview survives corruption");
         assert_eq!(result.status, DiffPreviewGetStatus::Ready);
+    }
+
+    #[test]
+    fn recover_aggregates_skipped_records_per_file() {
+        // Several malformed lines in one log file plus one valid record:
+        // recovery loads the valid one and counts every skipped record so
+        // the read loop can emit ONE aggregated `warn!` per file (guarded
+        // by `skipped > 0`) rather than one line per record per rescan.
+        // Asserting on the surfaced count is deterministic regardless of
+        // the process-global tracing max-level filter.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionKey("local:agg-diff-skip".into());
+        let valid_id = PreviewId::new();
+
+        {
+            let store = PendingDiffPreviewStore::with_config(DiffPreviewConfig::durable(
+                temp.path().into(),
+            ));
+            store.insert_with_snapshot(sample_preview(&session_id, valid_id.clone()), None);
+        }
+
+        let session_dir = temp
+            .path()
+            .join("ui-protocol")
+            .join(encode_session_dir_name(&session_id));
+        let log_files = list_log_files(&session_dir).expect("list logs");
+        let log_path = log_files.first().expect("log file").clone();
+        {
+            let mut f = OpenOptions::new()
+                .append(true)
+                .open(&log_path)
+                .expect("open log for append");
+            f.write_all(b"not json at all\n").expect("junk 1");
+            f.write_all(b"{\"v\":1}\n").expect("junk 2"); // missing fields
+            f.write_all(b"another bad line\n").expect("junk 3");
+        }
+
+        let outcome =
+            PendingDiffPreviewStore::recover(DiffPreviewConfig::durable(temp.path().into()));
+        assert_eq!(outcome.entries_recovered, 1, "the valid record is loaded");
+        let m = outcome.store.metrics();
+        assert_eq!(
+            m.recovery_records_skipped, 3,
+            "all 3 malformed records counted (aggregated into one per-file warn)"
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -123,8 +123,8 @@ impl LedgerConfig {
 
 /// Anything that can sit in the ledger ring.
 ///
-/// **Write side** serializes with an outer `record_kind` tag (the derived
-/// `Serialize`). The earlier name `"envelope"` collided with
+/// Serialized AND deserialized with an outer `record_kind` tag (the
+/// derived impls). The earlier name `"envelope"` collided with
 /// `EnvelopeNotification.envelope` once internally-tagged `UiNotification`
 /// flattened its variant data alongside the outer tag — serde produced two
 /// `"envelope"` keys in the same object and rejected the record on replay
@@ -132,81 +132,18 @@ impl LedgerConfig {
 /// every flattened inner field name on both branches, so it is the
 /// canonical on-disk tag going forward.
 ///
-/// **Read side** is back-compatible (`fix/ledger-legacy-envelope-tag`):
-/// records written by the *pre-#1358* binary carry the legacy tag key
-/// `envelope` (e.g. `{"envelope":"notification",…}`). serde's
-/// `#[serde(tag = "…")]` does not support an alias on the tag KEY, so the
-/// hand-written [`Deserialize`] below dual-reads: it accepts a record
-/// tagged with EITHER `record_kind` (new) OR `envelope` (legacy) as the
-/// outer discriminator, remaps the legacy key to `record_kind`, then
-/// dispatches via the derived [`UiProtocolLedgerEventTagged`] shim. This
-/// recovers ~30k pre-#1358 records that were previously dropped as
-/// "malformed" on every rescan.
-#[derive(Debug, Clone, PartialEq, Serialize)]
+/// Back-compat for the *pre-#1358* `envelope` tag is handled NOT here but
+/// at the read site (see [`LegacyLedgerDiskRecord`] and
+/// `read_session_disk_snapshot`). Both the canonical and legacy parses are
+/// DERIVED (`#[serde(tag = …)]`), so both stay STRICT: genuine duplicate
+/// keys (`record_kind` / `kind` / `session_id` / payload fields) still
+/// produce serde's `duplicate field …` error rather than being silently
+/// collapsed last-wins by a `serde_json::Value` round-trip.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "record_kind", rename_all = "snake_case")]
 pub(crate) enum UiProtocolLedgerEvent {
     Notification(UiNotification),
     Progress(UiProgressEvent),
-}
-
-/// Derived-`Deserialize` shim mirroring [`UiProtocolLedgerEvent`]'s
-/// canonical `record_kind` tagging. The hand-written `Deserialize` for
-/// `UiProtocolLedgerEvent` normalizes the outer discriminator key
-/// (`envelope` → `record_kind`) and then defers to this shim so all of
-/// serde's internally-tagged variant logic is reused verbatim (no
-/// hand-rolled variant dispatch).
-#[derive(Deserialize)]
-// Mirrors `UiProtocolLedgerEvent`'s own variant sizing; this internal
-// shim is immediately `From`-converted, so boxing would only churn an
-// allocation. The public enum carries the same (pre-existing) profile.
-#[allow(clippy::large_enum_variant)]
-#[serde(tag = "record_kind", rename_all = "snake_case")]
-enum UiProtocolLedgerEventTagged {
-    Notification(UiNotification),
-    Progress(UiProgressEvent),
-}
-
-impl From<UiProtocolLedgerEventTagged> for UiProtocolLedgerEvent {
-    fn from(tagged: UiProtocolLedgerEventTagged) -> Self {
-        match tagged {
-            UiProtocolLedgerEventTagged::Notification(n) => Self::Notification(n),
-            UiProtocolLedgerEventTagged::Progress(p) => Self::Progress(p),
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for UiProtocolLedgerEvent {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        use serde::de::Error as _;
-        // Read into a generic object first so we can normalize the outer
-        // discriminator key. The legacy pre-#1358 tag was `envelope`; the
-        // canonical tag is `record_kind`. We only treat `envelope` as the
-        // discriminator when (a) `record_kind` is absent AND (b) the
-        // `envelope` value is a STRING — the `Envelope` notification
-        // variant carries a nested `envelope` OBJECT field, so a string
-        // value unambiguously identifies the legacy outer tag and never
-        // misfires on inner payload data.
-        let value = Value::deserialize(deserializer)?;
-        let Value::Object(mut map) = value else {
-            return Err(D::Error::custom(
-                "ledger record must be a JSON object with a record_kind/envelope discriminator",
-            ));
-        };
-        if !map.contains_key("record_kind") {
-            if let Some(legacy) = map.get("envelope") {
-                if legacy.is_string() {
-                    let discriminator = map.remove("envelope").expect("checked present");
-                    map.insert("record_kind".to_string(), discriminator);
-                }
-            }
-        }
-        UiProtocolLedgerEventTagged::deserialize(Value::Object(map))
-            .map(Self::from)
-            .map_err(D::Error::custom)
-    }
 }
 
 impl UiProtocolLedgerEvent {
@@ -315,6 +252,110 @@ struct LedgerDiskRecord {
 }
 
 const LEDGER_DISK_VERSION: u32 = 1;
+
+/// Back-compat read shim for records written by the *pre-#1358* binary,
+/// whose `event` carried the outer discriminator under the legacy tag key
+/// `envelope` (renamed to `record_kind` in #1358 with no alias). Mirrors
+/// [`LedgerDiskRecord`] exactly except the inner event enum is tagged
+/// `envelope` instead of `record_kind`.
+///
+/// This is a DERIVED `Deserialize`, so it is just as STRICT as the
+/// canonical parse — duplicate `envelope` / `kind` / `session_id` /
+/// payload keys still error with serde's `duplicate field …`. There is no
+/// `serde_json::Value` round-trip anywhere on the read path, so duplicate
+/// keys are never silently collapsed last-wins.
+///
+/// LIMITATION (Step 0 finding, #1358): this shim CANNOT represent the
+/// legacy `UiNotification::Envelope` variant. Pre-#1358, the outer tag was
+/// `envelope` AND `EnvelopeNotification` carries a nested `envelope`
+/// OBJECT field, so internally-tagged flattening emitted TWO `envelope`
+/// keys in the same object — `duplicate field 'envelope'`. Those records
+/// were duplicate-key garbage on disk and were NEVER cleanly readable
+/// (that is precisely the bug #1358 fixed by renaming the outer tag).
+/// Recovering them is inherently impossible; the legacy shim's derived
+/// parse rejects them on the duplicate `envelope` key, so they fail
+/// gracefully and are counted in the per-file skip aggregate. This is NOT
+/// a regression — they had no clean prior representation.
+#[derive(Debug, Deserialize)]
+struct LegacyLedgerDiskRecord {
+    v: u32,
+    seq: u64,
+    event: LegacyUiProtocolLedgerEvent,
+}
+
+/// Legacy `envelope`-tagged twin of [`UiProtocolLedgerEvent`]. Derived
+/// (strict) — see [`LegacyLedgerDiskRecord`].
+#[derive(Debug, Deserialize)]
+// Mirrors `UiProtocolLedgerEvent`'s own variant sizing; this internal
+// shim is immediately converted into the canonical enum, so boxing would
+// only churn an allocation. The public enum carries the same (pre-existing)
+// profile.
+#[allow(clippy::large_enum_variant)]
+#[serde(tag = "envelope", rename_all = "snake_case")]
+enum LegacyUiProtocolLedgerEvent {
+    Notification(UiNotification),
+    Progress(UiProgressEvent),
+}
+
+impl From<LegacyUiProtocolLedgerEvent> for UiProtocolLedgerEvent {
+    fn from(legacy: LegacyUiProtocolLedgerEvent) -> Self {
+        match legacy {
+            LegacyUiProtocolLedgerEvent::Notification(n) => Self::Notification(n),
+            LegacyUiProtocolLedgerEvent::Progress(p) => Self::Progress(p),
+        }
+    }
+}
+
+impl From<LegacyLedgerDiskRecord> for LedgerDiskRecord {
+    fn from(legacy: LegacyLedgerDiskRecord) -> Self {
+        Self {
+            v: legacy.v,
+            seq: legacy.seq,
+            event: legacy.event.into(),
+        }
+    }
+}
+
+/// Parse one on-disk ledger line, dual-reading the outer event tag.
+///
+/// Tries the canonical [`LedgerDiskRecord`] parse (tag `record_kind`)
+/// first. If — and ONLY if — that fails because the event object is
+/// missing its `record_kind` discriminator (i.e. a *pre-#1358* legacy
+/// record tagged `envelope`), it retries via the strict
+/// [`LegacyLedgerDiskRecord`] shim. Both parses are derived and strict, so
+/// duplicate-key corruption is rejected on either path; the legacy retry
+/// only widens the *tag-key* alias, never the duplicate-key tolerance.
+///
+/// On genuine corruption the *canonical* error is returned (it reflects
+/// the format the writer actually emits) so debug logs stay meaningful.
+fn parse_ledger_disk_record(line: &str) -> Result<LedgerDiskRecord, serde_json::Error> {
+    match serde_json::from_str::<LedgerDiskRecord>(line) {
+        Ok(record) => Ok(record),
+        Err(canonical_err) => {
+            // Only attempt the legacy `envelope`-tagged shim when the
+            // canonical parse failed specifically because the event is
+            // missing its `record_kind` discriminator — i.e. a legacy
+            // record. Any other failure (duplicate field, malformed JSON,
+            // missing payload field, unknown version handled by caller) is
+            // genuine and must surface the canonical error unchanged so
+            // strictness is preserved.
+            if is_missing_record_kind_tag(&canonical_err) {
+                if let Ok(legacy) = serde_json::from_str::<LegacyLedgerDiskRecord>(line) {
+                    return Ok(legacy.into());
+                }
+            }
+            Err(canonical_err)
+        }
+    }
+}
+
+/// Whether a canonical-parse error is the "the event object lacks its
+/// `record_kind` discriminator" case — the signal that the record may be a
+/// legacy `envelope`-tagged one worth retrying. serde's internally-tagged
+/// enum reports this as `missing field \`record_kind\``.
+fn is_missing_record_kind_tag(err: &serde_json::Error) -> bool {
+    err.to_string().contains("missing field `record_kind`")
+}
 
 // ---------- Per-session state ----------
 
@@ -654,7 +695,13 @@ impl UiProtocolLedger {
                 if line.trim().is_empty() {
                     continue;
                 }
-                let record = match serde_json::from_str::<LedgerDiskRecord>(&line) {
+                // Dual-read the outer event tag: canonical `record_kind`
+                // first, then the strict legacy `envelope`-tagged shim for
+                // pre-#1358 records (see `parse_ledger_disk_record`). Both
+                // parses are derived + strict — no `serde_json::Value`
+                // round-trip — so duplicate-key corruption is still
+                // rejected on either path.
+                let record = match parse_ledger_disk_record(&line) {
                     Ok(record) if record.v == LEDGER_DISK_VERSION => record,
                     Ok(record) => {
                         skipped_unknown_version += 1;
@@ -667,11 +714,15 @@ impl UiProtocolLedger {
                         continue;
                     }
                     Err(error) => {
-                        // Valid-JSON-but-unknown-discriminator records are
-                        // now recovered by the dual-tag `Deserialize`
-                        // (legacy `envelope` outer tag), so reaching this
-                        // arm means genuine corruption — kept at `debug!`
-                        // per-record, aggregated into one `warn!` below.
+                        // Valid-JSON-but-unknown-discriminator records that
+                        // are legacy `envelope`-tagged are recovered by the
+                        // legacy shim above, so reaching this arm means
+                        // genuine corruption — OR a legacy
+                        // `UiNotification::Envelope` record, which is
+                        // inherently duplicate-key garbage (#1358 collision)
+                        // and was never cleanly readable. Either way it is
+                        // skipped, not panicked. Kept at `debug!` per-record,
+                        // aggregated into one `warn!` below.
                         skipped_malformed += 1;
                         debug!(
                             target = "octos::ledger",
@@ -3665,46 +3716,64 @@ mod tests {
 
     /// Construct a legacy on-disk `event` JSON as the PRE-#1358 binary
     /// wrote it: the outer ledger discriminator was named `envelope`
-    /// (renamed to `record_kind` in #1358). We synthesize it by
-    /// serializing with the current `record_kind` tag and renaming the
-    /// outer key back to `envelope` — exactly mirroring the byte shape on
-    /// disk for non-`Envelope` notifications and `Progress` records.
+    /// (renamed to `record_kind` in #1358). We synthesize it by serializing
+    /// with the current `record_kind` tag and renaming JUST the outer tag
+    /// KEY back to `envelope` via STRING manipulation.
+    ///
+    /// The string-level rename is load-bearing: for the `Envelope` notification
+    /// variant the canonical JSON already contains a nested `envelope` OBJECT
+    /// field, so renaming the outer tag to `envelope` re-creates the genuine
+    /// TWO-`envelope`-keys-in-one-object collision the pre-#1358 binary wrote.
+    /// A `serde_json::Map` could not represent that (it would collapse the two
+    /// keys to last-wins) — which is exactly why the collision was duplicate-key
+    /// garbage on disk (Step 0). For non-`Envelope` notifications and `Progress`
+    /// records there is no inner `envelope` field, so the rename is a clean
+    /// single-key swap.
     fn legacy_envelope_tagged_json(event: &UiProtocolLedgerEvent) -> String {
-        let value = serde_json::to_value(event).expect("serialize event");
-        let mut map = match value {
-            Value::Object(map) => map,
-            other => panic!("ledger event must serialize to an object, got {other:?}"),
-        };
-        let discriminator = map
-            .remove("record_kind")
-            .expect("current serialization carries the record_kind tag");
-        // Re-insert as the legacy `envelope` key at the front to match the
-        // historical serde-internally-tagged layout (tag is emitted first).
-        let mut legacy = Map::new();
-        legacy.insert("envelope".to_string(), discriminator);
-        for (k, v) in map {
-            legacy.insert(k, v);
-        }
-        serde_json::to_string(&Value::Object(legacy)).expect("serialize legacy json")
+        // serde emits the internally-tagged discriminator FIRST, so the
+        // canonical JSON always begins `{"record_kind":"…",`. Rename only
+        // that leading outer tag key, leaving every other key (including any
+        // nested `envelope` object) byte-for-byte intact.
+        let canonical = serde_json::to_string(event).expect("serialize event");
+        assert!(
+            canonical.starts_with("{\"record_kind\":"),
+            "expected canonical record_kind-tagged JSON, got {canonical}"
+        );
+        canonical.replacen("{\"record_kind\":", "{\"envelope\":", 1)
+    }
+
+    /// Wrap a legacy `envelope`-tagged event JSON into a full on-disk
+    /// `{v, seq, event}` record line — the shape the pre-#1358 binary
+    /// actually wrote. Back-compat lives at the disk-record READ SITE
+    /// (`parse_ledger_disk_record`), not on the bare `UiProtocolLedgerEvent`
+    /// type (whose derived `Deserialize` is now strictly `record_kind`),
+    /// so legacy recovery is exercised through that helper.
+    fn legacy_envelope_tagged_record_line(event: &UiProtocolLedgerEvent, seq: u64) -> String {
+        let event_json: Value =
+            serde_json::from_str(&legacy_envelope_tagged_json(event)).expect("legacy event json");
+        let record = json!({ "v": LEDGER_DISK_VERSION, "seq": seq, "event": event_json });
+        serde_json::to_string(&record).expect("serialize legacy record line")
     }
 
     #[test]
     fn legacy_envelope_tagged_notification_deserializes() {
-        // RED before back-compat: serde's `tag = "record_kind"` cannot
-        // find its discriminator in a record that carries the legacy
-        // `envelope` tag key, so this would fail with
-        // `missing field record_kind`.
+        // RED before back-compat: serde's `tag = "record_kind"` cannot find
+        // its discriminator in a record whose `event` carries the legacy
+        // `envelope` tag key, so the canonical parse fails with
+        // `missing field record_kind` and `parse_ledger_disk_record` retries
+        // the strict legacy `envelope`-tagged shim.
         let session = SessionKey("local:legacy-notif".into());
         let event = UiProtocolLedgerEvent::Notification(delta(&session, "legacy delta"));
-        let legacy = legacy_envelope_tagged_json(&event);
+        let event_json = legacy_envelope_tagged_json(&event);
         assert!(
-            legacy.contains("\"envelope\":\"notification\""),
-            "fixture must carry the legacy `envelope` outer tag — got {legacy}"
+            event_json.contains("\"envelope\":\"notification\""),
+            "fixture must carry the legacy `envelope` outer tag — got {event_json}"
         );
-        let parsed: UiProtocolLedgerEvent = serde_json::from_str(&legacy)
+        let line = legacy_envelope_tagged_record_line(&event, 1);
+        let record = parse_ledger_disk_record(&line)
             .unwrap_or_else(|e| panic!("legacy envelope-tagged record MUST deserialize: {e}"));
         assert_eq!(
-            parsed, event,
+            record.event, event,
             "legacy record must decode to the same variant"
         );
     }
@@ -3729,14 +3798,15 @@ mod tests {
                 extra: Default::default(),
             },
         });
-        let legacy = legacy_envelope_tagged_json(&event);
+        let event_json = legacy_envelope_tagged_json(&event);
         assert!(
-            legacy.contains("\"envelope\":\"progress\""),
-            "fixture must carry the legacy `envelope` outer tag — got {legacy}"
+            event_json.contains("\"envelope\":\"progress\""),
+            "fixture must carry the legacy `envelope` outer tag — got {event_json}"
         );
-        let parsed: UiProtocolLedgerEvent = serde_json::from_str(&legacy)
+        let line = legacy_envelope_tagged_record_line(&event, 1);
+        let record = parse_ledger_disk_record(&line)
             .unwrap_or_else(|e| panic!("legacy envelope-tagged progress MUST deserialize: {e}"));
-        assert_eq!(parsed, event);
+        assert_eq!(record.event, event);
     }
 
     #[test]
@@ -3763,7 +3833,8 @@ mod tests {
     fn genuinely_malformed_record_still_errors() {
         // A record with neither discriminator (and not even valid for the
         // inner variant) must still be rejected so real corruption is not
-        // silently accepted.
+        // silently accepted — both as a bare event and through the actual
+        // disk-record read path.
         let bad = r#"{"kind":"message_delta","text":"orphan, no outer tag"}"#;
         let result: Result<UiProtocolLedgerEvent, _> = serde_json::from_str(bad);
         assert!(
@@ -3775,6 +3846,211 @@ mod tests {
             serde_json::from_str::<UiProtocolLedgerEvent>(not_json).is_err(),
             "non-JSON must still error"
         );
+
+        // Disk-record read path: neither the canonical nor the legacy shim
+        // can decode these, and non-object JSON must not panic.
+        let bad_record = format!("{{\"v\":{LEDGER_DISK_VERSION},\"seq\":1,\"event\":{bad}}}");
+        assert!(
+            parse_ledger_disk_record(&bad_record).is_err(),
+            "malformed event in a disk record must still error via the read path"
+        );
+        assert!(
+            parse_ledger_disk_record("{not valid json}").is_err(),
+            "non-JSON disk line must error, not panic"
+        );
+        assert!(
+            parse_ledger_disk_record("[1,2,3]").is_err(),
+            "non-object JSON disk line must error, not panic"
+        );
+    }
+
+    /// Inject a duplicate key into a JSON object STRING by inserting
+    /// `"key":<value>,` immediately after the opening brace. The result is
+    /// valid JSON syntax with a genuine duplicate top-level key — which a
+    /// `serde_json::Map` cannot represent (it collapses to last-wins), so
+    /// the corruption can only be expressed at the string level. Used to
+    /// prove the deserializer stays STRICT and does not round-trip through
+    /// a duplicate-collapsing `Value`.
+    fn inject_duplicate_key(json: &str, key: &str, value: &str) -> String {
+        let brace = json.find('{').expect("object json");
+        let (head, tail) = json.split_at(brace + 1);
+        format!("{head}\"{key}\":{value},{tail}")
+    }
+
+    #[test]
+    fn duplicate_key_corruption_is_rejected() {
+        // STRICTNESS: the derived `Deserialize` rejects duplicate fields
+        // (`duplicate field …`). The dual-tag rework must NOT regress that
+        // into a duplicate-collapsing `serde_json::Value` round-trip, which
+        // silently keeps the LAST value and accepts corrupted JSON.
+        //
+        // Fixtures are built by serializing a fully-valid event (so every
+        // field — including the UUID `turn_id` — is genuinely valid) and
+        // then injecting ONE duplicate key into the JSON STRING. A
+        // `serde_json::Map` cannot hold duplicate keys, which is exactly why
+        // a Value round-trip loses the strictness the derived path
+        // guaranteed; the ONLY reason any fixture below can error is the
+        // duplicate key.
+        //
+        // RED on 39794cd1: the inner-field cases (`session_id`, `kind`,
+        // `text`) were SILENTLY ACCEPTED (last-wins) because the
+        // `Value::deserialize` step collapsed the duplicate before the
+        // derived shim ever saw it.
+        let session = SessionKey("local:dup".into());
+        let event = UiProtocolLedgerEvent::Notification(delta(&session, "corrupt"));
+        let valid = serde_json::to_string(&event).expect("serialize valid event");
+        // Sanity: the clean record must deserialize (so a failure below is
+        // attributable to the injected duplicate, not a broken fixture).
+        serde_json::from_str::<UiProtocolLedgerEvent>(&valid)
+            .expect("clean fixture must deserialize");
+
+        // Duplicate INNER payload field `session_id` — headline regression.
+        let dup_session = inject_duplicate_key(&valid, "session_id", "\"local:other\"");
+        assert!(
+            serde_json::from_str::<UiProtocolLedgerEvent>(&dup_session).is_err(),
+            "duplicate inner `session_id` must error, not last-wins — got {dup_session}"
+        );
+
+        // Duplicate INNER scalar `text`.
+        let dup_text = inject_duplicate_key(&valid, "text", "\"first\"");
+        assert!(
+            serde_json::from_str::<UiProtocolLedgerEvent>(&dup_text).is_err(),
+            "duplicate inner `text` must error, not last-wins — got {dup_text}"
+        );
+
+        // Duplicate INNER discriminator `kind`.
+        let dup_kind = inject_duplicate_key(&valid, "kind", "\"tool_started\"");
+        assert!(
+            serde_json::from_str::<UiProtocolLedgerEvent>(&dup_kind).is_err(),
+            "duplicate inner `kind` must error, not last-wins — got {dup_kind}"
+        );
+
+        // Duplicate OUTER discriminator `record_kind`.
+        let dup_record_kind = inject_duplicate_key(&valid, "record_kind", "\"progress\"");
+        assert!(
+            serde_json::from_str::<UiProtocolLedgerEvent>(&dup_record_kind).is_err(),
+            "duplicate outer `record_kind` must error, not last-wins — got {dup_record_kind}"
+        );
+
+        // The legacy `envelope`-tagged path runs only at the disk-record
+        // READ SITE (`parse_ledger_disk_record`), so legacy duplicate-key
+        // fixtures are exercised there — proving the STRICT legacy shim
+        // (not a Value collapse) is what recovers them. Wrap each corrupt
+        // legacy event in a `{v, seq, event}` line and assert it is
+        // rejected. (Sanity: the clean legacy line recovers, so failures
+        // below are attributable to the injected duplicate.)
+        let legacy_event = legacy_envelope_tagged_json(&event);
+        let clean_legacy_line = legacy_envelope_tagged_record_line(&event, 1);
+        parse_ledger_disk_record(&clean_legacy_line).expect("clean legacy line must recover");
+
+        // Duplicate legacy OUTER discriminator `envelope` (string tag).
+        let dup_envelope_event = inject_duplicate_key(&legacy_event, "envelope", "\"progress\"");
+        let dup_envelope_line =
+            format!("{{\"v\":{LEDGER_DISK_VERSION},\"seq\":1,\"event\":{dup_envelope_event}}}");
+        assert!(
+            parse_ledger_disk_record(&dup_envelope_line).is_err(),
+            "duplicate legacy outer `envelope` tag must error, not last-wins — got {dup_envelope_line}"
+        );
+
+        // Duplicate INNER `session_id` on a legacy-tagged record.
+        let dup_session_event =
+            inject_duplicate_key(&legacy_event, "session_id", "\"local:other\"");
+        let dup_session_line =
+            format!("{{\"v\":{LEDGER_DISK_VERSION},\"seq\":1,\"event\":{dup_session_event}}}");
+        assert!(
+            parse_ledger_disk_record(&dup_session_line).is_err(),
+            "duplicate inner `session_id` (legacy record) must error — got {dup_session_line}"
+        );
+    }
+
+    #[test]
+    fn legacy_envelope_variant_record_errors_gracefully_not_recovered() {
+        // STEP 0 finding: pre-#1358 `UiNotification::Envelope` records were
+        // NEVER cleanly (de)serializable. The outer ledger tag was named
+        // `envelope` AND `EnvelopeNotification` carries a nested `envelope`
+        // OBJECT field, so internally-tagged flattening emitted TWO
+        // `envelope` keys in the same object — exactly the
+        // `duplicate field 'envelope'` that #1358 fixed by renaming the
+        // outer tag to `record_kind`. Such records are duplicate-key
+        // garbage on disk; recovering them is inherently impossible.
+        //
+        // The contract here is therefore NOT "recover" but "fail
+        // gracefully": the record must ERROR (so the read loop counts it as
+        // a skip) and MUST NOT panic. This is NOT a regression — these
+        // records were always unreadable.
+        //
+        // Build the fixture authentically: serialize a real
+        // `UiNotification::Envelope` event (with the canonical `record_kind`
+        // tag) then rename the outer key back to the legacy `envelope` — the
+        // exact byte shape the pre-#1358 binary wrote. This produces the
+        // genuine two-`envelope`-keys-in-one-object collision.
+        let session = SessionKey("local:env".into());
+        let event =
+            UiProtocolLedgerEvent::Notification(UiNotification::Envelope(EnvelopeNotification {
+                session_id: session,
+                topic: Some("planning".into()),
+                envelope: Envelope {
+                    thread_id: "t".into(),
+                    seq: 1,
+                    client_message_id: None,
+                    payload: Payload::AssistantDelta { text: "x".into() },
+                },
+            }));
+        let legacy_event = legacy_envelope_tagged_json(&event);
+        // The collision: the outer string tag AND the nested object field
+        // both serialize to the key `envelope`.
+        assert!(
+            legacy_event.matches("\"envelope\":").count() >= 2,
+            "legacy Envelope record must carry the duplicate `envelope` key \
+             collision — got {legacy_event}"
+        );
+
+        // The bare strict event parse rejects it (no `record_kind`).
+        assert!(
+            serde_json::from_str::<UiProtocolLedgerEvent>(&legacy_event).is_err(),
+            "bare legacy Envelope event must error under the strict canonical parse"
+        );
+
+        // The actual READ PATH must also reject it gracefully: the legacy
+        // shim hits `duplicate field 'envelope'` and errors — counted as a
+        // skip, never recovered, never a panic.
+        let line = legacy_envelope_tagged_record_line(&event, 1);
+        let result = parse_ledger_disk_record(&line);
+        assert!(
+            result.is_err(),
+            "legacy Envelope-variant records are inherently duplicate-key \
+             garbage (#1358 collision) and must error gracefully, got {result:?}"
+        );
+
+        // Whole-chain: a log file containing ONLY such records recovers
+        // zero events and counts each as a skip (no panic).
+        let temp = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionKey("local:env-disk".into());
+        let session_dir = temp
+            .path()
+            .join("ui-protocol")
+            .join(encode_session_dir_name(&session_id));
+        fs::create_dir_all(&session_dir).expect("session dir");
+        let log_path = session_dir.join(new_log_file_name());
+        fs::write(&log_path, format!("{line}\n")).expect("write envelope log");
+
+        let ledger = UiProtocolLedger::with_config(LedgerConfig::durable(temp.path().into()));
+        let snapshot = ledger
+            .read_session_disk_snapshot(&session_id, &session_dir, None)
+            .expect("scan ok");
+        // An empty snapshot (`None`) is also acceptable (nothing
+        // recovered); when present it must show zero recovered + one skip.
+        if let Some(snap) = snapshot {
+            assert_eq!(
+                snap.retained_entries.len(),
+                0,
+                "legacy Envelope-variant records must not be recovered"
+            );
+            assert_eq!(
+                snap.skipped_records, 1,
+                "the single unreadable Envelope-variant record must be counted as a skip"
+            );
+        }
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -66,7 +66,7 @@ use octos_core::ui_protocol::{
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use tokio::sync::broadcast;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// Per-session broadcast buffer size. Bounded so a slow subscriber cannot
 /// pin unbounded memory; on overflow the receiver sees `Lagged(n)` and
@@ -123,17 +123,90 @@ impl LedgerConfig {
 
 /// Anything that can sit in the ledger ring.
 ///
-/// Serialized with an outer `record_kind` tag. The earlier name `"envelope"`
-/// collided with `EnvelopeNotification.envelope` once internally-tagged
-/// `UiNotification` flattened its variant data alongside the outer tag —
-/// serde produced two `"envelope"` keys in the same object and rejected
-/// the record on replay (`duplicate field 'envelope'`). `record_kind` is
-/// disjoint from every flattened inner field name on both branches.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// **Write side** serializes with an outer `record_kind` tag (the derived
+/// `Serialize`). The earlier name `"envelope"` collided with
+/// `EnvelopeNotification.envelope` once internally-tagged `UiNotification`
+/// flattened its variant data alongside the outer tag — serde produced two
+/// `"envelope"` keys in the same object and rejected the record on replay
+/// (`duplicate field 'envelope'`, #1358). `record_kind` is disjoint from
+/// every flattened inner field name on both branches, so it is the
+/// canonical on-disk tag going forward.
+///
+/// **Read side** is back-compatible (`fix/ledger-legacy-envelope-tag`):
+/// records written by the *pre-#1358* binary carry the legacy tag key
+/// `envelope` (e.g. `{"envelope":"notification",…}`). serde's
+/// `#[serde(tag = "…")]` does not support an alias on the tag KEY, so the
+/// hand-written [`Deserialize`] below dual-reads: it accepts a record
+/// tagged with EITHER `record_kind` (new) OR `envelope` (legacy) as the
+/// outer discriminator, remaps the legacy key to `record_kind`, then
+/// dispatches via the derived [`UiProtocolLedgerEventTagged`] shim. This
+/// recovers ~30k pre-#1358 records that were previously dropped as
+/// "malformed" on every rescan.
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(tag = "record_kind", rename_all = "snake_case")]
 pub(crate) enum UiProtocolLedgerEvent {
     Notification(UiNotification),
     Progress(UiProgressEvent),
+}
+
+/// Derived-`Deserialize` shim mirroring [`UiProtocolLedgerEvent`]'s
+/// canonical `record_kind` tagging. The hand-written `Deserialize` for
+/// `UiProtocolLedgerEvent` normalizes the outer discriminator key
+/// (`envelope` → `record_kind`) and then defers to this shim so all of
+/// serde's internally-tagged variant logic is reused verbatim (no
+/// hand-rolled variant dispatch).
+#[derive(Deserialize)]
+// Mirrors `UiProtocolLedgerEvent`'s own variant sizing; this internal
+// shim is immediately `From`-converted, so boxing would only churn an
+// allocation. The public enum carries the same (pre-existing) profile.
+#[allow(clippy::large_enum_variant)]
+#[serde(tag = "record_kind", rename_all = "snake_case")]
+enum UiProtocolLedgerEventTagged {
+    Notification(UiNotification),
+    Progress(UiProgressEvent),
+}
+
+impl From<UiProtocolLedgerEventTagged> for UiProtocolLedgerEvent {
+    fn from(tagged: UiProtocolLedgerEventTagged) -> Self {
+        match tagged {
+            UiProtocolLedgerEventTagged::Notification(n) => Self::Notification(n),
+            UiProtocolLedgerEventTagged::Progress(p) => Self::Progress(p),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for UiProtocolLedgerEvent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error as _;
+        // Read into a generic object first so we can normalize the outer
+        // discriminator key. The legacy pre-#1358 tag was `envelope`; the
+        // canonical tag is `record_kind`. We only treat `envelope` as the
+        // discriminator when (a) `record_kind` is absent AND (b) the
+        // `envelope` value is a STRING — the `Envelope` notification
+        // variant carries a nested `envelope` OBJECT field, so a string
+        // value unambiguously identifies the legacy outer tag and never
+        // misfires on inner payload data.
+        let value = Value::deserialize(deserializer)?;
+        let Value::Object(mut map) = value else {
+            return Err(D::Error::custom(
+                "ledger record must be a JSON object with a record_kind/envelope discriminator",
+            ));
+        };
+        if !map.contains_key("record_kind") {
+            if let Some(legacy) = map.get("envelope") {
+                if legacy.is_string() {
+                    let discriminator = map.remove("envelope").expect("checked present");
+                    map.insert("record_kind".to_string(), discriminator);
+                }
+            }
+        }
+        UiProtocolLedgerEventTagged::deserialize(Value::Object(map))
+            .map(Self::from)
+            .map_err(D::Error::custom)
+    }
 }
 
 impl UiProtocolLedgerEvent {
@@ -262,6 +335,12 @@ struct DiskSessionSnapshot {
     head_seq: u64,
     retained_entries: VecDeque<LedgerEntry>,
     replay_entries: Vec<LedgeredUiProtocolEvent>,
+    /// Total records skipped across all scanned log files (unknown
+    /// version + genuinely-malformed). Surfaced so callers/tests can
+    /// assert the aggregation deterministically without depending on the
+    /// process-global tracing subscriber's level filter.
+    #[cfg_attr(not(test), allow(dead_code))]
+    skipped_records: u64,
 }
 
 /// Per-session state held under the global lock. Disk writers live inside
@@ -543,11 +622,21 @@ impl UiProtocolLedger {
         let mut head_seq = 0u64;
         let mut retained_entries = VecDeque::new();
         let mut replay_entries = Vec::new();
+        let mut skipped_records = 0u64;
         let cap = self.config.retained_per_session;
 
         for path in log_files {
             let file = File::open(&path)?;
             let reader = BufReader::new(file);
+            // Aggregate skip counts per file: emit ONE summary `warn!`
+            // after the inner loop instead of one line per record per
+            // rescan. `read_session_disk_snapshot` re-reads every log
+            // from byte 0 on every recovery / re-hydration / replay, so
+            // per-record warnings multiply into log spam (~30k lines per
+            // scan on pre-#1358 ledgers). Per-record detail stays at
+            // `debug!` for when it is needed.
+            let mut skipped_unknown_version = 0u64;
+            let mut skipped_malformed = 0u64;
             for line_result in reader.lines() {
                 let line = match line_result {
                     Ok(line) => line,
@@ -568,7 +657,8 @@ impl UiProtocolLedger {
                 let record = match serde_json::from_str::<LedgerDiskRecord>(&line) {
                     Ok(record) if record.v == LEDGER_DISK_VERSION => record,
                     Ok(record) => {
-                        warn!(
+                        skipped_unknown_version += 1;
+                        debug!(
                             target = "octos::ledger",
                             version = record.v,
                             path = %path.display(),
@@ -577,7 +667,13 @@ impl UiProtocolLedger {
                         continue;
                     }
                     Err(error) => {
-                        warn!(
+                        // Valid-JSON-but-unknown-discriminator records are
+                        // now recovered by the dual-tag `Deserialize`
+                        // (legacy `envelope` outer tag), so reaching this
+                        // arm means genuine corruption — kept at `debug!`
+                        // per-record, aggregated into one `warn!` below.
+                        skipped_malformed += 1;
+                        debug!(
                             target = "octos::ledger",
                             ?error,
                             session_id = %session_id.0,
@@ -612,6 +708,19 @@ impl UiProtocolLedger {
                     retained_entries.pop_front();
                 }
             }
+            let skipped_total = skipped_unknown_version + skipped_malformed;
+            if skipped_total > 0 {
+                skipped_records = skipped_records.saturating_add(skipped_total);
+                warn!(
+                    target = "octos::ledger",
+                    session_id = %session_id.0,
+                    path = %path.display(),
+                    skipped = skipped_total,
+                    skipped_unknown_version,
+                    skipped_malformed,
+                    "skipped ledger records during scan (aggregated)"
+                );
+            }
         }
 
         Ok(Some(DiskSessionSnapshot {
@@ -622,6 +731,7 @@ impl UiProtocolLedger {
             head_seq,
             retained_entries,
             replay_entries,
+            skipped_records,
         }))
     }
 
@@ -3549,5 +3659,227 @@ mod tests {
         let parsed: UiProtocolLedgerEvent = serde_json::from_str(&serialized)
             .unwrap_or_else(|e| panic!("ledger replay MUST succeed: {e}; payload={serialized}"));
         assert_eq!(parsed, event, "round-trip must be field-equal");
+    }
+
+    // ---------- #1358 back-compat: legacy `envelope` outer tag ----------
+
+    /// Construct a legacy on-disk `event` JSON as the PRE-#1358 binary
+    /// wrote it: the outer ledger discriminator was named `envelope`
+    /// (renamed to `record_kind` in #1358). We synthesize it by
+    /// serializing with the current `record_kind` tag and renaming the
+    /// outer key back to `envelope` — exactly mirroring the byte shape on
+    /// disk for non-`Envelope` notifications and `Progress` records.
+    fn legacy_envelope_tagged_json(event: &UiProtocolLedgerEvent) -> String {
+        let value = serde_json::to_value(event).expect("serialize event");
+        let mut map = match value {
+            Value::Object(map) => map,
+            other => panic!("ledger event must serialize to an object, got {other:?}"),
+        };
+        let discriminator = map
+            .remove("record_kind")
+            .expect("current serialization carries the record_kind tag");
+        // Re-insert as the legacy `envelope` key at the front to match the
+        // historical serde-internally-tagged layout (tag is emitted first).
+        let mut legacy = Map::new();
+        legacy.insert("envelope".to_string(), discriminator);
+        for (k, v) in map {
+            legacy.insert(k, v);
+        }
+        serde_json::to_string(&Value::Object(legacy)).expect("serialize legacy json")
+    }
+
+    #[test]
+    fn legacy_envelope_tagged_notification_deserializes() {
+        // RED before back-compat: serde's `tag = "record_kind"` cannot
+        // find its discriminator in a record that carries the legacy
+        // `envelope` tag key, so this would fail with
+        // `missing field record_kind`.
+        let session = SessionKey("local:legacy-notif".into());
+        let event = UiProtocolLedgerEvent::Notification(delta(&session, "legacy delta"));
+        let legacy = legacy_envelope_tagged_json(&event);
+        assert!(
+            legacy.contains("\"envelope\":\"notification\""),
+            "fixture must carry the legacy `envelope` outer tag — got {legacy}"
+        );
+        let parsed: UiProtocolLedgerEvent = serde_json::from_str(&legacy)
+            .unwrap_or_else(|e| panic!("legacy envelope-tagged record MUST deserialize: {e}"));
+        assert_eq!(
+            parsed, event,
+            "legacy record must decode to the same variant"
+        );
+    }
+
+    #[test]
+    fn legacy_envelope_tagged_progress_deserializes() {
+        use octos_core::ui_protocol::UiProgressMetadata;
+        let session = SessionKey("local:legacy-progress".into());
+        let event = UiProtocolLedgerEvent::Progress(UiProgressEvent {
+            session_id: session,
+            turn_id: None,
+            metadata: UiProgressMetadata {
+                kind: "thinking".into(),
+                label: None,
+                message: None,
+                detail: None,
+                iteration: None,
+                progress_pct: None,
+                retry: None,
+                file_mutation: None,
+                token_cost: None,
+                extra: Default::default(),
+            },
+        });
+        let legacy = legacy_envelope_tagged_json(&event);
+        assert!(
+            legacy.contains("\"envelope\":\"progress\""),
+            "fixture must carry the legacy `envelope` outer tag — got {legacy}"
+        );
+        let parsed: UiProtocolLedgerEvent = serde_json::from_str(&legacy)
+            .unwrap_or_else(|e| panic!("legacy envelope-tagged progress MUST deserialize: {e}"));
+        assert_eq!(parsed, event);
+    }
+
+    #[test]
+    fn new_record_kind_tagged_notification_still_deserializes() {
+        // The write side MUST keep emitting `record_kind` (no #1358
+        // regression) and the reader must still accept it.
+        let session = SessionKey("local:new-notif".into());
+        let event = UiProtocolLedgerEvent::Notification(delta(&session, "new delta"));
+        let serialized = serde_json::to_string(&event).expect("serialize");
+        assert!(
+            serialized.contains("\"record_kind\":\"notification\""),
+            "write side must still emit `record_kind` — got {serialized}"
+        );
+        assert!(
+            !serialized.contains("\"envelope\":\"notification\""),
+            "write side must NOT regress to the legacy `envelope` tag — got {serialized}"
+        );
+        let parsed: UiProtocolLedgerEvent =
+            serde_json::from_str(&serialized).expect("record_kind record deserializes");
+        assert_eq!(parsed, event);
+    }
+
+    #[test]
+    fn genuinely_malformed_record_still_errors() {
+        // A record with neither discriminator (and not even valid for the
+        // inner variant) must still be rejected so real corruption is not
+        // silently accepted.
+        let bad = r#"{"kind":"message_delta","text":"orphan, no outer tag"}"#;
+        let result: Result<UiProtocolLedgerEvent, _> = serde_json::from_str(bad);
+        assert!(
+            result.is_err(),
+            "record lacking any outer discriminator must still error, got {result:?}"
+        );
+        let not_json = "this is not json at all";
+        assert!(
+            serde_json::from_str::<UiProtocolLedgerEvent>(not_json).is_err(),
+            "non-JSON must still error"
+        );
+    }
+
+    #[test]
+    fn ledger_recovers_legacy_envelope_tagged_records_from_disk() {
+        // Whole-chain: write a log file by hand using the legacy
+        // `envelope` outer tag (as the pre-#1358 binary did) and confirm
+        // recovery hydrates them rather than dropping them as malformed.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionKey("local:legacy-disk".into());
+        let session_dir = temp
+            .path()
+            .join("ui-protocol")
+            .join(encode_session_dir_name(&session_id));
+        fs::create_dir_all(&session_dir).expect("session dir");
+        let log_path = session_dir.join(new_log_file_name());
+        let mut lines = String::new();
+        for (seq, text) in [(1u64, "legacy-one"), (2, "legacy-two"), (3, "legacy-three")] {
+            let event = UiProtocolLedgerEvent::Notification(delta(&session_id, text));
+            let event_json: Value =
+                serde_json::from_str(&legacy_envelope_tagged_json(&event)).unwrap();
+            let record = json!({ "v": LEDGER_DISK_VERSION, "seq": seq, "event": event_json });
+            lines.push_str(&serde_json::to_string(&record).unwrap());
+            lines.push('\n');
+        }
+        fs::write(&log_path, lines).expect("write legacy log");
+
+        let outcome = UiProtocolLedger::recover(LedgerConfig::durable(temp.path().into()));
+        assert_eq!(
+            outcome.events_recovered, 3,
+            "all 3 legacy `envelope`-tagged records must be recovered, not skipped"
+        );
+        let replay = outcome
+            .ledger
+            .replay_after(
+                &session_id,
+                Some(&UiCursor {
+                    stream: session_id.0.clone(),
+                    seq: 1,
+                }),
+            )
+            .expect("replay recovered legacy session");
+        assert_eq!(replay_texts(&replay), vec!["legacy-two", "legacy-three"]);
+    }
+
+    #[test]
+    fn scanning_legacy_and_bad_records_aggregates_skips_per_file() {
+        // N legacy + M truly-bad records in ONE file: the N legacy
+        // records are recovered (0 skips, via part 1) and only the M bad
+        // records are counted. `skipped_records` is the per-file
+        // aggregate — proving the read loop emits a single summary `warn!`
+        // per file (the warn is guarded by `skipped_total > 0`, once per
+        // file) rather than one line per record per rescan. We assert on
+        // the returned count rather than captured logs because the
+        // process-global tracing max-level filter (set by the test
+        // harness / other tests) is not deterministically observable.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionKey("local:agg-skip".into());
+        let session_dir = temp
+            .path()
+            .join("ui-protocol")
+            .join(encode_session_dir_name(&session_id));
+        fs::create_dir_all(&session_dir).expect("session dir");
+        let log_path = session_dir.join(new_log_file_name());
+
+        let mut lines = String::new();
+        // 2 legacy `envelope`-tagged records → recovered by part 1.
+        for (seq, text) in [(1u64, "legacy-a"), (2, "legacy-b")] {
+            let event = UiProtocolLedgerEvent::Notification(delta(&session_id, text));
+            let event_json: Value =
+                serde_json::from_str(&legacy_envelope_tagged_json(&event)).unwrap();
+            let record = json!({ "v": LEDGER_DISK_VERSION, "seq": seq, "event": event_json });
+            lines.push_str(&serde_json::to_string(&record).unwrap());
+            lines.push('\n');
+        }
+        // 3 truly-bad records → skipped (aggregated into one summary).
+        lines.push_str("{not valid json}\n");
+        lines.push_str("{\"v\":1,\"seq\":99}\n"); // missing `event`
+        lines.push_str("garbage line\n");
+        fs::write(&log_path, lines).expect("write mixed log");
+
+        let ledger = UiProtocolLedger::with_config(LedgerConfig::durable(temp.path().into()));
+        let snapshot = ledger
+            .read_session_disk_snapshot(&session_id, &session_dir, None)
+            .expect("scan ok")
+            .expect("non-empty snapshot");
+
+        assert_eq!(
+            snapshot.skipped_records, 3,
+            "only the 3 truly-bad records are skipped; the 2 legacy records are recovered"
+        );
+        assert_eq!(
+            snapshot.retained_entries.len(),
+            2,
+            "the 2 legacy `envelope`-tagged records must be recovered, not skipped"
+        );
+        let recovered_texts: Vec<String> = snapshot
+            .retained_entries
+            .iter()
+            .filter_map(|entry| match &entry.event {
+                UiProtocolLedgerEvent::Notification(UiNotification::MessageDelta(d)) => {
+                    Some(d.text.clone())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(recovered_texts, vec!["legacy-a", "legacy-b"]);
     }
 }


### PR DESCRIPTION
Fixes the ~30k/day `skipping malformed ledger record` warnings. PR #1358 renamed the on-disk serde tag `envelope`→`record_kind` without back-compat, so pre-#1358 records (valid JSON, v:1, `envelope` tag) were rejected as malformed; the count was inflated by full-file re-scans on every recovery/reconnect.

## Fix
1. **Recover legacy records (strictly)**: `parse_ledger_disk_record` tries the canonical derived parse (`record_kind`) first and, ONLY on a `missing field record_kind` error, retries a strict DERIVED legacy shim (`#[serde(tag="envelope")]`). Both parses are derived — NO `serde_json::Value` round-trip on the read path — so duplicate-key corruption still errors (serde `duplicate field`). Legacy `notification`/`progress` records are recovered; the write side still emits `record_kind`.
2. **Legacy `Envelope`-variant records are inherently unrecoverable** and documented as such: pre-#1358 the outer tag `envelope` collided with `EnvelopeNotification.envelope` → duplicate keys → never cleanly (de)serializable (the exact collision #1358 renamed to fix; #1358 noted old records were already dropped). They now fail gracefully — counted in the per-file skip aggregate, no panic.
3. **Non-spammy warnings**: per-file aggregation + per-record `debug!` downgrade in both `ui_protocol_ledger.rs` and `ui_protocol_diff.rs` (one `warn!` per file with the skip count + path), with skip-counts surfaced for deterministic tests.

codex-reviewed (2 rounds): SHIP. Strictness restored + duplicate-key corruption rejected (tested); legacy non-Envelope recovery + graceful-skip tested. Build/test (1524 cli lib) / fmt / clippy clean.
Note: an earlier commit in this branch used a Value round-trip that codex flagged (dropped Envelope recovery + strictness); the follow-up commit reworked it to the strict derived approach above.