### PR TITLE
fix(release): drop phantom -p pipeline-guard (unbreaks the one-liner bundle build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CARGO_TERM_COLOR: always
   FEATURES: "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3"
-  SKILL_CRATES: "-p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather -p pipeline-guard -p skill-evolve"
+  SKILL_CRATES: "-p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather -p skill-evolve"
 
 jobs:
   dashboard:
@@ -498,7 +498,7 @@ jobs:
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather pipeline-guard; do
+          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-aarch64-apple-darwin.tar.gz *
@@ -526,7 +526,7 @@ jobs:
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather pipeline-guard; do
+          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-x86_64-unknown-linux-gnu.tar.gz *
@@ -556,7 +556,7 @@ jobs:
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather pipeline-guard; do
+          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-aarch64-unknown-linux-gnu.tar.gz *
@@ -587,7 +587,7 @@ jobs:
         shell: bash
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather pipeline-guard; do
+          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/${b}.exe" dist/ 2>/dev/null || true
           done
           cd dist && 7z a ../octos-bundle-x86_64-pc-windows-msvc.zip *

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -53,12 +53,12 @@ jobs:
         run: cargo build --release -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3"
 
       - name: Build app-skill binaries
-        run: cargo build --release -p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather -p pipeline-guard
+        run: cargo build --release -p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather
 
       - name: Bundle release tarball
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather pipeline-guard; do
+          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-aarch64-apple-darwin.tar.gz *

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   FEATURES: "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3"
-  SKILL_CRATES: "-p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather -p pipeline-guard"
+  SKILL_CRATES: "-p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather"
 
 jobs:
   build-macos-arm:
@@ -48,7 +48,7 @@ jobs:
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather pipeline-guard; do
+          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-aarch64-apple-darwin.tar.gz *
@@ -82,7 +82,7 @@ jobs:
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather pipeline-guard; do
+          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-x86_64-unknown-linux-gnu.tar.gz *
@@ -118,7 +118,7 @@ jobs:
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather pipeline-guard; do
+          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-aarch64-unknown-linux-gnu.tar.gz *
@@ -157,7 +157,7 @@ jobs:
         shell: bash
         run: |
           mkdir dist
-          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather pipeline-guard; do
+          for b in octos news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
             cp "target/release/${b}.exe" dist/ 2>/dev/null || true
           done
           cd dist && 7z a ../octos-bundle-x86_64-pc-windows-msvc.zip *


### PR DESCRIPTION
`pipeline-guard` is **not** a workspace package (`cargo metadata` confirms; no bin target), yet `release.yml`/`release-dispatch.yml`/`ci.yml` ran `cargo build --release … -p pipeline-guard`. cargo validates `-p` specs up front → that **Build step fails** → no `octos-bundle-<triple>.tar.gz` is produced → the public `curl | bash` installer (which downloads + extracts that bundle and installs every bin) gets no valid artifact / no skills.

Removes `-p pipeline-guard` from the build specs + the phantom from the copy loops across all three workflows. `SKILL_CRATES` now lists only real packages. `skill-evolve` (key-gated meta-skill, exempted from the #1432 preflight) left out by design.

Found while answering 'should the one-liner installer include the skill binaries?' — yes, and the *mechanism* does; this was the build that fed it being broken.