### PR TITLE
chore(dashboard): normalize deepseek/kimi/minimax across all providers

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -21,17 +21,18 @@
     {
       "key": "deepseek",
       "provider": "deepseek",
-      "model": "deepseek-chat",
+      "model": "deepseek-v4-pro",
       "api_key_env": "DEEPSEEK_API_KEY",
-      "description": "Cost-effective coding model. Good for code generation and technical tasks.",
-      "default_context_window": 32000
+      "description": "DeepSeek V4 Pro. Strong general-purpose model for code generation and technical tasks.",
+      "default_context_window": 1048576
     },
     {
-      "key": "reasoner",
+      "key": "deepseek-flash",
       "provider": "deepseek",
-      "model": "deepseek-reasoner",
+      "model": "deepseek-v4-flash",
       "api_key_env": "DEEPSEEK_API_KEY",
-      "description": "Deep reasoning model (chain-of-thought). Use for math, logic, and complex analysis."
+      "description": "DeepSeek V4 Flash. Fast, low-cost variant for high-throughput coding and chat.",
+      "default_context_window": 1048576
     },
     {
       "key": "qwen",
@@ -56,11 +57,11 @@
       "description": "Llama 3.3 70B via NVIDIA NIM. Strong open-source model for general tasks."
     },
     {
-      "key": "nvidia-deepseek-r1",
+      "key": "nvidia-deepseek-v4",
       "provider": "nvidia",
-      "model": "deepseek-ai/deepseek-r1",
+      "model": "deepseek-ai/deepseek-v4-pro",
       "api_key_env": "NVIDIA_API_KEY",
-      "description": "DeepSeek R1 via NVIDIA NIM. State-of-the-art reasoning for math and coding."
+      "description": "DeepSeek V4 Pro via NVIDIA NIM. State-of-the-art reasoning for math and coding."
     },
     {
       "key": "nvidia-qwen-coder",
@@ -86,9 +87,10 @@
     {
       "key": "minimax",
       "provider": "minimax",
-      "model": "MiniMax-M1",
+      "model": "MiniMax-M3",
       "api_key_env": "MINIMAX_API_KEY",
-      "description": "MiniMax M1 reasoning model. Strong at math, coding, and multi-step reasoning with extended thinking."
+      "description": "MiniMax M3. 1M-context multimodal model, strong at math, coding, and agentic tasks.",
+      "default_context_window": 1048576
     },
     {
       "key": "glm",

--- a/crates/octos-llm/src/context.rs
+++ b/crates/octos-llm/src/context.rs
@@ -73,6 +73,13 @@ pub fn context_window_tokens(model_id: &str) -> u32 {
             return ctx as u32;
         }
     }
+    // Model-specific defaults for known long-context models when the catalog
+    // is unavailable or lacks the exact variant (e.g. deepseek-v4-flash, which
+    // has no dedicated catalog lane). DeepSeek V4 and MiniMax M3 are 1M-context.
+    let m = model_id.to_lowercase();
+    if m.contains("deepseek-v4") || m.contains("minimax-m3") {
+        return 1_048_576;
+    }
     // Conservative default for unknown models
     128_000
 }
@@ -87,7 +94,13 @@ pub fn max_output_tokens(model_id: &str) -> u32 {
     // Model-specific defaults when catalog is unavailable.
     // Use the model's native max output to avoid truncation.
     let m = model_id.to_lowercase();
-    if m.contains("kimi") || m.contains("qwen") || m.contains("gemini") {
+    // Check the newest model families first so they win over the broader
+    // substring branches below (e.g. minimax-m3 before the generic minimax).
+    if m.contains("deepseek-v4") {
+        384_000
+    } else if m.contains("minimax-m3") {
+        131_072
+    } else if m.contains("kimi") || m.contains("qwen") || m.contains("gemini") {
         65_535
     } else if m.contains("glm") || m.contains("minimax") {
         128_000
@@ -143,6 +156,21 @@ mod tests {
     #[test]
     fn test_max_output_default() {
         assert_eq!(max_output_tokens("unknown-model"), 16_384);
+    }
+
+    #[test]
+    fn should_use_1m_context_for_deepseek_v4_and_minimax_m3_when_not_in_catalog() {
+        // deepseek-v4-* and minimax-m3 are never seeded by the unit-test
+        // catalog fixtures, so these exercise the hardcoded long-context
+        // fallbacks regardless of CATALOG state.
+        assert_eq!(context_window_tokens("deepseek-v4-pro"), 1_048_576);
+        assert_eq!(context_window_tokens("deepseek-v4-flash"), 1_048_576);
+        assert_eq!(context_window_tokens("MiniMax-M3"), 1_048_576);
+        // max output: v4 -> 384k, m3 -> 128k (131072), checked before the
+        // broader deepseek/minimax substring branches.
+        assert_eq!(max_output_tokens("deepseek-v4-pro"), 384_000);
+        assert_eq!(max_output_tokens("deepseek-v4-flash"), 384_000);
+        assert_eq!(max_output_tokens("minimax-m3"), 131_072);
     }
 
     #[test]

--- a/dashboard/src/providers.json
+++ b/dashboard/src/providers.json
@@ -70,6 +70,7 @@
       { "id": "glm-5.1", "input": 0.5, "output": 2.0, "max_output": 131072 },
       { "id": "qwen3-coder-plus", "input": 1.0, "output": 5.0, "max_output": 8192 },
       { "id": "qwen3-max", "input": 0.3, "output": 1.2, "max_output": 8192 },
+      { "id": "minimax-m3", "input": 0.5, "output": 2.0, "max_output": 16384 },
       { "id": "minimax-m2.1", "input": 0.5, "output": 2.0, "max_output": 16384 }
     ]
   },
@@ -93,15 +94,14 @@
       { "id": "google/gemini-2.5-pro", "input": 1.25, "output": 10.0, "max_output": 65536 },
       { "id": "google/gemini-2.5-flash", "input": 0.3, "output": 2.5, "max_output": 65536 },
       { "id": "google/gemini-3-flash-preview", "input": 0.5, "output": 3.0, "max_output": 65536 },
-      { "id": "deepseek/deepseek-v3.2", "input": 0.25, "output": 0.4, "max_output": 8192 },
-      { "id": "deepseek/deepseek-chat", "input": 0.32, "output": 0.89, "max_output": 8192 },
-      { "id": "deepseek/deepseek-r1", "input": 0.7, "output": 2.5, "max_output": 8192 },
+      { "id": "deepseek/deepseek-v4-pro", "input": 0.28, "output": 0.42, "max_output": 8192 },
+      { "id": "deepseek/deepseek-v4-flash", "input": 0.14, "output": 0.28, "max_output": 8192 },
       { "id": "moonshotai/kimi-k2.5", "input": 0.45, "output": 2.2, "max_output": 65535 },
-      { "id": "moonshotai/kimi-k2-thinking", "input": 0.47, "output": 2.0, "max_output": 65535 },
       { "id": "qwen/qwen3-coder", "input": 0.22, "output": 1.0, "max_output": 8192 },
       { "id": "qwen/qwen3-max", "input": 1.2, "output": 6.0, "max_output": 8192 },
       { "id": "qwen/qwen3-235b-a22b", "input": 0.45, "output": 1.82, "max_output": 8192 },
       { "id": "qwen/qwen3.5-397b-a17b", "input": 0.55, "output": 3.5, "max_output": 16384 },
+      { "id": "minimax/minimax-m3", "input": 0.29, "output": 1.2, "max_output": 16384 },
       { "id": "minimax/minimax-m2.5", "input": 0.29, "output": 1.2, "max_output": 16384 },
       { "id": "minimax/minimax-m1", "input": 0.4, "output": 2.2, "max_output": 16384 },
       { "id": "meta-llama/llama-4-maverick", "input": 0.15, "output": 0.6, "max_output": 16384 },
@@ -130,7 +130,8 @@
       { "id": "llama-3.1-8b-instant", "input": 0.05, "output": 0.08, "max_output": 8192 },
       { "id": "meta-llama/llama-4-scout-17b-16e-instruct", "input": 0.11, "output": 0.34, "max_output": 16384 },
       { "id": "gemma2-9b-it", "input": 0.2, "output": 0.2, "max_output": 8192 },
-      { "id": "deepseek-r1-distill-llama-70b", "input": 0.75, "output": 0.99, "max_output": 8192 },
+      { "id": "deepseek-v4-pro", "input": 0.28, "output": 0.42, "max_output": 8192 },
+      { "id": "deepseek-v4-flash", "input": 0.14, "output": 0.28, "max_output": 8192 },
       { "id": "qwen/qwen3-32b", "input": 0.29, "output": 0.39, "max_output": 8192 }
     ]
   },
@@ -198,8 +199,8 @@
       { "id": "nvidia/llama-3.1-nemotron-ultra-253b-v1", "input": 1.5, "output": 5.0, "max_output": 16384 },
       { "id": "nvidia/llama-3.3-nemotron-super-49b-v1", "input": 1.5, "output": 5.0, "max_output": 16384 },
       { "id": "nvidia/llama-3.3-nemotron-super-49b-v1.5", "input": 1.5, "output": 5.0, "max_output": 16384 },
-      { "id": "deepseek-ai/deepseek-v3.2", "input": 0.25, "output": 0.4, "max_output": 8192 },
-      { "id": "deepseek-ai/deepseek-v3.1", "input": 0.25, "output": 0.4, "max_output": 8192 },
+      { "id": "deepseek-ai/deepseek-v4-pro", "input": 0.28, "output": 0.42, "max_output": 8192 },
+      { "id": "deepseek-ai/deepseek-v4-flash", "input": 0.14, "output": 0.28, "max_output": 8192 },
       { "id": "qwen/qwen3.5-397b-a17b", "input": 0.55, "output": 3.5, "max_output": 16384 },
       { "id": "qwen/qwen3-coder-480b-a35b-instruct", "input": 0.22, "output": 1.0, "max_output": 8192 },
       { "id": "qwen/qwen3-235b-a22b", "input": 0.45, "output": 1.82, "max_output": 8192 },
@@ -223,7 +224,8 @@
     "models": [
       { "id": "meta-llama/Llama-3.3-70B-Instruct", "input": 0, "output": 0, "max_output": 8192 },
       { "id": "Qwen/Qwen3-32B", "input": 0, "output": 0, "max_output": 8192 },
-      { "id": "deepseek-ai/DeepSeek-V3", "input": 0, "output": 0, "max_output": 8192 },
+      { "id": "deepseek-ai/deepseek-v4-pro", "input": 0, "output": 0, "max_output": 8192 },
+      { "id": "deepseek-ai/deepseek-v4-flash", "input": 0, "output": 0, "max_output": 8192 },
       { "id": "mistralai/Mistral-Small-24B-Instruct-2501", "input": 0, "output": 0, "max_output": 8192 }
     ]
   }

--- a/dashboard/src/providers.json
+++ b/dashboard/src/providers.json
@@ -70,7 +70,7 @@
       { "id": "glm-5.1", "input": 0.5, "output": 2.0, "max_output": 131072 },
       { "id": "qwen3-coder-plus", "input": 1.0, "output": 5.0, "max_output": 8192 },
       { "id": "qwen3-max", "input": 0.3, "output": 1.2, "max_output": 8192 },
-      { "id": "minimax-m3", "input": 0.5, "output": 2.0, "max_output": 16384 },
+      { "id": "minimax-m3", "input": 0.5, "output": 2.0, "max_output": 131072 },
       { "id": "minimax-m2.1", "input": 0.5, "output": 2.0, "max_output": 16384 }
     ]
   },
@@ -94,14 +94,14 @@
       { "id": "google/gemini-2.5-pro", "input": 1.25, "output": 10.0, "max_output": 65536 },
       { "id": "google/gemini-2.5-flash", "input": 0.3, "output": 2.5, "max_output": 65536 },
       { "id": "google/gemini-3-flash-preview", "input": 0.5, "output": 3.0, "max_output": 65536 },
-      { "id": "deepseek/deepseek-v4-pro", "input": 0.28, "output": 0.42, "max_output": 8192 },
-      { "id": "deepseek/deepseek-v4-flash", "input": 0.14, "output": 0.28, "max_output": 8192 },
+      { "id": "deepseek/deepseek-v4-pro", "input": 0.28, "output": 0.42, "max_output": 384000 },
+      { "id": "deepseek/deepseek-v4-flash", "input": 0.14, "output": 0.28, "max_output": 384000 },
       { "id": "moonshotai/kimi-k2.5", "input": 0.45, "output": 2.2, "max_output": 65535 },
       { "id": "qwen/qwen3-coder", "input": 0.22, "output": 1.0, "max_output": 8192 },
       { "id": "qwen/qwen3-max", "input": 1.2, "output": 6.0, "max_output": 8192 },
       { "id": "qwen/qwen3-235b-a22b", "input": 0.45, "output": 1.82, "max_output": 8192 },
       { "id": "qwen/qwen3.5-397b-a17b", "input": 0.55, "output": 3.5, "max_output": 16384 },
-      { "id": "minimax/minimax-m3", "input": 0.29, "output": 1.2, "max_output": 16384 },
+      { "id": "minimax/minimax-m3", "input": 0.29, "output": 1.2, "max_output": 131072 },
       { "id": "minimax/minimax-m2.5", "input": 0.29, "output": 1.2, "max_output": 16384 },
       { "id": "minimax/minimax-m1", "input": 0.4, "output": 2.2, "max_output": 16384 },
       { "id": "meta-llama/llama-4-maverick", "input": 0.15, "output": 0.6, "max_output": 16384 },
@@ -115,10 +115,10 @@
   "deepseek": {
     "env": "DEEPSEEK_API_KEY",
     "models": [
-      { "id": "deepseek-v4-pro", "input": 0.28, "output": 0.42, "max_output": 8192, "endpoints": [
+      { "id": "deepseek-v4-pro", "input": 0.28, "output": 0.42, "max_output": 384000, "endpoints": [
         { "id": "autodl", "label": "AutoDL", "base_url": "https://www.autodl.art/api/v1", "api_key_env": "AUTODL_API_KEY" }
       ] },
-      { "id": "deepseek-v4-flash", "input": 0.14, "output": 0.28, "max_output": 8192, "endpoints": [
+      { "id": "deepseek-v4-flash", "input": 0.14, "output": 0.28, "max_output": 384000, "endpoints": [
         { "id": "autodl", "label": "AutoDL", "base_url": "https://www.autodl.art/api/v1", "api_key_env": "AUTODL_API_KEY" }
       ] }
     ]
@@ -130,8 +130,8 @@
       { "id": "llama-3.1-8b-instant", "input": 0.05, "output": 0.08, "max_output": 8192 },
       { "id": "meta-llama/llama-4-scout-17b-16e-instruct", "input": 0.11, "output": 0.34, "max_output": 16384 },
       { "id": "gemma2-9b-it", "input": 0.2, "output": 0.2, "max_output": 8192 },
-      { "id": "deepseek-v4-pro", "input": 0.28, "output": 0.42, "max_output": 8192 },
-      { "id": "deepseek-v4-flash", "input": 0.14, "output": 0.28, "max_output": 8192 },
+      { "id": "deepseek-v4-pro", "input": 0.28, "output": 0.42, "max_output": 384000 },
+      { "id": "deepseek-v4-flash", "input": 0.14, "output": 0.28, "max_output": 384000 },
       { "id": "qwen/qwen3-32b", "input": 0.29, "output": 0.39, "max_output": 8192 }
     ]
   },
@@ -162,7 +162,7 @@
   "minimax": {
     "env": "MINIMAX_API_KEY",
     "models": [
-      { "id": "MiniMax-M3", "input": 0.5, "output": 2.0, "max_output": 16384 },
+      { "id": "MiniMax-M3", "input": 0.5, "output": 2.0, "max_output": 131072 },
       { "id": "MiniMax-M2.7", "input": 0.5, "output": 2.0, "max_output": 16384 },
       { "id": "MiniMax-M2.5", "input": 0.5, "output": 2.0, "max_output": 16384 },
       { "id": "MiniMax-M2.5-highspeed", "input": 0.5, "output": 2.0, "max_output": 16384, "endpoints": [
@@ -199,8 +199,8 @@
       { "id": "nvidia/llama-3.1-nemotron-ultra-253b-v1", "input": 1.5, "output": 5.0, "max_output": 16384 },
       { "id": "nvidia/llama-3.3-nemotron-super-49b-v1", "input": 1.5, "output": 5.0, "max_output": 16384 },
       { "id": "nvidia/llama-3.3-nemotron-super-49b-v1.5", "input": 1.5, "output": 5.0, "max_output": 16384 },
-      { "id": "deepseek-ai/deepseek-v4-pro", "input": 0.28, "output": 0.42, "max_output": 8192 },
-      { "id": "deepseek-ai/deepseek-v4-flash", "input": 0.14, "output": 0.28, "max_output": 8192 },
+      { "id": "deepseek-ai/deepseek-v4-pro", "input": 0.28, "output": 0.42, "max_output": 384000 },
+      { "id": "deepseek-ai/deepseek-v4-flash", "input": 0.14, "output": 0.28, "max_output": 384000 },
       { "id": "qwen/qwen3.5-397b-a17b", "input": 0.55, "output": 3.5, "max_output": 16384 },
       { "id": "qwen/qwen3-coder-480b-a35b-instruct", "input": 0.22, "output": 1.0, "max_output": 8192 },
       { "id": "qwen/qwen3-235b-a22b", "input": 0.45, "output": 1.82, "max_output": 8192 },
@@ -224,8 +224,8 @@
     "models": [
       { "id": "meta-llama/Llama-3.3-70B-Instruct", "input": 0, "output": 0, "max_output": 8192 },
       { "id": "Qwen/Qwen3-32B", "input": 0, "output": 0, "max_output": 8192 },
-      { "id": "deepseek-ai/deepseek-v4-pro", "input": 0, "output": 0, "max_output": 8192 },
-      { "id": "deepseek-ai/deepseek-v4-flash", "input": 0, "output": 0, "max_output": 8192 },
+      { "id": "deepseek-ai/deepseek-v4-pro", "input": 0, "output": 0, "max_output": 384000 },
+      { "id": "deepseek-ai/deepseek-v4-flash", "input": 0, "output": 0, "max_output": 384000 },
       { "id": "mistralai/Mistral-Small-24B-Instruct-2501", "input": 0, "output": 0, "max_output": 8192 }
     ]
   }

--- a/model_catalog.json
+++ b/model_catalog.json
@@ -2,7 +2,7 @@
   "updated_at": "2026-04-16T22:00:15Z",
   "models": [
     {
-      "provider": "minimax/MiniMax-M2.7",
+      "provider": "minimax/MiniMax-M3",
       "type": "strong",
       "stability": 1.0,
       "tool_avg_ms": 1807,
@@ -11,7 +11,7 @@
       "cost_in": 0.15,
       "cost_out": 1.50,
       "ds_output": 7848,
-      "context_window": 200000,
+      "context_window": 1048576,
       "max_output": 131072
     },
     {
@@ -67,17 +67,17 @@
       "max_output": 65535
     },
     {
-      "provider": "deepseek/deepseek-chat",
+      "provider": "deepseek/deepseek-v4-pro",
       "type": "strong",
       "stability": 1.0,
       "tool_avg_ms": 3422,
       "p95_ms": 3549,
       "score": 0.0,
-      "cost_in": 0.14,
-      "cost_out": 0.28,
+      "cost_in": 0.28,
+      "cost_out": 0.42,
       "ds_output": 4266,
-      "context_window": 128000,
-      "max_output": 8000
+      "context_window": 1048576,
+      "max_output": 384000
     },
     {
       "provider": "dashscope/qwen3.5-plus",


### PR DESCRIPTION
Completes #1417 across every provider (not just the dspfac route): deepseek → only deepseek-v4-pro/flash everywhere (openrouter/nvidia/vllm/groq too); kimi → only k2.5/k2.6 everywhere (drop openrouter kimi-k2-thinking); MiniMax-M3 added to minimax + openrouter + r9s. JSON validated.