### PR TITLE
fix(pipeline): bound fan-out workers so a failed/hung child cannot wedge the pipeline forever

### DIFF
--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -65,6 +65,46 @@ const DEFAULT_PIPELINE_CONTRACT_ID: &str = "pipeline";
 /// with `max_parallel_workers = 8`.
 pub const MAX_PIPELINE_FANOUT_TOTAL: usize = 500;
 
+/// Absolute wall-clock ceiling for a single fan-out worker future, used when
+/// the worker node declares neither `deadline_secs` nor `timeout_secs`.
+///
+/// Fan-out workers are `join_all`-awaited, so a single worker future that
+/// never resolves wedges the WHOLE fan-out (the node never converges and the
+/// pipeline never terminates). The single-node path is already bounded by
+/// `dispatch_node`'s `tokio::time::timeout`; this constant gives the fan-out
+/// path the same fail-closed guarantee even when no per-node deadline is set.
+///
+/// Motivated by the deployed `deep_research` wedge: a `search` fan-out child
+/// whose `web_search` failed left its worker Agent stuck, re-emitting
+/// `ExecutingTool` every 5s while the task itself was already terminal
+/// `Failed`. `join_all` blocked forever, the heartbeat reported
+/// `search (0/3 nodes …)` for 25+ minutes, and every attached client hung.
+///
+/// One hour is generous enough that it never preempts a legitimately
+/// long-running worker, while still guaranteeing termination.
+pub const MAX_FANOUT_WORKER_SECS: u64 = 3600;
+
+/// Effective wall-clock deadline for a single fan-out worker, in priority
+/// order: the worker node's `deadline_secs`, then its `timeout_secs`, then the
+/// absolute [`MAX_FANOUT_WORKER_SECS`] ceiling. Never `None`: a fan-out worker
+/// must ALWAYS be bounded so a hung child cannot wedge `join_all` forever.
+fn fanout_worker_deadline(node: &PipelineNode) -> Duration {
+    if let Some(secs) = node.deadline_secs {
+        // `deadline_secs` is f64; clamp away non-finite / non-positive values
+        // so a malformed graph can't produce a zero/NaN deadline that fires
+        // instantly or panics in `Duration::from_secs_f64`.
+        if secs.is_finite() && secs > 0.0 {
+            return Duration::from_secs_f64(secs.min(MAX_FANOUT_WORKER_SECS as f64));
+        }
+    }
+    if let Some(secs) = node.timeout_secs {
+        if secs > 0 {
+            return Duration::from_secs(secs.min(MAX_FANOUT_WORKER_SECS));
+        }
+    }
+    Duration::from_secs(MAX_FANOUT_WORKER_SECS)
+}
+
 /// Structured pipeline-level error variants. Today only the cumulative
 /// fan-out cap surfaces this type; the rest of the executor still uses
 /// `eyre`-based errors. The enum is `Clone` so the cap-exceeded reason
@@ -1212,19 +1252,31 @@ fn cap_node_output_tokens_for_remaining_budget(
 }
 
 /// Process results from parallel worker execution, producing merged content and summaries.
+/// Aggregate outcome of a fan-out's worker futures.
+struct WorkerResults {
+    merged_content: String,
+    /// At least one worker returned an `Error` outcome (or its future failed,
+    /// e.g. exceeded the per-worker deadline).
+    any_error: bool,
+    /// At least one worker returned a `Pass` outcome. When this is `false`
+    /// EVERY worker failed — the fan-out produced nothing usable, so the
+    /// converged node must surface a hard `Error` that terminates the
+    /// pipeline (the production `search (0/3 nodes)` total-wedge case),
+    /// rather than silently converging on empty content.
+    any_pass: bool,
+    summaries: Vec<NodeSummary>,
+    tokens: TokenUsage,
+    outcomes: Vec<(String, NodeOutcome)>,
+}
+
 fn process_worker_results(
     results: Vec<(String, PipelineNode, Duration, Result<NodeOutcome>)>,
     bridge: Option<&PipelineStatusBridge>,
     working_dir: &std::path::Path,
-) -> (
-    String,
-    bool,
-    Vec<NodeSummary>,
-    TokenUsage,
-    Vec<(String, NodeOutcome)>,
-) {
+) -> WorkerResults {
     let mut merged_parts = Vec::new();
     let mut any_error = false;
+    let mut any_pass = false;
     let mut summaries = Vec::new();
     let mut total_tokens = TokenUsage::default();
     let mut outcomes = Vec::new();
@@ -1258,8 +1310,12 @@ fn process_worker_results(
                     success: outcome.status == OutcomeStatus::Pass,
                 });
 
-                if outcome.status == OutcomeStatus::Error {
-                    any_error = true;
+                match outcome.status {
+                    OutcomeStatus::Error => any_error = true,
+                    OutcomeStatus::Pass => any_pass = true,
+                    // `Fail` / `Skipped` count as neither a hard error nor a
+                    // usable pass for the all-failed determination.
+                    _ => {}
                 }
 
                 merged_parts.push(format!("## {label}\n\n{}", outcome.content));
@@ -1296,7 +1352,14 @@ fn process_worker_results(
     // content. This ensures the converge node gets actual data, not just paths.
     let merged_content = resolve_search_result_files(&merged_content, working_dir);
 
-    (merged_content, any_error, summaries, total_tokens, outcomes)
+    WorkerResults {
+        merged_content,
+        any_error,
+        any_pass,
+        summaries,
+        tokens: total_tokens,
+        outcomes,
+    }
 }
 
 /// Scan merged worker output for research directory paths and inline
@@ -2511,6 +2574,13 @@ impl PipelineExecutor {
                     let pipeline_id = graph.id.clone();
                     let guard_label = par_label.clone();
                     let guard_tid = tid.clone();
+                    // Bound EVERY fan-out worker so a child whose future never
+                    // resolves cannot wedge `join_all` (and with it the whole
+                    // pipeline) forever. The single-node path is already bounded
+                    // by `dispatch_node`'s timeout; this gives the fan-out path
+                    // the same fail-closed guarantee. See the deployed
+                    // `deep_research` wedge documented on `fanout_worker_deadline`.
+                    let worker_deadline = fanout_worker_deadline(&target_with_prompt);
                     futures.push(async move {
                         let _permit = sem.acquire().await.expect("semaphore closed");
                         // Arm the guard HERE — only once the future is actually
@@ -2523,13 +2593,31 @@ impl PipelineExecutor {
                             total_targets,
                         );
                         let start = Instant::now();
-                        let result = execute_with_retries_static(
-                            &handler,
-                            &target_with_prompt,
-                            &ctx,
-                            max_retries,
+                        let result = match tokio::time::timeout(
+                            worker_deadline,
+                            execute_with_retries_static(
+                                &handler,
+                                &target_with_prompt,
+                                &ctx,
+                                max_retries,
+                            ),
                         )
-                        .await;
+                        .await
+                        {
+                            Ok(result) => result,
+                            Err(_elapsed) => {
+                                warn!(
+                                    node = %target_with_prompt.id,
+                                    deadline_secs = worker_deadline.as_secs(),
+                                    "fan-out worker exceeded deadline; failing the branch"
+                                );
+                                Err(eyre::eyre!(
+                                    "fan-out worker '{}' exceeded deadline of {}s",
+                                    target_with_prompt.id,
+                                    worker_deadline.as_secs()
+                                ))
+                            }
+                        };
                         let n = par_done.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
                         let secs = start.elapsed().as_secs();
                         report_progress(&format!(
@@ -2567,12 +2655,18 @@ impl PipelineExecutor {
                 // budget projection.
                 drop(fanout_reservations);
 
-                let (merged_content, any_error, worker_summaries, worker_tokens, outcomes) =
-                    process_worker_results(
-                        results,
-                        self.config.status_bridge.as_ref(),
-                        &self.config.working_dir,
-                    );
+                let WorkerResults {
+                    merged_content,
+                    any_error,
+                    any_pass,
+                    summaries: worker_summaries,
+                    tokens: worker_tokens,
+                    outcomes,
+                } = process_worker_results(
+                    results,
+                    self.config.status_bridge.as_ref(),
+                    &self.config.working_dir,
+                );
 
                 total_tokens.input_tokens += worker_tokens.input_tokens;
                 total_tokens.output_tokens += worker_tokens.output_tokens;
@@ -2584,11 +2678,27 @@ impl PipelineExecutor {
 
                 let fan_duration = fan_start.elapsed().as_millis() as u64;
 
+                // When EVERY worker failed (no pass), the fan-out produced
+                // nothing usable — surface a hard `Error` so the pipeline
+                // terminates instead of silently converging on empty content.
+                // This is the `search (0/3 nodes)` total-wedge case from
+                // production. A partial failure (≥1 pass) stays `Fail` so the
+                // fault-tolerant "synthesize from what worked" path is kept.
+                let fan_status = if !any_pass {
+                    OutcomeStatus::Error
+                } else if any_error {
+                    OutcomeStatus::Fail
+                } else {
+                    OutcomeStatus::Pass
+                };
+
                 info!(
                     node = %node.id,
                     duration_ms = fan_duration,
                     targets = targets.len(),
                     errors = any_error,
+                    any_pass,
+                    status = ?fan_status,
                     "parallel fan-out complete, converging to '{}'",
                     converge_id
                 );
@@ -2600,22 +2710,40 @@ impl PipelineExecutor {
                     model: None,
                     token_usage: TokenUsage::default(),
                     duration_ms: fan_duration,
-                    success: !any_error,
+                    success: fan_status == OutcomeStatus::Pass,
                 });
                 completed.insert(
                     current_node_id.clone(),
                     NodeOutcome {
                         node_id: node.id.clone(),
-                        status: if any_error {
-                            OutcomeStatus::Fail
-                        } else {
-                            OutcomeStatus::Pass
-                        },
+                        status: fan_status,
                         content: merged_content,
                         token_usage: TokenUsage::default(),
                         files_modified: vec![],
                     },
                 );
+
+                // All workers failed → terminate the pipeline now rather than
+                // feeding empty merged content into the converge node. Mirrors
+                // the single-node `OutcomeStatus::Error` stop path below.
+                if fan_status == OutcomeStatus::Error {
+                    warn!(
+                        node = %node.id,
+                        "parallel fan-out: every worker failed, stopping pipeline"
+                    );
+                    return Ok(PipelineResult {
+                        output: format!(
+                            "Pipeline failed at fan-out node '{}': all {} workers failed",
+                            node.id,
+                            targets.len()
+                        ),
+                        success: false,
+                        token_usage: total_tokens,
+                        node_summaries: summaries,
+                        files_modified: vec![],
+                        node_costs: node_costs.clone(),
+                    });
+                }
 
                 // Update status words to show convergence node
                 if let Some(ref bridge) = self.config.status_bridge {
@@ -2946,6 +3074,11 @@ impl PipelineExecutor {
                     let pipeline_id = graph.id.clone();
                     let guard_label = worker_label.clone();
                     let guard_tid = task_id.clone();
+                    // Bound EVERY dynamic_parallel worker (this is the
+                    // `deep_research` fan-out path that wedged in production) so
+                    // a child whose future never resolves cannot block
+                    // `join_all` forever. See `fanout_worker_deadline`.
+                    let worker_deadline = fanout_worker_deadline(&synth_node);
                     futures.push(async move {
                         // Arm the guard HERE — only once the future is actually
                         // polled, guaranteeing a started/completed pair.
@@ -2957,9 +3090,26 @@ impl PipelineExecutor {
                             total_workers,
                         );
                         let start = Instant::now();
-                        let result =
-                            execute_with_retries_static(&handler, &synth_node, &ctx, max_retries)
-                                .await;
+                        let result = match tokio::time::timeout(
+                            worker_deadline,
+                            execute_with_retries_static(&handler, &synth_node, &ctx, max_retries),
+                        )
+                        .await
+                        {
+                            Ok(result) => result,
+                            Err(_elapsed) => {
+                                warn!(
+                                    node = %synth_node.id,
+                                    deadline_secs = worker_deadline.as_secs(),
+                                    "dynamic_parallel worker exceeded deadline; failing the branch"
+                                );
+                                Err(eyre::eyre!(
+                                    "dynamic_parallel worker '{}' exceeded deadline of {}s",
+                                    synth_node.id,
+                                    worker_deadline.as_secs()
+                                ))
+                            }
+                        };
                         let n = done_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
                         let secs = start.elapsed().as_secs();
                         report_progress(&format!(
@@ -2989,12 +3139,18 @@ impl PipelineExecutor {
                 let results = futures::future::join_all(futures).await;
                 drop(dp_reservations);
 
-                let (merged_content, any_error, worker_summaries, worker_tokens, outcomes) =
-                    process_worker_results(
-                        results,
-                        self.config.status_bridge.as_ref(),
-                        &self.config.working_dir,
-                    );
+                let WorkerResults {
+                    merged_content,
+                    any_error,
+                    any_pass,
+                    summaries: worker_summaries,
+                    tokens: worker_tokens,
+                    outcomes,
+                } = process_worker_results(
+                    results,
+                    self.config.status_bridge.as_ref(),
+                    &self.config.working_dir,
+                );
 
                 total_tokens.input_tokens += worker_tokens.input_tokens;
                 total_tokens.output_tokens += worker_tokens.output_tokens;
@@ -3011,11 +3167,27 @@ impl PipelineExecutor {
                     fan_duration as f64 / 1000.0
                 ));
 
+                // Same all-failed rule as the static `parallel` branch: when
+                // EVERY worker failed (the production `search (0/3 nodes)`
+                // total-wedge case) the dynamic fan-out produced nothing
+                // usable, so surface a hard `Error` that terminates the
+                // pipeline rather than converging on empty content. A partial
+                // failure stays `Fail` (fault-tolerant synthesize-from-rest).
+                let fan_status = if !any_pass {
+                    OutcomeStatus::Error
+                } else if any_error {
+                    OutcomeStatus::Fail
+                } else {
+                    OutcomeStatus::Pass
+                };
+
                 info!(
                     node = %node.id,
                     duration_ms = fan_duration,
                     tasks = tasks.len(),
                     errors = any_error,
+                    any_pass,
+                    status = ?fan_status,
                     "dynamic_parallel complete, converging to '{}'",
                     converge_id
                 );
@@ -3027,22 +3199,39 @@ impl PipelineExecutor {
                     model: None,
                     token_usage: plan_usage.clone(),
                     duration_ms: fan_duration,
-                    success: !any_error,
+                    success: fan_status == OutcomeStatus::Pass,
                 });
                 completed.insert(
                     current_node_id.clone(),
                     NodeOutcome {
                         node_id: node.id.clone(),
-                        status: if any_error {
-                            OutcomeStatus::Fail
-                        } else {
-                            OutcomeStatus::Pass
-                        },
+                        status: fan_status,
                         content: merged_content,
                         token_usage: plan_usage,
                         files_modified: vec![],
                     },
                 );
+
+                // All workers failed → terminate the pipeline instead of
+                // feeding empty merged content into the converge node.
+                if fan_status == OutcomeStatus::Error {
+                    warn!(
+                        node = %node.id,
+                        "dynamic_parallel: every worker failed, stopping pipeline"
+                    );
+                    return Ok(PipelineResult {
+                        output: format!(
+                            "Pipeline failed at dynamic_parallel node '{}': all {} workers failed",
+                            node.id,
+                            tasks.len()
+                        ),
+                        success: false,
+                        token_usage: total_tokens,
+                        node_summaries: summaries,
+                        files_modified: vec![],
+                        node_costs: node_costs.clone(),
+                    });
+                }
 
                 // Update status words to show convergence node
                 if let Some(ref bridge) = self.config.status_bridge {
@@ -4875,7 +5064,61 @@ fn dag_build_result(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::graph::{NodeOutcome, OutcomeStatus};
+    use crate::graph::{NodeOutcome, OutcomeStatus, PipelineNode};
+
+    #[test]
+    fn fanout_worker_deadline_priority_and_clamp() {
+        // No deadline/timeout → absolute ceiling (never `None`, so a worker can
+        // never hang forever).
+        let bare = PipelineNode {
+            id: "w".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            fanout_worker_deadline(&bare),
+            Duration::from_secs(MAX_FANOUT_WORKER_SECS)
+        );
+
+        // `timeout_secs` is used when no `deadline_secs`.
+        let timed = PipelineNode {
+            id: "w".into(),
+            timeout_secs: Some(42),
+            ..Default::default()
+        };
+        assert_eq!(fanout_worker_deadline(&timed), Duration::from_secs(42));
+
+        // `deadline_secs` WINS over `timeout_secs`.
+        let both = PipelineNode {
+            id: "w".into(),
+            deadline_secs: Some(7.5),
+            timeout_secs: Some(42),
+            ..Default::default()
+        };
+        assert_eq!(fanout_worker_deadline(&both), Duration::from_secs_f64(7.5));
+
+        // Non-finite / non-positive deadline_secs falls through to timeout_secs.
+        let bad_deadline = PipelineNode {
+            id: "w".into(),
+            deadline_secs: Some(0.0),
+            timeout_secs: Some(9),
+            ..Default::default()
+        };
+        assert_eq!(
+            fanout_worker_deadline(&bad_deadline),
+            Duration::from_secs(9)
+        );
+
+        // A pathological over-cap value is clamped to the absolute ceiling.
+        let over = PipelineNode {
+            id: "w".into(),
+            timeout_secs: Some(MAX_FANOUT_WORKER_SECS * 100),
+            ..Default::default()
+        };
+        assert_eq!(
+            fanout_worker_deadline(&over),
+            Duration::from_secs(MAX_FANOUT_WORKER_SECS)
+        );
+    }
 
     #[test]
     fn dag_schedulable_excludes_fanout_and_converge() {

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -2937,6 +2937,14 @@ impl PipelineExecutor {
                             tools: node.tools.clone(),
                             timeout_secs: node.timeout_secs,
                             max_retries: node.max_retries,
+                            // Inherit the source node's deadline settings so
+                            // `run_fanout_worker` honors deadline_action/
+                            // deadline_secs on dynamic_parallel workers too
+                            // (not just the static fan-out path). Without this
+                            // a dynamic worker defaults to the 1h ceiling/Abort
+                            // and ignores a configured skip/retry. (codex #1427)
+                            deadline_secs: node.deadline_secs,
+                            deadline_action: node.deadline_action.clone(),
                             ..Default::default()
                         },
                     ));

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -2576,11 +2576,13 @@ impl PipelineExecutor {
                     let guard_tid = tid.clone();
                     // Bound EVERY fan-out worker so a child whose future never
                     // resolves cannot wedge `join_all` (and with it the whole
-                    // pipeline) forever. The single-node path is already bounded
-                    // by `dispatch_node`'s timeout; this gives the fan-out path
-                    // the same fail-closed guarantee. See the deployed
-                    // `deep_research` wedge documented on `fanout_worker_deadline`.
-                    let worker_deadline = fanout_worker_deadline(&target_with_prompt);
+                    // pipeline) forever, while honoring the worker's configured
+                    // `deadline_action` (skip/retry/escalate) on a deadline
+                    // expiry — exactly like the single-node `dispatch_node`
+                    // path. `run_fanout_worker` keeps every timed attempt
+                    // bounded by `MAX_FANOUT_WORKER_SECS`, so the deployed
+                    // `deep_research` wedge cannot return.
+                    let hook_executor = self.config.hook_executor.clone();
                     futures.push(async move {
                         let _permit = sem.acquire().await.expect("semaphore closed");
                         // Arm the guard HERE — only once the future is actually
@@ -2593,31 +2595,14 @@ impl PipelineExecutor {
                             total_targets,
                         );
                         let start = Instant::now();
-                        let result = match tokio::time::timeout(
-                            worker_deadline,
-                            execute_with_retries_static(
-                                &handler,
-                                &target_with_prompt,
-                                &ctx,
-                                max_retries,
-                            ),
+                        let result = run_fanout_worker(
+                            &handler,
+                            &target_with_prompt,
+                            &ctx,
+                            max_retries,
+                            hook_executor.as_ref(),
                         )
-                        .await
-                        {
-                            Ok(result) => result,
-                            Err(_elapsed) => {
-                                warn!(
-                                    node = %target_with_prompt.id,
-                                    deadline_secs = worker_deadline.as_secs(),
-                                    "fan-out worker exceeded deadline; failing the branch"
-                                );
-                                Err(eyre::eyre!(
-                                    "fan-out worker '{}' exceeded deadline of {}s",
-                                    target_with_prompt.id,
-                                    worker_deadline.as_secs()
-                                ))
-                            }
-                        };
+                        .await;
                         let n = par_done.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
                         let secs = start.elapsed().as_secs();
                         report_progress(&format!(
@@ -2678,18 +2663,22 @@ impl PipelineExecutor {
 
                 let fan_duration = fan_start.elapsed().as_millis() as u64;
 
-                // When EVERY worker failed (no pass), the fan-out produced
-                // nothing usable — surface a hard `Error` so the pipeline
-                // terminates instead of silently converging on empty content.
-                // This is the `search (0/3 nodes)` total-wedge case from
-                // production. A partial failure (≥1 pass) stays `Fail` so the
-                // fault-tolerant "synthesize from what worked" path is kept.
-                let fan_status = if !any_pass {
+                // When EVERY worker hard-ERRORED (≥1 error, no pass), the
+                // fan-out produced nothing usable — surface a hard `Error` so
+                // the pipeline terminates instead of silently converging on
+                // empty content. This is the `search (0/3 nodes)` total-wedge
+                // case from production. A partial failure (≥1 pass) stays
+                // `Fail` so the fault-tolerant "synthesize from what worked"
+                // path is kept. An all-`Skipped` fan-out (deadline_action=skip
+                // on every branch) is NOT a hard failure — it carries no error,
+                // so it stays `Fail` and convergence proceeds rather than
+                // aborting; the configured `skip` action must continue.
+                let fan_status = if any_error && !any_pass {
                     OutcomeStatus::Error
-                } else if any_error {
-                    OutcomeStatus::Fail
-                } else {
+                } else if any_pass && !any_error {
                     OutcomeStatus::Pass
+                } else {
+                    OutcomeStatus::Fail
                 };
 
                 info!(
@@ -2725,8 +2714,12 @@ impl PipelineExecutor {
 
                 // All workers failed → terminate the pipeline now rather than
                 // feeding empty merged content into the converge node. Mirrors
-                // the single-node `OutcomeStatus::Error` stop path below.
-                if fan_status == OutcomeStatus::Error {
+                // the single-node `OutcomeStatus::Error` stop path below —
+                // including its `continue_on_error` escape hatch: when the
+                // fan-out node opts in, the pipeline intentionally tolerates a
+                // fully-failed fan-out and lets the normal convergence/error
+                // routing handle the empty merged content instead of aborting.
+                if fan_status == OutcomeStatus::Error && !node.continue_on_error {
                     warn!(
                         node = %node.id,
                         "parallel fan-out: every worker failed, stopping pipeline"
@@ -3077,8 +3070,10 @@ impl PipelineExecutor {
                     // Bound EVERY dynamic_parallel worker (this is the
                     // `deep_research` fan-out path that wedged in production) so
                     // a child whose future never resolves cannot block
-                    // `join_all` forever. See `fanout_worker_deadline`.
-                    let worker_deadline = fanout_worker_deadline(&synth_node);
+                    // `join_all` forever, while honoring the worker's configured
+                    // `deadline_action`. `run_fanout_worker` keeps every timed
+                    // attempt bounded by `MAX_FANOUT_WORKER_SECS`.
+                    let hook_executor = self.config.hook_executor.clone();
                     futures.push(async move {
                         // Arm the guard HERE — only once the future is actually
                         // polled, guaranteeing a started/completed pair.
@@ -3090,26 +3085,14 @@ impl PipelineExecutor {
                             total_workers,
                         );
                         let start = Instant::now();
-                        let result = match tokio::time::timeout(
-                            worker_deadline,
-                            execute_with_retries_static(&handler, &synth_node, &ctx, max_retries),
+                        let result = run_fanout_worker(
+                            &handler,
+                            &synth_node,
+                            &ctx,
+                            max_retries,
+                            hook_executor.as_ref(),
                         )
-                        .await
-                        {
-                            Ok(result) => result,
-                            Err(_elapsed) => {
-                                warn!(
-                                    node = %synth_node.id,
-                                    deadline_secs = worker_deadline.as_secs(),
-                                    "dynamic_parallel worker exceeded deadline; failing the branch"
-                                );
-                                Err(eyre::eyre!(
-                                    "dynamic_parallel worker '{}' exceeded deadline of {}s",
-                                    synth_node.id,
-                                    worker_deadline.as_secs()
-                                ))
-                            }
-                        };
+                        .await;
                         let n = done_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
                         let secs = start.elapsed().as_secs();
                         report_progress(&format!(
@@ -3168,17 +3151,20 @@ impl PipelineExecutor {
                 ));
 
                 // Same all-failed rule as the static `parallel` branch: when
-                // EVERY worker failed (the production `search (0/3 nodes)`
-                // total-wedge case) the dynamic fan-out produced nothing
-                // usable, so surface a hard `Error` that terminates the
-                // pipeline rather than converging on empty content. A partial
-                // failure stays `Fail` (fault-tolerant synthesize-from-rest).
-                let fan_status = if !any_pass {
+                // EVERY worker hard-ERRORED (≥1 error, no pass — the production
+                // `search (0/3 nodes)` total-wedge case) the dynamic fan-out
+                // produced nothing usable, so surface a hard `Error` that
+                // terminates the pipeline rather than converging on empty
+                // content. A partial failure stays `Fail` (fault-tolerant
+                // synthesize-from-rest). An all-`Skipped` fan-out carries no
+                // error, so it stays `Fail` and convergence proceeds — the
+                // configured `deadline_action=skip` must continue.
+                let fan_status = if any_error && !any_pass {
                     OutcomeStatus::Error
-                } else if any_error {
-                    OutcomeStatus::Fail
-                } else {
+                } else if any_pass && !any_error {
                     OutcomeStatus::Pass
+                } else {
+                    OutcomeStatus::Fail
                 };
 
                 info!(
@@ -3213,8 +3199,11 @@ impl PipelineExecutor {
                 );
 
                 // All workers failed → terminate the pipeline instead of
-                // feeding empty merged content into the converge node.
-                if fan_status == OutcomeStatus::Error {
+                // feeding empty merged content into the converge node. Honors
+                // the same `continue_on_error` escape hatch as the static
+                // `parallel` branch: an opted-in node tolerates a fully-failed
+                // fan-out and lets normal convergence/error routing proceed.
+                if fan_status == OutcomeStatus::Error && !node.continue_on_error {
                     warn!(
                         node = %node.id,
                         "dynamic_parallel: every worker failed, stopping pipeline"
@@ -4569,6 +4558,138 @@ async fn execute_with_retries_static(
         tokio::time::sleep(Duration::from_millis(1000 * 2u64.pow(attempt))).await;
     }
     unreachable!()
+}
+
+/// Run a single fan-out worker, honoring its `deadline_action` on a deadline
+/// expiry while ALWAYS bounding each timed attempt so a genuinely-hung worker
+/// cannot wedge `join_all`.
+///
+/// This is the fan-out analogue of [`PipelineExecutor::dispatch_node`]: it
+/// routes a fan-out worker's deadline expiry through the SAME
+/// `deadline_action` machinery the single-node path uses, so a parallel /
+/// dynamic_parallel target that declares `deadline_secs` with
+/// `deadline_action = skip|retry|escalate` gets the configured behavior
+/// instead of an unconditional `Err`.
+///
+/// Bounding guarantee (the production wedge must NOT return): every timed
+/// attempt is wrapped in [`fanout_worker_deadline`], which is itself clamped
+/// to the absolute [`MAX_FANOUT_WORKER_SECS`] ceiling. So even with no
+/// per-node `deadline_secs`, a worker whose future never resolves is cut off
+/// at the ceiling. `Skip` stops after the first expiry (it never re-runs the
+/// hung future); `Retry` re-attempts at most `max_attempts` times, each
+/// attempt independently bounded — so the worker always terminates.
+///
+/// Returns:
+/// * `Ok(NodeOutcome)` with `OutcomeStatus::Skipped` when the deadline fired
+///   and `deadline_action == Skip` — `process_worker_results` treats a
+///   `Skipped` outcome as neither a usable pass nor a hard error, so the
+///   normal convergence routing handles it.
+/// * `Err` when the deadline fired and the action is `Abort` (default),
+///   `Escalate`, or `Retry` with all attempts exhausted; or when the
+///   underlying handler itself errors.
+async fn run_fanout_worker(
+    handler: &Arc<dyn crate::handler::Handler>,
+    node: &crate::graph::PipelineNode,
+    ctx: &HandlerContext,
+    max_retries: u32,
+    hook_executor: Option<&Arc<HookExecutor>>,
+) -> Result<NodeOutcome> {
+    // Effective per-attempt deadline, already clamped to MAX_FANOUT_WORKER_SECS
+    // so even an action that re-runs the worker (Retry) stays bounded and the
+    // hung-worker wedge cannot return.
+    let deadline = fanout_worker_deadline(node);
+    let action = node.deadline_action.unwrap_or(DeadlineAction::Abort);
+    let label = node.label.as_deref().unwrap_or(&node.id).to_string();
+
+    // For Retry, loop over attempts; every other action runs once.
+    let max_attempts = match action {
+        DeadlineAction::Retry { max_attempts } => max_attempts.max(1),
+        _ => 1,
+    };
+
+    let mut last_err: Option<eyre::Report> = None;
+    for attempt in 0..max_attempts {
+        let fut = execute_with_retries_static(handler, node, ctx, max_retries);
+        match tokio::time::timeout(deadline, fut).await {
+            Ok(Ok(outcome)) => return Ok(outcome),
+            Ok(Err(e)) => {
+                // The handler itself errored (not a deadline expiry). Mirror the
+                // pre-existing behavior: surface the error to the worker result.
+                return Err(e);
+            }
+            Err(_timeout) => {
+                record_deadline_exceeded(&action);
+                warn!(
+                    node = %node.id,
+                    deadline_secs = deadline.as_secs(),
+                    attempt = attempt + 1,
+                    action = action.name(),
+                    "fan-out worker exceeded deadline"
+                );
+                match action {
+                    DeadlineAction::Abort => {
+                        return Err(eyre::eyre!(
+                            "fan-out worker '{}' exceeded deadline of {}s (action=abort)",
+                            node.id,
+                            deadline.as_secs()
+                        ));
+                    }
+                    DeadlineAction::Skip => {
+                        return Ok(NodeOutcome {
+                            node_id: node.id.clone(),
+                            status: OutcomeStatus::Skipped,
+                            content: format!("Node '{}' skipped (deadline exceeded)", node.id),
+                            token_usage: TokenUsage::default(),
+                            files_modified: vec![],
+                        });
+                    }
+                    DeadlineAction::Retry { .. } => {
+                        last_err = Some(eyre::eyre!(
+                            "fan-out worker '{}' exceeded deadline of {}s",
+                            node.id,
+                            deadline.as_secs()
+                        ));
+                        if attempt + 1 >= max_attempts {
+                            return Err(eyre::eyre!(
+                                "fan-out worker '{}' exceeded deadline on all {} retry attempt(s)",
+                                node.id,
+                                max_attempts
+                            ));
+                        }
+                        // else: fall through and try again (still bounded).
+                    }
+                    DeadlineAction::Escalate => {
+                        if let Some(hook) = hook_executor {
+                            let payload = HookPayload::on_spawn_failure(
+                                node.id.clone(),
+                                label.clone(),
+                                String::new(),
+                                String::new(),
+                                Some("pipeline"),
+                                Some(handler_kind_label(&node.handler)),
+                                format!(
+                                    "deadline_exceeded: fan-out worker '{}' deadline={}s",
+                                    node.id,
+                                    deadline.as_secs()
+                                ),
+                                Vec::new(),
+                                "deadline_exceeded",
+                                None::<&HookContext>,
+                            );
+                            let _ = hook.run(HookEvent::OnSpawnFailure, &payload).await;
+                        }
+                        return Err(eyre::eyre!(
+                            "fan-out worker '{}' exceeded deadline of {}s (action=escalate)",
+                            node.id,
+                            deadline.as_secs()
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    Err(last_err
+        .unwrap_or_else(|| eyre::eyre!("fan-out worker '{}' failed all retry attempts", node.id)))
 }
 
 /// Pick the edge with the highest weight, tie-break by lexicographic target.

--- a/crates/octos-pipeline/tests/fanout_deadline_action_and_continue.rs
+++ b/crates/octos-pipeline/tests/fanout_deadline_action_and_continue.rs
@@ -1,0 +1,344 @@
+//! Regression tests for the two code-review findings on the fan-out hang fix
+//! (PR #1427):
+//!
+//!   1. A fan-out worker that exceeds its `deadline_secs` must route through the
+//!      SAME `deadline_action` machinery (`skip` / `retry` / `escalate`) the
+//!      single-node `dispatch_node` path uses — not be unconditionally turned
+//!      into an `Err` that aborts the fan-out.
+//!
+//!   2. The new "all workers failed → terminate the pipeline" branch must NOT
+//!      fire when the fan-out node sets `continue_on_error = true`. In that case
+//!      the pipeline intentionally tolerates a fully-failed fan-out and lets the
+//!      normal convergence / error routing proceed.
+//!
+//! These drive the real static `parallel` fan-out path with injected handlers
+//! and assert behavior in bounded wall-clock time. The companion
+//! `fanout_failed_task_no_hang.rs` tests pin that none of this reintroduces the
+//! production wedge (a never-resolving worker must still terminate).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use octos_core::TokenUsage;
+use octos_memory::EpisodeStore;
+use octos_pipeline::executor::{ExecutorConfig, PipelineExecutor};
+use octos_pipeline::graph::{HandlerKind, NodeOutcome, OutcomeStatus, PipelineNode};
+use octos_pipeline::handler::{Handler, HandlerContext, HandlerRegistry};
+use tempfile::TempDir;
+
+// --- Stub provider: never called (the injected handler replaces dispatch). ---
+struct StubProvider;
+
+#[async_trait]
+impl octos_llm::LlmProvider for StubProvider {
+    async fn chat(
+        &self,
+        _messages: &[octos_core::Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &octos_llm::ChatConfig,
+    ) -> eyre::Result<octos_llm::ChatResponse> {
+        Ok(octos_llm::ChatResponse {
+            content: Some("stub".into()),
+            tool_calls: vec![],
+            stop_reason: octos_llm::StopReason::EndTurn,
+            usage: octos_llm::TokenUsage::default(),
+            reasoning_content: None,
+            provider_index: None,
+        })
+    }
+    fn provider_name(&self) -> &str {
+        "stub"
+    }
+    fn model_id(&self) -> &str {
+        "stub-1"
+    }
+}
+
+/// A handler that, for any node whose id is in `hang_nodes`, hangs FOREVER (the
+/// production never-resolving worker). For any node whose id is in
+/// `error_nodes`, returns an `Error` outcome immediately. Every other node
+/// passes. Each `execute` call increments `calls` so a test can assert retry
+/// attempts actually happened.
+struct ScriptedHandler {
+    hang_nodes: Vec<String>,
+    error_nodes: Vec<String>,
+    calls: Arc<AtomicUsize>,
+}
+
+impl ScriptedHandler {
+    fn new(hang_nodes: Vec<String>, error_nodes: Vec<String>) -> (Arc<Self>, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let handler = Arc::new(Self {
+            hang_nodes,
+            error_nodes,
+            calls: calls.clone(),
+        });
+        (handler, calls)
+    }
+}
+
+#[async_trait]
+impl Handler for ScriptedHandler {
+    async fn execute(
+        &self,
+        node: &PipelineNode,
+        _ctx: &HandlerContext,
+    ) -> eyre::Result<NodeOutcome> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        if self.hang_nodes.iter().any(|n| n == &node.id) {
+            std::future::pending::<()>().await;
+            unreachable!("hanging worker future must never resolve");
+        }
+        let status = if self.error_nodes.iter().any(|n| n == &node.id) {
+            OutcomeStatus::Error
+        } else {
+            OutcomeStatus::Pass
+        };
+        Ok(NodeOutcome {
+            node_id: node.id.clone(),
+            status,
+            content: format!("{} {:?}", node.id, status),
+            token_usage: TokenUsage::default(),
+            files_modified: vec![],
+        })
+    }
+}
+
+async fn make_executor(dir: &TempDir) -> PipelineExecutor {
+    let memory = Arc::new(EpisodeStore::open(dir.path().join(".octos")).await.unwrap());
+    let config = ExecutorConfig {
+        default_provider: Arc::new(StubProvider) as Arc<dyn octos_llm::LlmProvider>,
+        provider_router: None,
+        memory,
+        working_dir: dir.path().to_path_buf(),
+        provider_policy: None,
+        plugin_dirs: vec![],
+        plugin_require_signed: false,
+        status_bridge: None,
+        shutdown: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        max_parallel_workers: 8,
+        max_pipeline_fanout_total: None,
+        checkpoint_store: None,
+        hook_executor: None,
+        workspace_context: octos_pipeline::context::PipelineContext::default(),
+        host_context: octos_pipeline::host_context::PipelineHostContext::default(),
+        embedder: None,
+        catalog_dir: None,
+    };
+    PipelineExecutor::new(config)
+}
+
+fn handlers_for(handler: Arc<ScriptedHandler>) -> HandlerRegistry {
+    let mut handlers = HandlerRegistry::new();
+    handlers.register(HandlerKind::Codergen, handler.clone());
+    handlers.register(HandlerKind::Noop, handler.clone());
+    handlers.register(HandlerKind::Parallel, handler.clone());
+    handlers.register(HandlerKind::Gate, handler);
+    handlers
+}
+
+/// (a) Fan-out workers that time out with `deadline_action=skip` must be
+/// SKIPPED (not turned into hard Errors that abort the fan-out). With EVERY
+/// branch skipped, the old code (unconditional `Err` → all-failed → abort)
+/// terminates the pipeline; the fix routes the expiry through the
+/// `deadline_action` machinery so the branches are `Skipped` (carry no error),
+/// the fan-out converges, `merge` runs and the pipeline succeeds.
+#[tokio::test]
+async fn fanout_worker_deadline_skip_continues_not_aborts() {
+    let dir = TempDir::new().unwrap();
+    let exec = make_executor(&dir).await;
+
+    // BOTH branches hang forever but declare deadline_action=skip. Each
+    // deadline expiry must produce a SKIPPED outcome (neither pass nor hard
+    // error), so the fan-out is NOT all-failed and convergence proceeds.
+    let dot = r#"digraph fanout {
+        fan  [handler="parallel", converge="merge"]
+        s1 [handler="codergen", tools=read_file, prompt="s1", deadline_secs="1", deadline_action="skip"]
+        s2 [handler="codergen", tools=read_file, prompt="s2", deadline_secs="1", deadline_action="skip"]
+        merge [handler="codergen", tools=read_file, prompt="merge"]
+        fan -> s1
+        fan -> s2
+        s1 -> merge
+        s2 -> merge
+    }"#;
+
+    let (handler, _calls) = ScriptedHandler::new(vec!["s1".into(), "s2".into()], vec![]);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        exec.run_with_handlers(
+            dot,
+            "user-input",
+            &serde_json::Map::new(),
+            handlers_for(handler),
+        ),
+    )
+    .await
+    .expect("pipeline wedged: deadline_action=skip worker did not get cut off")
+    .expect("pipeline run returned an error result");
+
+    // No branch hard-errored (both skipped), so the all-failed termination must
+    // NOT fire; the converge node ran and passed.
+    assert!(
+        !result.output.contains("workers failed"),
+        "deadline_action=skip on every branch must NOT trip the all-failed \
+         abort; got: {}",
+        result.output
+    );
+    assert!(
+        result.success,
+        "deadline_action=skip must let the fan-out continue (skipped != error), \
+         got success={} output={}",
+        result.success, result.output
+    );
+}
+
+/// (b) A fan-out worker that times out with `deadline_action=retry:N` must
+/// actually re-attempt — `execute` is invoked more than once for that node.
+#[tokio::test]
+async fn fanout_worker_deadline_retry_attempts_retries() {
+    let dir = TempDir::new().unwrap();
+    let exec = make_executor(&dir).await;
+
+    // `flaky` hangs forever with a short deadline and retry:3. Each attempt is
+    // bounded by the deadline (1s), so all 3 attempts time out, but the handler
+    // must have been ENTERED 3 times for `flaky` — proving the retry action ran
+    // rather than a single unconditional Err.
+    let dot = r#"digraph fanout {
+        fan  [handler="parallel", converge="merge"]
+        good [handler="codergen", tools=read_file, prompt="good"]
+        flaky [handler="codergen", tools=read_file, prompt="flaky", deadline_secs="1", deadline_action="retry:3"]
+        merge [handler="codergen", tools=read_file, prompt="merge"]
+        fan -> good
+        fan -> flaky
+        good -> merge
+        flaky -> merge
+    }"#;
+
+    let (handler, calls) = ScriptedHandler::new(vec!["flaky".into()], vec![]);
+
+    let _ = tokio::time::timeout(
+        Duration::from_secs(30),
+        exec.run_with_handlers(
+            dot,
+            "user-input",
+            &serde_json::Map::new(),
+            handlers_for(handler),
+        ),
+    )
+    .await
+    .expect("pipeline wedged: retry worker did not terminate within its bounded attempts")
+    .expect("pipeline run returned an error result");
+
+    // 1 entry for `good` + 3 attempts for `flaky` = at least 4 handler entries.
+    // The load-bearing assertion is that `flaky` was entered MORE THAN ONCE.
+    let total = calls.load(Ordering::Relaxed);
+    assert!(
+        total >= 4,
+        "deadline_action=retry:3 must re-attempt the hung worker (>1 entry); \
+         saw {total} total handler entries (expected >=4: 1 good + 3 flaky)"
+    );
+}
+
+/// (c) An all-failed fan-out with `continue_on_error=true` must NOT abort the
+/// pipeline at the fan-out. Convergence runs on the (failed) merged content and
+/// the pipeline proceeds — here `merge` passes, so the run succeeds.
+#[tokio::test]
+async fn fanout_all_failed_with_continue_on_error_does_not_abort() {
+    let dir = TempDir::new().unwrap();
+    let exec = make_executor(&dir).await;
+
+    // Both workers return Error → all-failed fan-out. But the fan-out node opts
+    // in with continue_on_error=true, so the pipeline must NOT terminate at the
+    // fan-out; it jumps to `merge`, which passes.
+    let dot = r#"digraph fanout {
+        fan  [handler="parallel", converge="merge", continue_on_error="true"]
+        e1 [handler="codergen", tools=read_file, prompt="e1"]
+        e2 [handler="codergen", tools=read_file, prompt="e2"]
+        merge [handler="codergen", tools=read_file, prompt="merge"]
+        fan -> e1
+        fan -> e2
+        e1 -> merge
+        e2 -> merge
+    }"#;
+
+    let (handler, _calls) = ScriptedHandler::new(vec![], vec!["e1".into(), "e2".into()]);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        exec.run_with_handlers(
+            dot,
+            "user-input",
+            &serde_json::Map::new(),
+            handlers_for(handler),
+        ),
+    )
+    .await
+    .expect("pipeline wedged")
+    .expect("pipeline run returned an error result");
+
+    // continue_on_error short-circuits the all-failed abort; the converge node
+    // ran and passed, so the overall run succeeds. The KEY assertion is that
+    // the output is NOT the all-workers-failed abort message.
+    assert!(
+        !result.output.contains("all 2 workers failed"),
+        "continue_on_error=true must NOT abort an all-failed fan-out; \
+         got abort output: {}",
+        result.output
+    );
+    assert!(
+        result.success,
+        "with continue_on_error=true the fan-out tolerates total failure and \
+         convergence proceeds (merge passed), got success={} output={}",
+        result.success, result.output
+    );
+}
+
+/// (d) The default (continue_on_error=false) all-failed fan-out STILL
+/// terminates the pipeline — the production-hang fix is preserved. This is the
+/// same shape as (c) minus the `continue_on_error` attribute.
+#[tokio::test]
+async fn fanout_all_failed_default_still_terminates() {
+    let dir = TempDir::new().unwrap();
+    let exec = make_executor(&dir).await;
+
+    let dot = r#"digraph fanout {
+        fan  [handler="parallel", converge="merge"]
+        e1 [handler="codergen", tools=read_file, prompt="e1"]
+        e2 [handler="codergen", tools=read_file, prompt="e2"]
+        merge [handler="codergen", tools=read_file, prompt="merge"]
+        fan -> e1
+        fan -> e2
+        e1 -> merge
+        e2 -> merge
+    }"#;
+
+    let (handler, _calls) = ScriptedHandler::new(vec![], vec!["e1".into(), "e2".into()]);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        exec.run_with_handlers(
+            dot,
+            "user-input",
+            &serde_json::Map::new(),
+            handlers_for(handler),
+        ),
+    )
+    .await
+    .expect("pipeline wedged")
+    .expect("pipeline run returned an error result");
+
+    assert!(
+        !result.success,
+        "default (continue_on_error=false) all-failed fan-out must FAIL the \
+         pipeline, got success={}",
+        result.success
+    );
+    assert!(
+        result.output.contains("all 2 workers failed"),
+        "expected the all-workers-failed abort message, got: {}",
+        result.output
+    );
+}

--- a/crates/octos-pipeline/tests/fanout_failed_task_no_hang.rs
+++ b/crates/octos-pipeline/tests/fanout_failed_task_no_hang.rs
@@ -1,0 +1,240 @@
+//! Regression test for the production wedge where a fan-out node whose child
+//! task never resolves (its underlying work failed — e.g. `web_search` died on
+//! a `deep_research` `search` node) hangs the WHOLE pipeline forever.
+//!
+//! Live symptom on the deployed box:
+//!   * the heartbeat logged forever:
+//!     `Pipeline 'deep_research' running: search (0/3 nodes, 1525s elapsed, …)`
+//!     — 25+ minutes, ZERO of the fan-out children ever completing;
+//!   * the server logged every 5s:
+//!     `ignoring late mark_runtime_state: task already in terminal state …
+//!      current_status="failed" … attempted_runtime_state=ExecutingTool`.
+//!
+//! Root cause: the fan-out worker futures (`execute_with_retries_static` at the
+//! static `parallel` and `dynamic_parallel` sites in `executor.rs`) are
+//! `join_all`-awaited with NO deadline guard — unlike the single-node
+//! `dispatch_node` path which wraps execution in `tokio::time::timeout`. A
+//! child whose future never resolves therefore wedges `join_all`, so the
+//! fan-out node never converges, the pipeline never terminates, and every
+//! attached client hangs indefinitely.
+//!
+//! These tests drive the real fan-out path with an injected handler whose
+//! worker future hangs forever and assert the pipeline TERMINATES (with a
+//! failure) in bounded wall-clock time.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use octos_core::TokenUsage;
+use octos_memory::EpisodeStore;
+use octos_pipeline::executor::{ExecutorConfig, PipelineExecutor};
+use octos_pipeline::graph::{HandlerKind, NodeOutcome, OutcomeStatus, PipelineNode};
+use octos_pipeline::handler::{Handler, HandlerContext, HandlerRegistry};
+use tempfile::TempDir;
+
+// --- Stub provider: never called (the injected handler replaces dispatch). ---
+struct StubProvider;
+
+#[async_trait]
+impl octos_llm::LlmProvider for StubProvider {
+    async fn chat(
+        &self,
+        _messages: &[octos_core::Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &octos_llm::ChatConfig,
+    ) -> eyre::Result<octos_llm::ChatResponse> {
+        Ok(octos_llm::ChatResponse {
+            content: Some("stub".into()),
+            tool_calls: vec![],
+            stop_reason: octos_llm::StopReason::EndTurn,
+            usage: octos_llm::TokenUsage::default(),
+            reasoning_content: None,
+            provider_index: None,
+        })
+    }
+    fn provider_name(&self) -> &str {
+        "stub"
+    }
+    fn model_id(&self) -> &str {
+        "stub-1"
+    }
+}
+
+/// A handler that hangs forever for any node whose id is in `hang_nodes`, and
+/// passes every other node. This reproduces the production child task that
+/// reached a terminal `Failed` state but whose handler future never resolved —
+/// leaving the fan-out `join_all` blocked and the pipeline wedged.
+struct HangingWorkerHandler {
+    /// Node ids whose `execute` future never resolves.
+    hang_nodes: Vec<String>,
+}
+
+#[async_trait]
+impl Handler for HangingWorkerHandler {
+    async fn execute(
+        &self,
+        node: &PipelineNode,
+        _ctx: &HandlerContext,
+    ) -> eyre::Result<NodeOutcome> {
+        if self.hang_nodes.iter().any(|n| n == &node.id) {
+            // Never resolves — the smoking gun. In production this was a worker
+            // Agent stuck after its web_search sub-task went terminal `Failed`,
+            // still re-emitting `ExecutingTool` progress every 5s.
+            std::future::pending::<()>().await;
+            unreachable!("hanging worker future must never resolve");
+        }
+        Ok(NodeOutcome {
+            node_id: node.id.clone(),
+            status: OutcomeStatus::Pass,
+            content: format!("{} ok", node.id),
+            token_usage: TokenUsage::default(),
+            files_modified: vec![],
+        })
+    }
+}
+
+async fn make_executor(dir: &TempDir) -> PipelineExecutor {
+    let memory = Arc::new(EpisodeStore::open(dir.path().join(".octos")).await.unwrap());
+    let config = ExecutorConfig {
+        default_provider: Arc::new(StubProvider) as Arc<dyn octos_llm::LlmProvider>,
+        provider_router: None,
+        memory,
+        working_dir: dir.path().to_path_buf(),
+        provider_policy: None,
+        plugin_dirs: vec![],
+        plugin_require_signed: false,
+        status_bridge: None,
+        shutdown: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        max_parallel_workers: 8,
+        max_pipeline_fanout_total: None,
+        checkpoint_store: None,
+        hook_executor: None,
+        workspace_context: octos_pipeline::context::PipelineContext::default(),
+        host_context: octos_pipeline::host_context::PipelineHostContext::default(),
+        embedder: None,
+        catalog_dir: None,
+    };
+    PipelineExecutor::new(config)
+}
+
+fn handlers_for(handler: Arc<HangingWorkerHandler>) -> HandlerRegistry {
+    let mut handlers = HandlerRegistry::new();
+    handlers.register(HandlerKind::Codergen, handler.clone());
+    handlers.register(HandlerKind::Noop, handler.clone());
+    handlers.register(HandlerKind::Parallel, handler.clone());
+    handlers.register(HandlerKind::Gate, handler);
+    handlers
+}
+
+/// RED: a `parallel` fan-out whose children ALL hang forever (the production
+/// `search (0/3 nodes)` total-wedge) must TERMINATE the pipeline with a failure
+/// in bounded time — it must NOT wedge `join_all` and report "running" forever.
+#[tokio::test]
+async fn parallel_fanout_all_children_hung_terminates_with_failure() {
+    let dir = TempDir::new().unwrap();
+    let exec = make_executor(&dir).await;
+
+    // Both branches hang forever — exactly the deployed deep_research `search`
+    // node where every fan-out child wedged (0/3 ever completing). Each worker
+    // carries a short `timeout_secs` so the executor's per-worker deadline
+    // guard cuts the hung branches off quickly. Before the fix there is NO such
+    // guard, so `join_all` blocks and the outer test timeout fires.
+    let dot = r#"digraph fanout {
+        fan  [handler="parallel", converge="merge"]
+        s1 [handler="codergen", tools=read_file, prompt="s1", timeout_secs="2"]
+        s2 [handler="codergen", tools=read_file, prompt="s2", timeout_secs="2"]
+        s3 [handler="codergen", tools=read_file, prompt="s3", timeout_secs="2"]
+        merge [handler="codergen", tools=read_file, prompt="merge"]
+        fan -> s1
+        fan -> s2
+        fan -> s3
+        s1 -> merge
+        s2 -> merge
+        s3 -> merge
+    }"#;
+
+    let handler = Arc::new(HangingWorkerHandler {
+        hang_nodes: vec!["s1".into(), "s2".into(), "s3".into()],
+    });
+
+    // Bound the WHOLE run so a regression manifests as a test timeout, not a
+    // hung CI job. The fix must terminate well within this window.
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        exec.run_with_handlers(
+            dot,
+            "user-input",
+            &serde_json::Map::new(),
+            handlers_for(handler),
+        ),
+    )
+    .await;
+
+    let result = result.expect(
+        "pipeline wedged: a fan-out whose children never resolve hung the whole \
+         pipeline (join_all blocked forever) — this is the production bug",
+    );
+    let result = result.expect("pipeline run returned an error result");
+
+    assert!(
+        !result.success,
+        "a fan-out node whose every child failed must FAIL the pipeline, got success={}",
+        result.success
+    );
+    // The hung children must never have fed the converge node: `merge` must NOT
+    // have run on a usable-input path.
+    assert!(
+        result.output.contains("all 3 workers failed")
+            || result.output.to_lowercase().contains("failed"),
+        "expected an all-workers-failed failure message, got: {}",
+        result.output
+    );
+}
+
+/// A SINGLE hung child among otherwise-passing siblings must also TERMINATE in
+/// bounded time (the hang is gone) — but here the fault-tolerant
+/// "synthesize from what worked" path is preserved: the pipeline still
+/// converges and succeeds because ≥1 worker passed. This pins that the
+/// deadline fix did not turn every partial failure into a pipeline failure.
+#[tokio::test]
+async fn parallel_fanout_partial_failure_still_converges() {
+    let dir = TempDir::new().unwrap();
+    let exec = make_executor(&dir).await;
+
+    let dot = r#"digraph fanout {
+        fan  [handler="parallel", converge="merge"]
+        good [handler="codergen", tools=read_file, prompt="good", timeout_secs="2"]
+        bad  [handler="codergen", tools=read_file, prompt="bad",  timeout_secs="2"]
+        merge [handler="codergen", tools=read_file, prompt="merge"]
+        fan -> good
+        fan -> bad
+        good -> merge
+        bad -> merge
+    }"#;
+
+    let handler = Arc::new(HangingWorkerHandler {
+        hang_nodes: vec!["bad".into()],
+    });
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        exec.run_with_handlers(
+            dot,
+            "user-input",
+            &serde_json::Map::new(),
+            handlers_for(handler),
+        ),
+    )
+    .await
+    .expect("pipeline wedged on a single hung child — the bound did not fire")
+    .expect("pipeline run returned an error result");
+
+    // ≥1 worker passed, so the fault-tolerant convergence runs and succeeds.
+    assert!(
+        result.success,
+        "a partial fan-out failure (≥1 worker passed) must still converge and \
+         succeed (fault tolerance preserved), got success={} output={}",
+        result.success, result.output
+    );
+}


### PR DESCRIPTION
## The bug (observed live on a deployed box)

A `deep_research` pipeline's **`search` node is a fan-out**. One child's underlying work failed (its `web_search` died — DuckDuckGo 403, no API keys). Instead of failing the node, the pipeline got **permanently stuck**:

- the server logged every 5s: `ignoring late mark_runtime_state: task already in terminal state … current_status="failed" … attempted_runtime_state=ExecutingTool`
- the heartbeat logged forever: `Pipeline 'deep_research' running: search (0/3 nodes, 1525s elapsed, estimating…)` — 25+ minutes, **0 of 3 fan-out children ever completing**, pipeline never terminating, every attached client hung.

## Root cause (precise)

`crates/octos-pipeline/src/executor.rs` — the fan-out worker futures are `join_all`-awaited with **no deadline guard**:

- static `parallel` site (`execute_with_retries_static`, ~L2526)
- `dynamic_parallel` site (`execute_with_retries_static`, ~L2961) — this **is** the `deep_research` path

The single-node path (`dispatch_node`, ~L3652) already wraps execution in `tokio::time::timeout`; the fan-out path did not. So a child whose future never resolves (in prod: the worker Agent stuck after its `web_search` sub-task went terminal `Failed`, still re-emitting `ExecutingTool` progress every 5s) **blocks `join_all` forever** → the fan-out node never converges → `nodes_done` stays at 0 → the pipeline never terminates.

Secondary defect: the converged fan-out outcome was recorded as `Fail`-but-continue **even when EVERY child failed**, so a fully-wedged fan-out (`0/3`) could never fail the pipeline — it would silently converge on empty content.

## The fix

1. **Bound every fan-out worker** in `tokio::time::timeout` via a new `fanout_worker_deadline(node)` helper — priority `deadline_secs` → `timeout_secs` → absolute `MAX_FANOUT_WORKER_SECS` (1h) ceiling. **Never unbounded.** A hung worker now resolves to an `Err`, which `process_worker_results` already converts into a branch failure. This gives the fan-out path the same fail-closed guarantee the single-node path always had.
2. **All-failed → terminate.** When no worker passes (the `search (0/3 nodes)` total-wedge), the fan-out node now surfaces a hard `OutcomeStatus::Error` and the pipeline stops, instead of converging on empty content. A **partial** failure (≥1 pass) still converges and succeeds — the fault-tolerant "synthesize from what worked" behaviour of `deep_research` is preserved.

## Tests (TDD red → green)

New `crates/octos-pipeline/tests/fanout_failed_task_no_hang.rs` drives the **real fan-out path** with an injected handler whose worker future hangs forever (`std::future::pending`):

- `parallel_fanout_all_children_hung_terminates_with_failure` — all children hang → pipeline **terminates with failure in ~2s** (was a 30s+ hang; the outer test timeout was the only thing that unblocked it before the fix). Asserts `!success`.
- `parallel_fanout_partial_failure_still_converges` — one hung child among passers → still converges and succeeds (locks in no regression of fault tolerance).
- `fanout_worker_deadline_priority_and_clamp` (unit) — helper priority + clamp.

The RED run reproduced the production wedge exactly: `pipeline wedged … join_all blocked forever`.

## Why the split is executor-only

The `task_supervisor` guard that logs `ignoring late mark_runtime_state` is **correct** — it must refuse to flip an already-terminal task back to `ExecutingTool`. The missing observation was in the executor: the fan-out never gave a hung child a terminal escape hatch, so the node never transitioned. No supervisor change was needed.

## Verification

- `cargo test -p octos-pipeline` — all 17 binaries `ok`, 0 failed (incl. dag_scheduler 20/20, deadline_enforcement 4/4, dynamic_pipeline_enum 14/14, workspace_contract 10/10, new fanout 2/2).
- `cargo test -p octos-agent` — 1908 passed; the only failure is a **pre-existing, environment-dependent** macOS firmlink tmpdir test (`tools::path_tests::test_resolve_macos_firmlink_form_inside_upload_root`) that fails identically on the clean baseline (this dev box overrides `TMPDIR` to `/private/tmp/claude-501/…` instead of `/var/folders/…`) — unrelated to this change.
- `cargo clippy -p octos-pipeline -p octos-agent --all-targets` — no warnings.
- `cargo fmt --all -- --check` — clean.