### PR TITLE
feat(api): carry the real per-model context window on cost updates

### DIFF
--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -483,12 +483,25 @@ impl Agent {
         } else {
             Some(metadata.model.clone())
         };
+        // Resolve the context window from the SAME slot that answered. For the
+        // active slot (`provider_index == None`) use the provider's configured
+        // window (honors any context override); for a failover/routed slot
+        // derive it from the model that actually answered, parallel to how
+        // `model` and `pricing` are resolved above — otherwise the gauge could
+        // report the right model with the primary slot's window.
+        let context_window = match response.provider_index {
+            Some(_) if !metadata.model.is_empty() => {
+                octos_llm::context::context_window_tokens(&metadata.model)
+            }
+            _ => self.llm.context_window(),
+        };
         self.reporter().report(ProgressEvent::CostUpdate {
             session_input_tokens: total_usage.input_tokens,
             session_output_tokens: total_usage.output_tokens,
             response_cost,
             session_cost,
             model,
+            context_window: Some(context_window),
         });
     }
 

--- a/crates/octos-agent/src/progress.rs
+++ b/crates/octos-agent/src/progress.rs
@@ -140,6 +140,10 @@ pub enum ProgressEvent {
         /// `None` when the reporter cannot resolve a model id (e.g.
         /// synthetic test fixtures).
         model: Option<String>,
+        /// Model context window in tokens, when the provider exposes it.
+        /// Lets clients render an honest ctx-fill gauge against the real
+        /// window instead of a hardcoded default.
+        context_window: Option<u32>,
     },
 }
 

--- a/crates/octos-cli/src/api/events.rs
+++ b/crates/octos-cli/src/api/events.rs
@@ -122,6 +122,7 @@ pub(crate) fn event_to_json(event: &ProgressEvent, thread_id: Option<&str>) -> s
             session_output_tokens,
             session_cost,
             model,
+            context_window,
             ..
         } => {
             // Always serialize the cost_update payload as an object so we
@@ -136,6 +137,11 @@ pub(crate) fn event_to_json(event: &ProgressEvent, thread_id: Option<&str>) -> s
             });
             if let Some(model) = model.as_deref() {
                 payload["model"] = serde_json::Value::String(model.to_string());
+            }
+            // Per-model context window so clients render an honest ctx gauge
+            // against the real window instead of a hardcoded default.
+            if let Some(window) = context_window {
+                payload["context_window"] = serde_json::json!(window);
             }
             payload
         }
@@ -309,6 +315,7 @@ mod tests {
             response_cost: Some(0.001),
             session_cost: Some(0.005),
             model: None,
+            context_window: None,
         };
         let json = event_to_json(&event, None);
         assert_eq!(json["type"], "cost_update");
@@ -329,6 +336,7 @@ mod tests {
             response_cost: None,
             session_cost: None,
             model: None,
+            context_window: None,
         };
         let json = event_to_json(&event, None);
         assert_eq!(json["type"], "cost_update");
@@ -347,10 +355,25 @@ mod tests {
             response_cost: None,
             session_cost: None,
             model: Some("deepseek-v4-pro".into()),
+            context_window: None,
         };
         let json = event_to_json(&event, None);
         assert_eq!(json["type"], "cost_update");
         assert_eq!(json["model"], "deepseek-v4-pro");
+    }
+
+    #[test]
+    fn event_to_json_cost_update_carries_context_window() {
+        let event = ProgressEvent::CostUpdate {
+            session_input_tokens: 1,
+            session_output_tokens: 1,
+            response_cost: None,
+            session_cost: None,
+            model: None,
+            context_window: Some(200_000),
+        };
+        let json = event_to_json(&event, None);
+        assert_eq!(json["context_window"], 200_000);
     }
 
     #[test]
@@ -427,6 +450,7 @@ mod tests {
                     response_cost: None,
                     session_cost: None,
                     model: None,
+                    context_window: None,
                 },
                 "cost_update",
             ),

--- a/crates/octos-cli/src/api/ui_protocol_progress.rs
+++ b/crates/octos-cli/src/api/ui_protocol_progress.rs
@@ -431,6 +431,9 @@ fn map_cost_update(context: &ProgressMappingContext, event: &Value) -> UiProgres
     // sniff `metadata.label` continue to work (we still emit the field
     // omitted when absent).
     update.model = string_field(event, &["model"]);
+    // Carry the model context window so clients render an honest ctx-fill
+    // gauge against the real window instead of a hardcoded default.
+    update.context_window = u64_field(event, &["context_window"]);
 
     let mut metadata = UiProgressMetadata::token_cost(update);
     metadata.message = string_field(event, &["message", "status"]);
@@ -894,6 +897,28 @@ mod tests {
             .token_cost
             .expect("token cost metadata");
         assert_eq!(cost.model.as_deref(), Some("deepseek-v4-pro"));
+    }
+
+    #[test]
+    fn ui_protocol_progress_cost_update_carries_context_window_into_token_cost_metadata() {
+        let mapping = map_progress_json(
+            &context(),
+            &json!({
+                "type": "cost_update",
+                "input_tokens": 120,
+                "output_tokens": 45,
+                "model": "deepseek-v4-pro",
+                "context_window": 131072
+            }),
+        );
+
+        let status = mapping.status.expect("cost status");
+        let cost = status
+            .event
+            .metadata
+            .token_cost
+            .expect("token cost metadata");
+        assert_eq!(cost.context_window, Some(131072));
     }
 
     #[test]

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -177,6 +177,7 @@ impl ProgressReporter for ChannelStreamReporter {
                 session_output_tokens,
                 session_cost,
                 model,
+                context_window,
                 ..
             } => {
                 // Codex round-1 P2: every wire-shape mapper for
@@ -194,6 +195,12 @@ impl ProgressReporter for ChannelStreamReporter {
                 });
                 if let Some(model) = model.as_deref() {
                     payload["model"] = serde_json::Value::String(model.to_string());
+                }
+                // Carry the context window too so channel/web clients on this
+                // path render an honest ctx gauge, matching the BoundedChannel
+                // (`event_to_json`) path.
+                if let Some(window) = context_window {
+                    payload["context_window"] = serde_json::json!(window);
                 }
                 inject_thread_id(&mut payload, thread_id);
                 StreamProgressEvent::RawSse {
@@ -968,6 +975,7 @@ mod tests {
             response_cost: None,
             session_cost: None,
             model: None,
+            context_window: None,
         });
 
         let mut raw_payloads: Vec<String> = Vec::new();
@@ -1016,6 +1024,7 @@ mod tests {
             response_cost: None,
             session_cost: None,
             model: Some("deepseek-v4-pro".into()),
+            context_window: None,
         });
 
         let StreamProgressEvent::RawSse { json } = rx.try_recv().unwrap() else {
@@ -1024,6 +1033,33 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed["type"], "cost_update");
         assert_eq!(parsed["model"], "deepseek-v4-pro");
+    }
+
+    /// The channel-stream path must also carry the model context window so
+    /// channel/web clients render an honest ctx gauge, matching the
+    /// BoundedChannel (`event_to_json`) path.
+    #[test]
+    fn cost_update_carries_context_window_into_raw_sse_payload() {
+        use octos_agent::progress::ProgressEvent;
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let reporter = ChannelStreamReporter::new(tx);
+
+        reporter.report(ProgressEvent::CostUpdate {
+            session_input_tokens: 12,
+            session_output_tokens: 7,
+            response_cost: None,
+            session_cost: None,
+            model: None,
+            context_window: Some(131_072),
+        });
+
+        let StreamProgressEvent::RawSse { json } = rx.try_recv().unwrap() else {
+            panic!("expected RawSse for CostUpdate");
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["type"], "cost_update");
+        assert_eq!(parsed["context_window"], 131_072);
     }
 
     /// Symmetric to the test above: a `CostUpdate` without `model`
@@ -1043,6 +1079,7 @@ mod tests {
             response_cost: None,
             session_cost: None,
             model: None,
+            context_window: None,
         });
 
         let StreamProgressEvent::RawSse { json } = rx.try_recv().unwrap() else {

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -4341,6 +4341,11 @@ pub struct UiTokenCostUpdate {
     /// scraping the legacy `metadata.label` field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    /// Model context window in tokens, when the provider exposes it. Lets
+    /// clients render an honest context-fill gauge against the real window
+    /// instead of a hardcoded default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<u64>,
 }
 
 impl UiTokenCostUpdate {
@@ -4356,6 +4361,7 @@ impl UiTokenCostUpdate {
             session_cost: None,
             currency: None,
             model: None,
+            context_window: None,
         }
     }
 }

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -1262,6 +1262,7 @@ mod tests {
                     response_cost: Some(0.0008),
                     session_cost: Some(0.0008),
                     model: Some("claude-sonnet".into()),
+                    context_window: None,
                 });
             })
             .await;


### PR DESCRIPTION
## Why
The octos-tui ctx gauge has no per-model context window to divide by, so it uses a hardcoded **128k** denominator — reading ~100% long before the model's real window fills. That also makes the existing `ContextCompactionCompleted` notice look like it *never fires*: compaction triggers off the model's **real** window (`appui_context_compact_threshold_tokens`), so at a gauge-100% that's really ~50% of a larger window, nothing has compacted yet.

## What
Carry the real window on the wire so clients can render an honest gauge:
- agent `ProgressEvent::CostUpdate` gains `context_window` (emitted from `LlmProvider::context_window()`).
- `event_to_json` adds it to the `cost_update` frame.
- `UiTokenCostUpdate` gains `context_window: Option<u64>`; `map_cost_update` extracts it → `metadata.token_cost.context_window`.

Additive + optional; clients without the field ignore it. **No new compaction mechanism** — the existing `ContextCompactionCompleted` notice already renders; this just makes the gauge honest so 100% coincides with compaction actually firing.

## Consumer
octos-tui PR (octos-org/octos-tui#TBD) consumes `metadata.token_cost.context_window` as the gauge denominator (falls back to 128k until the first cost update).

## Tests
- `event_to_json_cost_update_carries_context_window`
- `ui_protocol_progress_cost_update_carries_context_window_into_token_cost_metadata`
- octos-agent progress (29) + compaction (39) green; api test-compile green; fmt clean.
- clippy: zero findings in touched files (pre-existing workspace clippy debt is unchanged/out of scope).