### PR TITLE
fix(agent): propagate approval/user-question task-locals across the tool spawn; truncate AUQ header

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -1625,7 +1625,11 @@ Structured field (governed by accepted `UPCR-2026-023`):
 
 - `questions`
   An array of 1–4 questions. Each question carries:
-  - `header` — short label, ≤ 12 characters.
+  - `header` — short label, ≤ 12 characters. An over-long header is
+    **truncated** to the limit (char-boundary safe, ellipsis-marked) server-side
+    rather than rejected, so a model that sends a descriptive header
+    ("Favorite Color") still gets a rendered picker (live-soak hardening
+    2026-06-04).
   - `question` — the question text.
   - `options` — an array of 2–4 options, each with `label` and `description`.
   - `multi_select` — `bool`; when `true` the user may select more than one

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -38,7 +38,10 @@ use crate::hooks::{HookEvent, HookPayload, HookResult};
 use crate::progress::ProgressEvent;
 use crate::task_supervisor::{TaskRuntimeState, TaskTerminalGuard};
 use crate::tools::spawn::{BackgroundResultKind, BackgroundResultPayload};
-use crate::tools::{ConcurrencyClass, TOOL_CTX, TURN_ATTACHMENT_CTX, ToolContext};
+use crate::tools::{
+    ConcurrencyClass, TOOL_APPROVAL_CTX, TOOL_CTX, TURN_ATTACHMENT_CTX, ToolApprovalRequester,
+    ToolContext, USER_QUESTION_CTX, UserQuestionRequester,
+};
 use crate::workspace_contract::{
     SpawnTaskContractResult, enforce_spawn_task_contract_with_args_and_output,
 };
@@ -377,6 +380,23 @@ impl Agent {
         // consumers (pipeline workers, file tools, plugins) come online
         // in Phase 2.
         let session_scope = self.session_scope.clone();
+
+        // UPCR-2026-023 live-soak BUG 1: capture the per-turn human-blocking
+        // bridges (`TOOL_APPROVAL_CTX`, `USER_QUESTION_CTX`) HERE — in the turn
+        // task where they are still scoped — before the `tokio::spawn` below.
+        // tokio task-locals are NOT inherited across `tokio::spawn`, so without
+        // re-establishing them inside the spawned task a tool that reads either
+        // requester (`shell`/`edit_file` approval, `ask_user_question`) would
+        // find NONE and silently degrade (the live mini5 soak symptom: a valid
+        // `ask_user_question` call emitted its "no synchronous host response
+        // channel" text fallback even though the serve turn handler had
+        // installed a `SessionUserQuestionRequester`). `try_with` returns the
+        // `Arc` clone when scoped and `None` for a non-interactive turn (e.g.
+        // CLI / gateway batch), preserving the graceful-degradation contract.
+        let captured_approval_ctx: Option<std::sync::Arc<dyn ToolApprovalRequester>> =
+            TOOL_APPROVAL_CTX.try_with(std::sync::Arc::clone).ok();
+        let captured_user_question_ctx: Option<std::sync::Arc<dyn UserQuestionRequester>> =
+            USER_QUESTION_CTX.try_with(std::sync::Arc::clone).ok();
 
         tokio::spawn(async move {
             let tool_start = Instant::now();
@@ -1658,12 +1678,40 @@ impl Agent {
             // whose trait impl only overrides `execute` still work via the
             // default delegation path; migrated tools read the typed fields.
             // TOOL_CTX is still scoped for plugin tools that read the task-local.
-            let result = TOOL_CTX
-                .scope(
-                    ctx.clone(),
-                    tools.execute_with_context(&ctx, &tc_name, &effective_args),
-                )
-                .await;
+            //
+            // UPCR-2026-023 live-soak BUG 1: re-establish the per-turn
+            // human-blocking bridges (captured above before this `tokio::spawn`)
+            // INSIDE the spawned task so approval-gated tools (`shell`,
+            // `edit_file`, …) and `ask_user_question` see their requester via
+            // `try_with`. Without this, both the parallel (`join_all`) and
+            // serial dispatch paths — which BOTH run the tool through this
+            // `spawn_tool_task` `tokio::spawn` — would lose the task-local and
+            // the tool would degrade (approval denied / question text fallback).
+            // We scope each bridge ONLY when it was scoped in the parent
+            // (`Some(_)`), so a non-interactive turn (CLI / gateway batch with
+            // no requester) keeps the graceful-degradation path unchanged.
+            let exec_future = TOOL_CTX.scope(ctx.clone(), async {
+                tools
+                    .execute_with_context(&ctx, &tc_name, &effective_args)
+                    .await
+            });
+            let result = match (&captured_approval_ctx, &captured_user_question_ctx) {
+                (Some(approval), Some(question)) => {
+                    TOOL_APPROVAL_CTX
+                        .scope(
+                            approval.clone(),
+                            USER_QUESTION_CTX.scope(question.clone(), exec_future),
+                        )
+                        .await
+                }
+                (Some(approval), None) => {
+                    TOOL_APPROVAL_CTX.scope(approval.clone(), exec_future).await
+                }
+                (None, Some(question)) => {
+                    USER_QUESTION_CTX.scope(question.clone(), exec_future).await
+                }
+                (None, None) => exec_future.await,
+            };
 
             let duration = tool_start.elapsed();
 

--- a/crates/octos-agent/src/tools/ask_user_question.rs
+++ b/crates/octos-agent/src/tools/ask_user_question.rs
@@ -32,8 +32,28 @@ const MIN_QUESTIONS: usize = 1;
 const MAX_QUESTIONS: usize = 4;
 const MIN_OPTIONS: usize = 2;
 const MAX_OPTIONS: usize = 4;
-/// `header` is a short label; the spec caps it at 12 characters.
+/// `header` is a short label; the spec caps it at 12 characters. Over-long
+/// headers are TRUNCATED to this ceiling (not rejected) — see [`clamp_header`].
 const MAX_HEADER_CHARS: usize = 12;
+/// Ellipsis appended when a `header` is truncated. Counts toward the
+/// [`MAX_HEADER_CHARS`] budget so the final label never exceeds the ceiling.
+const HEADER_TRUNCATION_ELLIPSIS: char = '\u{2026}';
+
+/// Clamp a `header` to [`MAX_HEADER_CHARS`] on a char boundary, appending an
+/// ellipsis when truncation occurs. The ellipsis is counted INSIDE the budget
+/// so the returned label is always `<= MAX_HEADER_CHARS` characters. A header
+/// already within the limit is returned verbatim. Char-based (not byte-based)
+/// so multibyte labels ("颜色偏好…") clamp correctly.
+fn clamp_header(header: &str) -> String {
+    if header.chars().count() <= MAX_HEADER_CHARS {
+        return header.to_owned();
+    }
+    // Reserve one char for the ellipsis so the total stays within the ceiling.
+    let keep = MAX_HEADER_CHARS.saturating_sub(1);
+    let mut clamped: String = header.chars().take(keep).collect();
+    clamped.push(HEADER_TRUNCATION_ELLIPSIS);
+    clamped
+}
 
 /// Structured user-question tool (`ask_user_question`).
 #[derive(Debug, Default)]
@@ -70,20 +90,23 @@ fn parse_questions(args: &Value) -> Result<Vec<UserQuestion>> {
             .as_object()
             .ok_or_else(|| eyre!("ask_user_question: question {idx} must be an object"))?;
 
-        let header = entry
+        let header_raw = entry
             .get("header")
             .and_then(Value::as_str)
             .map(str::trim)
             .filter(|h| !h.is_empty())
             .ok_or_else(|| {
                 eyre!("ask_user_question: question {idx} requires a non-empty `header`")
-            })?
-            .to_owned();
-        if header.chars().count() > MAX_HEADER_CHARS {
-            return Err(eyre!(
-                "ask_user_question: question {idx} `header` exceeds {MAX_HEADER_CHARS} characters"
-            ));
-        }
+            })?;
+        // Header length is a COSMETIC ceiling (the picker renders a short tab
+        // label). Real LLMs routinely send a longer descriptive header
+        // ("Favorite Color") — hard-failing there made the whole call fail and
+        // the agent degrade (live mini5 soak: a DeepSeek call with a 14-char
+        // header hard-erred, then the retry fell to the text fallback). Clamp
+        // it char-boundary-safe instead of rejecting so the request stays
+        // answerable. The truncation marker keeps the label readable when it
+        // overflows.
+        let header = clamp_header(header_raw);
 
         let question = entry
             .get("question")
@@ -217,11 +240,12 @@ impl Tool for AskUserQuestionTool {
 
     fn description(&self) -> &str {
         "Ask the user a structured multiple-choice question mid-turn and block on \
-         the answer. Carry 1-4 questions, each with a short `header` (<=12 chars), \
-         a `question`, 2-4 `options` (each `label` + `description`), and a \
-         `multi_select` flag. The user is always also offered a free-text \"Other\". \
-         Use this instead of guessing when a bounded choice would resolve an \
-         ambiguity (which framework, which file, opt-in to a cleanup)."
+         the answer. Carry 1-4 questions, each with a short `header` (kept to <=12 \
+         chars — a longer header is truncated, not rejected), a `question`, 2-4 \
+         `options` (each `label` + `description`), and a `multi_select` flag. The \
+         user is always also offered a free-text \"Other\". Use this instead of \
+         guessing when a bounded choice would resolve an ambiguity (which \
+         framework, which file, opt-in to a cleanup)."
     }
 
     fn tags(&self) -> &[&str] {
@@ -257,7 +281,7 @@ impl Tool for AskUserQuestionTool {
                             "header": {
                                 "type": "string",
                                 "maxLength": MAX_HEADER_CHARS,
-                                "description": "Short label for the question (<=12 chars)."
+                                "description": "Short label for the question (kept to <=12 chars; a longer header is truncated server-side, not rejected)."
                             },
                             "question": {
                                 "type": "string",
@@ -560,11 +584,15 @@ mod tests {
         });
         assert!(tool.execute(&bad_options).await.is_err());
 
-        // Over-long header (> 12 chars).
-        let long_header = json!({
+        // NOTE: an over-long `header` is NOT a hard error — it is truncated.
+        // See `over_long_header_is_truncated_not_rejected`.
+
+        // Empty `header` (after trim) IS still a hard error — a question with no
+        // label is not answerable.
+        let empty_header = json!({
             "questions": [
                 {
-                    "header": "this-header-is-way-too-long",
+                    "header": "   ",
                     "question": "q?",
                     "options": [
                         { "label": "a", "description": "" },
@@ -573,6 +601,111 @@ mod tests {
                 }
             ]
         });
-        assert!(tool.execute(&long_header).await.is_err());
+        assert!(tool.execute(&empty_header).await.is_err());
+
+        // Empty option `label` IS still a hard error — an unlabeled option is
+        // not selectable.
+        let empty_label = json!({
+            "questions": [
+                {
+                    "header": "Pick",
+                    "question": "q?",
+                    "options": [
+                        { "label": "  ", "description": "" },
+                        { "label": "b", "description": "" }
+                    ]
+                }
+            ]
+        });
+        assert!(tool.execute(&empty_label).await.is_err());
+    }
+
+    #[test]
+    fn clamp_header_keeps_short_headers_verbatim() {
+        assert_eq!(clamp_header("Framework"), "Framework");
+        // Exactly at the ceiling is left untouched.
+        let exactly_12 = "abcdefghijkl";
+        assert_eq!(exactly_12.chars().count(), MAX_HEADER_CHARS);
+        assert_eq!(clamp_header(exactly_12), exactly_12);
+    }
+
+    #[test]
+    fn clamp_header_truncates_with_ellipsis_within_budget() {
+        // "Favorite Color" is 14 chars — the exact live-soak failure header.
+        let clamped = clamp_header("Favorite Color");
+        assert!(
+            clamped.chars().count() <= MAX_HEADER_CHARS,
+            "clamped header must fit the ceiling, got {} chars: {clamped:?}",
+            clamped.chars().count()
+        );
+        assert!(
+            clamped.ends_with(HEADER_TRUNCATION_ELLIPSIS),
+            "truncated header must end with the ellipsis marker: {clamped:?}"
+        );
+        // The kept prefix is the start of the original.
+        assert!(clamped.starts_with("Favorite Co"));
+    }
+
+    #[test]
+    fn clamp_header_is_char_boundary_safe_for_multibyte() {
+        // 颜色偏好选择题目 = 8 multibyte chars; build a >12-char multibyte header.
+        let header = "颜色偏好选择题目内容标签字段值"; // 13 chars
+        assert!(header.chars().count() > MAX_HEADER_CHARS);
+        let clamped = clamp_header(header);
+        assert!(clamped.chars().count() <= MAX_HEADER_CHARS);
+        // Must still be valid UTF-8 (no panic / no split codepoint).
+        assert!(clamped.is_char_boundary(clamped.len()));
+        assert!(clamped.ends_with(HEADER_TRUNCATION_ELLIPSIS));
+    }
+
+    #[tokio::test]
+    async fn over_long_header_is_truncated_not_rejected() {
+        // Real LLMs send descriptive headers longer than 12 chars. The tool
+        // must TRUNCATE (not reject) so the question stays answerable. We
+        // capture the validated request via a recording requester and assert
+        // the header was clamped to the ceiling.
+        let answer = vec![UserQuestionAnswer {
+            selected_labels: vec!["red".into()],
+            free_text: None,
+        }];
+        let requester = Arc::new(RecordingRequester {
+            captured: Mutex::new(None),
+            answer,
+        });
+        let requester_dyn: Arc<dyn UserQuestionRequester> = requester.clone();
+
+        let tool = AskUserQuestionTool::new();
+        let args = json!({
+            "questions": [
+                {
+                    "header": "Favorite Color",
+                    "question": "Which color do you prefer?",
+                    "options": [
+                        { "label": "red", "description": "" },
+                        { "label": "blue", "description": "" }
+                    ]
+                }
+            ]
+        });
+
+        let result = USER_QUESTION_CTX
+            .scope(requester_dyn, async move { tool.execute(&args).await })
+            .await
+            .expect("over-long header is truncated, not an error");
+        assert!(result.success);
+
+        let captured = requester
+            .captured
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("captured request");
+        let header = &captured.questions[0].header;
+        assert!(
+            header.chars().count() <= MAX_HEADER_CHARS,
+            "header must be truncated to the ceiling, got {} chars: {header:?}",
+            header.chars().count()
+        );
+        assert_eq!(header, &clamp_header("Favorite Color"));
     }
 }

--- a/crates/octos-agent/tests/human_wait_ctx_propagation.rs
+++ b/crates/octos-agent/tests/human_wait_ctx_propagation.rs
@@ -1,0 +1,352 @@
+//! UPCR-2026-023 live-soak BUG 1 — a human-blocking tool dispatched through the
+//! agent batch executor must still see the per-turn `USER_QUESTION_CTX` /
+//! `TOOL_APPROVAL_CTX` requester scoped around `process_message`.
+//!
+//! Regression being pinned: the batch executor runs every tool call through
+//! `spawn_tool_task`, which `tokio::spawn`s the tool future onto a fresh task.
+//! tokio task-locals are NOT inherited across `tokio::spawn`, and the spawned
+//! task only re-scoped `TOOL_CTX` — never `USER_QUESTION_CTX` or
+//! `TOOL_APPROVAL_CTX`. So a tool that reads either requester via `try_with`
+//! found NONE inside the spawned task and degraded (e.g. `ask_user_question`
+//! emitted its "no synchronous host response channel" text fallback even
+//! though the serve turn handler had installed a `SessionUserQuestionRequester`).
+//!
+//! These tests drive a REAL `Agent` loop with a scripted `MockLlm`. The turn's
+//! `process_message` future is wrapped in `USER_QUESTION_CTX.scope(...)` /
+//! `TOOL_APPROVAL_CTX.scope(...)` exactly as the serve turn handler wraps it
+//! (`ui_protocol.rs` run_standalone_turn). A probe tool reads the task-local at
+//! execution time and records whether the requester was visible.
+//!
+//! RED before the fix: the probe records `requester_seen=false` (task-local
+//! lost across the spawn) and `ask_user_question` returns its fallback.
+//! GREEN after the fix: `spawn_tool_task` captures the requesters before the
+//! spawn and re-scopes them around the tool execution, so the probe sees the
+//! requester and `ask_user_question` blocks + returns the real answer.
+
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+
+use async_trait::async_trait;
+use octos_agent::tools::{TOOL_APPROVAL_CTX, USER_QUESTION_CTX};
+use octos_agent::{
+    Agent, AgentConfig, AskUserQuestionTool, ConcurrencyClass, Tool, ToolApprovalDecision,
+    ToolApprovalRequest, ToolApprovalRequester, ToolRegistry, ToolResult, UserQuestionOutcome,
+    UserQuestionRequest, UserQuestionRequester,
+};
+use octos_core::ui_protocol::UserQuestionAnswer;
+use octos_core::{AgentId, Message, ToolCall};
+use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, TokenUsage, ToolSpec};
+use octos_memory::EpisodeStore;
+use tempfile::TempDir;
+
+/// Probe tool: at execution time, records whether `USER_QUESTION_CTX` is
+/// scoped. Stays `ConcurrencyClass::Safe` so a batch of only this tool runs
+/// through the PARALLEL dispatch path (the live-soak shape).
+struct UserQuestionProbeTool {
+    seen: Arc<AtomicBool>,
+    class: ConcurrencyClass,
+}
+
+#[async_trait]
+impl Tool for UserQuestionProbeTool {
+    fn name(&self) -> &str {
+        "uq_probe"
+    }
+    fn description(&self) -> &str {
+        "test-only: records whether USER_QUESTION_CTX is in scope at execute time"
+    }
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+    fn concurrency_class(&self) -> ConcurrencyClass {
+        self.class
+    }
+    async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+        let seen = USER_QUESTION_CTX.try_with(|_| ()).is_ok();
+        self.seen.store(seen, Ordering::SeqCst);
+        Ok(ToolResult {
+            output: format!("requester_seen={seen}"),
+            success: true,
+            ..Default::default()
+        })
+    }
+}
+
+/// Probe tool for the approval bridge: records whether `TOOL_APPROVAL_CTX` is
+/// scoped at execute time. `Exclusive` so it forces the SERIAL dispatch path.
+struct ApprovalProbeTool {
+    seen: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl Tool for ApprovalProbeTool {
+    fn name(&self) -> &str {
+        "approval_probe"
+    }
+    fn description(&self) -> &str {
+        "test-only: records whether TOOL_APPROVAL_CTX is in scope at execute time"
+    }
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+    fn concurrency_class(&self) -> ConcurrencyClass {
+        ConcurrencyClass::Exclusive
+    }
+    async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+        let seen = TOOL_APPROVAL_CTX.try_with(|_| ()).is_ok();
+        self.seen.store(seen, Ordering::SeqCst);
+        Ok(ToolResult {
+            output: format!("approval_seen={seen}"),
+            success: true,
+            ..Default::default()
+        })
+    }
+}
+
+/// Records that it was asked and replays a canned answer — the test stand-in
+/// for the serve `SessionUserQuestionRequester`.
+struct RecordingQuestionRequester {
+    asked: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl UserQuestionRequester for RecordingQuestionRequester {
+    async fn request_user_question(&self, _request: UserQuestionRequest) -> UserQuestionOutcome {
+        self.asked.store(true, Ordering::SeqCst);
+        UserQuestionOutcome::Answered(vec![UserQuestionAnswer {
+            selected_labels: vec!["axum".into()],
+            free_text: None,
+        }])
+    }
+}
+
+struct AlwaysApprove;
+
+#[async_trait]
+impl ToolApprovalRequester for AlwaysApprove {
+    async fn request_approval(&self, _request: ToolApprovalRequest) -> ToolApprovalDecision {
+        ToolApprovalDecision::Approve
+    }
+}
+
+struct MockLlm {
+    responses: Mutex<Vec<ChatResponse>>,
+}
+
+impl MockLlm {
+    fn new(responses: Vec<ChatResponse>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for MockLlm {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> eyre::Result<ChatResponse> {
+        let mut responses = self.responses.lock().unwrap();
+        if responses.is_empty() {
+            eyre::bail!("MockLlm: no more scripted responses");
+        }
+        Ok(responses.remove(0))
+    }
+    fn context_window(&self) -> u32 {
+        128_000
+    }
+    fn model_id(&self) -> &str {
+        "mock-upcr-023-ctx"
+    }
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+fn tool_use(calls: Vec<ToolCall>) -> ChatResponse {
+    ChatResponse {
+        content: None,
+        reasoning_content: None,
+        tool_calls: calls,
+        stop_reason: StopReason::ToolUse,
+        usage: TokenUsage {
+            input_tokens: 50,
+            output_tokens: 5,
+            ..Default::default()
+        },
+        provider_index: None,
+    }
+}
+
+fn end(text: &str) -> ChatResponse {
+    ChatResponse {
+        content: Some(text.into()),
+        reasoning_content: None,
+        tool_calls: vec![],
+        stop_reason: StopReason::EndTurn,
+        usage: TokenUsage {
+            input_tokens: 5,
+            output_tokens: 5,
+            ..Default::default()
+        },
+        provider_index: None,
+    }
+}
+
+fn tc(id: &str, name: &str, args: serde_json::Value) -> ToolCall {
+    ToolCall {
+        id: id.into(),
+        name: name.into(),
+        arguments: args,
+        metadata: None,
+    }
+}
+
+async fn agent_with(dir: &TempDir, tools: ToolRegistry, responses: Vec<ChatResponse>) -> Agent {
+    let memory = Arc::new(EpisodeStore::open(dir.path().join(".octos")).await.unwrap());
+    let llm: Arc<dyn LlmProvider> = Arc::new(MockLlm::new(responses));
+    Agent::new(AgentId::new("upcr-023-ctx"), llm, tools, memory).with_config(AgentConfig {
+        save_episodes: false,
+        ..Default::default()
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parallel_batch_propagates_user_question_ctx_to_spawned_tool() {
+    // PARALLEL path (Safe-only batch). The probe must see USER_QUESTION_CTX
+    // scoped around process_message even though it runs inside spawn_tool_task's
+    // tokio::spawn.
+    let dir = TempDir::new().unwrap();
+    let seen = Arc::new(AtomicBool::new(false));
+    let mut tools = ToolRegistry::new();
+    tools.register(UserQuestionProbeTool {
+        seen: seen.clone(),
+        class: ConcurrencyClass::Safe,
+    });
+
+    let agent = agent_with(
+        &dir,
+        tools,
+        vec![
+            tool_use(vec![tc("probe", "uq_probe", serde_json::json!({}))]),
+            end("done"),
+        ],
+    )
+    .await;
+
+    let requester: Arc<dyn UserQuestionRequester> = Arc::new(RecordingQuestionRequester {
+        asked: Arc::new(AtomicBool::new(false)),
+    });
+    let resp = USER_QUESTION_CTX
+        .scope(requester, agent.process_message("probe", &[], vec![]))
+        .await
+        .expect("agent loop must succeed");
+
+    assert_eq!(resp.content, "done");
+    assert!(
+        seen.load(Ordering::SeqCst),
+        "USER_QUESTION_CTX must be visible inside the spawned (parallel) tool task"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn serial_batch_propagates_approval_ctx_to_spawned_tool() {
+    // SERIAL path (Exclusive tool). The approval probe must see
+    // TOOL_APPROVAL_CTX scoped around process_message even though it runs
+    // inside spawn_tool_task's tokio::spawn.
+    let dir = TempDir::new().unwrap();
+    let seen = Arc::new(AtomicBool::new(false));
+    let mut tools = ToolRegistry::new();
+    tools.register(ApprovalProbeTool { seen: seen.clone() });
+
+    let agent = agent_with(
+        &dir,
+        tools,
+        vec![
+            tool_use(vec![tc("probe", "approval_probe", serde_json::json!({}))]),
+            end("done"),
+        ],
+    )
+    .await;
+
+    let requester: Arc<dyn ToolApprovalRequester> = Arc::new(AlwaysApprove);
+    let resp = TOOL_APPROVAL_CTX
+        .scope(requester, agent.process_message("probe", &[], vec![]))
+        .await
+        .expect("agent loop must succeed");
+
+    assert_eq!(resp.content, "done");
+    assert!(
+        seen.load(Ordering::SeqCst),
+        "TOOL_APPROVAL_CTX must be visible inside the spawned (serial) tool task"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ask_user_question_blocks_through_batch_when_ctx_scoped() {
+    // End-to-end: the REAL ask_user_question tool, dispatched through the agent
+    // batch, must reach the scoped requester (block + return the answer) rather
+    // than degrade to its "no synchronous host response channel" fallback.
+    let dir = TempDir::new().unwrap();
+    let asked = Arc::new(AtomicBool::new(false));
+    let mut tools = ToolRegistry::new();
+    tools.register(AskUserQuestionTool::new());
+
+    let agent = agent_with(
+        &dir,
+        tools,
+        vec![
+            tool_use(vec![tc(
+                "auq",
+                "ask_user_question",
+                serde_json::json!({
+                    "questions": [{
+                        "header": "Framework",
+                        "question": "Which web framework should I scaffold?",
+                        "options": [
+                            { "label": "axum", "description": "tower-based async" },
+                            { "label": "actix", "description": "actor-based" }
+                        ],
+                        "multi_select": false
+                    }]
+                }),
+            )]),
+            end("done"),
+        ],
+    )
+    .await;
+
+    let requester: Arc<dyn UserQuestionRequester> = Arc::new(RecordingQuestionRequester {
+        asked: asked.clone(),
+    });
+    let resp = USER_QUESTION_CTX
+        .scope(requester, agent.process_message("ask", &[], vec![]))
+        .await
+        .expect("agent loop must succeed");
+
+    assert_eq!(resp.content, "done");
+    assert!(
+        asked.load(Ordering::SeqCst),
+        "the scoped requester must be asked (tool must NOT degrade to the no-channel fallback)"
+    );
+    let auq = resp
+        .messages
+        .iter()
+        .find(|m| m.tool_call_id.as_deref() == Some("auq"))
+        .expect("ask_user_question tool result recorded");
+    assert!(
+        auq.content.contains("answered") && auq.content.contains("axum"),
+        "ask_user_question must record the REAL answer; got: {}",
+        auq.content
+    );
+    assert!(
+        !auq.content.contains("no synchronous host response channel"),
+        "ask_user_question must NOT degrade to the unsupported fallback when a requester is scoped; got: {}",
+        auq.content
+    );
+}

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_023_ASK_USER_QUESTION.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_023_ASK_USER_QUESTION.md
@@ -64,8 +64,10 @@ Pauses the turn at the blocking-tool boundary. Carries:
 - Required fallback: `session_id`, `question_id`, `turn_id`, `title`, `body`
   (generic, mandatory).
 - Structured (gated by `user_question.v1`): `questions` — 1–4 entries, each with
-  `header` (≤ 12 chars), `question`, `options` (2–4 of `label` + `description`),
-  `multi_select` (bool), and `allow_free_text` (bool, server-forced `true`).
+  `header` (≤ 12 chars — a longer header is **truncated** server-side, not
+  rejected; live-soak hardening 2026-06-04), `question`, `options` (2–4 of
+  `label` + `description`), `multi_select` (bool), and `allow_free_text` (bool,
+  server-forced `true`).
 
 ### `user_question/respond` (command)
 

--- a/docs/design/ask-user-question-2026-06-03.md
+++ b/docs/design/ask-user-question-2026-06-03.md
@@ -175,7 +175,7 @@ pub struct UserQuestionRequestedEvent {
 }
 
 pub struct UserQuestion {
-    pub header: String,                 // short label, ≤ 12 chars
+    pub header: String,                 // short label, ≤ 12 chars (over-long truncated, not rejected)
     pub question: String,
     pub options: Vec<UserQuestionOption>, // 2..=4
     pub multi_select: bool,


### PR DESCRIPTION
Two runtime fixes found by exercising AskUserQuestion (UPCR-2026-023, #1405) live in the soak — the picker was falling back to text.

## BUG 1 (load-bearing) — task-locals lost across the tool `tokio::spawn`
tokio task-locals are NOT inherited across `tokio::spawn`. `spawn_tool_task` (octos-agent/src/agent/execution.rs) runs every tool call in a spawned task but only re-scoped `TOOL_CTX` — so `USER_QUESTION_CTX` (and, latently, `TOOL_APPROVAL_CTX`) were invisible inside the spawned task. `ask_user_question` therefore degraded to its text fallback instead of blocking + rendering the picker. **This also fixes a latent approval-flow bug** (blocking approval tools run via the same batch spawn and would lose `TOOL_APPROVAL_CTX` too — just never exercised). Fix: capture both requester `Arc`s in the turn task BEFORE the spawn and re-scope them around the tool execution inside the spawned task (each only when `Some`, preserving CLI/gateway graceful degradation). Both parallel + serial dispatch paths covered.

## BUG 2 — AUQ header hard-failed on real LLM output
`ask_user_question` rejected a `header` > 12 chars with an error; DeepSeek routinely sends longer ("Favorite Color"), so the tool failed. Now `clamp_header` truncates (char-boundary-safe, ellipsis within budget). Hard errors kept only for unanswerable input (0/>4 questions, <2/>4 options, empty header/label). Spec/UPCR/design updated to "<=12 (truncated, not rejected)".

## Validation
codex-reviewed: SHIP. New `human_wait_ctx_propagation` tests (parallel + serial ctx propagation + end-to-end block-through-batch) + `clamp_header` tests, RED to GREEN. Build/test/fmt/clippy clean. **Confirmed live on the soak**: the agent calls `ask_user_question`, the TUI renders the radio/checkbox picker + free-text Other, and the turn blocks on the answer (no fallback).
