### PR TITLE
perf(voice): lean prompt on voice turns — defer tools + cap history

### DIFF
--- a/crates/octos-cli/src/api/context_manager.rs
+++ b/crates/octos-cli/src/api/context_manager.rs
@@ -1669,6 +1669,19 @@ fn first_removable_prompt_group(entries: &[PromptMessageEntry]) -> Option<(usize
     let mut end = start + 1;
 
     if matches!(entries[start].message.role, MessageRole::User) {
+        // Never trim away the most recent user turn: it is the current request
+        // the model must answer. When no later user message exists, this group
+        // IS that request (plus any in-turn tool-recovery replies), so it stays
+        // even under a tight cap — `max_prompt_token_estimate` is a soft latency
+        // target, and dropping the live request (e.g. a voice turn whose
+        // protected compaction summary already fills the budget) would leave the
+        // model answering nothing. See `voice_cap_keeps_current_request_*`.
+        let has_later_user = entries[start + 1..]
+            .iter()
+            .any(|entry| matches!(entry.message.role, MessageRole::User));
+        if !has_later_user {
+            return None;
+        }
         while end < entries.len()
             && !entries[end].protected
             && !matches!(entries[end].message.role, MessageRole::User)
@@ -2596,6 +2609,45 @@ mod tests {
         assert!(
             frame.report.truncated_item_ids.contains(&tool_item_id),
             "context-pressure truncation should report the affected tool output item"
+        );
+    }
+
+    #[test]
+    fn voice_cap_keeps_current_request_even_when_protected_context_fills_budget() {
+        // Regression (#1464 P1): a voice turn caps the outgoing projection, but a
+        // protected compaction summary / context injection can alone meet or
+        // exceed that cap. The trim must still keep the CURRENT user request —
+        // otherwise the model receives only the summary and answers nothing.
+        let mut manager = ContextManager::new("s", None);
+        // A context injection is emitted as a protected entry, standing in for a
+        // large protected compaction summary that already fills the budget.
+        manager.record_item(
+            TranscriptItemKind::ContextInjection {
+                label: "summary".into(),
+                content: "older context ".repeat(300),
+            },
+            TranscriptItemSource::AgentLoop,
+        );
+        manager.record_message(&Message::user("what is my current question's answer"));
+
+        let frame = manager.for_prompt(&PromptBuildPolicy {
+            // Tighter than the protected injection on its own.
+            max_prompt_token_estimate: Some(20),
+            ..PromptBuildPolicy::default()
+        });
+
+        assert!(
+            frame
+                .messages
+                .iter()
+                .any(|message| message.role == MessageRole::User
+                    && message.content.contains("current question")),
+            "the current user request must survive the voice cap, got: {:?}",
+            frame
+                .messages
+                .iter()
+                .map(|message| (message.role, message.content.clone()))
+                .collect::<Vec<_>>()
         );
     }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2102,11 +2102,21 @@ struct AppUiLoopPromptScratch {
     runtime_system: Option<Message>,
 }
 
+/// Default per-turn history budget (tokens) for the model prompt on a voice
+/// turn. Caps ONLY the outgoing projection the model sees — the persisted
+/// transcript is untouched — so older turns are trimmed (recent-first kept,
+/// any compaction summary preserved) to keep the spoken-turn prefill small.
+/// Override via `OCTOS_VOICE_MAX_PROMPT_TOKENS`.
+const VOICE_TURN_MAX_PROMPT_TOKENS: usize = 3000;
+
 struct AppUiPromptContextBridge {
     session_id: SessionKey,
     data_dir: PathBuf,
     context_manager: Arc<StdMutex<ContextManager>>,
     scratch: StdMutex<Option<AppUiLoopPromptScratch>>,
+    /// When true, the outgoing model prompt is capped at
+    /// [`VOICE_TURN_MAX_PROMPT_TOKENS`] (see [`Self::outgoing_prompt_policy`]).
+    voice_turn: bool,
 }
 
 impl AppUiPromptContextBridge {
@@ -2114,13 +2124,38 @@ impl AppUiPromptContextBridge {
         session_id: SessionKey,
         data_dir: PathBuf,
         context_manager: Arc<StdMutex<ContextManager>>,
+        voice_turn: bool,
     ) -> Self {
         Self {
             session_id,
             data_dir,
             context_manager,
             scratch: StdMutex::new(None),
+            voice_turn,
         }
+    }
+
+    /// Voice-turn history budget (tokens), env-overridable.
+    fn voice_prompt_budget() -> usize {
+        std::env::var("OCTOS_VOICE_MAX_PROMPT_TOKENS")
+            .ok()
+            .and_then(|raw| raw.parse::<usize>().ok())
+            .unwrap_or(VOICE_TURN_MAX_PROMPT_TOKENS)
+    }
+
+    /// Policy for the FINAL outgoing projection (`for_prompt`) sent to the
+    /// model. Identical to [`Self::prompt_policy`] except that voice turns add
+    /// a `max_prompt_token_estimate` cap. Kept separate from `prompt_policy`
+    /// because the coverage/record and compaction passes MUST run uncapped —
+    /// capping their `for_prompt` view would make the manager treat trimmed-off
+    /// older messages as "not covered" and re-record them, duplicating the
+    /// persisted transcript.
+    fn outgoing_prompt_policy(&self, request: &PromptContextRequest) -> PromptBuildPolicy {
+        let mut policy = Self::prompt_policy(request);
+        if self.voice_turn {
+            policy.max_prompt_token_estimate = Some(Self::voice_prompt_budget());
+        }
+        policy
     }
 
     fn threshold_tokens(request: &PromptContextRequest) -> usize {
@@ -2233,7 +2268,12 @@ impl PromptContextManager for AppUiPromptContextBridge {
                 .cloned();
         }
         let runtime_system = scratch.runtime_system.clone();
-        let frame = scratch.manager.for_prompt(&policy);
+        // Project the OUTGOING prompt with the (possibly voice-capped) policy.
+        // `policy` above stays uncapped for the record/coverage/compaction
+        // passes so the persisted transcript is never re-recorded from a
+        // trimmed view.
+        let out_policy = self.outgoing_prompt_policy(&request);
+        let frame = scratch.manager.for_prompt(&out_policy);
         let prompt_replaced = messages.len() != frame.messages.len()
             || messages
                 .iter()
@@ -16527,6 +16567,17 @@ async fn run_standalone_turn(
     // the chat path's `maybe_advance_goal_runtime_after_turn(goal_turn_start)`
     // pattern in `SessionActor`.
     let goal_turn_start = goal_context.as_ref().map(|_| std::time::Instant::now());
+    // Voice-turn lean-prompt signal. Derived cheaply from the turn's media
+    // (an audio attachment) WITHOUT waiting for STT — a safe over-approximation
+    // of `had_audio_input` that is available before the tool registry and the
+    // prompt-context bridge are built. When set we (1) defer all non-essential
+    // tools so the spoken turn's first LLM call carries a lean tool set, and
+    // (2) cap the projected history the context bridge sends to the model.
+    // Both shrink the prompt prefill, which dominates voice-turn latency.
+    let voice_turn_hint = params
+        .media
+        .iter()
+        .any(|file_ref| octos_bus::media::is_audio(&file_ref.path));
     let mut tool_registry = session_runtime.tools.snapshot_excluding(&[]);
     // Stamp the per-turn snapshot with this session's key so
     // `spawn::register_with_lineage` writes `session_key:
@@ -17329,6 +17380,8 @@ async fn run_standalone_turn(
                     child_session_id,
                     child_context_data_dir.clone(),
                     Arc::new(StdMutex::new(child_manager)),
+                    // Spawned subagent: not a spoken turn, never voice-capped.
+                    false,
                 )))
             },
         ));
@@ -17452,6 +17505,19 @@ async fn run_standalone_turn(
     let progress_workspace_root = workspace_root
         .clone()
         .or_else(|| tool_registry.workspace_root().map(Path::to_path_buf));
+    // Voice turn: defer all non-essential tools on this per-turn snapshot so
+    // the (usually single) spoken-reply LLM call is not taxed by the full tool
+    // set. The per-turn snapshot is private to this turn, so this never leaks
+    // into other turns / sessions. Deferred tools stay recoverable via
+    // `activate_tools`. Must run BEFORE the `Arc::new` wrap below — `defer`
+    // takes `&mut self`.
+    if voice_turn_hint {
+        let deferred = crate::api::voice_turn::defer_tools_for_voice_turn(&mut tool_registry);
+        tracing::info!(
+            deferred,
+            "voice turn: deferred non-essential tools for a lean prefill"
+        );
+    }
     // Wrap the per-turn `ToolRegistry` in an `Arc` here so we retain a
     // handle after `Agent::new_shared` consumes its own clone. The
     // post-terminal drain task (issue #961) inspects
@@ -17540,6 +17606,7 @@ async fn run_standalone_turn(
             session_id.clone(),
             session_runtime.profile.data_dir.clone(),
             context_manager.clone(),
+            voice_turn_hint,
         ));
     request_agent = request_agent.with_prompt_context_manager(prompt_context_bridge);
     if let Some(hooks) = session_runtime.profile.hook_executor.clone() {
@@ -22499,8 +22566,12 @@ mod tests {
             &history,
         )));
         let dir = tempfile::tempdir().unwrap();
-        let bridge =
-            AppUiPromptContextBridge::new(session_id.clone(), dir.path().to_path_buf(), manager);
+        let bridge = AppUiPromptContextBridge::new(
+            session_id.clone(),
+            dir.path().to_path_buf(),
+            manager,
+            false,
+        );
         let mut prompt = vec![test_message(MessageRole::System, "runtime system")];
         prompt.extend(history);
         prompt.push(test_message(MessageRole::User, "current request"));
@@ -22545,6 +22616,52 @@ mod tests {
             crate::context_manager::context_ledger_path(dir.path(), &session_id.to_string())
                 .exists(),
             "AppUI prompt-context preparation should persist the canonical context ledger"
+        );
+    }
+
+    #[test]
+    fn voice_turn_bridge_caps_outgoing_prompt_only() {
+        // Lever 2: a voice turn caps the OUTGOING projection at the voice
+        // budget so the spoken-turn prefill stays small; a text turn leaves it
+        // uncapped. The cap lives on `outgoing_prompt_policy` only — the
+        // record/coverage/compaction passes use the uncapped `prompt_policy`,
+        // so the persisted transcript is never re-recorded from a trimmed view.
+        let session_id = SessionKey::new("api", "voice-cap");
+        let dir = tempfile::tempdir().unwrap();
+        let manager = Arc::new(StdMutex::new(ContextManager::from_session_history(
+            session_id.to_string(),
+            None,
+            &[],
+        )));
+        let request = PromptContextRequest {
+            phase: PromptContextPhase::TurnStart,
+            iteration: 1,
+            provider_name: "test".to_string(),
+            model_id: "m".to_string(),
+            context_window: 16_000,
+        };
+
+        let voice = AppUiPromptContextBridge::new(
+            session_id.clone(),
+            dir.path().to_path_buf(),
+            manager.clone(),
+            true,
+        );
+        assert_eq!(
+            voice
+                .outgoing_prompt_policy(&request)
+                .max_prompt_token_estimate,
+            Some(AppUiPromptContextBridge::voice_prompt_budget()),
+            "voice turns must cap the outgoing prompt projection"
+        );
+
+        let text =
+            AppUiPromptContextBridge::new(session_id, dir.path().to_path_buf(), manager, false);
+        assert_eq!(
+            text.outgoing_prompt_policy(&request)
+                .max_prompt_token_estimate,
+            None,
+            "text turns must leave the outgoing prompt uncapped"
         );
     }
 

--- a/crates/octos-cli/src/api/voice_turn.rs
+++ b/crates/octos-cli/src/api/voice_turn.rs
@@ -59,6 +59,39 @@ pub(crate) async fn transcribe_audio_media(
     out
 }
 
+/// Tools kept active during a voice turn; everything else is deferred.
+///
+/// A spoken turn is almost always a single-iteration conversational reply that
+/// calls no tools, yet the full registry (50+ specs in a skill-rich profile)
+/// otherwise dominates the prompt's prefill — measured as the single largest
+/// contributor to voice-turn latency (≈half of a 34k-token input). Deferring
+/// keeps the tools *recoverable* via `activate_tools`, so a voice query that
+/// genuinely needs one pays a single extra round-trip instead of taxing every
+/// turn. We keep `activate_tools` itself so that recovery path stays reachable.
+const VOICE_TURN_KEEP_TOOLS: &[&str] = &["activate_tools"];
+
+/// Pure core of [`defer_tools_for_voice_turn`]: every registered name that is
+/// not on the keep-list. Split out so it is unit-testable without standing up
+/// a real `ToolRegistry`.
+fn voice_turn_deferred_names(all: &[String], keep: &[&str]) -> Vec<String> {
+    all.iter()
+        .filter(|name| !keep.contains(&name.as_str()))
+        .cloned()
+        .collect()
+}
+
+/// Defer every tool except the voice-turn keep-list on a per-turn registry
+/// snapshot, so the spoken turn's first LLM call carries a lean tool set.
+/// Returns the number of tools deferred. Safe on any registry: `defer` only
+/// acts on names that are actually registered. Call on the mutable per-turn
+/// snapshot BEFORE it is wrapped in `Arc`.
+pub(crate) fn defer_tools_for_voice_turn(registry: &mut octos_agent::ToolRegistry) -> usize {
+    let to_defer = voice_turn_deferred_names(&registry.tool_names(), VOICE_TURN_KEEP_TOOLS);
+    let count = to_defer.len();
+    registry.defer(to_defer);
+    count
+}
+
 /// Whether a char is safe to hand to TTS: letters/digits (incl. CJK),
 /// whitespace, and common sentence punctuation. Everything else — emoji,
 /// pictographs, math/misc symbols — is dropped, because some on-device engines
@@ -375,6 +408,39 @@ mod tests {
         assert!(got.contains("晚上好呀！"));
         assert!(got.contains("今天第 N 次"));
         assert!(got.contains("打招呼"));
+    }
+
+    #[test]
+    fn voice_turn_defers_everything_but_the_keep_list() {
+        // A spoken turn keeps only the recovery tool; every other registered
+        // tool is deferred so the first LLM call is not taxed by the full set.
+        let all = vec![
+            "read_file".to_string(),
+            "shell".to_string(),
+            "web_search".to_string(),
+            "activate_tools".to_string(),
+            "spawn".to_string(),
+        ];
+        let deferred = voice_turn_deferred_names(&all, VOICE_TURN_KEEP_TOOLS);
+        assert_eq!(
+            deferred,
+            vec![
+                "read_file".to_string(),
+                "shell".to_string(),
+                "web_search".to_string(),
+                "spawn".to_string(),
+            ]
+        );
+        assert!(
+            !deferred.contains(&"activate_tools".to_string()),
+            "activate_tools must stay active so deferred tools remain recoverable"
+        );
+    }
+
+    #[test]
+    fn voice_turn_defer_is_noop_when_only_keep_tools_present() {
+        let all = vec!["activate_tools".to_string()];
+        assert!(voice_turn_deferred_names(&all, VOICE_TURN_KEEP_TOOLS).is_empty());
     }
 
     #[test]

--- a/crates/octos-cli/src/api/voice_turn.rs
+++ b/crates/octos-cli/src/api/voice_turn.rs
@@ -80,13 +80,28 @@ fn voice_turn_deferred_names(all: &[String], keep: &[&str]) -> Vec<String> {
         .collect()
 }
 
+/// Whether deferral is safe on this registry: at least one keep-list (recovery)
+/// tool is actually registered. Without it, deferring would hide every tool with
+/// no `activate_tools` path back, stranding a voice request that genuinely needs
+/// one of the remaining allowed tools. Split out for unit-testing.
+fn voice_turn_can_defer(all: &[String], keep: &[&str]) -> bool {
+    all.iter().any(|name| keep.contains(&name.as_str()))
+}
+
 /// Defer every tool except the voice-turn keep-list on a per-turn registry
 /// snapshot, so the spoken turn's first LLM call carries a lean tool set.
 /// Returns the number of tools deferred. Safe on any registry: `defer` only
 /// acts on names that are actually registered. Call on the mutable per-turn
 /// snapshot BEFORE it is wrapped in `Arc`.
 pub(crate) fn defer_tools_for_voice_turn(registry: &mut octos_agent::ToolRegistry) -> usize {
-    let to_defer = voice_turn_deferred_names(&registry.tool_names(), VOICE_TURN_KEEP_TOOLS);
+    let all = registry.tool_names();
+    // If the recovery tool isn't registered (e.g. a tool surface small enough to
+    // skip auto-defer), deferring everything would leave the first LLM call with
+    // no tools AND no `activate_tools` to recover one. Skip deferral entirely.
+    if !voice_turn_can_defer(&all, VOICE_TURN_KEEP_TOOLS) {
+        return 0;
+    }
+    let to_defer = voice_turn_deferred_names(&all, VOICE_TURN_KEEP_TOOLS);
     let count = to_defer.len();
     registry.defer(to_defer);
     count
@@ -441,6 +456,23 @@ mod tests {
     fn voice_turn_defer_is_noop_when_only_keep_tools_present() {
         let all = vec!["activate_tools".to_string()];
         assert!(voice_turn_deferred_names(&all, VOICE_TURN_KEEP_TOOLS).is_empty());
+    }
+
+    #[test]
+    fn voice_turn_skips_defer_when_no_recovery_tool_present() {
+        // Regression (#1464 P2): without `activate_tools` on the surface,
+        // deferring everything would strand the turn — no tools and no way to
+        // recover one. `defer_tools_for_voice_turn` must skip in that case.
+        let without = vec!["read_file".to_string(), "shell".to_string()];
+        assert!(
+            !voice_turn_can_defer(&without, VOICE_TURN_KEEP_TOOLS),
+            "no recovery tool ⇒ must not defer"
+        );
+        let with = vec!["read_file".to_string(), "activate_tools".to_string()];
+        assert!(
+            voice_turn_can_defer(&with, VOICE_TURN_KEEP_TOOLS),
+            "recovery tool present ⇒ deferral is safe"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Voice-turn LLM latency was dominated by prompt **prefill**. A spoken turn sent the **full tool registry (52 specs)** and the **full conversation history (142 messages)** on every call — ~**34k input tokens**, of which tools and history were each roughly half. Time-to-first-token was ~9s.

The existing LRU tool deferral (target 15 active) never helped here: it only evicts on iteration ≥ 2 after an idle threshold, but conversational voice turns are **single-iteration** (zero tool calls, `EndTurn`). So every spoken turn paid the full tool tax.

## Fix

Two per-turn levers, both gated on a cheap `voice_turn_hint` — derived from the turn carrying an audio attachment (`params.media`), available **before** STT so it can shape the registry and the prompt bridge:

**1. Lean tool set** — defer every tool except `activate_tools` on the **per-turn registry snapshot** (private to the turn; never leaks to other sessions/text turns). Deferred tools stay recoverable via `activate_tools`, so a voice query that genuinely needs a tool pays one extra round-trip instead of every turn paying the full prefill.

**2. Capped history projection** — set `max_prompt_token_estimate` (default **3000**, `OCTOS_VOICE_MAX_PROMPT_TOKENS`) on the **outgoing** prompt projection only. The record / coverage / compaction passes keep the **uncapped** policy, so the persisted transcript is never re-recorded from a trimmed view (no duplication / corruption). Trimming drops oldest-first while preserving any compaction summary and recent turns.

## UX trade-off (intended, short-term)

Both levers fire on **every** audio-attachment turn. So a tool-bearing voice query ("what's the weather") pays one extra `activate_tools` round-trip, and a follow-up spoken turn ("and the one before that?") can lose mid-conversation context once history exceeds the cap. Both are env-tunable (`OCTOS_VOICE_MAX_PROMPT_TOKENS`). This is the accepted trade-off for voice turns for now; the plan is to replace the hard history cap with a Claude-Code-style context-compaction pass for voice turns, so follow-ups keep a compressed view of earlier context instead of dropping it oldest-first.

## Result (measured on a real voice turn)

| | before | after |
|---|---|---|
| tools | 52 | **1** |
| messages | 142 | **4** |
| input_tokens | 34,390 | **~8,800** |
| LLM stage | ~10.2s | **~1.4s** |

## Tests

- `voice_turn_defers_everything_but_the_keep_list`, `voice_turn_defer_is_noop_when_only_keep_tools_present` — pure deferral helper
- `voice_turn_bridge_caps_outgoing_prompt_only` — cap on outgoing policy only
- existing `appui_prompt_context_bridge_preserves_current_user_turn` — green (no regression)
- `cargo build` / `cargo clippy -p octos-cli --features api` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
