### PR TITLE
Fix run_pipeline synthetic report delivery

### DIFF
--- a/crates/octos-agent/src/bundled_app_skills.rs
+++ b/crates/octos-agent/src/bundled_app_skills.rs
@@ -79,7 +79,7 @@ mod tests {
 
     #[test]
     fn bundled_app_skills_is_non_empty() {
-        assert!(!BUNDLED_APP_SKILLS.is_empty());
+        assert_ne!(BUNDLED_APP_SKILLS.len(), 0);
     }
 
     #[test]
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn platform_skills_is_non_empty() {
-        assert!(!PLATFORM_SKILLS.is_empty());
+        assert_ne!(PLATFORM_SKILLS.len(), 0);
     }
 
     #[test]

--- a/crates/octos-agent/src/bundled_pipelines.rs
+++ b/crates/octos-agent/src/bundled_pipelines.rs
@@ -49,7 +49,7 @@ mod tests {
 
     #[test]
     fn bundled_pipelines_is_non_empty() {
-        assert!(!BUNDLED_PIPELINES.is_empty());
+        assert_ne!(BUNDLED_PIPELINES.len(), 0);
     }
 
     #[test]

--- a/crates/octos-cli/src/config_context.rs
+++ b/crates/octos-cli/src/config_context.rs
@@ -137,9 +137,9 @@ fn xdg_config_home() -> PathBuf {
                 return p.join("octos");
             }
         }
-        return dirs::home_dir()
+        dirs::home_dir()
             .map(|h| h.join(".config").join("octos"))
-            .unwrap_or_else(default_data_dir);
+            .unwrap_or_else(default_data_dir)
     }
 }
 

--- a/crates/octos-cli/tests/coding_multi_session.rs
+++ b/crates/octos-cli/tests/coding_multi_session.rs
@@ -213,6 +213,7 @@ async fn make_m11g_profile(profile_id: &str, data_dir: &std::path::Path) -> Arc<
         plugin_hooks: Vec::new(),
         review_config: None,
         system_prompt: "test-system-prompt".to_string(),
+        voice: octos_cli::config::VoiceConfig::default(),
         memory,
         memory_store,
         tool_config,

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -6628,7 +6628,7 @@ mod tests {
                 "router/get_metrics",
             ]
         );
-        assert!(UI_PROTOCOL_FIRST_SERVER_UNSUPPORTED_METHODS.is_empty());
+        assert_eq!(UI_PROTOCOL_FIRST_SERVER_UNSUPPORTED_METHODS.len(), 0);
     }
 
     #[test]

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -2944,7 +2944,7 @@ impl PipelineExecutor {
                             // a dynamic worker defaults to the 1h ceiling/Abort
                             // and ignores a configured skip/retry. (codex #1427)
                             deadline_secs: node.deadline_secs,
-                            deadline_action: node.deadline_action.clone(),
+                            deadline_action: node.deadline_action,
                             ..Default::default()
                         },
                     ));

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -988,7 +988,7 @@ impl Tool for RunPipelineTool {
             default_provider: self.default_provider.clone(),
             provider_router: self.provider_router.clone(),
             memory: self.memory.clone(),
-            working_dir: effective_working_dir,
+            working_dir: effective_working_dir.clone(),
             provider_policy: self.provider_policy.clone(),
             plugin_dirs: self.plugin_dirs.clone(),
             plugin_require_signed: self.plugin_require_signed,
@@ -1166,8 +1166,12 @@ impl Tool for RunPipelineTool {
         // truncation marker then points at this report so nothing is lost and
         // the LLM/user knows where the full output is. When not truncated, the
         // prior spawn_only delivery path is unchanged (real `.md` wins; else
-        // synthesize a payload so `files_to_send` is non-empty).
-        let synthetic_dir = std::env::temp_dir().join("octos_pipeline_synthetic");
+        // synthesize a payload so `files_to_send` is non-empty). Keep the
+        // synthetic report under `working_dir` so the spawn_only send_file path
+        // can deliver it; system temp is outside that allowlist.
+        let synthetic_dir = effective_working_dir
+            .join("skill-output")
+            .join("run_pipeline");
         let delivery = resolve_report_delivery(
             &result.output,
             &result.files_modified,
@@ -1240,7 +1244,8 @@ pub(crate) struct ReportDelivery {
 ///   `ToolResult.output` already carries the whole result).
 ///
 /// `synthetic_dir` is injected so tests can use a tempdir; production passes
-/// `std::env::temp_dir().join("octos_pipeline_synthetic")`.
+/// `<working_dir>/skill-output/run_pipeline` so spawn_only delivery stays
+/// inside the `send_file` allowlist.
 pub(crate) fn resolve_report_delivery(
     full_output: &str,
     files_modified: &[PathBuf],

--- a/crates/octos-pipeline/tests/pre_flight_validation.rs
+++ b/crates/octos-pipeline/tests/pre_flight_validation.rs
@@ -21,7 +21,7 @@ impl octos_llm::LlmProvider for MockProvider {
         _config: &octos_llm::ChatConfig,
     ) -> eyre::Result<octos_llm::ChatResponse> {
         Ok(octos_llm::ChatResponse {
-            content: Some("ok".into()),
+            content: Some("DOT_UI_SMOKE_OK".into()),
             tool_calls: vec![],
             stop_reason: octos_llm::StopReason::EndTurn,
             usage: octos_llm::TokenUsage::default(),
@@ -219,5 +219,45 @@ async fn pre_flight_rejects_malformed_json_args() {
     assert!(
         err.contains("invalid run_pipeline input"),
         "error must reference the input shape — got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn text_only_ir_pipeline_synthesizes_report_under_working_dir() {
+    let (tool, working, _data) = make_tool().await;
+    let tool = tool.with_ir_enabled(true);
+    let args = serde_json::json!({
+        "input": "ignored",
+        "ir": r#"{"id":"dot_delivery_smoke","nodes":[{"id":"start","kind":{"type":"transform","prompt":"Return exactly DOT_UI_SMOKE_OK"}}],"edges":[]}"#,
+    });
+
+    let result = tool
+        .execute(&args)
+        .await
+        .expect("text-only IR pipeline should execute");
+
+    assert!(result.success, "pipeline should succeed: {}", result.output);
+    assert!(
+        result.output.contains("DOT_UI_SMOKE_OK"),
+        "pipeline stdout should be in tool output: {}",
+        result.output
+    );
+    assert_eq!(
+        result.files_to_send.len(),
+        1,
+        "text-only pipeline should synthesize one deliverable report"
+    );
+
+    let report = &result.files_to_send[0];
+    let expected_root = working.path().join("skill-output").join("run_pipeline");
+    assert!(
+        report.starts_with(&expected_root),
+        "synthetic report must live under the tool working dir so send_file can deliver it; got {}",
+        report.display()
+    );
+    assert!(
+        report.exists(),
+        "synthetic report path should exist: {}",
+        report.display()
     );
 }

--- a/e2e/tests/run-pipeline-ir-delivery.spec.ts
+++ b/e2e/tests/run-pipeline-ir-delivery.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test } from '@playwright/test';
+import {
+  freshTurnId,
+  M9WsClient,
+  uniqueSessionId,
+  type UiNotification,
+} from '../lib/m9-ws-client';
+
+const BASE = process.env.OCTOS_TEST_URL || 'http://127.0.0.1:50123';
+const TOKEN =
+  process.env.OCTOS_AUTH_TOKEN ||
+  process.env.OCTOS_LIVE_TOKEN ||
+  process.env.OCTOS_TEST_TOKEN ||
+  '';
+const PROFILE = process.env.OCTOS_PROFILE || 'admin';
+
+test.setTimeout(180_000);
+
+function waitForMatchingNotification(
+  client: M9WsClient,
+  label: string,
+  predicate: (notification: UiNotification) => boolean,
+  timeoutMs: number,
+): Promise<UiNotification> {
+  const existing = client.notificationsLog().find(predicate);
+  if (existing) return Promise.resolve(existing);
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`timed out waiting for ${label}`));
+    }, timeoutMs);
+
+    client.onNotification((notification) => {
+      if (!predicate(notification)) return;
+      clearTimeout(timer);
+      resolve(notification);
+    });
+  });
+}
+
+test('text-only IR run_pipeline reaches the user as a background completion', async () => {
+  expect(TOKEN, 'OCTOS_AUTH_TOKEN must be set for live e2e').not.toEqual('');
+
+  const client = new M9WsClient({
+    url: BASE,
+    token: TOKEN,
+    profileId: PROFILE,
+    requestTimeoutMs: 45_000,
+    uiFeatures: [
+      'event.message_persisted.v1',
+      'event.spawn_complete.v1',
+      'auxiliary.rest_to_ws.v1',
+    ],
+  });
+
+  const sessionId = uniqueSessionId('run-pipeline-ir-delivery');
+  const turnId = freshTurnId();
+  const ir =
+    '{"id":"ir_delivery_smoke","nodes":[{"id":"start","kind":{"type":"transform","prompt":"Return exactly DOT_UI_SMOKE_OK and no other text."}}],"edges":[]}';
+  const prompt =
+    'Call run_pipeline exactly once. Use input exactly DOT_UI_SMOKE_OK. ' +
+    `Use this exact typed IR JSON string as the ir argument: ${ir} ` +
+    'Do not answer directly and do not call any other tool.';
+
+  try {
+    await client.connect();
+
+    const foregroundDone = waitForMatchingNotification(
+      client,
+      'foreground turn/completed',
+      (notification) =>
+        notification.method === 'turn/completed' &&
+        notification.params?.turn_id === turnId,
+      90_000,
+    );
+    const backgroundDone = waitForMatchingNotification(
+      client,
+      'run_pipeline turn/spawn_complete',
+      (notification) =>
+        notification.method === 'turn/spawn_complete' &&
+        notification.params?.turn_id === turnId &&
+        notification.params?.tool_call_id,
+      120_000,
+    );
+
+    await client.openSession({ session_id: sessionId, profile_id: PROFILE });
+    await client.startTurn({
+      session_id: sessionId,
+      turn_id: turnId,
+      input: [{ kind: 'text', text: prompt }],
+    });
+
+    await foregroundDone;
+    const background = await backgroundDone;
+    const content = String(background.params?.content ?? '');
+    const media = Array.isArray(background.params?.media)
+      ? background.params.media.map(String)
+      : [];
+
+    console.log(
+      `[run_pipeline-ir-delivery] content=${JSON.stringify(content.slice(0, 240))} media=${JSON.stringify(media)}`,
+    );
+
+    expect(content).toContain('DOT_UI_SMOKE_OK');
+    expect(content).not.toMatch(/run_pipeline failed|file delivery failed/i);
+    expect(
+      media.some(
+        (path) => path.includes('/skill-output/run_pipeline/') && path.endsWith('.md'),
+      ),
+    ).toBe(true);
+  } finally {
+    await client.close();
+  }
+});


### PR DESCRIPTION
## Summary
- write synthetic run_pipeline reports under the effective working directory at `skill-output/run_pipeline` instead of the system temp directory
- keep synthetic reports inside the spawn_only `send_file` allowlist so text-only pipeline results can be delivered to users
- add Rust and WebSocket e2e regression coverage for text-only IR pipeline delivery

## Verification
- `cargo test -p octos-pipeline --test pre_flight_validation -- --nocapture` — 9 passed / 0 failed
- `cargo test -p octos-pipeline --test dora_inspection_dot_smoke -- --nocapture` — 4 passed / 0 failed
- `cargo test -p octos-pipeline --lib executor::tests -- --nocapture` — 45 passed / 0 failed / 1 ignored
- `cargo build -p octos-cli --features 'octos-cli/api,octos-cli/telegram'` — passed, existing octos-bus warning only\n- `OCTOS_PIPELINE_IR=1` local serve + `npx --prefix e2e playwright test e2e/tests/run-pipeline-ir-delivery.spec.ts --workers=1 --reporter=list` — passed 3 times after fix\n\n## Notes\nBefore the fix, the same delivery path reproduced as `run_pipeline failed: completed but file delivery failed (0/1)` because the synthetic report was written to macOS system temp and rejected by `send_file` path scoping.