### PR TITLE
chore(deploy): install tmux during cloud-host bootstrap

### DIFF
--- a/scripts/cloud-host-deploy.sh
+++ b/scripts/cloud-host-deploy.sh
@@ -551,6 +551,49 @@ run_cmd_best_effort() {
     fi
 }
 
+run_install_host_tools() {
+    section "Installing host tools (tmux)"
+    # tmux hosts the attachable soak / interactive-TUI sessions on the fleet
+    # (e.g. the DeepSeek soak and the solo-onboarding TUI). Idempotent: skip
+    # when already present. Best-effort by design — a missing package manager
+    # warns rather than failing the whole deploy, since tmux is only needed
+    # for the manual soak workflow, not the production serve daemon.
+    if command -v tmux >/dev/null 2>&1; then
+        ok "tmux already installed ($(tmux -V 2>/dev/null))"
+        return 0
+    fi
+    # The install commands trail `|| warn` so a failed/aborted install does
+    # NOT kill the deploy under `set -eEuo pipefail` (the `||` exempts them
+    # from errexit) — tmux is non-critical host tooling, not the serve daemon.
+    case "$OS" in
+        Darwin)
+            if command -v brew >/dev/null 2>&1; then
+                run_cmd brew install tmux || warn "tmux install failed; install manually (brew install tmux)"
+            else
+                warn "Homebrew not found; install tmux manually (brew install tmux)"
+            fi
+            ;;
+        Linux)
+            if command -v apt-get >/dev/null 2>&1; then
+                run_cmd sudo apt-get install -y tmux || warn "tmux install failed; install manually (apt-get install -y tmux)"
+            elif command -v dnf >/dev/null 2>&1; then
+                run_cmd sudo dnf install -y tmux || warn "tmux install failed; install manually (dnf install -y tmux)"
+            elif command -v yum >/dev/null 2>&1; then
+                run_cmd sudo yum install -y tmux || warn "tmux install failed; install manually (yum install -y tmux)"
+            else
+                warn "no supported package manager (apt-get/dnf/yum); install tmux manually"
+            fi
+            ;;
+    esac
+    if [ "$DRY_RUN" = false ]; then
+        if command -v tmux >/dev/null 2>&1; then
+            ok "tmux installed ($(tmux -V 2>/dev/null))"
+        else
+            warn "tmux not available after install attempt; soak/TUI sessions need it installed manually"
+        fi
+    fi
+}
+
 run_install() {
     section "Installing octos serve"
     local cmd=("$INSTALL_SCRIPT" --version "$VERSION" --prefix "$PREFIX" --port "$PORT" --auth-token "$AUTH_TOKEN")
@@ -877,8 +920,10 @@ section "Writing local state"
 write_cloud_config
 write_state_file
 
-run_install
+run_install_host_tools
 # Refresh sudo credentials between long-running steps (macOS default timeout is 5 min)
+[ "$DRY_RUN" = true ] || sudo -v 2>/dev/null || true
+run_install
 [ "$DRY_RUN" = true ] || sudo -v 2>/dev/null || true
 run_setup_frps
 [ "$DRY_RUN" = true ] || sudo -v 2>/dev/null || true


### PR DESCRIPTION
## What

Adds an idempotent `run_install_host_tools` step (tmux) to `scripts/cloud-host-deploy.sh`, run before `run_install` in the bootstrap flow.

## Why

The fleet's soak / interactive-TUI workflow (DeepSeek soak, solo-onboarding TUI) is hosted in **tmux** sessions, but tmux was never part of host provisioning — mini4 had none, so the solo-onboarding deploy had to `brew install tmux` ad hoc. This bakes it into the bootstrap.

## Behavior

- **Idempotent**: skips with an `OK` line when tmux is already present.
- **OS-aware**: `brew install` on Darwin; `apt-get`/`dnf`/`yum` on Linux.
- **`set -e` safe**: the script runs under `set -eEuo pipefail`, so each install command trails `|| warn` (the `||` exempts it from errexit). A failed/unavailable installer or missing package manager **warns and the deploy continues** — tmux is non-critical host tooling, not the production serve daemon.
- No change to the serve/frps/caddy install path.

## Validation

- `bash -n` clean; dry-run renders the step (`==> Installing host tools (tmux)` → `OK: tmux already installed`).
- codex-reviewed: it flagged the `set -e`/`run_cmd` fatality on the first pass; the `|| warn` guard (in this commit) resolves it.
- Pre-existing `test-cloud-host-deploy.sh` "purge dry run" failure is unrelated (fails identically on clean `main`).
