### PR TITLE
fix(agent): liveness-gate orphan-sweep so per-turn supervisor rebuild does not falsely reap live detached tasks

### DIFF
--- a/crates/octos-agent/src/agent/detection.rs
+++ b/crates/octos-agent/src/agent/detection.rs
@@ -1,12 +1,33 @@
 //! Detection of repetitive output and retriable responses.
 
 use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use octos_core::ToolCall;
 use octos_llm::{ChatResponse, StopReason};
 use regex::Regex;
 
 use super::Agent;
+
+/// Process-global monotonic counter for synthesizing inline-`<invoke>`
+/// tool-call ids.
+///
+/// Models that emit tool calls as inline `<invoke name=...>` XML in assistant
+/// TEXT (rather than native structured `tool_calls`) carry no call id, so octos
+/// synthesizes one. Like the Gemini synthesizer (`call_gemini_`) and the
+/// agent's empty-id fallback (`call_synth_`), this id MUST be process-unique:
+/// it becomes `BackgroundTask::tool_call_id`, and the supervisor's synth-ack
+/// set (commit 9e972d8a), the `mark_descendants_failed` pipeline cascade, and
+/// the orphan-sweep liveness gate's tool_call_id-family exemption
+/// (fix/orphan-sweep-liveness-gate) all key on it. A per-response positional
+/// index reset every turn, so two first-position inline calls to the SAME tool
+/// (e.g. `run_pipeline`) in different turns both got
+/// `call_inline_0_run_pipeline` — colliding, which could match a stale
+/// synth-ack or let a live task's tcid falsely exempt a dead one from orphan
+/// reaping. A process-global monotonic counter never repeats within the
+/// process; the `call_inline_` prefix keeps it disjoint from the other two
+/// synthesized id spaces.
+static INLINE_TOOL_CALL_SEQ: AtomicU64 = AtomicU64::new(0);
 
 static INVOKE_TAG_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(?is)<invoke\b(?P<attrs>[^>]*)>(?P<body>.*?)</invoke\s*>"#).unwrap()
@@ -132,13 +153,13 @@ fn extract_inline_invokes(content: &str) -> (String, Vec<ToolCall>) {
     for caps in INVOKE_TAG_RE.captures_iter(content) {
         let attrs = caps.name("attrs").map(|m| m.as_str()).unwrap_or("");
         let body = caps.name("body").map(|m| m.as_str()).unwrap_or("");
-        if let Some(call) = build_tool_call_from_invoke(attrs, body, calls.len()) {
+        if let Some(call) = build_tool_call_from_invoke(attrs, body) {
             calls.push(call);
         }
     }
     for caps in INVOKE_SELF_RE.captures_iter(content) {
         let attrs = caps.name("attrs").map(|m| m.as_str()).unwrap_or("");
-        if let Some(call) = build_tool_call_from_invoke(attrs, "", calls.len()) {
+        if let Some(call) = build_tool_call_from_invoke(attrs, "") {
             calls.push(call);
         }
     }
@@ -149,7 +170,7 @@ fn extract_inline_invokes(content: &str) -> (String, Vec<ToolCall>) {
     (cleaned, calls)
 }
 
-fn build_tool_call_from_invoke(attrs: &str, body: &str, idx: usize) -> Option<ToolCall> {
+fn build_tool_call_from_invoke(attrs: &str, body: &str) -> Option<ToolCall> {
     let attr_map = parse_attrs(attrs);
     let name = attr_map.get("name")?.trim();
     if name.is_empty() {
@@ -172,7 +193,11 @@ fn build_tool_call_from_invoke(attrs: &str, body: &str, idx: usize) -> Option<To
     };
 
     Some(ToolCall {
-        id: format!("call_inline_{}_{}", idx, sanitize_tool_name(name)),
+        id: format!(
+            "call_inline_{}_{}",
+            INLINE_TOOL_CALL_SEQ.fetch_add(1, Ordering::Relaxed),
+            sanitize_tool_name(name)
+        ),
         name: name.to_string(),
         arguments,
         metadata: None,
@@ -336,6 +361,47 @@ mod tests {
         assert_eq!(r.tool_calls[0].name, "cron");
         assert_eq!(r.tool_calls[0].arguments["action"], "list");
         assert_eq!(r.content.as_deref(), Some("before  after"));
+    }
+
+    /// Regression (codex round-4 / fix/orphan-sweep-liveness-gate): inline
+    /// `<invoke>` tool-call ids must be PROCESS-UNIQUE, not positional. The id
+    /// previously embedded the within-response index, so the FIRST inline call
+    /// to a given tool in any response was always `call_inline_0_<tool>`. Two
+    /// separate responses each calling `run_pipeline` first thus collided —
+    /// breaking the tool_call_id-uniqueness invariant the supervisor's
+    /// synth-ack set, the `mark_descendants_failed` pipeline cascade, and the
+    /// orphan-sweep tool_call_id-family exemption all rely on.
+    #[test]
+    fn inline_invoke_ids_are_unique_across_responses() {
+        let body = "<invoke name=\"run_pipeline\">{\"k\":\"deep_research\"}</invoke>";
+        let (_, calls1) = extract_inline_invokes(body);
+        let (_, calls2) = extract_inline_invokes(body);
+        assert_eq!(calls1.len(), 1);
+        assert_eq!(calls2.len(), 1);
+        assert!(
+            calls1[0].id.starts_with("call_inline_"),
+            "got {}",
+            calls1[0].id
+        );
+        assert!(
+            calls1[0].id.ends_with("_run_pipeline"),
+            "keeps the readable tool-name suffix: {}",
+            calls1[0].id
+        );
+        assert_ne!(
+            calls1[0].id, calls2[0].id,
+            "the same tool at position 0 in two responses must NOT collide",
+        );
+    }
+
+    /// Within a single response, multiple inline calls still get distinct ids
+    /// (the monotonic counter increments per call).
+    #[test]
+    fn inline_invoke_ids_distinct_within_one_response() {
+        let body = "<invoke name=\"a\">{}</invoke><invoke name=\"b\">{}</invoke>";
+        let (_, calls) = extract_inline_invokes(body);
+        assert_eq!(calls.len(), 2);
+        assert_ne!(calls[0].id, calls[1].id);
     }
 
     #[test]

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -676,18 +676,28 @@ impl Agent {
                 // `tokio::spawn` moves `task_id` into the closure) can carry
                 // the same handle the supervisor and the SubAgentOutputRouter
                 // know it by.
+                // C1 step 2 / codex round-5 (orphan-sweep liveness): arm the
+                // RAII terminal guard HERE, in the FOREGROUND, before the
+                // `tokio::spawn`. `register_task_with_input_and_cmid` above
+                // already persisted a non-terminal `Spawned` row; arming the
+                // guard inside the spawned future (its previous home) left a
+                // window where a fast next-turn orphan-sweep could see the row
+                // non-terminal AND not-live and falsely reap a
+                // scheduled-but-not-yet-polled worker. Constructing it
+                // synchronously within the spawning turn inserts the id into
+                // the process-global live-set before the turn returns (turns
+                // are serialized per session, so this completes before any
+                // next-turn `enable_persistence` sweep). The guard is MOVED
+                // into the future below so its Drop — which clears the live-set
+                // and drives an unfinished task to Failed (so the TUI task
+                // count decrements instead of hanging on "N running") — still
+                // fires when the worker terminates. Idempotent on normal
+                // completion: the body's own terminal mark wins; Drop no-ops.
+                let terminal_guard = TaskTerminalGuard::new(bg_supervisor.clone(), task_id.clone());
                 let task_id_for_handle = task_id.clone();
                 tokio::spawn(async move {
+                    let _terminal_guard = terminal_guard;
                     bg_supervisor.mark_running(&task_id);
-                    // C1 step 2: arm a RAII terminal guard right after
-                    // mark_running. If this body panics or is aborted before
-                    // one of its mark_completed/mark_failed arms runs, the
-                    // guard's Drop drives the task to Failed so the TUI task
-                    // count decrements instead of hanging on "N running".
-                    // Idempotent on normal completion (the body's own
-                    // terminal mark wins; Drop then no-ops).
-                    let _terminal_guard =
-                        TaskTerminalGuard::new(bg_supervisor.clone(), task_id.clone());
                     // M8.7 (item 4): start a periodic-summary watcher for
                     // this background task. The watcher honours
                     // `min_runtime` so short tasks never trigger an LLM

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -671,6 +671,66 @@ fn is_terminal_runtime_state(state: &TaskRuntimeState) -> bool {
     )
 }
 
+/// Process-global set of task ids whose DETACHED worker is currently live in
+/// THIS process.
+///
+/// fix/orphan-sweep-liveness-gate — root cause: the WS turn path builds a
+/// BRAND-NEW per-turn [`TaskSupervisor`] every turn (`run_standalone_turn` →
+/// `ToolRegistry::snapshot_excluding` → `TaskSupervisor::new()`) and calls
+/// [`TaskSupervisor::enable_persistence`] every turn over the SHARED per-session
+/// ledger. The orphan-sweep inside `enable_persistence` *assumes* "non-terminal
+/// ⇒ no live worker" (true only at true cross-process startup). But a detached
+/// `spawn_only` task (e.g. `run_pipeline deep_research`, up to ~3600s) outlives
+/// the turn that launched it: when turn N+1 opens, its fresh supervisor restores
+/// turn N's still-`Running` row and falsely reaps it as "orphaned across
+/// restart" — even though the worker is alive on turn N's supervisor and will
+/// `mark_completed` shortly (evidence: 23/23 tasks ever marked orphaned ended
+/// `completed`).
+///
+/// The set CHECKS that precondition instead of assuming it. It is a
+/// `static`/`OnceLock` so it survives the per-turn supervisor rebuild within one
+/// process (the different per-turn `TaskSupervisor` instances are distinct
+/// objects, so per-supervisor state cannot carry liveness across the rebuild),
+/// yet starts EMPTY after a genuine cross-process restart (new process ⇒ no
+/// entries ⇒ stale rows still reaped). No `unsafe` — the workspace is
+/// `deny(unsafe_code)`.
+///
+/// Membership is owned by the detached worker via [`TaskTerminalGuard`]:
+/// constructed (insert) at the top of the `tokio::spawn` body right after
+/// `mark_running`, dropped (clear) on EVERY exit path — success, failure,
+/// cancel, or panic-unwind — so a finished task is never kept "live" forever.
+fn live_detached_tasks() -> &'static Mutex<HashSet<String>> {
+    static LIVE: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    LIVE.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Record that the detached worker for `task_id` is live in this process.
+/// Called by [`TaskTerminalGuard::new`]; idempotent.
+fn mark_task_live(task_id: &str) {
+    live_detached_tasks()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(task_id.to_string());
+}
+
+/// Remove `task_id` from the live-set once its worker terminates. Called by
+/// [`TaskTerminalGuard`]'s `Drop` on every exit path; idempotent.
+fn clear_task_live(task_id: &str) {
+    live_detached_tasks()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(task_id);
+}
+
+/// Whether the detached worker for `task_id` is currently live in this process.
+/// Used by the orphan-sweep filter to skip still-live detached tasks.
+fn is_task_live(task_id: &str) -> bool {
+    live_detached_tasks()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .contains(task_id)
+}
+
 fn record_workflow_phase_transition(workflow_kind: &str, from_phase: &str, to_phase: &str) {
     counter!(
         "octos_workflow_phase_transition_total",
@@ -1256,7 +1316,17 @@ impl TaskSupervisor {
             let tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
             tasks
                 .values()
-                .filter(|task| !is_terminal_runtime_state(&task.runtime_state))
+                // fix/orphan-sweep-liveness-gate: CHECK the sweep's
+                // "non-terminal ⇒ no live worker" precondition instead of
+                // assuming it. A still-live DETACHED spawn_only worker (alive
+                // on a prior per-turn supervisor in THIS process) is in the
+                // process-global live-set, so it is NEVER swept — its own
+                // worker will drive it terminal. A genuinely dead task from a
+                // true cross-process restart is absent from the live-set (new
+                // process ⇒ empty set) ⇒ still correctly reaped below.
+                .filter(|task| {
+                    !is_terminal_runtime_state(&task.runtime_state) && !is_task_live(&task.id)
+                })
                 .map(|task| {
                     (
                         task.id.clone(),
@@ -2977,7 +3047,16 @@ pub struct TaskTerminalGuard {
 
 impl TaskTerminalGuard {
     /// Arm a guard for `task_id` on `supervisor`.
+    ///
+    /// fix/orphan-sweep-liveness-gate: arming the guard also records the task
+    /// id in the process-global live-set ([`mark_task_live`]). The guard is
+    /// constructed at the top of every detached `spawn_only` worker body
+    /// (`execution.rs`, `spawn.rs`) right after `mark_running`, so this is the
+    /// single insert site for "a detached worker is live". The matching clear
+    /// happens in `Drop`, which runs on EVERY exit path (success, failure,
+    /// cancel, panic-unwind).
     pub fn new(supervisor: Arc<TaskSupervisor>, task_id: String) -> Self {
+        mark_task_live(&task_id);
         Self {
             supervisor,
             task_id,
@@ -2987,6 +3066,11 @@ impl TaskTerminalGuard {
 
 impl Drop for TaskTerminalGuard {
     fn drop(&mut self) {
+        // fix/orphan-sweep-liveness-gate: clear the live-set entry FIRST so the
+        // task is no longer "live" the instant its worker future terminates —
+        // on every exit path, including panic-unwind. After this, a genuinely
+        // stale row from a later restart is correctly reapable.
+        clear_task_live(&self.task_id);
         // Only fire if the task is still active. For already-terminal tasks
         // this lookup short-circuits and we leave the recorded outcome
         // (Completed/Failed/Cancelled) untouched — and even if we raced and
@@ -6253,6 +6337,191 @@ mod tests {
         assert_eq!(
             task.error.as_deref(),
             Some("worker dropped before reaching terminal state"),
+        );
+    }
+
+    // ── Orphan-sweep liveness gate (fix/orphan-sweep-liveness-gate) ──
+    //
+    // The WS turn path rebuilds a BRAND-NEW per-turn `TaskSupervisor`
+    // every turn and calls `enable_persistence(...)` over the SHARED
+    // per-session ledger. `enable_persistence`'s orphan-sweep ASSUMES
+    // "non-terminal ⇒ no live worker", so it FALSELY marks a still-Running
+    // DETACHED spawn_only task (run_pipeline deep_research, up to ~3600s)
+    // as "orphaned across restart" — even though the worker is alive on the
+    // PREVIOUS turn's supervisor and will mark_completed shortly. The fix
+    // gates the sweep on a process-global live-set that survives the
+    // per-turn supervisor rebuild and is empty after a true cross-process
+    // restart.
+
+    /// RED→GREEN: a task in the process-global live-set + a `Running` row in
+    /// the shared ledger must NOT be swept as "orphaned across restart" by a
+    /// NEW supervisor's `enable_persistence`. Mirrors the real bug: turn N's
+    /// detached worker is alive (id in live-set) when turn N+1's fresh
+    /// supervisor opens the same ledger.
+    #[test]
+    fn live_detached_task_is_not_swept_as_orphan() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let ledger_path = dir.path().join("tasks.jsonl");
+
+        // Turn N: supervisor registers + runs a detached spawn_only task and
+        // persists a still-Running row.
+        let turn_n = TaskSupervisor::new();
+        turn_n.enable_persistence(&ledger_path).unwrap();
+        let id = turn_n.register("run_pipeline", "call-live-1", Some("api:sess"));
+        turn_n.mark_running(&id);
+
+        // The detached worker is alive: its id is in the process-global
+        // live-set (in production the TaskTerminalGuard inserts it).
+        mark_task_live(&id);
+        // RAII clear at scope end so the global set does not leak across tests.
+        struct ClearOnDrop<'a>(&'a str);
+        impl Drop for ClearOnDrop<'_> {
+            fn drop(&mut self) {
+                clear_task_live(self.0);
+            }
+        }
+        let _clear = ClearOnDrop(&id);
+
+        // Turn N+1: a BRAND-NEW supervisor opens the SAME ledger. Pre-fix this
+        // sweep marks the still-Running row "orphaned across restart".
+        let turn_n1 = TaskSupervisor::new();
+        turn_n1.enable_persistence(&ledger_path).unwrap();
+
+        let restored = turn_n1.get_task(&id).expect("row restored");
+        assert_eq!(
+            restored.status,
+            TaskStatus::Running,
+            "a LIVE detached task (id in live-set) must NOT be swept as orphan",
+        );
+        assert_ne!(
+            restored.error.as_deref(),
+            Some("orphaned across restart"),
+            "live detached task must never carry the false-orphan reason",
+        );
+    }
+
+    /// A `Running` row whose id is NOT in the live-set (a true cross-process
+    /// restart: new process ⇒ empty live-set) is STILL reaped. Reaping
+    /// behaviour for genuinely-orphaned tasks is preserved.
+    #[test]
+    fn dead_task_not_in_live_set_is_still_reaped() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let ledger_path = dir.path().join("tasks.jsonl");
+
+        let writer = TaskSupervisor::new();
+        writer.enable_persistence(&ledger_path).unwrap();
+        let id = writer.register("run_pipeline", "call-dead-1", Some("api:sess"));
+        writer.mark_running(&id);
+        drop(writer);
+
+        // Simulate a true cross-process restart: the live-set is empty for
+        // this id (no live worker in this process). Defensive clear in case a
+        // prior test leaked the id.
+        clear_task_live(&id);
+
+        let restored = TaskSupervisor::new();
+        restored.enable_persistence(&ledger_path).unwrap();
+
+        let task = restored.get_task(&id).expect("row restored");
+        assert_eq!(
+            task.status,
+            TaskStatus::Failed,
+            "a dead task absent from the live-set must still be reaped",
+        );
+        assert_eq!(
+            task.error.as_deref(),
+            Some("orphaned across restart"),
+            "genuine orphan must still carry the standard reason",
+        );
+    }
+
+    /// The RAII drop-guard removes the id from the live-set when the worker
+    /// future completes/drops, so a finished task is not kept "live" forever
+    /// and a later genuine restart can reap a stale row.
+    #[test]
+    fn live_set_cleared_on_task_terminal() {
+        let supervisor = Arc::new(TaskSupervisor::new());
+        let id = supervisor.register("run_pipeline", "call-clear-1", Some("api:sess"));
+        supervisor.mark_running(&id);
+
+        {
+            // Constructing the guard (production: top of the spawn_only body)
+            // inserts the id into the live-set.
+            let _guard = TaskTerminalGuard::new(Arc::clone(&supervisor), id.clone());
+            assert!(
+                is_task_live(&id),
+                "guard construction must mark the task live",
+            );
+            supervisor.mark_completed(&id, vec!["deck.pdf".to_string()]);
+            // Guard still in scope: id stays live until the worker future drops.
+            assert!(is_task_live(&id), "task stays live until the future drops");
+        }
+
+        // Drop ran (worker future terminated): id is cleared.
+        assert!(
+            !is_task_live(&id),
+            "guard Drop must clear the id from the live-set on every exit path",
+        );
+    }
+
+    /// Higher-level guard mirroring the real bug: turn-1 spawns a (mock) long
+    /// detached spawn_only task whose worker stays alive; turn-2 supervisor
+    /// rebuild + sweep does NOT orphan it; then the task completes normally.
+    #[tokio::test]
+    async fn turn_rebuild_does_not_orphan_live_detached_task() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let ledger_path = dir.path().join("tasks.jsonl");
+
+        // Turn 1: register + spawn a detached worker (guarded), persist Running.
+        let turn1 = Arc::new(TaskSupervisor::new());
+        turn1.enable_persistence(&ledger_path).unwrap();
+        let id = turn1.register("run_pipeline", "call-real-bug", Some("api:sess"));
+
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let worker_sup = Arc::clone(&turn1);
+        let worker_id = id.clone();
+        let worker = tokio::spawn(async move {
+            worker_sup.mark_running(&worker_id);
+            // Production: TaskTerminalGuard armed right after mark_running.
+            let _guard = TaskTerminalGuard::new(Arc::clone(&worker_sup), worker_id.clone());
+            // Long detached work: block until the test releases us.
+            let _ = release_rx.await;
+            worker_sup.mark_completed(&worker_id, vec!["report.md".to_string()]);
+        });
+
+        // Spin until the worker has marked the task Running + live.
+        for _ in 0..1000 {
+            if is_task_live(&id) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            is_task_live(&id),
+            "worker should be live before turn-2 sweep"
+        );
+
+        // Turn 2: a fresh per-turn supervisor opens the SAME ledger and sweeps.
+        let turn2 = TaskSupervisor::new();
+        turn2.enable_persistence(&ledger_path).unwrap();
+        let mid_turn = turn2.get_task(&id).expect("row restored on turn-2");
+        assert_ne!(
+            mid_turn.error.as_deref(),
+            Some("orphaned across restart"),
+            "turn-2 sweep must NOT falsely orphan the still-live detached task",
+        );
+
+        // The detached worker finishes normally and returns its artifact.
+        release_tx.send(()).unwrap();
+        worker.await.unwrap();
+
+        let done = turn1.get_task(&id).expect("task");
+        assert_eq!(done.status, TaskStatus::Completed);
+        assert_eq!(done.output_files, vec!["report.md".to_string()]);
+        // Worker future dropped ⇒ live-set cleared.
+        assert!(
+            !is_task_live(&id),
+            "live-set cleared after the worker completes"
         );
     }
 }

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -1323,20 +1323,32 @@ impl TaskSupervisor {
             // live-set. Gating solely on `is_task_live(&task.id)` therefore
             // protects the live parent yet still falsely reaps its active
             // children. Collect the `tool_call_id` of every currently-live
-            // task so the sweep can exempt the whole family: while a parent
-            // worker is live it OWNS its tool_call_id family (it drives the
-            // children to terminal, or cascade-fails them on its own timeout
-            // via `mark_descendants_failed`), so none of them is an orphan.
-            // `tool_call_id`s are unique per LLM tool call (synthesized ids are
-            // process-unique), so the only rows sharing a live tcid are that
-            // parent and its pipeline children — no unrelated task is exempted.
-            // Empty tcids are skipped so an id-less row cannot blanket-exempt
-            // every other empty-tcid row.
+            // task so the sweep can exempt the children: while a parent worker
+            // is live it OWNS its tool_call_id family (it drives the children
+            // to terminal, or cascade-fails them on its own timeout via
+            // `mark_descendants_failed`), so none of them is an orphan. Empty
+            // tcids are skipped so an id-less row cannot blanket-exempt every
+            // other empty-tcid row.
             let live_tool_call_ids: HashSet<&str> = tasks
                 .values()
                 .filter(|task| !task.tool_call_id.is_empty() && is_task_live(&task.id))
                 .map(|task| task.tool_call_id.as_str())
                 .collect();
+
+            // True for a row that is live-by-proxy: a `pipeline:<node>` child
+            // whose live parent shares its `tool_call_id`. Synthesized
+            // `tool_call_id`s are process-unique (codex round-3/4 made Gemini +
+            // inline-invoke so), and native provider ids are unique, so the
+            // only rows sharing a live tcid are that parent and its pipeline
+            // children. The `pipeline:` guard is defense-in-depth: it bounds
+            // the proxy-exemption to genuine pipeline nodes, so even a FUTURE
+            // non-unique producer could at worst spare a stray `pipeline:` row,
+            // never an arbitrary dead task. The live parent itself is exempted
+            // by its own unique id below, not by this proxy.
+            let is_live_pipeline_child = |task: &BackgroundTask| {
+                task.tool_name.starts_with("pipeline:")
+                    && live_tool_call_ids.contains(task.tool_call_id.as_str())
+            };
 
             tasks
                 .values()
@@ -1344,16 +1356,16 @@ impl TaskSupervisor {
                 // precondition instead of assuming it. A still-live DETACHED
                 // spawn_only worker (alive on a prior per-turn supervisor in
                 // THIS process) is in the process-global live-set, so it is
-                // NEVER swept — its own worker will drive it terminal. A child
-                // of such a worker is live-by-proxy (it shares the live
-                // parent's tool_call_id) and is likewise exempt. A genuinely
-                // dead task from a true cross-process restart is absent from
-                // the live-set (new process ⇒ empty set) and shares no live
-                // tcid ⇒ still correctly reaped below.
+                // NEVER swept — its own worker will drive it terminal. A
+                // pipeline child of such a worker is live-by-proxy and is
+                // likewise exempt. A genuinely dead task from a true
+                // cross-process restart is absent from the live-set (new
+                // process ⇒ empty set) and shares no live tcid ⇒ still
+                // correctly reaped below.
                 .filter(|task| {
                     !is_terminal_runtime_state(&task.runtime_state)
                         && !is_task_live(&task.id)
-                        && !live_tool_call_ids.contains(task.tool_call_id.as_str())
+                        && !is_live_pipeline_child(task)
                 })
                 .map(|task| {
                     (
@@ -6652,6 +6664,52 @@ mod tests {
             restored.get_task(&child).expect("child").status,
             TaskStatus::Failed,
             "dead pipeline child must still be reaped when no parent is live",
+        );
+    }
+
+    /// Defense-in-depth (codex round-4): the proxy-exemption is bounded to
+    /// `pipeline:<node>` rows. Even if a future non-unique producer let an
+    /// UNRELATED dead task collide on a live task's `tool_call_id`, that dead
+    /// task — being a NON-pipeline tool — must still be reaped. Only genuine
+    /// pipeline children may be spared by proxy; the live owner is spared by
+    /// its own unique id, not by sharing a tcid.
+    #[test]
+    fn non_pipeline_task_sharing_live_tcid_is_still_reaped() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let ledger_path = dir.path().join("tasks.jsonl");
+
+        let turn_n = TaskSupervisor::new();
+        turn_n.enable_persistence(&ledger_path).unwrap();
+        // A live detached parent.
+        let live = turn_n.register("run_pipeline", "call-collide", Some("api:sess"));
+        turn_n.mark_running(&live);
+        // A SEPARATE, genuinely-dead NON-pipeline task that (hypothetically)
+        // collides on the same tcid — simulating a future non-unique producer.
+        let dead = turn_n.register("tts", "call-collide", Some("api:sess"));
+        turn_n.mark_running(&dead);
+
+        mark_task_live(&live);
+        struct ClearOnDrop<'a>(&'a str);
+        impl Drop for ClearOnDrop<'_> {
+            fn drop(&mut self) {
+                clear_task_live(self.0);
+            }
+        }
+        let _clear = ClearOnDrop(&live);
+
+        let turn_n1 = TaskSupervisor::new();
+        turn_n1.enable_persistence(&ledger_path).unwrap();
+
+        assert_eq!(
+            turn_n1.get_task(&live).expect("live").status,
+            TaskStatus::Running,
+            "the live task is exempt via its own unique id",
+        );
+        assert_eq!(
+            turn_n1.get_task(&dead).expect("dead").status,
+            TaskStatus::Failed,
+            "a NON-pipeline task sharing a live tcid must still be reaped \
+             (proxy-exemption is bounded to pipeline children)",
         );
     }
 }

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -1314,18 +1314,46 @@ impl TaskSupervisor {
         // load and sweep.
         let orphans: Vec<(String, String, String)> = {
             let tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
+
+            // fix/orphan-sweep-liveness-gate (codex round-2): a live detached
+            // parent (e.g. `run_pipeline deep_research`) registers
+            // `pipeline:<node>` CHILD rows that SHARE its `tool_call_id` but
+            // carry their OWN task ids — and only the PARENT worker arms a
+            // `TaskTerminalGuard`, so the children are never inserted into the
+            // live-set. Gating solely on `is_task_live(&task.id)` therefore
+            // protects the live parent yet still falsely reaps its active
+            // children. Collect the `tool_call_id` of every currently-live
+            // task so the sweep can exempt the whole family: while a parent
+            // worker is live it OWNS its tool_call_id family (it drives the
+            // children to terminal, or cascade-fails them on its own timeout
+            // via `mark_descendants_failed`), so none of them is an orphan.
+            // `tool_call_id`s are unique per LLM tool call (synthesized ids are
+            // process-unique), so the only rows sharing a live tcid are that
+            // parent and its pipeline children — no unrelated task is exempted.
+            // Empty tcids are skipped so an id-less row cannot blanket-exempt
+            // every other empty-tcid row.
+            let live_tool_call_ids: HashSet<&str> = tasks
+                .values()
+                .filter(|task| !task.tool_call_id.is_empty() && is_task_live(&task.id))
+                .map(|task| task.tool_call_id.as_str())
+                .collect();
+
             tasks
                 .values()
-                // fix/orphan-sweep-liveness-gate: CHECK the sweep's
-                // "non-terminal ⇒ no live worker" precondition instead of
-                // assuming it. A still-live DETACHED spawn_only worker (alive
-                // on a prior per-turn supervisor in THIS process) is in the
-                // process-global live-set, so it is NEVER swept — its own
-                // worker will drive it terminal. A genuinely dead task from a
-                // true cross-process restart is absent from the live-set (new
-                // process ⇒ empty set) ⇒ still correctly reaped below.
+                // CHECK the sweep's "non-terminal ⇒ no live worker"
+                // precondition instead of assuming it. A still-live DETACHED
+                // spawn_only worker (alive on a prior per-turn supervisor in
+                // THIS process) is in the process-global live-set, so it is
+                // NEVER swept — its own worker will drive it terminal. A child
+                // of such a worker is live-by-proxy (it shares the live
+                // parent's tool_call_id) and is likewise exempt. A genuinely
+                // dead task from a true cross-process restart is absent from
+                // the live-set (new process ⇒ empty set) and shares no live
+                // tcid ⇒ still correctly reaped below.
                 .filter(|task| {
-                    !is_terminal_runtime_state(&task.runtime_state) && !is_task_live(&task.id)
+                    !is_terminal_runtime_state(&task.runtime_state)
+                        && !is_task_live(&task.id)
+                        && !live_tool_call_ids.contains(task.tool_call_id.as_str())
                 })
                 .map(|task| {
                     (
@@ -6522,6 +6550,108 @@ mod tests {
         assert!(
             !is_task_live(&id),
             "live-set cleared after the worker completes"
+        );
+    }
+
+    /// codex round-2 DO-NOT-SHIP regression: a live `run_pipeline` parent
+    /// registers `pipeline:<node>` CHILD rows that SHARE its `tool_call_id`
+    /// but carry their OWN task ids. Only the PARENT worker arms a
+    /// `TaskTerminalGuard`, so the children are never inserted into the
+    /// live-set. The turn N+1 sweep must NOT reap those active children as
+    /// orphans while their parent is live — otherwise `run_pipeline
+    /// deep_research` shows the mini3 "spinner stuck orchestrating" symptom:
+    /// children falsely marked "orphaned across restart" (direct sweep) /
+    /// "parent task orphaned across restart" (cascade) even though the
+    /// pipeline is still running on the prior turn's live worker.
+    #[test]
+    fn live_pipeline_child_is_not_swept_when_parent_is_live() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let ledger_path = dir.path().join("tasks.jsonl");
+
+        // Turn N: a detached run_pipeline parent + its active pipeline child,
+        // both persisted Running under the SAME tool_call_id.
+        let turn_n = TaskSupervisor::new();
+        turn_n.enable_persistence(&ledger_path).unwrap();
+        let parent = turn_n.register("run_pipeline", "call-pipe-1", Some("api:sess"));
+        turn_n.mark_running(&parent);
+        let child = turn_n.register("pipeline:research_node", "call-pipe-1", Some("api:sess"));
+        turn_n.mark_running(&child);
+
+        // Only the PARENT worker is live (pipeline children don't arm guards).
+        mark_task_live(&parent);
+        struct ClearOnDrop<'a>(Vec<&'a str>);
+        impl Drop for ClearOnDrop<'_> {
+            fn drop(&mut self) {
+                for id in &self.0 {
+                    clear_task_live(id);
+                }
+            }
+        }
+        let _clear = ClearOnDrop(vec![&parent, &child]);
+
+        // Turn N+1: a brand-new supervisor opens the SAME ledger and sweeps.
+        let turn_n1 = TaskSupervisor::new();
+        turn_n1.enable_persistence(&ledger_path).unwrap();
+
+        let restored_parent = turn_n1.get_task(&parent).expect("parent restored");
+        assert_eq!(
+            restored_parent.status,
+            TaskStatus::Running,
+            "live run_pipeline parent must not be swept",
+        );
+
+        let restored_child = turn_n1.get_task(&child).expect("child restored");
+        assert_eq!(
+            restored_child.status,
+            TaskStatus::Running,
+            "an active pipeline child of a LIVE parent must NOT be reaped",
+        );
+        assert_ne!(
+            restored_child.error.as_deref(),
+            Some("orphaned across restart"),
+            "child must not carry the direct-sweep false-orphan reason",
+        );
+        assert_ne!(
+            restored_child.error.as_deref(),
+            Some("parent task orphaned across restart"),
+            "child must not carry the cascade false-orphan reason either",
+        );
+    }
+
+    /// Boundary counterpart: when NO member of the tool_call_id family is live
+    /// (a true cross-process restart ⇒ empty live-set), BOTH the parent and
+    /// its pipeline children are still reaped. The proxy-exemption only fires
+    /// for a genuinely live family, so reaping of real orphans is preserved.
+    #[test]
+    fn dead_pipeline_family_is_still_reaped() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let ledger_path = dir.path().join("tasks.jsonl");
+
+        let writer = TaskSupervisor::new();
+        writer.enable_persistence(&ledger_path).unwrap();
+        let parent = writer.register("run_pipeline", "call-pipe-dead", Some("api:sess"));
+        writer.mark_running(&parent);
+        let child = writer.register("pipeline:node", "call-pipe-dead", Some("api:sess"));
+        writer.mark_running(&child);
+        drop(writer);
+
+        // True restart: empty live-set for the whole family. Defensive clears
+        // in case a prior test leaked an id.
+        clear_task_live(&parent);
+        clear_task_live(&child);
+
+        let restored = TaskSupervisor::new();
+        restored.enable_persistence(&ledger_path).unwrap();
+
+        assert_eq!(
+            restored.get_task(&parent).expect("parent").status,
+            TaskStatus::Failed,
+            "dead parent absent from the live-set must still be reaped",
+        );
+        assert_eq!(
+            restored.get_task(&child).expect("child").status,
+            TaskStatus::Failed,
+            "dead pipeline child must still be reaped when no parent is live",
         );
     }
 }

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -6712,4 +6712,65 @@ mod tests {
              (proxy-exemption is bounded to pipeline children)",
         );
     }
+
+    /// codex round-5 DO-NOT-SHIP regression: the terminal guard is now armed in
+    /// the FOREGROUND (in `execution.rs` / `spawn.rs`, before `tokio::spawn`),
+    /// not inside the spawned worker future. This mirrors the real call-site
+    /// ordering — register (persist `Spawned`) → arm guard (foreground) →
+    /// spawn → [a fast next turn sweeps] → the worker future finally gets its
+    /// first poll. The pre-fix code armed the guard INSIDE the future, so a
+    /// sweep that ran in the pre-poll window saw the row non-terminal AND
+    /// not-live and falsely reaped a scheduled-but-not-yet-polled worker. With
+    /// foreground arming the id is in the live-set before the spawning turn
+    /// returns, so the pre-poll sweep skips it.
+    #[tokio::test]
+    async fn foreground_armed_guard_survives_sweep_before_worker_polls() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let ledger_path = dir.path().join("tasks.jsonl");
+
+        let turn1 = Arc::new(TaskSupervisor::new());
+        turn1.enable_persistence(&ledger_path).unwrap();
+        // Foreground: register persists a Spawned row, THEN the guard is armed
+        // in the foreground (the fix), BEFORE the worker future is spawned.
+        let id = turn1.register("run_pipeline", "call-fg-guard", Some("api:sess"));
+        let guard = TaskTerminalGuard::new(Arc::clone(&turn1), id.clone());
+
+        // The worker future is spawned but blocked on a gate: it has NOT yet
+        // polled past the gate, so it has NOT called mark_running. In the
+        // pre-fix world the guard would not exist yet either.
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let worker_sup = Arc::clone(&turn1);
+        let worker_id = id.clone();
+        let worker = tokio::spawn(async move {
+            // Foreground-armed guard moved into the future; Drop fires at end.
+            let _guard = guard;
+            let _ = release_rx.await;
+            worker_sup.mark_running(&worker_id);
+            worker_sup.mark_completed(&worker_id, vec!["report.md".to_string()]);
+        });
+
+        // Turn 2 sweeps the SAME ledger BEFORE the worker future progresses
+        // past the gate. Pre-fix (guard armed inside the future) this reaps the
+        // still-`Spawned`, not-yet-live row.
+        let turn2 = TaskSupervisor::new();
+        turn2.enable_persistence(&ledger_path).unwrap();
+        let mid = turn2.get_task(&id).expect("row restored on turn-2");
+        assert_ne!(
+            mid.error.as_deref(),
+            Some("orphaned across restart"),
+            "a foreground-armed guard must keep a pre-poll worker out of the sweep",
+        );
+
+        // The worker finishes normally.
+        release_tx.send(()).unwrap();
+        worker.await.unwrap();
+        assert_eq!(
+            turn1.get_task(&id).expect("task").status,
+            TaskStatus::Completed,
+        );
+        assert!(
+            !is_task_live(&id),
+            "live-set cleared after the worker future drops"
+        );
+    }
 }

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -696,9 +696,12 @@ fn is_terminal_runtime_state(state: &TaskRuntimeState) -> bool {
 /// `deny(unsafe_code)`.
 ///
 /// Membership is owned by the detached worker via [`TaskTerminalGuard`]:
-/// constructed (insert) at the top of the `tokio::spawn` body right after
-/// `mark_running`, dropped (clear) on EVERY exit path — success, failure,
-/// cancel, or panic-unwind — so a finished task is never kept "live" forever.
+/// constructed (insert) in the FOREGROUND, before the `tokio::spawn`, so the
+/// id is live within the spawning turn (closing the pre-poll window where a
+/// fast next-turn sweep could reap a scheduled-but-not-yet-polled worker); the
+/// guard is then moved into the worker future and dropped (clear) on EVERY
+/// exit path — success, failure, cancel, panic-unwind, or unpolled drop — so a
+/// finished task is never kept "live" forever.
 fn live_detached_tasks() -> &'static Mutex<HashSet<String>> {
     static LIVE: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
     LIVE.get_or_init(|| Mutex::new(HashSet::new()))
@@ -3074,11 +3077,11 @@ impl TaskSupervisor {
 /// would otherwise leave the task `Running` forever — the TUI task count
 /// never decrements and the chip stays "Orchestrating".
 ///
-/// Construct the guard at the top of each background body right after
-/// `mark_running`. No explicit disarm is needed: on normal completion the
-/// body's own `mark_*` arm has already moved the task terminal, so by the
-/// time `Drop` runs the task is no longer `is_active()` and the guard's
-/// `mark_failed` is a no-op (the terminal guards inside `mark_failed` /
+/// Construct the guard in the FOREGROUND (before `tokio::spawn`) and move it
+/// into the background body. No explicit disarm is needed: on normal
+/// completion the body's own `mark_*` arm has already moved the task terminal,
+/// so by the time `Drop` runs the task is no longer `is_active()` and the
+/// guard's `mark_failed` is a no-op (the terminal guards inside `mark_failed` /
 /// `mark_completed` make this idempotent).
 pub struct TaskTerminalGuard {
     supervisor: Arc<TaskSupervisor>,
@@ -3090,11 +3093,13 @@ impl TaskTerminalGuard {
     ///
     /// fix/orphan-sweep-liveness-gate: arming the guard also records the task
     /// id in the process-global live-set ([`mark_task_live`]). The guard is
-    /// constructed at the top of every detached `spawn_only` worker body
-    /// (`execution.rs`, `spawn.rs`) right after `mark_running`, so this is the
-    /// single insert site for "a detached worker is live". The matching clear
-    /// happens in `Drop`, which runs on EVERY exit path (success, failure,
-    /// cancel, panic-unwind).
+    /// constructed in the FOREGROUND, before each detached `spawn_only` worker
+    /// is spawned (`execution.rs`, `spawn.rs`), then moved into the worker
+    /// future — so the id enters the live-set synchronously within the
+    /// spawning turn (closing the pre-poll window) and this is the single
+    /// insert site for "a detached worker is live". The matching clear happens
+    /// in `Drop`, which runs on EVERY exit path (success, failure, cancel,
+    /// panic-unwind, or unpolled drop).
     pub fn new(supervisor: Arc<TaskSupervisor>, task_id: String) -> Self {
         mark_task_live(&task_id);
         Self {
@@ -6717,10 +6722,11 @@ mod tests {
     /// the FOREGROUND (in `execution.rs` / `spawn.rs`, before `tokio::spawn`),
     /// not inside the spawned worker future. This mirrors the real call-site
     /// ordering — register (persist `Spawned`) → arm guard (foreground) →
-    /// spawn → [a fast next turn sweeps] → the worker future finally gets its
-    /// first poll. The pre-fix code armed the guard INSIDE the future, so a
-    /// sweep that ran in the pre-poll window saw the row non-terminal AND
-    /// not-live and falsely reaped a scheduled-but-not-yet-polled worker. With
+    /// spawn → [a fast next turn sweeps] → the worker future finally runs. The
+    /// pre-fix code armed the guard INSIDE the future, so a sweep that ran
+    /// before the worker future had progressed (the test gates it explicitly)
+    /// saw the row non-terminal AND not-live and falsely reaped a
+    /// scheduled-but-not-yet-run worker. With
     /// foreground arming the id is in the live-set before the spawning turn
     /// returns, so the pre-poll sweep skips it.
     #[tokio::test]

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -2714,6 +2714,25 @@ impl Tool for SpawnTool {
                     )),
                 );
             }
+            // codex round-5 (orphan-sweep liveness): arm the RAII terminal
+            // guard HERE, in the FOREGROUND, before the `tokio::spawn` below.
+            // `register_with_lineage` above already persisted a non-terminal
+            // `Spawned` row; arming the guard inside the spawned future left a
+            // window where a fast next-turn orphan-sweep could see the row
+            // non-terminal AND not-live and falsely reap a
+            // scheduled-but-not-yet-polled detached child. Constructing it
+            // synchronously within the spawning turn inserts the id into the
+            // process-global live-set before the turn returns (turns are
+            // serialized per session ⇒ this completes before any next-turn
+            // sweep). Moved into the future below so its Drop (clear live-set +
+            // drive an unfinished task to Failed) still fires at worker end.
+            let foreground_terminal_guard: Option<TaskTerminalGuard> =
+                match (self.task_supervisor.as_ref(), tracked_task_id.as_ref()) {
+                    (Some(supervisor), Some(task_id)) => {
+                        Some(TaskTerminalGuard::new(supervisor.clone(), task_id.clone()))
+                    }
+                    _ => None,
+                };
             let llm = sub_llm;
             let memory = self.memory.clone();
             let working_dir = self.working_dir.clone();
@@ -2812,18 +2831,22 @@ impl Tool for SpawnTool {
             let child_session_scope = ctx.session_scope.clone();
 
             tokio::spawn(async move {
-                // C1 step 2: arm a RAII terminal guard right after
-                // mark_running so an aborted/panicked child body does not
-                // leave the task stuck Running (TUI count never decrements).
-                // Idempotent on the normal terminal arms below; Drop no-ops
-                // once the body marked the task terminal itself.
-                let mut _terminal_guard: Option<TaskTerminalGuard> = None;
+                // codex round-5: the terminal guard was armed in the
+                // FOREGROUND (before this spawn) so the task id entered the
+                // process-global live-set synchronously within the spawning
+                // turn — closing the window where a fast next-turn orphan-sweep
+                // could reap a scheduled-but-not-yet-polled detached child.
+                // Move it in here so its Drop — which clears the live-set and
+                // drives an unfinished task to Failed (so the TUI count
+                // decrements instead of hanging on "N running") — still fires
+                // when this worker future terminates. Idempotent on the normal
+                // terminal arms below; Drop no-ops once the body marked the
+                // task terminal itself.
+                let _terminal_guard = foreground_terminal_guard;
                 if let (Some(supervisor), Some(task_id)) =
                     (task_supervisor.as_ref(), tracked_task_id.as_ref())
                 {
                     supervisor.mark_running(task_id);
-                    _terminal_guard =
-                        Some(TaskTerminalGuard::new(supervisor.clone(), task_id.clone()));
                     if let Some(workflow) = workflow_metadata.as_ref() {
                         // Seed `runtime_detail.progress` with a small non-null
                         // value at workflow start. Without this, dashboards

--- a/crates/octos-llm/src/gemini.rs
+++ b/crates/octos-llm/src/gemini.rs
@@ -17,6 +17,38 @@ use crate::provider::{LlmProvider, endpoint_label_from_base_url};
 use crate::types::{
     ChatResponse, ChatStream, ProviderMetadata, StopReason, StreamEvent, TokenUsage, ToolSpec,
 };
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Process-global monotonic counter for synthesizing Gemini tool-call ids.
+///
+/// Gemini's API returns `functionCall` parts WITHOUT a call id — it matches
+/// `functionResponse` parts back by function NAME, not by id (see the
+/// `MessageRole::Tool` arm of `to_gemini_contents`, which resolves the name
+/// from a `tool_call_id → name` map). The synthesized id is therefore purely
+/// octos-internal correlation, but it MUST be process-unique: it becomes
+/// `BackgroundTask::tool_call_id`, and several long-lived per-session
+/// structures key on it — `TaskSupervisor`'s synth-ack set (commit 9e972d8a),
+/// the `mark_descendants_failed` pipeline cascade, and the orphan-sweep
+/// liveness gate's tool_call_id-family exemption (fix/orphan-sweep-liveness-
+/// gate). A POSITIONAL `call_{index}` resets every response, so two unrelated
+/// tool calls in different turns both get `call_0`, which (a) could match a
+/// stale synth-ack and fire an unwarranted recovery turn, and (b) lets a live
+/// task's tcid falsely exempt a genuinely-dead task from orphan reaping. A
+/// process-global monotonic counter never repeats within the process.
+///
+/// octos-agent's empty-id fallback (`streaming.rs`) uses the same scheme with
+/// a distinct `call_synth_` prefix; the `call_gemini_` prefix here keeps the
+/// two synthesized id spaces disjoint even if one session ever switched
+/// providers mid-conversation.
+static GEMINI_TOOL_CALL_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Mint the next process-unique synthesized Gemini tool-call id.
+fn next_gemini_tool_call_id() -> String {
+    format!(
+        "call_gemini_{}",
+        GEMINI_TOOL_CALL_SEQ.fetch_add(1, Ordering::Relaxed)
+    )
+}
 
 /// Google Gemini provider.
 pub struct GeminiProvider {
@@ -157,7 +189,7 @@ impl LlmProvider for GeminiProvider {
                     let metadata = thought_signature
                         .map(|sig| serde_json::json!({ "thought_signature": sig }));
                     tool_calls.push(octos_core::ToolCall {
-                        id: format!("call_{}", tool_calls.len()),
+                        id: next_gemini_tool_call_id(),
                         name: function_call.name,
                         arguments: function_call.args,
                         metadata,
@@ -716,7 +748,7 @@ fn map_gemini_sse(state: &mut GeminiStreamState, event: &crate::sse::SseEvent) -
                             .map(|s| serde_json::json!({ "thought_signature": s }));
                         events.push(StreamEvent::ToolCallDelta {
                             index: state.tool_count,
-                            id: Some(format!("call_{}", state.tool_count)),
+                            id: Some(next_gemini_tool_call_id()),
                             name: Some(name),
                             arguments_delta: args.to_string(),
                         });
@@ -1036,6 +1068,55 @@ mod tests {
             events
                 .iter()
                 .any(|e| matches!(e, StreamEvent::Done(StopReason::ToolUse)))
+        );
+    }
+
+    fn first_tool_call_id(events: Vec<StreamEvent>) -> String {
+        events
+            .into_iter()
+            .find_map(|e| match e {
+                StreamEvent::ToolCallDelta { id, .. } => id,
+                _ => None,
+            })
+            .expect("a ToolCallDelta carrying an id")
+    }
+
+    /// Regression (codex round-3 / fix/orphan-sweep-liveness-gate): Gemini
+    /// synthesizes tool-call ids (its API supplies none — it matches results
+    /// by function name). Those ids MUST be PROCESS-UNIQUE, not positional. A
+    /// positional `call_{index}` resets every response, so two unrelated tool
+    /// calls in different turns both get `call_0` — colliding in the
+    /// supervisor's per-session synth-ack set and the orphan-sweep
+    /// tool_call_id-family exemption (a live task's tcid would then falsely
+    /// exempt a genuinely-dead task from reaping). Two independent SSE
+    /// responses (each a fresh state with tool_count back at 0) must mint
+    /// disjoint ids.
+    #[test]
+    fn synthesized_gemini_tool_call_ids_are_unique_across_responses() {
+        let fc = r#"{"candidates": [{"content": {"parts": [{"functionCall": {"name": "search", "args": {}}}]}}]}"#;
+
+        let mut resp1 = GeminiStreamState::default();
+        let id1 = first_tool_call_id(map_gemini_sse(
+            &mut resp1,
+            &crate::sse::SseEvent {
+                event: None,
+                data: fc.into(),
+            },
+        ));
+
+        let mut resp2 = GeminiStreamState::default();
+        let id2 = first_tool_call_id(map_gemini_sse(
+            &mut resp2,
+            &crate::sse::SseEvent {
+                event: None,
+                data: fc.into(),
+            },
+        ));
+
+        assert!(id1.starts_with("call_gemini_"), "got {id1}");
+        assert_ne!(
+            id1, id2,
+            "synthesized ids must be process-unique across responses, not positional",
         );
     }
 


### PR DESCRIPTION
## Problem

On mini3, a `run_pipeline deep_research` background task returned its report, but the TUI showed the deep-research nodes as **orphaned** and the spinner stuck on "orchestrating". Root cause: the serve/WS turn path builds a **brand-new `TaskSupervisor` per turn** and runs `enable_persistence`'s orphan-sweep over the **shared per-session ledger**. That sweep assumed *"non-terminal ⇒ no live worker"* — true only at a real cross-process restart. A detached `spawn_only` task (up to ~3600s) outlives the turn that launched it, so turn N+1's fresh supervisor restored turn N's still-`Running` row and falsely reaped it as `"orphaned across restart"` — even though the worker was alive and would `mark_completed` shortly. (Evidence: 23/23 tasks ever marked orphaned ended `completed`.)

## Fix (process-global liveness gate, hardened over 6 review rounds)

The sweep now **checks** the precondition instead of assuming it, via a process-global live-set keyed by **unique task id**:

1. **`5df903cd`** — `static LIVE: OnceLock<Mutex<HashSet<task_id>>>` armed by `TaskTerminalGuard`; the sweep exempts tasks live by their own id. Survives the per-turn supervisor rebuild; empty after a true cross-process restart (so genuine orphans still reap).
2. **`324ea73e`** — also exempt `pipeline:<node>` **children**: they share the live parent's `tool_call_id` but carry their own ids (only the parent arms a guard). This is the piece that fixes the mini3 symptom directly.
3. **`710f6527`** — `324ea73e` relied on `tool_call_id` uniqueness, but **Gemini** synthesized positional `call_{index}` that reset every response → minted from a process-global counter (`call_gemini_{n}`). Also heals two pre-existing latent bugs (the synth-ack set and the `mark_descendants_failed` cascade key on tcid).
4. **`14cc35dd`** — same violation in the **inline-`<invoke>`** parser (`call_inline_{idx}_{tool}`) → process-global counter. Audited: these were the only two non-unique production producers.
5. **`a0b0e421`** — defense-in-depth: **bound the proxy-exemption to `pipeline:` rows**, so even a *future* non-unique producer could at most spare a stray pipeline row, never an arbitrary dead task. The live owner is still exempt via its own unique id.
6. **`8e1f6c37`** — the guard was armed *inside* the spawned future (after `mark_running`), leaving a pre-poll window where a fast next-turn sweep could reap a scheduled-but-not-yet-polled worker. Now armed **synchronously in the foreground before `tokio::spawn`** and moved into the future (Drop still clears on every exit). Turns are serialized per session, so this completes before any next-turn sweep.
7. **`4cfc1d38`** — doc-only: align stale comments with foreground arming.

## Why preserved behavior holds

- **True cross-process restart** still reaps non-terminal rows (new process ⇒ empty live-set).
- **Gateway** path is unaffected — it uses a persistent supervisor (`enable_persistence` once per session at actor setup), not a per-turn sweep.
- **Drop** clears the live-set + drives an unfinished task to `Failed` on every exit (success/failure/cancel/panic/unpolled-drop).
- Lock ordering (`tasks` then live-set) is unchanged and acyclic.

## Tests

New RED→GREEN + boundary tests in `task_supervisor` (`live_pipeline_child_is_not_swept_when_parent_is_live`, `dead_pipeline_family_is_still_reaped`, `non_pipeline_task_sharing_live_tcid_is_still_reaped`, `foreground_armed_guard_survives_sweep_before_worker_polls`, plus the original liveness-gate four), `gemini` (cross-response id disjointness), `detection` (inline-invoke id uniqueness across responses + within one). Full workspace green except the pre-existing macOS firmlink env flake; `clippy --workspace` clean.

## Review

Reviewed across 6 `codex` rounds — each round caught a real DO-NOT-SHIP (pipeline children, Gemini tcid collision, inline-invoke tcid collision, the foreground-arming race). Final verdict: **SHIPPABLE**.
