### PR TITLE
Fix Matrix user channel follow-ups

### DIFF
--- a/crates/octos-bus/src/matrix_user_channel.rs
+++ b/crates/octos-bus/src/matrix_user_channel.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use eyre::{Result, WrapErr, eyre};
+use futures::StreamExt;
 use octos_core::{InboundMessage, OutboundMessage};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -42,6 +43,7 @@ const MATRIX_INVITES_FILE: &str = "matrix-invites.json";
 /// Long-poll timeout for the `/sync` request (server holds the connection open
 /// until an event arrives or this elapses).
 const SYNC_TIMEOUT_MS: u64 = 30_000;
+const MATRIX_ERROR_BODY_MAX_BYTES: usize = 2048;
 const DEFAULT_DEVICE_NAME: &str = "octos";
 
 /// Matrix invite auto-join policy.
@@ -463,6 +465,79 @@ fn is_stable_join_target(target: &str) -> bool {
     trimmed == "*" || trimmed.starts_with('!') || trimmed.starts_with('#')
 }
 
+fn matrix_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("failed to build Matrix HTTP client")
+}
+
+async fn matrix_error_body(resp: reqwest::Response) -> String {
+    let mut buf = Vec::new();
+    let mut truncated = resp
+        .content_length()
+        .map(|len| len > MATRIX_ERROR_BODY_MAX_BYTES as u64)
+        .unwrap_or(false);
+    let mut stream = resp.bytes_stream();
+
+    while let Some(chunk) = stream.next().await {
+        match chunk {
+            Ok(chunk) => {
+                if buf.len() + chunk.len() > MATRIX_ERROR_BODY_MAX_BYTES {
+                    let remaining = MATRIX_ERROR_BODY_MAX_BYTES.saturating_sub(buf.len());
+                    buf.extend_from_slice(&chunk[..remaining]);
+                    truncated = true;
+                    break;
+                }
+                buf.extend_from_slice(&chunk);
+            }
+            Err(_) => {
+                truncated = true;
+                break;
+            }
+        }
+    }
+
+    sanitize_matrix_error_body(&String::from_utf8_lossy(&buf), truncated)
+}
+
+fn sanitize_matrix_error_body(raw: &str, truncated: bool) -> String {
+    let mut out = String::new();
+    let mut last_space = false;
+    for ch in raw.chars() {
+        let ch = if ch.is_control() { ' ' } else { ch };
+        if ch.is_whitespace() {
+            if !last_space {
+                out.push(' ');
+                last_space = true;
+            }
+        } else {
+            out.push(ch);
+            last_space = false;
+        }
+    }
+
+    let mut out = out.trim().to_string();
+    if truncated {
+        if out.is_empty() {
+            out.push_str("[truncated]");
+        } else {
+            out.push_str(" ... [truncated]");
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+fn initial_sync_retry_delay() -> Duration {
+    Duration::from_millis(10)
+}
+
+#[cfg(not(test))]
+fn initial_sync_retry_delay() -> Duration {
+    Duration::from_secs(1)
+}
+
 /// Build the JSON body for a `m.login.password` request.
 fn password_login_body(user_id: &str, password: &str, device_name: Option<&str>) -> Value {
     json!({
@@ -548,7 +623,7 @@ impl MatrixUserChannel {
                 .filter(|s| !s.is_empty())
                 .collect(),
             shutdown,
-            http: reqwest::Client::new(),
+            http: matrix_http_client(),
             dedup: Arc::new(MessageDedup::new()),
             resolved: Mutex::new(None),
         }
@@ -582,7 +657,7 @@ impl MatrixUserChannel {
                 .wrap_err("Matrix whoami request failed")?;
             if !resp.status().is_success() {
                 let status = resp.status();
-                let body = resp.text().await.unwrap_or_default();
+                let body = matrix_error_body(resp).await;
                 return Err(eyre!("Matrix whoami failed (status={status}): {body}"));
             }
             let payload: Value = resp.json().await.wrap_err("invalid whoami response")?;
@@ -618,7 +693,7 @@ impl MatrixUserChannel {
             .wrap_err("Matrix password login request failed")?;
         if !resp.status().is_success() {
             let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
+            let body = matrix_error_body(resp).await;
             return Err(eyre!(
                 "Matrix password login failed (status={status}): {body}"
             ));
@@ -659,7 +734,7 @@ impl MatrixUserChannel {
             .wrap_err("Matrix sync request failed")?;
         if !resp.status().is_success() {
             let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
+            let body = matrix_error_body(resp).await;
             return Err(eyre!("Matrix sync failed (status={status}): {body}"));
         }
         let payload: Value = resp.json().await.wrap_err("invalid sync response")?;
@@ -682,7 +757,7 @@ impl MatrixUserChannel {
             .wrap_err("Matrix join room request failed")?;
         if !resp.status().is_success() {
             let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
+            let body = matrix_error_body(resp).await;
             return Err(eyre!("Matrix join room failed (status={status}): {body}"));
         }
         Ok(())
@@ -705,7 +780,7 @@ impl MatrixUserChannel {
         }
         if !resp.status().is_success() {
             let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
+            let body = matrix_error_body(resp).await;
             return Err(eyre!(
                 "Matrix room alias lookup failed (status={status}): {body}"
             ));
@@ -816,6 +891,31 @@ impl MatrixUserChannel {
         }
     }
 
+    async fn initial_sync_cursor(&self, token: &str, self_user_id: &str) -> Result<Option<String>> {
+        let mut backoff = initial_sync_retry_delay();
+        while !self.shutdown.load(Ordering::Acquire) {
+            match self.sync_once(token, self_user_id, None, 0).await {
+                Ok(initial) => {
+                    self.join_allowed_invites(token, initial.invites).await;
+                    if let Some(next_batch) = initial.next_batch {
+                        return Ok(Some(next_batch));
+                    }
+                    warn!("initial Matrix sync response missing next_batch; retrying");
+                }
+                Err(e) => {
+                    warn!(error = %e, "initial Matrix sync failed; retrying");
+                }
+            }
+
+            if self.shutdown.load(Ordering::Acquire) {
+                break;
+            }
+            tokio::time::sleep(backoff).await;
+            backoff = (backoff * 2).min(Duration::from_secs(30));
+        }
+        Ok(None)
+    }
+
     /// Forward parsed messages to the bus, applying dedup and allowlists.
     async fn forward_messages(
         &self,
@@ -890,26 +990,19 @@ impl Channel for MatrixUserChannel {
 
         // Initial sync (timeout=0): pick up the latest position and any pending
         // invites without replaying historical messages.
-        let mut since = match self.sync_once(&token, &self_user_id, None, 0).await {
-            Ok(initial) => {
-                self.join_allowed_invites(&token, initial.invites).await;
-                initial.next_batch
-            }
-            Err(e) => {
-                warn!(error = %e, "initial Matrix sync failed; continuing");
-                None
-            }
+        let Some(mut since) = self.initial_sync_cursor(&token, &self_user_id).await? else {
+            return Ok(());
         };
 
         let mut backoff = Duration::from_secs(1);
         while !self.shutdown.load(Ordering::Acquire) {
             match self
-                .sync_once(&token, &self_user_id, since.as_deref(), SYNC_TIMEOUT_MS)
+                .sync_once(&token, &self_user_id, Some(&since), SYNC_TIMEOUT_MS)
                 .await
             {
                 Ok(parsed) => {
-                    if parsed.next_batch.is_some() {
-                        since = parsed.next_batch;
+                    if let Some(next_batch) = parsed.next_batch {
+                        since = next_batch;
                     }
                     self.join_allowed_invites(&token, parsed.invites).await;
                     self.forward_messages(parsed.messages, &inbound_tx).await?;
@@ -960,7 +1053,7 @@ impl Channel for MatrixUserChannel {
             .wrap_err("failed to send Matrix message")?;
         if !resp.status().is_success() {
             let status = resp.status();
-            let text = resp.text().await.unwrap_or_default();
+            let text = matrix_error_body(resp).await;
             return Err(eyre!("Matrix send failed (status={status}): {text}"));
         }
         Ok(())
@@ -1152,6 +1245,88 @@ mod tests {
             sync_path(Some("  "), 100),
             "/_matrix/client/v3/sync?timeout=100"
         );
+    }
+
+    #[tokio::test]
+    async fn initial_sync_retries_until_cursor_obtained() {
+        use std::sync::atomic::AtomicUsize;
+
+        use axum::Router;
+        use axum::http::StatusCode;
+        use axum::response::IntoResponse;
+        use axum::routing::get;
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_for_route = attempts.clone();
+        let app = Router::new().route(
+            "/_matrix/client/v3/sync",
+            get(move || {
+                let attempts = attempts_for_route.clone();
+                async move {
+                    let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                    if attempt == 0 {
+                        (StatusCode::BAD_GATEWAY, "temporary").into_response()
+                    } else {
+                        axum::Json(json!({ "next_batch": "s2" })).into_response()
+                    }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let ch = MatrixUserChannel::new(
+            &format!("http://{addr}"),
+            Some("@bot:example.org".into()),
+            Some("tok".into()),
+            None,
+            None,
+            vec![],
+            MatrixAutoJoin::Off,
+            vec![],
+            MatrixGroupPolicy::Open,
+            false,
+            vec![],
+            shutdown,
+        );
+
+        let cursor = ch
+            .initial_sync_cursor("tok", "@bot:example.org")
+            .await
+            .unwrap();
+
+        assert_eq!(cursor.as_deref(), Some("s2"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn matrix_runtime_http_client_does_not_follow_redirects() {
+        use axum::Router;
+        use axum::response::Redirect;
+        use axum::routing::get;
+
+        let app = Router::new()
+            .route(
+                "/redirect",
+                get(|| async { Redirect::temporary("/target") }),
+            )
+            .route("/target", get(|| async { "target" }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let resp = matrix_http_client()
+            .get(format!("http://{addr}/redirect"))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), reqwest::StatusCode::TEMPORARY_REDIRECT);
     }
 
     #[test]

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -1468,12 +1468,8 @@ fn matrix_test_channel_config(
         if let Some(value) = non_empty_string_opt(channel.user_id.as_deref()) {
             config.user_id = Some(value);
         }
-        if let Some(value) = non_display_secret_string_opt(channel.access_token.as_deref()) {
-            config.access_token = Some(value);
-        }
-        if let Some(value) = non_display_secret_string_opt(channel.password.as_deref()) {
-            config.password = Some(value);
-        }
+        apply_matrix_draft_secret(&mut config.access_token, channel.access_token.as_deref());
+        apply_matrix_draft_secret(&mut config.password, channel.password.as_deref());
         if let Some(value) = non_empty_string_opt(channel.device_name.as_deref()) {
             config.device_name = Some(value);
         }
@@ -1521,15 +1517,19 @@ fn non_empty_string_opt(value: Option<&str>) -> Option<String> {
     value.and_then(non_empty_string)
 }
 
-fn non_display_secret_string_opt(value: Option<&str>) -> Option<String> {
-    value.and_then(|value| {
-        let trimmed = value.trim();
-        if trimmed.is_empty() || is_display_secret_value(trimmed) {
-            None
-        } else {
-            Some(trimmed.to_string())
-        }
-    })
+fn apply_matrix_draft_secret(target: &mut Option<String>, draft: Option<&str>) {
+    let Some(value) = draft else {
+        return;
+    };
+    let trimmed = value.trim();
+    if is_display_secret_value(trimmed) {
+        return;
+    }
+    if trimmed.is_empty() {
+        *target = None;
+    } else {
+        *target = Some(trimmed.to_string());
+    }
 }
 
 fn validate_matrix_user_id(user_id: &str) -> Result<(), (StatusCode, String)> {
@@ -1589,6 +1589,8 @@ fn matrix_percent_encode_path(s: &str) -> String {
     encoded
 }
 
+const MATRIX_ERROR_BODY_MAX_BYTES: usize = 2048;
+
 fn matrix_api_url(homeserver: &str, path: &str) -> String {
     format!("{}{}", homeserver.trim_end_matches('/'), path)
 }
@@ -1601,8 +1603,65 @@ fn matrix_api_url(homeserver: &str, path: &str) -> String {
 fn matrix_http_client() -> reqwest::Client {
     reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
+        .redirect(reqwest::redirect::Policy::none())
         .build()
-        .unwrap_or_else(|_| reqwest::Client::new())
+        .expect("failed to build Matrix HTTP client")
+}
+
+async fn matrix_error_body(resp: reqwest::Response) -> String {
+    let mut buf = Vec::new();
+    let mut truncated = resp
+        .content_length()
+        .map(|len| len > MATRIX_ERROR_BODY_MAX_BYTES as u64)
+        .unwrap_or(false);
+    let mut stream = resp.bytes_stream();
+
+    while let Some(chunk) = stream.next().await {
+        match chunk {
+            Ok(chunk) => {
+                if buf.len() + chunk.len() > MATRIX_ERROR_BODY_MAX_BYTES {
+                    let remaining = MATRIX_ERROR_BODY_MAX_BYTES.saturating_sub(buf.len());
+                    buf.extend_from_slice(&chunk[..remaining]);
+                    truncated = true;
+                    break;
+                }
+                buf.extend_from_slice(&chunk);
+            }
+            Err(_) => {
+                truncated = true;
+                break;
+            }
+        }
+    }
+
+    sanitize_matrix_error_body(&String::from_utf8_lossy(&buf), truncated)
+}
+
+fn sanitize_matrix_error_body(raw: &str, truncated: bool) -> String {
+    let mut out = String::new();
+    let mut last_space = false;
+    for ch in raw.chars() {
+        let ch = if ch.is_control() { ' ' } else { ch };
+        if ch.is_whitespace() {
+            if !last_space {
+                out.push(' ');
+                last_space = true;
+            }
+        } else {
+            out.push(ch);
+            last_space = false;
+        }
+    }
+
+    let mut out = out.trim().to_string();
+    if truncated {
+        if out.is_empty() {
+            out.push_str("[truncated]");
+        } else {
+            out.push_str(" ... [truncated]");
+        }
+    }
+    out
 }
 
 async fn resolve_matrix_login(
@@ -1619,7 +1678,7 @@ async fn resolve_matrix_login(
             .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
         if !resp.status().is_success() {
             let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
+            let body = matrix_error_body(resp).await;
             return Err((
                 StatusCode::BAD_GATEWAY,
                 format!("Matrix whoami failed (status={status}): {body}"),
@@ -1673,7 +1732,7 @@ async fn resolve_matrix_login(
         .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
     if !resp.status().is_success() {
         let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
+        let body = matrix_error_body(resp).await;
         return Err((StatusCode::BAD_GATEWAY, matrix_login_error(status, &body)));
     }
     let payload: serde_json::Value = resp
@@ -1769,7 +1828,7 @@ async fn matrix_join_room(
         .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
     if !resp.status().is_success() {
         let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
+        let body = matrix_error_body(resp).await;
         return Err((
             StatusCode::BAD_GATEWAY,
             format!("Matrix join room failed (status={status}): {body}"),
@@ -1798,7 +1857,7 @@ async fn matrix_leave_room(
         .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
     if !resp.status().is_success() {
         let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
+        let body = matrix_error_body(resp).await;
         return Err((
             StatusCode::BAD_GATEWAY,
             format!("Matrix reject invite failed (status={status}): {body}"),
@@ -1821,7 +1880,7 @@ async fn matrix_probe_sync(
         .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?;
     if !resp.status().is_success() {
         let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
+        let body = matrix_error_body(resp).await;
         return Err((
             StatusCode::BAD_GATEWAY,
             format!("Matrix sync probe failed (status={status}): {body}"),
@@ -3667,6 +3726,42 @@ mod tests {
     }
 
     #[test]
+    fn matrix_error_body_sanitizes_and_marks_truncation() {
+        let summary = sanitize_matrix_error_body("line1\nline2\t\u{0}secret", true);
+
+        assert_eq!(summary, "line1 line2 secret ... [truncated]");
+        assert!(!summary.contains('\n'));
+        assert!(!summary.contains('\t'));
+    }
+
+    #[tokio::test]
+    async fn matrix_http_client_does_not_follow_redirects() {
+        use axum::Router;
+        use axum::response::Redirect;
+        use axum::routing::get;
+
+        let app = Router::new()
+            .route(
+                "/redirect",
+                get(|| async { Redirect::temporary("/target") }),
+            )
+            .route("/target", get(|| async { "target" }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let resp = matrix_http_client()
+            .get(format!("http://{addr}/redirect"))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), reqwest::StatusCode::TEMPORARY_REDIRECT);
+    }
+
+    #[test]
     fn matrix_accept_adds_room_to_allowlist_once() {
         let mut profile = make_user_profile("matrix-user", "Matrix User");
         profile.config.channels.push(ChannelCredentials::Matrix {
@@ -3784,6 +3879,47 @@ mod tests {
         );
         assert_eq!(config.password.as_deref(), Some("real-password"));
         assert_eq!(config.device_name.as_deref(), Some("new-device"));
+    }
+
+    #[test]
+    fn matrix_test_config_empty_access_token_clears_saved_token() {
+        let mut profile = make_user_profile("matrix-user", "Matrix User");
+        profile.config.channels.push(ChannelCredentials::Matrix {
+            homeserver: "https://matrix.example.org".into(),
+            as_token: String::new(),
+            hs_token: String::new(),
+            server_name: String::new(),
+            sender_localpart: "octos".into(),
+            user_prefix: "octos_".into(),
+            port: 8009,
+            allowed_senders: Vec::new(),
+            mode: "user".into(),
+            user_id: "@bot:example.org".into(),
+            access_token: "syt_real_access_token".into(),
+            password: String::new(),
+            device_name: "old-device".into(),
+            rooms: Vec::new(),
+            auto_join: "off".into(),
+            auto_join_allowlist: Vec::new(),
+            group_policy: "allowlist".into(),
+            require_mention: true,
+        });
+
+        let request = MatrixTestConnectionRequest {
+            channel_index: Some(0),
+            channel: Some(MatrixTestChannelDraft {
+                mode: Some("user".into()),
+                homeserver: None,
+                user_id: None,
+                access_token: Some(String::new()),
+                password: Some("new-password".into()),
+                device_name: None,
+            }),
+        };
+
+        let config = matrix_test_channel_config(&profile, &request).unwrap();
+        assert_eq!(config.access_token, None);
+        assert_eq!(config.password.as_deref(), Some("new-password"));
     }
 
     #[test]

--- a/crates/octos-cli/src/commands/gateway/adapters/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/adapters/mod.rs
@@ -105,6 +105,9 @@ pub fn register_all(
     entries: &[ChannelEntry],
     ctx: &mut ChannelRegistrationCtx<'_>,
 ) -> eyre::Result<()> {
+    #[cfg(feature = "matrix")]
+    ensure_single_matrix_channel(entries)?;
+
     for (channel_index, entry) in entries.iter().enumerate() {
         // `channel_index` is only consumed by the matrix arm below.
         #[cfg(not(feature = "matrix"))]
@@ -164,4 +167,51 @@ pub fn register_all(
         }
     }
     Ok(())
+}
+
+#[cfg(feature = "matrix")]
+fn ensure_single_matrix_channel(entries: &[ChannelEntry]) -> eyre::Result<()> {
+    let mut first_index: Option<usize> = None;
+    for (idx, entry) in entries.iter().enumerate() {
+        if entry.channel_type != "matrix" {
+            continue;
+        }
+        if let Some(first) = first_index {
+            eyre::bail!(
+                "multiple Matrix channels are not supported yet; channel indexes {first} and {idx} share the same routing key"
+            );
+        }
+        first_index = Some(idx);
+    }
+    Ok(())
+}
+
+#[cfg(all(test, feature = "matrix"))]
+mod tests {
+    use super::*;
+
+    fn entry(channel_type: &str) -> ChannelEntry {
+        ChannelEntry {
+            channel_type: channel_type.to_string(),
+            allowed_senders: Vec::new(),
+            settings: serde_json::json!({}),
+        }
+    }
+
+    #[test]
+    fn rejects_multiple_matrix_channels_before_registration() {
+        let entries = vec![entry("cli"), entry("matrix"), entry("matrix")];
+
+        let err = ensure_single_matrix_channel(&entries).unwrap_err();
+
+        assert!(err.to_string().contains("multiple Matrix channels"));
+        assert!(err.to_string().contains("1 and 2"));
+    }
+
+    #[test]
+    fn allows_single_matrix_channel() {
+        let entries = vec![entry("cli"), entry("matrix")];
+
+        ensure_single_matrix_channel(&entries).unwrap();
+    }
 }


### PR DESCRIPTION
## Summary
- reject multiple configured Matrix channels before registration so they cannot overwrite each other in `ChannelManager`
- retry Matrix user-mode initial sync until a `next_batch` cursor is available before forwarding live traffic
- let Matrix connection tests treat an explicitly empty access token as a cleared token
- disable redirects for direct Matrix Client-Server requests and bound/sanitize reflected Matrix error bodies

## Root Cause
Matrix user-account support reused the shared `matrix` routing key while allowing multiple Matrix entries, continued after failed startup sync with no cursor, treated empty draft secrets as unchanged during connection tests, and used reqwest's default redirect-following behavior for user-supplied homeserver URLs.

## Validation
- `cargo test -p octos-bus --features matrix matrix_user_channel -- --nocapture`
- `cargo test -p octos-cli --features api,matrix matrix -- --nocapture`
- `cargo check -p octos-cli --lib --features matrix`
- `git diff --check`

Closes #1481