### PR TITLE
Add profile-backed home dashboard config

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -25880,7 +25880,10 @@ ignore = []
             .collect::<Vec<_>>();
         let visible_refs = visible.iter().map(String::as_str).collect::<Vec<_>>();
         let disabled_refs = disabled.iter().map(String::as_str).collect::<Vec<_>>();
-        let deferred_refs = recoverable_deferred.iter().map(String::as_str).collect::<Vec<_>>();
+        let deferred_refs = recoverable_deferred
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
         let payload = coding_tool_contract::tool_status_list_payload(
             coding_tool_contract::ToolStatusListContext {
                 available_model_tools: &visible_refs,
@@ -25944,7 +25947,9 @@ ignore = []
             .cloned()
             .collect();
         assert!(
-            !recoverable_deferred.iter().any(|name| name == "exec_command"),
+            !recoverable_deferred
+                .iter()
+                .any(|name| name == "exec_command"),
             "denied+deferred exec_command must NOT be recoverable, got {recoverable_deferred:?}"
         );
         assert!(

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -4,7 +4,7 @@
 //! channel credentials, and gateway settings. Profiles are stored as individual
 //! JSON files in `~/.octos/profiles/`.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
@@ -72,6 +72,10 @@ pub struct ProfileConfig {
     /// Robotics runtime configuration (heartbeat + sensor context injection).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub robot: Option<RobotConfig>,
+    /// Home dashboard user-facing state. This is the canonical cross-device
+    /// store for the touch dashboard; web localStorage is only a migration cache.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub home: Option<HomeConfig>,
     /// Channel configurations.
     #[serde(default)]
     pub channels: Vec<ChannelCredentials>,
@@ -144,6 +148,69 @@ pub struct ProfileConfig {
     /// **overrides**.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lane_routing: Option<octos_llm::LaneRoutingConfig>,
+}
+
+/// Home dashboard configuration persisted inside a profile.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HomeConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub settings: Option<HomeSettingsConfig>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub events: Vec<HomeCalendarEvent>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub photos: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub widgets: Vec<HomeWidgetConfig>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metro_layout: BTreeMap<String, HomeTileLayout>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HomeSettingsConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub city: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temp_unit: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clock_format: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_seconds: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub night_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lang: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub news_feed_url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HomeCalendarEvent {
+    pub id: String,
+    pub title: String,
+    pub time: String,
+    pub date: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recurring: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HomeWidgetConfig {
+    pub r#type: String,
+    pub enabled: bool,
+    pub order: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HomeTileLayout {
+    pub col: u32,
+    pub row: u32,
+    pub w: u32,
+    pub h: u32,
 }
 
 /// Profile-owned review workflow configuration.
@@ -439,6 +506,8 @@ pub struct ProfileConfigPatch {
     #[serde(default)]
     pub robot: PatchField<RobotConfig>,
     #[serde(default)]
+    pub home: PatchField<HomeConfig>,
+    #[serde(default)]
     pub channels: Option<Vec<ChannelCredentials>>,
     #[serde(default)]
     pub gateway: Option<GatewaySettingsPatch>,
@@ -665,6 +734,11 @@ impl ProfileConfig {
             PatchField::Absent => {}
             PatchField::Clear => self.robot = None,
             PatchField::Value(robot) => self.robot = Some(robot),
+        }
+        match patch.home {
+            PatchField::Absent => {}
+            PatchField::Clear => self.home = None,
+            PatchField::Value(home) => self.home = Some(home),
         }
         if let Some(channels) = patch.channels {
             self.channels = channels;
@@ -2311,6 +2385,40 @@ mod tests {
                     default_theme: Some("crew".into()),
                 }),
             }),
+            home: PatchField::Value(HomeConfig {
+                settings: Some(HomeSettingsConfig {
+                    city: Some("Tokyo".into()),
+                    temp_unit: Some("C".into()),
+                    clock_format: Some("24h".into()),
+                    idle_seconds: Some(45),
+                    night_mode: Some("auto".into()),
+                    lang: Some("zh".into()),
+                    news_feed_url: Some("https://example.test/feed.xml".into()),
+                }),
+                events: vec![HomeCalendarEvent {
+                    id: "evt-1".into(),
+                    title: "Breakfast".into(),
+                    time: "08:00".into(),
+                    date: "2026-06-14".into(),
+                    recurring: Some("daily".into()),
+                }],
+                photos: vec!["https://example.test/home.jpg".into()],
+                widgets: vec![HomeWidgetConfig {
+                    r#type: "calendar".into(),
+                    enabled: true,
+                    order: 6,
+                }],
+                metro_layout: [(
+                    "clock".into(),
+                    HomeTileLayout {
+                        col: 1,
+                        row: 1,
+                        w: 4,
+                        h: 2,
+                    },
+                )]
+                .into(),
+            }),
             ..Default::default()
         });
 
@@ -2339,6 +2447,20 @@ mod tests {
                 .and_then(|slides| slides.default_theme.as_deref()),
             Some("crew")
         );
+        let home = config
+            .home
+            .as_ref()
+            .expect("home config should be preserved");
+        assert_eq!(
+            home.settings
+                .as_ref()
+                .and_then(|settings| settings.city.as_deref()),
+            Some("Tokyo")
+        );
+        assert_eq!(home.events[0].title, "Breakfast");
+        assert_eq!(home.photos, vec!["https://example.test/home.jpg"]);
+        assert_eq!(home.widgets[0].r#type, "calendar");
+        assert_eq!(home.metro_layout["clock"].w, 4);
     }
 
     #[test]
@@ -3317,6 +3439,19 @@ mod tests {
         .expect_err("unknown deep_crawl field should be rejected");
 
         assert!(err.to_string().contains("unknown field `max_chrs`"));
+    }
+
+    #[test]
+    fn test_profile_config_patch_rejects_unknown_home_field() {
+        let err = serde_json::from_value::<ProfileConfigPatch>(serde_json::json!({
+            "home": {
+                "settings": { "city": "Tokyo" },
+                "bogus": true
+            }
+        }))
+        .expect_err("unknown home field should be rejected");
+
+        assert!(err.to_string().contains("unknown field `bogus`"));
     }
 
     #[test]

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -15891,7 +15891,12 @@ mod tests {
         let t2 = supervisor.register("mofa_slides", "call-cap-2", Some("cli:test"));
         supervisor.mark_synth_ack_emitted("call-cap-2");
         supervisor.mark_failed(&t2, "fail #2".to_string());
-        drain_until(&mut rx, "Background failure could not be recovered", &mut seen).await;
+        drain_until(
+            &mut rx,
+            "Background failure could not be recovered",
+            &mut seen,
+        )
+        .await;
 
         // The first two recovery LLM turns must have run.
         assert!(

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -122,11 +122,51 @@ export interface AppsConfig {
   slides?: SlidesAppConfig | null
 }
 
+export interface HomeSettingsConfig {
+  city?: string | null
+  temp_unit?: string | null
+  clock_format?: string | null
+  idle_seconds?: number | null
+  night_mode?: string | null
+  lang?: string | null
+  news_feed_url?: string | null
+}
+
+export interface HomeCalendarEvent {
+  id: string
+  title: string
+  time: string
+  date: string
+  recurring?: string | null
+}
+
+export interface HomeWidgetConfig {
+  type: string
+  enabled: boolean
+  order: number
+}
+
+export interface HomeTileLayout {
+  col: number
+  row: number
+  w: number
+  h: number
+}
+
+export interface HomeConfig {
+  settings?: HomeSettingsConfig | null
+  events?: HomeCalendarEvent[]
+  photos?: string[]
+  widgets?: HomeWidgetConfig[]
+  metro_layout?: Record<string, HomeTileLayout>
+}
+
 export interface ProfileConfig {
   llm?: LlmProfileConfig | null
   search?: SearchConfig | null
   deep_crawl?: DeepCrawlConfig | null
   apps?: AppsConfig | null
+  home?: HomeConfig | null
   channels: ChannelCredentials[]
   gateway: GatewaySettings
   email?: EmailSettings | null


### PR DESCRIPTION
## Summary
- add typed `config.home` support to profile config patches
- persist Home settings, calendar events, photo URLs, widget ordering, and Metro tile layout in the profile contract
- mirror the Home config contract in dashboard TypeScript types
- include rustfmt-only cleanup required by current `origin/main` for two existing test blocks

## Why
This is the backend schema companion for octos-web PR octos-org/octos-web#213. Without this schema, the web dashboard can still use local fallback state, but canonical cross-device Home persistence cannot be accepted by `/api/my/profile`.

## Verification
- `cargo fmt --check` → passed
- `cargo test -p octos-cli profile_config_patch --lib` → 9 passed, 0 failed