### PR TITLE
chore(pipeline): cargo fmt octos-pipeline (#1414 fmt residue)

### DIFF
--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -29,9 +29,7 @@ use crate::graph::{
     DeadlineAction, HandlerKind, NodeOutcome, NodeSummary, OutcomeStatus, PipelineEdge,
     PipelineGraph, PipelineNode,
 };
-use crate::handler::{
-    CodergenHandler, GateHandler, HandlerContext, HandlerRegistry, NoopHandler,
-};
+use crate::handler::{CodergenHandler, GateHandler, HandlerContext, HandlerRegistry, NoopHandler};
 use crate::parser::parse_dot;
 use crate::validate;
 
@@ -3865,7 +3863,9 @@ impl PipelineExecutor {
                         DagStep::Aborted(reason) => {
                             return Ok(dag_build_result(
                                 Some(false),
-                                Some(format!("Pipeline aborted before node '{node_id}': {reason}")),
+                                Some(format!(
+                                    "Pipeline aborted before node '{node_id}': {reason}"
+                                )),
                                 &completed,
                                 summaries,
                                 total_tokens,
@@ -3896,7 +3896,10 @@ impl PipelineExecutor {
                         let msg = format!(
                             "Pipeline failed at node '{}': {}",
                             node_id,
-                            completed.get(&node_id).map(|o| o.content.as_str()).unwrap_or("")
+                            completed
+                                .get(&node_id)
+                                .map(|o| o.content.as_str())
+                                .unwrap_or("")
                         );
                         return Ok(dag_build_result(
                             Some(false),
@@ -3966,8 +3969,7 @@ impl PipelineExecutor {
                             .get(&node_id)
                             .map(|src| dag_back_edge_fires(e, src).unwrap_or(false))
                             .unwrap_or(false);
-                        if fires
-                            && retry_count.get(&e.target).copied().unwrap_or(0) < MAX_NODE_RUNS
+                        if fires && retry_count.get(&e.target).copied().unwrap_or(0) < MAX_NODE_RUNS
                         {
                             *retry_count.entry(e.target.clone()).or_insert(0) += 1;
                             if let Some(src_outcome) = completed.get(&node_id).cloned() {
@@ -3993,12 +3995,12 @@ impl PipelineExecutor {
                     .nodes
                     .keys()
                     .filter(|id| !settled(id))
-                    .filter_map(|id| {
-                        match dag_node_readiness(graph, id, &completed, &pruned) {
+                    .filter_map(
+                        |id| match dag_node_readiness(graph, id, &completed, &pruned) {
                             Ok(NodeReadiness::Prune(reason)) => Some((id.clone(), reason)),
                             _ => None,
-                        }
-                    })
+                        },
+                    )
                     .min_by(|a, b| a.0.cmp(&b.0));
 
                 match prunable {
@@ -4177,7 +4179,9 @@ impl PipelineExecutor {
             }
         }
 
-        let node_reservation = self.reserve_node_budget(&graph.id, &node_with_prompt).await?;
+        let node_reservation = self
+            .reserve_node_budget(&graph.id, &node_with_prompt)
+            .await?;
         let node_reserved_usd = node_reservation
             .as_ref()
             .map(|h| h.reserved_amount_usd())
@@ -4482,8 +4486,7 @@ fn graph_is_dag_schedulable(graph: &PipelineGraph) -> bool {
     // edge; DAG firing would fan out to all) is routing the DAG firing logic
     // does not implement → keep such graphs on the legacy walk.
     let edges_ok = graph.edges.iter().all(|e| {
-        edge_is_back(graph, e)
-            || (e.label.is_none() && (e.weight - 1.0).abs() < f64::EPSILON)
+        edge_is_back(graph, e) || (e.label.is_none() && (e.weight - 1.0).abs() < f64::EPSILON)
     });
     // A back-edge must (a) carry a condition — a conditionless back-edge can't
     // fire meaningfully (always → guard loop; never → dead retry) — and (b)
@@ -4511,7 +4514,10 @@ fn graph_is_dag_schedulable(graph: &PipelineGraph) -> bool {
 /// forward graph, or its target would become a spurious root), and only marked
 /// edges may legally close a cycle (validation rejects unmarked ones).
 fn edge_is_back(graph: &PipelineGraph, edge: &PipelineEdge) -> bool {
-    let marked = edge.label.as_deref().is_some_and(validate::has_back_edge_marker)
+    let marked = edge
+        .label
+        .as_deref()
+        .is_some_and(validate::has_back_edge_marker)
         || edge
             .condition
             .as_deref()
@@ -4770,7 +4776,10 @@ fn forward_reachable(graph: &PipelineGraph, start: &str) -> HashSet<String> {
 /// the single-path walk stops — so both the result output and the success
 /// verdict derive from them, not from raw structural sinks (which a dead/pruned
 /// branch could distort). Sorted for determinism.
-fn dag_terminal_nodes(graph: &PipelineGraph, completed: &HashMap<String, NodeOutcome>) -> Vec<String> {
+fn dag_terminal_nodes(
+    graph: &PipelineGraph,
+    completed: &HashMap<String, NodeOutcome>,
+) -> Vec<String> {
     let mut terms: Vec<String> = completed
         .keys()
         .filter(|n| {
@@ -4847,7 +4856,11 @@ fn dag_build_result(
     // when the terminal outcome was Fail/guard-hit (parity with the legacy
     // no-outgoing terminal); only explicit early-exit failures (hard error /
     // budget / aborted registration) drop them.
-    let files_modified = if success || derived { all_files } else { vec![] };
+    let files_modified = if success || derived {
+        all_files
+    } else {
+        vec![]
+    };
 
     PipelineResult {
         output,

--- a/crates/octos-pipeline/src/profile.rs
+++ b/crates/octos-pipeline/src/profile.rs
@@ -18,13 +18,7 @@ use crate::graph::{HandlerKind, PipelineGraph};
 /// Tool names treated as a shell escape hatch and banned under `ban_shell`.
 /// `write_stdin` is included: it can drive an existing `exec-*` shell session
 /// (created by `exec_command`), so it's a shell escape just like the starters.
-pub(crate) const SHELL_TOOLS: &[&str] = &[
-    "shell",
-    "bash",
-    "exec",
-    "exec_command",
-    "write_stdin",
-];
+pub(crate) const SHELL_TOOLS: &[&str] = &["shell", "bash", "exec", "exec_command", "write_stdin"];
 
 /// Bounds applied to an LLM-authored / -influenced graph at a given autonomy
 /// level.

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -563,8 +563,7 @@ fn resolve_pipeline_timeout(llm_value: Option<u64>, dot_default: Option<u64>) ->
 /// model could name arbitrary tools/handlers (incl. `shell`) or an empty
 /// tool-list that silently expanded to all builtins. Agents now author via the
 /// capability-locked `ir` palette, or name a sanctioned pipeline.
-const INLINE_DOT_REJECTION: &str =
-    "inline DOT graphs are not accepted: free-form DOT was the unsafe legacy \
+const INLINE_DOT_REJECTION: &str = "inline DOT graphs are not accepted: free-form DOT was the unsafe legacy \
      authoring surface and has been removed. To run a multi-step workflow, \
      either name a sanctioned pipeline (e.g. `deep_research`) in `pipeline`, or \
      compose a typed-IR workflow program in `ir`.";
@@ -573,8 +572,7 @@ const INLINE_DOT_REJECTION: &str =
 /// name) to `run_pipeline`. A caller-supplied `.dot` path would let a model
 /// smuggle the same arbitrary handler/tool surface that inline DOT did (e.g. a
 /// written `/tmp/pwn.dot` with `handler=shell`) through direct-path resolution.
-const PIPELINE_PATH_REJECTION: &str =
-    "pipeline file paths are not accepted: name a sanctioned pipeline (e.g. \
+const PIPELINE_PATH_REJECTION: &str = "pipeline file paths are not accepted: name a sanctioned pipeline (e.g. \
      `deep_research`) — a bare name, not a path — or compose a typed-IR workflow \
      program in `ir`.";
 
@@ -849,8 +847,7 @@ impl Tool for RunPipelineTool {
         let input: Input =
             serde_json::from_value(args.clone()).wrap_err("invalid run_pipeline input")?;
 
-        let using_ir =
-            self.ir_enabled && input.ir.as_deref().is_some_and(|s| !s.trim().is_empty());
+        let using_ir = self.ir_enabled && input.ir.as_deref().is_some_and(|s| !s.trim().is_empty());
 
         // Free-form inline DOT is no longer an agent-authorable surface. Reject
         // it up front with an actionable message (mirrors the IR compose-error
@@ -933,8 +930,8 @@ impl Tool for RunPipelineTool {
                     }
                 },
                 Ok(ResolvedPipeline::Dot(dot)) => {
-                    let graph = crate::parser::parse_dot(&dot)
-                        .wrap_err("failed to parse pipeline DOT")?;
+                    let graph =
+                        crate::parser::parse_dot(&dot).wrap_err("failed to parse pipeline DOT")?;
                     let id = graph_id_from_dot(&dot);
                     (graph, id)
                 }

--- a/crates/octos-pipeline/tests/dag_real_llm.rs
+++ b/crates/octos-pipeline/tests/dag_real_llm.rs
@@ -19,8 +19,7 @@ use octos_memory::EpisodeStore;
 use octos_pipeline::executor::{ExecutorConfig, PipelineExecutor};
 use tempfile::TempDir;
 
-const TOPIC: &str =
-    "The economic and environmental impacts of urban vertical farming.";
+const TOPIC: &str = "The economic and environmental impacts of urban vertical farming.";
 
 // Text-only nodes (`tools=""` = deny-all sentinel) so the run is deterministic
 // LLM reasoning with no tool-calling. `plan` fans out to two angles; both
@@ -39,9 +38,7 @@ const RESEARCH_DIAMOND: &str = r#"digraph deep_research_dag {
 
 fn deepseek() -> Arc<dyn LlmProvider> {
     let key = std::env::var("DEEPSEEK_API_KEY").expect("DEEPSEEK_API_KEY required");
-    Arc::new(
-        OpenAIProvider::new(key, "deepseek-chat").with_base_url("https://api.deepseek.com/v1"),
-    )
+    Arc::new(OpenAIProvider::new(key, "deepseek-chat").with_base_url("https://api.deepseek.com/v1"))
 }
 
 async fn make_executor(dir: &TempDir, dag: bool) -> PipelineExecutor {
@@ -93,7 +90,10 @@ async fn dag_deep_research_diamond_joins_both_angles() {
 
     assert!(result.success, "DAG pipeline failed: {}", result.output);
     for n in ["plan", "angle_a", "angle_b", "synthesize"] {
-        assert!(ran.contains(&n.to_string()), "node {n} must run; ran={ran:?}");
+        assert!(
+            ran.contains(&n.to_string()),
+            "node {n} must run; ran={ran:?}"
+        );
     }
     let out = result.output.to_uppercase();
     assert!(

--- a/crates/octos-pipeline/tests/dag_scheduler.rs
+++ b/crates/octos-pipeline/tests/dag_scheduler.rs
@@ -68,7 +68,11 @@ struct RecordingHandler {
 
 #[async_trait]
 impl Handler for RecordingHandler {
-    async fn execute(&self, node: &PipelineNode, ctx: &HandlerContext) -> eyre::Result<NodeOutcome> {
+    async fn execute(
+        &self,
+        node: &PipelineNode,
+        ctx: &HandlerContext,
+    ) -> eyre::Result<NodeOutcome> {
         let call = {
             let mut st = self.state.lock().unwrap();
             let c = st.calls.entry(node.id.clone()).or_insert(0);
@@ -95,7 +99,11 @@ fn pass_all() -> Decider {
     Arc::new(|_n, _c| OutcomeStatus::Pass)
 }
 
-async fn run_with(dot: &str, decide: Decider, dag: bool) -> (PipelineResult, Arc<Mutex<ExecState>>) {
+async fn run_with(
+    dot: &str,
+    decide: Decider,
+    dag: bool,
+) -> (PipelineResult, Arc<Mutex<ExecState>>) {
     let dir = TempDir::new().unwrap();
     let memory = Arc::new(EpisodeStore::open(dir.path().join(".octos")).await.unwrap());
     let config = ExecutorConfig {
@@ -285,7 +293,11 @@ async fn bounded_retry_loop_terminates_on_pass() {
     });
     let (result, state) = run_with(dot, decide, true).await;
     let st = state.lock().unwrap();
-    assert!(result.success, "loop must settle to success: {}", result.output);
+    assert!(
+        result.success,
+        "loop must settle to success: {}",
+        result.output
+    );
     let work_runs = st.calls.get("work").copied().unwrap_or(0);
     assert!(
         work_runs >= 2,
@@ -512,7 +524,10 @@ async fn back_edge_retries_before_failure_consumer_runs() {
         "loop should settle to success: {}",
         result.output
     );
-    assert!(st.calls.contains_key("done"), "the pass path must run on settle");
+    assert!(
+        st.calls.contains_key("done"),
+        "the pass path must run on settle"
+    );
     assert!(
         !st.calls.contains_key("report"),
         "failure consumer must NOT run on a transient (retried) failure; ran {:?}",
@@ -756,4 +771,3 @@ async fn back_edge_firing_before_target_runs_is_bounded() {
         st.calls.get("a")
     );
 }
-

--- a/crates/octos-pipeline/tests/deep_research_ir.rs
+++ b/crates/octos-pipeline/tests/deep_research_ir.rs
@@ -118,8 +118,8 @@ fn deep_research_ir_composes_to_a_dynamic_web_research_pipeline() {
 #[tokio::test]
 #[ignore = "requires DEEPSEEK_API_KEY (real LLM); optional web-search backend"]
 async fn deep_research_ir_runs_end_to_end() {
-    use octos_llm::openai::OpenAIProvider;
     use octos_llm::LlmProvider;
+    use octos_llm::openai::OpenAIProvider;
     use octos_memory::EpisodeStore;
     use octos_pipeline::executor::{ExecutorConfig, PipelineExecutor};
     use octos_pipeline::profile::ValidationProfile;
@@ -129,8 +129,7 @@ async fn deep_research_ir_runs_end_to_end() {
     let memory = Arc::new(EpisodeStore::open(dir.path().join(".octos")).await.unwrap());
     let config = ExecutorConfig {
         default_provider: Arc::new(
-            OpenAIProvider::new(key, "deepseek-chat")
-                .with_base_url("https://api.deepseek.com/v1"),
+            OpenAIProvider::new(key, "deepseek-chat").with_base_url("https://api.deepseek.com/v1"),
         ) as Arc<dyn LlmProvider>,
         provider_router: None,
         memory,
@@ -174,10 +173,7 @@ async fn deep_research_ir_runs_end_to_end() {
     eprintln!("=== report:\n{}\n===", result.output);
 
     assert!(ran.iter().any(|n| n == "search"), "fan-out search must run");
-    assert!(
-        ran.iter().any(|n| n == "synthesize"),
-        "synthesis must run"
-    );
+    assert!(ran.iter().any(|n| n == "synthesize"), "synthesis must run");
     assert!(
         result.output.len() > 200,
         "must produce a non-trivial report"

--- a/crates/octos-pipeline/tests/deepseek_routing_probe.rs
+++ b/crates/octos-pipeline/tests/deepseek_routing_probe.rs
@@ -139,7 +139,11 @@ async fn deepseek_prefers_run_pipeline_for_deep_research() {
     let web_fetch = WebFetchTool::new();
     let dir = tempfile::TempDir::new().unwrap();
     let data = tempfile::TempDir::new().unwrap();
-    let memory = Arc::new(EpisodeStore::open(data.path().join(".octos")).await.unwrap());
+    let memory = Arc::new(
+        EpisodeStore::open(data.path().join(".octos"))
+            .await
+            .unwrap(),
+    );
     let run_pipeline = RunPipelineTool::new(
         provider.clone(),
         memory,
@@ -154,7 +158,9 @@ async fn deepseek_prefers_run_pipeline_for_deep_research() {
     assert_eq!(new_pipeline_spec.name, "run_pipeline");
     assert!(
         new_pipeline_spec.description.contains("PREFER")
-            || new_pipeline_spec.description.contains("ALWAYS use `deep_research`"),
+            || new_pipeline_spec
+                .description
+                .contains("ALWAYS use `deep_research`"),
         "NEW spec must carry the imperative steering — got: {}",
         new_pipeline_spec.description
     );
@@ -162,10 +168,7 @@ async fn deepseek_prefers_run_pipeline_for_deep_research() {
     let mut old_pipeline_spec = new_pipeline_spec.clone();
     old_pipeline_spec.description = OLD_NON_IR_DESCRIPTION.to_string();
 
-    let variants: [(&str, ToolSpec); 2] = [
-        ("OLD", old_pipeline_spec),
-        ("NEW", new_pipeline_spec),
-    ];
+    let variants: [(&str, ToolSpec); 2] = [("OLD", old_pipeline_spec), ("NEW", new_pipeline_spec)];
 
     // (label, prompt, expect_pipeline)
     let mut cases: Vec<(&str, &str, bool)> = Vec::new();
@@ -181,7 +184,10 @@ async fn deepseek_prefers_run_pipeline_for_deep_research() {
 
     eprintln!("\n================= deepseek tool-selection A/B =================");
     eprintln!("model=deepseek-chat  tool_choice=Auto  temp=0  ir_enabled=false");
-    eprintln!("tools offered: run_pipeline, {}, {}\n", web_search_spec.name, web_fetch_spec.name);
+    eprintln!(
+        "tools offered: run_pipeline, {}, {}\n",
+        web_search_spec.name, web_fetch_spec.name
+    );
 
     let mut deep_pipeline = [0usize; 2];
     let mut bord_pipeline = [0usize; 2];
@@ -206,7 +212,11 @@ async fn deepseek_prefers_run_pipeline_for_deep_research() {
                 "ctrl" if routed => ctrl_pipeline[vi] += 1,
                 _ => {}
             }
-            let want = if *expect_pipeline { "→run_pipeline" } else { "→inline/direct" };
+            let want = if *expect_pipeline {
+                "→run_pipeline"
+            } else {
+                "→inline/direct"
+            };
             // borderline has no single "right" answer, so don't mark it ok/!!
             let mark = if *label == "bord" {
                 "   "
@@ -220,7 +230,12 @@ async fn deepseek_prefers_run_pipeline_for_deep_research() {
         }
         eprintln!(
             "  >>> {vname}: deep→pipeline {}/{}, BORDERLINE→pipeline {}/{}, ctrl→pipeline {}/{}\n",
-            deep_pipeline[vi], deep_total, bord_pipeline[vi], bord_total, ctrl_pipeline[vi], ctrl_total
+            deep_pipeline[vi],
+            deep_total,
+            bord_pipeline[vi],
+            bord_total,
+            ctrl_pipeline[vi],
+            ctrl_total
         );
     }
 

--- a/crates/octos-pipeline/tests/pre_flight_validation.rs
+++ b/crates/octos-pipeline/tests/pre_flight_validation.rs
@@ -208,7 +208,6 @@ async fn deep_research_resolves_to_the_bundled_ir() {
         .expect("bundled deep_research IR must pre-flight clean");
 }
 
-
 #[tokio::test]
 async fn pre_flight_rejects_malformed_json_args() {
     let (tool, _working, _data) = make_tool().await;


### PR DESCRIPTION
Pure `cargo fmt -p octos-pipeline` — fixes the 33 formatting diffs the #1414 DAG merge left on main (rustfmt drift on the self-hosted runner), which currently fail the `check` job on every PR. No logic changes.