### PR TITLE
Add Matrix user-account channel support

### DIFF
--- a/crates/octos-bus/src/lib.rs
+++ b/crates/octos-bus/src/lib.rs
@@ -26,6 +26,8 @@ pub mod feishu_channel;
 pub mod line_channel;
 #[cfg(feature = "matrix")]
 pub mod matrix_channel;
+#[cfg(feature = "matrix")]
+pub mod matrix_user_channel;
 #[cfg(feature = "qq-bot")]
 pub mod qq_bot_channel;
 #[cfg(feature = "slack")]
@@ -79,6 +81,10 @@ pub use matrix_channel::{
     BotEntry, BotManager, BotRouter, BotVisibility, MatrixChannel, MatrixEventId, MatrixRoomId,
     MatrixUserId, SWARM_SUPERVISOR_EVENT_SCHEMA_V1, SteeringInput, SwarmHarnessEvent,
     SwarmSupervisorParams,
+};
+#[cfg(feature = "matrix")]
+pub use matrix_user_channel::{
+    MatrixAutoJoin, MatrixGroupPolicy, MatrixInviteStore, MatrixPendingInvite, MatrixUserChannel,
 };
 #[cfg(feature = "qq-bot")]
 pub use qq_bot_channel::QQBotChannel;

--- a/crates/octos-bus/src/matrix_channel.rs
+++ b/crates/octos-bus/src/matrix_channel.rs
@@ -795,7 +795,7 @@ impl MatrixChannel {
 /// Encodes characters that are not unreserved (per RFC 3986) and also encodes
 /// characters commonly found in Matrix identifiers that could conflict with
 /// URL parsing (`:`, `@`, `!`, `#`).
-fn percent_encode_path(s: &str) -> String {
+pub(crate) fn percent_encode_path(s: &str) -> String {
     let mut encoded = String::with_capacity(s.len() * 3);
     for byte in s.bytes() {
         match byte {

--- a/crates/octos-bus/src/matrix_user_channel.rs
+++ b/crates/octos-bus/src/matrix_user_channel.rs
@@ -1,0 +1,1350 @@
+//! Matrix client (user-account) channel.
+//!
+//! Unlike [`crate::matrix_channel`] (Appservice mode), this logs in as a regular
+//! Matrix user account — via an access token or password — and long-polls the
+//! Client-Server `/sync` API to receive messages. No homeserver-side appservice
+//! registration is required, so it works with any account on any homeserver
+//! (matrix.org, a self-hosted server, etc.).
+//!
+//! Modeled after the user-mode integration in the sibling `savfox` project, but
+//! hand-rolled on the workspace `reqwest` (rustls) client to avoid pulling in a
+//! second HTTP stack — consistent with the existing appservice channel.
+
+use std::collections::HashSet;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use eyre::{Result, WrapErr, eyre};
+use octos_core::{InboundMessage, OutboundMessage};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::sync::{Mutex, mpsc};
+use tracing::{debug, info, warn};
+
+use crate::channel::{Channel, ChannelHealth};
+use crate::dedup::MessageDedup;
+use crate::markdown_html::markdown_to_matrix_html;
+use crate::matrix_channel::percent_encode_path;
+
+const CHANNEL_NAME: &str = "matrix";
+const EVENT_ROOM_MESSAGE: &str = "m.room.message";
+const EVENT_ROOM_MEMBER: &str = "m.room.member";
+const EVENT_ROOM_NAME: &str = "m.room.name";
+const EVENT_ROOM_CANONICAL_ALIAS: &str = "m.room.canonical_alias";
+const MSGTYPE_TEXT: &str = "m.text";
+const MATRIX_INVITES_FILE: &str = "matrix-invites.json";
+/// Long-poll timeout for the `/sync` request (server holds the connection open
+/// until an event arrives or this elapses).
+const SYNC_TIMEOUT_MS: u64 = 30_000;
+const DEFAULT_DEVICE_NAME: &str = "octos";
+
+/// Matrix invite auto-join policy.
+///
+/// Mirrors OpenClaw's Matrix model: invites are evaluated before the runtime
+/// can reliably classify a room as a DM or a group, so this policy applies to
+/// every invite.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MatrixAutoJoin {
+    #[default]
+    Off,
+    Allowlist,
+    Always,
+}
+
+impl MatrixAutoJoin {
+    pub fn parse(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "always" | "on" | "true" => Self::Always,
+            "allowlist" | "allow_list" | "allowed" => Self::Allowlist,
+            _ => Self::Off,
+        }
+    }
+}
+
+/// Matrix room/group authorization policy.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MatrixGroupPolicy {
+    Open,
+    #[default]
+    Allowlist,
+    Disabled,
+}
+
+impl MatrixGroupPolicy {
+    pub fn parse(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "open" | "all" => Self::Open,
+            "disabled" | "off" | "false" => Self::Disabled,
+            _ => Self::Allowlist,
+        }
+    }
+}
+
+/// Credentials resolved after a successful login (token reuse or password).
+#[derive(Clone, Debug)]
+struct ResolvedClient {
+    access_token: String,
+    user_id: String,
+    logout_on_stop: bool,
+}
+
+/// A single text message extracted from a `/sync` response.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ParsedMessage {
+    room_id: String,
+    sender: String,
+    body: String,
+    event_id: Option<String>,
+    mentioned_self: bool,
+}
+
+/// A room invite extracted from `/sync`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ParsedInvite {
+    room_id: String,
+    room_name: Option<String>,
+    canonical_alias: Option<String>,
+    inviter: Option<String>,
+    membership_event_id: Option<String>,
+}
+
+impl ParsedInvite {
+    fn pending(&self, channel_index: usize) -> MatrixPendingInvite {
+        let now = Utc::now();
+        MatrixPendingInvite {
+            channel_index,
+            room_id: self.room_id.clone(),
+            room_name: self.room_name.clone(),
+            canonical_alias: self.canonical_alias.clone(),
+            inviter: self.inviter.clone(),
+            membership_event_id: self.membership_event_id.clone(),
+            received_at: now,
+            last_seen_at: now,
+            dismissed_at: None,
+        }
+    }
+}
+
+/// An invite waiting for an administrator decision.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MatrixPendingInvite {
+    /// Index in the profile's channel list. This keeps the on-disk schema ready
+    /// for multiple Matrix account channels without changing the API later.
+    #[serde(default)]
+    pub channel_index: usize,
+    pub room_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub room_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_alias: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inviter: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub membership_event_id: Option<String>,
+    pub received_at: DateTime<Utc>,
+    pub last_seen_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dismissed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct MatrixInviteStoreData {
+    #[serde(default)]
+    invites: Vec<MatrixPendingInvite>,
+}
+
+/// Small JSON-backed store for Matrix invites that require admin review.
+#[derive(Clone, Debug)]
+pub struct MatrixInviteStore {
+    path: PathBuf,
+}
+
+impl MatrixInviteStore {
+    pub fn for_profile_data_dir(data_dir: &Path) -> Self {
+        Self {
+            path: data_dir.join(MATRIX_INVITES_FILE),
+        }
+    }
+
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn load_data(&self) -> Result<MatrixInviteStoreData> {
+        match fs::read_to_string(&self.path) {
+            Ok(body) => serde_json::from_str(&body).wrap_err_with(|| {
+                format!(
+                    "failed to parse Matrix invite store: {}",
+                    self.path.display()
+                )
+            }),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(MatrixInviteStoreData::default()),
+            Err(e) => Err(e).wrap_err_with(|| {
+                format!(
+                    "failed to read Matrix invite store: {}",
+                    self.path.display()
+                )
+            }),
+        }
+    }
+
+    fn save_data(&self, data: &MatrixInviteStoreData) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).wrap_err_with(|| {
+                format!("failed to create Matrix invite dir: {}", parent.display())
+            })?;
+        }
+        let body =
+            serde_json::to_string_pretty(data).wrap_err("failed to serialize Matrix invites")?;
+        let tmp = self.path.with_extension("json.tmp");
+        fs::write(&tmp, body)
+            .wrap_err_with(|| format!("failed to write Matrix invite store: {}", tmp.display()))?;
+        fs::rename(&tmp, &self.path).wrap_err_with(|| {
+            format!(
+                "failed to replace Matrix invite store: {}",
+                self.path.display()
+            )
+        })?;
+        Ok(())
+    }
+
+    pub fn list(&self, include_dismissed: bool) -> Result<Vec<MatrixPendingInvite>> {
+        let mut invites = self.load_data()?.invites;
+        if !include_dismissed {
+            invites.retain(|invite| invite.dismissed_at.is_none());
+        }
+        invites.sort_by(|a, b| b.last_seen_at.cmp(&a.last_seen_at));
+        Ok(invites)
+    }
+
+    pub fn upsert(&self, invite: MatrixPendingInvite) -> Result<()> {
+        let mut data = self.load_data()?;
+        match data.invites.iter_mut().find(|existing| {
+            existing.channel_index == invite.channel_index && existing.room_id == invite.room_id
+        }) {
+            Some(existing) => {
+                let membership_changed = invite.membership_event_id.is_some()
+                    && existing.membership_event_id != invite.membership_event_id;
+                existing.room_name = invite.room_name;
+                existing.canonical_alias = invite.canonical_alias;
+                existing.inviter = invite.inviter;
+                existing.membership_event_id = invite.membership_event_id;
+                existing.last_seen_at = invite.last_seen_at;
+                if membership_changed {
+                    existing.received_at = invite.received_at;
+                    existing.dismissed_at = None;
+                }
+            }
+            None => data.invites.push(invite),
+        }
+        self.save_data(&data)
+    }
+
+    pub fn remove(&self, channel_index: usize, room_id: &str) -> Result<bool> {
+        let mut data = self.load_data()?;
+        let original_len = data.invites.len();
+        data.invites
+            .retain(|invite| invite.channel_index != channel_index || invite.room_id != room_id);
+        let removed = data.invites.len() != original_len;
+        if removed {
+            self.save_data(&data)?;
+        }
+        Ok(removed)
+    }
+
+    pub fn dismiss(&self, channel_index: usize, room_id: &str) -> Result<bool> {
+        let mut data = self.load_data()?;
+        let mut changed = false;
+        let now = Utc::now();
+        for invite in &mut data.invites {
+            if invite.channel_index == channel_index && invite.room_id == room_id {
+                invite.dismissed_at = Some(now);
+                changed = true;
+            }
+        }
+        if changed {
+            self.save_data(&data)?;
+        }
+        Ok(changed)
+    }
+}
+
+/// Structured result of parsing one `/sync` response body.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct ParsedSync {
+    next_batch: Option<String>,
+    /// Room invites the account received (candidates for auto-join or review).
+    invites: Vec<ParsedInvite>,
+    messages: Vec<ParsedMessage>,
+}
+
+/// Parse a Matrix `/sync` response into auto-join invites and inbound text
+/// messages, skipping the account's own messages.
+fn parse_sync(payload: &Value, self_user_id: &str) -> ParsedSync {
+    let next_batch = payload
+        .get("next_batch")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+
+    let rooms = payload.get("rooms");
+
+    let invites = rooms
+        .and_then(|r| r.get("invite"))
+        .and_then(Value::as_object)
+        .map(|obj| {
+            obj.iter()
+                .map(|(room_id, room)| parse_invite(room_id, room, self_user_id))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut messages = Vec::new();
+    if let Some(joined) = rooms.and_then(|r| r.get("join")).and_then(Value::as_object) {
+        for (room_id, room) in joined {
+            let events = room
+                .get("timeline")
+                .and_then(|t| t.get("events"))
+                .and_then(Value::as_array);
+            let Some(events) = events else { continue };
+
+            for event in events {
+                if event.get("type").and_then(Value::as_str) != Some(EVENT_ROOM_MESSAGE) {
+                    continue;
+                }
+                let sender = event.get("sender").and_then(Value::as_str).unwrap_or("");
+                if sender.is_empty() || sender.eq_ignore_ascii_case(self_user_id) {
+                    continue;
+                }
+                let content = match event.get("content") {
+                    Some(c) => c,
+                    None => continue,
+                };
+                if content.get("msgtype").and_then(Value::as_str) != Some(MSGTYPE_TEXT) {
+                    continue;
+                }
+                let body = content.get("body").and_then(Value::as_str).unwrap_or("");
+                if body.is_empty() {
+                    continue;
+                }
+                let event_id = event
+                    .get("event_id")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned);
+                let mentioned_self = content_mentions_user(content, self_user_id)
+                    || contains_matrix_user_id_mention(body, self_user_id);
+                messages.push(ParsedMessage {
+                    room_id: room_id.clone(),
+                    sender: sender.to_owned(),
+                    body: body.to_owned(),
+                    event_id,
+                    mentioned_self,
+                });
+            }
+        }
+    }
+
+    ParsedSync {
+        next_batch,
+        invites,
+        messages,
+    }
+}
+
+fn parse_invite(room_id: &str, room: &Value, self_user_id: &str) -> ParsedInvite {
+    let mut parsed = ParsedInvite {
+        room_id: room_id.to_owned(),
+        room_name: None,
+        canonical_alias: None,
+        inviter: None,
+        membership_event_id: None,
+    };
+
+    let Some(events) = room
+        .get("invite_state")
+        .and_then(|state| state.get("events"))
+        .and_then(Value::as_array)
+    else {
+        return parsed;
+    };
+
+    for event in events {
+        let event_type = event.get("type").and_then(Value::as_str);
+        let null_content = Value::Null;
+        let content = event.get("content").unwrap_or(&null_content);
+        match event_type {
+            Some(EVENT_ROOM_NAME) if parsed.room_name.is_none() => {
+                parsed.room_name = content
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToOwned::to_owned);
+            }
+            Some(EVENT_ROOM_CANONICAL_ALIAS) if parsed.canonical_alias.is_none() => {
+                parsed.canonical_alias = content
+                    .get("alias")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToOwned::to_owned);
+            }
+            Some(EVENT_ROOM_MEMBER) => {
+                let membership = content.get("membership").and_then(Value::as_str);
+                let state_key = event.get("state_key").and_then(Value::as_str);
+                if membership == Some("invite")
+                    && (state_key.is_none() || state_key == Some(self_user_id))
+                {
+                    parsed.inviter = event
+                        .get("sender")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned);
+                    parsed.membership_event_id = event
+                        .get("event_id")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    parsed
+}
+
+/// Build the `/sync` request path with optional `since` token.
+fn sync_path(since: Option<&str>, timeout_ms: u64) -> String {
+    let mut path = format!("/_matrix/client/v3/sync?timeout={timeout_ms}");
+    if let Some(since) = since.map(str::trim).filter(|s| !s.is_empty()) {
+        path.push_str("&since=");
+        path.push_str(&percent_encode_path(since));
+    }
+    path
+}
+
+fn content_mentions_user(content: &Value, user_id: &str) -> bool {
+    content
+        .get("m.mentions")
+        .and_then(|m| m.get("user_ids"))
+        .and_then(Value::as_array)
+        .is_some_and(|ids| ids.iter().any(|id| id.as_str() == Some(user_id)))
+}
+
+fn contains_matrix_user_id_mention(text: &str, user_id: &str) -> bool {
+    let Some(start) = text.find(user_id) else {
+        return false;
+    };
+    let before_ok = text[..start]
+        .chars()
+        .next_back()
+        .is_none_or(|c| c.is_whitespace() || matches!(c, '<' | '(' | '['));
+    let end = start + user_id.len();
+    let after_ok = text[end..].chars().next().is_none_or(|c| {
+        c.is_whitespace() || matches!(c, ':' | ',' | '.' | '!' | '?' | ')' | ']' | '>')
+    });
+    before_ok && after_ok
+}
+
+fn is_slash_command(text: &str) -> bool {
+    text.trim_start().starts_with('/')
+}
+
+fn is_stable_join_target(target: &str) -> bool {
+    let trimmed = target.trim();
+    trimmed == "*" || trimmed.starts_with('!') || trimmed.starts_with('#')
+}
+
+/// Build the JSON body for a `m.login.password` request.
+fn password_login_body(user_id: &str, password: &str, device_name: Option<&str>) -> Value {
+    json!({
+        "type": "m.login.password",
+        "identifier": { "type": "m.id.user", "user": user_id },
+        "password": password,
+        "initial_device_display_name": device_name.unwrap_or(DEFAULT_DEVICE_NAME),
+    })
+}
+
+/// Matrix user-account channel.
+///
+/// Authenticates with a regular Matrix account and receives messages by
+/// long-polling the Client-Server `/sync` API. Outbound messages are sent via
+/// `PUT .../send/m.room.message/{txn_id}` as that account.
+pub struct MatrixUserChannel {
+    homeserver: String,
+    user_id: Option<String>,
+    access_token: Option<String>,
+    password: Option<String>,
+    device_name: Option<String>,
+    /// Room allowlist used when `group_policy` is `Allowlist`.
+    rooms: Vec<String>,
+    auto_join: MatrixAutoJoin,
+    auto_join_allowlist: Vec<String>,
+    group_policy: MatrixGroupPolicy,
+    require_mention: bool,
+    channel_index: usize,
+    invite_store: Option<MatrixInviteStore>,
+    /// Optional sender allowlist. Empty means any sender in an allowed room.
+    allowed_senders: HashSet<String>,
+    shutdown: Arc<AtomicBool>,
+    http: reqwest::Client,
+    dedup: Arc<MessageDedup>,
+    /// Populated on `start()` after a successful login; reused by `send()`.
+    resolved: Mutex<Option<ResolvedClient>>,
+}
+
+impl MatrixUserChannel {
+    /// Create a new user-mode Matrix channel.
+    ///
+    /// Either `access_token` or (`user_id` + `password`) must be provided; this
+    /// is validated lazily at `start()` so construction never fails.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        homeserver: &str,
+        user_id: Option<String>,
+        access_token: Option<String>,
+        password: Option<String>,
+        device_name: Option<String>,
+        rooms: Vec<String>,
+        auto_join: MatrixAutoJoin,
+        auto_join_allowlist: Vec<String>,
+        group_policy: MatrixGroupPolicy,
+        require_mention: bool,
+        allowed_senders: Vec<String>,
+        shutdown: Arc<AtomicBool>,
+    ) -> Self {
+        Self {
+            homeserver: homeserver.trim_end_matches('/').to_string(),
+            user_id: user_id.filter(|s| !s.trim().is_empty()),
+            access_token: access_token.filter(|s| !s.trim().is_empty()),
+            password: password.filter(|s| !s.trim().is_empty()),
+            device_name: device_name.filter(|s| !s.trim().is_empty()),
+            rooms: rooms
+                .into_iter()
+                .map(|r| r.trim().to_owned())
+                .filter(|r| !r.is_empty())
+                .collect(),
+            auto_join,
+            auto_join_allowlist: auto_join_allowlist
+                .into_iter()
+                .map(|r| r.trim().to_owned())
+                .filter(|r| !r.is_empty())
+                .collect(),
+            group_policy,
+            require_mention,
+            channel_index: 0,
+            invite_store: None,
+            allowed_senders: allowed_senders
+                .into_iter()
+                .map(|s| s.trim().to_owned())
+                .filter(|s| !s.is_empty())
+                .collect(),
+            shutdown,
+            http: reqwest::Client::new(),
+            dedup: Arc::new(MessageDedup::new()),
+            resolved: Mutex::new(None),
+        }
+    }
+
+    pub fn with_channel_index(mut self, channel_index: usize) -> Self {
+        self.channel_index = channel_index;
+        self
+    }
+
+    pub fn with_invite_store(mut self, invite_store: MatrixInviteStore) -> Self {
+        self.invite_store = Some(invite_store);
+        self
+    }
+
+    fn api_url(&self, path: &str) -> String {
+        format!("{}{}", self.homeserver, path)
+    }
+
+    /// Resolve credentials: validate an access token via `whoami`, or perform a
+    /// password login. Returns the access token and canonical user ID.
+    async fn resolve_login(&self) -> Result<ResolvedClient> {
+        if let Some(token) = self.access_token.as_deref() {
+            let url = self.api_url("/_matrix/client/v3/account/whoami");
+            let resp = self
+                .http
+                .get(&url)
+                .bearer_auth(token)
+                .send()
+                .await
+                .wrap_err("Matrix whoami request failed")?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                return Err(eyre!("Matrix whoami failed (status={status}): {body}"));
+            }
+            let payload: Value = resp.json().await.wrap_err("invalid whoami response")?;
+            let user_id = payload
+                .get("user_id")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .or_else(|| self.user_id.clone())
+                .ok_or_else(|| eyre!("whoami response missing user_id"))?;
+            return Ok(ResolvedClient {
+                access_token: token.to_owned(),
+                user_id,
+                logout_on_stop: false,
+            });
+        }
+
+        let user_id = self.user_id.as_deref().ok_or_else(|| {
+            eyre!("matrix user channel requires access_token or user_id+password")
+        })?;
+        let password = self
+            .password
+            .as_deref()
+            .ok_or_else(|| eyre!("matrix user channel requires a password when no access_token"))?;
+
+        let url = self.api_url("/_matrix/client/v3/login");
+        let body = password_login_body(user_id, password, self.device_name.as_deref());
+        let resp = self
+            .http
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .wrap_err("Matrix password login request failed")?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(eyre!(
+                "Matrix password login failed (status={status}): {body}"
+            ));
+        }
+        let payload: Value = resp.json().await.wrap_err("invalid login response")?;
+        let access_token = payload
+            .get("access_token")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .ok_or_else(|| eyre!("login response missing access_token"))?;
+        let resolved_user_id = payload
+            .get("user_id")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .unwrap_or_else(|| user_id.to_owned());
+        Ok(ResolvedClient {
+            access_token,
+            user_id: resolved_user_id,
+            logout_on_stop: true,
+        })
+    }
+
+    /// Perform a single `/sync` request and return the parsed response.
+    async fn sync_once(
+        &self,
+        token: &str,
+        self_user_id: &str,
+        since: Option<&str>,
+        timeout_ms: u64,
+    ) -> Result<ParsedSync> {
+        let url = self.api_url(&sync_path(since, timeout_ms));
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(token)
+            .send()
+            .await
+            .wrap_err("Matrix sync request failed")?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(eyre!("Matrix sync failed (status={status}): {body}"));
+        }
+        let payload: Value = resp.json().await.wrap_err("invalid sync response")?;
+        Ok(parse_sync(&payload, self_user_id))
+    }
+
+    /// Join a room by ID (used to auto-accept invites).
+    async fn join_room(&self, token: &str, room_id: &str) -> Result<()> {
+        let url = self.api_url(&format!(
+            "/_matrix/client/v3/rooms/{}/join",
+            percent_encode_path(room_id)
+        ));
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(token)
+            .json(&json!({}))
+            .send()
+            .await
+            .wrap_err("Matrix join room request failed")?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(eyre!("Matrix join room failed (status={status}): {body}"));
+        }
+        Ok(())
+    }
+
+    async fn resolve_room_alias(&self, token: &str, alias: &str) -> Result<Option<String>> {
+        let url = self.api_url(&format!(
+            "/_matrix/client/v3/directory/room/{}",
+            percent_encode_path(alias)
+        ));
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(token)
+            .send()
+            .await
+            .wrap_err("Matrix room alias lookup failed")?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(eyre!(
+                "Matrix room alias lookup failed (status={status}): {body}"
+            ));
+        }
+        let payload: Value = resp
+            .json()
+            .await
+            .wrap_err("invalid alias lookup response")?;
+        Ok(payload
+            .get("room_id")
+            .and_then(Value::as_str)
+            .map(str::to_owned))
+    }
+
+    async fn auto_join_allowed(&self, token: &str, room_id: &str) -> bool {
+        match self.auto_join {
+            MatrixAutoJoin::Off => false,
+            MatrixAutoJoin::Always => true,
+            MatrixAutoJoin::Allowlist => {
+                let targets = if self.auto_join_allowlist.is_empty() {
+                    // Backward compatibility for early user-mode configs where
+                    // `rooms` doubled as the invite allowlist.
+                    &self.rooms
+                } else {
+                    &self.auto_join_allowlist
+                };
+                for target in targets {
+                    let trimmed = target.trim();
+                    if !is_stable_join_target(trimmed) {
+                        warn!(
+                            target = trimmed,
+                            "Matrix auto-join target ignored; use !room_id, #alias, or *"
+                        );
+                        continue;
+                    }
+                    if trimmed == "*" || trimmed == room_id {
+                        return true;
+                    }
+                    if trimmed.starts_with('#') {
+                        match self.resolve_room_alias(token, trimmed).await {
+                            Ok(Some(resolved)) if resolved == room_id => return true,
+                            Ok(_) => {}
+                            Err(e) => warn!(
+                                target = trimmed,
+                                error = %e,
+                                "Matrix auto-join alias resolution failed"
+                            ),
+                        }
+                    }
+                }
+                false
+            }
+        }
+    }
+
+    /// Whether a room passes the configured room/group policy.
+    fn room_allowed(&self, room_id: &str) -> bool {
+        match self.group_policy {
+            MatrixGroupPolicy::Disabled => false,
+            MatrixGroupPolicy::Open => true,
+            MatrixGroupPolicy::Allowlist => self.rooms.iter().any(|r| r == "*" || r == room_id),
+        }
+    }
+
+    fn sender_allowed(&self, sender_id: &str) -> bool {
+        self.allowed_senders.is_empty() || self.allowed_senders.contains(sender_id)
+    }
+
+    fn record_pending_invite(&self, invite: &ParsedInvite) {
+        let Some(store) = &self.invite_store else {
+            return;
+        };
+        if let Err(e) = store.upsert(invite.pending(self.channel_index)) {
+            warn!(
+                room_id = %invite.room_id,
+                error = %e,
+                "failed to record pending Matrix invite"
+            );
+        }
+    }
+
+    fn clear_pending_invite(&self, room_id: &str) {
+        let Some(store) = &self.invite_store else {
+            return;
+        };
+        if let Err(e) = store.remove(self.channel_index, room_id) {
+            warn!(room_id, error = %e, "failed to clear pending Matrix invite");
+        }
+    }
+
+    async fn join_allowed_invites(&self, token: &str, invites: Vec<ParsedInvite>) {
+        for invite in invites {
+            if !self.auto_join_allowed(token, &invite.room_id).await {
+                debug!(
+                    room_id = %invite.room_id,
+                    auto_join = ?self.auto_join,
+                    "Matrix invite queued for admin review by auto-join policy"
+                );
+                self.record_pending_invite(&invite);
+                continue;
+            }
+            if let Err(e) = self.join_room(token, &invite.room_id).await {
+                warn!(room_id = %invite.room_id, error = %e, "Matrix auto-join failed");
+                self.record_pending_invite(&invite);
+            } else {
+                self.clear_pending_invite(&invite.room_id);
+            }
+        }
+    }
+
+    /// Forward parsed messages to the bus, applying dedup and allowlists.
+    async fn forward_messages(
+        &self,
+        messages: Vec<ParsedMessage>,
+        inbound_tx: &mpsc::Sender<InboundMessage>,
+    ) -> Result<()> {
+        for msg in messages {
+            if !self.room_allowed(&msg.room_id) {
+                continue;
+            }
+            if !self.sender_allowed(&msg.sender) {
+                continue;
+            }
+            if self.require_mention && !msg.mentioned_self && !is_slash_command(&msg.body) {
+                debug!(
+                    room_id = %msg.room_id,
+                    sender = %msg.sender,
+                    "Matrix message ignored; mention required"
+                );
+                continue;
+            }
+            if let Some(event_id) = &msg.event_id {
+                if self.dedup.is_duplicate(event_id) {
+                    continue;
+                }
+            }
+            let inbound = InboundMessage {
+                channel: CHANNEL_NAME.into(),
+                sender_id: msg.sender,
+                chat_id: msg.room_id,
+                content: msg.body,
+                timestamp: Utc::now(),
+                media: vec![],
+                metadata: json!({}),
+                message_id: msg.event_id,
+                origin: octos_core::MessageOrigin::ExternalUser,
+            };
+            if inbound_tx.send(inbound).await.is_err() {
+                return Err(eyre!("inbound channel closed"));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Channel for MatrixUserChannel {
+    fn name(&self) -> &str {
+        CHANNEL_NAME
+    }
+
+    fn max_message_length(&self) -> usize {
+        65535
+    }
+
+    fn is_allowed(&self, sender_id: &str) -> bool {
+        self.sender_allowed(sender_id)
+    }
+
+    async fn start(&self, inbound_tx: mpsc::Sender<InboundMessage>) -> Result<()> {
+        let resolved = self.resolve_login().await?;
+        info!(
+            user_id = %resolved.user_id,
+            homeserver = %self.homeserver,
+            "Matrix user channel authenticated"
+        );
+        {
+            *self.resolved.lock().await = Some(resolved.clone());
+        }
+        let token = resolved.access_token.clone();
+        let self_user_id = resolved.user_id.clone();
+
+        // Initial sync (timeout=0): pick up the latest position and any pending
+        // invites without replaying historical messages.
+        let mut since = match self.sync_once(&token, &self_user_id, None, 0).await {
+            Ok(initial) => {
+                self.join_allowed_invites(&token, initial.invites).await;
+                initial.next_batch
+            }
+            Err(e) => {
+                warn!(error = %e, "initial Matrix sync failed; continuing");
+                None
+            }
+        };
+
+        let mut backoff = Duration::from_secs(1);
+        while !self.shutdown.load(Ordering::Acquire) {
+            match self
+                .sync_once(&token, &self_user_id, since.as_deref(), SYNC_TIMEOUT_MS)
+                .await
+            {
+                Ok(parsed) => {
+                    if parsed.next_batch.is_some() {
+                        since = parsed.next_batch;
+                    }
+                    self.join_allowed_invites(&token, parsed.invites).await;
+                    self.forward_messages(parsed.messages, &inbound_tx).await?;
+                    backoff = Duration::from_secs(1);
+                }
+                Err(e) => {
+                    warn!(error = %e, "Matrix sync error; backing off");
+                    if self.shutdown.load(Ordering::Acquire) {
+                        break;
+                    }
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(30));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn send(&self, msg: &OutboundMessage) -> Result<()> {
+        let resolved = {
+            self.resolved
+                .lock()
+                .await
+                .clone()
+                .ok_or_else(|| eyre!("Matrix user channel not started"))?
+        };
+        let txn_id = uuid::Uuid::now_v7().to_string();
+        let url = self.api_url(&format!(
+            "/_matrix/client/v3/rooms/{}/send/m.room.message/{}",
+            percent_encode_path(&msg.chat_id),
+            percent_encode_path(&txn_id),
+        ));
+        let formatted_body = markdown_to_matrix_html(&msg.content);
+        let body = json!({
+            "msgtype": MSGTYPE_TEXT,
+            "body": msg.content,
+            "format": "org.matrix.custom.html",
+            "formatted_body": formatted_body,
+        });
+        let resp = self
+            .http
+            .put(&url)
+            .bearer_auth(&resolved.access_token)
+            .json(&body)
+            .send()
+            .await
+            .wrap_err("failed to send Matrix message")?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(eyre!("Matrix send failed (status={status}): {text}"));
+        }
+        Ok(())
+    }
+
+    async fn send_typing(&self, chat_id: &str) -> Result<()> {
+        let resolved = match self.resolved.lock().await.clone() {
+            Some(r) => r,
+            None => return Ok(()),
+        };
+        let url = self.api_url(&format!(
+            "/_matrix/client/v3/rooms/{}/typing/{}",
+            percent_encode_path(chat_id),
+            percent_encode_path(&resolved.user_id),
+        ));
+        let body = json!({ "typing": true, "timeout": SYNC_TIMEOUT_MS });
+        if let Err(e) = self
+            .http
+            .put(&url)
+            .bearer_auth(&resolved.access_token)
+            .json(&body)
+            .send()
+            .await
+        {
+            debug!(error = %e, "Matrix typing indicator failed");
+        }
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        self.shutdown.store(true, Ordering::Release);
+        let resolved = self.resolved.lock().await.take();
+        if let Some(resolved) = resolved.filter(|r| r.logout_on_stop) {
+            let url = self.api_url("/_matrix/client/v3/logout");
+            match self
+                .http
+                .post(&url)
+                .bearer_auth(&resolved.access_token)
+                .json(&json!({}))
+                .send()
+                .await
+            {
+                Ok(resp) if !resp.status().is_success() => {
+                    warn!(status = %resp.status(), "Matrix logout request returned non-success");
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    warn!(error = %e, "Matrix logout request failed");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn health_check(&self) -> Result<ChannelHealth> {
+        let resolved = match self.resolved.lock().await.clone() {
+            Some(r) => r,
+            None => return Ok(ChannelHealth::Unknown),
+        };
+        let url = self.api_url("/_matrix/client/v3/account/whoami");
+        match self
+            .http
+            .get(&url)
+            .bearer_auth(&resolved.access_token)
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => Ok(ChannelHealth::Healthy),
+            Ok(resp) => Ok(ChannelHealth::Down(format!("status={}", resp.status()))),
+            Err(e) => Ok(ChannelHealth::Down(e.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_parse_text_message_from_join_timeline() {
+        let payload = json!({
+            "next_batch": "s2",
+            "rooms": {
+                "join": {
+                    "!room:example.org": {
+                        "timeline": {
+                            "events": [
+                                {
+                                    "type": "m.room.message",
+                                    "sender": "@alice:example.org",
+                                    "event_id": "$evt1",
+                                    "content": { "msgtype": "m.text", "body": "hello" }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        });
+
+        let parsed = parse_sync(&payload, "@bot:example.org");
+        assert_eq!(parsed.next_batch.as_deref(), Some("s2"));
+        assert_eq!(parsed.messages.len(), 1);
+        let m = &parsed.messages[0];
+        assert_eq!(m.room_id, "!room:example.org");
+        assert_eq!(m.sender, "@alice:example.org");
+        assert_eq!(m.body, "hello");
+        assert_eq!(m.event_id.as_deref(), Some("$evt1"));
+    }
+
+    #[test]
+    fn should_skip_own_messages() {
+        let payload = json!({
+            "rooms": { "join": { "!r:example.org": { "timeline": { "events": [
+                { "type": "m.room.message", "sender": "@bot:example.org",
+                  "content": { "msgtype": "m.text", "body": "from me" } }
+            ] } } } }
+        });
+        let parsed = parse_sync(&payload, "@bot:example.org");
+        assert!(parsed.messages.is_empty());
+    }
+
+    #[test]
+    fn should_skip_non_text_and_empty_bodies() {
+        let payload = json!({
+            "rooms": { "join": { "!r:example.org": { "timeline": { "events": [
+                { "type": "m.room.message", "sender": "@a:example.org",
+                  "content": { "msgtype": "m.image", "body": "pic.png" } },
+                { "type": "m.room.message", "sender": "@a:example.org",
+                  "content": { "msgtype": "m.text", "body": "" } },
+                { "type": "m.reaction", "sender": "@a:example.org",
+                  "content": { "msgtype": "m.text", "body": "ignored" } }
+            ] } } } }
+        });
+        let parsed = parse_sync(&payload, "@bot:example.org");
+        assert!(parsed.messages.is_empty());
+    }
+
+    #[test]
+    fn should_collect_invites() {
+        let payload = json!({
+            "rooms": { "invite": {
+                "!a:example.org": {
+                    "invite_state": {
+                        "events": [
+                            {
+                                "type": "m.room.name",
+                                "content": { "name": "Ops Room" }
+                            },
+                            {
+                                "type": "m.room.canonical_alias",
+                                "content": { "alias": "#ops:example.org" }
+                            },
+                            {
+                                "type": "m.room.member",
+                                "sender": "@alice:example.org",
+                                "state_key": "@bot:example.org",
+                                "event_id": "$invite1",
+                                "content": { "membership": "invite" }
+                            }
+                        ]
+                    }
+                },
+                "!b:example.org": {}
+            } }
+        });
+        let parsed = parse_sync(&payload, "@bot:example.org");
+        assert_eq!(parsed.invites.len(), 2);
+        let invite = parsed
+            .invites
+            .iter()
+            .find(|invite| invite.room_id == "!a:example.org")
+            .expect("invite parsed");
+        assert_eq!(invite.room_name.as_deref(), Some("Ops Room"));
+        assert_eq!(invite.canonical_alias.as_deref(), Some("#ops:example.org"));
+        assert_eq!(invite.inviter.as_deref(), Some("@alice:example.org"));
+        assert_eq!(invite.membership_event_id.as_deref(), Some("$invite1"));
+    }
+
+    #[test]
+    fn should_build_sync_path_with_since() {
+        assert_eq!(sync_path(None, 0), "/_matrix/client/v3/sync?timeout=0");
+        assert_eq!(
+            sync_path(Some("s2"), 30000),
+            "/_matrix/client/v3/sync?timeout=30000&since=s2"
+        );
+        // empty/whitespace since is ignored
+        assert_eq!(
+            sync_path(Some("  "), 100),
+            "/_matrix/client/v3/sync?timeout=100"
+        );
+    }
+
+    #[test]
+    fn should_build_password_login_body() {
+        let body = password_login_body("@u:example.org", "secret", Some("MyDevice"));
+        assert_eq!(body["type"], "m.login.password");
+        assert_eq!(body["identifier"]["type"], "m.id.user");
+        assert_eq!(body["identifier"]["user"], "@u:example.org");
+        assert_eq!(body["password"], "secret");
+        assert_eq!(body["initial_device_display_name"], "MyDevice");
+
+        let default_body = password_login_body("@u:example.org", "secret", None);
+        assert_eq!(
+            default_body["initial_device_display_name"],
+            DEFAULT_DEVICE_NAME
+        );
+    }
+
+    #[test]
+    fn should_apply_room_allowlist() {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let ch = MatrixUserChannel::new(
+            "https://example.org",
+            Some("@u:example.org".into()),
+            Some("tok".into()),
+            None,
+            None,
+            vec!["!allowed:example.org".into()],
+            MatrixAutoJoin::Off,
+            vec![],
+            MatrixGroupPolicy::Allowlist,
+            false,
+            vec![],
+            shutdown,
+        );
+        assert!(ch.room_allowed("!allowed:example.org"));
+        assert!(!ch.room_allowed("!other:example.org"));
+
+        let shutdown2 = Arc::new(AtomicBool::new(false));
+        let open = MatrixUserChannel::new(
+            "https://example.org",
+            None,
+            Some("tok".into()),
+            None,
+            None,
+            vec![],
+            MatrixAutoJoin::Off,
+            vec![],
+            MatrixGroupPolicy::Open,
+            false,
+            vec![],
+            shutdown2,
+        );
+        assert!(open.room_allowed("!anything:example.org"));
+    }
+
+    #[test]
+    fn should_apply_sender_allowlist() {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let ch = MatrixUserChannel::new(
+            "https://example.org",
+            None,
+            Some("tok".into()),
+            None,
+            None,
+            vec![],
+            MatrixAutoJoin::Off,
+            vec![],
+            MatrixGroupPolicy::Open,
+            false,
+            vec!["@alice:example.org".into()],
+            shutdown,
+        );
+        assert!(ch.sender_allowed("@alice:example.org"));
+        assert!(ch.is_allowed("@alice:example.org"));
+        assert!(!ch.sender_allowed("@mallory:example.org"));
+        assert!(!ch.is_allowed("@mallory:example.org"));
+
+        let shutdown2 = Arc::new(AtomicBool::new(false));
+        let open = MatrixUserChannel::new(
+            "https://example.org",
+            None,
+            Some("tok".into()),
+            None,
+            None,
+            vec![],
+            MatrixAutoJoin::Off,
+            vec![],
+            MatrixGroupPolicy::Open,
+            false,
+            vec![],
+            shutdown2,
+        );
+        assert!(open.sender_allowed("@anyone:example.org"));
+    }
+
+    #[tokio::test]
+    async fn should_apply_auto_join_policy() {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let off = MatrixUserChannel::new(
+            "https://example.org",
+            None,
+            Some("tok".into()),
+            None,
+            None,
+            vec!["!allowed:example.org".into()],
+            MatrixAutoJoin::Off,
+            vec![],
+            MatrixGroupPolicy::Allowlist,
+            false,
+            vec![],
+            shutdown,
+        );
+        assert!(
+            !off.auto_join_allowed("tok", "!allowed:example.org").await,
+            "auto_join=off must reject even allowlisted room invites"
+        );
+
+        let shutdown2 = Arc::new(AtomicBool::new(false));
+        let allowlist = MatrixUserChannel::new(
+            "https://example.org",
+            None,
+            Some("tok".into()),
+            None,
+            None,
+            vec!["!allowed:example.org".into()],
+            MatrixAutoJoin::Allowlist,
+            vec![],
+            MatrixGroupPolicy::Allowlist,
+            false,
+            vec![],
+            shutdown2,
+        );
+        assert!(
+            allowlist
+                .auto_join_allowed("tok", "!allowed:example.org")
+                .await
+        );
+        assert!(
+            !allowlist
+                .auto_join_allowed("tok", "!other:example.org")
+                .await
+        );
+
+        let shutdown3 = Arc::new(AtomicBool::new(false));
+        let always = MatrixUserChannel::new(
+            "https://example.org",
+            None,
+            Some("tok".into()),
+            None,
+            None,
+            vec![],
+            MatrixAutoJoin::Always,
+            vec![],
+            MatrixGroupPolicy::Open,
+            false,
+            vec![],
+            shutdown3,
+        );
+        assert!(
+            always
+                .auto_join_allowed("tok", "!anything:example.org")
+                .await
+        );
+    }
+
+    #[test]
+    fn should_persist_pending_invites() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = MatrixInviteStore::for_profile_data_dir(tmp.path());
+        let invite = MatrixPendingInvite {
+            channel_index: 2,
+            room_id: "!room:example.org".into(),
+            room_name: Some("Ops".into()),
+            canonical_alias: Some("#ops:example.org".into()),
+            inviter: Some("@alice:example.org".into()),
+            membership_event_id: Some("$invite1".into()),
+            received_at: Utc::now(),
+            last_seen_at: Utc::now(),
+            dismissed_at: None,
+        };
+
+        store.upsert(invite).unwrap();
+        let listed = store.list(false).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].room_id, "!room:example.org");
+        assert_eq!(listed[0].channel_index, 2);
+
+        assert!(store.dismiss(2, "!room:example.org").unwrap());
+        assert!(store.list(false).unwrap().is_empty());
+        assert_eq!(store.list(true).unwrap().len(), 1);
+
+        assert!(store.remove(2, "!room:example.org").unwrap());
+        assert!(store.list(true).unwrap().is_empty());
+    }
+}

--- a/crates/octos-bus/src/matrix_user_channel.rs
+++ b/crates/octos-bus/src/matrix_user_channel.rs
@@ -223,7 +223,7 @@ impl MatrixInviteStore {
         if !include_dismissed {
             invites.retain(|invite| invite.dismissed_at.is_none());
         }
-        invites.sort_by(|a, b| b.last_seen_at.cmp(&a.last_seen_at));
+        invites.sort_by_key(|b| std::cmp::Reverse(b.last_seen_at));
         Ok(invites)
     }
 

--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -109,7 +109,11 @@ keyring = { workspace = true, features = ["windows-native"] }
 
 [features]
 default = []
-api = ["dep:axum", "dep:tower-http", "dep:futures", "dep:rust-embed", "dep:metrics-exporter-prometheus", "dep:lettre", "dep:rand", "dep:sysinfo", "dep:subtle", "octos-bus/api"]
+# `matrix` is pulled in unconditionally: the `/api/my/profile/matrix/*`
+# handlers and the admin dashboard's Matrix invite UI reference matrix-only
+# types (e.g. `octos_bus::MatrixInviteStore`), so the API cannot compile
+# without it.
+api = ["dep:axum", "dep:tower-http", "dep:futures", "dep:rust-embed", "dep:metrics-exporter-prometheus", "dep:lettre", "dep:rand", "dep:sysinfo", "dep:subtle", "octos-bus/api", "matrix"]
 admin-bot = ["dep:teloxide", "dep:futures", "api"]
 telegram = ["octos-bus/telegram"]
 discord = ["octos-bus/discord"]

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -10,11 +10,12 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 use super::AppState;
 use super::admin::ProfileResponse;
 use super::handlers::response_path_for_profile_file;
-use crate::profiles::mask_secrets;
+use crate::profiles::{ChannelCredentials, UserProfile, is_display_secret_value, mask_secrets};
 use crate::user_store::{User, UserRole};
 
 use super::router::AuthIdentity;
@@ -1301,6 +1302,855 @@ pub async fn set_my_voice(
         ok: true,
         voice: canonical,
     }))
+}
+
+// ── Matrix invite review endpoints ────────────────────────────────────
+
+#[derive(Clone, Debug)]
+struct MatrixUserChannelConfig {
+    homeserver: String,
+    user_id: Option<String>,
+    access_token: Option<String>,
+    password: Option<String>,
+    device_name: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct MatrixResolvedLogin {
+    access_token: String,
+    user_id: String,
+    device_id: Option<String>,
+    logout_after: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct MatrixSyncProbe {
+    joined_rooms: usize,
+    pending_invites: usize,
+    has_next_batch: bool,
+    pending_invite_details: Vec<MatrixSyncInviteSummary>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct MatrixSyncInviteSummary {
+    room_id: String,
+    room_name: Option<String>,
+    canonical_alias: Option<String>,
+    inviter: Option<String>,
+    membership_event_id: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct MatrixInviteActionRequest {
+    #[serde(default)]
+    pub channel_index: Option<usize>,
+    #[serde(default)]
+    pub add_to_allowed_rooms: Option<bool>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct MatrixTestConnectionRequest {
+    #[serde(default)]
+    pub channel_index: Option<usize>,
+    #[serde(default)]
+    pub channel: Option<MatrixTestChannelDraft>,
+}
+
+#[derive(Clone, Debug, Deserialize, Default)]
+pub struct MatrixTestChannelDraft {
+    #[serde(default)]
+    pub mode: Option<String>,
+    #[serde(default)]
+    pub homeserver: Option<String>,
+    #[serde(default)]
+    pub user_id: Option<String>,
+    #[serde(default)]
+    pub access_token: Option<String>,
+    #[serde(default)]
+    pub password: Option<String>,
+    #[serde(default)]
+    pub device_name: Option<String>,
+}
+
+fn matrix_user_channel_config(
+    profile: &UserProfile,
+    channel_index: usize,
+) -> Result<MatrixUserChannelConfig, (StatusCode, String)> {
+    let Some(channel) = profile.config.channels.get(channel_index) else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("Matrix channel index {channel_index} not found"),
+        ));
+    };
+
+    let ChannelCredentials::Matrix {
+        homeserver,
+        mode,
+        user_id,
+        access_token,
+        password,
+        device_name,
+        ..
+    } = channel
+    else {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("Channel index {channel_index} is not a Matrix channel"),
+        ));
+    };
+
+    if !mode.eq_ignore_ascii_case("user") {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Matrix invite review is only supported for user-account mode".into(),
+        ));
+    }
+
+    let has_token = !access_token.trim().is_empty();
+    let has_password_login = !user_id.trim().is_empty() && !password.trim().is_empty();
+    if !has_token && !has_password_login {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Matrix user channel requires an access token or user_id + password".into(),
+        ));
+    }
+    if !has_token {
+        validate_matrix_user_id(user_id)?;
+    }
+
+    let homeserver = if homeserver.trim().is_empty() {
+        "http://localhost:6167".to_string()
+    } else {
+        homeserver.trim_end_matches('/').to_string()
+    };
+
+    Ok(MatrixUserChannelConfig {
+        homeserver,
+        user_id: non_empty_string(user_id),
+        access_token: non_empty_string(access_token),
+        password: non_empty_string(password),
+        device_name: non_empty_string(device_name),
+    })
+}
+
+fn matrix_test_channel_config(
+    profile: &UserProfile,
+    request: &MatrixTestConnectionRequest,
+) -> Result<MatrixUserChannelConfig, (StatusCode, String)> {
+    let draft = request.channel.as_ref();
+    if let Some(mode) = draft.and_then(|channel| non_empty_string_opt(channel.mode.as_deref())) {
+        if !mode.eq_ignore_ascii_case("user") {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Matrix connection test is only supported for user-account mode".into(),
+            ));
+        }
+    }
+
+    let mut config = match request
+        .channel_index
+        .or_else(|| first_matrix_user_channel_index(profile))
+    {
+        Some(channel_index) => matrix_user_channel_config(profile, channel_index)?,
+        None => MatrixUserChannelConfig {
+            homeserver: "http://localhost:6167".into(),
+            user_id: None,
+            access_token: None,
+            password: None,
+            device_name: None,
+        },
+    };
+
+    if let Some(channel) = draft {
+        if let Some(value) = non_empty_string_opt(channel.homeserver.as_deref()) {
+            config.homeserver = value.trim_end_matches('/').to_string();
+        }
+        if let Some(value) = non_empty_string_opt(channel.user_id.as_deref()) {
+            config.user_id = Some(value);
+        }
+        if let Some(value) = non_display_secret_string_opt(channel.access_token.as_deref()) {
+            config.access_token = Some(value);
+        }
+        if let Some(value) = non_display_secret_string_opt(channel.password.as_deref()) {
+            config.password = Some(value);
+        }
+        if let Some(value) = non_empty_string_opt(channel.device_name.as_deref()) {
+            config.device_name = Some(value);
+        }
+    }
+
+    if config.access_token.is_none() && (config.user_id.is_none() || config.password.is_none()) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Matrix user channel requires an access token or user_id + password".into(),
+        ));
+    }
+    if config.access_token.is_none() {
+        if let Some(user_id) = config.user_id.as_deref() {
+            validate_matrix_user_id(user_id)?;
+        }
+    }
+
+    Ok(config)
+}
+
+fn first_matrix_user_channel_index(profile: &UserProfile) -> Option<usize> {
+    profile
+        .config
+        .channels
+        .iter()
+        .enumerate()
+        .find_map(|(idx, channel)| match channel {
+            ChannelCredentials::Matrix { mode, .. } if mode.eq_ignore_ascii_case("user") => {
+                Some(idx)
+            }
+            _ => None,
+        })
+}
+
+fn non_empty_string(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn non_empty_string_opt(value: Option<&str>) -> Option<String> {
+    value.and_then(non_empty_string)
+}
+
+fn non_display_secret_string_opt(value: Option<&str>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() || is_display_secret_value(trimmed) {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn validate_matrix_user_id(user_id: &str) -> Result<(), (StatusCode, String)> {
+    let trimmed = user_id.trim();
+    if is_matrix_full_user_id(trimmed) || is_matrix_login_localpart(trimmed) {
+        return Ok(());
+    }
+    Err((
+        StatusCode::BAD_REQUEST,
+        "Matrix login user must be a localpart like octos or a full Matrix ID like @octos:octos.meldry.com; do not use octos:octos.meldry.com without @.".into(),
+    ))
+}
+
+fn is_matrix_full_user_id(value: &str) -> bool {
+    let Some(rest) = value.strip_prefix('@') else {
+        return false;
+    };
+    let Some((localpart, server_name)) = rest.split_once(':') else {
+        return false;
+    };
+    !localpart.is_empty() && !server_name.trim().is_empty()
+}
+
+fn is_matrix_login_localpart(value: &str) -> bool {
+    !value.is_empty()
+        && !value.contains(':')
+        && !value.starts_with('@')
+        && value.bytes().all(|byte| {
+            matches!(
+                byte,
+                b'a'..=b'z'
+                    | b'A'..=b'Z'
+                    | b'0'..=b'9'
+                    | b'.'
+                    | b'_'
+                    | b'='
+                    | b'-'
+                    | b'/'
+                    | b'+'
+            )
+        })
+}
+
+fn matrix_percent_encode_path(s: &str) -> String {
+    let mut encoded = String::with_capacity(s.len() * 3);
+    for byte in s.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                encoded.push(byte as char)
+            }
+            _ => {
+                encoded.push('%');
+                encoded.push_str(&format!("{byte:02X}"));
+            }
+        }
+    }
+    encoded
+}
+
+fn matrix_api_url(homeserver: &str, path: &str) -> String {
+    format!("{}{}", homeserver.trim_end_matches('/'), path)
+}
+
+/// HTTP client for Matrix admin calls (whoami/login/join/leave/sync?timeout=0).
+///
+/// All of these are immediate requests — unlike the gateway's long-poll `/sync`
+/// — so a bounded timeout keeps a slow or unreachable user-supplied homeserver
+/// from holding an axum worker open indefinitely.
+fn matrix_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
+}
+
+async fn resolve_matrix_login(
+    http: &reqwest::Client,
+    config: &MatrixUserChannelConfig,
+) -> Result<MatrixResolvedLogin, (StatusCode, String)> {
+    if let Some(token) = config.access_token.as_deref() {
+        let url = matrix_api_url(&config.homeserver, "/_matrix/client/v3/account/whoami");
+        let resp = http
+            .get(&url)
+            .bearer_auth(token)
+            .send()
+            .await
+            .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err((
+                StatusCode::BAD_GATEWAY,
+                format!("Matrix whoami failed (status={status}): {body}"),
+            ));
+        }
+        let payload: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+        let user_id = payload
+            .get("user_id")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+            .or_else(|| config.user_id.clone())
+            .ok_or((
+                StatusCode::BAD_GATEWAY,
+                "Matrix whoami response missing user_id".into(),
+            ))?;
+        let device_id = payload
+            .get("device_id")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string);
+        return Ok(MatrixResolvedLogin {
+            access_token: token.to_string(),
+            user_id,
+            device_id,
+            logout_after: false,
+        });
+    }
+
+    let user_id = config
+        .user_id
+        .as_deref()
+        .ok_or((StatusCode::BAD_REQUEST, "Matrix user_id is required".into()))?;
+    let password = config.password.as_deref().ok_or((
+        StatusCode::BAD_REQUEST,
+        "Matrix password is required".into(),
+    ))?;
+    let body = json!({
+        "type": "m.login.password",
+        "identifier": { "type": "m.id.user", "user": user_id },
+        "password": password,
+        "initial_device_display_name": config.device_name.as_deref().unwrap_or("octos"),
+    });
+    let url = matrix_api_url(&config.homeserver, "/_matrix/client/v3/login");
+    let resp = http
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err((StatusCode::BAD_GATEWAY, matrix_login_error(status, &body)));
+    }
+    let payload: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+    let token = payload
+        .get("access_token")
+        .and_then(serde_json::Value::as_str)
+        .ok_or((
+            StatusCode::BAD_GATEWAY,
+            "Matrix login response missing access_token".into(),
+        ))?;
+    let user_id = payload
+        .get("user_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| user_id.to_string());
+    let device_id = payload
+        .get("device_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    Ok(MatrixResolvedLogin {
+        access_token: token.to_string(),
+        user_id,
+        device_id,
+        logout_after: true,
+    })
+}
+
+fn matrix_login_error(status: reqwest::StatusCode, body: &str) -> String {
+    let server_error = serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("error")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+        .filter(|message| !message.trim().is_empty())
+        .unwrap_or_else(|| body.trim().to_string());
+    let lower = server_error.to_ascii_lowercase();
+    if lower.contains("delegated authentication") || lower.contains("oidc") {
+        return format!(
+            "Matrix password login is not available on this homeserver (status={status}): \
+             it uses delegated authentication/OIDC. Paste a valid Matrix access token in \
+             Access token, or enable password login on the homeserver."
+        );
+    }
+    if server_error.is_empty() {
+        format!("Matrix login failed (status={status})")
+    } else {
+        format!("Matrix login failed (status={status}): {server_error}")
+    }
+}
+
+async fn logout_matrix_login(
+    http: &reqwest::Client,
+    homeserver: &str,
+    login: &MatrixResolvedLogin,
+) {
+    if !login.logout_after {
+        return;
+    }
+    let url = matrix_api_url(homeserver, "/_matrix/client/v3/logout");
+    if let Err(e) = http
+        .post(&url)
+        .bearer_auth(&login.access_token)
+        .send()
+        .await
+    {
+        tracing::warn!(error = %e, "Matrix logout after invite action failed");
+    }
+}
+
+async fn matrix_join_room(
+    http: &reqwest::Client,
+    config: &MatrixUserChannelConfig,
+    login: &MatrixResolvedLogin,
+    room_id: &str,
+) -> Result<(), (StatusCode, String)> {
+    let path = format!(
+        "/_matrix/client/v3/rooms/{}/join",
+        matrix_percent_encode_path(room_id)
+    );
+    let url = matrix_api_url(&config.homeserver, &path);
+    let resp = http
+        .post(&url)
+        .bearer_auth(&login.access_token)
+        .json(&json!({}))
+        .send()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            format!("Matrix join room failed (status={status}): {body}"),
+        ));
+    }
+    Ok(())
+}
+
+async fn matrix_leave_room(
+    http: &reqwest::Client,
+    config: &MatrixUserChannelConfig,
+    login: &MatrixResolvedLogin,
+    room_id: &str,
+) -> Result<(), (StatusCode, String)> {
+    let path = format!(
+        "/_matrix/client/v3/rooms/{}/leave",
+        matrix_percent_encode_path(room_id)
+    );
+    let url = matrix_api_url(&config.homeserver, &path);
+    let resp = http
+        .post(&url)
+        .bearer_auth(&login.access_token)
+        .json(&json!({}))
+        .send()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            format!("Matrix reject invite failed (status={status}): {body}"),
+        ));
+    }
+    Ok(())
+}
+
+async fn matrix_probe_sync(
+    http: &reqwest::Client,
+    config: &MatrixUserChannelConfig,
+    login: &MatrixResolvedLogin,
+) -> Result<MatrixSyncProbe, (StatusCode, String)> {
+    let url = matrix_api_url(&config.homeserver, "/_matrix/client/v3/sync?timeout=0");
+    let resp = http
+        .get(&url)
+        .bearer_auth(&login.access_token)
+        .send()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            format!("Matrix sync probe failed (status={status}): {body}"),
+        ));
+    }
+    let payload: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
+    let rooms = payload.get("rooms");
+    let joined_rooms = rooms
+        .and_then(|rooms| rooms.get("join"))
+        .and_then(serde_json::Value::as_object)
+        .map_or(0, serde_json::Map::len);
+    let invite_rooms = rooms
+        .and_then(|rooms| rooms.get("invite"))
+        .and_then(serde_json::Value::as_object);
+    let pending_invites = invite_rooms.map_or(0, serde_json::Map::len);
+    let pending_invite_details = invite_rooms
+        .map(|rooms| matrix_sync_invite_details(rooms, &login.user_id))
+        .unwrap_or_default();
+    let has_next_batch = payload
+        .get("next_batch")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty());
+    Ok(MatrixSyncProbe {
+        joined_rooms,
+        pending_invites,
+        has_next_batch,
+        pending_invite_details,
+    })
+}
+
+fn matrix_sync_invite_details(
+    invite_rooms: &serde_json::Map<String, serde_json::Value>,
+    self_user_id: &str,
+) -> Vec<MatrixSyncInviteSummary> {
+    invite_rooms
+        .iter()
+        .map(|(room_id, room)| matrix_sync_invite_detail(room_id, room, self_user_id))
+        .collect()
+}
+
+fn matrix_sync_invite_detail(
+    room_id: &str,
+    room: &serde_json::Value,
+    self_user_id: &str,
+) -> MatrixSyncInviteSummary {
+    let mut summary = MatrixSyncInviteSummary {
+        room_id: room_id.to_string(),
+        room_name: None,
+        canonical_alias: None,
+        inviter: None,
+        membership_event_id: None,
+    };
+
+    let Some(events) = room
+        .get("invite_state")
+        .and_then(|state| state.get("events"))
+        .and_then(serde_json::Value::as_array)
+    else {
+        return summary;
+    };
+
+    for event in events {
+        let event_type = event.get("type").and_then(serde_json::Value::as_str);
+        let content = event.get("content").unwrap_or(&serde_json::Value::Null);
+        match event_type {
+            Some("m.room.name") if summary.room_name.is_none() => {
+                summary.room_name = content
+                    .get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string);
+            }
+            Some("m.room.canonical_alias") if summary.canonical_alias.is_none() => {
+                summary.canonical_alias = content
+                    .get("alias")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string);
+            }
+            Some("m.room.member") => {
+                let membership = content
+                    .get("membership")
+                    .and_then(serde_json::Value::as_str);
+                let state_key = event.get("state_key").and_then(serde_json::Value::as_str);
+                if membership == Some("invite")
+                    && (state_key.is_none() || state_key == Some(self_user_id))
+                {
+                    summary.inviter = event
+                        .get("sender")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string);
+                    summary.membership_event_id = event
+                        .get("event_id")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    summary
+}
+
+fn resolve_invite_channel_index(
+    profile: &UserProfile,
+    store: &octos_bus::MatrixInviteStore,
+    room_id: &str,
+    requested: Option<usize>,
+) -> Result<usize, (StatusCode, String)> {
+    if let Some(channel_index) = requested {
+        return Ok(channel_index);
+    }
+    let invites = store
+        .list(true)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    if let Some(invite) = invites.iter().find(|invite| invite.room_id == room_id) {
+        return Ok(invite.channel_index);
+    }
+    first_matrix_user_channel_index(profile).ok_or((
+        StatusCode::NOT_FOUND,
+        "No Matrix user-account channel configured".into(),
+    ))
+}
+
+fn add_room_to_matrix_allowlist(
+    profile: &mut UserProfile,
+    channel_index: usize,
+    room_id: &str,
+) -> Result<bool, (StatusCode, String)> {
+    let Some(channel) = profile.config.channels.get_mut(channel_index) else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("Matrix channel index {channel_index} not found"),
+        ));
+    };
+    let ChannelCredentials::Matrix { rooms, .. } = channel else {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("Channel index {channel_index} is not a Matrix channel"),
+        ));
+    };
+    if rooms.iter().any(|room| room == room_id || room == "*") {
+        return Ok(false);
+    }
+    rooms.push(room_id.to_string());
+    Ok(true)
+}
+
+/// POST /api/my/profile/matrix/test
+pub async fn test_my_matrix_connection(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::Extension(identity): axum::Extension<AuthIdentity>,
+    Json(req): Json<MatrixTestConnectionRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let ps = state.profile_store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "admin not configured".into(),
+    ))?;
+    let profile = resolve_my_profile(&identity, ps, &state, &headers)
+        .map_err(|s| (s, "profile not found".into()))?;
+    let config = matrix_test_channel_config(&profile, &req)?;
+
+    let http = matrix_http_client();
+    let login = resolve_matrix_login(&http, &config).await?;
+    let sync_result = matrix_probe_sync(&http, &config, &login).await;
+    logout_matrix_login(&http, &config.homeserver, &login).await;
+    let probe = sync_result?;
+
+    Ok(Json(json!({
+        "ok": true,
+        "message": "Matrix connection is healthy",
+        "homeserver": config.homeserver,
+        "user_id": login.user_id,
+        "device_id": login.device_id,
+        "joined_rooms": probe.joined_rooms,
+        "pending_invites": probe.pending_invites,
+        "pending_invite_details": probe.pending_invite_details,
+        "sync": {
+            "ok": true,
+            "has_next_batch": probe.has_next_batch,
+        },
+    })))
+}
+
+/// GET /api/my/profile/matrix/invites
+pub async fn my_matrix_invites(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::Extension(identity): axum::Extension<AuthIdentity>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let ps = state.profile_store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "admin not configured".into(),
+    ))?;
+    let profile = resolve_my_profile(&identity, ps, &state, &headers)
+        .map_err(|s| (s, "profile not found".into()))?;
+    let data_dir = ps.resolve_data_dir(&profile);
+    let store = octos_bus::MatrixInviteStore::for_profile_data_dir(&data_dir);
+    let invites = store
+        .list(false)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(json!({ "invites": invites })))
+}
+
+/// POST /api/my/profile/matrix/invites/:room_id/accept
+pub async fn accept_my_matrix_invite(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::Extension(identity): axum::Extension<AuthIdentity>,
+    Path(room_id): Path<String>,
+    Json(req): Json<MatrixInviteActionRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let ps = state.profile_store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "admin not configured".into(),
+    ))?;
+    let mut profile = resolve_my_profile(&identity, ps, &state, &headers)
+        .map_err(|s| (s, "profile not found".into()))?;
+    let data_dir = ps.resolve_data_dir(&profile);
+    let store = octos_bus::MatrixInviteStore::for_profile_data_dir(&data_dir);
+    let channel_index =
+        resolve_invite_channel_index(&profile, &store, &room_id, req.channel_index)?;
+    let config = matrix_user_channel_config(&profile, channel_index)?;
+
+    let http = matrix_http_client();
+    let login = resolve_matrix_login(&http, &config).await?;
+    let join_result = matrix_join_room(&http, &config, &login, &room_id).await;
+    logout_matrix_login(&http, &config.homeserver, &login).await;
+    join_result?;
+
+    let add_to_allowed_rooms = req.add_to_allowed_rooms.unwrap_or(true);
+    let allowlist_updated = if add_to_allowed_rooms {
+        add_room_to_matrix_allowlist(&mut profile, channel_index, &room_id)?
+    } else {
+        false
+    };
+    if allowlist_updated {
+        profile.updated_at = chrono::Utc::now();
+        ps.save_with_merge(&mut profile).map_err(|e| {
+            tracing::error!(profile = %profile.id, error = %e, "failed to save Matrix room allowlist");
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+        })?;
+    }
+    store
+        .remove(channel_index, &room_id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(json!({
+        "ok": true,
+        "message": if allowlist_updated {
+            "Matrix invite accepted and room added to allowed rooms"
+        } else {
+            "Matrix invite accepted"
+        },
+        "allowlist_updated": allowlist_updated,
+    })))
+}
+
+/// POST /api/my/profile/matrix/invites/:room_id/reject
+pub async fn reject_my_matrix_invite(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::Extension(identity): axum::Extension<AuthIdentity>,
+    Path(room_id): Path<String>,
+    Json(req): Json<MatrixInviteActionRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let ps = state.profile_store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "admin not configured".into(),
+    ))?;
+    let profile = resolve_my_profile(&identity, ps, &state, &headers)
+        .map_err(|s| (s, "profile not found".into()))?;
+    let data_dir = ps.resolve_data_dir(&profile);
+    let store = octos_bus::MatrixInviteStore::for_profile_data_dir(&data_dir);
+    let channel_index =
+        resolve_invite_channel_index(&profile, &store, &room_id, req.channel_index)?;
+    let config = matrix_user_channel_config(&profile, channel_index)?;
+
+    let http = matrix_http_client();
+    let login = resolve_matrix_login(&http, &config).await?;
+    let leave_result = matrix_leave_room(&http, &config, &login, &room_id).await;
+    logout_matrix_login(&http, &config.homeserver, &login).await;
+    leave_result?;
+
+    store
+        .remove(channel_index, &room_id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(json!({
+        "ok": true,
+        "message": "Matrix invite rejected",
+    })))
+}
+
+/// POST /api/my/profile/matrix/invites/:room_id/dismiss
+pub async fn dismiss_my_matrix_invite(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::Extension(identity): axum::Extension<AuthIdentity>,
+    Path(room_id): Path<String>,
+    Json(req): Json<MatrixInviteActionRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let ps = state.profile_store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "admin not configured".into(),
+    ))?;
+    let profile = resolve_my_profile(&identity, ps, &state, &headers)
+        .map_err(|s| (s, "profile not found".into()))?;
+    let data_dir = ps.resolve_data_dir(&profile);
+    let store = octos_bus::MatrixInviteStore::for_profile_data_dir(&data_dir);
+    let channel_index =
+        resolve_invite_channel_index(&profile, &store, &room_id, req.channel_index)?;
+    let dismissed = store
+        .dismiss(channel_index, &room_id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(json!({
+        "ok": true,
+        "dismissed": dismissed,
+        "message": "Matrix invite dismissed locally",
+    })))
 }
 
 // ── Soul endpoints ───────────────────────────────────────────────────
@@ -2766,6 +3616,248 @@ mod tests {
         headers.insert("Host", "localhost:3000".parse().unwrap());
         headers.insert("X-Profile-Id", profile_id.parse().unwrap());
         headers
+    }
+
+    #[test]
+    fn matrix_percent_encode_path_encodes_room_ids() {
+        assert_eq!(
+            matrix_percent_encode_path("!room:example.org"),
+            "%21room%3Aexample.org"
+        );
+    }
+
+    #[test]
+    fn matrix_sync_invite_details_include_room_and_inviter() {
+        let invite_rooms = json!({
+            "!ops:example.org": {
+                "invite_state": {
+                    "events": [
+                        {
+                            "type": "m.room.name",
+                            "content": { "name": "Ops Room" }
+                        },
+                        {
+                            "type": "m.room.canonical_alias",
+                            "content": { "alias": "#ops:example.org" }
+                        },
+                        {
+                            "type": "m.room.member",
+                            "sender": "@alice:example.org",
+                            "state_key": "@octos:example.org",
+                            "event_id": "$invite1",
+                            "content": { "membership": "invite" }
+                        }
+                    ]
+                }
+            }
+        });
+        let invite_rooms = invite_rooms.as_object().unwrap();
+
+        let details = matrix_sync_invite_details(invite_rooms, "@octos:example.org");
+
+        assert_eq!(details.len(), 1);
+        assert_eq!(details[0].room_id, "!ops:example.org");
+        assert_eq!(details[0].room_name.as_deref(), Some("Ops Room"));
+        assert_eq!(
+            details[0].canonical_alias.as_deref(),
+            Some("#ops:example.org")
+        );
+        assert_eq!(details[0].inviter.as_deref(), Some("@alice:example.org"));
+        assert_eq!(details[0].membership_event_id.as_deref(), Some("$invite1"));
+    }
+
+    #[test]
+    fn matrix_accept_adds_room_to_allowlist_once() {
+        let mut profile = make_user_profile("matrix-user", "Matrix User");
+        profile.config.channels.push(ChannelCredentials::Matrix {
+            homeserver: "https://matrix.example.org".into(),
+            as_token: String::new(),
+            hs_token: String::new(),
+            server_name: String::new(),
+            sender_localpart: "octos".into(),
+            user_prefix: "octos_".into(),
+            port: 8009,
+            allowed_senders: Vec::new(),
+            mode: "user".into(),
+            user_id: "@bot:example.org".into(),
+            access_token: "syt_token".into(),
+            password: String::new(),
+            device_name: "octos".into(),
+            rooms: Vec::new(),
+            auto_join: "off".into(),
+            auto_join_allowlist: Vec::new(),
+            group_policy: "allowlist".into(),
+            require_mention: true,
+        });
+
+        assert!(add_room_to_matrix_allowlist(&mut profile, 0, "!room:example.org").unwrap());
+        assert!(!add_room_to_matrix_allowlist(&mut profile, 0, "!room:example.org").unwrap());
+        let ChannelCredentials::Matrix { rooms, .. } = &profile.config.channels[0] else {
+            panic!("expected matrix channel");
+        };
+        assert_eq!(rooms, &vec!["!room:example.org".to_string()]);
+    }
+
+    #[test]
+    fn matrix_test_config_overlays_draft_values() {
+        let mut profile = make_user_profile("matrix-user", "Matrix User");
+        profile.config.channels.push(ChannelCredentials::Matrix {
+            homeserver: "https://old.example.org".into(),
+            as_token: String::new(),
+            hs_token: String::new(),
+            server_name: String::new(),
+            sender_localpart: "octos".into(),
+            user_prefix: "octos_".into(),
+            port: 8009,
+            allowed_senders: Vec::new(),
+            mode: "user".into(),
+            user_id: "@old:example.org".into(),
+            access_token: "old_token".into(),
+            password: String::new(),
+            device_name: "old-device".into(),
+            rooms: Vec::new(),
+            auto_join: "off".into(),
+            auto_join_allowlist: Vec::new(),
+            group_policy: "allowlist".into(),
+            require_mention: true,
+        });
+
+        let request = MatrixTestConnectionRequest {
+            channel_index: Some(0),
+            channel: Some(MatrixTestChannelDraft {
+                mode: Some("user".into()),
+                homeserver: Some("https://new.example.org/".into()),
+                user_id: Some("@new:example.org".into()),
+                access_token: Some("new_token".into()),
+                password: None,
+                device_name: None,
+            }),
+        };
+
+        let config = matrix_test_channel_config(&profile, &request).unwrap();
+        assert_eq!(config.homeserver, "https://new.example.org");
+        assert_eq!(config.user_id.as_deref(), Some("@new:example.org"));
+        assert_eq!(config.access_token.as_deref(), Some("new_token"));
+        assert_eq!(config.device_name.as_deref(), Some("old-device"));
+    }
+
+    #[test]
+    fn matrix_test_config_ignores_masked_draft_secrets() {
+        let mut profile = make_user_profile("matrix-user", "Matrix User");
+        profile.config.channels.push(ChannelCredentials::Matrix {
+            homeserver: "https://matrix.example.org".into(),
+            as_token: String::new(),
+            hs_token: String::new(),
+            server_name: String::new(),
+            sender_localpart: "octos".into(),
+            user_prefix: "octos_".into(),
+            port: 8009,
+            allowed_senders: Vec::new(),
+            mode: "user".into(),
+            user_id: "@bot:example.org".into(),
+            access_token: "syt_real_access_token".into(),
+            password: "real-password".into(),
+            device_name: "old-device".into(),
+            rooms: Vec::new(),
+            auto_join: "off".into(),
+            auto_join_allowlist: Vec::new(),
+            group_policy: "allowlist".into(),
+            require_mention: true,
+        });
+
+        let request = MatrixTestConnectionRequest {
+            channel_index: Some(0),
+            channel: Some(MatrixTestChannelDraft {
+                mode: Some("user".into()),
+                homeserver: None,
+                user_id: None,
+                access_token: Some("syt_***ken".into()),
+                password: Some("***".into()),
+                device_name: Some("new-device".into()),
+            }),
+        };
+
+        let config = matrix_test_channel_config(&profile, &request).unwrap();
+        assert_eq!(
+            config.access_token.as_deref(),
+            Some("syt_real_access_token")
+        );
+        assert_eq!(config.password.as_deref(), Some("real-password"));
+        assert_eq!(config.device_name.as_deref(), Some("new-device"));
+    }
+
+    #[test]
+    fn matrix_test_config_accepts_password_login_localpart() {
+        let profile = make_user_profile("matrix-user", "Matrix User");
+        let request = MatrixTestConnectionRequest {
+            channel_index: None,
+            channel: Some(MatrixTestChannelDraft {
+                mode: Some("user".into()),
+                homeserver: Some("https://matrix.example.org".into()),
+                user_id: Some("octos".into()),
+                access_token: None,
+                password: Some("secret".into()),
+                device_name: None,
+            }),
+        };
+
+        let config = matrix_test_channel_config(&profile, &request).unwrap();
+        assert_eq!(config.user_id.as_deref(), Some("octos"));
+    }
+
+    #[test]
+    fn matrix_test_config_accepts_password_login_full_user_id() {
+        let profile = make_user_profile("matrix-user", "Matrix User");
+        let request = MatrixTestConnectionRequest {
+            channel_index: None,
+            channel: Some(MatrixTestChannelDraft {
+                mode: Some("user".into()),
+                homeserver: Some("https://matrix.example.org".into()),
+                user_id: Some("@octos:octos.meldry.com".into()),
+                access_token: None,
+                password: Some("secret".into()),
+                device_name: None,
+            }),
+        };
+
+        let config = matrix_test_channel_config(&profile, &request).unwrap();
+        assert_eq!(config.user_id.as_deref(), Some("@octos:octos.meldry.com"));
+    }
+
+    #[test]
+    fn matrix_test_config_rejects_password_login_bare_localpart_with_server() {
+        let profile = make_user_profile("matrix-user", "Matrix User");
+        let request = MatrixTestConnectionRequest {
+            channel_index: None,
+            channel: Some(MatrixTestChannelDraft {
+                mode: Some("user".into()),
+                homeserver: Some("https://matrix.example.org".into()),
+                user_id: Some("bot:example.org".into()),
+                access_token: None,
+                password: Some("secret".into()),
+                device_name: None,
+            }),
+        };
+
+        let err = matrix_test_channel_config(&profile, &request).unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(err.1.contains("localpart like octos"));
+        assert!(
+            err.1
+                .contains("do not use octos:octos.meldry.com without @")
+        );
+    }
+
+    #[test]
+    fn matrix_login_error_explains_oidc_password_login_rejection() {
+        let message = matrix_login_error(
+            reqwest::StatusCode::FORBIDDEN,
+            r#"{"errcode":"M_FORBIDDEN","error":"This server uses delegated authentication. Use the OIDC provider to log in."}"#,
+        );
+
+        assert!(message.contains("password login is not available"));
+        assert!(message.contains("Access token"));
+        assert!(!message.contains("M_FORBIDDEN"));
     }
 
     #[test]

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -240,6 +240,26 @@ pub fn build_router(state: Arc<AppState>) -> Router {
             "/api/my/profile/status",
             get(auth_handlers::my_gateway_status),
         )
+        .route(
+            "/api/my/profile/matrix/invites",
+            get(auth_handlers::my_matrix_invites),
+        )
+        .route(
+            "/api/my/profile/matrix/test",
+            post(auth_handlers::test_my_matrix_connection),
+        )
+        .route(
+            "/api/my/profile/matrix/invites/{room_id}/accept",
+            post(auth_handlers::accept_my_matrix_invite),
+        )
+        .route(
+            "/api/my/profile/matrix/invites/{room_id}/reject",
+            post(auth_handlers::reject_my_matrix_invite),
+        )
+        .route(
+            "/api/my/profile/matrix/invites/{room_id}/dismiss",
+            post(auth_handlers::dismiss_my_matrix_invite),
+        )
         .route("/api/my/profile/logs", get(auth_handlers::my_gateway_logs))
         .route(
             "/api/my/profile/whatsapp/qr",

--- a/crates/octos-cli/src/commands/gateway/adapters/matrix.rs
+++ b/crates/octos-cli/src/commands/gateway/adapters/matrix.rs
@@ -11,9 +11,20 @@ pub fn register(
     channel_mgr: &mut ChannelManager,
     matrix_channel: &mut Option<Arc<octos_bus::MatrixChannel>>,
     entry: &ChannelEntry,
+    channel_index: usize,
     shutdown: &Arc<AtomicBool>,
     data_dir: &Path,
 ) -> eyre::Result<()> {
+    // User-account (client) mode: log in with a Matrix account and long-poll
+    // `/sync`. Leaves `matrix_channel` (the appservice handle) unset — there is
+    // no virtual-user/bot management in this mode.
+    if matrix_is_user_mode(entry) {
+        let settings = MatrixUserChannelSettings::from_entry(entry)?;
+        let _ =
+            register_matrix_user_channel(channel_mgr, &settings, shutdown, data_dir, channel_index);
+        return Ok(());
+    }
+
     let settings = MatrixChannelSettings::from_entry(entry)?;
     let _ = register_matrix_channel(channel_mgr, matrix_channel, &settings, shutdown, data_dir);
     Ok(())

--- a/crates/octos-cli/src/commands/gateway/adapters/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/adapters/mod.rs
@@ -106,6 +106,9 @@ pub fn register_all(
     ctx: &mut ChannelRegistrationCtx<'_>,
 ) -> eyre::Result<()> {
     for (channel_index, entry) in entries.iter().enumerate() {
+        // `channel_index` is only consumed by the matrix arm below.
+        #[cfg(not(feature = "matrix"))]
+        let _ = channel_index;
         match entry.channel_type.as_str() {
             "cli" => cli::register(channel_mgr, entry, ctx.shutdown)?,
             #[cfg(feature = "telegram")]

--- a/crates/octos-cli/src/commands/gateway/adapters/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/adapters/mod.rs
@@ -105,7 +105,7 @@ pub fn register_all(
     entries: &[ChannelEntry],
     ctx: &mut ChannelRegistrationCtx<'_>,
 ) -> eyre::Result<()> {
-    for entry in entries {
+    for (channel_index, entry) in entries.iter().enumerate() {
         match entry.channel_type.as_str() {
             "cli" => cli::register(channel_mgr, entry, ctx.shutdown)?,
             #[cfg(feature = "telegram")]
@@ -147,6 +147,7 @@ pub fn register_all(
                 channel_mgr,
                 ctx.matrix_channel,
                 entry,
+                channel_index,
                 ctx.shutdown,
                 ctx.data_dir,
             )?,

--- a/crates/octos-cli/src/commands/gateway/matrix_integration.rs
+++ b/crates/octos-cli/src/commands/gateway/matrix_integration.rs
@@ -41,6 +41,51 @@ pub(super) const MATRIX_MISSING_TOKENS_ERROR: &str =
 #[cfg(feature = "matrix")]
 pub(super) const MATRIX_BOT_USER_ID_ENV_KEY: &str = "OCTOS_MATRIX_BOT_USER_ID";
 
+// ── User-mode (Matrix account login) settings ────────────────────────────────
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_SETTING_MODE: &str = "mode";
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_MODE_USER: &str = "user";
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_MODE_APPSERVICE: &str = "appservice";
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_SETTING_USER_ID: &str = "user_id";
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_SETTING_ACCESS_TOKEN: &str = "access_token";
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_SETTING_PASSWORD: &str = "password";
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_SETTING_DEVICE_NAME: &str = "device_name";
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_SETTING_ROOMS: &str = "rooms";
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_SETTING_AUTO_JOIN: &str = "auto_join";
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_SETTING_AUTO_JOIN_CAMEL: &str = "autoJoin";
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_SETTING_AUTO_JOIN_ALLOWLIST: &str = "auto_join_allowlist";
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_SETTING_AUTO_JOIN_ALLOWLIST_CAMEL: &str = "autoJoinAllowlist";
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_SETTING_GROUP_POLICY: &str = "group_policy";
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_SETTING_GROUP_POLICY_CAMEL: &str = "groupPolicy";
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_SETTING_REQUIRE_MENTION: &str = "require_mention";
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_SETTING_REQUIRE_MENTION_CAMEL: &str = "requireMention";
+#[cfg(feature = "matrix")]
+pub(super) const MATRIX_USER_MISSING_AUTH_ERROR: &str =
+    "matrix user channel requires settings.access_token or settings.user_id + settings.password";
+
+/// Returns `true` when the channel entry selects user-account (client) mode.
+/// Defaults to appservice mode when `mode` is unset.
+#[cfg(feature = "matrix")]
+pub(super) fn matrix_is_user_mode(entry: &crate::config::ChannelEntry) -> bool {
+    settings_str(&entry.settings, MATRIX_SETTING_MODE, MATRIX_MODE_APPSERVICE)
+        .eq_ignore_ascii_case(MATRIX_MODE_USER)
+}
+
 #[cfg(feature = "matrix")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct MatrixChannelSettings {
@@ -146,6 +191,153 @@ pub(super) fn register_matrix_channel(
     data_dir: &std::path::Path,
 ) -> Arc<octos_bus::MatrixChannel> {
     let channel = get_or_create_matrix_channel(matrix_channel, settings, shutdown, data_dir);
+    channel_mgr.register(channel.clone());
+    channel
+}
+
+/// Settings for the user-account (client) Matrix channel.
+///
+/// Logs in as a regular Matrix account via an access token or password and
+/// long-polls `/sync` — no homeserver-side appservice registration needed.
+#[cfg(feature = "matrix")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct MatrixUserChannelSettings {
+    pub(super) homeserver: String,
+    pub(super) user_id: Option<String>,
+    pub(super) access_token: Option<String>,
+    pub(super) password: Option<String>,
+    pub(super) device_name: Option<String>,
+    pub(super) rooms: Vec<String>,
+    pub(super) auto_join: octos_bus::MatrixAutoJoin,
+    pub(super) auto_join_allowlist: Vec<String>,
+    pub(super) group_policy: octos_bus::MatrixGroupPolicy,
+    pub(super) require_mention: bool,
+    pub(super) allowed_senders: Vec<String>,
+}
+
+#[cfg(feature = "matrix")]
+impl MatrixUserChannelSettings {
+    pub(super) fn from_entry(entry: &crate::config::ChannelEntry) -> Result<Self> {
+        let opt = |key: &str| {
+            let value = settings_str(&entry.settings, key, "");
+            if value.trim().is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        };
+
+        let opt_any = |keys: &[&str]| {
+            keys.iter()
+                .map(|key| settings_str(&entry.settings, key, ""))
+                .find(|value| !value.trim().is_empty())
+        };
+
+        let access_token = opt(MATRIX_SETTING_ACCESS_TOKEN);
+        let user_id = opt(MATRIX_SETTING_USER_ID);
+        let password = opt(MATRIX_SETTING_PASSWORD);
+        if access_token.is_none() && (user_id.is_none() || password.is_none()) {
+            eyre::bail!(MATRIX_USER_MISSING_AUTH_ERROR);
+        }
+
+        let string_array = |keys: &[&str]| {
+            keys.iter()
+                .find_map(|key| entry.settings.get(key))
+                .and_then(|value| {
+                    if let Some(arr) = value.as_array() {
+                        Some(
+                            arr.iter()
+                                .filter_map(|v| v.as_str())
+                                .map(str::to_string)
+                                .collect::<Vec<_>>(),
+                        )
+                    } else {
+                        value.as_str().map(|raw| {
+                            raw.split(',')
+                                .map(str::trim)
+                                .filter(|s| !s.is_empty())
+                                .map(str::to_string)
+                                .collect::<Vec<_>>()
+                        })
+                    }
+                })
+                .unwrap_or_default()
+        };
+
+        let auto_join = opt_any(&[MATRIX_SETTING_AUTO_JOIN, MATRIX_SETTING_AUTO_JOIN_CAMEL])
+            .map(|raw| octos_bus::MatrixAutoJoin::parse(&raw))
+            .unwrap_or_default();
+        let group_policy = opt_any(&[
+            MATRIX_SETTING_GROUP_POLICY,
+            MATRIX_SETTING_GROUP_POLICY_CAMEL,
+        ])
+        .map(|raw| octos_bus::MatrixGroupPolicy::parse(&raw))
+        .unwrap_or_default();
+        let require_mention = entry
+            .settings
+            .get(MATRIX_SETTING_REQUIRE_MENTION)
+            .or_else(|| entry.settings.get(MATRIX_SETTING_REQUIRE_MENTION_CAMEL))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
+        Ok(Self {
+            homeserver: settings_str(
+                &entry.settings,
+                MATRIX_SETTING_HOMESERVER,
+                MATRIX_DEFAULT_HOMESERVER,
+            ),
+            user_id,
+            access_token,
+            password,
+            device_name: opt(MATRIX_SETTING_DEVICE_NAME),
+            rooms: string_array(&[MATRIX_SETTING_ROOMS]),
+            auto_join,
+            auto_join_allowlist: string_array(&[
+                MATRIX_SETTING_AUTO_JOIN_ALLOWLIST,
+                MATRIX_SETTING_AUTO_JOIN_ALLOWLIST_CAMEL,
+            ]),
+            group_policy,
+            require_mention,
+            allowed_senders: entry.allowed_senders.clone(),
+        })
+    }
+
+    fn build_channel(
+        &self,
+        shutdown: Arc<AtomicBool>,
+        data_dir: &std::path::Path,
+        channel_index: usize,
+    ) -> Arc<octos_bus::MatrixUserChannel> {
+        Arc::new(
+            octos_bus::MatrixUserChannel::new(
+                &self.homeserver,
+                self.user_id.clone(),
+                self.access_token.clone(),
+                self.password.clone(),
+                self.device_name.clone(),
+                self.rooms.clone(),
+                self.auto_join,
+                self.auto_join_allowlist.clone(),
+                self.group_policy,
+                self.require_mention,
+                self.allowed_senders.clone(),
+                shutdown,
+            )
+            .with_channel_index(channel_index)
+            .with_invite_store(octos_bus::MatrixInviteStore::for_profile_data_dir(data_dir)),
+        )
+    }
+}
+
+#[cfg(feature = "matrix")]
+pub(super) fn register_matrix_user_channel(
+    channel_mgr: &mut ChannelManager,
+    settings: &MatrixUserChannelSettings,
+    shutdown: &Arc<AtomicBool>,
+    data_dir: &std::path::Path,
+    channel_index: usize,
+) -> Arc<octos_bus::MatrixUserChannel> {
+    let channel = settings.build_channel(shutdown.clone(), data_dir, channel_index);
     channel_mgr.register(channel.clone());
     channel
 }

--- a/crates/octos-cli/src/commands/gateway/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/mod.rs
@@ -193,6 +193,7 @@ mod tests {
             enabled: false,
             data_dir: None,
             parent_id: None,
+            public_subdomain: None,
             config: crate::profiles::ProfileConfig {
                 gateway: crate::profiles::GatewaySettings {
                     system_prompt: system_prompt.map(str::to_string),
@@ -224,11 +225,19 @@ mod tests {
             primary: Some(crate::profiles::LlmModelSelectionConfig {
                 family_id: Some("openai".into()),
                 model_id: Some("gpt-4o-mini".into()),
+                route: Some(crate::profiles::LlmRouteConfig {
+                    api_key_env: Some("OPENAI_API_KEY".into()),
+                    ..Default::default()
+                }),
                 ..Default::default()
             }),
             fallbacks: vec![crate::profiles::LlmModelSelectionConfig {
                 family_id: Some("openai".into()),
                 model_id: Some("gpt-4o".into()),
+                route: Some(crate::profiles::LlmRouteConfig {
+                    api_key_env: Some("OPENAI_API_KEY".into()),
+                    ..Default::default()
+                }),
                 ..Default::default()
             }],
             ..Default::default()
@@ -423,6 +432,132 @@ mod tests {
     }
 
     #[test]
+    fn matrix_defaults_to_appservice_mode() {
+        let entry = matrix_entry(serde_json::json!({}));
+        assert!(!matrix_is_user_mode(&entry));
+    }
+
+    #[test]
+    fn matrix_user_mode_detected_case_insensitive() {
+        let entry = matrix_entry(serde_json::json!({ MATRIX_SETTING_MODE: "User" }));
+        assert!(matrix_is_user_mode(&entry));
+    }
+
+    #[test]
+    fn matrix_user_settings_accept_access_token() {
+        let entry = matrix_entry(serde_json::json!({
+            MATRIX_SETTING_MODE: MATRIX_MODE_USER,
+            MATRIX_SETTING_HOMESERVER: "https://matrix.org",
+            MATRIX_SETTING_ACCESS_TOKEN: "syt_token",
+            MATRIX_SETTING_ROOMS: ["!a:matrix.org", "!b:matrix.org"],
+        }));
+
+        let settings = MatrixUserChannelSettings::from_entry(&entry).unwrap();
+
+        assert_eq!(settings.homeserver, "https://matrix.org");
+        assert_eq!(settings.access_token.as_deref(), Some("syt_token"));
+        assert!(settings.password.is_none());
+        assert_eq!(settings.rooms, vec!["!a:matrix.org", "!b:matrix.org"]);
+        assert_eq!(settings.auto_join, octos_bus::MatrixAutoJoin::Off);
+        assert_eq!(
+            settings.group_policy,
+            octos_bus::MatrixGroupPolicy::Allowlist
+        );
+        assert!(settings.require_mention);
+    }
+
+    #[test]
+    fn matrix_user_settings_copy_allowed_senders() {
+        let entry = crate::config::ChannelEntry {
+            channel_type: MATRIX_CHANNEL_TYPE.to_string(),
+            allowed_senders: vec!["@alice:matrix.org".into(), "@bob:matrix.org".into()],
+            settings: serde_json::json!({
+                MATRIX_SETTING_MODE: MATRIX_MODE_USER,
+                MATRIX_SETTING_ACCESS_TOKEN: "syt_token",
+            }),
+        };
+
+        let settings = MatrixUserChannelSettings::from_entry(&entry).unwrap();
+
+        assert_eq!(
+            settings.allowed_senders,
+            vec![
+                "@alice:matrix.org".to_string(),
+                "@bob:matrix.org".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn matrix_user_settings_accept_openclaw_style_policy_keys() {
+        let entry = matrix_entry(serde_json::json!({
+            MATRIX_SETTING_MODE: MATRIX_MODE_USER,
+            MATRIX_SETTING_ACCESS_TOKEN: "syt_token",
+            "autoJoin": "allowlist",
+            "autoJoinAllowlist": ["!ops:matrix.org", "#support:matrix.org"],
+            "groupPolicy": "open",
+            "requireMention": false,
+        }));
+
+        let settings = MatrixUserChannelSettings::from_entry(&entry).unwrap();
+
+        assert_eq!(settings.auto_join, octos_bus::MatrixAutoJoin::Allowlist);
+        assert_eq!(
+            settings.auto_join_allowlist,
+            vec![
+                "!ops:matrix.org".to_string(),
+                "#support:matrix.org".to_string()
+            ]
+        );
+        assert_eq!(settings.group_policy, octos_bus::MatrixGroupPolicy::Open);
+        assert!(!settings.require_mention);
+    }
+
+    #[test]
+    fn matrix_user_settings_accept_password_login() {
+        let entry = matrix_entry(serde_json::json!({
+            MATRIX_SETTING_MODE: MATRIX_MODE_USER,
+            MATRIX_SETTING_USER_ID: "@bot:matrix.org",
+            MATRIX_SETTING_PASSWORD: "secret",
+            MATRIX_SETTING_DEVICE_NAME: "octos-gw",
+        }));
+
+        let settings = MatrixUserChannelSettings::from_entry(&entry).unwrap();
+
+        assert_eq!(settings.user_id.as_deref(), Some("@bot:matrix.org"));
+        assert_eq!(settings.password.as_deref(), Some("secret"));
+        assert_eq!(settings.device_name.as_deref(), Some("octos-gw"));
+        assert!(settings.access_token.is_none());
+    }
+
+    #[test]
+    fn matrix_user_settings_require_credentials() {
+        let entry = matrix_entry(serde_json::json!({
+            MATRIX_SETTING_MODE: MATRIX_MODE_USER,
+            MATRIX_SETTING_USER_ID: "@bot:matrix.org",
+        }));
+
+        let err = MatrixUserChannelSettings::from_entry(&entry).unwrap_err();
+        assert!(err.to_string().contains(MATRIX_USER_MISSING_AUTH_ERROR));
+    }
+
+    #[test]
+    fn test_gateway_registers_matrix_user_channel() {
+        let entry = matrix_entry(serde_json::json!({
+            MATRIX_SETTING_MODE: MATRIX_MODE_USER,
+            MATRIX_SETTING_ACCESS_TOKEN: "syt_token",
+        }));
+        let settings = MatrixUserChannelSettings::from_entry(&entry).unwrap();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let mut channel_mgr = ChannelManager::new();
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        let _ = register_matrix_user_channel(&mut channel_mgr, &settings, &shutdown, tmp.path(), 0);
+
+        assert!(channel_mgr.get_channel(MATRIX_CHANNEL_TYPE).is_some());
+    }
+
+    #[test]
     fn test_dispatch_unknown_profile_falls_back() {
         let dir = tempfile::TempDir::new().unwrap();
         let store = crate::profiles::ProfileStore::open(dir.path()).unwrap();
@@ -492,6 +627,16 @@ mod tests {
                 user_prefix: "bot_".to_string(),
                 port: MATRIX_DEFAULT_PORT,
                 allowed_senders: vec![],
+                mode: String::new(),
+                user_id: String::new(),
+                access_token: String::new(),
+                password: String::new(),
+                device_name: String::new(),
+                rooms: vec![],
+                auto_join: "off".to_string(),
+                auto_join_allowlist: vec![],
+                group_policy: "allowlist".to_string(),
+                require_mention: true,
             });
         store.save(&parent).unwrap();
 
@@ -578,6 +723,16 @@ mod tests {
                 user_prefix: "bot_".to_string(),
                 port: MATRIX_DEFAULT_PORT,
                 allowed_senders: vec![],
+                mode: String::new(),
+                user_id: String::new(),
+                access_token: String::new(),
+                password: String::new(),
+                device_name: String::new(),
+                rooms: vec![],
+                auto_join: "off".to_string(),
+                auto_join_allowlist: vec![],
+                group_policy: "allowlist".to_string(),
+                require_mention: true,
             });
         store.save(&parent).unwrap();
 
@@ -651,6 +806,16 @@ mod tests {
                 user_prefix: "bot_".to_string(),
                 port: MATRIX_DEFAULT_PORT,
                 allowed_senders: vec!["@admin:localhost".to_string()],
+                mode: String::new(),
+                user_id: String::new(),
+                access_token: String::new(),
+                password: String::new(),
+                device_name: String::new(),
+                rooms: vec![],
+                auto_join: "off".to_string(),
+                auto_join_allowlist: vec![],
+                group_policy: "allowlist".to_string(),
+                require_mention: true,
             });
         store.save(&parent).unwrap();
 

--- a/crates/octos-cli/src/commands/gateway/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/mod.rs
@@ -193,7 +193,6 @@ mod tests {
             enabled: false,
             data_dir: None,
             parent_id: None,
-            public_subdomain: None,
             config: crate::profiles::ProfileConfig {
                 gateway: crate::profiles::GatewaySettings {
                     system_prompt: system_prompt.map(str::to_string),

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -921,9 +921,16 @@ pub enum ChannelCredentials {
         secret_env: String,
     },
     Matrix {
+        #[serde(default)]
         homeserver: String,
+        // Appservice-mode tokens. Optional so a user-mode entry (which has no
+        // appservice registration) still deserializes; emptiness is enforced
+        // downstream only for appservice mode.
+        #[serde(default)]
         as_token: String,
+        #[serde(default)]
         hs_token: String,
+        #[serde(default)]
         server_name: String,
         #[serde(default = "default_matrix_sender_localpart")]
         sender_localpart: String,
@@ -933,6 +940,36 @@ pub enum ChannelCredentials {
         port: u16,
         #[serde(default)]
         allowed_senders: Vec<String>,
+        /// Channel mode: "appservice" (default) or "user" (regular account login).
+        #[serde(default)]
+        mode: String,
+        /// User-mode: Matrix user ID, e.g. "@bot:matrix.org".
+        #[serde(default)]
+        user_id: String,
+        /// User-mode: access token (alternative to password login).
+        #[serde(default)]
+        access_token: String,
+        /// User-mode: account password (alternative to access token).
+        #[serde(default)]
+        password: String,
+        /// User-mode: device display name created at login.
+        #[serde(default)]
+        device_name: String,
+        /// User-mode: room allowlist used when group_policy is "allowlist".
+        #[serde(default)]
+        rooms: Vec<String>,
+        /// User-mode: invite auto-join policy: "off", "allowlist", or "always".
+        #[serde(default = "default_matrix_auto_join")]
+        auto_join: String,
+        /// User-mode: invite allowlist used when auto_join is "allowlist".
+        #[serde(default)]
+        auto_join_allowlist: Vec<String>,
+        /// User-mode: room/group policy: "open", "allowlist", or "disabled".
+        #[serde(default = "default_matrix_group_policy")]
+        group_policy: String,
+        /// User-mode: require an explicit bot mention or slash command in allowed rooms.
+        #[serde(default = "crate::config::default_true")]
+        require_mention: bool,
     },
     #[serde(rename = "qq-bot")]
     QQBot {
@@ -1020,6 +1057,12 @@ fn default_matrix_user_prefix() -> String {
 }
 fn default_matrix_port() -> u16 {
     8009
+}
+fn default_matrix_auto_join() -> String {
+    "off".into()
+}
+fn default_matrix_group_policy() -> String {
+    "allowlist".into()
 }
 fn default_qq_bot_secret_env() -> String {
     "QQ_BOT_CLIENT_SECRET".into()
@@ -1175,15 +1218,28 @@ impl ProfileStore {
     pub fn save_with_merge(&self, profile: &mut UserProfile) -> Result<()> {
         if let Some(existing) = self.get(&profile.id)? {
             for (key, new_val) in profile.config.env_vars.iter_mut() {
-                let is_masked = new_val.contains("***")
-                    || new_val.contains(KEYCHAIN_DISPLAY)
-                    || new_val.is_empty();
+                let is_masked = is_display_secret_value(new_val) || new_val.is_empty();
                 // Never overwrite the real stored value with a display artifact,
                 // but DO allow explicit "keychain:" marker (it's the real value).
                 if is_masked && new_val != crate::auth::KEYCHAIN_MARKER {
                     if let Some(old_val) = existing.config.env_vars.get(key) {
                         *new_val = old_val.clone();
                     }
+                }
+            }
+            for (idx, new_channel) in profile.config.channels.iter_mut().enumerate() {
+                let old_channel = existing
+                    .config
+                    .channels
+                    .iter()
+                    .find(|old_channel| channel_secret_identity_matches(new_channel, old_channel))
+                    .or_else(|| {
+                        existing.config.channels.get(idx).filter(|old_channel| {
+                            same_secret_channel_variant(new_channel, old_channel)
+                        })
+                    });
+                if let Some(old_channel) = old_channel {
+                    restore_masked_channel_secrets(new_channel, old_channel);
                 }
             }
         }
@@ -1436,12 +1492,19 @@ pub fn mask_secrets(profile: &UserProfile) -> UserProfile {
             *value = mask_value(value);
         }
     }
+    for channel in &mut masked.config.channels {
+        mask_channel_secrets(channel);
+    }
     masked.config.normalize_llm_contract();
     masked
 }
 
 /// Display string for keychain-backed values in API responses.
 const KEYCHAIN_DISPLAY: &str = "\u{1f511} (keychain)";
+
+pub(crate) fn is_display_secret_value(value: &str) -> bool {
+    value.contains("***") || value.contains(KEYCHAIN_DISPLAY)
+}
 
 fn mask_value(s: &str) -> String {
     let chars: Vec<char> = s.chars().collect();
@@ -1454,6 +1517,152 @@ fn mask_value(s: &str) -> String {
         "***".into()
     } else {
         String::new()
+    }
+}
+
+fn mask_channel_secrets(channel: &mut ChannelCredentials) {
+    match channel {
+        ChannelCredentials::Api { auth_token, .. } => {
+            if let Some(token) = auth_token {
+                *token = mask_value(token);
+            }
+        }
+        ChannelCredentials::Matrix {
+            as_token,
+            hs_token,
+            access_token,
+            password,
+            ..
+        } => {
+            *as_token = mask_value(as_token);
+            *hs_token = mask_value(hs_token);
+            *access_token = mask_value(access_token);
+            *password = mask_value(password);
+        }
+        _ => {}
+    }
+}
+
+fn restore_masked_channel_secrets(
+    new_channel: &mut ChannelCredentials,
+    old_channel: &ChannelCredentials,
+) {
+    match (new_channel, old_channel) {
+        (
+            ChannelCredentials::Api {
+                auth_token: new_token,
+                ..
+            },
+            ChannelCredentials::Api {
+                auth_token: old_token,
+                ..
+            },
+        ) => restore_masked_optional_secret(new_token, old_token),
+        (
+            ChannelCredentials::Matrix {
+                as_token: new_as_token,
+                hs_token: new_hs_token,
+                access_token: new_access_token,
+                password: new_password,
+                ..
+            },
+            ChannelCredentials::Matrix {
+                as_token: old_as_token,
+                hs_token: old_hs_token,
+                access_token: old_access_token,
+                password: old_password,
+                ..
+            },
+        ) => {
+            restore_masked_secret(new_as_token, old_as_token);
+            restore_masked_secret(new_hs_token, old_hs_token);
+            restore_masked_secret(new_access_token, old_access_token);
+            restore_masked_secret(new_password, old_password);
+        }
+        _ => {}
+    }
+}
+
+fn same_secret_channel_variant(
+    new_channel: &ChannelCredentials,
+    old_channel: &ChannelCredentials,
+) -> bool {
+    matches!(
+        (new_channel, old_channel),
+        (
+            ChannelCredentials::Api { .. },
+            ChannelCredentials::Api { .. }
+        ) | (
+            ChannelCredentials::Matrix { .. },
+            ChannelCredentials::Matrix { .. }
+        )
+    )
+}
+
+fn channel_secret_identity_matches(
+    new_channel: &ChannelCredentials,
+    old_channel: &ChannelCredentials,
+) -> bool {
+    match (new_channel, old_channel) {
+        (
+            ChannelCredentials::Api { port: new_port, .. },
+            ChannelCredentials::Api { port: old_port, .. },
+        ) => new_port == old_port,
+        (
+            ChannelCredentials::Matrix {
+                homeserver: new_homeserver,
+                mode: new_mode,
+                user_id: new_user_id,
+                server_name: new_server_name,
+                sender_localpart: new_sender_localpart,
+                user_prefix: new_user_prefix,
+                port: new_port,
+                ..
+            },
+            ChannelCredentials::Matrix {
+                homeserver: old_homeserver,
+                mode: old_mode,
+                user_id: old_user_id,
+                server_name: old_server_name,
+                sender_localpart: old_sender_localpart,
+                user_prefix: old_user_prefix,
+                port: old_port,
+                ..
+            },
+        ) => {
+            if !new_mode.eq_ignore_ascii_case(old_mode) {
+                return false;
+            }
+            let same_homeserver = !new_homeserver.trim().is_empty()
+                && new_homeserver.trim_end_matches('/') == old_homeserver.trim_end_matches('/');
+            if new_mode.eq_ignore_ascii_case("user") {
+                same_homeserver && !new_user_id.trim().is_empty() && new_user_id == old_user_id
+            } else {
+                same_homeserver
+                    && new_port == old_port
+                    && !new_server_name.trim().is_empty()
+                    && new_server_name == old_server_name
+                    && new_sender_localpart == old_sender_localpart
+                    && new_user_prefix == old_user_prefix
+            }
+        }
+        _ => false,
+    }
+}
+
+fn restore_masked_secret(new_value: &mut String, old_value: &str) {
+    if is_display_secret_value(new_value) {
+        *new_value = old_value.to_string();
+    }
+}
+
+fn restore_masked_optional_secret(new_value: &mut Option<String>, old_value: &Option<String>) {
+    let should_restore = new_value
+        .as_deref()
+        .map(is_display_secret_value)
+        .unwrap_or(false);
+    if should_restore {
+        *new_value = old_value.clone();
     }
 }
 
@@ -1756,19 +1965,58 @@ fn channel_to_entry(cred: &ChannelCredentials) -> serde_json::Value {
             user_prefix,
             port,
             allowed_senders,
-        } => serde_json::json!({
-            "type": "matrix",
-            "allowed_senders": allowed_senders,
-            "settings": {
-                "homeserver": homeserver,
-                "as_token": as_token,
-                "hs_token": hs_token,
-                "server_name": server_name,
-                "sender_localpart": sender_localpart,
-                "user_prefix": user_prefix,
-                "port": port,
+            mode,
+            user_id,
+            access_token,
+            password,
+            device_name,
+            rooms,
+            auto_join,
+            auto_join_allowlist,
+            group_policy,
+            require_mention,
+        } => {
+            let mut settings = serde_json::json!({ "homeserver": homeserver });
+            if mode.eq_ignore_ascii_case("user") {
+                // User-account (client) mode: log in as a regular Matrix user
+                // and long-poll `/sync`. Only emit the credentials that are set.
+                settings["mode"] = serde_json::json!("user");
+                settings["auto_join"] = serde_json::json!(auto_join);
+                settings["group_policy"] = serde_json::json!(group_policy);
+                settings["require_mention"] = serde_json::json!(require_mention);
+                if !user_id.is_empty() {
+                    settings["user_id"] = serde_json::json!(user_id);
+                }
+                if !access_token.is_empty() {
+                    settings["access_token"] = serde_json::json!(access_token);
+                }
+                if !password.is_empty() {
+                    settings["password"] = serde_json::json!(password);
+                }
+                if !device_name.is_empty() {
+                    settings["device_name"] = serde_json::json!(device_name);
+                }
+                if !rooms.is_empty() {
+                    settings["rooms"] = serde_json::json!(rooms);
+                }
+                if !auto_join_allowlist.is_empty() {
+                    settings["auto_join_allowlist"] = serde_json::json!(auto_join_allowlist);
+                }
+            } else {
+                // Appservice mode (default): homeserver-side registration.
+                settings["as_token"] = serde_json::json!(as_token);
+                settings["hs_token"] = serde_json::json!(hs_token);
+                settings["server_name"] = serde_json::json!(server_name);
+                settings["sender_localpart"] = serde_json::json!(sender_localpart);
+                settings["user_prefix"] = serde_json::json!(user_prefix);
+                settings["port"] = serde_json::json!(port);
             }
-        }),
+            serde_json::json!({
+                "type": "matrix",
+                "allowed_senders": allowed_senders,
+                "settings": settings,
+            })
+        }
         ChannelCredentials::QQBot {
             app_id,
             client_secret_env,
@@ -2613,6 +2861,32 @@ mod tests {
                     ("SHORT".into(), "abc".into()),
                 ]
                 .into(),
+                channels: vec![
+                    ChannelCredentials::Api {
+                        port: 9911,
+                        auth_token: Some("api-token-secret".into()),
+                    },
+                    ChannelCredentials::Matrix {
+                        homeserver: "https://matrix.example.org".into(),
+                        as_token: "as-token-secret".into(),
+                        hs_token: "hs-token-secret".into(),
+                        server_name: "example.org".into(),
+                        sender_localpart: "octos".into(),
+                        user_prefix: "octos_".into(),
+                        port: 8009,
+                        allowed_senders: Vec::new(),
+                        mode: "user".into(),
+                        user_id: "@bot:example.org".into(),
+                        access_token: "syt_access_token_secret".into(),
+                        password: "matrix-password".into(),
+                        device_name: "octos".into(),
+                        rooms: Vec::new(),
+                        auto_join: "off".into(),
+                        auto_join_allowlist: Vec::new(),
+                        group_policy: "allowlist".into(),
+                        require_mention: true,
+                    },
+                ],
                 ..Default::default()
             },
             created_at: Utc::now(),
@@ -2622,6 +2896,24 @@ mod tests {
         let masked = mask_secrets(&profile);
         assert_eq!(masked.config.env_vars["API_KEY"], "sk-1***def");
         assert_eq!(masked.config.env_vars["SHORT"], "***");
+        let ChannelCredentials::Api { auth_token, .. } = &masked.config.channels[0] else {
+            panic!("expected api channel");
+        };
+        assert_eq!(auth_token.as_deref(), Some("api-***ret"));
+        let ChannelCredentials::Matrix {
+            as_token,
+            hs_token,
+            access_token,
+            password,
+            ..
+        } = &masked.config.channels[1]
+        else {
+            panic!("expected matrix channel");
+        };
+        assert_eq!(as_token, "as-t***ret");
+        assert_eq!(hs_token, "hs-t***ret");
+        assert_eq!(access_token, "syt_***ret");
+        assert_eq!(password, "matr***ord");
     }
 
     #[test]
@@ -2701,6 +2993,236 @@ mod tests {
         assert_eq!(loaded.config.env_vars["API_KEY"], "sk-real-secret-key");
         assert_eq!(loaded.config.env_vars["OTHER"], "new-value");
         assert_eq!(loaded.config.env_vars["NEW_KEY"], "brand-new");
+    }
+
+    #[test]
+    fn test_save_with_merge_preserves_masked_channel_secrets() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ProfileStore::open(dir.path()).unwrap();
+
+        let original = UserProfile {
+            id: "channel-merge".into(),
+            name: "Channel Merge".into(),
+            enabled: false,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig {
+                channels: vec![
+                    ChannelCredentials::Api {
+                        port: 9911,
+                        auth_token: Some("api-real-token".into()),
+                    },
+                    ChannelCredentials::Matrix {
+                        homeserver: "https://old.example.org".into(),
+                        as_token: "as-real-token".into(),
+                        hs_token: "hs-real-token".into(),
+                        server_name: "old.example.org".into(),
+                        sender_localpart: "octos".into(),
+                        user_prefix: "octos_".into(),
+                        port: 8009,
+                        allowed_senders: Vec::new(),
+                        mode: "user".into(),
+                        user_id: "@bot:old.example.org".into(),
+                        access_token: "syt_real_access_token".into(),
+                        password: "real-password".into(),
+                        device_name: "old-device".into(),
+                        rooms: Vec::new(),
+                        auto_join: "off".into(),
+                        auto_join_allowlist: Vec::new(),
+                        group_policy: "allowlist".into(),
+                        require_mention: true,
+                    },
+                ],
+                ..Default::default()
+            },
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        store.save(&original).unwrap();
+
+        let mut updated = original.clone();
+        let ChannelCredentials::Api { auth_token, .. } = &mut updated.config.channels[0] else {
+            panic!("expected api channel");
+        };
+        *auth_token = Some("api-***ken".into());
+        let ChannelCredentials::Matrix {
+            homeserver,
+            as_token,
+            hs_token,
+            access_token,
+            password,
+            device_name,
+            ..
+        } = &mut updated.config.channels[1]
+        else {
+            panic!("expected matrix channel");
+        };
+        *homeserver = "https://new.example.org".into();
+        *as_token = "as-r***ken".into();
+        *hs_token = "hs-r***ken".into();
+        *access_token = "syt_***ken".into();
+        *password = "***".into();
+        *device_name = "new-device".into();
+        store.save_with_merge(&mut updated).unwrap();
+
+        let loaded = store.get("channel-merge").unwrap().unwrap();
+        let ChannelCredentials::Api { auth_token, .. } = &loaded.config.channels[0] else {
+            panic!("expected api channel");
+        };
+        assert_eq!(auth_token.as_deref(), Some("api-real-token"));
+        let ChannelCredentials::Matrix {
+            homeserver,
+            as_token,
+            hs_token,
+            access_token,
+            password,
+            device_name,
+            ..
+        } = &loaded.config.channels[1]
+        else {
+            panic!("expected matrix channel");
+        };
+        assert_eq!(homeserver, "https://new.example.org");
+        assert_eq!(as_token, "as-real-token");
+        assert_eq!(hs_token, "hs-real-token");
+        assert_eq!(access_token, "syt_real_access_token");
+        assert_eq!(password, "real-password");
+        assert_eq!(device_name, "new-device");
+    }
+
+    #[test]
+    fn test_save_with_merge_allows_clearing_channel_secret() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ProfileStore::open(dir.path()).unwrap();
+
+        let original = UserProfile {
+            id: "channel-clear".into(),
+            name: "Channel Clear".into(),
+            enabled: false,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig {
+                channels: vec![ChannelCredentials::Matrix {
+                    homeserver: "https://matrix.example.org".into(),
+                    as_token: String::new(),
+                    hs_token: String::new(),
+                    server_name: String::new(),
+                    sender_localpart: "octos".into(),
+                    user_prefix: "octos_".into(),
+                    port: 8009,
+                    allowed_senders: Vec::new(),
+                    mode: "user".into(),
+                    user_id: "@bot:example.org".into(),
+                    access_token: "syt_old_access_token".into(),
+                    password: "old-password".into(),
+                    device_name: "octos".into(),
+                    rooms: Vec::new(),
+                    auto_join: "off".into(),
+                    auto_join_allowlist: Vec::new(),
+                    group_policy: "allowlist".into(),
+                    require_mention: true,
+                }],
+                ..Default::default()
+            },
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        store.save(&original).unwrap();
+
+        let mut updated = original.clone();
+        let ChannelCredentials::Matrix {
+            access_token,
+            password,
+            ..
+        } = &mut updated.config.channels[0]
+        else {
+            panic!("expected matrix channel");
+        };
+        *access_token = String::new();
+        *password = "new-password".into();
+        store.save_with_merge(&mut updated).unwrap();
+
+        let loaded = store.get("channel-clear").unwrap().unwrap();
+        let ChannelCredentials::Matrix {
+            access_token,
+            password,
+            ..
+        } = &loaded.config.channels[0]
+        else {
+            panic!("expected matrix channel");
+        };
+        assert_eq!(access_token, "");
+        assert_eq!(password, "new-password");
+    }
+
+    #[test]
+    fn test_save_with_merge_preserves_channel_secret_after_delete() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ProfileStore::open(dir.path()).unwrap();
+
+        let matrix_channel = |user_id: &str, token: &str| ChannelCredentials::Matrix {
+            homeserver: "https://matrix.example.org".into(),
+            as_token: String::new(),
+            hs_token: String::new(),
+            server_name: String::new(),
+            sender_localpart: "octos".into(),
+            user_prefix: "octos_".into(),
+            port: 8009,
+            allowed_senders: Vec::new(),
+            mode: "user".into(),
+            user_id: user_id.into(),
+            access_token: token.into(),
+            password: String::new(),
+            device_name: "octos".into(),
+            rooms: Vec::new(),
+            auto_join: "off".into(),
+            auto_join_allowlist: Vec::new(),
+            group_policy: "allowlist".into(),
+            require_mention: true,
+        };
+
+        let original = UserProfile {
+            id: "channel-delete".into(),
+            name: "Channel Delete".into(),
+            enabled: false,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig {
+                channels: vec![
+                    matrix_channel("@first:example.org", "syt_first_token"),
+                    matrix_channel("@second:example.org", "syt_second_token"),
+                ],
+                ..Default::default()
+            },
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        store.save(&original).unwrap();
+
+        let mut updated = original.clone();
+        updated.config.channels.remove(0);
+        let ChannelCredentials::Matrix { access_token, .. } = &mut updated.config.channels[0]
+        else {
+            panic!("expected matrix channel");
+        };
+        *access_token = "syt_***ken".into();
+        store.save_with_merge(&mut updated).unwrap();
+
+        let loaded = store.get("channel-delete").unwrap().unwrap();
+        assert_eq!(loaded.config.channels.len(), 1);
+        let ChannelCredentials::Matrix {
+            user_id,
+            access_token,
+            ..
+        } = &loaded.config.channels[0]
+        else {
+            panic!("expected matrix channel");
+        };
+        assert_eq!(user_id, "@second:example.org");
+        assert_eq!(access_token, "syt_second_token");
     }
 
     #[test]
@@ -3684,5 +4206,58 @@ mod tests {
         assert_eq!(json["sender_localpart"], "bot");
         assert_eq!(json["user_prefix"], "bot_");
         assert_eq!(json["port"], 8009);
+    }
+
+    #[test]
+    fn test_matrix_user_mode_channel_to_entry_emits_account_settings() {
+        let channel: ChannelCredentials = serde_json::from_value(serde_json::json!({
+            "type": "matrix",
+            "mode": "user",
+            "homeserver": "https://matrix.org",
+            "access_token": "syt_token",
+            "rooms": ["!a:matrix.org", "!b:matrix.org"],
+            "auto_join": "allowlist",
+            "auto_join_allowlist": ["!a:matrix.org"],
+            "group_policy": "allowlist",
+            "require_mention": true,
+        }))
+        .unwrap();
+
+        let entry = channel_to_entry(&channel);
+        assert_eq!(entry["type"], "matrix");
+        let settings = &entry["settings"];
+        assert_eq!(settings["mode"], "user");
+        assert_eq!(settings["homeserver"], "https://matrix.org");
+        assert_eq!(settings["access_token"], "syt_token");
+        assert_eq!(settings["rooms"][0], "!a:matrix.org");
+        assert_eq!(settings["auto_join"], "allowlist");
+        assert_eq!(settings["auto_join_allowlist"][0], "!a:matrix.org");
+        assert_eq!(settings["group_policy"], "allowlist");
+        assert_eq!(settings["require_mention"], true);
+        // Appservice-only keys must not leak into a user-mode entry.
+        assert!(settings.get("as_token").is_none());
+        assert!(settings.get("hs_token").is_none());
+        assert!(settings.get("port").is_none());
+    }
+
+    #[test]
+    fn test_matrix_user_mode_password_login_deserializes_without_appservice_tokens() {
+        // A user-mode entry omits as_token/hs_token entirely; this must still
+        // deserialize (regression guard for the now-optional appservice fields).
+        let channel: ChannelCredentials = serde_json::from_value(serde_json::json!({
+            "type": "matrix",
+            "mode": "user",
+            "homeserver": "https://matrix.org",
+            "user_id": "@bot:matrix.org",
+            "password": "secret",
+            "device_name": "octos-gw",
+        }))
+        .unwrap();
+
+        let entry = channel_to_entry(&channel);
+        let settings = &entry["settings"];
+        assert_eq!(settings["user_id"], "@bot:matrix.org");
+        assert_eq!(settings["password"], "secret");
+        assert_eq!(settings["device_name"], "octos-gw");
     }
 }

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -843,6 +843,9 @@ impl LlmModelSelectionConfig {
 }
 
 /// Channel-specific credentials (tagged by type).
+// The Matrix variant carries many user-mode fields; boxing a serde
+// `tag`-serialized struct variant isn't worth the (de)serialization churn.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum ChannelCredentials {
@@ -1522,10 +1525,11 @@ fn mask_value(s: &str) -> String {
 
 fn mask_channel_secrets(channel: &mut ChannelCredentials) {
     match channel {
-        ChannelCredentials::Api { auth_token, .. } => {
-            if let Some(token) = auth_token {
-                *token = mask_value(token);
-            }
+        ChannelCredentials::Api {
+            auth_token: Some(token),
+            ..
+        } => {
+            *token = mask_value(token);
         }
         ChannelCredentials::Matrix {
             as_token,

--- a/scripts/build-dashboard.ps1
+++ b/scripts/build-dashboard.ps1
@@ -1,0 +1,153 @@
+# Build the admin dashboard SPA into the octos-cli embed dir.
+#
+# PowerShell equivalent of scripts/build-dashboard.sh.
+#
+# Usage:
+#   .\scripts\build-dashboard.ps1
+#   .\scripts\build-dashboard.ps1 -InstallDeps
+#   .\scripts\build-dashboard.ps1 --install-deps
+
+[CmdletBinding()]
+param(
+    [switch]$InstallDeps,
+    [Alias("h")]
+    [switch]$Help,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$RemainingArgs
+)
+
+$ErrorActionPreference = "Stop"
+
+# Accept the bash script's GNU-style flag for parity.
+foreach ($arg in $RemainingArgs) {
+    switch ($arg) {
+        "--install-deps" { $InstallDeps = $true }
+        "--help" { $Help = $true }
+        "-h" { $Help = $true }
+        default { throw "Unknown option: $arg" }
+    }
+}
+
+$Root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$DashboardDir = Join-Path $Root "dashboard"
+$OutDir = Join-Path $Root "crates\octos-cli\static\admin"
+
+function Show-Help {
+    Write-Host @"
+Usage: .\scripts\build-dashboard.ps1 [-InstallDeps]
+       .\scripts\build-dashboard.ps1 [--install-deps]
+
+Builds the dashboard SPA into:
+  $OutDir
+
+Options:
+  -InstallDeps, --install-deps
+      Install Node.js LTS with winget when npm is missing.
+"@
+}
+
+function Resolve-Npm {
+    $cmd = Get-Command npm.cmd -ErrorAction SilentlyContinue
+    if ($cmd) {
+        return $cmd.Source
+    }
+
+    $cmd = Get-Command npm -ErrorAction SilentlyContinue
+    if ($cmd) {
+        return $cmd.Source
+    }
+
+    return $null
+}
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory)]
+        [string]$FilePath,
+        [Parameter(ValueFromRemainingArguments)]
+        [string[]]$CommandArgs
+    )
+
+    & $FilePath @CommandArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code ${LASTEXITCODE}: $FilePath $($CommandArgs -join ' ')"
+    }
+}
+
+function Install-NodeIfRequested {
+    if (-not $InstallDeps) {
+        Write-Error @"
+npm is required to build dashboard assets.
+
+Install Node.js from:
+  https://nodejs.org/en/download
+
+Or re-run:
+  .\scripts\build-dashboard.ps1 -InstallDeps
+"@
+    }
+
+    $winget = Get-Command winget -ErrorAction SilentlyContinue
+    if (-not $winget) {
+        Write-Error "npm is missing and winget is not available. Install Node.js from https://nodejs.org/en/download"
+    }
+
+    Write-Host "==> Installing Node.js LTS with winget"
+    Invoke-Checked -FilePath $winget.Source install --id OpenJS.NodeJS.LTS --exact --source winget --accept-package-agreements --accept-source-agreements
+
+    $npm = Resolve-Npm
+    if (-not $npm) {
+        Write-Error "Node.js was installed, but npm is not available in this PowerShell session. Open a new terminal and re-run this script."
+    }
+
+    return $npm
+}
+
+if ($Help) {
+    Show-Help
+    exit 0
+}
+
+if (-not (Test-Path (Join-Path $DashboardDir "package.json"))) {
+    Write-Error "dashboard/package.json not found at $DashboardDir"
+}
+
+$npm = Resolve-Npm
+if (-not $npm) {
+    $npm = Install-NodeIfRequested
+}
+
+Push-Location $DashboardDir
+try {
+    if (-not (Test-Path "node_modules")) {
+        Write-Host "Installing dashboard dependencies..."
+        Invoke-Checked -FilePath $npm ci
+    }
+
+    Write-Host "Building dashboard into $OutDir"
+    $oldOutDir = $env:VITE_OUT_DIR
+    $oldBasePath = $env:VITE_BASE_PATH
+    try {
+        $env:VITE_OUT_DIR = $OutDir
+        $env:VITE_BASE_PATH = "/admin/"
+        Invoke-Checked -FilePath $npm run build
+    }
+    finally {
+        if ($null -eq $oldOutDir) {
+            Remove-Item Env:VITE_OUT_DIR -ErrorAction SilentlyContinue
+        } else {
+            $env:VITE_OUT_DIR = $oldOutDir
+        }
+
+        if ($null -eq $oldBasePath) {
+            Remove-Item Env:VITE_BASE_PATH -ErrorAction SilentlyContinue
+        } else {
+            $env:VITE_BASE_PATH = $oldBasePath
+        }
+    }
+}
+finally {
+    Pop-Location
+}
+
+Write-Host "Dashboard assets synced to $OutDir"


### PR DESCRIPTION
## Summary

Adds Matrix user-account channel support in the Octos gateway and admin API:

- add a Matrix Client-Server `/sync` channel that logs in as a regular Matrix account
- support access-token auth and password login, including localpart or full MXID login identifiers
- add room policy, allowed room/sender filtering, mention gating, and invite handling policies
- add admin API endpoints for connection testing and pending invite review/accept/reject/dismiss flows
- keep the existing Matrix appservice channel path intact

## Why

The existing Matrix appservice integration is appropriate for administrator-managed homeservers, but appservices require homeserver-side registration. That means an ordinary Matrix user on a hosted homeserver cannot set it up without server administrator access.

User-account mode is the normal-user path. It logs in as a regular Matrix account and consumes the standard Client-Server API, so users can connect Octos with their own account using an access token or password without installing an appservice registration on the homeserver.

## Frontend / submodule note

The matching Settings UI is in draft PR https://github.com/octos-org/octos-web/pull/234.

This PR intentionally does not update the `octos-web` submodule pointer yet. The frontend branch currently lives on a fork, and pointing the `octos` submodule at a fork-only commit would make clean checkouts fail because the submodule URL is `octos-org/octos-web`. The submodule pointer should be bumped after the frontend PR lands upstream.

## Validation

- `cargo test -p octos-cli --features "api,matrix" matrix_test_config -- --nocapture`
- Frontend companion PR: `npm run build`
