### PR TITLE
feat(serve): per-turn reasoning_effort override + ReasoningEffort::Max

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -9972,6 +9972,7 @@ async fn maybe_spawn_appui_master_continuation_runner(
         media: Vec::new(),
         topic: None,
         rewrite_for: None,
+        reasoning_effort: None,
     };
     let prompt = prompt_text(&params.input).unwrap_or_default();
     let routed_profile_id = Some(profile_id.clone());
@@ -16108,6 +16109,20 @@ fn appui_loop_assistant_reply_for_self_paced(
     }
 }
 
+/// Map the wire-level reasoning effort (octos-core) to octos-llm's enum.
+fn reasoning_effort_from_wire(
+    level: octos_core::ui_protocol::ReasoningEffortLevel,
+) -> octos_llm::ReasoningEffort {
+    use octos_core::ui_protocol::ReasoningEffortLevel as L;
+    use octos_llm::ReasoningEffort as E;
+    match level {
+        L::Low => E::Low,
+        L::Medium => E::Medium,
+        L::High => E::High,
+        L::Max => E::Max,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_standalone_turn(
     ws: WsConnection,
@@ -16332,7 +16347,14 @@ async fn run_standalone_turn(
     let workspace_root: Option<PathBuf> = Some(session_runtime.workspace_root.clone());
     let llm_provider: Arc<dyn octos_llm::LlmProvider> = session_runtime.profile.llm.clone();
     let memory_store: Arc<octos_memory::EpisodeStore> = session_runtime.profile.memory.clone();
-    let agent_config = session_runtime.agent.agent_config();
+    let mut agent_config = session_runtime.agent.agent_config();
+    // Per-turn reasoning/thinking effort override (TUI `/thinking`). When the
+    // client attaches `reasoning_effort` to turn/start it wins over the
+    // gateway/profile default for this turn; providers translate it per model
+    // (no-op for models without a reasoning style).
+    if let Some(level) = params.reasoning_effort {
+        agent_config.reasoning_effort = Some(reasoning_effort_from_wire(level));
+    }
     // Per-session system prompt override. Gateway path reads
     // `data_dir/session_prompts/<topic>.md` for structured-template
     // sessions (`/new slides X`, `/new site X`) and CONCATENATES the
@@ -23687,6 +23709,7 @@ ignore = []
             media: Vec::new(),
             topic: None,
             rewrite_for: None,
+            reasoning_effort: None,
         })
         .into_rpc_request("1")
         .expect("request");
@@ -30508,6 +30531,7 @@ ignore = []
             media: Vec::new(),
             topic: None,
             rewrite_for: None,
+            reasoning_effort: None,
         };
         let turn_state = Arc::new(TokioMutex::new(TurnState::Active));
         let (interrupt_tx, interrupt_rx) = mpsc::channel::<()>(1);

--- a/crates/octos-core/src/app_ui.rs
+++ b/crates/octos-core/src/app_ui.rs
@@ -274,6 +274,7 @@ mod tests {
             media: Vec::new(),
             topic: None,
             rewrite_for: None,
+            reasoning_effort: None,
         });
 
         assert_eq!(command.method(), methods::TURN_START);

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -1658,6 +1658,25 @@ pub struct TurnStartParams {
     /// Absent on regular sends.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rewrite_for: Option<String>,
+    /// Per-turn reasoning/thinking effort override for thinking-capable models
+    /// (DeepSeek V4, OpenAI reasoning models, Grok-4). Set by the TUI `/thinking`
+    /// command and attached to every turn for the rest of the session. `None`
+    /// (absent) falls back to the gateway/profile default; otherwise the server
+    /// overrides the turn's effort. No-op for models without a reasoning style.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<ReasoningEffortLevel>,
+}
+
+/// Reasoning/thinking effort level carried on the wire (octos-core cannot depend
+/// on octos-llm's `ReasoningEffort`, so the serve maps between them). Snake-case
+/// on the wire: `"low" | "medium" | "high" | "max"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningEffortLevel {
+    Low,
+    Medium,
+    High,
+    Max,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -5778,6 +5797,45 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    fn reasoning_effort_level_wire_shape() {
+        // Snake-case wire strings, incl. the DeepSeek "max" tier.
+        assert_eq!(
+            serde_json::to_value(ReasoningEffortLevel::Max).unwrap(),
+            json!("max")
+        );
+        assert_eq!(
+            serde_json::to_value(ReasoningEffortLevel::High).unwrap(),
+            json!("high")
+        );
+        assert_eq!(
+            serde_json::from_value::<ReasoningEffortLevel>(json!("low")).unwrap(),
+            ReasoningEffortLevel::Low
+        );
+        // Absent on turn/start is the common case; present round-trips.
+        let params = TurnStartParams {
+            session_id: SessionKey("local:demo".into()),
+            turn_id: TurnId::new(),
+            input: vec![],
+            media: vec![],
+            topic: None,
+            rewrite_for: None,
+            reasoning_effort: Some(ReasoningEffortLevel::Max),
+        };
+        let wire = serde_json::to_value(&params).unwrap();
+        assert_eq!(wire["reasoning_effort"], json!("max"));
+        let back: TurnStartParams = serde_json::from_value(wire).unwrap();
+        assert_eq!(back.reasoning_effort, Some(ReasoningEffortLevel::Max));
+        // Omitted field deserializes to None (backward compatible).
+        let legacy = json!({
+            "session_id": "local:demo",
+            "turn_id": "00000000-0000-0000-0000-000000000001",
+            "input": []
+        });
+        let parsed: TurnStartParams = serde_json::from_value(legacy).unwrap();
+        assert_eq!(parsed.reasoning_effort, None);
+    }
+
+    #[test]
     fn ui_command_method_matches_expected_transport_name() {
         let cmd = UiCommand::TurnInterrupt(TurnInterruptParams {
             session_id: SessionKey("local:demo".into()),
@@ -6499,6 +6557,7 @@ mod tests {
             media: Vec::new(),
             topic: None,
             rewrite_for: None,
+            reasoning_effort: None,
         })
         .into_rpc_request("req-turn-start")
         .expect("serialize turn/start");
@@ -7173,6 +7232,7 @@ mod tests {
             media: Vec::new(),
             topic: None,
             rewrite_for: None,
+            reasoning_effort: None,
         });
 
         let request = command
@@ -7238,6 +7298,7 @@ mod tests {
             ],
             topic: None,
             rewrite_for: None,
+            reasoning_effort: None,
         });
 
         let wire = serde_json::to_value(
@@ -7277,6 +7338,7 @@ mod tests {
             media: Vec::new(),
             topic: Some("slides".into()),
             rewrite_for: None,
+            reasoning_effort: None,
         });
 
         let wire = serde_json::to_value(
@@ -7316,6 +7378,7 @@ mod tests {
             media: Vec::new(),
             topic: None,
             rewrite_for: Some("cmid-queued-original".into()),
+            reasoning_effort: None,
         });
 
         let wire = serde_json::to_value(
@@ -7360,6 +7423,7 @@ mod tests {
             }],
             topic: Some("research".into()),
             rewrite_for: Some("cmid-original".into()),
+            reasoning_effort: None,
         });
 
         let wire = serde_json::to_value(

--- a/crates/octos-llm/src/config.rs
+++ b/crates/octos-llm/src/config.rs
@@ -66,6 +66,10 @@ pub enum ReasoningEffort {
     Low,
     Medium,
     High,
+    /// Maximum reasoning. DeepSeek V4 accepts `reasoning_effort:"max"`; providers
+    /// without a distinct max tier (OpenAI/Grok) clamp this to `high`, and Gemini
+    /// maps it to an unbounded thinking budget.
+    Max,
 }
 
 impl Default for ChatConfig {

--- a/crates/octos-llm/src/gemini.rs
+++ b/crates/octos-llm/src/gemini.rs
@@ -409,7 +409,8 @@ fn build_gemini_generation_config(config: &ChatConfig) -> GeminiGenerationConfig
         let budget = match effort {
             ReasoningEffort::Low => Some(1024),
             ReasoningEffort::Medium => Some(8192),
-            ReasoningEffort::High => None, // let model decide
+            // High and Max both let the model decide (unbounded thinking budget).
+            ReasoningEffort::High | ReasoningEffort::Max => None,
         };
         GeminiThinkingConfig {
             thinking_budget: budget,

--- a/crates/octos-llm/src/openai.rs
+++ b/crates/octos-llm/src/openai.rs
@@ -419,10 +419,15 @@ impl OpenAIProvider {
         let (reasoning_effort, thinking) =
             match (config.reasoning_effort, self.hints.reasoning_style) {
                 (Some(effort), style) if style != ReasoningStyle::None => {
-                    let effort_str = match effort {
-                        crate::config::ReasoningEffort::Low => "low",
-                        crate::config::ReasoningEffort::Medium => "medium",
-                        crate::config::ReasoningEffort::High => "high",
+                    use crate::config::ReasoningEffort as RE;
+                    let effort_str = match (effort, style) {
+                        (RE::Low, _) => "low",
+                        (RE::Medium, _) => "medium",
+                        (RE::High, _) => "high",
+                        // DeepSeek V4 accepts "max"; Effort-style providers
+                        // (OpenAI/Grok) have no max tier, so clamp to "high".
+                        (RE::Max, ReasoningStyle::EffortAndThinkingToggle) => "max",
+                        (RE::Max, _) => "high",
                     };
                     let thinking = if style == ReasoningStyle::EffortAndThinkingToggle {
                         Some(serde_json::json!({ "type": "enabled" }))
@@ -1288,6 +1293,23 @@ mod tests {
         let v = serde_json::to_value(p.build_request(&msgs, &[], &cfg, false)).unwrap();
         assert_eq!(v["reasoning_effort"], "high");
         assert_eq!(v["thinking"], serde_json::json!({ "type": "enabled" }));
+    }
+
+    #[test]
+    fn build_request_maps_max_effort_by_style() {
+        let msgs = [msg("hi")];
+        let cfg = ChatConfig {
+            reasoning_effort: Some(crate::config::ReasoningEffort::Max),
+            ..Default::default()
+        };
+        // deepseek (EffortAndThinkingToggle) emits DeepSeek's real "max".
+        let ds = OpenAIProvider::new("k", "deepseek-v4-pro");
+        let v = serde_json::to_value(ds.build_request(&msgs, &[], &cfg, false)).unwrap();
+        assert_eq!(v["reasoning_effort"], "max");
+        // Effort-style providers (grok) have no max tier -> clamp to "high".
+        let grok = OpenAIProvider::new("k", "grok-4.3");
+        let v2 = serde_json::to_value(grok.build_request(&msgs, &[], &cfg, false)).unwrap();
+        assert_eq!(v2["reasoning_effort"], "high");
     }
 
     #[test]

--- a/crates/octos-llm/src/openai_responses.rs
+++ b/crates/octos-llm/src/openai_responses.rs
@@ -88,6 +88,8 @@ impl OpenAIResponsesProvider {
                 crate::config::ReasoningEffort::Low => "low",
                 crate::config::ReasoningEffort::Medium => "medium",
                 crate::config::ReasoningEffort::High => "high",
+                // The Responses API reasoning.effort has no "max"; clamp to high.
+                crate::config::ReasoningEffort::Max => "high",
             };
             body["reasoning"] = serde_json::json!({
                 "effort": effort_str,


### PR DESCRIPTION
## What
Foundation for the TUI `/thinking` command (per-session reasoning effort). Shipped as a **per-turn override on `turn/start`** rather than a standalone method — simpler, and achieves the same per-session scoping (the client attaches the chosen effort to every turn for the session).

## Changes
- **octos-llm**: `ReasoningEffort::Max`. DeepSeek V4 accepts `reasoning_effort:"max"` (verified live); Effort-style providers (OpenAI/Grok) have no max tier, so the chat path clamps `Max→"high"`, the Responses API clamps to `"high"`, and Gemini maps `High`/`Max` to an unbounded thinking budget.
- **octos-core**: `ReasoningEffortLevel` wire enum (`low|medium|high|max`) + `TurnStartParams.reasoning_effort` (optional, additive, backward-compatible — omitted on legacy clients → `None`).
- **octos serve**: `run_standalone_turn` overrides the turn's `agent_config.reasoning_effort` from `params` (`reasoning_effort_from_wire` maps core→llm). No-op when absent.

## Tests
Max maps by style (deepseek→max, grok→high); wire shape incl. `"max"`; `TurnStartParams` round-trip + legacy-omitted→None. octos-llm + octos-core green, clippy + fmt clean.

## Follow-up
octos-tui `/thinking` command (separate PR, depends on this `ReasoningEffortLevel`).
