### PR TITLE
feat(agent): AskUserQuestion backend + tool (UPCR-2026-023, server slice)

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -89,12 +89,14 @@ fn should_auto_send_tool_files(
 /// - `delegate_task` (`tools/delegate.rs`)
 /// - `search` (`tools/deep_search.rs`), `deep_crawl` (`tools/site_crawl.rs`)
 /// - `synthesize_research` (`tools/synthesize_research.rs`)
-/// - `ask_user_question` (`tools/ask_user_question.rs`) — a human-wait tool:
-///   it blocks on the requester until the client answers, exactly as the
-///   approval gate blocks. It must keep the long ceiling at the batch level
-///   (and is fully timeout-exempt at the registry dispatch boundary via
-///   `Tool::blocks_on_human_input`), so the short interactive default never
-///   kills the receiver and leaks the pending question store entry (#1).
+///
+/// NOTE: human-wait tools (`ask_user_question`) are deliberately NOT in this
+/// list. A batch containing one gets NO batch-level timeout at all (see
+/// [`compute_batch_timeout_secs`] / `any_human_wait`), so the long-vs-short
+/// classification never applies to it — wrapping it in even the 1800s ceiling
+/// would detach the still-running tool task and leak the pending question
+/// (UPCR-2026-023). They remain fully timeout-exempt at the registry dispatch
+/// boundary too, via `Tool::blocks_on_human_input`.
 const LONG_RUNNING_TOOLS: &[&str] = &[
     "shell",
     "bash",
@@ -107,7 +109,6 @@ const LONG_RUNNING_TOOLS: &[&str] = &[
     "deep_crawl",
     "site_crawl",
     "synthesize_research",
-    "ask_user_question",
 ];
 
 /// Whether `name` is a genuinely long-running tool (keeps the 1800s default).
@@ -115,9 +116,25 @@ fn is_long_running_tool(name: &str) -> bool {
     LONG_RUNNING_TOOLS.contains(&name)
 }
 
-/// Compute the timeout (seconds) for a parallel/serial tool batch.
+/// Compute the timeout for a parallel/serial tool batch.
+///
+/// Returns `None` when the batch must run with NO finite batch-level timeout,
+/// and `Some(secs)` otherwise.
 ///
 /// Behaviour:
+/// - **Human-wait batch (UPCR-2026-023):** when `any_human_wait` is `true`
+///   (some tool in the batch reports [`crate::tools::Tool::blocks_on_human_input`],
+///   e.g. `ask_user_question`), return `None`. Such a batch MUST NOT be wrapped
+///   in `tokio::time::timeout`: a human may legitimately take longer than any
+///   finite ceiling, and firing the ceiling would detach the still-running tool
+///   task (its `JoinHandle` dropped, not awaited), so its
+///   `PendingQuestionWaiterGuard` never drops → the pending question leaks and
+///   is later replayed as a stale prompt after the turn moved on. Cleanup for a
+///   human-wait batch comes from the user answering (resolves the oneshot) or a
+///   turn interrupt/abort (the interrupt drains pending questions and aborts the
+///   turn task), NEVER from the batch timeout. NON-human-wait tools sharing the
+///   batch keep their own per-tool registry timeouts, applied INSIDE each tool's
+///   registry dispatch — unaffected by removing this outer wrap.
 /// - When the LLM requested a per-call `timeout_secs` (`llm_requested > 0`),
 ///   honour it: clamp to [`MAX_TOOL_TIMEOUT_SECS`] and floor at the batch's
 ///   default (so an explicit request never makes a batch flakier than its
@@ -128,20 +145,25 @@ fn is_long_running_tool(name: &str) -> bool {
 ///   shorter `interactive_default`.
 fn compute_batch_timeout_secs(
     tool_names: &[&str],
+    any_human_wait: bool,
     llm_requested: u64,
     config_tool_timeout: u64,
     interactive_default: u64,
-) -> u64 {
+) -> Option<u64> {
+    // A human-wait batch is unbounded at the batch layer — see the doc above.
+    if any_human_wait {
+        return None;
+    }
     let batch_default = if tool_names.iter().any(|n| is_long_running_tool(n)) {
         config_tool_timeout
     } else {
         interactive_default
     };
-    if llm_requested > 0 {
+    Some(if llm_requested > 0 {
         llm_requested.min(MAX_TOOL_TIMEOUT_SECS).max(batch_default)
     } else {
         batch_default
-    }
+    })
 }
 
 /// Issue #896 — spawn_only filename propagation (Layer 1).
@@ -1884,19 +1906,34 @@ impl Agent {
             .filter_map(|tc| tc.arguments.get("timeout_secs").and_then(|v| v.as_u64()))
             .max()
             .unwrap_or(0);
+        // UPCR-2026-023: a batch containing a human-wait tool
+        // (`ask_user_question`) must run with NO finite batch timeout — the
+        // human may take arbitrarily long, and a fired ceiling would detach the
+        // still-running tool task and leak the pending question (replayed later
+        // as a stale prompt). `compute_batch_timeout_secs` returns `None` for
+        // such a batch; the dispatch paths below branch on that. NON-human-wait
+        // peers keep their per-tool registry timeouts (applied inside each
+        // tool's registry dispatch), unaffected by skipping this outer wrap.
+        let any_human_wait = response
+            .tool_calls
+            .iter()
+            .any(|tc| self.tools.blocks_on_human_input(&tc.name));
+
         // mini5 soak fix: when the LLM omits `timeout_secs`, a batch of only
         // fast/interactive tools (e.g. `glob`, `list_dir`) defaults to the
         // short `default_interactive_tool_timeout_secs` instead of inheriting
         // the 1800s ceiling that hung the turn. A batch containing any
         // genuinely long-running tool keeps the long default; an explicit
-        // LLM-requested timeout is still honoured (clamped + floored).
+        // LLM-requested timeout is still honoured (clamped + floored). A
+        // human-wait batch yields `None` (no batch timeout at all).
         let tool_timeout_secs = compute_batch_timeout_secs(
             &tool_names,
+            any_human_wait,
             llm_requested_timeout,
             self.config.tool_timeout_secs,
             self.config.default_interactive_tool_timeout_secs,
         );
-        let tool_timeout = Duration::from_secs(tool_timeout_secs);
+        let tool_timeout = tool_timeout_secs.map(Duration::from_secs);
 
         let results: Vec<ToolCallResult> = if any_exclusive {
             // Serial admission: run each tool in LLM call order, bail out of
@@ -1925,15 +1962,33 @@ impl Agent {
                 })
                 .collect();
 
-            match tokio::time::timeout(tool_timeout, futures::future::join_all(handles)).await {
+            // UPCR-2026-023: a human-wait batch (`tool_timeout == None`) awaits
+            // `join_all` DIRECTLY, with no `tokio::time::timeout` wrap, so the
+            // human-wait tool task is never detached by a fired ceiling. It is
+            // unblocked by the user answering or by a turn interrupt/abort
+            // (which drains the pending question). All other batches keep the
+            // finite ceiling. `Ok(Vec<JoinResult>)` is mapped identically in
+            // both arms.
+            let join_outcome = match tool_timeout {
+                Some(dur) => tokio::time::timeout(dur, futures::future::join_all(handles))
+                    .await
+                    .map_err(|_| ()),
+                None => Ok(futures::future::join_all(handles).await),
+            };
+
+            match join_outcome {
                 Ok(results) => results
                     .into_iter()
                     .zip(response.tool_calls.iter())
                     .map(|(r, tc)| r.unwrap_or_else(|e| panic_result(tc, &e.to_string())))
                     .collect(),
-                Err(_) => {
+                Err(()) => {
+                    // Only reachable when `tool_timeout` was `Some` (a `None`
+                    // human-wait batch always yields `Ok`), so the seconds are
+                    // present for the diagnostic / synthetic-result message.
+                    let elapsed_secs = tool_timeout_secs.unwrap_or(0);
                     tracing::error!(
-                        timeout_secs = tool_timeout_secs,
+                        timeout_secs = elapsed_secs,
                         tool_count = response.tool_calls.len(),
                         tools = %tool_names.join(", "),
                         "tool execution timed out -- spawned tasks continue running for cleanup"
@@ -1945,7 +2000,7 @@ impl Agent {
                             role: MessageRole::Tool,
                             content: format!(
                                 "Tool '{}' timed out after {} seconds",
-                                tc.name, tool_timeout_secs
+                                tc.name, elapsed_secs
                             ),
                             media: vec![],
                             tool_calls: None,
@@ -2053,13 +2108,22 @@ impl Agent {
     /// single-call [`JoinHandle`] in `tokio::time::timeout`. A timeout on any
     /// one call fails that call and cascades to its peers the same way a
     /// regular error does.
+    ///
+    /// UPCR-2026-023: when the batch contains a human-wait tool the caller
+    /// passes `tool_timeout == None`; every call in the batch is then awaited
+    /// DIRECTLY with no `tokio::time::timeout` wrap, so the human-wait tool is
+    /// never detached by a fired ceiling. NON-human-wait peers in the same
+    /// (now-unbounded) batch keep their own per-tool registry timeouts, applied
+    /// inside `spawn_tool_task` → `ToolRegistry::execute_with_context`. Cleanup
+    /// of the human-wait call comes from the user answering or a turn
+    /// interrupt/abort draining the pending question — never from this wrap.
     async fn execute_serial_batch(
         &self,
         response: &ChatResponse,
         explicit_send_file_requested: bool,
         turn_attachment_ctx: &crate::tools::TurnAttachmentContext,
-        tool_timeout: Duration,
-        tool_timeout_secs: u64,
+        tool_timeout: Option<Duration>,
+        tool_timeout_secs: Option<u64>,
     ) -> Vec<ToolCallResult> {
         let mut results: Vec<ToolCallResult> = Vec::with_capacity(response.tool_calls.len());
         let mut cancelled = false;
@@ -2080,7 +2144,18 @@ impl Agent {
             let handle =
                 self.spawn_tool_task(tool_call, explicit_send_file_requested, turn_attachment_ctx);
 
-            let outcome = match tokio::time::timeout(tool_timeout, handle).await {
+            // `None` (human-wait batch) awaits the handle directly — no finite
+            // wrap — so the human-wait call cannot be detached by a ceiling.
+            // The `Err(())` arm is unreachable in that case.
+            let join_outcome = match tool_timeout {
+                Some(dur) => match tokio::time::timeout(dur, handle).await {
+                    Ok(joined) => Ok(joined),
+                    Err(_) => Err(()),
+                },
+                None => Ok(handle.await),
+            };
+
+            let outcome = match join_outcome {
                 Ok(Ok(r)) => r,
                 Ok(Err(e)) => {
                     tracing::warn!(
@@ -2090,9 +2165,10 @@ impl Agent {
                     );
                     panic_result(tool_call, &e.to_string())
                 }
-                Err(_) => {
+                Err(()) => {
+                    let elapsed_secs = tool_timeout_secs.unwrap_or(0);
                     tracing::error!(
-                        timeout_secs = tool_timeout_secs,
+                        timeout_secs = elapsed_secs,
                         tool = %tool_call.name,
                         tool_id = %tool_call.id,
                         "serial tool execution timed out"
@@ -2102,7 +2178,7 @@ impl Agent {
                             role: MessageRole::Tool,
                             content: format!(
                                 "Tool '{}' timed out after {} seconds",
-                                tool_call.name, tool_timeout_secs
+                                tool_call.name, elapsed_secs
                             ),
                             media: vec![],
                             tool_calls: None,
@@ -2392,10 +2468,6 @@ mod tests {
             "deep_crawl",
             "search",
             "synthesize_research",
-            // A human-wait tool must never be killed by the short
-            // interactive batch default — it blocks on the requester exactly
-            // like `shell`'s approval gate does (#1).
-            "ask_user_question",
         ] {
             assert!(
                 is_long_running_tool(name),
@@ -2405,18 +2477,80 @@ mod tests {
     }
 
     #[test]
-    fn batch_with_ask_user_question_keeps_the_long_ceiling() {
-        // A batch containing `ask_user_question` (a human-wait tool) must keep
-        // the long config default when the LLM omits `timeout_secs`, never the
-        // short interactive default that would kill the receiver and leak the
-        // pending store entry. Mirrors `shell`'s batch-level exemption.
+    fn human_wait_tool_is_not_in_long_running_set() {
+        // UPCR-2026-023: `ask_user_question` is NOT classified long-running.
+        // A batch containing it gets NO batch timeout at all (the
+        // `any_human_wait` short-circuit), so the long-vs-short ceiling never
+        // applies — wrapping it in even the 1800s ceiling would detach the
+        // still-running tool task and leak the pending question.
+        assert!(
+            !is_long_running_tool("ask_user_question"),
+            "ask_user_question must be handled by the any_human_wait no-timeout \
+             path, not the long-running ceiling"
+        );
+    }
+
+    #[test]
+    fn batch_with_human_wait_tool_has_no_batch_timeout() {
+        // UPDATED for UPCR-2026-023 (was `batch_with_ask_user_question_keeps_
+        // the_long_ceiling`, which asserted 1800s). A batch containing a
+        // human-wait tool must run with NO finite batch timeout: the previous
+        // 1800s ceiling, while long, would still eventually FIRE and detach the
+        // still-running `ask_user_question` task (its `JoinHandle` dropped, not
+        // awaited), so its `PendingQuestionWaiterGuard` never drops → the
+        // pending question leaks and is later replayed as a stale prompt. The
+        // human may take arbitrarily long; cleanup comes from the user
+        // answering or a turn interrupt/abort, never from the batch timeout.
         let secs = compute_batch_timeout_secs(
             &["ask_user_question"],
+            /* any_human_wait */ true,
             /* llm_requested */ 0,
             /* config_tool_timeout */ 1800,
             /* interactive_default */ 120,
         );
-        assert_eq!(secs, 1800);
+        assert_eq!(
+            secs, None,
+            "a human-wait batch must yield None (no finite batch timeout)"
+        );
+    }
+
+    #[test]
+    fn human_wait_batch_has_no_timeout_even_with_llm_requested_secs() {
+        // The `any_human_wait` short-circuit wins over an explicit
+        // LLM-requested `timeout_secs`: a human-wait tool is unbounded at the
+        // batch layer regardless of what the LLM asked for, so a bogus tiny or
+        // huge `timeout_secs` cannot reintroduce the detach/leak.
+        let secs = compute_batch_timeout_secs(
+            &["ask_user_question"],
+            /* any_human_wait */ true,
+            /* llm_requested */ 30,
+            /* config_tool_timeout */ 1800,
+            /* interactive_default */ 120,
+        );
+        assert_eq!(secs, None);
+    }
+
+    #[test]
+    fn mixed_human_wait_batch_is_unbounded_normal_tool_keeps_per_tool_timeout() {
+        // A mixed batch (human-wait + a normal/long-running tool) is unbounded
+        // at the BATCH layer (None). The normal tool does NOT lose its bound —
+        // its per-tool registry timeout is applied INSIDE the tool's own
+        // registry dispatch (`ToolRegistry::execute_with_context`), which is
+        // untouched by removing the outer batch wrap. So the human-wait call
+        // waits for the human while the `shell` peer is still bounded by its
+        // registry-level ceiling.
+        let secs = compute_batch_timeout_secs(
+            &["ask_user_question", "shell"],
+            /* any_human_wait */ true,
+            /* llm_requested */ 0,
+            /* config_tool_timeout */ 1800,
+            /* interactive_default */ 120,
+        );
+        assert_eq!(
+            secs, None,
+            "a mixed human-wait batch is unbounded at the batch layer; \
+             normal peers keep their per-tool registry timeouts"
+        );
     }
 
     #[test]
@@ -2445,11 +2579,12 @@ mod tests {
         // 1800s tool ceiling that hung the turn.
         let secs = compute_batch_timeout_secs(
             &["list_dir", "glob"],
+            /* any_human_wait */ false,
             /* llm_requested */ 0,
             /* config_tool_timeout */ 1800,
             /* interactive_default */ 120,
         );
-        assert_eq!(secs, 120);
+        assert_eq!(secs, Some(120));
     }
 
     #[test]
@@ -2458,11 +2593,12 @@ mod tests {
         // config-default timeout when the LLM omits `timeout_secs`.
         let secs = compute_batch_timeout_secs(
             &["glob", "shell"],
+            /* any_human_wait */ false,
             /* llm_requested */ 0,
             /* config_tool_timeout */ 1800,
             /* interactive_default */ 120,
         );
-        assert_eq!(secs, 1800);
+        assert_eq!(secs, Some(1800));
     }
 
     #[test]
@@ -2472,16 +2608,22 @@ mod tests {
         // fast-only batch the floor is the interactive default, not 1800.
         let secs = compute_batch_timeout_secs(
             &["glob"],
+            /* any_human_wait */ false,
             /* llm_requested */ 300,
             /* config_tool_timeout */ 1800,
             /* interactive_default */ 120,
         );
-        assert_eq!(secs, 300);
+        assert_eq!(secs, Some(300));
 
         // Over-the-cap request is clamped to MAX_TOOL_TIMEOUT_SECS.
-        let capped =
-            compute_batch_timeout_secs(&["glob"], /* llm_requested */ 99_999, 1800, 120);
-        assert_eq!(capped, MAX_TOOL_TIMEOUT_SECS);
+        let capped = compute_batch_timeout_secs(
+            &["glob"],
+            /* any_human_wait */ false,
+            /* llm_requested */ 99_999,
+            1800,
+            120,
+        );
+        assert_eq!(capped, Some(MAX_TOOL_TIMEOUT_SECS));
     }
 
     #[test]
@@ -2490,11 +2632,12 @@ mod tests {
         // LLM-requested value cannot make the batch flakier than baseline.
         let secs = compute_batch_timeout_secs(
             &["glob"],
+            /* any_human_wait */ false,
             /* llm_requested */ 5,
             /* config_tool_timeout */ 1800,
             /* interactive_default */ 120,
         );
-        assert_eq!(secs, 120);
+        assert_eq!(secs, Some(120));
     }
 
     #[test]
@@ -2503,10 +2646,11 @@ mod tests {
         // behaviour preserved).
         let secs = compute_batch_timeout_secs(
             &["shell"],
+            /* any_human_wait */ false,
             /* llm_requested */ 10,
             /* config_tool_timeout */ 1800,
             /* interactive_default */ 120,
         );
-        assert_eq!(secs, 1800);
+        assert_eq!(secs, Some(1800));
     }
 }

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -89,6 +89,12 @@ fn should_auto_send_tool_files(
 /// - `delegate_task` (`tools/delegate.rs`)
 /// - `search` (`tools/deep_search.rs`), `deep_crawl` (`tools/site_crawl.rs`)
 /// - `synthesize_research` (`tools/synthesize_research.rs`)
+/// - `ask_user_question` (`tools/ask_user_question.rs`) — a human-wait tool:
+///   it blocks on the requester until the client answers, exactly as the
+///   approval gate blocks. It must keep the long ceiling at the batch level
+///   (and is fully timeout-exempt at the registry dispatch boundary via
+///   `Tool::blocks_on_human_input`), so the short interactive default never
+///   kills the receiver and leaks the pending question store entry (#1).
 const LONG_RUNNING_TOOLS: &[&str] = &[
     "shell",
     "bash",
@@ -101,6 +107,7 @@ const LONG_RUNNING_TOOLS: &[&str] = &[
     "deep_crawl",
     "site_crawl",
     "synthesize_research",
+    "ask_user_question",
 ];
 
 /// Whether `name` is a genuinely long-running tool (keeps the 1800s default).
@@ -2385,12 +2392,31 @@ mod tests {
             "deep_crawl",
             "search",
             "synthesize_research",
+            // A human-wait tool must never be killed by the short
+            // interactive batch default — it blocks on the requester exactly
+            // like `shell`'s approval gate does (#1).
+            "ask_user_question",
         ] {
             assert!(
                 is_long_running_tool(name),
                 "{name} should be classified long-running"
             );
         }
+    }
+
+    #[test]
+    fn batch_with_ask_user_question_keeps_the_long_ceiling() {
+        // A batch containing `ask_user_question` (a human-wait tool) must keep
+        // the long config default when the LLM omits `timeout_secs`, never the
+        // short interactive default that would kill the receiver and leak the
+        // pending store entry. Mirrors `shell`'s batch-level exemption.
+        let secs = compute_batch_timeout_secs(
+            &["ask_user_question"],
+            /* llm_requested */ 0,
+            /* config_tool_timeout */ 1800,
+            /* interactive_default */ 120,
+        );
+        assert_eq!(secs, 1800);
     }
 
     #[test]

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -157,9 +157,9 @@ pub use task_supervisor::{
     TaskSupervisor, TerminalEvent, TerminalOutcome, parse_alternatives,
 };
 pub use tools::{
-    ActivateToolsTool, BackgroundResultKind, BackgroundResultPayload, BrowserTool,
-    CheckBackgroundTasksTool, CheckWorkspaceContractTool, ConcurrencyClass, ConfigureToolTool,
-    DEFAULT_DISPATCH_TIMEOUT_SECS, DEFAULT_HTTP_CONNECT_TIMEOUT_SECS,
+    ActivateToolsTool, AskUserQuestionTool, BackgroundResultKind, BackgroundResultPayload,
+    BrowserTool, CheckBackgroundTasksTool, CheckWorkspaceContractTool, ConcurrencyClass,
+    ConfigureToolTool, DEFAULT_DISPATCH_TIMEOUT_SECS, DEFAULT_HTTP_CONNECT_TIMEOUT_SECS,
     DEFAULT_HTTP_READ_TIMEOUT_SECS, DELEGATED_DENY_GROUP, DELEGATION_METRIC, DeepSearchTool,
     DelegateTool, DelegationEvent, DelegationOutcome, DepthBudget, DiffEditTool,
     DispatchContextContract, DispatchOutcome, DispatchRequest, DispatchResponse, EditFileTool,
@@ -168,7 +168,8 @@ pub use tools::{
     RecallMemoryTool, RobotToolRegistry, SaveMemoryTool, SendFileTool, SharedBackend, ShellTool,
     SpawnTool, StdioMcpAgent, SynthesizeResearchTool, Tool, ToolApprovalDecision,
     ToolApprovalRequest, ToolApprovalRequester, ToolConfigStore, ToolPolicy, ToolRegistry,
-    ToolResult, TurnAttachmentContext, WebFetchTool, WebSearchTool, WriteFileTool,
+    ToolResult, TurnAttachmentContext, UserQuestionOutcome, UserQuestionRequest,
+    UserQuestionRequester, WebFetchTool, WebSearchTool, WriteFileTool,
     admin::{AdminApiContext, register_admin_api_tools},
     build_backend_from_config, build_delegated_child_policy, build_dispatch_event_payload,
     dispatch_with_metrics, install_robot_registry, keep_tool_in_slides_session, record_dispatch,

--- a/crates/octos-agent/src/role_template.rs
+++ b/crates/octos-agent/src/role_template.rs
@@ -85,6 +85,7 @@ pub const APPROVAL_NEVER: &str = "never";
 /// from inside a detached subagent.
 pub(crate) const SPAWN_BUILTIN_TOOLS: &[&str] = &[
     "apply_patch",
+    "ask_user_question",
     "bash",
     "browser",
     "check_workspace_contract",

--- a/crates/octos-agent/src/tools/ask_user_question.rs
+++ b/crates/octos-agent/src/tools/ask_user_question.rs
@@ -228,6 +228,20 @@ impl Tool for AskUserQuestionTool {
         &["code"]
     }
 
+    /// This tool BLOCKS on the human until the client answers via
+    /// `user_question/respond` (the `request_user_question` await below),
+    /// exactly as the approval gate blocks on the approval requester. It must
+    /// therefore be exempt from the dispatch-boundary timeout: a human may
+    /// take longer than any finite ceiling, and firing the Gap-3.3 timeout
+    /// would drop the requester's receiver and leak the pending question
+    /// store entry forever. The turn-interrupt drain is the correct
+    /// cancellation path (resolves the waiter as `Cancelled`). See
+    /// `ToolRegistry::execute_with_context` and the `LONG_RUNNING_TOOLS`
+    /// batch-level exemption in `agent::execution`.
+    fn blocks_on_human_input(&self) -> bool {
+        true
+    }
+
     fn input_schema(&self) -> Value {
         json!({
             "type": "object",
@@ -296,6 +310,10 @@ impl Tool for AskUserQuestionTool {
         };
 
         let (title, body) = fallback_title_body(&questions);
+        // Keep a copy of the parsed questions so the `Unsupported` fallback
+        // (a requester that could not surface the prompt) can describe the
+        // REAL questions even after `request` is moved into the requester (#6).
+        let questions_for_fallback = questions.clone();
         let request = UserQuestionRequest {
             questions,
             title,
@@ -338,8 +356,13 @@ impl Tool for AskUserQuestionTool {
             }),
             // A requester was attached but reported it could not surface the
             // question (e.g. wire delivery failed). Degrade like the no-context
-            // path so the turn never hard-blocks.
-            UserQuestionOutcome::Unsupported => Ok(unsupported_fallback_result(args, &[])),
+            // path so the turn never hard-blocks — and describe the ACTUAL
+            // parsed questions (carried on `request.questions`) so the
+            // structured-metadata/text fallback reflects the real prompt
+            // rather than an empty one (#6).
+            UserQuestionOutcome::Unsupported => {
+                Ok(unsupported_fallback_result(args, &questions_for_fallback))
+            }
         }
     }
 }
@@ -388,6 +411,17 @@ mod tests {
     impl UserQuestionRequester for CancellingRequester {
         async fn request_user_question(&self, _request: Req) -> UserQuestionOutcome {
             UserQuestionOutcome::Cancelled
+        }
+    }
+
+    /// A requester that was attached but could not surface the question
+    /// (wire delivery failed). Exercises the `Unsupported` fallback arm.
+    struct UnsupportedRequester;
+
+    #[async_trait]
+    impl UserQuestionRequester for UnsupportedRequester {
+        async fn request_user_question(&self, _request: Req) -> UserQuestionOutcome {
+            UserQuestionOutcome::Unsupported
         }
     }
 
@@ -459,6 +493,33 @@ mod tests {
         assert!(!result.success);
         let output: Value = serde_json::from_str(&result.output).expect("output json");
         assert_eq!(output["status"], json!("cancelled"));
+    }
+
+    #[tokio::test]
+    async fn unsupported_fallback_describes_the_real_questions() {
+        // A requester reported `Unsupported` (wire delivery failed). The
+        // structured-metadata fallback must describe the ACTUAL parsed
+        // questions, not an empty prompt (#6).
+        let requester_dyn: Arc<dyn UserQuestionRequester> = Arc::new(UnsupportedRequester);
+        let tool = AskUserQuestionTool::new();
+        let args = one_valid_question();
+        let result = USER_QUESTION_CTX
+            .scope(requester_dyn, async move { tool.execute(&args).await })
+            .await
+            .expect("unsupported degrades to fallback ok");
+        assert!(result.success);
+        let output: Value = serde_json::from_str(&result.output).expect("output json");
+        // The fallback title is the single question's text — proving the real
+        // questions reached the fallback rather than the empty `&[]` slice.
+        assert_eq!(
+            output["title"],
+            json!("Which web framework should I scaffold?")
+        );
+        let body = output["body"].as_str().expect("body string");
+        assert!(
+            body.contains("axum") && body.contains("actix"),
+            "fallback body must list the real option labels, got: {body}"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/ask_user_question.rs
+++ b/crates/octos-agent/src/tools/ask_user_question.rs
@@ -1,0 +1,517 @@
+//! `ask_user_question` — structured mid-turn user question (UPCR-2026-023).
+//!
+//! The model-visible AskUserQuestion tool. It carries 1–4 multiple-choice
+//! questions (each with a short `header`, a `question`, 2–4 labeled `options`,
+//! and a `multi_select` flag); the server forces a free-text "Other" escape
+//! hatch on every question.
+//!
+//! This is the synchronous, answer-routed superset of the codex
+//! `request_user_input` tool. It mirrors the proven approval flow end-to-end:
+//!
+//! - When a capable client is attached for the turn (the interactive server
+//!   wires a [`UserQuestionRequester`] into the [`USER_QUESTION_CTX`]
+//!   task-local), `execute` builds a [`UserQuestionRequest`] and `await`s the
+//!   requester — exactly the boundary `shell`'s approval gate blocks at — then
+//!   returns the per-question answers to the model.
+//! - When NO requester is attached, the tool does NOT block. It degrades to a
+//!   `request_user_input`-style structured-metadata + generic-text result and
+//!   the turn continues (the agent can fall back to its own best guess). A
+//!   non-supporting client therefore never sees a hung turn (§4.4).
+
+use async_trait::async_trait;
+use eyre::{Result, eyre};
+use octos_core::ui_protocol::{UserQuestion, UserQuestionOption};
+use serde_json::{Value, json};
+
+use super::{
+    Tool, ToolContext, ToolResult, USER_QUESTION_CTX, UserQuestionOutcome, UserQuestionRequest,
+};
+
+/// Inclusive bounds the spec pins on a single AskUserQuestion call.
+const MIN_QUESTIONS: usize = 1;
+const MAX_QUESTIONS: usize = 4;
+const MIN_OPTIONS: usize = 2;
+const MAX_OPTIONS: usize = 4;
+/// `header` is a short label; the spec caps it at 12 characters.
+const MAX_HEADER_CHARS: usize = 12;
+
+/// Structured user-question tool (`ask_user_question`).
+#[derive(Debug, Default)]
+pub struct AskUserQuestionTool;
+
+impl AskUserQuestionTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Parse + validate the LLM-supplied `questions` array against the spec
+/// bounds. Returns a typed input error so the model sees the failure and can
+/// retry with corrected arguments. The server forces `allow_free_text = true`
+/// on every question regardless of what the model sent — the "Other" escape
+/// hatch is always offered (UPCR-2026-023 "Decision").
+fn parse_questions(args: &Value) -> Result<Vec<UserQuestion>> {
+    let raw = args
+        .get("questions")
+        .ok_or_else(|| eyre!("ask_user_question: missing required `questions` array"))?
+        .as_array()
+        .ok_or_else(|| eyre!("ask_user_question: `questions` must be an array"))?;
+
+    if raw.len() < MIN_QUESTIONS || raw.len() > MAX_QUESTIONS {
+        return Err(eyre!(
+            "ask_user_question: expected {MIN_QUESTIONS}..={MAX_QUESTIONS} questions, got {}",
+            raw.len()
+        ));
+    }
+
+    let mut questions = Vec::with_capacity(raw.len());
+    for (idx, entry) in raw.iter().enumerate() {
+        let entry = entry
+            .as_object()
+            .ok_or_else(|| eyre!("ask_user_question: question {idx} must be an object"))?;
+
+        let header = entry
+            .get("header")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|h| !h.is_empty())
+            .ok_or_else(|| {
+                eyre!("ask_user_question: question {idx} requires a non-empty `header`")
+            })?
+            .to_owned();
+        if header.chars().count() > MAX_HEADER_CHARS {
+            return Err(eyre!(
+                "ask_user_question: question {idx} `header` exceeds {MAX_HEADER_CHARS} characters"
+            ));
+        }
+
+        let question = entry
+            .get("question")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|q| !q.is_empty())
+            .ok_or_else(|| {
+                eyre!("ask_user_question: question {idx} requires a non-empty `question`")
+            })?
+            .to_owned();
+
+        let raw_options = entry
+            .get("options")
+            .and_then(Value::as_array)
+            .ok_or_else(|| {
+                eyre!("ask_user_question: question {idx} requires an `options` array")
+            })?;
+        if raw_options.len() < MIN_OPTIONS || raw_options.len() > MAX_OPTIONS {
+            return Err(eyre!(
+                "ask_user_question: question {idx} expected {MIN_OPTIONS}..={MAX_OPTIONS} options, got {}",
+                raw_options.len()
+            ));
+        }
+
+        let mut options = Vec::with_capacity(raw_options.len());
+        for (opt_idx, opt) in raw_options.iter().enumerate() {
+            let opt = opt.as_object().ok_or_else(|| {
+                eyre!("ask_user_question: question {idx} option {opt_idx} must be an object")
+            })?;
+            let label = opt
+                .get("label")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|l| !l.is_empty())
+                .ok_or_else(|| {
+                    eyre!(
+                        "ask_user_question: question {idx} option {opt_idx} requires a non-empty `label`"
+                    )
+                })?
+                .to_owned();
+            // `description` is optional-friendly: default to empty so a terse
+            // model call still validates.
+            let description = opt
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            options.push(UserQuestionOption { label, description });
+        }
+
+        let multi_select = entry
+            .get("multi_select")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+
+        questions.push(UserQuestion {
+            header,
+            question,
+            options,
+            multi_select,
+            // Server-forced: a free-text "Other" is always offered.
+            allow_free_text: true,
+        });
+    }
+
+    Ok(questions)
+}
+
+/// Generic fallback `title`/`body` text derived from the validated questions.
+/// These are mandatory on the wire so a client that does not understand the
+/// structured `questions` field still renders something actionable.
+fn fallback_title_body(questions: &[UserQuestion]) -> (String, String) {
+    let title = if questions.len() == 1 {
+        questions[0].question.clone()
+    } else {
+        format!("The agent has {} questions for you", questions.len())
+    };
+    let body = questions
+        .iter()
+        .enumerate()
+        .map(|(idx, q)| {
+            let opts = q
+                .options
+                .iter()
+                .map(|o| o.label.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(
+                "{}. {} (options: {opts}; or reply with your own)",
+                idx + 1,
+                q.question
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    (title, body)
+}
+
+/// Build the graceful-fallback result emitted when no host response channel is
+/// attached. Mirrors `request_user_input_body` in `coding_tools.rs`: the model
+/// sees that no synchronous answer is available and continues the turn.
+fn unsupported_fallback_result(args: &Value, questions: &[UserQuestion]) -> ToolResult {
+    let (title, body) = fallback_title_body(questions);
+    ToolResult {
+        output: json!({
+            "ok": true,
+            "kind": "user_question_request",
+            "status": "requested",
+            "title": title,
+            "body": body,
+            "request": args,
+            "answers": null,
+            "message": "User question recorded; no synchronous host response channel is attached to this runtime."
+        })
+        .to_string(),
+        success: true,
+        structured_metadata: Some(json!({
+            "codex_tool": "ask_user_question",
+            "request": args,
+            "host_response_channel": "not_attached",
+        })),
+        ..Default::default()
+    }
+}
+
+#[async_trait]
+impl Tool for AskUserQuestionTool {
+    fn name(&self) -> &str {
+        "ask_user_question"
+    }
+
+    fn description(&self) -> &str {
+        "Ask the user a structured multiple-choice question mid-turn and block on \
+         the answer. Carry 1-4 questions, each with a short `header` (<=12 chars), \
+         a `question`, 2-4 `options` (each `label` + `description`), and a \
+         `multi_select` flag. The user is always also offered a free-text \"Other\". \
+         Use this instead of guessing when a bounded choice would resolve an \
+         ambiguity (which framework, which file, opt-in to a cleanup)."
+    }
+
+    fn tags(&self) -> &[&str] {
+        &["code"]
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "questions": {
+                    "type": "array",
+                    "minItems": MIN_QUESTIONS,
+                    "maxItems": MAX_QUESTIONS,
+                    "description": "1-4 multiple-choice questions to ask the user.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "header": {
+                                "type": "string",
+                                "maxLength": MAX_HEADER_CHARS,
+                                "description": "Short label for the question (<=12 chars)."
+                            },
+                            "question": {
+                                "type": "string",
+                                "description": "The question text."
+                            },
+                            "options": {
+                                "type": "array",
+                                "minItems": MIN_OPTIONS,
+                                "maxItems": MAX_OPTIONS,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "label": { "type": "string" },
+                                        "description": { "type": "string" }
+                                    },
+                                    "required": ["label"]
+                                }
+                            },
+                            "multi_select": {
+                                "type": "boolean",
+                                "description": "When true the user may select more than one option."
+                            }
+                        },
+                        "required": ["header", "question", "options"]
+                    }
+                }
+            },
+            "required": ["questions"]
+        })
+    }
+
+    async fn execute(&self, args: &Value) -> Result<ToolResult> {
+        self.execute_with_context(&ToolContext::zero(), args).await
+    }
+
+    async fn execute_with_context(&self, _ctx: &ToolContext, args: &Value) -> Result<ToolResult> {
+        // Validate first so a malformed call fails the same way regardless of
+        // whether a client is attached.
+        let questions = parse_questions(args)?;
+
+        // No interactive client supporting user_question.v1 → graceful
+        // fallback (§4.4): do not block, emit structured metadata, continue.
+        let Some(requester) = USER_QUESTION_CTX.try_with(Clone::clone).ok() else {
+            tracing::debug!(
+                target: "octos::tools::ask_user_question",
+                question_count = questions.len(),
+                "no user-question requester attached; degrading to structured-metadata fallback"
+            );
+            return Ok(unsupported_fallback_result(args, &questions));
+        };
+
+        let (title, body) = fallback_title_body(&questions);
+        let request = UserQuestionRequest {
+            questions,
+            title,
+            body,
+        };
+
+        // This is the await boundary: the turn is now PAUSED until the client
+        // answers via user_question/respond (or the turn is interrupted).
+        match requester.request_user_question(request).await {
+            UserQuestionOutcome::Answered(answers) => {
+                let answers_value = serde_json::to_value(&answers).unwrap_or(Value::Null);
+                Ok(ToolResult {
+                    output: json!({
+                        "ok": true,
+                        "kind": "user_question_answer",
+                        "status": "answered",
+                        "answers": answers_value,
+                    })
+                    .to_string(),
+                    success: true,
+                    structured_metadata: Some(json!({
+                        "codex_tool": "ask_user_question",
+                        "host_response_channel": "attached",
+                        "answers": serde_json::to_value(&answers).unwrap_or(Value::Null),
+                    })),
+                    ..Default::default()
+                })
+            }
+            UserQuestionOutcome::Cancelled => Ok(ToolResult {
+                output: json!({
+                    "ok": false,
+                    "kind": "user_question_answer",
+                    "status": "cancelled",
+                    "answers": null,
+                    "message": "User question was cancelled before an answer arrived (turn interrupted)."
+                })
+                .to_string(),
+                success: false,
+                ..Default::default()
+            }),
+            // A requester was attached but reported it could not surface the
+            // question (e.g. wire delivery failed). Degrade like the no-context
+            // path so the turn never hard-blocks.
+            UserQuestionOutcome::Unsupported => Ok(unsupported_fallback_result(args, &[])),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::{UserQuestionRequest as Req, UserQuestionRequester};
+    use octos_core::ui_protocol::UserQuestionAnswer;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    fn one_valid_question() -> Value {
+        json!({
+            "questions": [
+                {
+                    "header": "Framework",
+                    "question": "Which web framework should I scaffold?",
+                    "options": [
+                        { "label": "axum", "description": "tower-based async" },
+                        { "label": "actix", "description": "actor-based" }
+                    ],
+                    "multi_select": false
+                }
+            ]
+        })
+    }
+
+    /// Records the request it received and replays a canned answer.
+    struct RecordingRequester {
+        captured: Mutex<Option<Req>>,
+        answer: Vec<UserQuestionAnswer>,
+    }
+
+    #[async_trait]
+    impl UserQuestionRequester for RecordingRequester {
+        async fn request_user_question(&self, request: Req) -> UserQuestionOutcome {
+            *self.captured.lock().unwrap() = Some(request);
+            UserQuestionOutcome::Answered(self.answer.clone())
+        }
+    }
+
+    struct CancellingRequester;
+
+    #[async_trait]
+    impl UserQuestionRequester for CancellingRequester {
+        async fn request_user_question(&self, _request: Req) -> UserQuestionOutcome {
+            UserQuestionOutcome::Cancelled
+        }
+    }
+
+    #[tokio::test]
+    async fn should_emit_structured_metadata_when_no_requester() {
+        let tool = AskUserQuestionTool::new();
+        let args = one_valid_question();
+        let result = tool.execute(&args).await.expect("fallback ok");
+        assert!(result.success);
+        let meta = result
+            .structured_metadata
+            .as_ref()
+            .expect("fallback must emit structured_metadata");
+        assert_eq!(meta["codex_tool"], json!("ask_user_question"));
+        assert_eq!(meta["host_response_channel"], json!("not_attached"));
+        // Request round-trips into the structured event for the client.
+        assert_eq!(meta["request"], args);
+    }
+
+    #[tokio::test]
+    async fn should_block_and_return_answers_when_requester_present() {
+        let answer = vec![UserQuestionAnswer {
+            selected_labels: vec!["axum".into()],
+            free_text: None,
+        }];
+        let requester = Arc::new(RecordingRequester {
+            captured: Mutex::new(None),
+            answer: answer.clone(),
+        });
+        let requester_dyn: Arc<dyn UserQuestionRequester> = requester.clone();
+
+        let tool = AskUserQuestionTool::new();
+        let args = one_valid_question();
+        let result = USER_QUESTION_CTX
+            .scope(requester_dyn, async move { tool.execute(&args).await })
+            .await
+            .expect("answered ok");
+
+        assert!(result.success);
+        let output: Value = serde_json::from_str(&result.output).expect("output json");
+        assert_eq!(output["status"], json!("answered"));
+        assert_eq!(output["answers"][0]["selected_labels"][0], json!("axum"));
+
+        // The requester saw the validated, server-forced request.
+        let captured = requester
+            .captured
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("captured");
+        assert_eq!(captured.questions.len(), 1);
+        assert!(
+            captured.questions[0].allow_free_text,
+            "server must force allow_free_text=true"
+        );
+        assert!(!captured.title.is_empty(), "mandatory generic title");
+        assert!(!captured.body.is_empty(), "mandatory generic body");
+    }
+
+    #[tokio::test]
+    async fn should_return_cancelled_when_turn_interrupted() {
+        let requester_dyn: Arc<dyn UserQuestionRequester> = Arc::new(CancellingRequester);
+        let tool = AskUserQuestionTool::new();
+        let args = one_valid_question();
+        let result = USER_QUESTION_CTX
+            .scope(requester_dyn, async move { tool.execute(&args).await })
+            .await
+            .expect("cancelled is not an error");
+        assert!(!result.success);
+        let output: Value = serde_json::from_str(&result.output).expect("output json");
+        assert_eq!(output["status"], json!("cancelled"));
+    }
+
+    #[tokio::test]
+    async fn should_reject_when_questions_out_of_range() {
+        let tool = AskUserQuestionTool::new();
+
+        // Zero questions.
+        assert!(tool.execute(&json!({ "questions": [] })).await.is_err());
+
+        // Five questions.
+        let too_many: Vec<Value> = (0..5)
+            .map(|i| {
+                json!({
+                    "header": format!("H{i}"),
+                    "question": "q?",
+                    "options": [
+                        { "label": "a", "description": "" },
+                        { "label": "b", "description": "" }
+                    ]
+                })
+            })
+            .collect();
+        assert!(
+            tool.execute(&json!({ "questions": too_many }))
+                .await
+                .is_err()
+        );
+
+        // Only one option (below the 2..=4 floor).
+        let bad_options = json!({
+            "questions": [
+                {
+                    "header": "Pick",
+                    "question": "q?",
+                    "options": [ { "label": "only", "description": "" } ]
+                }
+            ]
+        });
+        assert!(tool.execute(&bad_options).await.is_err());
+
+        // Over-long header (> 12 chars).
+        let long_header = json!({
+            "questions": [
+                {
+                    "header": "this-header-is-way-too-long",
+                    "question": "q?",
+                    "options": [
+                        { "label": "a", "description": "" },
+                        { "label": "b", "description": "" }
+                    ]
+                }
+            ]
+        });
+        assert!(tool.execute(&long_header).await.is_err());
+    }
+}

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -353,6 +353,53 @@ tokio::task_local! {
     pub static TOOL_APPROVAL_CTX: Arc<dyn ToolApprovalRequester>;
 }
 
+/// Request emitted by the `ask_user_question` tool when it asks the user a
+/// structured multiple-choice question mid-turn (UPCR-2026-023).
+///
+/// Mirrors [`ToolApprovalRequest`]: a typed payload the
+/// [`UserQuestionRequester`] surfaces to the attached client, blocking the
+/// tool on a oneshot until the client answers. `questions` is already
+/// validated (1..=4 questions, 2..=4 options each); `title`/`body` are the
+/// mandatory generic fallback text a non-structured client renders.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserQuestionRequest {
+    pub questions: Vec<octos_core::ui_protocol::UserQuestion>,
+    pub title: String,
+    pub body: String,
+}
+
+/// Outcome returned to the blocked `ask_user_question` tool after client
+/// handling (UPCR-2026-023). Mirrors [`ToolApprovalDecision`] but carries the
+/// structured per-question answers and distinguishes a cancelled turn from an
+/// unsupported client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UserQuestionOutcome {
+    /// The client answered; one entry per question, in question order.
+    Answered(Vec<octos_core::ui_protocol::UserQuestionAnswer>),
+    /// The turn was interrupted / the pending question drained before an
+    /// answer arrived. The tool returns a cancelled result.
+    Cancelled,
+    /// No capable client was attached for this turn; the tool degrades to the
+    /// structured-metadata fallback (§4.4).
+    Unsupported,
+}
+
+/// Async user-question bridge provided by clients that negotiated
+/// `user_question.v1` (UPCR-2026-023). Mirrors [`ToolApprovalRequester`]:
+/// scoped per-turn via [`USER_QUESTION_CTX`] so the `ask_user_question` tool
+/// can block on a oneshot until `user_question/respond` resolves it.
+#[async_trait]
+pub trait UserQuestionRequester: Send + Sync {
+    async fn request_user_question(&self, request: UserQuestionRequest) -> UserQuestionOutcome;
+}
+
+tokio::task_local! {
+    /// Optional task-local user-question bridge scoped around a turn by
+    /// interactive clients that negotiated `user_question.v1`. When unset the
+    /// `ask_user_question` tool degrades gracefully (no hard block).
+    pub static USER_QUESTION_CTX: Arc<dyn UserQuestionRequester>;
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct TurnAttachmentContext {
     pub attachment_paths: Vec<String>,
@@ -669,6 +716,7 @@ pub use robot_groups::{RobotToolRegistry, install_registry as install_robot_regi
 pub mod ssrf;
 
 // Built-in tools
+pub mod ask_user_question;
 pub mod coding_tools;
 pub mod deep_search;
 pub mod delegate;
@@ -711,6 +759,7 @@ pub mod git;
 #[cfg(feature = "ast")]
 pub mod code_structure;
 
+pub use ask_user_question::AskUserQuestionTool;
 pub use coding_tools::{
     ApplyPatchTool, BashTool, CloseAgentTool, DelegateAliasTool, ExecCommandTool,
     ImageGenerationTool, RequestUserInputTool, ResumeAgentTool, SendInputTool, SpawnAgentTool,

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -611,6 +611,24 @@ pub trait Tool: Send + Sync {
     fn execution_timeout_secs(&self) -> Option<u64> {
         None
     }
+
+    /// Whether this tool BLOCKS on human input (e.g. `ask_user_question`
+    /// awaits the [`USER_QUESTION_CTX`] requester until the client answers,
+    /// exactly as the approval gate blocks on [`TOOL_APPROVAL_CTX`]). Such a
+    /// tool must be EXEMPT from the dispatch-boundary timeout in
+    /// [`ToolRegistry::execute_with_context`]: a human may legitimately take
+    /// longer than any finite tool timeout, and firing the timeout would drop
+    /// the requester's receiver and leak the pending question/approval store
+    /// entry forever (Gap-3.3 interaction). The waiting future is instead
+    /// cancelled the right way — when the turn is interrupted the pending
+    /// store drains the entry and resolves the waiter as `Cancelled`.
+    ///
+    /// Returning `true` here makes the registry skip wrapping the call in the
+    /// dispatch timeout entirely (it still composes with the agent loop's
+    /// per-turn lifecycle and the turn-interrupt drain). Default: `false`.
+    fn blocks_on_human_input(&self) -> bool {
+        false
+    }
 }
 
 /// LRU-based tool lifecycle manager.

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -15,13 +15,13 @@ use crate::task_supervisor::TaskSupervisor;
 use super::CodeStructureTool;
 use super::policy::{self, ToolPolicy};
 use super::{
-    ApplyPatchTool, BrowserTool, CheckWorkspaceContractTool, CloseAgentTool, ConfigureToolTool,
-    DiffEditTool, EditFileTool, ExecCommandTool, GlobTool, GrepTool, ImageGenerationTool,
-    ListDirTool, ReadFileTool, RequestUserInputTool, ResumeAgentTool, SendInputTool, ShellTool,
-    SpawnAgentTool, Tool, ToolCatalogEntry, ToolConfigStore, ToolLifecycle, ToolResult,
-    ToolSearchTool, ToolSuggestTool, UpdatePlanTool, ViewImageTool, WaitAgentTool, WebFetchTool,
-    WebSearchTool, WorkspaceDiffTool, WorkspaceLogTool, WorkspaceShowTool, WriteFileTool,
-    WriteStdinTool,
+    ApplyPatchTool, AskUserQuestionTool, BrowserTool, CheckWorkspaceContractTool, CloseAgentTool,
+    ConfigureToolTool, DiffEditTool, EditFileTool, ExecCommandTool, GlobTool, GrepTool,
+    ImageGenerationTool, ListDirTool, ReadFileTool, RequestUserInputTool, ResumeAgentTool,
+    SendInputTool, ShellTool, SpawnAgentTool, Tool, ToolCatalogEntry, ToolConfigStore,
+    ToolLifecycle, ToolResult, ToolSearchTool, ToolSuggestTool, UpdatePlanTool, ViewImageTool,
+    WaitAgentTool, WebFetchTool, WebSearchTool, WorkspaceDiffTool, WorkspaceLogTool,
+    WorkspaceShowTool, WriteFileTool, WriteStdinTool,
 };
 use crate::sandbox::{NoSandbox, Sandbox};
 
@@ -1298,6 +1298,9 @@ impl ToolRegistry {
         registry.register(WriteStdinTool);
         registry.register(UpdatePlanTool);
         registry.register(RequestUserInputTool);
+        // UPCR-2026-023: structured AskUserQuestion. The synchronous,
+        // answer-routed superset of `request_user_input`.
+        registry.register(AskUserQuestionTool::new());
         registry.register(SpawnAgentTool::new());
         // #1172: Codex-compatible `delegate` one-call wrapper. The default
         // instance has no spawn_agent bound — `register("spawn")` swaps

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -1184,22 +1184,6 @@ impl ToolRegistry {
         // Track usage for LRU auto-eviction
         self.record_usage(name);
 
-        // Gap 3.3: per-tool execution timeout. A hung foreground tool used to
-        // block the caller's turn (the session actor's "10-min opaque
-        // pipeline" / hung-tool class) indefinitely — the agent loop's
-        // per-batch timeout only guards the agent::execution dispatch path,
-        // leaving direct registry callers (serve/API tool path, workspace
-        // contract auto-send) unbounded. This dispatch-boundary timeout
-        // bounds EVERY caller. The per-tool override
-        // (`Tool::execution_timeout_secs`) wins when present; otherwise the
-        // registry's generous global backstop applies. `spawn_only` tools are
-        // intercepted/backgrounded earlier and never reach this path.
-        let timeout_secs = tool
-            .execution_timeout_secs()
-            .unwrap_or(self.tool_timeout_secs)
-            .max(1);
-        let timeout = std::time::Duration::from_secs(timeout_secs);
-
         // Layer 2 (mini5 soak): isolate a tool panic at this single dispatch
         // boundary. A panic inside a tool used to unwind through the session
         // actor's task, killing the actor AND every in-process sub-agent it had
@@ -1216,25 +1200,43 @@ impl ToolRegistry {
         // tool future entirely and returns a fresh failure.
         let invocation = tool.execute_with_context(ctx, args);
         let guarded = futures::FutureExt::catch_unwind(std::panic::AssertUnwindSafe(invocation));
+
+        // #1 — human-wait exemption. A tool that blocks on human input (e.g.
+        // `ask_user_question` awaiting the requester, mirroring the approval
+        // gate) must NOT be killed by the dispatch timeout: a human may take
+        // longer than any finite ceiling, and firing the timeout would drop
+        // the requester's receiver and leak the pending store entry forever.
+        // Skip the timeout wrap entirely for these tools — the turn-interrupt
+        // drain (which resolves the waiter as `Cancelled`) is the correct
+        // cancellation path, not a fixed timeout. Panic isolation still
+        // applies. This matches how the approval-blocking `shell` gate is not
+        // double-killed by the tool timeout.
+        if tool.blocks_on_human_input() {
+            return match guarded.await {
+                Ok(result) => result,
+                Err(panic) => Ok(panic_to_failed_result(name, panic)),
+            };
+        }
+
+        // Gap 3.3: per-tool execution timeout. A hung foreground tool used to
+        // block the caller's turn (the session actor's "10-min opaque
+        // pipeline" / hung-tool class) indefinitely — the agent loop's
+        // per-batch timeout only guards the agent::execution dispatch path,
+        // leaving direct registry callers (serve/API tool path, workspace
+        // contract auto-send) unbounded. This dispatch-boundary timeout
+        // bounds EVERY caller. The per-tool override
+        // (`Tool::execution_timeout_secs`) wins when present; otherwise the
+        // registry's generous global backstop applies. `spawn_only` tools are
+        // intercepted/backgrounded earlier and never reach this path.
+        let timeout_secs = tool
+            .execution_timeout_secs()
+            .unwrap_or(self.tool_timeout_secs)
+            .max(1);
+        let timeout = std::time::Duration::from_secs(timeout_secs);
+
         match tokio::time::timeout(timeout, guarded).await {
             Ok(Ok(result)) => result,
-            Ok(Err(panic)) => {
-                let detail = panic
-                    .downcast_ref::<&str>()
-                    .map(|s| (*s).to_string())
-                    .or_else(|| panic.downcast_ref::<String>().cloned())
-                    .unwrap_or_else(|| "unknown panic".to_string());
-                tracing::error!(
-                    tool = name,
-                    panic = %detail,
-                    "tool execution panicked — isolated to a tool error; session actor preserved"
-                );
-                Ok(ToolResult {
-                    output: format!("tool '{name}' failed (internal error): {detail}"),
-                    success: false,
-                    ..Default::default()
-                })
-            }
+            Ok(Err(panic)) => Ok(panic_to_failed_result(name, panic)),
             Err(_elapsed) => {
                 tracing::error!(
                     tool = name,
@@ -1249,6 +1251,28 @@ impl ToolRegistry {
                 })
             }
         }
+    }
+}
+
+/// Degrade a caught tool panic to a failed [`ToolResult`] (Layer-2 panic
+/// isolation, mini5 soak). Shared by the timeout-guarded dispatch arm and the
+/// human-wait (timeout-exempt) dispatch arm so both isolate a panic
+/// identically.
+fn panic_to_failed_result(name: &str, panic: Box<dyn std::any::Any + Send>) -> ToolResult {
+    let detail = panic
+        .downcast_ref::<&str>()
+        .map(|s| (*s).to_string())
+        .or_else(|| panic.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "unknown panic".to_string());
+    tracing::error!(
+        tool = name,
+        panic = %detail,
+        "tool execution panicked — isolated to a tool error; session actor preserved"
+    );
+    ToolResult {
+        output: format!("tool '{name}' failed (internal error): {detail}"),
+        success: false,
+        ..Default::default()
     }
 }
 
@@ -2535,6 +2559,76 @@ mod context_threading_tests {
             futures::future::pending::<()>().await;
             unreachable!("pending() never resolves");
         }
+    }
+
+    /// A human-wait tool: blocks on a requester (like `ask_user_question`'s
+    /// `request_user_question` await). It must be EXEMPT from the dispatch
+    /// timeout — a human may legitimately take longer than any finite tool
+    /// timeout, and killing the future would drop the receiver and leak the
+    /// pending store entry forever.
+    struct HumanWaitTool {
+        unblock: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl Tool for HumanWaitTool {
+        fn name(&self) -> &str {
+            "human_wait"
+        }
+        fn description(&self) -> &str {
+            "test-only: blocks on a human until notified"
+        }
+        fn input_schema(&self) -> Value {
+            serde_json::json!({"type": "object"})
+        }
+        fn blocks_on_human_input(&self) -> bool {
+            true
+        }
+        async fn execute(&self, _args: &Value) -> Result<ToolResult> {
+            self.unblock.notified().await;
+            Ok(ToolResult {
+                output: "answered".into(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn human_wait_tool_is_exempt_from_dispatch_timeout() {
+        // A human-wait tool must NOT be killed by the dispatch timeout even
+        // when the registry backstop is set to 1s — it stays blocked until
+        // the human answers, then returns success. Mirrors how `shell`'s
+        // approval gate is not killed by the tool timeout (#1).
+        let mut reg = ToolRegistry::new();
+        let unblock = Arc::new(tokio::sync::Notify::new());
+        reg.register_arc(Arc::new(HumanWaitTool {
+            unblock: unblock.clone(),
+        }));
+        // A tight backstop that WOULD kill a normal tool.
+        reg.set_tool_timeout_secs(1);
+
+        let unblock_for_task = unblock.clone();
+        // Answer the "human" after 2s — comfortably past the 1s backstop.
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            unblock_for_task.notify_one();
+        });
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            reg.execute("human_wait", &serde_json::json!({})),
+        )
+        .await
+        .expect("human-wait tool must not hang the test")
+        .expect("registry returns Ok");
+
+        assert!(
+            result.success,
+            "human-wait tool must survive the dispatch timeout and return its answer, got: {}",
+            result.output
+        );
+        assert_eq!(result.output, "answered");
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -522,6 +522,25 @@ impl ToolRegistry {
             .unwrap_or_default()
     }
 
+    /// Whether the named tool blocks on human input (e.g. `ask_user_question`
+    /// awaiting the requester until the client answers). Mirrors
+    /// [`Tool::blocks_on_human_input`]; unknown tools report `false`.
+    ///
+    /// Used by the agent batch dispatcher (`agent::execution`) to detect a
+    /// human-wait batch and skip the finite batch-level `tokio::time::timeout`
+    /// wrap that would otherwise detach the still-running tool task after the
+    /// ceiling fired — leaking the pending-question store entry and replaying a
+    /// stale prompt after the turn moved on (UPCR-2026-023). The registry
+    /// dispatch boundary already exempts these tools via
+    /// [`Tool::blocks_on_human_input`]; this surfaces the same fact one layer
+    /// up so the outer batch wrap can be skipped too.
+    pub fn blocks_on_human_input(&self, name: &str) -> bool {
+        self.tools
+            .get(name)
+            .map(|t| t.blocks_on_human_input())
+            .unwrap_or(false)
+    }
+
     /// Get tool specifications for the LLM, filtered by provider policy if set.
     /// Results are cached and invalidated when the registry is mutated.
     /// Codex round 2 P2: visibility-aware tool lookup.

--- a/crates/octos-agent/tests/human_wait_batch_timeout.rs
+++ b/crates/octos-agent/tests/human_wait_batch_timeout.rs
@@ -22,7 +22,7 @@
 //! - serial: pairing the human-wait tool with an `Exclusive` peer forces the
 //!   serial (per-call) dispatch path.
 //!
-//! RED on d3caf325 (the batch ceiling is finite and fires after 1s, producing
+//! RED before this fix (the batch ceiling is finite and fires after 1s, producing
 //! `"timed out"`); GREEN after `compute_batch_timeout_secs` yields `None` for a
 //! human-wait batch and both dispatch paths await the handles directly.
 

--- a/crates/octos-agent/tests/human_wait_batch_timeout.rs
+++ b/crates/octos-agent/tests/human_wait_batch_timeout.rs
@@ -1,0 +1,361 @@
+//! UPCR-2026-023 — a tool batch containing a human-wait tool
+//! (`Tool::blocks_on_human_input() == true`, e.g. `ask_user_question`) must
+//! run with NO finite batch-level timeout.
+//!
+//! Regression being pinned: the agent batch dispatcher wraps the spawned tool
+//! tasks in `tokio::time::timeout(compute_batch_timeout_secs(...), ...)`. Before
+//! this fix `compute_batch_timeout_secs` returned a finite ceiling even when a
+//! human-wait tool was present, so once that ceiling fired the dispatcher
+//! returned synthetic `"… timed out after N seconds"` results AND dropped the
+//! still-running `JoinHandle`s — detaching the human-wait task so its
+//! `PendingQuestionWaiterGuard` never dropped (pending question leaked and was
+//! later replayed as a stale prompt).
+//!
+//! These tests drive a REAL `Agent` loop with a scripted `MockLlm` and a
+//! deliberately tiny `tool_timeout_secs` / `default_interactive_tool_timeout_secs`
+//! (1s). A human-wait tool whose "human" answers AFTER that ceiling must still
+//! return its real answer rather than a synthetic timeout — proving the batch
+//! layer no longer bounds it. Both dispatch shapes are exercised:
+//!
+//! - parallel: a human-wait tool is `ConcurrencyClass::Safe`, so a batch of
+//!   only-Safe tools dispatches through the parallel (`join_all`) path.
+//! - serial: pairing the human-wait tool with an `Exclusive` peer forces the
+//!   serial (per-call) dispatch path.
+//!
+//! RED on d3caf325 (the batch ceiling is finite and fires after 1s, producing
+//! `"timed out"`); GREEN after `compute_batch_timeout_secs` yields `None` for a
+//! human-wait batch and both dispatch paths await the handles directly.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use octos_agent::{Agent, AgentConfig, ConcurrencyClass, Tool, ToolRegistry, ToolResult};
+use octos_core::{AgentId, Message, ToolCall};
+use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, TokenUsage, ToolSpec};
+use octos_memory::EpisodeStore;
+use tempfile::TempDir;
+
+/// A human-wait tool: blocks on a "human" (a `Notify` tripped after `delay`)
+/// before returning its answer. Declares `blocks_on_human_input() == true`,
+/// mirroring `ask_user_question`. The delay is comfortably longer than the
+/// batch ceiling the test configures, so a surviving batch timeout would turn
+/// the result into a synthetic `"timed out"` message.
+struct HumanWaitTool {
+    delay: Duration,
+}
+
+#[async_trait]
+impl Tool for HumanWaitTool {
+    fn name(&self) -> &str {
+        "human_wait"
+    }
+    fn description(&self) -> &str {
+        "test-only: blocks on a human (delayed Notify) before answering"
+    }
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+    fn blocks_on_human_input(&self) -> bool {
+        true
+    }
+    async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+        // Emulate the human taking longer than any finite batch ceiling.
+        tokio::time::sleep(self.delay).await;
+        Ok(ToolResult {
+            output: "human answered".into(),
+            success: true,
+            ..Default::default()
+        })
+    }
+}
+
+/// A fast, side-effect-free reader. Stays `Safe`, so a batch of
+/// {human_wait, fast_reader} dispatches through the PARALLEL path.
+struct FastSafeTool;
+
+#[async_trait]
+impl Tool for FastSafeTool {
+    fn name(&self) -> &str {
+        "fast_reader"
+    }
+    fn description(&self) -> &str {
+        "test-only: fast safe reader"
+    }
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+    async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+        Ok(ToolResult {
+            output: "read ok".into(),
+            success: true,
+            ..Default::default()
+        })
+    }
+}
+
+/// An `Exclusive` tool. Pairing it with the human-wait tool forces the SERIAL
+/// dispatch path (any-Exclusive batch). It is fast and side-effect-free for
+/// the test, but reports `Exclusive` so the executor serializes the batch.
+struct ExclusiveFastTool;
+
+#[async_trait]
+impl Tool for ExclusiveFastTool {
+    fn name(&self) -> &str {
+        "exclusive_fast"
+    }
+    fn description(&self) -> &str {
+        "test-only: exclusive but fast"
+    }
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+    fn concurrency_class(&self) -> ConcurrencyClass {
+        ConcurrencyClass::Exclusive
+    }
+    async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+        Ok(ToolResult {
+            output: "exclusive ok".into(),
+            success: true,
+            ..Default::default()
+        })
+    }
+}
+
+struct MockLlm {
+    responses: Mutex<Vec<ChatResponse>>,
+}
+
+impl MockLlm {
+    fn new(responses: Vec<ChatResponse>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for MockLlm {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> eyre::Result<ChatResponse> {
+        let mut responses = self.responses.lock().unwrap();
+        if responses.is_empty() {
+            eyre::bail!("MockLlm: no more scripted responses");
+        }
+        Ok(responses.remove(0))
+    }
+    fn context_window(&self) -> u32 {
+        128_000
+    }
+    fn model_id(&self) -> &str {
+        "mock-upcr-023"
+    }
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+fn tool_use(calls: Vec<ToolCall>) -> ChatResponse {
+    ChatResponse {
+        content: None,
+        reasoning_content: None,
+        tool_calls: calls,
+        stop_reason: StopReason::ToolUse,
+        usage: TokenUsage {
+            input_tokens: 50,
+            output_tokens: 5,
+            ..Default::default()
+        },
+        provider_index: None,
+    }
+}
+
+fn end(text: &str) -> ChatResponse {
+    ChatResponse {
+        content: Some(text.into()),
+        reasoning_content: None,
+        tool_calls: vec![],
+        stop_reason: StopReason::EndTurn,
+        usage: TokenUsage {
+            input_tokens: 5,
+            output_tokens: 5,
+            ..Default::default()
+        },
+        provider_index: None,
+    }
+}
+
+fn tc(id: &str, name: &str, args: serde_json::Value) -> ToolCall {
+    ToolCall {
+        id: id.into(),
+        name: name.into(),
+        arguments: args,
+        metadata: None,
+    }
+}
+
+/// Capture the tool-result messages the agent recorded so we can assert NONE
+/// of them are the synthetic batch-timeout message.
+fn assert_no_timeout_message(history: &[Message], answered_id: &str) {
+    let timed_out: Vec<&Message> = history
+        .iter()
+        .filter(|m| m.content.contains("timed out after"))
+        .collect();
+    assert!(
+        timed_out.is_empty(),
+        "no tool result should be a synthetic batch-timeout; got: {:?}",
+        timed_out.iter().map(|m| &m.content).collect::<Vec<_>>()
+    );
+    let answered = history.iter().any(|m| {
+        m.tool_call_id.as_deref() == Some(answered_id) && m.content.contains("human answered")
+    });
+    assert!(
+        answered,
+        "human-wait tool must record its REAL answer (not detach/timeout) for \
+         tool_call_id={answered_id}; history={:?}",
+        history
+            .iter()
+            .map(|m| (m.tool_call_id.clone(), m.content.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Build an agent whose batch ceiling is a tiny 1s — short enough that a
+/// surviving batch timeout would fire well before the human-wait tool's 2s
+/// "human" answers.
+async fn agent_with_tiny_batch_timeout(
+    dir: &TempDir,
+    tools: ToolRegistry,
+    responses: Vec<ChatResponse>,
+) -> Agent {
+    let memory = Arc::new(EpisodeStore::open(dir.path().join(".octos")).await.unwrap());
+    let llm: Arc<dyn LlmProvider> = Arc::new(MockLlm::new(responses));
+    Agent::new(AgentId::new("upcr-023"), llm, tools, memory).with_config(AgentConfig {
+        save_episodes: false,
+        // Tiny ceilings: a surviving batch timeout fires at 1s, before the
+        // 2s human answer. The fix must make the human-wait batch unbounded.
+        tool_timeout_secs: 1,
+        default_interactive_tool_timeout_secs: 1,
+        ..Default::default()
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parallel_batch_with_human_wait_is_not_timed_out_at_batch_layer() {
+    // PARALLEL path: human_wait (Safe) alone → join_all dispatch. With a 1s
+    // batch ceiling and a 2s "human", the pre-fix code returned a synthetic
+    // "timed out" and detached the task. The fix awaits join_all directly.
+    let dir = TempDir::new().unwrap();
+    let mut tools = ToolRegistry::new();
+    tools.register(HumanWaitTool {
+        delay: Duration::from_secs(2),
+    });
+
+    let agent = agent_with_tiny_batch_timeout(
+        &dir,
+        tools,
+        vec![
+            tool_use(vec![tc("hw_call", "human_wait", serde_json::json!({}))]),
+            end("done"),
+        ],
+    )
+    .await;
+
+    let resp = tokio::time::timeout(
+        Duration::from_secs(10),
+        agent.process_message("ask the human", &[], vec![]),
+    )
+    .await
+    .expect("agent loop must not hang")
+    .expect("agent loop must succeed");
+
+    assert_eq!(resp.content, "done");
+    assert_no_timeout_message(&resp.messages, "hw_call");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn serial_batch_with_human_wait_is_not_timed_out_at_batch_layer() {
+    // SERIAL path: human_wait + an Exclusive peer → any-Exclusive serial
+    // dispatch. The human-wait call must still NOT be bounded by the batch
+    // ceiling; it returns its real answer after 2s under a 1s ceiling.
+    let dir = TempDir::new().unwrap();
+    let mut tools = ToolRegistry::new();
+    tools.register(HumanWaitTool {
+        delay: Duration::from_secs(2),
+    });
+    tools.register(ExclusiveFastTool);
+
+    let agent = agent_with_tiny_batch_timeout(
+        &dir,
+        tools,
+        vec![
+            tool_use(vec![
+                tc("hw_call", "human_wait", serde_json::json!({})),
+                tc("ex_call", "exclusive_fast", serde_json::json!({})),
+            ]),
+            end("done"),
+        ],
+    )
+    .await;
+
+    let resp = tokio::time::timeout(
+        Duration::from_secs(10),
+        agent.process_message("ask the human then mutate", &[], vec![]),
+    )
+    .await
+    .expect("agent loop must not hang")
+    .expect("agent loop must succeed");
+
+    assert_eq!(resp.content, "done");
+    assert_no_timeout_message(&resp.messages, "hw_call");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mixed_parallel_batch_human_wait_unbounded_fast_peer_completes() {
+    // MIXED PARALLEL batch: human_wait (Safe, 2s) + fast_reader (Safe). The
+    // batch is unbounded at the batch layer (so the human-wait survives the 1s
+    // ceiling), while the fast peer still completes normally — proving the
+    // no-timeout decision does not break the rest of the batch.
+    let dir = TempDir::new().unwrap();
+    let mut tools = ToolRegistry::new();
+    tools.register(HumanWaitTool {
+        delay: Duration::from_secs(2),
+    });
+    tools.register(FastSafeTool);
+
+    let agent = agent_with_tiny_batch_timeout(
+        &dir,
+        tools,
+        vec![
+            tool_use(vec![
+                tc("hw_call", "human_wait", serde_json::json!({})),
+                tc("fast_call", "fast_reader", serde_json::json!({})),
+            ]),
+            end("done"),
+        ],
+    )
+    .await;
+
+    let resp = tokio::time::timeout(
+        Duration::from_secs(10),
+        agent.process_message("ask + read", &[], vec![]),
+    )
+    .await
+    .expect("agent loop must not hang")
+    .expect("agent loop must succeed");
+
+    assert_eq!(resp.content, "done");
+    assert_no_timeout_message(&resp.messages, "hw_call");
+    let fast_ok = resp
+        .messages
+        .iter()
+        .any(|m| m.tool_call_id.as_deref() == Some("fast_call") && m.content.contains("read ok"));
+    assert!(
+        fast_ok,
+        "the fast Safe peer must still complete normally in a mixed human-wait batch"
+    );
+}

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -38,6 +38,7 @@ mod ui_protocol_audit;
 mod ui_protocol_diff;
 mod ui_protocol_ledger;
 pub(crate) mod ui_protocol_progress;
+mod ui_protocol_questions;
 mod ui_protocol_sanitize;
 mod ui_protocol_scope;
 mod ui_protocol_task_output;

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -148,6 +148,10 @@ const INTERRUPT_ACK_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 /// traffic. Tunable per session size.
 const WS_WRITER_CHANNEL_CAPACITY: usize = 1024;
 const APPROVAL_CANCELLED_REASON_REQUEST_SEND_FAILED: &str = "request_send_failed";
+/// Reason recorded when a pending structured-question entry is cancelled
+/// because the `ask_user_question` tool's waiting future was dropped (timeout,
+/// interrupt, abort, panic, connection close) — UPCR-2026-023 drop-guard.
+const APPROVAL_CANCELLED_REASON_WAITER_DROPPED: &str = "waiter_dropped";
 const APPUI_METHOD_CONFIG_CAPABILITIES_LIST: &str =
     octos_core::ui_protocol::methods::CONFIG_CAPABILITIES_LIST;
 const APPUI_METHOD_CLIENT_HELLO: &str = "client_hello";
@@ -3241,6 +3245,70 @@ struct SessionUserQuestionRequester {
     turn_id: TurnId,
 }
 
+/// RAII drop-guard around the requester's wait on `response_rx`
+/// (UPCR-2026-023, fix #2). If the `ask_user_question` tool's future is
+/// dropped while it is parked on the answer — a per-tool timeout firing, a
+/// turn interrupt aborting the task, a panic unwinding, or the connection
+/// closing — this guard's `Drop` CANCELS the matching pending-question store
+/// entry (resolving the waiter as cancelled and removing the entry) instead
+/// of leaking it forever.
+///
+/// This closes the cancel-on-interrupt race codex flagged: the turn-interrupt
+/// drain (`cancel_pending_for_turn`) only cancels entries that are visible at
+/// drain time, so a question inserted AFTER the drain (the narrow window
+/// between drain and the agent task actually stopping) would otherwise leak.
+/// The guard makes cancellation robust regardless of drain timing because it
+/// is keyed to the lifetime of the waiting future itself, not to a one-shot
+/// sweep.
+///
+/// The guard is DISARMED on a clean resolution (`Answered`/`Cancelled`/wire
+/// send failure), where the store entry has already moved out of `Pending`
+/// and re-cancelling would be a no-op anyway. `cancel_pending_question` only
+/// acts on a still-`Pending` entry, so an armed drop after a clean resolution
+/// is harmless — disarming just skips the redundant lock.
+///
+/// (Approvals lack an equivalent guard today — a latent approval gap; not
+/// fixed here.)
+struct PendingQuestionWaiterGuard {
+    contracts: Arc<UiProtocolContractStores>,
+    session_id: SessionKey,
+    question_id: octos_core::ui_protocol::QuestionId,
+    armed: bool,
+}
+
+impl PendingQuestionWaiterGuard {
+    fn new(
+        contracts: Arc<UiProtocolContractStores>,
+        session_id: SessionKey,
+        question_id: octos_core::ui_protocol::QuestionId,
+    ) -> Self {
+        Self {
+            contracts,
+            session_id,
+            question_id,
+            armed: true,
+        }
+    }
+
+    /// Mark the wait as resolved cleanly so the guard does not cancel on drop.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PendingQuestionWaiterGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        self.contracts.user_questions.cancel_pending_question(
+            &self.session_id,
+            &self.question_id,
+            APPROVAL_CANCELLED_REASON_WAITER_DROPPED,
+        );
+    }
+}
+
 #[async_trait::async_trait]
 impl octos_agent::UserQuestionRequester for SessionUserQuestionRequester {
     async fn request_user_question(&self, request: UserQuestionRequest) -> UserQuestionOutcome {
@@ -3257,6 +3325,19 @@ impl octos_agent::UserQuestionRequester for SessionUserQuestionRequester {
 
         let response_rx = self.contracts.user_questions.request_runtime(event.clone());
 
+        // #2 — RAII drop-guard. Arm a guard keyed to THIS pending entry the
+        // instant it is registered. If our future is dropped before a clean
+        // resolution (per-tool timeout firing, turn interrupt aborting the
+        // task, panic, connection close) the guard's `Drop` cancels the entry,
+        // closing the cancel-on-interrupt race (an entry inserted after the
+        // turn-interrupt drain would otherwise leak). We disarm it on every
+        // clean exit path below.
+        let mut waiter_guard = PendingQuestionWaiterGuard::new(
+            self.contracts.clone(),
+            self.session_id.clone(),
+            question_id.clone(),
+        );
+
         // The event is durable: if the WS drop strands the request, the ledger
         // still records it and a reconnecting client can rehydrate. We cancel
         // the pending entry and degrade to the fallback so the turn continues
@@ -3266,11 +3347,15 @@ impl octos_agent::UserQuestionRequester for SessionUserQuestionRequester {
             &self.ledger,
             UiNotification::UserQuestionRequested(event),
         ) {
+            // Explicit send-failure cancellation records the precise reason;
+            // disarm the guard so its `Drop` does not also fire (a no-op on a
+            // now-cancelled entry, but cleaner to skip).
             self.contracts.user_questions.cancel_pending_question(
                 &self.session_id,
                 &question_id,
                 APPROVAL_CANCELLED_REASON_REQUEST_SEND_FAILED,
             );
+            waiter_guard.disarm();
             tracing::warn!(
                 target: "octos::ui_protocol::ws",
                 error = ?err,
@@ -3281,11 +3366,17 @@ impl octos_agent::UserQuestionRequester for SessionUserQuestionRequester {
 
         // This is the await boundary: the turn stays paused until the client
         // answers via user_question/respond (resolves the oneshot) or the turn
-        // is interrupted (cancel_pending_for_turn drops the sender → Err).
-        match response_rx.await {
+        // is interrupted (cancel_pending_for_turn drops the sender → Err). If
+        // OUR future is dropped here, `waiter_guard` cancels the entry.
+        let outcome = match response_rx.await {
             Ok(answers) => UserQuestionOutcome::Answered(answers),
             Err(_) => UserQuestionOutcome::Cancelled,
-        }
+        };
+        // Clean resolution — the store entry has already left `Pending`
+        // (Answered) or its sender was dropped by the turn-interrupt drain
+        // (Cancelled). Disarm so the guard does not re-cancel.
+        waiter_guard.disarm();
+        outcome
     }
 }
 
@@ -3759,6 +3850,7 @@ async fn ui_protocol_connection(
                     &state,
                     &ledger,
                     &contracts.approvals,
+                    &contracts.user_questions,
                     &live_forwarders,
                     connection_profile_id,
                     features,
@@ -3857,6 +3949,7 @@ async fn ui_protocol_connection(
                     &state,
                     &ledger,
                     &contracts.approvals,
+                    &contracts.user_questions,
                     &active_turns,
                     connection_profile_id,
                     routed_profile_id,
@@ -4270,6 +4363,7 @@ where
                     &state,
                     &ledger,
                     &contracts.approvals,
+                    &contracts.user_questions,
                     &live_forwarders,
                     next_connection_profile_id.as_deref(),
                     features,
@@ -4416,6 +4510,7 @@ where
                     &state,
                     &ledger,
                     &contracts.approvals,
+                    &contracts.user_questions,
                     &active_turns,
                     connection_profile_id_owned.as_deref(),
                     None,
@@ -7837,6 +7932,7 @@ async fn handle_session_open(
     state: &Arc<AppState>,
     ledger: &Arc<UiProtocolLedger>,
     approvals: &PendingApprovalStore,
+    questions: &PendingQuestionStore,
     live_forwarders: &SharedLiveForwarders,
     connection_profile_id: Option<&str>,
     features: ConnectionUiFeatures,
@@ -7860,6 +7956,7 @@ async fn handle_session_open(
         state,
         ledger,
         approvals,
+        questions,
         ws.connection_id,
         connection_profile_id,
         features,
@@ -7930,6 +8027,20 @@ async fn handle_session_open(
             ledger,
             UiProtocolLedgerEvent::Notification(UiNotification::ApprovalRequested(event)),
         );
+    }
+    // UPCR-2026-023: replay still-pending structured user-questions, gated by
+    // `user_question.v1`. A client that did not negotiate the feature never
+    // received a `user_question/requested` it could answer, so it must not
+    // get one on reconnect either — run each through the same per-connection
+    // capability filter the live broadcast uses so replay and live stay in
+    // lockstep (mirrors the `message/persisted` replay-gate rationale above).
+    for event in outcome.pending_questions {
+        let ledger_event =
+            UiProtocolLedgerEvent::Notification(UiNotification::UserQuestionRequested(event));
+        if !live_event_passes_capability_filter(&ledger_event, features) {
+            continue;
+        }
+        let _ = send_ledger_event_durable(ws, ledger, ledger_event);
     }
     // Baseline = head_seq captured atomically with replay (codex MUST-FIX-1).
     // Using opened_event.cursor.seq instead would silently filter out any
@@ -8202,6 +8313,20 @@ fn live_event_passes_capability_filter(
             return false;
         }
     }
+    // UPCR-2026-023 `user_question.v1` gate. A client that did not negotiate
+    // the structured-question capability never installed a
+    // `SessionUserQuestionRequester` and has no `user_question/respond` path,
+    // so it must never receive a `user_question/requested` it cannot answer —
+    // neither via the live broadcast NOR via reconnect replay (both routes
+    // call this filter). Mirrors the `ApprovalRequested` / typed-approval
+    // gating discipline: only deliver an interactive prompt to a connection
+    // that can act on it.
+    if !features.user_question_v1 {
+        if let UiProtocolLedgerEvent::Notification(UiNotification::UserQuestionRequested(_)) = event
+        {
+            return false;
+        }
+    }
     // UPCR-2026-014 M9-γ cutover: per-connection mutual exclusion.
     //
     // Connections that NEGOTIATED `projection.envelope.v1` see canonical
@@ -8248,6 +8373,10 @@ struct SessionOpenOutcome {
     result: SessionOpenResult,
     replay: Vec<LedgeredUiProtocolEvent>,
     pending_approvals: Vec<ApprovalRequestedEvent>,
+    /// UPCR-2026-023: still-pending structured user-questions to replay on
+    /// reconnect, mirroring [`pending_approvals`](Self::pending_approvals).
+    /// Gated by the `user_question.v1` capability at the send site.
+    pending_questions: Vec<UserQuestionRequestedEvent>,
     opened_event: LedgeredUiProtocolEvent,
     /// Head seq observed atomically with the replay snapshot. The live
     /// forwarder uses this — NOT `opened_event.cursor.seq` — as its
@@ -8257,10 +8386,15 @@ struct SessionOpenOutcome {
     replay_baseline_seq: u64,
 }
 
+// Threading both the approval store and the (UPCR-2026-023) question store
+// through the session/open contract pushes this past clippy's 7-arg lint;
+// the parameters are a flat dependency list, not a missing struct.
+#[allow(clippy::too_many_arguments)]
 async fn open_session_result(
     state: &Arc<AppState>,
     ledger: &UiProtocolLedger,
     approvals: &PendingApprovalStore,
+    questions: &PendingQuestionStore,
     connection_id: ConnectionId,
     connection_profile_id: Option<&str>,
     features: ConnectionUiFeatures,
@@ -8389,6 +8523,34 @@ async fn open_session_result(
         .filter(|approval| !replayed_approval_ids.contains(&approval.approval_id))
         .collect::<Vec<_>>();
 
+    // UPCR-2026-023: replay still-pending structured user-questions on
+    // reconnect, mirroring the pending-approval replay above EXACTLY —
+    // topic-scope filtered, and de-duplicated against any question already
+    // carried in the cursor replay window. The `user_question.v1` capability
+    // gate is applied at the send site (`live_event_passes_capability_filter`
+    // / the dedicated send loop) so a non-negotiated client never receives a
+    // question it cannot answer.
+    let replayed_question_ids = replay
+        .iter()
+        .filter_map(|event| match &event.event {
+            UiProtocolLedgerEvent::Notification(UiNotification::UserQuestionRequested(
+                question,
+            )) => Some(question.question_id.clone()),
+            _ => None,
+        })
+        .collect::<HashSet<_>>();
+    let pending_questions = questions
+        .pending_for_session(&params.session_id)
+        .into_iter()
+        .filter(|question| {
+            let event = UiProtocolLedgerEvent::Notification(UiNotification::UserQuestionRequested(
+                question.clone(),
+            ));
+            ledger_event_matches_topic_scope(&event, topic_scope.as_deref())
+        })
+        .filter(|question| !replayed_question_ids.contains(&question.question_id))
+        .collect::<Vec<_>>();
+
     let Some(sessions) = resolve_sessions_for_lookup(
         state,
         connection_profile_id,
@@ -8451,6 +8613,7 @@ async fn open_session_result(
         result: SessionOpenResult::new(opened),
         replay,
         pending_approvals,
+        pending_questions,
         opened_event,
         replay_baseline_seq,
     })
@@ -11042,6 +11205,7 @@ async fn handle_session_hydrate(
     state: &Arc<AppState>,
     ledger: &Arc<UiProtocolLedger>,
     approvals: &PendingApprovalStore,
+    questions: &PendingQuestionStore,
     active_turns: &SharedActiveTurns,
     connection_profile_id: Option<&str>,
     routed_profile_id: Option<&str>,
@@ -11281,6 +11445,18 @@ async fn handle_session_hydrate(
         None
     };
 
+    // UPCR-2026-023: hydrate still-pending structured user-questions alongside
+    // pending approvals (same `pending_approvals` include section), but only
+    // for a connection that negotiated `user_question.v1` — a client without
+    // the capability has no `user_question/respond` path, so the section is
+    // omitted (not `null`) exactly like a non-negotiated wire event is
+    // filtered out. Mirrors the `session/open` pending-question replay gate.
+    let pending_questions = if include_set.pending_approvals && features.user_question_v1 {
+        Some(questions.pending_for_session(&params.session_id))
+    } else {
+        None
+    };
+
     let result = SessionHydrateResult {
         session_id: params.session_id,
         cursor: head_cursor,
@@ -11290,6 +11466,7 @@ async fn handle_session_hydrate(
         threads,
         turns,
         pending_approvals,
+        pending_questions,
         replayed_envelopes,
     };
     send_serialized_rpc_result(
@@ -22723,6 +22900,7 @@ ignore = []
         let (ws, mut rx) = ws_connection_for_test(16);
         let ledger = Arc::new(UiProtocolLedger::new(16));
         let approvals = PendingApprovalStore::default();
+        let questions = PendingQuestionStore::default();
         let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
         let features = ConnectionUiFeatures::stdio_defaults();
         let mut binding = Some("ada".to_owned());
@@ -22742,6 +22920,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &questions,
             &forwarders,
             candidate.as_deref(),
             features,
@@ -22794,6 +22973,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &questions,
             &forwarders,
             candidate.as_deref(),
             features,
@@ -22942,6 +23122,7 @@ ignore = []
                 &state,
                 &ledger,
                 &approvals,
+                &PendingQuestionStore::default(),
                 ConnectionId::next(),
                 Some(profile_id),
                 features,
@@ -26431,6 +26612,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             None,
             ConnectionUiFeatures::default(),
@@ -26492,6 +26674,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             None,
             ConnectionUiFeatures::default(),
@@ -26521,6 +26704,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             None,
             ConnectionUiFeatures::default(),
@@ -26559,6 +26743,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             None,
             ConnectionUiFeatures::default(),
@@ -26618,6 +26803,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             None,
             ConnectionUiFeatures::default(),
@@ -26673,6 +26859,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             None,
             ConnectionUiFeatures::default(),
@@ -26691,6 +26878,348 @@ ignore = []
         assert_eq!(outcome.pending_approvals.len(), 1);
         assert_eq!(outcome.pending_approvals[0].approval_id, approval_id);
         assert_eq!(outcome.pending_approvals[0].title, "Run command");
+    }
+
+    // ---- UPCR-2026-023 pending-question reconnect + capability gating ----
+
+    fn sample_pending_question(
+        session_id: SessionKey,
+        question_id: QuestionId,
+        turn_id: TurnId,
+    ) -> UserQuestionRequestedEvent {
+        use octos_core::ui_protocol::{UserQuestion, UserQuestionOption};
+        UserQuestionRequestedEvent::new(
+            session_id,
+            question_id,
+            turn_id,
+            "Pick a framework",
+            "Which framework should I scaffold?",
+            vec![UserQuestion {
+                header: "Framework".into(),
+                question: "Which framework?".into(),
+                options: vec![
+                    UserQuestionOption {
+                        label: "axum".into(),
+                        description: "tower-based".into(),
+                    },
+                    UserQuestionOption {
+                        label: "actix".into(),
+                        description: "actor-based".into(),
+                    },
+                ],
+                multi_select: false,
+                allow_free_text: true,
+            }],
+        )
+    }
+
+    fn features_with_user_question_v1() -> ConnectionUiFeatures {
+        ConnectionUiFeatures {
+            user_question_v1: true,
+            ..ConnectionUiFeatures::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn session_open_replays_pending_question_for_negotiated_client() {
+        // #3: a reconnecting client that negotiated `user_question.v1` must see
+        // the still-pending structured question in `pending_questions`.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state = state_with_sessions(temp.path());
+        let ledger = UiProtocolLedger::new(16);
+        let approvals = PendingApprovalStore::default();
+        let questions = PendingQuestionStore::default();
+        let session_id = SessionKey("local:test".into());
+        let question_id = QuestionId::new();
+        let _rx = questions.request_runtime(sample_pending_question(
+            session_id.clone(),
+            question_id.clone(),
+            TurnId::new(),
+        ));
+
+        let outcome = open_session_result(
+            &state,
+            &ledger,
+            &approvals,
+            &questions,
+            ConnectionId::next(),
+            None,
+            features_with_user_question_v1(),
+            SessionOpenParams {
+                session_id: session_id.clone(),
+                topic: None,
+                profile_id: None,
+                cwd: None,
+                after: None,
+            },
+        )
+        .await
+        .expect("open session should replay pending question");
+
+        assert_eq!(outcome.pending_questions.len(), 1);
+        assert_eq!(outcome.pending_questions[0].question_id, question_id);
+        assert_eq!(
+            outcome.pending_questions[0].title, "Pick a framework",
+            "the reconnecting client must re-render the pending question"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_open_pending_question_filtered_out_without_capability() {
+        // #4 (replay path): a client lacking `user_question.v1` must NOT
+        // receive the pending question even though it is in the store — the
+        // outcome carries it (computed unconditionally) but the send-site
+        // capability filter drops it. Assert the filter at the unit level so
+        // the contract is pinned regardless of send wiring.
+        let event = sample_pending_question(
+            SessionKey("local:test".into()),
+            QuestionId::new(),
+            TurnId::new(),
+        );
+        let ledger_event =
+            UiProtocolLedgerEvent::Notification(UiNotification::UserQuestionRequested(event));
+        assert!(
+            !live_event_passes_capability_filter(&ledger_event, ConnectionUiFeatures::default()),
+            "a connection without user_question.v1 must not receive UserQuestionRequested"
+        );
+        assert!(
+            live_event_passes_capability_filter(&ledger_event, features_with_user_question_v1()),
+            "a negotiated connection must receive UserQuestionRequested"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_open_does_not_duplicate_pending_question_already_in_cursor_replay() {
+        // #3: a question already carried by the cursor replay window must not
+        // be re-sent as a supplemental pending question (mirrors the approval
+        // de-dup).
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state = state_with_sessions(temp.path());
+        let ledger = UiProtocolLedger::new(16);
+        let approvals = PendingApprovalStore::default();
+        let questions = PendingQuestionStore::default();
+        let session_id = SessionKey("local:test".into());
+        let question_id = QuestionId::new();
+        let event = sample_pending_question(session_id.clone(), question_id.clone(), TurnId::new());
+        let _rx = questions.request_runtime(event.clone());
+        ledger.append_notification(UiNotification::MessageDelta(MessageDeltaEvent {
+            session_id: session_id.clone(),
+            topic: None,
+            turn_id: TurnId::new(),
+            text: "before".into(),
+        }));
+        ledger.append_notification(UiNotification::UserQuestionRequested(event));
+
+        let outcome = open_session_result(
+            &state,
+            &ledger,
+            &approvals,
+            &questions,
+            ConnectionId::next(),
+            None,
+            features_with_user_question_v1(),
+            SessionOpenParams {
+                session_id: session_id.clone(),
+                topic: None,
+                profile_id: None,
+                cwd: None,
+                after: Some(UiCursor {
+                    stream: session_id.0.clone(),
+                    seq: 1,
+                }),
+            },
+        )
+        .await
+        .expect("open session should rely on cursor replay");
+
+        assert!(
+            outcome.pending_questions.is_empty(),
+            "a question already in the cursor replay must not be re-sent"
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_question_waiter_guard_cancels_entry_on_drop() {
+        // #2: when the requester's waiting future is dropped (timeout,
+        // interrupt, abort, panic) before a clean resolution, the RAII guard
+        // cancels the pending store entry — the blocked tool sees a closed
+        // receiver (Cancelled) and the entry does not leak.
+        let contracts = Arc::new(UiProtocolContractStores::default());
+        let session_id = SessionKey("local:test".into());
+        let question_id = QuestionId::new();
+        let turn_id = TurnId::new();
+        let rx = contracts
+            .user_questions
+            .request_runtime(sample_pending_question(
+                session_id.clone(),
+                question_id.clone(),
+                turn_id,
+            ));
+
+        // Arm a guard exactly as the requester does, then drop it WITHOUT
+        // disarming — simulating the tool future being dropped mid-wait.
+        {
+            let _guard = PendingQuestionWaiterGuard::new(
+                contracts.clone(),
+                session_id.clone(),
+                question_id.clone(),
+            );
+        }
+
+        // The waiter is resolved-as-cancelled (sender dropped → Err).
+        assert!(
+            rx.await.is_err(),
+            "dropping the guard must cancel the pending entry, closing the waiter"
+        );
+        // The entry is no longer pending (it was moved to Cancelled).
+        assert!(
+            contracts
+                .user_questions
+                .pending_for_session(&session_id)
+                .is_empty(),
+            "cancelled entry must not appear as pending"
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_question_waiter_guard_disarmed_does_not_cancel() {
+        // The guard must NOT cancel a cleanly-resolved entry: after disarm,
+        // dropping it is a no-op and the still-pending entry survives.
+        let contracts = Arc::new(UiProtocolContractStores::default());
+        let session_id = SessionKey("local:test".into());
+        let question_id = QuestionId::new();
+        let _rx = contracts
+            .user_questions
+            .request_runtime(sample_pending_question(
+                session_id.clone(),
+                question_id.clone(),
+                TurnId::new(),
+            ));
+
+        {
+            let mut guard = PendingQuestionWaiterGuard::new(
+                contracts.clone(),
+                session_id.clone(),
+                question_id.clone(),
+            );
+            guard.disarm();
+        }
+
+        assert_eq!(
+            contracts
+                .user_questions
+                .pending_for_session(&session_id)
+                .len(),
+            1,
+            "a disarmed guard must not cancel the still-pending entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_hydrate_returns_pending_question_for_negotiated_client() {
+        // #3 (hydrate path): a reconnecting client that requests the
+        // pending-approvals section and negotiated `user_question.v1` gets the
+        // pending structured question back in `pending_questions`.
+        use octos_core::ui_protocol::hydrate_sections;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state = state_with_sessions(temp.path());
+        let ledger = Arc::new(UiProtocolLedger::new(16));
+        let approvals = PendingApprovalStore::default();
+        let questions = PendingQuestionStore::default();
+        let active_turns: SharedActiveTurns = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let session_id = SessionKey("local:test".into());
+        let question_id = QuestionId::new();
+        let _rx = questions.request_runtime(sample_pending_question(
+            session_id.clone(),
+            question_id.clone(),
+            TurnId::new(),
+        ));
+        // Make the session known so hydrate does not reject it.
+        {
+            let sessions = state.sessions.as_ref().expect("sessions");
+            let mut guard = sessions.lock().await;
+            guard.get_or_create(&session_id).await;
+        }
+
+        let (ws, mut rx) = ws_connection_for_test(16);
+        handle_session_hydrate(
+            &ws,
+            &state,
+            &ledger,
+            &approvals,
+            &questions,
+            &active_turns,
+            None,
+            None,
+            features_with_user_question_v1(),
+            "hydrate-q".into(),
+            SessionHydrateParams {
+                session_id: session_id.clone(),
+                after: None,
+                include: vec![hydrate_sections::PENDING_APPROVALS.into()],
+            },
+        )
+        .await;
+
+        let frame = recv_rpc_json(&mut rx).await;
+        assert_eq!(frame["id"], json!("hydrate-q"));
+        let pending = frame["result"]["pending_questions"]
+            .as_array()
+            .expect("pending_questions must be present for a negotiated client");
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0]["question_id"], json!(question_id.0.to_string()));
+    }
+
+    #[tokio::test]
+    async fn session_hydrate_omits_pending_question_without_capability() {
+        // #3/#4: a client lacking `user_question.v1` must not receive the
+        // `pending_questions` section at all (omitted, not `null`).
+        use octos_core::ui_protocol::hydrate_sections;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state = state_with_sessions(temp.path());
+        let ledger = Arc::new(UiProtocolLedger::new(16));
+        let approvals = PendingApprovalStore::default();
+        let questions = PendingQuestionStore::default();
+        let active_turns: SharedActiveTurns = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let session_id = SessionKey("local:test".into());
+        let _rx = questions.request_runtime(sample_pending_question(
+            session_id.clone(),
+            QuestionId::new(),
+            TurnId::new(),
+        ));
+        {
+            let sessions = state.sessions.as_ref().expect("sessions");
+            let mut guard = sessions.lock().await;
+            guard.get_or_create(&session_id).await;
+        }
+
+        let (ws, mut rx) = ws_connection_for_test(16);
+        handle_session_hydrate(
+            &ws,
+            &state,
+            &ledger,
+            &approvals,
+            &questions,
+            &active_turns,
+            None,
+            None,
+            ConnectionUiFeatures::default(),
+            "hydrate-no-q".into(),
+            SessionHydrateParams {
+                session_id: session_id.clone(),
+                after: None,
+                include: vec![hydrate_sections::PENDING_APPROVALS.into()],
+            },
+        )
+        .await;
+
+        let frame = recv_rpc_json(&mut rx).await;
+        assert_eq!(frame["id"], json!("hydrate-no-q"));
+        assert!(
+            frame["result"].get("pending_questions").is_none(),
+            "non-negotiated client must not receive pending_questions; got {}",
+            frame["result"]
+        );
     }
 
     #[tokio::test]
@@ -26722,6 +27251,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             None,
             ConnectionUiFeatures::default(),
@@ -26767,6 +27297,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             None,
             ConnectionUiFeatures {
@@ -26840,6 +27371,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             None,
             ConnectionUiFeatures::default(),
@@ -26877,6 +27409,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             None,
             ConnectionUiFeatures::default(),
@@ -26948,6 +27481,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             None,
             features,
@@ -28973,6 +29507,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             None,
             ConnectionUiFeatures::default(),
@@ -28997,6 +29532,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             None,
             ConnectionUiFeatures::default(),
@@ -30762,6 +31298,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             None,
             ConnectionUiFeatures::default(),
@@ -31477,6 +32014,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             &active_turns,
             None,
             None,
@@ -31869,6 +32407,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             &active_turns,
             None,
             None,
@@ -32023,6 +32562,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             &active_turns,
             None,
             None,
@@ -32102,6 +32642,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             &active_turns,
             None,
             None,
@@ -32180,6 +32721,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             &active_turns,
             None,
             None,
@@ -35320,6 +35862,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             Some("m11e-custom-cwd"),
             features,
@@ -35410,6 +35953,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             Some("m11e-multi-cwd"),
             features,
@@ -35429,6 +35973,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             Some("m11e-multi-cwd"),
             features,
@@ -35577,6 +36122,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             Some("m11e-rebind-attempt"),
             features,
@@ -35595,6 +36141,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             Some("m11e-rebind-attempt"),
             features,
@@ -35666,6 +36213,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             // No connection identity so the routed id falls to the
             // session-id-embedded "m11e-not-registered".
@@ -35734,6 +36282,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             Some("m11e-symlink"),
             features,
@@ -35858,6 +36407,7 @@ ignore = []
             &state,
             &ledger,
             &approvals,
+            &PendingQuestionStore::default(),
             ConnectionId::next(),
             Some("m11f-tier2-default"),
             features,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -21,6 +21,7 @@ use futures::{SinkExt, StreamExt};
 use octos_agent::{
     Agent, BackgroundResultKind, BackgroundResultPayload, PromptContextManager, PromptContextPhase,
     PromptContextReport, PromptContextRequest, ToolApprovalDecision, ToolApprovalRequest,
+    UserQuestionOutcome, UserQuestionRequest,
 };
 use octos_core::app_ui_codec::{self, AppUiFrame, MAX_TEXT_FRAME_BYTES};
 use octos_core::ui_protocol::{
@@ -54,13 +55,14 @@ use octos_core::ui_protocol::{
     UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1, UI_PROTOCOL_FEATURE_REVIEW_START_V1,
     UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1, UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
     UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1, UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1,
-    UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1, UiAgentRecord, UiArtifactPaneItem,
-    UiArtifactPaneSnapshot, UiCommand, UiContextCompactionRecord, UiContextNormalizationReport,
-    UiContextState, UiCursor, UiFileMutationNotice, UiGitHistoryItem, UiGitPaneSnapshot,
-    UiGitStatusItem, UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation, UiProgressEvent,
-    UiProgressMetadata, UiProtocolCapabilities, UiRpcResult, UiWorkspacePaneEntry,
-    UiWorkspacePaneSnapshot, UnsupportedCapabilityReport, approval_cancelled_reasons,
-    approval_kinds, hydrate_sections, progress_kinds, thread_status,
+    UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1, UI_PROTOCOL_FEATURE_USER_QUESTION_V1, UiAgentRecord,
+    UiArtifactPaneItem, UiArtifactPaneSnapshot, UiCommand, UiContextCompactionRecord,
+    UiContextNormalizationReport, UiContextState, UiCursor, UiFileMutationNotice, UiGitHistoryItem,
+    UiGitPaneSnapshot, UiGitStatusItem, UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation,
+    UiProgressEvent, UiProgressMetadata, UiProtocolCapabilities, UiRpcResult, UiWorkspacePaneEntry,
+    UiWorkspacePaneSnapshot, UnsupportedCapabilityReport, UserQuestionRequestedEvent,
+    UserQuestionRespondParams, approval_cancelled_reasons, approval_kinds, hydrate_sections,
+    progress_kinds, thread_status,
 };
 use octos_core::{
     AgentId, InboundMessage, MAIN_PROFILE_ID, Message, MessageRole, SessionKey, TaskId,
@@ -106,6 +108,7 @@ use super::ui_protocol_progress::{
     ProgressMappingContext, UiProgressMapping, background_task_to_progress_json, map_progress_json,
     replay_task_updated_notification,
 };
+use super::ui_protocol_questions::PendingQuestionStore;
 use super::ui_protocol_sanitize::sanitize_display_path;
 use super::ui_protocol_scope::{ApprovalScopeKind, ScopePolicy, match_key_for};
 use super::ui_protocol_task_output;
@@ -667,6 +670,10 @@ impl WsConnection {
 #[derive(Default)]
 struct UiProtocolContractStores {
     approvals: PendingApprovalStore,
+    /// UPCR-2026-023: pending structured user-questions, keyed by
+    /// `question_id`. Mirrors `approvals`; the blocked `ask_user_question`
+    /// tool awaits a oneshot resolved by `user_question/respond`.
+    user_questions: PendingQuestionStore,
     /// Lazily-initialized pending diff-preview store. With a `data_dir`
     /// the first call hydrates from disk and subsequent inserts
     /// write-ahead before returning, so `diff/preview/get` survives
@@ -1007,6 +1014,12 @@ struct ConnectionUiFeatures {
     review_start_v1: bool,
     /// M16 backend-owned context generation/checkpoint/compaction lifecycle.
     context_lifecycle_v1: bool,
+    /// UPCR-2026-023 `user_question.v1` negotiated. When set, the connection's
+    /// turn task installs a [`SessionUserQuestionRequester`] so the agent's
+    /// `ask_user_question` tool blocks on `user_question/respond`. When unset,
+    /// the requester is not installed and the tool degrades to its
+    /// structured-metadata fallback.
+    user_question_v1: bool,
     /// `true` when the client sent at least one feature token via the
     /// `X-Octos-Ui-Features` header or the `ui_feature` / `ui_features`
     /// query parameter (UPCR-2026-007). Distinguishes "no header at all"
@@ -1086,6 +1099,7 @@ impl ConnectionUiFeatures {
                 query,
                 UI_PROTOCOL_FEATURE_CONTEXT_LIFECYCLE_V1,
             ),
+            user_question_v1: has_ui_feature(headers, query, UI_PROTOCOL_FEATURE_USER_QUESTION_V1),
             header_present: has_any_ui_feature_token(headers, query),
             stdio_transport: false,
         }
@@ -1112,6 +1126,7 @@ impl ConnectionUiFeatures {
             coding_loop_runtime_v1: true,
             review_start_v1: true,
             context_lifecycle_v1: true,
+            user_question_v1: true,
             header_present: true,
             stdio_transport: true,
         }
@@ -1148,6 +1163,7 @@ impl ConnectionUiFeatures {
             coding_loop_runtime_v1: has(UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1),
             review_start_v1: has(UI_PROTOCOL_FEATURE_REVIEW_START_V1),
             context_lifecycle_v1: has(UI_PROTOCOL_FEATURE_CONTEXT_LIFECYCLE_V1),
+            user_question_v1: has(UI_PROTOCOL_FEATURE_USER_QUESTION_V1),
             header_present: true,
             stdio_transport,
         }
@@ -1223,6 +1239,9 @@ impl ConnectionUiFeatures {
         }
         if self.review_start_v1 {
             requested.push(UI_PROTOCOL_FEATURE_REVIEW_START_V1);
+        }
+        if self.user_question_v1 {
+            requested.push(UI_PROTOCOL_FEATURE_USER_QUESTION_V1);
         }
         UiProtocolCapabilities::for_negotiated_features(requested)
     }
@@ -3204,6 +3223,72 @@ fn cancel_approval_after_request_send_failure(
     );
 }
 
+/// UPCR-2026-023 bridge: implements the agent's [`UserQuestionRequester`]
+/// trait by minting a `question_id`, parking the request in the
+/// [`PendingQuestionStore`], emitting `user_question/requested`, and awaiting
+/// the oneshot the `user_question/respond` handler resolves. Mirrors
+/// [`UiProtocolApprovalRequester`] end-to-end.
+///
+/// The requester is gated on the connection negotiating `user_question.v1`:
+/// when the feature is NOT negotiated this requester is never installed (the
+/// task-local stays unset), so the `ask_user_question` tool degrades to its
+/// structured-metadata fallback and the turn never hard-blocks.
+struct SessionUserQuestionRequester {
+    ws: WsConnection,
+    ledger: Arc<UiProtocolLedger>,
+    contracts: Arc<UiProtocolContractStores>,
+    session_id: SessionKey,
+    turn_id: TurnId,
+}
+
+#[async_trait::async_trait]
+impl octos_agent::UserQuestionRequester for SessionUserQuestionRequester {
+    async fn request_user_question(&self, request: UserQuestionRequest) -> UserQuestionOutcome {
+        let question_id = octos_core::ui_protocol::QuestionId::new();
+        let event = UserQuestionRequestedEvent {
+            session_id: self.session_id.clone(),
+            topic: self.session_id.topic().map(ToOwned::to_owned),
+            question_id: question_id.clone(),
+            turn_id: self.turn_id.clone(),
+            title: request.title,
+            body: request.body,
+            questions: request.questions,
+        };
+
+        let response_rx = self.contracts.user_questions.request_runtime(event.clone());
+
+        // The event is durable: if the WS drop strands the request, the ledger
+        // still records it and a reconnecting client can rehydrate. We cancel
+        // the pending entry and degrade to the fallback so the turn continues
+        // rather than hanging on a dead channel.
+        if let Err(err) = send_notification_durable(
+            &self.ws,
+            &self.ledger,
+            UiNotification::UserQuestionRequested(event),
+        ) {
+            self.contracts.user_questions.cancel_pending_question(
+                &self.session_id,
+                &question_id,
+                APPROVAL_CANCELLED_REASON_REQUEST_SEND_FAILED,
+            );
+            tracing::warn!(
+                target: "octos::ui_protocol::ws",
+                error = ?err,
+                "user_question/requested notification not delivered; degrading to fallback"
+            );
+            return UserQuestionOutcome::Unsupported;
+        }
+
+        // This is the await boundary: the turn stays paused until the client
+        // answers via user_question/respond (resolves the oneshot) or the turn
+        // is interrupted (cancel_pending_for_turn drops the sender → Err).
+        match response_rx.await {
+            Ok(answers) => UserQuestionOutcome::Answered(answers),
+            Err(_) => UserQuestionOutcome::Cancelled,
+        }
+    }
+}
+
 fn approval_event_from_tool_request(
     request: ToolApprovalRequest,
     session_id: SessionKey,
@@ -3737,6 +3822,10 @@ async fn ui_protocol_connection(
                 )
                 .await;
             }
+            UiCommand::UserQuestionRespond(params) => {
+                handle_user_question_respond(&ws, &contracts, connection_profile_id, id, params)
+                    .await;
+            }
             UiCommand::DiffPreviewGet(params) => {
                 let store = diff_preview_store(&state, contracts.as_ref()).await;
                 handle_diff_preview_get(&ws, store.as_ref(), connection_profile_id, id, params)
@@ -3995,6 +4084,7 @@ async fn ui_protocol_connection(
         &contracts.scopes,
         &ledger,
         &contracts.approvals,
+        &contracts.user_questions,
     )
     .await;
     abort_live_forwarders(&live_forwarders, &ledger).await;
@@ -4231,6 +4321,16 @@ where
                 handle_approval_scopes_list(
                     &ws,
                     &contracts.scopes,
+                    connection_profile_id_owned.as_deref(),
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::UserQuestionRespond(params) => {
+                handle_user_question_respond(
+                    &ws,
+                    &contracts,
                     connection_profile_id_owned.as_deref(),
                     id,
                     params,
@@ -4690,6 +4790,7 @@ async fn cleanup_stdio_connection_resources(
         &contracts.scopes,
         ledger,
         &contracts.approvals,
+        &contracts.user_questions,
     )
     .await;
     abort_live_forwarders(live_forwarders, ledger).await;
@@ -7571,6 +7672,11 @@ fn route_rpc_command(
         | octos_core::ui_protocol::methods::CONTENT_BULK_DELETE => {
             Some(features.auxiliary_rest_to_ws_v1)
         }
+        // UPCR-2026-023: `user_question/respond` is strict opt-in. A client
+        // that did not negotiate `user_question.v1` never received a
+        // `user_question/requested`, so it has nothing to answer; reject the
+        // method outright instead of routing a forged response.
+        octos_core::ui_protocol::methods::USER_QUESTION_RESPOND => Some(features.user_question_v1),
         _ => None,
     };
     if let Some(false) = strict_gated {
@@ -10330,6 +10436,46 @@ async fn handle_approval_respond(
             );
         }
     }
+}
+
+/// UPCR-2026-023 `user_question/respond` handler. Mirrors
+/// [`handle_approval_respond`]: validate session scope, resolve the pending
+/// question's oneshot (typed `user_question_unknown` / `user_question_stale`
+/// on miss), and return the ack result.
+async fn handle_user_question_respond(
+    ws: &WsConnection,
+    contracts: &Arc<UiProtocolContractStores>,
+    connection_profile_id: Option<&str>,
+    id: String,
+    params: UserQuestionRespondParams,
+) {
+    if let Err(error) = validate_session_scope(&params.session_id, None, connection_profile_id) {
+        send_scope_error(ws, id, error);
+        return;
+    }
+
+    let outcome = match contracts.user_questions.respond_with_context(&params) {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+            return;
+        }
+    };
+
+    let result = match serde_json::to_value(&outcome.result) {
+        Ok(value) => value,
+        Err(error) => {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::internal_error(format!(
+                    "failed to serialize user_question/respond result: {error}"
+                )),
+            );
+            return;
+        }
+    };
+    let _ = send_rpc_result(ws, id, result);
 }
 
 async fn handle_approval_scopes_list(
@@ -17023,6 +17169,20 @@ async fn run_standalone_turn(
             turn_id: turn_id.clone(),
             features,
         });
+    // UPCR-2026-023: install the structured-user-question bridge ONLY when the
+    // connection negotiated `user_question.v1`. When unset the task-local stays
+    // empty, so the agent's `ask_user_question` tool degrades to its
+    // structured-metadata fallback and the turn never hard-blocks.
+    let user_question_requester: Option<Arc<dyn octos_agent::UserQuestionRequester>> =
+        features.user_question_v1.then(|| {
+            Arc::new(SessionUserQuestionRequester {
+                ws: ws.clone(),
+                ledger: ledger.clone(),
+                contracts: contracts.clone(),
+                session_id: session_id.clone(),
+                turn_id: turn_id.clone(),
+            }) as Arc<dyn octos_agent::UserQuestionRequester>
+        });
     // PR F (M8.10): capture the originating `TurnId` as a string so the
     // tokio::spawn closure (which moves everything it touches) can pre-stamp
     // each persisted Assistant/Tool message with the correct thread_id.
@@ -17127,14 +17287,30 @@ async fn run_standalone_turn(
         // recurses through the agent loop. Lane and router contexts
         // are orthogonal — lane filters slot eligibility, router
         // context attributes failover events.
+        // UPCR-2026-023: nest the user-question task-local INSIDE the approval
+        // scope, mirroring how `TOOL_APPROVAL_CTX` wraps the turn. The two are
+        // orthogonal blocking bridges. The scope is installed only when the
+        // connection negotiated `user_question.v1` (`user_question_requester`
+        // is `Some`); otherwise the agent's `ask_user_question` tool sees no
+        // requester and degrades to its structured-metadata fallback.
+        let message_future = request_agent.process_message(&prompt, &history, turn_media_paths);
+        let scoped_message_future: std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = eyre::Result<octos_agent::ConversationResponse>>
+                    + Send,
+            >,
+        > = match user_question_requester {
+            Some(requester) => {
+                Box::pin(octos_agent::tools::USER_QUESTION_CTX.scope(requester, message_future))
+            }
+            None => Box::pin(message_future),
+        };
         let result = octos_llm::with_router_context(
             router_ctx,
             octos_llm::with_lane_context(
                 lane_ctx,
-                octos_agent::tools::TOOL_APPROVAL_CTX.scope(
-                    approval_requester,
-                    request_agent.process_message(&prompt, &history, turn_media_paths),
-                ),
+                octos_agent::tools::TOOL_APPROVAL_CTX
+                    .scope(approval_requester, scoped_message_future),
             ),
         )
         .await;
@@ -17868,6 +18044,17 @@ async fn run_standalone_turn(
                 )),
             );
         }
+        // UPCR-2026-023: drain pending structured user-questions for the
+        // interrupted turn, mirroring the approval drain. Dropping each
+        // oneshot resolves the blocked `ask_user_question` tool to a
+        // `Cancelled` outcome; the turn then terminates via the
+        // `turn/error code=interrupted` emitted below (Phase-1 reuses the
+        // terminal path rather than a dedicated question-cancelled signal).
+        contracts.user_questions.cancel_pending_for_turn(
+            &session_id,
+            &turn_id,
+            approval_cancelled_reasons::TURN_INTERRUPTED,
+        );
         // Handler is awaiting our terminal emission + ack. Emit exactly once.
         try_emit_terminal(
             &turn_state,
@@ -18936,6 +19123,7 @@ async fn abort_connection_turns(
     scopes: &ScopePolicy,
     ledger: &UiProtocolLedger,
     approvals: &PendingApprovalStore,
+    user_questions: &PendingQuestionStore,
 ) {
     let turns = std::mem::take(&mut *connection_turns.lock().await);
     if turns.is_empty() {
@@ -18996,6 +19184,14 @@ async fn abort_connection_turns(
                 },
             ));
         }
+        // UPCR-2026-023: also drain pending structured user-questions for the
+        // aborted turn so a reconnect doesn't re-show a question for a dead
+        // turn and the blocked `ask_user_question` tool unblocks (Cancelled).
+        user_questions.cancel_pending_for_turn(
+            &session_id,
+            &turn_id,
+            approval_cancelled_reasons::TURN_INTERRUPTED,
+        );
         // FIX-06: connection close is the de-facto "session close" hook in
         // v1alpha1 — drop every recorded scope for this session so it cannot
         // outlive the WebSocket. Per M9-FIX-06 § "Out of scope", an explicit
@@ -20286,6 +20482,10 @@ fn ledger_event_cursor(event: &UiProtocolLedgerEvent) -> Option<UiCursor> {
             | UiNotification::ApprovalAutoResolved(_)
             | UiNotification::ApprovalDecided(_)
             | UiNotification::ApprovalCancelled(_)
+            // UPCR-2026-023: structured user-questions are non-cursor-bearing
+            // (like approval/requested); the durable ledger cursor on the
+            // surrounding LedgeredUiProtocolEvent is authoritative for replay.
+            | UiNotification::UserQuestionRequested(_)
             | UiNotification::TaskUpdated(_)
             // TaskOutputDelta carries an `OutputCursor`, not a `UiCursor`.
             | UiNotification::TaskOutputDelta(_)
@@ -20404,7 +20604,7 @@ mod tests {
         ApprovalDecision, ApprovalId, ApprovalRespondParams, ApprovalRespondStatus, DiffPreview,
         DiffPreviewFile, DiffPreviewFileStatus, DiffPreviewGetParams, DiffPreviewGetStatus,
         DiffPreviewHunk, DiffPreviewLine, DiffPreviewLineKind, DiffPreviewSource, PreviewId,
-        approval_scopes, methods, rpc_error_codes,
+        QuestionId, approval_scopes, methods, rpc_error_codes,
     };
 
     fn local_profile_state(dir: &Path) -> AppState {
@@ -20523,6 +20723,11 @@ mod tests {
                 "decision": "approve",
             }),
             methods::APPROVAL_SCOPES_LIST => json!({ "session_id": session_id }),
+            methods::USER_QUESTION_RESPOND => json!({
+                "session_id": session_id,
+                "question_id": QuestionId::new(),
+                "answers": [{ "selected_labels": ["axum"] }],
+            }),
             methods::PERMISSION_PROFILE_LIST => json!({ "session_id": session_id }),
             methods::PERMISSION_PROFILE_SET => json!({
                 "session_id": session_id,
@@ -24412,6 +24617,7 @@ ignore = []
                 coding_loop_runtime_v1: false,
                 review_start_v1: false,
                 context_lifecycle_v1: false,
+                user_question_v1: false,
                 header_present: true,
                 stdio_transport: false,
             },
@@ -24473,6 +24679,7 @@ ignore = []
                 coding_loop_runtime_v1: false,
                 review_start_v1: false,
                 context_lifecycle_v1: false,
+                user_question_v1: false,
                 header_present: true,
                 stdio_transport: false,
             },
@@ -24579,6 +24786,7 @@ ignore = []
                 coding_loop_runtime_v1: false,
                 review_start_v1: false,
                 context_lifecycle_v1: false,
+                user_question_v1: false,
                 header_present: true,
                 stdio_transport: false,
             },
@@ -24640,6 +24848,7 @@ ignore = []
                 coding_loop_runtime_v1: false,
                 review_start_v1: false,
                 context_lifecycle_v1: false,
+                user_question_v1: false,
                 header_present: true,
                 stdio_transport: false,
             },
@@ -24694,6 +24903,7 @@ ignore = []
                 coding_loop_runtime_v1: false,
                 review_start_v1: false,
                 context_lifecycle_v1: false,
+                user_question_v1: false,
                 header_present: true,
                 stdio_transport: false,
             },
@@ -24791,6 +25001,7 @@ ignore = []
                 coding_loop_runtime_v1: false,
                 review_start_v1: false,
                 context_lifecycle_v1: false,
+                user_question_v1: false,
                 header_present: true,
                 stdio_transport: false,
             },
@@ -26578,6 +26789,7 @@ ignore = []
                 coding_loop_runtime_v1: false,
                 review_start_v1: false,
                 context_lifecycle_v1: false,
+                user_question_v1: false,
                 header_present: true,
                 stdio_transport: false,
             },
@@ -28599,12 +28811,14 @@ ignore = []
         let scopes = ScopePolicy::default();
         let ledger = UiProtocolLedger::new(16);
         let approvals = PendingApprovalStore::default();
+        let user_questions = PendingQuestionStore::default();
         abort_connection_turns(
             &active_turns,
             &connection_turns,
             &scopes,
             &ledger,
             &approvals,
+            &user_questions,
         )
         .await;
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -148,10 +148,14 @@ const INTERRUPT_ACK_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 /// traffic. Tunable per session size.
 const WS_WRITER_CHANNEL_CAPACITY: usize = 1024;
 const APPROVAL_CANCELLED_REASON_REQUEST_SEND_FAILED: &str = "request_send_failed";
-/// Reason recorded when a pending structured-question entry is cancelled
-/// because the `ask_user_question` tool's waiting future was dropped (timeout,
-/// interrupt, abort, panic, connection close) — UPCR-2026-023 drop-guard.
-const APPROVAL_CANCELLED_REASON_WAITER_DROPPED: &str = "waiter_dropped";
+/// Reason recorded when a pending structured-USER-QUESTION entry is cancelled
+/// because the `ask_user_question` tool's waiting future was dropped (turn
+/// interrupt/abort, panic, connection close) — UPCR-2026-023 drop-guard. This
+/// is the QUESTION-store reason and is intentionally distinct from the approval
+/// reasons (`APPROVAL_CANCELLED_REASON_*`): approvals keep their own audit
+/// reasons. The wire value stays `"waiter_dropped"` (used by both stores'
+/// drop-guards conceptually, but each store records it under its own const).
+const USER_QUESTION_CANCELLED_REASON_WAITER_DROPPED: &str = "waiter_dropped";
 const APPUI_METHOD_CONFIG_CAPABILITIES_LIST: &str =
     octos_core::ui_protocol::methods::CONFIG_CAPABILITIES_LIST;
 const APPUI_METHOD_CLIENT_HELLO: &str = "client_hello";
@@ -3304,7 +3308,7 @@ impl Drop for PendingQuestionWaiterGuard {
         self.contracts.user_questions.cancel_pending_question(
             &self.session_id,
             &self.question_id,
-            APPROVAL_CANCELLED_REASON_WAITER_DROPPED,
+            USER_QUESTION_CANCELLED_REASON_WAITER_DROPPED,
         );
     }
 }

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -2237,6 +2237,7 @@ fn notification_session_id(notification: &UiNotification) -> &SessionKey {
         UiNotification::ContextCompactionCompleted(event) => &event.session_id,
         UiNotification::ContextNormalizationReported(event) => &event.session_id,
         UiNotification::SessionOrchestration(event) => &event.session_id,
+        UiNotification::UserQuestionRequested(event) => &event.session_id,
         UiNotification::Envelope(event) => &event.session_id,
     }
 }

--- a/crates/octos-cli/src/api/ui_protocol_questions.rs
+++ b/crates/octos-cli/src/api/ui_protocol_questions.rs
@@ -1,0 +1,420 @@
+//! Pending structured-user-question store (UPCR-2026-023).
+//!
+//! Mirrors [`super::ui_protocol_approvals::PendingApprovalStore`] for the
+//! `ask_user_question` flow: a per-`question_id` map holding the originating
+//! [`UserQuestionRequestedEvent`] and a oneshot `Sender` the
+//! `user_question/respond` handler resolves. The blocked
+//! `ask_user_question` tool awaits the matching `Receiver`; turn interrupt
+//! drains pending questions exactly like approval cancellation.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use octos_core::SessionKey;
+use octos_core::ui_protocol::{
+    QuestionId, RpcError, TurnId, UserQuestionAnswer, UserQuestionRequestedEvent,
+    UserQuestionRespondParams, UserQuestionRespondResult, methods, rpc_error_codes,
+};
+use serde_json::json;
+
+/// Resolution delivered to the waiting `ask_user_question` tool when a client
+/// answers. A *closed* oneshot (sender dropped) means the question was
+/// cancelled (turn interrupt) — the tool treats that as `Cancelled`.
+pub(super) type UserQuestionResolution = Vec<UserQuestionAnswer>;
+
+#[derive(Debug)]
+struct QuestionEntry {
+    session_id: SessionKey,
+    state: QuestionEntryState,
+    request: UserQuestionRequestedEvent,
+    runtime_resumable: bool,
+    response_tx: Option<tokio::sync::oneshot::Sender<UserQuestionResolution>>,
+}
+
+#[derive(Debug)]
+enum QuestionEntryState {
+    Pending,
+    Answered,
+    /// The server cancelled this question (turn interrupt) before any client
+    /// answered. Late `respond` calls return a typed `user_question_stale`.
+    Cancelled {
+        reason: String,
+    },
+}
+
+/// One cancelled question surfaced by [`PendingQuestionStore::cancel_pending_for_turn`].
+///
+/// Mirrors `ui_protocol_approvals::CancelledApproval`. Phase-1 turn-interrupt
+/// reuses the terminal `turn/error` path rather than emitting a per-question
+/// cancelled wire event, so the production drain discards these; the fields
+/// are read by the store tests and by the follow-up wire-emit slice.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub(super) struct CancelledQuestion {
+    pub(super) question_id: QuestionId,
+    pub(super) turn_id: TurnId,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct QuestionRespondOutcome {
+    pub(super) result: UserQuestionRespondResult,
+}
+
+#[derive(Default)]
+pub(super) struct PendingQuestionStore {
+    entries: RwLock<HashMap<QuestionId, QuestionEntry>>,
+}
+
+impl PendingQuestionStore {
+    /// Register a runtime-blocking question and return the oneshot the waiting
+    /// tool awaits. Mirrors `PendingApprovalStore::request_runtime`.
+    pub(super) fn request_runtime(
+        &self,
+        event: UserQuestionRequestedEvent,
+    ) -> tokio::sync::oneshot::Receiver<UserQuestionResolution> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let mut entries = self.entries.write().unwrap_or_else(|p| p.into_inner());
+        entries.insert(
+            event.question_id.clone(),
+            QuestionEntry {
+                session_id: event.session_id.clone(),
+                state: QuestionEntryState::Pending,
+                request: event,
+                runtime_resumable: true,
+                response_tx: Some(tx),
+            },
+        );
+        rx
+    }
+
+    /// Resolve a pending question with the client's answers. Mirrors
+    /// `PendingApprovalStore::respond_with_context`: typed errors on
+    /// unknown/stale ids; resolves the waiting tool's oneshot at most once.
+    pub(super) fn respond_with_context(
+        &self,
+        params: &UserQuestionRespondParams,
+    ) -> Result<QuestionRespondOutcome, RpcError> {
+        let mut entries = self.entries.write().unwrap_or_else(|p| p.into_inner());
+        let Some(entry) = entries.get_mut(&params.question_id) else {
+            return Err(question_unknown_error(params));
+        };
+
+        if entry.session_id != params.session_id {
+            return Err(question_unknown_error(params));
+        }
+
+        match &entry.state {
+            QuestionEntryState::Pending => {
+                entry.state = QuestionEntryState::Answered;
+                let runtime_resumed = entry
+                    .response_tx
+                    .take()
+                    .is_some_and(|tx| tx.send(params.answers.clone()).is_ok());
+                Ok(QuestionRespondOutcome {
+                    result: UserQuestionRespondResult::accepted_with_runtime_resumed(
+                        params.question_id.clone(),
+                        entry.runtime_resumable && runtime_resumed,
+                    ),
+                })
+            }
+            QuestionEntryState::Answered => Err(question_stale_error(
+                params,
+                "already_answered",
+                &entry.request.turn_id,
+            )),
+            QuestionEntryState::Cancelled { reason } => {
+                Err(question_stale_error(params, reason, &entry.request.turn_id))
+            }
+        }
+    }
+
+    /// Atomically cancel every still-pending question for the given turn.
+    /// Idempotent. Mirrors `PendingApprovalStore::cancel_pending_for_turn`.
+    pub(super) fn cancel_pending_for_turn(
+        &self,
+        session_id: &SessionKey,
+        turn_id: &TurnId,
+        reason: &str,
+    ) -> Vec<CancelledQuestion> {
+        let mut entries = self.entries.write().unwrap_or_else(|p| p.into_inner());
+        let mut cancelled = Vec::new();
+        for (question_id, entry) in entries.iter_mut() {
+            if entry.session_id != *session_id {
+                continue;
+            }
+            if !matches!(&entry.state, QuestionEntryState::Pending) {
+                continue;
+            }
+            if entry.request.turn_id != *turn_id {
+                continue;
+            }
+            entry.state = QuestionEntryState::Cancelled {
+                reason: reason.to_owned(),
+            };
+            // Drop the runtime waiter; the blocked tool sees the closed
+            // receiver and treats it as Cancelled.
+            entry.response_tx = None;
+            cancelled.push(CancelledQuestion {
+                question_id: question_id.clone(),
+                turn_id: entry.request.turn_id.clone(),
+            });
+        }
+        cancelled
+    }
+
+    /// Cancel a single pending question (e.g. when the requested notification
+    /// failed to send). Mirrors `PendingApprovalStore::cancel_pending_approval`.
+    pub(super) fn cancel_pending_question(
+        &self,
+        session_id: &SessionKey,
+        question_id: &QuestionId,
+        reason: &str,
+    ) -> Option<CancelledQuestion> {
+        let mut entries = self.entries.write().unwrap_or_else(|p| p.into_inner());
+        let entry = entries.get_mut(question_id)?;
+        if entry.session_id != *session_id {
+            return None;
+        }
+        if !matches!(&entry.state, QuestionEntryState::Pending) {
+            return None;
+        }
+        let turn_id = entry.request.turn_id.clone();
+        entry.state = QuestionEntryState::Cancelled {
+            reason: reason.to_owned(),
+        };
+        entry.response_tx = None;
+        Some(CancelledQuestion {
+            question_id: question_id.clone(),
+            turn_id,
+        })
+    }
+
+    /// Pending requests for reconnect hydration. Mirrors
+    /// `PendingApprovalStore::pending_for_session`. Wired into `session/hydrate`
+    /// by the follow-up reconnect slice; kept here so the store API matches the
+    /// approval store one-to-one.
+    #[allow(dead_code)]
+    pub(super) fn pending_for_session(
+        &self,
+        session_id: &SessionKey,
+    ) -> Vec<UserQuestionRequestedEvent> {
+        let entries = self.entries.read().unwrap_or_else(|p| p.into_inner());
+        entries
+            .values()
+            .filter(|entry| {
+                entry.session_id == *session_id
+                    && matches!(&entry.state, QuestionEntryState::Pending)
+            })
+            .map(|entry| entry.request.clone())
+            .collect()
+    }
+}
+
+fn question_unknown_error(params: &UserQuestionRespondParams) -> RpcError {
+    RpcError::new(
+        rpc_error_codes::USER_QUESTION_UNKNOWN,
+        "user_question/respond target was not found for this session",
+    )
+    .with_data(json!({
+        "kind": "user_question_unknown",
+        "method": methods::USER_QUESTION_RESPOND,
+        "session_id": params.session_id,
+        "question_id": params.question_id,
+        "recoverable": false,
+    }))
+}
+
+fn question_stale_error(
+    params: &UserQuestionRespondParams,
+    reason: &str,
+    turn_id: &TurnId,
+) -> RpcError {
+    RpcError::new(
+        rpc_error_codes::USER_QUESTION_STALE,
+        "user_question/respond target is no longer pending",
+    )
+    .with_data(json!({
+        "kind": "user_question_stale",
+        "method": methods::USER_QUESTION_RESPOND,
+        "session_id": params.session_id,
+        "question_id": params.question_id,
+        "turn_id": turn_id,
+        "reason": reason,
+        "recoverable": false,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use octos_core::ui_protocol::{QuestionId, TurnId, UserQuestion, UserQuestionOption};
+
+    fn sample_event(
+        session_id: SessionKey,
+        question_id: QuestionId,
+        turn_id: TurnId,
+    ) -> UserQuestionRequestedEvent {
+        UserQuestionRequestedEvent::new(
+            session_id,
+            question_id,
+            turn_id,
+            "Pick a framework",
+            "Which framework should I scaffold?",
+            vec![UserQuestion {
+                header: "Framework".into(),
+                question: "Which framework?".into(),
+                options: vec![
+                    UserQuestionOption {
+                        label: "axum".into(),
+                        description: "tower-based".into(),
+                    },
+                    UserQuestionOption {
+                        label: "actix".into(),
+                        description: "actor-based".into(),
+                    },
+                ],
+                multi_select: false,
+                allow_free_text: true,
+            }],
+        )
+    }
+
+    fn answer(label: &str) -> Vec<UserQuestionAnswer> {
+        vec![UserQuestionAnswer {
+            selected_labels: vec![label.into()],
+            free_text: None,
+        }]
+    }
+
+    #[tokio::test]
+    async fn request_then_respond_resolves_waiting_tool_once() {
+        let store = PendingQuestionStore::default();
+        let session_id = SessionKey("local:test".into());
+        let question_id = QuestionId::new();
+        let turn_id = TurnId::new();
+
+        let rx = store.request_runtime(sample_event(
+            session_id.clone(),
+            question_id.clone(),
+            turn_id,
+        ));
+
+        let params =
+            UserQuestionRespondParams::new(session_id.clone(), question_id.clone(), answer("axum"));
+        let outcome = store
+            .respond_with_context(&params)
+            .expect("pending question accepts");
+        assert!(outcome.result.accepted);
+        assert!(outcome.result.runtime_resumed);
+        assert_eq!(rx.await.expect("answer received"), answer("axum"));
+
+        // Second respond is stale.
+        let err = store
+            .respond_with_context(&params)
+            .expect_err("answered question is stale");
+        assert_eq!(err.code, rpc_error_codes::USER_QUESTION_STALE);
+        assert_eq!(
+            err.data.as_ref().and_then(|d| d.get("kind")),
+            Some(&json!("user_question_stale"))
+        );
+    }
+
+    #[test]
+    fn unknown_question_id_returns_typed_error() {
+        let store = PendingQuestionStore::default();
+        let params = UserQuestionRespondParams::new(
+            SessionKey("local:test".into()),
+            QuestionId::new(),
+            answer("axum"),
+        );
+        let err = store
+            .respond_with_context(&params)
+            .expect_err("unknown question id fails");
+        assert_eq!(err.code, rpc_error_codes::USER_QUESTION_UNKNOWN);
+        assert_eq!(
+            err.data.as_ref().and_then(|d| d.get("kind")),
+            Some(&json!("user_question_unknown"))
+        );
+    }
+
+    #[test]
+    fn cross_session_respond_is_unknown() {
+        let store = PendingQuestionStore::default();
+        let session_id = SessionKey("local:test".into());
+        let other = SessionKey("local:other".into());
+        let question_id = QuestionId::new();
+        store.request_runtime(sample_event(
+            session_id.clone(),
+            question_id.clone(),
+            TurnId::new(),
+        ));
+
+        let err = store
+            .respond_with_context(&UserQuestionRespondParams::new(
+                other,
+                question_id,
+                answer("axum"),
+            ))
+            .expect_err("question is scoped to its owning session");
+        assert_eq!(err.code, rpc_error_codes::USER_QUESTION_UNKNOWN);
+    }
+
+    #[tokio::test]
+    async fn cancel_on_interrupt_drops_runtime_waiter_and_marks_stale() {
+        let store = PendingQuestionStore::default();
+        let session_id = SessionKey("local:test".into());
+        let question_id = QuestionId::new();
+        let turn_id = TurnId::new();
+        let rx = store.request_runtime(sample_event(
+            session_id.clone(),
+            question_id.clone(),
+            turn_id.clone(),
+        ));
+
+        let cancelled = store.cancel_pending_for_turn(&session_id, &turn_id, "turn_interrupted");
+        assert_eq!(cancelled.len(), 1);
+        assert_eq!(cancelled[0].question_id, question_id);
+        assert_eq!(cancelled[0].turn_id, turn_id);
+
+        // The blocked tool sees the receiver close (Cancelled).
+        assert!(rx.await.is_err(), "cancel drops the runtime sender");
+
+        // A late respond is stale, not unknown.
+        let err = store
+            .respond_with_context(&UserQuestionRespondParams::new(
+                session_id.clone(),
+                question_id,
+                answer("axum"),
+            ))
+            .expect_err("late respond against cancelled question");
+        assert_eq!(err.code, rpc_error_codes::USER_QUESTION_STALE);
+        assert_eq!(
+            err.data.as_ref().unwrap()["reason"],
+            json!("turn_interrupted")
+        );
+
+        // Idempotent: second cancel is a no-op.
+        assert!(
+            store
+                .cancel_pending_for_turn(&session_id, &turn_id, "turn_interrupted")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn cancelled_question_excluded_from_pending_for_session() {
+        let store = PendingQuestionStore::default();
+        let session_id = SessionKey("local:test".into());
+        let question_id = QuestionId::new();
+        let turn_id = TurnId::new();
+        store.request_runtime(sample_event(
+            session_id.clone(),
+            question_id,
+            turn_id.clone(),
+        ));
+        assert_eq!(store.pending_for_session(&session_id).len(), 1);
+
+        store.cancel_pending_for_turn(&session_id, &turn_id, "turn_interrupted");
+        assert!(store.pending_for_session(&session_id).is_empty());
+    }
+}

--- a/crates/octos-cli/src/api/ui_protocol_questions.rs
+++ b/crates/octos-cli/src/api/ui_protocol_questions.rs
@@ -105,6 +105,15 @@ impl PendingQuestionStore {
 
         match &entry.state {
             QuestionEntryState::Pending => {
+                // Validate the client's answers against the STORED request
+                // BEFORE resolving the waiter — a malformed answer (wrong
+                // count, an out-of-options label, multiple labels on a
+                // single-select, or free text where disallowed) must not flow
+                // into the blocked tool. The entry stays `Pending` on
+                // rejection so a corrected respond can still resolve it.
+                if let Err(reason) = validate_answers(&entry.request.questions, &params.answers) {
+                    return Err(question_invalid_error(params, &reason));
+                }
                 entry.state = QuestionEntryState::Answered;
                 let runtime_resumed = entry
                     .response_tx
@@ -190,10 +199,9 @@ impl PendingQuestionStore {
     }
 
     /// Pending requests for reconnect hydration. Mirrors
-    /// `PendingApprovalStore::pending_for_session`. Wired into `session/hydrate`
-    /// by the follow-up reconnect slice; kept here so the store API matches the
-    /// approval store one-to-one.
-    #[allow(dead_code)]
+    /// `PendingApprovalStore::pending_for_session`. Replayed on `session/open`
+    /// and `session/hydrate` (gated by `user_question.v1`) so a reconnecting
+    /// client re-renders and can still answer a pending question.
     pub(super) fn pending_for_session(
         &self,
         session_id: &SessionKey,
@@ -208,6 +216,59 @@ impl PendingQuestionStore {
             .map(|entry| entry.request.clone())
             .collect()
     }
+}
+
+/// Validate a `user_question/respond` answer set against the originating
+/// request's questions/options (UPCR-2026-023 spec/design contract). Returns a
+/// short machine-stable `reason` string on the first violation:
+///
+/// - exactly one answer entry per question, in order (`answer_count`);
+/// - every `selected_labels` value is one of THAT question's option labels
+///   (`unknown_label`);
+/// - a non-`multi_select` question has at most one selected label
+///   (`multi_select_violation`);
+/// - `free_text` is present only when the question allows it
+///   (`free_text_not_allowed`).
+///
+/// Mirrors the trust-boundary discipline of the approval `respond` path: the
+/// server validates the client payload against server-held state before
+/// resolving the runtime waiter, so a bad answer never reaches the tool.
+fn validate_answers(
+    questions: &[octos_core::ui_protocol::UserQuestion],
+    answers: &[UserQuestionAnswer],
+) -> Result<(), String> {
+    if answers.len() != questions.len() {
+        return Err("answer_count".to_owned());
+    }
+    for (question, answer) in questions.iter().zip(answers.iter()) {
+        if !question.multi_select && answer.selected_labels.len() > 1 {
+            return Err("multi_select_violation".to_owned());
+        }
+        for label in &answer.selected_labels {
+            if !question.options.iter().any(|opt| &opt.label == label) {
+                return Err("unknown_label".to_owned());
+            }
+        }
+        if answer.free_text.is_some() && !question.allow_free_text {
+            return Err("free_text_not_allowed".to_owned());
+        }
+    }
+    Ok(())
+}
+
+fn question_invalid_error(params: &UserQuestionRespondParams, reason: &str) -> RpcError {
+    RpcError::new(
+        rpc_error_codes::USER_QUESTION_INVALID,
+        "user_question/respond answers do not match the stored question",
+    )
+    .with_data(json!({
+        "kind": "user_question_invalid",
+        "method": methods::USER_QUESTION_RESPOND,
+        "session_id": params.session_id,
+        "question_id": params.question_id,
+        "reason": reason,
+        "recoverable": true,
+    }))
 }
 
 fn question_unknown_error(params: &UserQuestionRespondParams) -> RpcError {
@@ -284,6 +345,38 @@ mod tests {
             selected_labels: vec![label.into()],
             free_text: None,
         }]
+    }
+
+    /// A two-option single-select question with free-text DISALLOWED, used to
+    /// exercise the answer-validation contract (fix #5).
+    fn no_free_text_event(
+        session_id: SessionKey,
+        question_id: QuestionId,
+        turn_id: TurnId,
+    ) -> UserQuestionRequestedEvent {
+        UserQuestionRequestedEvent::new(
+            session_id,
+            question_id,
+            turn_id,
+            "Pick one",
+            "Pick exactly one",
+            vec![UserQuestion {
+                header: "Pick".into(),
+                question: "Pick one".into(),
+                options: vec![
+                    UserQuestionOption {
+                        label: "red".into(),
+                        description: String::new(),
+                    },
+                    UserQuestionOption {
+                        label: "blue".into(),
+                        description: String::new(),
+                    },
+                ],
+                multi_select: false,
+                allow_free_text: false,
+            }],
+        )
     }
 
     #[tokio::test]
@@ -399,6 +492,139 @@ mod tests {
                 .cancel_pending_for_turn(&session_id, &turn_id, "turn_interrupted")
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn respond_with_wrong_answer_count_is_invalid_and_does_not_resolve() {
+        let store = PendingQuestionStore::default();
+        let session_id = SessionKey("local:test".into());
+        let question_id = QuestionId::new();
+        // sample_event has exactly ONE question; supply TWO answers.
+        let rx = store.request_runtime(sample_event(
+            session_id.clone(),
+            question_id.clone(),
+            TurnId::new(),
+        ));
+        let params = UserQuestionRespondParams::new(
+            session_id.clone(),
+            question_id.clone(),
+            vec![
+                UserQuestionAnswer {
+                    selected_labels: vec!["axum".into()],
+                    free_text: None,
+                },
+                UserQuestionAnswer {
+                    selected_labels: vec!["actix".into()],
+                    free_text: None,
+                },
+            ],
+        );
+        let err = store
+            .respond_with_context(&params)
+            .expect_err("answer count mismatch must be rejected");
+        assert_eq!(err.code, rpc_error_codes::USER_QUESTION_INVALID);
+        assert_eq!(
+            err.data.as_ref().and_then(|d| d.get("kind")),
+            Some(&json!("user_question_invalid"))
+        );
+        // The waiter is NOT resolved with bad data — it is still pending and a
+        // VALID respond still resolves it.
+        let good = UserQuestionRespondParams::new(session_id, question_id, answer("axum"));
+        store
+            .respond_with_context(&good)
+            .expect("valid respond after an invalid one still accepts");
+        assert_eq!(rx.await.expect("answer received"), answer("axum"));
+    }
+
+    #[tokio::test]
+    async fn respond_with_label_not_in_options_is_invalid() {
+        let store = PendingQuestionStore::default();
+        let session_id = SessionKey("local:test".into());
+        let question_id = QuestionId::new();
+        let rx = store.request_runtime(sample_event(
+            session_id.clone(),
+            question_id.clone(),
+            TurnId::new(),
+        ));
+        let params = UserQuestionRespondParams::new(session_id, question_id, answer("rocket")); // not an option
+        let err = store
+            .respond_with_context(&params)
+            .expect_err("unknown label must be rejected");
+        assert_eq!(err.code, rpc_error_codes::USER_QUESTION_INVALID);
+        // Waiter left untouched (closed only on drop), not resolved.
+        drop(store);
+        assert!(rx.await.is_err(), "waiter must not have been resolved");
+    }
+
+    #[tokio::test]
+    async fn respond_with_two_labels_on_single_select_is_invalid() {
+        let store = PendingQuestionStore::default();
+        let session_id = SessionKey("local:test".into());
+        let question_id = QuestionId::new();
+        store.request_runtime(sample_event(
+            session_id.clone(),
+            question_id.clone(),
+            TurnId::new(),
+        ));
+        let params = UserQuestionRespondParams::new(
+            session_id,
+            question_id,
+            vec![UserQuestionAnswer {
+                selected_labels: vec!["axum".into(), "actix".into()],
+                free_text: None,
+            }],
+        );
+        let err = store
+            .respond_with_context(&params)
+            .expect_err("two labels on a single-select must be rejected");
+        assert_eq!(err.code, rpc_error_codes::USER_QUESTION_INVALID);
+    }
+
+    #[tokio::test]
+    async fn respond_with_free_text_when_disallowed_is_invalid() {
+        let store = PendingQuestionStore::default();
+        let session_id = SessionKey("local:test".into());
+        let question_id = QuestionId::new();
+        store.request_runtime(no_free_text_event(
+            session_id.clone(),
+            question_id.clone(),
+            TurnId::new(),
+        ));
+        let params = UserQuestionRespondParams::new(
+            session_id,
+            question_id,
+            vec![UserQuestionAnswer {
+                selected_labels: vec!["red".into()],
+                free_text: Some("magenta".into()),
+            }],
+        );
+        let err = store
+            .respond_with_context(&params)
+            .expect_err("free text on a no-free-text question must be rejected");
+        assert_eq!(err.code, rpc_error_codes::USER_QUESTION_INVALID);
+    }
+
+    #[tokio::test]
+    async fn respond_free_text_only_with_no_labels_is_accepted_when_allowed() {
+        // sample_event forces allow_free_text=true; a free-text-only answer
+        // (the "Other" escape hatch) with zero selected labels is valid.
+        let store = PendingQuestionStore::default();
+        let session_id = SessionKey("local:test".into());
+        let question_id = QuestionId::new();
+        let rx = store.request_runtime(sample_event(
+            session_id.clone(),
+            question_id.clone(),
+            TurnId::new(),
+        ));
+        let custom = vec![UserQuestionAnswer {
+            selected_labels: vec![],
+            free_text: Some("rocket".into()),
+        }];
+        let params = UserQuestionRespondParams::new(session_id, question_id, custom.clone());
+        store
+            .respond_with_context(&params)
+            .expect("free-text-only answer is valid when allow_free_text=true");
+        assert_eq!(rx.await.expect("answer received"), custom);
     }
 
     #[test]

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -227,6 +227,16 @@ pub const UI_PROTOCOL_FEATURE_HARNESS_TASK_SUPERVISION_INSPECTION_V1: &str =
 /// `agent/artifact/*` aliases remain gated on agent control.
 pub const UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1: &str = "harness.task_artifacts.v1";
 
+/// Feature flag for UPCR-2026-023 structured `AskUserQuestion` mid-turn
+/// user questions. Gates the `user_question/respond` command, the
+/// `user_question/requested` notification, and the structured `questions`
+/// field on the request event. Advertised through optional
+/// `supported_features` in [`UiProtocolCapabilities`]; clients request it
+/// through `X-Octos-Ui-Features`. When it is NOT negotiated the agent's
+/// `ask_user_question` tool degrades to the `request_user_input`
+/// structured-metadata fallback, so the turn never hard-blocks.
+pub const UI_PROTOCOL_FEATURE_USER_QUESTION_V1: &str = "user_question.v1";
+
 /// Server-known feature registry. Used by
 /// [`UiProtocolCapabilities::for_negotiated_features`] (UPCR-2026-007) to
 /// intersect a client's `X-Octos-Ui-Features` request with the names the
@@ -253,6 +263,7 @@ pub const UI_PROTOCOL_KNOWN_FEATURES: &[&str] = &[
     UI_PROTOCOL_FEATURE_CONTEXT_LIFECYCLE_V1,
     UI_PROTOCOL_FEATURE_HARNESS_TASK_SUPERVISION_INSPECTION_V1,
     UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1,
+    UI_PROTOCOL_FEATURE_USER_QUESTION_V1,
 ];
 
 /// Returns the feature flag that gates `method` per spec § 7 capability
@@ -306,6 +317,7 @@ fn method_capability_gate(method: &str) -> Option<&'static str> {
         | methods::LOOP_RESUME
         | methods::LOOP_FIRE_NOW => Some(UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1),
         methods::REVIEW_START => Some(UI_PROTOCOL_FEATURE_REVIEW_START_V1),
+        methods::USER_QUESTION_RESPOND => Some(UI_PROTOCOL_FEATURE_USER_QUESTION_V1),
         _ => None,
     }
 }
@@ -426,6 +438,16 @@ pub mod rpc_error_codes {
     /// Spec §10 `approval_cancelled`: `respond` against an administratively cancelled approval.
     pub const APPROVAL_CANCELLED: i64 = -32105;
 
+    /// UPCR-2026-023 `user_question_unknown`: `user_question/respond` against a
+    /// `question_id` not pending for the caller's session. Mirrors
+    /// [`UNKNOWN_APPROVAL_ID`] for the structured-question surface.
+    pub const USER_QUESTION_UNKNOWN: i64 = -32106;
+    /// UPCR-2026-023 `user_question_stale`: `user_question/respond` against a
+    /// question that was already answered or cancelled. Mirrors
+    /// [`APPROVAL_NOT_PENDING`] / [`APPROVAL_CANCELLED`] for the
+    /// structured-question surface.
+    pub const USER_QUESTION_STALE: i64 = -32107;
+
     /// Spec §10 `cursor_out_of_range`: stale or future cursor relative to ledger.
     pub const CURSOR_OUT_OF_RANGE: i64 = -32110;
     /// Spec §10 cursor variant: cursor malformed or wrong-session. Distinct from
@@ -513,6 +535,27 @@ impl ApprovalId {
 }
 
 impl Default for ApprovalId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Stable identity for a structured user-question request (UPCR-2026-023).
+///
+/// Mirrors [`ApprovalId`]: a `Uuid` newtype minted server-side per
+/// `ask_user_question` tool call. The client cannot forge it — a
+/// `user_question/respond` is accepted only for a pending `question_id`
+/// on the caller's session.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct QuestionId(pub Uuid);
+
+impl QuestionId {
+    pub fn new() -> Self {
+        Self(Uuid::now_v7())
+    }
+}
+
+impl Default for QuestionId {
     fn default() -> Self {
         Self::new()
     }
@@ -892,6 +935,9 @@ pub mod methods {
     pub const TURN_INTERRUPT: &str = "turn/interrupt";
     pub const APPROVAL_RESPOND: &str = "approval/respond";
     pub const APPROVAL_SCOPES_LIST: &str = "approval/scopes/list";
+    /// UPCR-2026-023 `user_question/respond` — answer a structured
+    /// `user_question/requested` event. Gated by `user_question.v1`.
+    pub const USER_QUESTION_RESPOND: &str = "user_question/respond";
     pub const PERMISSION_PROFILE_LIST: &str = "permission/profile/list";
     pub const PERMISSION_PROFILE_SET: &str = "permission/profile/set";
     pub const DIFF_PREVIEW_GET: &str = "diff/preview/get";
@@ -952,6 +998,11 @@ pub mod methods {
     pub const APPROVAL_AUTO_RESOLVED: &str = "approval/auto_resolved";
     pub const APPROVAL_DECIDED: &str = "approval/decided";
     pub const APPROVAL_CANCELLED: &str = "approval/cancelled";
+    /// UPCR-2026-023 `user_question/requested` — structured multiple-choice
+    /// question the agent is asking the user mid-turn. While unresolved the
+    /// turn stays paused at the blocking-tool boundary (same boundary as
+    /// `approval/requested`). Gated by `user_question.v1`.
+    pub const USER_QUESTION_REQUESTED: &str = "user_question/requested";
     pub const TASK_UPDATED: &str = "task/updated";
     pub const TASK_OUTPUT_DELTA: &str = "task/output/delta";
     pub const PROGRESS_UPDATED: &str = "progress/updated";
@@ -1082,6 +1133,7 @@ pub const UI_PROTOCOL_COMMAND_METHODS: &[&str] = &[
     methods::TURN_INTERRUPT,
     methods::APPROVAL_RESPOND,
     methods::APPROVAL_SCOPES_LIST,
+    methods::USER_QUESTION_RESPOND,
     methods::PERMISSION_PROFILE_LIST,
     methods::PERMISSION_PROFILE_SET,
     methods::DIFF_PREVIEW_GET,
@@ -1142,6 +1194,7 @@ pub const UI_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &[
     methods::APPROVAL_AUTO_RESOLVED,
     methods::APPROVAL_DECIDED,
     methods::APPROVAL_CANCELLED,
+    methods::USER_QUESTION_REQUESTED,
     methods::TASK_UPDATED,
     methods::TASK_OUTPUT_DELTA,
     methods::PROGRESS_UPDATED,
@@ -1174,6 +1227,7 @@ pub const UI_PROTOCOL_FIRST_SERVER_METHODS: &[&str] = &[
     methods::TURN_INTERRUPT,
     methods::APPROVAL_RESPOND,
     methods::APPROVAL_SCOPES_LIST,
+    methods::USER_QUESTION_RESPOND,
     methods::PERMISSION_PROFILE_LIST,
     methods::PERMISSION_PROFILE_SET,
     methods::DIFF_PREVIEW_GET,
@@ -1715,6 +1769,75 @@ impl ApprovalRespondResult {
             approval_id,
             accepted: true,
             status: ApprovalRespondStatus::Accepted,
+            runtime_resumed,
+        }
+    }
+}
+
+/// One per-question answer carried by `user_question/respond` (UPCR-2026-023).
+///
+/// Forward-compat: serde defaults mean a client that omits `selected_labels`
+/// (free-text only) or `free_text` still decodes; unknown sibling fields are
+/// ignored. `selected_labels` holds 0..1 entries for a single-select question
+/// and 0..N for a `multi_select` question; the labels must match the option
+/// labels from the originating request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserQuestionAnswer {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub selected_labels: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub free_text: Option<String>,
+}
+
+/// Params for `user_question/respond` — the client's answer to a
+/// `user_question/requested` event (UPCR-2026-023). Mirrors
+/// [`ApprovalRespondParams`]: correlated by `question_id`, scoped to the
+/// caller's `session_id`, with an optional audit/display `client_note` the
+/// server must not require.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserQuestionRespondParams {
+    pub session_id: SessionKey,
+    pub question_id: QuestionId,
+    /// One entry per question, in question order.
+    pub answers: Vec<UserQuestionAnswer>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_note: Option<String>,
+}
+
+impl UserQuestionRespondParams {
+    pub fn new(
+        session_id: SessionKey,
+        question_id: QuestionId,
+        answers: Vec<UserQuestionAnswer>,
+    ) -> Self {
+        Self {
+            session_id,
+            question_id,
+            answers,
+            client_note: None,
+        }
+    }
+}
+
+/// Ack result for `user_question/respond` (UPCR-2026-023). Mirrors
+/// [`ApprovalRespondResult`]: confirms the answer was accepted and whether the
+/// waiting runtime turn was resumed by it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserQuestionRespondResult {
+    pub question_id: QuestionId,
+    pub accepted: bool,
+    pub runtime_resumed: bool,
+}
+
+impl UserQuestionRespondResult {
+    pub fn accepted(question_id: QuestionId) -> Self {
+        Self::accepted_with_runtime_resumed(question_id, false)
+    }
+
+    pub fn accepted_with_runtime_resumed(question_id: QuestionId, runtime_resumed: bool) -> Self {
+        Self {
+            question_id,
+            accepted: true,
             runtime_resumed,
         }
     }
@@ -3273,6 +3396,7 @@ pub enum UiCommand {
     TurnInterrupt(TurnInterruptParams),
     ApprovalRespond(ApprovalRespondParams),
     ApprovalScopesList(ApprovalScopesListParams),
+    UserQuestionRespond(UserQuestionRespondParams),
     PermissionProfileList(PermissionProfileListParams),
     PermissionProfileSet(PermissionProfileSetParams),
     DiffPreviewGet(DiffPreviewGetParams),
@@ -3313,6 +3437,7 @@ impl UiCommand {
             Self::TurnInterrupt(_) => methods::TURN_INTERRUPT,
             Self::ApprovalRespond(_) => methods::APPROVAL_RESPOND,
             Self::ApprovalScopesList(_) => methods::APPROVAL_SCOPES_LIST,
+            Self::UserQuestionRespond(_) => methods::USER_QUESTION_RESPOND,
             Self::PermissionProfileList(_) => methods::PERMISSION_PROFILE_LIST,
             Self::PermissionProfileSet(_) => methods::PERMISSION_PROFILE_SET,
             Self::DiffPreviewGet(_) => methods::DIFF_PREVIEW_GET,
@@ -3355,6 +3480,7 @@ impl UiCommand {
             Self::TurnInterrupt(params) => serde_json::to_value(params),
             Self::ApprovalRespond(params) => serde_json::to_value(params),
             Self::ApprovalScopesList(params) => serde_json::to_value(params),
+            Self::UserQuestionRespond(params) => serde_json::to_value(params),
             Self::PermissionProfileList(params) => serde_json::to_value(params),
             Self::PermissionProfileSet(params) => serde_json::to_value(params),
             Self::DiffPreviewGet(params) => serde_json::to_value(params),
@@ -3410,6 +3536,9 @@ impl UiCommand {
             methods::APPROVAL_RESPOND => Ok(Self::ApprovalRespond(decode_params(method, params)?)),
             methods::APPROVAL_SCOPES_LIST => {
                 Ok(Self::ApprovalScopesList(decode_params(method, params)?))
+            }
+            methods::USER_QUESTION_RESPOND => {
+                Ok(Self::UserQuestionRespond(decode_params(method, params)?))
             }
             methods::PERMISSION_PROFILE_LIST => {
                 Ok(Self::PermissionProfileList(decode_params(method, params)?))
@@ -4563,6 +4692,73 @@ impl ApprovalCancelledEvent {
     }
 }
 
+/// One selectable option on a [`UserQuestion`] (UPCR-2026-023).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserQuestionOption {
+    pub label: String,
+    pub description: String,
+}
+
+/// One structured multiple-choice question carried by a
+/// [`UserQuestionRequestedEvent`] (UPCR-2026-023). 2–4 `options`, an optional
+/// `multi_select`, and a server-forced `allow_free_text` ("Other" escape
+/// hatch). `header` is a short label (≤ 12 chars).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserQuestion {
+    pub header: String,
+    pub question: String,
+    pub options: Vec<UserQuestionOption>,
+    #[serde(default)]
+    pub multi_select: bool,
+    /// Server forces this `true` so a free-text "Other" is always offered.
+    #[serde(default)]
+    pub allow_free_text: bool,
+}
+
+/// Notification emitted when the agent's `ask_user_question` tool asks the user
+/// a structured multiple-choice question mid-turn (UPCR-2026-023). Mirrors
+/// [`ApprovalRequestedEvent`]: while unresolved the turn stays paused at the
+/// blocking-tool boundary, and the mandatory generic `title`/`body` keep a
+/// client that does not understand the structured `questions` field
+/// actionable. The structured `questions` field is gated by `user_question.v1`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserQuestionRequestedEvent {
+    pub session_id: SessionKey,
+    /// Topic routing key (see [`ToolStartedEvent::topic`]; #1329).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+    pub question_id: QuestionId,
+    pub turn_id: TurnId,
+    /// Mandatory generic fallback text.
+    pub title: String,
+    /// Mandatory generic fallback text.
+    pub body: String,
+    /// 1–4 structured questions. A client that does not understand this field
+    /// falls back to rendering `title`/`body` and answering via free text.
+    pub questions: Vec<UserQuestion>,
+}
+
+impl UserQuestionRequestedEvent {
+    pub fn new(
+        session_id: SessionKey,
+        question_id: QuestionId,
+        turn_id: TurnId,
+        title: impl Into<String>,
+        body: impl Into<String>,
+        questions: Vec<UserQuestion>,
+    ) -> Self {
+        Self {
+            session_id,
+            topic: None,
+            question_id,
+            turn_id,
+            title: title.into(),
+            body: body.into(),
+            questions,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskRuntimeState {
@@ -5126,6 +5322,9 @@ pub enum UiNotification {
     ApprovalAutoResolved(ApprovalAutoResolvedEvent),
     ApprovalDecided(ApprovalDecidedEvent),
     ApprovalCancelled(ApprovalCancelledEvent),
+    /// UPCR-2026-023: structured mid-turn user question. Mirrors
+    /// `ApprovalRequested`; pauses the turn at the blocking-tool boundary.
+    UserQuestionRequested(UserQuestionRequestedEvent),
     TaskUpdated(TaskUpdatedEvent),
     TaskOutputDelta(TaskOutputDeltaEvent),
     ProgressUpdated(ProgressUpdatedEvent),
@@ -5217,6 +5416,7 @@ impl UiNotification {
             Self::ApprovalAutoResolved(_) => methods::APPROVAL_AUTO_RESOLVED,
             Self::ApprovalDecided(_) => methods::APPROVAL_DECIDED,
             Self::ApprovalCancelled(_) => methods::APPROVAL_CANCELLED,
+            Self::UserQuestionRequested(_) => methods::USER_QUESTION_REQUESTED,
             Self::TaskUpdated(_) => methods::TASK_UPDATED,
             Self::TaskOutputDelta(_) => methods::TASK_OUTPUT_DELTA,
             Self::ProgressUpdated(_) => methods::PROGRESS_UPDATED,
@@ -5258,6 +5458,7 @@ impl UiNotification {
             Self::ApprovalAutoResolved(event) => &event.session_id,
             Self::ApprovalDecided(event) => &event.session_id,
             Self::ApprovalCancelled(event) => &event.session_id,
+            Self::UserQuestionRequested(event) => &event.session_id,
             Self::TaskUpdated(event) => &event.session_id,
             Self::TaskOutputDelta(event) => &event.session_id,
             Self::ProgressUpdated(event) => &event.session_id,
@@ -5312,6 +5513,9 @@ impl UiNotification {
             Self::ApprovalCancelled(event) => {
                 event.topic.as_deref().or_else(|| event.session_id.topic())
             }
+            Self::UserQuestionRequested(event) => {
+                event.topic.as_deref().or_else(|| event.session_id.topic())
+            }
             Self::TaskUpdated(event) => event.topic.as_deref().or_else(|| event.session_id.topic()),
             Self::TaskOutputDelta(event) => {
                 event.topic.as_deref().or_else(|| event.session_id.topic())
@@ -5351,6 +5555,7 @@ impl UiNotification {
             Self::ApprovalAutoResolved(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::ApprovalDecided(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::ApprovalCancelled(event) => set_topic_if_absent(&mut event.topic, &topic),
+            Self::UserQuestionRequested(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::TaskUpdated(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::TaskOutputDelta(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::TurnCompleted(event) => set_topic_if_absent(&mut event.topic, &topic),
@@ -5378,6 +5583,7 @@ impl UiNotification {
             Self::ApprovalAutoResolved(params) => serde_json::to_value(params),
             Self::ApprovalDecided(params) => serde_json::to_value(params),
             Self::ApprovalCancelled(params) => serde_json::to_value(params),
+            Self::UserQuestionRequested(params) => serde_json::to_value(params),
             Self::TaskUpdated(params) => serde_json::to_value(params),
             Self::TaskOutputDelta(params) => serde_json::to_value(params),
             Self::ProgressUpdated(params) => serde_json::to_value(params),
@@ -5477,6 +5683,9 @@ impl UiNotification {
             methods::APPROVAL_DECIDED => Ok(Self::ApprovalDecided(decode_params(method, params)?)),
             methods::APPROVAL_CANCELLED => {
                 Ok(Self::ApprovalCancelled(decode_params(method, params)?))
+            }
+            methods::USER_QUESTION_REQUESTED => {
+                Ok(Self::UserQuestionRequested(decode_params(method, params)?))
             }
             methods::TASK_UPDATED => Ok(Self::TaskUpdated(decode_params(method, params)?)),
             methods::TASK_OUTPUT_DELTA => Ok(Self::TaskOutputDelta(decode_params(method, params)?)),
@@ -5983,6 +6192,7 @@ mod tests {
                 "turn/interrupt",
                 "approval/respond",
                 "approval/scopes/list",
+                "user_question/respond",
                 "permission/profile/list",
                 "permission/profile/set",
                 "diff/preview/get",
@@ -6044,6 +6254,7 @@ mod tests {
                 "approval/auto_resolved",
                 "approval/decided",
                 "approval/cancelled",
+                "user_question/requested",
                 "task/updated",
                 "task/output/delta",
                 "progress/updated",
@@ -6077,6 +6288,7 @@ mod tests {
                 "turn/interrupt",
                 "approval/respond",
                 "approval/scopes/list",
+                "user_question/respond",
                 "permission/profile/list",
                 "permission/profile/set",
                 "diff/preview/get",
@@ -6149,6 +6361,7 @@ mod tests {
                     "turn/interrupt",
                     "approval/respond",
                     "approval/scopes/list",
+                    "user_question/respond",
                     "permission/profile/list",
                     "permission/profile/set",
                     "diff/preview/get",
@@ -6207,6 +6420,7 @@ mod tests {
                     "approval/auto_resolved",
                     "approval/decided",
                     "approval/cancelled",
+                    "user_question/requested",
                     "task/updated",
                     "task/output/delta",
                     "progress/updated",
@@ -6251,7 +6465,8 @@ mod tests {
                     "review.start.v1",
                     "context.lifecycle.v1",
                     "harness.task_supervision_inspection.v1",
-                    "harness.task_artifacts.v1"
+                    "harness.task_artifacts.v1",
+                    "user_question.v1"
                 ]
             })
         );
@@ -6697,6 +6912,187 @@ mod tests {
         );
         assert_eq!(decoded.title, "Future approval");
         assert_eq!(decoded.body, "Fallback body remains actionable");
+    }
+
+    // ---- UPCR-2026-023 AskUserQuestion protocol round-trips ----
+
+    #[test]
+    fn user_question_methods_and_feature_are_registered() {
+        assert_eq!(methods::USER_QUESTION_RESPOND, "user_question/respond");
+        assert_eq!(methods::USER_QUESTION_REQUESTED, "user_question/requested");
+        assert_eq!(UI_PROTOCOL_FEATURE_USER_QUESTION_V1, "user_question.v1");
+        assert!(UI_PROTOCOL_COMMAND_METHODS.contains(&methods::USER_QUESTION_RESPOND));
+        assert!(UI_PROTOCOL_NOTIFICATION_METHODS.contains(&methods::USER_QUESTION_REQUESTED));
+        assert!(UI_PROTOCOL_KNOWN_FEATURES.contains(&UI_PROTOCOL_FEATURE_USER_QUESTION_V1));
+        assert_eq!(
+            method_capability_gate(methods::USER_QUESTION_RESPOND),
+            Some(UI_PROTOCOL_FEATURE_USER_QUESTION_V1)
+        );
+    }
+
+    #[test]
+    fn user_question_requested_event_round_trips_with_structured_questions() {
+        let event = UserQuestionRequestedEvent::new(
+            SessionKey("local:demo".into()),
+            QuestionId(Uuid::from_u128(7)),
+            TurnId(Uuid::from_u128(1)),
+            "Pick a framework",
+            "The agent needs you to choose a target framework and runtimes.",
+            vec![
+                UserQuestion {
+                    header: "Framework".into(),
+                    question: "Which web framework should I scaffold?".into(),
+                    options: vec![
+                        UserQuestionOption {
+                            label: "axum".into(),
+                            description: "tower-based async framework".into(),
+                        },
+                        UserQuestionOption {
+                            label: "actix".into(),
+                            description: "actor-based framework".into(),
+                        },
+                    ],
+                    multi_select: false,
+                    allow_free_text: true,
+                },
+                UserQuestion {
+                    header: "Runtimes".into(),
+                    question: "Which runtimes should CI cover?".into(),
+                    options: vec![
+                        UserQuestionOption {
+                            label: "stable".into(),
+                            description: "latest stable toolchain".into(),
+                        },
+                        UserQuestionOption {
+                            label: "nightly".into(),
+                            description: "nightly toolchain".into(),
+                        },
+                        UserQuestionOption {
+                            label: "msrv".into(),
+                            description: "minimum supported rust version".into(),
+                        },
+                    ],
+                    multi_select: true,
+                    allow_free_text: true,
+                },
+            ],
+        );
+
+        let notification = UiNotification::UserQuestionRequested(event.clone());
+        assert_eq!(notification.method(), methods::USER_QUESTION_REQUESTED);
+        let wire = notification
+            .clone()
+            .into_rpc_notification()
+            .expect("serialize user_question/requested");
+        assert_eq!(wire.method, methods::USER_QUESTION_REQUESTED);
+        // snake_case wire field names + mandatory title/body fallback.
+        assert_eq!(wire.params["title"], json!("Pick a framework"));
+        assert_eq!(wire.params["questions"][0]["header"], json!("Framework"));
+        assert_eq!(wire.params["questions"][0]["multi_select"], json!(false));
+        assert_eq!(wire.params["questions"][1]["multi_select"], json!(true));
+        assert_eq!(wire.params["questions"][1]["allow_free_text"], json!(true));
+        assert_eq!(
+            wire.params["questions"][0]["options"][0]["label"],
+            json!("axum")
+        );
+
+        let decoded =
+            UiNotification::from_rpc_notification(wire).expect("decode user_question/requested");
+        assert_eq!(decoded, notification);
+    }
+
+    #[test]
+    fn user_question_respond_params_round_trip_multi_question_and_free_text() {
+        let params = UserQuestionRespondParams {
+            session_id: SessionKey("local:demo".into()),
+            question_id: QuestionId(Uuid::from_u128(7)),
+            answers: vec![
+                // single-select: one label
+                UserQuestionAnswer {
+                    selected_labels: vec!["axum".into()],
+                    free_text: None,
+                },
+                // multi-select: several labels
+                UserQuestionAnswer {
+                    selected_labels: vec!["stable".into(), "msrv".into()],
+                    free_text: None,
+                },
+                // free-text-only: empty labels + free_text
+                UserQuestionAnswer {
+                    selected_labels: Vec::new(),
+                    free_text: Some("rocket, please".into()),
+                },
+            ],
+            client_note: Some("answered from TUI".into()),
+        };
+
+        let command = UiCommand::UserQuestionRespond(params.clone());
+        assert_eq!(command.method(), methods::USER_QUESTION_RESPOND);
+        let request = command
+            .clone()
+            .into_rpc_request("req-uq-1")
+            .expect("serialize user_question/respond");
+        assert_eq!(request.method, methods::USER_QUESTION_RESPOND);
+        // free-text-only answer omits the empty selected_labels but keeps free_text.
+        assert_eq!(
+            request.params["answers"][2]["free_text"],
+            json!("rocket, please")
+        );
+        assert!(
+            request.params["answers"][2]
+                .get("selected_labels")
+                .is_none()
+        );
+
+        let decoded = UiCommand::from_rpc_request(request).expect("decode user_question/respond");
+        assert_eq!(decoded, command);
+    }
+
+    #[test]
+    fn user_question_respond_decodes_minimal_and_unknown_fields() {
+        // Minimal params: client_note omitted, free-text-only answer with no
+        // selected_labels, plus an unknown forward-compat sibling field.
+        let value = json!({
+            "session_id": "local:demo",
+            "question_id": QuestionId(Uuid::from_u128(7)),
+            "answers": [
+                { "free_text": "something else" }
+            ],
+            "future_field": { "anything": true }
+        });
+        let decoded: UserQuestionRespondParams =
+            serde_json::from_value(value).expect("minimal user_question/respond decodes");
+        assert_eq!(decoded.client_note, None);
+        assert_eq!(decoded.answers.len(), 1);
+        assert!(decoded.answers[0].selected_labels.is_empty());
+        assert_eq!(
+            decoded.answers[0].free_text.as_deref(),
+            Some("something else")
+        );
+    }
+
+    #[test]
+    fn user_question_requested_keeps_generic_fallback_on_unknown_fields() {
+        // A client that does not understand `questions` must still get the
+        // mandatory generic title/body, and an unknown extra field must not
+        // break decoding (forward-compat).
+        let value = json!({
+            "session_id": "local:demo",
+            "question_id": QuestionId(Uuid::from_u128(7)),
+            "turn_id": TurnId(Uuid::from_u128(1)),
+            "title": "Generic fallback title",
+            "body": "Generic fallback body the user can still answer via free text.",
+            "questions": [],
+            "future_render_hint": "wizard"
+        });
+        let decoded: UserQuestionRequestedEvent =
+            serde_json::from_value(value).expect("unknown-field event decodes");
+        assert_eq!(decoded.title, "Generic fallback title");
+        assert_eq!(
+            decoded.body,
+            "Generic fallback body the user can still answer via free text."
+        );
+        assert!(decoded.questions.is_empty());
     }
 
     #[test]

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -447,6 +447,16 @@ pub mod rpc_error_codes {
     /// [`APPROVAL_NOT_PENDING`] / [`APPROVAL_CANCELLED`] for the
     /// structured-question surface.
     pub const USER_QUESTION_STALE: i64 = -32107;
+    /// UPCR-2026-023 `user_question_invalid`: `user_question/respond` carried
+    /// answers that do not match the STORED request (wrong answer count, a
+    /// `selected_labels` value not in that question's options, more than one
+    /// label on a non-`multi_select` question, or free text where the question
+    /// disallows it). The server rejects the call and does NOT resolve the
+    /// blocked tool with bad data. Distinct from `user_question_unknown`
+    /// (target not found) and `user_question_stale` (target no longer
+    /// pending) so the client can tell "fix your answer and retry" from "this
+    /// question is gone".
+    pub const USER_QUESTION_INVALID: i64 = -32108;
 
     /// Spec §10 `cursor_out_of_range`: stale or future cursor relative to ledger.
     pub const CURSOR_OUT_OF_RANGE: i64 = -32110;
@@ -1349,6 +1359,7 @@ impl UiProtocolCapabilities {
             UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1,
             UI_PROTOCOL_FEATURE_REVIEW_START_V1,
             UI_PROTOCOL_FEATURE_CONTEXT_LIFECYCLE_V1,
+            UI_PROTOCOL_FEATURE_USER_QUESTION_V1,
         ])
     }
 
@@ -2497,6 +2508,14 @@ pub struct SessionHydrateResult {
     pub turns: Option<Vec<HydratedTurn>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_approvals: Option<Vec<ApprovalRequestedEvent>>,
+    /// UPCR-2026-023: still-pending structured user-questions for this
+    /// session, mirroring [`pending_approvals`](Self::pending_approvals). A
+    /// reconnecting client that negotiated `user_question.v1` re-renders these
+    /// and can still answer them; omitted (not `null`) when the request did
+    /// not ask for the `pending_approvals` section or the connection lacks the
+    /// capability.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_questions: Option<Vec<UserQuestionRequestedEvent>>,
     /// M10 Phase 6.2 (Bug C). Retained `turn/spawn_complete` envelopes
     /// from the ledger replay window for clients that negotiated
     /// [`UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1`]. Populated only when
@@ -6931,6 +6950,23 @@ mod tests {
     }
 
     #[test]
+    fn full_protocol_advertises_user_question_feature() {
+        // `full_protocol()` must agree with the known/first-server feature
+        // lists, both of which already include `user_question.v1`. A client
+        // that handshakes against `full_protocol()` must see the question
+        // capability or it will never negotiate `user_question.v1` and the
+        // tool silently degrades to its fallback.
+        let caps = UiProtocolCapabilities::full_protocol();
+        assert!(
+            caps.supported_features
+                .iter()
+                .any(|f| f == UI_PROTOCOL_FEATURE_USER_QUESTION_V1),
+            "full_protocol() must advertise user_question.v1; got {:?}",
+            caps.supported_features
+        );
+    }
+
+    #[test]
     fn user_question_requested_event_round_trips_with_structured_questions() {
         let event = UserQuestionRequestedEvent::new(
             SessionKey("local:demo".into()),
@@ -9025,6 +9061,32 @@ mod tests {
             .with_timezone(&Utc)
     }
 
+    fn sample_user_question_requested_event() -> UserQuestionRequestedEvent {
+        UserQuestionRequestedEvent::new(
+            sample_session_id(),
+            QuestionId(Uuid::from_u128(0x77)),
+            sample_turn_id(),
+            "Pick a framework",
+            "Which framework should I scaffold?",
+            vec![UserQuestion {
+                header: "Framework".into(),
+                question: "Which framework?".into(),
+                options: vec![
+                    UserQuestionOption {
+                        label: "axum".into(),
+                        description: "tower-based".into(),
+                    },
+                    UserQuestionOption {
+                        label: "actix".into(),
+                        description: "actor-based".into(),
+                    },
+                ],
+                multi_select: false,
+                allow_free_text: true,
+            }],
+        )
+    }
+
     #[test]
     fn golden_session_hydrate_params_serde() {
         let params = SessionHydrateParams {
@@ -9084,6 +9146,7 @@ mod tests {
                 thread_id: Some("thread-1".into()),
             }]),
             pending_approvals: Some(vec![]),
+            pending_questions: Some(vec![sample_user_question_requested_event()]),
             replayed_envelopes: Some(vec![]),
         };
         let value = serde_json::to_value(&result).expect("serialize hydrate result");
@@ -9101,6 +9164,7 @@ mod tests {
             threads: None,
             turns: None,
             pending_approvals: None,
+            pending_questions: None,
             replayed_envelopes: None,
         };
         let value = serde_json::to_value(&messages_only).expect("serialize messages-only");
@@ -9109,6 +9173,9 @@ mod tests {
         assert!(!object.contains_key("threads"));
         assert!(!object.contains_key("turns"));
         assert!(!object.contains_key("pending_approvals"));
+        // UPCR-2026-023: a client that did not request pending questions never
+        // sees the new field — it is omitted, never serialized as `null`.
+        assert!(!object.contains_key("pending_questions"));
         // Bug C: a non-negotiated client never sees the new field.
         assert!(!object.contains_key("replayed_envelopes"));
     }


### PR DESCRIPTION
Implements the server+protocol+agent side of codex-style AskUserQuestion (spec'd in #1403 / UPCR-2026-023). The agent asks the user a structured multiple-choice question mid-turn and blocks on the answer, mirroring the proven approval flow. **PR1 of 2** — client/TUI rendering follows in octos-org/octos-tui; until then the tool degrades to a structured-metadata/text fallback, so this is safe to ship on its own.

## What's here
- **octos-core**: `user_question/requested` event + `user_question/respond` command + `UserQuestion`/`UserQuestionOption`/`UserQuestionAnswer` types + `user_question.v1` feature flag + dispatch + golden/round-trip tests.
- **octos-cli**: `PendingQuestionStore` (parallel to `PendingApprovalStore`) + WS/stdio `handle_user_question_respond` + `SessionUserQuestionRequester` injected into the turn task; capability-gated event + strict respond gate; reconnect durability (`pending_questions` replayed on session/open + hydrate); turn-interrupt drains pending questions; **answer validation** against the stored request (typed `user_question_invalid`); a `PendingQuestionWaiterGuard` RAII that cancels the entry if the tool future drops.
- **octos-agent**: `ask_user_question` tool (1–4 questions, 2–4 options each, header ≤12, server-forced free-text "Other"); blocks on the requester when attached, else structured-metadata/text fallback; `UserQuestionRequester` trait + `USER_QUESTION_CTX` task-local; registered + policy-allowed. **Human-wait tools are exempt from BOTH the per-tool registry timeout AND the agent batch timeout** (a batch containing a `blocks_on_human_input` tool runs unbounded — a human can take arbitrarily long; cleanup is via the user answering or turn interrupt/abort), so a question is never timed-out/detached.

## Quality
codex-reviewed across 3 rounds; 5 DO-NOT-SHIP closed (timeout-detach leak, reconnect durability, capability filter on the notification, cancel-race drop-guard, answer validation). ~40 new tests (protocol round-trip, store request/respond/cancel/validate, tool block+fallback+validation, hydrate replay, capability filter, batch-timeout integration). Build/test/fmt/clippy clean (only the known unrelated env-tmpdir + process-static flakes).