### PR TITLE
feat(serve): embed octos-web SPA, served same-origin at /app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,7 +491,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build release
+        shell: bash
         run: |
+          # rust_embed bakes static/{admin,web} in at compile time → build both
+          # SPAs before cargo so the bundle artifact serves /admin and /app.
+          cd dashboard && npm ci && npm run build && cd ..
+          git submodule update --init octos-web && bash scripts/build-web-app.sh
           cargo build --release -p octos-cli --features ${{ env.FEATURES }}
           cargo build --release ${{ env.SKILL_CRATES }}
 
@@ -519,7 +524,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build release
+        shell: bash
         run: |
+          # rust_embed bakes static/{admin,web} in at compile time → build both
+          # SPAs before cargo so the bundle artifact serves /admin and /app.
+          cd dashboard && npm ci && npm run build && cd ..
+          git submodule update --init octos-web && bash scripts/build-web-app.sh
           cargo build --release -p octos-cli --features ${{ env.FEATURES }}
           cargo build --release ${{ env.SKILL_CRATES }}
 
@@ -549,7 +559,12 @@ jobs:
           shared-key: arm64-release
 
       - name: Build release
+        shell: bash
         run: |
+          # rust_embed bakes static/{admin,web} in at compile time → build both
+          # SPAs before cargo so the bundle artifact serves /admin and /app.
+          cd dashboard && npm ci && npm run build && cd ..
+          git submodule update --init octos-web && bash scripts/build-web-app.sh
           cargo build --release -p octos-cli --features ${{ env.FEATURES }}
           cargo build --release ${{ env.SKILL_CRATES }}
 
@@ -579,7 +594,12 @@ jobs:
           shared-key: windows-release
 
       - name: Build release
+        shell: bash
         run: |
+          # rust_embed bakes static/{admin,web} in at compile time → build both
+          # SPAs before cargo so the bundle artifact serves /admin and /app.
+          cd dashboard && npm ci && npm run build && cd ..
+          git submodule update --init octos-web && bash scripts/build-web-app.sh
           cargo build --release -p octos-cli --features ${{ env.FEATURES }}
           cargo build --release ${{ env.SKILL_CRATES }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,8 +495,14 @@ jobs:
         run: |
           # rust_embed bakes static/{admin,web} in at compile time → build both
           # SPAs before cargo so the bundle artifact serves /admin and /app.
-          cd dashboard && npm ci && npm run build && cd ..
-          git submodule update --init octos-web && bash scripts/build-web-app.sh
+          # One command per line so `set -e` aborts on ANY failure (a chained
+          # `&&` can mask an early failure → an artifact missing /admin or /app).
+          cd dashboard
+          npm ci
+          npm run build
+          cd ..
+          git submodule update --init octos-web
+          bash scripts/build-web-app.sh
           cargo build --release -p octos-cli --features ${{ env.FEATURES }}
           cargo build --release ${{ env.SKILL_CRATES }}
 
@@ -528,8 +534,14 @@ jobs:
         run: |
           # rust_embed bakes static/{admin,web} in at compile time → build both
           # SPAs before cargo so the bundle artifact serves /admin and /app.
-          cd dashboard && npm ci && npm run build && cd ..
-          git submodule update --init octos-web && bash scripts/build-web-app.sh
+          # One command per line so `set -e` aborts on ANY failure (a chained
+          # `&&` can mask an early failure → an artifact missing /admin or /app).
+          cd dashboard
+          npm ci
+          npm run build
+          cd ..
+          git submodule update --init octos-web
+          bash scripts/build-web-app.sh
           cargo build --release -p octos-cli --features ${{ env.FEATURES }}
           cargo build --release ${{ env.SKILL_CRATES }}
 
@@ -563,8 +575,14 @@ jobs:
         run: |
           # rust_embed bakes static/{admin,web} in at compile time → build both
           # SPAs before cargo so the bundle artifact serves /admin and /app.
-          cd dashboard && npm ci && npm run build && cd ..
-          git submodule update --init octos-web && bash scripts/build-web-app.sh
+          # One command per line so `set -e` aborts on ANY failure (a chained
+          # `&&` can mask an early failure → an artifact missing /admin or /app).
+          cd dashboard
+          npm ci
+          npm run build
+          cd ..
+          git submodule update --init octos-web
+          bash scripts/build-web-app.sh
           cargo build --release -p octos-cli --features ${{ env.FEATURES }}
           cargo build --release ${{ env.SKILL_CRATES }}
 
@@ -598,8 +616,14 @@ jobs:
         run: |
           # rust_embed bakes static/{admin,web} in at compile time → build both
           # SPAs before cargo so the bundle artifact serves /admin and /app.
-          cd dashboard && npm ci && npm run build && cd ..
-          git submodule update --init octos-web && bash scripts/build-web-app.sh
+          # One command per line so `set -e` aborts on ANY failure (a chained
+          # `&&` can mask an early failure → an artifact missing /admin or /app).
+          cd dashboard
+          npm ci
+          npm run build
+          cd ..
+          git submodule update --init octos-web
+          bash scripts/build-web-app.sh
           cargo build --release -p octos-cli --features ${{ env.FEATURES }}
           cargo build --release ${{ env.SKILL_CRATES }}
 

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -54,8 +54,14 @@ jobs:
         # compile time, so both SPAs MUST be built before `cargo build`. Without
         # this the published bundle serves a 503 at /admin and /app.
         run: |
-          cd dashboard && npm ci && npm run build && cd ..
-          git submodule update --init octos-web && bash scripts/build-web-app.sh
+          # One command per line so `set -e` aborts on ANY failure (a chained
+          # `&&` can mask an early failure → a published binary missing /admin or /app).
+          cd dashboard
+          npm ci
+          npm run build
+          cd ..
+          git submodule update --init octos-web
+          bash scripts/build-web-app.sh
 
       - name: Build octos CLI
         run: cargo build --release -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3"

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -49,6 +49,14 @@ jobs:
       - name: Run cargo release
         run: cargo release ${{ inputs.bump }} --execute --no-confirm
 
+      - name: Build embedded SPAs (admin dashboard + octos-web)
+        # rust_embed bakes crates/octos-cli/static/{admin,web} into the binary at
+        # compile time, so both SPAs MUST be built before `cargo build`. Without
+        # this the published bundle serves a 503 at /admin and /app.
+        run: |
+          cd dashboard && npm ci && npm run build && cd ..
+          git submodule update --init octos-web && bash scripts/build-web-app.sh
+
       - name: Build octos CLI
         run: cargo build --release -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,16 @@ jobs:
           echo "OCTOS_BUILD_DATE=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
 
       - name: Build dashboard
-        run: cd dashboard && npm ci && npm run build && cd .. && git submodule update --init octos-web && bash scripts/build-web-app.sh
+        run: |
+          # One command per line so `set -e` aborts on ANY failure — a chained
+          # `&&` can let an early failure slip and publish a binary missing the
+          # embedded /admin or /app SPA.
+          cd dashboard
+          npm ci
+          npm run build
+          cd ..
+          git submodule update --init octos-web
+          bash scripts/build-web-app.sh
 
       - name: Build
         run: |
@@ -72,7 +81,16 @@ jobs:
           echo "OCTOS_BUILD_DATE=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
 
       - name: Build dashboard
-        run: cd dashboard && npm ci && npm run build && cd .. && git submodule update --init octos-web && bash scripts/build-web-app.sh
+        run: |
+          # One command per line so `set -e` aborts on ANY failure — a chained
+          # `&&` can let an early failure slip and publish a binary missing the
+          # embedded /admin or /app SPA.
+          cd dashboard
+          npm ci
+          npm run build
+          cd ..
+          git submodule update --init octos-web
+          bash scripts/build-web-app.sh
 
       - name: Build
         run: |
@@ -108,7 +126,16 @@ jobs:
           echo "OCTOS_BUILD_DATE=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
 
       - name: Build dashboard
-        run: cd dashboard && npm ci && npm run build && cd .. && git submodule update --init octos-web && bash scripts/build-web-app.sh
+        run: |
+          # One command per line so `set -e` aborts on ANY failure — a chained
+          # `&&` can let an early failure slip and publish a binary missing the
+          # embedded /admin or /app SPA.
+          cd dashboard
+          npm ci
+          npm run build
+          cd ..
+          git submodule update --init octos-web
+          bash scripts/build-web-app.sh
 
       - name: Build
         run: |
@@ -146,7 +173,16 @@ jobs:
 
       - name: Build dashboard
         shell: bash
-        run: cd dashboard && npm ci && npm run build && cd .. && git submodule update --init octos-web && bash scripts/build-web-app.sh
+        run: |
+          # One command per line so `set -e` aborts on ANY failure — a chained
+          # `&&` can let an early failure slip and publish a binary missing the
+          # embedded /admin or /app SPA.
+          cd dashboard
+          npm ci
+          npm run build
+          cd ..
+          git submodule update --init octos-web
+          bash scripts/build-web-app.sh
 
       - name: Build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           echo "OCTOS_BUILD_DATE=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
 
       - name: Build dashboard
-        run: cd dashboard && npm ci && npm run build
+        run: cd dashboard && npm ci && npm run build && cd .. && git submodule update --init octos-web && bash scripts/build-web-app.sh
 
       - name: Build
         run: |
@@ -72,7 +72,7 @@ jobs:
           echo "OCTOS_BUILD_DATE=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
 
       - name: Build dashboard
-        run: cd dashboard && npm ci && npm run build
+        run: cd dashboard && npm ci && npm run build && cd .. && git submodule update --init octos-web && bash scripts/build-web-app.sh
 
       - name: Build
         run: |
@@ -108,7 +108,7 @@ jobs:
           echo "OCTOS_BUILD_DATE=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
 
       - name: Build dashboard
-        run: cd dashboard && npm ci && npm run build
+        run: cd dashboard && npm ci && npm run build && cd .. && git submodule update --init octos-web && bash scripts/build-web-app.sh
 
       - name: Build
         run: |
@@ -146,7 +146,7 @@ jobs:
 
       - name: Build dashboard
         shell: bash
-        run: cd dashboard && npm ci && npm run build
+        run: cd dashboard && npm ci && npm run build && cd .. && git submodule update --init octos-web && bash scripts/build-web-app.sh
 
       - name: Build
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ crates/octos-cli/static/admin/
 # Swarm-app build output
 crates/octos-cli/static/swarm/
 
+# octos-web build output (scripts/build-web-app.sh; embedded at /app)
+crates/octos-cli/static/web/
+
 # Environment
 .env
 .env.local

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "octos-web"]
+	path = octos-web
+	url = https://github.com/octos-org/octos-web.git

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ curl -fsSL https://github.com/octos-org/octos/releases/latest/download/install.s
 irm https://github.com/octos-org/octos/releases/latest/download/install.ps1 | iex
 ```
 
-This installs the binary, sets up `octos serve` as a service, and starts the local dashboard at `http://localhost:8080/admin/`.
+This installs the binary, sets up `octos serve` as a service, and starts the local dashboard at `http://localhost:8080/admin/`. The end-user web app is served same-origin at `http://localhost:8080/app/` (embedded in the binary — no separate web server needed).
 
 Alternatively, install just the binaries (the `octos` server plus its bundled skills) via a package manager:
 

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -58,6 +58,9 @@ pub fn cors_allowlist_for_base_domain(base: Option<&str>) -> Vec<String> {
         format!("https://api.{base}"),
         "http://localhost:3000".to_string(),
         "http://localhost:5173".to_string(),
+        // octos-web Vite dev server (embedded same-origin at /app in prod, so
+        // CORS is only needed when running the web app from `vite dev`).
+        "http://localhost:5174".to_string(),
     ]
 }
 

--- a/crates/octos-cli/src/api/static_files.rs
+++ b/crates/octos-cli/src/api/static_files.rs
@@ -116,6 +116,34 @@ async fn serve_with<A: AssetStore>(assets: &A, state: &AppState, request_path: &
             .into_response();
     }
 
+    // octos-web SPA: under /app/* with its own asset tree (built by
+    // scripts/build-web-app.sh into static/web/ with BASE_URL=/app/). Same
+    // pattern as the swarm branch: segment-match so `/application` etc. fall
+    // through to admin; serve the embedded asset, else the SPA index for
+    // client-side routes, else a 503 naming the build script when the bundle
+    // wasn't embedded. The app is same-origin (`API_BASE=""`) so it talks to
+    // this server's API/WS with no CORS.
+    if path == "app" || path.starts_with("app/") {
+        let web_path = format!("web/{}", path.trim_start_matches("app/"));
+        if let Some(data) = assets.get(&web_path) {
+            return serve_file(&web_path, &data);
+        }
+        if let Some(data) = assets.get("web/index.html") {
+            return serve_file("web/index.html", &data);
+        }
+        let body = serde_json::json!({
+            "error": "web_bundle_missing",
+            "message":
+                "Run ./scripts/build-web-app.sh + rebuild octos-cli to include the octos-web app.",
+        });
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            [(header::CONTENT_TYPE, "application/json")],
+            body.to_string(),
+        )
+            .into_response();
+    }
+
     // Try under admin/ prefix (e.g. /assets/foo.js → admin/assets/foo.js)
     let admin_path = format!("admin/{path}");
     if let Some(data) = assets.get(&admin_path) {

--- a/crates/octos-cli/src/api/static_files.rs
+++ b/crates/octos-cli/src/api/static_files.rs
@@ -124,6 +124,17 @@ async fn serve_with<A: AssetStore>(assets: &A, state: &AppState, request_path: &
     // wasn't embedded. The app is same-origin (`API_BASE=""`) so it talks to
     // this server's API/WS with no CORS.
     if path == "app" || path.starts_with("app/") {
+        // Bare `/app` (no trailing slash) must redirect to `/app/`: the SPA's
+        // `BrowserRouter basename="/app/"` does not match the pathname `/app`,
+        // so serving index.html directly renders blank. 307 preserves method.
+        if path == "app" {
+            return (
+                StatusCode::TEMPORARY_REDIRECT,
+                [(header::LOCATION, "/app/")],
+                "",
+            )
+                .into_response();
+        }
         let web_path = format!("web/{}", path.trim_start_matches("app/"));
         if let Some(data) = assets.get(&web_path) {
             return serve_file(&web_path, &data);

--- a/scripts/build-local-bundle.sh
+++ b/scripts/build-local-bundle.sh
@@ -94,6 +94,16 @@ else
     DASHBOARD_ARGS=()
     [ "$INSTALL_DEPS" = true ] && DASHBOARD_ARGS+=(--install-deps)
     ./scripts/build-dashboard.sh "${DASHBOARD_ARGS[@]}"
+
+    # octos-web SPA (embedded same-origin at /app — also baked in by rust_embed,
+    # so it must be built before cargo). Best-effort: skip with a warning if the
+    # submodule isn't checked out, so a bundle still builds (the binary serves a
+    # 503 "web_bundle_missing" at /app until octos-web is built).
+    if [ -f octos-web/package.json ] || git submodule update --init octos-web 2>/dev/null; then
+        bash scripts/build-web-app.sh
+    else
+        echo "==> Skipping octos-web build (submodule not available); /app will 503 until built"
+    fi
 fi
 
 # ── Build (delegates to milestone-ci.sh release-bundle) ──────────────

--- a/scripts/build-web-app.sh
+++ b/scripts/build-web-app.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Build the octos-web SPA into the octos-cli embed dir so `octos serve` can
+# serve it same-origin at `/app` (no separate Caddy needed).
+#
+# octos-web is a git submodule at `octos-web/`. Its Vite config hardcodes
+# `outDir: "dist"` and honours `BASE_URL` for the asset base + the React Router
+# basename (`API_BASE` is "" so the app is same-origin by design). We build with
+# `BASE_URL=/app/` then copy `dist/` into `crates/octos-cli/static/web/`, which
+# `static_files.rs` embeds via rust-embed (`#[folder = "static/"]`).
+#
+# Mirrors scripts/build-dashboard.sh (admin SPA) and the swarm-app pattern.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WEB_DIR="$ROOT/octos-web"
+OUT_DIR="$ROOT/crates/octos-cli/static/web"
+BASE_PATH="/app/"
+
+if [ ! -d "$WEB_DIR" ] || [ ! -f "$WEB_DIR/package.json" ]; then
+    echo "error: octos-web submodule is not checked out at $WEB_DIR" >&2
+    echo "  run: git submodule update --init octos-web" >&2
+    exit 1
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+    echo "error: npm not found — install Node.js (https://nodejs.org) to build octos-web" >&2
+    exit 1
+fi
+
+cd "$WEB_DIR"
+if [ ! -d node_modules ]; then
+    echo "Installing octos-web dependencies (npm ci)…"
+    npm ci
+fi
+
+echo "Building octos-web (BASE_URL=$BASE_PATH) → $OUT_DIR"
+BASE_URL="$BASE_PATH" npm run build
+
+# Replace the embed dir atomically-ish: clear then copy the fresh dist.
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+cp -R "$WEB_DIR/dist/." "$OUT_DIR/"
+
+echo "octos-web assets synced to $OUT_DIR (serve at /app)"


### PR DESCRIPTION
Makes the one-line install (`curl|bash` / `brew` / `npm`) serve the end-user web app at `/app` with **no separate Caddy** — octos-web is a pure static React/Vite SPA (`API_BASE=""`, `basename=BASE_URL`), so it embeds like the admin dashboard.

- **Submodule** `octos-web` (octos-org/octos-web, pinned) + `scripts/build-web-app.sh` (`BASE_URL=/app/` → `static/web/`, embedded via rust_embed; release builds bake it in, debug reads from disk).
- **`/app` route** (static_files.rs, mirrors the swarm branch): bare `/app`→307 `/app/` (so the SPA basename matches), exact assets, `web/index.html` SPA fallback, 503 if unbuilt; segment-matched so `/application` falls through to `/admin`.
- **All publishers wired** to build dashboard + octos-web before cargo: release.yml (4 triples), release-dispatch.yml (**also fixed a pre-existing gap: it never built the dashboard → shipped no /admin**), build-local-bundle.sh, and ci.yml's 4 bundle-artifact jobs. One-command-per-line so `set -e` catches build failures.
- CORS `localhost:5174` (vite dev); README note; `.gitignore` the output.

Verified live: `/app`→307, `/app/`→200, hashed JS asset→200 (correct MIME), SPA route fallback→200, `/application`→307 (not hijacked), `/admin/`→200 intact, `/api` not hijacked. 513 lib tests; codex-reviewed (3 rounds) — route/hijack clean, all findings (release-dispatch + ci.yml SPA wiring, bare-/app redirect, set -e masking) closed. Prod Caddy unaffected (embedded /app is additive).