### PR TITLE
feat(llm): Vertex AI auth for Gemini (service-account JSON, keychain-backed)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3122,6 +3122,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "keyring"
 version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3675,10 +3690,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -3914,6 +3948,7 @@ dependencies = [
  "chrono",
  "eyre",
  "futures",
+ "jsonwebtoken",
  "metrics",
  "octos-core",
  "redb",
@@ -4116,6 +4151,16 @@ dependencies = [
  "postscript",
  "type1-encoding-parser",
  "unicode-normalization",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -5443,6 +5488,18 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ cbc = { version = "0.1", features = ["alloc"] }
 rand = "0.8"
 secrecy = { version = "0.10", features = ["serde"] }
 subtle = "2"
+# JWT signing for Google service-account (Vertex AI) auth. Uses `ring`
+# (already in tree via rustls) for RS256 — no OpenSSL.
+jsonwebtoken = "9"
 
 # Error handling (dora-rs pattern)
 eyre = "0.6"

--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -226,6 +226,38 @@ pub async fn get_profile(
     ))
 }
 
+/// Move any keychain-backed secrets (e.g. the Vertex service-account JSON, which
+/// carries a private key) out of plaintext profile config and into the OS
+/// keychain. Shared by every profile/sub-account create/update save path so they
+/// all uphold the same keychain-only contract as `PUT /api/my/profile`. A raw
+/// secret on a non-macOS host is rejected rather than silently persisted.
+///
+/// Detection is by **content** (a raw service-account JSON), not just the
+/// declared `VERTEX_SA_JSON` name — so a private key pasted under a custom env
+/// var (e.g. a dashboard "Custom" provider deriving `VERTEX_API_KEY`) can't slip
+/// past into plaintext config.
+pub(crate) fn relocate_keychain_backed_secrets(
+    env_vars: &mut std::collections::HashMap<String, String>,
+    profile_id: &str,
+) -> Result<(), (StatusCode, String)> {
+    let keys: Vec<String> = env_vars
+        .iter()
+        .filter(|(key, value)| crate::auth::keychain::needs_keychain_relocation(key, value))
+        .map(|(key, _)| key.clone())
+        .collect();
+    for key in keys {
+        super::auth_handlers::relocate_secret_to_keychain(
+            env_vars,
+            &key,
+            profile_id,
+            cfg!(target_os = "macos"),
+            crate::auth::keychain::set_secret,
+        )
+        .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
+    }
+    Ok(())
+}
+
 /// POST /api/admin/profiles
 pub async fn create_profile(
     State(state): State<Arc<AppState>>,
@@ -253,7 +285,7 @@ pub async fn create_profile(
     }
 
     let now = Utc::now();
-    let profile = UserProfile {
+    let mut profile = UserProfile {
         id: req.id,
         name: req.name,
         public_subdomain: req
@@ -267,6 +299,12 @@ pub async fn create_profile(
         created_at: now,
         updated_at: now,
     };
+
+    // Relocate freshly-entered keychain-backed secrets (e.g. the Vertex SA
+    // JSON, which carries a private key) out of plaintext config and into the
+    // OS keychain before persisting — same contract as `PUT /api/my/profile`.
+    let profile_id = profile.id.clone();
+    relocate_keychain_backed_secrets(&mut profile.config.env_vars, &profile_id)?;
 
     store.save(&profile).map_err(|e| {
         tracing::error!(profile = %profile.id, error = %e, "failed to create profile");
@@ -337,6 +375,10 @@ pub async fn update_profile(
         profile.data_dir = data_dir;
     }
     merge_profile_config_from_body(&mut profile.config, &body, false);
+    // Relocate freshly-entered keychain-backed secrets (e.g. the Vertex SA
+    // JSON) into the OS keychain before persisting, so an admin edit can't
+    // write a private key into plaintext profile config.
+    relocate_keychain_backed_secrets(&mut profile.config.env_vars, &id)?;
     profile.updated_at = Utc::now();
 
     store.save_with_merge(&mut profile).map_err(|e| {
@@ -724,7 +766,11 @@ pub async fn test_provider(
     // Gemini 2.5+ "thinking" models consume tokens on internal reasoning,
     // so 16 tokens is too small — they return empty content.  Use 128 for
     // Gemini and keep 16 for everyone else (fast, cheap connectivity check).
-    let max_tokens = if req.provider == "gemini" { 128 } else { 16 };
+    let max_tokens = if req.provider == "gemini" || req.provider == "vertex" {
+        128
+    } else {
+        16
+    };
     let config = ChatConfig {
         max_tokens: Some(max_tokens),
         temperature: Some(0.0),
@@ -931,12 +977,15 @@ fn resolve_saved_key(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .ok_or((StatusCode::NOT_FOUND, "profile not found".into()))?;
 
-    Ok(profile
+    let raw = profile
         .config
         .env_vars
         .get(env_name)
         .cloned()
-        .unwrap_or_default())
+        .unwrap_or_default();
+    // Resolve a `keychain:` marker to the real secret (e.g. a Vertex SA JSON
+    // stored in the OS keychain); plain values pass through unchanged.
+    Ok(crate::auth::keychain::resolve_value(env_name, &raw).unwrap_or_default())
 }
 
 #[derive(Deserialize)]
@@ -1404,6 +1453,10 @@ pub async fn create_sub_account(
     // Set channel-specific env vars if provided
     if !req.env_vars.is_empty() {
         sub.config.env_vars = req.env_vars;
+        // Relocate keychain-backed secrets (e.g. the Vertex SA JSON) before
+        // persisting so a sub-account never writes a private key to disk.
+        let sub_id = sub.id.clone();
+        relocate_keychain_backed_secrets(&mut sub.config.env_vars, &sub_id)?;
         sub.updated_at = Utc::now();
         store
             .save(&sub)
@@ -4670,6 +4723,51 @@ mod register_flow_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn relocate_keychain_backed_secrets_never_persists_raw_vertex_json_off_macos() {
+        // The shared helper used by every profile/sub-account save path must
+        // refuse a raw SA JSON on a non-macOS host (where keychain storage
+        // isn't available) rather than let it fall through to plaintext config.
+        // On macOS it would relocate to the keychain instead, so only assert on
+        // the non-macOS path (the one CI runs and the plaintext risk lives on).
+        if cfg!(target_os = "macos") {
+            return;
+        }
+        let mut env = std::collections::HashMap::new();
+        env.insert(
+            "VERTEX_SA_JSON".to_string(),
+            r#"{"type":"service_account","private_key":"x","project_id":"p"}"#.to_string(),
+        );
+        let res = relocate_keychain_backed_secrets(&mut env, "sub-account-1");
+        assert!(
+            res.is_err(),
+            "raw VERTEX_SA_JSON must be rejected off macOS, never saved as plaintext"
+        );
+        // The raw value is left untouched (the caller bails before saving).
+        assert!(env.get("VERTEX_SA_JSON").unwrap().starts_with('{'));
+    }
+
+    #[test]
+    fn relocate_rejects_service_account_json_under_custom_env_name_off_macos() {
+        // The dashboard "Custom" bypass: SA JSON pasted under VERTEX_API_KEY
+        // (not the whitelisted name) must still be caught by content detection
+        // and rejected off macOS — never written to plaintext config.
+        if cfg!(target_os = "macos") {
+            return;
+        }
+        let mut env = std::collections::HashMap::new();
+        env.insert(
+            "VERTEX_API_KEY".to_string(),
+            r#"{"type":"service_account","private_key":"x"}"#.to_string(),
+        );
+        let res = relocate_keychain_backed_secrets(&mut env, "tenant-1");
+        assert!(
+            res.is_err(),
+            "SA JSON under a custom env name must be rejected off macOS"
+        );
+        assert!(env.get("VERTEX_API_KEY").unwrap().starts_with('{'));
+    }
 
     #[test]
     fn shell_request_deserialize_minimal() {

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -1041,7 +1041,48 @@ pub async fn remove_my_profile_skill(
     }))
 }
 
-/// PUT /api/my/profile
+/// Move a freshly-entered keychain-backed secret out of `env_vars` and into the
+/// OS keychain, replacing the stored value with the keychain marker so the
+/// secret never lands in the profile config on disk.
+///
+/// Only a raw, freshly-entered value (JSON object, i.e. starts with `{`) is
+/// relocated. A keychain marker, a masked display value, or an empty string all
+/// mean "unchanged" and are left untouched. Keychain-backed config is
+/// macOS-only: a raw secret on another OS is rejected rather than silently
+/// persisted in plaintext.
+///
+/// The secret is stored under a **profile-scoped** keychain account
+/// (`<key>::<profile_id>`) and the stored marker carries that account, so two
+/// profiles saving different secrets under the same env var never overwrite a
+/// single shared keychain item (each profile reads back its own credential).
+///
+/// `is_macos` and `set_secret` are injected for testability.
+pub(crate) fn relocate_secret_to_keychain(
+    env_vars: &mut HashMap<String, String>,
+    key: &str,
+    profile_id: &str,
+    is_macos: bool,
+    set_secret: impl Fn(&str, &str) -> eyre::Result<()>,
+) -> Result<(), String> {
+    let Some(value) = env_vars.get(key) else {
+        return Ok(());
+    };
+    let value = value.trim().to_string();
+    // Markers / masked / empty values mean "leave as configured".
+    if !value.starts_with('{') {
+        return Ok(());
+    }
+    if !is_macos {
+        return Err(format!(
+            "{key}: keychain-backed credential storage is only supported on macOS"
+        ));
+    }
+    let account = crate::auth::keychain::scoped_account(key, profile_id);
+    set_secret(&account, &value).map_err(|e| format!("failed to store {key} in keychain: {e}"))?;
+    env_vars.insert(key.to_string(), crate::auth::keychain::marker_for(&account));
+    Ok(())
+}
+
 pub async fn update_my_profile(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -1084,6 +1125,12 @@ pub async fn update_my_profile(
         profile.enabled = enabled;
     }
     super::admin::merge_profile_config_from_body(&mut profile.config, &body, true);
+    // Relocate freshly-entered keychain-backed secrets (e.g. the Vertex SA JSON,
+    // including a private key pasted under a custom env name) into the OS
+    // keychain before persisting. Uses the shared content-detecting helper so
+    // this path can't diverge from the others.
+    let profile_id = profile.id.clone();
+    super::admin::relocate_keychain_backed_secrets(&mut profile.config.env_vars, &profile_id)?;
     profile.updated_at = chrono::Utc::now();
 
     ps.save_with_merge(&mut profile).map_err(|e| {
@@ -1770,6 +1817,10 @@ pub async fn create_my_sub_account(
 
     if !req.env_vars.is_empty() {
         sub.config.env_vars = req.env_vars;
+        // Relocate keychain-backed secrets (e.g. the Vertex SA JSON) before
+        // persisting so a sub-account never writes a private key to disk.
+        let sub_id = sub.id.clone();
+        super::admin::relocate_keychain_backed_secrets(&mut sub.config.env_vars, &sub_id)?;
         sub.updated_at = chrono::Utc::now();
         ps.save(&sub)
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -1863,6 +1914,10 @@ pub async fn update_my_sub_account(
         sub.enabled = enabled;
     }
     super::admin::merge_profile_config_from_body(&mut sub.config, &body, true);
+    // Relocate keychain-backed secrets (e.g. the Vertex SA JSON) before
+    // persisting so a sub-account never writes a private key to disk.
+    let sub_id = sub.id.clone();
+    super::admin::relocate_keychain_backed_secrets(&mut sub.config.env_vars, &sub_id)?;
     sub.updated_at = chrono::Utc::now();
 
     ps.save_with_merge(&mut sub)
@@ -2342,6 +2397,124 @@ mod tests {
     use crate::user_store::UserStore;
     use axum::http::HeaderMap;
     use axum::http::Request;
+
+    // --- relocate_secret_to_keychain ---
+
+    use std::cell::RefCell;
+
+    fn env_with(key: &str, val: &str) -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert(key.to_string(), val.to_string());
+        m
+    }
+
+    #[test]
+    fn relocates_raw_json_to_keychain_on_macos() {
+        let mut env = env_with("VERTEX_SA_JSON", r#"{"private_key":"x","project_id":"p"}"#);
+        let stored: RefCell<Vec<(String, String)>> = RefCell::new(vec![]);
+        let res = relocate_secret_to_keychain(&mut env, "VERTEX_SA_JSON", "alice", true, |n, s| {
+            stored.borrow_mut().push((n.to_string(), s.to_string()));
+            Ok(())
+        });
+        assert!(res.is_ok());
+        // value replaced with a profile-scoped marker; raw JSON went to the
+        // keychain under a profile-scoped account.
+        assert_eq!(
+            env.get("VERTEX_SA_JSON").unwrap(),
+            "keychain:VERTEX_SA_JSON::alice"
+        );
+        assert_eq!(stored.borrow().len(), 1);
+        assert_eq!(stored.borrow()[0].0, "VERTEX_SA_JSON::alice");
+        assert!(stored.borrow()[0].1.contains("private_key"));
+    }
+
+    #[test]
+    fn two_profiles_get_distinct_keychain_accounts() {
+        // The core of the fix: two profiles saving a Vertex SA under the same
+        // env var must land in DISTINCT keychain accounts (and persist distinct
+        // markers), so neither overwrites nor resolves the other's private key.
+        let json = r#"{"private_key":"x"}"#;
+        let stored: RefCell<Vec<(String, String)>> = RefCell::new(vec![]);
+        let mut alice = env_with("VERTEX_SA_JSON", json);
+        let mut bob = env_with("VERTEX_SA_JSON", json);
+        relocate_secret_to_keychain(&mut alice, "VERTEX_SA_JSON", "alice", true, |n, s| {
+            stored.borrow_mut().push((n.to_string(), s.to_string()));
+            Ok(())
+        })
+        .unwrap();
+        relocate_secret_to_keychain(&mut bob, "VERTEX_SA_JSON", "bob", true, |n, s| {
+            stored.borrow_mut().push((n.to_string(), s.to_string()));
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(stored.borrow()[0].0, "VERTEX_SA_JSON::alice");
+        assert_eq!(stored.borrow()[1].0, "VERTEX_SA_JSON::bob");
+        assert_eq!(
+            alice.get("VERTEX_SA_JSON").unwrap(),
+            "keychain:VERTEX_SA_JSON::alice"
+        );
+        assert_eq!(
+            bob.get("VERTEX_SA_JSON").unwrap(),
+            "keychain:VERTEX_SA_JSON::bob"
+        );
+        assert_ne!(alice.get("VERTEX_SA_JSON"), bob.get("VERTEX_SA_JSON"));
+    }
+
+    #[test]
+    fn rejects_raw_json_on_non_macos() {
+        let mut env = env_with("VERTEX_SA_JSON", r#"{"private_key":"x"}"#);
+        let called = RefCell::new(false);
+        let res =
+            relocate_secret_to_keychain(&mut env, "VERTEX_SA_JSON", "alice", false, |_, _| {
+                *called.borrow_mut() = true;
+                Ok(())
+            });
+        assert!(res.is_err());
+        assert!(!*called.borrow(), "must not write keychain off macOS");
+        // value left untouched (not persisted plaintext silently).
+        assert!(env.get("VERTEX_SA_JSON").unwrap().starts_with('{'));
+    }
+
+    #[test]
+    fn leaves_keychain_marker_untouched() {
+        let mut env = env_with("VERTEX_SA_JSON", crate::auth::KEYCHAIN_MARKER);
+        let called = RefCell::new(false);
+        let res = relocate_secret_to_keychain(&mut env, "VERTEX_SA_JSON", "alice", true, |_, _| {
+            *called.borrow_mut() = true;
+            Ok(())
+        });
+        assert!(res.is_ok());
+        assert!(
+            !*called.borrow(),
+            "marker means unchanged — no keychain write"
+        );
+        assert_eq!(
+            env.get("VERTEX_SA_JSON").unwrap(),
+            crate::auth::KEYCHAIN_MARKER
+        );
+    }
+
+    #[test]
+    fn is_noop_when_key_absent_or_masked() {
+        // absent key
+        let mut empty = HashMap::new();
+        assert!(
+            relocate_secret_to_keychain(&mut empty, "VERTEX_SA_JSON", "alice", true, |_, _| Ok(()))
+                .is_ok()
+        );
+        // masked / non-JSON value is treated as "unchanged"
+        let mut masked = env_with("VERTEX_SA_JSON", "abcd***xyz");
+        let called = RefCell::new(false);
+        let res =
+            relocate_secret_to_keychain(&mut masked, "VERTEX_SA_JSON", "alice", true, |_, _| {
+                *called.borrow_mut() = true;
+                Ok(())
+            });
+        assert!(res.is_ok());
+        assert!(!*called.borrow());
+        assert_eq!(masked.get("VERTEX_SA_JSON").unwrap(), "abcd***xyz");
+    }
 
     fn temp_profile_store() -> (tempfile::TempDir, ProfileStore) {
         let dir = tempfile::tempdir().unwrap();
@@ -2932,6 +3105,48 @@ mod tests {
         assert!(
             stored.config.env_vars.is_empty(),
             "an explicit empty env_vars map must clear all entries"
+        );
+    }
+
+    #[tokio::test]
+    async fn my_profile_rejects_service_account_json_under_custom_env_off_macos() {
+        // Regression for the dashboard "Custom" bypass: a raw Vertex SA JSON
+        // pasted under a CUSTOM env name (VERTEX_API_KEY, not the whitelisted
+        // VERTEX_SA_JSON) via PUT /api/my/profile must never reach plaintext
+        // config. Off macOS it's rejected; on macOS it would be relocated to the
+        // keychain instead (skip — that hits the real keychain).
+        if cfg!(target_os = "macos") {
+            return;
+        }
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        profile_store
+            .save(&make_user_profile("tenant", "Tenant Owner"))
+            .unwrap();
+
+        let res = update_my_profile(
+            State(Arc::new(state)),
+            HeaderMap::new(),
+            axum::Extension(AuthIdentity::User {
+                id: "tenant".into(),
+                role: UserRole::User,
+            }),
+            serde_json::json!({
+                "config": { "env_vars": {
+                    "VERTEX_API_KEY": "{\"type\":\"service_account\",\"private_key\":\"x\"}"
+                } }
+            })
+            .to_string(),
+        )
+        .await;
+
+        assert!(
+            res.is_err(),
+            "raw SA JSON under a custom env name must be rejected off macOS"
+        );
+        let stored = profile_store.get("tenant").unwrap().expect("profile");
+        assert!(
+            !stored.config.env_vars.contains_key("VERTEX_API_KEY"),
+            "the private key must never be persisted to plaintext config"
         );
     }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -6877,6 +6877,11 @@ async fn raw_profile_llm_upsert(
         upsert_llm_fallback(&mut llm.fallbacks, selection);
     }
     profile.config.llm = Some(llm);
+    // Relocate keychain-backed secrets (e.g. a Vertex SA JSON supplied as the
+    // route api_key) into the OS keychain before persisting, so this RPC can't
+    // write a private key to plaintext profile config.
+    crate::api::admin::relocate_keychain_backed_secrets(&mut profile.config.env_vars, &profile_id)
+        .map_err(|(_, msg)| RpcError::invalid_params(msg))?;
     profile.updated_at = Utc::now();
     store
         .save_with_merge(&mut profile)
@@ -6966,10 +6971,12 @@ async fn raw_profile_llm_test(
     };
 
     let Some(api_key) = secret_from_value(params.api_key).or_else(|| {
-        route
-            .api_key_env
-            .as_ref()
-            .and_then(|env_name| profile.as_ref()?.config.env_vars.get(env_name).cloned())
+        route.api_key_env.as_ref().and_then(|env_name| {
+            // Resolve a keychain marker to the real secret (e.g. a scoped Vertex
+            // SA JSON); plain values pass through unchanged.
+            let raw = profile.as_ref()?.config.env_vars.get(env_name)?;
+            crate::auth::keychain::resolve_value(env_name, raw)
+        })
     }) else {
         return Ok(profile_llm_test_result(
             state,
@@ -7094,9 +7101,12 @@ async fn raw_profile_llm_fetch_models(
         .or_else(|| dashboard_family_api_key_env(&family_id));
 
     let api_key = secret_from_value(params.api_key).or_else(|| {
-        api_key_env
-            .as_ref()
-            .and_then(|env_name| profile.as_ref()?.config.env_vars.get(env_name).cloned())
+        api_key_env.as_ref().and_then(|env_name| {
+            // Resolve a keychain marker to the real secret (e.g. a scoped Vertex
+            // SA JSON); plain values pass through unchanged.
+            let raw = profile.as_ref()?.config.env_vars.get(env_name)?;
+            crate::auth::keychain::resolve_value(env_name, raw)
+        })
     });
 
     let Some(api_key) = api_key else {

--- a/crates/octos-cli/src/auth/keychain.rs
+++ b/crates/octos-cli/src/auth/keychain.rs
@@ -15,9 +15,68 @@ use std::collections::HashMap;
 
 use eyre::{Result, WrapErr};
 
-/// Sentinel value stored in profile `env_vars` to indicate
-/// that the real secret lives in the macOS Keychain.
+/// Sentinel prefix stored in profile `env_vars` to indicate that the real
+/// secret lives in the macOS Keychain.
+///
+/// Two forms exist:
+/// - **bare** `"keychain:"` — legacy / single-account: the keychain account is
+///   the env-var name itself. Still read for backward compatibility.
+/// - **scoped** `"keychain:<account>"` — the suffix is the exact keychain
+///   account to read, which lets per-profile secrets (e.g. each tenant's Vertex
+///   service account) live under distinct accounts so saves can't collide.
 pub const KEYCHAIN_MARKER: &str = "keychain:";
+
+/// Env-var credentials that must live in the OS keychain, never in plaintext
+/// profile config (each carries a private key — e.g. the Vertex service-account
+/// JSON). Stored under per-profile [`scoped_account`]s so tenants can't collide.
+///
+/// Lives here (not in the `api`-gated module) so non-API CLI commands
+/// (`octos auth set-key/keys/remove-key`) can scope the same set consistently.
+pub const KEYCHAIN_BACKED_ENV_VARS: &[&str] = &["VERTEX_SA_JSON"];
+
+/// Whether `value` is a raw Google service-account JSON (i.e. carries a private
+/// key). Detected by **content**, not by the env-var name, so the credential is
+/// protected even when stored under a non-whitelisted name (e.g. a dashboard
+/// "Custom" provider that derives `VERTEX_API_KEY`).
+pub fn is_service_account_json(value: &str) -> bool {
+    let v = value.trim_start();
+    v.starts_with('{') && value.contains("\"private_key\"") && value.contains("service_account")
+}
+
+/// Whether the stored env var (`key` = `value`) holds a raw secret that must be
+/// relocated into the keychain before persisting: a declared keychain-backed var
+/// holding a raw value, OR any var whose value is a service-account JSON. The
+/// content check closes the bypass of saving the SA key under a custom name.
+pub fn needs_keychain_relocation(key: &str, value: &str) -> bool {
+    is_service_account_json(value)
+        || (KEYCHAIN_BACKED_ENV_VARS.contains(&key) && value.trim_start().starts_with('{'))
+}
+
+/// Whether `value` is any keychain marker (bare or scoped).
+pub fn is_marker(value: &str) -> bool {
+    value.starts_with(KEYCHAIN_MARKER)
+}
+
+/// The keychain account name for `env_var` scoped to `profile_id`. Distinct
+/// profiles get distinct accounts, so two profiles saving different secrets
+/// under the same env var no longer overwrite a single shared keychain item.
+pub fn scoped_account(env_var: &str, profile_id: &str) -> String {
+    format!("{env_var}::{profile_id}")
+}
+
+/// Build the marker stored in profile config for a given keychain `account`.
+pub fn marker_for(account: &str) -> String {
+    format!("{KEYCHAIN_MARKER}{account}")
+}
+
+/// The keychain account a marker `value` points at: the scoped suffix when
+/// present, else `fallback_name` (the env-var name) for a legacy bare marker.
+pub fn marker_account<'a>(value: &'a str, fallback_name: &'a str) -> &'a str {
+    value
+        .strip_prefix(KEYCHAIN_MARKER)
+        .filter(|account| !account.is_empty())
+        .unwrap_or(fallback_name)
+}
 
 /// The service name used for all octos keychain entries.
 const SERVICE: &str = "octos";
@@ -84,6 +143,32 @@ pub fn set_secret(name: &str, secret: &str) -> Result<()> {
     Ok(())
 }
 
+/// `security find-generic-password -w` prints the password as a **hex string**
+/// (no marker) whenever it contains non-printable bytes — notably the newlines
+/// in a service-account JSON. Decode that back to text.
+///
+/// Decoding is deliberately scoped to the multi-line case: we only decode when
+/// the whole string is even-length ASCII hex, the bytes are valid UTF-8, AND
+/// the decoded text contains a newline. `security` hex-encodes a stored secret
+/// *only* when it can't emit it verbatim on one line (i.e. it has newlines), so
+/// a single-line secret that happens to be valid even-length ASCII hex (e.g.
+/// `41424344`) was returned as-is and must NOT be decoded — doing so would
+/// silently corrupt it into `ABCD`. Requiring a newline removes that ambiguity.
+fn decode_security_hex(s: &str) -> Option<String> {
+    let s = s.trim();
+    if s.len() < 2 || s.len() % 2 != 0 || !s.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let bytes: Option<Vec<u8>> = (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).ok())
+        .collect();
+    let decoded = String::from_utf8(bytes?).ok()?;
+    // Only a genuinely multi-line secret would have been hex-encoded by
+    // `security`; refuse single-line values to avoid corrupting hex-shaped keys.
+    decoded.contains('\n').then_some(decoded)
+}
+
 /// Retrieve a secret from the macOS Keychain.
 ///
 /// Returns `Ok(Some(secret))` on success, `Ok(None)` if not found,
@@ -113,7 +198,8 @@ pub fn get_secret(name: &str) -> Result<Option<String>> {
             if secret.is_empty() {
                 Ok(None)
             } else {
-                Ok(Some(secret))
+                // `security` may have hex-encoded a multi-line secret (e.g. SA JSON).
+                Ok(Some(decode_security_hex(&secret).unwrap_or(secret)))
             }
         }
         Ok(Ok(out)) => {
@@ -195,14 +281,18 @@ pub fn is_accessible() -> bool {
 ///
 /// On keychain failure, logs a warning and returns `None`.
 pub fn resolve_value(name: &str, value: &str) -> Option<String> {
-    if value != KEYCHAIN_MARKER {
+    if !is_marker(value) {
         return Some(value.to_string());
     }
-    match get_secret(name) {
+    // Scoped markers carry the account in the suffix; bare ones fall back to the
+    // env-var name. This keeps existing single-account entries working.
+    let account = marker_account(value, name);
+    match get_secret(account) {
         Ok(Some(secret)) => Some(secret),
         Ok(None) => {
             tracing::warn!(
                 var = %name,
+                account = %account,
                 "keychain marker found but no secret stored in keychain"
             );
             None
@@ -210,6 +300,7 @@ pub fn resolve_value(name: &str, value: &str) -> Option<String> {
         Err(e) => {
             tracing::warn!(
                 var = %name,
+                account = %account,
                 error = %e,
                 "failed to read secret from keychain, skipping"
             );
@@ -237,6 +328,40 @@ mod tests {
     use super::*;
 
     #[test]
+    fn decodes_hex_password_emitted_by_security_for_multiline_secret() {
+        // `security -w` hex-encodes a value containing newlines (e.g. SA JSON).
+        let json = "{\n  \"type\": \"service_account\",\n  \"project_id\": \"p\"\n}";
+        let hex: String = json.bytes().map(|b| format!("{b:02x}")).collect();
+        assert_eq!(decode_security_hex(&hex).as_deref(), Some(json));
+    }
+
+    #[test]
+    fn leaves_ordinary_api_key_untouched() {
+        // Contains non-hex characters → not decoded.
+        assert!(decode_security_hex("sk-proj-abc123XYZ").is_none());
+    }
+
+    #[test]
+    fn leaves_odd_length_or_non_hex_untouched() {
+        assert!(decode_security_hex("abc").is_none()); // odd length
+        assert!(decode_security_hex("zzzz").is_none()); // non-hex chars
+    }
+
+    #[test]
+    fn leaves_binary_hex_untouched_when_not_utf8() {
+        // Pure hex that decodes to non-UTF-8 bytes is left as-is.
+        assert!(decode_security_hex("deadbeef").is_none());
+    }
+
+    #[test]
+    fn leaves_single_line_ascii_hex_secret_untouched() {
+        // A real secret that is even-length ASCII hex and valid UTF-8 but
+        // single-line (e.g. "41424344") was returned verbatim by `security`,
+        // never hex-encoded — decoding it would corrupt it into "ABCD".
+        assert_eq!(decode_security_hex("41424344"), None);
+    }
+
+    #[test]
     fn test_resolve_value_passthrough() {
         // Non-marker values pass through unchanged
         assert_eq!(resolve_value("FOO", "bar"), Some("bar".to_string()));
@@ -262,6 +387,87 @@ mod tests {
     #[test]
     fn test_keychain_marker_constant() {
         assert_eq!(KEYCHAIN_MARKER, "keychain:");
+    }
+
+    #[test]
+    fn scoped_account_and_marker_roundtrip() {
+        let acct = scoped_account("VERTEX_SA_JSON", "alice");
+        assert_eq!(acct, "VERTEX_SA_JSON::alice");
+        assert_eq!(marker_for(&acct), "keychain:VERTEX_SA_JSON::alice");
+        assert!(is_marker(&marker_for(&acct)));
+        assert!(is_marker("keychain:")); // legacy bare marker
+        assert!(!is_marker("sk-proj-abc123"));
+    }
+
+    #[test]
+    fn detects_service_account_json_by_content_regardless_of_name() {
+        let sa = r#"{"type":"service_account","private_key":"x","project_id":"p"}"#;
+        assert!(is_service_account_json(sa));
+        // Leading whitespace is tolerated.
+        assert!(is_service_account_json(&format!("  \n{sa}")));
+        // Ordinary API keys / non-SA JSON are not flagged.
+        assert!(!is_service_account_json("sk-proj-abc123"));
+        assert!(!is_service_account_json(r#"{"model":"x","temperature":1}"#));
+        assert!(!is_service_account_json(""));
+    }
+
+    #[test]
+    fn needs_relocation_closes_custom_env_name_bypass() {
+        let sa = r#"{"type":"service_account","private_key":"x"}"#;
+        // The declared name with a raw value → relocate.
+        assert!(needs_keychain_relocation("VERTEX_SA_JSON", sa));
+        // SA JSON under a CUSTOM name (the dashboard bypass) → still relocate.
+        assert!(needs_keychain_relocation("VERTEX_API_KEY", sa));
+        assert!(needs_keychain_relocation("ANYTHING", sa));
+        // A plain key, or a non-SA JSON under a non-whitelisted name → leave it.
+        assert!(!needs_keychain_relocation("VERTEX_API_KEY", "sk-plain"));
+        assert!(!needs_keychain_relocation("OPENAI_API_KEY", r#"{"a":1}"#));
+        // An already-relocated marker is not a raw value → no relocation.
+        assert!(!needs_keychain_relocation(
+            "VERTEX_SA_JSON",
+            "keychain:VERTEX_SA_JSON::alice"
+        ));
+    }
+
+    #[test]
+    fn marker_account_prefers_scope_else_falls_back_to_name() {
+        // Scoped marker → account taken from the suffix (per-profile isolation).
+        assert_eq!(
+            marker_account("keychain:VERTEX_SA_JSON::alice", "VERTEX_SA_JSON"),
+            "VERTEX_SA_JSON::alice"
+        );
+        // Bare legacy marker → the env-var name (backward compatible).
+        assert_eq!(
+            marker_account("keychain:", "VERTEX_SA_JSON"),
+            "VERTEX_SA_JSON"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires macOS Keychain access"]
+    fn keychain_integration_scoped_accounts_dont_collide() {
+        // Real-keychain proof of the P1 fix: two profiles' scoped accounts are
+        // independent — writing/deleting one never affects the other.
+        let alice = scoped_account("VERTEX_SA_JSON", "alice-itest");
+        let bob = scoped_account("VERTEX_SA_JSON", "bob-itest");
+        let _ = delete_secret(&alice);
+        let _ = delete_secret(&bob);
+
+        set_secret(&alice, "alice-key").unwrap();
+        set_secret(&bob, "bob-key").unwrap();
+        assert_eq!(get_secret(&alice).unwrap().as_deref(), Some("alice-key"));
+        assert_eq!(
+            get_secret(&bob).unwrap().as_deref(),
+            Some("bob-key"),
+            "bob's account must not be overwritten by alice's"
+        );
+
+        // Deleting alice's account leaves bob's intact.
+        delete_secret(&alice).unwrap();
+        assert!(get_secret(&alice).unwrap().is_none());
+        assert_eq!(get_secret(&bob).unwrap().as_deref(), Some("bob-key"));
+
+        delete_secret(&bob).unwrap();
     }
 
     // Integration tests that require a real Keychain session.

--- a/crates/octos-cli/src/commands/auth.rs
+++ b/crates/octos-cli/src/commands/auth.rs
@@ -191,6 +191,28 @@ fn open_profile_store() -> Result<ProfileStore> {
     ProfileStore::open(&home.join(".octos"))
 }
 
+/// Whether storing `secret` under `name` must be scoped per profile: a declared
+/// keychain-backed var, OR any value that is a service-account JSON (detected by
+/// content, so the same protection applies under a custom env name such as the
+/// dashboard "Custom" provider's `VERTEX_API_KEY`). Mirrors the API-side
+/// `keychain::needs_keychain_relocation` contract.
+fn should_scope(name: &str, secret: &str) -> bool {
+    keychain::KEYCHAIN_BACKED_ENV_VARS.contains(&name) || keychain::is_service_account_json(secret)
+}
+
+/// The keychain account and the profile-config marker to persist for `name` in
+/// `profile_id`. Scoped creds get a per-profile account + scoped marker; other
+/// keys keep the bare account + bare marker.
+fn keychain_target(name: &str, profile_id: &str, secret: &str) -> (String, String) {
+    if should_scope(name, secret) {
+        let account = keychain::scoped_account(name, profile_id);
+        let marker = keychain::marker_for(&account);
+        (account, marker)
+    } else {
+        (name.to_string(), keychain::KEYCHAIN_MARKER.to_string())
+    }
+}
+
 fn set_key(name: &str, value: Option<String>, profile_id: Option<&str>) -> Result<()> {
     // Get the secret value: from argument or interactive prompt
     let secret = match value {
@@ -208,20 +230,30 @@ fn set_key(name: &str, value: Option<String>, profile_id: Option<&str>) -> Resul
         }
     };
 
-    // Store in keychain
-    keychain::set_secret(name, &secret)?;
+    // Keychain-backed credentials (e.g. a Vertex SA JSON, even under a custom
+    // env name) are stored under a PER-PROFILE account so distinct profiles
+    // never share — and overwrite — one keychain item. Other keys keep a single
+    // shared account.
+    let scoped = should_scope(name, &secret);
 
-    // Update profile(s) to use keychain marker
+    // Shared keys: store once up front (also covers the orphan / no-profile
+    // case). Scoped keys are stored per profile in the loop below.
+    if !scoped {
+        keychain::set_secret(name, &secret)?;
+    }
+
+    // Update profile(s) to use the keychain marker
     let store = open_profile_store()?;
     let profiles = get_profiles(&store, profile_id)?;
 
     let mut updated_count = 0;
     for mut profile in profiles {
         if profile.config.env_vars.contains_key(name) {
-            profile
-                .config
-                .env_vars
-                .insert(name.to_string(), keychain::KEYCHAIN_MARKER.to_string());
+            let (account, marker) = keychain_target(name, &profile.id, &secret);
+            if scoped {
+                keychain::set_secret(&account, &secret)?;
+            }
+            profile.config.env_vars.insert(name.to_string(), marker);
             profile.updated_at = chrono::Utc::now();
             store.save(&profile)?;
             updated_count += 1;
@@ -231,6 +263,18 @@ fn set_key(name: &str, value: Option<String>, profile_id: Option<&str>) -> Resul
                 profile.id.cyan()
             );
         }
+    }
+
+    // A scoped key is only ever written inside the per-profile loop, so if no
+    // profile referenced it nothing was stored — don't claim otherwise.
+    if scoped && updated_count == 0 {
+        println!(
+            "{} No profile references {}; nothing stored. Add the key to a profile \
+             (or save it via the dashboard) first.",
+            "!".yellow().bold(),
+            name.cyan(),
+        );
+        return Ok(());
     }
 
     println!(
@@ -250,14 +294,21 @@ fn list_keys(profile_id: Option<&str>) -> Result<()> {
     let store = open_profile_store()?;
     let profiles = get_profiles(&store, profile_id)?;
 
-    // Collect all unique env var names and their storage type
-    let mut keychain_keys = std::collections::BTreeSet::new();
+    // Collect DISTINCT (env var, keychain account) pairs — the account is
+    // resolved from the marker, so a profile-scoped key has one entry per
+    // account and we never collapse two profiles' distinct accounts into one
+    // (which would hide a missing/broken entry for one of them).
+    let mut keychain_keys: std::collections::BTreeSet<(String, String)> =
+        std::collections::BTreeSet::new();
     let mut plain_keys = std::collections::BTreeSet::new();
 
     for profile in &profiles {
         for (key, value) in &profile.config.env_vars {
-            if value == keychain::KEYCHAIN_MARKER {
-                keychain_keys.insert(key.clone());
+            if keychain::is_marker(value) {
+                keychain_keys.insert((
+                    key.clone(),
+                    keychain::marker_account(value, key).to_string(),
+                ));
             } else if !value.is_empty() {
                 plain_keys.insert(key.clone());
             }
@@ -271,13 +322,18 @@ fn list_keys(profile_id: Option<&str>) -> Result<()> {
 
     if !keychain_keys.is_empty() {
         println!("{}", "Keychain-stored keys:".bold());
-        for key in &keychain_keys {
-            let status = match keychain::get_secret(key) {
+        for (key, account) in &keychain_keys {
+            let status = match keychain::get_secret(account) {
                 Ok(Some(_)) => "available".green().to_string(),
                 Ok(None) => "missing from keychain!".red().to_string(),
                 Err(_) => "keychain error".yellow().to_string(),
             };
-            println!("  {key}: {status}");
+            // Show the scoped account when it differs from the bare env-var name.
+            if account == key {
+                println!("  {key}: {status}");
+            } else {
+                println!("  {key} ({account}): {status}");
+            }
         }
     }
 
@@ -294,18 +350,95 @@ fn list_keys(profile_id: Option<&str>) -> Result<()> {
     Ok(())
 }
 
+/// What a `remove-key` invocation should do, computed purely (no keychain or
+/// store I/O) so it's unit-testable.
+struct RemovalPlan {
+    /// Profile ids to drop the env var from.
+    profiles_to_update: Vec<String>,
+    /// Keychain accounts that are safe to delete.
+    accounts_to_delete: Vec<String>,
+}
+
+/// Plan a `remove-key name` over `entries` — `(profile_id, stored value for
+/// name)` for EVERY profile that has the key. `is_target` selects the profiles
+/// being removed from.
+///
+/// The subtle case: a **bare** account (`VERTEX_SA_JSON`) can be shared by many
+/// legacy profiles, so it is only deleted when no *non-target* profile still
+/// references it. A **scoped** account (`VERTEX_SA_JSON::<id>`) is unique to one
+/// profile and always safe to delete.
+fn plan_removal(
+    entries: &[(String, String)],
+    name: &str,
+    is_target: impl Fn(&str) -> bool,
+) -> RemovalPlan {
+    let bare_shared_by_other = entries.iter().any(|(pid, value)| {
+        !is_target(pid)
+            && keychain::is_marker(value)
+            && keychain::marker_account(value, name) == name
+    });
+
+    let mut profiles_to_update = Vec::new();
+    let mut accounts_to_delete = Vec::new();
+    for (pid, value) in entries {
+        if !is_target(pid) || !keychain::is_marker(value) {
+            continue;
+        }
+        profiles_to_update.push(pid.clone());
+        let account = keychain::marker_account(value, name);
+        let shared_bare = account == name && bare_shared_by_other;
+        if !shared_bare {
+            accounts_to_delete.push(account.to_string());
+        }
+    }
+    accounts_to_delete.sort();
+    accounts_to_delete.dedup();
+    RemovalPlan {
+        profiles_to_update,
+        accounts_to_delete,
+    }
+}
+
 fn remove_key(name: &str, profile_id: Option<&str>) -> Result<()> {
-    // Remove from keychain
-    let deleted = keychain::delete_secret(name)?;
-
-    // Remove env_var entry from profile(s) that use keychain marker
     let store = open_profile_store()?;
-    let profiles = get_profiles(&store, profile_id)?;
+    // Load ALL profiles (not just the target) so we can tell whether a shared
+    // bare keychain account is still referenced by a profile we're NOT removing.
+    let all_profiles = store.list()?;
+    if let Some(id) = profile_id {
+        if !all_profiles.iter().any(|p| p.id == id) {
+            eyre::bail!("profile '{id}' not found");
+        }
+    }
 
+    let entries: Vec<(String, String)> = all_profiles
+        .iter()
+        .filter_map(|p| {
+            p.config
+                .env_vars
+                .get(name)
+                .map(|v| (p.id.clone(), v.clone()))
+        })
+        .collect();
+    let plan = plan_removal(&entries, name, |pid| match profile_id {
+        Some(id) => pid == id,
+        None => true,
+    });
+
+    let mut deleted = false;
+    for account in &plan.accounts_to_delete {
+        deleted |= keychain::delete_secret(account).unwrap_or(false);
+    }
+    // A global removal (no `--profile`) also cleans up a legacy/orphan bare
+    // account not referenced by any profile.
+    if profile_id.is_none() {
+        deleted |= keychain::delete_secret(name).unwrap_or(false);
+    }
+
+    let to_update: std::collections::HashSet<&str> =
+        plan.profiles_to_update.iter().map(String::as_str).collect();
     let mut updated_count = 0;
-    for mut profile in profiles {
-        if profile.config.env_vars.get(name).map(|v| v.as_str()) == Some(keychain::KEYCHAIN_MARKER)
-        {
+    for mut profile in all_profiles {
+        if to_update.contains(profile.id.as_str()) {
             profile.config.env_vars.remove(name);
             profile.updated_at = chrono::Utc::now();
             store.save(&profile)?;
@@ -313,17 +446,22 @@ fn remove_key(name: &str, profile_id: Option<&str>) -> Result<()> {
         }
     }
 
-    if deleted {
+    if updated_count == 0 && !deleted {
+        println!("No {} key found to remove.", name.cyan());
+    } else {
+        // Distinguish "deleted the keychain account" from "removed the env var
+        // but kept a shared account another profile still uses".
+        let keychain_note = if deleted {
+            "keychain account removed".to_string()
+        } else {
+            "shared keychain account kept (still used by another profile)".to_string()
+        };
         println!(
-            "{} Removed {} from keychain ({} profile(s) updated)",
+            "{} Removed {} from {} profile(s); {}",
             "OK".green().bold(),
             name.cyan(),
-            updated_count
-        );
-    } else {
-        println!(
-            "No keychain entry found for {} ({} profile(s) updated)",
-            name, updated_count
+            updated_count,
+            keychain_note
         );
     }
     Ok(())
@@ -368,5 +506,105 @@ fn get_profiles(
         }
     } else {
         store.list()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keychain_target_scopes_by_name_and_by_content() {
+        let sa = r#"{"type":"service_account","private_key":"x"}"#;
+        // Declared keychain-backed name → per-profile scoped account.
+        let (account, marker) = keychain_target("VERTEX_SA_JSON", "alice", sa);
+        assert_eq!(account, "VERTEX_SA_JSON::alice");
+        assert_eq!(marker, "keychain:VERTEX_SA_JSON::alice");
+
+        // SA JSON under a CUSTOM env name (the dashboard "Custom" bypass) is
+        // ALSO scoped — by content — so CLI saves can't collide cross-profile.
+        let (account, marker) = keychain_target("VERTEX_API_KEY", "alice", sa);
+        assert_eq!(account, "VERTEX_API_KEY::alice");
+        assert_eq!(marker, "keychain:VERTEX_API_KEY::alice");
+        assert_ne!(
+            keychain_target("VERTEX_API_KEY", "alice", sa).0,
+            keychain_target("VERTEX_API_KEY", "bob", sa).0,
+            "distinct profiles must get distinct accounts"
+        );
+
+        // An ordinary (non-SA) key keeps the single bare account + bare marker.
+        let (account, marker) = keychain_target("OPENAI_API_KEY", "alice", "sk-plain");
+        assert_eq!(account, "OPENAI_API_KEY");
+        assert_eq!(marker, keychain::KEYCHAIN_MARKER);
+    }
+
+    const NAME: &str = "VERTEX_SA_JSON";
+
+    fn entry(pid: &str, value: &str) -> (String, String) {
+        (pid.to_string(), value.to_string())
+    }
+
+    #[test]
+    fn remove_plan_keeps_shared_bare_account_when_another_profile_uses_it() {
+        // The codex scenario: alice and bob are BOTH on the legacy bare marker
+        // (shared account). Removing only alice must drop alice's env var but
+        // NOT delete the shared keychain account bob still depends on.
+        let entries = vec![entry("alice", "keychain:"), entry("bob", "keychain:")];
+        let plan = plan_removal(&entries, NAME, |pid| pid == "alice");
+        assert_eq!(plan.profiles_to_update, vec!["alice"]);
+        assert!(
+            plan.accounts_to_delete.is_empty(),
+            "must NOT delete the shared bare account while bob still uses it"
+        );
+    }
+
+    #[test]
+    fn remove_plan_deletes_sole_bare_account() {
+        // Only alice references the bare account → safe to delete it.
+        let entries = vec![entry("alice", "keychain:")];
+        let plan = plan_removal(&entries, NAME, |pid| pid == "alice");
+        assert_eq!(plan.profiles_to_update, vec!["alice"]);
+        assert_eq!(plan.accounts_to_delete, vec![NAME.to_string()]);
+    }
+
+    #[test]
+    fn remove_plan_deletes_scoped_account_only_for_target() {
+        // alice is scoped, bob is bare. Removing alice deletes alice's unique
+        // scoped account and leaves bob's bare account intact.
+        let entries = vec![
+            entry("alice", "keychain:VERTEX_SA_JSON::alice"),
+            entry("bob", "keychain:"),
+        ];
+        let plan = plan_removal(&entries, NAME, |pid| pid == "alice");
+        assert_eq!(plan.profiles_to_update, vec!["alice"]);
+        assert_eq!(
+            plan.accounts_to_delete,
+            vec!["VERTEX_SA_JSON::alice".to_string()]
+        );
+    }
+
+    #[test]
+    fn remove_plan_global_deletes_every_referenced_account() {
+        let entries = vec![
+            entry("alice", "keychain:VERTEX_SA_JSON::alice"),
+            entry("bob", "keychain:"),
+        ];
+        let plan = plan_removal(&entries, NAME, |_| true);
+        assert_eq!(plan.profiles_to_update.len(), 2);
+        assert!(
+            plan.accounts_to_delete
+                .contains(&"VERTEX_SA_JSON::alice".to_string())
+        );
+        assert!(plan.accounts_to_delete.contains(&NAME.to_string()));
+    }
+
+    #[test]
+    fn remove_plan_ignores_plaintext_values() {
+        // A plaintext (non-marker) value isn't keychain-backed; remove-key
+        // leaves it alone (no env removal, no keychain delete).
+        let entries = vec![entry("alice", "sk-plaintext")];
+        let plan = plan_removal(&entries, NAME, |_| true);
+        assert!(plan.profiles_to_update.is_empty());
+        assert!(plan.accounts_to_delete.is_empty());
     }
 }

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -332,11 +332,18 @@ pub(crate) fn build_plugin_env(
             env.push(("OPENAI_API_KEY".to_string(), api_key));
         } else {
             let key_var = match provider_name {
-                "gemini" | "google" => "GEMINI_API_KEY",
-                "dashscope" | "qwen" => "DASHSCOPE_API_KEY",
-                _ => "OPENAI_API_KEY",
+                "gemini" | "google" => Some("GEMINI_API_KEY"),
+                "dashscope" | "qwen" => Some("DASHSCOPE_API_KEY"),
+                // Vertex authenticates with a service-account JSON, not an API
+                // key. It is not a usable credential for any plugin, and must
+                // never be forwarded under the wrong `OPENAI_API_KEY` name —
+                // so inject nothing for it.
+                "vertex" | "vertex-ai" | "vertexai" => None,
+                _ => Some("OPENAI_API_KEY"),
             };
-            env.push((key_var.to_string(), api_key));
+            if let Some(key_var) = key_var {
+                env.push((key_var.to_string(), api_key));
+            }
         }
     }
 
@@ -1102,6 +1109,30 @@ mod tests {
         if let Some(v) = prev_key {
             unsafe { std::env::set_var("OPENAI_API_KEY", v) };
         }
+    }
+
+    #[test]
+    fn build_plugin_env_does_not_forward_vertex_sa_json_as_api_key() {
+        // A Vertex service-account JSON is not an API key. It must never be
+        // injected into plugin env under any `*_API_KEY` name (the catch-all
+        // arm would otherwise hand it to plugins as a bogus OPENAI_API_KEY).
+        let mut env_vars = std::collections::HashMap::new();
+        env_vars.insert(
+            "VERTEX_SA_JSON".to_string(),
+            "{\"type\":\"service_account\",\"project_id\":\"p\"}".to_string(),
+        );
+        let config = crate::config::Config {
+            provider: Some("vertex".to_string()),
+            env_vars,
+            ..Default::default()
+        };
+
+        let env = build_plugin_env(&config, "vertex");
+
+        assert!(
+            !env.iter().any(|(k, _)| k.ends_with("_API_KEY")),
+            "Vertex SA JSON must not be forwarded to plugins as an API key: {env:?}"
+        );
     }
 
     /// Gap 4.1 BLOCKER 1 (standalone gateway child-profile uses the wrong

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1417,7 +1417,9 @@ fn validate_public_subdomain(slug: &str) -> Result<()> {
 pub fn mask_secrets(profile: &UserProfile) -> UserProfile {
     let mut masked = profile.clone();
     for value in masked.config.env_vars.values_mut() {
-        if value == crate::auth::KEYCHAIN_MARKER {
+        // Any keychain marker (bare or profile-scoped) shows the indicator,
+        // never a mangled mask of the marker string itself.
+        if crate::auth::keychain::is_marker(value) {
             *value = KEYCHAIN_DISPLAY.to_string();
         } else {
             *value = mask_value(value);

--- a/crates/octos-llm/Cargo.toml
+++ b/crates/octos-llm/Cargo.toml
@@ -29,6 +29,7 @@ base64 = { workspace = true }
 chrono = { workspace = true }
 redb = { workspace = true }
 metrics = { workspace = true }
+jsonwebtoken = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/octos-llm/src/gemini.rs
+++ b/crates/octos-llm/src/gemini.rs
@@ -9,7 +9,9 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
 use secrecy::{ExposeSecret, SecretString};
+use std::sync::Arc;
 
+use crate::vertex_auth::{ServiceAccount, TokenSource, VertexTokenProvider};
 use crate::vision;
 
 use crate::config::ChatConfig;
@@ -50,26 +52,95 @@ fn next_gemini_tool_call_id() -> String {
     )
 }
 
+/// Default AI Studio base URL (the `generativelanguage.googleapis.com` host).
+const STUDIO_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
+
+/// How a [`GeminiProvider`] authenticates.
+///
+/// `ApiKey` is AI Studio (`x-goog-api-key` against
+/// `generativelanguage.googleapis.com`). `Vertex` is Vertex AI: an OAuth2
+/// `Authorization: Bearer` token (minted from a service account) against the
+/// `aiplatform.googleapis.com` `projects/.../locations/global` endpoint.
+enum GeminiAuth {
+    ApiKey(SecretString),
+    Vertex {
+        project: String,
+        token: Arc<dyn TokenSource>,
+    },
+}
+
 /// Google Gemini provider.
 pub struct GeminiProvider {
     client: Client,
-    api_key: SecretString,
+    auth: GeminiAuth,
     model: String,
     base_url: String,
 }
 
 impl GeminiProvider {
-    /// Create a new Gemini provider.
+    /// Create a new Gemini provider authenticating with an AI Studio API key.
     pub fn new(api_key: impl Into<String>, model: impl Into<String>) -> Self {
         Self {
             client: crate::provider::build_http_client(
                 crate::provider::DEFAULT_LLM_TIMEOUT_SECS,
                 crate::provider::DEFAULT_LLM_CONNECT_TIMEOUT_SECS,
             ),
-            api_key: SecretString::from(api_key.into()),
+            auth: GeminiAuth::ApiKey(SecretString::from(api_key.into())),
             model: model.into(),
-            base_url: "https://generativelanguage.googleapis.com/v1beta".to_string(),
+            base_url: STUDIO_BASE_URL.to_string(),
         }
+    }
+
+    /// Create a Gemini provider that calls **Vertex AI** with an OAuth2 token
+    /// source. `project` is the GCP project id; the region is fixed to `global`.
+    pub fn vertex(
+        project: impl Into<String>,
+        model: impl Into<String>,
+        token: Arc<dyn TokenSource>,
+    ) -> Self {
+        Self {
+            client: crate::provider::build_http_client(
+                crate::provider::DEFAULT_LLM_TIMEOUT_SECS,
+                crate::provider::DEFAULT_LLM_CONNECT_TIMEOUT_SECS,
+            ),
+            auth: GeminiAuth::Vertex {
+                project: project.into(),
+                token,
+            },
+            model: model.into(),
+            // Unused in Vertex mode (endpoint is computed), kept for metadata.
+            base_url: STUDIO_BASE_URL.to_string(),
+        }
+    }
+
+    /// Create a Vertex-mode provider from a service account. The GCP project is
+    /// taken from the service account's `project_id`.
+    pub fn vertex_from_service_account(sa: ServiceAccount, model: impl Into<String>) -> Self {
+        Self::vertex_from_service_account_with_timeout(sa, model, None)
+    }
+
+    /// Like [`vertex_from_service_account`], but threads the provider's HTTP
+    /// timeout into the OAuth token-exchange client as well. Without this the
+    /// token fetcher uses an unbounded `reqwest::Client`, so a stalled token
+    /// endpoint would block a Vertex chat past the configured LLM timeout before
+    /// `generateContent` is ever reached.
+    pub fn vertex_from_service_account_with_timeout(
+        sa: ServiceAccount,
+        model: impl Into<String>,
+        http_timeout: Option<(u64, u64)>,
+    ) -> Self {
+        let project = sa.project_id.clone();
+        let token: Arc<dyn TokenSource> =
+            if let Some((timeout_secs, connect_timeout_secs)) = http_timeout {
+                Arc::new(VertexTokenProvider::from_service_account_with_timeout(
+                    sa,
+                    timeout_secs,
+                    connect_timeout_secs,
+                ))
+            } else {
+                Arc::new(VertexTokenProvider::from_service_account(sa))
+            };
+        Self::vertex(project, model, token)
     }
 
     /// Create a provider using the GEMINI_API_KEY environment variable.
@@ -80,7 +151,7 @@ impl GeminiProvider {
         Ok(Self::new(api_key, "gemini-2.5-flash"))
     }
 
-    /// Set a custom base URL.
+    /// Set a custom base URL (AI Studio mode only; ignored for Vertex).
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = base_url.into();
         self
@@ -90,6 +161,36 @@ impl GeminiProvider {
     pub fn with_http_timeout(mut self, timeout_secs: u64, connect_timeout_secs: u64) -> Self {
         self.client = crate::provider::build_http_client(timeout_secs, connect_timeout_secs);
         self
+    }
+
+    /// Build the generateContent endpoint URL for the active auth mode.
+    fn build_url(&self, streaming: bool) -> String {
+        let action = if streaming {
+            "streamGenerateContent?alt=sse"
+        } else {
+            "generateContent"
+        };
+        match &self.auth {
+            GeminiAuth::ApiKey(_) => {
+                format!("{}/models/{}:{}", self.base_url, self.model, action)
+            }
+            GeminiAuth::Vertex { project, .. } => format!(
+                "https://aiplatform.googleapis.com/v1/projects/{project}/locations/global/publishers/google/models/{}:{}",
+                self.model, action
+            ),
+        }
+    }
+
+    /// Attach the auth header for the active mode (resolving a fresh Vertex
+    /// token when needed).
+    async fn apply_auth(&self, req: reqwest::RequestBuilder) -> Result<reqwest::RequestBuilder> {
+        Ok(match &self.auth {
+            GeminiAuth::ApiKey(key) => req.header("x-goog-api-key", key.expose_secret()),
+            GeminiAuth::Vertex { token, .. } => {
+                let t = token.token().await?;
+                req.header("Authorization", format!("Bearer {t}"))
+            }
+        })
     }
 }
 
@@ -133,17 +234,19 @@ impl LlmProvider for GeminiProvider {
             cached_content: None,
         };
 
-        let url = format!("{}/models/{}:generateContent", self.base_url, self.model);
+        let url = self.build_url(false);
 
-        let response = self
+        let req = self
             .client
             .post(&url)
             .header("Content-Type", "application/json")
-            .header("x-goog-api-key", self.api_key.expose_secret())
             .timeout(std::time::Duration::from_secs(
                 crate::provider::DEFAULT_LLM_TIMEOUT_SECS,
             ))
-            .json(&request)
+            .json(&request);
+        let response = self
+            .apply_auth(req)
+            .await?
             .send()
             .await
             .wrap_err("failed to send request to Gemini")?;
@@ -278,17 +381,16 @@ impl LlmProvider for GeminiProvider {
             cached_content: None,
         };
 
-        let url = format!(
-            "{}/models/{}:streamGenerateContent?alt=sse",
-            self.base_url, self.model
-        );
+        let url = self.build_url(true);
 
-        let response = self
+        let req = self
             .client
             .post(&url)
             .header("Content-Type", "application/json")
-            .header("x-goog-api-key", self.api_key.expose_secret())
-            .json(&request)
+            .json(&request);
+        let response = self
+            .apply_auth(req)
+            .await?
             .send()
             .await
             .wrap_err("failed to send streaming request to Gemini")?;
@@ -322,7 +424,13 @@ impl LlmProvider for GeminiProvider {
     }
 
     fn provider_name(&self) -> &str {
-        "gemini"
+        // Vertex AI and AI Studio Gemini must be distinguishable for routing,
+        // adaptive-lane matching and metrics — they're different backends even
+        // though both use `GeminiProvider`.
+        match self.auth {
+            GeminiAuth::Vertex { .. } => "vertex",
+            GeminiAuth::ApiKey(_) => "gemini",
+        }
     }
 
     fn provider_metadata(&self) -> ProviderMetadata {
@@ -331,7 +439,9 @@ impl LlmProvider for GeminiProvider {
         } else {
             None
         };
-        ProviderMetadata::new("gemini", self.model.clone(), endpoint)
+        // Derive the metadata name from the auth mode (same as `provider_name`)
+        // so Vertex calls aren't mislabelled as AI Studio gemini in provenance.
+        ProviderMetadata::new(self.provider_name(), self.model.clone(), endpoint)
     }
 }
 
@@ -1159,6 +1269,76 @@ mod tests {
         let provider =
             GeminiProvider::new("key", "model").with_base_url("https://custom.googleapis.com");
         assert_eq!(provider.base_url, "https://custom.googleapis.com");
+    }
+
+    // --- Vertex / Gemini auth-mode tests ---
+
+    struct StaticToken(&'static str);
+
+    #[async_trait::async_trait]
+    impl crate::vertex_auth::TokenSource for StaticToken {
+        async fn token(&self) -> Result<String> {
+            Ok(self.0.to_string())
+        }
+    }
+
+    #[test]
+    fn should_build_global_vertex_endpoint_when_vertex_mode() {
+        let provider =
+            GeminiProvider::vertex("my-proj", "gemini-2.5-flash", Arc::new(StaticToken("tok")));
+        assert_eq!(
+            provider.build_url(false),
+            "https://aiplatform.googleapis.com/v1/projects/my-proj/locations/global/publishers/google/models/gemini-2.5-flash:generateContent"
+        );
+        assert_eq!(
+            provider.build_url(true),
+            "https://aiplatform.googleapis.com/v1/projects/my-proj/locations/global/publishers/google/models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+        );
+    }
+
+    #[test]
+    fn provider_name_distinguishes_vertex_from_studio_gemini() {
+        use crate::provider::LlmProvider;
+        let vertex = GeminiProvider::vertex("p", "m", Arc::new(StaticToken("tok")));
+        let studio = GeminiProvider::new("key", "gemini-2.5-flash");
+        assert_eq!(vertex.provider_name(), "vertex");
+        assert_eq!(studio.provider_name(), "gemini");
+        // provider_metadata must agree with provider_name (provenance label).
+        assert_eq!(vertex.provider_metadata().provider, "vertex");
+        assert_eq!(studio.provider_metadata().provider, "gemini");
+    }
+
+    #[test]
+    fn should_build_studio_endpoint_when_api_key_mode() {
+        let provider = GeminiProvider::new("key", "gemini-2.5-flash");
+        assert_eq!(
+            provider.build_url(false),
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_send_bearer_header_when_vertex_mode() {
+        let provider = GeminiProvider::vertex("p", "m", Arc::new(StaticToken("abc123")));
+        let req = provider.client.post("https://example.com");
+        let built = provider.apply_auth(req).await.unwrap().build().unwrap();
+        assert_eq!(
+            built.headers().get("Authorization").unwrap(),
+            "Bearer abc123"
+        );
+        assert!(
+            built.headers().get("x-goog-api-key").is_none(),
+            "Vertex mode must not send the AI Studio api-key header"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_send_api_key_header_when_studio_mode() {
+        let provider = GeminiProvider::new("secret-key", "m");
+        let req = provider.client.post("https://example.com");
+        let built = provider.apply_auth(req).await.unwrap().build().unwrap();
+        assert_eq!(built.headers().get("x-goog-api-key").unwrap(), "secret-key");
+        assert!(built.headers().get("Authorization").is_none());
     }
 
     // --- Generation config tests ---

--- a/crates/octos-llm/src/lib.rs
+++ b/crates/octos-llm/src/lib.rs
@@ -39,6 +39,7 @@ pub mod openai;
 pub mod openai_responses;
 pub mod openrouter;
 pub mod registry;
+pub mod vertex_auth;
 
 pub use adaptive::{
     AdaptiveConfig, AdaptiveMode, AdaptiveRouter, AdaptiveStatus, AutoEscalationCallback,

--- a/crates/octos-llm/src/registry/mod.rs
+++ b/crates/octos-llm/src/registry/mod.rs
@@ -24,6 +24,7 @@ mod ollama;
 mod openai;
 mod openrouter;
 mod r9s;
+mod vertex;
 mod vllm;
 mod zai;
 mod zhipu;
@@ -90,6 +91,7 @@ static ALL: &[ProviderEntry] = &[
     anthropic::ENTRY,
     openai::ENTRY,
     gemini::ENTRY,
+    vertex::ENTRY,
     r9s::ENTRY,
     openrouter::ENTRY,
     deepseek::ENTRY,
@@ -203,7 +205,18 @@ mod tests {
 
     #[test]
     fn all_entries_count() {
-        assert_eq!(all_entries().len(), 15);
+        assert_eq!(all_entries().len(), 16);
+    }
+
+    #[test]
+    fn vertex_entry_is_registered_with_sa_json_credential() {
+        let e = lookup("vertex").expect("vertex provider should be registered");
+        assert_eq!(e.name, "vertex");
+        // Credential is the SA JSON, resolved through the VERTEX_SA_JSON channel.
+        assert_eq!(e.api_key_env, Some("VERTEX_SA_JSON"));
+        assert!(e.requires_api_key);
+        // bare gemini model names must NOT auto-route to vertex.
+        assert_eq!(detect_provider("gemini-2.5-flash"), Some("gemini"));
     }
 
     #[test]

--- a/crates/octos-llm/src/registry/vertex.rs
+++ b/crates/octos-llm/src/registry/vertex.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use eyre::{Result, WrapErr};
+
+use crate::gemini::GeminiProvider;
+use crate::provider::LlmProvider;
+use crate::vertex_auth::ServiceAccount;
+
+use super::{CreateParams, ProviderEntry};
+
+/// Vertex AI (Gemini) provider — authenticates with a Google service-account
+/// JSON instead of an API key. The GCP project is read from the JSON's
+/// `project_id`; the region is fixed to `global`.
+///
+/// Selected explicitly via `provider: "vertex"` (no auto-detection from model
+/// name — bare `gemini-*` models still resolve to the AI Studio `gemini`
+/// provider). The credential is the service-account JSON *content*, resolved
+/// through the normal key channel under `VERTEX_SA_JSON` (a keychain marker →
+/// macOS Keychain, a plain config value, or the process env). The private key
+/// never has to live as a file path.
+pub const ENTRY: ProviderEntry = ProviderEntry {
+    name: "vertex",
+    aliases: &["vertex-ai", "vertexai"],
+    default_model: Some("gemini-2.5-flash"),
+    api_key_env: Some("VERTEX_SA_JSON"),
+    default_base_url: None,
+    requires_api_key: true,
+    requires_base_url: false,
+    requires_model: false,
+    detect_patterns: &[],
+    create,
+};
+
+fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
+    let http_timeout = p.http_timeout();
+    let json = p.api_key.ok_or_else(|| {
+        eyre::eyre!(
+            "vertex provider requires a service-account JSON credential \
+             (VERTEX_SA_JSON — store it via the dashboard or `octos auth`)"
+        )
+    })?;
+    let sa = ServiceAccount::from_json(&json)
+        .wrap_err("failed to parse Vertex service-account JSON credential")?;
+    let model = p.model.unwrap_or_else(|| "gemini-2.5-flash".into());
+    // Thread the timeout into both the chat client (`with_http_timeout`) and the
+    // OAuth token-exchange client (the `_with_timeout` constructor).
+    let mut provider =
+        GeminiProvider::vertex_from_service_account_with_timeout(sa, &model, http_timeout);
+    if let Some((t, c)) = http_timeout {
+        provider = provider.with_http_timeout(t, c);
+    }
+    Ok(Arc::new(provider))
+}

--- a/crates/octos-llm/src/vertex_auth.rs
+++ b/crates/octos-llm/src/vertex_auth.rs
@@ -1,0 +1,344 @@
+//! Vertex AI service-account auth.
+//!
+//! Google Vertex AI does not accept a plain API key like AI Studio. It uses
+//! OAuth2 Bearer tokens minted from a service-account JSON key:
+//!
+//! 1. Parse the SA JSON (`client_email`, `private_key`, `project_id`, `token_uri`).
+//! 2. Sign a short-lived JWT assertion (RS256) with the SA private key.
+//! 3. Exchange the assertion at `token_uri` for an `access_token` (~1h TTL).
+//! 4. Cache the token and refresh shortly before expiry.
+//!
+//! [`GeminiProvider`](crate::gemini::GeminiProvider) holds a
+//! [`TokenSource`] (typically a [`VertexTokenProvider`]) and attaches
+//! `Authorization: Bearer <token>` to each request when in Vertex mode.
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use eyre::{Result, WrapErr};
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+
+/// OAuth2 scope required for Vertex AI generateContent.
+const SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
+/// JWT assertion lifetime (Google caps this at 1h).
+const ASSERTION_TTL_SECS: u64 = 3600;
+/// Refresh this long before actual expiry so a token is never used right as it
+/// lapses (clock skew + in-flight request slack).
+const EXPIRY_SKEW: Duration = Duration::from_secs(60);
+/// Google's default token endpoint, used when the SA JSON omits `token_uri`.
+fn default_token_uri() -> String {
+    "https://oauth2.googleapis.com/token".to_string()
+}
+
+/// A Google service account, parsed from its JSON key file.
+#[derive(Clone)]
+pub struct ServiceAccount {
+    pub client_email: String,
+    pub private_key: SecretString,
+    pub project_id: String,
+    pub token_uri: String,
+}
+
+#[derive(Deserialize)]
+struct RawServiceAccount {
+    client_email: Option<String>,
+    private_key: Option<String>,
+    project_id: Option<String>,
+    #[serde(default = "default_token_uri")]
+    token_uri: String,
+}
+
+impl ServiceAccount {
+    /// Parse a service account from its JSON contents.
+    pub fn from_json(s: &str) -> Result<Self> {
+        let raw: RawServiceAccount =
+            serde_json::from_str(s).wrap_err("invalid service account JSON")?;
+        Ok(Self {
+            client_email: raw
+                .client_email
+                .ok_or_else(|| eyre::eyre!("service account JSON missing 'client_email'"))?,
+            private_key: SecretString::from(
+                raw.private_key
+                    .ok_or_else(|| eyre::eyre!("service account JSON missing 'private_key'"))?,
+            ),
+            project_id: raw
+                .project_id
+                .ok_or_else(|| eyre::eyre!("service account JSON missing 'project_id'"))?,
+            token_uri: raw.token_uri,
+        })
+    }
+
+    /// Read and parse a service account from a JSON file on disk.
+    pub fn from_path(path: &std::path::Path) -> Result<Self> {
+        let data = std::fs::read_to_string(path)
+            .wrap_err_with(|| format!("failed to read service account JSON: {}", path.display()))?;
+        Self::from_json(&data)
+    }
+}
+
+/// Current unix time in seconds (wall clock).
+fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Build the JWT claim set for a service-account token exchange.
+///
+/// Split out from signing so the claim shape is unit-testable without a real
+/// RSA key.
+fn build_claims(sa: &ServiceAccount, now_unix: u64) -> serde_json::Value {
+    serde_json::json!({
+        "iss": sa.client_email,
+        "scope": SCOPE,
+        "aud": sa.token_uri,
+        "iat": now_unix,
+        "exp": now_unix + ASSERTION_TTL_SECS,
+    })
+}
+
+/// Sign a JWT assertion (RS256) for the service account.
+fn build_assertion(sa: &ServiceAccount, now_unix: u64) -> Result<String> {
+    use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+
+    let claims = build_claims(sa, now_unix);
+    let key = EncodingKey::from_rsa_pem(sa.private_key.expose_secret().as_bytes())
+        .wrap_err("invalid RSA private_key in service account")?;
+    encode(&Header::new(Algorithm::RS256), &claims, &key).wrap_err("failed to sign JWT assertion")
+}
+
+/// Something that yields a Vertex AI bearer token (cached + auto-refreshing).
+#[async_trait]
+pub trait TokenSource: Send + Sync {
+    /// Return a currently-valid access token.
+    async fn token(&self) -> Result<String>;
+}
+
+/// Fetches a fresh `(token, ttl)` from the token endpoint. Split from caching so
+/// the cache logic can be tested with a fake fetcher (no network, no signing).
+#[async_trait]
+trait TokenFetch: Send + Sync {
+    async fn fetch(&self) -> Result<(String, Duration)>;
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    #[serde(default = "default_expires_in")]
+    expires_in: u64,
+}
+fn default_expires_in() -> u64 {
+    ASSERTION_TTL_SECS
+}
+
+/// Real fetcher: sign an assertion and exchange it at Google's token endpoint.
+struct GoogleJwtFetch {
+    sa: ServiceAccount,
+    client: reqwest::Client,
+}
+
+#[async_trait]
+impl TokenFetch for GoogleJwtFetch {
+    async fn fetch(&self) -> Result<(String, Duration)> {
+        let assertion = build_assertion(&self.sa, now_unix())?;
+        let params = [
+            ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+            ("assertion", assertion.as_str()),
+        ];
+        let resp = self
+            .client
+            .post(&self.sa.token_uri)
+            .form(&params)
+            .send()
+            .await
+            .wrap_err("failed to request Vertex access token")?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            eyre::bail!("Vertex token endpoint returned {status}: {body}");
+        }
+        let tr: TokenResponse = resp
+            .json()
+            .await
+            .wrap_err("invalid Vertex token response body")?;
+        Ok((tr.access_token, Duration::from_secs(tr.expires_in)))
+    }
+}
+
+struct Cached {
+    value: String,
+    expires_at: Instant,
+}
+
+/// Caching, auto-refreshing Vertex token provider.
+pub struct VertexTokenProvider {
+    fetcher: Box<dyn TokenFetch>,
+    cache: Mutex<Option<Cached>>,
+    skew: Duration,
+}
+
+impl VertexTokenProvider {
+    /// Build a provider that signs + exchanges tokens for the given service
+    /// account, using the default LLM HTTP timeouts for the token-exchange call.
+    pub fn from_service_account(sa: ServiceAccount) -> Self {
+        Self::from_service_account_with_timeout(
+            sa,
+            crate::provider::DEFAULT_LLM_TIMEOUT_SECS,
+            crate::provider::DEFAULT_LLM_CONNECT_TIMEOUT_SECS,
+        )
+    }
+
+    /// Like [`from_service_account`], but bounds the token-exchange HTTP client
+    /// with the given timeouts so a stalled OAuth endpoint can't hang a chat
+    /// past the configured LLM timeout before `generateContent` is reached.
+    pub fn from_service_account_with_timeout(
+        sa: ServiceAccount,
+        timeout_secs: u64,
+        connect_timeout_secs: u64,
+    ) -> Self {
+        Self {
+            fetcher: Box::new(GoogleJwtFetch {
+                sa,
+                client: crate::provider::build_http_client(timeout_secs, connect_timeout_secs),
+            }),
+            cache: Mutex::new(None),
+            skew: EXPIRY_SKEW,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_fetcher(fetcher: Box<dyn TokenFetch>) -> Self {
+        Self {
+            fetcher,
+            cache: Mutex::new(None),
+            skew: EXPIRY_SKEW,
+        }
+    }
+}
+
+#[async_trait]
+impl TokenSource for VertexTokenProvider {
+    async fn token(&self) -> Result<String> {
+        // Fast path: a cached token with comfortable remaining lifetime.
+        {
+            let guard = self.cache.lock().expect("token cache poisoned");
+            if let Some(c) = guard.as_ref() {
+                if c.expires_at.saturating_duration_since(Instant::now()) > self.skew {
+                    return Ok(c.value.clone());
+                }
+            }
+        }
+        // Slow path: refresh. (A rare concurrent double-fetch is harmless.)
+        let (value, ttl) = self.fetcher.fetch().await?;
+        let expires_at = Instant::now() + ttl;
+        let mut guard = self.cache.lock().expect("token cache poisoned");
+        *guard = Some(Cached {
+            value: value.clone(),
+            expires_at,
+        });
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn sample_sa_json() -> &'static str {
+        r#"{
+            "type": "service_account",
+            "project_id": "my-proj",
+            "client_email": "svc@my-proj.iam.gserviceaccount.com",
+            "private_key": "-----BEGIN PRIVATE KEY-----\nNOTAREALKEY\n-----END PRIVATE KEY-----\n",
+            "token_uri": "https://oauth2.googleapis.com/token"
+        }"#
+    }
+
+    #[test]
+    fn should_parse_service_account_fields_when_valid_json() {
+        let sa = ServiceAccount::from_json(sample_sa_json()).unwrap();
+        assert_eq!(sa.project_id, "my-proj");
+        assert_eq!(sa.client_email, "svc@my-proj.iam.gserviceaccount.com");
+        assert_eq!(sa.token_uri, "https://oauth2.googleapis.com/token");
+        assert!(sa.private_key.expose_secret().contains("BEGIN PRIVATE KEY"));
+    }
+
+    #[test]
+    fn should_default_token_uri_when_absent() {
+        let json = r#"{"project_id":"p","client_email":"e","private_key":"k"}"#;
+        let sa = ServiceAccount::from_json(json).unwrap();
+        assert_eq!(sa.token_uri, "https://oauth2.googleapis.com/token");
+    }
+
+    #[test]
+    fn should_error_when_private_key_missing() {
+        let json = r#"{"project_id":"p","client_email":"e"}"#;
+        let err = ServiceAccount::from_json(json)
+            .err()
+            .expect("missing private_key should error")
+            .to_string();
+        assert!(err.contains("private_key"), "got: {err}");
+    }
+
+    #[test]
+    fn should_build_jwt_claims_with_expected_fields_when_signing() {
+        let sa = ServiceAccount::from_json(sample_sa_json()).unwrap();
+        let claims = build_claims(&sa, 1_000);
+        assert_eq!(claims["iss"], "svc@my-proj.iam.gserviceaccount.com");
+        assert_eq!(claims["scope"], SCOPE);
+        assert_eq!(claims["aud"], "https://oauth2.googleapis.com/token");
+        assert_eq!(claims["iat"], 1_000);
+        assert_eq!(claims["exp"], 1_000 + 3600);
+    }
+
+    #[test]
+    fn should_error_when_private_key_invalid_pem() {
+        // The signing path must surface a clear error rather than panic when the
+        // SA carries a malformed private key.
+        let sa = ServiceAccount::from_json(sample_sa_json()).unwrap();
+        assert!(build_assertion(&sa, 1_000).is_err());
+    }
+
+    struct CountingFetch {
+        count: AtomicUsize,
+        ttl: Duration,
+    }
+
+    #[async_trait]
+    impl TokenFetch for CountingFetch {
+        async fn fetch(&self) -> Result<(String, Duration)> {
+            let n = self.count.fetch_add(1, Ordering::SeqCst);
+            Ok((format!("tok{n}"), self.ttl))
+        }
+    }
+
+    #[tokio::test]
+    async fn should_cache_token_until_near_expiry() {
+        let provider = VertexTokenProvider::with_fetcher(Box::new(CountingFetch {
+            count: AtomicUsize::new(0),
+            ttl: Duration::from_secs(3600),
+        }));
+        let a = provider.token().await.unwrap();
+        let b = provider.token().await.unwrap();
+        assert_eq!(a, "tok0");
+        assert_eq!(b, "tok0", "second call should hit the cache");
+    }
+
+    #[tokio::test]
+    async fn should_refresh_token_after_expiry() {
+        // ttl=0 → the cached token is always within the skew window, so every
+        // call must refetch a fresh token.
+        let provider = VertexTokenProvider::with_fetcher(Box::new(CountingFetch {
+            count: AtomicUsize::new(0),
+            ttl: Duration::from_secs(0),
+        }));
+        let a = provider.token().await.unwrap();
+        let b = provider.token().await.unwrap();
+        assert_eq!(a, "tok0");
+        assert_eq!(b, "tok1", "expired token should be refreshed");
+    }
+}

--- a/crates/octos-llm/tests/vertex_integration.rs
+++ b/crates/octos-llm/tests/vertex_integration.rs
@@ -1,0 +1,63 @@
+//! Live Vertex AI integration test.
+//!
+//! `#[ignore]` — needs real Google credentials, a real image, and network.
+//! Run with:
+//!
+//! ```bash
+//! VERTEX_SA_JSON=/path/to/service_account.json \
+//! VERTEX_TEST_IMAGE=/path/to/photo.jpg \
+//!   cargo test -p octos-llm --test vertex_integration -- --ignored --nocapture
+//! ```
+//!
+//! Use a normal photo (jpg/png/webp). Vertex rejects degenerate images
+//! ("Provided image is not valid"), so a 1x1 placeholder won't do.
+
+use octos_core::{Message, MessageRole};
+use octos_llm::gemini::GeminiProvider;
+use octos_llm::vertex_auth::ServiceAccount;
+use octos_llm::{ChatConfig, LlmProvider, ToolSpec};
+
+fn user_with_image(text: &str, image_path: &str) -> Message {
+    Message {
+        role: MessageRole::User,
+        content: text.to_string(),
+        media: vec![image_path.to_string()],
+        tool_calls: None,
+        tool_call_id: None,
+        reasoning_content: None,
+        client_message_id: None,
+        thread_id: None,
+        timestamp: chrono::Utc::now(),
+    }
+}
+
+#[tokio::test]
+#[ignore = "needs VERTEX_SA_JSON + VERTEX_TEST_IMAGE + network"]
+async fn vertex_gemini_answers_a_vision_request() {
+    let path = std::env::var("VERTEX_SA_JSON")
+        .expect("set VERTEX_SA_JSON to the service-account JSON path");
+    let image_path = std::env::var("VERTEX_TEST_IMAGE")
+        .expect("set VERTEX_TEST_IMAGE to a real image file path");
+    assert!(
+        std::path::Path::new(&image_path).is_file(),
+        "VERTEX_TEST_IMAGE does not point to a file: {image_path}"
+    );
+
+    let sa = ServiceAccount::from_path(std::path::Path::new(&path)).unwrap();
+    let provider = GeminiProvider::vertex_from_service_account(sa, "gemini-2.5-flash");
+
+    let messages = vec![user_with_image(
+        "Describe this image in one short sentence.",
+        &image_path,
+    )];
+
+    let no_tools: &[ToolSpec] = &[];
+    let resp = provider
+        .chat(&messages, no_tools, &ChatConfig::default())
+        .await
+        .expect("vertex chat should succeed");
+
+    let text = resp.content.unwrap_or_default();
+    assert!(!text.trim().is_empty(), "expected a non-empty reply");
+    eprintln!("vertex reply: {text}");
+}


### PR DESCRIPTION
## Summary
Adds a **Vertex AI** auth path to the Gemini provider so it can be driven by a Google **service-account JSON** instead of an AI Studio API key, and makes it configurable from the dashboard with the private key stored in the macOS Keychain (never in plaintext config).

## What's included
- **`vertex_auth.rs`** — parse SA JSON, sign an RS256 JWT assertion, exchange it for an OAuth2 access token, cache + auto-refresh (`TokenSource`).
- **`gemini.rs`** — `GeminiAuth { ApiKey | Vertex }`; Vertex mode targets `aiplatform.googleapis.com/.../locations/global` with `Authorization: Bearer`. AI Studio path unchanged (regression-tested).
- **`registry/vertex`** — new `vertex` provider (aliases `vertex-ai`/`vertexai`). Credential is the SA JSON *content*, resolved through the `VERTEX_SA_JSON` key channel; project read from the JSON, region fixed to `global`.
- **`update_my_profile`** — relocate a freshly-entered SA JSON out of `env_vars` into the OS keychain, storing only the `keychain:` marker. macOS-only; a raw secret on another OS is rejected, not persisted.
- **`test_provider` / `resolve_saved_key`** — Test Connection resolves the keychain marker and uses a 128-token budget for Vertex (gemini-2.5 thinking models return empty at 16).
- **`keychain::get_secret`** — decode the hex output `security -w` emits for multi-line secrets (the SA JSON newlines), which otherwise corrupted the resolved credential. Ordinary single-line keys pass through untouched.

## Notes
- Pairs with octos-web PR (`feat/vertex-admin-config`) for the settings UI.
- Keychain config is **macOS-only** (by design — no cross-platform fallback).
- New dep: `jsonwebtoken` (RS256 via `ring`, already in tree via rustls — no OpenSSL).

## Test plan
- `cargo test -p octos-llm` (unit: SA parsing, JWT claims, token cache/refresh, endpoint/header per mode).
- `cargo test -p octos-cli --features api` (keychain hex decode, profile keychain relocation).
- Live: `VERTEX_SA_JSON=… VERTEX_TEST_IMAGE=… cargo test -p octos-llm --test vertex_integration -- --ignored`.
- End-to-end verified: configure Vertex in the dashboard → Test Connection OK → chat replies via Gemini/Vertex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)