### PR TITLE
feat(config): XDG-primary config/auth via a single canonical resolver

### DIFF
--- a/crates/octos-cli/src/api/admin_setup.rs
+++ b/crates/octos-cli/src/api/admin_setup.rs
@@ -263,14 +263,25 @@ fn require_config_path(state: &AppState) -> Result<PathBuf, (StatusCode, Json<Er
     match &state.config_path {
         Some(p) => Ok(p.clone()),
         None => {
-            let data_dir = data_dir_from_state(state).ok_or((
+            // Confirm the server has a resolvable data dir (else it cannot
+            // safely write anything) before computing the config target.
+            data_dir_from_state(state).ok_or((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorBody {
                     code: "no_data_dir",
                     message: "server has no resolvable data directory".into(),
                 }),
             ))?;
-            Ok(crate::config::Config::data_dir_config_path(&data_dir))
+            // Resolve the canonical config_home (NOT data_dir) so admin writes
+            // land where the resolver READS config. The daemon carries its
+            // OCTOS_HOME / OCTOS_CONFIG_DIR in the environment, so resolving
+            // with no override reproduces serve's own config_home: XDG for a
+            // default install, the state dir for an explicit OCTOS_HOME, the
+            // tenant dir for OCTOS_CONFIG_DIR. This closes the leak where the
+            // old `data_dir/config.json` fallback could write the host's
+            // `~/.octos/config.json` under an OCTOS_CONFIG_DIR tenant.
+            let ctx = crate::config_context::resolve_config_context(None);
+            Ok(ctx.config_home.join("config.json"))
         }
     }
 }

--- a/crates/octos-cli/src/auth/store.rs
+++ b/crates/octos-cli/src/auth/store.rs
@@ -1,11 +1,20 @@
-//! Auth credential storage at ~/.octos/auth.json (mode 0600).
+//! Auth credential storage (mode 0600).
+//!
+//! The store path is `auth_home/auth.json`, where `auth_home` comes from the
+//! canonical [`ConfigContext`](crate::config_context::ConfigContext) — GLOBAL
+//! (XDG) unless `OCTOS_CONFIG_DIR` is set. The store NEVER recomputes its path
+//! from the environment on its own; callers pass the resolved location via
+//! [`AuthStore::open`] or [`AuthStore::at`]. There is intentionally no no-arg
+//! `load()` so no site can diverge from the resolver.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use eyre::{Result, WrapErr};
 use serde::{Deserialize, Serialize};
+
+use crate::config_context::ConfigContext;
 
 /// A stored authentication credential.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -39,9 +48,15 @@ pub struct AuthStore {
 }
 
 impl AuthStore {
-    /// Load the auth store from disk (or create empty).
-    pub fn load() -> Result<Self> {
-        let path = Self::store_path()?;
+    /// Open the auth store at the context's `auth_home` (i.e.
+    /// `auth_home/auth.json`). This is the canonical entrypoint.
+    pub fn open(ctx: &ConfigContext) -> Result<Self> {
+        Self::at(&ctx.auth_home)
+    }
+
+    /// Open the auth store at `auth_home/auth.json` (or create empty in memory).
+    pub fn at(auth_home: &Path) -> Result<Self> {
+        let path = auth_home.join("auth.json");
         let data = if path.exists() {
             let content = std::fs::read_to_string(&path).wrap_err("failed to read auth store")?;
             serde_json::from_str(&content).wrap_err("failed to parse auth store")?
@@ -106,13 +121,6 @@ impl AuthStore {
         }
 
         Ok(())
-    }
-
-    /// Path: ~/.octos/auth.json
-    fn store_path() -> Result<PathBuf> {
-        let home =
-            dirs::home_dir().ok_or_else(|| eyre::eyre!("cannot determine home directory"))?;
-        Ok(home.join(".octos").join("auth.json"))
     }
 }
 
@@ -197,6 +205,41 @@ mod tests {
             auth_method: "paste_token".to_string(),
         };
         assert!(!no_expiry.is_expired());
+    }
+
+    #[test]
+    fn at_resolves_auth_json_under_auth_home() {
+        let tmp = TempDir::new().unwrap();
+        let auth_home = tmp.path().join("xdg").join("octos");
+        let store = AuthStore::at(&auth_home).unwrap();
+        assert_eq!(store.path, auth_home.join("auth.json"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_writes_0600() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let tmp = TempDir::new().unwrap();
+        let auth_home = tmp.path().join("octos");
+        let mut store = AuthStore::at(&auth_home).unwrap();
+        store
+            .set(
+                "anthropic",
+                AuthCredential {
+                    access_token: "tok".into(),
+                    refresh_token: None,
+                    expires_at: None,
+                    provider: "anthropic".into(),
+                    auth_method: "paste_token".into(),
+                },
+            )
+            .unwrap();
+        let mode = std::fs::metadata(auth_home.join("auth.json"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
     }
 
     #[test]

--- a/crates/octos-cli/src/auth/store.rs
+++ b/crates/octos-cli/src/auth/store.rs
@@ -58,6 +58,20 @@ impl AuthStore {
     pub fn at(auth_home: &Path) -> Result<Self> {
         let path = auth_home.join("auth.json");
         let data = if path.exists() {
+            // Harden an existing store on open: a credential file created by an
+            // older octos (or copied in by hand) may be 0644. `save()` always
+            // writes 0600, but a file we only ever READ would stay world/group
+            // readable forever — tighten it best-effort whenever we open it.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt as _;
+                if let Ok(meta) = std::fs::metadata(&path) {
+                    if meta.permissions().mode() & 0o077 != 0 {
+                        let _ =
+                            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+                    }
+                }
+            }
             let content = std::fs::read_to_string(&path).wrap_err("failed to read auth store")?;
             serde_json::from_str(&content).wrap_err("failed to parse auth store")?
         } else {
@@ -240,6 +254,24 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn at_tightens_loose_permissions_on_open() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let tmp = TempDir::new().unwrap();
+        let auth_home = tmp.path().join("octos");
+        std::fs::create_dir_all(&auth_home).unwrap();
+        let path = auth_home.join("auth.json");
+        // Simulate a legacy / hand-copied store that is world-readable.
+        std::fs::write(&path, "{\"credentials\":{}}").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        // Opening it must tighten the perms to 0600 (no plain-read leaving creds
+        // world/group readable).
+        let _store = AuthStore::at(&auth_home).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "at() must tighten a loose auth.json to 0600");
     }
 
     #[test]

--- a/crates/octos-cli/src/auth/store.rs
+++ b/crates/octos-cli/src/auth/store.rs
@@ -257,6 +257,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn at_tightens_loose_permissions_on_open() {
         use std::os::unix::fs::PermissionsExt as _;
         let tmp = TempDir::new().unwrap();

--- a/crates/octos-cli/src/commands/auth.rs
+++ b/crates/octos-cli/src/commands/auth.rs
@@ -8,7 +8,20 @@ use eyre::Result;
 
 use super::Executable;
 use crate::auth::{AuthStore, keychain, oauth, token};
+use crate::config_context::{resolve_config_context, run_migrations};
 use crate::profiles::ProfileStore;
+
+/// Open the global auth store for the `auth login/logout/status` commands.
+///
+/// Auth is GLOBAL: it lives under the resolver's `auth_home` (OCTOS_CONFIG_DIR
+/// if set, else the XDG default), independent of `--data-dir`. We run the
+/// migrations first so a legacy `~/.octos/auth.json` is copied into the XDG
+/// location (0600, legacy left intact) before the store opens.
+fn open_global_auth_store() -> Result<AuthStore> {
+    let ctx = resolve_config_context(None);
+    run_migrations(&ctx);
+    AuthStore::open(&ctx)
+}
 
 /// Manage authentication for LLM providers.
 #[derive(Debug, Args)]
@@ -121,7 +134,7 @@ async fn login(provider: &str, device_code: bool) -> Result<()> {
         _ => token::paste_token_flow(provider)?,
     };
 
-    let mut store = AuthStore::load()?;
+    let mut store = open_global_auth_store()?;
     store.set(provider, cred)?;
 
     println!(
@@ -133,7 +146,7 @@ async fn login(provider: &str, device_code: bool) -> Result<()> {
 }
 
 fn logout(provider: &str) -> Result<()> {
-    let mut store = AuthStore::load()?;
+    let mut store = open_global_auth_store()?;
     if store.remove(provider)? {
         println!("{} Logged out from {}", "OK".green().bold(), provider);
     } else {
@@ -143,7 +156,7 @@ fn logout(provider: &str) -> Result<()> {
 }
 
 fn status() -> Result<()> {
-    let store = AuthStore::load()?;
+    let store = open_global_auth_store()?;
     let creds: Vec<_> = store.list().collect();
 
     if creds.is_empty() {

--- a/crates/octos-cli/src/commands/channels.rs
+++ b/crates/octos-cli/src/commands/channels.rs
@@ -47,8 +47,8 @@ impl Executable for ChannelsCommand {
 }
 
 fn cmd_status(cwd: &std::path::Path) -> Result<()> {
-    let data_dir = super::resolve_data_dir(None)?;
-    let config = Config::load(cwd, &data_dir)?;
+    let ctx = super::resolve_command_context(None)?;
+    let config = Config::load_with_context(cwd, &ctx)?;
 
     let channels = match &config.gateway {
         Some(gw) => &gw.channels,

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -97,14 +97,16 @@ impl ChatCommand {
             None => std::env::current_dir().wrap_err("failed to get current directory")?,
         };
 
-        // Resolve data directory (--data-dir > $OCTOS_HOME > ~/.octos)
-        let data_dir = super::resolve_data_dir(self.data_dir)?;
+        // Resolve the canonical config context (data_dir, config_home,
+        // auth_home, is_default) once and run migrations.
+        let ctx = super::resolve_command_context(self.data_dir)?;
+        let data_dir = ctx.data_dir.clone();
 
         // Load config
         let config = if let Some(config_path) = &self.config {
             Config::from_file(config_path)?
         } else {
-            Config::load(&cwd, &data_dir)?
+            Config::load_with_context(&cwd, &ctx)?
         };
 
         let model = self.model.or(config.model.clone());

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -33,7 +33,7 @@ use super::profile_factory::{
 use super::{account_handler, adapters, skills_handler};
 use super::{build_profiled_session_key, resolve_dispatch_profile_id};
 use crate::commands::chat::{self, create_embedder, resolve_provider_policy};
-use crate::commands::{load_prompt, resolve_data_dir};
+use crate::commands::load_prompt;
 use crate::config::{Config, detect_provider};
 use crate::config_watcher::{ConfigChange, ConfigWatcher};
 use crate::persona_service::PersonaService;
@@ -153,7 +153,8 @@ impl GatewayRuntime {
             Some(p) => p,
             None => std::env::current_dir().wrap_err("failed to get current directory")?,
         };
-        let data_dir = resolve_data_dir(cmd.data_dir.clone())?;
+        let ctx = crate::commands::resolve_command_context(cmd.data_dir.clone())?;
+        let data_dir = ctx.data_dir.clone();
         #[cfg(feature = "api")]
         let metrics_handle = Some(crate::api::init_metrics());
         #[cfg(not(feature = "api"))]
@@ -214,7 +215,7 @@ impl GatewayRuntime {
         } else if let Some(config_path) = &cmd.config {
             Config::from_file(config_path)?
         } else {
-            Config::load(&cwd, &data_dir)?
+            Config::load_with_context(&cwd, &ctx)?
         };
         // Section B (codex review round-5 P1.2): the `--profile` path
         // bypasses `Config::from_file`, so call the same env-var OR-merge
@@ -1339,9 +1340,9 @@ impl GatewayRuntime {
                 if local.exists() {
                     paths.push(local);
                 }
-                let data_dir_config = Config::data_dir_config_path(&data_dir);
-                if data_dir_config.exists() {
-                    paths.push(data_dir_config);
+                let config_home_config = ctx.config_home.join("config.json");
+                if config_home_config.exists() {
+                    paths.push(config_home_config);
                 }
             }
             paths

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -1336,9 +1336,15 @@ impl GatewayRuntime {
             } else if let Some(ref p) = cmd.config {
                 paths.push(p.clone());
             } else {
-                let local = project_dir.join("config.json");
-                if local.exists() {
-                    paths.push(local);
+                // Project-local config is watched ONLY in the default context,
+                // mirroring `Config::load_resolved`'s `is_default` gate. In an
+                // explicit/tenant gateway we must not hot-reload an ambient
+                // `cwd/.octos/config.json` (e.g. the host's), only config_home.
+                if ctx.is_default {
+                    let local = project_dir.join("config.json");
+                    if local.exists() {
+                        paths.push(local);
+                    }
                 }
                 let config_home_config = ctx.config_home.join("config.json");
                 if config_home_config.exists() {

--- a/crates/octos-cli/src/commands/init.rs
+++ b/crates/octos-cli/src/commands/init.rs
@@ -154,9 +154,18 @@ impl Executable for InitCommand {
         println!("{}", "octos init".cyan().bold());
         println!();
 
+        // Where to write the starter config:
+        //   --cwd C        → C/.octos (explicit project-local request)
+        //   otherwise      → the resolver's config_home (OCTOS_CONFIG_DIR if
+        //                    set; the state dir for an explicit OCTOS_HOME /
+        //                    --data-dir; else the XDG default for a default
+        //                    install).
         let config_dir = match self.cwd {
             Some(cwd) => cwd.join(".octos"),
-            None => super::resolve_data_dir(None)?,
+            None => {
+                let ctx = super::resolve_command_context(None)?;
+                ctx.config_home
+            }
         };
         let config_path = config_dir.join("config.json");
 

--- a/crates/octos-cli/src/commands/mcp_serve.rs
+++ b/crates/octos-cli/src/commands/mcp_serve.rs
@@ -105,16 +105,17 @@ impl McpServeCommand {
             Some(p) => p,
             None => std::env::current_dir().wrap_err("failed to get current directory")?,
         };
-        let data_dir = super::resolve_data_dir(self.data_dir.clone())?;
+        let ctx = super::resolve_command_context(self.data_dir.clone())?;
+        let data_dir = ctx.data_dir.clone();
 
         // Load config — same precedence as chat/gateway: project-local
-        // `.octos/config.json` wins over data-dir `config.json`. Missing
+        // `.octos/config.json` wins over the resolved config_home. Missing
         // config is fine for stdio mode; the LLM factory will fail later
         // if no provider is configured.
         let config = if let Some(ref config_path) = self.config {
             Config::from_file(config_path)?
         } else {
-            Config::load(&cwd, &data_dir)?
+            Config::load_with_context(&cwd, &ctx)?
         };
 
         let factory = AgentLlmFactory::from_config(config)

--- a/crates/octos-cli/src/commands/mod.rs
+++ b/crates/octos-cli/src/commands/mod.rs
@@ -118,18 +118,28 @@ pub trait Executable {
 /// Resolve the data directory for episodes, memory, sessions, etc.
 ///
 /// Priority: `--data-dir` CLI flag > `OCTOS_HOME` env var > `~/.octos` default.
+/// Delegates to the canonical [`resolve_config_context`] so the `data_dir`
+/// computation (including empty-string env handling) never diverges from
+/// config/auth resolution.
 pub fn resolve_data_dir(cli_override: Option<PathBuf>) -> eyre::Result<PathBuf> {
-    let dir = if let Some(d) = cli_override {
-        d
-    } else if let Ok(env_dir) = std::env::var("OCTOS_HOME") {
-        PathBuf::from(env_dir)
-    } else {
-        dirs::home_dir()
-            .ok_or_else(|| eyre::eyre!("cannot determine home directory"))?
-            .join(".octos")
-    };
-    std::fs::create_dir_all(&dir).ok();
-    Ok(dir)
+    let ctx = crate::config_context::resolve_config_context(cli_override.as_deref());
+    std::fs::create_dir_all(&ctx.data_dir).ok();
+    Ok(ctx.data_dir)
+}
+
+/// Resolve the canonical [`ConfigContext`](crate::config_context::ConfigContext)
+/// for a command, create the data dir, and run the (idempotent, best-effort)
+/// config + auth migrations exactly once.
+///
+/// Every command that loads config should go through this so the resolver runs
+/// at a single shared entrypoint per invocation.
+pub fn resolve_command_context(
+    cli_override: Option<PathBuf>,
+) -> eyre::Result<crate::config_context::ConfigContext> {
+    let ctx = crate::config_context::resolve_config_context(cli_override.as_deref());
+    std::fs::create_dir_all(&ctx.data_dir).ok();
+    crate::config_context::run_migrations(&ctx);
+    Ok(ctx)
 }
 
 /// Load a prompt from `~/.octos/prompts/{name}.md` at runtime.

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -296,15 +296,17 @@ impl ServeCommand {
             Some(p) => p.clone(),
             None => std::env::current_dir().wrap_err("failed to get current directory")?,
         };
-        // Resolve data directory once and treat it as the canonical home for
-        // runtime state and config unless an explicit --config path is given.
-        let data_dir = super::resolve_data_dir(self.data_dir.clone())?;
+        // Resolve the canonical config context once (data_dir for runtime
+        // state; config_home/is_default for config; auth_home for global auth)
+        // and run migrations.
+        let ctx = super::resolve_command_context(self.data_dir.clone())?;
+        let data_dir = ctx.data_dir.clone();
 
         let (config, resolved_config_path) = if let Some(config_path) = &self.config {
             tracing::info!(path = %config_path.display(), "loading config (--config)");
             (Config::from_file(config_path)?, Some(config_path.clone()))
         } else {
-            Config::load_with_path(&cwd, &data_dir)?
+            Config::load_with_context_path(&cwd, &ctx)?
         };
         tracing::info!(data_dir = %data_dir.display(), "data directory resolved");
         if let Err(error) = crate::api::agent_orchestrator::default_agent_orchestrator()

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -639,7 +639,13 @@ impl ServeCommand {
             allowlist_store: Some(allowlist_store),
             auth_manager,
             http_client: reqwest::Client::new(),
-            config_path: resolved_config_path,
+            // If a config file was loaded, admin edits target that exact file.
+            // If none existed at startup, fall back to THIS serve's resolved
+            // config_home (which already accounts for the `--data-dir` FLAG —
+            // not just env), so admin writes under `serve --data-dir T` land in
+            // `T/config.json`, not a recomputed XDG path. (admin_setup's own
+            // None branch can't see the CLI flag; this closes that leak.)
+            config_path: resolved_config_path.or_else(|| Some(ctx.config_home.join("config.json"))),
             watchdog_enabled: watchdog_flag.clone(),
             alerts_enabled: alerts_flag.clone(),
             sysinfo: tokio::sync::Mutex::new(sysinfo::System::new_all()),

--- a/crates/octos-cli/src/commands/status.rs
+++ b/crates/octos-cli/src/commands/status.rs
@@ -55,7 +55,11 @@ fn show_system_status(cwd: &std::path::Path) -> Result<()> {
 
     // Config location — report the ACTUAL resolved config_home, not the data
     // dir, so the operator sees where config really lives (XDG by default).
-    if config_path.exists() {
+    // Project-local `cwd/.octos/config.json` is only honored by the loader in a
+    // DEFAULT context (`load_resolved` skips it for explicit/tenant), so only
+    // surface it when `ctx.is_default` — else status would claim a project-local
+    // config that the loader will not read.
+    if ctx.is_default && config_path.exists() {
         println!(
             "{}: {} {}",
             "Config".green(),

--- a/crates/octos-cli/src/commands/status.rs
+++ b/crates/octos-cli/src/commands/status.rs
@@ -47,10 +47,14 @@ fn show_system_status(cwd: &std::path::Path) -> Result<()> {
     println!();
 
     let config_path = cwd.join(".octos").join("config.json");
-    let data_dir = super::resolve_data_dir(None)?;
-    let data_dir_config = Config::data_dir_config_path(&data_dir);
+    let ctx = super::resolve_command_context(None)?;
+    let data_dir = ctx.data_dir.clone();
+    let config_home_config = ctx.config_home.join("config.json");
+    // Legacy back-compat location (default installs only).
+    let legacy_config = dirs::home_dir().map(|h| h.join(".octos").join("config.json"));
 
-    // Config location
+    // Config location — report the ACTUAL resolved config_home, not the data
+    // dir, so the operator sees where config really lives (XDG by default).
     if config_path.exists() {
         println!(
             "{}: {} {}",
@@ -58,12 +62,24 @@ fn show_system_status(cwd: &std::path::Path) -> Result<()> {
             config_path.display(),
             "(found)".green()
         );
-    } else if data_dir_config.exists() {
+    } else if config_home_config.exists() {
         println!(
             "{}: {} {}",
             "Config".green(),
-            data_dir_config.display(),
+            config_home_config.display(),
             "(found)".green()
+        );
+    } else if ctx.is_default
+        && legacy_config
+            .as_deref()
+            .map(|p| p != config_home_config && p.exists())
+            .unwrap_or(false)
+    {
+        println!(
+            "{}: {} {}",
+            "Config".green(),
+            legacy_config.as_deref().unwrap().display(),
+            "(legacy)".yellow()
         );
     } else {
         println!(
@@ -86,7 +102,7 @@ fn show_system_status(cwd: &std::path::Path) -> Result<()> {
     }
 
     // Load config for provider/model info
-    let config = Config::load(cwd, &data_dir).unwrap_or_default();
+    let config = Config::load_with_context(cwd, &ctx).unwrap_or_default();
 
     let provider = config.provider.as_deref().unwrap_or("(not configured)");
     let model = config.model.as_deref().unwrap_or("(not configured)");

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -1019,41 +1019,82 @@ impl Config {
         data_dir.join("config.json")
     }
 
-    /// Load config from the current project plus the already-resolved data dir.
-    pub fn load(cwd: &Path, data_dir: &Path) -> Result<Self> {
-        Self::load_with_path(cwd, data_dir).map(|(config, _)| config)
+    /// Load config from the current project plus the canonical config context.
+    ///
+    /// This is the preferred entrypoint: it threads the single
+    /// [`ConfigContext`](crate::config_context::ConfigContext) so the precedence
+    /// is identical at every call site.
+    pub fn load_with_context(
+        cwd: &Path,
+        ctx: &crate::config_context::ConfigContext,
+    ) -> Result<Self> {
+        Self::load_with_context_path(cwd, ctx).map(|(config, _)| config)
     }
 
-    /// Load config and return the resolved config path when one exists.
-    pub fn load_with_path(cwd: &Path, data_dir: &Path) -> Result<(Self, Option<PathBuf>)> {
-        // Try project-local config first
-        let local_config = cwd.join(".octos").join("config.json");
-        if local_config.exists() {
-            tracing::info!(path = %local_config.display(), "loading config (project-local)");
-            return Ok((Self::from_file(&local_config)?, Some(local_config)));
-        }
+    /// Like [`Self::load_with_context`] but also returns the resolved config
+    /// path when one exists.
+    pub fn load_with_context_path(
+        cwd: &Path,
+        ctx: &crate::config_context::ConfigContext,
+    ) -> Result<(Self, Option<PathBuf>)> {
+        Self::load_resolved(cwd, &ctx.config_home, ctx.is_default)
+    }
 
-        // The caller resolves --data-dir > OCTOS_HOME > ~/.octos exactly once
-        // and passes the canonical data dir here.
-        let data_dir_config = Self::data_dir_config_path(data_dir);
-        if data_dir_config.exists() {
-            tracing::info!(path = %data_dir_config.display(), "loading config (data dir)");
-            return Ok((Self::from_file(&data_dir_config)?, Some(data_dir_config)));
-        }
-
-        // Try legacy platform config dir (~/Library/Application Support/octos/ or ~/.config/octos/)
-        if let Some(legacy_config) = dirs::config_dir().map(|d| d.join("octos").join("config.json"))
-        {
-            if legacy_config.exists() {
-                tracing::warn!(
-                    path = %legacy_config.display(),
-                    "loading config from legacy location — consider moving to ~/.octos/config.json"
-                );
-                return Ok((Self::from_file(&legacy_config)?, Some(legacy_config)));
+    /// Core loader. Precedence:
+    /// 1. (only when `is_default`) project-local `cwd/.octos/config.json`
+    /// 2. `config_home/config.json`
+    /// 3. (only when `is_default`) legacy `~/.octos/config.json`
+    /// 4. defaults (with `merge_env_plugin_policy`)
+    ///
+    /// Explicit / tenant contexts (`is_default == false`) read ONLY from
+    /// `config_home`. They MUST NOT read the ambient project-local
+    /// `cwd/.octos/config.json` either: a tenant/`serve` process whose `cwd`
+    /// happens to be `$HOME` would otherwise pick up the host's
+    /// `~/.octos/config.json` (and, in `serve`, expose it to admin writes via
+    /// `AppState.config_path`). That isolation is the whole point of this
+    /// resolver. The project-local convenience is reserved for default-context
+    /// `octos chat`/`gateway` invocations.
+    fn load_resolved(
+        cwd: &Path,
+        config_home: &Path,
+        is_default: bool,
+    ) -> Result<(Self, Option<PathBuf>)> {
+        // 1. Project-local config — DEFAULT context only. In explicit/tenant
+        //    contexts this is skipped so an ambient `cwd/.octos/config.json`
+        //    (e.g. the host's `~/.octos`) can never leak in.
+        if is_default {
+            let local_config = cwd.join(".octos").join("config.json");
+            if local_config.exists() {
+                tracing::info!(path = %local_config.display(), "loading config (project-local)");
+                return Ok((Self::from_file(&local_config)?, Some(local_config)));
             }
         }
 
-        // No config found, use defaults. Even on the no-file path, honour
+        // 2. The resolved config_home (XDG for default, data_dir/OCTOS_CONFIG_DIR
+        //    for explicit). Resolved exactly once by `resolve_config_context`.
+        let home_config = config_home.join("config.json");
+        if home_config.exists() {
+            tracing::info!(path = %home_config.display(), "loading config (config home)");
+            return Ok((Self::from_file(&home_config)?, Some(home_config)));
+        }
+
+        // 3. Legacy back-compat: only for default installs, and only when the
+        //    legacy path differs from config_home (so we don't double-check the
+        //    same file). Explicit/tenant contexts never reach here.
+        if is_default {
+            if let Some(home) = dirs::home_dir() {
+                let legacy_config = home.join(".octos").join("config.json");
+                if legacy_config != home_config && legacy_config.exists() {
+                    tracing::info!(
+                        path = %legacy_config.display(),
+                        "loading config (legacy ~/.octos — consider running `octos init` to migrate)"
+                    );
+                    return Ok((Self::from_file(&legacy_config)?, Some(legacy_config)));
+                }
+            }
+        }
+
+        // 4. No config found, use defaults. Even on the no-file path, honour
         // `OCTOS_PLUGINS_REQUIRE_SIGNED` so spawned gateways without a
         // config.json still inherit the host's strict-signing policy.
         tracing::info!("no config.json found, using defaults");
@@ -1157,8 +1198,13 @@ impl Config {
         });
         octos_agent::register_secret_env_names([env_var.as_str()]);
 
-        // Check auth store first.
-        if let Ok(store) = crate::auth::AuthStore::load() {
+        // Check auth store first. Auth is GLOBAL: it lives under the resolver's
+        // `auth_home` (OCTOS_CONFIG_DIR if set, else the XDG default). This is
+        // independent of `--data-dir`, so per-profile gateways keep the host's
+        // shared `octos auth login` credentials. We resolve the context with no
+        // cli_data_dir because auth_home never depends on it.
+        let auth_home = crate::config_context::resolve_config_context(None).auth_home;
+        if let Ok(store) = crate::auth::AuthStore::at(&auth_home) {
             if let Some(cred) = store.get(provider) {
                 if !cred.is_expired() {
                     return Ok(cred.access_token.clone());
@@ -1315,6 +1361,13 @@ pub fn detect_provider(model: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Crate-wide lock for EVERY test that pivots the global `HOME` /
+    /// `OCTOS_HOME` / `OCTOS_CONFIG_DIR` env vars. These are process-global, so
+    /// all such tests (here and in `config_context`) must serialize against the
+    /// SAME mutex — per-module locks would let env-mutating tests race across
+    /// modules (a flaky-failure source).
+    use crate::config_context::TEST_ENV_LOCK as HOME_ENV_LOCK;
 
     #[test]
     fn write_mutation_creates_file_with_pretty_json() {
@@ -1537,7 +1590,8 @@ mod tests {
         )
         .unwrap();
 
-        let (config, path) = Config::load_with_path(cwd.path(), data_dir.path()).unwrap();
+        // Explicit context: config_home == data_dir, is_default == false.
+        let (config, path) = Config::load_resolved(cwd.path(), data_dir.path(), false).unwrap();
         assert_eq!(config.provider.as_deref(), Some("openai"));
         assert_eq!(config.model.as_deref(), Some("gpt-4o"));
         assert_eq!(path.as_deref(), Some(data_dir_config.as_path()));
@@ -1563,9 +1617,223 @@ mod tests {
         )
         .unwrap();
 
-        let (config, path) = Config::load_with_path(cwd.path(), data_dir.path()).unwrap();
+        // Project-local precedence is a DEFAULT-context convenience.
+        let (config, path) = Config::load_resolved(cwd.path(), data_dir.path(), true).unwrap();
         assert_eq!(config.provider.as_deref(), Some("anthropic"));
         assert_eq!(path.as_deref(), Some(local_config.as_path()));
+    }
+
+    /// Explicit/tenant context MUST NOT read the ambient project-local
+    /// `cwd/.octos/config.json` — only `config_home`. This closes the codex P1
+    /// where a tenant `serve` with `cwd == $HOME` picked up the host's
+    /// `~/.octos/config.json` and exposed it to admin writes.
+    #[test]
+    fn load_explicit_ignores_project_local_config() {
+        let cwd = tempfile::tempdir().unwrap();
+        let config_home = tempfile::tempdir().unwrap();
+        let local_dir = cwd.path().join(".octos");
+        std::fs::create_dir_all(&local_dir).unwrap();
+        // Ambient project-local config that would leak if isolation broke.
+        std::fs::write(
+            local_dir.join("config.json"),
+            r#"{"provider":"anthropic","auth_token":"HOST_SECRET"}"#,
+        )
+        .unwrap();
+
+        // Explicit context (is_default == false), empty config_home.
+        let (config, path) = Config::load_resolved(cwd.path(), config_home.path(), false).unwrap();
+        assert!(
+            config.provider.is_none(),
+            "explicit context must NOT read cwd/.octos/config.json"
+        );
+        assert!(config.auth_token.is_none());
+        assert!(path.is_none());
+    }
+
+    /// Gate 1: default install + XDG config present + an intact legacy
+    /// ~/.octos/config.json → XDG wins (legacy is the lower-precedence
+    /// fallback, not consulted when config_home has a file).
+    #[test]
+    fn load_default_prefers_xdg_config_home_over_legacy() {
+        // config_home (XDG) holds a config; legacy is a *different* path that
+        // also holds one. With is_default == true, config_home must win.
+        let cwd = tempfile::tempdir().unwrap();
+        let xdg = tempfile::tempdir().unwrap();
+        let xdg_config = xdg.path().join("config.json");
+        std::fs::write(&xdg_config, r#"{"provider":"openai"}"#).unwrap();
+
+        let (config, path) = Config::load_resolved(cwd.path(), xdg.path(), true).unwrap();
+        assert_eq!(config.provider.as_deref(), Some("openai"));
+        assert_eq!(path.as_deref(), Some(xdg_config.as_path()));
+    }
+
+    /// Gate 2 (back-compat): default install where config_home (XDG) has NO
+    /// config but the legacy ~/.octos/config.json does → legacy loads.
+    #[test]
+    #[allow(unsafe_code)]
+    fn load_default_falls_back_to_legacy_home_octos() {
+        let _g = HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let fake_home = tmp.path();
+        let cwd = fake_home.join("work");
+        std::fs::create_dir_all(&cwd).unwrap();
+
+        // Legacy ~/.octos/config.json present; XDG (config_home) empty.
+        let legacy = fake_home.join(".octos").join("config.json");
+        std::fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+        std::fs::write(&legacy, r#"{"provider":"gemini"}"#).unwrap();
+
+        let empty_config_home = fake_home.join("empty-xdg");
+
+        let original_home = std::env::var_os("HOME");
+        // SAFETY: single-threaded inside LOCK; restored below.
+        unsafe { std::env::set_var("HOME", fake_home) };
+
+        let result = Config::load_resolved(&cwd, &empty_config_home, true);
+
+        match original_home {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+
+        let (config, path) = result.unwrap();
+        assert_eq!(config.provider.as_deref(), Some("gemini"));
+        assert_eq!(path.as_deref(), Some(legacy.as_path()));
+    }
+
+    /// Gate 2 (defaults): default install, neither XDG nor legacy → defaults.
+    #[test]
+    #[allow(unsafe_code)]
+    fn load_default_uses_defaults_when_no_config_anywhere() {
+        let _g = HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let fake_home = tmp.path();
+        let cwd = fake_home.join("work");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let empty_config_home = fake_home.join("empty-xdg");
+
+        let original_home = std::env::var_os("HOME");
+        // SAFETY: single-threaded inside LOCK; restored below.
+        unsafe { std::env::set_var("HOME", fake_home) };
+
+        let result = Config::load_resolved(&cwd, &empty_config_home, true);
+
+        match original_home {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+
+        let (config, path) = result.unwrap();
+        assert!(config.provider.is_none());
+        assert!(path.is_none());
+    }
+
+    /// Gate 3 (tenant isolation): explicit context (is_default == false) with
+    /// an empty config_home MUST NOT fall through to the host's legacy
+    /// ~/.octos/config.json — it loads defaults instead.
+    #[test]
+    #[allow(unsafe_code)]
+    fn load_explicit_never_reads_host_legacy_octos() {
+        let _g = HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let fake_home = tmp.path();
+        let cwd = fake_home.join("work");
+        std::fs::create_dir_all(&cwd).unwrap();
+
+        // Host legacy config is present and would leak if isolation broke.
+        let legacy = fake_home.join(".octos").join("config.json");
+        std::fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+        std::fs::write(&legacy, r#"{"provider":"anthropic","auth_token":"SECRET"}"#).unwrap();
+
+        // Explicit tenant data dir, no config inside it.
+        let tenant = fake_home.join("tenant-data");
+
+        let original_home = std::env::var_os("HOME");
+        // SAFETY: single-threaded inside LOCK; restored below.
+        unsafe { std::env::set_var("HOME", fake_home) };
+
+        let result = Config::load_resolved(&cwd, &tenant, false);
+
+        match original_home {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+
+        let (config, path) = result.unwrap();
+        assert!(
+            config.provider.is_none(),
+            "explicit/tenant context must NOT read host ~/.octos/config.json"
+        );
+        assert!(config.auth_token.is_none());
+        assert!(path.is_none());
+    }
+
+    /// Gate 7 (end-to-end, the load-bearing "no per-profile login regression"):
+    /// `get_api_key` resolves the GLOBAL auth store (XDG `auth_home`), NOT a
+    /// per-profile `data_dir/auth.json`. We seed a credential at the XDG
+    /// location and prove the API-key lookup finds it. `OCTOS_CONFIG_DIR` must
+    /// be unset for the default/global case, so this test serializes on the
+    /// shared env lock and clears all three env vars.
+    #[test]
+    #[allow(unsafe_code)]
+    fn get_api_key_reads_global_xdg_auth_store() {
+        let _g = HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let fake_home = tmp.path();
+
+        let original_home = std::env::var_os("HOME");
+        let original_octos_home = std::env::var_os("OCTOS_HOME");
+        let original_octos_config = std::env::var_os("OCTOS_CONFIG_DIR");
+        // SAFETY: serialized by HOME_ENV_LOCK; restored below.
+        unsafe {
+            std::env::set_var("HOME", fake_home);
+            std::env::remove_var("OCTOS_HOME");
+            std::env::remove_var("OCTOS_CONFIG_DIR");
+        }
+
+        // Resolve the GLOBAL auth_home (XDG) and seed a credential there.
+        let ctx = crate::config_context::resolve_config_context(None);
+        let mut store = crate::auth::AuthStore::open(&ctx).unwrap();
+        store
+            .set(
+                "anthropic",
+                crate::auth::AuthCredential {
+                    access_token: "global-xdg-token".to_string(),
+                    refresh_token: None,
+                    expires_at: None,
+                    provider: "anthropic".to_string(),
+                    auth_method: "paste_token".to_string(),
+                },
+            )
+            .unwrap();
+
+        // A default config — get_api_key should consult the GLOBAL auth store
+        // and return the seeded token (it does NOT look at any data_dir).
+        let config = Config::default();
+        let key = config.get_api_key("anthropic");
+
+        match original_home {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        match original_octos_home {
+            Some(v) => unsafe { std::env::set_var("OCTOS_HOME", v) },
+            None => unsafe { std::env::remove_var("OCTOS_HOME") },
+        }
+        match original_octos_config {
+            Some(v) => unsafe { std::env::set_var("OCTOS_CONFIG_DIR", v) },
+            None => unsafe { std::env::remove_var("OCTOS_CONFIG_DIR") },
+        }
+
+        assert_eq!(
+            key.unwrap(),
+            "global-xdg-token",
+            "get_api_key must read the GLOBAL XDG auth store (shared login)"
+        );
     }
 
     #[test]
@@ -1637,8 +1905,7 @@ mod tests {
     #[allow(unsafe_code)]
     fn plugin_dirs_from_project_drops_legacy_home_rooted_globals() {
         // Serialize env mutation so parallel tests don't fight over HOME.
-        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let tmp = tempfile::tempdir().unwrap();
         let fake_home = tmp.path();
@@ -1655,8 +1922,8 @@ mod tests {
         // Pivot HOME for the duration of this assertion. dirs::home_dir()
         // honors HOME on Unix; we restore the original after the check.
         let original_home = std::env::var_os("HOME");
-        // SAFETY: single-threaded inside the static LOCK above; restored on
-        // both the success and panic-unwind paths below.
+        // SAFETY: serialized by HOME_ENV_LOCK above; restored on both the
+        // success and panic-unwind paths below.
         unsafe { std::env::set_var("HOME", fake_home) };
 
         let scan = Config::plugin_dirs_from_project(&project_dir);

--- a/crates/octos-cli/src/config_context.rs
+++ b/crates/octos-cli/src/config_context.rs
@@ -69,6 +69,24 @@ fn normalize_for_compare(path: &Path) -> PathBuf {
     std::fs::canonicalize(&absolute).unwrap_or(absolute)
 }
 
+/// Normalize a path for RETURN (config_home / auth_home / data_dir): expand a
+/// leading `~` and make it absolute, but do NOT `canonicalize`. Canonicalize is
+/// reserved for the `is_default` *comparison* — applying it to returned paths
+/// would resolve symlinks (e.g. macOS `/var`→`/private/var`), require the path
+/// to already exist, and surprise callers/tests with a rewritten prefix. We
+/// only need to guarantee no literal `~`/relative segment leaks into a file
+/// path.
+fn normalize_for_return(path: &Path) -> PathBuf {
+    let expanded = expand_tilde(path);
+    if expanded.is_absolute() {
+        expanded
+    } else if let Ok(cwd) = std::env::current_dir() {
+        cwd.join(&expanded)
+    } else {
+        expanded
+    }
+}
+
 /// Expand a leading `~` or `~/` against `$HOME`.
 fn expand_tilde(path: &Path) -> PathBuf {
     let s = path.to_string_lossy();
@@ -139,10 +157,14 @@ pub fn resolve_config_context(cli_data_dir: Option<&Path>) -> ConfigContext {
     // auth_home is GLOBAL: OCTOS_CONFIG_DIR if set, else XDG. NEVER data_dir.
     let auth_home = octos_config_dir.clone().unwrap_or_else(xdg_config_home);
 
+    // Normalize the RETURNED paths (expand a leading `~`, make absolute,
+    // canonicalize-if-it-exists). Without this, an env value like
+    // `OCTOS_HOME=~/x` or a relative `--data-dir foo` would propagate a literal
+    // `~`/relative segment into the config/auth/state file paths.
     ConfigContext {
-        config_home,
-        auth_home,
-        data_dir,
+        config_home: normalize_for_return(&config_home),
+        auth_home: normalize_for_return(&auth_home),
+        data_dir: normalize_for_return(&data_dir),
         is_default,
     }
 }

--- a/crates/octos-cli/src/config_context.rs
+++ b/crates/octos-cli/src/config_context.rs
@@ -1,0 +1,620 @@
+//! Canonical config/auth/data path resolver — the single source of truth.
+//!
+//! Every site that needs to know *where* octos reads/writes user config, auth
+//! credentials, or runtime state MUST resolve through [`resolve_config_context`]
+//! and consume the returned [`ConfigContext`]. No call site recomputes these
+//! paths from the environment on its own — that split-brain divergence was the
+//! root cause of the two prior failed attempts at XDG-primary config.
+//!
+//! # Resolution rules (codex-vetted)
+//!
+//! Inputs: the `--data-dir` CLI flag plus the `OCTOS_HOME` and
+//! `OCTOS_CONFIG_DIR` environment variables. Empty-string env vars are treated
+//! as unset. `OCTOS_HOME` is normalized (tilde-expanded, made absolute,
+//! `canonicalize`d best-effort) before being compared to the default `~/.octos`.
+//!
+//! * `data_dir` = `--data-dir` > `$OCTOS_HOME` > `~/.octos`
+//!   (state/sessions/skills — unchanged semantics).
+//! * `is_explicit` = `--data-dir` set OR `OCTOS_CONFIG_DIR` set OR
+//!   (`OCTOS_HOME` set AND its normalized form != `~/.octos`).
+//!   `is_default = !is_explicit`.
+//! * `config_home` = `OCTOS_CONFIG_DIR` if set, else `data_dir` when explicit,
+//!   else the XDG default (`dirs::config_dir()/octos`).
+//! * `auth_home` = `OCTOS_CONFIG_DIR` if set, else the XDG default
+//!   (`dirs::config_dir()/octos`). **DECOUPLED from `data_dir`** so per-profile
+//!   gateways (which run with `--data-dir <profile-data>`) keep the host's
+//!   shared, global `octos auth login`.
+
+use std::path::{Path, PathBuf};
+
+/// Resolved, canonical paths for config / auth / runtime state.
+///
+/// Constructed exactly once per command entrypoint via
+/// [`resolve_config_context`] and threaded to every consumer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigContext {
+    /// Where `config.json` is read from / written to (when not project-local).
+    pub config_home: PathBuf,
+    /// Where `auth.json` lives. GLOBAL (XDG) unless `OCTOS_CONFIG_DIR` is set.
+    pub auth_home: PathBuf,
+    /// Runtime state root: episodes, sessions, skills, memory, logs.
+    pub data_dir: PathBuf,
+    /// `true` when no explicit override was supplied (default install). When
+    /// `true`, config load may fall back to the legacy `~/.octos/config.json`
+    /// and config migration into XDG is permitted.
+    pub is_default: bool,
+}
+
+/// Read an environment variable, treating empty strings as unset.
+fn env_nonempty(name: &str) -> Option<String> {
+    match std::env::var(name) {
+        Ok(v) if !v.trim().is_empty() => Some(v),
+        _ => None,
+    }
+}
+
+/// Best-effort path normalization for comparison: expand a leading `~`, make
+/// the path absolute relative to `$HOME`/CWD, then `canonicalize` if the path
+/// exists on disk. Falls back to the lexical form when canonicalization fails
+/// (e.g. the directory does not exist yet).
+fn normalize_for_compare(path: &Path) -> PathBuf {
+    let expanded = expand_tilde(path);
+    let absolute = if expanded.is_absolute() {
+        expanded
+    } else if let Ok(cwd) = std::env::current_dir() {
+        cwd.join(&expanded)
+    } else {
+        expanded
+    };
+    std::fs::canonicalize(&absolute).unwrap_or(absolute)
+}
+
+/// Expand a leading `~` or `~/` against `$HOME`.
+fn expand_tilde(path: &Path) -> PathBuf {
+    let s = path.to_string_lossy();
+    if s == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home;
+        }
+    } else if let Some(rest) = s.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    }
+    path.to_path_buf()
+}
+
+/// The default runtime data dir: `~/.octos`.
+fn default_data_dir() -> PathBuf {
+    dirs::home_dir()
+        .map(|h| h.join(".octos"))
+        .unwrap_or_else(|| PathBuf::from(".octos"))
+}
+
+/// The XDG config home for octos:
+/// `~/Library/Application Support/octos` (macOS) or
+/// `${XDG_CONFIG_HOME:-~/.config}/octos` (Linux). Falls back to the default
+/// `~/.octos` when the platform config dir cannot be determined.
+fn xdg_config_home() -> PathBuf {
+    dirs::config_dir()
+        .map(|d| d.join("octos"))
+        .unwrap_or_else(default_data_dir)
+}
+
+/// Resolve the canonical [`ConfigContext`] from the `--data-dir` flag plus the
+/// `OCTOS_HOME` / `OCTOS_CONFIG_DIR` environment variables.
+///
+/// See the module docs for the full rule set. This is the ONLY function that
+/// reads those env vars for path resolution.
+pub fn resolve_config_context(cli_data_dir: Option<&Path>) -> ConfigContext {
+    let octos_home = env_nonempty("OCTOS_HOME").map(PathBuf::from);
+    let octos_config_dir = env_nonempty("OCTOS_CONFIG_DIR").map(PathBuf::from);
+
+    // data_dir: --data-dir > $OCTOS_HOME > ~/.octos
+    let data_dir = cli_data_dir
+        .map(PathBuf::from)
+        .or_else(|| octos_home.clone())
+        .unwrap_or_else(default_data_dir);
+
+    // Is OCTOS_HOME a non-default override? Compare normalized paths so
+    // `OCTOS_HOME=~/.octos`, `OCTOS_HOME=$HOME/.octos`, and a trailing-slash
+    // variant all resolve to the default (no split-brain).
+    let octos_home_is_nondefault = octos_home
+        .as_deref()
+        .map(|h| normalize_for_compare(h) != normalize_for_compare(&default_data_dir()))
+        .unwrap_or(false);
+
+    let is_explicit =
+        cli_data_dir.is_some() || octos_config_dir.is_some() || octos_home_is_nondefault;
+    let is_default = !is_explicit;
+
+    let config_home = if let Some(ref cfg) = octos_config_dir {
+        cfg.clone()
+    } else if is_explicit {
+        data_dir.clone()
+    } else {
+        xdg_config_home()
+    };
+
+    // auth_home is GLOBAL: OCTOS_CONFIG_DIR if set, else XDG. NEVER data_dir.
+    let auth_home = octos_config_dir.clone().unwrap_or_else(xdg_config_home);
+
+    ConfigContext {
+        config_home,
+        auth_home,
+        data_dir,
+        is_default,
+    }
+}
+
+/// Atomically copy `src` into `dest`, non-destructively and idempotently.
+///
+/// Semantics (shared by config + auth migration):
+/// * No-op (returns `false`) if `dest` already exists or `src` is missing —
+///   we never overwrite a destination or invent a source.
+/// * `mkdir -p` the destination's parent directory.
+/// * Write into a temp file *in the destination directory*, `fsync` it, set
+///   `mode` (Unix only) on the temp file before the rename so the final file
+///   never exists with looser permissions, then `fs::rename` (atomic on the
+///   same filesystem).
+/// * Best-effort: any I/O error is swallowed and reported as `false` (the
+///   legacy file is always left intact, so a failed migration degrades to
+///   "config/auth still read from legacy" rather than data loss).
+///
+/// Returns `true` when a copy was performed.
+pub fn atomic_copy_into(src: &Path, dest: &Path, mode: Option<u32>) -> bool {
+    if dest.exists() || !src.exists() {
+        return false;
+    }
+    let Some(parent) = dest.parent() else {
+        return false;
+    };
+    if std::fs::create_dir_all(parent).is_err() {
+        return false;
+    }
+    let Ok(bytes) = std::fs::read(src) else {
+        return false;
+    };
+
+    // Unpredictable temp name in the destination directory (same filesystem →
+    // atomic rename). Combining pid, a monotonic counter, and the nanosecond
+    // clock keeps the name from being guessable so an attacker cannot
+    // pre-plant a file/symlink that we would open-and-truncate.
+    let tmp = parent.join(format!(
+        ".{}.{}.{}.{}.tmp",
+        dest.file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "octos-migrate".to_string()),
+        std::process::id(),
+        next_temp_counter(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+    ));
+
+    let write_ok = write_temp(&tmp, &bytes, mode);
+    if !write_ok {
+        let _ = std::fs::remove_file(&tmp);
+        return false;
+    }
+
+    // `fs::rename` overwrites an existing dest on Unix. We already established
+    // `!dest.exists()` above and migration runs once at startup, so the
+    // remaining window is negligible; keep the rename (atomic same-fs swap).
+    if std::fs::rename(&tmp, dest).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+        return false;
+    }
+    true
+}
+
+/// Monotonic per-process counter for temp-file name uniqueness.
+fn next_temp_counter() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Write `bytes` to a FRESH temp file (`create_new` — never opens an existing
+/// path, so a pre-planted file/symlink at `tmp` causes a clean failure rather
+/// than a truncate-and-write), applying `mode` on Unix, and fsync before close.
+fn write_temp(tmp: &Path, bytes: &[u8], mode: Option<u32>) -> bool {
+    use std::io::Write as _;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        let mut opts = std::fs::OpenOptions::new();
+        // create_new(true) ⇒ O_CREAT|O_EXCL: fails if `tmp` already exists,
+        // and applies `mode` atomically at creation (no looser-perm window).
+        opts.write(true).create_new(true);
+        if let Some(m) = mode {
+            opts.mode(m);
+        }
+        let Ok(mut f) = opts.open(tmp) else {
+            return false;
+        };
+        if f.write_all(bytes).is_err() {
+            return false;
+        }
+        // Defense in depth: re-assert the mode after creation in case a umask
+        // or platform quirk loosened it. Failure here aborts the copy.
+        if let Some(m) = mode {
+            use std::os::unix::fs::PermissionsExt as _;
+            if std::fs::set_permissions(tmp, std::fs::Permissions::from_mode(m)).is_err() {
+                return false;
+            }
+        }
+        f.sync_all().is_ok()
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = mode;
+        let Ok(mut f) = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(tmp)
+        else {
+            return false;
+        };
+        if f.write_all(bytes).is_err() {
+            return false;
+        }
+        f.sync_all().is_ok()
+    }
+}
+
+/// Run the config + auth migrations for the given context. Idempotent and
+/// best-effort. Call once at the command entrypoint.
+///
+/// * Config migration: only when `ctx.is_default`. Copies legacy
+///   `~/.octos/config.json` → `ctx.config_home/config.json` (the XDG default).
+///   Logs a one-line notice when the copy happens so the user knows their
+///   config now lives at the XDG path. Legacy file is left intact.
+/// * Auth migration: only when `ctx.auth_home` is the XDG default (i.e.
+///   `OCTOS_CONFIG_DIR` is unset). Copies legacy `~/.octos/auth.json` →
+///   `ctx.auth_home/auth.json` with mode `0600`. Never migrates host auth into
+///   an `OCTOS_CONFIG_DIR` tenant directory. Legacy file is left intact.
+pub fn run_migrations(ctx: &ConfigContext) {
+    let legacy_root = default_data_dir();
+
+    // `auth_home`/config XDG-default gating is derived from the resolved
+    // context — NOT re-read from the environment — so the migration can never
+    // diverge from what the resolver decided. `auth_home == xdg_config_home()`
+    // holds exactly when `OCTOS_CONFIG_DIR` was unset, which is the only case
+    // in which we touch the XDG location.
+    let xdg = xdg_config_home();
+    let auth_home_is_xdg_default = ctx.auth_home == xdg;
+
+    // ── Config migration (default installs only) ──────────────────────
+    if ctx.is_default {
+        let legacy_config = legacy_root.join("config.json");
+        let dest_config = ctx.config_home.join("config.json");
+        if legacy_config != dest_config && atomic_copy_into(&legacy_config, &dest_config, None) {
+            tracing::info!(
+                from = %legacy_config.display(),
+                to = %dest_config.display(),
+                "migrated config.json to the XDG config directory (legacy copy left intact)"
+            );
+        }
+    } else if auth_home_is_xdg_default {
+        // Non-default via OCTOS_HOME (not OCTOS_CONFIG_DIR): config now lives in
+        // the state dir. Surface a one-line notice so an
+        // `OCTOS_HOME=~/projects/foo` user is not surprised their config lives
+        // there. No copy — explicit dirs are isolated; this is informational.
+        tracing::info!(
+            config_home = %ctx.config_home.display(),
+            "OCTOS_HOME override active: config.json is read/written under the state dir"
+        );
+    }
+
+    // ── Auth migration (XDG-default auth_home only) ───────────────────
+    if auth_home_is_xdg_default {
+        let legacy_auth = legacy_root.join("auth.json");
+        let dest_auth = ctx.auth_home.join("auth.json");
+        if legacy_auth != dest_auth && atomic_copy_into(&legacy_auth, &dest_auth, Some(0o600)) {
+            tracing::info!(
+                from = %legacy_auth.display(),
+                to = %dest_auth.display(),
+                "migrated auth.json to the XDG config directory (mode 0600, legacy copy left intact)"
+            );
+        }
+    }
+}
+
+/// Process-wide lock for tests that mutate the global `HOME` / `OCTOS_HOME` /
+/// `OCTOS_CONFIG_DIR` environment variables. These vars are process-global, so
+/// EVERY env-pivoting test in the crate (here and in `config.rs`) must
+/// serialize against this single mutex — separate per-module locks would let
+/// tests in different modules race each other and flake.
+#[cfg(test)]
+pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Alias for the crate-wide env lock (see [`super::TEST_ENV_LOCK`]).
+    use super::TEST_ENV_LOCK as ENV_LOCK;
+
+    struct EnvGuard {
+        home: Option<std::ffi::OsString>,
+        octos_home: Option<std::ffi::OsString>,
+        octos_config_dir: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        #[allow(unsafe_code)]
+        fn pivot(home: &Path) -> Self {
+            let g = EnvGuard {
+                home: std::env::var_os("HOME"),
+                octos_home: std::env::var_os("OCTOS_HOME"),
+                octos_config_dir: std::env::var_os("OCTOS_CONFIG_DIR"),
+            };
+            // SAFETY: callers hold ENV_LOCK; restored in Drop.
+            unsafe {
+                std::env::set_var("HOME", home);
+                std::env::remove_var("OCTOS_HOME");
+                std::env::remove_var("OCTOS_CONFIG_DIR");
+            }
+            g
+        }
+    }
+
+    impl Drop for EnvGuard {
+        #[allow(unsafe_code)]
+        fn drop(&mut self) {
+            // SAFETY: callers hold ENV_LOCK for the guard's lifetime.
+            unsafe {
+                restore("HOME", &self.home);
+                restore("OCTOS_HOME", &self.octos_home);
+                restore("OCTOS_CONFIG_DIR", &self.octos_config_dir);
+            }
+        }
+    }
+
+    #[allow(unsafe_code)]
+    unsafe fn restore(key: &str, val: &Option<std::ffi::OsString>) {
+        match val {
+            Some(v) => unsafe { std::env::set_var(key, v) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+    }
+
+    #[allow(unsafe_code)]
+    fn set_env(key: &str, val: &str) {
+        // SAFETY: callers hold ENV_LOCK.
+        unsafe { std::env::set_var(key, val) };
+    }
+
+    /// Gate 4 + 10: `OCTOS_HOME == ~/.octos` (and the empty-string case) are
+    /// treated as the default — no split-brain, config_home is XDG.
+    #[test]
+    fn octos_home_equal_to_default_is_treated_as_default() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let _env = EnvGuard::pivot(home);
+
+        // OCTOS_HOME explicitly set to the default location.
+        set_env("OCTOS_HOME", home.join(".octos").to_str().unwrap());
+        let ctx = resolve_config_context(None);
+        assert!(ctx.is_default, "OCTOS_HOME==~/.octos must be is_default");
+        assert_eq!(
+            ctx.config_home,
+            xdg_config_home(),
+            "OCTOS_HOME==~/.octos must resolve config_home to XDG (no split-brain)"
+        );
+        assert_eq!(ctx.data_dir, home.join(".octos"));
+    }
+
+    /// Gate 10: empty-string OCTOS_HOME is treated as unset → default.
+    #[test]
+    fn empty_octos_home_is_unset() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::pivot(tmp.path());
+        set_env("OCTOS_HOME", "");
+        let ctx = resolve_config_context(None);
+        assert!(ctx.is_default);
+        assert_eq!(ctx.data_dir, tmp.path().join(".octos"));
+        assert_eq!(ctx.config_home, xdg_config_home());
+    }
+
+    /// Gate 5: non-default OCTOS_HOME → config_home == that state dir.
+    #[test]
+    fn nondefault_octos_home_sets_config_home_to_state_dir() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::pivot(tmp.path());
+        let custom = tmp.path().join("projects").join("foo");
+        set_env("OCTOS_HOME", custom.to_str().unwrap());
+        let ctx = resolve_config_context(None);
+        assert!(!ctx.is_default);
+        assert_eq!(ctx.data_dir, custom);
+        assert_eq!(ctx.config_home, custom);
+        // auth stays GLOBAL.
+        assert_eq!(ctx.auth_home, xdg_config_home());
+    }
+
+    /// Gate 3 + 7: `--data-dir T` → config_home == T, but auth_home stays the
+    /// GLOBAL XDG default (shared login across per-profile gateways).
+    #[test]
+    fn cli_data_dir_isolates_config_but_auth_stays_global() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::pivot(tmp.path());
+        let t = tmp.path().join("profile-data");
+        let ctx = resolve_config_context(Some(&t));
+        assert!(!ctx.is_default);
+        assert_eq!(ctx.data_dir, t);
+        assert_eq!(ctx.config_home, t, "explicit --data-dir → config in T");
+        assert_eq!(
+            ctx.auth_home,
+            xdg_config_home(),
+            "auth MUST stay global (XDG) across --data-dir profiles"
+        );
+    }
+
+    /// Gate 6: `OCTOS_CONFIG_DIR=C` → BOTH config and auth resolve under C.
+    #[test]
+    fn octos_config_dir_governs_both_config_and_auth() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::pivot(tmp.path());
+        let c = tmp.path().join("tenant-config");
+        set_env("OCTOS_CONFIG_DIR", c.to_str().unwrap());
+        // Even with a --data-dir, OCTOS_CONFIG_DIR wins for config + auth.
+        let t = tmp.path().join("tenant-data");
+        let ctx = resolve_config_context(Some(&t));
+        assert!(!ctx.is_default);
+        assert_eq!(ctx.data_dir, t);
+        assert_eq!(ctx.config_home, c, "OCTOS_CONFIG_DIR governs config_home");
+        assert_eq!(ctx.auth_home, c, "OCTOS_CONFIG_DIR governs auth_home");
+    }
+
+    /// Gate 1/2 baseline: no env, no flag → default install. data_dir is
+    /// ~/.octos, config_home is XDG, auth_home is XDG, is_default true.
+    #[test]
+    fn pure_default_resolves_to_xdg_config_and_legacy_data() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::pivot(tmp.path());
+        let ctx = resolve_config_context(None);
+        assert!(ctx.is_default);
+        assert_eq!(ctx.data_dir, tmp.path().join(".octos"));
+        assert_eq!(ctx.config_home, xdg_config_home());
+        assert_eq!(ctx.auth_home, xdg_config_home());
+    }
+
+    // ── atomic_copy_into ──────────────────────────────────────────────
+
+    #[test]
+    fn atomic_copy_into_copies_when_dest_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src.json");
+        let dest = tmp.path().join("nested").join("dest.json");
+        std::fs::write(&src, b"{\"k\":1}").unwrap();
+
+        assert!(atomic_copy_into(&src, &dest, None));
+        assert_eq!(std::fs::read(&dest).unwrap(), b"{\"k\":1}");
+        // src left intact.
+        assert!(src.exists());
+    }
+
+    #[test]
+    fn atomic_copy_into_is_idempotent_and_nondestructive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src.json");
+        let dest = tmp.path().join("dest.json");
+        std::fs::write(&src, b"new").unwrap();
+        std::fs::write(&dest, b"existing").unwrap();
+
+        // Dest exists → no copy, dest preserved.
+        assert!(!atomic_copy_into(&src, &dest, None));
+        assert_eq!(std::fs::read(&dest).unwrap(), b"existing");
+    }
+
+    #[test]
+    fn atomic_copy_into_noop_when_src_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("absent.json");
+        let dest = tmp.path().join("dest.json");
+        assert!(!atomic_copy_into(&src, &dest, None));
+        assert!(!dest.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_copy_into_applies_0600_mode() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src.json");
+        let dest = tmp.path().join("dest.json");
+        // Simulate a world-readable legacy file (0644).
+        std::fs::write(&src, b"secret").unwrap();
+        std::fs::set_permissions(&src, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert!(atomic_copy_into(&src, &dest, Some(0o600)));
+        let mode = std::fs::metadata(&dest).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "dest must be 0600 regardless of src perms");
+    }
+
+    // ── run_migrations (gates 8 + 9) ──────────────────────────────────
+
+    /// Gate 9: default install + legacy ~/.octos/config.json + no XDG →
+    /// XDG config created, legacy left intact.
+    #[test]
+    fn config_migration_copies_legacy_to_xdg_and_leaves_legacy_intact() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::pivot(tmp.path());
+
+        let legacy = tmp.path().join(".octos").join("config.json");
+        std::fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+        std::fs::write(&legacy, b"{\"provider\":\"anthropic\"}").unwrap();
+
+        let ctx = resolve_config_context(None);
+        run_migrations(&ctx);
+
+        let xdg = ctx.config_home.join("config.json");
+        assert!(xdg.exists(), "XDG config.json must be created");
+        assert_eq!(
+            std::fs::read(&xdg).unwrap(),
+            b"{\"provider\":\"anthropic\"}"
+        );
+        assert!(legacy.exists(), "legacy config.json must be left intact");
+    }
+
+    /// Gate 8: legacy ~/.octos/auth.json (0644) → XDG auth.json at 0600;
+    /// legacy left intact.
+    #[cfg(unix)]
+    #[test]
+    fn auth_migration_produces_0600_and_leaves_legacy_intact() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::pivot(tmp.path());
+
+        let legacy = tmp.path().join(".octos").join("auth.json");
+        std::fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+        std::fs::write(&legacy, b"{\"credentials\":{}}").unwrap();
+        std::fs::set_permissions(&legacy, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let ctx = resolve_config_context(None);
+        run_migrations(&ctx);
+
+        let xdg = ctx.auth_home.join("auth.json");
+        assert!(xdg.exists(), "XDG auth.json must be created");
+        let mode = std::fs::metadata(&xdg).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "migrated auth.json must be 0600");
+        assert!(legacy.exists(), "legacy auth.json must be left intact");
+    }
+
+    /// Gate 8 (tenant): OCTOS_CONFIG_DIR set → host auth is NOT migrated into
+    /// the tenant dir.
+    #[test]
+    fn auth_migration_does_not_touch_tenant_config_dir() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::pivot(tmp.path());
+
+        let legacy = tmp.path().join(".octos").join("auth.json");
+        std::fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+        std::fs::write(&legacy, b"{\"credentials\":{}}").unwrap();
+
+        let tenant = tmp.path().join("tenant");
+        set_env("OCTOS_CONFIG_DIR", tenant.to_str().unwrap());
+
+        let ctx = resolve_config_context(None);
+        run_migrations(&ctx);
+
+        assert!(
+            !tenant.join("auth.json").exists(),
+            "host auth must NOT be migrated into an OCTOS_CONFIG_DIR tenant dir"
+        );
+        assert!(legacy.exists(), "legacy auth.json must be left intact");
+    }
+}

--- a/crates/octos-cli/src/lib.rs
+++ b/crates/octos-cli/src/lib.rs
@@ -13,6 +13,7 @@ pub mod cli_agent_adapter;
 pub mod commands;
 pub mod compaction;
 pub mod config;
+pub mod config_context;
 pub mod config_watcher;
 #[cfg(feature = "api")]
 pub mod content_catalog;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -135,6 +135,76 @@ normalize_path() {
 PREFIX="$(normalize_path "$PREFIX")"
 DATA_DIR="$(normalize_path "$DATA_DIR")"
 
+# ── Config home resolver (bash mirror of resolve_config_context in Rust) ──
+# Keep this EXACTLY consistent with crates/octos-cli/src/config_context.rs.
+#
+#   config_home = $OCTOS_CONFIG_DIR                       (if set, non-empty)
+#               | $DATA_DIR                               (if explicit: an
+#                                                          OCTOS_HOME override
+#                                                          != $HOME/.octos)
+#               | XDG default                             (otherwise)
+#
+# XDG default:
+#   macOS → $HOME/Library/Application Support/octos
+#   Linux → ${XDG_CONFIG_HOME:-$HOME/.config}/octos
+#           NOTE: a RELATIVE $XDG_CONFIG_HOME is ignored (matching Rust's
+#           dirs::config_dir(), which per the XDG spec only honours absolute
+#           values) — we fall back to $HOME/.config in that case.
+#
+# Empty-string env vars are treated as unset (matching env_nonempty in Rust).
+xdg_config_home() {
+    case "$(uname -s)" in
+        Darwin) printf '%s/Library/Application Support/octos\n' "$HOME" ;;
+        *)
+            # Honour XDG_CONFIG_HOME only when it is an ABSOLUTE path.
+            if [ -n "${XDG_CONFIG_HOME:-}" ] && [ "${XDG_CONFIG_HOME#/}" != "$XDG_CONFIG_HOME" ]; then
+                printf '%s/octos\n' "$XDG_CONFIG_HOME"
+            else
+                printf '%s/octos\n' "$HOME/.config"
+            fi
+            ;;
+    esac
+}
+
+# Resolve symlinks/. /.. best-effort so the OCTOS_HOME-vs-default comparison
+# matches Rust's canonicalize() (which resolves symlinks when the path exists).
+# Prefer python3's os.path.realpath (consistent across macOS/Linux, handles
+# non-existent paths), then GNU `realpath -m`, then BSD `realpath`, finally the
+# lexical path stripped of any trailing slash.
+canonicalize_path() {
+    local p="$1"
+    if command -v python3 >/dev/null 2>&1; then
+        OCTOS_CANON_IN="$p" python3 -c 'import os; print(os.path.realpath(os.environ["OCTOS_CANON_IN"]))' 2>/dev/null && return 0
+    fi
+    if command -v realpath >/dev/null 2>&1; then
+        # GNU realpath supports -m (no existence requirement); BSD does not.
+        realpath -m "$p" 2>/dev/null && return 0
+        realpath "$p" 2>/dev/null && return 0
+    fi
+    # Lexical fallback: drop a trailing slash so "X/" == "X".
+    case "$p" in
+        */) printf '%s\n' "${p%/}" ;;
+        *)  printf '%s\n' "$p" ;;
+    esac
+}
+
+compute_config_home() {
+    if [ -n "${OCTOS_CONFIG_DIR:-}" ]; then
+        normalize_path "$OCTOS_CONFIG_DIR"
+        return 0
+    fi
+    # Explicit when DATA_DIR (from OCTOS_HOME) is a non-default override.
+    # Compare CANONICALIZED paths so symlinked / trailing-slash variants of
+    # ~/.octos still resolve to the default (mirrors normalize_for_compare).
+    if [ "$(canonicalize_path "$DATA_DIR")" != "$(canonicalize_path "$HOME/.octos")" ]; then
+        printf '%s\n' "$DATA_DIR"
+        return 0
+    fi
+    xdg_config_home
+}
+
+CONFIG_HOME="$(compute_config_home)"
+
 validate() {
     local name="$1" value="$2" pattern="$3"
     if ! printf '%s' "$value" | grep -qE "^${pattern}\$"; then
@@ -158,6 +228,11 @@ validate_inputs() {
     [ -n "$VERSION" ] && [ "$VERSION" != "latest" ] && validate "version" "$VERSION" '[a-zA-Z0-9._-]+'
     [ -n "$PREFIX" ]        && validate "prefix"      "$PREFIX"      '/[a-zA-Z0-9/._~-]*'
     [ -n "$DATA_DIR" ]      && validate "data-dir"    "$DATA_DIR"    '/[a-zA-Z0-9/._~-]*'
+    # CONFIG_HOME may legitimately contain a space (macOS XDG default is
+    # ".../Library/Application Support/octos"). It is only ever used with the
+    # shell tools below (quoted), never interpolated into TOML/plist/systemd
+    # units, so the space-tolerant pattern is safe here.
+    [ -n "${CONFIG_HOME:-}" ] && validate "config-home" "$CONFIG_HOME" '/[a-zA-Z0-9 /._~-]*'
     return 0
 }
 
@@ -588,6 +663,8 @@ write_octos_service() {
         <string>$HOME</string>
         <key>OCTOS_DATA_DIR</key>
         <string>$DATA_DIR</string>
+        <key>OCTOS_HOME</key>
+        <string>$DATA_DIR</string>
     <key>OCTOS_AUTH_TOKEN</key>
     <string>$AUTH_TOKEN</string>
 $(launchd_env_var_xml "FRPS_TOKEN" "${FRPS_TOKEN:-}")
@@ -771,15 +848,27 @@ if [ "$RUN_DOCTOR" = true ]; then
 
     if [ -d "$DATA_DIR" ]; then
         ok "found: $DATA_DIR"
-        if [ -f "$DATA_DIR/config.json" ]; then
-            ok "config.json exists"
-        else
-            warn "config.json missing"
-            hint "Run: octos init"
-        fi
     else
         err "$DATA_DIR does not exist"
         hint "Run: octos init --defaults"
+    fi
+
+    # ── Config ────────────────────────────────────────────────────────
+    # Report the ACTUAL resolved config_home (XDG by default), with the legacy
+    # ~/.octos/config.json honoured as a back-compat fallback for default
+    # installs (matches the Rust resolver precedence).
+    section "Config"
+
+    _DOCTOR_LEGACY_CONFIG="$HOME/.octos/config.json"
+    if [ -f "$CONFIG_HOME/config.json" ]; then
+        ok "config.json: $CONFIG_HOME/config.json"
+    elif [ "$CONFIG_HOME" = "$(xdg_config_home)" ] && [ -z "${OCTOS_CONFIG_DIR:-}" ] \
+         && [ -f "$_DOCTOR_LEGACY_CONFIG" ]; then
+        ok "config.json (legacy): $_DOCTOR_LEGACY_CONFIG"
+        hint "Run 'octos init' to migrate it to $CONFIG_HOME"
+    else
+        warn "config.json missing (expected at $CONFIG_HOME/config.json)"
+        hint "Run: octos init"
     fi
 
     # ── octos serve process ──────────────────────────────────────────
@@ -1500,8 +1589,33 @@ fi
 
 # Ensure required subdirectories, config, and bootstrap files exist.
 # These match what `octos init --defaults` creates (see init.rs).
+#
+# Runtime STATE (profiles/sessions/skills/...) lives under $DATA_DIR. The
+# starter config.json is written to $CONFIG_HOME — the bash mirror of the Rust
+# resolver (XDG for a default install; the state dir for an explicit
+# OCTOS_HOME; OCTOS_CONFIG_DIR when set).
 mkdir -p "$DATA_DIR"/{profiles,memory,sessions,skills,logs,research,history}
-if [ ! -f "$DATA_DIR/config.json" ]; then
+
+# Legacy config for the default case: never shadow an existing legacy config.
+_LEGACY_CONFIG="$HOME/.octos/config.json"
+_CONFIG_FILE="$CONFIG_HOME/config.json"
+
+# Decide whether to write the starter config:
+#   - skip if $CONFIG_HOME/config.json already exists, and
+#   - for the DEFAULT install (CONFIG_HOME == XDG default, i.e. not an explicit
+#     override), also skip if the legacy ~/.octos/config.json exists so the
+#     resolver's back-compat path keeps loading it (no shadowing).
+_WRITE_CONFIG=true
+if [ -f "$_CONFIG_FILE" ]; then
+    _WRITE_CONFIG=false
+elif [ "$CONFIG_HOME" = "$(xdg_config_home)" ] && [ -z "${OCTOS_CONFIG_DIR:-}" ] \
+     && [ -f "$_LEGACY_CONFIG" ]; then
+    # Default install with an existing legacy config — do not shadow it.
+    _WRITE_CONFIG=false
+    ok "existing legacy config kept: $_LEGACY_CONFIG (not shadowed)"
+fi
+
+if [ "$_WRITE_CONFIG" = true ]; then
     # Auto-detect provider from available API keys
     if [ -n "${OPENAI_API_KEY:-}" ]; then
         _PROV="openai"; _MODEL="gpt-4.1-mini"; _ENV="OPENAI_API_KEY"
@@ -1532,7 +1646,8 @@ if [ ! -f "$DATA_DIR/config.json" ]; then
 INITEOF
 )
     fi
-    cat > "$DATA_DIR/config.json" << INITEOF
+    mkdir -p "$CONFIG_HOME"
+    cat > "$_CONFIG_FILE" << INITEOF
 {
   "provider": "$_PROV",
   "model": "$_MODEL",
@@ -1540,8 +1655,9 @@ INITEOF
   "mode": "$_MODE"$_EXTRA_CONFIG
 }
 INITEOF
-    chmod 600 "$DATA_DIR/config.json"
+    chmod 600 "$_CONFIG_FILE"
     ok "auto-detected provider: $_PROV ($_ENV)"
+    ok "wrote config: $_CONFIG_FILE"
 fi
 [ ! -f "$DATA_DIR/.gitignore" ] && cat > "$DATA_DIR/.gitignore" << 'INITEOF'
 # Ignore task state and database files
@@ -1875,7 +1991,7 @@ section "Installation complete!"
 echo ""
 echo "    Binary:     $PREFIX/octos"
 echo "    Data dir:   $DATA_DIR"
-echo "    Config:     $DATA_DIR/config.json"
+echo "    Config:     $CONFIG_HOME/config.json"
 echo "    Auth token: $AUTH_TOKEN"
 echo "    Logs:       tail -f $DATA_DIR/logs/serve.\$(date +%F).log"
 echo ""


### PR DESCRIPTION
Moves user **config + auth** out of the install dir (`~/.octos/bin`) so the installer can never clobber them — config now lives in XDG (`~/.config/octos` / `~/Library/Application Support/octos`), with the install dir holding only artifacts + runtime state.

## Design — ONE canonical resolver (`config_context.rs`)
`resolve_config_context(cli_data_dir) -> ConfigContext { config_home, auth_home, data_dir, is_default }` — the single source of truth; every site uses it (the prior two attempts failed review because 4 sites computed default-vs-explicit independently → 9 P1 leaks).
- `data_dir` = --data-dir > $OCTOS_HOME > ~/.octos
- `is_explicit` = --data-dir || OCTOS_CONFIG_DIR || (OCTOS_HOME ≠ ~/.octos); paths normalized, empty env = unset
- `config_home` = OCTOS_CONFIG_DIR else (explicit ? data_dir : XDG)
- **`auth_home` = OCTOS_CONFIG_DIR else XDG — DECOUPLED from data_dir** so per-profile gateways (spawned `--data-dir <profile>`) keep the shared `octos auth login`.

## Guarantees
- **Tenant isolation:** explicit/`--data-dir`/`OCTOS_CONFIG_DIR` sessions never read host XDG or `~/.octos` config; admin writes under `serve --data-dir T` land in `T/config.json`.
- **Migrations** (config + auth, default-only): atomic temp-in-dest → rename, legacy left INTACT as backup, idempotent.
- **Auth perms:** all writes + an existing loose `auth.json` tightened to 0600 on open.
- **Back-compat:** existing `~/.octos/config.json`/`auth.json` still load (back-compat fallback) until migrated; `OCTOS_HOME=~/.octos` treated as default (CLI == service, no split-brain).
- **install.sh** mirrors the resolver; never shadows an existing legacy config; `--doctor`/summary report the real config_home.

513 lib tests (incl. 13 config_context + full truth-table + migration/perms). codex-reviewed **4 rounds**; all 9 prior P1s + the round-4 portability nit closed; clippy/fmt clean. Override: `OCTOS_CONFIG_DIR`.