### PR TITLE
feat(serve): persist per-session reasoning_effort across restart

### DIFF
--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -39,6 +39,7 @@ mod ui_protocol_diff;
 mod ui_protocol_ledger;
 pub(crate) mod ui_protocol_progress;
 mod ui_protocol_questions;
+mod ui_protocol_reasoning_effort;
 mod ui_protocol_sanitize;
 mod ui_protocol_scope;
 mod ui_protocol_task_output;

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -8611,10 +8611,11 @@ async fn open_session_result(
     // mark its menu. Read from the same disk-backed store the turn path writes
     // (`<data_dir>/users/.../<topic>.reasoning_effort.json`); `None` when the
     // session has never set an effort.
-    let reasoning_effort = crate::api::ui_protocol_reasoning_effort::read_reasoning_effort(
+    let reasoning_effort = crate::api::ui_protocol_reasoning_effort::read_reasoning_effort_async(
         &data_dir,
         &params.session_id,
-    );
+    )
+    .await;
     // Tag the broadcast with our connection id so the live forwarder
     // installed below skips this event (we direct-send it inline at the
     // call site). Other connections still observe the broadcast.
@@ -16379,7 +16380,8 @@ async fn run_standalone_turn(
             &effort_data_dir,
             &session_id,
             params.reasoning_effort,
-        );
+        )
+        .await;
     if let Some(level) = resolved_effort {
         agent_config.reasoning_effort = Some(reasoning_effort_from_wire(level));
     }

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -8606,6 +8606,15 @@ async fn open_session_result(
     // clients don't have to rely on out-of-band knowledge of which feature
     // tokens the server honours.
     let capabilities = features.advertised_capabilities(state);
+    // Surface the server-persisted per-session reasoning/thinking effort so a
+    // restarting/reconnecting TUI can restore its local `/thinking` state and
+    // mark its menu. Read from the same disk-backed store the turn path writes
+    // (`<data_dir>/users/.../<topic>.reasoning_effort.json`); `None` when the
+    // session has never set an effort.
+    let reasoning_effort = crate::api::ui_protocol_reasoning_effort::read_reasoning_effort(
+        &data_dir,
+        &params.session_id,
+    );
     // Tag the broadcast with our connection id so the live forwarder
     // installed below skips this event (we direct-send it inline at the
     // call site). Other connections still observe the broadcast.
@@ -8619,6 +8628,7 @@ async fn open_session_result(
             cursor: None,
             panes,
             capabilities,
+            reasoning_effort,
         }),
         connection_id,
     );
@@ -16348,11 +16358,29 @@ async fn run_standalone_turn(
     let llm_provider: Arc<dyn octos_llm::LlmProvider> = session_runtime.profile.llm.clone();
     let memory_store: Arc<octos_memory::EpisodeStore> = session_runtime.profile.memory.clone();
     let mut agent_config = session_runtime.agent.agent_config();
-    // Per-turn reasoning/thinking effort override (TUI `/thinking`). When the
-    // client attaches `reasoning_effort` to turn/start it wins over the
-    // gateway/profile default for this turn; providers translate it per model
-    // (no-op for models without a reasoning style).
-    if let Some(level) = params.reasoning_effort {
+    // Per-session reasoning/thinking effort (TUI `/thinking`), persisted
+    // server-side so it survives a full serve/TUI restart (in `--stdio` mode a
+    // TUI restart respawns the serve; only the disk-backed value reloads).
+    //
+    // Precedence:
+    //   1. A turn that CARRIES `reasoning_effort` wins — apply it AND persist it
+    //      for this session so a later restart (or a turn that omits it) sees
+    //      the same value.
+    //   2. A turn that OMITS it falls back to the persisted stored value, so the
+    //      stored choice is authoritative across a restart even before the
+    //      client re-sends it.
+    //   3. No turn-param and nothing stored → the gateway/profile default is
+    //      left untouched (no override).
+    // Providers translate the chosen effort per model (no-op for models without
+    // a reasoning style).
+    let effort_data_dir = sessions.lock().await.data_dir();
+    let resolved_effort =
+        crate::api::ui_protocol_reasoning_effort::resolve_and_persist_reasoning_effort(
+            &effort_data_dir,
+            &session_id,
+            params.reasoning_effort,
+        );
+    if let Some(level) = resolved_effort {
         agent_config.reasoning_effort = Some(reasoning_effort_from_wire(level));
     }
     // Per-session system prompt override. Gateway path reads
@@ -23818,6 +23846,7 @@ ignore = []
                 cursor: Some(cursor.clone()),
                 panes: None,
                 capabilities: octos_core::ui_protocol::UiProtocolCapabilities::first_server_slice(),
+                reasoning_effort: None,
             }));
         assert_eq!(ledger_event_cursor(&opened), Some(cursor.clone()));
 
@@ -35412,6 +35441,7 @@ ignore = []
                 cursor: None,
                 panes: None,
                 capabilities: UiProtocolCapabilities::first_server_slice(),
+                reasoning_effort: None,
             }),
             ws.connection_id(),
         );

--- a/crates/octos-cli/src/api/ui_protocol_reasoning_effort.rs
+++ b/crates/octos-cli/src/api/ui_protocol_reasoning_effort.rs
@@ -57,7 +57,10 @@ pub(crate) fn reasoning_effort_path(data_dir: &Path, session_id: &SessionKey) ->
         .join(format!("{encoded_topic}.reasoning_effort.json"))
 }
 
-/// Read the persisted reasoning effort for a session, if any.
+/// Read the persisted reasoning effort for a session, if any. **Blocking** —
+/// performs synchronous disk IO. Async callers must reach it via
+/// [`read_reasoning_effort_async`] (which offloads it onto a blocking thread)
+/// rather than calling it directly on a Tokio worker.
 ///
 /// Returns `None` when no file exists or the file is unreadable/corrupt — the
 /// caller treats that as "no override".
@@ -71,7 +74,26 @@ pub(crate) fn read_reasoning_effort(
     Some(record.reasoning_effort)
 }
 
+/// Read the persisted reasoning effort, offloading the blocking disk read onto a
+/// Tokio blocking thread so it never stalls an async executor worker.
+///
+/// `None` on missing/corrupt/cancelled — identical "no override" semantics to
+/// the sync [`read_reasoning_effort`].
+pub(crate) async fn read_reasoning_effort_async(
+    data_dir: &Path,
+    session_id: &SessionKey,
+) -> Option<ReasoningEffortLevel> {
+    let data_dir = data_dir.to_path_buf();
+    let session_id = session_id.clone();
+    tokio::task::spawn_blocking(move || read_reasoning_effort(&data_dir, &session_id))
+        .await
+        .ok()
+        .flatten()
+}
+
 /// Persist the reasoning effort for a session (atomic write-then-rename).
+/// **Blocking** — performs synchronous disk IO including an `fsync`. Async
+/// callers must offload it (see [`resolve_and_persist_reasoning_effort`]).
 ///
 /// Best-effort: returns the IO error to the caller, which logs and continues —
 /// a failed persist must never abort a turn.
@@ -94,19 +116,23 @@ pub(crate) fn write_reasoning_effort(
     // target. The temp name embeds the pid so concurrent writers from the same
     // data_dir don't clobber each other's temp file before the rename.
     let tmp_path = path.with_extension(format!("json.tmp.{}", std::process::id()));
-    {
+    // Write + fsync the temp file. On ANY failure along the way (create,
+    // write_all, sync_all, or the rename) we must remove the temp sibling so we
+    // never leak `*.reasoning_effort.json.tmp.<pid>` files on disk.
+    let write_result = (|| {
         let mut file = std::fs::File::create(&tmp_path)?;
         file.write_all(&serialized)?;
-        file.sync_all()?;
+        file.sync_all()
+    })();
+    if let Err(error) = write_result {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(error);
     }
-    match std::fs::rename(&tmp_path, &path) {
-        Ok(()) => Ok(()),
-        Err(error) => {
-            // Clean up the temp file on a failed rename so we don't leak it.
-            let _ = std::fs::remove_file(&tmp_path);
-            Err(error)
-        }
+    if let Err(error) = std::fs::rename(&tmp_path, &path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(error);
     }
+    Ok(())
 }
 
 /// Resolve the effective per-session reasoning effort for a turn and persist
@@ -122,23 +148,58 @@ pub(crate) fn write_reasoning_effort(
 ///      before the client re-sends it.
 ///   3. `turn_param = None` and nothing stored — return `None`; the caller
 ///      leaves the gateway/profile default untouched.
-pub(crate) fn resolve_and_persist_reasoning_effort(
+///
+/// Async + write-on-change. The TUI attaches `reasoning_effort` to **every**
+/// `turn/start`, so this runs on every turn once an effort is set. To keep the
+/// hot path off the disk:
+///   - the stored value is read first on a blocking thread, and
+///   - the `fsync`ing write is issued **only when the incoming value actually
+///     differs** from what is already stored, and even then it is offloaded onto
+///     a blocking thread.
+///
+/// In the common case (effort unchanged turn-to-turn) no write — and thus no
+/// `fsync` — happens at all, and the executor worker is never blocked.
+pub(crate) async fn resolve_and_persist_reasoning_effort(
     data_dir: &Path,
     session_id: &SessionKey,
     turn_param: Option<ReasoningEffortLevel>,
 ) -> Option<ReasoningEffortLevel> {
+    let stored = read_reasoning_effort_async(data_dir, session_id).await;
     match turn_param {
+        // Turn carries an explicit effort: it wins. Persist only when it changed
+        // the stored value (this is the per-turn write the TUI would otherwise
+        // trigger on every turn). The write — and its fsync — runs on a blocking
+        // thread so it never stalls the executor.
         Some(level) => {
-            if let Err(error) = write_reasoning_effort(data_dir, session_id, level) {
-                tracing::warn!(
-                    session_id = %session_id.0,
-                    %error,
-                    "failed to persist per-session reasoning_effort; applying for this turn only"
-                );
+            if stored != Some(level) {
+                let data_dir = data_dir.to_path_buf();
+                let session_id_owned = session_id.clone();
+                let persist = tokio::task::spawn_blocking(move || {
+                    write_reasoning_effort(&data_dir, &session_id_owned, level)
+                })
+                .await;
+                match persist {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => {
+                        tracing::warn!(
+                            session_id = %session_id.0,
+                            %error,
+                            "failed to persist per-session reasoning_effort; applying for this turn only"
+                        );
+                    }
+                    Err(join_error) => {
+                        tracing::warn!(
+                            session_id = %session_id.0,
+                            %join_error,
+                            "reasoning_effort persist task failed to join; applying for this turn only"
+                        );
+                    }
+                }
             }
             Some(level)
         }
-        None => read_reasoning_effort(data_dir, session_id),
+        // Turn omits the effort: fall back to the stored value (already read).
+        None => stored,
     }
 }
 
@@ -197,8 +258,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn should_let_turn_param_win_and_persist_it() {
+    #[tokio::test]
+    async fn should_let_turn_param_win_and_persist_it() {
         // A turn that carries reasoning_effort wins over any stored value AND
         // is persisted so a later restart sees it.
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -211,7 +272,8 @@ mod tests {
             data_dir,
             &session,
             Some(ReasoningEffortLevel::Max),
-        );
+        )
+        .await;
         assert_eq!(resolved, Some(ReasoningEffortLevel::Max));
         // Persisted, so a subsequent turn that omits the param observes Max.
         assert_eq!(
@@ -220,8 +282,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn should_fall_back_to_stored_when_turn_omits_effort() {
+    #[tokio::test]
+    async fn should_fall_back_to_stored_when_turn_omits_effort() {
         // A turn that omits reasoning_effort falls back to the persisted value —
         // the stored choice survives a restart even before the client re-sends.
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -230,20 +292,86 @@ mod tests {
 
         write_reasoning_effort(data_dir, &session, ReasoningEffortLevel::High).expect("seed high");
 
-        let resolved = resolve_and_persist_reasoning_effort(data_dir, &session, None);
+        let resolved = resolve_and_persist_reasoning_effort(data_dir, &session, None).await;
         assert_eq!(resolved, Some(ReasoningEffortLevel::High));
     }
 
-    #[test]
-    fn should_resolve_none_when_no_param_and_nothing_stored() {
+    #[tokio::test]
+    async fn should_resolve_none_when_no_param_and_nothing_stored() {
         // Nothing stored + turn omits → no override; caller keeps the default.
         let tmp = tempfile::tempdir().expect("tempdir");
         let data_dir = tmp.path();
         let session = SessionKey("api:fresh".into());
 
         assert_eq!(
-            resolve_and_persist_reasoning_effort(data_dir, &session, None),
+            resolve_and_persist_reasoning_effort(data_dir, &session, None).await,
             None
+        );
+    }
+
+    #[tokio::test]
+    async fn should_not_rewrite_when_turn_param_matches_stored() {
+        // The hot path: the TUI re-attaches the SAME effort on every turn. When
+        // the incoming value already equals the stored value we must NOT touch
+        // the file (no write, no fsync) — the per-turn write is exactly what the
+        // P2 fix eliminates.
+        //
+        // Detect the no-write deterministically (no clock/mtime-resolution
+        // dependence): seed the file with a byte-distinct-but-equivalent JSON
+        // encoding (extra whitespace) that still parses to `High`. A genuine
+        // rewrite would normalize it to serde's compact form, so byte-equality
+        // after the call proves no write happened.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_dir = tmp.path();
+        let session = SessionKey("api:abc".into());
+
+        let path = reasoning_effort_path(data_dir, &session);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let sentinel = b"{ \"reasoning_effort\" : \"high\" }";
+        std::fs::write(&path, sentinel).expect("seed sentinel");
+        // Sanity: the sentinel parses to High but is NOT byte-equal to a fresh
+        // canonical write, so a rewrite is observable.
+        assert_eq!(
+            read_reasoning_effort(data_dir, &session),
+            Some(ReasoningEffortLevel::High)
+        );
+        assert_ne!(
+            std::fs::read(&path).unwrap(),
+            serde_json::to_vec(&ReasoningEffortRecord {
+                reasoning_effort: ReasoningEffortLevel::High
+            })
+            .unwrap()
+        );
+
+        let resolved = resolve_and_persist_reasoning_effort(
+            data_dir,
+            &session,
+            Some(ReasoningEffortLevel::High),
+        )
+        .await;
+        assert_eq!(resolved, Some(ReasoningEffortLevel::High));
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            sentinel,
+            "unchanged effort must not rewrite (and re-fsync) the file"
+        );
+
+        // A genuinely different value, by contrast, DOES rewrite.
+        let resolved_changed = resolve_and_persist_reasoning_effort(
+            data_dir,
+            &session,
+            Some(ReasoningEffortLevel::Low),
+        )
+        .await;
+        assert_eq!(resolved_changed, Some(ReasoningEffortLevel::Low));
+        assert_ne!(
+            std::fs::read(&path).unwrap(),
+            sentinel,
+            "a changed effort must rewrite the file"
+        );
+        assert_eq!(
+            read_reasoning_effort(data_dir, &session),
+            Some(ReasoningEffortLevel::Low)
         );
     }
 

--- a/crates/octos-cli/src/api/ui_protocol_reasoning_effort.rs
+++ b/crates/octos-cli/src/api/ui_protocol_reasoning_effort.rs
@@ -1,0 +1,261 @@
+//! Disk-backed per-session reasoning/thinking effort store.
+//!
+//! The octos-tui sets a per-session reasoning effort (`/thinking
+//! low|medium|high|max`) and attaches it to every `turn/start` via
+//! [`TurnStartParams::reasoning_effort`]. The serve must persist that choice
+//! **server-side and on disk** so it survives a full serve/TUI restart: in
+//! `--stdio` mode the serve is a child of the TUI, so a TUI restart respawns
+//! the serve and only a disk-backed value reloads.
+//!
+//! Persistence shape mirrors the per-session task ledger
+//! ([`super::ui_protocol_task_output::task_state_path`]): a small file keyed by
+//! the full [`SessionKey`] (base + topic) under
+//! `<data_dir>/users/<encoded base>/sessions/<encoded topic>.reasoning_effort.json`.
+//! Because the key embeds the topic, the path is deterministic regardless of
+//! which per-profile [`octos_bus::SessionManager`] instance computes it — the
+//! persist-on-turn site (`run_standalone_turn`) and the surface-on-open site
+//! (`open_session_result`) resolve to the same `data_dir` root and therefore
+//! the same file.
+//!
+//! The on-disk format is a tiny JSON object (`{"reasoning_effort":"high"}`)
+//! written atomically (write-temp-then-rename) so a crash mid-write never
+//! leaves a torn file. Reads tolerate a missing/corrupt file by returning
+//! `None` (treated as "no override / default").
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use octos_core::SessionKey;
+use octos_core::ui_protocol::ReasoningEffortLevel;
+use serde::{Deserialize, Serialize};
+
+/// On-disk record. A struct (rather than a bare enum) so future per-session
+/// reasoning knobs can be added as additive `serde(default)` fields without a
+/// format break.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ReasoningEffortRecord {
+    reasoning_effort: ReasoningEffortLevel,
+}
+
+/// Resolve the per-session reasoning-effort file path.
+///
+/// Sibling to [`super::ui_protocol_task_output::task_state_path`]; keyed
+/// identically (encoded base key + encoded topic, defaulting the empty topic to
+/// `"default"`).
+pub(crate) fn reasoning_effort_path(data_dir: &Path, session_id: &SessionKey) -> PathBuf {
+    let encoded_base = octos_bus::session::encode_path_component(session_id.base_key());
+    let topic = session_id
+        .topic()
+        .filter(|topic| !topic.is_empty())
+        .unwrap_or("default");
+    let encoded_topic = octos_bus::session::encode_path_component(topic);
+
+    data_dir
+        .join("users")
+        .join(encoded_base)
+        .join("sessions")
+        .join(format!("{encoded_topic}.reasoning_effort.json"))
+}
+
+/// Read the persisted reasoning effort for a session, if any.
+///
+/// Returns `None` when no file exists or the file is unreadable/corrupt — the
+/// caller treats that as "no override".
+pub(crate) fn read_reasoning_effort(
+    data_dir: &Path,
+    session_id: &SessionKey,
+) -> Option<ReasoningEffortLevel> {
+    let path = reasoning_effort_path(data_dir, session_id);
+    let contents = std::fs::read_to_string(&path).ok()?;
+    let record: ReasoningEffortRecord = serde_json::from_str(&contents).ok()?;
+    Some(record.reasoning_effort)
+}
+
+/// Persist the reasoning effort for a session (atomic write-then-rename).
+///
+/// Best-effort: returns the IO error to the caller, which logs and continues —
+/// a failed persist must never abort a turn.
+pub(crate) fn write_reasoning_effort(
+    data_dir: &Path,
+    session_id: &SessionKey,
+    level: ReasoningEffortLevel,
+) -> std::io::Result<()> {
+    let path = reasoning_effort_path(data_dir, session_id);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let record = ReasoningEffortRecord {
+        reasoning_effort: level,
+    };
+    let serialized = serde_json::to_vec(&record)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+
+    // Atomic: write a uniquely-named temp sibling, fsync, then rename over the
+    // target. The temp name embeds the pid so concurrent writers from the same
+    // data_dir don't clobber each other's temp file before the rename.
+    let tmp_path = path.with_extension(format!("json.tmp.{}", std::process::id()));
+    {
+        let mut file = std::fs::File::create(&tmp_path)?;
+        file.write_all(&serialized)?;
+        file.sync_all()?;
+    }
+    match std::fs::rename(&tmp_path, &path) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            // Clean up the temp file on a failed rename so we don't leak it.
+            let _ = std::fs::remove_file(&tmp_path);
+            Err(error)
+        }
+    }
+}
+
+/// Resolve the effective per-session reasoning effort for a turn and persist
+/// the turn-carried value when present. This is the single precedence point the
+/// turn handler (`run_standalone_turn`) calls:
+///
+///   1. `turn_param = Some(level)` — the turn carries an explicit effort. It
+///      WINS, and is persisted so a later restart (or a turn that omits it)
+///      observes the same value. A failed persist is logged and the value is
+///      still applied for this turn.
+///   2. `turn_param = None` — fall back to the persisted stored value, so the
+///      stored choice stays authoritative across a serve/TUI restart even
+///      before the client re-sends it.
+///   3. `turn_param = None` and nothing stored — return `None`; the caller
+///      leaves the gateway/profile default untouched.
+pub(crate) fn resolve_and_persist_reasoning_effort(
+    data_dir: &Path,
+    session_id: &SessionKey,
+    turn_param: Option<ReasoningEffortLevel>,
+) -> Option<ReasoningEffortLevel> {
+    match turn_param {
+        Some(level) => {
+            if let Err(error) = write_reasoning_effort(data_dir, session_id, level) {
+                tracing::warn!(
+                    session_id = %session_id.0,
+                    %error,
+                    "failed to persist per-session reasoning_effort; applying for this turn only"
+                );
+            }
+            Some(level)
+        }
+        None => read_reasoning_effort(data_dir, session_id),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_roundtrip_persisted_reasoning_effort_across_restart() {
+        // Simulates persist-on-turn then a cold reload (fresh process / new
+        // store call against the same data_dir).
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_dir = tmp.path();
+        let session = SessionKey("api:abc".into());
+
+        assert_eq!(read_reasoning_effort(data_dir, &session), None);
+
+        write_reasoning_effort(data_dir, &session, ReasoningEffortLevel::High)
+            .expect("write high effort");
+        assert_eq!(
+            read_reasoning_effort(data_dir, &session),
+            Some(ReasoningEffortLevel::High)
+        );
+
+        // Overwrite wins (last `/thinking` set is authoritative).
+        write_reasoning_effort(data_dir, &session, ReasoningEffortLevel::Max)
+            .expect("overwrite to max");
+        assert_eq!(
+            read_reasoning_effort(data_dir, &session),
+            Some(ReasoningEffortLevel::Max)
+        );
+    }
+
+    #[test]
+    fn should_key_reasoning_effort_per_topic() {
+        // Topic-suffixed sessions persist independently of the base session.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_dir = tmp.path();
+        let base = SessionKey("api:abc".into());
+        let topic = SessionKey("api:abc#slides".into());
+
+        write_reasoning_effort(data_dir, &base, ReasoningEffortLevel::Low).expect("write base");
+        write_reasoning_effort(data_dir, &topic, ReasoningEffortLevel::Max).expect("write topic");
+
+        assert_eq!(
+            read_reasoning_effort(data_dir, &base),
+            Some(ReasoningEffortLevel::Low)
+        );
+        assert_eq!(
+            read_reasoning_effort(data_dir, &topic),
+            Some(ReasoningEffortLevel::Max)
+        );
+        assert_ne!(
+            reasoning_effort_path(data_dir, &base),
+            reasoning_effort_path(data_dir, &topic)
+        );
+    }
+
+    #[test]
+    fn should_let_turn_param_win_and_persist_it() {
+        // A turn that carries reasoning_effort wins over any stored value AND
+        // is persisted so a later restart sees it.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_dir = tmp.path();
+        let session = SessionKey("api:abc".into());
+
+        write_reasoning_effort(data_dir, &session, ReasoningEffortLevel::Low).expect("seed low");
+
+        let resolved = resolve_and_persist_reasoning_effort(
+            data_dir,
+            &session,
+            Some(ReasoningEffortLevel::Max),
+        );
+        assert_eq!(resolved, Some(ReasoningEffortLevel::Max));
+        // Persisted, so a subsequent turn that omits the param observes Max.
+        assert_eq!(
+            read_reasoning_effort(data_dir, &session),
+            Some(ReasoningEffortLevel::Max)
+        );
+    }
+
+    #[test]
+    fn should_fall_back_to_stored_when_turn_omits_effort() {
+        // A turn that omits reasoning_effort falls back to the persisted value —
+        // the stored choice survives a restart even before the client re-sends.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_dir = tmp.path();
+        let session = SessionKey("api:abc".into());
+
+        write_reasoning_effort(data_dir, &session, ReasoningEffortLevel::High).expect("seed high");
+
+        let resolved = resolve_and_persist_reasoning_effort(data_dir, &session, None);
+        assert_eq!(resolved, Some(ReasoningEffortLevel::High));
+    }
+
+    #[test]
+    fn should_resolve_none_when_no_param_and_nothing_stored() {
+        // Nothing stored + turn omits → no override; caller keeps the default.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_dir = tmp.path();
+        let session = SessionKey("api:fresh".into());
+
+        assert_eq!(
+            resolve_and_persist_reasoning_effort(data_dir, &session, None),
+            None
+        );
+    }
+
+    #[test]
+    fn should_return_none_for_corrupt_record() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_dir = tmp.path();
+        let session = SessionKey("api:abc".into());
+        let path = reasoning_effort_path(data_dir, &session);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"{not json").unwrap();
+
+        assert_eq!(read_reasoning_effort(data_dir, &session), None);
+    }
+}

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -3787,6 +3787,20 @@ pub struct SessionOpened {
     /// `serde(default)` for forward compatibility.
     #[serde(default = "UiProtocolCapabilities::first_server_slice")]
     pub capabilities: UiProtocolCapabilities,
+    /// Server-persisted per-session reasoning/thinking effort, surfaced on
+    /// session open/reconnect so a restarting TUI can restore its local
+    /// `/thinking` state and mark its menu without re-deriving it. `None`
+    /// (omitted on the wire) means no effort has ever been persisted for this
+    /// session — the client should treat that as "default" (no override).
+    ///
+    /// This is the authoritative value across a full serve/TUI restart: in
+    /// `--stdio` mode the serve is a child of the TUI, so a TUI restart
+    /// respawns the serve and only this disk-backed value survives. The server
+    /// persists it whenever a `turn/start` carries `reasoning_effort` and reads
+    /// it back here. Additive + backward-compatible: older clients ignore the
+    /// field, and older serialized payloads decode it as `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<ReasoningEffortLevel>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -5836,6 +5850,50 @@ mod tests {
     }
 
     #[test]
+    fn should_surface_persisted_reasoning_effort_on_session_open() {
+        // The persisted per-session effort is surfaced back to a
+        // reconnecting/restarting TUI via `SessionOpened.reasoning_effort` so
+        // the client can restore its local `/thinking` state and mark its menu.
+        let opened = SessionOpened {
+            session_id: SessionKey("local:demo".into()),
+            active_profile_id: None,
+            workspace_root: None,
+            context: None,
+            context_state: None,
+            cursor: None,
+            panes: None,
+            capabilities: UiProtocolCapabilities::first_server_slice(),
+            reasoning_effort: Some(ReasoningEffortLevel::High),
+        };
+        let wire = serde_json::to_value(&opened).expect("serialize SessionOpened");
+        assert_eq!(wire["reasoning_effort"], json!("high"));
+        let back: SessionOpened = serde_json::from_value(wire).expect("round-trip");
+        assert_eq!(back.reasoning_effort, Some(ReasoningEffortLevel::High));
+
+        // Omitted on the wire when None, and older payloads (no field) decode
+        // to None — additive + backward-compatible.
+        let none_opened = SessionOpened {
+            reasoning_effort: None,
+            ..opened.clone()
+        };
+        let none_wire = serde_json::to_value(&none_opened).expect("serialize None");
+        assert!(
+            none_wire.get("reasoning_effort").is_none(),
+            "reasoning_effort must be omitted from the wire when None"
+        );
+        let legacy = json!({
+            "session_id": "local:demo",
+            "capabilities": serde_json::to_value(
+                UiProtocolCapabilities::first_server_slice()
+            )
+            .unwrap()
+        });
+        let parsed: SessionOpened =
+            serde_json::from_value(legacy).expect("legacy payload without field decodes");
+        assert_eq!(parsed.reasoning_effort, None);
+    }
+
+    #[test]
     fn ui_command_method_matches_expected_transport_name() {
         let cmd = UiCommand::TurnInterrupt(TurnInterruptParams {
             session_id: SessionKey("local:demo".into()),
@@ -6008,6 +6066,7 @@ mod tests {
                 limitations: Vec::new(),
             }),
             capabilities: UiProtocolCapabilities::first_server_slice(),
+            reasoning_effort: None,
         };
 
         let wire = serde_json::to_value(&opened).expect("serialize session/open panes");
@@ -6041,6 +6100,7 @@ mod tests {
             cursor: None,
             panes: None,
             capabilities: UiProtocolCapabilities::first_server_slice(),
+            reasoning_effort: None,
         };
         let wire = serde_json::to_value(&opened).expect("serialize SessionOpened");
         let capabilities = wire
@@ -7554,6 +7614,7 @@ mod tests {
             }),
             panes: None,
             capabilities: UiProtocolCapabilities::first_server_slice(),
+            reasoning_effort: None,
         };
 
         let session_result = UiRpcResult::SessionOpen(SessionOpenResult::new(opened));
@@ -8396,6 +8457,7 @@ mod tests {
             cursor: Some(opened_cursor.clone()),
             panes: None,
             capabilities: UiProtocolCapabilities::first_server_slice(),
+            reasoning_effort: None,
         });
 
         let opened_wire = opened


### PR DESCRIPTION
## What
Persist per-session **reasoning effort** server-side so it survives a full serve/TUI restart (in `--stdio` mode the serve is a child of the TUI, so this must be disk-backed). Builds on #1421/#1423 (`TurnStartParams.reasoning_effort` + `run_standalone_turn` override).

## How
- New disk store `crates/octos-cli/src/api/ui_protocol_reasoning_effort.rs`: per-session `reasoning_effort` at `<data_dir>/users/<base>/sessions/<topic>.reasoning_effort.json` (atomic write; keyed like the task ledger; corrupt/missing → None).
- `run_standalone_turn`: `resolve_and_persist_reasoning_effort` — turn-param **wins + is persisted**; a turn that omits it **falls back to the stored value** (authoritative across restart); nothing stored → profile default untouched.
- Surface on open: additive `SessionOpened.reasoning_effort: Option<ReasoningEffortLevel>` (serde default + skip-if-none) so a reconnecting/restarting TUI reads it back. No new method — persist-on-turn is sufficient.

## Tests
octos-core wire-shape + back-compat; octos-cli store roundtrip-across-restart, per-topic keying, corrupt→None, + 3 precedence cases. `cargo test -p octos-core` 280✓; `-p octos-cli --features api --lib` 1551✓; fmt + clippy clean.

## Client follow-up
octos-tui reads `opened.reasoning_effort` on session/open to restore its `/thinking` state (separate PR).
