### PR TITLE
docs(spec): UPCR-2026-023 — AskUserQuestion (structured user-question) contract

### DIFF
--- a/api/OCTOS_APP_FEATURE_REQUIREMENTS.md
+++ b/api/OCTOS_APP_FEATURE_REQUIREMENTS.md
@@ -72,6 +72,7 @@ truth.
 | APP-034 | Build and packaging | P0 | App builds on supported platforms, has reproducible release profile, and CI runs store/transport/app checks. | CI |
 | APP-035 | Observability | P1 | App records sanitized telemetry for connection failures, protocol errors, approval failures, task output failures, and panics. | telemetry tests |
 | APP-036 | Client parity | P0 | App behavior remains protocol-compatible with `octos-tui` for core flows: session, turns, approvals, diffs, tasks, replay, cwd, and errors. | shared fixture tests |
+| APP-037 | Structured user-question picker | P0 | `user_question/requested` renders a question picker (single/multi-select options plus a free-text "Other") for each of the 1–4 questions, with generic title/body fallback when the structured `questions` field is unknown. The picker sends `user_question/respond` with the correct `question_id` and per-question `answers` (selected labels + optional free text). Stale/expired questions render as decided/expired, not as pending. | UI snapshot and contract tests |
 
 ## Major Interaction Flows
 

--- a/api/OCTOS_SERVER_FEATURE_REQUIREMENTS.md
+++ b/api/OCTOS_SERVER_FEATURE_REQUIREMENTS.md
@@ -78,6 +78,7 @@ logs, prompt text, or private implementation details.
 | SRV-038 | Auth and profile isolation | P0 | WebSocket/API requests are authenticated, profile scoped, and cannot read/control sessions or tasks outside the authorized profile/session. | auth tests |
 | SRV-039 | Metrics and audit | P1 | Server records counters for dropped sends, replay-lossy, approval decisions, task terminal states, tool failures, and task-control commands. | metrics tests |
 | SRV-040 | Live coding UX support | P1 | Server emits enough structured data for clients to show model working state, tool cards, approvals, diffs, plan/task progress, final recap, and background task status without parsing assistant prose. | long coding tmux harness |
+| SRV-041 | Structured user-question lifecycle | P0 | Server emits `user_question/requested` with 1–4 structured questions (header, question, 2–4 options, multi_select, free-text "Other") plus mandatory generic title/body fallback; accepts `user_question/respond`, correlates it to the waiting turn/tool by `question_id`, and resumes the turn only on a valid match. Pending questions are cancelled on turn interrupt and are durable enough for reconnecting clients to render true state. Clients lacking `user_question.v1` receive the agent tool's structured-metadata/generic-text fallback instead of a hard block. | user-question unit and e2e tests; interrupt-drain and reconnect tests |
 
 ## Major Server Flows
 

--- a/api/OCTOS_TUI_FEATURE_REQUIREMENTS.md
+++ b/api/OCTOS_TUI_FEATURE_REQUIREMENTS.md
@@ -77,6 +77,7 @@ where a coding user can always answer four questions:
 | TUI-034 | Interrupt behavior | P0 | `Ctrl+C` interrupts active turn. `Esc` with queued messages interrupts active turn and sends queued work after the turn stops. Status text must distinguish interrupt requested vs no active turn. | event-loop tests |
 | TUI-035 | Secret hygiene | P0 | Captures and normal UI must not show auth tokens, provider keys, raw bearer headers, or secret environment values. | redaction/harness checks |
 | TUI-036 | Long-session stability | P0 | A 30+ minute real coding session remains responsive, does not truncate all history to only visible rows, and keeps enough transcript history for review. | live mini host parity test |
+| TUI-037 | Structured user-question picker | P0 | `user_question/requested` shows a blocking question picker (one card per question) with single-select or multi-select options and a free-text "Other" entry; the model/tool stream must not appear to continue until an answer is sent. Selecting and confirming sends `user_question/respond` with the correct `question_id` and per-question `answers` (selected labels + optional free text). Unknown structured fields fall back to the generic title/body and stay actionable; stale/expired questions render as decided/expired. | render snapshot and reducer tests |
 
 ## Major Interaction Flows
 

--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -287,6 +287,20 @@ Current M9 sandbox-parity decision:
   It lets AppUI clients inspect the server-owned prompt context generation,
   transcript hash, checkpoint, compaction, and recovery state without
   reconstructing it from chat rows.
+- The additive structured mid-turn user-question surface (the
+  `user_question/respond` command, the `user_question/requested` notification,
+  the `questions[]` / `answers[]` payloads, and the new `question_id`
+  correlation id) is governed by proposed
+  [UPCR-2026-023](../docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_023_ASK_USER_QUESTION.md),
+  gated behind the `user_question.v1` feature flag. It is the codex/Claude
+  `AskUserQuestion` shape implemented as "approval + choices + free-text": the
+  agent tool blocks the turn at a deterministic tool boundary (mirroring
+  `approval/requested`), the server emits `user_question/requested`, the client
+  renders a single/multi-select picker plus a free-text "Other", and
+  `user_question/respond` resumes the waiting tool. A turn interrupt cancels
+  pending questions; a client lacking the capability receives the agent tool's
+  structured-metadata/generic-text fallback instead of a blocking question. See
+  [docs/design/ask-user-question-2026-06-03.md](../docs/design/ask-user-question-2026-06-03.md).
 
 ## 5. Identity Model
 
@@ -362,6 +376,7 @@ Session, turn, and approval core:
 - `thread/graph/get` (gate `state.thread_graph.v1`, accepted `UPCR-2026-010`)
 - `approval/respond`
 - `approval/scopes/list` (approval-scope discovery; first-server slice)
+- `user_question/respond` (gate `user_question.v1`, proposed `UPCR-2026-023`)
 - `permission/profile/list`, `permission/profile/set`
   (accepted `UPCR-2026-018`)
 - `diff/preview/get`
@@ -436,6 +451,11 @@ Approval lifecycle:
 
 - `approval/requested`, `approval/auto_resolved`, `approval/decided`,
   `approval/cancelled`
+
+Structured user-question lifecycle (gate `user_question.v1`, proposed
+`UPCR-2026-023`):
+
+- `user_question/requested`
 
 Task and progress:
 
@@ -735,6 +755,30 @@ Optional params from accepted `UPCR-2026-001`:
   String registry with initial values `request`, `turn`, and `session`.
   Scope is advisory in v1alpha1 and must not silently create persistent allow
   rules.
+- `client_note`
+  Human-readable client note for audit/display. Servers must not require it.
+
+### `user_question/respond`
+
+Purpose:
+
+- answer a `user_question/requested` event
+
+Minimum params:
+
+- `session_id`
+- `question_id`
+- `answers`
+  Per-question answer list, one entry per question in the originating
+  `user_question/requested` event, in question order. Each entry carries:
+  - `selected_labels` — selected option label(s). Empty when the user supplied
+    only free text. For a single-select question this is 0 or 1 entries; for a
+    `multi_select` question it is 0..N. Labels must match the option labels from
+    the request.
+  - `free_text` — optional string from the free-text "Other" escape hatch.
+
+Optional params (governed by accepted `UPCR-2026-023`):
+
 - `client_note`
   Human-readable client note for audit/display. Servers must not require it.
 
@@ -1560,6 +1604,52 @@ Capability feature:
 - `approval.typed.v1`
   Advertised through optional `supported_features` in `UiProtocolCapabilities`.
   The capability payload schema version is `2`.
+
+### `user_question/requested`
+
+Carries a structured multiple-choice question the agent is asking the user
+mid-turn. While this is unresolved, the turn remains paused at a deterministic
+boundary (the same blocking-tool boundary as `approval/requested`).
+
+Required fallback fields:
+
+- `session_id`
+- `question_id`
+- `turn_id`
+- `title`
+  Mandatory generic fallback text.
+- `body`
+  Mandatory generic fallback text.
+
+Structured field (governed by accepted `UPCR-2026-023`):
+
+- `questions`
+  An array of 1–4 questions. Each question carries:
+  - `header` — short label, ≤ 12 characters.
+  - `question` — the question text.
+  - `options` — an array of 2–4 options, each with `label` and `description`.
+  - `multi_select` — `bool`; when `true` the user may select more than one
+    option.
+  - `allow_free_text` — `bool`; the server forces this `true` so a free-text
+    "Other" escape hatch is always offered alongside the options.
+
+Compatibility rules:
+
+- Generic `title` and `body` remain mandatory fallback text for v1alpha1.
+- Unknown fields must fall back to generic rendering and remain actionable: a
+  client that does not understand `questions` renders `title`/`body` and the
+  user can still answer (for example via free text).
+- Clients that do not advertise the `user_question.v1` capability receive the
+  agent tool's structured-metadata / generic-text fallback instead of a blocking
+  question, so the turn never hard-blocks on a non-supporting client (the agent
+  tool degrades exactly like the existing `request_user_input` codex tool).
+
+Capability feature:
+
+- `user_question.v1`
+  Advertised through optional `supported_features` in `UiProtocolCapabilities`.
+  Clients request it through `X-Octos-Ui-Features` using comma or
+  space-separated feature tokens.
 
 ### `task/updated`
 

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_023_ASK_USER_QUESTION.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_023_ASK_USER_QUESTION.md
@@ -1,0 +1,142 @@
+# UPCR-2026-023: AppUI Structured User Question (AskUserQuestion)
+
+Status: proposed
+Date: 2026-06-03
+
+## Summary
+
+Let an Octos agent ask the user a structured multiple-choice question mid-turn
+and block on the answer, instead of guessing or emitting an unstructured text
+prompt the client cannot reliably render or route a reply for.
+
+This is the codex/Claude `AskUserQuestion` capability for Octos. The agent calls
+a model-visible `ask_user_question` tool carrying 1–4 questions, each with a
+short `header`, a `question`, 2–4 labeled `options`, and a `multi_select` flag;
+the server forces a free-text "Other" escape hatch on every question. The server
+emits a `user_question/requested` notification and pauses the turn at the
+blocking-tool boundary (the same deterministic boundary as `approval/requested`).
+The client renders a single/multi-select picker plus "Other" and replies with
+`user_question/respond`, which resolves the waiting tool and resumes the turn.
+
+This UPCR reuses the proven approval machinery (a pending-store keyed by id +
+oneshot resume + a task-local requester + turn-scoped cancellation). It does NOT
+introduce turn suspension/serialization, a new `TurnState` variant, or a
+client-driven survey/wizard runtime — the turn stays `Active`, paused at the
+tool's await point. A turn-suspension generalization is a possible future UPCR;
+the pipeline `HumanInputType::Choice` gate remains a separate workflow-scoped
+mechanism and is not wired to agent turns here.
+
+## Decision
+
+Do add a model-visible `ask_user_question` backend tool, resolved through the
+same profile runtime factory as every other Octos tool (profile, memory, MCP,
+skill, sandbox, approval, QoE, and model-portfolio policy apply).
+
+Do add one server→client notification (`user_question/requested`) and one
+client→server command (`user_question/respond`), correlated by `question_id`,
+mirroring `approval/requested` + `approval/respond`.
+
+Do require generic `title`/`body` fallback text on every request so a client
+that does not understand the structured `questions` field stays actionable.
+
+Do NOT let clients construct or invoke the tool directly, define new turn
+lifecycle states, or persist answers as durable policy (a question answer is a
+one-shot turn input, not an allow rule).
+
+## Capabilities
+
+Servers that support this contract advertise:
+
+- `user_question.v1`
+
+Advertised through optional `supported_features` in `UiProtocolCapabilities`;
+clients request it through `X-Octos-Ui-Features` (comma/space-separated tokens).
+Capability-gated fields must be omitted when the capability is not negotiated.
+
+## AppUI Surface
+
+Defined in the v1 spec §7 (command) and §8 (event):
+
+### `user_question/requested` (event)
+
+Pauses the turn at the blocking-tool boundary. Carries:
+
+- Required fallback: `session_id`, `question_id`, `turn_id`, `title`, `body`
+  (generic, mandatory).
+- Structured (gated by `user_question.v1`): `questions` — 1–4 entries, each with
+  `header` (≤ 12 chars), `question`, `options` (2–4 of `label` + `description`),
+  `multi_select` (bool), and `allow_free_text` (bool, server-forced `true`).
+
+### `user_question/respond` (command)
+
+Answers a `user_question/requested` event. Carries:
+
+- `session_id`, `question_id`.
+- `answers` — one entry per question, in question order, each with
+  `selected_labels` (0..1 for single-select, 0..N for multi-select; empty when
+  only free text was supplied; labels must match the request's option labels)
+  and optional `free_text` (the "Other" escape hatch).
+- Optional `client_note` (audit/display; servers must not require it).
+
+## Backend Tool Contract
+
+- `ask_user_question` — model-visible structured user-question tool. Input is the
+  `questions` array above. It runs inside the server-owned session runtime and,
+  when a capable client is attached, blocks on a oneshot until
+  `user_question/respond` resolves it, then returns the per-question answers to
+  the model.
+- This is the synchronous extension of UPCR-2026-020's `request_user_input`
+  primitive (which emits structured metadata but does not block). Where
+  `user_question.v1` is negotiated, `ask_user_question` is the blocking,
+  answer-routed form.
+
+## Security And Runtime Rules
+
+- Question/answer routing happens inside the server-owned runtime; the client
+  cannot invoke `ask_user_question` or forge a `question_id`.
+- A `user_question/respond` is accepted only for a pending `question_id` on the
+  caller's session; stale/unknown/duplicate ids return typed errors and do not
+  resume a turn.
+- Answers are one-shot turn input, never persisted as an allow rule or policy.
+- Turn interrupt cancels all pending questions for the turn (mirroring approval
+  cancellation), and the waiting tool observes a cancelled result.
+- Question/answer state must be identical over WebSocket and stdio.
+- Secret values must never be embedded in `title`/`body`/options.
+
+## Error Model
+
+Reuse the existing AppUI error taxonomy; add where more specific data helps:
+
+- `user_question_unknown` — no pending question for the id/session.
+- `user_question_stale` — the question was already answered or cancelled.
+
+Structured error `data` should include `session_id`, `question_id`, and
+`recoverable` when applicable. Secret values must be omitted.
+
+## Compatibility
+
+- Generic `title`/`body` remain mandatory fallback text for v1alpha1; a client
+  that does not understand `questions` renders them and the user can still answer
+  (e.g. via free text).
+- Clients that do NOT advertise `user_question.v1` receive the agent tool's
+  structured-metadata / generic-text fallback instead of a blocking question, so
+  the turn never hard-blocks on a non-supporting client — the tool degrades
+  exactly like `request_user_input`.
+- Older servers omit `user_question.v1` and never emit `user_question/requested`;
+  agents on those servers fall back to plain text prompts.
+
+## Tests
+
+- Protocol round-trip: `user_question/requested` and `user_question/respond`
+  serialize/deserialize with the structured `questions`/`answers` shapes and the
+  generic fallback fields.
+- Server: a pending question resumes the waiting tool exactly once on
+  `user_question/respond`; stale/unknown ids return typed errors; turn interrupt
+  cancels pending questions; payloads identical over WebSocket and stdio.
+- Agent tool: `ask_user_question` blocks and returns the selected answers when a
+  requester context is attached; with no context it degrades to
+  structured-metadata + generic text and continues (no hard block).
+- Client: renders single/multi-select + "Other"; sends `user_question/respond`
+  with correct ids; renders stale/expired as decided/expired, not pending.
+- Live tmux soak: an agent calls `ask_user_question`, the TUI renders the picker,
+  the user selects, and the agent receives the answer and continues the turn.

--- a/docs/design/ask-user-question-2026-06-03.md
+++ b/docs/design/ask-user-question-2026-06-03.md
@@ -1,0 +1,415 @@
+# AskUserQuestion — Structured Mid-Turn User Questions
+
+Date: 2026-06-03
+
+Status: design draft (Phase 1: synchronous tool-block).
+
+Owner: octos-agent + octos-cli (AppUI/UI Protocol) + octos-tui.
+
+Related contract surfaces:
+
+- [api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md](../../api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md)
+  (§7 `user_question/respond`, §8 `user_question/requested`, §4.1 UPCR-2026-023)
+- [api/OCTOS_SERVER_FEATURE_REQUIREMENTS.md](../../api/OCTOS_SERVER_FEATURE_REQUIREMENTS.md) (`SRV-041`)
+- [api/OCTOS_APP_FEATURE_REQUIREMENTS.md](../../api/OCTOS_APP_FEATURE_REQUIREMENTS.md) (`APP-037`)
+- [api/OCTOS_TUI_FEATURE_REQUIREMENTS.md](../../api/OCTOS_TUI_FEATURE_REQUIREMENTS.md) (`TUI-037`)
+
+Existing machinery this design reuses (read these before implementing):
+
+- `crates/octos-agent/src/tools/mod.rs` — `ToolApprovalRequester` trait,
+  `TOOL_APPROVAL_CTX` task-local, `ToolApprovalRequest` / `ToolApprovalDecision`.
+- `crates/octos-cli/src/api/ui_protocol_approvals.rs` — `PendingApprovalStore`,
+  oneshot response channel, turn-scoped cancellation.
+- `crates/octos-cli/src/api/ui_protocol.rs` — `UiProtocolApprovalRequester`
+  impl, `AppState.approvals`, the `TOOL_APPROVAL_CTX.scope(...)` turn wrapper,
+  and the `approval/respond` dispatch path.
+- `crates/octos-agent/src/tools/coding_tools.rs` — the `request_user_input`
+  codex tool (`request_user_input_body`) whose structured-metadata shape is the
+  graceful-fallback template.
+
+---
+
+## 1. Motivation
+
+octos agents frequently reach a point mid-turn where they must make an
+assumption the user could resolve in one tap: which framework, which target
+environment, which of two ambiguous files, opt-in to a destructive cleanup, and
+so on. Today the agent has two poor options:
+
+1. Ask the question as free assistant prose and hope the user types a usable
+   reply on the next turn. This loses the turn's context, forces the user to
+   read and re-type, and produces unstructured answers the model has to
+   re-parse.
+2. Guess. This is the dominant failure mode behind "the agent did the wrong
+   thing confidently" — the model picks a default because there is no
+   first-class way to surface a bounded choice.
+
+Frontier coding agents (codex, Claude) solve this with a structured
+`AskUserQuestion` tool: the agent emits 1–4 multiple-choice questions, the
+client renders selectable options plus a free-text escape hatch, and the
+selected answer routes straight back into the same turn. octos already has every
+primitive needed to do this — the approval flow is exactly "pause the turn at a
+tool boundary, surface a typed decision point to the client, route the client's
+answer back, resume." AskUserQuestion is **approval + choices + free-text**.
+
+This document specs the Phase-1 implementation: a synchronous tool-block that
+mirrors the approval flow.
+
+## 2. Goals
+
+- Let the agent ask the user a **structured multiple-choice question** mid-turn
+  and receive a structured answer that continues the same turn.
+- Carry 1–4 questions per call; each question has a short `header`, a `question`
+  string, 2–4 `options` (`label` + `description`), and a `multi_select` flag.
+- The client always also offers a free-text "Other" so the user is never boxed
+  in by the agent's options.
+- Reuse the **proven approval machinery** (pending store + oneshot + task-local
+  requester + turn-scoped cancellation) rather than inventing a new turn-state
+  model.
+- **Never hard-block a non-supporting client**: if no capable client is
+  attached, degrade gracefully to structured-metadata + generic text and
+  continue the turn (the `request_user_input` behavior).
+- **Turn-interrupt cancels pending questions**, exactly like approval
+  cancellation.
+
+## 3. Non-Goals
+
+- This is not a generic forms/wizard engine. It is a bounded multiple-choice +
+  free-text question, nothing more.
+- **Turn-suspension** (releasing the turn while the question is outstanding and
+  resuming it from a durable checkpoint when the answer arrives) is explicitly
+  **out of scope for Phase 1**. See §8 (Phase 2 / future work). Phase 1 keeps
+  the turn paused at the tool's await boundary, identical to `approval/requested`.
+- Persisting answers as durable policy ("always pick X") is out of scope.
+- Pipeline human-gate integration (`octos-pipeline` already has
+  `HumanInputType::Choice`) is a separate, already-existing surface; see §7.
+
+## 4. Chosen Approach: Synchronous Tool-Block Mirroring Approvals
+
+### 4.1 Why this shape
+
+The approval flow has already solved the hard problem AskUserQuestion needs:
+**deterministically pausing a turn at a tool boundary, surfacing a typed
+decision point to whichever client is attached, routing the client's reply back
+to the exact waiting tool invocation, and cancelling cleanly on interrupt.**
+The relevant invariants are already documented and tested:
+
+- `approval/requested` (§8 of the protocol spec): "While this is unresolved, the
+  turn remains paused at a deterministic boundary."
+- `turn/interrupt` (`SRV-006`): "drains pending approvals, cancels active work
+  safely, and emits terminal state."
+- `approval/requested` is durable enough for reconnecting clients to render true
+  state (`SRV-010`).
+
+Building AskUserQuestion as a parallel of this flow means we inherit all of that
+machinery and its test coverage. We do **not** redesign turn state, we do not add
+a suspend/resume checkpoint, and we do not introduce a new way for a turn to be
+"alive but waiting." The agent tool simply `await`s a oneshot, exactly as the
+approval-gated tools do today.
+
+The cost of this choice is that the turn holds its execution context (and any
+upstream connection/turn budget) while the user thinks. That is an accepted
+trade-off for Phase 1 and is identical to the existing approval behavior. The
+turn-suspension variant that removes this cost is deferred to Phase 2 (§8).
+
+### 4.2 End-to-end flow
+
+```
+agent loop (turn active)
+  └─ model emits ask_user_question tool call (1–4 questions)
+       └─ ask_user_question tool .execute()
+            ├─ reads USER_QUESTION_CTX task-local (the UserQuestionRequester)
+            │    ├─ if NOT present  → graceful fallback (§4.4): emit
+            │    │     structured_metadata + generic text, return immediately,
+            │    │     turn continues with no answer
+            │    └─ if present → requester.request_user_question(req).await
+            │         (this is the await boundary; the turn is now PAUSED)
+            │
+            │  ── server side (octos-cli) ──
+            │   SessionUserQuestionRequester::request_user_question:
+            │     1. mint question_id, store pending in PendingQuestionStore
+            │        keyed by (session, turn, question_id) with a oneshot Sender
+            │     2. emit user_question/requested notification (structured
+            │        questions + mandatory generic title/body fallback)
+            │     3. .await the oneshot Receiver
+            │
+            │   client renders the question picker (single/multi-select + Other)
+            │   client → user_question/respond { session_id, question_id,
+            │                                     answers, client_note? }
+            │
+            │   server handler:
+            │     - validate session/turn/question_id (typed errors on stale)
+            │     - PendingQuestionStore: take the oneshot Sender, send answers
+            │     - (this resolves the await in request_user_question)
+            │
+            └─ tool .execute() receives answers, returns them as the ToolResult
+       └─ tool result appended to the message history
+  └─ agent loop continues the SAME turn with the answer in context
+```
+
+Turn interrupt path (mirrors approval cancellation): `turn/interrupt` calls
+`PendingQuestionStore::cancel_pending_for_turn`, which drops/cancels each
+pending oneshot. The blocked tool's `await` resolves to a `Cancelled` outcome;
+the tool returns a cancelled result and the turn terminates. The server emits a
+`user_question/cancelled`-equivalent terminal signal (Phase-1 reuses the warning
+/ turn-error path; see §6 test plan).
+
+### 4.3 Type shapes
+
+The wire types live in `octos-core` (the protocol source of truth). Names below
+are the proposed Rust struct/field names; the JSON field names are the
+snake_case serde renames.
+
+Request — emitted by the agent, carried in `user_question/requested`:
+
+```rust
+/// One AskUserQuestion call. 1–4 questions.
+pub struct UserQuestionRequestedEvent {
+    pub session_id: SessionKey,
+    pub topic: Option<String>,          // skip_serializing_if None
+    pub question_id: QuestionId,        // newtype over Uuid, like ApprovalId
+    pub turn_id: TurnId,
+    pub title: String,                  // MANDATORY generic fallback text
+    pub body: String,                   // MANDATORY generic fallback text
+    pub questions: Vec<UserQuestion>,   // 1..=4
+}
+
+pub struct UserQuestion {
+    pub header: String,                 // short label, ≤ 12 chars
+    pub question: String,
+    pub options: Vec<UserQuestionOption>, // 2..=4
+    pub multi_select: bool,
+    pub allow_free_text: bool,          // server forces true: "Other" always offered
+}
+
+pub struct UserQuestionOption {
+    pub label: String,
+    pub description: String,
+}
+```
+
+Response — sent by the client in `user_question/respond`:
+
+```rust
+pub struct UserQuestionRespondParams {
+    pub session_id: SessionKey,
+    pub question_id: QuestionId,
+    pub answers: Vec<UserQuestionAnswer>, // one per question, in order
+    pub client_note: Option<String>,      // optional, audit/display
+}
+
+pub struct UserQuestionAnswer {
+    /// Selected option label(s). Empty when the user only supplied free_text.
+    /// For single-select questions this is 0 or 1 entries; for multi_select,
+    /// 0..N. Labels MUST match the option labels from the request.
+    pub selected_labels: Vec<String>,
+    /// Optional free-text from the "Other" escape hatch.
+    pub free_text: Option<String>,
+}
+```
+
+The agent-facing tool surfaces the same answer shape back to the model as its
+`ToolResult.output` JSON, so the model sees `{ answers: [{ selected_labels,
+free_text }, ...] }`.
+
+Agent-side bridge types in `octos-agent` (mirror `ToolApprovalRequest` /
+`ToolApprovalDecision`):
+
+```rust
+pub struct UserQuestionRequest {
+    pub questions: Vec<UserQuestion>, // validated 1..=4, options 2..=4
+    pub title: String,
+    pub body: String,
+}
+
+pub enum UserQuestionOutcome {
+    Answered(Vec<UserQuestionAnswer>),
+    Cancelled,        // turn interrupted / pending drained
+    Unsupported,      // no capable client; tool degrades to fallback
+}
+
+#[async_trait]
+pub trait UserQuestionRequester: Send + Sync {
+    async fn request_user_question(&self, req: UserQuestionRequest)
+        -> UserQuestionOutcome;
+}
+```
+
+### 4.4 Graceful fallback (no capable client)
+
+If `USER_QUESTION_CTX` is not present in the task-local context (no interactive
+client supporting `user_question.v1` is attached for this turn), the
+`ask_user_question` tool does **not** block. It returns immediately with a
+`request_user_input`-style result:
+
+- `success: true`
+- `output`: a JSON object describing the question(s) and noting that no
+  synchronous host response channel is attached.
+- `structured_metadata`: `{ "codex_tool": "ask_user_question", "request": {…},
+  "host_response_channel": "not_attached" }`.
+
+This is exactly the degradation the existing `request_user_input` tool performs
+(`request_user_input_body` in `coding_tools.rs`). The model receives the
+fallback result, sees that no answer is available, and continues the turn (it
+can fall back to its own best guess and state the assumption in prose). A
+non-supporting client therefore never sees a hung turn.
+
+The server is also responsible for the wire-level fallback: a client that does
+NOT negotiate `user_question.v1` but is otherwise attached must still receive an
+actionable rendering. The `user_question/requested` event carries **mandatory**
+generic `title`/`body` text (just like `approval/requested`) so that a client
+which does not understand the structured `questions` field can render the
+generic text and the user can still respond (e.g. via free-text). Unknown fields
+fall back to generic rendering and stay actionable.
+
+## 5. Component / File Checklist (Phase-B implementation)
+
+This is the implementation map for the follow-on coding stack. It is not built
+in this docs-only change.
+
+**octos-core** (protocol source of truth):
+
+- `crates/octos-core/src/ui_protocol.rs`:
+  - `QuestionId` newtype (mirror `ApprovalId`).
+  - `UserQuestion`, `UserQuestionOption`, `UserQuestionRequestedEvent`.
+  - `UserQuestionRespondParams`, `UserQuestionRespondResult`,
+    `UserQuestionAnswer`.
+  - Add `user_question/respond` to `UI_PROTOCOL_COMMAND_METHODS`.
+  - Add `user_question/requested` (and any terminal/cancelled variant) to
+    `UI_PROTOCOL_NOTIFICATION_METHODS`.
+  - Add `user_question.v1` to the known feature registry surfaced via
+    `supported_features` in `UiProtocolCapabilities`.
+  - Add the new method/notification + a representative wire payload to the
+    golden contract tests (gated by accepted UPCR-2026-023).
+
+**octos-agent** (tool + bridge):
+
+- `crates/octos-agent/src/tools/mod.rs`:
+  - `UserQuestionRequest`, `UserQuestionOutcome`, `UserQuestionRequester`
+    trait, and the `USER_QUESTION_CTX` task-local (mirror
+    `ToolApprovalRequester` / `TOOL_APPROVAL_CTX`).
+- `crates/octos-agent/src/tools/coding_tools.rs` (or a dedicated module):
+  - `AskUserQuestionTool` implementing `Tool`; `spec()` declares the
+    `questions[]` schema (1–4, `header`/`question`/`options`/`multi_select`);
+    `execute()` validates, reads `USER_QUESTION_CTX`, blocks on the requester,
+    falls back when absent (§4.4).
+- `crates/octos-agent/src/tools/registry.rs`: register `AskUserQuestionTool`
+  (mirror `registry.register(RequestUserInputTool)`).
+- `crates/octos-agent/src/role_template.rs`: add `ask_user_question` to the
+  coding tool roster alongside `request_user_input`.
+- Tool policy: ensure `ask_user_question` is allowed under the relevant
+  groups/provider policy (`tools/policy.rs`).
+
+**octos-cli** (server: store + handler + requester + wiring):
+
+- `crates/octos-cli/src/api/ui_protocol_approvals.rs` (or a sibling
+  `ui_protocol_user_questions.rs`): `PendingQuestionStore` (mirror
+  `PendingApprovalStore`): pending map keyed by `(session, turn, question_id)`,
+  oneshot `Sender`, `register_pending`, `take`/respond, and
+  `cancel_pending_for_turn`.
+- `crates/octos-cli/src/api/ui_protocol.rs`:
+  - `SessionUserQuestionRequester` impl of `UserQuestionRequester` (mirror
+    `UiProtocolApprovalRequester`): mint id, store pending, emit
+    `user_question/requested`, await oneshot.
+  - `AppState.user_questions: PendingQuestionStore` field (mirror
+    `AppState.approvals`).
+  - Scope `USER_QUESTION_CTX` around the turn (alongside the existing
+    `TOOL_APPROVAL_CTX.scope(...)` wrapper).
+  - `user_question/respond` dispatch handler: validate, resolve oneshot,
+    return result; typed errors on stale/unknown/closed.
+  - `turn/interrupt`: also drain `user_questions.cancel_pending_for_turn`.
+  - `session/hydrate`: include pending questions for reconnecting clients
+    (mirror `pending_approvals`).
+  - Capability negotiation: advertise `user_question.v1` in
+    `supported_features` when the client requests it.
+
+**octos-tui** (rendering):
+
+- `crates/octos-tui/src/store.rs` + `src/app.rs` (mirror the approval-card
+  handling): render the question picker — one card per question, single-select
+  vs multi-select, each option as a selectable line, plus an "Other" free-text
+  entry. Send `user_question/respond` with the correct `question_id` and
+  per-question `answers`. Handle stale/expired as decided/expired (mirror the
+  approval-cancelled handling).
+
+## 6. Test Plan
+
+Follow the project RED → GREEN → REFACTOR cycle. Tests by layer:
+
+**octos-core (golden contract):**
+
+- `user_question/respond` is in `UI_PROTOCOL_COMMAND_METHODS`;
+  `user_question/requested` is in `UI_PROTOCOL_NOTIFICATION_METHODS`.
+- `user_question.v1` is in the known-feature registry.
+- Representative `UserQuestionRequestedEvent` / `UserQuestionRespondParams`
+  serialize to the expected wire JSON (snake_case, mandatory `title`/`body`,
+  `questions[]` with `header`/`question`/`options`/`multi_select`/
+  `allow_free_text`).
+- Round-trip: a generic-fallback event with an unknown extra field still
+  deserializes and keeps `title`/`body`.
+
+**octos-agent (tool):**
+
+- `should_emit_structured_metadata_when_no_requester` — with no
+  `USER_QUESTION_CTX`, `execute()` returns the fallback result with
+  `codex_tool = "ask_user_question"` and `host_response_channel =
+  "not_attached"` (mirrors `request_user_input_emits_structured_metadata_event`).
+- `should_block_and_return_answers_when_requester_present` — with a recording
+  requester scoped via `USER_QUESTION_CTX`, `execute()` awaits and returns the
+  injected answers.
+- `should_reject_when_questions_out_of_range` — 0 or >4 questions, or an option
+  count outside 2..=4, is a tool input error.
+
+**octos-cli (server + e2e):**
+
+- `should_emit_user_question_requested_with_structured_questions`.
+- `should_resume_tool_when_user_question_respond_matches`.
+- `should_reject_stale_user_question_respond_with_typed_error`.
+- `should_cancel_pending_questions_on_turn_interrupt` (mirror the approval-drain
+  test).
+- `should_replay_pending_user_question_on_hydrate` (reconnect path).
+- `should_degrade_to_generic_when_client_lacks_capability`.
+
+**octos-tui:**
+
+- Render snapshot of single-select and multi-select cards + the "Other" entry.
+- Reducer test: `user_question/respond` carries the right `question_id` and
+  per-question `answers`; stale renders as decided/expired.
+
+## 7. Alternatives Considered
+
+**A. Turn-suspension (Phase 2 candidate).** Instead of holding the turn at the
+tool await boundary, release the turn, persist a checkpoint, and resume from it
+when `user_question/respond` arrives. This frees the execution context and any
+upstream connection/budget while the user thinks, and degrades better for slow
+human responses. Rejected for Phase 1 because it requires a durable turn-state
+checkpoint/resume mechanism octos does not yet have; that is real new turn-state
+machinery, not a reuse of the approval flow. Deferred to §8.
+
+**B. Pipeline human-gate.** `octos-pipeline` already has a human-input gate with
+`HumanInputType::Choice` (`crates/octos-pipeline/src/human_gate.rs`, re-exported
+from `lib.rs`). That solves a structurally similar problem — a pipeline node
+pauses for a typed human choice. It was considered as the home for this feature
+but rejected for the interactive-chat path: the pipeline gate is node-scoped and
+checkpoint-based (it fits the DOT-graph pipeline engine), whereas the chat agent
+loop needs a mid-turn, in-place block that the existing approval flow already
+provides. The two can converge later (the pipeline `Choice` gate and the chat
+AskUserQuestion could share the `octos-core` wire types), but Phase 1 keeps the
+chat path on the approval-mirror mechanism.
+
+**C. Free-text only (status quo `request_user_input`).** The existing codex
+`request_user_input` tool already emits a structured-metadata request but has no
+synchronous response channel and no structured options. AskUserQuestion is the
+superset: it keeps the same graceful fallback (§4.4) but adds the bounded
+options, multi-select, and the synchronous answer route. We keep
+`request_user_input` as-is; AskUserQuestion is the new, richer tool.
+
+## 8. Phase 2 / Future Work (not specced here)
+
+- **Turn-suspension variant** (Alternative A): release the turn while a question
+  is outstanding and resume from a durable checkpoint when the answer arrives.
+  Requires turn-state checkpoint/resume infrastructure. Tracked as a possible
+  future UPCR; not part of `user_question.v1`.
+- **Durable answer policy** ("remember this choice").
+- **Convergence with the pipeline `HumanInputType::Choice` gate** on shared
+  `octos-core` wire types.


### PR DESCRIPTION
**Spec/design only — no code.** Locks the UI-Protocol contract for a codex-style `AskUserQuestion` in octos BEFORE implementation (Phase A of the feature). Please review the contract here; the implementation (octos backend + agent tool, then octos-tui rendering) follows as separate PRs against this contract.

## What this specs
The octos agent asks the user a structured multiple-choice question mid-turn; the client renders selectable options + a free-text 'Other'; the answer routes back and the turn continues. **Mechanism: synchronous tool-block, mirroring the proven approval flow** (`approval/requested` + `approval/respond` + pending-store + oneshot + task-local requester + turn-scoped cancellation) — AskUserQuestion = 'approval + choices + free-text'. No new turn-state, no turn serialization.

## Contract added
- **Event `user_question/requested`** (§8): mandatory generic `title`/`body` fallback + structured `questions` (1–4, each `header` ≤12 chars, `question`, 2–4 `options` of `label`+`description`, `multi_select`, `allow_free_text`). Pauses the turn at the same deterministic boundary as `approval/requested`.
- **Command `user_question/respond`** (§7): `session_id`, `question_id`, `answers` (per-question `selected_labels` + optional `free_text`), optional `client_note`.
- **Capability `user_question.v1`** (advertised via `supported_features`). Clients without it get the agent tool's structured-metadata/text fallback, so the turn never hard-blocks.
- **UPCR-2026-023** change-control doc + §6 catalog entries.
- Requirement rows: **SRV-041**, **APP-037**, **TUI-037** (mirror the approval rows).

## Design doc
`docs/design/ask-user-question-2026-06-03.md` — rationale, end-to-end flow, type shapes, graceful fallback, alternatives (turn-suspension as a possible Phase 2; pipeline `HumanInputType::Choice` as a separate workflow-scoped mechanism), Phase-B component/file checklist, and test plan.

Files: 4 `api/*.md` + the design doc + the UPCR doc (docs-only).