### PR TITLE
fix(publish): homebrew tap push detects a brand-new octos.rb

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -92,11 +92,15 @@ jobs:
           cd tap
           git config user.name "octos-release-bot"
           git config user.email "151983+ymote@users.noreply.github.com"
-          if git diff --quiet; then
+          # `git add` FIRST, then check the STAGED diff: a brand-new untracked
+          # Formula/octos.rb is invisible to a plain `git diff --quiet` (that only
+          # inspects tracked files), so the first publish would silently skip the
+          # push. `git diff --cached --quiet` correctly sees the new staged file.
+          git add Formula/octos.rb
+          if git diff --cached --quiet; then
             echo "Formula/octos.rb unchanged; nothing to push."
             exit 0
           fi
-          git add Formula/octos.rb
           git commit -m "octos ${TAG}"
           git push origin HEAD
 


### PR DESCRIPTION
v1.1.0 reached npm + the GitHub release, but `Formula/octos.rb` never landed in the tap: the push step ran `git diff --quiet` (tracked-files only) to skip-if-unchanged BEFORE `git add`, so a brand-new untracked formula looked like 'nothing to push' → exited early. Fix: `git add` first, then `git diff --cached --quiet`. After merge I'll re-dispatch publish-packages for v1.1.0 to actually push the formula.