### PR TITLE
feat(voice): live-camera context hint on audio+image turns

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -768,8 +768,15 @@ impl Agent {
                 // transcribed into `user_content` by this point), and image
                 // detection looks at the outgoing `media`.
                 let has_image = media.iter().any(|p| octos_llm::vision::is_image(p));
-                let had_audio = TURN_ATTACHMENT_CTX
-                    .try_with(|ctx| !ctx.audio_attachment_paths.is_empty())
+                // Live-video is an EXPLICIT per-turn signal carried on the turn
+                // context (set by the ingress from `inbound.metadata.live_video`),
+                // not inferred from attachments: a spoken note plus an uploaded
+                // image is not a camera frame, and the AppUI voice path strips
+                // the audio attachment before this point — so an `audio && image`
+                // heuristic both mis-fires and misses the real voice+image path.
+                // Only treat the image as a live camera frame when the client said so.
+                let live_video = TURN_ATTACHMENT_CTX
+                    .try_with(|ctx| ctx.live_video)
                     .ok()
                     .unwrap_or(false);
                 let summary = TURN_ATTACHMENT_CTX
@@ -779,7 +786,7 @@ impl Agent {
                 let content = compose_turn_user_content(
                     user_content,
                     !media.is_empty(),
-                    had_audio && has_image,
+                    live_video && has_image,
                     summary.as_deref(),
                 );
 
@@ -2910,7 +2917,10 @@ mod tests {
     // --- compose_turn_user_content (video-call context hint) ---
 
     #[test]
-    fn should_use_video_call_hint_when_turn_has_audio_and_image() {
+    fn should_use_video_call_hint_when_turn_is_flagged_live_video() {
+        // `is_video_call` is now the EXPLICIT live-video signal (set from the
+        // turn ingress via `inbound.metadata.live_video`), no longer inferred
+        // from audio+image attachments.
         let out = compose_turn_user_content("what am I holding", true, true, None);
         assert!(out.starts_with(VIDEO_CALL_NOTE), "got: {out}");
         assert!(out.contains("what am I holding"));
@@ -2923,15 +2933,17 @@ mod tests {
     }
 
     #[test]
-    fn should_keep_uploaded_image_hint_when_image_only() {
-        // No audio attachment → not a video call → legacy placeholder kept.
+    fn should_keep_uploaded_image_hint_when_not_flagged_video() {
+        // Image present but the turn is NOT flagged a live video call → legacy
+        // placeholder kept. (A voice note + uploaded image lands here: it must
+        // NOT be treated as a camera frame.)
         let out = compose_turn_user_content("", true, false, None);
         assert_eq!(out, "[User sent an image]");
     }
 
     #[test]
-    fn should_not_add_hint_when_audio_only() {
-        // Audio but no image → not a video call; plain transcript passes through.
+    fn should_not_add_hint_when_no_image() {
+        // No image and not flagged → plain transcript passes through.
         let out = compose_turn_user_content("hello there", false, false, None);
         assert_eq!(out, "hello there");
     }
@@ -4121,6 +4133,7 @@ printf '{"output":"voice saved","success":true}\n'
                     audio_attachment_paths: vec![first_audio.clone()],
                     file_attachment_paths: vec![],
                     prompt_summary: Some("[Attached audio files]\n- yangmi_ref2.wav".to_string()),
+                    live_video: false,
                 },
             )
             .await
@@ -4137,6 +4150,7 @@ printf '{"output":"voice saved","success":true}\n'
                     audio_attachment_paths: vec![second_audio.clone()],
                     file_attachment_paths: vec![],
                     prompt_summary: Some("[Attached audio files]\n- douwentao.wav".to_string()),
+                    live_video: false,
                 },
             )
             .await

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -32,6 +32,51 @@ const MAX_TOKENS_CONTINUATION_LIMIT: usize = 2;
 const MAX_TOKENS_CONTINUATION_PROMPT: &str = "Your output was truncated at the token limit. Continue directly from where you stopped. Do not repeat or summarize what you already wrote.";
 const SHELL_RETRY_RECOVERY_THRESHOLD: usize = 4;
 
+/// Prepended to the user content on a live video-call turn so the model treats
+/// the attached image as the user's real-time camera view rather than a file
+/// they uploaded.
+const VIDEO_CALL_NOTE: &str =
+    "[Live video call — the attached image is the user's current camera frame.]";
+
+/// Compose the user message content for a turn.
+///
+/// - `is_video_call` (the turn carries both an audio attachment AND an image)
+///   prepends [`VIDEO_CALL_NOTE`] so a real-time camera frame isn't mistaken
+///   for an uploaded file — applied whether or not the spoken turn was
+///   transcribed into non-empty text.
+/// - With empty `user_content` and media present (but not a video call), the
+///   legacy `[User sent an image]` placeholder is kept.
+/// - Any per-turn `prompt_summary` is appended, mirroring the previous
+///   behaviour.
+///
+/// Pure (no task-locals) so it is unit-testable in isolation.
+fn compose_turn_user_content(
+    user_content: &str,
+    has_media: bool,
+    is_video_call: bool,
+    prompt_summary: Option<&str>,
+) -> String {
+    let base_content = if user_content.is_empty() {
+        if is_video_call {
+            VIDEO_CALL_NOTE.to_string()
+        } else if has_media {
+            "[User sent an image]".to_string()
+        } else {
+            String::new()
+        }
+    } else if is_video_call {
+        format!("{VIDEO_CALL_NOTE}\n\n{user_content}")
+    } else {
+        user_content.to_string()
+    };
+
+    match prompt_summary {
+        Some(summary) if base_content.trim().is_empty() => summary.to_string(),
+        Some(summary) => format!("{base_content}\n\n{summary}"),
+        None => base_content,
+    }
+}
+
 /// Audit Gap-8 helper: consult the workspace-contract layer at EndTurn time
 /// and return a human-readable summary of failing validators when the
 /// contract is NOT ready. Returns `None` when the workspace has no
@@ -715,24 +760,28 @@ impl Agent {
 
                 messages.extend_from_slice(history);
 
-                let base_content = if user_content.is_empty() && !media.is_empty() {
-                    "[User sent an image]".to_string()
-                } else {
-                    user_content.to_string()
-                };
-                let content = if let Some(summary) = TURN_ATTACHMENT_CTX
+                // A turn carrying BOTH an audio attachment (a spoken/voice turn)
+                // and an image is a live video call: the image is the user's
+                // current camera frame, not an uploaded file. Tell the model so
+                // it treats the picture as a real-time view. `had_audio` comes
+                // from the per-turn attachment context (the audio is already
+                // transcribed into `user_content` by this point), and image
+                // detection looks at the outgoing `media`.
+                let has_image = media.iter().any(|p| octos_llm::vision::is_image(p));
+                let had_audio = TURN_ATTACHMENT_CTX
+                    .try_with(|ctx| !ctx.audio_attachment_paths.is_empty())
+                    .ok()
+                    .unwrap_or(false);
+                let summary = TURN_ATTACHMENT_CTX
                     .try_with(|ctx| ctx.prompt_summary.clone())
                     .ok()
-                    .flatten()
-                {
-                    if base_content.trim().is_empty() {
-                        summary
-                    } else {
-                        format!("{base_content}\n\n{summary}")
-                    }
-                } else {
-                    base_content
-                };
+                    .flatten();
+                let content = compose_turn_user_content(
+                    user_content,
+                    !media.is_empty(),
+                    had_audio && has_image,
+                    summary.as_deref(),
+                );
 
                 let current_user = Message {
                     role: MessageRole::User,
@@ -2857,6 +2906,49 @@ mod tests {
 
     use async_trait::async_trait;
     use octos_core::{AgentId, MessageRole, TaskContext, TaskKind, ToolCall};
+
+    // --- compose_turn_user_content (video-call context hint) ---
+
+    #[test]
+    fn should_use_video_call_hint_when_turn_has_audio_and_image() {
+        let out = compose_turn_user_content("what am I holding", true, true, None);
+        assert!(out.starts_with(VIDEO_CALL_NOTE), "got: {out}");
+        assert!(out.contains("what am I holding"));
+    }
+
+    #[test]
+    fn should_use_video_call_hint_even_when_transcript_empty() {
+        let out = compose_turn_user_content("", true, true, None);
+        assert_eq!(out, VIDEO_CALL_NOTE);
+    }
+
+    #[test]
+    fn should_keep_uploaded_image_hint_when_image_only() {
+        // No audio attachment → not a video call → legacy placeholder kept.
+        let out = compose_turn_user_content("", true, false, None);
+        assert_eq!(out, "[User sent an image]");
+    }
+
+    #[test]
+    fn should_not_add_hint_when_audio_only() {
+        // Audio but no image → not a video call; plain transcript passes through.
+        let out = compose_turn_user_content("hello there", false, false, None);
+        assert_eq!(out, "hello there");
+    }
+
+    #[test]
+    fn should_append_prompt_summary_unchanged_for_non_video_turn() {
+        let out = compose_turn_user_content("hi", true, false, Some("SUMMARY"));
+        assert_eq!(out, "hi\n\nSUMMARY");
+    }
+
+    #[test]
+    fn should_combine_video_hint_and_summary() {
+        let out = compose_turn_user_content("look", true, true, Some("SUMMARY"));
+        assert!(out.starts_with(VIDEO_CALL_NOTE));
+        assert!(out.contains("look"));
+        assert!(out.ends_with("SUMMARY"));
+    }
     use octos_llm::{
         ChatResponse, LlmError, LlmErrorKind, LlmProvider, StopReason, TokenUsage as LlmTokenUsage,
         ToolChoice,

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -406,6 +406,13 @@ pub struct TurnAttachmentContext {
     pub audio_attachment_paths: Vec<String>,
     pub file_attachment_paths: Vec<String>,
     pub prompt_summary: Option<String>,
+    /// Explicit live-video signal for this turn, set by the ingress from the
+    /// client (`InboundMessage.metadata.live_video`) — NOT inferred from
+    /// attachment types. True only when the turn is a real-time video call
+    /// whose attached image is the user's current camera frame; drives the
+    /// agent loop's video-call note. Defaults false (no auto-detection): a
+    /// voice note plus an uploaded image is not a camera frame.
+    pub live_video: bool,
 }
 
 tokio::task_local! {

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -6082,6 +6082,7 @@ impl SessionActor {
         &self,
         attachment_media: Vec<String>,
         attachment_prompt: Option<String>,
+        live_video: bool,
     ) -> TurnAttachmentContext {
         let mut audio_attachment_paths = Vec::new();
         let mut file_attachment_paths = Vec::new();
@@ -6098,7 +6099,20 @@ impl SessionActor {
             audio_attachment_paths,
             file_attachment_paths,
             prompt_summary: attachment_prompt,
+            live_video,
         }
+    }
+
+    /// Whether this turn is an explicit live video call — the client signals it
+    /// by setting `metadata.live_video = true` on the inbound (e.g. a turn/start
+    /// from a video-call surface). Defaults false; never inferred from
+    /// attachment types (a voice note + uploaded image is not a camera frame).
+    fn inbound_live_video(inbound: &octos_core::InboundMessage) -> bool {
+        inbound
+            .metadata
+            .get("live_video")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false)
     }
 
     fn persisted_user_content(
@@ -6596,7 +6610,11 @@ impl SessionActor {
         let agent = Arc::clone(&self.agent);
         let content = inbound.content.clone();
         let media = image_media;
-        let attachments = self.build_turn_attachment_context(attachment_media, attachment_prompt);
+        let attachments = self.build_turn_attachment_context(
+            attachment_media,
+            attachment_prompt,
+            Self::inbound_live_video(&inbound),
+        );
         let tracker = Arc::clone(&token_tracker);
         let session_timeout = self.session_timeout;
         // Wave-4 B3.4 — stamp session_id / turn_id into the task-local
@@ -8189,7 +8207,11 @@ impl SessionActor {
                     &inbound.content,
                     &history,
                     image_media,
-                    self.build_turn_attachment_context(attachment_media, attachment_prompt),
+                    self.build_turn_attachment_context(
+                        attachment_media,
+                        attachment_prompt,
+                        Self::inbound_live_video(&inbound),
+                    ),
                     &token_tracker,
                 ),
             ),
@@ -8727,6 +8749,45 @@ mod tests {
 
     fn test_context_manager(key: &SessionKey) -> Arc<StdMutex<ContextManager>> {
         Arc::new(StdMutex::new(context_manager_from_history(key, &[])))
+    }
+
+    fn inbound_with(metadata: serde_json::Value, media: Vec<String>) -> octos_core::InboundMessage {
+        octos_core::InboundMessage {
+            channel: "appui".into(),
+            sender_id: "user".into(),
+            chat_id: "c".into(),
+            content: "look".into(),
+            timestamp: chrono::Utc::now(),
+            media,
+            metadata,
+            message_id: None,
+            origin: octos_core::MessageOrigin::ExternalUser,
+        }
+    }
+
+    #[test]
+    fn inbound_live_video_reads_explicit_flag_not_attachments() {
+        // Explicit client signal → live video call.
+        assert!(SessionActor::inbound_live_video(&inbound_with(
+            serde_json::json!({ "live_video": true }),
+            vec![],
+        )));
+        // Explicit false / absent → not a video call.
+        assert!(!SessionActor::inbound_live_video(&inbound_with(
+            serde_json::json!({ "live_video": false }),
+            vec![],
+        )));
+        assert!(!SessionActor::inbound_live_video(&inbound_with(
+            serde_json::json!({}),
+            vec![],
+        )));
+        // Regression (the codex P2): a voice note + uploaded image — audio AND
+        // image attachments but NO explicit flag — must NOT be treated as a
+        // live camera frame.
+        assert!(!SessionActor::inbound_live_video(&inbound_with(
+            serde_json::json!({}),
+            vec!["/tmp/note.ogg".into(), "/tmp/photo.png".into()],
+        )));
     }
 
     fn test_message(role: MessageRole, content: impl Into<String>) -> Message {


### PR DESCRIPTION
Backend half of the voice **camera / video chat** feature (frontend landed in octos-web #233).

When a voice turn carries both audio and a camera frame, inject a short context hint so the model knows it is seeing a *live* camera frame (not an uploaded photo) and can answer about what's in view.

## Notes
- Pairs with the merged frontend (octos-web #233) that sends the per-turn camera frame.
- Independent of the rich-output PR; if both land, merge this first (they touch adjacent voice-turn code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)