### PR TITLE
feat(voice): wire live_video signal from ingress (backend, #1478)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -10196,6 +10196,7 @@ async fn maybe_spawn_appui_master_continuation_runner(
         topic: None,
         rewrite_for: None,
         reasoning_effort: None,
+        live_video: false,
     };
     let prompt = prompt_text(&params.input).unwrap_or_default();
     let routed_profile_id = Some(profile_id.clone());
@@ -17828,7 +17829,21 @@ async fn run_standalone_turn(
         // connection negotiated `user_question.v1` (`user_question_requester`
         // is `Some`); otherwise the agent's `ask_user_question` tool sees no
         // requester and degrades to its structured-metadata fallback.
-        let message_future = request_agent.process_message(&prompt, &history, turn_media_paths);
+        // #1478: thread the explicit live-video signal into the turn so the
+        // agent loop's video-call note (and the rich-output camera-frame
+        // grounding) fire only when the client says this is a live camera turn
+        // — never inferred from attachment types. Other attachment-context
+        // fields stay at their serve-path defaults.
+        let turn_attachments = octos_agent::TurnAttachmentContext {
+            live_video: params.live_video,
+            ..Default::default()
+        };
+        let message_future = request_agent.process_message_with_attachments(
+            &prompt,
+            &history,
+            turn_media_paths,
+            turn_attachments,
+        );
         let scoped_message_future: std::pin::Pin<
             Box<
                 dyn std::future::Future<Output = eyre::Result<octos_agent::ConversationResponse>>
@@ -24807,6 +24822,7 @@ ignore = []
             topic: None,
             rewrite_for: None,
             reasoning_effort: None,
+            live_video: false,
         })
         .into_rpc_request("1")
         .expect("request");
@@ -32152,6 +32168,7 @@ ignore = []
             topic: None,
             rewrite_for: None,
             reasoning_effort: None,
+            live_video: false,
         };
         let turn_state = Arc::new(TokioMutex::new(TurnState::Active));
         let (interrupt_tx, interrupt_rx) = mpsc::channel::<()>(1);

--- a/crates/octos-core/src/app_ui.rs
+++ b/crates/octos-core/src/app_ui.rs
@@ -275,6 +275,7 @@ mod tests {
             topic: None,
             rewrite_for: None,
             reasoning_effort: None,
+            live_video: false,
         });
 
         assert_eq!(command.method(), methods::TURN_START);

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -1718,7 +1718,6 @@ pub struct TurnStartParams {
     /// UPCR-2026-015 (M9-β-1): optional sub-topic suffix that scopes
     /// this send to a per-topic session bucket (`<session>#<topic>`
     /// shape). Mirrors the legacy SSE `topic` query/body field. The
-    /// server folds this into the resolved `SessionKey` before
     /// validating scope and looking up history. Empty / absent for
     /// the default-topic case.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1739,6 +1738,14 @@ pub struct TurnStartParams {
     /// overrides the turn's effort. No-op for models without a reasoning style.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<ReasoningEffortLevel>,
+    /// Explicit "this turn is a live video call" signal — the attached image
+    /// (if any) is the user's current camera frame, not an uploaded file. Set
+    /// by video-call surfaces (the voice screen with the camera on). The server
+    /// folds it into `inbound.metadata["live_video"]`; consumers read it from
+    /// `TurnAttachmentContext.live_video` and NEVER infer it from attachment
+    /// types. Defaults false; omitted on the wire when false.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub live_video: bool,
 }
 
 /// Reasoning/thinking effort level carried on the wire (octos-core cannot depend
@@ -5990,12 +5997,14 @@ mod tests {
             topic: None,
             rewrite_for: None,
             reasoning_effort: Some(ReasoningEffortLevel::Max),
+            live_video: false,
         };
         let wire = serde_json::to_value(&params).unwrap();
         assert_eq!(wire["reasoning_effort"], json!("max"));
         let back: TurnStartParams = serde_json::from_value(wire).unwrap();
         assert_eq!(back.reasoning_effort, Some(ReasoningEffortLevel::Max));
-        // Omitted field deserializes to None (backward compatible).
+        // Omitted optional fields deserialize to their defaults (backward
+        // compatible): no reasoning_effort, and `live_video` false.
         let legacy = json!({
             "session_id": "local:demo",
             "turn_id": "00000000-0000-0000-0000-000000000001",
@@ -6003,6 +6012,33 @@ mod tests {
         });
         let parsed: TurnStartParams = serde_json::from_value(legacy).unwrap();
         assert_eq!(parsed.reasoning_effort, None);
+        assert!(!parsed.live_video);
+    }
+
+    #[test]
+    fn turn_start_live_video_roundtrips_and_is_omitted_when_false() {
+        // Explicit true is carried on the wire and read back.
+        let on = json!({
+            "session_id": "local:demo",
+            "turn_id": "00000000-0000-0000-0000-000000000001",
+            "input": [],
+            "live_video": true
+        });
+        let parsed: TurnStartParams = serde_json::from_value(on).unwrap();
+        assert!(parsed.live_video);
+        // Default false is omitted from the serialized form (no wire bloat).
+        let params = TurnStartParams {
+            session_id: SessionKey("local:demo".into()),
+            turn_id: TurnId(Uuid::from_u128(1)),
+            input: vec![],
+            media: vec![],
+            topic: None,
+            rewrite_for: None,
+            reasoning_effort: None,
+            live_video: false,
+        };
+        let wire = serde_json::to_value(&params).unwrap();
+        assert!(wire.get("live_video").is_none());
     }
 
     #[test]
@@ -6774,6 +6810,7 @@ mod tests {
             topic: None,
             rewrite_for: None,
             reasoning_effort: None,
+            live_video: false,
         })
         .into_rpc_request("req-turn-start")
         .expect("serialize turn/start");
@@ -7449,6 +7486,7 @@ mod tests {
             topic: None,
             rewrite_for: None,
             reasoning_effort: None,
+            live_video: false,
         });
 
         let request = command
@@ -7515,6 +7553,7 @@ mod tests {
             topic: None,
             rewrite_for: None,
             reasoning_effort: None,
+            live_video: false,
         });
 
         let wire = serde_json::to_value(
@@ -7555,6 +7594,7 @@ mod tests {
             topic: Some("slides".into()),
             rewrite_for: None,
             reasoning_effort: None,
+            live_video: false,
         });
 
         let wire = serde_json::to_value(
@@ -7595,6 +7635,7 @@ mod tests {
             topic: None,
             rewrite_for: Some("cmid-queued-original".into()),
             reasoning_effort: None,
+            live_video: false,
         });
 
         let wire = serde_json::to_value(
@@ -7640,6 +7681,7 @@ mod tests {
             topic: Some("research".into()),
             rewrite_for: Some("cmid-original".into()),
             reasoning_effort: None,
+            live_video: false,
         });
 
         let wire = serde_json::to_value(


### PR DESCRIPTION
Backend half of #1478 — activates the explicit live-video-call signal that #1476 merged but left **dormant** (no producer set the flag).

## What
- **octos-core**: add `live_video: bool` to `TurnStartParams` (serde `default` false; omitted on the wire when false — no bloat for non-video turns).
- **octos-cli (serve/WS path)**: thread `params.live_video` into the turn via `process_message_with_attachments` (`TurnAttachmentContext.live_video`) instead of the always-false default attachments.

The consumer side (session_actor → `TurnAttachmentContext` → loop_runner video-call note) already merged in #1476; this fills the producer gap on the serve path.

## Effect
A client that sets `live_video: true` on `turn/start` activates the camera-frame context note. Also unblocks the rich-output camera-frame grounding (voice-rich-output PR).

## Remaining for #1478
- Frontend (octos-web): the voice client sets `live_video: true` when the camera is on (separate PR).

## Tests
`TurnStartParams.live_video` serde: default false, true roundtrip, omitted-when-false. CI/unit green.

Refs #1478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)