### PR TITLE
fix(api): unlink reasoning-effort sidecar on session/delete

### DIFF
--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -1563,6 +1563,23 @@ pub async fn delete_session(
                     "delete session from profile-scoped store failed"
                 );
             }
+            // `SessionManager::clear` removes only the chat JSONL. The
+            // per-session reasoning/thinking effort lives in a sidecar
+            // (`<topic>.reasoning_effort.json`) next to it, keyed off the same
+            // `data_dir`. Without this unlink a deleted session's stale effort
+            // is resurrected on the next `session/open` of the same key. The
+            // helper reuses `reasoning_effort_path` so the encoding matches, and
+            // is best-effort/idempotent (missing file = `Ok(())`).
+            let data_dir = sess.data_dir();
+            if let Err(e) =
+                super::ui_protocol_reasoning_effort::clear_reasoning_effort(&data_dir, &key)
+            {
+                tracing::warn!(
+                    session_key = %key,
+                    error = %e,
+                    "failed to clear per-session reasoning_effort sidecar on delete"
+                );
+            }
         }
     }
 
@@ -5277,6 +5294,68 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
         let fresh = octos_bus::SessionManager::open(data_dir.path()).unwrap();
         assert!(fresh.load(&topic_key).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_session_removes_persisted_reasoning_effort_sidecar() {
+        // Regression: `/thinking` persists a per-session reasoning-effort
+        // sidecar (`<topic>.reasoning_effort.json`) next to the session JSONL.
+        // The delete path previously removed only the JSONL, so a later
+        // `session/open` of the same key resurrected the stale effort for an
+        // otherwise-fresh session. Deleting the session must unlink the sidecar.
+        use crate::api::ui_protocol_reasoning_effort::{
+            read_reasoning_effort, reasoning_effort_path, write_reasoning_effort,
+        };
+        use octos_core::ui_protocol::ReasoningEffortLevel;
+
+        let data_dir = tempfile::tempdir().unwrap();
+        let sessions = std::sync::Arc::new(tokio::sync::Mutex::new(
+            octos_bus::SessionManager::open(data_dir.path()).unwrap(),
+        ));
+        let topic_key =
+            SessionKey::with_profile_topic(MAIN_PROFILE_ID, "api", "web-topic", "research");
+        {
+            let mut sess = sessions.lock().await;
+            sess.add_message(&topic_key, Message::user("topic"))
+                .await
+                .unwrap();
+            assert!(sess.load(&topic_key).await.is_some());
+        }
+
+        // The `data_dir` the reasoning-effort store keys against is the
+        // SessionManager's own `data_dir()` (same root the turn/open paths use).
+        let effort_data_dir = sessions.lock().await.data_dir();
+        write_reasoning_effort(&effort_data_dir, &topic_key, ReasoningEffortLevel::High)
+            .expect("seed reasoning effort sidecar");
+        let sidecar = reasoning_effort_path(&effort_data_dir, &topic_key);
+        assert!(sidecar.exists(), "sidecar should exist before delete");
+
+        let state = std::sync::Arc::new(AppState {
+            sessions: Some(sessions),
+            ..AppState::empty_for_tests()
+        });
+
+        let response = delete_session(
+            State(state),
+            HeaderMap::new(),
+            None,
+            axum::extract::Path("web-topic#research".to_string()),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        assert!(
+            !sidecar.exists(),
+            "delete must unlink the reasoning-effort sidecar at {}",
+            sidecar.display()
+        );
+        // And a subsequent read (what session/open does) must NOT resurrect the
+        // old effort for the now-deleted session.
+        assert_eq!(
+            read_reasoning_effort(&effort_data_dir, &topic_key),
+            None,
+            "stale reasoning effort must not be resurrected after delete"
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -1563,23 +1563,26 @@ pub async fn delete_session(
                     "delete session from profile-scoped store failed"
                 );
             }
-            // `SessionManager::clear` removes only the chat JSONL. The
-            // per-session reasoning/thinking effort lives in a sidecar
-            // (`<topic>.reasoning_effort.json`) next to it, keyed off the same
-            // `data_dir`. Without this unlink a deleted session's stale effort
-            // is resurrected on the next `session/open` of the same key. The
-            // helper reuses `reasoning_effort_path` so the encoding matches, and
-            // is best-effort/idempotent (missing file = `Ok(())`).
-            let data_dir = sess.data_dir();
-            if let Err(e) =
-                super::ui_protocol_reasoning_effort::clear_reasoning_effort(&data_dir, &key)
-            {
-                tracing::warn!(
-                    session_key = %key,
-                    error = %e,
-                    "failed to clear per-session reasoning_effort sidecar on delete"
-                );
-            }
+        }
+        // `SessionManager::clear` removes only the chat JSONL. The
+        // per-session reasoning/thinking effort lives in a sidecar
+        // (`<topic>.reasoning_effort.json`) next to it, keyed off the same
+        // `data_dir`. Clear it for every candidate INDEPENDENTLY of whether a
+        // chat JSONL loaded: a sidecar can outlive its JSONL — an older delete
+        // that left it behind, or a `session/open` that wrote the sidecar for
+        // an otherwise-fresh key before any message was persisted. Without this
+        // unlink a deleted session's stale effort is resurrected on the next
+        // `session/open` of the same key. The helper reuses
+        // `reasoning_effort_path` so the encoding matches, and is
+        // best-effort/idempotent (missing file = `Ok(())`).
+        let data_dir = sess.data_dir();
+        if let Err(e) = super::ui_protocol_reasoning_effort::clear_reasoning_effort(&data_dir, &key)
+        {
+            tracing::warn!(
+                session_key = %key,
+                error = %e,
+                "failed to clear per-session reasoning_effort sidecar on delete"
+            );
         }
     }
 
@@ -5355,6 +5358,63 @@ mod tests {
             read_reasoning_effort(&effort_data_dir, &topic_key),
             None,
             "stale reasoning effort must not be resurrected after delete"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_session_removes_reasoning_effort_sidecar_without_jsonl() {
+        // Codex #1428 P2: a reasoning-effort sidecar can exist WITHOUT a chat
+        // JSONL — an older delete left it behind, or `session/open` wrote it for
+        // an otherwise-fresh key before any message was persisted. The unlink
+        // must run per candidate regardless of whether `sess.load` finds a
+        // JSONL, else the stale effort is resurrected on the next open.
+        use crate::api::ui_protocol_reasoning_effort::{
+            read_reasoning_effort, reasoning_effort_path, write_reasoning_effort,
+        };
+        use octos_core::ui_protocol::ReasoningEffortLevel;
+
+        let data_dir = tempfile::tempdir().unwrap();
+        let sessions = std::sync::Arc::new(tokio::sync::Mutex::new(
+            octos_bus::SessionManager::open(data_dir.path()).unwrap(),
+        ));
+        let topic_key =
+            SessionKey::with_profile_topic(MAIN_PROFILE_ID, "api", "web-topic", "research");
+
+        // Deliberately NO `add_message`: there is no chat JSONL for this key, so
+        // `sess.load(&key)` returns None and the old (nested) cleanup was skipped.
+        let effort_data_dir = sessions.lock().await.data_dir();
+        assert!(
+            sessions.lock().await.load(&topic_key).await.is_none(),
+            "precondition: no chat JSONL for this key"
+        );
+        write_reasoning_effort(&effort_data_dir, &topic_key, ReasoningEffortLevel::High)
+            .expect("seed reasoning effort sidecar");
+        let sidecar = reasoning_effort_path(&effort_data_dir, &topic_key);
+        assert!(sidecar.exists(), "sidecar should exist before delete");
+
+        let state = std::sync::Arc::new(AppState {
+            sessions: Some(sessions),
+            ..AppState::empty_for_tests()
+        });
+
+        let response = delete_session(
+            State(state),
+            HeaderMap::new(),
+            None,
+            axum::extract::Path("web-topic#research".to_string()),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        assert!(
+            !sidecar.exists(),
+            "delete must unlink the sidecar even with no chat JSONL, at {}",
+            sidecar.display()
+        );
+        assert_eq!(
+            read_reasoning_effort(&effort_data_dir, &topic_key),
+            None,
+            "stale reasoning effort must not survive a JSONL-less delete"
         );
     }
 


### PR DESCRIPTION
## Problem

The per-session `/thinking` reasoning-effort is persisted to a sidecar file at `<data_dir>/users/<encoded base>/sessions/<encoded topic>.reasoning_effort.json` (see `ui_protocol_reasoning_effort.rs`), a sibling of the session JSONL.

The `session/delete` path (`delete_session` → `SessionManager::clear`) removes **only** the chat JSONL (flat + per-user layout) and never touches the reasoning-effort sidecar. So:

1. Set `/thinking high` on a session.
2. Delete the session via `session/delete`.
3. `session/open` the same key.

→ the stale `.reasoning_effort.json` is read back and the old effort is **resurrected** for an otherwise-fresh session (`open_session_result` reads it via `read_reasoning_effort_async`).

## Fix

Wire the already-existing `clear_reasoning_effort(...)` helper into the delete path in `delete_session` (`crates/octos-cli/src/api/handlers.rs`), inside the per-candidate-key loop where the session JSONL is cleared. It:

- reuses the existing `reasoning_effort_path` helper (via `clear_reasoning_effort`) so the path encoding matches the persist/read sites exactly — no hand-rolled path,
- keys off the locked `SessionManager`'s own `data_dir()` (same root the turn/open paths use),
- is best-effort and idempotent (`NotFound` → `Ok(())`), and logs (never aborts the delete) on a real IO error.

## Test

RED → GREEN unit test `delete_session_removes_persisted_reasoning_effort_sidecar` (models the existing `delete_session_accepts_listed_topic_session_id_from_standalone_store` scaffolding): seeds a reasoning-effort sidecar for a session key, runs `delete_session`, and asserts (a) the sidecar file is gone and (b) a subsequent `read_reasoning_effort` returns `None` (no resurrection).

- `cargo test -p octos-cli --features api`: lib green (1554 passed; new test passes; the previously-failing run was the unrelated flaky `background_failure_recovery_capped_at_max_retries`, confirmed flaky on baseline too).
- `cargo clippy -p octos-cli --features api --lib`: no new warnings (50 → 50, identical to baseline; none on the touched lines).
- `cargo fmt --all -- --check`: clean.

Pre-existing unrelated failure ignored per task scope: the macOS `/tmp` vs `/private/tmp` firmlink mismatch in `coding_multi_session::coding_agent_two_sessions_isolated_workspaces` reproduces identically on baseline with this change stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)