### PR TITLE
feat(config): config home at ~/.config/octos on macOS too (+docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,20 @@ bash scripts/cloud-host-deploy.sh --uninstall
 bash scripts/cloud-host-deploy.sh --uninstall --purge
 ```
 
+### Where config lives
+
+User config + credentials live **outside** the install dir so reinstalls/upgrades never touch them:
+
+- **macOS + Linux:** `~/.config/octos/` (`config.json`, `auth.json`) — honours `$XDG_CONFIG_HOME`
+- **Windows:** `%APPDATA%\octos\`
+- **Override:** set `OCTOS_CONFIG_DIR` to put config/auth anywhere
+- `~/.octos/` holds only the **install + runtime state** (binaries, bundled skills, sessions, logs). The installer writes only there.
+
+An existing `~/.octos/config.json` from older versions is auto-migrated to `~/.config/octos/` on first run (copied, not moved — the original stays as a backup).
+
 ### Runtime deployment modes
 
-Octos uses `"mode"` in `~/.octos/config.json` to describe how a running node behaves:
+Octos uses `"mode"` in `config.json` (see *Where config lives* above) to describe how a running node behaves:
 
 - **`local`** — standalone machine
 - **`tenant`** — end-user machine with an optional public tunnel
@@ -304,7 +315,7 @@ For a repo-local tenant deploy (builds from source, sets up the same service + t
 What it does:
 
 1. Detects your host triple (mirrors `install.sh`'s platform mapping).
-2. Runs `scripts/build-dashboard.sh` so `rust_embed` bakes a complete SPA into the binary. Skip this and `/admin/` will 307-loop.
+2. Runs `scripts/build-dashboard.sh` (admin SPA → `/admin/`) and `scripts/build-web-app.sh` (the octos-web submodule → `/app/`) so `rust_embed` bakes both SPAs into the binary. Skip the dashboard build and `/admin/` will 307-loop; skip the web build and `/app/` returns `web_bundle_missing`.
 3. Delegates `cargo build --release` to `scripts/milestone-ci.sh release-bundle` (single source of truth for `FEATURES` / `SKILL_CRATES`).
 4. Tars binaries into `scripts/octos-bundle-<TRIPLE>.tar.gz`, which `install.sh` auto-detects via `file://`, skipping the GitHub download.
 5. With `--install`, chains into `install.sh` — copies binaries to `$PREFIX`, rewrites the service plist/unit, reloads the daemon.

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -1788,11 +1788,15 @@ mod tests {
         let original_home = std::env::var_os("HOME");
         let original_octos_home = std::env::var_os("OCTOS_HOME");
         let original_octos_config = std::env::var_os("OCTOS_CONFIG_DIR");
+        // Must also clear XDG_CONFIG_HOME: auth_home derives from it, so an
+        // ambient absolute value would write auth.json outside the temp HOME.
+        let original_xdg = std::env::var_os("XDG_CONFIG_HOME");
         // SAFETY: serialized by HOME_ENV_LOCK; restored below.
         unsafe {
             std::env::set_var("HOME", fake_home);
             std::env::remove_var("OCTOS_HOME");
             std::env::remove_var("OCTOS_CONFIG_DIR");
+            std::env::remove_var("XDG_CONFIG_HOME");
         }
 
         // Resolve the GLOBAL auth_home (XDG) and seed a credential there.
@@ -1827,6 +1831,10 @@ mod tests {
         match original_octos_config {
             Some(v) => unsafe { std::env::set_var("OCTOS_CONFIG_DIR", v) },
             None => unsafe { std::env::remove_var("OCTOS_CONFIG_DIR") },
+        }
+        match original_xdg {
+            Some(v) => unsafe { std::env::set_var("XDG_CONFIG_HOME", v) },
+            None => unsafe { std::env::remove_var("XDG_CONFIG_HOME") },
         }
 
         assert_eq!(

--- a/crates/octos-cli/src/config_context.rs
+++ b/crates/octos-cli/src/config_context.rs
@@ -19,9 +19,10 @@
 //!   (`OCTOS_HOME` set AND its normalized form != `~/.octos`).
 //!   `is_default = !is_explicit`.
 //! * `config_home` = `OCTOS_CONFIG_DIR` if set, else `data_dir` when explicit,
-//!   else the XDG default (`dirs::config_dir()/octos`).
-//! * `auth_home` = `OCTOS_CONFIG_DIR` if set, else the XDG default
-//!   (`dirs::config_dir()/octos`). **DECOUPLED from `data_dir`** so per-profile
+//!   else the XDG default (`${XDG_CONFIG_HOME:-~/.config}/octos` on macOS+Linux,
+//!   `%APPDATA%\octos` on Windows — see `xdg_config_home`).
+//! * `auth_home` = `OCTOS_CONFIG_DIR` if set, else the same XDG default.
+//!   **DECOUPLED from `data_dir`** so per-profile
 //!   gateways (which run with `--data-dir <profile-data>`) keep the host's
 //!   shared, global `octos auth login`.
 
@@ -109,14 +110,37 @@ fn default_data_dir() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from(".octos"))
 }
 
-/// The XDG config home for octos:
-/// `~/Library/Application Support/octos` (macOS) or
-/// `${XDG_CONFIG_HOME:-~/.config}/octos` (Linux). Falls back to the default
-/// `~/.octos` when the platform config dir cannot be determined.
+/// The default config home for octos:
+/// * Unix (macOS **and** Linux): `${XDG_CONFIG_HOME:-~/.config}/octos`. We use
+///   true XDG `~/.config` on macOS too — NOT Apple's `~/Library/Application
+///   Support` — because octos is a CLI and that's the prevailing CLI convention
+///   (gh, nvim, helix, …); it's discoverable and matches Linux for one mental
+///   model.
+/// * Windows: `%APPDATA%\octos` (via `dirs::config_dir()`), the correct per-user
+///   config home there (no `~/.config` convention on Windows).
+///
+/// Falls back to `~/.octos` only if the home/config dir can't be determined.
 fn xdg_config_home() -> PathBuf {
-    dirs::config_dir()
-        .map(|d| d.join("octos"))
-        .unwrap_or_else(default_data_dir)
+    #[cfg(windows)]
+    {
+        return dirs::config_dir()
+            .map(|d| d.join("octos"))
+            .unwrap_or_else(default_data_dir);
+    }
+    #[cfg(not(windows))]
+    {
+        // $XDG_CONFIG_HOME wins when set to an ABSOLUTE path (the spec ignores
+        // relative values); else ~/.config.
+        if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+            let p = PathBuf::from(xdg);
+            if p.is_absolute() {
+                return p.join("octos");
+            }
+        }
+        return dirs::home_dir()
+            .map(|h| h.join(".config").join("octos"))
+            .unwrap_or_else(default_data_dir);
+    }
 }
 
 /// Resolve the canonical [`ConfigContext`] from the `--data-dir` flag plus the
@@ -365,6 +389,7 @@ mod tests {
         home: Option<std::ffi::OsString>,
         octos_home: Option<std::ffi::OsString>,
         octos_config_dir: Option<std::ffi::OsString>,
+        xdg_config_home: Option<std::ffi::OsString>,
     }
 
     impl EnvGuard {
@@ -374,12 +399,14 @@ mod tests {
                 home: std::env::var_os("HOME"),
                 octos_home: std::env::var_os("OCTOS_HOME"),
                 octos_config_dir: std::env::var_os("OCTOS_CONFIG_DIR"),
+                xdg_config_home: std::env::var_os("XDG_CONFIG_HOME"),
             };
             // SAFETY: callers hold ENV_LOCK; restored in Drop.
             unsafe {
                 std::env::set_var("HOME", home);
                 std::env::remove_var("OCTOS_HOME");
                 std::env::remove_var("OCTOS_CONFIG_DIR");
+                std::env::remove_var("XDG_CONFIG_HOME");
             }
             g
         }
@@ -393,6 +420,7 @@ mod tests {
                 restore("HOME", &self.home);
                 restore("OCTOS_HOME", &self.octos_home);
                 restore("OCTOS_CONFIG_DIR", &self.octos_config_dir);
+                restore("XDG_CONFIG_HOME", &self.xdg_config_home);
             }
         }
     }
@@ -443,6 +471,34 @@ mod tests {
         assert!(ctx.is_default);
         assert_eq!(ctx.data_dir, tmp.path().join(".octos"));
         assert_eq!(ctx.config_home, xdg_config_home());
+    }
+
+    /// Default config_home on unix is true XDG `~/.config/octos` — NOT Apple's
+    /// `~/Library/Application Support` — and honours an absolute $XDG_CONFIG_HOME.
+    #[test]
+    #[cfg(not(windows))]
+    fn unix_default_config_home_is_dot_config_not_app_support() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::pivot(tmp.path()); // clears XDG_CONFIG_HOME
+
+        // No XDG_CONFIG_HOME → ~/.config/octos.
+        let ctx = resolve_config_context(None);
+        assert_eq!(ctx.config_home, tmp.path().join(".config").join("octos"));
+        assert_eq!(ctx.auth_home, tmp.path().join(".config").join("octos"));
+        assert!(
+            !ctx.config_home
+                .to_string_lossy()
+                .contains("Application Support"),
+            "config must not live in ~/Library/Application Support, got {}",
+            ctx.config_home.display()
+        );
+
+        // Absolute XDG_CONFIG_HOME wins.
+        let xdg = tmp.path().join("xdgcfg");
+        set_env("XDG_CONFIG_HOME", xdg.to_str().unwrap());
+        let ctx2 = resolve_config_context(None);
+        assert_eq!(ctx2.config_home, xdg.join("octos"));
     }
 
     /// Gate 5: non-default OCTOS_HOME → config_home == that state dir.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -665,7 +665,7 @@ write_octos_service() {
     <key>OCTOS_AUTH_TOKEN</key>
     <string>$AUTH_TOKEN</string>
 $(launchd_env_var_xml "XDG_CONFIG_HOME" "${XDG_CONFIG_HOME:-}")
-$(launchd_env_var_xml "OCTOS_CONFIG_DIR" "${OCTOS_CONFIG_DIR:-}")
+$(launchd_env_var_xml "OCTOS_CONFIG_DIR" "${OCTOS_CONFIG_DIR:+$CONFIG_HOME}")
 $(launchd_env_var_xml "FRPS_TOKEN" "${FRPS_TOKEN:-}")
 $(launchd_env_var_xml "SMTP_HOST" "${SMTP_HOST:-}")
 $(launchd_env_var_xml "SMTP_PORT" "${SMTP_PORT:-}")
@@ -708,7 +708,7 @@ Environment=OCTOS_HOME=$DATA_DIR
 Environment=OCTOS_AUTH_TOKEN=$AUTH_TOKEN
 Environment=PATH=$PREFIX:/usr/local/bin:/usr/bin:/bin
 $(systemd_env_var_line "XDG_CONFIG_HOME" "${XDG_CONFIG_HOME:-}")
-$(systemd_env_var_line "OCTOS_CONFIG_DIR" "${OCTOS_CONFIG_DIR:-}")
+$(systemd_env_var_line "OCTOS_CONFIG_DIR" "${OCTOS_CONFIG_DIR:+$CONFIG_HOME}")
 $(systemd_env_var_line "FRPS_TOKEN" "${FRPS_TOKEN:-}")
 $(systemd_env_var_line "SMTP_HOST" "${SMTP_HOST:-}")
 $(systemd_env_var_line "SMTP_PORT" "${SMTP_PORT:-}")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -144,26 +144,23 @@ DATA_DIR="$(normalize_path "$DATA_DIR")"
 #                                                          != $HOME/.octos)
 #               | XDG default                             (otherwise)
 #
-# XDG default:
-#   macOS → $HOME/Library/Application Support/octos
-#   Linux → ${XDG_CONFIG_HOME:-$HOME/.config}/octos
-#           NOTE: a RELATIVE $XDG_CONFIG_HOME is ignored (matching Rust's
-#           dirs::config_dir(), which per the XDG spec only honours absolute
-#           values) — we fall back to $HOME/.config in that case.
+# XDG default (mirror of config_context::xdg_config_home in Rust):
+#   macOS + Linux → ${XDG_CONFIG_HOME:-$HOME/.config}/octos
+#       octos is a CLI, so it uses true XDG ~/.config on macOS too (not Apple's
+#       ~/Library/Application Support) — the prevailing CLI convention and
+#       consistent with Linux.
+#       NOTE: a RELATIVE $XDG_CONFIG_HOME is ignored (XDG spec only honours
+#       absolute values) — fall back to $HOME/.config in that case.
+#   (Windows uses %APPDATA%\octos in Rust; this installer is unix-only.)
 #
 # Empty-string env vars are treated as unset (matching env_nonempty in Rust).
 xdg_config_home() {
-    case "$(uname -s)" in
-        Darwin) printf '%s/Library/Application Support/octos\n' "$HOME" ;;
-        *)
-            # Honour XDG_CONFIG_HOME only when it is an ABSOLUTE path.
-            if [ -n "${XDG_CONFIG_HOME:-}" ] && [ "${XDG_CONFIG_HOME#/}" != "$XDG_CONFIG_HOME" ]; then
-                printf '%s/octos\n' "$XDG_CONFIG_HOME"
-            else
-                printf '%s/octos\n' "$HOME/.config"
-            fi
-            ;;
-    esac
+    # Honour XDG_CONFIG_HOME only when it is an ABSOLUTE path; else ~/.config.
+    if [ -n "${XDG_CONFIG_HOME:-}" ] && [ "${XDG_CONFIG_HOME#/}" != "$XDG_CONFIG_HOME" ]; then
+        printf '%s/octos\n' "$XDG_CONFIG_HOME"
+    else
+        printf '%s/octos\n' "$HOME/.config"
+    fi
 }
 
 # Resolve symlinks/. /.. best-effort so the OCTOS_HOME-vs-default comparison

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -664,6 +664,8 @@ write_octos_service() {
         <string>$DATA_DIR</string>
     <key>OCTOS_AUTH_TOKEN</key>
     <string>$AUTH_TOKEN</string>
+$(launchd_env_var_xml "XDG_CONFIG_HOME" "${XDG_CONFIG_HOME:-}")
+$(launchd_env_var_xml "OCTOS_CONFIG_DIR" "${OCTOS_CONFIG_DIR:-}")
 $(launchd_env_var_xml "FRPS_TOKEN" "${FRPS_TOKEN:-}")
 $(launchd_env_var_xml "SMTP_HOST" "${SMTP_HOST:-}")
 $(launchd_env_var_xml "SMTP_PORT" "${SMTP_PORT:-}")
@@ -705,6 +707,8 @@ Environment=OCTOS_DATA_DIR=$DATA_DIR
 Environment=OCTOS_HOME=$DATA_DIR
 Environment=OCTOS_AUTH_TOKEN=$AUTH_TOKEN
 Environment=PATH=$PREFIX:/usr/local/bin:/usr/bin:/bin
+$(systemd_env_var_line "XDG_CONFIG_HOME" "${XDG_CONFIG_HOME:-}")
+$(systemd_env_var_line "OCTOS_CONFIG_DIR" "${OCTOS_CONFIG_DIR:-}")
 $(systemd_env_var_line "FRPS_TOKEN" "${FRPS_TOKEN:-}")
 $(systemd_env_var_line "SMTP_HOST" "${SMTP_HOST:-}")
 $(systemd_env_var_line "SMTP_PORT" "${SMTP_PORT:-}")


### PR DESCRIPTION
Switches macOS config from Apple's `~/Library/Application Support/octos` to true XDG **`~/.config/octos`** (matching Linux; Windows stays `%APPDATA%\octos`) — octos is a CLI, so this is the prevailing convention (gh/nvim/helix) and far more discoverable.

- `xdg_config_home()`: unix → `${XDG_CONFIG_HOME:-~/.config}/octos` (absolute XDG honoured, relative ignored per spec); windows → `dirs::config_dir()/octos`. install.sh bash mirror matched.
- Service env (launchd + systemd) now carries `XDG_CONFIG_HOME` + the normalized `OCTOS_CONFIG_DIR` so `octos serve` resolves the same config_home the installer used.
- README: 'Where config lives' note (location, `OCTOS_CONFIG_DIR` override, ~/.octos = install+state, non-destructive migration).
- No config lost — migration copies (never moves) legacy `~/.octos/config.json`, which stays a load fallback.

514 lib tests; clippy/fmt clean; codex-reviewed (2 rounds — both findings + the OCTOS_CONFIG_DIR edge closed).