### PR TITLE
[codex] Persist Home profile config

### DIFF
--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -336,7 +336,7 @@ pub async fn update_profile(
     if let Some(data_dir) = req.data_dir {
         profile.data_dir = data_dir;
     }
-    merge_profile_config_from_body(&mut profile.config, &body);
+    merge_profile_config_from_body(&mut profile.config, &body, false);
     profile.updated_at = Utc::now();
 
     store.save_with_merge(&mut profile).map_err(|e| {
@@ -835,24 +835,35 @@ pub(crate) async fn fetch_provider_models(
 /// Only keys present in `config` are overwritten; absent keys are preserved.
 /// This lets callers send `{"config":{"model":"x"}}` without wiping
 /// channels/env_vars, while dashboards can still send a full config object.
-pub(crate) fn merge_profile_config_from_body(config: &mut ProfileConfig, body: &str) {
+/// Merge a `{ "config": {...} }` request body into `config`. RFC-7396 semantics:
+/// keys the client omits are preserved. `env_vars_authoritative` selects how a
+/// provided `env_vars` map is treated:
+/// - `true` — self-service `/api/my/*`, where the dashboard sends the COMPLETE
+///   desired map (including `{}` to clear): replace `env_vars` wholesale so the
+///   client can drop keys / clear secrets (a deep-merge can only add, never
+///   remove).
+/// - `false` — admin tool `admin_update_profile`, which sends only the keys the
+///   operator supplied: deep-merge `env_vars` so a partial update never deletes
+///   unrelated secrets.
+///
+/// Either way, masked/empty display values are restored per-key downstream by
+/// `ProfileStore::save_with_merge`, so round-tripping masked secrets does not
+/// lose them.
+pub(crate) fn merge_profile_config_from_body(
+    config: &mut ProfileConfig,
+    body: &str,
+    env_vars_authoritative: bool,
+) {
     let raw: serde_json::Value = serde_json::from_str(body).unwrap_or(serde_json::Value::Null);
     if let Some(config_patch) = raw.get("config") {
         if config_patch.is_object() {
             let mut existing = serde_json::to_value(&mut *config).unwrap_or(serde_json::json!({}));
             json_merge(&mut existing, config_patch);
-            // `env_vars` is a complete map the client owns: the dashboard sends
-            // the full desired set (including `{}` to clear). The RFC-7396
-            // deep-merge above can only add/overwrite keys, never remove them,
-            // so a recursive merge makes it impossible to clear a secret or drop
-            // a key. When the patch provides `env_vars`, treat it as
-            // authoritative and replace the map wholesale. Masked/empty display
-            // values are still restored per-key downstream by
-            // `ProfileStore::save_with_merge`, so round-tripping masked secrets
-            // through the UI does not lose them.
-            if let Some(env_vars) = config_patch.get("env_vars").filter(|v| v.is_object()) {
-                if let Some(existing_obj) = existing.as_object_mut() {
-                    existing_obj.insert("env_vars".to_string(), env_vars.clone());
+            if env_vars_authoritative {
+                if let Some(env_vars) = config_patch.get("env_vars").filter(|v| v.is_object()) {
+                    if let Some(existing_obj) = existing.as_object_mut() {
+                        existing_obj.insert("env_vars".to_string(), env_vars.clone());
+                    }
                 }
             }
             if let Ok(merged) = serde_json::from_value(existing) {
@@ -4667,6 +4678,56 @@ mod tests {
         assert_eq!(req.command, "echo hello");
         assert!(req.cwd.is_none());
         assert!(req.timeout_secs.is_none());
+    }
+
+    // The admin tool (`admin_update_profile`) sends only the keys the operator
+    // supplied, so its path must NOT be authoritative — a partial env_vars
+    // update must merge and preserve omitted secrets, never delete them.
+    #[test]
+    fn merge_config_admin_path_preserves_omitted_env_vars() {
+        let mut config = ProfileConfig::default();
+        config
+            .env_vars
+            .insert("OPENAI_API_KEY".into(), "sk-real".into());
+        config.env_vars.insert("SMTP_PASSWORD".into(), "old".into());
+
+        merge_profile_config_from_body(
+            &mut config,
+            r#"{"config":{"env_vars":{"SMTP_PASSWORD":"new"}}}"#,
+            false,
+        );
+
+        assert_eq!(
+            config.env_vars.get("SMTP_PASSWORD").map(String::as_str),
+            Some("new")
+        );
+        assert_eq!(
+            config.env_vars.get("OPENAI_API_KEY").map(String::as_str),
+            Some("sk-real"),
+            "a partial admin update must not delete env vars it didn't mention"
+        );
+    }
+
+    // Self-service `/api/my/*` sends the complete desired map, so its path is
+    // authoritative: an omitted key is dropped and `{}` clears everything.
+    #[test]
+    fn merge_config_self_service_replaces_env_vars() {
+        let mut config = ProfileConfig::default();
+        config.env_vars.insert("A".into(), "a".into());
+        config.env_vars.insert("B".into(), "b".into());
+
+        merge_profile_config_from_body(&mut config, r#"{"config":{"env_vars":{"A":"a2"}}}"#, true);
+        assert_eq!(config.env_vars.get("A").map(String::as_str), Some("a2"));
+        assert!(
+            !config.env_vars.contains_key("B"),
+            "authoritative replace drops omitted keys"
+        );
+
+        merge_profile_config_from_body(&mut config, r#"{"config":{"env_vars":{}}}"#, true);
+        assert!(
+            config.env_vars.is_empty(),
+            "an explicit empty map clears all entries"
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -841,6 +841,20 @@ pub(crate) fn merge_profile_config_from_body(config: &mut ProfileConfig, body: &
         if config_patch.is_object() {
             let mut existing = serde_json::to_value(&mut *config).unwrap_or(serde_json::json!({}));
             json_merge(&mut existing, config_patch);
+            // `env_vars` is a complete map the client owns: the dashboard sends
+            // the full desired set (including `{}` to clear). The RFC-7396
+            // deep-merge above can only add/overwrite keys, never remove them,
+            // so a recursive merge makes it impossible to clear a secret or drop
+            // a key. When the patch provides `env_vars`, treat it as
+            // authoritative and replace the map wholesale. Masked/empty display
+            // values are still restored per-key downstream by
+            // `ProfileStore::save_with_merge`, so round-tripping masked secrets
+            // through the UI does not lose them.
+            if let Some(env_vars) = config_patch.get("env_vars").filter(|v| v.is_object()) {
+                if let Some(existing_obj) = existing.as_object_mut() {
+                    existing_obj.insert("env_vars".to_string(), env_vars.clone());
+                }
+            }
             if let Ok(merged) = serde_json::from_value(existing) {
                 *config = merged;
             }

--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -336,23 +336,7 @@ pub async fn update_profile(
     if let Some(data_dir) = req.data_dir {
         profile.data_dir = data_dir;
     }
-    // Merge config: parse the raw JSON "config" object and overlay only the
-    // keys that are explicitly present, preserving all other existing fields.
-    // This lets the admin tool send `{"config":{"model":"x"}}` without wiping
-    // channels/env_vars, while the dashboard can still send a full config object.
-    {
-        let raw: serde_json::Value = serde_json::from_str(&body).unwrap_or(serde_json::Value::Null);
-        if let Some(config_patch) = raw.get("config") {
-            if config_patch.is_object() {
-                let mut existing =
-                    serde_json::to_value(&profile.config).unwrap_or(serde_json::json!({}));
-                json_merge(&mut existing, config_patch);
-                if let Ok(merged) = serde_json::from_value(existing) {
-                    profile.config = merged;
-                }
-            }
-        }
-    }
+    merge_profile_config_from_body(&mut profile.config, &body);
     profile.updated_at = Utc::now();
 
     store.save_with_merge(&mut profile).map_err(|e| {
@@ -844,6 +828,24 @@ pub(crate) async fn fetch_provider_models(
         ids.sort();
         ids
     })
+}
+
+/// Merge a request body's `config` object into an existing profile config.
+///
+/// Only keys present in `config` are overwritten; absent keys are preserved.
+/// This lets callers send `{"config":{"model":"x"}}` without wiping
+/// channels/env_vars, while dashboards can still send a full config object.
+pub(crate) fn merge_profile_config_from_body(config: &mut ProfileConfig, body: &str) {
+    let raw: serde_json::Value = serde_json::from_str(body).unwrap_or(serde_json::Value::Null);
+    if let Some(config_patch) = raw.get("config") {
+        if config_patch.is_object() {
+            let mut existing = serde_json::to_value(&mut *config).unwrap_or(serde_json::json!({}));
+            json_merge(&mut existing, config_patch);
+            if let Ok(merged) = serde_json::from_value(existing) {
+                *config = merged;
+            }
+        }
+    }
 }
 
 /// Recursively merge `patch` into `target` (RFC 7396 JSON Merge Patch).

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -2880,6 +2880,103 @@ mod tests {
         assert_eq!(home["events"][0]["title"], "Dinner");
     }
 
+    // The config merge preserves sections the client omits (above), but a
+    // provided `env_vars` map must still be able to DROP keys and clear the set
+    // — otherwise secrets could never be removed via self-service. `env_vars` is
+    // replaced wholesale when provided (see `merge_profile_config_from_body`).
+    #[tokio::test]
+    async fn my_profile_env_vars_can_drop_keys_and_clear() {
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        let state = Arc::new(state);
+        let mut profile = make_user_profile("tenant", "Tenant Owner");
+        profile.config.env_vars.insert("KEEP".into(), "old".into());
+        profile.config.env_vars.insert("DROP".into(), "gone".into());
+        profile_store.save(&profile).unwrap();
+
+        // A smaller map: KEEP updated, DROP omitted → removed. (Assert on the
+        // persisted profile: the API response masks secret values.)
+        update_my_profile(
+            State(state.clone()),
+            HeaderMap::new(),
+            axum::Extension(AuthIdentity::User {
+                id: "tenant".into(),
+                role: UserRole::User,
+            }),
+            serde_json::json!({ "config": { "env_vars": { "KEEP": "new" } } }).to_string(),
+        )
+        .await
+        .unwrap();
+        let stored = profile_store.get("tenant").unwrap().expect("profile");
+        assert_eq!(
+            stored.config.env_vars.get("KEEP").map(String::as_str),
+            Some("new")
+        );
+        assert!(
+            !stored.config.env_vars.contains_key("DROP"),
+            "a key omitted from the provided env_vars map must be removed"
+        );
+
+        // An explicit empty map clears everything.
+        update_my_profile(
+            State(state),
+            HeaderMap::new(),
+            axum::Extension(AuthIdentity::User {
+                id: "tenant".into(),
+                role: UserRole::User,
+            }),
+            serde_json::json!({ "config": { "env_vars": {} } }).to_string(),
+        )
+        .await
+        .unwrap();
+        let stored = profile_store.get("tenant").unwrap().expect("profile");
+        assert!(
+            stored.config.env_vars.is_empty(),
+            "an explicit empty env_vars map must clear all entries"
+        );
+    }
+
+    // Replacing `env_vars` wholesale must NOT clobber a real secret when the UI
+    // round-trips it masked: `save_with_merge` restores masked/empty values
+    // per-key from the stored profile. Sections absent from the patch are still
+    // preserved.
+    #[tokio::test]
+    async fn my_profile_env_vars_replace_preserves_masked_and_other_sections() {
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        let mut profile = make_user_profile("tenant", "Tenant Owner");
+        profile
+            .config
+            .env_vars
+            .insert("SECRET".into(), "realval".into());
+        profile.config.plugins = crate::config::PluginsConfig {
+            require_signed: true,
+        };
+        profile_store.save(&profile).unwrap();
+
+        update_my_profile(
+            State(Arc::new(state)),
+            HeaderMap::new(),
+            axum::Extension(AuthIdentity::User {
+                id: "tenant".into(),
+                role: UserRole::User,
+            }),
+            serde_json::json!({ "config": { "env_vars": { "SECRET": "***" } } }).to_string(),
+        )
+        .await
+        .unwrap();
+
+        // Assert on the persisted profile (the response masks secret values).
+        let stored = profile_store.get("tenant").unwrap().expect("profile");
+        assert_eq!(
+            stored.config.env_vars.get("SECRET").map(String::as_str),
+            Some("realval"),
+            "a masked value round-tripped by the UI must not overwrite the real secret"
+        );
+        assert!(
+            stored.config.plugins.require_signed,
+            "sections omitted from the patch must still be preserved"
+        );
+    }
+
     #[tokio::test]
     async fn sub_account_cannot_change_own_public_subdomain() {
         let (_dir, state, _user_store, profile_store) = temp_app_state();

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -1083,9 +1083,7 @@ pub async fn update_my_profile(
     if let Some(enabled) = req.enabled {
         profile.enabled = enabled;
     }
-    if let Some(config) = req.config {
-        profile.config = config;
-    }
+    super::admin::merge_profile_config_from_body(&mut profile.config, &body);
     profile.updated_at = chrono::Utc::now();
 
     ps.save_with_merge(&mut profile).map_err(|e| {
@@ -1864,9 +1862,7 @@ pub async fn update_my_sub_account(
     if let Some(enabled) = req.enabled {
         sub.enabled = enabled;
     }
-    if let Some(config) = req.config {
-        sub.config = config;
-    }
+    super::admin::merge_profile_config_from_body(&mut sub.config, &body);
     sub.updated_at = chrono::Utc::now();
 
     ps.save_with_merge(&mut sub)
@@ -2839,6 +2835,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn my_profile_config_patch_preserves_existing_sections() {
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        let mut profile = make_user_profile("tenant", "Tenant Owner");
+        profile.config.plugins = crate::config::PluginsConfig {
+            require_signed: true,
+        };
+        profile.config.home = Some(serde_json::json!({
+            "settings": {
+                "city": "Tokyo",
+                "clock_format": "24h"
+            },
+            "events": [
+                { "id": "dinner", "title": "Dinner" }
+            ]
+        }));
+        profile_store.save(&profile).unwrap();
+
+        let Json(resp) = update_my_profile(
+            State(Arc::new(state)),
+            HeaderMap::new(),
+            axum::Extension(AuthIdentity::User {
+                id: "tenant".into(),
+                role: UserRole::User,
+            }),
+            serde_json::json!({
+                "config": {
+                    "home": {
+                        "settings": {
+                            "city": "Osaka"
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+
+        assert!(resp.profile.config.plugins.require_signed);
+        let home = resp.profile.config.home.expect("home config");
+        assert_eq!(home["settings"]["city"], "Osaka");
+        assert_eq!(home["settings"]["clock_format"], "24h");
+        assert_eq!(home["events"][0]["title"], "Dinner");
+    }
+
+    #[tokio::test]
     async fn sub_account_cannot_change_own_public_subdomain() {
         let (_dir, state, _user_store, profile_store) = temp_app_state();
         profile_store
@@ -2873,6 +2915,64 @@ mod tests {
             err.1,
             "sub-accounts cannot change their own public subdomain"
         );
+    }
+
+    #[tokio::test]
+    async fn managed_sub_account_config_patch_preserves_existing_sections() {
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        let state = AppState {
+            process_manager: Some(Arc::new(crate::process_manager::ProcessManager::new(
+                profile_store.clone(),
+            ))),
+            ..state
+        };
+        profile_store
+            .save(&make_user_profile("tenant", "Tenant Owner"))
+            .unwrap();
+        let mut child = make_user_profile("tenant--assistant", "Assistant");
+        child.parent_id = Some("tenant".into());
+        child.public_subdomain = Some("assistant".into());
+        child.config.plugins = crate::config::PluginsConfig {
+            require_signed: true,
+        };
+        child.config.home = Some(serde_json::json!({
+            "settings": {
+                "city": "Tokyo",
+                "clock_format": "24h"
+            },
+            "events": [
+                { "id": "school", "title": "School pickup" }
+            ]
+        }));
+        profile_store.save(&child).unwrap();
+
+        let Json(resp) = update_my_sub_account(
+            State(Arc::new(state)),
+            HeaderMap::new(),
+            axum::Extension(AuthIdentity::User {
+                id: "tenant".into(),
+                role: UserRole::User,
+            }),
+            Path("tenant--assistant".into()),
+            serde_json::json!({
+                "config": {
+                    "home": {
+                        "settings": {
+                            "city": "Kyoto"
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+
+        assert!(resp.profile.config.plugins.require_signed);
+        let home = resp.profile.config.home.expect("home config");
+        assert_eq!(home["settings"]["city"], "Kyoto");
+        assert_eq!(home["settings"]["clock_format"], "24h");
+        assert_eq!(home["events"][0]["title"], "School pickup");
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -1083,7 +1083,7 @@ pub async fn update_my_profile(
     if let Some(enabled) = req.enabled {
         profile.enabled = enabled;
     }
-    super::admin::merge_profile_config_from_body(&mut profile.config, &body);
+    super::admin::merge_profile_config_from_body(&mut profile.config, &body, true);
     profile.updated_at = chrono::Utc::now();
 
     ps.save_with_merge(&mut profile).map_err(|e| {
@@ -1862,7 +1862,7 @@ pub async fn update_my_sub_account(
     if let Some(enabled) = req.enabled {
         sub.enabled = enabled;
     }
-    super::admin::merge_profile_config_from_body(&mut sub.config, &body);
+    super::admin::merge_profile_config_from_body(&mut sub.config, &body, true);
     sub.updated_at = chrono::Utc::now();
 
     ps.save_with_merge(&mut sub)

--- a/crates/octos-cli/src/cli_agent_adapter.rs
+++ b/crates/octos-cli/src/cli_agent_adapter.rs
@@ -341,6 +341,11 @@ mod tests {
     }
 
     #[cfg(unix)]
+    fn shell_fixture_config(script: &std::path::Path) -> CliAgentCommandConfig {
+        CliAgentCommandConfig::new("/bin/sh").arg(script.to_string_lossy())
+    }
+
+    #[cfg(unix)]
     #[tokio::test]
     async fn captures_stdout_stderr_and_declared_artifacts() {
         let dir = tempfile::tempdir().unwrap();
@@ -356,7 +361,7 @@ printf '# report\n' > "$1"
         );
 
         let result = run_cli_agent_command(
-            CliAgentCommandConfig::new(script)
+            shell_fixture_config(&script)
                 .arg(artifact.to_string_lossy())
                 .declared_artifact(&artifact),
         )
@@ -391,7 +396,7 @@ printf '# report\n' > report.md
         );
 
         let result = run_cli_agent_command(
-            CliAgentCommandConfig::new(script)
+            shell_fixture_config(&script)
                 .cwd(dir.path())
                 .declared_artifact("report.md"),
         )
@@ -419,7 +424,7 @@ perl -e 'print "x" x (1024 * 1024 + 64)'
 "#,
         );
 
-        let result = run_cli_agent_command(CliAgentCommandConfig::new(script))
+        let result = run_cli_agent_command(shell_fixture_config(&script))
             .await
             .unwrap();
 
@@ -446,7 +451,7 @@ printf done > "$1"
         );
 
         let result = run_cli_agent_command(
-            CliAgentCommandConfig::new(script)
+            shell_fixture_config(&script)
                 .arg(marker.to_string_lossy())
                 .timeout(Duration::from_millis(100)),
         )
@@ -473,7 +478,7 @@ printf done > "$1"
         );
 
         let mut process = CliAgentProcess::spawn(
-            CliAgentCommandConfig::new(script)
+            shell_fixture_config(&script)
                 .arg(marker.to_string_lossy())
                 .timeout(Duration::from_secs(5)),
         )
@@ -500,7 +505,7 @@ printf done > "$1"
         );
 
         let mut process = CliAgentProcess::spawn(
-            CliAgentCommandConfig::new(script)
+            shell_fixture_config(&script)
                 .arg(marker.to_string_lossy())
                 .timeout(Duration::from_secs(5)),
         )
@@ -526,7 +531,7 @@ printf '%s\n' "$1"
         );
 
         let payload = format!("literal; touch {}", injected.display());
-        let result = run_cli_agent_command(CliAgentCommandConfig::new(script).arg(payload.clone()))
+        let result = run_cli_agent_command(shell_fixture_config(&script).arg(payload.clone()))
             .await
             .unwrap();
 

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -1143,6 +1143,39 @@ impl ServeCommand {
 mod tests {
     use super::*;
 
+    fn dashboard_smtp_test_env_lock() -> &'static std::sync::Mutex<()> {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        #[allow(unsafe_code)]
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            // SAFETY: dashboard SMTP env tests hold `dashboard_smtp_test_env_lock`,
+            // serializing mutation of process-wide environment variables.
+            unsafe { std::env::remove_var(key) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        #[allow(unsafe_code)]
+        fn drop(&mut self) {
+            // SAFETY: callers keep the env lock for the full guard lifetime.
+            match self.previous.as_ref() {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
     #[test]
     fn deployment_mode_is_explicit_and_ignores_tunnel_settings() {
         let config = Config {
@@ -1220,6 +1253,8 @@ mod tests {
 
     #[test]
     fn dashboard_smtp_password_prefers_matching_admin_profile_email_tool() {
+        let _guard = dashboard_smtp_test_env_lock().lock().unwrap();
+        let _env = EnvVarGuard::remove("OCTOS_TEST_DASHBOARD_AUTH_ADMIN_SMTP_PASSWORD");
         let dir = tempfile::tempdir().unwrap();
         let store = crate::profiles::ProfileStore::open(dir.path()).unwrap();
         store
@@ -1257,7 +1292,7 @@ mod tests {
                 host: "smtp.example.com".into(),
                 port: 465,
                 username: "admin@example.com".into(),
-                password_env: "SMTP_PASSWORD".into(),
+                password_env: "OCTOS_TEST_DASHBOARD_AUTH_ADMIN_SMTP_PASSWORD".into(),
                 from_address: "admin@example.com".into(),
             }),
             session_expiry_hours: 24,
@@ -1342,6 +1377,8 @@ mod tests {
 
     #[test]
     fn dashboard_smtp_password_prefers_matching_non_admin_profile_email_tool() {
+        let _guard = dashboard_smtp_test_env_lock().lock().unwrap();
+        let _env = EnvVarGuard::remove("OCTOS_TEST_DASHBOARD_AUTH_PROFILE_SMTP_PASSWORD");
         let dir = tempfile::tempdir().unwrap();
         let store = crate::profiles::ProfileStore::open(dir.path()).unwrap();
         store
@@ -1383,7 +1420,7 @@ mod tests {
                 host: "smtp.gmail.com".into(),
                 port: 465,
                 username: "dspfac@gmail.com".into(),
-                password_env: "SMTP_PASSWORD".into(),
+                password_env: "OCTOS_TEST_DASHBOARD_AUTH_PROFILE_SMTP_PASSWORD".into(),
                 from_address: "dspfac@gmail.com".into(),
             }),
             session_expiry_hours: 24,

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -69,6 +69,10 @@ pub struct ProfileConfig {
     /// First-party app configuration.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub apps: Option<AppsConfig>,
+    /// Home dashboard UI configuration. The backend stores this as opaque JSON
+    /// because Home is a web-owned surface; typed validation lives in octos-web.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub home: Option<serde_json::Value>,
     /// Robotics runtime configuration (heartbeat + sensor context injection).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub robot: Option<RobotConfig>,
@@ -437,6 +441,8 @@ pub struct ProfileConfigPatch {
     #[serde(default)]
     pub apps: PatchField<AppsConfig>,
     #[serde(default)]
+    pub home: PatchField<serde_json::Value>,
+    #[serde(default)]
     pub robot: PatchField<RobotConfig>,
     #[serde(default)]
     pub channels: Option<Vec<ChannelCredentials>>,
@@ -462,6 +468,10 @@ pub struct ProfileConfigPatch {
     pub content_routing: PatchField<octos_llm::RoutingConfig>,
     #[serde(default)]
     pub credential_pool: PatchField<CredentialPoolConfig>,
+    #[serde(default)]
+    pub plugins: Option<crate::config::PluginsConfig>,
+    #[serde(default)]
+    pub lane_routing: PatchField<octos_llm::LaneRoutingConfig>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
@@ -661,6 +671,11 @@ impl ProfileConfig {
             PatchField::Clear => self.apps = None,
             PatchField::Value(apps) => self.apps = Some(apps),
         }
+        match patch.home {
+            PatchField::Absent => {}
+            PatchField::Clear => self.home = None,
+            PatchField::Value(home) => self.home = Some(home),
+        }
         match patch.robot {
             PatchField::Absent => {}
             PatchField::Clear => self.robot = None,
@@ -713,6 +728,14 @@ impl ProfileConfig {
             PatchField::Absent => {}
             PatchField::Clear => self.credential_pool = None,
             PatchField::Value(credential_pool) => self.credential_pool = Some(credential_pool),
+        }
+        if let Some(plugins) = patch.plugins {
+            self.plugins = plugins;
+        }
+        match patch.lane_routing {
+            PatchField::Absent => {}
+            PatchField::Clear => self.lane_routing = None,
+            PatchField::Value(lane_routing) => self.lane_routing = Some(lane_routing),
         }
 
         self.normalize_llm_contract();
@@ -1798,8 +1821,8 @@ pub enum ProfileChange {
 
 /// Compare two profiles and classify the nature of changes.
 ///
-/// Restart-required: llm, review, search, deep_crawl, apps, channels,
-///   env_vars, email, hooks, credential_pool.
+/// Restart-required: llm, review, search, deep_crawl, apps, robot, channels,
+///   env_vars, email, hooks, sandbox, routing, credential_pool, plugins.
 /// Hot-reloadable: system_prompt, max_history, max_iterations,
 ///   max_concurrent_sessions, browser_timeout_secs.
 pub fn diff_profiles(old: &UserProfile, new: &UserProfile) -> ProfileChange {
@@ -1842,6 +1865,24 @@ pub fn diff_profiles(old: &UserProfile, new: &UserProfile) -> ProfileChange {
     if oc.hooks != nc.hooks {
         restart_fields.push("hooks".into());
     }
+    if oc.admin_mode != nc.admin_mode {
+        restart_fields.push("admin_mode".into());
+    }
+    if oc.sandbox != nc.sandbox {
+        restart_fields.push("sandbox".into());
+    }
+    if oc.adaptive_routing != nc.adaptive_routing {
+        restart_fields.push("adaptive_routing".into());
+    }
+    if oc.cost_budget != nc.cost_budget {
+        restart_fields.push("cost_budget".into());
+    }
+    if oc.matrix != nc.matrix {
+        restart_fields.push("matrix".into());
+    }
+    if oc.content_routing != nc.content_routing {
+        restart_fields.push("content_routing".into());
+    }
     if oc.credential_pool != nc.credential_pool {
         restart_fields.push("credential_pool".into());
     }
@@ -1851,6 +1892,9 @@ pub fn diff_profiles(old: &UserProfile, new: &UserProfile) -> ProfileChange {
     // the stale plugin registry and apply the new gate.
     if oc.plugins != nc.plugins {
         restart_fields.push("plugins".into());
+    }
+    if oc.lane_routing != nc.lane_routing {
+        restart_fields.push("lane_routing".into());
     }
 
     if !restart_fields.is_empty() {
@@ -2342,6 +2386,65 @@ mod tests {
     }
 
     #[test]
+    fn test_profile_config_patch_persists_home_dashboard_json() {
+        let mut config = ProfileConfig::default();
+        let home = serde_json::json!({
+            "settings": {
+                "city": "Tokyo",
+                "clock_format": "24h",
+                "idle_seconds": 45
+            },
+            "events": [
+                { "id": "dinner", "title": "Dinner", "date": "2026-06-16", "time": "19:30" }
+            ],
+            "metro_layout": {
+                "clock": { "col": 1, "row": 1, "w": 4, "h": 2 }
+            }
+        });
+
+        config.apply_patch(ProfileConfigPatch {
+            home: PatchField::Value(home.clone()),
+            ..Default::default()
+        });
+
+        assert_eq!(config.home.as_ref(), Some(&home));
+
+        config.apply_patch(ProfileConfigPatch {
+            home: PatchField::Clear,
+            ..Default::default()
+        });
+
+        assert!(config.home.is_none());
+    }
+
+    #[test]
+    fn test_profile_config_patch_updates_plugin_and_lane_policy() {
+        let mut config = ProfileConfig::default();
+        let mut lane_routing = octos_llm::LaneRoutingConfig::default();
+        lane_routing
+            .topic_lanes
+            .insert("code".into(), octos_llm::Lane::CodeCapable);
+
+        config.apply_patch(ProfileConfigPatch {
+            plugins: Some(crate::config::PluginsConfig {
+                require_signed: true,
+            }),
+            lane_routing: PatchField::Value(lane_routing.clone()),
+            ..Default::default()
+        });
+
+        assert!(config.plugins.require_signed);
+        assert_eq!(config.lane_routing.as_ref(), Some(&lane_routing));
+
+        config.apply_patch(ProfileConfigPatch {
+            lane_routing: PatchField::Clear,
+            ..Default::default()
+        });
+
+        assert!(config.lane_routing.is_none());
+    }
+
+    #[test]
     fn test_profile_config_patch_replaces_review_contract() {
         let mut config = ProfileConfig::default();
 
@@ -2823,6 +2926,59 @@ mod tests {
                     fields.iter().any(|f| f == "credential_pool"),
                     "expected `credential_pool` in restart-required fields, got {fields:?}",
                 );
+            }
+            other => panic!("expected RestartRequired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_classify_runtime_policy_config_as_restart_required() {
+        let base = UserProfile {
+            id: "runtime-policy-diff".into(),
+            name: "Runtime Policy".into(),
+            enabled: false,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig::default(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        let mut lane_routing = octos_llm::LaneRoutingConfig::default();
+        lane_routing
+            .topic_lanes
+            .insert("code".into(), octos_llm::Lane::CodeCapable);
+
+        let mut changed = base.clone();
+        changed.config.admin_mode = true;
+        changed.config.sandbox.allow_network = true;
+        changed.config.adaptive_routing = Some(crate::config::AdaptiveRoutingConfig {
+            enabled: true,
+            ..Default::default()
+        });
+        changed.config.content_routing = Some(octos_llm::RoutingConfig {
+            enabled: true,
+            ..Default::default()
+        });
+        changed.config.plugins.require_signed = true;
+        changed.config.lane_routing = Some(lane_routing);
+
+        match diff_profiles(&base, &changed) {
+            ProfileChange::RestartRequired(fields) => {
+                for field in [
+                    "admin_mode",
+                    "sandbox",
+                    "adaptive_routing",
+                    "content_routing",
+                    "plugins",
+                    "lane_routing",
+                ] {
+                    assert!(
+                        fields.iter().any(|candidate| candidate == field),
+                        "expected `{field}` in restart-required fields, got {fields:?}",
+                    );
+                }
             }
             other => panic!("expected RestartRequired, got {other:?}"),
         }

--- a/crates/octos-cli/tests/coding_multi_session.rs
+++ b/crates/octos-cli/tests/coding_multi_session.rs
@@ -311,6 +311,8 @@ async fn coding_agent_two_sessions_isolated_workspaces() {
     std::fs::create_dir_all(&repo_b).expect("create repo-B");
     std::fs::write(repo_a.join("a.txt"), "hello-A\n").expect("seed a.txt");
     std::fs::write(repo_b.join("b.txt"), "hello-B\n").expect("seed b.txt");
+    let repo_a_canon = std::fs::canonicalize(&repo_a).expect("canonicalize repo-A");
+    let repo_b_canon = std::fs::canonicalize(&repo_b).expect("canonicalize repo-B");
 
     // 3. The session keys we drive turns against. We pre-warm the
     //    cache with the desired `workspace_hint` per session — the
@@ -348,12 +350,12 @@ async fn coding_agent_two_sessions_isolated_workspaces() {
         "per-session workspace roots must differ when distinct hints are supplied",
     );
     assert_eq!(
-        rt_a.workspace_root, repo_a,
+        rt_a.workspace_root, repo_a_canon,
         "session A's workspace must be the supplied workspace_hint (repo-A); \
          if this fails, `SessionRuntime::bootstrap` is dropping `workspace_hint`",
     );
     assert_eq!(
-        rt_b.workspace_root, repo_b,
+        rt_b.workspace_root, repo_b_canon,
         "session B's workspace must be the supplied workspace_hint (repo-B); \
          if this fails, `SessionRuntime::bootstrap` is dropping `workspace_hint`",
     );

--- a/crates/octos-cli/tests/speculative_overflow_delivery.rs
+++ b/crates/octos-cli/tests/speculative_overflow_delivery.rs
@@ -73,6 +73,7 @@ async fn should_emit_session_result_metadata_for_overflow_reply() {
         media: vec![],
         metadata: serde_json::json!({
             "_history_persisted": true,
+            "thread_id": "client-msg-bravo",
             "_session_result": {
                 "seq": 42,
                 "role": "assistant",
@@ -80,6 +81,7 @@ async fn should_emit_session_result_metadata_for_overflow_reply() {
                 "timestamp": "2026-04-23T17:30:00Z",
                 "media": [],
                 "response_to_client_message_id": "client-msg-bravo",
+                "thread_id": "client-msg-bravo",
             }
         }),
     };
@@ -116,5 +118,13 @@ async fn should_emit_session_result_metadata_for_overflow_reply() {
     assert_eq!(
         event["message"]["response_to_client_message_id"], "client-msg-bravo",
         "correlation id must survive for reducer-layer bubble routing"
+    );
+    assert_eq!(
+        event["thread_id"], "client-msg-bravo",
+        "wire event must carry the originating thread_id"
+    );
+    assert_eq!(
+        event["message"]["thread_id"], "client-msg-bravo",
+        "message body must carry the originating thread_id"
     );
 }


### PR DESCRIPTION
## Summary
- store Home dashboard config as opaque profile JSON for web-owned settings
- add patch support for home, plugins, and lane_routing fields
- classify runtime policy config changes as restart-required in profile diffs

## Test Plan
- cargo fmt --all -- --check
- cargo test -p octos-cli test_profile_config_patch_
- cargo test -p octos-cli should_classify_runtime_policy_config_as_restart_required
- cargo test -p octos-cli profiles::tests::
- cargo test -p octos-cli
- OCTOS_LIVE_E2E=1 OCTOS_LIVE_E2E_MUTATE=1 BASE_URL=http://127.0.0.1:5174 npx playwright test tests/live-settings-profile.spec.ts