### PR TITLE
chore(dashboard): DeepSeek V4 — Official API endpoint + correct pro pricing

### DIFF
--- a/dashboard/src/providers.json
+++ b/dashboard/src/providers.json
@@ -115,10 +115,12 @@
   "deepseek": {
     "env": "DEEPSEEK_API_KEY",
     "models": [
-      { "id": "deepseek-v4-pro", "input": 0.28, "output": 0.42, "max_output": 384000, "endpoints": [
+      { "id": "deepseek-v4-pro", "input": 0.42, "output": 0.83, "max_output": 384000, "endpoints": [
+        { "id": "deepseek", "label": "Official API" },
         { "id": "autodl", "label": "AutoDL", "base_url": "https://www.autodl.art/api/v1", "api_key_env": "AUTODL_API_KEY" }
       ] },
       { "id": "deepseek-v4-flash", "input": 0.14, "output": 0.28, "max_output": 384000, "endpoints": [
+        { "id": "deepseek", "label": "Official API" },
         { "id": "autodl", "label": "AutoDL", "base_url": "https://www.autodl.art/api/v1", "api_key_env": "AUTODL_API_KEY" }
       ] }
     ]


### PR DESCRIPTION
Adds the **Official API** endpoint (api.deepseek.com) alongside AutoDL for both `deepseek-v4-pro` and `deepseek-v4-flash` in the admin provider catalog, and corrects v4-pro pricing to the official rate.

| model | input | output | max_output | endpoints |
|---|---|---|---|---|
| deepseek-v4-pro | $0.42 | $0.83 | 384000 | Official API · AutoDL |
| deepseek-v4-flash | $0.14 | $0.28 | 384000 | Official API · AutoDL |

Pricing from https://api-docs.deepseek.com/zh-cn/quick_start/pricing (¥3/¥6 pro, ¥1/¥2 flash cache-miss, converted CNY→USD ~7.2). max_output 384000 / ctx 1048576 from the model catalog. Model IDs confirmed by the docs' deprecation note (deepseek-chat/reasoner → v4-flash, sunset 2026-07-24).

Takes effect in /admin after `./scripts/build-dashboard.sh` + redeploy.