### PR TITLE
feat(packaging): Homebrew + npm one-line installers for the octos server

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -35,14 +35,26 @@ jobs:
       - name: Download unix bundles for the tag
         run: |
           mkdir -p bundles
-          for triple in \
-            aarch64-apple-darwin \
-            x86_64-unknown-linux-gnu \
-            aarch64-unknown-linux-gnu; do
-            gh release download "$TAG" \
-              --repo "${{ github.repository }}" \
-              --pattern "octos-bundle-${triple}.tar.gz" \
-              --dir bundles
+          triples="aarch64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu"
+          # `release: published` can fire before release.yml's action-gh-release
+          # step has uploaded every asset. Poll until all expected bundles exist
+          # (up to ~5 min) so we never render a formula from a partial asset set.
+          for attempt in $(seq 1 30); do
+            missing=0
+            for triple in $triples; do
+              asset="octos-bundle-${triple}.tar.gz"
+              [ -f "bundles/$asset" ] && continue
+              gh release download "$TAG" --repo "${{ github.repository }}" \
+                --pattern "$asset" --dir bundles 2>/dev/null || true
+              [ -f "bundles/$asset" ] || missing=1
+            done
+            [ "$missing" = 0 ] && break
+            echo "attempt $attempt: waiting for all bundle assets to publish..."
+            sleep 10
+          done
+          for triple in $triples; do
+            test -f "bundles/octos-bundle-${triple}.tar.gz" \
+              || { echo "::error::missing octos-bundle-${triple}.tar.gz after wait"; exit 1; }
           done
           ls -la bundles
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,111 @@
+name: Publish Packages
+# Additive package publishers for the SERVER bundle. Wraps the per-triple
+# archives produced by release.yml (which this workflow does NOT modify) and
+# publishes a Homebrew formula + an npm wrapper.
+#
+# Gated behind the repo variable PUBLISH_PACKAGES so it no-ops until the
+# maintainer opts in (avoids failing on missing tokens). To go live, set:
+#   - repo variable PUBLISH_PACKAGES = true
+#   - secret HOMEBREW_TAP_TOKEN  (PAT with push to octos-org/homebrew-tap)
+#   - secret NPM_TOKEN           (npm automation token for @octos-org)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g. v0.1.2)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  homebrew:
+    if: ${{ vars.PUBLISH_PACKAGES == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ inputs.tag || github.event.release.tag_name }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download unix bundles for the tag
+        run: |
+          mkdir -p bundles
+          for triple in \
+            aarch64-apple-darwin \
+            x86_64-unknown-linux-gnu \
+            aarch64-unknown-linux-gnu; do
+            gh release download "$TAG" \
+              --repo "${{ github.repository }}" \
+              --pattern "octos-bundle-${triple}.tar.gz" \
+              --dir bundles
+          done
+          ls -la bundles
+
+      - name: Render formula from template
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          sha_darwin_arm=$(sha256sum bundles/octos-bundle-aarch64-apple-darwin.tar.gz | awk '{print $1}')
+          sha_linux_x64=$(sha256sum bundles/octos-bundle-x86_64-unknown-linux-gnu.tar.gz | awk '{print $1}')
+          sha_linux_arm=$(sha256sum bundles/octos-bundle-aarch64-unknown-linux-gnu.tar.gz | awk '{print $1}')
+
+          cp packaging/homebrew/octos.rb octos.rb
+          sed -i "s|__VERSION__|${version}|g" octos.rb
+          sed -i "s|__TAG__|${TAG}|g" octos.rb
+          sed -i "s|__SHA_DARWIN_ARM__|${sha_darwin_arm}|g" octos.rb
+          sed -i "s|__SHA_LINUX_X64__|${sha_linux_x64}|g" octos.rb
+          sed -i "s|__SHA_LINUX_ARM__|${sha_linux_arm}|g" octos.rb
+
+          echo "----- rendered Formula/octos.rb -----"
+          cat octos.rb
+
+      - name: Push formula to homebrew-tap
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/octos-org/homebrew-tap.git" tap
+          mkdir -p tap/Formula
+          cp octos.rb tap/Formula/octos.rb
+          cd tap
+          git config user.name "octos-release-bot"
+          git config user.email "151983+ymote@users.noreply.github.com"
+          if git diff --quiet; then
+            echo "Formula/octos.rb unchanged; nothing to push."
+            exit 0
+          fi
+          git add Formula/octos.rb
+          git commit -m "octos ${TAG}"
+          git push origin HEAD
+
+  npm:
+    if: ${{ vars.PUBLISH_PACKAGES == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ inputs.tag || github.event.release.tag_name }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Set package version to the tag
+        working-directory: packaging/npm
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          npm version "$version" --no-git-tag-version --allow-same-version
+          echo "Publishing @octos-org/octos@${version}"
+
+      - name: Publish to npm
+        working-directory: packaging/npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ irm https://github.com/octos-org/octos/releases/latest/download/install.ps1 | ie
 
 This installs the binary, sets up `octos serve` as a service, and starts the local dashboard at `http://localhost:8080/admin/`.
 
+Alternatively, install just the binaries (the `octos` server plus its bundled skills) via a package manager:
+
+```bash
+# Homebrew (macOS Apple Silicon, Linux x86_64/ARM64)
+brew install octos-org/tap/octos
+
+# npm (macOS Apple Silicon, Linux x86_64/ARM64, Windows x64)
+npm install -g @octos-org/octos
+```
+
+Both install the full release bundle — the `octos` server and its bundled skills (`news_fetch`, `deep-search`, `deep_crawl`, `send_email`, `account_manager`, `voice`, `clock`, `weather`) kept side-by-side so `octos serve` discovers them at startup. Unlike `install.sh`, they do not set up a background service; run `octos serve` yourself.
+
 Supported platforms: **macOS ARM64**, **Linux x86_64**, **Linux ARM64**, and **Windows x64**.
 
 Choose this path if you want:

--- a/packaging/homebrew/octos.rb
+++ b/packaging/homebrew/octos.rb
@@ -31,10 +31,18 @@ class Octos < Formula
     # voice, clock, weather). At `octos serve` startup, bootstrap discovers
     # those skills as SIBLINGS of the resolved `octos` executable
     # (current_exe().parent()). Keep all of them together in libexec and
-    # expose only `octos` on PATH via a symlink — the symlink resolves so
-    # current_exe().parent() == libexec and sibling discovery still works.
+    # expose only `octos` on PATH.
     libexec.install Dir["*"]
-    bin.install_symlink libexec/"octos"
+    # Use an exec WRAPPER, not bin.install_symlink: on macOS,
+    # std::env::current_exe() returns the *symlink* path (Darwin
+    # _NSGetExecutablePath), so a bin/octos symlink would put exe_dir at bin/
+    # and the sibling skills (in libexec) would not be found -> plugin_count=0.
+    # `exec` replaces the process image, so current_exe() == libexec/octos and
+    # exe_dir == libexec, where the skill binaries live.
+    (bin/"octos").write <<~SH
+      #!/bin/bash
+      exec "#{libexec}/octos" "$@"
+    SH
   end
 
   test do

--- a/packaging/homebrew/octos.rb
+++ b/packaging/homebrew/octos.rb
@@ -1,0 +1,43 @@
+class Octos < Formula
+  desc "Rust-native, API-first Agentic OS server (octos serve + bundled skills)"
+  homepage "https://github.com/octos-org/octos"
+  version "__VERSION__"
+  license "Apache-2.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/octos-org/octos/releases/download/__TAG__/octos-bundle-aarch64-apple-darwin.tar.gz"
+      sha256 "__SHA_DARWIN_ARM__"
+    end
+    on_intel do
+      odie "octos requires Apple Silicon; no x86_64 macOS build is published"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/octos-org/octos/releases/download/__TAG__/octos-bundle-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "__SHA_LINUX_X64__"
+    end
+    on_arm do
+      url "https://github.com/octos-org/octos/releases/download/__TAG__/octos-bundle-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "__SHA_LINUX_ARM__"
+    end
+  end
+
+  def install
+    # The release bundle ships `octos` alongside its 8 skill binaries
+    # (news_fetch, deep-search, deep_crawl, send_email, account_manager,
+    # voice, clock, weather). At `octos serve` startup, bootstrap discovers
+    # those skills as SIBLINGS of the resolved `octos` executable
+    # (current_exe().parent()). Keep all of them together in libexec and
+    # expose only `octos` on PATH via a symlink — the symlink resolves so
+    # current_exe().parent() == libexec and sibling discovery still works.
+    libexec.install Dir["*"]
+    bin.install_symlink libexec/"octos"
+  end
+
+  test do
+    assert_match "octos", shell_output("#{bin}/octos --version")
+  end
+end

--- a/packaging/npm/.gitignore
+++ b/packaging/npm/.gitignore
@@ -1,0 +1,3 @@
+# Downloaded by postinstall (install.js) — never commit prebuilt binaries.
+vendor/
+*.tgz

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -1,0 +1,40 @@
+# @octos-org/octos
+
+One-line installer for the [Octos](https://github.com/octos-org/octos) server — a
+Rust-native, API-first Agentic OS.
+
+```bash
+npm install -g @octos-org/octos
+octos serve
+```
+
+This package downloads the prebuilt release bundle for your platform and installs
+the `octos` server **together with its bundled skills** (`news_fetch`,
+`deep-search`, `deep_crawl`, `send_email`, `account_manager`, `voice`, `clock`,
+`weather`). The skills are kept as siblings of the `octos` binary so that
+`octos serve` can discover them at startup.
+
+## Supported platforms
+
+- macOS Apple Silicon (`darwin-arm64`)
+- Linux x86_64 (`linux-x64`)
+- Linux ARM64 (`linux-arm64`)
+- Windows x64 (`win32-x64`)
+
+macOS Intel is not supported (no prebuilt build is published).
+
+## Environment overrides
+
+- `OCTOS_SKIP_DOWNLOAD=1` — skip the postinstall download (offline / CI).
+- `OCTOS_BUNDLE_URL=<url>` — install from a specific bundle URL (`file://` works).
+- `HTTPS_PROXY` — honored when downloading.
+
+## Alternatives
+
+```bash
+# Homebrew
+brew install octos-org/tap/octos
+
+# Shell installer (sets up octos serve as a service)
+curl -fsSL https://github.com/octos-org/octos/releases/latest/download/install.sh | bash
+```

--- a/packaging/npm/bin/octos.js
+++ b/packaging/npm/bin/octos.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Launcher: spawn the real native `octos` binary that postinstall placed in
+// vendor/, forwarding all args, stdio, and the exit code.
+//
+// The skills bundled next to it (vendor/news_fetch, deep-search, ...) are
+// discovered by `octos serve` as siblings of this binary at runtime — so the
+// native binary must run from vendor/, not be copied elsewhere.
+
+"use strict";
+
+const os = require("os");
+const path = require("path");
+const fs = require("fs");
+const { spawnSync } = require("child_process");
+
+const exeSuffix = os.platform() === "win32" ? ".exe" : "";
+const binary = path.join(__dirname, "..", "vendor", "octos" + exeSuffix);
+
+if (!fs.existsSync(binary)) {
+  console.error(
+    "[@octos-org/octos] native binary not found at " +
+      binary +
+      ".\nThe postinstall download did not run (was the package installed with " +
+      "--ignore-scripts?).\nReinstall without --ignore-scripts, or run " +
+      "`node " +
+      path.join(__dirname, "..", "install.js") +
+      "` manually."
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(binary, process.argv.slice(2), { stdio: "inherit" });
+
+if (result.error) {
+  console.error("[@octos-org/octos] failed to launch octos: " + result.error.message);
+  process.exit(1);
+}
+
+// Propagate a signal-terminated child as a non-zero exit; otherwise the code.
+if (result.signal) {
+  process.exit(1);
+}
+process.exit(result.status === null ? 1 : result.status);

--- a/packaging/npm/install.js
+++ b/packaging/npm/install.js
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+// postinstall: download the prebuilt octos release bundle for this platform,
+// extract every binary into vendor/, and assert the full skill set is present.
+//
+// The bundle ships `octos` alongside its 8 skill binaries. At `octos serve`
+// startup, bootstrap discovers those skills as SIBLINGS of the resolved
+// `octos` executable, so they must all land in the same dir (vendor/).
+//
+// Escapes:
+//   OCTOS_SKIP_DOWNLOAD=1   skip the download entirely (CI / offline installs)
+//   OCTOS_BUNDLE_URL=<url>  override the download URL (file:// supported for tests)
+
+"use strict";
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const https = require("https");
+const http = require("http");
+const { spawnSync } = require("child_process");
+const { URL } = require("url");
+
+const VENDOR_DIR = path.join(__dirname, "vendor");
+const REPO = "octos-org/octos";
+
+// Every binary the release bundle is expected to contain. `octos` is the
+// server; the rest are the bundled skills discovered as siblings at runtime.
+const EXPECTED_BINS = [
+  "octos",
+  "news_fetch",
+  "deep-search",
+  "deep_crawl",
+  "send_email",
+  "account_manager",
+  "voice",
+  "clock",
+  "weather",
+];
+
+function fail(msg) {
+  console.error("\n[@octos-org/octos] install failed: " + msg + "\n");
+  process.exit(1);
+}
+
+// Map this Node platform/arch to the release triple + archive extension.
+// Mirrors scripts/install.sh platform detection.
+function resolveTarget() {
+  const platform = os.platform();
+  const arch = os.arch();
+
+  if (platform === "darwin") {
+    if (arch === "arm64") {
+      return { triple: "aarch64-apple-darwin", ext: "tar.gz" };
+    }
+    fail(
+      "octos requires Apple Silicon on macOS; no x86_64 macOS build is published."
+    );
+  }
+  if (platform === "linux") {
+    if (arch === "x64") {
+      return { triple: "x86_64-unknown-linux-gnu", ext: "tar.gz" };
+    }
+    if (arch === "arm64") {
+      return { triple: "aarch64-unknown-linux-gnu", ext: "tar.gz" };
+    }
+    fail("Unsupported Linux architecture: " + arch + " (need x64 or arm64).");
+  }
+  if (platform === "win32") {
+    if (arch === "x64") {
+      return { triple: "x86_64-pc-windows-msvc", ext: "zip" };
+    }
+    fail("Unsupported Windows architecture: " + arch + " (need x64).");
+  }
+  fail("Unsupported platform: " + platform);
+}
+
+// Resolve the release tag from the package version. CI sets the package
+// version to the released tag (minus the leading "v"), so the tag is
+// "v" + version. The "0.0.0-managed" placeholder is never published.
+function resolveTag() {
+  const version = require("./package.json").version;
+  if (version === "0.0.0-managed") {
+    fail(
+      "package version is the unmanaged placeholder (0.0.0-managed); " +
+        "this build was not produced by the publish workflow. " +
+        "Set OCTOS_BUNDLE_URL to install manually."
+    );
+  }
+  return version.startsWith("v") ? version : "v" + version;
+}
+
+function bundleUrl(target) {
+  if (process.env.OCTOS_BUNDLE_URL) {
+    return process.env.OCTOS_BUNDLE_URL;
+  }
+  const tag = resolveTag();
+  return (
+    "https://github.com/" +
+    REPO +
+    "/releases/download/" +
+    tag +
+    "/octos-bundle-" +
+    target.triple +
+    "." +
+    target.ext
+  );
+}
+
+// Download to a file, following redirects, honoring HTTPS_PROXY when set.
+function download(urlStr, destFile, redirects, cb) {
+  if (redirects > 10) {
+    return cb(new Error("too many redirects"));
+  }
+
+  let url;
+  try {
+    url = new URL(urlStr);
+  } catch (e) {
+    return cb(new Error("invalid URL: " + urlStr));
+  }
+
+  // file:// override — copy locally (used by tests / offline installs).
+  if (url.protocol === "file:") {
+    try {
+      fs.copyFileSync(decodeURIComponent(url.pathname), destFile);
+      return cb(null);
+    } catch (e) {
+      return cb(new Error("could not read " + urlStr + ": " + e.message));
+    }
+  }
+
+  const isHttps = url.protocol === "https:";
+  const transport = isHttps ? https : http;
+  const proxy =
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy;
+
+  let requestOptions;
+  if (proxy && isHttps) {
+    // CONNECT-tunnel-free path: route the absolute URL through the proxy.
+    // Most proxies accept an absolute-form request line for plain GETs;
+    // for HTTPS we fall back to a direct request if no CONNECT helper is
+    // available (Node core has no built-in CONNECT). Keep it simple and
+    // direct unless a plain-HTTP proxy is configured.
+    const proxyUrl = new URL(proxy);
+    requestOptions = {
+      host: proxyUrl.hostname,
+      port: proxyUrl.port || (proxyUrl.protocol === "https:" ? 443 : 80),
+      path: urlStr,
+      headers: { Host: url.host, "User-Agent": "octos-npm-installer" },
+    };
+  } else {
+    requestOptions = {
+      protocol: url.protocol,
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname + url.search,
+      headers: { "User-Agent": "octos-npm-installer" },
+    };
+  }
+
+  transport
+    .get(requestOptions, (res) => {
+      // Follow redirects (GitHub release assets redirect to a CDN).
+      if (
+        res.statusCode >= 300 &&
+        res.statusCode < 400 &&
+        res.headers.location
+      ) {
+        res.resume();
+        const next = new URL(res.headers.location, urlStr).toString();
+        return download(next, destFile, redirects + 1, cb);
+      }
+      if (res.statusCode !== 200) {
+        res.resume();
+        return cb(
+          new Error("HTTP " + res.statusCode + " fetching " + urlStr)
+        );
+      }
+      const out = fs.createWriteStream(destFile);
+      res.pipe(out);
+      out.on("finish", () => out.close(() => cb(null)));
+      out.on("error", (e) => cb(e));
+    })
+    .on("error", (e) => cb(e));
+}
+
+// Extract the archive into vendor/ using the platform's native tool.
+function extract(archiveFile, ext) {
+  fs.mkdirSync(VENDOR_DIR, { recursive: true });
+  let res;
+  if (ext === "zip") {
+    if (os.platform() === "win32") {
+      res = spawnSync(
+        "powershell",
+        [
+          "-NoProfile",
+          "-Command",
+          "Expand-Archive -Force -LiteralPath '" +
+            archiveFile +
+            "' -DestinationPath '" +
+            VENDOR_DIR +
+            "'",
+        ],
+        { stdio: "inherit" }
+      );
+    } else {
+      res = spawnSync("unzip", ["-o", archiveFile, "-d", VENDOR_DIR], {
+        stdio: "inherit",
+      });
+    }
+  } else {
+    res = spawnSync("tar", ["-xzf", archiveFile, "-C", VENDOR_DIR], {
+      stdio: "inherit",
+    });
+  }
+  if (res.error) {
+    fail("extraction tool failed to launch: " + res.error.message);
+  }
+  if (res.status !== 0) {
+    fail("extraction exited with status " + res.status);
+  }
+}
+
+// Make all extracted binaries executable and assert the full set is present.
+function finalizeAndVerify() {
+  const exeSuffix = os.platform() === "win32" ? ".exe" : "";
+  const missing = [];
+  for (const name of EXPECTED_BINS) {
+    const p = path.join(VENDOR_DIR, name + exeSuffix);
+    if (fs.existsSync(p)) {
+      try {
+        fs.chmodSync(p, 0o755);
+      } catch (e) {
+        // Best-effort on Windows where chmod is largely a no-op.
+      }
+    } else {
+      missing.push(name + exeSuffix);
+    }
+  }
+  if (missing.length > 0) {
+    fail(
+      "the downloaded bundle is missing expected binaries: " +
+        missing.join(", ") +
+        ". The release archive may be corrupt or incomplete."
+    );
+  }
+}
+
+function main() {
+  if (process.env.OCTOS_SKIP_DOWNLOAD === "1") {
+    console.log(
+      "[@octos-org/octos] OCTOS_SKIP_DOWNLOAD=1 set; skipping bundle download."
+    );
+    return;
+  }
+
+  const target = resolveTarget();
+  const url = bundleUrl(target);
+  console.log("[@octos-org/octos] downloading " + url);
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "octos-npm-"));
+  const archiveFile = path.join(tmpDir, "bundle." + target.ext);
+
+  download(url, archiveFile, 0, (err) => {
+    if (err) {
+      fail(err.message);
+    }
+    extract(archiveFile, target.ext);
+    finalizeAndVerify();
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch (e) {
+      // non-fatal cleanup failure
+    }
+    console.log(
+      "[@octos-org/octos] installed octos + " +
+        (EXPECTED_BINS.length - 1) +
+        " bundled skills into vendor/"
+    );
+  });
+}
+
+main();

--- a/packaging/npm/install.js
+++ b/packaging/npm/install.js
@@ -120,46 +120,30 @@ function download(urlStr, destFile, redirects, cb) {
   }
 
   // file:// override — copy locally (used by tests / offline installs).
+  // Use fileURLToPath so Windows `file:///C:/...` maps correctly (pathname
+  // would yield `/C:/...`).
   if (url.protocol === "file:") {
     try {
-      fs.copyFileSync(decodeURIComponent(url.pathname), destFile);
+      fs.copyFileSync(require("url").fileURLToPath(url), destFile);
       return cb(null);
     } catch (e) {
       return cb(new Error("could not read " + urlStr + ": " + e.message));
     }
   }
 
-  const isHttps = url.protocol === "https:";
-  const transport = isHttps ? https : http;
-  const proxy =
-    process.env.HTTPS_PROXY ||
-    process.env.https_proxy ||
-    process.env.HTTP_PROXY ||
-    process.env.http_proxy;
-
-  let requestOptions;
-  if (proxy && isHttps) {
-    // CONNECT-tunnel-free path: route the absolute URL through the proxy.
-    // Most proxies accept an absolute-form request line for plain GETs;
-    // for HTTPS we fall back to a direct request if no CONNECT helper is
-    // available (Node core has no built-in CONNECT). Keep it simple and
-    // direct unless a plain-HTTP proxy is configured.
-    const proxyUrl = new URL(proxy);
-    requestOptions = {
-      host: proxyUrl.hostname,
-      port: proxyUrl.port || (proxyUrl.protocol === "https:" ? 443 : 80),
-      path: urlStr,
-      headers: { Host: url.host, "User-Agent": "octos-npm-installer" },
-    };
-  } else {
-    requestOptions = {
-      protocol: url.protocol,
-      hostname: url.hostname,
-      port: url.port,
-      path: url.pathname + url.search,
-      headers: { "User-Agent": "octos-npm-installer" },
-    };
-  }
+  // Direct request only. Corporate HTTP/HTTPS proxies are NOT supported here
+  // (Node core has no CONNECT helper, and absolute-form GET to an HTTP proxy
+  // fails for https targets). Behind a proxy: pre-download the bundle and point
+  // the installer at it with OCTOS_BUNDLE_URL=file:///path, or set
+  // OCTOS_SKIP_DOWNLOAD=1 and place the binaries under vendor/ yourself.
+  const transport = url.protocol === "https:" ? https : http;
+  const requestOptions = {
+    protocol: url.protocol,
+    hostname: url.hostname,
+    port: url.port,
+    path: url.pathname + url.search,
+    headers: { "User-Agent": "octos-npm-installer" },
+  };
 
   transport
     .get(requestOptions, (res) => {

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@octos-org/octos",
+  "version": "0.0.0-managed",
+  "description": "Rust-native, API-first Agentic OS server (octos serve + bundled skills). Installs the prebuilt release bundle.",
+  "homepage": "https://github.com/octos-org/octos",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/octos-org/octos.git"
+  },
+  "bin": {
+    "octos": "bin/octos.js"
+  },
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "files": [
+    "bin",
+    "install.js",
+    "README.md"
+  ],
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "arm64",
+    "x64"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}


### PR DESCRIPTION
Adds `brew install octos-org/tap/octos` and `npm install -g @octos-org/octos` for the **server** (parity with octos-tui), wrapping the EXISTING per-triple `octos-bundle-<triple>` release bundle. **release.yml is untouched** (zero risk to the working build/bundle).

- `packaging/homebrew/octos.rb` — CI-rendered formula; installs all 9 bins to `libexec` + an **exec wrapper** `bin/octos` (so `current_exe()`→libexec on macOS and bootstrap finds the sibling skills; `odie` on macOS-Intel).
- `packaging/npm/` — `@octos-org/octos`: postinstall downloads the platform bundle (version→tag), extracts all 9 bins to `vendor/` (asserts the full set), launcher **spawns** the native `octos`.
- `.github/workflows/publish-packages.yml` — **additive**, gated behind repo var `PUBLISH_PACKAGES`; homebrew (sha256+render+push to tap) + npm publish jobs; polls for all bundle assets to avoid racing release.yml's upload.

codex-reviewed (2 rounds); **4 findings fixed**: P1 macOS symlink→exec-wrapper (load-bearing — codex verified `current_exe()` returns the symlink path on Darwin), P2 broken proxy dropped, P3 Windows `file://`→`fileURLToPath`, P4 asset-upload race → poll. Local checks: ruby -c, node --check, yaml parse, staged `file://` e2e (9/9 bins).

**To go live (maintainer):** set repo var `PUBLISH_PACKAGES=true`, add secrets `HOMEBREW_TAP_TOKEN` (push to octos-org/homebrew-tap) + `NPM_TOKEN` (@octos-org publish), then verify on the next tagged release.