### PR TITLE
fix(voice): dual-emit projection envelope for voice message deltas (#1477 P2)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -18734,16 +18734,19 @@ async fn run_standalone_turn(
                             }
                             let visible = uf.push(t);
                             if !visible.is_empty() {
-                                let _ = send_notification_ephemeral(
-                                    &ws,
-                                    &ledger,
-                                    UiNotification::MessageDelta(MessageDeltaEvent {
-                                        session_id: session_id.clone(),
-                                        topic: None,
-                                        turn_id: turn_id.clone(),
-                                        text: visible,
-                                    }),
-                                );
+                                // #1477 P2: dual-emit the canonical envelope so
+                                // projection.envelope.v1 clients also receive the
+                                // voice delta — a bare ephemeral send is filtered
+                                // out for them. Mirrors forward_progress_event's
+                                // MessageDelta handling (emit envelope, then legacy).
+                                let delta = UiNotification::MessageDelta(MessageDeltaEvent {
+                                    session_id: session_id.clone(),
+                                    topic: None,
+                                    turn_id: turn_id.clone(),
+                                    text: visible,
+                                });
+                                emit_envelope_for_legacy_notification(&ledger, &session_id, &delta);
+                                let _ = send_notification_ephemeral(&ws, &ledger, delta);
                                 saw_delta = true;
                             }
                         }
@@ -18787,16 +18790,17 @@ async fn run_standalone_turn(
             if !interrupt_observed {
                 let recovered = uf.finish();
                 if !recovered.is_empty() {
-                    let _ = send_notification_ephemeral(
-                        &ws,
-                        &ledger,
-                        UiNotification::MessageDelta(MessageDeltaEvent {
-                            session_id: session_id.clone(),
-                            topic: None,
-                            turn_id: turn_id.clone(),
-                            text: recovered,
-                        }),
-                    );
+                    // #1477 P2: dual-emit the envelope (see the streaming path
+                    // above) so projection.envelope.v1 clients also get the
+                    // recovered tail delta.
+                    let delta = UiNotification::MessageDelta(MessageDeltaEvent {
+                        session_id: session_id.clone(),
+                        topic: None,
+                        turn_id: turn_id.clone(),
+                        text: recovered,
+                    });
+                    emit_envelope_for_legacy_notification(&ledger, &session_id, &delta);
+                    let _ = send_notification_ephemeral(&ws, &ledger, delta);
                 }
             }
         }


### PR DESCRIPTION
Targets @alan0x's #1477 branch so you keep ownership. Fixes the codex P2: voice deltas were direct-sent (filtered for `projection.envelope.v1` clients) — now dual-emit the envelope via `emit_envelope_for_legacy_notification` before the legacy send, in both the streaming token path and the recovered-tail flush path, mirroring `forward_progress_event`. No behavior change for legacy clients. Verified: octos-cli --features api → 1748 lib tests pass (voice_turn 33), build + api-test-compile clean. Merge this into your branch (or cherry-pick) and #1477 is good to land.