### PR TITLE
feat(diagnostics): GitHub client + octos update --check + doctor Network (Stage 2, octos-tui#182)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,6 +3892,7 @@ version = "0.1.1"
 dependencies = [
  "eyre",
  "octos-core",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -12,7 +12,10 @@ path = "src/main.rs"
 
 [dependencies]
 octos-core = { workspace = true }
-octos-diagnostics = { workspace = true }
+# `github` feature on for Stage 2: enables the shared GitHub Releases client so
+# `octos update --check` + `octos doctor`'s Network category can reach the public
+# Releases API. Self-update mutation stays on the existing `updater.rs` (Stage 3).
+octos-diagnostics = { workspace = true, features = ["github"] }
 octos-agent = { workspace = true }
 octos-memory = { workspace = true }
 octos-llm = { workspace = true }

--- a/crates/octos-cli/src/commands/doctor.rs
+++ b/crates/octos-cli/src/commands/doctor.rs
@@ -8,11 +8,17 @@
 //! `--verbose` adds resolved paths/versions; `--strict` promotes warnings to
 //! failures.
 //!
-//! Stage 1 is **local checks only** — binary/install-method/on-path/shadow,
-//! terminal, config+data writability, and a structural protocol-skew check
-//! against the server's compiled-in capabilities. There is NO network (GitHub
-//! reachability + live WS capability probe are Stage 2) and NO update wiring
-//! (Stage 3); see the `// TODO Stage 2` markers below.
+//! Local checks (Stage 1): binary/install-method/on-path/shadow, terminal,
+//! config+data writability, and a structural protocol-skew check against the
+//! server's compiled-in capabilities.
+//!
+//! **Stage 2** adds a `Network` category (behind octos-diagnostics' `github`
+//! feature, which octos-cli enables): GitHub reachability via the shared
+//! `reachability()` and a best-effort newer-release check via `update_check`.
+//! Both are advisory — a network/API failure WARNs, never FAILs, so `doctor`
+//! works offline. There is still NO update mutation (Stage 3), and the LIVE-WS
+//! `config/capabilities/list` probe for protocol skew is left as a documented
+//! `// TODO Stage 2.5` (it needs a client WS connection).
 
 use std::path::PathBuf;
 
@@ -20,13 +26,15 @@ use clap::Args;
 use eyre::Result;
 use octos_core::ui_protocol::{UI_PROTOCOL_KNOWN_FEATURES, UI_PROTOCOL_V1, UiProtocolCapabilities};
 use octos_diagnostics::{
-    Check, ProductSpec, Report, config_writability_check, data_writability_check, detect, locate,
-    on_path_check, protocol_skew_check, shadow_check, terminal_checks,
+    Check, InstallMethod, ProductSpec, Reachability, Report, UpdatePlan, config_writability_check,
+    data_writability_check, detect, locate, on_path_check, protocol_skew_check, reachability,
+    shadow_check, terminal_checks, update_check,
 };
 
 use super::Executable;
 
 const CAT_BINARY: &str = "Binary & version";
+const CAT_NETWORK: &str = "Network";
 
 /// Run local environment diagnostics for the octos server.
 #[derive(Debug, Args)]
@@ -55,6 +63,7 @@ fn octos_server_spec() -> ProductSpec {
         "octos-org/octos",         // github repo
         "octos-bundle",            // asset prefix → octos-bundle-<triple>
     )
+    .with_github_token_env("OCTOS_GITHUB_TOKEN")
     .with_brew_formula("octos-org/tap/octos")
     .with_npm_package("@octos-org/octos")
     .with_cargo_install("octos-cli")
@@ -63,7 +72,8 @@ fn octos_server_spec() -> ProductSpec {
 
 impl Executable for DoctorCommand {
     fn execute(self) -> Result<()> {
-        let report = build_report(&self)?;
+        // Network checks run for the real `octos doctor` invocation (Stage 2).
+        let report = build_report(&self, true)?;
         if self.json {
             let bundle = report.to_json(
                 self.strict,
@@ -80,9 +90,11 @@ impl Executable for DoctorCommand {
     }
 }
 
-/// Assemble the full local-checks report. Separated from `execute` so it does
-/// not call `process::exit` and can be exercised by tests.
-fn build_report(cmd: &DoctorCommand) -> Result<Report> {
+/// Assemble the full report. Separated from `execute` so it does not call
+/// `process::exit` and can be exercised by tests. `with_network` gates the
+/// Stage-2 Network category (GitHub reachability + newer-release check) so unit
+/// tests stay offline/deterministic; the real command always passes `true`.
+fn build_report(cmd: &DoctorCommand, with_network: bool) -> Result<Report> {
     let spec = octos_server_spec();
     let mut report = Report::default();
 
@@ -130,8 +142,16 @@ fn build_report(cmd: &DoctorCommand) -> Result<Report> {
         &spec,
     ));
     report.push(shadow_check(&located, &method, &spec));
-    // TODO Stage 2: GitHub latest-release reachability + "newer release
-    // available" check (needs the `github` feature / reqwest).
+
+    // --- Network (Stage 2: github feature) --------------------------------
+    // GitHub reachability + a best-effort "newer release available" check.
+    // Both are advisory: a network failure WARNs (never FAILs) so `doctor`
+    // works offline. The LIVE-WS `config/capabilities/list` probe for protocol
+    // skew is still TODO Stage 2.5 (it needs a client WS connection); the
+    // compiled-in `protocol_skew_check` from Stage 1 remains the skew check.
+    if with_network {
+        report.extend(network_checks(&spec, &method));
+    }
 
     // --- Terminal environment ---------------------------------------------
     report.extend(terminal_checks());
@@ -150,8 +170,10 @@ fn build_report(cmd: &DoctorCommand) -> Result<Report> {
     // full known-feature registry (what `octos serve` actually negotiates), so
     // comparing it against that same registry confirms the build's octos-core
     // matches the protocol it ships — a divergence would surface here.
-    // TODO Stage 2: replace the compiled-in caps with a LIVE WS
-    // `config/capabilities/list` probe against a configured/running server.
+    // TODO Stage 2.5: replace the compiled-in caps with a LIVE WS
+    // `config/capabilities/list` probe against a configured/running server (it
+    // needs a client WS connection, deliberately out of Stage 2 scope). Until
+    // then the compiled-in `protocol_skew_check` is authoritative.
     let server_caps = UiProtocolCapabilities::first_server_slice();
     report.push(protocol_skew_check(
         &server_caps,
@@ -159,6 +181,69 @@ fn build_report(cmd: &DoctorCommand) -> Result<Report> {
     ));
 
     Ok(report)
+}
+
+/// Network category (Stage 2, `github` feature): GitHub API reachability + a
+/// best-effort newer-release check. Both are advisory — a network/API failure
+/// produces a `[!]` WARN, never a `[✗]` FAIL, so `doctor` never blocks offline.
+fn network_checks(spec: &ProductSpec, method: &InstallMethod) -> Vec<Check> {
+    let mut checks = Vec::new();
+
+    // GitHub reachability (shared probe) — called once, result reused below.
+    let reach = reachability(spec);
+    let reachable = matches!(reach, Reachability::Reachable);
+    match reach {
+        Reachability::Reachable => checks.push(
+            Check::pass(CAT_NETWORK, "GitHub reachable", "api.github.com responded")
+                .with_value("https://api.github.com".to_string()),
+        ),
+        Reachability::Unreachable { reason } => checks.push(Check::warn(
+            CAT_NETWORK,
+            "GitHub reachable",
+            format!("could not reach api.github.com: {reason}"),
+            "check network/proxy/DNS, or set OCTOS_GITHUB_TOKEN to dodge rate limits",
+        )),
+    }
+
+    // Best-effort "newer release available" via the shared planner. Only attempt
+    // when GitHub looked reachable; any failure is a WARN, never a FAIL.
+    if reachable {
+        match update_check(spec, method) {
+            Ok(UpdatePlan::UpToDate) => checks.push(Check::pass(
+                CAT_NETWORK,
+                "latest release",
+                format!("up to date (v{})", spec.current_version),
+            )),
+            Ok(UpdatePlan::UpdateAvailable { latest }) => checks.push(Check::warn(
+                CAT_NETWORK,
+                "latest release",
+                format!("a newer octos is available: v{latest}"),
+                method
+                    .upgrade_hint(spec)
+                    .unwrap_or_else(|| "run `octos update --check`".to_string()),
+            )),
+            Ok(UpdatePlan::DeferToPackageManager { cmd }) => checks.push(Check::warn(
+                CAT_NETWORK,
+                "latest release",
+                "a newer octos is available",
+                cmd,
+            )),
+            Ok(UpdatePlan::SelfUpdateAllowed) => checks.push(Check::warn(
+                CAT_NETWORK,
+                "latest release",
+                "a newer octos is available (this install can self-update in Stage 3)",
+                "run `octos update --check`",
+            )),
+            Err(err) => checks.push(Check::warn(
+                CAT_NETWORK,
+                "latest release",
+                format!("could not check for a newer release: {err}"),
+                "retry when online, or set OCTOS_GITHUB_TOKEN if rate-limited",
+            )),
+        }
+    }
+
+    checks
 }
 
 #[cfg(test)]
@@ -188,7 +273,7 @@ mod tests {
 
     #[test]
     fn report_includes_core_categories_and_protocol_skew_passes() {
-        let report = build_report(&cmd()).expect("report builds");
+        let report = build_report(&cmd(), false).expect("report builds");
         let text = report.render(false, false);
         assert!(text.contains("Binary & version"));
         assert!(text.contains("Terminal environment"));

--- a/crates/octos-cli/src/commands/mod.rs
+++ b/crates/octos-cli/src/commands/mod.rs
@@ -18,6 +18,7 @@ mod office;
 mod serve;
 pub mod skills;
 mod status;
+mod update;
 
 use std::path::PathBuf;
 
@@ -42,6 +43,7 @@ pub use office::OfficeCommand;
 pub use serve::ServeCommand;
 pub use skills::SkillsCommand;
 pub use status::StatusCommand;
+pub use update::UpdateCommand;
 
 /// octos: Rust-native coding agent orchestration.
 #[derive(Debug, Parser)]
@@ -104,6 +106,8 @@ pub enum Command {
     Skills(SkillsCommand),
     /// Show system status.
     Status(StatusCommand),
+    /// Check for a newer octos release (`--check`); self-update is Stage 3.
+    Update(UpdateCommand),
     /// Run as a persistent messaging gateway.
     Gateway(GatewayCommand),
     /// Clean up stale state and cache files.
@@ -308,6 +312,7 @@ impl Executable for Command {
             Self::Serve(cmd) => cmd.execute(),
             Self::Skills(cmd) => cmd.execute(),
             Self::Status(cmd) => cmd.execute(),
+            Self::Update(cmd) => cmd.execute(),
             Self::Gateway(cmd) => cmd.execute(),
             Self::Clean(cmd) => cmd.execute(),
             Self::Completions(cmd) => cmd.execute(),

--- a/crates/octos-cli/src/commands/update.rs
+++ b/crates/octos-cli/src/commands/update.rs
@@ -1,0 +1,248 @@
+//! `octos update` — Stage 2 ships **`--check` only** (plan, never mutate).
+//!
+//! `octos update --check` resolves the octos-server [`ProductSpec`], detects the
+//! install method, calls the shared `octos_diagnostics::update_check` (a public
+//! GitHub Releases fetch + the pure planner), and prints the resulting
+//! [`UpdatePlan`]. It NEVER mutates a binary.
+//!
+//! Bare `octos update` (no `--check`) is intentionally inert in Stage 2: it
+//! prints that self-update is not yet wired for this install method (that fold-in
+//! over the existing `updater.rs` is Stage 3) plus the per-method upgrade hint,
+//! and exits 0. It does NOT call `updater.rs`.
+//!
+//! Exit-code contract for `--check` (the design's `--check` contract):
+//! - `0`  — up to date.
+//! - `10` — a newer release is available (any of update-available /
+//!   defer-to-package-manager / self-update-allowed).
+//! - non-10 nonzero (`2`) — network/API error; a clear message is printed.
+
+use clap::Args;
+use colored::Colorize;
+use eyre::Result;
+use octos_diagnostics::{InstallMethod, ProductSpec, UpdatePlan, detect, update_check};
+
+use super::Executable;
+
+/// Exit code emitted by `--check` when a newer release is available.
+const EXIT_UPDATE_AVAILABLE: i32 = 10;
+/// Exit code emitted by `--check` on a network/API error (non-10 nonzero).
+const EXIT_CHECK_ERROR: i32 = 2;
+
+/// Check for (and, in a future Stage 3, apply) octos updates.
+#[derive(Debug, Args)]
+pub struct UpdateCommand {
+    /// Only check for a newer release and print the plan — never mutate. Exits
+    /// 10 when an update is available, 0 when up to date.
+    #[arg(long)]
+    pub check: bool,
+    /// Emit the check result as machine-readable JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Build the octos-server [`ProductSpec`]. `current_version` is the CLI's OWN
+/// `CARGO_PKG_VERSION`, passed IN here — never the diagnostics crate's.
+fn octos_server_spec() -> ProductSpec {
+    ProductSpec::new(
+        "octos",                   // binary on PATH
+        "octos",                   // package / display name
+        env!("CARGO_PKG_VERSION"), // passed IN — octos-cli's own version
+        "octos-org/octos",         // github repo
+        "octos-bundle",            // asset prefix → octos-bundle-<triple>
+    )
+    .with_github_token_env("OCTOS_GITHUB_TOKEN")
+    .with_brew_formula("octos-org/tap/octos")
+    .with_npm_package("@octos-org/octos")
+    .with_cargo_install("octos-cli")
+    .with_cargo_dist_app("octos")
+}
+
+impl Executable for UpdateCommand {
+    fn execute(self) -> Result<()> {
+        if !self.check {
+            // Stage 2: no self-update mutation wired yet (Stage 3 folds in
+            // updater.rs). Print a clear status + the per-method upgrade hint.
+            print_not_yet_wired();
+            return Ok(());
+        }
+
+        let spec = octos_server_spec();
+        let method = detect(&spec);
+        match update_check(&spec, &method) {
+            Ok(plan) => {
+                let (text, json, code) = render_check(&plan, &method, &spec);
+                if self.json {
+                    println!("{json}");
+                } else {
+                    print!("{text}");
+                }
+                std::process::exit(code);
+            }
+            Err(err) => {
+                if self.json {
+                    let body = serde_json::json!({
+                        "status": "error",
+                        "current": spec.current_version,
+                        "error": err.to_string(),
+                    });
+                    println!("{}", serde_json::to_string_pretty(&body)?);
+                } else {
+                    eprintln!(
+                        "{} could not check for updates: {err}",
+                        "error:".red().bold()
+                    );
+                    eprintln!("  (no network? the public GitHub Releases API was unreachable)");
+                }
+                std::process::exit(EXIT_CHECK_ERROR);
+            }
+        }
+    }
+}
+
+/// Bare `octos update` Stage-2 message: not yet wired, here's the hint.
+fn print_not_yet_wired() {
+    let spec = octos_server_spec();
+    let method = detect(&spec);
+    println!(
+        "self-update for this install method ({}) is not yet wired (Stage 3); \
+run with --check to see status",
+        method.label()
+    );
+    if let Some(hint) = method.upgrade_hint(&spec) {
+        println!("  upgrade with: {hint}");
+    }
+}
+
+/// Map an [`UpdatePlan`] to `(human text, json string, exit code)`. Pure — no
+/// IO — so the exit-code contract and rendering are unit-testable.
+fn render_check(
+    plan: &UpdatePlan,
+    method: &InstallMethod,
+    spec: &ProductSpec,
+) -> (String, String, i32) {
+    let current = &spec.current_version;
+    let (status, mut text, code) = match plan {
+        UpdatePlan::UpToDate => (
+            "up-to-date",
+            format!("{} octos is up to date (v{current})\n", "[✓]".green()),
+            0,
+        ),
+        UpdatePlan::UpdateAvailable { latest } => (
+            "update-available",
+            format!(
+                "{} a newer octos is available: v{current} → v{latest}\n",
+                "[!]".yellow()
+            ),
+            EXIT_UPDATE_AVAILABLE,
+        ),
+        UpdatePlan::DeferToPackageManager { cmd } => (
+            "defer-to-package-manager",
+            format!(
+                "{} a newer octos is available (current v{current})\n  upgrade with: {cmd}\n",
+                "[!]".yellow()
+            ),
+            EXIT_UPDATE_AVAILABLE,
+        ),
+        UpdatePlan::SelfUpdateAllowed => (
+            "self-update-allowed",
+            format!(
+                "{} a newer octos is available (current v{current})\n  this install can self-update (run `octos update` once Stage 3 lands)\n",
+                "[!]".yellow()
+            ),
+            EXIT_UPDATE_AVAILABLE,
+        ),
+    };
+
+    // For UpdateAvailable / SelfUpdateAllowed, still surface the per-method hint
+    // so the user has an actionable command even before Stage 3.
+    if matches!(
+        plan,
+        UpdatePlan::UpdateAvailable { .. } | UpdatePlan::SelfUpdateAllowed
+    ) {
+        if let Some(hint) = method.upgrade_hint(spec) {
+            text.push_str(&format!("  upgrade with: {hint}\n"));
+        }
+    }
+
+    let latest = match plan {
+        UpdatePlan::UpdateAvailable { latest } => Some(latest.clone()),
+        _ => None,
+    };
+    let json = serde_json::json!({
+        "status": status,
+        "current": current,
+        "latest": latest,
+        "method": method.id(),
+        "exit_code": code,
+    });
+    (
+        text,
+        serde_json::to_string_pretty(&json).unwrap_or_default(),
+        code,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec() -> ProductSpec {
+        octos_server_spec()
+    }
+
+    #[test]
+    fn spec_carries_cli_version_and_token_env() {
+        let s = spec();
+        assert_eq!(s.current_version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(s.github_repo, "octos-org/octos");
+        assert_eq!(s.github_token_env.as_deref(), Some("OCTOS_GITHUB_TOKEN"));
+    }
+
+    #[test]
+    fn up_to_date_exits_zero() {
+        let (text, json, code) =
+            render_check(&UpdatePlan::UpToDate, &InstallMethod::Homebrew, &spec());
+        assert_eq!(code, 0);
+        assert!(text.contains("up to date"));
+        assert!(json.contains("\"status\": \"up-to-date\""));
+        assert!(json.contains("\"exit_code\": 0"));
+    }
+
+    #[test]
+    fn update_available_exits_ten() {
+        let plan = UpdatePlan::UpdateAvailable {
+            latest: "9.9.9".into(),
+        };
+        let (text, json, code) = render_check(&plan, &InstallMethod::Unknown, &spec());
+        assert_eq!(code, EXIT_UPDATE_AVAILABLE);
+        assert!(text.contains("9.9.9"));
+        assert!(json.contains("\"latest\": \"9.9.9\""));
+        assert!(json.contains("\"exit_code\": 10"));
+    }
+
+    #[test]
+    fn defer_to_package_manager_exits_ten_and_prints_cmd() {
+        let plan = UpdatePlan::DeferToPackageManager {
+            cmd: "brew upgrade octos-org/tap/octos".into(),
+        };
+        let (text, _json, code) = render_check(&plan, &InstallMethod::Homebrew, &spec());
+        assert_eq!(code, EXIT_UPDATE_AVAILABLE);
+        assert!(text.contains("brew upgrade octos-org/tap/octos"));
+    }
+
+    #[test]
+    fn self_update_allowed_exits_ten() {
+        let (_text, _json, code) = render_check(
+            &UpdatePlan::SelfUpdateAllowed,
+            &InstallMethod::CargoDistInstaller,
+            &spec(),
+        );
+        assert_eq!(code, EXIT_UPDATE_AVAILABLE);
+    }
+
+    #[test]
+    fn check_error_code_is_nonzero_and_not_ten() {
+        assert_ne!(EXIT_CHECK_ERROR, 0);
+        assert_ne!(EXIT_CHECK_ERROR, EXIT_UPDATE_AVAILABLE);
+    }
+}

--- a/crates/octos-diagnostics/Cargo.toml
+++ b/crates/octos-diagnostics/Cargo.toml
@@ -11,11 +11,21 @@ octos-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 eyre = { workspace = true }
+# Stage 2: blocking GitHub Releases client. OPTIONAL — pulled in ONLY when the
+# `github` feature is enabled. The default build (`default = []`) must NOT carry
+# reqwest. We reuse the workspace pin (rustls-tls, blocking, json) so the TLS
+# stack stays consistent with octos-llm/octos-agent rather than introducing a
+# second `rustls-tls-native-roots` variant that would feature-unify the whole
+# workspace onto a different TLS-roots backend.
+reqwest = { workspace = true, optional = true }
 
 [features]
-# Stage 1 is dependency-light: NO `github`/`update` features, NO reqwest,
-# NO axoupdater. GitHub reachability is Stage 2; self-update is Stage 3.
+# Stage 1 stays dependency-light: `default = []` carries NO network/update deps.
+# Stage 2 adds an OPTIONAL `github` feature gating the reqwest GitHub client +
+# `update --check` planning. Self-update (axoupdater) is still Stage 3 and is
+# NOT introduced here.
 default = []
+github = ["dep:reqwest"]
 
 [lints]
 workspace = true

--- a/crates/octos-diagnostics/src/github.rs
+++ b/crates/octos-diagnostics/src/github.rs
@@ -1,0 +1,321 @@
+//! Minimal **blocking** GitHub Releases client for `update --check` and the
+//! `doctor` network category (Stage 2). Behind the `github` feature → `reqwest`.
+//!
+//! Ported, product-agnostic, from octos-tui's `cmd/github.rs`: a plain blocking
+//! `reqwest` GET against the public Releases API. No auth is required for public
+//! repos, but the product's token env var (`spec.github_token_env`) is honored
+//! when set to dodge the unauthenticated rate limit — optional, never a hard
+//! requirement.
+//!
+//! Stage 2 is **read + plan only**: [`latest_release`] fetches the newest
+//! release, [`reachability`] probes `api.github.com`, and [`update_check`]
+//! threads the result through the pure Stage-1 [`crate::plan`]. NOTHING here
+//! mutates a binary — self-update is Stage 3.
+
+use std::time::Duration;
+
+use eyre::{Result, WrapErr, eyre};
+
+use crate::install_method::InstallMethod;
+use crate::spec::ProductSpec;
+use crate::update::{UpdatePlan, plan};
+
+const API_BASE: &str = "https://api.github.com";
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+/// User-Agent for GitHub API calls. The version is the *diagnostics* crate's
+/// version — this identifies the HTTP client, not the product, so it is the one
+/// legitimate `CARGO_PKG_VERSION` use here (the product version travels in
+/// [`ProductSpec::current_version`]).
+const USER_AGENT: &str = concat!("octos-diagnostics/", env!("CARGO_PKG_VERSION"));
+
+/// The release info `update --check`/`doctor` care about.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseInfo {
+    /// Version with any leading `v` stripped, e.g. `0.1.2`.
+    pub version: String,
+    /// The raw release tag, e.g. `v0.1.2`.
+    pub tag: String,
+    /// `browser_download_url` of the asset matching this host's triple, if the
+    /// release published one. `None` when no matching asset is present (a
+    /// package-manager install never needs it).
+    pub asset_url: Option<String>,
+}
+
+/// Result of the `api.github.com` reachability probe used by `doctor`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Reachability {
+    /// `api.github.com` answered successfully (or with a benign rate-limit;
+    /// see [`Reachability::reason`] semantics — a 403 is folded into
+    /// `Unreachable` only for connectivity, never for planning).
+    Reachable,
+    /// Not reachable, or answered with an error/rate-limit status. `reason`
+    /// carries a short human-readable cause (network error or `HTTP <status>`).
+    Unreachable { reason: String },
+}
+
+/// The platform target triple for asset selection, derived from the compile
+/// target (`std::env::consts::{OS, ARCH}`). Mirrors the cargo-dist asset names
+/// (`<prefix>-<triple>`). Unknown OS/arch combinations fall back to a
+/// best-effort `<arch>-unknown-<os>` so selection degrades gracefully rather
+/// than panicking.
+pub fn host_target_triple() -> String {
+    let arch = std::env::consts::ARCH; // e.g. "aarch64", "x86_64"
+    match std::env::consts::OS {
+        "macos" => format!("{arch}-apple-darwin"),
+        "linux" => format!("{arch}-unknown-linux-gnu"),
+        "windows" => format!("{arch}-pc-windows-msvc"),
+        other => format!("{arch}-unknown-{other}"),
+    }
+}
+
+fn client() -> Result<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .user_agent(USER_AGENT)
+        .timeout(TIMEOUT)
+        .build()
+        .wrap_err("failed to build HTTP client")
+}
+
+/// The product's GitHub token from its configured env var, if set and non-blank.
+/// Optional — used only to dodge the unauthenticated rate limit.
+fn token(spec: &ProductSpec) -> Option<String> {
+    let var = spec.github_token_env.as_deref()?;
+    std::env::var(var).ok().filter(|t| !t.trim().is_empty())
+}
+
+fn authed(
+    req: reqwest::blocking::RequestBuilder,
+    spec: &ProductSpec,
+) -> reqwest::blocking::RequestBuilder {
+    let req = req
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28");
+    match token(spec) {
+        Some(t) => req.bearer_auth(t),
+        None => req,
+    }
+}
+
+/// Whether `api.github.com` is reachable (a cheap GET against the API root).
+/// Used by `doctor`'s network check. Any non-success status (including a 403
+/// rate-limit) or transport error becomes [`Reachability::Unreachable`] with a
+/// short reason — `doctor` renders this as a WARN, never a hard failure.
+pub fn reachability(spec: &ProductSpec) -> Reachability {
+    let client = match client() {
+        Ok(c) => c,
+        Err(_) => {
+            return Reachability::Unreachable {
+                reason: "failed to build HTTP client".into(),
+            };
+        }
+    };
+    match authed(client.get(API_BASE), spec).send() {
+        Ok(resp) if resp.status().is_success() => Reachability::Reachable,
+        Ok(resp) if resp.status().as_u16() == 403 => Reachability::Unreachable {
+            reason: "rate-limited (HTTP 403)".into(),
+        },
+        Ok(resp) => Reachability::Unreachable {
+            reason: format!("HTTP {}", resp.status()),
+        },
+        Err(err) => Reachability::Unreachable {
+            reason: err.to_string(),
+        },
+    }
+}
+
+/// Fetch the latest published release for `spec.github_repo` from the public
+/// GitHub Releases API, honoring the spec's token env var when set.
+pub fn latest_release(spec: &ProductSpec) -> Result<ReleaseInfo> {
+    let client = client()?;
+    let url = format!("{API_BASE}/repos/{}/releases/latest", spec.github_repo);
+    let resp = authed(client.get(&url), spec)
+        .send()
+        .wrap_err("failed to reach api.github.com")?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(eyre!(
+            "GitHub returned {status} for the latest {} release",
+            spec.package_name
+        ));
+    }
+    let payload: serde_json::Value = resp
+        .json()
+        .wrap_err("failed to decode GitHub release payload")?;
+    parse_release(&payload, spec)
+}
+
+/// Pure parser: turn a GitHub `/releases/latest` JSON payload into a
+/// [`ReleaseInfo`], selecting the asset whose name matches this host's triple.
+/// Network-free so it is unit-testable against a fixture (no live github.com).
+pub fn parse_release(payload: &serde_json::Value, spec: &ProductSpec) -> Result<ReleaseInfo> {
+    let tag = payload["tag_name"]
+        .as_str()
+        .ok_or_else(|| eyre!("release payload is missing `tag_name`"))?
+        .to_string();
+    let version = tag.strip_prefix('v').unwrap_or(&tag).to_string();
+
+    // Asset selection: the cargo-dist asset is `<prefix>-<triple>` with some
+    // archive extension (`.tar.gz`/`.zip`). Match by *prefix* of the asset name
+    // so we don't have to hardcode the extension per OS.
+    let wanted = spec.asset_selector.asset_name(&host_target_triple());
+    let asset_url = payload["assets"].as_array().and_then(|assets| {
+        assets
+            .iter()
+            .filter_map(|a| {
+                let name = a["name"].as_str()?;
+                let url = a["browser_download_url"].as_str()?;
+                Some((name, url))
+            })
+            .find(|(name, _)| name.starts_with(&wanted))
+            .map(|(_, url)| url.to_string())
+    });
+
+    Ok(ReleaseInfo {
+        version,
+        tag,
+        asset_url,
+    })
+}
+
+/// Fetch the latest release and produce an [`UpdatePlan`] via the pure Stage-1
+/// [`plan`]. NO mutation: this only decides what *should* happen given the
+/// current version (from `spec.current_version`), the fetched latest, and the
+/// install `method`. The caller (Stage 3 driver) executes the plan.
+pub fn update_check(spec: &ProductSpec, method: &InstallMethod) -> Result<UpdatePlan> {
+    let latest = latest_release(spec)?;
+    Ok(plan(&spec.current_version, &latest.version, method, spec))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn octos_spec() -> ProductSpec {
+        ProductSpec::new("octos", "octos", "1.0.0", "octos-org/octos", "octos-bundle")
+            .with_brew_formula("octos-org/tap/octos")
+            .with_cargo_dist_app("octos")
+    }
+
+    /// A GitHub `/releases/latest` fixture carrying assets for several triples.
+    fn releases_fixture() -> serde_json::Value {
+        serde_json::json!({
+            "tag_name": "v9.9.9",
+            "name": "octos 9.9.9",
+            "prerelease": false,
+            "draft": false,
+            "assets": [
+                {
+                    "name": "octos-bundle-aarch64-apple-darwin.tar.gz",
+                    "browser_download_url": "https://github.com/octos-org/octos/releases/download/v9.9.9/octos-bundle-aarch64-apple-darwin.tar.gz"
+                },
+                {
+                    "name": "octos-bundle-x86_64-unknown-linux-gnu.tar.gz",
+                    "browser_download_url": "https://github.com/octos-org/octos/releases/download/v9.9.9/octos-bundle-x86_64-unknown-linux-gnu.tar.gz"
+                },
+                {
+                    "name": "octos-bundle-x86_64-pc-windows-msvc.zip",
+                    "browser_download_url": "https://github.com/octos-org/octos/releases/download/v9.9.9/octos-bundle-x86_64-pc-windows-msvc.zip"
+                }
+            ]
+        })
+    }
+
+    #[test]
+    fn parse_release_reads_tag_and_strips_v_prefix() {
+        let info = parse_release(&releases_fixture(), &octos_spec()).expect("parses");
+        assert_eq!(info.tag, "v9.9.9");
+        assert_eq!(info.version, "9.9.9");
+    }
+
+    #[test]
+    fn parse_release_selects_asset_for_this_host_triple() {
+        // The asset URL chosen must match THIS host's triple (whichever the test
+        // runs on), proving asset selection uses the live triple + spec prefix.
+        let info = parse_release(&releases_fixture(), &octos_spec()).expect("parses");
+        let triple = host_target_triple();
+        let expected_prefix = format!("octos-bundle-{triple}");
+        // Our fixture only carries darwin/linux-gnu/windows-msvc assets; on any
+        // of those hosts we must find a matching URL.
+        if [
+            "aarch64-apple-darwin",
+            "x86_64-unknown-linux-gnu",
+            "x86_64-pc-windows-msvc",
+        ]
+        .contains(&triple.as_str())
+        {
+            let url = info.asset_url.expect("asset for this host triple");
+            assert!(
+                url.contains(&expected_prefix),
+                "asset url {url} should contain {expected_prefix}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_release_returns_none_asset_when_no_triple_matches() {
+        // A release that published no asset for any known triple → asset_url None,
+        // but tag/version still parse (package-manager installs don't need an asset).
+        let payload = serde_json::json!({
+            "tag_name": "v2.0.0",
+            "assets": [
+                { "name": "SOURCE.tar.gz", "browser_download_url": "https://example.com/src" }
+            ]
+        });
+        let info = parse_release(&payload, &octos_spec()).expect("parses");
+        assert_eq!(info.version, "2.0.0");
+        assert!(info.asset_url.is_none());
+    }
+
+    #[test]
+    fn parse_release_errors_without_tag_name() {
+        let payload = serde_json::json!({ "assets": [] });
+        assert!(parse_release(&payload, &octos_spec()).is_err());
+    }
+
+    #[test]
+    fn host_target_triple_is_dash_joined_arch_first() {
+        let t = host_target_triple();
+        assert!(
+            t.starts_with(std::env::consts::ARCH),
+            "triple {t} starts with arch"
+        );
+        assert!(t.contains('-'));
+    }
+
+    #[test]
+    fn token_reads_only_the_specs_env_var() {
+        // No env var configured on the spec → never reads anything.
+        let mut spec = octos_spec();
+        assert!(token(&spec).is_none());
+        spec.github_token_env = Some("OCTOS_DIAG_TEST_TOKEN_UNSET_XYZ".into());
+        // Unset → None (we don't fall through to a default var).
+        assert!(token(&spec).is_none());
+    }
+
+    // --- live-network tests (CI-safe: ignored) ------------------------------
+
+    #[test]
+    #[ignore = "hits live api.github.com; run manually with --ignored"]
+    fn live_reachability_is_reachable() {
+        assert_eq!(reachability(&octos_spec()), Reachability::Reachable);
+    }
+
+    #[test]
+    #[ignore = "hits live api.github.com; run manually with --ignored"]
+    fn live_latest_release_parses() {
+        let info = latest_release(&octos_spec()).expect("fetches latest");
+        assert!(!info.version.is_empty());
+        assert!(info.tag.starts_with('v') || !info.tag.is_empty());
+    }
+
+    #[test]
+    #[ignore = "hits live api.github.com; run manually with --ignored"]
+    fn live_update_check_returns_a_plan() {
+        // Current version 0.0.0 forces "newer available" so we exercise planning.
+        let mut spec = octos_spec();
+        spec.current_version = "0.0.0".into();
+        let plan = update_check(&spec, &InstallMethod::Unknown).expect("plans");
+        assert_ne!(plan, UpdatePlan::UpToDate);
+    }
+}

--- a/crates/octos-diagnostics/src/lib.rs
+++ b/crates/octos-diagnostics/src/lib.rs
@@ -21,11 +21,19 @@
 //!   comparator.
 //!
 //! Stage 1 deliberately carries **no** network/update deps (no `reqwest`, no
-//! `axoupdater`); GitHub reachability is Stage 2 and self-update is Stage 3.
+//! `axoupdater`); the default build (`default = []`) stays dep-light.
+//!
+//! **Stage 2** adds an OPTIONAL `github` feature gating a blocking GitHub
+//! Releases client ([`reachability`], [`latest_release`], [`parse_release`]) and
+//! [`update_check`] — fetch-latest + the pure [`plan`], **planning only, no
+//! mutation**. `reqwest` is pulled in ONLY under `github`; the default build is
+//! unchanged. Self-update (axoupdater) remains Stage 3 and is NOT introduced.
 
 #![allow(clippy::result_large_err)]
 
 mod checks;
+#[cfg(feature = "github")]
+mod github;
 mod install_method;
 mod locate;
 mod report;
@@ -35,6 +43,11 @@ mod update;
 pub use checks::{
     TerminfoProbe, config_writability_check, data_writability_check, protocol_skew_check,
     terminal_checks, writability_check,
+};
+#[cfg(feature = "github")]
+pub use github::{
+    Reachability, ReleaseInfo, host_target_triple, latest_release, parse_release, reachability,
+    update_check,
 };
 pub use install_method::{InstallMethod, PathClassifierInput, classify_path, detect};
 pub use locate::{LocatedBinaries, locate, on_path_check, shadow_check};

--- a/crates/octos-diagnostics/src/spec.rs
+++ b/crates/octos-diagnostics/src/spec.rs
@@ -50,6 +50,11 @@ pub struct ProductSpec {
     pub current_version: String,
     /// `owner/repo` on GitHub, e.g. `octos-org/octos`.
     pub github_repo: String,
+    /// Env var holding an optional GitHub token to dodge the unauthenticated
+    /// rate limit, e.g. `OCTOS_GITHUB_TOKEN`. Optional auth — the GitHub client
+    /// (Stage 2, `github` feature) reads it only when this is `Some` and the var
+    /// is set & non-blank; a public repo never requires it.
+    pub github_token_env: Option<String>,
     /// Homebrew formula (tap-qualified), e.g. `octos-org/tap/octos`.
     pub brew_formula: Option<String>,
     /// npm package name, e.g. `@octos-org/octos`.
@@ -77,12 +82,19 @@ impl ProductSpec {
             package_name: package_name.into(),
             current_version: current_version.into(),
             github_repo: github_repo.into(),
+            github_token_env: None,
             brew_formula: None,
             npm_package: None,
             cargo_install: None,
             cargo_dist_app: None,
             asset_selector: AssetSelector::new(asset_prefix),
         }
+    }
+
+    /// Set the env var name holding an optional GitHub token (rate-limit auth).
+    pub fn with_github_token_env(mut self, env_var: impl Into<String>) -> Self {
+        self.github_token_env = Some(env_var.into());
+        self
     }
 
     pub fn with_brew_formula(mut self, formula: impl Into<String>) -> Self {


### PR DESCRIPTION
Stage 2 of #182. GitHub client behind a `github` feature (reqwest gated — absent by default, present only with the feature; inherits the workspace rustls-tls pin to avoid a TLS-roots split). `octos update --check` (plan ONLY, no mutation; exit 0 up-to-date / 10 newer / 2 network-error) via the shared pure `plan()` + Stage-1 ProductSpec (version passed in). `octos doctor` gains a Network category (GitHub reachable + latest-release; failures WARN, never FAIL). Bare `octos update` prints the Stage-3 hint; `updater.rs` untouched; no axoupdater.

51 diagnostics (+github) / 522 cli tests; clippy/fmt clean; cargo tree confirms reqwest is feature-gated. codex 5/5 PASS (the one caveat — doctor's dir-writability probe creates+removes a temp file — is inherited Stage-1 behavior, intentional for a writability check). Live-WS capabilities probe is a Stage-2.5 TODO; self-update is Stage 3.