### PR TITLE
feat(diagnostics): octos-diagnostics crate + octos doctor (Stage 1, octos-tui#182)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,6 +3837,7 @@ dependencies = [
  "octos-agent",
  "octos-bus",
  "octos-core",
+ "octos-diagnostics",
  "octos-llm",
  "octos-memory",
  "octos-pipeline",
@@ -3883,6 +3884,17 @@ dependencies = [
  "tokio-test",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "octos-diagnostics"
+version = "0.1.1"
+dependencies = [
+ "eyre",
+ "octos-core",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/octos-core",
+    "crates/octos-diagnostics",
     "crates/octos-memory",
     "crates/octos-llm",
     "crates/octos-agent",
@@ -42,6 +43,7 @@ unsafe_code = "deny"
 [workspace.dependencies]
 # Internal crates
 octos-core = { path = "crates/octos-core" }
+octos-diagnostics = { path = "crates/octos-diagnostics" }
 octos-memory = { path = "crates/octos-memory" }
 octos-llm = { path = "crates/octos-llm" }
 octos-agent = { path = "crates/octos-agent" }

--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 octos-core = { workspace = true }
+octos-diagnostics = { workspace = true }
 octos-agent = { workspace = true }
 octos-memory = { workspace = true }
 octos-llm = { workspace = true }

--- a/crates/octos-cli/src/commands/doctor.rs
+++ b/crates/octos-cli/src/commands/doctor.rs
@@ -109,10 +109,17 @@ fn build_report(cmd: &DoctorCommand) -> Result<Report> {
     report.push(Check::pass(CAT_BINARY, "install method", method.label()).with_value(method.id()));
     if let Some(hint) = method.upgrade_hint(&spec) {
         // Informational only in Stage 1 (no version comparison without the
-        // network); surface the per-method upgrade command as the value.
-        report.push(
-            Check::pass(CAT_BINARY, "upgrade path", "package-manager owned").with_value(hint),
-        );
+        // network); surface the per-method upgrade command as the value, and
+        // label the OWNERSHIP honestly — self-update vs package-manager vs a
+        // manual install whose hint is just an advisory reinstall line.
+        let detail = if method.is_self_updating() {
+            "self-updating (octos update)"
+        } else if method.is_package_managed() {
+            "package-manager owned"
+        } else {
+            "manual install — upgrade by reinstalling"
+        };
+        report.push(Check::pass(CAT_BINARY, "upgrade path", detail).with_value(hint));
     }
 
     let located = locate(&spec);

--- a/crates/octos-cli/src/commands/doctor.rs
+++ b/crates/octos-cli/src/commands/doctor.rs
@@ -1,0 +1,201 @@
+//! `octos doctor` — flutter-doctor-style local diagnostics (Stage 1).
+//!
+//! Runs the shared, product-agnostic checks from `octos-diagnostics` against an
+//! octos-server [`ProductSpec`] and renders them through the shared [`Report`]:
+//! one line per check (`[✓]` pass / `[!]` warn / `[✗]` fail), grouped by
+//! category, each non-pass line followed by an indented `→ fix:` action,
+//! closing with a one-line summary. `--json` emits the support bundle;
+//! `--verbose` adds resolved paths/versions; `--strict` promotes warnings to
+//! failures.
+//!
+//! Stage 1 is **local checks only** — binary/install-method/on-path/shadow,
+//! terminal, config+data writability, and a structural protocol-skew check
+//! against the server's compiled-in capabilities. There is NO network (GitHub
+//! reachability + live WS capability probe are Stage 2) and NO update wiring
+//! (Stage 3); see the `// TODO Stage 2` markers below.
+
+use std::path::PathBuf;
+
+use clap::Args;
+use eyre::Result;
+use octos_core::ui_protocol::{UI_PROTOCOL_KNOWN_FEATURES, UI_PROTOCOL_V1, UiProtocolCapabilities};
+use octos_diagnostics::{
+    Check, ProductSpec, Report, config_writability_check, data_writability_check, detect, locate,
+    on_path_check, protocol_skew_check, shadow_check, terminal_checks,
+};
+
+use super::Executable;
+
+const CAT_BINARY: &str = "Binary & version";
+
+/// Run local environment diagnostics for the octos server.
+#[derive(Debug, Args)]
+pub struct DoctorCommand {
+    /// Emit machine-readable JSON (support bundle).
+    #[arg(long)]
+    pub json: bool,
+    /// Add resolved paths / versions to each line.
+    #[arg(long)]
+    pub verbose: bool,
+    /// Promote warnings to failures (affects exit code).
+    #[arg(long)]
+    pub strict: bool,
+    /// Data dir override (defaults to the resolved `~/.octos`).
+    #[arg(long)]
+    pub data_dir: Option<PathBuf>,
+}
+
+/// Build the octos-server [`ProductSpec`]. `current_version` is the CLI's OWN
+/// `CARGO_PKG_VERSION`, passed IN here — never the diagnostics crate's.
+fn octos_server_spec() -> ProductSpec {
+    ProductSpec::new(
+        "octos",                   // binary on PATH
+        "octos",                   // package / display name
+        env!("CARGO_PKG_VERSION"), // passed IN — octos-cli's own version
+        "octos-org/octos",         // github repo
+        "octos-bundle",            // asset prefix → octos-bundle-<triple>
+    )
+    .with_brew_formula("octos-org/tap/octos")
+    .with_npm_package("@octos-org/octos")
+    .with_cargo_install("octos-cli")
+    .with_cargo_dist_app("octos")
+}
+
+impl Executable for DoctorCommand {
+    fn execute(self) -> Result<()> {
+        let report = build_report(&self)?;
+        if self.json {
+            let bundle = report.to_json(
+                self.strict,
+                "octos",
+                env!("CARGO_PKG_VERSION"),
+                UI_PROTOCOL_V1,
+                octos_core::ui_protocol::UI_PROTOCOL_SCHEMA_VERSION,
+            );
+            println!("{}", serde_json::to_string_pretty(&bundle)?);
+        } else {
+            print!("{}", report.render(self.verbose, self.strict));
+        }
+        std::process::exit(report.exit_code(self.strict));
+    }
+}
+
+/// Assemble the full local-checks report. Separated from `execute` so it does
+/// not call `process::exit` and can be exercised by tests.
+fn build_report(cmd: &DoctorCommand) -> Result<Report> {
+    let spec = octos_server_spec();
+    let mut report = Report::default();
+
+    // --- Binary & version --------------------------------------------------
+    let current_exe = std::env::current_exe().ok();
+    match &current_exe {
+        Some(exe) => report.push(
+            Check::pass(
+                CAT_BINARY,
+                "octos binary",
+                format!("v{}", spec.current_version),
+            )
+            .with_value(exe.display().to_string()),
+        ),
+        None => report.push(Check::warn(
+            CAT_BINARY,
+            "octos binary",
+            "could not resolve current executable",
+            "ensure octos is on a real filesystem path",
+        )),
+    }
+
+    let method = detect(&spec);
+    report.push(Check::pass(CAT_BINARY, "install method", method.label()).with_value(method.id()));
+    if let Some(hint) = method.upgrade_hint(&spec) {
+        // Informational only in Stage 1 (no version comparison without the
+        // network); surface the per-method upgrade command as the value.
+        report.push(
+            Check::pass(CAT_BINARY, "upgrade path", "package-manager owned").with_value(hint),
+        );
+    }
+
+    let located = locate(&spec);
+    report.push(on_path_check(
+        &located,
+        current_exe.as_deref(),
+        &method,
+        &spec,
+    ));
+    report.push(shadow_check(&located, &method, &spec));
+    // TODO Stage 2: GitHub latest-release reachability + "newer release
+    // available" check (needs the `github` feature / reqwest).
+
+    // --- Terminal environment ---------------------------------------------
+    report.extend(terminal_checks());
+
+    // --- Config & data -----------------------------------------------------
+    // Resolve the REAL config_home (~/.config/octos by default) and data_dir
+    // (~/.octos) via the canonical resolver so doctor reports what octos
+    // actually reads/writes. Read-only here: no migrations, no dir creation.
+    let ctx = crate::config_context::resolve_config_context(cmd.data_dir.as_deref());
+    report.push(config_writability_check(&ctx.config_home));
+    report.push(data_writability_check(&ctx.data_dir));
+
+    // --- Backend / protocol skew ------------------------------------------
+    // The server's own compiled-in capabilities are authoritative for the
+    // structural skew check. `first_server_slice()` advertises the protocol's
+    // full known-feature registry (what `octos serve` actually negotiates), so
+    // comparing it against that same registry confirms the build's octos-core
+    // matches the protocol it ships — a divergence would surface here.
+    // TODO Stage 2: replace the compiled-in caps with a LIVE WS
+    // `config/capabilities/list` probe against a configured/running server.
+    let server_caps = UiProtocolCapabilities::first_server_slice();
+    report.push(protocol_skew_check(
+        &server_caps,
+        UI_PROTOCOL_KNOWN_FEATURES.iter().copied(),
+    ));
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cmd() -> DoctorCommand {
+        DoctorCommand {
+            json: false,
+            verbose: false,
+            strict: false,
+            data_dir: None,
+        }
+    }
+
+    #[test]
+    fn spec_carries_cli_version_not_diagnostics_crate_version() {
+        let spec = octos_server_spec();
+        assert_eq!(spec.current_version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(spec.binary_name, "octos");
+        assert_eq!(spec.github_repo, "octos-org/octos");
+        assert_eq!(
+            spec.asset_selector.asset_name("aarch64-apple-darwin"),
+            "octos-bundle-aarch64-apple-darwin"
+        );
+    }
+
+    #[test]
+    fn report_includes_core_categories_and_protocol_skew_passes() {
+        let report = build_report(&cmd()).expect("report builds");
+        let text = report.render(false, false);
+        assert!(text.contains("Binary & version"));
+        assert!(text.contains("Terminal environment"));
+        assert!(text.contains("Config & data"));
+        assert!(text.contains("Backend"));
+        // The server's own build advertises every known feature, so the
+        // structural skew check must pass.
+        let skew = report
+            .checks
+            .iter()
+            .find(|c| c.name == "protocol skew")
+            .expect("protocol skew check present");
+        assert_eq!(skew.status, octos_diagnostics::CheckStatus::Pass);
+        // Glyphs are present in the rendered output.
+        assert!(text.contains("[✓]"));
+    }
+}

--- a/crates/octos-cli/src/commands/mod.rs
+++ b/crates/octos-cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ mod clean;
 mod completions;
 mod cron;
 mod docs;
+mod doctor;
 pub mod gateway;
 mod init;
 pub mod mcp_serve;
@@ -32,6 +33,7 @@ pub use clean::CleanCommand;
 pub use completions::CompletionsCommand;
 pub use cron::CronCommand;
 pub use docs::DocsCommand;
+pub use doctor::DoctorCommand;
 pub use gateway::GatewayCommand;
 pub use init::InitCommand;
 pub use mcp_serve::McpServeCommand;
@@ -87,6 +89,8 @@ pub enum Command {
     Chat(ChatCommand),
     /// Manage scheduled cron jobs.
     Cron(CronCommand),
+    /// Run local environment diagnostics (flutter-doctor style).
+    Doctor(DoctorCommand),
     /// Generate documentation for tools and providers.
     Docs(DocsCommand),
     /// Initialize a new .octos configuration.
@@ -296,6 +300,7 @@ impl Executable for Command {
             Self::Channels(cmd) => cmd.execute(),
             Self::Chat(cmd) => cmd.execute(),
             Self::Cron(cmd) => cmd.execute(),
+            Self::Doctor(cmd) => cmd.execute(),
             Self::Docs(cmd) => cmd.execute(),
             Self::Init(cmd) => cmd.execute(),
             Self::McpServe(cmd) => cmd.execute(),

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -1489,6 +1489,80 @@ fn is_autonomy_optional_feature(feature: &str) -> bool {
     )
 }
 
+/// Result of comparing a server's advertised [`UiProtocolCapabilities`] against
+/// a caller-supplied required-feature set. This is the **pure** protocol
+/// semantics primitive: it has no dependency on any network/transport crate and
+/// reasons only over the protocol family string, the schema version, and the
+/// advertised `supported_features`.
+///
+/// `octos-diagnostics` wraps the result of [`compare_protocol`] into a
+/// `Check`/report line (the product-facing adapter); both the TUI and the
+/// server reuse this same comparator so the skew logic never forks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProtocolCompat {
+    /// The server speaks the same protocol family, its schema version is at
+    /// least the client's, and every required feature is advertised.
+    Compatible,
+    /// The protocol family + schema are compatible, but the server does not
+    /// advertise one or more features the client requires. Carries the missing
+    /// feature names (in the order they were requested).
+    MissingFeatures(Vec<String>),
+    /// The server is on a different protocol family, or its schema version is
+    /// *older* than the client's compiled-in [`UI_PROTOCOL_SCHEMA_VERSION`] —
+    /// the two cannot interoperate regardless of features.
+    SchemaIncompatible { server: u32, client: u32 },
+}
+
+impl ProtocolCompat {
+    /// Whether the comparison found no problems at all.
+    pub fn is_compatible(&self) -> bool {
+        matches!(self, ProtocolCompat::Compatible)
+    }
+}
+
+/// Pure protocol-compatibility comparator (no new deps; reasons only over the
+/// existing protocol consts + the advertised capability payload).
+///
+/// Decision order (first wins), mirroring the client/server handshake contract:
+///
+/// 1. **Family mismatch** → [`ProtocolCompat::SchemaIncompatible`] with the
+///    server's schema vs the client's compiled-in [`UI_PROTOCOL_SCHEMA_VERSION`]
+///    (a different `protocol` string means the wire dialects differ — we report
+///    it as schema-incompatible because no feature negotiation can bridge it).
+/// 2. **Older server schema** (`server.version.schema_version <
+///    UI_PROTOCOL_SCHEMA_VERSION`) → [`ProtocolCompat::SchemaIncompatible`]. A
+///    server *newer* than the client is allowed (forward-compatible additive
+///    schema), so only an older server is rejected.
+/// 3. **Missing required features** → [`ProtocolCompat::MissingFeatures`],
+///    preserving the order in `required`.
+/// 4. Otherwise → [`ProtocolCompat::Compatible`].
+pub fn compare_protocol<I, S>(server: &UiProtocolCapabilities, required: I) -> ProtocolCompat
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    if server.version.protocol != UI_PROTOCOL_V1
+        || server.version.schema_version < UI_PROTOCOL_SCHEMA_VERSION
+    {
+        return ProtocolCompat::SchemaIncompatible {
+            server: server.version.schema_version,
+            client: UI_PROTOCOL_SCHEMA_VERSION,
+        };
+    }
+
+    let missing: Vec<String> = required
+        .into_iter()
+        .filter(|feature| !server.supports_feature(feature.as_ref()))
+        .map(|feature| feature.as_ref().to_owned())
+        .collect();
+
+    if missing.is_empty() {
+        ProtocolCompat::Compatible
+    } else {
+        ProtocolCompat::MissingFeatures(missing)
+    }
+}
+
 fn string_list(values: &[&str]) -> Vec<String> {
     values.iter().map(|value| (*value).to_owned()).collect()
 }
@@ -5809,6 +5883,88 @@ impl UiNotification {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn compare_protocol_compatible_for_full_protocol_with_known_features() {
+        // The full-protocol capabilities advertise every known feature, so any
+        // subset (here: the whole known registry) is satisfied.
+        let server = UiProtocolCapabilities::full_protocol();
+        let required: Vec<&str> = vec![
+            UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
+            UI_PROTOCOL_FEATURE_USER_QUESTION_V1,
+        ];
+        assert_eq!(
+            compare_protocol(&server, required),
+            ProtocolCompat::Compatible
+        );
+    }
+
+    #[test]
+    fn compare_protocol_empty_required_is_always_compatible() {
+        let server = UiProtocolCapabilities::full_protocol();
+        let required: Vec<&str> = Vec::new();
+        assert_eq!(
+            compare_protocol(&server, required),
+            ProtocolCompat::Compatible
+        );
+        assert!(compare_protocol(&server, Vec::<&str>::new()).is_compatible());
+    }
+
+    #[test]
+    fn compare_protocol_reports_missing_features_in_request_order() {
+        let mut server = UiProtocolCapabilities::full_protocol();
+        server
+            .supported_features
+            .retain(|f| f != UI_PROTOCOL_FEATURE_USER_QUESTION_V1);
+        let required = vec![
+            UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1, // present
+            UI_PROTOCOL_FEATURE_USER_QUESTION_V1,  // removed → missing
+        ];
+        assert_eq!(
+            compare_protocol(&server, required),
+            ProtocolCompat::MissingFeatures(vec![UI_PROTOCOL_FEATURE_USER_QUESTION_V1.to_owned()])
+        );
+    }
+
+    #[test]
+    fn compare_protocol_schema_incompatible_when_server_older() {
+        if UI_PROTOCOL_SCHEMA_VERSION == 0 {
+            return; // can't model an older schema below zero
+        }
+        let mut server = UiProtocolCapabilities::full_protocol();
+        server.version.schema_version = UI_PROTOCOL_SCHEMA_VERSION - 1;
+        assert_eq!(
+            compare_protocol(&server, [UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1]),
+            ProtocolCompat::SchemaIncompatible {
+                server: UI_PROTOCOL_SCHEMA_VERSION - 1,
+                client: UI_PROTOCOL_SCHEMA_VERSION,
+            }
+        );
+    }
+
+    #[test]
+    fn compare_protocol_allows_newer_server_schema() {
+        // A server ahead of the client (additive forward-compat) is fine.
+        let mut server = UiProtocolCapabilities::full_protocol();
+        server.version.schema_version = UI_PROTOCOL_SCHEMA_VERSION + 5;
+        assert_eq!(
+            compare_protocol(&server, [UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1]),
+            ProtocolCompat::Compatible
+        );
+    }
+
+    #[test]
+    fn compare_protocol_schema_incompatible_on_wrong_protocol_family() {
+        let mut server = UiProtocolCapabilities::full_protocol();
+        server.version.protocol = "octos-ui/v2alpha".into();
+        // Even with a same/newer schema number, a different family can't bridge.
+        match compare_protocol(&server, [UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1]) {
+            ProtocolCompat::SchemaIncompatible { client, .. } => {
+                assert_eq!(client, UI_PROTOCOL_SCHEMA_VERSION);
+            }
+            other => panic!("expected SchemaIncompatible, got {other:?}"),
+        }
+    }
 
     #[test]
     fn reasoning_effort_level_wire_shape() {

--- a/crates/octos-diagnostics/Cargo.toml
+++ b/crates/octos-diagnostics/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "octos-diagnostics"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Shared, product-agnostic diagnostics + update-planning for octos binaries (doctor)"
+
+[dependencies]
+octos-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+eyre = { workspace = true }
+
+[features]
+# Stage 1 is dependency-light: NO `github`/`update` features, NO reqwest,
+# NO axoupdater. GitHub reachability is Stage 2; self-update is Stage 3.
+default = []
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/octos-diagnostics/src/checks.rs
+++ b/crates/octos-diagnostics/src/checks.rs
@@ -1,0 +1,400 @@
+//! Generic, product-agnostic local checks: terminal environment, config/data
+//! directory writability, and the protocol-skew **adapter** over the pure
+//! `octos_core::ui_protocol` comparator.
+//!
+//! No network here (Stage 1). The terminal checks are ported from octos-tui's
+//! `doctor.rs`; the writability checks take their directories as parameters so
+//! callers (octos-cli) resolve the real `~/.config/octos` + `~/.octos`.
+
+use std::path::Path;
+
+use octos_core::ui_protocol::{
+    ProtocolCompat, UI_PROTOCOL_SCHEMA_VERSION, UI_PROTOCOL_V1, UiProtocolCapabilities,
+    compare_protocol,
+};
+
+use crate::report::Check;
+
+const CAT_TERM: &str = "Terminal environment";
+const CAT_CONFIG: &str = "Config & data";
+const CAT_BACKEND: &str = "Backend";
+
+// ---------------------------------------------------------------------------
+// Terminal environment
+// ---------------------------------------------------------------------------
+
+/// All terminal-environment checks, reading the live `TERM`/locale/`COLORTERM`
+/// env vars. Returns `[TERM, UTF-8 locale, CJK width, color support]`.
+pub fn terminal_checks() -> Vec<Check> {
+    let term = std::env::var("TERM").ok();
+    let lang = std::env::var("LANG").ok();
+    let lc_all = std::env::var("LC_ALL").ok();
+    let lc_ctype = std::env::var("LC_CTYPE").ok();
+    let colorterm = std::env::var("COLORTERM").ok();
+    vec![
+        term_check(term.as_deref()),
+        locale_check(lang.as_deref(), lc_all.as_deref(), lc_ctype.as_deref()),
+        cjk_check(),
+        color_check(term.as_deref(), colorterm.as_deref()),
+    ]
+}
+
+/// Whether a `TERM` value has a loadable terminfo entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminfoProbe {
+    /// `infocmp` confirmed the terminfo entry loads.
+    Found,
+    /// `infocmp` ran but reported the entry is missing (non-zero exit).
+    Missing,
+    /// `infocmp` itself isn't available — we can't probe, so don't hard-fail.
+    ProberAbsent,
+}
+
+fn term_check(term: Option<&str>) -> Check {
+    term_check_with(term, probe_terminfo)
+}
+
+fn term_check_with(term: Option<&str>, probe: impl Fn(&str) -> TerminfoProbe) -> Check {
+    match term {
+        Some("dumb") => Check::warn(
+            CAT_TERM,
+            "TERM set",
+            "TERM=dumb has no terminfo capabilities",
+            "export TERM=xterm-256color",
+        ),
+        Some(t) if !t.is_empty() => match probe(t) {
+            TerminfoProbe::Found | TerminfoProbe::ProberAbsent => {
+                Check::pass(CAT_TERM, "TERM set", t.to_string()).with_value(t.to_string())
+            }
+            TerminfoProbe::Missing => Check::warn(
+                CAT_TERM,
+                "TERM set",
+                format!("TERM=`{t}` has no terminfo entry (the TUI will report 'can't find terminfo database')"),
+                "set TERM=xterm-256color or install the terminfo package for your terminal",
+            )
+            .with_value(t.to_string()),
+        },
+        _ => Check::warn(
+            CAT_TERM,
+            "TERM set",
+            "TERM is unset; the TUI may not render or may report 'can't find terminfo database'",
+            "export TERM=xterm-256color",
+        ),
+    }
+}
+
+/// Probe whether `term`'s terminfo entry is loadable via `infocmp`.
+fn probe_terminfo(term: &str) -> TerminfoProbe {
+    match std::process::Command::new("infocmp")
+        .arg("-1")
+        .arg(term)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+    {
+        Ok(status) if status.success() => TerminfoProbe::Found,
+        Ok(_) => TerminfoProbe::Missing,
+        Err(_) => TerminfoProbe::ProberAbsent,
+    }
+}
+
+fn locale_check(lang: Option<&str>, lc_all: Option<&str>, lc_ctype: Option<&str>) -> Check {
+    let effective = lc_all.or(lc_ctype).or(lang);
+    match effective {
+        Some(v)
+            if v.to_ascii_uppercase().contains("UTF-8")
+                || v.to_ascii_uppercase().contains("UTF8") =>
+        {
+            Check::pass(CAT_TERM, "UTF-8 locale", v.to_string()).with_value(v.to_string())
+        }
+        Some(v) => Check::warn(
+            CAT_TERM,
+            "UTF-8 locale",
+            format!("locale `{v}` is not UTF-8; box-drawing and CJK may break"),
+            "export LANG=en_US.UTF-8 (or your locale with .UTF-8)",
+        ),
+        None => Check::warn(
+            CAT_TERM,
+            "UTF-8 locale",
+            "no LANG/LC_ALL/LC_CTYPE set",
+            "export LANG=en_US.UTF-8",
+        ),
+    }
+}
+
+fn cjk_check() -> Check {
+    Check::pass(
+        CAT_TERM,
+        "CJK width",
+        "uses unicode-width for double-width glyphs (also depends on terminal font)",
+    )
+}
+
+fn color_check(term: Option<&str>, colorterm: Option<&str>) -> Check {
+    let truecolor = colorterm
+        .map(|c| c.contains("truecolor") || c.contains("24bit"))
+        .unwrap_or(false);
+    let has_256 = term.map(|t| t.contains("256color")).unwrap_or(false);
+    if truecolor {
+        Check::pass(CAT_TERM, "color support", "truecolor (24-bit)")
+    } else if has_256 {
+        Check::pass(CAT_TERM, "color support", "256-color")
+    } else {
+        Check::warn(
+            CAT_TERM,
+            "color support",
+            "no truecolor/256-color advertised; themes may look flat",
+            "use a 256-color terminal and set TERM=xterm-256color (COLORTERM=truecolor)",
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Config & data directory writability
+// ---------------------------------------------------------------------------
+
+/// Writability check for a config dir, named appropriately.
+pub fn config_writability_check(dir: &Path) -> Check {
+    writability_check("config dir", dir)
+}
+
+/// Writability check for a data dir, named appropriately.
+pub fn data_writability_check(dir: &Path) -> Check {
+    writability_check("data dir", dir)
+}
+
+/// Check that a directory exists and is writable (or creatable). A missing dir
+/// that can be created is a `[!]` warn with a `mkdir -p` fix; a path that exists
+/// but isn't a directory is a `[✗]` failure (the `mkdir -p` hint would fail).
+pub fn writability_check(name: &'static str, dir: &Path) -> Check {
+    if dir.is_dir() {
+        if is_writable(dir) {
+            Check::pass(CAT_CONFIG, name, "present and writable")
+                .with_value(dir.display().to_string())
+        } else {
+            Check::fail(
+                CAT_CONFIG,
+                name,
+                format!("{} is not writable", dir.display()),
+                format!("chmod u+w {}", dir.display()),
+            )
+            .with_value(dir.display().to_string())
+        }
+    } else if dir.exists() {
+        Check::fail(
+            CAT_CONFIG,
+            name,
+            format!("{} exists but is not a directory", dir.display()),
+            format!(
+                "remove the file at {} or point the dir elsewhere",
+                dir.display()
+            ),
+        )
+        .with_value(dir.display().to_string())
+    } else {
+        Check::warn(
+            CAT_CONFIG,
+            name,
+            format!("{} does not exist yet", dir.display()),
+            format!("mkdir -p {}", dir.display()),
+        )
+        .with_value(dir.display().to_string())
+    }
+}
+
+fn is_writable(dir: &Path) -> bool {
+    let probe = dir.join(".octos-doctor-write-probe");
+    match std::fs::File::create(&probe) {
+        Ok(_) => {
+            let _ = std::fs::remove_file(&probe);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Protocol skew (adapter over the pure octos-core comparator)
+// ---------------------------------------------------------------------------
+
+/// Adapter: run the pure [`compare_protocol`] comparator and turn its
+/// [`ProtocolCompat`] result into a [`Check`]. `server` is the advertised (or
+/// compiled-in) capabilities; `required` is the caller's required-feature set.
+///
+/// - [`ProtocolCompat::Compatible`] → `[✓]`.
+/// - [`ProtocolCompat::MissingFeatures`] → `[!]` (degraded; upgrade the server).
+/// - [`ProtocolCompat::SchemaIncompatible`] → `[✗]` (cannot interoperate).
+pub fn protocol_skew_check<'a, I>(server: &UiProtocolCapabilities, required: I) -> Check
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    match compare_protocol(server, required) {
+        ProtocolCompat::Compatible => Check::pass(
+            CAT_BACKEND,
+            "protocol skew",
+            format!(
+                "compatible ({UI_PROTOCOL_V1} schema v{}, all required features present)",
+                server.version.schema_version
+            ),
+        )
+        .with_value(format!(
+            "{UI_PROTOCOL_V1} schema v{UI_PROTOCOL_SCHEMA_VERSION}"
+        )),
+        ProtocolCompat::MissingFeatures(missing) => Check::warn(
+            CAT_BACKEND,
+            "protocol skew",
+            format!(
+                "server is missing required features: {}",
+                missing.join(", ")
+            ),
+            "upgrade the octos server to advertise these features, or expect degraded behavior",
+        ),
+        ProtocolCompat::SchemaIncompatible { server, client } => Check::fail(
+            CAT_BACKEND,
+            "protocol skew",
+            format!("server schema v{server} is incompatible with the client's v{client}"),
+            "upgrade whichever side is on the wrong protocol family/schema",
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::CheckStatus;
+    use octos_core::ui_protocol::{
+        UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1, UI_PROTOCOL_FEATURE_USER_QUESTION_V1,
+    };
+
+    // --- terminal -----------------------------------------------------------
+
+    #[test]
+    fn term_check_warns_when_unset_or_dumb() {
+        let found = |_: &str| TerminfoProbe::Found;
+        assert_eq!(term_check_with(None, found).status, CheckStatus::Warn);
+        assert_eq!(
+            term_check_with(Some("dumb"), found).status,
+            CheckStatus::Warn
+        );
+        assert_eq!(
+            term_check_with(Some("xterm-256color"), found).status,
+            CheckStatus::Pass
+        );
+    }
+
+    #[test]
+    fn term_check_warns_when_terminfo_entry_missing() {
+        let missing = |_: &str| TerminfoProbe::Missing;
+        let check = term_check_with(Some("xterm-256color"), missing);
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.detail.contains("terminfo"));
+    }
+
+    #[test]
+    fn term_check_passes_when_prober_absent() {
+        let absent = |_: &str| TerminfoProbe::ProberAbsent;
+        assert_eq!(
+            term_check_with(Some("xterm-256color"), absent).status,
+            CheckStatus::Pass
+        );
+    }
+
+    #[test]
+    fn locale_check_requires_utf8() {
+        assert_eq!(
+            locale_check(Some("en_US.UTF-8"), None, None).status,
+            CheckStatus::Pass
+        );
+        assert_eq!(
+            locale_check(Some("C"), None, None).status,
+            CheckStatus::Warn
+        );
+        assert_eq!(locale_check(None, None, None).status, CheckStatus::Warn);
+        // LC_ALL overrides LANG.
+        assert_eq!(
+            locale_check(Some("C"), Some("en_US.UTF-8"), None).status,
+            CheckStatus::Pass
+        );
+    }
+
+    #[test]
+    fn color_check_recognizes_truecolor_and_256() {
+        assert_eq!(
+            color_check(Some("xterm"), Some("truecolor")).status,
+            CheckStatus::Pass
+        );
+        assert_eq!(
+            color_check(Some("xterm-256color"), None).status,
+            CheckStatus::Pass
+        );
+        assert_eq!(color_check(Some("xterm"), None).status, CheckStatus::Warn);
+    }
+
+    // --- writability --------------------------------------------------------
+
+    #[test]
+    fn writability_check_passes_for_writable_tempdir() {
+        let dir = std::env::temp_dir();
+        assert_eq!(writability_check("tmp", &dir).status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn writability_check_warns_for_missing_dir() {
+        let missing = std::env::temp_dir().join("octos-diagnostics-doctor-nope-xyz-12345");
+        let _ = std::fs::remove_dir_all(&missing);
+        let check = writability_check("missing", &missing);
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.fix.unwrap().contains("mkdir -p"));
+    }
+
+    #[test]
+    fn writability_check_fails_when_path_is_a_file() {
+        let file = std::env::temp_dir().join("octos-diagnostics-datadir-as-file-98765");
+        let _ = std::fs::remove_file(&file);
+        std::fs::write(&file, b"not a dir").expect("create probe file");
+        let check = writability_check("data dir", &file);
+        let _ = std::fs::remove_file(&file);
+        assert_eq!(check.status, CheckStatus::Fail);
+        let fix = check.fix.unwrap();
+        assert!(fix.contains("remove the file"));
+        assert!(!fix.contains("mkdir -p"));
+    }
+
+    // --- protocol skew adapter ---------------------------------------------
+
+    #[test]
+    fn protocol_skew_passes_for_full_protocol() {
+        let server = UiProtocolCapabilities::full_protocol();
+        let check = protocol_skew_check(
+            &server,
+            [
+                UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
+                UI_PROTOCOL_FEATURE_USER_QUESTION_V1,
+            ],
+        );
+        assert_eq!(check.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn protocol_skew_warns_when_feature_missing() {
+        let mut server = UiProtocolCapabilities::full_protocol();
+        server
+            .supported_features
+            .retain(|f| f != UI_PROTOCOL_FEATURE_USER_QUESTION_V1);
+        let check = protocol_skew_check(&server, [UI_PROTOCOL_FEATURE_USER_QUESTION_V1]);
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.detail.contains(UI_PROTOCOL_FEATURE_USER_QUESTION_V1));
+    }
+
+    #[test]
+    fn protocol_skew_fails_on_older_schema() {
+        if UI_PROTOCOL_SCHEMA_VERSION == 0 {
+            return;
+        }
+        let mut server = UiProtocolCapabilities::full_protocol();
+        server.version.schema_version = UI_PROTOCOL_SCHEMA_VERSION - 1;
+        let check = protocol_skew_check(&server, [UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1]);
+        assert_eq!(check.status, CheckStatus::Fail);
+        assert!(check.detail.contains("incompatible"));
+    }
+}

--- a/crates/octos-diagnostics/src/install_method.rs
+++ b/crates/octos-diagnostics/src/install_method.rs
@@ -110,6 +110,20 @@ impl InstallMethod {
     pub fn is_self_updating(&self) -> bool {
         matches!(self, InstallMethod::CargoDistInstaller)
     }
+
+    /// Whether this install is owned by a package manager (or cargo) the user
+    /// upgrades through — as opposed to a manual install we can't drive.
+    /// `Unknown` is NOT package-managed: there's no owning manager to defer to,
+    /// even though `upgrade_hint` offers an advisory `curl | sh` reinstall line.
+    pub fn is_package_managed(&self) -> bool {
+        matches!(
+            self,
+            InstallMethod::Homebrew
+                | InstallMethod::Npm
+                | InstallMethod::CargoRegistry
+                | InstallMethod::CargoGit
+        )
+    }
 }
 
 /// Inputs to the pure path classifier. All prefixes are optional because they

--- a/crates/octos-diagnostics/src/install_method.rs
+++ b/crates/octos-diagnostics/src/install_method.rs
@@ -1,0 +1,491 @@
+//! Install-method detection, product-agnostic.
+//!
+//! Ported from octos-tui's `install_method.rs`, but every product-specific
+//! string (formula, package, repo, crate) now comes from the [`ProductSpec`]
+//! rather than being hardcoded. The path classifier ([`classify_path`]) stays
+//! pure/testable; [`detect`] wires it to the live host.
+//!
+//! Stage 1 is dependency-light: the cargo-dist install-receipt probe is a
+//! Stage-3 stub that always returns "no receipt", so `detect` classifies via
+//! path heuristics + env. When the `update` engine lands (Stage 3) this is the
+//! one seam that flips to an axoupdater receipt check.
+
+use std::path::{Path, PathBuf};
+
+use crate::spec::ProductSpec;
+
+/// How a product binary was installed. Drives upgrade advice (self-update vs.
+/// print-the-command) and `doctor`'s fix lines.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstallMethod {
+    /// Installed by the cargo-dist shell/PowerShell installer — a receipt is
+    /// present and (Stage 3) the binary can self-update in place.
+    CargoDistInstaller,
+    /// Installed via Homebrew.
+    Homebrew,
+    /// Installed via npm global.
+    Npm,
+    /// `cargo install <crate>` from the crates.io registry.
+    CargoRegistry,
+    /// `cargo install --git …` from the GitHub repo.
+    CargoGit,
+    /// Anything else (distro package, manual copy, dev build, …).
+    Unknown,
+}
+
+impl InstallMethod {
+    /// Short, stable identifier for `--json` output.
+    pub fn id(&self) -> &'static str {
+        match self {
+            InstallMethod::CargoDistInstaller => "cargo-dist-installer",
+            InstallMethod::Homebrew => "homebrew",
+            InstallMethod::Npm => "npm",
+            InstallMethod::CargoRegistry => "cargo-registry",
+            InstallMethod::CargoGit => "cargo-git",
+            InstallMethod::Unknown => "unknown",
+        }
+    }
+
+    /// Human-readable label.
+    pub fn label(&self) -> &'static str {
+        match self {
+            InstallMethod::CargoDistInstaller => "cargo-dist installer (self-updating)",
+            InstallMethod::Homebrew => "Homebrew",
+            InstallMethod::Npm => "npm (global)",
+            InstallMethod::CargoRegistry => "cargo install (crates.io)",
+            InstallMethod::CargoGit => "cargo install --git",
+            InstallMethod::Unknown => "unknown / distro package",
+        }
+    }
+
+    /// The exact command the user should run to upgrade, built from the
+    /// [`ProductSpec`]. `None` for the self-updating installer (the caller
+    /// prints a self-update message instead). For package-manager methods whose
+    /// spec field is absent, falls back to the one-line installer hint.
+    pub fn upgrade_hint(&self, spec: &ProductSpec) -> Option<String> {
+        match self {
+            InstallMethod::CargoDistInstaller => None,
+            InstallMethod::Homebrew => spec
+                .brew_formula
+                .as_ref()
+                .map(|f| format!("brew update && brew upgrade {f}"))
+                .or_else(|| Some(self.installer_hint(spec))),
+            InstallMethod::Npm => spec
+                .npm_package
+                .as_ref()
+                .map(|p| format!("npm update -g {p}"))
+                .or_else(|| Some(self.installer_hint(spec))),
+            InstallMethod::CargoRegistry => spec
+                .cargo_install
+                .as_ref()
+                .map(|c| format!("cargo install {c} --force"))
+                .or_else(|| Some(self.installer_hint(spec))),
+            InstallMethod::CargoGit => Some(format!(
+                "cargo install --git {} {} --force",
+                spec.github_url(),
+                spec.cargo_install
+                    .clone()
+                    .unwrap_or_else(|| spec.binary_name.clone())
+            )),
+            // No package manager owns the binary; suggest the one-line installer.
+            InstallMethod::Unknown => Some(self.installer_hint(spec)),
+        }
+    }
+
+    /// The one-line cargo-dist installer command for this product.
+    fn installer_hint(&self, spec: &ProductSpec) -> String {
+        let app = spec
+            .cargo_dist_app
+            .clone()
+            .unwrap_or_else(|| spec.binary_name.clone());
+        format!(
+            "curl --proto '=https' --tlsv1.2 -LsSf \
+{}/releases/latest/download/{app}-installer.sh | sh",
+            spec.github_url()
+        )
+    }
+
+    /// Whether `update` can mutate the binary in place (only the cargo-dist
+    /// installer; everything else defers to its package manager).
+    pub fn is_self_updating(&self) -> bool {
+        matches!(self, InstallMethod::CargoDistInstaller)
+    }
+}
+
+/// Inputs to the pure path classifier. All prefixes are optional because they
+/// are resolved best-effort from the host.
+#[derive(Debug, Default, Clone)]
+pub struct PathClassifierInput {
+    /// Resolved `current_exe()` path (canonicalized when possible).
+    pub current_exe: PathBuf,
+    /// Confirmed Homebrew prefixes to test as ancestors. `/usr/local` is
+    /// included only when brew actually lives there.
+    pub brew_prefixes: Vec<PathBuf>,
+    /// npm global root(s) (`npm root -g`, i.e. `…/lib/node_modules`).
+    pub npm_global_roots: Vec<PathBuf>,
+    /// `~/.cargo/bin`.
+    pub cargo_bin: Option<PathBuf>,
+    /// Whether `.crates2.json` records this crate as a `--git` source.
+    /// `Some(true)` → git, `Some(false)` → registry, `None` → unknown.
+    pub cargo_source_is_git: Option<bool>,
+}
+
+/// Classify the binary purely from its path + resolved prefixes (no receipt).
+/// First match wins.
+pub fn classify_path(input: &PathClassifierInput) -> InstallMethod {
+    let exe = &input.current_exe;
+
+    // npm global: under an npm root, or any ancestor is a node_modules dir.
+    if input
+        .npm_global_roots
+        .iter()
+        .any(|root| is_ancestor(root, exe))
+        || path_has_segment(exe, "node_modules")
+    {
+        return InstallMethod::Npm;
+    }
+
+    // Homebrew: under a brew prefix, or anywhere under a `Cellar` dir.
+    if input
+        .brew_prefixes
+        .iter()
+        .any(|prefix| is_ancestor(prefix, exe))
+        || path_has_segment(exe, "Cellar")
+    {
+        return InstallMethod::Homebrew;
+    }
+
+    // cargo install destination (`~/.cargo/bin/<bin>`).
+    if input
+        .cargo_bin
+        .as_ref()
+        .is_some_and(|bin| is_ancestor(bin, exe))
+        || path_has_segments(exe, &[".cargo", "bin"])
+    {
+        return match input.cargo_source_is_git {
+            Some(true) => InstallMethod::CargoGit,
+            // Default cargo installs come from the registry; treat unknown
+            // source as registry so the printed command is the common case.
+            Some(false) | None => InstallMethod::CargoRegistry,
+        };
+    }
+
+    InstallMethod::Unknown
+}
+
+/// Returns true when `ancestor` is a component-wise path prefix of `path`.
+fn is_ancestor(ancestor: &Path, path: &Path) -> bool {
+    if ancestor.as_os_str().is_empty() {
+        return false;
+    }
+    let mut a = ancestor.components();
+    let mut p = path.components();
+    loop {
+        match (a.next(), p.next()) {
+            (Some(ac), Some(pc)) if ac == pc => continue,
+            (Some(_), _) => return false, // ancestor longer / diverged
+            (None, _) => return true,     // ancestor fully consumed → prefix
+        }
+    }
+}
+
+/// Whether any path component equals `segment`.
+fn path_has_segment(path: &Path, segment: &str) -> bool {
+    path.components()
+        .any(|c| c.as_os_str().to_string_lossy() == segment)
+}
+
+/// Whether `segments` appear as a contiguous run of path components.
+fn path_has_segments(path: &Path, segments: &[&str]) -> bool {
+    let comps: Vec<String> = path
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect();
+    comps
+        .windows(segments.len())
+        .any(|w| w.iter().zip(segments).all(|(a, b)| a == b))
+}
+
+/// Detect the install method for `spec` against the live host.
+///
+/// Stage 1: the cargo-dist receipt probe is a stub (always "absent"), so this
+/// classifies via [`classify_path`] over `current_exe()` + best-effort
+/// package-manager prefix resolution. Stage 3 flips [`receipt_for_this_executable`]
+/// to a real axoupdater receipt check behind an `update` feature.
+pub fn detect(spec: &ProductSpec) -> InstallMethod {
+    if receipt_for_this_executable(spec) {
+        return InstallMethod::CargoDistInstaller;
+    }
+    classify_path(&live_classifier_input(spec))
+}
+
+/// Stage-1 stub: there is no axoupdater receipt to load without the (Stage-3)
+/// `update` feature, so path heuristics decide. Kept as a named seam so Stage 3
+/// only has to change this function.
+fn receipt_for_this_executable(_spec: &ProductSpec) -> bool {
+    false
+}
+
+/// Assemble the live classifier input from `current_exe()` + best-effort
+/// package-manager prefix resolution.
+fn live_classifier_input(spec: &ProductSpec) -> PathClassifierInput {
+    let current_exe = std::env::current_exe()
+        .map(|p| std::fs::canonicalize(&p).unwrap_or(p))
+        .unwrap_or_default();
+
+    PathClassifierInput {
+        current_exe,
+        brew_prefixes: brew_prefixes(),
+        npm_global_roots: npm_global_roots(),
+        cargo_bin: cargo_bin(),
+        cargo_source_is_git: cargo_source_is_git(spec),
+    }
+}
+
+/// Candidate Homebrew prefixes. `/opt/homebrew` is always a candidate (Apple
+/// Silicon default); `/usr/local` is added only when `brew --prefix` confirms
+/// brew lives there.
+fn brew_prefixes() -> Vec<PathBuf> {
+    let mut prefixes = vec![PathBuf::from("/opt/homebrew")];
+    if let Ok(out) = std::process::Command::new("brew").arg("--prefix").output() {
+        if out.status.success() {
+            let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !p.is_empty() {
+                prefixes.push(PathBuf::from(p));
+            }
+        }
+    }
+    prefixes
+}
+
+/// `npm root -g` only (the specific `…/lib/node_modules` path that owns global
+/// packages; deliberately NOT `npm prefix -g`).
+fn npm_global_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Ok(out) = std::process::Command::new("npm")
+        .args(["root", "-g"])
+        .output()
+    {
+        if out.status.success() {
+            let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !p.is_empty() {
+                roots.push(PathBuf::from(p));
+            }
+        }
+    }
+    roots
+}
+
+/// `~/.cargo/bin`, honoring `CARGO_HOME`.
+fn cargo_bin() -> Option<PathBuf> {
+    cargo_home().map(|home| home.join("bin"))
+}
+
+fn cargo_home() -> Option<PathBuf> {
+    if let Ok(home) = std::env::var("CARGO_HOME") {
+        if !home.is_empty() {
+            return Some(PathBuf::from(home));
+        }
+    }
+    home_dir().map(|h| h.join(".cargo"))
+}
+
+/// Inspect `~/.cargo/.crates2.json` for the recorded source of the crate.
+/// Returns `Some(true)` for a git source, `Some(false)` for a registry source,
+/// `None` if not found / unparseable. Keys look like
+/// `<crate> <version> (registry+https://…)` or `(git+https://…)`.
+fn cargo_source_is_git(spec: &ProductSpec) -> Option<bool> {
+    let crate_name = spec.cargo_install.as_deref().unwrap_or(&spec.binary_name);
+    let path = cargo_home()?.join(".crates2.json");
+    let contents = std::fs::read_to_string(path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&contents).ok()?;
+    let installs = value.get("installs")?.as_object()?;
+    let prefix = format!("{crate_name} ");
+    for key in installs.keys() {
+        if key.starts_with(&prefix) {
+            return Some(key.contains("(git+"));
+        }
+    }
+    None
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .filter(|h| !h.is_empty())
+        .map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec::ProductSpec;
+
+    fn input(exe: &str) -> PathClassifierInput {
+        PathClassifierInput {
+            current_exe: PathBuf::from(exe),
+            ..Default::default()
+        }
+    }
+
+    fn octos_spec() -> ProductSpec {
+        ProductSpec::new("octos", "octos", "1.0.0", "octos-org/octos", "octos-bundle")
+            .with_brew_formula("octos-org/tap/octos")
+            .with_npm_package("@octos-org/octos")
+            .with_cargo_install("octos-cli")
+            .with_cargo_dist_app("octos")
+    }
+
+    #[test]
+    fn should_classify_npm_global_when_under_npm_root() {
+        let mut i = input("/usr/local/lib/node_modules/@octos-org/octos/bin/octos");
+        i.npm_global_roots = vec![PathBuf::from("/usr/local/lib/node_modules")];
+        assert_eq!(classify_path(&i), InstallMethod::Npm);
+    }
+
+    #[test]
+    fn should_classify_npm_when_node_modules_in_path() {
+        let i = input("/home/u/.nvm/versions/node/v20/lib/node_modules/octos/octos");
+        assert_eq!(classify_path(&i), InstallMethod::Npm);
+    }
+
+    #[test]
+    fn should_classify_homebrew_when_under_prefix() {
+        let mut i = input("/opt/homebrew/bin/octos");
+        i.brew_prefixes = vec![PathBuf::from("/opt/homebrew")];
+        assert_eq!(classify_path(&i), InstallMethod::Homebrew);
+    }
+
+    #[test]
+    fn should_classify_homebrew_when_cellar_segment_present() {
+        let i = input("/usr/local/Cellar/octos/1.0.0/bin/octos");
+        assert_eq!(classify_path(&i), InstallMethod::Homebrew);
+    }
+
+    #[test]
+    fn should_classify_usr_local_as_unknown_when_no_brew_present() {
+        // No brew present → `/usr/local` is NOT a brew prefix → Unknown (avoids
+        // printing a wrong `brew upgrade`). Mirrors octos-tui finding #1.
+        let i = input("/usr/local/bin/octos");
+        assert_eq!(classify_path(&i), InstallMethod::Unknown);
+    }
+
+    #[test]
+    fn should_classify_cellar_as_homebrew_not_npm_with_real_npm_root() {
+        let mut i = input("/opt/homebrew/Cellar/octos/1.0.0/bin/octos");
+        i.npm_global_roots = vec![PathBuf::from("/opt/homebrew/lib/node_modules")];
+        i.brew_prefixes = vec![PathBuf::from("/opt/homebrew")];
+        assert_eq!(classify_path(&i), InstallMethod::Homebrew);
+    }
+
+    #[test]
+    fn should_classify_cargo_registry_without_git_source() {
+        let mut i = input("/home/u/.cargo/bin/octos");
+        i.cargo_bin = Some(PathBuf::from("/home/u/.cargo/bin"));
+        i.cargo_source_is_git = Some(false);
+        assert_eq!(classify_path(&i), InstallMethod::CargoRegistry);
+    }
+
+    #[test]
+    fn should_classify_cargo_git_when_source_is_git() {
+        let mut i = input("/home/u/.cargo/bin/octos");
+        i.cargo_bin = Some(PathBuf::from("/home/u/.cargo/bin"));
+        i.cargo_source_is_git = Some(true);
+        assert_eq!(classify_path(&i), InstallMethod::CargoGit);
+    }
+
+    #[test]
+    fn should_default_cargo_to_registry_when_source_unknown() {
+        let i = input("/home/u/.cargo/bin/octos");
+        assert_eq!(classify_path(&i), InstallMethod::CargoRegistry);
+    }
+
+    #[test]
+    fn should_classify_unknown_for_distro_path() {
+        let i = input("/usr/bin/octos");
+        assert_eq!(classify_path(&i), InstallMethod::Unknown);
+    }
+
+    #[test]
+    fn npm_takes_precedence_over_cargo_bin_when_both_match() {
+        let mut i = input("/x/.cargo/bin/node_modules/octos/octos");
+        i.cargo_bin = Some(PathBuf::from("/x/.cargo/bin"));
+        assert_eq!(classify_path(&i), InstallMethod::Npm);
+    }
+
+    #[test]
+    fn upgrade_hints_are_method_and_spec_specific() {
+        let spec = octos_spec();
+        assert!(
+            InstallMethod::CargoDistInstaller
+                .upgrade_hint(&spec)
+                .is_none()
+        );
+        assert_eq!(
+            InstallMethod::Homebrew.upgrade_hint(&spec).unwrap(),
+            "brew update && brew upgrade octos-org/tap/octos"
+        );
+        assert_eq!(
+            InstallMethod::Npm.upgrade_hint(&spec).unwrap(),
+            "npm update -g @octos-org/octos"
+        );
+        assert_eq!(
+            InstallMethod::CargoRegistry.upgrade_hint(&spec).unwrap(),
+            "cargo install octos-cli --force"
+        );
+        assert_eq!(
+            InstallMethod::CargoGit.upgrade_hint(&spec).unwrap(),
+            "cargo install --git https://github.com/octos-org/octos octos-cli --force"
+        );
+        assert!(
+            InstallMethod::Unknown
+                .upgrade_hint(&spec)
+                .unwrap()
+                .contains("octos-installer.sh")
+        );
+    }
+
+    #[test]
+    fn upgrade_hint_falls_back_to_installer_when_pkg_field_absent() {
+        // A spec lacking brew/npm/cargo fields must still produce a usable hint
+        // (the one-line installer), not panic or return None.
+        let bare = ProductSpec::new("octos", "octos", "1.0.0", "octos-org/octos", "octos-bundle");
+        assert!(
+            InstallMethod::Homebrew
+                .upgrade_hint(&bare)
+                .unwrap()
+                .contains("installer.sh")
+        );
+        assert!(
+            InstallMethod::Npm
+                .upgrade_hint(&bare)
+                .unwrap()
+                .contains("installer.sh")
+        );
+    }
+
+    #[test]
+    fn only_cargo_dist_is_self_updating() {
+        assert!(InstallMethod::CargoDistInstaller.is_self_updating());
+        for m in [
+            InstallMethod::Homebrew,
+            InstallMethod::Npm,
+            InstallMethod::CargoRegistry,
+            InstallMethod::CargoGit,
+            InstallMethod::Unknown,
+        ] {
+            assert!(!m.is_self_updating(), "{} should not self-update", m.id());
+        }
+    }
+
+    #[test]
+    fn is_ancestor_is_component_wise_not_substring() {
+        assert!(!is_ancestor(
+            Path::new("/opt/home"),
+            Path::new("/opt/homebrew/bin/octos")
+        ));
+        assert!(is_ancestor(
+            Path::new("/opt/homebrew"),
+            Path::new("/opt/homebrew/bin/octos")
+        ));
+    }
+}

--- a/crates/octos-diagnostics/src/lib.rs
+++ b/crates/octos-diagnostics/src/lib.rs
@@ -1,0 +1,43 @@
+//! `octos-diagnostics` — shared, **product-agnostic** diagnostics + update
+//! *planning* for the octos binaries (`octos doctor`, and later `octos update
+//! --check`).
+//!
+//! This crate is the dependency-light seam factored out of octos-tui's
+//! `doctor`/`install_method` modules (octos-tui#182, ADR
+//! `docs/adr/octos-diagnostics-extraction-scope.md`). Stage 1 ships:
+//!
+//! - the report model ([`CheckStatus`] / [`Check`] / [`Report`]) with the
+//!   `[✓]/[!]/[✗]` glyphs, JSON support-bundle output, and exit-code policy;
+//! - a [`ProductSpec`] seam so the same logic serves both octos-tui and the
+//!   octos server — **the current version is always passed IN** by the caller,
+//!   never read from this crate's `CARGO_PKG_VERSION`;
+//! - [`InstallMethod`] classification ([`classify_path`] pure + [`detect`]
+//!   path/env heuristics), PATH/shadow detection ([`locate`], [`on_path_check`],
+//!   [`shadow_check`]) including the #189 npm-shim handling;
+//! - semver parse/compare helpers + a pure [`plan`] producing an [`UpdatePlan`]
+//!   (NO network, NO mutation);
+//! - generic local checks (terminal, config/data-dir writability) and a
+//!   [`protocol_skew_check`] adapter over `octos_core::ui_protocol`'s pure
+//!   comparator.
+//!
+//! Stage 1 deliberately carries **no** network/update deps (no `reqwest`, no
+//! `axoupdater`); GitHub reachability is Stage 2 and self-update is Stage 3.
+
+#![allow(clippy::result_large_err)]
+
+mod checks;
+mod install_method;
+mod locate;
+mod report;
+mod spec;
+mod update;
+
+pub use checks::{
+    TerminfoProbe, config_writability_check, data_writability_check, protocol_skew_check,
+    terminal_checks, writability_check,
+};
+pub use install_method::{InstallMethod, PathClassifierInput, classify_path, detect};
+pub use locate::{LocatedBinaries, locate, on_path_check, shadow_check};
+pub use report::{Check, CheckStatus, Report};
+pub use spec::{AssetSelector, ProductSpec};
+pub use update::{SemVer, UpdatePlan, is_newer, parse_version, plan};

--- a/crates/octos-diagnostics/src/locate.rs
+++ b/crates/octos-diagnostics/src/locate.rs
@@ -1,0 +1,278 @@
+//! PATH resolution + shadow detection, product-agnostic.
+//!
+//! Ported from octos-tui's `doctor.rs` locate/on_path/shadow logic, with the
+//! binary name driven by [`ProductSpec`]. Carries the #189 npm fix: when the
+//! method is [`InstallMethod::Npm`] and nothing is located, both the on-PATH
+//! and shadow checks PASS (the real binary lives under `node_modules/.bin_real`
+//! whose dir isn't on PATH and whose basename isn't the product name; the shim
+//! IS runnable by name).
+
+use std::path::{Path, PathBuf};
+
+use crate::install_method::InstallMethod;
+use crate::report::Check;
+use crate::spec::ProductSpec;
+
+const CAT_BINARY: &str = "Binary & version";
+
+/// Product binaries discovered on the host. `$PATH` hits are tracked separately
+/// from extra known-install prefixes (cargo bin, brew, …) that may not be on
+/// `$PATH`, so "on PATH" reflects bare-name runnability, not mere on-disk
+/// presence.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LocatedBinaries {
+    /// Resolved via `$PATH` (runnable by bare name), in PATH precedence order.
+    pub on_path: Vec<PathBuf>,
+    /// Found only in extra known-install prefixes NOT on `$PATH`.
+    pub off_path: Vec<PathBuf>,
+}
+
+impl LocatedBinaries {
+    /// Every distinct location (PATH hits first, then off-PATH extras).
+    pub fn all(&self) -> Vec<PathBuf> {
+        let mut v = self.on_path.clone();
+        v.extend(self.off_path.iter().cloned());
+        v
+    }
+}
+
+/// Enumerate every product binary on `$PATH` plus known install prefixes,
+/// de-duplicated by canonical path, preserving PATH precedence (first wins).
+pub fn locate(spec: &ProductSpec) -> LocatedBinaries {
+    let exe_name = spec.binary_file_name();
+    let mut located = LocatedBinaries::default();
+    let mut seen: Vec<PathBuf> = Vec::new();
+
+    let push_if_present = |dir: &Path, dest: &mut Vec<PathBuf>, seen: &mut Vec<PathBuf>| {
+        let candidate = dir.join(&exe_name);
+        if !candidate.is_file() {
+            return;
+        }
+        let canonical = std::fs::canonicalize(&candidate).unwrap_or_else(|_| candidate.clone());
+        if seen.contains(&canonical) {
+            return;
+        }
+        seen.push(canonical);
+        dest.push(candidate);
+    };
+
+    // Actual `$PATH` resolutions, in precedence order (first wins).
+    if let Some(path) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&path) {
+            push_if_present(&dir, &mut located.on_path, &mut seen);
+        }
+    }
+
+    // Extra known-install prefixes that may NOT be on `$PATH`.
+    let mut extras: Vec<PathBuf> = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin"]
+        .iter()
+        .map(PathBuf::from)
+        .collect();
+    if let Some(home) = std::env::var_os("HOME") {
+        extras.push(PathBuf::from(&home).join(".cargo").join("bin"));
+        extras.push(PathBuf::from(&home).join(".local").join("bin"));
+    }
+    for dir in extras {
+        push_if_present(&dir, &mut located.off_path, &mut seen);
+    }
+
+    located
+}
+
+/// Whether the product is runnable by bare name (`$PATH`-resolvable).
+pub fn on_path_check(
+    located: &LocatedBinaries,
+    current_exe: Option<&Path>,
+    method: &InstallMethod,
+    spec: &ProductSpec,
+) -> Check {
+    let bin = &spec.binary_name;
+    let name = format!("{bin} on PATH");
+    if let Some(first) = located.on_path.first() {
+        return Check::pass(CAT_BINARY, name, "resolvable by name")
+            .with_value(first.display().to_string());
+    }
+    // #189: npm global (esp. Windows) — the launcher shim is on PATH and
+    // runnable by name, but `current_exe()` resolves to the real binary deep
+    // under `node_modules/.bin_real`, whose dir is NOT on PATH and whose
+    // basename isn't the product name — so the PATH scan finds nothing. Don't
+    // false-warn, and never suggest adding an internal node_modules dir.
+    if matches!(method, InstallMethod::Npm) {
+        return Check::pass(CAT_BINARY, name, "runnable by name via the npm global shim")
+            .with_value(
+                current_exe
+                    .map(|e| e.display().to_string())
+                    .unwrap_or_default(),
+            );
+    }
+    // Not on $PATH at all. If we know where this exe lives, point at its dir.
+    match current_exe.and_then(|e| e.parent()) {
+        Some(dir) => Check::warn(
+            CAT_BINARY,
+            name,
+            format!("{bin} isn't on $PATH — you ran it by path"),
+            format!("add {} to PATH to run by name", dir.display()),
+        )
+        .with_value(dir.display().to_string()),
+        None => Check::warn(
+            CAT_BINARY,
+            name,
+            format!("{bin} not found on $PATH"),
+            "add the install dir to your PATH",
+        ),
+    }
+}
+
+/// Shadowing-install check from the located binaries. >1 total is the
+/// shadowing failure mode; npm-with-nothing-located is exactly one healthy
+/// install (#189), not a missing one.
+pub fn shadow_check(
+    located: &LocatedBinaries,
+    method: &InstallMethod,
+    spec: &ProductSpec,
+) -> Check {
+    let bin = &spec.binary_name;
+    let all = located.all();
+    match all.len() {
+        0 if matches!(method, InstallMethod::Npm) => Check::pass(
+            CAT_BINARY,
+            "no shadowing installs",
+            "exactly one (npm global)",
+        ),
+        0 => Check::warn(
+            CAT_BINARY,
+            "no shadowing installs",
+            format!("{bin} not found on $PATH or known install dirs"),
+            format!("install {bin} or add its dir to your PATH"),
+        ),
+        1 => {
+            let only = &all[0];
+            let where_ = if located.on_path.is_empty() {
+                "off PATH"
+            } else {
+                "on PATH"
+            };
+            Check::pass(
+                CAT_BINARY,
+                "no shadowing installs",
+                format!("exactly one ({where_})"),
+            )
+            .with_value(only.display().to_string())
+        }
+        n => {
+            let label = |p: &PathBuf| -> String {
+                let tag = if located.on_path.contains(p) {
+                    "PATH"
+                } else {
+                    "known-dir"
+                };
+                format!("{} [{tag}]", p.display())
+            };
+            let labelled: Vec<String> = all.iter().map(label).collect();
+            Check::warn(
+                CAT_BINARY,
+                "no shadowing installs",
+                format!("{n} {bin} binaries found; first wins: {}", labelled[0]),
+                format!("remove the extras: {}", labelled[1..].join(", ")),
+            )
+            .with_value(labelled.join(" | "))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::CheckStatus;
+
+    fn spec() -> ProductSpec {
+        ProductSpec::new("octos", "octos", "1.0.0", "octos-org/octos", "octos-bundle")
+    }
+
+    #[test]
+    fn shadow_check_passes_for_single_and_warns_for_multiple() {
+        let one = shadow_check(
+            &LocatedBinaries {
+                on_path: vec![PathBuf::from("/usr/local/bin/octos")],
+                off_path: vec![],
+            },
+            &InstallMethod::Homebrew,
+            &spec(),
+        );
+        assert_eq!(one.status, CheckStatus::Pass);
+        assert!(one.detail.contains("on PATH"));
+
+        let two = shadow_check(
+            &LocatedBinaries {
+                on_path: vec![PathBuf::from("/opt/homebrew/bin/octos")],
+                off_path: vec![PathBuf::from("/home/u/.cargo/bin/octos")],
+            },
+            &InstallMethod::Homebrew,
+            &spec(),
+        );
+        assert_eq!(two.status, CheckStatus::Warn);
+        assert!(two.detail.contains("2 octos binaries"));
+        let fix = two.fix.unwrap();
+        assert!(fix.contains(".cargo/bin/octos"));
+        assert!(fix.contains("[known-dir]") || two.detail.contains("[PATH]"));
+    }
+
+    #[test]
+    fn shadow_check_warns_when_nothing_found() {
+        let none = shadow_check(
+            &LocatedBinaries::default(),
+            &InstallMethod::Homebrew,
+            &spec(),
+        );
+        assert_eq!(none.status, CheckStatus::Warn);
+    }
+
+    #[test]
+    fn npm_install_does_not_false_warn_on_path_or_shadow() {
+        // #189: npm-global — the locator finds nothing on PATH (the shim is
+        // .ps1/.cmd; the real .exe is under node_modules/.bin_real). Both
+        // checks must PASS, not warn, and on-PATH must not suggest a fix.
+        let located = LocatedBinaries::default();
+        let exe = PathBuf::from(
+            "C:/Users/u/AppData/Roaming/npm/node_modules/@octos-org/octos/node_modules/.bin_real/octos.exe",
+        );
+        let on_path = on_path_check(&located, Some(exe.as_path()), &InstallMethod::Npm, &spec());
+        assert_eq!(on_path.status, CheckStatus::Pass);
+        assert!(
+            on_path.fix.is_none(),
+            "npm on-PATH check must not suggest a fix"
+        );
+
+        let shadow = shadow_check(&located, &InstallMethod::Npm, &spec());
+        assert_eq!(shadow.status, CheckStatus::Pass);
+        assert!(shadow.detail.contains("npm"));
+    }
+
+    #[test]
+    fn on_path_check_passes_when_resolvable_by_name() {
+        let located = LocatedBinaries {
+            on_path: vec![PathBuf::from("/usr/local/bin/octos")],
+            off_path: vec![],
+        };
+        let check = on_path_check(
+            &located,
+            Some(Path::new("/usr/local/bin/octos")),
+            &InstallMethod::Homebrew,
+            &spec(),
+        );
+        assert_eq!(check.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn on_path_check_warns_when_ran_by_abs_path_and_dir_not_on_path() {
+        let located = LocatedBinaries {
+            on_path: vec![],
+            off_path: vec![PathBuf::from("/home/u/.cargo/bin/octos")],
+        };
+        let exe = PathBuf::from("/home/u/.cargo/bin/octos");
+        let check = on_path_check(&located, Some(&exe), &InstallMethod::CargoGit, &spec());
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.detail.contains("isn't on $PATH"));
+        assert!(check.fix.unwrap().contains("/home/u/.cargo/bin"));
+    }
+}

--- a/crates/octos-diagnostics/src/report.rs
+++ b/crates/octos-diagnostics/src/report.rs
@@ -1,0 +1,312 @@
+//! The product-agnostic diagnostic report model: [`CheckStatus`], [`Check`],
+//! and [`Report`]. Ported from octos-tui's `doctor.rs` but with the
+//! product-specific JSON keys (the binary's own version/schema) supplied by the
+//! caller via [`Report::to_json`] arguments rather than baked in from this
+//! crate's `CARGO_PKG_VERSION`.
+
+use serde_json::{Value, json};
+
+/// Pass / warn / fail per check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckStatus {
+    Pass,
+    Warn,
+    Fail,
+}
+
+impl CheckStatus {
+    /// The flutter-doctor-style glyph rendered at the start of each line.
+    pub fn glyph(self) -> &'static str {
+        match self {
+            CheckStatus::Pass => "[✓]",
+            CheckStatus::Warn => "[!]",
+            CheckStatus::Fail => "[✗]",
+        }
+    }
+
+    /// Stable lower-case identifier for `--json` output.
+    pub fn json_str(self) -> &'static str {
+        match self {
+            CheckStatus::Pass => "pass",
+            CheckStatus::Warn => "warn",
+            CheckStatus::Fail => "fail",
+        }
+    }
+}
+
+/// A single diagnostic line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Check {
+    /// Group heading the line is rendered under.
+    pub category: &'static str,
+    /// Short check name (e.g. `octos on PATH`).
+    pub name: String,
+    pub status: CheckStatus,
+    /// One-line detail shown after the name.
+    pub detail: String,
+    /// Actionable fix, rendered as a `→ fix:` line. `None` for passing checks.
+    pub fix: Option<String>,
+    /// Optional resolved value (path/version) shown in `--verbose` and JSON.
+    pub value: Option<String>,
+}
+
+impl Check {
+    /// Construct a passing check (no fix line).
+    pub fn pass(
+        category: &'static str,
+        name: impl Into<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            category,
+            name: name.into(),
+            status: CheckStatus::Pass,
+            detail: detail.into(),
+            fix: None,
+            value: None,
+        }
+    }
+
+    /// Construct a warning check (soft problem; exit 0 unless `--strict`).
+    pub fn warn(
+        category: &'static str,
+        name: impl Into<String>,
+        detail: impl Into<String>,
+        fix: impl Into<String>,
+    ) -> Self {
+        Self {
+            category,
+            name: name.into(),
+            status: CheckStatus::Warn,
+            detail: detail.into(),
+            fix: Some(fix.into()),
+            value: None,
+        }
+    }
+
+    /// Construct a failing check (hard problem; exit 1).
+    pub fn fail(
+        category: &'static str,
+        name: impl Into<String>,
+        detail: impl Into<String>,
+        fix: impl Into<String>,
+    ) -> Self {
+        Self {
+            category,
+            name: name.into(),
+            status: CheckStatus::Fail,
+            detail: detail.into(),
+            fix: Some(fix.into()),
+            value: None,
+        }
+    }
+
+    /// Attach a resolved value (path/version) for `--verbose`/JSON.
+    pub fn with_value(mut self, value: impl Into<String>) -> Self {
+        self.value = Some(value.into());
+        self
+    }
+}
+
+/// Aggregated diagnostic report.
+#[derive(Debug, Clone, Default)]
+pub struct Report {
+    pub checks: Vec<Check>,
+}
+
+impl Report {
+    pub fn new(checks: Vec<Check>) -> Self {
+        Self { checks }
+    }
+
+    /// Append a single check (builder-ish convenience for callers assembling a
+    /// report incrementally).
+    pub fn push(&mut self, check: Check) {
+        self.checks.push(check);
+    }
+
+    /// Append a batch of checks.
+    pub fn extend(&mut self, checks: impl IntoIterator<Item = Check>) {
+        self.checks.extend(checks);
+    }
+
+    /// `(passed, warnings, failures)`.
+    pub fn counts(&self) -> (usize, usize, usize) {
+        let mut pass = 0;
+        let mut warn = 0;
+        let mut fail = 0;
+        for c in &self.checks {
+            match c.status {
+                CheckStatus::Pass => pass += 1,
+                CheckStatus::Warn => warn += 1,
+                CheckStatus::Fail => fail += 1,
+            }
+        }
+        (pass, warn, fail)
+    }
+
+    /// Exit code: `1` on any failure, or (with `strict`) any warning.
+    pub fn exit_code(&self, strict: bool) -> i32 {
+        let (_, warn, fail) = self.counts();
+        if fail > 0 || (strict && warn > 0) {
+            1
+        } else {
+            0
+        }
+    }
+
+    /// Render the flutter-doctor-style human report to a string.
+    pub fn render(&self, verbose: bool, strict: bool) -> String {
+        let mut out = String::new();
+        let mut last_category: Option<&str> = None;
+        for check in &self.checks {
+            if last_category != Some(check.category) {
+                if last_category.is_some() {
+                    out.push('\n');
+                }
+                out.push_str(check.category);
+                out.push('\n');
+                last_category = Some(check.category);
+            }
+            out.push_str(check.status.glyph());
+            out.push(' ');
+            out.push_str(&check.name);
+            if !check.detail.is_empty() {
+                out.push_str(" — ");
+                out.push_str(&check.detail);
+            }
+            if verbose {
+                if let Some(value) = &check.value {
+                    out.push_str(" (");
+                    out.push_str(value);
+                    out.push(')');
+                }
+            }
+            out.push('\n');
+            if let Some(fix) = &check.fix {
+                out.push_str("    → fix: ");
+                out.push_str(fix);
+                out.push('\n');
+            }
+        }
+
+        let (pass, warn, fail) = self.counts();
+        out.push('\n');
+        if fail == 0 && (warn == 0 || !strict) {
+            out.push_str(&format!(
+                "• Doctor summary: {pass} passed, {warn} warning(s). No fatal issues found."
+            ));
+        } else {
+            out.push_str(&format!(
+                "• Doctor summary: {pass} passed, {warn} warning(s), {fail} failure(s)."
+            ));
+        }
+        out.push('\n');
+        out
+    }
+
+    /// Render the support-bundle JSON.
+    ///
+    /// `product` is the binary name (e.g. `octos`), `version` is the caller's
+    /// own `CARGO_PKG_VERSION` (passed IN — never this crate's), and
+    /// `protocol` / `schema_version` describe the compiled-in UI protocol so
+    /// the bundle is self-describing for skew triage.
+    pub fn to_json(
+        &self,
+        strict: bool,
+        product: &str,
+        version: &str,
+        protocol: &str,
+        schema_version: u32,
+    ) -> Value {
+        let (pass, warn, fail) = self.counts();
+        let checks: Vec<_> = self
+            .checks
+            .iter()
+            .map(|c| {
+                json!({
+                    "category": c.category,
+                    "name": c.name,
+                    "status": c.status.json_str(),
+                    "detail": c.detail,
+                    "fix": c.fix,
+                    "value": c.value,
+                })
+            })
+            .collect();
+        json!({
+            "checks": checks,
+            "summary": {
+                "passed": pass,
+                "warnings": warn,
+                "failures": fail,
+            },
+            "exit_code": self.exit_code(strict),
+            "product": product,
+            "version": version,
+            "protocol": protocol,
+            "schema_version": schema_version,
+            "platform": format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renderer_groups_by_category_and_shows_fix_lines() {
+        let checks = vec![
+            Check::pass("Cat A", "ok thing", "all good"),
+            Check::warn("Cat A", "warny thing", "soft problem", "do the fix"),
+            Check::fail("Cat B", "broken thing", "hard problem", "fix me"),
+        ];
+        let report = Report::new(checks);
+        let text = report.render(false, false);
+        assert!(text.contains("Cat A\n"));
+        assert!(text.contains("Cat B\n"));
+        assert!(text.contains("[✓] ok thing"));
+        assert!(text.contains("[!] warny thing"));
+        assert!(text.contains("[✗] broken thing"));
+        assert!(text.contains("    → fix: do the fix"));
+        assert!(text.contains("    → fix: fix me"));
+        assert!(!text.contains("→ fix: \n"));
+        assert!(text.contains("1 passed, 1 warning(s), 1 failure(s)"));
+    }
+
+    #[test]
+    fn exit_code_is_one_on_failure_zero_on_warnings() {
+        let warn_only = Report::new(vec![Check::warn("c", "n", "d", "f")]);
+        assert_eq!(warn_only.exit_code(false), 0);
+        assert_eq!(warn_only.exit_code(true), 1); // strict promotes warnings
+
+        let with_fail = Report::new(vec![Check::fail("c", "n", "d", "f")]);
+        assert_eq!(with_fail.exit_code(false), 1);
+    }
+
+    #[test]
+    fn json_carries_caller_version_not_crate_version() {
+        let report = Report::new(vec![Check::pass("c", "n", "d")]);
+        // The caller passes in its own version; the bundle must echo exactly
+        // that, never octos-diagnostics' own CARGO_PKG_VERSION.
+        let json = report.to_json(false, "octos", "9.9.9-caller", "octos-ui/v1alpha1", 1);
+        assert_eq!(json["summary"]["passed"], 1);
+        assert_eq!(json["product"], "octos");
+        assert_eq!(json["version"], "9.9.9-caller");
+        assert_eq!(json["protocol"], "octos-ui/v1alpha1");
+        assert_eq!(json["schema_version"], 1);
+        assert!(json["checks"].is_array());
+    }
+
+    #[test]
+    fn verbose_appends_value_in_parens() {
+        let report = Report::new(vec![
+            Check::pass("Cat", "thing", "detail").with_value("/usr/local/bin/octos"),
+        ]);
+        let plain = report.render(false, false);
+        let verbose = report.render(true, false);
+        assert!(!plain.contains("(/usr/local/bin/octos)"));
+        assert!(verbose.contains("(/usr/local/bin/octos)"));
+    }
+}

--- a/crates/octos-diagnostics/src/spec.rs
+++ b/crates/octos-diagnostics/src/spec.rs
@@ -1,0 +1,161 @@
+//! [`ProductSpec`] — the product-agnostic seam.
+//!
+//! Shared diagnostics code must never hardcode `octos-tui` vs `octos`. Callers
+//! describe their product once via a `ProductSpec`; everything else
+//! (install-method labels/upgrade hints, PATH/shadow locating, asset selection)
+//! reads from it.
+//!
+//! The single most important rule (ADR "Traps"): **`current_version` is passed
+//! IN by the caller** (its own `env!("CARGO_PKG_VERSION")`). This crate must
+//! never read its *own* `CARGO_PKG_VERSION` to describe the product — that would
+//! report the diagnostics-crate version instead of the binary's.
+
+/// How to build the per-OS release asset name for a product. Stage 1 only needs
+/// the *shape* (Stage 2 will consume it when the GitHub client lands); we model
+/// it as a template prefix joined to the platform triple, e.g.
+/// `octos-bundle-<triple>` or `octos-tui-<triple>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssetSelector {
+    /// Prefix prepended to the target triple (no trailing dash), e.g.
+    /// `octos-bundle` → `octos-bundle-aarch64-apple-darwin`.
+    pub prefix: String,
+}
+
+impl AssetSelector {
+    pub fn new(prefix: impl Into<String>) -> Self {
+        Self {
+            prefix: prefix.into(),
+        }
+    }
+
+    /// Build the asset base name for a target triple, e.g.
+    /// `octos-bundle-aarch64-apple-darwin`. The archive extension is left to the
+    /// caller/Stage 2 (tarball vs zip differs per OS).
+    pub fn asset_name(&self, target_triple: &str) -> String {
+        format!("{}-{}", self.prefix, target_triple)
+    }
+}
+
+/// Product description threaded into every shared diagnostic. Constructed by the
+/// binary (octos-cli / octos-tui), never inferred from this crate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProductSpec {
+    /// Bare binary name as run on PATH (no extension; `.exe` is appended on
+    /// Windows by the locator), e.g. `octos` or `octos-tui`.
+    pub binary_name: String,
+    /// Package / display name, e.g. `octos`.
+    pub package_name: String,
+    /// The caller's own version — passed IN (its `env!("CARGO_PKG_VERSION")`).
+    /// NEVER this crate's `CARGO_PKG_VERSION`.
+    pub current_version: String,
+    /// `owner/repo` on GitHub, e.g. `octos-org/octos`.
+    pub github_repo: String,
+    /// Homebrew formula (tap-qualified), e.g. `octos-org/tap/octos`.
+    pub brew_formula: Option<String>,
+    /// npm package name, e.g. `@octos-org/octos`.
+    pub npm_package: Option<String>,
+    /// `cargo install` crate name (registry), e.g. `octos-cli`.
+    pub cargo_install: Option<String>,
+    /// cargo-dist app name used by the shell/PowerShell installer + receipt.
+    pub cargo_dist_app: Option<String>,
+    /// Per-OS release asset selector.
+    pub asset_selector: AssetSelector,
+}
+
+impl ProductSpec {
+    /// Minimal constructor; optional package-manager fields default to `None`
+    /// and can be filled with the builder-style setters below.
+    pub fn new(
+        binary_name: impl Into<String>,
+        package_name: impl Into<String>,
+        current_version: impl Into<String>,
+        github_repo: impl Into<String>,
+        asset_prefix: impl Into<String>,
+    ) -> Self {
+        Self {
+            binary_name: binary_name.into(),
+            package_name: package_name.into(),
+            current_version: current_version.into(),
+            github_repo: github_repo.into(),
+            brew_formula: None,
+            npm_package: None,
+            cargo_install: None,
+            cargo_dist_app: None,
+            asset_selector: AssetSelector::new(asset_prefix),
+        }
+    }
+
+    pub fn with_brew_formula(mut self, formula: impl Into<String>) -> Self {
+        self.brew_formula = Some(formula.into());
+        self
+    }
+
+    pub fn with_npm_package(mut self, package: impl Into<String>) -> Self {
+        self.npm_package = Some(package.into());
+        self
+    }
+
+    pub fn with_cargo_install(mut self, crate_name: impl Into<String>) -> Self {
+        self.cargo_install = Some(crate_name.into());
+        self
+    }
+
+    pub fn with_cargo_dist_app(mut self, app: impl Into<String>) -> Self {
+        self.cargo_dist_app = Some(app.into());
+        self
+    }
+
+    /// Platform-aware binary file name (appends `.exe` on Windows).
+    pub fn binary_file_name(&self) -> String {
+        if cfg!(windows) {
+            format!("{}.exe", self.binary_name)
+        } else {
+            self.binary_name.clone()
+        }
+    }
+
+    /// `https://github.com/<owner/repo>`.
+    pub fn github_url(&self) -> String {
+        format!("https://github.com/{}", self.github_repo)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn asset_selector_joins_prefix_and_triple() {
+        let sel = AssetSelector::new("octos-bundle");
+        assert_eq!(
+            sel.asset_name("aarch64-apple-darwin"),
+            "octos-bundle-aarch64-apple-darwin"
+        );
+    }
+
+    #[test]
+    fn builder_sets_optional_fields() {
+        let spec = ProductSpec::new("octos", "octos", "1.2.3", "octos-org/octos", "octos-bundle")
+            .with_brew_formula("octos-org/tap/octos")
+            .with_npm_package("@octos-org/octos")
+            .with_cargo_install("octos-cli")
+            .with_cargo_dist_app("octos");
+        assert_eq!(spec.current_version, "1.2.3");
+        assert_eq!(spec.brew_formula.as_deref(), Some("octos-org/tap/octos"));
+        assert_eq!(spec.npm_package.as_deref(), Some("@octos-org/octos"));
+        assert_eq!(spec.cargo_install.as_deref(), Some("octos-cli"));
+        assert_eq!(spec.cargo_dist_app.as_deref(), Some("octos"));
+        assert_eq!(spec.github_url(), "https://github.com/octos-org/octos");
+        assert_eq!(
+            spec.asset_selector.asset_name("x86_64-unknown-linux-gnu"),
+            "octos-bundle-x86_64-unknown-linux-gnu"
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn binary_file_name_is_bare_on_unix() {
+        let spec = ProductSpec::new("octos", "octos", "0.1.0", "octos-org/octos", "octos-bundle");
+        assert_eq!(spec.binary_file_name(), "octos");
+    }
+}

--- a/crates/octos-diagnostics/src/update.rs
+++ b/crates/octos-diagnostics/src/update.rs
@@ -81,9 +81,12 @@ pub fn plan(current: &str, latest: &str, method: &InstallMethod, spec: &ProductS
     if method.is_self_updating() {
         return UpdatePlan::SelfUpdateAllowed;
     }
-    match method.upgrade_hint(spec) {
-        Some(cmd) => UpdatePlan::DeferToPackageManager { cmd },
-        None => UpdatePlan::UpdateAvailable {
+    // Only genuinely package-manager/cargo-owned installs defer to a manager.
+    // `Unknown` (manual install) has an advisory installer hint but no owning
+    // manager, so it's a plain `UpdateAvailable` — not "package-manager owned".
+    match (method.is_package_managed(), method.upgrade_hint(spec)) {
+        (true, Some(cmd)) => UpdatePlan::DeferToPackageManager { cmd },
+        _ => UpdatePlan::UpdateAvailable {
             latest: latest.to_owned(),
         },
     }
@@ -178,6 +181,18 @@ mod tests {
         assert_eq!(
             plan("garbage", "1.1.0", &InstallMethod::Homebrew, &spec()),
             UpdatePlan::UpToDate
+        );
+    }
+
+    #[test]
+    fn plan_unknown_install_is_update_available_not_package_manager() {
+        // codex: a manual (Unknown) install has an advisory curl|sh hint but is
+        // NOT package-manager owned — it must be UpdateAvailable, not deferred.
+        assert_eq!(
+            plan("1.0.0", "1.1.0", &InstallMethod::Unknown, &spec()),
+            UpdatePlan::UpdateAvailable {
+                latest: "1.1.0".to_owned()
+            }
         );
     }
 }

--- a/crates/octos-diagnostics/src/update.rs
+++ b/crates/octos-diagnostics/src/update.rs
@@ -1,0 +1,183 @@
+//! Semver parse/compare helpers + the pure update *planner*.
+//!
+//! Stage 1 ships **types + a pure decision function only** — NO network, NO
+//! mutation. Given the current version, a (separately-fetched, Stage 2) latest
+//! version, and the [`InstallMethod`], [`plan`] returns an [`UpdatePlan`]
+//! describing what *should* happen. Each binary's own driver (Stage 3) executes
+//! it.
+
+use crate::install_method::InstallMethod;
+use crate::spec::ProductSpec;
+
+/// Minimal semantic version (major.minor.patch), pre-release/build metadata
+/// stripped. Sufficient for "is latest newer than current" comparisons.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SemVer {
+    pub major: u64,
+    pub minor: u64,
+    pub patch: u64,
+}
+
+/// Parse a version string, tolerating a leading `v` and trailing
+/// pre-release/build metadata (`-rc.1`, `+build`). Returns `None` if the
+/// major/minor/patch core can't be read.
+pub fn parse_version(s: &str) -> Option<SemVer> {
+    let s = s.trim();
+    let s = s.strip_prefix('v').unwrap_or(s);
+    // Drop pre-release (`-`) and build (`+`) metadata before splitting.
+    let core = s.split(['-', '+']).next().unwrap_or(s);
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().unwrap_or("0").parse().ok()?;
+    let patch = parts.next().unwrap_or("0").parse().ok()?;
+    Some(SemVer {
+        major,
+        minor,
+        patch,
+    })
+}
+
+/// Whether `latest` is strictly newer than `current`.
+pub fn is_newer(current: &SemVer, latest: &SemVer) -> bool {
+    latest > current
+}
+
+/// What the caller's update driver should do. Pure planning only — produced by
+/// [`plan`], never executed here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdatePlan {
+    /// Current is >= latest; nothing to do.
+    UpToDate,
+    /// A newer release exists; carries the latest version string. For a
+    /// self-updating install this is paired with [`UpdatePlan::SelfUpdateAllowed`]
+    /// semantics — see [`plan`], which returns the package-manager or
+    /// self-update variant directly.
+    UpdateAvailable { latest: String },
+    /// A newer release exists but a package manager owns the binary; the caller
+    /// should print this command rather than mutate a file it doesn't own.
+    DeferToPackageManager { cmd: String },
+    /// A newer release exists and the install is self-updating (cargo-dist
+    /// receipt); the caller's Stage-3 driver may mutate in place.
+    SelfUpdateAllowed,
+}
+
+/// Decide what to do given the current version, the latest known version, and
+/// the install method. Pure: no IO.
+///
+/// - current >= latest (or unparseable comparison) → [`UpdatePlan::UpToDate`].
+/// - newer + self-updating install → [`UpdatePlan::SelfUpdateAllowed`].
+/// - newer + package-manager install with an upgrade hint →
+///   [`UpdatePlan::DeferToPackageManager`].
+/// - newer but no upgrade command available → [`UpdatePlan::UpdateAvailable`].
+pub fn plan(current: &str, latest: &str, method: &InstallMethod, spec: &ProductSpec) -> UpdatePlan {
+    let (Some(cur), Some(lat)) = (parse_version(current), parse_version(latest)) else {
+        // Can't compare — treat as up-to-date so we never push a spurious
+        // update; a precise check is the caller's (Stage 2) responsibility.
+        return UpdatePlan::UpToDate;
+    };
+    if !is_newer(&cur, &lat) {
+        return UpdatePlan::UpToDate;
+    }
+    if method.is_self_updating() {
+        return UpdatePlan::SelfUpdateAllowed;
+    }
+    match method.upgrade_hint(spec) {
+        Some(cmd) => UpdatePlan::DeferToPackageManager { cmd },
+        None => UpdatePlan::UpdateAvailable {
+            latest: latest.to_owned(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec() -> ProductSpec {
+        ProductSpec::new("octos", "octos", "1.0.0", "octos-org/octos", "octos-bundle")
+            .with_brew_formula("octos-org/tap/octos")
+    }
+
+    #[test]
+    fn parse_tolerates_v_prefix_and_metadata() {
+        assert_eq!(
+            parse_version("v1.2.3"),
+            Some(SemVer {
+                major: 1,
+                minor: 2,
+                patch: 3
+            })
+        );
+        assert_eq!(
+            parse_version("1.2.3-rc.1+build5"),
+            Some(SemVer {
+                major: 1,
+                minor: 2,
+                patch: 3
+            })
+        );
+        assert_eq!(
+            parse_version("2"),
+            Some(SemVer {
+                major: 2,
+                minor: 0,
+                patch: 0
+            })
+        );
+        assert_eq!(parse_version("not-a-version"), None);
+    }
+
+    #[test]
+    fn is_newer_compares_by_precedence() {
+        let a = parse_version("1.2.3").unwrap();
+        let b = parse_version("1.2.4").unwrap();
+        let c = parse_version("1.3.0").unwrap();
+        assert!(is_newer(&a, &b));
+        assert!(is_newer(&a, &c));
+        assert!(!is_newer(&b, &a));
+        assert!(!is_newer(&a, &a));
+    }
+
+    #[test]
+    fn plan_up_to_date_when_current_ge_latest() {
+        assert_eq!(
+            plan("1.2.3", "1.2.3", &InstallMethod::Homebrew, &spec()),
+            UpdatePlan::UpToDate
+        );
+        assert_eq!(
+            plan("1.3.0", "1.2.9", &InstallMethod::Homebrew, &spec()),
+            UpdatePlan::UpToDate
+        );
+    }
+
+    #[test]
+    fn plan_self_update_for_cargo_dist_installer() {
+        assert_eq!(
+            plan(
+                "1.0.0",
+                "1.1.0",
+                &InstallMethod::CargoDistInstaller,
+                &spec()
+            ),
+            UpdatePlan::SelfUpdateAllowed
+        );
+    }
+
+    #[test]
+    fn plan_defers_to_package_manager_for_brew() {
+        match plan("1.0.0", "1.1.0", &InstallMethod::Homebrew, &spec()) {
+            UpdatePlan::DeferToPackageManager { cmd } => {
+                assert!(cmd.contains("brew upgrade octos-org/tap/octos"));
+            }
+            other => panic!("expected DeferToPackageManager, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_up_to_date_on_unparseable() {
+        assert_eq!(
+            plan("garbage", "1.1.0", &InstallMethod::Homebrew, &spec()),
+            UpdatePlan::UpToDate
+        );
+    }
+}


### PR DESCRIPTION
Stage 1 of the #182 sharing phase (scope: docs/adr/octos-diagnostics-extraction-scope.md). No network, no update mutation.

- New dep-light **`octos-diagnostics`** crate (`default = []`, no reqwest/axoupdater): Check/Report model, ProductSpec seam (version passed IN), InstallMethod detect + PATH/shadow (with the #189 npm fix), semver + pure `UpdatePlan`, generic local checks, protocol-skew adapter.
- **`octos-core::ui_protocol::compare_protocol`** — pure comparator over existing consts (no new deps).
- **`octos doctor`** (octos-cli) wired to the shared report, local checks only; resolves the real `~/.config/octos` + `~/.octos`; `--json/--verbose/--strict`. Live WS + GitHub probes are Stage-2 TODOs; self-update is Stage 3.

Tests: diagnostics 45, octos-core +6 comparator, octos-cli +2 doctor; clippy/fmt clean; cargo tree confirms no reqwest/axoupdater + no duplicate octos-core. codex-reviewed (7/7 PASS; the one Medium — Unknown-install mislabeled package-manager-owned — fixed + tested).