### PR TITLE
fix(interrupt): turn/interrupt aborts running spawn_only pipelines

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -695,6 +695,18 @@ impl Agent {
                 // completion: the body's own terminal mark wins; Drop no-ops.
                 let terminal_guard = TaskTerminalGuard::new(bg_supervisor.clone(), task_id.clone());
                 let task_id_for_handle = task_id.clone();
+                // Esc/`/stop`/`turn/interrupt` cancellation: acquire the
+                // supervisor's per-task cancel token in the FOREGROUND (so it
+                // exists before any `supervisor.cancel(task_id)` race) and move
+                // it into the detached worker. Without this the spawn_only
+                // background task — a `run_pipeline` / `deep_research` fan-out —
+                // runs to completion regardless of a turn interrupt: aborting
+                // the foreground agent loop never touches this independent
+                // `tokio::spawn`, and the body never polled a cancel signal. We
+                // race the tool future against `cancel_token.cancelled()` below
+                // so the in-flight pipeline/LLM/web_search await is DROPPED at
+                // the next poll and the worker terminates promptly.
+                let cancel_token = bg_supervisor.cancel_token(&task_id);
                 tokio::spawn(async move {
                     let _terminal_guard = terminal_guard;
                     bg_supervisor.mark_running(&task_id);
@@ -775,12 +787,50 @@ impl Agent {
                     // `file_state_cache` through to the tool. The TOOL_CTX
                     // scope still wraps the call so plugin/MCP tools that
                     // read the task-local see the same fields.
-                    let mut result = TOOL_CTX
-                        .scope(
+                    let mut result = {
+                        // Bind the inner ctx to a `let` so the `&exec_ctx`
+                        // borrow lives across the `select!` (the previous
+                        // inline `&make_ctx()` temporary was freed at the end
+                        // of the statement, which the longer-lived `exec`
+                        // future would outlive).
+                        let exec_ctx = make_ctx();
+                        let exec = TOOL_CTX.scope(
                             make_ctx(),
-                            bg_tools.execute_with_context(&make_ctx(), &bg_name, &bg_args),
-                        )
-                        .await;
+                            bg_tools.execute_with_context(&exec_ctx, &bg_name, &bg_args),
+                        );
+                        tokio::select! {
+                            biased;
+                            // Interrupt won the race: a `turn/interrupt` (or any
+                            // `supervisor.cancel(task_id)`) fired the token while
+                            // the tool was mid-await. Drop `exec` (the pipeline /
+                            // LLM / web_search future) on the spot and short-
+                            // circuit the worker so a hung pipeline stops promptly
+                            // instead of running to completion.
+                            _ = cancel_token.cancelled() => {
+                                tracing::info!(
+                                    tool = %bg_name,
+                                    task_id = %task_id,
+                                    "spawn_only background tool cancelled (turn interrupt)"
+                                );
+                                // `supervisor.cancel` already transitioned the
+                                // record to `Cancelled`; mark again defensively
+                                // for the path where the token fires without a
+                                // supervisor transition (idempotent — the
+                                // terminal guard inside `mark_*` no-ops on an
+                                // already-terminal task).
+                                bg_supervisor.mark_failed(&task_id, "cancelled by turn interrupt".to_string());
+                                if let Some(ref router) = bg_output_router {
+                                    let _ = router.append(
+                                        bg_session_id_for_watcher.as_str(),
+                                        task_id.as_str(),
+                                        b"[cancelled] turn interrupted by client\n",
+                                    );
+                                }
+                                return;
+                            }
+                            res = exec => res,
+                        }
+                    };
 
                     // M8.7 (item 4): route the tool's textual output to
                     // the router so it lands on disk for the dashboard
@@ -808,13 +858,38 @@ impl Agent {
                                 || r.output.contains("connection refused"))
                         {
                             tracing::warn!(tool = %bg_name, "spawn_only tool failed (transient), retrying in 5s");
-                            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                            result = TOOL_CTX
-                                .scope(
-                                    make_ctx(),
-                                    bg_tools.execute_with_context(&make_ctx(), &bg_name, &bg_args),
-                                )
-                                .await;
+                            // Cancel-aware backoff + retry: a `turn/interrupt`
+                            // during the 5s wait or the retried execute must
+                            // still abort the worker rather than soldier on.
+                            let retry = async {
+                                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                                TOOL_CTX
+                                    .scope(
+                                        make_ctx(),
+                                        bg_tools.execute_with_context(
+                                            &make_ctx(),
+                                            &bg_name,
+                                            &bg_args,
+                                        ),
+                                    )
+                                    .await
+                            };
+                            tokio::select! {
+                                biased;
+                                _ = cancel_token.cancelled() => {
+                                    tracing::info!(
+                                        tool = %bg_name,
+                                        task_id = %task_id,
+                                        "spawn_only background tool cancelled during retry (turn interrupt)"
+                                    );
+                                    bg_supervisor
+                                        .mark_failed(&task_id, "cancelled by turn interrupt".to_string());
+                                    return;
+                                }
+                                res = retry => {
+                                    result = res;
+                                }
+                            }
                         }
                     }
 

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -825,6 +825,16 @@ impl Agent {
                                         task_id.as_str(),
                                         b"[cancelled] turn interrupted by client\n",
                                     );
+                                    // Codex #1429 P2: a cancelled spawn_only task must run
+                                    // the same terminal teardown as the completion path.
+                                    // Otherwise the output handle stays in the running
+                                    // phase and the summary watcher keeps polling —
+                                    // AgentSummaryGenerator does NOT treat `Cancelled` as
+                                    // terminal, so it would re-summarise an aborted task.
+                                    router.mark_terminal(&task_id);
+                                }
+                                if let Some(ref summary_gen) = bg_summary_generator {
+                                    summary_gen.stop_watcher(&task_id);
                                 }
                                 return;
                             }
@@ -884,6 +894,16 @@ impl Agent {
                                     );
                                     bg_supervisor
                                         .mark_failed(&task_id, "cancelled by turn interrupt".to_string());
+                                    // Codex #1429 P2: same terminal teardown as the
+                                    // completion path so a task cancelled during the
+                                    // transient-retry wait doesn't leave its output
+                                    // handle running / summary watcher registered.
+                                    if let Some(ref router) = bg_output_router {
+                                        router.mark_terminal(&task_id);
+                                    }
+                                    if let Some(ref summary_gen) = bg_summary_generator {
+                                        summary_gen.stop_watcher(&task_id);
+                                    }
                                     return;
                                 }
                                 res = retry => {

--- a/crates/octos-agent/tests/spawn_only_interrupt_cancellation.rs
+++ b/crates/octos-agent/tests/spawn_only_interrupt_cancellation.rs
@@ -290,3 +290,131 @@ async fn supervisor_cancel_aborts_running_spawn_only_task() {
          interrupt). Status flipped to Cancelled but the work never stopped."
     );
 }
+
+/// Codex #1429 P2: when a `SubAgentOutputRouter` is configured, the cancel arm
+/// must run the SAME terminal teardown as the completion path
+/// (`router.mark_terminal`). On the unfixed cancel arm the worker `return`ed
+/// early, leaving the output handle stuck in the Running phase — so dashboards
+/// show the task running forever and `AgentSummaryGenerator` (which does NOT
+/// treat `Cancelled` as terminal) keeps polling an aborted task.
+#[tokio::test]
+async fn cancel_runs_terminal_teardown_for_routed_spawn_only_task() {
+    let memory_dir = TempDir::new().unwrap();
+    let router_dir = TempDir::new().unwrap();
+
+    let entered = Arc::new(AtomicBool::new(false));
+    let completed = Arc::new(AtomicBool::new(false));
+    let dropped_while_running = Arc::new(AtomicBool::new(false));
+    let probe = HangingTool {
+        name: "hang_bg",
+        entered: entered.clone(),
+        completed: completed.clone(),
+        dropped_while_running: dropped_while_running.clone(),
+        block_for: Duration::from_secs(30),
+    };
+
+    let mut tools = ToolRegistry::new();
+    tools.register(probe);
+    tools.mark_spawn_only("hang_bg", None);
+
+    let memory = open_memory(&memory_dir).await;
+    let llm: Arc<dyn LlmProvider> = Arc::new(ScriptedLlm::new(vec![
+        tool_use(vec![tc("call-hang", "hang_bg")]),
+        end_turn("kicked off the background pipeline"),
+    ]));
+
+    // The load-bearing addition vs. the abort test: a real output router, so
+    // the cancel arm actually has terminal teardown to run (or skip, pre-fix).
+    // The worker seeds a startup line via `router.append` before the tool runs,
+    // creating the handle in the Running phase.
+    let router = Arc::new(octos_agent::SubAgentOutputRouter::new(router_dir.path()));
+
+    let agent = Agent::new(AgentId::new("interrupt-teardown"), llm, tools, memory)
+        .with_config(AgentConfig {
+            save_episodes: false,
+            suppress_auto_send_files: true,
+            ..Default::default()
+        })
+        .with_subagent_output_router(router.clone());
+
+    let supervisor = agent.tool_registry().supervisor();
+    let captured_id: Arc<std::sync::Mutex<Option<String>>> = Arc::new(std::sync::Mutex::new(None));
+    {
+        let captured_id = captured_id.clone();
+        supervisor.set_on_change(move |task| {
+            if task.tool_name == "hang_bg" {
+                *captured_id.lock().unwrap() = Some(task.id.clone());
+            }
+        });
+    }
+
+    let _ = agent
+        .process_message("kick the hanging spawn_only pipeline", &[], vec![])
+        .await
+        .expect("agent loop should not error launching a spawn_only tool");
+
+    let mut waited = Duration::ZERO;
+    while !entered.load(Ordering::SeqCst) && waited < Duration::from_secs(5) {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        waited += Duration::from_millis(10);
+    }
+    assert!(
+        entered.load(Ordering::SeqCst),
+        "background spawn_only tool body never started"
+    );
+
+    let task_id = captured_id
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("supervisor must have registered the spawn_only task id");
+
+    // Precondition: the routed handle is Running (not terminal) before cancel.
+    assert!(
+        !router.is_terminal(&task_id),
+        "routed output handle should be Running before cancel"
+    );
+
+    supervisor
+        .cancel(&task_id)
+        .expect("cancel of a running task must succeed");
+
+    // Wait for terminal `Cancelled` status (bounded).
+    let mut waited = Duration::ZERO;
+    let deadline = Duration::from_secs(3);
+    loop {
+        let cancelled = supervisor
+            .get_task(&task_id)
+            .map(|t| matches!(t.status, octos_agent::TaskStatus::Cancelled))
+            .unwrap_or(false);
+        if cancelled {
+            break;
+        }
+        assert!(
+            waited < deadline,
+            "task did not reach terminal Cancelled within {deadline:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        waited += Duration::from_millis(20);
+    }
+
+    // THE P2 ASSERTION: the cancel arm must have run the terminal teardown, so
+    // the routed output handle is flagged Terminal. Pre-fix the cancel arm
+    // `return`ed before `router.mark_terminal`, leaving it stuck Running (the
+    // worker runs the teardown just after the token fires, so poll briefly).
+    let mut waited = Duration::ZERO;
+    while !router.is_terminal(&task_id) && waited < Duration::from_secs(1) {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        waited += Duration::from_millis(20);
+    }
+    assert!(
+        router.is_terminal(&task_id),
+        "cancelled spawn_only task left its output handle in the Running phase — \
+         the cancel arm skipped router.mark_terminal (codex #1429 P2)"
+    );
+    // The abort itself still holds (the tool body did not run to completion).
+    assert!(
+        !completed.load(Ordering::SeqCst),
+        "tool body ran to completion despite cancel"
+    );
+}

--- a/crates/octos-agent/tests/spawn_only_interrupt_cancellation.rs
+++ b/crates/octos-agent/tests/spawn_only_interrupt_cancellation.rs
@@ -1,0 +1,292 @@
+//! Regression: a `turn/interrupt` (or any `supervisor.cancel(task_id)`) must
+//! actually ABORT the still-running spawn_only background task — not merely
+//! flip its dashboard status while the detached `tokio::spawn` body keeps
+//! executing to completion.
+//!
+//! Origin: the user-reported "pressing Esc / `/stop` does not break a running
+//! turn" bug. The serve `turn/interrupt` handler aborts the foreground agent
+//! loop, but a `spawn_only` tool (`run_pipeline` / `deep_research`) detaches
+//! into its OWN `tokio::spawn` task whose `JoinHandle` is dropped, not awaited.
+//! Aborting the agent loop never touched it, and the background body never
+//! polled the supervisor's per-task cancel token — so a hung `deep_research`
+//! pipeline kept running for minutes after the user asked to stop.
+//!
+//! Contract pinned here: when the supervisor cancels a running spawn_only
+//! task, the detached worker's tool future is DROPPED at the next safe point
+//! and the task reaches the terminal `Cancelled` state PROMPTLY — the
+//! long-running tool body must NOT run to completion.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use octos_agent::{Agent, AgentConfig, Tool, ToolRegistry, ToolResult};
+use octos_core::{AgentId, Message, ToolCall};
+use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, TokenUsage, ToolSpec};
+use octos_memory::EpisodeStore;
+use tempfile::TempDir;
+
+struct ScriptedLlm {
+    responses: std::sync::Mutex<Vec<ChatResponse>>,
+}
+
+impl ScriptedLlm {
+    fn new(responses: Vec<ChatResponse>) -> Self {
+        Self {
+            responses: std::sync::Mutex::new(responses),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for ScriptedLlm {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> eyre::Result<ChatResponse> {
+        let mut r = self.responses.lock().unwrap();
+        if r.is_empty() {
+            eyre::bail!("ScriptedLlm: no more responses");
+        }
+        Ok(r.remove(0))
+    }
+    fn context_window(&self) -> u32 {
+        128_000
+    }
+    fn model_id(&self) -> &str {
+        "interrupt-cancel-test"
+    }
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+/// Flips `dropped_while_running` if the future it lives in is dropped before
+/// the body marks itself complete. This is the load-bearing signal: a real
+/// cooperative abort DROPS the tool future mid-`await`; a status-only "cancel"
+/// that leaves the detached `tokio::spawn` body alive never drops it.
+struct AbortSentinel {
+    dropped_while_running: Arc<AtomicBool>,
+    finished: bool,
+}
+
+impl Drop for AbortSentinel {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.dropped_while_running.store(true, Ordering::SeqCst);
+        }
+    }
+}
+
+/// A spawn_only tool whose `execute` blocks for a long time (simulating a hung
+/// `deep_research` pipeline). It sets `entered` once it starts and `completed`
+/// only if it runs all the way to the end without being aborted. The
+/// `AbortSentinel` independently records whether the future was DROPPED
+/// mid-flight (the real-abort signal) vs. merely left running.
+struct HangingTool {
+    name: &'static str,
+    entered: Arc<AtomicBool>,
+    completed: Arc<AtomicBool>,
+    dropped_while_running: Arc<AtomicBool>,
+    block_for: Duration,
+}
+
+#[async_trait]
+impl Tool for HangingTool {
+    fn name(&self) -> &str {
+        self.name
+    }
+    fn description(&self) -> &str {
+        "spawn_only hang probe"
+    }
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+    async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+        let mut sentinel = AbortSentinel {
+            dropped_while_running: self.dropped_while_running.clone(),
+            finished: false,
+        };
+        self.entered.store(true, Ordering::SeqCst);
+        // Simulate a long-running pipeline (deep_research fan-out). A
+        // cooperative cancel must DROP this future before it finishes.
+        tokio::time::sleep(self.block_for).await;
+        sentinel.finished = true;
+        self.completed.store(true, Ordering::SeqCst);
+        Ok(ToolResult {
+            output: format!("{} ran to completion\n", self.name),
+            success: true,
+            ..Default::default()
+        })
+    }
+}
+
+fn tool_use(calls: Vec<ToolCall>) -> ChatResponse {
+    ChatResponse {
+        content: None,
+        reasoning_content: None,
+        tool_calls: calls,
+        stop_reason: StopReason::ToolUse,
+        usage: TokenUsage {
+            input_tokens: 50,
+            output_tokens: 5,
+            ..Default::default()
+        },
+        provider_index: None,
+    }
+}
+
+fn end_turn(text: &str) -> ChatResponse {
+    ChatResponse {
+        content: Some(text.into()),
+        reasoning_content: None,
+        tool_calls: vec![],
+        stop_reason: StopReason::EndTurn,
+        usage: TokenUsage {
+            input_tokens: 5,
+            output_tokens: 5,
+            ..Default::default()
+        },
+        provider_index: None,
+    }
+}
+
+fn tc(id: &str, name: &str) -> ToolCall {
+    ToolCall {
+        id: id.into(),
+        name: name.into(),
+        arguments: serde_json::json!({}),
+        metadata: None,
+    }
+}
+
+async fn open_memory(dir: &TempDir) -> Arc<EpisodeStore> {
+    Arc::new(EpisodeStore::open(dir.path().join(".octos")).await.unwrap())
+}
+
+#[tokio::test]
+async fn supervisor_cancel_aborts_running_spawn_only_task() {
+    let memory_dir = TempDir::new().unwrap();
+
+    let entered = Arc::new(AtomicBool::new(false));
+    let completed = Arc::new(AtomicBool::new(false));
+    let dropped_while_running = Arc::new(AtomicBool::new(false));
+    let probe = HangingTool {
+        name: "hang_bg",
+        entered: entered.clone(),
+        completed: completed.clone(),
+        dropped_while_running: dropped_while_running.clone(),
+        // Long enough that, absent cancellation, the body is still running
+        // well past the bounded interrupt window we assert below.
+        block_for: Duration::from_secs(30),
+    };
+
+    let mut tools = ToolRegistry::new();
+    tools.register(probe);
+    tools.mark_spawn_only("hang_bg", None);
+
+    let memory = open_memory(&memory_dir).await;
+    let llm: Arc<dyn LlmProvider> = Arc::new(ScriptedLlm::new(vec![
+        tool_use(vec![tc("call-hang", "hang_bg")]),
+        end_turn("kicked off the background pipeline"),
+    ]));
+
+    let agent =
+        Agent::new(AgentId::new("interrupt-cancel"), llm, tools, memory).with_config(AgentConfig {
+            save_episodes: false,
+            suppress_auto_send_files: true,
+            ..Default::default()
+        });
+
+    // Capture the supervisor-assigned task_id the moment the background task
+    // is registered / starts running. spawn_only registers a `Spawned` row in
+    // the foreground before `tokio::spawn`, so `on_change` fires with the id.
+    let supervisor = agent.tool_registry().supervisor();
+    let captured_id: Arc<std::sync::Mutex<Option<String>>> = Arc::new(std::sync::Mutex::new(None));
+    {
+        let captured_id = captured_id.clone();
+        supervisor.set_on_change(move |task| {
+            if task.tool_name == "hang_bg" {
+                *captured_id.lock().unwrap() = Some(task.id.clone());
+            }
+        });
+    }
+
+    // The agent main loop returns immediately: spawn_only detaches and the
+    // LLM's EndTurn finishes the foreground turn.
+    let _ = agent
+        .process_message("kick the hanging spawn_only pipeline", &[], vec![])
+        .await
+        .expect("agent loop should not error launching a spawn_only tool");
+
+    // Wait for the background tool body to actually enter (bounded).
+    let mut waited = Duration::ZERO;
+    while !entered.load(Ordering::SeqCst) && waited < Duration::from_secs(5) {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        waited += Duration::from_millis(10);
+    }
+    assert!(
+        entered.load(Ordering::SeqCst),
+        "background spawn_only tool body never started"
+    );
+
+    let task_id = captured_id
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("supervisor must have registered the spawn_only task id");
+
+    // === THE INTERRUPT === cancel the running task, exactly as the serve
+    // `turn/interrupt` path now does for a turn's spawn_only background work.
+    supervisor
+        .cancel(&task_id)
+        .expect("cancel of a running task must succeed");
+
+    // Within a BOUNDED window the detached worker must be aborted: its tool
+    // future is dropped at the cancel safe-point, so `completed` never flips
+    // and the supervisor record is terminal `Cancelled`.
+    let mut waited = Duration::ZERO;
+    let deadline = Duration::from_secs(3);
+    loop {
+        let task = supervisor.get_task(&task_id);
+        let is_cancelled = task
+            .as_ref()
+            .map(|t| matches!(t.status, octos_agent::TaskStatus::Cancelled))
+            .unwrap_or(false);
+        if is_cancelled {
+            break;
+        }
+        assert!(
+            waited < deadline,
+            "task did not reach terminal Cancelled within {deadline:?}; \
+             status={:?}",
+            task.map(|t| t.status)
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        waited += Duration::from_millis(20);
+    }
+
+    // The 30s tool body must have been DROPPED — it must not run to completion.
+    // Give it a brief grace window so the dropped-future Drop guard can fire.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(
+        !completed.load(Ordering::SeqCst),
+        "spawn_only tool body ran to completion despite supervisor.cancel — \
+         the detached worker ignored the cancel token (turn interrupt cannot \
+         break a running pipeline)"
+    );
+
+    // The load-bearing assertion: the tool future must actually have been
+    // DROPPED mid-flight. On unfixed HEAD `supervisor.cancel` only flips the
+    // dashboard status; the detached `tokio::spawn` body keeps sleeping its
+    // full 30s and the sentinel is never dropped, so this fails.
+    assert!(
+        dropped_while_running.load(Ordering::SeqCst),
+        "supervisor.cancel did NOT abort the detached spawn_only worker — its \
+         tool future is still alive and running (a hung pipeline survives the \
+         interrupt). Status flipped to Cancelled but the work never stopped."
+    );
+}

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -18256,6 +18256,19 @@ async fn run_standalone_turn(
     if interrupt_observed {
         // Stop the agent so any in-flight LLM/tool await unblocks promptly.
         agent_task.abort();
+        // Esc/`/stop`/`turn/interrupt` did not used to break a still-running
+        // `spawn_only` background task (e.g. `run_pipeline` / `deep_research`):
+        // those detach into their OWN `tokio::spawn` whose `JoinHandle` is
+        // dropped, not awaited, so `agent_task.abort()` above never touched
+        // them and a hung pipeline kept running for minutes after the user
+        // asked to stop. Cancel every non-terminal background task this
+        // session registered (turns are serialized per session, so the live
+        // ones belong to the turn being interrupted). `supervisor.cancel`
+        // fires the per-task cancel token the spawn_only worker now races
+        // against (`agent/execution.rs`), dropping the in-flight pipeline /
+        // LLM / web_search future at its next poll. Idempotent: already-
+        // terminal tasks return `AlreadyTerminal` and are skipped.
+        cancel_session_spawn_only_tasks(&tool_registry.supervisor(), &session_id);
         // FIX-04: also flush any accumulated drops before the lifecycle
         // terminal so the client knows the cursor is incomplete.
         flush_replay_lossy(&ws, &ledger, &session_id, &progress_dropped);
@@ -18627,6 +18640,32 @@ fn build_turn_session_result_from_done(event: &Value) -> Option<TurnSessionResul
         // picks up cmid naturally.
         client_message_id: None,
     })
+}
+
+/// Cancel every still-running `spawn_only` background task this session
+/// registered, on `turn/interrupt`.
+///
+/// Root cause this closes: a `spawn_only` tool (`run_pipeline` /
+/// `deep_research`) detaches into its OWN `tokio::spawn` whose `JoinHandle` is
+/// dropped, not awaited. The interrupt path's `agent_task.abort()` only stops
+/// the foreground agent loop, so a hung pipeline kept running for minutes
+/// after the user pressed Esc / `/stop`. `supervisor.cancel` fires each task's
+/// cancel token, which the spawn_only worker now races against
+/// (`octos-agent/src/agent/execution.rs`) and drops the in-flight pipeline /
+/// LLM / web_search future at its next poll.
+///
+/// Turns are serialized per session, so the live background tasks belong to
+/// the turn being interrupted. Already-terminal tasks are skipped
+/// (`cancel` would return `AlreadyTerminal`); the call is idempotent.
+fn cancel_session_spawn_only_tasks(
+    supervisor: &octos_agent::TaskSupervisor,
+    session_id: &SessionKey,
+) {
+    for task in supervisor.get_tasks_for_session(&session_id.to_string()) {
+        if !task.status.is_terminal() {
+            let _ = supervisor.cancel(&task.id);
+        }
+    }
 }
 
 /// Atomically transition the turn state to `Terminal(_)` exactly once.
@@ -29538,6 +29577,65 @@ ignore = []
         assert!(connection_turns.lock().await.is_empty());
         owned_handle.abort();
         newer_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn interrupt_cancels_running_spawn_only_tasks_for_session() {
+        // Root-cause regression: `turn/interrupt` must cancel the session's
+        // still-running spawn_only background tasks (a hung `run_pipeline` /
+        // `deep_research`), not only abort the foreground agent loop. The
+        // interrupt path calls `cancel_session_spawn_only_tasks`, which fires
+        // each task's supervisor cancel token so the detached worker drops its
+        // in-flight pipeline future at the next poll.
+        let supervisor = octos_agent::TaskSupervisor::new();
+        let session_id = SessionKey("api:profile/local:owned".into());
+        let session_key = session_id.to_string();
+
+        // Two live spawn_only tasks for THIS session and one for another
+        // session that must survive (turns are per-session; a sibling
+        // session's background work is unrelated to this interrupt).
+        let running_a = supervisor.register("run_pipeline", "tc-a", Some(&session_key));
+        let running_b = supervisor.register("deep_research", "tc-b", Some(&session_key));
+        supervisor.mark_running(&running_a);
+        supervisor.mark_running(&running_b);
+
+        let other_session = SessionKey("api:profile/local:other".into());
+        let other_running =
+            supervisor.register("run_pipeline", "tc-c", Some(&other_session.to_string()));
+        supervisor.mark_running(&other_running);
+
+        // An already-terminal task for this session: cancel must skip it
+        // (idempotent — `cancel` would otherwise return `AlreadyTerminal`).
+        let done = supervisor.register("run_pipeline", "tc-d", Some(&session_key));
+        supervisor.mark_completed(&done, vec![]);
+
+        cancel_session_spawn_only_tasks(&supervisor, &session_id);
+
+        // Both live tasks for this session are now terminal `Cancelled`,
+        // which fires their cancel tokens.
+        assert!(matches!(
+            supervisor.get_task(&running_a).map(|t| t.status),
+            Some(octos_agent::TaskStatus::Cancelled)
+        ));
+        assert!(supervisor.cancel_token(&running_a).is_cancelled());
+        assert!(matches!(
+            supervisor.get_task(&running_b).map(|t| t.status),
+            Some(octos_agent::TaskStatus::Cancelled)
+        ));
+        assert!(supervisor.cancel_token(&running_b).is_cancelled());
+
+        // The completed task is left intact (still `Completed`, not clobbered).
+        assert!(matches!(
+            supervisor.get_task(&done).map(|t| t.status),
+            Some(octos_agent::TaskStatus::Completed)
+        ));
+
+        // A different session's running task is untouched by this interrupt.
+        assert!(matches!(
+            supervisor.get_task(&other_running).map(|t| t.status),
+            Some(octos_agent::TaskStatus::Running)
+        ));
+        assert!(!supervisor.cancel_token(&other_running).is_cancelled());
     }
 
     /// Mirror of `handle_turn_interrupt`'s post-abort drain step. Used by


### PR DESCRIPTION
## Problem

Pressing **Esc / `/stop`** (`turn/interrupt`) did **not** break a running turn when that turn had launched a `spawn_only` tool — most importantly `run_pipeline` / `deep_research`. The turn kept running for minutes after the user asked to stop.

## Root cause (file:line)

- `spawn_only` tools detach into their **own** `tokio::spawn` (`crates/octos-agent/src/agent/execution.rs:698`) whose `JoinHandle` is dropped, not awaited.
- The serve interrupt path (`crates/octos-cli/src/api/ui_protocol.rs`, `run_standalone_turn` interrupt branch) only called `agent_task.abort()` — which stops the **foreground agent loop**, never the detached background task.
- The background worker never polled the supervisor's per-task **cancel token**, so even `supervisor.cancel()` only flipped the dashboard status while the hung pipeline kept executing. The token was only ever fired by the explicit task-stop tool (`coding_tools.rs:1752`), never by `turn/interrupt`.

Net effect: a hung `deep_research` pipeline could not be killed by the interrupt.

## Fix (cooperative cancellation, two parts)

1. **octos-agent** — the `spawn_only` worker now races its tool future against `supervisor.cancel_token(task_id).cancelled()`. The token is acquired in the **foreground** before `tokio::spawn` so it pre-dates any cancel race. On cancel the in-flight pipeline/LLM/web_search future is **dropped at the next poll** and the worker short-circuits. The transient-retry path is cancel-aware too.
2. **octos-cli** — the interrupt branch now calls a new `cancel_session_spawn_only_tasks`, cancelling every **non-terminal** background task this session registered. Turns are serialized per session, so the live tasks belong to the interrupted turn. Pairs with #1427's fan-out timeout: interrupt breaks a still-running pipeline rather than relying on a deadline.

## Tests (RED → GREEN)

- `supervisor_cancel_aborts_running_spawn_only_task` (octos-agent integration): a 30s hanging `spawn_only` tool is **dropped mid-flight** on cancel — a `Drop` sentinel proves the future actually died, not just a status flip. RED before part 1 (the body ran to its full 30s; status flipped to `Cancelled` but the work never stopped).
- `interrupt_cancels_running_spawn_only_tasks_for_session` (octos-cli lib): the interrupt step cancels this session's running tasks + fires their tokens, skips already-terminal tasks, and leaves a **sibling session's** running task untouched.

## Build / test / clippy

Off `origin/main` (eb48e7dc, includes #1427). New tests pass; `cargo clippy -p octos-agent --all-targets` and `-p octos-cli --features api --lib` clean; `octos-cli --features api --lib` 1547 pass / 0 fail; `octos-agent --lib` clean except the unrelated pre-existing `test_resolve_macos_firmlink_form_inside_upload_root` TMPDIR sandbox flake. `cargo fmt --check` clean on all touched files.

## Companion

The client-side `/esc` alias gap is fixed in octos-org/octos-tui (`/esc` was an unknown command). This PR is the server-side root-cause fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)