### PR TITLE
feat(voice): rich output — illustrated HTML / image in voice turns

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -474,6 +474,17 @@ Projection and session bridging (accepted `UPCR-2026-014`):
 - `file/attached`
 - `session/event`
 
+Voice rich-output visual lifecycle (#1477, ungated; accepted
+`UPCR-2026-024`):
+
+- `visual/generating`, `visual/succeeded`, `visual/failed` — typed
+  lifecycle for a background visual artifact (illustrated HTML / image /
+  infographic) produced by a voice turn. Emitted on the same
+  ledger-backed live path as `file/attached`, but kept distinct from it:
+  `file/attached` stays a pure artifact-delivery signal while these carry
+  the placeholder lifecycle, so the split survives a future
+  `projection.envelope.v1` cutover. See § 8.
+
 Router and queue (Wave4-A):
 
 - `router/status`, `router/failover`, `queue/state`
@@ -1705,6 +1716,30 @@ declare `files_to_send`. Payload fields:
   background-result paths that don't run inside a tool execution).
 - `mime` — MIME-type hint (optional; clients fall back to extension
   sniffing when absent).
+
+### `visual/generating`, `visual/succeeded`, `visual/failed`
+
+Typed visual-artifact lifecycle introduced by `UPCR-2026-024` (#1477,
+voice rich output). A voice turn may append an in-band `[[VISUAL:...]]`
+control marker; the backend strips it from every model-/client-facing
+surface and instead drives the client off these three structured events,
+so the client never scrapes the marker out of the assistant text. Ungated
+and emitted on the same ledger-backed live path as `file/attached` (durable
+append → replayed on reconnect).
+
+The lifecycle is `generating → (succeeded | failed)` and is deliberately
+decoupled from `file/attached`, which stays a pure artifact-delivery
+signal: the client raises and clears the "generating" placeholder off
+these events, NOT off `file/attached`. Payload fields:
+
+- `visual/generating` — `session_id`, `turn_id` (required); `kind`
+  (`html` | `illustrated` | `image` | `infographic`); optional `topic`.
+- `visual/succeeded` — same fields as `generating`, plus `files`: the
+  workspace-relative filenames of the delivered artifact(s) (the same paths
+  carried on the accompanying `file/attached` event(s); omitted when empty).
+  Emitted alongside `file/attached` on the success branch.
+- `visual/failed` — `session_id`, `turn_id` (required); optional `topic`
+  and `reason` (failure/timeout/cancel detail).
 
 ### `session/event`
 

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -12,6 +12,7 @@ pub mod loop_state;
 pub mod memory;
 mod message_repair;
 pub mod realtime;
+pub mod rich_output;
 mod streaming;
 mod turn_state;
 pub mod verifier;

--- a/crates/octos-agent/src/agent/rich_output.rs
+++ b/crates/octos-agent/src/agent/rich_output.rs
@@ -107,6 +107,15 @@ pub async fn author_html(llm: &dyn LlmProvider, ctx: &RichHtmlContext) -> eyre::
         ..Default::default()
     };
     let resp = llm.chat(&messages, &[], &config).await?;
+    // #1477 P2: this focused authoring call runs OUTSIDE the turn's token
+    // accounting (the turn already emitted `done`), so surface its spend here
+    // for observability of the otherwise-invisible background cost.
+    tracing::info!(
+        input_tokens = resp.usage.input_tokens,
+        output_tokens = resp.usage.output_tokens,
+        illustration = ctx.illustration,
+        "rich_output: author_html token usage"
+    );
     let raw = resp
         .content
         .filter(|c| !c.trim().is_empty())

--- a/crates/octos-agent/src/agent/rich_output.rs
+++ b/crates/octos-agent/src/agent/rich_output.rs
@@ -1,0 +1,229 @@
+//! Rich output: produce a self-contained HTML document from a short brief.
+//!
+//! This is a **focused, tool-less LLM call** — the same class as
+//! [`super::verifier`] / the compaction `Summarizer`: system-initiated, single
+//! shot, outside the agent loop, and offered no tools. On a voice turn the fast
+//! model signals "a visual would help" with an in-band `[[VISUAL:html|brief]]`
+//! marker after its spoken reply; the backend then calls this module to produce
+//! the HTML and delivers it over the existing `files_attached` channel. The
+//! model emits no tool call, so the Gemini-3 thought_signature 400 never arises.
+//!
+//! # Security — delivery contract (LOAD-BEARING)
+//!
+//! The produced document is **untrusted, model-authored HTML and may contain
+//! author-controlled `<script>`** (interactivity is the whole point). It is
+//! delivered as a `.html` file artifact. Any client that renders it **MUST**
+//! isolate it in a sandboxed iframe with scripts but **no same-origin access**
+//! — i.e. `srcdoc` + `sandbox="allow-scripts"` (NOT `allow-same-origin`), as the
+//! octos-web `VisualPanel` does. Never inject it into the host DOM or render it
+//! same-origin: that would expose the host origin's cookies/storage/DOM to the
+//! model output (XSS / credential theft). The host `/api/files` endpoint does
+//! not serve `.html` as `text/html`, so direct navigation can't execute it
+//! either.
+
+use base64::{Engine, engine::general_purpose::STANDARD};
+use octos_core::Message;
+use octos_llm::{ChatConfig, LlmProvider, ReasoningEffort, ToolChoice};
+
+/// Fixed `src` token the model is told to use for the embedded illustration.
+/// The backend swaps it for an inlined `data:` URI before delivery, so the
+/// produced HTML stays a single self-contained file (no external asset).
+/// A sentinel is more reliable than hoping the model echoes a real filename.
+pub const ILLUSTRATION_PLACEHOLDER: &str = "__ILLUSTRATION__";
+
+/// Input context for the rich HTML authoring call.
+pub struct RichHtmlContext {
+    /// The user's raw speech transcript.
+    pub transcript: String,
+    /// What the fast turn already spoke to the user (marker stripped) — the
+    /// consistency contract: the artifact must honor what was said.
+    pub spoken_reply: String,
+    /// The brief carried by the marker.
+    pub brief: String,
+    /// When true, an AI illustration has been generated for this turn; the model
+    /// must embed it via `<img src="__ILLUSTRATION__">` (the backend inlines it)
+    /// and build labels/interaction around it instead of redrawing the subject.
+    pub illustration: bool,
+}
+
+/// Replace the [`ILLUSTRATION_PLACEHOLDER`] `src` in `html` with an inlined
+/// `data:image/png;base64,…` URI built from `png`. No-op if the placeholder is
+/// absent. Keeps the artifact a single self-contained HTML file (works inside
+/// the frontend's sandboxed `srcDoc` iframe, which has no base URL).
+pub fn inline_illustration(html: &str, png: &[u8]) -> String {
+    if !html.contains(ILLUSTRATION_PLACEHOLDER) {
+        return html.to_string();
+    }
+    let data_uri = format!("data:image/png;base64,{}", STANDARD.encode(png));
+    html.replace(ILLUSTRATION_PLACEHOLDER, &data_uri)
+}
+
+const RICH_HTML_SYSTEM: &str = "你是可视化生成器。根据用户请求与已给出的口头回复，产出一个【单文件、自包含】的 HTML 文档：内联 CSS/JS，不依赖任何外部资源或 CDN，可使用 <script>/SVG/<canvas> 实现交互。只输出 HTML 本身（可放在 ```html 围栏内），不要任何解释。";
+
+/// Extract HTML from the model reply. Prefers a fenced `html` code block;
+/// otherwise, if the whole reply looks like an HTML document (contains `<html`
+/// or `<!doctype`), returns it as-is. Returns `None` if neither matches.
+pub fn extract_html(raw: &str) -> Option<String> {
+    if let Some(after) = raw.split("```html").nth(1) {
+        if let Some(end) = after.find("```") {
+            let body = after[..end].trim();
+            if !body.is_empty() {
+                return Some(body.to_string());
+            }
+        }
+    }
+    let lower = raw.to_lowercase();
+    if lower.contains("<html") || lower.contains("<!doctype") {
+        return Some(raw.trim().to_string());
+    }
+    None
+}
+
+/// Single-shot, tool-less focused call: produce self-contained HTML from the
+/// context. On failure / no HTML in the output → `Err` (the caller falls back
+/// to a plain spoken reply and delivers no artifact).
+pub async fn author_html(llm: &dyn LlmProvider, ctx: &RichHtmlContext) -> eyre::Result<String> {
+    let mut user = format!(
+        "用户的语音请求：\n{}\n\n你刚才已口头回复：\n{}\n\n现在把这个可视化出来：\n{}",
+        ctx.transcript, ctx.spoken_reply, ctx.brief
+    );
+    if ctx.illustration {
+        user.push_str(&format!(
+            "\n\n已为你生成一张写实插图。请在页面合适位置用 <img src=\"{ILLUSTRATION_PLACEHOLDER}\" ...> 内嵌它\
+             （务必保留这个确切的 src 占位符原样，系统会替换为真实图片），并围绕它做标注、交互或讲解；\
+             不要用 SVG/canvas 重画该实物本身。"
+        ));
+    }
+    let messages = vec![Message::system(RICH_HTML_SYSTEM), Message::user(user)];
+    // A whole HTML document needs a large output budget; on thinking models
+    // (e.g. Gemini-3) thoughts also draw from it, so we cap thinking to `Low`
+    // (a bounded budget) — otherwise the model can spend the entire budget
+    // reasoning and return a turn with no text part (empty content).
+    let config = ChatConfig {
+        max_tokens: Some(32768),
+        temperature: Some(0.2),
+        tool_choice: ToolChoice::None,
+        reasoning_effort: Some(ReasoningEffort::Low),
+        ..Default::default()
+    };
+    let resp = llm.chat(&messages, &[], &config).await?;
+    let raw = resp
+        .content
+        .filter(|c| !c.trim().is_empty())
+        .ok_or_else(|| eyre::eyre!("rich_output: model returned empty content"))?;
+    extract_html(&raw).ok_or_else(|| eyre::eyre!("rich_output: no HTML in model output"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use octos_llm::{ChatResponse, ChatStream, StopReason, TokenUsage, ToolSpec};
+    use std::sync::Arc;
+
+    struct StubProvider {
+        reply: String,
+    }
+
+    #[async_trait]
+    impl LlmProvider for StubProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            _config: &ChatConfig,
+        ) -> eyre::Result<ChatResponse> {
+            Ok(ChatResponse {
+                content: Some(self.reply.clone()),
+                reasoning_content: None,
+                tool_calls: Vec::new(),
+                stop_reason: StopReason::EndTurn,
+                usage: TokenUsage::default(),
+                provider_index: None,
+            })
+        }
+
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            _config: &ChatConfig,
+        ) -> eyre::Result<ChatStream> {
+            unimplemented!("stub does not stream")
+        }
+
+        fn model_id(&self) -> &str {
+            "stub-model"
+        }
+
+        fn provider_name(&self) -> &str {
+            "stub"
+        }
+    }
+
+    #[test]
+    fn extract_html_takes_fenced_block() {
+        let raw = "这是演示：\n```html\n<!doctype html><html><body>hi</body></html>\n```\n完成。";
+        let got = extract_html(raw).unwrap();
+        assert!(got.starts_with("<!doctype html>"));
+        assert!(!got.contains("```"));
+        assert!(!got.contains("这是演示"));
+    }
+
+    #[test]
+    fn extract_html_falls_back_to_bare_document() {
+        let raw = "<!DOCTYPE html><html><body>x</body></html>";
+        assert!(extract_html(raw).unwrap().contains("<body>x</body>"));
+    }
+
+    #[test]
+    fn extract_html_none_for_prose() {
+        assert!(extract_html("就是一段普通文字，没有 HTML。").is_none());
+    }
+
+    #[test]
+    fn inline_illustration_swaps_placeholder_for_data_uri() {
+        let html = "<body><img src=\"__ILLUSTRATION__\" alt=\"x\"></body>";
+        let out = inline_illustration(html, b"PNGBYTES");
+        assert!(out.contains("data:image/png;base64,"));
+        assert!(!out.contains("__ILLUSTRATION__"));
+        // single-quoted src form is handled too
+        let html2 = "<img src='__ILLUSTRATION__'>";
+        assert!(inline_illustration(html2, b"x").contains("data:image/png;base64,"));
+    }
+
+    #[test]
+    fn inline_illustration_noop_without_placeholder() {
+        let html = "<div>no image here</div>";
+        assert_eq!(inline_illustration(html, b"bytes"), html);
+    }
+
+    #[tokio::test]
+    async fn author_html_returns_extracted_document() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(StubProvider {
+            reply: "好的：\n```html\n<!doctype html><html><body>NF</body></html>\n```".into(),
+        });
+        let ctx = RichHtmlContext {
+            transcript: "我想直观看到负反馈电路如何负反馈".into(),
+            spoken_reply: "我给你画一个可调增益的负反馈电路。".into(),
+            brief: "负反馈电路交互演示".into(),
+            illustration: false,
+        };
+        let html = author_html(provider.as_ref(), &ctx).await.expect("html");
+        assert!(html.contains("<body>NF</body>"));
+    }
+
+    #[tokio::test]
+    async fn author_html_errors_when_model_returns_no_html() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(StubProvider {
+            reply: "抱歉做不了".into(),
+        });
+        let ctx = RichHtmlContext {
+            transcript: "x".into(),
+            spoken_reply: "y".into(),
+            brief: "z".into(),
+            illustration: false,
+        };
+        assert!(author_html(provider.as_ref(), &ctx).await.is_err());
+    }
+}

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -81,6 +81,7 @@ pub use agent::{
         AgentError, Heartbeat, HeartbeatState, RealtimeConfig, RealtimeHookEnricher,
         SensorContextInjector, SensorSnapshot, SensorSource,
     },
+    rich_output,
     verifier::{
         AgentVerifierConfig, ErrorClass, TURN_LEDGER_SCHEMA_VERSION, TurnLedgerEntry, TurnOutcome,
         VerifierVerdict,

--- a/crates/octos-cli/src/api/context_manager.rs
+++ b/crates/octos-cli/src/api/context_manager.rs
@@ -578,6 +578,41 @@ fn context_ledger_covers_history(manager: &ContextManager, messages: &[Message])
     max_source_seq + 1 >= messages.len()
 }
 
+/// #1477: scrub the in-band `[[VISUAL:...]]` directive from items IMPORTED from
+/// a persisted snapshot or a forked parent. The record-time sanitizer in
+/// `record_message_with_source_ref` only covers freshly-recorded messages; items
+/// loaded verbatim from a (possibly pre-fix) ledger snapshot or inherited across
+/// a fork bypass it and would otherwise re-emit the marker through `for_prompt`.
+/// Strips the trailing marker from `AssistantFinal` (dropping a reply that
+/// collapses to empty) and removes any marker folded into an old
+/// `CompactionSummary`. No-op for marker-free items.
+fn sanitize_imported_visual_markers(items: Vec<TranscriptItem>) -> Vec<TranscriptItem> {
+    items
+        .into_iter()
+        .filter_map(|mut item| {
+            match &mut item.kind {
+                TranscriptItemKind::AssistantFinal { content } => {
+                    let cleaned = crate::api::voice_turn::strip_visual_marker(content);
+                    if cleaned.len() != content.len() {
+                        *content = cleaned.to_string();
+                    }
+                    if content.trim().is_empty() {
+                        // The reply was only a marker — no model-facing row.
+                        return None;
+                    }
+                }
+                TranscriptItemKind::CompactionSummary { summary, .. } => {
+                    if summary.contains("[[VISUAL:") {
+                        *summary = crate::api::voice_turn::remove_all_visual_markers(summary);
+                    }
+                }
+                _ => {}
+            }
+            Some(item)
+        })
+        .collect()
+}
+
 impl ContextManager {
     pub(crate) fn new(session_id: impl Into<String>, thread_id: Option<String>) -> Self {
         Self {
@@ -627,6 +662,10 @@ impl ContextManager {
             .into_iter()
             .filter(|item| !matches!(item.kind, TranscriptItemKind::SystemInstruction { .. }))
             .collect();
+        // #1477: a forked parent's items bypass `record_message_with_source_ref`,
+        // so scrub any in-band visual marker here too (see
+        // `sanitize_imported_visual_markers`).
+        let items = sanitize_imported_visual_markers(items);
         let next_item_seq = items
             .iter()
             .filter_map(|item| {
@@ -733,6 +772,14 @@ impl ContextManager {
             .into_iter()
             .filter(|item| !matches!(item.kind, TranscriptItemKind::SystemInstruction { .. }))
             .collect();
+        // #1477: a snapshot persisted by a pre-fix daemon can hold
+        // marker-bearing `AssistantFinal` / `CompactionSummary` items. These are
+        // imported verbatim (NOT through `record_message_with_source_ref`), and
+        // `context_ledger_covers_history` will happily Load such a snapshot
+        // instead of rebuilding — so `for_prompt` would re-emit the marker to
+        // the model. Scrub it at the import boundary, the snapshot-side
+        // complement to the record-time sanitizer.
+        let items = sanitize_imported_visual_markers(items);
         let next_item_seq = items
             .iter()
             .filter_map(|item| item.id.as_str().strip_prefix("ctxitem_"))
@@ -922,10 +969,30 @@ impl ContextManager {
                         source_ref.clone(),
                     ));
                 }
-                if !message.content.trim().is_empty() {
+                // Voice rich output (#1477): strip the in-band `[[VISUAL:...]]`
+                // directive from the assistant reply BEFORE it enters the
+                // transcript model. This is the record-time sanitizer — it
+                // covers every FRESHLY-RECORDED message path: boot replay
+                // (`from_session_history`), the in-loop bridge recording, and
+                // persisted-message merge. Items IMPORTED verbatim from a prior
+                // ledger snapshot or a forked parent do NOT pass through here;
+                // they are cleaned separately at the import boundary by
+                // `sanitize_imported_visual_markers`. Together the two keep the
+                // model-facing prompt, the compaction summaries (compaction
+                // reads `for_prompt` output), and the persisted manager snapshot
+                // free of the internal control protocol. The marker is
+                // intentionally still carried on the wire / session JSONL /
+                // displayed bubble, which the voice frontend depends on (it
+                // renders the "generating" state from the marker and strips it
+                // for display — see octos-web `use-voice-conversation.ts`); the
+                // ContextManager is model-only, so cleaning here never touches
+                // those surfaces. No-op for a reply without a trailing marker.
+                let assistant_content =
+                    crate::api::voice_turn::strip_visual_marker(&message.content);
+                if !assistant_content.trim().is_empty() {
                     ids.push(self.record_item_with_source_ref(
                         TranscriptItemKind::AssistantFinal {
-                            content: message.content.clone(),
+                            content: assistant_content.to_string(),
                         },
                         TranscriptItemSource::AgentLoop,
                         source_ref.clone(),
@@ -1982,6 +2049,191 @@ mod tests {
         assert!(frame.messages[1].content.contains("missing"));
         assert_eq!(frame.report.synthetic_item_ids.len(), 1);
         assert_eq!(frame.report.dropped_item_ids.len(), 1);
+    }
+
+    // #1477: the in-band `[[VISUAL:...]]` directive must never reach the
+    // model-facing prompt. It is sanitized at the single record chokepoint, so
+    // it leaks neither through live recording (`record_message`) nor through
+    // boot/snapshot replay (`from_session_history`), and the stored item it
+    // produces is clean (so the persisted snapshot + any compaction summary —
+    // which reads `for_prompt` output — are clean too).
+    #[test]
+    fn assistant_visual_marker_is_stripped_from_model_prompt_and_stored_item() {
+        let reply = "好的,我给你画一张细胞结构图。\n[[VISUAL:illustrated|人类细胞结构写实插图]]";
+
+        for manager in [
+            {
+                let mut m = ContextManager::new("s", None);
+                m.record_message(&Message::user("讲讲细胞结构"));
+                m.record_message(&Message::assistant(reply));
+                m
+            },
+            // Boot/snapshot replay path funnels through the same chokepoint.
+            ContextManager::from_session_history(
+                "s",
+                None,
+                &[Message::user("讲讲细胞结构"), Message::assistant(reply)],
+            ),
+        ] {
+            // The stored AssistantFinal item (hence the persisted snapshot) is
+            // already clean.
+            assert!(
+                !manager
+                    .items()
+                    .iter()
+                    .any(|i| matches!(&i.kind, TranscriptItemKind::AssistantFinal { content } if content.contains("VISUAL"))),
+                "stored AssistantFinal item must not contain the marker"
+            );
+            // The projected model prompt is clean (this is what the bridge sends
+            // and what compaction summarizes).
+            let frame = manager.for_prompt(&PromptBuildPolicy::default());
+            assert!(
+                !frame.messages.iter().any(|m| m.content.contains("VISUAL")),
+                "model prompt must not contain the marker"
+            );
+            // The spoken text itself survives.
+            let assistant = frame
+                .messages
+                .iter()
+                .find(|m| m.role == MessageRole::Assistant)
+                .expect("assistant message present");
+            assert_eq!(assistant.content, "好的,我给你画一张细胞结构图。");
+        }
+    }
+
+    // #1477 (codex follow-up): the compaction SUMMARY must also be marker-free.
+    // The real appui flow summarizes `for_prompt` output (now sanitized), so the
+    // summary text — and the installed CompactionSummary item it becomes — never
+    // carry the marker.
+    #[test]
+    fn compaction_summary_is_marker_free() {
+        let mut manager = ContextManager::new("s", None);
+        manager.record_message(&Message::system("system"));
+        for index in 0..6 {
+            manager.record_message(&Message::user(format!("u{index}")));
+            // Each assistant turn appends a trailing visual marker.
+            manager.record_message(&Message::assistant(format!(
+                "a{index}\n[[VISUAL:html|示意图{index}]]"
+            )));
+        }
+        // Summarize EXACTLY what the appui path feeds compaction: the projected
+        // prompt. With the record-time strip, that projection is already clean.
+        let before = manager.for_prompt(&PromptBuildPolicy::default());
+        let summary = octos_agent::compaction::compact_messages(&before.messages, 512);
+        assert!(
+            !summary.contains("VISUAL"),
+            "compaction summary input/output must be marker-free, got: {summary}"
+        );
+        let _ = manager.install_compaction_summary(&summary, 2);
+        let prompt = manager.for_prompt(&PromptBuildPolicy::default());
+        assert!(
+            !prompt.messages.iter().any(|m| m.content.contains("VISUAL")),
+            "post-compaction prompt (incl. System summary) must be marker-free"
+        );
+    }
+
+    // #1477 (codex round-3): a snapshot persisted by a PRE-fix daemon holds
+    // dirty `AssistantFinal` / `CompactionSummary` items that bypass the
+    // record-time sanitizer. When `context_ledger_covers_history` Loads it
+    // (instead of rebuilding), `for_prompt` must still not leak the marker.
+    #[test]
+    fn loaded_dirty_snapshot_does_not_leak_visual_marker_to_prompt() {
+        // Build a dirty manager via `record_item`, which injects the raw item
+        // kind WITHOUT the message-level sanitizer (simulating a pre-fix write).
+        let mut dirty = ContextManager::new("s", None);
+        dirty.record_item(
+            TranscriptItemKind::AssistantFinal {
+                content: "这是答案。\n[[VISUAL:html|示意图]]".to_owned(),
+            },
+            TranscriptItemSource::AgentLoop,
+        );
+        dirty.record_item(
+            TranscriptItemKind::CompactionSummary {
+                compaction_id: ContextCompactionId::new("c1"),
+                summary: "早些轮次:用户问了电路 [[VISUAL:html|旧图]] 然后继续。".to_owned(),
+                input_transcript_hash: "h0".to_owned(),
+                replacement_transcript_hash: "h1".to_owned(),
+            },
+            TranscriptItemSource::AgentLoop,
+        );
+
+        // Round-trip through the snapshot import path (the Loaded branch).
+        let loaded = ContextManager::from_snapshot(dirty.snapshot());
+
+        // Stored items are scrubbed (so the re-persisted snapshot is clean too).
+        assert!(!loaded.items().iter().any(|i| match &i.kind {
+            TranscriptItemKind::AssistantFinal { content } => content.contains("VISUAL"),
+            TranscriptItemKind::CompactionSummary { summary, .. } => summary.contains("VISUAL"),
+            _ => false,
+        }));
+        // The model-facing prompt is clean.
+        let frame = loaded.for_prompt(&PromptBuildPolicy::default());
+        assert!(
+            !frame.messages.iter().any(|m| m.content.contains("VISUAL")),
+            "loaded snapshot must not re-emit the marker to the model"
+        );
+        // The spoken answer text survives.
+        assert!(
+            frame
+                .messages
+                .iter()
+                .any(|m| m.content.contains("这是答案。"))
+        );
+    }
+
+    // #1477 (codex round-4, P3 strengthening): exercise the REAL production
+    // path — persist a dirty snapshot whose `source_seq` covers the history,
+    // then `load_or_rebuild_context_manager` must take the `Loaded` branch (not
+    // rebuild) AND still project a marker-free prompt.
+    #[test]
+    fn load_or_rebuild_loaded_branch_strips_visual_marker_from_prompt() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let session_id = "voice:local:test#voice";
+        let source = |seq: usize, kind: &str| {
+            Some(TranscriptSourceRef {
+                session_id: session_id.to_owned(),
+                thread_id: None,
+                source_seq: Some(seq),
+                source_event_kind: kind.to_owned(),
+            })
+        };
+
+        // Build a dirty manager directly (bypassing the record-time sanitizer)
+        // with source_seqs that will COVER the two-message history below.
+        let mut dirty = ContextManager::new(session_id, None);
+        dirty.record_item_with_source_ref(
+            TranscriptItemKind::UserInput {
+                content: "讲讲电路".to_owned(),
+                media: Vec::new(),
+            },
+            TranscriptItemSource::SessionLog,
+            source(0, "user_message"),
+        );
+        dirty.record_item_with_source_ref(
+            TranscriptItemKind::AssistantFinal {
+                content: "好的。\n[[VISUAL:html|电路图]]".to_owned(),
+            },
+            TranscriptItemSource::AgentLoop,
+            source(1, "assistant_final"),
+        );
+        persist_context_manager_snapshot(temp.path(), session_id, &dirty)
+            .expect("persist dirty snapshot");
+
+        let history = vec![
+            Message::user("讲讲电路"),
+            Message::assistant("好的。\n[[VISUAL:html|电路图]]"),
+        ];
+        let (loaded, status) =
+            load_or_rebuild_context_manager(temp.path(), session_id, None, &history);
+
+        // The snapshot covers the history → Loaded, NOT rebuilt.
+        assert_eq!(status, ContextLedgerLoadStatus::Loaded);
+        let frame = loaded.for_prompt(&PromptBuildPolicy::default());
+        assert!(
+            !frame.messages.iter().any(|m| m.content.contains("VISUAL")),
+            "Loaded snapshot must not re-emit the marker to the model"
+        );
+        assert!(frame.messages.iter().any(|m| m.content == "好的。"));
     }
 
     #[test]

--- a/crates/octos-cli/src/api/context_manager.rs
+++ b/crates/octos-cli/src/api/context_manager.rs
@@ -653,10 +653,10 @@ fn sanitize_imported_visual_markers(items: Vec<TranscriptItem>) -> Vec<Transcrip
                         return None;
                     }
                 }
-                TranscriptItemKind::CompactionSummary { summary, .. } => {
-                    if summary.contains("[[VISUAL:") {
-                        *summary = remove_all_visual_markers(summary);
-                    }
+                TranscriptItemKind::CompactionSummary { summary, .. }
+                    if summary.contains("[[VISUAL:") =>
+                {
+                    *summary = remove_all_visual_markers(summary);
                 }
                 _ => {}
             }

--- a/crates/octos-cli/src/api/context_manager.rs
+++ b/crates/octos-cli/src/api/context_manager.rs
@@ -578,6 +578,58 @@ fn context_ledger_covers_history(manager: &ContextManager, messages: &[Message])
     max_source_seq + 1 >= messages.len()
 }
 
+/// #1477: drop a trailing `[[VISUAL:...]]` rich-output directive from an
+/// assistant reply, returning the speakable prefix. Self-contained twin of
+/// `api::voice_turn::strip_visual_marker` — this module is ALSO compiled
+/// WITHOUT the `api` feature (it is re-exported as `crate::context_manager` for
+/// `session_actor`), so it must not depend on the api-gated `voice_turn`. Only a
+/// TRAILING marker is removed (the closing `]]` ends the trimmed reply); a
+/// mid-text mention is left intact.
+fn strip_trailing_visual_marker(reply: &str) -> &str {
+    const OPEN: &str = "[[VISUAL:";
+    const CLOSE: &str = "]]";
+    let trimmed = reply.trim_end();
+    let Some(start) = trimmed.rfind(OPEN) else {
+        return reply;
+    };
+    let after = &trimmed[start + OPEN.len()..];
+    let Some(end) = after.find(CLOSE) else {
+        return reply;
+    };
+    // The marker must be the trailing token: nothing after its closing `]]`.
+    if start + OPEN.len() + end + CLOSE.len() == trimmed.len() {
+        trimmed[..start].trim_end()
+    } else {
+        reply
+    }
+}
+
+/// #1477: remove EVERY `[[VISUAL:...]]` span (not just a trailing one) — for
+/// scrubbing a free-form compaction summary that may have folded a marker in at
+/// an arbitrary position. Self-contained twin of
+/// `api::voice_turn::remove_all_visual_markers` (see
+/// [`strip_trailing_visual_marker`] for why this module cannot call into
+/// `voice_turn`). An unterminated `[[VISUAL:` drops the remainder.
+fn remove_all_visual_markers(s: &str) -> String {
+    const OPEN: &str = "[[VISUAL:";
+    const CLOSE: &str = "]]";
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(start) = rest.find(OPEN) {
+        out.push_str(&rest[..start]);
+        let after = &rest[start..];
+        match after.find(CLOSE) {
+            Some(end) => rest = &after[end + CLOSE.len()..],
+            None => {
+                rest = "";
+                break;
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
 /// #1477: scrub the in-band `[[VISUAL:...]]` directive from items IMPORTED from
 /// a persisted snapshot or a forked parent. The record-time sanitizer in
 /// `record_message_with_source_ref` only covers freshly-recorded messages; items
@@ -592,7 +644,7 @@ fn sanitize_imported_visual_markers(items: Vec<TranscriptItem>) -> Vec<Transcrip
         .filter_map(|mut item| {
             match &mut item.kind {
                 TranscriptItemKind::AssistantFinal { content } => {
-                    let cleaned = crate::api::voice_turn::strip_visual_marker(content);
+                    let cleaned = strip_trailing_visual_marker(content);
                     if cleaned.len() != content.len() {
                         *content = cleaned.to_string();
                     }
@@ -603,7 +655,7 @@ fn sanitize_imported_visual_markers(items: Vec<TranscriptItem>) -> Vec<Transcrip
                 }
                 TranscriptItemKind::CompactionSummary { summary, .. } => {
                     if summary.contains("[[VISUAL:") {
-                        *summary = crate::api::voice_turn::remove_all_visual_markers(summary);
+                        *summary = remove_all_visual_markers(summary);
                     }
                 }
                 _ => {}
@@ -987,8 +1039,7 @@ impl ContextManager {
                 // for display — see octos-web `use-voice-conversation.ts`); the
                 // ContextManager is model-only, so cleaning here never touches
                 // those surfaces. No-op for a reply without a trailing marker.
-                let assistant_content =
-                    crate::api::voice_turn::strip_visual_marker(&message.content);
+                let assistant_content = strip_trailing_visual_marker(&message.content);
                 if !assistant_content.trim().is_empty() {
                     ids.push(self.record_item_with_source_ref(
                         TranscriptItemKind::AssistantFinal {

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -19005,8 +19005,9 @@ async fn run_standalone_turn(
         if let Some(directive) = visual_directive {
             use crate::api::voice_turn::VisualKind;
             // Tell the client a visual is generating (typed signal, replaces the
-            // old in-band-marker scrape). Cleared by `file/attached` (success)
-            // or `visual/failed` (below).
+            // old in-band-marker scrape). The lifecycle terminates on the typed
+            // `visual/succeeded` or `visual/failed` (below) — never on
+            // `file/attached`, which is a pure artifact-delivery signal.
             super::ui_protocol_alpha9_bridge::emit_visual_generating_from_background(
                 &ledger,
                 &session_id,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -18734,16 +18734,19 @@ async fn run_standalone_turn(
                             }
                             let visible = uf.push(t);
                             if !visible.is_empty() {
-                                let _ = send_notification_ephemeral(
-                                    &ws,
-                                    &ledger,
-                                    UiNotification::MessageDelta(MessageDeltaEvent {
-                                        session_id: session_id.clone(),
-                                        topic: None,
-                                        turn_id: turn_id.clone(),
-                                        text: visible,
-                                    }),
-                                );
+                                // #1477 P2: dual-emit the canonical envelope so
+                                // projection.envelope.v1 clients also receive the
+                                // voice delta — a bare ephemeral send is filtered
+                                // out for them. Mirrors forward_progress_event's
+                                // MessageDelta handling (emit envelope, then legacy).
+                                let delta = UiNotification::MessageDelta(MessageDeltaEvent {
+                                    session_id: session_id.clone(),
+                                    topic: None,
+                                    turn_id: turn_id.clone(),
+                                    text: visible,
+                                });
+                                emit_envelope_for_legacy_notification(&ledger, &session_id, &delta);
+                                let _ = send_notification_ephemeral(&ws, &ledger, delta);
                                 saw_delta = true;
                             }
                         }
@@ -18787,16 +18790,17 @@ async fn run_standalone_turn(
             if !interrupt_observed {
                 let recovered = uf.finish();
                 if !recovered.is_empty() {
-                    let _ = send_notification_ephemeral(
-                        &ws,
-                        &ledger,
-                        UiNotification::MessageDelta(MessageDeltaEvent {
-                            session_id: session_id.clone(),
-                            topic: None,
-                            turn_id: turn_id.clone(),
-                            text: recovered,
-                        }),
-                    );
+                    // #1477 P2: dual-emit the envelope (see the streaming path
+                    // above) so projection.envelope.v1 clients also get the
+                    // recovered tail delta.
+                    let delta = UiNotification::MessageDelta(MessageDeltaEvent {
+                        session_id: session_id.clone(),
+                        topic: None,
+                        turn_id: turn_id.clone(),
+                        text: recovered,
+                    });
+                    emit_envelope_for_legacy_notification(&ledger, &session_id, &delta);
+                    let _ = send_notification_ephemeral(&ws, &ledger, delta);
                 }
             }
         }

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -19058,6 +19058,13 @@ async fn run_standalone_turn(
             tracing::info!(
                 kind = ?directive.kind,
                 brief = %directive.brief,
+                // Diagnostics for camera-frame grounding: `live_video` is the
+                // explicit signal from the client; `ref_images` is how many
+                // camera frames are forwarded to the illustration generator.
+                // Both 0/false here means the generated image cannot be
+                // grounded on the real subject in front of the camera.
+                live_video = params.live_video,
+                ref_images = r_ref_images.len(),
                 "voice rich: dispatching visual directive"
             );
             tokio::spawn(async move {

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -17818,7 +17818,18 @@ async fn run_standalone_turn(
         // ask for short, speakable answers. Text chat (had_audio_input == false)
         // keeps its normal detailed/formatted persona — this branch never runs there.
         prompt = format!(
-            "{prompt}\n\n[语音模式:用口语化中文、一两句话简短回答;不要使用 Markdown、列表、代码块或 emoji。]"
+            "{prompt}\n\n[语音模式:用口语化中文、一两句话简短回答;不要使用 Markdown、列表、代码块或 emoji。\
+             \n若(且仅若)可视化更能帮助用户理解——例如他想『看到/画出/演示/直观理解』某个结构性、空间性或图示性的东西(电路、波形、数学曲线、流程、UI 草图等)——\
+             在口播正文之后【另起一行】追加一个标记:[[VISUAL:kind|brief]]。\
+             按【用户的认知需求】选 kind:\
+             html=纯动态/可调交互、靠动手玩参数理解、不需要看实物的样子(电路、波形、数学曲线、流程、算法);\
+             illustrated=既要看清实物真实样子、又要交互讲解/标注的结构性内容(细胞、器官、动植物、解剖、天体、机械构造等)——系统会先生成写实插图再叠加交互标注;\
+             image=只要一张写实或艺术单图(某物长什么样、画作);\
+             infographic=多段并列要点/步骤的信息图。\
+             brief 是给生成器的一句话简述。\
+             普通问答/闲聊/事实回答【不要】加标记。\
+             示例1:用户说『我想直观看到负反馈电路如何负反馈』→ 口播『我给你画一个可调增益的负反馈电路,你可以拖滑块看输出怎么被拉回来。』,然后另起一行:[[VISUAL:html|可调增益的负反馈电路交互演示,滑块调增益,实时显示反馈如何稳定输出]]\
+             示例2:用户说『能结合图片讲讲人类细胞的结构吗』→ 口播『我给你画一张细胞结构图,点各个部分能看它们的作用。』,然后另起一行:[[VISUAL:illustrated|人类动物细胞结构写实插图,标注细胞核、线粒体、细胞膜、细胞质、内质网]]]"
         );
         // The audio is now in the prompt as text. Drop it from the
         // agent-visible media so the model answers the transcript directly
@@ -18486,38 +18497,17 @@ async fn run_standalone_turn(
     // streams `token` events, instead of waiting for the whole reply. A FIFO
     // worker keeps the emitted audio ordered without blocking this loop. All
     // gated on `had_audio_input`, so text chat is untouched.
-    fn drain_voice_sentences(buf: &mut String) -> Vec<String> {
-        // Strong boundaries always split; commas (soft) split once the segment is
-        // long enough (>=8 chars) so the first audio comes out fast. Now that
-        // few-shot synthesis keeps comma-fragments free of the "啊/哦" filler
-        // (that was zero-shot, not chunking), comma-splitting buys ~1s lower
-        // first-audio latency vs whole-sentence without the artifacts.
-        const STRONG: &[char] = &['。', '！', '？', '!', '?', '…', '；', ';', '\n'];
-        const SOFT: &[char] = &['，', ',', '、'];
-        const SOFT_MIN_CHARS: usize = 8;
-        let mut out = Vec::new();
-        loop {
-            let mut cut = None;
-            for (count, (i, c)) in buf.char_indices().enumerate() {
-                if STRONG.contains(&c) || (SOFT.contains(&c) && count + 1 >= SOFT_MIN_CHARS) {
-                    cut = Some(i + c.len_utf8());
-                    break;
-                }
-            }
-            match cut {
-                Some(idx) => {
-                    let sentence = buf[..idx].trim().to_string();
-                    *buf = buf[idx..].to_string();
-                    if !sentence.is_empty() {
-                        out.push(sentence);
-                    }
-                }
-                None => break,
-            }
-        }
-        out
-    }
-    let mut voice_buf = String::new();
+    // Voice turn: a `VoiceReplySplitter` feeds complete sentences to the TTS
+    // worker AS tokens stream, while holding back any trailing in-band
+    // `[[VISUAL:kind|brief]]` marker so it never reaches TTS. Sentence-splitting
+    // lives in `voice_turn::VoiceReplySplitter` (unit-tested). The rich-output
+    // directive is parsed later from the authoritative final reply (not the
+    // splitter), so it is robust whether or not the reply was streamed.
+    let mut voice_splitter = if had_audio_input {
+        Some(crate::api::voice_turn::VoiceReplySplitter::new())
+    } else {
+        None
+    };
     let mut voice_streamed_count: usize = 0;
     let (voice_tx, voice_handle) = if had_audio_input {
         let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(64);
@@ -18692,11 +18682,10 @@ async fn run_standalone_turn(
                 // Voice turn: accumulate streamed `token` text and hand off
                 // each complete sentence to the FIFO TTS worker for immediate
                 // synthesis (overlaps with the rest of LLM generation).
-                if let Some(ref tx) = voice_tx {
+                if let (Some(tx), Some(sp)) = (voice_tx.as_ref(), voice_splitter.as_mut()) {
                     if event.get("type").and_then(Value::as_str) == Some("token") {
                         if let Some(t) = event.get("text").and_then(Value::as_str) {
-                            voice_buf.push_str(t);
-                            for sentence in drain_voice_sentences(&mut voice_buf) {
+                            for sentence in sp.push(t) {
                                 if tx.try_send(sentence).is_ok() {
                                     voice_streamed_count += 1;
                                 }
@@ -18719,13 +18708,17 @@ async fn run_standalone_turn(
         }
     }
 
-    // Voice turn: flush the trailing partial sentence, close the channel, and
-    // wait for the FIFO TTS worker to finish emitting all sentence audio.
+    // Voice turn: flush the trailing partial sentence (marker already held back
+    // by the splitter), close the channel, and wait for the FIFO TTS worker.
     if let Some(tx) = voice_tx {
-        if !interrupt_observed {
-            let tail = voice_buf.trim().to_string();
-            if !tail.is_empty() && tx.try_send(tail).is_ok() {
-                voice_streamed_count += 1;
+        if let Some(sp) = voice_splitter.take() {
+            let (tail, _directive) = sp.finish();
+            if !interrupt_observed {
+                if let Some(t) = tail {
+                    if tx.try_send(t).is_ok() {
+                        voice_streamed_count += 1;
+                    }
+                }
             }
         }
         drop(tx);
@@ -18916,6 +18909,146 @@ async fn run_standalone_turn(
     // `await` will not block.
     let final_response_content: Option<String> = final_reply_rx.await.ok().flatten();
 
+    // Voice rich output: dispatch the in-band [[VISUAL]] directive parsed from
+    // the AUTHORITATIVE final reply (robust whether or not it was streamed).
+    // HTML → a focused tool-less LLM call (rich_output); image-class → a
+    // backend-orchestrated mofa skill. Fire-and-forget: the artifact arrives
+    // async via the same `files_attached` channel as the reply audio, so the
+    // turn completes while the client shows a "generating" state. The model
+    // emits no tool call, so the Gemini-3 thought_signature path never arises.
+    if had_audio_input && !interrupt_observed {
+        if let Some(directive) = final_response_content
+            .as_deref()
+            .and_then(crate::api::voice_turn::parse_visual_marker)
+        {
+            use crate::api::voice_turn::VisualKind;
+            let r_ledger = ledger.clone();
+            let r_session = session_id.clone();
+            let r_turn = turn_id.clone();
+            let r_dir = session_runtime.workspace_root.clone();
+            let r_provider = llm_provider.clone();
+            let r_registry = tool_registry.clone();
+            let r_transcript = voice_transcripts.join("\n");
+            let r_spoken = final_response_content
+                .as_deref()
+                .map(|r| crate::api::voice_turn::strip_visual_marker(r).to_string())
+                .unwrap_or_default();
+            // This turn's camera frame(s) → forwarded to the Illustrated path as
+            // reference images so the generated illustration depicts the real
+            // subject in front of the camera. Gated on the EXPLICIT live-video
+            // signal (#1478), consistent with the loop_runner video-call note —
+            // never inferred from "there's an image attached" (a voice note +
+            // uploaded image is not a live camera frame).
+            let r_ref_images: Vec<String> = if params.live_video {
+                asr_media
+                    .iter()
+                    .filter(|p| octos_bus::media::is_image(p))
+                    .cloned()
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            tracing::info!(
+                kind = ?directive.kind,
+                brief = %directive.brief,
+                "voice rich: dispatching visual directive"
+            );
+            tokio::spawn(async move {
+                let rels: Vec<String> = match directive.kind {
+                    VisualKind::Html => {
+                        let ctx = octos_agent::rich_output::RichHtmlContext {
+                            transcript: r_transcript,
+                            spoken_reply: r_spoken,
+                            brief: directive.brief,
+                            illustration: false,
+                        };
+                        match octos_agent::rich_output::author_html(r_provider.as_ref(), &ctx).await
+                        {
+                            Ok(html) => {
+                                let name = format!("visual-{}.html", uuid::Uuid::now_v7());
+                                match tokio::fs::write(r_dir.join(&name), html).await {
+                                    Ok(()) => vec![name],
+                                    Err(e) => {
+                                        tracing::warn!(error = %e, "voice rich: html write failed");
+                                        Vec::new()
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(error = %e, "voice rich: author_html failed");
+                                Vec::new()
+                            }
+                        }
+                    }
+                    VisualKind::Illustrated => {
+                        // Stage 1: generate a realistic illustration PNG.
+                        let png_bytes = match crate::api::voice_turn::run_illustration_image(
+                            &r_registry,
+                            &directive.brief,
+                            &r_dir,
+                            &r_ref_images,
+                        )
+                        .await
+                        {
+                            Some(p) => tokio::fs::read(&p).await.ok(),
+                            None => None,
+                        };
+                        // Stage 2: author HTML that embeds it (model uses the
+                        // placeholder src), then inline the PNG as a data URI so
+                        // the artifact is a single self-contained file. If image
+                        // gen failed, fall back to a no-illustration document.
+                        let ctx = octos_agent::rich_output::RichHtmlContext {
+                            transcript: r_transcript,
+                            spoken_reply: r_spoken,
+                            brief: directive.brief,
+                            illustration: png_bytes.is_some(),
+                        };
+                        match octos_agent::rich_output::author_html(r_provider.as_ref(), &ctx).await
+                        {
+                            Ok(html) => {
+                                let html = match png_bytes {
+                                    Some(bytes) => {
+                                        octos_agent::rich_output::inline_illustration(&html, &bytes)
+                                    }
+                                    None => html,
+                                };
+                                let name = format!("visual-{}.html", uuid::Uuid::now_v7());
+                                match tokio::fs::write(r_dir.join(&name), html).await {
+                                    Ok(()) => vec![name],
+                                    Err(e) => {
+                                        tracing::warn!(error = %e, "voice rich: html write failed");
+                                        Vec::new()
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(error = %e, "voice rich: author_html (illustrated) failed");
+                                Vec::new()
+                            }
+                        }
+                    }
+                    VisualKind::Image | VisualKind::Infographic => {
+                        crate::api::voice_turn::run_image_skill(&r_registry, &directive, &r_dir)
+                            .await
+                    }
+                };
+                if rels.is_empty() {
+                    tracing::warn!("voice rich: produced no artifact to deliver");
+                } else {
+                    tracing::info!(files = ?rels, "voice rich: delivering artifact(s)");
+                    super::ui_protocol_alpha9_bridge::emit_files_attached_from_background(
+                        &r_ledger,
+                        &r_session,
+                        &r_turn,
+                        &rels,
+                        &[],
+                        None,
+                    );
+                }
+            });
+        }
+    }
+
     // ── 语音轮 TTS（serve 路径）────────────────────────────────────
     // 仅当本轮有音频输入（语音轮）时，把最终文本回复合成为音频并下发，
     // 客户端据此自动播放。失败静默跳过，不影响文本回复。
@@ -18929,6 +19062,10 @@ async fn run_standalone_turn(
     // path above produced no audio (e.g. a reply with no sentence boundaries).
     if had_audio_input && voice_streamed_count == 0 {
         if let Some(reply) = final_response_content.as_deref() {
+            // Strip any in-band [[VISUAL:...]] marker so the fallback synth does
+            // not read the marker aloud (the streamed path's splitter already
+            // does this; this is the no-sentence-boundary fallback).
+            let reply = crate::api::voice_turn::strip_visual_marker(reply);
             // Per-tenant reply voice: live override wins, else profile default.
             let voice = crate::api::voices::resolve_reply_voice(
                 &session_runtime.profile.profile_id,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -19061,6 +19061,10 @@ async fn run_standalone_turn(
             );
             tokio::spawn(async move {
                 r_supervisor.mark_running(&r_task_id);
+                // Capture the kind token before `produce` consumes `directive`
+                // (its `brief` is moved into the skill calls); needed for the
+                // typed `visual/succeeded` on the success branch.
+                let r_kind = directive.kind.as_str();
                 // #1477 P2: bound the background visual task. Image generation +
                 // HTML authoring are network/LLM calls with no other ceiling on
                 // this detached path, so cap them so a hung skill / provider
@@ -19205,6 +19209,13 @@ async fn run_standalone_turn(
                 } else {
                     tracing::info!(files = ?rels, "voice rich: delivering artifact(s)");
                     r_supervisor.mark_completed(&r_task_id, rels.clone());
+                    // Deliver the artifact(s) AND emit the typed success signal.
+                    // `file/attached` stays a pure artifact-delivery event; the
+                    // visual lifecycle terminates on `visual/succeeded` (#1477),
+                    // so the client never has to infer success from a file
+                    // extension — and the lifecycle survives a future
+                    // `projection.envelope.v1` cutover that supersedes
+                    // `file/attached`.
                     super::ui_protocol_alpha9_bridge::emit_files_attached_from_background(
                         &r_ledger,
                         &r_session,
@@ -19212,6 +19223,9 @@ async fn run_standalone_turn(
                         &rels,
                         &[],
                         None,
+                    );
+                    super::ui_protocol_alpha9_bridge::emit_visual_succeeded_from_background(
+                        &r_ledger, &r_session, &r_turn, r_kind, &rels,
                     );
                 }
             });
@@ -22178,6 +22192,7 @@ fn ledger_event_cursor(event: &UiProtocolLedgerEvent) -> Option<UiCursor> {
             UiNotification::TurnStarted(_)
             | UiNotification::MessageDelta(_)
             | UiNotification::VisualGenerating(_)
+            | UiNotification::VisualSucceeded(_)
             | UiNotification::VisualFailed(_)
             | UiNotification::ToolStarted(_)
             | UiNotification::ToolProgress(_)

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -17893,6 +17893,12 @@ async fn run_standalone_turn(
     // most one final response and we only need it once in the post-turn
     // block.
     let (final_reply_tx, final_reply_rx) = tokio::sync::oneshot::channel::<Option<String>>();
+    // Voice rich output (#1477): the agent task lifts the trailing in-band
+    // `[[VISUAL:...]]` directive out of `response.content` (and strips it from
+    // every authoritative surface) and hands it here for the post-turn
+    // background dispatch. `None` for text turns or replies without a marker.
+    let (visual_directive_tx, visual_directive_rx) =
+        tokio::sync::oneshot::channel::<Option<crate::api::voice_turn::VisualDirective>>();
     let agent_task = tokio::spawn(async move {
         let start = std::time::Instant::now();
         // RFC-3 (#1292): wrap the agent.process_message future in the
@@ -17953,7 +17959,26 @@ async fn run_standalone_turn(
         }
 
         match result {
-            Ok(response) => {
+            Ok(mut response) => {
+                // Voice rich output (#1477): lift the trailing in-band
+                // `[[VISUAL:...]]` directive out of the reply and strip it from
+                // `response.content` AND every Assistant carrier in
+                // `response.messages` BEFORE capture / persist / done, so the
+                // internal control protocol never reaches the wire
+                // (`message/delta` from `done`, `message/persisted`) or storage
+                // (session JSONL). The directive is dispatched post-turn from the
+                // oneshot below; the client learns a visual is coming from the
+                // typed `visual/generating` event. Gated on voice turns. No-op
+                // (returns `None`, mutates nothing) without a real trailing marker.
+                let visual_directive = if had_audio_input {
+                    crate::api::voice_turn::strip_visual_directive(
+                        &mut response.content,
+                        &mut response.messages,
+                    )
+                } else {
+                    None
+                };
+                let _ = visual_directive_tx.send(visual_directive);
                 // #1134 — capture the LLM reply for the post-turn
                 // self-paced reschedule block. The receiver of this
                 // oneshot uses the captured content instead of
@@ -18454,6 +18479,8 @@ async fn run_standalone_turn(
                 // back to the session-history scan, matching the
                 // pre-#1134 behaviour.
                 let _ = final_reply_tx.send(None);
+                // No reply → no rich-output directive to dispatch.
+                let _ = visual_directive_tx.send(None);
                 // Codex round-2 MAJOR 2: prefer the typed user-actionable
                 // message over the raw LLM Display string. The agent
                 // loop's classifier (`HarnessError::classify_report` at
@@ -18505,6 +18532,15 @@ async fn run_standalone_turn(
     // splitter), so it is robust whether or not the reply was streamed.
     let mut voice_splitter = if had_audio_input {
         Some(crate::api::voice_turn::VoiceReplySplitter::new())
+    } else {
+        None
+    };
+    // Voice turn: marker-aware UI delta filter (#1477). Streams the reply to the
+    // chat bubble token-by-token while holding back the trailing
+    // `[[VISUAL:...]]` marker, so the live `message/delta` wire never carries the
+    // internal control protocol (durable surfaces are stripped in the agent task).
+    let mut voice_delta_filter = if had_audio_input {
+        Some(crate::api::voice_turn::VisibleDeltaFilter::new())
     } else {
         None
     };
@@ -18679,10 +18715,16 @@ async fn run_standalone_turn(
                 break;
             }
             _ => {
-                // Voice turn: accumulate streamed `token` text and hand off
-                // each complete sentence to the FIFO TTS worker for immediate
-                // synthesis (overlaps with the rest of LLM generation).
-                if let (Some(tx), Some(sp)) = (voice_tx.as_ref(), voice_splitter.as_mut()) {
+                // Voice turn: accumulate streamed `token` text and hand off each
+                // complete sentence to the FIFO TTS worker for immediate synthesis,
+                // AND emit the same text — minus the trailing `[[VISUAL:...]]`
+                // marker — as the UI `message/delta`, then SKIP the generic token
+                // forward so the raw marker never reaches the wire (#1477).
+                if let (Some(tx), Some(sp), Some(uf)) = (
+                    voice_tx.as_ref(),
+                    voice_splitter.as_mut(),
+                    voice_delta_filter.as_mut(),
+                ) {
                     if event.get("type").and_then(Value::as_str) == Some("token") {
                         if let Some(t) = event.get("text").and_then(Value::as_str) {
                             for sentence in sp.push(t) {
@@ -18690,7 +18732,24 @@ async fn run_standalone_turn(
                                     voice_streamed_count += 1;
                                 }
                             }
+                            let visible = uf.push(t);
+                            if !visible.is_empty() {
+                                let _ = send_notification_ephemeral(
+                                    &ws,
+                                    &ledger,
+                                    UiNotification::MessageDelta(MessageDeltaEvent {
+                                        session_id: session_id.clone(),
+                                        topic: None,
+                                        turn_id: turn_id.clone(),
+                                        text: visible,
+                                    }),
+                                );
+                                saw_delta = true;
+                            }
                         }
+                        // Token handled for this voice turn — do NOT forward the
+                        // raw token (it may carry the in-band marker).
+                        continue;
                     }
                 }
                 forward_progress_event(
@@ -18718,6 +18777,26 @@ async fn run_standalone_turn(
                     if tx.try_send(t).is_ok() {
                         voice_streamed_count += 1;
                     }
+                }
+            }
+        }
+        // Flush any held UI text the marker-aware filter retained that turned out
+        // NOT to be a real trailing marker (rare mid-reply `[[VISUAL:`); a genuine
+        // trailing marker yields nothing so it never reaches the wire (#1477).
+        if let Some(uf) = voice_delta_filter.take() {
+            if !interrupt_observed {
+                let recovered = uf.finish();
+                if !recovered.is_empty() {
+                    let _ = send_notification_ephemeral(
+                        &ws,
+                        &ledger,
+                        UiNotification::MessageDelta(MessageDeltaEvent {
+                            session_id: session_id.clone(),
+                            topic: None,
+                            turn_id: turn_id.clone(),
+                            text: recovered,
+                        }),
+                    );
                 }
             }
         }
@@ -18908,20 +18987,50 @@ async fn run_standalone_turn(
     // half is guaranteed to be either delivered or dropped — this
     // `await` will not block.
     let final_response_content: Option<String> = final_reply_rx.await.ok().flatten();
+    // Voice rich output (#1477): the directive was lifted + stripped inside the
+    // agent task; receive it here (`None` for text turns / replies with no
+    // marker). `final_response_content` is now the clean spoken reply (marker
+    // already gone), so it doubles as the HTML author's "spoken_reply" context.
+    let visual_directive = visual_directive_rx.await.ok().flatten();
 
-    // Voice rich output: dispatch the in-band [[VISUAL]] directive parsed from
-    // the AUTHORITATIVE final reply (robust whether or not it was streamed).
+    // Voice rich output: dispatch the in-band [[VISUAL]] directive.
     // HTML → a focused tool-less LLM call (rich_output); image-class → a
     // backend-orchestrated mofa skill. Fire-and-forget: the artifact arrives
     // async via the same `files_attached` channel as the reply audio, so the
-    // turn completes while the client shows a "generating" state. The model
-    // emits no tool call, so the Gemini-3 thought_signature path never arises.
+    // turn completes while the client shows a "generating" state. The client is
+    // told a visual is coming by the typed `visual/generating` event below (no
+    // in-band marker is on the wire). The model emits no tool call, so the
+    // Gemini-3 thought_signature path never arises.
     if had_audio_input && !interrupt_observed {
-        if let Some(directive) = final_response_content
-            .as_deref()
-            .and_then(crate::api::voice_turn::parse_visual_marker)
-        {
+        if let Some(directive) = visual_directive {
             use crate::api::voice_turn::VisualKind;
+            // Tell the client a visual is generating (typed signal, replaces the
+            // old in-band-marker scrape). Cleared by `file/attached` (success)
+            // or `visual/failed` (below).
+            super::ui_protocol_alpha9_bridge::emit_visual_generating_from_background(
+                &ledger,
+                &session_id,
+                &turn_id,
+                directive.kind.as_str(),
+            );
+            // #1477 P2: register the visual generation as a SUPERVISED background
+            // task (not a bare detached spawn) so it is observable in the admin
+            // dashboard, carries terminal status, and is cancelable — both via
+            // the session interrupt path (`cancel_session_spawn_only_tasks`) and
+            // its own cancel token, which the worker races below.
+            let r_supervisor = tool_registry.supervisor();
+            let r_task_call_id = format!("voice-visual-{}", uuid::Uuid::now_v7());
+            // Register under the FULL session key (incl. any `#topic` /
+            // profile dimension), NOT `base_key()`: the interrupt path queries
+            // `get_tasks_for_session(&session_id.to_string())` with an EXACT
+            // string match (`cancel_session_spawn_only_tasks`). A `base_key()`
+            // registration would file the task under `…web-123` while the
+            // interrupt of `…web-123#voice` looks for the full key and miss it.
+            // Using the full key also means an interrupt cancels only THIS
+            // topic's visual task, never a sibling topic's.
+            let r_task_id =
+                r_supervisor.register("voice_visual", &r_task_call_id, Some(session_id.0.as_str()));
+            let r_cancel = r_supervisor.cancel_token(&r_task_id);
             let r_ledger = ledger.clone();
             let r_session = session_id.clone();
             let r_turn = turn_id.clone();
@@ -18929,10 +19038,7 @@ async fn run_standalone_turn(
             let r_provider = llm_provider.clone();
             let r_registry = tool_registry.clone();
             let r_transcript = voice_transcripts.join("\n");
-            let r_spoken = final_response_content
-                .as_deref()
-                .map(|r| crate::api::voice_turn::strip_visual_marker(r).to_string())
-                .unwrap_or_default();
+            let r_spoken = final_response_content.clone().unwrap_or_default();
             // This turn's camera frame(s) → forwarded to the Illustrated path as
             // reference images so the generated illustration depicts the real
             // subject in front of the camera. Gated on the EXPLICIT live-video
@@ -18954,88 +19060,151 @@ async fn run_standalone_turn(
                 "voice rich: dispatching visual directive"
             );
             tokio::spawn(async move {
-                let rels: Vec<String> = match directive.kind {
-                    VisualKind::Html => {
-                        let ctx = octos_agent::rich_output::RichHtmlContext {
-                            transcript: r_transcript,
-                            spoken_reply: r_spoken,
-                            brief: directive.brief,
-                            illustration: false,
-                        };
-                        match octos_agent::rich_output::author_html(r_provider.as_ref(), &ctx).await
-                        {
-                            Ok(html) => {
-                                let name = format!("visual-{}.html", uuid::Uuid::now_v7());
-                                match tokio::fs::write(r_dir.join(&name), html).await {
-                                    Ok(()) => vec![name],
-                                    Err(e) => {
-                                        tracing::warn!(error = %e, "voice rich: html write failed");
-                                        Vec::new()
+                r_supervisor.mark_running(&r_task_id);
+                // #1477 P2: bound the background visual task. Image generation +
+                // HTML authoring are network/LLM calls with no other ceiling on
+                // this detached path, so cap them so a hung skill / provider
+                // cannot leak a task for the process lifetime. On timeout we
+                // deliver nothing (observable via the warn below), matching the
+                // other failure branches.
+                const VISUAL_DISPATCH_TIMEOUT: std::time::Duration =
+                    std::time::Duration::from_secs(180);
+                let produce = async {
+                    let rels: Vec<String> = match directive.kind {
+                        VisualKind::Html => {
+                            let ctx = octos_agent::rich_output::RichHtmlContext {
+                                transcript: r_transcript,
+                                spoken_reply: r_spoken,
+                                brief: directive.brief,
+                                illustration: false,
+                            };
+                            match octos_agent::rich_output::author_html(r_provider.as_ref(), &ctx)
+                                .await
+                            {
+                                Ok(html) => {
+                                    let name = format!("visual-{}.html", uuid::Uuid::now_v7());
+                                    match tokio::fs::write(r_dir.join(&name), html).await {
+                                        Ok(()) => vec![name],
+                                        Err(e) => {
+                                            tracing::warn!(error = %e, "voice rich: html write failed");
+                                            Vec::new()
+                                        }
                                     }
                                 }
-                            }
-                            Err(e) => {
-                                tracing::warn!(error = %e, "voice rich: author_html failed");
-                                Vec::new()
-                            }
-                        }
-                    }
-                    VisualKind::Illustrated => {
-                        // Stage 1: generate a realistic illustration PNG.
-                        let png_bytes = match crate::api::voice_turn::run_illustration_image(
-                            &r_registry,
-                            &directive.brief,
-                            &r_dir,
-                            &r_ref_images,
-                        )
-                        .await
-                        {
-                            Some(p) => tokio::fs::read(&p).await.ok(),
-                            None => None,
-                        };
-                        // Stage 2: author HTML that embeds it (model uses the
-                        // placeholder src), then inline the PNG as a data URI so
-                        // the artifact is a single self-contained file. If image
-                        // gen failed, fall back to a no-illustration document.
-                        let ctx = octos_agent::rich_output::RichHtmlContext {
-                            transcript: r_transcript,
-                            spoken_reply: r_spoken,
-                            brief: directive.brief,
-                            illustration: png_bytes.is_some(),
-                        };
-                        match octos_agent::rich_output::author_html(r_provider.as_ref(), &ctx).await
-                        {
-                            Ok(html) => {
-                                let html = match png_bytes {
-                                    Some(bytes) => {
-                                        octos_agent::rich_output::inline_illustration(&html, &bytes)
-                                    }
-                                    None => html,
-                                };
-                                let name = format!("visual-{}.html", uuid::Uuid::now_v7());
-                                match tokio::fs::write(r_dir.join(&name), html).await {
-                                    Ok(()) => vec![name],
-                                    Err(e) => {
-                                        tracing::warn!(error = %e, "voice rich: html write failed");
-                                        Vec::new()
-                                    }
+                                Err(e) => {
+                                    tracing::warn!(error = %e, "voice rich: author_html failed");
+                                    Vec::new()
                                 }
                             }
-                            Err(e) => {
-                                tracing::warn!(error = %e, "voice rich: author_html (illustrated) failed");
-                                Vec::new()
-                            }
                         }
-                    }
-                    VisualKind::Image | VisualKind::Infographic => {
-                        crate::api::voice_turn::run_image_skill(&r_registry, &directive, &r_dir)
+                        VisualKind::Illustrated => {
+                            // Stage 1: generate a realistic illustration PNG.
+                            let png_bytes = match crate::api::voice_turn::run_illustration_image(
+                                &r_registry,
+                                &directive.brief,
+                                &r_dir,
+                                &r_ref_images,
+                            )
                             .await
+                            {
+                                Some(p) => tokio::fs::read(&p).await.ok(),
+                                None => None,
+                            };
+                            // Stage 2: author HTML that embeds it (model uses the
+                            // placeholder src), then inline the PNG as a data URI so
+                            // the artifact is a single self-contained file. If image
+                            // gen failed, fall back to a no-illustration document.
+                            let ctx = octos_agent::rich_output::RichHtmlContext {
+                                transcript: r_transcript,
+                                spoken_reply: r_spoken,
+                                brief: directive.brief,
+                                illustration: png_bytes.is_some(),
+                            };
+                            match octos_agent::rich_output::author_html(r_provider.as_ref(), &ctx)
+                                .await
+                            {
+                                Ok(html) => {
+                                    let html = match png_bytes {
+                                        Some(bytes) => {
+                                            octos_agent::rich_output::inline_illustration(
+                                                &html, &bytes,
+                                            )
+                                        }
+                                        None => html,
+                                    };
+                                    let name = format!("visual-{}.html", uuid::Uuid::now_v7());
+                                    match tokio::fs::write(r_dir.join(&name), html).await {
+                                        Ok(()) => vec![name],
+                                        Err(e) => {
+                                            tracing::warn!(error = %e, "voice rich: html write failed");
+                                            Vec::new()
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!(error = %e, "voice rich: author_html (illustrated) failed");
+                                    Vec::new()
+                                }
+                            }
+                        }
+                        VisualKind::Image | VisualKind::Infographic => {
+                            crate::api::voice_turn::run_image_skill(&r_registry, &directive, &r_dir)
+                                .await
+                        }
+                    };
+                    rels
+                };
+                // Race the work against the task's cancel token (fired by the
+                // session interrupt path) and the timeout. Each terminal branch
+                // reports its OWN reason so the supervisor row + `visual/failed`
+                // distinguish cancellation, timeout, and a clean-but-empty
+                // result (rather than folding all three into one message).
+                let rels = tokio::select! {
+                    biased;
+                    _ = r_cancel.cancelled() => {
+                        tracing::info!("voice rich: visual dispatch cancelled");
+                        r_supervisor.mark_failed(&r_task_id, "cancelled".to_owned());
+                        super::ui_protocol_alpha9_bridge::emit_visual_failed_from_background(
+                            &r_ledger,
+                            &r_session,
+                            &r_turn,
+                            Some("cancelled".to_owned()),
+                        );
+                        return;
+                    }
+                    res = tokio::time::timeout(VISUAL_DISPATCH_TIMEOUT, produce) => match res {
+                        Ok(rels) => rels,
+                        Err(_) => {
+                            let reason =
+                                format!("timed out after {}s", VISUAL_DISPATCH_TIMEOUT.as_secs());
+                            tracing::warn!(
+                                timeout_s = VISUAL_DISPATCH_TIMEOUT.as_secs(),
+                                "voice rich: visual dispatch timed out, delivering nothing"
+                            );
+                            r_supervisor.mark_failed(&r_task_id, reason.clone());
+                            super::ui_protocol_alpha9_bridge::emit_visual_failed_from_background(
+                                &r_ledger,
+                                &r_session,
+                                &r_turn,
+                                Some(reason),
+                            );
+                            return;
+                        }
                     }
                 };
                 if rels.is_empty() {
                     tracing::warn!("voice rich: produced no artifact to deliver");
+                    r_supervisor.mark_failed(&r_task_id, "produced no artifact".to_owned());
+                    // Clear the client's "generating" placeholder (#1477).
+                    super::ui_protocol_alpha9_bridge::emit_visual_failed_from_background(
+                        &r_ledger,
+                        &r_session,
+                        &r_turn,
+                        Some("visual generation produced no artifact".to_owned()),
+                    );
                 } else {
                     tracing::info!(files = ?rels, "voice rich: delivering artifact(s)");
+                    r_supervisor.mark_completed(&r_task_id, rels.clone());
                     super::ui_protocol_alpha9_bridge::emit_files_attached_from_background(
                         &r_ledger,
                         &r_session,
@@ -22008,6 +22177,8 @@ fn ledger_event_cursor(event: &UiProtocolLedgerEvent) -> Option<UiCursor> {
             // future addition forces an explicit decision here.
             UiNotification::TurnStarted(_)
             | UiNotification::MessageDelta(_)
+            | UiNotification::VisualGenerating(_)
+            | UiNotification::VisualFailed(_)
             | UiNotification::ToolStarted(_)
             | UiNotification::ToolProgress(_)
             | UiNotification::ToolCompleted(_)

--- a/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
+++ b/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
@@ -48,7 +48,7 @@ use octos_agent::BackgroundResultPayload;
 use octos_core::SessionKey;
 use octos_core::ui_protocol::{
     FileAttachedEvent, SessionEventBridgedEvent, TurnCompletedEvent, TurnId, TurnSessionResult,
-    TurnStartedEvent, UiNotification,
+    TurnStartedEvent, UiNotification, VisualFailedEvent, VisualGeneratingEvent,
 };
 use serde_json::Value;
 
@@ -302,6 +302,46 @@ pub(super) fn emit_files_attached_from_background(
             mime,
         );
     }
+}
+
+/// #1477 voice rich output: announce that a background visual artifact began
+/// generating, so the client can show a "generating" placeholder driven by this
+/// typed event instead of scraping an in-band marker out of the assistant text.
+/// Routed on the BASE session key (like [`emit_files_attached_from_background`])
+/// while still carrying the topic so topic-scoped subscribers accept it.
+pub(super) fn emit_visual_generating_from_background(
+    ledger: &Arc<UiProtocolLedger>,
+    session_id: &SessionKey,
+    turn_id: &TurnId,
+    kind: &str,
+) {
+    let topic = session_id.topic().map(ToOwned::to_owned);
+    let base_session = SessionKey(session_id.base_key().to_owned());
+    let _ = ledger.append_notification(UiNotification::VisualGenerating(VisualGeneratingEvent {
+        session_id: base_session,
+        topic,
+        turn_id: turn_id.clone(),
+        kind: kind.to_owned(),
+    }));
+}
+
+/// #1477 voice rich output: the background visual task failed / timed out, so
+/// the client should clear the "generating" placeholder. Success needs no such
+/// event — it is signalled by the eventual `file/attached`.
+pub(super) fn emit_visual_failed_from_background(
+    ledger: &Arc<UiProtocolLedger>,
+    session_id: &SessionKey,
+    turn_id: &TurnId,
+    reason: Option<String>,
+) {
+    let topic = session_id.topic().map(ToOwned::to_owned);
+    let base_session = SessionKey(session_id.base_key().to_owned());
+    let _ = ledger.append_notification(UiNotification::VisualFailed(VisualFailedEvent {
+        session_id: base_session,
+        topic,
+        turn_id: turn_id.clone(),
+        reason,
+    }));
 }
 
 /// Lightweight extension-based MIME sniffer used by

--- a/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
+++ b/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
@@ -49,6 +49,7 @@ use octos_core::SessionKey;
 use octos_core::ui_protocol::{
     FileAttachedEvent, SessionEventBridgedEvent, TurnCompletedEvent, TurnId, TurnSessionResult,
     TurnStartedEvent, UiNotification, VisualFailedEvent, VisualGeneratingEvent,
+    VisualSucceededEvent,
 };
 use serde_json::Value;
 
@@ -325,9 +326,33 @@ pub(super) fn emit_visual_generating_from_background(
     }));
 }
 
+/// #1477 voice rich output: the background visual task produced its artifact(s).
+/// The structured success counterpart of
+/// [`emit_visual_generating_from_background`] — the client clears the
+/// "generating" placeholder off THIS, keeping the visual lifecycle decoupled
+/// from `file/attached` (emitted alongside it, NOT in place of it). `files` are
+/// the workspace-relative artifact names, same as the accompanying
+/// `file/attached`.
+pub(super) fn emit_visual_succeeded_from_background(
+    ledger: &Arc<UiProtocolLedger>,
+    session_id: &SessionKey,
+    turn_id: &TurnId,
+    kind: &str,
+    files: &[String],
+) {
+    let topic = session_id.topic().map(ToOwned::to_owned);
+    let base_session = SessionKey(session_id.base_key().to_owned());
+    let _ = ledger.append_notification(UiNotification::VisualSucceeded(VisualSucceededEvent {
+        session_id: base_session,
+        topic,
+        turn_id: turn_id.clone(),
+        kind: kind.to_owned(),
+        files: files.to_vec(),
+    }));
+}
+
 /// #1477 voice rich output: the background visual task failed / timed out, so
-/// the client should clear the "generating" placeholder. Success needs no such
-/// event — it is signalled by the eventual `file/attached`.
+/// the client should clear the "generating" placeholder.
 pub(super) fn emit_visual_failed_from_background(
     ledger: &Arc<UiProtocolLedger>,
     session_id: &SessionKey,

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -2205,6 +2205,8 @@ fn notification_session_id(notification: &UiNotification) -> &SessionKey {
         UiNotification::SessionOpened(event) => &event.session_id,
         UiNotification::TurnStarted(event) => &event.session_id,
         UiNotification::MessageDelta(event) => &event.session_id,
+        UiNotification::VisualGenerating(event) => &event.session_id,
+        UiNotification::VisualFailed(event) => &event.session_id,
         UiNotification::ToolStarted(event) => &event.session_id,
         UiNotification::ToolProgress(event) => &event.session_id,
         UiNotification::ToolCompleted(event) => &event.session_id,

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -2206,6 +2206,7 @@ fn notification_session_id(notification: &UiNotification) -> &SessionKey {
         UiNotification::TurnStarted(event) => &event.session_id,
         UiNotification::MessageDelta(event) => &event.session_id,
         UiNotification::VisualGenerating(event) => &event.session_id,
+        UiNotification::VisualSucceeded(event) => &event.session_id,
         UiNotification::VisualFailed(event) => &event.session_id,
         UiNotification::ToolStarted(event) => &event.session_id,
         UiNotification::ToolProgress(event) => &event.session_id,

--- a/crates/octos-cli/src/api/voice_turn.rs
+++ b/crates/octos-cli/src/api/voice_turn.rs
@@ -6,6 +6,7 @@
 
 use std::path::{Path, PathBuf};
 
+use octos_core::{Message, MessageRole};
 use octos_llm::ominix::OminixClient;
 
 /// 解析 OminiX 服务基址（平台级，env 优先）。与 `api/admin.rs` 的同名 helper 等价；
@@ -260,6 +261,16 @@ impl VisualKind {
             _ => None,
         }
     }
+
+    /// Wire token for the `visual/generating` event (`kind` field).
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Html => "html",
+            Self::Illustrated => "illustrated",
+            Self::Image => "image",
+            Self::Infographic => "infographic",
+        }
+    }
 }
 
 /// A parsed in-band rich-output directive.
@@ -428,6 +439,121 @@ pub(crate) fn strip_visual_marker(reply: &str) -> &str {
     }
 }
 
+/// Remove EVERY `[[VISUAL:...]]` span from `s` (not just a trailing one).
+///
+/// Unlike [`strip_visual_marker`] (which only drops a trailing directive and
+/// preserves a mid-text mention), this scrubs the marker wherever it appears —
+/// used for sanitizing free-form text that may have folded a marker in at an
+/// arbitrary position, e.g. a pre-fix compaction summary. An unterminated
+/// `[[VISUAL:` drops the remainder.
+pub(crate) fn remove_all_visual_markers(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(start) = rest.find("[[VISUAL:") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start..];
+        match after.find("]]") {
+            Some(end) => rest = &after[end + "]]".len()..],
+            None => {
+                rest = "";
+                break;
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Lift the trailing `[[VISUAL:...]]` directive out of the turn's authoritative
+/// reply surfaces and strip it in place, so the internal control protocol never
+/// reaches the WIRE (`message/delta` from `done`, `message/persisted`) or
+/// STORAGE (session JSONL). Strips both `content` (the final `response.content`)
+/// and every Assistant carrier in `messages` that ends with the same trailing
+/// marker. Returns the parsed directive for background dispatch, or `None` (and
+/// leaves everything intact) when there is no real trailing marker. The frontend
+/// learns a visual is coming from the typed `visual/generating` event instead.
+pub(crate) fn strip_visual_directive(
+    content: &mut String,
+    messages: &mut [Message],
+) -> Option<VisualDirective> {
+    let directive = parse_visual_marker(content)?;
+    *content = strip_visual_marker(content).to_string();
+    for message in messages.iter_mut() {
+        if message.role == MessageRole::Assistant {
+            let stripped = strip_visual_marker(&message.content);
+            if stripped.len() != message.content.len() {
+                message.content = stripped.to_string();
+            }
+        }
+    }
+    Some(directive)
+}
+
+/// Byte length of the marker-free visible prefix of `full`: everything up to a
+/// (possibly mid-reply) `[[VISUAL:` occurrence, else everything minus a trailing
+/// partial that could still grow into the marker. Trailing whitespace before
+/// that cut is also held back — the marker convention puts it on its own line,
+/// so the preceding newline would otherwise leak as a blank line. Cut points
+/// fall on char boundaries (`MARKER` is ASCII; `trim_end` is boundary-safe).
+fn visible_prefix_len(full: &str) -> usize {
+    let cut = match full.find(MARKER) {
+        Some(i) => i,
+        None => full.len() - marker_prefix_hold(full),
+    };
+    full[..cut].trim_end().len()
+}
+
+/// Token-granular twin of [`VoiceReplySplitter`] for the **UI message delta**
+/// stream of a voice turn: emits the reply text token-by-token while holding
+/// back any trailing (or still-forming) `[[VISUAL:...]]` marker, so the live
+/// `message/delta` wire never carries the internal control protocol (the
+/// durable surfaces are stripped separately by [`strip_visual_directive`]).
+pub(crate) struct VisibleDeltaFilter {
+    /// All text seen so far.
+    full: String,
+    /// Byte count already emitted as deltas (monotonic).
+    emitted: usize,
+}
+
+impl VisibleDeltaFilter {
+    pub(crate) fn new() -> Self {
+        Self {
+            full: String::new(),
+            emitted: 0,
+        }
+    }
+
+    /// Feed a streamed token; returns the newly-visible marker-free text to emit
+    /// as a delta now (empty when the token only extended a held-back marker).
+    pub(crate) fn push(&mut self, token: &str) -> String {
+        self.full.push_str(token);
+        let visible = visible_prefix_len(&self.full);
+        if visible > self.emitted {
+            let out = self.full[self.emitted..visible].to_string();
+            self.emitted = visible;
+            out
+        } else {
+            String::new()
+        }
+    }
+
+    /// End of stream: returns any held-back text that turned out NOT to be a
+    /// real trailing marker (a rare mid-reply `[[VISUAL:` quote), so nothing is
+    /// lost. A real trailing marker yields `""` (stays off the wire).
+    pub(crate) fn finish(self) -> String {
+        let visible = if parse_visual_marker(&self.full).is_some() {
+            strip_visual_marker(&self.full).len()
+        } else {
+            self.full.len()
+        };
+        if visible > self.emitted {
+            self.full[self.emitted..visible].to_string()
+        } else {
+            String::new()
+        }
+    }
+}
+
 /// Maps a `kind` to a mofa tool name + input args. `Html` is not a skill →
 /// `None`.
 fn image_skill_call(
@@ -443,11 +569,17 @@ fn image_skill_call(
                 "out": format!("{out}/infographic.png"),
             }),
         )),
+        // `mofa_image` (not `mofa_cards`): a plain "generate an image" request
+        // wants a single picture, and — unlike `mofa_cards`, which emits no
+        // `files_to_send` (octos #1041, see `workspace_policy` test) so the
+        // backend would get empty rels and deliver nothing — `mofa_image`
+        // reports its produced PNG via `files_to_send`, the same proven path
+        // the Illustrated stage-1 call relies on.
         VisualKind::Image => Some((
-            "mofa_cards",
+            "mofa_image",
             serde_json::json!({
-                "cards": [{ "prompt": d.brief }],
-                "card_dir": out,
+                "prompt": d.brief,
+                "out": format!("{out}/image.png"),
             }),
         )),
         // Html (focused LLM call) and Illustrated (two-stage: run_illustration_image
@@ -469,13 +601,6 @@ pub(crate) async fn run_illustration_image(
     out_dir: &Path,
     ref_images: &[String],
 ) -> Option<PathBuf> {
-    let Some(tool) = registry.get_tool("mofa_image") else {
-        tracing::warn!(
-            tool = "mofa_image",
-            "voice rich: illustration skill not installed"
-        );
-        return None;
-    };
     let mut args = serde_json::json!({
         "prompt": brief,
         "out": out_dir.join("illustration.png").to_string_lossy(),
@@ -483,7 +608,11 @@ pub(crate) async fn run_illustration_image(
     if !ref_images.is_empty() {
         args["ref_images"] = serde_json::json!(ref_images);
     }
-    match tool.execute(&args).await {
+    // #1477 P2: route through the registry (provider policy + arg-size limit +
+    // deferred-tool auto-activation) rather than a bare `tool.execute()`, so the
+    // background visual call is governed like any other tool execution. `Err`
+    // covers skill-not-installed, policy-denied, and generation failure alike.
+    match registry.execute("mofa_image", &args).await {
         Ok(res) => res.files_to_send.into_iter().next(),
         Err(e) => {
             tracing::warn!(tool = "mofa_image", error = %e, "voice rich: illustration gen failed");
@@ -505,11 +634,9 @@ pub(crate) async fn run_image_skill(
     let Some((name, args)) = image_skill_call(d, out_dir) else {
         return Vec::new();
     };
-    let Some(tool) = registry.get_tool(name) else {
-        tracing::warn!(tool = name, "voice rich: image skill not installed");
-        return Vec::new();
-    };
-    match tool.execute(&args).await {
+    // #1477 P2: route through the registry (policy + arg-size + auto-activation)
+    // instead of a bare `tool.execute()`. `Err` = not installed / denied / failed.
+    match registry.execute(name, &args).await {
         Ok(res) => res
             .files_to_send
             .iter()
@@ -1147,6 +1274,113 @@ mod tests {
             run_illustration_image(&reg, "x", Path::new("/tmp"), &[])
                 .await
                 .is_none()
+        );
+    }
+
+    // octos #1041: `image` kind must route to `mofa_image` (which reports its
+    // PNG via `files_to_send`), NOT `mofa_cards` (which emits none, so the old
+    // mapping delivered nothing for a plain "generate an image" request).
+    #[tokio::test]
+    async fn run_image_skill_image_kind_uses_mofa_image_and_delivers_file() {
+        use octos_agent::{Tool, ToolRegistry, ToolResult};
+        use std::path::PathBuf;
+
+        struct FakeMofaImage;
+        #[async_trait::async_trait]
+        impl Tool for FakeMofaImage {
+            fn name(&self) -> &str {
+                "mofa_image"
+            }
+            fn description(&self) -> &str {
+                "fake"
+            }
+            fn input_schema(&self) -> serde_json::Value {
+                serde_json::json!({ "type": "object" })
+            }
+            async fn execute(&self, args: &serde_json::Value) -> eyre::Result<ToolResult> {
+                // The brief is forwarded as the generation prompt, and the
+                // produced file is named under the turn's out dir.
+                assert_eq!(args["prompt"], serde_json::json!("一只猫"));
+                assert_eq!(args["out"], serde_json::json!("/tmp/out/image.png"));
+                Ok(ToolResult {
+                    success: true,
+                    output: "ok".into(),
+                    files_to_send: vec![PathBuf::from("/tmp/out/image.png")],
+                    ..Default::default()
+                })
+            }
+        }
+
+        let mut reg = ToolRegistry::new();
+        reg.register(FakeMofaImage);
+        let reg = std::sync::Arc::new(reg);
+        let d = VisualDirective {
+            kind: VisualKind::Image,
+            brief: "一只猫".into(),
+        };
+        let rels = run_image_skill(&reg, &d, Path::new("/tmp/out")).await;
+        assert_eq!(rels, vec!["image.png".to_string()]);
+    }
+
+    #[test]
+    fn strip_visual_directive_strips_content_and_assistant_carriers() {
+        let mut content = "好的我给你画一个。\n[[VISUAL:html|可调增益电路]]".to_string();
+        let mut messages = vec![
+            Message::user("画个电路".to_string()),
+            Message::assistant("好的我给你画一个。\n[[VISUAL:html|可调增益电路]]".to_string()),
+        ];
+        let directive = strip_visual_directive(&mut content, &mut messages);
+        assert_eq!(directive.as_ref().map(|d| d.kind), Some(VisualKind::Html));
+        assert_eq!(content, "好的我给你画一个。");
+        assert_eq!(messages[1].content, "好的我给你画一个。");
+        assert_eq!(messages[0].content, "画个电路");
+    }
+
+    #[test]
+    fn strip_visual_directive_noop_without_trailing_marker() {
+        let mut content = "用 [[VISUAL:html|x]] 举例。".to_string();
+        let mut messages = vec![Message::assistant(content.clone())];
+        assert!(strip_visual_directive(&mut content, &mut messages).is_none());
+        assert!(content.contains("[[VISUAL:html|x]]"));
+    }
+
+    #[test]
+    fn visible_delta_filter_hides_trailing_marker() {
+        let mut f = VisibleDeltaFilter::new();
+        let mut seen = String::new();
+        for tok in ["你好", "世界。", "\n[[VIS", "UAL:html|猫]]"] {
+            seen.push_str(&f.push(tok));
+        }
+        seen.push_str(&f.finish());
+        assert_eq!(seen, "你好世界。");
+    }
+
+    #[test]
+    fn visible_delta_filter_recovers_false_marker_on_finish() {
+        let mut f = VisibleDeltaFilter::new();
+        let mut seen = String::new();
+        for tok in ["用 ", "[[VISUAL:html|x]]", " 举例。"] {
+            seen.push_str(&f.push(tok));
+        }
+        seen.push_str(&f.finish());
+        assert_eq!(seen, "用 [[VISUAL:html|x]] 举例。");
+    }
+
+    #[test]
+    fn remove_all_visual_markers_scrubs_every_occurrence() {
+        // Mid-text + trailing markers are both removed (unlike strip_visual_marker).
+        assert_eq!(
+            remove_all_visual_markers(
+                "讲了电路 [[VISUAL:html|图A]] 又讲了细胞[[VISUAL:image|图B]]"
+            ),
+            "讲了电路  又讲了细胞"
+        );
+        // Marker-free text is returned unchanged.
+        assert_eq!(remove_all_visual_markers("普通总结文本"), "普通总结文本");
+        // An unterminated marker drops the remainder.
+        assert_eq!(
+            remove_all_visual_markers("abc [[VISUAL:html|没闭合"),
+            "abc "
         );
     }
 }

--- a/crates/octos-cli/src/api/voice_turn.rs
+++ b/crates/octos-cli/src/api/voice_turn.rs
@@ -561,12 +561,18 @@ fn image_skill_call(
     out_dir: &Path,
 ) -> Option<(&'static str, serde_json::Value)> {
     let out = out_dir.to_string_lossy().to_string();
+    // A UNIQUE output filename per dispatch (#1477 follow-up): the mofa skill
+    // caches by output path (`is_cached`: returns the existing file when it is
+    // >10KB, skipping generation). A fixed name like `image.png` therefore made
+    // every turn after the first in a session return the PREVIOUS turn's image
+    // (and skip generation entirely, so reference frames were never applied).
+    let uniq = uuid::Uuid::now_v7();
     match d.kind {
         VisualKind::Infographic => Some((
             "mofa_infographic",
             serde_json::json!({
                 "sections": [{ "prompt": d.brief }],
-                "out": format!("{out}/infographic.png"),
+                "out": format!("{out}/infographic-{uniq}.png"),
             }),
         )),
         // `mofa_image` (not `mofa_cards`): a plain "generate an image" request
@@ -579,7 +585,7 @@ fn image_skill_call(
             "mofa_image",
             serde_json::json!({
                 "prompt": d.brief,
-                "out": format!("{out}/image.png"),
+                "out": format!("{out}/image-{uniq}.png"),
             }),
         )),
         // Html (focused LLM call) and Illustrated (two-stage: run_illustration_image
@@ -601,9 +607,17 @@ pub(crate) async fn run_illustration_image(
     out_dir: &Path,
     ref_images: &[String],
 ) -> Option<PathBuf> {
+    // Unique output filename per dispatch — the mofa skill caches by output
+    // path (`is_cached`), so a fixed `illustration.png` returned the prior
+    // turn's image and skipped generation (hence reference frames were never
+    // applied). See `image_skill_call`.
+    let out = out_dir
+        .join(format!("illustration-{}.png", uuid::Uuid::now_v7()))
+        .to_string_lossy()
+        .into_owned();
     let mut args = serde_json::json!({
         "prompt": brief,
-        "out": out_dir.join("illustration.png").to_string_lossy(),
+        "out": out,
     });
     if !ref_images.is_empty() {
         args["ref_images"] = serde_json::json!(ref_images);
@@ -1299,13 +1313,19 @@ mod tests {
             }
             async fn execute(&self, args: &serde_json::Value) -> eyre::Result<ToolResult> {
                 // The brief is forwarded as the generation prompt, and the
-                // produced file is named under the turn's out dir.
+                // produced file is named UNIQUELY under the turn's out dir
+                // (`image-<uuid>.png`) so the mofa skill's path cache never
+                // returns a stale image.
                 assert_eq!(args["prompt"], serde_json::json!("一只猫"));
-                assert_eq!(args["out"], serde_json::json!("/tmp/out/image.png"));
+                let out = args["out"].as_str().expect("out is a string");
+                assert!(
+                    out.starts_with("/tmp/out/image-") && out.ends_with(".png"),
+                    "out must be a unique image-<uuid>.png under the out dir, got: {out}"
+                );
                 Ok(ToolResult {
                     success: true,
                     output: "ok".into(),
-                    files_to_send: vec![PathBuf::from("/tmp/out/image.png")],
+                    files_to_send: vec![PathBuf::from(out)],
                     ..Default::default()
                 })
             }
@@ -1319,7 +1339,12 @@ mod tests {
             brief: "一只猫".into(),
         };
         let rels = run_image_skill(&reg, &d, Path::new("/tmp/out")).await;
-        assert_eq!(rels, vec!["image.png".to_string()]);
+        assert_eq!(rels.len(), 1);
+        assert!(
+            rels[0].starts_with("image-") && rels[0].ends_with(".png"),
+            "delivered a unique image-<uuid>.png, got: {}",
+            rels[0]
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/api/voice_turn.rs
+++ b/crates/octos-cli/src/api/voice_turn.rs
@@ -230,6 +230,298 @@ pub(crate) fn clean_for_tts(text: &str) -> String {
         .to_string()
 }
 
+// ── Voice-turn rich output (in-band `[[VISUAL:kind|brief]]` marker) ────────
+//
+// The fast turn may append a marker after the spoken reply when the model
+// decides a visual would help. The backend parses it and dispatches: `html`
+// goes to a focused tool-less LLM authoring call (octos-agent `rich_output`),
+// the rest to mofa skills. The model never emits a tool call, sidestepping the
+// Gemini-3 thought_signature 400.
+
+/// Rich-output kind. `Html` goes to the focused LLM authoring call; the rest
+/// go to mofa skills.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VisualKind {
+    Html,
+    /// Realistic illustration embedded inside interactive HTML (two-stage:
+    /// `mofa_image` generates a PNG → inlined into an `author_html` document).
+    Illustrated,
+    Image,
+    Infographic,
+}
+
+impl VisualKind {
+    fn from_token(s: &str) -> Option<Self> {
+        match s.trim() {
+            "html" => Some(Self::Html),
+            "illustrated" => Some(Self::Illustrated),
+            "image" => Some(Self::Image),
+            "infographic" => Some(Self::Infographic),
+            _ => None,
+        }
+    }
+}
+
+/// A parsed in-band rich-output directive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VisualDirective {
+    pub kind: VisualKind,
+    pub brief: String,
+}
+
+/// Parse a trailing `[[VISUAL:kind|brief]]` marker from the model reply.
+/// Returns `None` (treat as a plain spoken reply) when absent, the kind is
+/// unrecognized, the marker is malformed, or the brief is empty.
+pub(crate) fn parse_visual_marker(reply: &str) -> Option<VisualDirective> {
+    // The marker is appended AFTER the spoken reply, so only accept it when its
+    // closing `]]` ends the (right-trimmed) reply. This stops a mid-reply
+    // mention or quote of the `[[VISUAL:...]]` syntax from triggering an artifact.
+    let trimmed = reply.trim_end();
+    let start = trimmed.rfind("[[VISUAL:")?;
+    let after = &trimmed[start + "[[VISUAL:".len()..];
+    let end = after.find("]]")?;
+    if start + "[[VISUAL:".len() + end + "]]".len() != trimmed.len() {
+        return None; // not the trailing marker
+    }
+    let body = &after[..end];
+    let (kind_tok, brief) = body.split_once('|')?;
+    let kind = VisualKind::from_token(kind_tok)?;
+    let brief = brief.trim().to_string();
+    if brief.is_empty() {
+        return None;
+    }
+    Some(VisualDirective { kind, brief })
+}
+
+/// The in-band marker opener. Streaming holds back only text that is — or could
+/// still grow into — this exact prefix, **not** any `[[`, so ordinary bracket
+/// notation (e.g. a `[[1]]` citation) never suppresses the rest of the TTS.
+const MARKER: &str = "[[VISUAL:";
+
+/// Length in bytes of the longest suffix of `s` that is a non-empty prefix of
+/// [`MARKER`]. Those trailing chars are held back from TTS because the next
+/// streamed token might complete the marker. `MARKER` is ASCII, so any match is
+/// at a char boundary (safe to slice).
+fn marker_prefix_hold(s: &str) -> usize {
+    let sb = s.as_bytes();
+    let mb = MARKER.as_bytes();
+    let max = mb.len().min(sb.len());
+    (1..=max)
+        .rev()
+        .find(|&n| sb[sb.len() - n..] == mb[..n])
+        .unwrap_or(0)
+}
+
+/// Sentence chunking: strong boundaries (。！？!?…；;\n) always split; commas /
+/// ideographic commas (soft) split once the segment is >=8 chars (faster first
+/// audio). Returns the complete sentences; `buf` keeps the unfinished tail.
+/// Module-level twin of the `ui_protocol` inline version, used by
+/// [`VoiceReplySplitter`] and unit tests.
+fn drain_sentences(buf: &mut String) -> Vec<String> {
+    const STRONG: &[char] = &['。', '！', '？', '!', '?', '…', '；', ';', '\n'];
+    const SOFT: &[char] = &['，', ',', '、'];
+    const SOFT_MIN_CHARS: usize = 8;
+    let mut out = Vec::new();
+    loop {
+        let mut cut = None;
+        for (count, (i, c)) in buf.char_indices().enumerate() {
+            if STRONG.contains(&c) || (SOFT.contains(&c) && count + 1 >= SOFT_MIN_CHARS) {
+                cut = Some(i + c.len_utf8());
+                break;
+            }
+        }
+        match cut {
+            Some(idx) => {
+                let sentence = buf[..idx].trim().to_string();
+                *buf = buf[idx..].to_string();
+                if !sentence.is_empty() {
+                    out.push(sentence);
+                }
+            }
+            None => break,
+        }
+    }
+    out
+}
+
+/// Streams speakable text apart from a trailing `[[VISUAL:...]]` marker. Once
+/// `[[` appears, everything from there on is held back from TTS (it may be the
+/// marker); at the end the directive is parsed from the accumulated full text.
+pub(crate) struct VoiceReplySplitter {
+    /// Text seen but not yet emitted to TTS. Speakable sentences are drained
+    /// from its front each push; a (possibly partial) trailing marker is held
+    /// back here until `finish` decides whether it was a real marker.
+    pending: String,
+    /// All text seen so far (used to parse the trailing marker on `finish`).
+    full: String,
+}
+
+impl VoiceReplySplitter {
+    pub(crate) fn new() -> Self {
+        Self {
+            pending: String::new(),
+            full: String::new(),
+        }
+    }
+
+    /// Feed a streamed token; returns the complete sentences ready for TTS now.
+    pub(crate) fn push(&mut self, token: &str) -> Vec<String> {
+        self.full.push_str(token);
+        self.pending.push_str(token);
+
+        if let Some(idx) = self.pending.find(MARKER) {
+            // A full `[[VISUAL:` appeared — treat everything from it onward as
+            // the (trailing) marker region and hold it back. Emit the speakable
+            // text before it; keep the unfinished pre-marker tail + the held
+            // region in `pending` (recovered in `finish` if it turns out not to
+            // be a real trailing marker).
+            let mut head = self.pending[..idx].to_string();
+            let rest = self.pending[idx..].to_string();
+            let out = drain_sentences(&mut head);
+            self.pending = head;
+            self.pending.push_str(&rest);
+            return out;
+        }
+
+        // No full marker yet: hold back only a trailing partial that could still
+        // grow into `[[VISUAL:` (not arbitrary `[[`); drain the rest.
+        let hold = marker_prefix_hold(&self.pending);
+        let split = self.pending.len() - hold;
+        let mut head = self.pending[..split].to_string();
+        let held = self.pending[split..].to_string();
+        let out = drain_sentences(&mut head);
+        self.pending = head;
+        self.pending.push_str(&held);
+        out
+    }
+
+    /// End of stream: returns the remaining speakable tail + parsed directive.
+    /// If no real trailing marker parsed, any held-back text is recovered as
+    /// speech so nothing is lost to a mid-reply `[[` or stray partial.
+    pub(crate) fn finish(self) -> (Option<String>, Option<VisualDirective>) {
+        let directive = parse_visual_marker(&self.full);
+        let speak = if directive.is_some() {
+            strip_visual_marker(&self.pending)
+        } else {
+            self.pending.as_str()
+        }
+        .trim();
+        let tail = if speak.is_empty() {
+            None
+        } else {
+            Some(speak.to_string())
+        };
+        (tail, directive)
+    }
+}
+
+/// Drop a trailing `[[VISUAL:...]]` marker, returning the speakable prefix. For
+/// the **non-streamed fallback** (whole-reply synth) so the marker isn't read
+/// aloud as text. Only a TRAILING marker is stripped (consistent with
+/// [`parse_visual_marker`]); a mid-reply mention is left intact.
+pub(crate) fn strip_visual_marker(reply: &str) -> &str {
+    if parse_visual_marker(reply).is_some() {
+        let i = reply.rfind("[[VISUAL:").expect("trailing marker present");
+        reply[..i].trim_end()
+    } else {
+        reply
+    }
+}
+
+/// Maps a `kind` to a mofa tool name + input args. `Html` is not a skill →
+/// `None`.
+fn image_skill_call(
+    d: &VisualDirective,
+    out_dir: &Path,
+) -> Option<(&'static str, serde_json::Value)> {
+    let out = out_dir.to_string_lossy().to_string();
+    match d.kind {
+        VisualKind::Infographic => Some((
+            "mofa_infographic",
+            serde_json::json!({
+                "sections": [{ "text": d.brief }],
+                "out": format!("{out}/infographic.png"),
+            }),
+        )),
+        VisualKind::Image => Some((
+            "mofa_cards",
+            serde_json::json!({
+                "cards": [{ "prompt": d.brief }],
+                "card_dir": out,
+            }),
+        )),
+        // Html (focused LLM call) and Illustrated (two-stage: run_illustration_image
+        // then author_html) are not direct file-delivering skills.
+        VisualKind::Html | VisualKind::Illustrated => None,
+    }
+}
+
+/// Illustrated path, stage 1: generate one PNG via `mofa_image` and return the
+/// **absolute** produced path so the caller can read + inline its bytes into the
+/// HTML (the PNG itself is not delivered as a separate artifact). `None` when the
+/// skill is missing / failed / produced no file.
+///
+/// `ref_images` (e.g. this turn's camera frame) are forwarded to ground the
+/// illustration on the real subject; omitted from the args entirely when empty.
+pub(crate) async fn run_illustration_image(
+    registry: &std::sync::Arc<octos_agent::ToolRegistry>,
+    brief: &str,
+    out_dir: &Path,
+    ref_images: &[String],
+) -> Option<PathBuf> {
+    let Some(tool) = registry.get_tool("mofa_image") else {
+        tracing::warn!(
+            tool = "mofa_image",
+            "voice rich: illustration skill not installed"
+        );
+        return None;
+    };
+    let mut args = serde_json::json!({
+        "prompt": brief,
+        "out": out_dir.join("illustration.png").to_string_lossy(),
+    });
+    if !ref_images.is_empty() {
+        args["ref_images"] = serde_json::json!(ref_images);
+    }
+    match tool.execute(&args).await {
+        Ok(res) => res.files_to_send.into_iter().next(),
+        Err(e) => {
+            tracing::warn!(tool = "mofa_image", error = %e, "voice rich: illustration gen failed");
+            None
+        }
+    }
+}
+
+/// Backend orchestration: fetch the mofa skill for `kind` and run it directly
+/// (a spawn_only skill is awaited synchronously here — the caller is already in
+/// its own `tokio::spawn`, latency-insensitive), returning the produced files'
+/// relative names. Skill not installed / execution failed → empty vec. The
+/// caller delivers them via files_attached.
+pub(crate) async fn run_image_skill(
+    registry: &std::sync::Arc<octos_agent::ToolRegistry>,
+    d: &VisualDirective,
+    out_dir: &Path,
+) -> Vec<String> {
+    let Some((name, args)) = image_skill_call(d, out_dir) else {
+        return Vec::new();
+    };
+    let Some(tool) = registry.get_tool(name) else {
+        tracing::warn!(tool = name, "voice rich: image skill not installed");
+        return Vec::new();
+    };
+    match tool.execute(&args).await {
+        Ok(res) => res
+            .files_to_send
+            .iter()
+            .filter_map(|p| p.file_name().map(|f| f.to_string_lossy().into_owned()))
+            .collect(),
+        Err(e) => {
+            tracing::warn!(tool = name, error = %e, "voice rich: image skill failed");
+            Vec::new()
+        }
+    }
+}
+
 /// Ensure the text ends on a *strong* terminal boundary so the TTS engine
 /// fully renders the final syllable.
 ///
@@ -564,6 +856,297 @@ mod tests {
         assert_eq!(
             got,
             vec!["/tmp/a/note.ogg".to_string(), "/tmp/a/clip.wav".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_visual_marker_extracts_kind_and_brief() {
+        let d =
+            parse_visual_marker("好的我给你画一个。\n[[VISUAL:html|可调增益的负反馈电路交互演示]]")
+                .expect("marker present");
+        assert_eq!(d.kind, VisualKind::Html);
+        assert_eq!(d.brief, "可调增益的负反馈电路交互演示");
+    }
+
+    #[test]
+    fn parse_visual_marker_maps_image_kinds() {
+        assert_eq!(
+            parse_visual_marker("x [[VISUAL:image|一只猫]]")
+                .unwrap()
+                .kind,
+            VisualKind::Image
+        );
+        assert_eq!(
+            parse_visual_marker("x [[VISUAL:infographic|三段]]")
+                .unwrap()
+                .kind,
+            VisualKind::Infographic
+        );
+        assert_eq!(
+            parse_visual_marker("讲解细胞 [[VISUAL:illustrated|人类细胞结构]]")
+                .unwrap()
+                .kind,
+            VisualKind::Illustrated
+        );
+    }
+
+    #[test]
+    fn parse_visual_marker_none_when_absent_or_unknown_kind() {
+        assert!(parse_visual_marker("纯口播回复，没有标记。").is_none());
+        assert!(parse_visual_marker("[[VISUAL:bogus|x]]").is_none());
+        assert!(parse_visual_marker("[[VISUAL:html|]]").is_none()); // empty brief
+    }
+
+    #[test]
+    fn parse_visual_marker_requires_trailing_position() {
+        // A mid-reply mention / quote of the syntax must NOT trigger an artifact.
+        assert!(
+            parse_visual_marker("我用 [[VISUAL:html|x]] 这种写法举个例子，然后继续说。").is_none()
+        );
+        // Trailing marker (with trailing whitespace/newline) is accepted.
+        let d = parse_visual_marker("好的。\n[[VISUAL:html|电路]]  \n").expect("trailing");
+        assert_eq!(d.kind, VisualKind::Html);
+        assert_eq!(d.brief, "电路");
+    }
+
+    #[test]
+    fn strip_visual_marker_only_strips_trailing() {
+        assert_eq!(
+            strip_visual_marker("我画一个。\n[[VISUAL:html|电路]]"),
+            "我画一个。"
+        );
+        // Mid-reply mention is left intact (not truncated).
+        let mid = "用 [[VISUAL:html|x]] 举例，然后继续。";
+        assert_eq!(strip_visual_marker(mid), mid);
+    }
+
+    #[test]
+    fn splitter_ignores_non_visual_double_bracket() {
+        let mut sp = VoiceReplySplitter::new();
+        let mut spoken = String::new();
+        for tok in ["看这个 [[1]] 参考。", "后面还有内容。"] {
+            for s in sp.push(tok) {
+                spoken.push_str(&s);
+            }
+        }
+        let (tail, directive) = sp.finish();
+        if let Some(t) = tail {
+            spoken.push_str(&t);
+        }
+        assert!(spoken.contains("看这个"));
+        assert!(
+            spoken.contains("后面还有内容"),
+            "ordinary [[ must not truncate TTS: {spoken:?}"
+        );
+        assert!(directive.is_none());
+    }
+
+    #[test]
+    fn splitter_holds_back_marker_from_tts_even_when_token_split() {
+        let mut sp = VoiceReplySplitter::new();
+        let mut spoken = String::new();
+        // The marker streams in as several chunks; none may leak "[[VIS..." to TTS.
+        for tok in ["你好。\n", "[[VIS", "UAL:html|画个", "电路]]"] {
+            for s in sp.push(tok) {
+                spoken.push_str(&s);
+                spoken.push('\n');
+            }
+        }
+        let (tail, directive) = sp.finish();
+        if let Some(t) = tail {
+            spoken.push_str(&t);
+        }
+        assert!(spoken.contains("你好"));
+        assert!(
+            !spoken.contains("VISUAL"),
+            "marker must never reach TTS: {spoken:?}"
+        );
+        assert!(!spoken.contains("[["), "no bracket leak: {spoken:?}");
+        assert_eq!(directive.unwrap().kind, VisualKind::Html);
+    }
+
+    #[test]
+    fn splitter_holds_back_when_double_bracket_split_across_tokens() {
+        let mut sp = VoiceReplySplitter::new();
+        let mut spoken = String::new();
+        for tok in ["你好世界[", "[VISUAL:image|猫]]"] {
+            for s in sp.push(tok) {
+                spoken.push_str(&s);
+            }
+        }
+        let (tail, directive) = sp.finish();
+        if let Some(t) = tail {
+            spoken.push_str(&t);
+        }
+        assert!(spoken.contains("你好世界"));
+        assert!(
+            !spoken.contains("["),
+            "single bracket must not leak: {spoken:?}"
+        );
+        assert_eq!(directive.unwrap().kind, VisualKind::Image);
+    }
+
+    #[test]
+    fn splitter_passes_through_when_no_marker() {
+        let mut sp = VoiceReplySplitter::new();
+        let mut spoken = String::new();
+        for s in sp.push("第一句。第二句！") {
+            spoken.push_str(&s);
+        }
+        let (tail, directive) = sp.finish();
+        if let Some(t) = tail {
+            spoken.push_str(&t);
+        }
+        assert!(spoken.contains("第一句"));
+        assert!(spoken.contains("第二句"));
+        assert!(directive.is_none());
+    }
+
+    #[test]
+    fn strip_visual_marker_drops_trailing_directive() {
+        assert_eq!(
+            strip_visual_marker("我给你画一个。\n[[VISUAL:html|电路]]"),
+            "我给你画一个。"
+        );
+        assert_eq!(strip_visual_marker("纯口播没有标记"), "纯口播没有标记");
+    }
+
+    #[tokio::test]
+    async fn run_image_skill_delivers_relative_filenames() {
+        use octos_agent::{Tool, ToolRegistry, ToolResult};
+        use std::path::PathBuf;
+
+        struct FakeImageTool;
+        #[async_trait::async_trait]
+        impl Tool for FakeImageTool {
+            fn name(&self) -> &str {
+                "mofa_infographic"
+            }
+            fn description(&self) -> &str {
+                "fake"
+            }
+            fn input_schema(&self) -> serde_json::Value {
+                serde_json::json!({ "type": "object" })
+            }
+            async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+                Ok(ToolResult {
+                    success: true,
+                    output: "ok".into(),
+                    files_to_send: vec![PathBuf::from("/tmp/out/poster.png")],
+                    ..Default::default()
+                })
+            }
+        }
+
+        let mut reg = ToolRegistry::new();
+        reg.register(FakeImageTool);
+        let reg = std::sync::Arc::new(reg);
+        let d = VisualDirective {
+            kind: VisualKind::Infographic,
+            brief: "三段信息图".into(),
+        };
+        let rels = run_image_skill(&reg, &d, Path::new("/tmp/out")).await;
+        assert_eq!(rels, vec!["poster.png".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn run_image_skill_empty_when_skill_missing() {
+        use octos_agent::ToolRegistry;
+        let reg = std::sync::Arc::new(ToolRegistry::new());
+        let d = VisualDirective {
+            kind: VisualKind::Image,
+            brief: "猫".into(),
+        };
+        assert!(
+            run_image_skill(&reg, &d, Path::new("/tmp"))
+                .await
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn run_illustration_image_returns_produced_path() {
+        use octos_agent::{Tool, ToolRegistry, ToolResult};
+        use std::path::PathBuf;
+
+        struct FakeMofaImage;
+        #[async_trait::async_trait]
+        impl Tool for FakeMofaImage {
+            fn name(&self) -> &str {
+                "mofa_image"
+            }
+            fn description(&self) -> &str {
+                "fake"
+            }
+            fn input_schema(&self) -> serde_json::Value {
+                serde_json::json!({ "type": "object" })
+            }
+            async fn execute(&self, args: &serde_json::Value) -> eyre::Result<ToolResult> {
+                // The brief is forwarded as the generation prompt, and any camera
+                // frame is forwarded as a reference image to ground the result.
+                assert_eq!(args["prompt"], serde_json::json!("细胞结构"));
+                assert_eq!(args["ref_images"], serde_json::json!(["/cam/frame.jpg"]));
+                Ok(ToolResult {
+                    success: true,
+                    output: "ok".into(),
+                    files_to_send: vec![PathBuf::from("/tmp/out/illustration.png")],
+                    ..Default::default()
+                })
+            }
+        }
+
+        let mut reg = ToolRegistry::new();
+        reg.register(FakeMofaImage);
+        let reg = std::sync::Arc::new(reg);
+        let refs = vec!["/cam/frame.jpg".to_string()];
+        let got = run_illustration_image(&reg, "细胞结构", Path::new("/tmp/out"), &refs).await;
+        assert_eq!(got, Some(PathBuf::from("/tmp/out/illustration.png")));
+    }
+
+    #[tokio::test]
+    async fn run_illustration_image_omits_ref_images_when_none() {
+        use octos_agent::{Tool, ToolRegistry, ToolResult};
+        use std::path::PathBuf;
+
+        struct NoRefTool;
+        #[async_trait::async_trait]
+        impl Tool for NoRefTool {
+            fn name(&self) -> &str {
+                "mofa_image"
+            }
+            fn description(&self) -> &str {
+                "fake"
+            }
+            fn input_schema(&self) -> serde_json::Value {
+                serde_json::json!({ "type": "object" })
+            }
+            async fn execute(&self, args: &serde_json::Value) -> eyre::Result<ToolResult> {
+                // No frame this turn → the arg is absent (not an empty array).
+                assert!(args.get("ref_images").is_none());
+                Ok(ToolResult {
+                    success: true,
+                    output: "ok".into(),
+                    files_to_send: vec![PathBuf::from("/tmp/out/illustration.png")],
+                    ..Default::default()
+                })
+            }
+        }
+
+        let mut reg = ToolRegistry::new();
+        reg.register(NoRefTool);
+        let reg = std::sync::Arc::new(reg);
+        let got = run_illustration_image(&reg, "x", Path::new("/tmp/out"), &[]).await;
+        assert_eq!(got, Some(PathBuf::from("/tmp/out/illustration.png")));
+    }
+
+    #[tokio::test]
+    async fn run_illustration_image_none_when_skill_missing() {
+        use octos_agent::ToolRegistry;
+        let reg = std::sync::Arc::new(ToolRegistry::new());
+        assert!(
+            run_illustration_image(&reg, "x", Path::new("/tmp"), &[])
+                .await
+                .is_none()
         );
     }
 }

--- a/crates/octos-cli/src/api/voice_turn.rs
+++ b/crates/octos-cli/src/api/voice_turn.rs
@@ -439,7 +439,7 @@ fn image_skill_call(
         VisualKind::Infographic => Some((
             "mofa_infographic",
             serde_json::json!({
-                "sections": [{ "text": d.brief }],
+                "sections": [{ "prompt": d.brief }],
                 "out": format!("{out}/infographic.png"),
             }),
         )),

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -1042,9 +1042,16 @@ pub mod methods {
     /// client show a "generating" placeholder WITHOUT scraping an in-band
     /// marker out of the assistant text. Ungated; emitted on the same
     /// ledger-backed live path as `file/attached` (durable append, so a
-    /// reconnecting client replays it). Success is signalled by the eventual
-    /// `file/attached`, failure by `visual/failed`.
+    /// reconnecting client replays it). The lifecycle is terminated by a typed
+    /// `visual/succeeded` or `visual/failed` — NOT by `file/attached` (which is
+    /// purely an artifact-delivery signal).
     pub const VISUAL_GENERATING: &str = "visual/generating";
+    /// #1477 voice rich output — the background visual task produced its
+    /// artifact(s). The structured success counterpart of `visual/generating`:
+    /// the client clears the "generating" placeholder off THIS event, keeping
+    /// the visual lifecycle decoupled from `file/attached`. Emitted alongside
+    /// `file/attached` on the success branch.
+    pub const VISUAL_SUCCEEDED: &str = "visual/succeeded";
     /// #1477 voice rich output — the background visual task failed or timed
     /// out, so the client should clear the "generating" placeholder.
     pub const VISUAL_FAILED: &str = "visual/failed";
@@ -1225,6 +1232,7 @@ pub const UI_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &[
     methods::TURN_SPAWN_COMPLETE,
     methods::FILE_ATTACHED,
     methods::VISUAL_GENERATING,
+    methods::VISUAL_SUCCEEDED,
     methods::VISUAL_FAILED,
     methods::PROJECTION_ENVELOPE,
     methods::SESSION_EVENT,
@@ -4514,7 +4522,7 @@ pub struct MessageDeltaEvent {
 /// the turn. The client renders a "generating" placeholder keyed off this
 /// typed event instead of scraping an in-band `[[VISUAL:...]]` marker out of the
 /// assistant text (which the backend now keeps out of the wire/persisted
-/// surfaces entirely). Cleared by the eventual `file/attached` (success) or
+/// surfaces entirely). The lifecycle terminates on `visual/succeeded` or
 /// `visual/failed`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VisualGeneratingEvent {
@@ -4524,6 +4532,25 @@ pub struct VisualGeneratingEvent {
     pub turn_id: TurnId,
     /// `html` | `illustrated` | `image` | `infographic`.
     pub kind: String,
+}
+
+/// #1477 voice rich output: the background visual task produced its artifact(s).
+/// The structured success counterpart of [`VisualGeneratingEvent`] — the client
+/// clears the "generating" placeholder off this, NOT off `file/attached` (which
+/// stays a pure artifact-delivery signal). Emitted alongside `file/attached` on
+/// the success branch.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VisualSucceededEvent {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+    pub turn_id: TurnId,
+    /// `html` | `illustrated` | `image` | `infographic`.
+    pub kind: String,
+    /// Workspace-relative filenames of the delivered artifact(s) — the same
+    /// paths carried on the accompanying `file/attached` event(s).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<String>,
 }
 
 /// #1477 voice rich output: the background visual task failed or timed out, so
@@ -5491,6 +5518,8 @@ pub enum UiNotification {
     MessageDelta(MessageDeltaEvent),
     /// #1477 voice rich output: a background visual artifact started generating.
     VisualGenerating(VisualGeneratingEvent),
+    /// #1477 voice rich output: a background visual artifact was produced.
+    VisualSucceeded(VisualSucceededEvent),
     /// #1477 voice rich output: a background visual task failed / timed out.
     VisualFailed(VisualFailedEvent),
     ToolStarted(ToolStartedEvent),
@@ -5588,6 +5617,7 @@ impl UiNotification {
             Self::TurnStarted(_) => methods::TURN_STARTED,
             Self::MessageDelta(_) => methods::MESSAGE_DELTA,
             Self::VisualGenerating(_) => methods::VISUAL_GENERATING,
+            Self::VisualSucceeded(_) => methods::VISUAL_SUCCEEDED,
             Self::VisualFailed(_) => methods::VISUAL_FAILED,
             Self::ToolStarted(_) => methods::TOOL_STARTED,
             Self::ToolProgress(_) => methods::TOOL_PROGRESS,
@@ -5632,6 +5662,7 @@ impl UiNotification {
             Self::TurnStarted(event) => &event.session_id,
             Self::MessageDelta(event) => &event.session_id,
             Self::VisualGenerating(event) => &event.session_id,
+            Self::VisualSucceeded(event) => &event.session_id,
             Self::VisualFailed(event) => &event.session_id,
             Self::ToolStarted(event) => &event.session_id,
             Self::ToolProgress(event) => &event.session_id,
@@ -5677,6 +5708,9 @@ impl UiNotification {
                 event.topic.as_deref().or_else(|| event.session_id.topic())
             }
             Self::VisualGenerating(event) => {
+                event.topic.as_deref().or_else(|| event.session_id.topic())
+            }
+            Self::VisualSucceeded(event) => {
                 event.topic.as_deref().or_else(|| event.session_id.topic())
             }
             Self::VisualFailed(event) => {
@@ -5737,6 +5771,7 @@ impl UiNotification {
             Self::TurnStarted(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::MessageDelta(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::VisualGenerating(event) => set_topic_if_absent(&mut event.topic, &topic),
+            Self::VisualSucceeded(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::VisualFailed(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::ToolStarted(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::ToolProgress(event) => set_topic_if_absent(&mut event.topic, &topic),
@@ -5767,6 +5802,7 @@ impl UiNotification {
             Self::TurnStarted(params) => serde_json::to_value(params),
             Self::MessageDelta(params) => serde_json::to_value(params),
             Self::VisualGenerating(params) => serde_json::to_value(params),
+            Self::VisualSucceeded(params) => serde_json::to_value(params),
             Self::VisualFailed(params) => serde_json::to_value(params),
             Self::ToolStarted(params) => serde_json::to_value(params),
             Self::ToolProgress(params) => serde_json::to_value(params),
@@ -5866,6 +5902,7 @@ impl UiNotification {
             methods::VISUAL_GENERATING => {
                 Ok(Self::VisualGenerating(decode_params(method, params)?))
             }
+            methods::VISUAL_SUCCEEDED => Ok(Self::VisualSucceeded(decode_params(method, params)?)),
             methods::VISUAL_FAILED => Ok(Self::VisualFailed(decode_params(method, params)?)),
             methods::TOOL_STARTED => Ok(Self::ToolStarted(decode_params(method, params)?)),
             methods::TOOL_PROGRESS => Ok(Self::ToolProgress(decode_params(method, params)?)),
@@ -6201,6 +6238,11 @@ mod tests {
             decoded
                 .supported_notifications
                 .contains(&methods::VISUAL_GENERATING.to_owned())
+        );
+        assert!(
+            decoded
+                .supported_notifications
+                .contains(&methods::VISUAL_SUCCEEDED.to_owned())
         );
         assert!(
             decoded
@@ -6668,6 +6710,7 @@ mod tests {
                 "turn/spawn_complete",
                 "file/attached",
                 "visual/generating",
+                "visual/succeeded",
                 "visual/failed",
                 "projection/envelope",
                 "session/event",
@@ -6836,6 +6879,7 @@ mod tests {
                     "turn/spawn_complete",
                     "file/attached",
                     "visual/generating",
+                    "visual/succeeded",
                     "visual/failed",
                     "projection/envelope",
                     "session/event",
@@ -7449,6 +7493,24 @@ mod tests {
         let decoded =
             UiNotification::from_rpc_notification(wire).expect("decode visual/generating");
         assert_eq!(decoded, generating);
+
+        let succeeded = UiNotification::VisualSucceeded(VisualSucceededEvent {
+            session_id: SessionKey("local:voice".into()),
+            topic: None,
+            turn_id: TurnId(Uuid::from_u128(1)),
+            kind: "html".into(),
+            files: vec!["visual-abc.html".into()],
+        });
+        assert_eq!(succeeded.method(), methods::VISUAL_SUCCEEDED);
+        let wire = succeeded
+            .clone()
+            .into_rpc_notification()
+            .expect("serialize visual/succeeded");
+        assert_eq!(wire.method, methods::VISUAL_SUCCEEDED);
+        assert_eq!(wire.params["kind"], json!("html"));
+        assert_eq!(wire.params["files"], json!(["visual-abc.html"]));
+        let decoded = UiNotification::from_rpc_notification(wire).expect("decode visual/succeeded");
+        assert_eq!(decoded, succeeded);
 
         let failed = UiNotification::VisualFailed(VisualFailedEvent {
             session_id: SessionKey("local:voice".into()),

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -1037,6 +1037,17 @@ pub mod methods {
     /// event mirroring the SSE `file:` frame from `files_to_send` tool
     /// surfaces.
     pub const FILE_ATTACHED: &str = "file/attached";
+    /// #1477 voice rich output — a background visual artifact (illustrated
+    /// HTML / image / infographic) began generating for the turn. Lets the
+    /// client show a "generating" placeholder WITHOUT scraping an in-band
+    /// marker out of the assistant text. Ungated; emitted on the same
+    /// ledger-backed live path as `file/attached` (durable append, so a
+    /// reconnecting client replays it). Success is signalled by the eventual
+    /// `file/attached`, failure by `visual/failed`.
+    pub const VISUAL_GENERATING: &str = "visual/generating";
+    /// #1477 voice rich output — the background visual task failed or timed
+    /// out, so the client should clear the "generating" placeholder.
+    pub const VISUAL_FAILED: &str = "visual/failed";
     /// UPCR-2026-014 (M9-γ) `projection/envelope` — canonical projection
     /// envelope notification (spec § 14). γ-1 reserves the method name
     /// in the notification methods list as part of capability negotiation
@@ -1213,6 +1224,8 @@ pub const UI_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &[
     methods::MESSAGE_PERSISTED,
     methods::TURN_SPAWN_COMPLETE,
     methods::FILE_ATTACHED,
+    methods::VISUAL_GENERATING,
+    methods::VISUAL_FAILED,
     methods::PROJECTION_ENVELOPE,
     methods::SESSION_EVENT,
     methods::ROUTER_STATUS,
@@ -4497,6 +4510,34 @@ pub struct MessageDeltaEvent {
     pub text: String,
 }
 
+/// #1477 voice rich output: a background visual artifact began generating for
+/// the turn. The client renders a "generating" placeholder keyed off this
+/// typed event instead of scraping an in-band `[[VISUAL:...]]` marker out of the
+/// assistant text (which the backend now keeps out of the wire/persisted
+/// surfaces entirely). Cleared by the eventual `file/attached` (success) or
+/// `visual/failed`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VisualGeneratingEvent {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+    pub turn_id: TurnId,
+    /// `html` | `illustrated` | `image` | `infographic`.
+    pub kind: String,
+}
+
+/// #1477 voice rich output: the background visual task failed or timed out, so
+/// the client should clear the "generating" placeholder.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VisualFailedEvent {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+    pub turn_id: TurnId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolStartedEvent {
     pub session_id: SessionKey,
@@ -5448,6 +5489,10 @@ pub enum UiNotification {
     SessionOpened(SessionOpened),
     TurnStarted(TurnStartedEvent),
     MessageDelta(MessageDeltaEvent),
+    /// #1477 voice rich output: a background visual artifact started generating.
+    VisualGenerating(VisualGeneratingEvent),
+    /// #1477 voice rich output: a background visual task failed / timed out.
+    VisualFailed(VisualFailedEvent),
     ToolStarted(ToolStartedEvent),
     ToolProgress(ToolProgressEvent),
     ToolCompleted(ToolCompletedEvent),
@@ -5542,6 +5587,8 @@ impl UiNotification {
             Self::SessionOpened(_) => methods::SESSION_OPEN,
             Self::TurnStarted(_) => methods::TURN_STARTED,
             Self::MessageDelta(_) => methods::MESSAGE_DELTA,
+            Self::VisualGenerating(_) => methods::VISUAL_GENERATING,
+            Self::VisualFailed(_) => methods::VISUAL_FAILED,
             Self::ToolStarted(_) => methods::TOOL_STARTED,
             Self::ToolProgress(_) => methods::TOOL_PROGRESS,
             Self::ToolCompleted(_) => methods::TOOL_COMPLETED,
@@ -5584,6 +5631,8 @@ impl UiNotification {
             Self::SessionOpened(event) => &event.session_id,
             Self::TurnStarted(event) => &event.session_id,
             Self::MessageDelta(event) => &event.session_id,
+            Self::VisualGenerating(event) => &event.session_id,
+            Self::VisualFailed(event) => &event.session_id,
             Self::ToolStarted(event) => &event.session_id,
             Self::ToolProgress(event) => &event.session_id,
             Self::ToolCompleted(event) => &event.session_id,
@@ -5625,6 +5674,12 @@ impl UiNotification {
         match self {
             Self::TurnStarted(event) => event.topic.as_deref().or_else(|| event.session_id.topic()),
             Self::MessageDelta(event) => {
+                event.topic.as_deref().or_else(|| event.session_id.topic())
+            }
+            Self::VisualGenerating(event) => {
+                event.topic.as_deref().or_else(|| event.session_id.topic())
+            }
+            Self::VisualFailed(event) => {
                 event.topic.as_deref().or_else(|| event.session_id.topic())
             }
             Self::ToolStarted(event) => event.topic.as_deref().or_else(|| event.session_id.topic()),
@@ -5681,6 +5736,8 @@ impl UiNotification {
         match self {
             Self::TurnStarted(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::MessageDelta(event) => set_topic_if_absent(&mut event.topic, &topic),
+            Self::VisualGenerating(event) => set_topic_if_absent(&mut event.topic, &topic),
+            Self::VisualFailed(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::ToolStarted(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::ToolProgress(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::ToolCompleted(event) => set_topic_if_absent(&mut event.topic, &topic),
@@ -5709,6 +5766,8 @@ impl UiNotification {
             Self::SessionOpened(params) => serde_json::to_value(params),
             Self::TurnStarted(params) => serde_json::to_value(params),
             Self::MessageDelta(params) => serde_json::to_value(params),
+            Self::VisualGenerating(params) => serde_json::to_value(params),
+            Self::VisualFailed(params) => serde_json::to_value(params),
             Self::ToolStarted(params) => serde_json::to_value(params),
             Self::ToolProgress(params) => serde_json::to_value(params),
             Self::ToolCompleted(params) => serde_json::to_value(params),
@@ -5804,6 +5863,10 @@ impl UiNotification {
             methods::SESSION_OPEN => Ok(Self::SessionOpened(decode_params(method, params)?)),
             methods::TURN_STARTED => Ok(Self::TurnStarted(decode_params(method, params)?)),
             methods::MESSAGE_DELTA => Ok(Self::MessageDelta(decode_params(method, params)?)),
+            methods::VISUAL_GENERATING => {
+                Ok(Self::VisualGenerating(decode_params(method, params)?))
+            }
+            methods::VISUAL_FAILED => Ok(Self::VisualFailed(decode_params(method, params)?)),
             methods::TOOL_STARTED => Ok(Self::ToolStarted(decode_params(method, params)?)),
             methods::TOOL_PROGRESS => Ok(Self::ToolProgress(decode_params(method, params)?)),
             methods::TOOL_COMPLETED => Ok(Self::ToolCompleted(decode_params(method, params)?)),
@@ -6131,6 +6194,18 @@ mod tests {
             decoded
                 .supported_notifications
                 .contains(&methods::SESSION_OPEN.to_owned())
+        );
+        // #1477: the typed visual lifecycle events are advertised as supported
+        // notifications, so a negotiating client knows to expect them.
+        assert!(
+            decoded
+                .supported_notifications
+                .contains(&methods::VISUAL_GENERATING.to_owned())
+        );
+        assert!(
+            decoded
+                .supported_notifications
+                .contains(&methods::VISUAL_FAILED.to_owned())
         );
     }
 
@@ -6592,6 +6667,8 @@ mod tests {
                 "message/persisted",
                 "turn/spawn_complete",
                 "file/attached",
+                "visual/generating",
+                "visual/failed",
                 "projection/envelope",
                 "session/event",
                 "router/status",
@@ -6758,6 +6835,8 @@ mod tests {
                     "message/persisted",
                     "turn/spawn_complete",
                     "file/attached",
+                    "visual/generating",
+                    "visual/failed",
                     "projection/envelope",
                     "session/event",
                     "router/status",
@@ -7347,6 +7426,45 @@ mod tests {
         let decoded =
             UiNotification::from_rpc_notification(wire).expect("decode user_question/requested");
         assert_eq!(decoded, notification);
+    }
+
+    // #1477 voice rich output: the typed visual lifecycle events carry the
+    // right method + snake_case wire fields (server→client only).
+    #[test]
+    fn visual_generating_and_failed_wire_contract() {
+        let generating = UiNotification::VisualGenerating(VisualGeneratingEvent {
+            session_id: SessionKey("local:voice".into()),
+            topic: None,
+            turn_id: TurnId(Uuid::from_u128(1)),
+            kind: "illustrated".into(),
+        });
+        assert_eq!(generating.method(), methods::VISUAL_GENERATING);
+        let wire = generating
+            .clone()
+            .into_rpc_notification()
+            .expect("serialize visual/generating");
+        assert_eq!(wire.method, methods::VISUAL_GENERATING);
+        assert_eq!(wire.params["kind"], json!("illustrated"));
+        // Round-trip: decode must reconstruct the same notification.
+        let decoded =
+            UiNotification::from_rpc_notification(wire).expect("decode visual/generating");
+        assert_eq!(decoded, generating);
+
+        let failed = UiNotification::VisualFailed(VisualFailedEvent {
+            session_id: SessionKey("local:voice".into()),
+            topic: None,
+            turn_id: TurnId(Uuid::from_u128(1)),
+            reason: Some("timed out".into()),
+        });
+        assert_eq!(failed.method(), methods::VISUAL_FAILED);
+        let wire = failed
+            .clone()
+            .into_rpc_notification()
+            .expect("serialize visual/failed");
+        assert_eq!(wire.method, methods::VISUAL_FAILED);
+        assert_eq!(wire.params["reason"], json!("timed out"));
+        let decoded = UiNotification::from_rpc_notification(wire).expect("decode visual/failed");
+        assert_eq!(decoded, failed);
     }
 
     #[test]

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_024_VOICE_VISUAL_LIFECYCLE.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_024_VOICE_VISUAL_LIFECYCLE.md
@@ -1,0 +1,132 @@
+# UPCR-2026-024: Voice Rich-Output Visual Lifecycle
+
+Status: accepted
+Date: 2026-06-23
+PR: #1477
+
+## Summary
+
+Let a voice turn reply with an interactive visual artifact (illustrated HTML /
+image / infographic) in addition to speech, and let the client render the
+artifact's progress through a typed lifecycle instead of scraping an in-band
+marker out of the assistant text.
+
+The model appends a trailing `[[VISUAL:kind|brief]]` control marker after its
+spoken reply — **no tool call**, so the Gemini-3 `thought_signature` 400 never
+arises and voice turns keep a lean, tool-deferred prefill. The marker is an
+internal control protocol: the backend strips it from every model-/client-facing
+surface (live `message/delta`, persisted `response.content`, assistant carriers,
+snapshot/fork import boundaries, and compaction summaries) so it never replays
+into a later prompt. In its place the server drives the client off three
+structured notifications: `visual/generating`, `visual/succeeded`,
+`visual/failed`.
+
+## Decision
+
+Do add three server→client notifications — `visual/generating`,
+`visual/succeeded`, `visual/failed` — carrying a typed visual-artifact
+lifecycle for the turn.
+
+Do keep the lifecycle decoupled from `file/attached`: `file/attached` stays a
+pure artifact-delivery signal; the client raises and clears the "generating"
+placeholder off the `visual/*` events, NOT off `file/attached`. This split is
+deliberate so the lifecycle survives a future `projection.envelope.v1` cutover.
+
+Do emit the events on the same ledger-backed live path as `file/attached`
+(durable append → replayed on reconnect).
+
+Do NOT add a client→server command, a new `TurnState` variant, or a
+model-visible tool. The artifact is produced by a background task the model
+requests through the in-band marker; the client only observes.
+
+Do NOT leak the `[[VISUAL:...]]` marker onto any model- or client-facing
+surface.
+
+## Capabilities
+
+None. The three notifications are **ungated** — they are members of
+`UI_PROTOCOL_NOTIFICATION_METHODS` and are advertised in `supported_methods`
+for every server slice. A client that does not understand them ignores them
+(unknown-notification tolerance); the spoken reply and `file/attached` delivery
+are unaffected.
+
+## AppUI Surface
+
+Defined in the v1 spec § 6 (catalog) and § 8 (event semantics).
+
+### `visual/generating` (event)
+
+A background visual artifact began generating for the turn. Fields:
+
+- `session_id`, `turn_id` — required turn-scoping.
+- `kind` — `html` | `illustrated` | `image` | `infographic`.
+- `topic` — optional sub-topic routing key.
+
+### `visual/succeeded` (event)
+
+The background visual task produced its artifact(s). The structured success
+counterpart of `visual/generating`; the client clears the placeholder off this
+event. Emitted alongside `file/attached` on the success branch. Fields:
+
+- `session_id`, `turn_id`, `kind` — as above.
+- `files` — workspace-relative filenames of the delivered artifact(s) (the same
+  paths carried on the accompanying `file/attached` event(s); omitted when
+  empty).
+- `topic` — optional.
+
+### `visual/failed` (event)
+
+The background visual task failed, timed out, or was cancelled; the client
+clears the placeholder. Fields:
+
+- `session_id`, `turn_id` — required.
+- `reason` — optional failure/timeout/cancel detail.
+- `topic` — optional.
+
+## Dispatch by kind
+
+- `html` → `octos-agent::rich_output::author_html` writes a self-contained
+  interactive document (focused, tool-less authoring call).
+- `illustrated` → two-stage: `mofa_image` PNG inlined as a `data:` URI into a
+  single self-contained interactive HTML file. The turn's live camera frame is
+  forwarded to `mofa_image` as a reference image when the explicit `live_video`
+  signal (#1476) is present.
+- `image` / `infographic` → backend-orchestrated mofa skill.
+
+Each dispatch runs through `ToolRegistry::execute` (provider policy + arg-size
+limit + deferred-tool auto-activation), is registered as a cancelable
+`TaskSupervisor` task with a 180s timeout and token-usage logging, and writes a
+unique output filename so the mofa skill's path cache cannot return a stale
+image across turns.
+
+## Compatibility
+
+Backward-compatible. New notification methods + optional fields only; no command
+or existing-event change. The lifecycle is decoupled from `file/attached` so the
+`projection.envelope.v1` cutover (UPCR-2026-014 γ-2) can drop the legacy
+`message/delta`/`tool/*`/`turn/completed` notifications without disturbing the
+visual lifecycle.
+
+Voice-turn `message/delta` streaming dual-emits the canonical projection
+envelope (PR #1496), so `projection.envelope.v1` clients receive the sanitized
+assistant deltas on voice turns rather than having the bare ephemeral
+`message/delta` filtered out.
+
+## Tests
+
+- `crates/octos-core/src/ui_protocol.rs` — `visual/*` method registration,
+  round-trip encode/decode, topic-propagation, and `supported_methods`
+  membership (28 markers across the suite).
+- `--features api` `voice_turn` tests — marker stripping across live delta,
+  persist, snapshot/fork, and compaction surfaces (the module is feature-gated;
+  the default `--workspace` test does not compile it).
+
+## References
+
+- v1 spec § 6 (catalog), § 8 (`visual/generating`, `visual/succeeded`,
+  `visual/failed`).
+- `UI_PROTOCOL_NOTIFICATION_METHODS` + `methods::VISUAL_*` in
+  `crates/octos-core/src/ui_protocol.rs`.
+- UPCR-2026-014 (projection envelope) — the cutover this lifecycle is designed
+  to survive.
+- #1476 (live-camera context hint), frontend octos-web #232 / #238 / #239.

--- a/scripts/milestone-ci.sh
+++ b/scripts/milestone-ci.sh
@@ -65,6 +65,10 @@ run_hosted_fast() {
   cargo test -p octos-llm test_derive_cold_start_catalog_assigns_non_zero_scores -- --nocapture
   cargo test -p octos-llm test_compatible_fallbacks_prefers_lower_seeded_qos_score -- --nocapture
   cargo test -p octos-cli gateway_runtime::tests --features api -- --nocapture
+  # #1477: the `api` module (incl. voice_turn rich-output marker/splitter/delta
+  # helpers) is feature-gated, so `cargo test --workspace` above never compiles
+  # it. Run the api-gated unit tests explicitly so this coverage is real.
+  cargo test -p octos-cli --features api voice_turn -- --nocapture
   cargo test -p octos-agent --test activate_tools_regression -- --nocapture
   cargo test -p octos-bus --test file_handle_resolve_tool_path -- --nocapture
 }


### PR DESCRIPTION
Lets a voice turn reply with an interactive visual (illustrated HTML / image /
infographic), not just speech, when the model decides one helps.

## Design (two layers)

**LLM-facing — in-band marker, no tool call.** The model appends a trailing
`[[VISUAL:kind|brief]]` marker after its spoken reply. It emits **no tool call**,
so the Gemini-3 `thought_signature` 400 never arises (voice turns also defer all
tools for a lean prefill). The marker is an internal control protocol and is kept
OFF every model-/client-facing surface:
- stripped from `response.content` + assistant carriers before persist/`done`;
- held back from live `message/delta` (marker-aware `VisibleDeltaFilter`);
- sanitized in the `ContextManager` at the record chokepoint AND at
  snapshot/fork import boundaries, so neither rebuilt nor loaded (pre-fix)
  ledgers replay it into a later prompt; compaction summaries stay clean too.

**Client-facing — typed visual lifecycle.** A structured event stream replaces
marker-scraping: `visual/generating{kind}` on dispatch, `visual/succeeded{kind,
files}` on success, `visual/failed{reason}` on failure/timeout/cancel.
`file/attached` stays a pure artifact-delivery signal, so the lifecycle survives
a future `projection.envelope.v1` cutover.

## Dispatch by kind
- `html` → `octos-agent::rich_output::author_html` writes a self-contained
  interactive document (focused, tool-less authoring call).
- `illustrated` → two-stage: `mofa_image` PNG → inlined as a `data:` URI into
  interactive HTML (single self-contained file).
- `image` / `infographic` → backend-orchestrated mofa skill.

## Governance & correctness
- Background visual runs through `ToolRegistry::execute` (provider policy +
  arg-size limit + deferred-tool auto-activation), registered as a cancelable
  `TaskSupervisor` task (terminal status, full session key so the interrupt path
  finds it), with a 180s timeout and token-usage logging.
- **Camera-frame grounding** (illustrated): the turn's live camera frame is
  forwarded to `mofa_image` as a reference image. Gated on the explicit
  `live_video` signal (#1476), never inferred from attachment types.
- **Unique output filename per dispatch** so the mofa skill's path cache can't
  return a stale image across turns.
- CI runs the `--features api` `voice_turn` tests (the module is feature-gated,
  so the default `--workspace` test never compiled them).

## Related
- Frontend (octos-web): #232, #238, #239 — all merged.
- Built on #1476 (live-camera context hint) — merged.
- `illustrated` / `image` paths require the `mofa_image` / mofa skills installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)