### PR TITLE
feat(voice): exit intent — leave /voice on goodbye after farewell (UPCR-2026-025)

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -488,6 +488,16 @@ Voice rich-output visual lifecycle (#1477, ungated; accepted
   the placeholder lifecycle, so the split survives a future
   `projection.envelope.v1` cutover. See § 8.
 
+Voice exit intent (ungated; accepted `UPCR-2026-025`):
+
+- `voice/exit` — the voice turn detected an end / goodbye / mute intent
+  (the model appended an in-band `[[EXIT]]` control marker, which the
+  backend strips from every model-/client-facing surface). The client
+  leaves the `/voice` screen and returns home — after the turn's farewell
+  audio finishes playing (navigation is gated client-side on the reply
+  audio draining). Emitted on the same ledger-backed live path as
+  `file/attached`. See § 8.
+
 Router and queue (Wave4-A):
 
 - `router/status`, `router/failover`, `queue/state`
@@ -1743,6 +1753,24 @@ these events, NOT off `file/attached`. Payload fields:
   Emitted alongside `file/attached` on the success branch.
 - `visual/failed` — `session_id`, `turn_id` (required); optional `topic`
   and `reason` (failure/timeout/cancel detail).
+
+### `voice/exit`
+
+Typed voice-exit signal introduced by `UPCR-2026-025`. A voice turn may
+append an in-band `[[EXIT]]` control marker after a short spoken farewell
+when the user expresses an end / goodbye / mute intent; the backend strips
+it from every model-/client-facing surface (live `message/delta`, persisted
+`response.content`, assistant carriers) and instead emits this structured
+event, so the client never scrapes the marker out of the assistant text.
+Ungated and emitted on the same ledger-backed live path as `file/attached`
+(durable append → replayed on reconnect).
+
+The client uses it to leave the `/voice` screen and return home, but gates
+the actual navigation on its OWN reply-audio queue draining — so the spoken
+farewell is heard before the screen changes. The event is the trigger; the
+client owns the timing. Payload fields:
+
+- `voice/exit` — `session_id`, `turn_id` (required); optional `topic`.
 
 ### `session/event`
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -18366,7 +18366,10 @@ async fn run_standalone_turn(
              brief 是给生成器的一句话简述。\
              普通问答/闲聊/事实回答【不要】加标记。\
              示例1:用户说『我想直观看到负反馈电路如何负反馈』→ 口播『我给你画一个可调增益的负反馈电路,你可以拖滑块看输出怎么被拉回来。』,然后另起一行:[[VISUAL:html|可调增益的负反馈电路交互演示,滑块调增益,实时显示反馈如何稳定输出]]\
-             示例2:用户说『能结合图片讲讲人类细胞的结构吗』→ 口播『我给你画一张细胞结构图,点各个部分能看它们的作用。』,然后另起一行:[[VISUAL:illustrated|人类动物细胞结构写实插图,标注细胞核、线粒体、细胞膜、细胞质、内质网]]]"
+             示例2:用户说『能结合图片讲讲人类细胞的结构吗』→ 口播『我给你画一张细胞结构图,点各个部分能看它们的作用。』,然后另起一行:[[VISUAL:illustrated|人类动物细胞结构写实插图,标注细胞核、线粒体、细胞膜、细胞质、内质网]]\
+             \n退出意图:当用户明确想结束对话/离开/不聊了/再见/拜拜/静音/退出语音助手时——先用一句简短自然的话告别(如『好的,再见啦!』),然后【另起一行】只追加一个标记:[[EXIT]]。\
+             仅在用户确实想退出时才加;普通问答/闲聊/继续提问【绝对不要】加。\
+             示例:用户说『再见』或『退出吧』→ 口播『好的,再见!』,然后另起一行:[[EXIT]]]"
         );
         // The audio is now in the prompt as text. Drop it from the
         // agent-visible media so the model answers the transcript directly
@@ -18436,6 +18439,13 @@ async fn run_standalone_turn(
     // background dispatch. `None` for text turns or replies without a marker.
     let (visual_directive_tx, visual_directive_rx) =
         tokio::sync::oneshot::channel::<Option<crate::api::voice_turn::VisualDirective>>();
+    // Voice exit intent (UPCR-2026-025): the agent task lifts the trailing
+    // in-band `[[EXIT]]` marker out of `response.content` (stripping it from
+    // every authoritative surface) and signals here whether the user asked to
+    // leave. The post-turn block emits the typed `voice/exit` event so the
+    // client returns home after the farewell audio. `false` for text turns or
+    // replies without the marker.
+    let (exit_directive_tx, exit_directive_rx) = tokio::sync::oneshot::channel::<bool>();
     let agent_task = tokio::spawn(async move {
         let start = std::time::Instant::now();
         // RFC-3 (#1292): wrap the agent.process_message future in the
@@ -18516,6 +18526,20 @@ async fn run_standalone_turn(
                     None
                 };
                 let _ = visual_directive_tx.send(visual_directive);
+                // Voice exit intent (UPCR-2026-025): lift + strip the trailing
+                // `[[EXIT]]` marker the same way, BEFORE capture / persist / done,
+                // so it never reaches the wire or storage. The post-turn block
+                // emits the typed `voice/exit` event from this signal. Gated on
+                // voice turns; `false` without a real trailing marker.
+                let exit_requested = if had_audio_input {
+                    crate::api::voice_turn::strip_exit_directive(
+                        &mut response.content,
+                        &mut response.messages,
+                    )
+                } else {
+                    false
+                };
+                let _ = exit_directive_tx.send(exit_requested);
                 // #1134 — capture the LLM reply for the post-turn
                 // self-paced reschedule block. The receiver of this
                 // oneshot uses the captured content instead of
@@ -19586,6 +19610,20 @@ async fn run_standalone_turn(
     // marker). `final_response_content` is now the clean spoken reply (marker
     // already gone), so it doubles as the HTML author's "spoken_reply" context.
     let visual_directive = visual_directive_rx.await.ok().flatten();
+
+    // Voice exit intent (UPCR-2026-025): the agent task signalled whether the
+    // user asked to leave (the `[[EXIT]]` marker was lifted + stripped there).
+    // Emit the typed `voice/exit` so the client returns home from /voice — the
+    // client gates the actual navigation on its own reply-audio queue draining,
+    // so the farewell is heard first. No in-band marker is on the wire.
+    let exit_requested = exit_directive_rx.await.unwrap_or(false);
+    if had_audio_input && !interrupt_observed && exit_requested {
+        super::ui_protocol_alpha9_bridge::emit_voice_exit_from_background(
+            &ledger,
+            &session_id,
+            &turn_id,
+        );
+    }
 
     // Voice rich output: dispatch the in-band [[VISUAL]] directive.
     // HTML → a focused tool-less LLM call (rich_output); image-class → a

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -22877,6 +22877,7 @@ fn ledger_event_cursor(event: &UiProtocolLedgerEvent) -> Option<UiCursor> {
             | UiNotification::VisualGenerating(_)
             | UiNotification::VisualSucceeded(_)
             | UiNotification::VisualFailed(_)
+            | UiNotification::VoiceExit(_)
             | UiNotification::ToolStarted(_)
             | UiNotification::ToolProgress(_)
             | UiNotification::ToolCompleted(_)

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -18507,38 +18507,28 @@ async fn run_standalone_turn(
 
         match result {
             Ok(mut response) => {
-                // Voice rich output (#1477): lift the trailing in-band
-                // `[[VISUAL:...]]` directive out of the reply and strip it from
+                // Voice control markers: lift the trailing in-band
+                // `[[VISUAL:...]]` (#1477) and `[[EXIT]]` (UPCR-2026-025)
+                // directives out of the reply and strip them from
                 // `response.content` AND every Assistant carrier in
                 // `response.messages` BEFORE capture / persist / done, so the
                 // internal control protocol never reaches the wire
                 // (`message/delta` from `done`, `message/persisted`) or storage
-                // (session JSONL). The directive is dispatched post-turn from the
-                // oneshot below; the client learns a visual is coming from the
-                // typed `visual/generating` event. Gated on voice turns. No-op
-                // (returns `None`, mutates nothing) without a real trailing marker.
-                let visual_directive = if had_audio_input {
-                    crate::api::voice_turn::strip_visual_directive(
+                // (session JSONL). Stacked markers in either order are both
+                // peeled (review fix). The directives are dispatched post-turn
+                // from the oneshots below; the client learns a visual is coming
+                // from `visual/generating` and an exit from `voice/exit`. Gated
+                // on voice turns. No-op (returns `(None, false)`, mutates
+                // nothing) without a real trailing marker.
+                let (visual_directive, exit_requested) = if had_audio_input {
+                    crate::api::voice_turn::strip_control_directives(
                         &mut response.content,
                         &mut response.messages,
                     )
                 } else {
-                    None
+                    (None, false)
                 };
                 let _ = visual_directive_tx.send(visual_directive);
-                // Voice exit intent (UPCR-2026-025): lift + strip the trailing
-                // `[[EXIT]]` marker the same way, BEFORE capture / persist / done,
-                // so it never reaches the wire or storage. The post-turn block
-                // emits the typed `voice/exit` event from this signal. Gated on
-                // voice turns; `false` without a real trailing marker.
-                let exit_requested = if had_audio_input {
-                    crate::api::voice_turn::strip_exit_directive(
-                        &mut response.content,
-                        &mut response.messages,
-                    )
-                } else {
-                    false
-                };
                 let _ = exit_directive_tx.send(exit_requested);
                 // #1134 — capture the LLM reply for the post-turn
                 // self-paced reschedule block. The receiver of this
@@ -19613,17 +19603,13 @@ async fn run_standalone_turn(
 
     // Voice exit intent (UPCR-2026-025): the agent task signalled whether the
     // user asked to leave (the `[[EXIT]]` marker was lifted + stripped there).
-    // Emit the typed `voice/exit` so the client returns home from /voice — the
-    // client gates the actual navigation on its own reply-audio queue draining,
-    // so the farewell is heard first. No in-band marker is on the wire.
+    // Receive the flag now, but DEFER emitting `voice/exit` until AFTER the
+    // farewell reply audio has been attached (the streamed path above, or the
+    // whole-reply fallback synth below) — review fix: emitting here would let a
+    // no-sentence-boundary reply's `voice/exit` reach the client before its
+    // farewell `file/attached`, so the client could navigate away before the
+    // goodbye is heard, violating the "farewell first" contract.
     let exit_requested = exit_directive_rx.await.unwrap_or(false);
-    if had_audio_input && !interrupt_observed && exit_requested {
-        super::ui_protocol_alpha9_bridge::emit_voice_exit_from_background(
-            &ledger,
-            &session_id,
-            &turn_id,
-        );
-    }
 
     // Voice rich output: dispatch the in-band [[VISUAL]] directive.
     // HTML → a focused tool-less LLM call (rich_output); image-class → a
@@ -19922,6 +19908,21 @@ async fn run_standalone_turn(
                 tracing::info!(audio = %audio_path.display(), "voice_turn: synthesized reply audio");
             }
         }
+    }
+
+    // Voice exit intent (UPCR-2026-025): NOW that the farewell reply audio has
+    // been attached (streamed sentences awaited above, or the whole-reply
+    // fallback synth just above), emit the typed `voice/exit`. Emitting here —
+    // strictly AFTER the farewell `file/attached` — guarantees the client has
+    // the goodbye audio queued before it sees the exit signal, so it plays the
+    // farewell before leaving /voice (the events share the ordered ledger live
+    // path). No in-band marker is on the wire.
+    if had_audio_input && !interrupt_observed && exit_requested {
+        super::ui_protocol_alpha9_bridge::emit_voice_exit_from_background(
+            &ledger,
+            &session_id,
+            &turn_id,
+        );
     }
 
     // #1128 codex P1 re-review #2 — apply self-paced rescheduling

--- a/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
+++ b/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
@@ -49,7 +49,7 @@ use octos_core::SessionKey;
 use octos_core::ui_protocol::{
     FileAttachedEvent, SessionEventBridgedEvent, TurnCompletedEvent, TurnId, TurnSessionResult,
     TurnStartedEvent, UiNotification, VisualFailedEvent, VisualGeneratingEvent,
-    VisualSucceededEvent,
+    VisualSucceededEvent, VoiceExitEvent,
 };
 use serde_json::Value;
 
@@ -366,6 +366,26 @@ pub(super) fn emit_visual_failed_from_background(
         topic,
         turn_id: turn_id.clone(),
         reason,
+    }));
+}
+
+/// UPCR-2026-025 voice exit intent: announce that the voice turn detected an
+/// end / goodbye / mute intent, so the client leaves the `/voice` screen and
+/// returns home. The marker `[[EXIT]]` was already stripped from every
+/// model-/client-facing surface; this typed event is the sole signal. Routed on
+/// the BASE session key (like the visual lifecycle) while still carrying the
+/// topic so topic-scoped subscribers accept it.
+pub(super) fn emit_voice_exit_from_background(
+    ledger: &Arc<UiProtocolLedger>,
+    session_id: &SessionKey,
+    turn_id: &TurnId,
+) {
+    let topic = session_id.topic().map(ToOwned::to_owned);
+    let base_session = SessionKey(session_id.base_key().to_owned());
+    let _ = ledger.append_notification(UiNotification::VoiceExit(VoiceExitEvent {
+        session_id: base_session,
+        topic,
+        turn_id: turn_id.clone(),
     }));
 }
 

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -2214,6 +2214,7 @@ fn notification_session_id(notification: &UiNotification) -> &SessionKey {
         UiNotification::VisualGenerating(event) => &event.session_id,
         UiNotification::VisualSucceeded(event) => &event.session_id,
         UiNotification::VisualFailed(event) => &event.session_id,
+        UiNotification::VoiceExit(event) => &event.session_id,
         UiNotification::ToolStarted(event) => &event.session_id,
         UiNotification::ToolProgress(event) => &event.session_id,
         UiNotification::ToolCompleted(event) => &event.session_id,

--- a/crates/octos-cli/src/api/voice_turn.rs
+++ b/crates/octos-cli/src/api/voice_turn.rs
@@ -304,23 +304,53 @@ pub(crate) fn parse_visual_marker(reply: &str) -> Option<VisualDirective> {
     Some(VisualDirective { kind, brief })
 }
 
-/// The in-band marker opener. Streaming holds back only text that is — or could
-/// still grow into — this exact prefix, **not** any `[[`, so ordinary bracket
-/// notation (e.g. a `[[1]]` citation) never suppresses the rest of the TTS.
+/// The in-band visual marker opener. Streaming holds back only text that is —
+/// or could still grow into — this exact prefix, **not** any `[[`, so ordinary
+/// bracket notation (e.g. a `[[1]]` citation) never suppresses the rest of the
+/// TTS.
 const MARKER: &str = "[[VISUAL:";
 
+/// The in-band exit-intent marker (UPCR-2026-025). A fixed, self-contained
+/// trailing token the model appends after a farewell when the user wants to end
+/// / leave / mute. Held back from TTS and the `message/delta` wire exactly like
+/// [`MARKER`]; the actual exit decision is lifted off the final reply content
+/// via [`parse_exit_marker`] / [`strip_exit_directive`].
+const EXIT_MARKER: &str = "[[EXIT]]";
+
+/// Every in-band control marker held back from TTS / the delta wire. All share
+/// the `[[` opener; a trailing partial that could still grow into ANY of them is
+/// held back, and a full occurrence of any marks the start of the held region.
+/// Ordinary `[[…]]` notation (citations) matches none, so it is still spoken.
+const CONTROL_MARKERS: &[&str] = &[MARKER, EXIT_MARKER];
+
 /// Length in bytes of the longest suffix of `s` that is a non-empty prefix of
-/// [`MARKER`]. Those trailing chars are held back from TTS because the next
-/// streamed token might complete the marker. `MARKER` is ASCII, so any match is
-/// at a char boundary (safe to slice).
-fn marker_prefix_hold(s: &str) -> usize {
+/// `marker`. Both control markers are ASCII, so any match is at a char boundary
+/// (safe to slice).
+fn single_marker_prefix_hold(s: &str, marker: &str) -> usize {
     let sb = s.as_bytes();
-    let mb = MARKER.as_bytes();
+    let mb = marker.as_bytes();
     let max = mb.len().min(sb.len());
     (1..=max)
         .rev()
         .find(|&n| sb[sb.len() - n..] == mb[..n])
         .unwrap_or(0)
+}
+
+/// Length in bytes of the longest trailing partial that could still grow into
+/// ANY control marker — those chars are held back from TTS because the next
+/// streamed token might complete a marker.
+fn marker_prefix_hold(s: &str) -> usize {
+    CONTROL_MARKERS
+        .iter()
+        .map(|m| single_marker_prefix_hold(s, m))
+        .max()
+        .unwrap_or(0)
+}
+
+/// Earliest byte index in `s` of a fully-present control-marker opener (visual
+/// or exit), or `None`. Everything from that index onward is held back.
+fn find_control_marker(s: &str) -> Option<usize> {
+    CONTROL_MARKERS.iter().filter_map(|m| s.find(m)).min()
 }
 
 /// Sentence chunking: strong boundaries (。！？!?…；;\n) always split; commas /
@@ -380,12 +410,12 @@ impl VoiceReplySplitter {
         self.full.push_str(token);
         self.pending.push_str(token);
 
-        if let Some(idx) = self.pending.find(MARKER) {
-            // A full `[[VISUAL:` appeared — treat everything from it onward as
-            // the (trailing) marker region and hold it back. Emit the speakable
-            // text before it; keep the unfinished pre-marker tail + the held
-            // region in `pending` (recovered in `finish` if it turns out not to
-            // be a real trailing marker).
+        if let Some(idx) = find_control_marker(&self.pending) {
+            // A full control marker (`[[VISUAL:` or `[[EXIT]]`) appeared — treat
+            // everything from it onward as the (trailing) marker region and hold
+            // it back. Emit the speakable text before it; keep the unfinished
+            // pre-marker tail + the held region in `pending` (recovered in
+            // `finish` if it turns out not to be a real trailing marker).
             let mut head = self.pending[..idx].to_string();
             let rest = self.pending[idx..].to_string();
             let out = drain_sentences(&mut head);
@@ -411,12 +441,20 @@ impl VoiceReplySplitter {
     /// speech so nothing is lost to a mid-reply `[[` or stray partial.
     pub(crate) fn finish(self) -> (Option<String>, Option<VisualDirective>) {
         let directive = parse_visual_marker(&self.full);
-        let speak = if directive.is_some() {
-            strip_visual_marker(&self.pending)
-        } else {
-            self.pending.as_str()
+        // Drop whichever REAL trailing control marker(s) the full reply carries
+        // from the spoken tail, so neither reaches TTS. A held-back region that
+        // turned out NOT to be a real trailing marker (a rare mid-reply `[[`) is
+        // left intact and recovered as speech. The visual directive is returned
+        // for dispatch; the exit marker's decision is lifted separately off the
+        // final content (`strip_exit_directive`).
+        let mut speak: &str = self.pending.as_str();
+        if directive.is_some() {
+            speak = strip_visual_marker(speak);
         }
-        .trim();
+        if parse_exit_marker(&self.full) {
+            speak = strip_exit_marker(speak);
+        }
+        let speak = speak.trim();
         let tail = if speak.is_empty() {
             None
         } else {
@@ -433,6 +471,32 @@ impl VoiceReplySplitter {
 pub(crate) fn strip_visual_marker(reply: &str) -> &str {
     if parse_visual_marker(reply).is_some() {
         let i = reply.rfind("[[VISUAL:").expect("trailing marker present");
+        reply[..i].trim_end()
+    } else {
+        reply
+    }
+}
+
+/// Whether the model reply carries a TRAILING `[[EXIT]]` control marker
+/// (UPCR-2026-025). Trailing-only: the marker must end the right-trimmed reply,
+/// so a mid-reply mention / quote of the syntax never triggers an exit (mirrors
+/// [`parse_visual_marker`]).
+pub(crate) fn parse_exit_marker(reply: &str) -> bool {
+    let trimmed = reply.trim_end();
+    match trimmed.rfind(EXIT_MARKER) {
+        Some(start) => start + EXIT_MARKER.len() == trimmed.len(),
+        None => false,
+    }
+}
+
+/// Drop a trailing `[[EXIT]]` marker, returning the speakable prefix. Only a
+/// TRAILING marker is stripped (consistent with [`parse_exit_marker`]); a
+/// mid-reply mention is left intact.
+pub(crate) fn strip_exit_marker(reply: &str) -> &str {
+    if parse_exit_marker(reply) {
+        let i = reply
+            .rfind(EXIT_MARKER)
+            .expect("trailing exit marker present");
         reply[..i].trim_end()
     } else {
         reply
@@ -489,6 +553,31 @@ pub(crate) fn strip_visual_directive(
     Some(directive)
 }
 
+/// Lift the trailing `[[EXIT]]` control marker out of the turn's authoritative
+/// reply surfaces and strip it in place, so the internal control protocol never
+/// reaches the WIRE (`message/delta`, `message/persisted`) or STORAGE (session
+/// JSONL). Strips both `content` (the final `response.content`) and every
+/// Assistant carrier in `messages` whose trailing marker matches. Returns `true`
+/// when a real trailing marker was found and removed (the caller then emits the
+/// typed `voice/exit` event), or `false` (leaving everything intact) otherwise.
+/// Mirrors [`strip_visual_directive`]; the client learns to leave the voice
+/// screen from the typed `voice/exit` event, not from the marker text.
+pub(crate) fn strip_exit_directive(content: &mut String, messages: &mut [Message]) -> bool {
+    if !parse_exit_marker(content) {
+        return false;
+    }
+    *content = strip_exit_marker(content).to_string();
+    for message in messages.iter_mut() {
+        if message.role == MessageRole::Assistant {
+            let stripped = strip_exit_marker(&message.content);
+            if stripped.len() != message.content.len() {
+                message.content = stripped.to_string();
+            }
+        }
+    }
+    true
+}
+
 /// Byte length of the marker-free visible prefix of `full`: everything up to a
 /// (possibly mid-reply) `[[VISUAL:` occurrence, else everything minus a trailing
 /// partial that could still grow into the marker. Trailing whitespace before
@@ -496,7 +585,7 @@ pub(crate) fn strip_visual_directive(
 /// so the preceding newline would otherwise leak as a blank line. Cut points
 /// fall on char boundaries (`MARKER` is ASCII; `trim_end` is boundary-safe).
 fn visible_prefix_len(full: &str) -> usize {
-    let cut = match full.find(MARKER) {
+    let cut = match find_control_marker(full) {
         Some(i) => i,
         None => full.len() - marker_prefix_hold(full),
     };
@@ -538,14 +627,17 @@ impl VisibleDeltaFilter {
     }
 
     /// End of stream: returns any held-back text that turned out NOT to be a
-    /// real trailing marker (a rare mid-reply `[[VISUAL:` quote), so nothing is
-    /// lost. A real trailing marker yields `""` (stays off the wire).
+    /// real trailing marker (a rare mid-reply `[[VISUAL:` / `[[EXIT]]` quote), so
+    /// nothing is lost. A real trailing control marker (visual or exit) yields
+    /// `""` for that span (stays off the wire).
     pub(crate) fn finish(self) -> String {
-        let visible = if parse_visual_marker(&self.full).is_some() {
-            strip_visual_marker(&self.full).len()
-        } else {
-            self.full.len()
-        };
+        let mut visible = self.full.len();
+        if parse_visual_marker(&self.full).is_some() {
+            visible = visible.min(strip_visual_marker(&self.full).len());
+        }
+        if parse_exit_marker(&self.full) {
+            visible = visible.min(strip_exit_marker(&self.full).len());
+        }
         if visible > self.emitted {
             self.full[self.emitted..visible].to_string()
         } else {
@@ -1407,5 +1499,121 @@ mod tests {
             remove_all_visual_markers("abc [[VISUAL:html|没闭合"),
             "abc "
         );
+    }
+
+    // ── voice exit intent (UPCR-2026-025) ─────────────────────────────────
+
+    #[test]
+    fn parse_exit_marker_requires_trailing_position() {
+        // Trailing marker (with trailing whitespace / newline) is accepted.
+        assert!(parse_exit_marker("好的，再见啦！\n[[EXIT]]"));
+        assert!(parse_exit_marker("拜拜。[[EXIT]]  \n"));
+        // A mid-reply mention / quote must NOT trigger an exit.
+        assert!(!parse_exit_marker("我说 [[EXIT]] 只是举个例子，然后继续。"));
+        // Absent.
+        assert!(!parse_exit_marker("普通口播回复，没有标记。"));
+    }
+
+    #[test]
+    fn strip_exit_marker_only_strips_trailing() {
+        assert_eq!(strip_exit_marker("再见啦。\n[[EXIT]]"), "再见啦。");
+        // Mid-reply mention is left intact (not truncated).
+        let mid = "用 [[EXIT]] 举例，然后继续。";
+        assert_eq!(strip_exit_marker(mid), mid);
+        // No marker → unchanged.
+        assert_eq!(strip_exit_marker("纯口播没有标记"), "纯口播没有标记");
+    }
+
+    #[test]
+    fn strip_exit_directive_strips_content_and_assistant_carriers() {
+        let mut content = "好的，再见！\n[[EXIT]]".to_string();
+        let mut messages = vec![
+            Message::user("再见".to_string()),
+            Message::assistant("好的，再见！\n[[EXIT]]".to_string()),
+        ];
+        assert!(strip_exit_directive(&mut content, &mut messages));
+        assert_eq!(content, "好的，再见！");
+        assert_eq!(messages[1].content, "好的，再见！");
+        assert_eq!(messages[0].content, "再见");
+    }
+
+    #[test]
+    fn strip_exit_directive_noop_without_trailing_marker() {
+        let mut content = "用 [[EXIT]] 举例。".to_string();
+        let mut messages = vec![Message::assistant(content.clone())];
+        assert!(!strip_exit_directive(&mut content, &mut messages));
+        assert!(content.contains("[[EXIT]]"));
+    }
+
+    #[test]
+    fn splitter_holds_back_exit_marker_from_tts_even_when_token_split() {
+        let mut sp = VoiceReplySplitter::new();
+        let mut spoken = String::new();
+        // The exit marker streams in as several chunks; none may leak to TTS.
+        for tok in ["好的，", "再见啦！\n", "[[EX", "IT]]"] {
+            for s in sp.push(tok) {
+                spoken.push_str(&s);
+                spoken.push('\n');
+            }
+        }
+        let (tail, directive) = sp.finish();
+        if let Some(t) = tail {
+            spoken.push_str(&t);
+        }
+        assert!(spoken.contains("再见啦"));
+        assert!(
+            !spoken.contains("EXIT"),
+            "marker must never reach TTS: {spoken:?}"
+        );
+        assert!(!spoken.contains("[["), "no bracket leak: {spoken:?}");
+        // The splitter returns no visual directive for an exit-only reply.
+        assert!(directive.is_none());
+    }
+
+    #[test]
+    fn visible_delta_filter_hides_trailing_exit_marker() {
+        let mut f = VisibleDeltaFilter::new();
+        let mut seen = String::new();
+        for tok in ["再见", "啦。", "\n[[EX", "IT]]"] {
+            seen.push_str(&f.push(tok));
+        }
+        seen.push_str(&f.finish());
+        assert_eq!(seen, "再见啦。");
+    }
+
+    #[test]
+    fn visible_delta_filter_recovers_false_exit_marker_on_finish() {
+        // A mid-reply `[[EXIT]]` quote is NOT a trailing marker → recovered.
+        let mut f = VisibleDeltaFilter::new();
+        let mut seen = String::new();
+        for tok in ["用 ", "[[EXIT]]", " 举例。"] {
+            seen.push_str(&f.push(tok));
+        }
+        seen.push_str(&f.finish());
+        assert_eq!(seen, "用 [[EXIT]] 举例。");
+    }
+
+    #[test]
+    fn ordinary_double_bracket_still_reaches_tts_with_exit_marker_added() {
+        // Regression: generalizing the hold-back to the control-marker SET must
+        // not suppress ordinary `[[1]]` citations — they are a prefix of neither
+        // `[[VISUAL:` nor `[[EXIT]]` past the shared `[[`.
+        let mut sp = VoiceReplySplitter::new();
+        let mut spoken = String::new();
+        for tok in ["看这个 [[1]] 参考。", "后面还有内容。"] {
+            for s in sp.push(tok) {
+                spoken.push_str(&s);
+            }
+        }
+        let (tail, _directive) = sp.finish();
+        if let Some(t) = tail {
+            spoken.push_str(&t);
+        }
+        assert!(spoken.contains("看这个"));
+        assert!(
+            spoken.contains("[[1]]"),
+            "citation must still be spoken: {spoken:?}"
+        );
+        assert!(spoken.contains("后面还有内容"));
     }
 }

--- a/crates/octos-cli/src/api/voice_turn.rs
+++ b/crates/octos-cli/src/api/voice_turn.rs
@@ -441,18 +441,24 @@ impl VoiceReplySplitter {
     /// speech so nothing is lost to a mid-reply `[[` or stray partial.
     pub(crate) fn finish(self) -> (Option<String>, Option<VisualDirective>) {
         let directive = parse_visual_marker(&self.full);
-        // Drop whichever REAL trailing control marker(s) the full reply carries
-        // from the spoken tail, so neither reaches TTS. A held-back region that
-        // turned out NOT to be a real trailing marker (a rare mid-reply `[[`) is
-        // left intact and recovered as speech. The visual directive is returned
-        // for dispatch; the exit marker's decision is lifted separately off the
-        // final content (`strip_exit_directive`).
+        // Drop ALL real trailing control markers (visual and/or exit, in either
+        // order) from the spoken tail so neither reaches TTS — a stacked
+        // `…[[VISUAL:…]][[EXIT]]` must peel both. A held-back region that turned
+        // out NOT to be a real trailing marker (a rare mid-reply `[[`) is left
+        // intact and recovered as speech. The visual directive is returned for
+        // dispatch; the exit decision is lifted separately off the final content
+        // (`strip_control_directives`).
         let mut speak: &str = self.pending.as_str();
-        if directive.is_some() {
-            speak = strip_visual_marker(speak);
-        }
-        if parse_exit_marker(&self.full) {
-            speak = strip_exit_marker(speak);
+        loop {
+            if parse_visual_marker(speak).is_some() {
+                speak = strip_visual_marker(speak);
+                continue;
+            }
+            if parse_exit_marker(speak) {
+                speak = strip_exit_marker(speak);
+                continue;
+            }
+            break;
         }
         let speak = speak.trim();
         let tail = if speak.is_empty() {
@@ -578,6 +584,38 @@ pub(crate) fn strip_exit_directive(content: &mut String, messages: &mut [Message
     true
 }
 
+/// Strip STACKED trailing control markers ([[VISUAL:...]] and/or [[EXIT]]) from
+/// the turn's authoritative reply surfaces in EITHER order, returning the parsed
+/// visual directive (if any) and whether an exit was requested.
+///
+/// A reply may end with both markers (e.g. `…[[VISUAL:…]][[EXIT]]`): stripping
+/// only the outermost would leave the inner one trailing on the wire
+/// (`message/delta`, `message/persisted`) and in storage (session JSONL), and —
+/// for the visual case — never dispatch it. So this loops, peeling whichever
+/// marker is currently trailing, until neither is. Reuses (and supersedes on the
+/// turn path) the per-marker [`strip_visual_directive`] / [`strip_exit_directive`].
+pub(crate) fn strip_control_directives(
+    content: &mut String,
+    messages: &mut [Message],
+) -> (Option<VisualDirective>, bool) {
+    let mut directive = None;
+    let mut exit = false;
+    loop {
+        if let Some(d) = strip_visual_directive(content, messages) {
+            if directive.is_none() {
+                directive = Some(d);
+            }
+            continue;
+        }
+        if strip_exit_directive(content, messages) {
+            exit = true;
+            continue;
+        }
+        break;
+    }
+    (directive, exit)
+}
+
 /// Byte length of the marker-free visible prefix of `full`: everything up to a
 /// (possibly mid-reply) `[[VISUAL:` occurrence, else everything minus a trailing
 /// partial that could still grow into the marker. Trailing whitespace before
@@ -631,13 +669,22 @@ impl VisibleDeltaFilter {
     /// nothing is lost. A real trailing control marker (visual or exit) yields
     /// `""` for that span (stays off the wire).
     pub(crate) fn finish(self) -> String {
-        let mut visible = self.full.len();
-        if parse_visual_marker(&self.full).is_some() {
-            visible = visible.min(strip_visual_marker(&self.full).len());
+        // Peel ALL real trailing control markers (visual and/or exit, in either
+        // order) so a stacked `…[[VISUAL:…]][[EXIT]]` never leaks the inner one
+        // onto the `message/delta` wire.
+        let mut clean: &str = self.full.as_str();
+        loop {
+            if parse_visual_marker(clean).is_some() {
+                clean = strip_visual_marker(clean);
+                continue;
+            }
+            if parse_exit_marker(clean) {
+                clean = strip_exit_marker(clean);
+                continue;
+            }
+            break;
         }
-        if parse_exit_marker(&self.full) {
-            visible = visible.min(strip_exit_marker(&self.full).len());
-        }
+        let visible = clean.len();
         if visible > self.emitted {
             self.full[self.emitted..visible].to_string()
         } else {
@@ -1615,5 +1662,96 @@ mod tests {
             "citation must still be spoken: {spoken:?}"
         );
         assert!(spoken.contains("后面还有内容"));
+    }
+
+    // ── stacked control markers (review fix: visual + exit, either order) ──
+
+    #[test]
+    fn strip_control_directives_handles_visual_then_exit() {
+        // `…[[VISUAL:…]][[EXIT]]` — peeling only the outer EXIT would leave the
+        // visual marker trailing in content/messages. The combined strip must
+        // return the visual directive AND exit=true, leaving the text clean.
+        let mut content = "好的，给你画一个，再见！\n[[VISUAL:html|电路]]\n[[EXIT]]".to_string();
+        let mut messages = vec![
+            Message::user("画个电路然后再见".to_string()),
+            Message::assistant(
+                "好的，给你画一个，再见！\n[[VISUAL:html|电路]]\n[[EXIT]]".to_string(),
+            ),
+        ];
+        let (directive, exit) = strip_control_directives(&mut content, &mut messages);
+        assert_eq!(directive.as_ref().map(|d| d.kind), Some(VisualKind::Html));
+        assert!(exit);
+        assert_eq!(content, "好的，给你画一个，再见！");
+        assert_eq!(messages[1].content, "好的，给你画一个，再见！");
+        assert!(!content.contains("[["), "no marker may leak: {content:?}");
+    }
+
+    #[test]
+    fn strip_control_directives_handles_exit_then_visual() {
+        // Reverse order: `…[[EXIT]][[VISUAL:…]]`. Order-independent.
+        let mut content = "再见！\n[[EXIT]]\n[[VISUAL:image|一只猫]]".to_string();
+        let mut messages = vec![Message::assistant(
+            "再见！\n[[EXIT]]\n[[VISUAL:image|一只猫]]".to_string(),
+        )];
+        let (directive, exit) = strip_control_directives(&mut content, &mut messages);
+        assert_eq!(directive.as_ref().map(|d| d.kind), Some(VisualKind::Image));
+        assert!(exit);
+        assert_eq!(content, "再见！");
+        assert!(!content.contains("[["));
+    }
+
+    #[test]
+    fn strip_control_directives_single_markers_and_none() {
+        // Exit only.
+        let mut c = "再见！\n[[EXIT]]".to_string();
+        let (d, e) = strip_control_directives(&mut c, &mut []);
+        assert!(d.is_none() && e);
+        assert_eq!(c, "再见！");
+        // Visual only.
+        let mut c = "看图。\n[[VISUAL:html|电路]]".to_string();
+        let (d, e) = strip_control_directives(&mut c, &mut []);
+        assert_eq!(d.map(|d| d.kind), Some(VisualKind::Html));
+        assert!(!e);
+        assert_eq!(c, "看图。");
+        // Neither.
+        let mut c = "普通回复。".to_string();
+        let (d, e) = strip_control_directives(&mut c, &mut []);
+        assert!(d.is_none() && !e);
+        assert_eq!(c, "普通回复。");
+    }
+
+    #[test]
+    fn splitter_holds_back_stacked_visual_and_exit_markers() {
+        // Neither marker may reach TTS when both trail the reply.
+        let mut sp = VoiceReplySplitter::new();
+        let mut spoken = String::new();
+        for tok in ["好的，再见！\n", "[[VISUAL:html|电路]]", "\n[[EXIT]]"] {
+            for s in sp.push(tok) {
+                spoken.push_str(&s);
+                spoken.push('\n');
+            }
+        }
+        let (tail, _directive) = sp.finish();
+        if let Some(t) = tail {
+            spoken.push_str(&t);
+        }
+        assert!(spoken.contains("再见"));
+        assert!(
+            !spoken.contains("VISUAL"),
+            "visual leaked to TTS: {spoken:?}"
+        );
+        assert!(!spoken.contains("EXIT"), "exit leaked to TTS: {spoken:?}");
+        assert!(!spoken.contains("[["), "no bracket leak: {spoken:?}");
+    }
+
+    #[test]
+    fn visible_delta_filter_hides_stacked_visual_and_exit_markers() {
+        let mut f = VisibleDeltaFilter::new();
+        let mut seen = String::new();
+        for tok in ["好的，再见！", "\n[[VISUAL:html|电路]]", "\n[[EXIT]]"] {
+            seen.push_str(&f.push(tok));
+        }
+        seen.push_str(&f.finish());
+        assert_eq!(seen, "好的，再见！");
     }
 }

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -1059,6 +1059,14 @@ pub mod methods {
     /// #1477 voice rich output — the background visual task failed or timed
     /// out, so the client should clear the "generating" placeholder.
     pub const VISUAL_FAILED: &str = "visual/failed";
+    /// UPCR-2026-025 voice exit intent — the voice turn detected an end /
+    /// goodbye / mute intent (the model appended an in-band `[[EXIT]]` control
+    /// marker, which the backend strips from every model-/client-facing surface
+    /// and replaces with this typed event). The client uses it to leave the
+    /// `/voice` screen and return home AFTER the turn's farewell audio finishes
+    /// playing — it must NOT navigate before the reply audio drains. Ungated;
+    /// emitted on the same ledger-backed live path as `file/attached`.
+    pub const VOICE_EXIT: &str = "voice/exit";
     /// UPCR-2026-014 (M9-γ) `projection/envelope` — canonical projection
     /// envelope notification (spec § 14). γ-1 reserves the method name
     /// in the notification methods list as part of capability negotiation
@@ -1238,6 +1246,7 @@ pub const UI_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &[
     methods::VISUAL_GENERATING,
     methods::VISUAL_SUCCEEDED,
     methods::VISUAL_FAILED,
+    methods::VOICE_EXIT,
     methods::PROJECTION_ENVELOPE,
     methods::SESSION_EVENT,
     methods::ROUTER_STATUS,
@@ -4587,6 +4596,21 @@ pub struct VisualFailedEvent {
     pub reason: Option<String>,
 }
 
+/// UPCR-2026-025 voice exit intent: the voice turn detected an end / goodbye /
+/// mute intent. The model appended an in-band `[[EXIT]]` control marker; the
+/// backend strips it from every model-/client-facing surface (so it never
+/// reaches TTS, the `message/delta` wire, or the persisted session) and emits
+/// this typed event instead. The client leaves the `/voice` screen and returns
+/// home — but only AFTER the turn's farewell audio finishes playing, so the
+/// goodbye is heard before navigation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VoiceExitEvent {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+    pub turn_id: TurnId,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolStartedEvent {
     pub session_id: SessionKey,
@@ -5544,6 +5568,9 @@ pub enum UiNotification {
     VisualSucceeded(VisualSucceededEvent),
     /// #1477 voice rich output: a background visual task failed / timed out.
     VisualFailed(VisualFailedEvent),
+    /// UPCR-2026-025 voice exit intent: the voice turn detected an end /
+    /// goodbye / mute intent; the client returns home after the farewell audio.
+    VoiceExit(VoiceExitEvent),
     ToolStarted(ToolStartedEvent),
     ToolProgress(ToolProgressEvent),
     ToolCompleted(ToolCompletedEvent),
@@ -5641,6 +5668,7 @@ impl UiNotification {
             Self::VisualGenerating(_) => methods::VISUAL_GENERATING,
             Self::VisualSucceeded(_) => methods::VISUAL_SUCCEEDED,
             Self::VisualFailed(_) => methods::VISUAL_FAILED,
+            Self::VoiceExit(_) => methods::VOICE_EXIT,
             Self::ToolStarted(_) => methods::TOOL_STARTED,
             Self::ToolProgress(_) => methods::TOOL_PROGRESS,
             Self::ToolCompleted(_) => methods::TOOL_COMPLETED,
@@ -5686,6 +5714,7 @@ impl UiNotification {
             Self::VisualGenerating(event) => &event.session_id,
             Self::VisualSucceeded(event) => &event.session_id,
             Self::VisualFailed(event) => &event.session_id,
+            Self::VoiceExit(event) => &event.session_id,
             Self::ToolStarted(event) => &event.session_id,
             Self::ToolProgress(event) => &event.session_id,
             Self::ToolCompleted(event) => &event.session_id,
@@ -5735,6 +5764,7 @@ impl UiNotification {
             Self::VisualSucceeded(event) => {
                 event.topic.as_deref().or_else(|| event.session_id.topic())
             }
+            Self::VoiceExit(event) => event.topic.as_deref().or_else(|| event.session_id.topic()),
             Self::VisualFailed(event) => {
                 event.topic.as_deref().or_else(|| event.session_id.topic())
             }
@@ -5795,6 +5825,7 @@ impl UiNotification {
             Self::VisualGenerating(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::VisualSucceeded(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::VisualFailed(event) => set_topic_if_absent(&mut event.topic, &topic),
+            Self::VoiceExit(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::ToolStarted(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::ToolProgress(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::ToolCompleted(event) => set_topic_if_absent(&mut event.topic, &topic),
@@ -5826,6 +5857,7 @@ impl UiNotification {
             Self::VisualGenerating(params) => serde_json::to_value(params),
             Self::VisualSucceeded(params) => serde_json::to_value(params),
             Self::VisualFailed(params) => serde_json::to_value(params),
+            Self::VoiceExit(params) => serde_json::to_value(params),
             Self::ToolStarted(params) => serde_json::to_value(params),
             Self::ToolProgress(params) => serde_json::to_value(params),
             Self::ToolCompleted(params) => serde_json::to_value(params),
@@ -5926,6 +5958,7 @@ impl UiNotification {
             }
             methods::VISUAL_SUCCEEDED => Ok(Self::VisualSucceeded(decode_params(method, params)?)),
             methods::VISUAL_FAILED => Ok(Self::VisualFailed(decode_params(method, params)?)),
+            methods::VOICE_EXIT => Ok(Self::VoiceExit(decode_params(method, params)?)),
             methods::TOOL_STARTED => Ok(Self::ToolStarted(decode_params(method, params)?)),
             methods::TOOL_PROGRESS => Ok(Self::ToolProgress(decode_params(method, params)?)),
             methods::TOOL_COMPLETED => Ok(Self::ToolCompleted(decode_params(method, params)?)),
@@ -6745,6 +6778,7 @@ mod tests {
                 "visual/generating",
                 "visual/succeeded",
                 "visual/failed",
+                "voice/exit",
                 "projection/envelope",
                 "session/event",
                 "router/status",
@@ -6914,6 +6948,7 @@ mod tests {
                     "visual/generating",
                     "visual/succeeded",
                     "visual/failed",
+                    "voice/exit",
                     "projection/envelope",
                     "session/event",
                     "router/status",
@@ -7561,6 +7596,31 @@ mod tests {
         assert_eq!(wire.params["reason"], json!("timed out"));
         let decoded = UiNotification::from_rpc_notification(wire).expect("decode visual/failed");
         assert_eq!(decoded, failed);
+    }
+
+    #[test]
+    fn voice_exit_wire_contract() {
+        // UPCR-2026-025: the typed exit notification carries session_id + turn_id
+        // (and an optional topic); it round-trips intact and the topic is stamped
+        // from a topic-scoped session key, mirroring the visual/* lifecycle.
+        let exit = UiNotification::VoiceExit(VoiceExitEvent {
+            session_id: SessionKey("local:voice#exit".into()),
+            topic: None,
+            turn_id: TurnId(Uuid::from_u128(42)),
+        });
+        assert_eq!(exit.method(), methods::VOICE_EXIT);
+        let wire = exit
+            .clone()
+            .into_rpc_notification()
+            .expect("serialize voice/exit");
+        assert_eq!(wire.method, methods::VOICE_EXIT);
+        // Topic is stamped from the `#exit` suffix of the session key on the wire.
+        assert_eq!(wire.params["topic"], json!("exit"));
+        let decoded = UiNotification::from_rpc_notification(wire).expect("decode voice/exit");
+        // Equality holds after the topic was stamped from the session key.
+        assert_eq!(decoded.method(), methods::VOICE_EXIT);
+        assert_eq!(decoded.session_id().0, "local:voice#exit");
+        assert_eq!(decoded.topic(), Some("exit"));
     }
 
     #[test]

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_025_VOICE_EXIT.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_025_VOICE_EXIT.md
@@ -1,0 +1,101 @@
+# UPCR-2026-025: Voice Exit Intent
+
+Status: accepted
+Date: 2026-06-23
+PR: TBD
+
+## Summary
+
+Let a voice turn end the voice-assistant session when the user expresses an
+end / goodbye / mute intent ("再见", "退出", "拜拜", "静音", "goodbye", …), so the
+client leaves the `/voice` screen and returns home — after the turn's farewell
+audio finishes playing.
+
+The model appends a trailing `[[EXIT]]` control marker after a short spoken
+farewell — **no tool call**, mirroring the `[[VISUAL:kind|brief]]` rich-output
+marker (UPCR-2026-024). The marker is an internal control protocol: the backend
+strips it from every model-/client-facing surface (live `message/delta`,
+persisted `response.content`, assistant carriers) so it never reaches TTS, the
+wire, or a later prompt. In its place the server emits one structured
+notification: `voice/exit`.
+
+## Decision
+
+Do add one server→client notification — `voice/exit` — carrying the turn-scoped
+signal that the voice session should end.
+
+Do let the **client** own the timing of the actual navigation: it leaves
+`/voice` only AFTER its reply-audio queue drains, so the spoken farewell is heard
+before the screen changes. The event is the trigger; the client gates the
+transition on its own playback state.
+
+Do emit the event on the same ledger-backed live path as `file/attached`
+(durable append → replayed on reconnect).
+
+Do NOT add a client→server command, a new `TurnState` variant, or a
+model-visible tool. The intent is recognised by the model via the in-band
+marker; the client only observes the typed event.
+
+Do NOT leak the `[[EXIT]]` marker onto any model- or client-facing surface.
+
+## Capabilities
+
+None. The notification is **ungated** — it is a member of
+`UI_PROTOCOL_NOTIFICATION_METHODS` and is advertised in `supported_methods` for
+every server slice. A client that does not understand it ignores it
+(unknown-notification tolerance); the spoken farewell is unaffected, the user
+simply stays on `/voice`.
+
+## AppUI Surface
+
+Defined in the v1 spec § 6 (catalog) and § 8 (event semantics).
+
+### `voice/exit` (event)
+
+The voice turn detected an end / goodbye / mute intent; the client returns home
+from `/voice` after the farewell audio finishes. Fields:
+
+- `session_id`, `turn_id` — required turn-scoping.
+- `topic` — optional sub-topic routing key.
+
+## Detection & stripping
+
+- Voice-turn system prompt instructs the model to reply with one short farewell
+  then append `[[EXIT]]` on its own trailing line — and only when the user truly
+  wants to leave (never for ordinary Q&A / chat).
+- `parse_exit_marker` accepts the marker only in TRAILING position, so a
+  mid-reply mention / quote of the syntax never triggers an exit.
+- `strip_exit_directive` lifts + removes the marker from `response.content` and
+  every Assistant carrier in `response.messages` before capture / persist / done.
+- The streaming `VoiceReplySplitter` (TTS) and `VisibleDeltaFilter`
+  (`message/delta`) hold back `[[EXIT]]` as part of the control-marker SET it
+  shares with `[[VISUAL:` — ordinary `[[…]]` notation (citations) is still
+  spoken.
+
+## Compatibility
+
+Backward-compatible. One new notification method + optional field only; no
+command or existing-event change. The event is decoupled from `file/attached`
+and `turn/completed`, so the `projection.envelope.v1` cutover (UPCR-2026-014
+γ-2) can drop the legacy notifications without disturbing the exit signal.
+
+## Tests
+
+- `crates/octos-core/src/ui_protocol.rs` — `voice/exit` method registration,
+  round-trip encode/decode, topic-propagation, and `UI_PROTOCOL_NOTIFICATION_METHODS`
+  membership.
+- `--features api` `voice_turn` tests — `[[EXIT]]` parse/strip across the live
+  delta and persist surfaces, splitter/filter hold-back (incl. token-split and
+  false mid-reply marker recovery), and the regression that ordinary `[[1]]`
+  citations still reach TTS (the module is feature-gated; the default
+  `--workspace` test does not compile it).
+
+## References
+
+- v1 spec § 6 (catalog), § 8 (`voice/exit`).
+- `UI_PROTOCOL_NOTIFICATION_METHODS` + `methods::VOICE_EXIT` in
+  `crates/octos-core/src/ui_protocol.rs`.
+- UPCR-2026-024 (voice rich-output visual lifecycle) — the in-band-marker +
+  typed-event pattern this change mirrors.
+- Frontend: octos-web `feat/voice-exit-intent` (`voice/exit` → `crew:voice_exit`
+  DOM event → voice hook navigates home after audio drains).


### PR DESCRIPTION
## What & why

Adds an exit mechanism to the voice assistant: when the user expresses an end / goodbye / mute intent ("退出 / 再见 / 静音 / 不聊了", "goodbye", …), the assistant says a short farewell and the frontend returns from `/voice` to the home page.

Reuses the existing `[[VISUAL:...]]` rich-output pattern (UPCR-2026-024) — in-band marker → backend strips it → typed event: the model appends an `[[EXIT]]` control marker after the farewell, the backend strips it from every model-/client-facing surface (never reaches TTS, the wire, or storage) and instead emits a typed `voice/exit` notification. The client uses it to navigate away **after the farewell audio finishes playing**.

> Companion frontend PR: octos-org/octos-web#240

## Protocol (UPCR-2026-025)

New server→client notification `voice/exit { session_id, turn_id, topic? }`, ungated, emitted on the same ledger-backed live path as `file/attached`.

- `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` §6 catalog + §8 event semantics
- `docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_025_VOICE_EXIT.md`
- `octos-core`: `methods::VOICE_EXIT` + `UI_PROTOCOL_NOTIFICATION_METHODS` registration + all enum match arms + wire round-trip test

## Implementation

- `voice_turn.rs`: `parse/strip_exit_marker`, `strip_control_directives` (peels stacked `[[VISUAL:…]][[EXIT]]` markers in either order); `VoiceReplySplitter` / `VisibleDeltaFilter` add `[[EXIT]]` to the held-back control-marker set, while ordinary `[[1]]` citations are still spoken
- `ui_protocol.rs`: the voice-turn system prompt instructs the model to append `[[EXIT]]`; the turn path lifts/strips the marker and emits `voice/exit` **after the farewell audio (streamed + whole-reply fallback) is attached**, so the client receives the audio before the exit signal
- `emit_voice_exit_from_background` (mirrors the visual lifecycle emit)

## Review fixes (pre-PR)

- **Ordering blocker**: a no-sentence-boundary reply takes the whole-reply fallback TTS path; the original emit ran before the farewell `file/attached` → moved the emit to after attachment
- **Stacked-marker leak**: `[[VISUAL:…]][[EXIT]]` left the inner marker behind → switched to an order-independent loop strip (durable surfaces + the streaming finish paths)

## Tests

- `cargo test -p octos-core --lib ui_protocol` ✅
- `cargo test -p octos-cli --features api --lib` → 1841 passed, 0 failed ✅ (incl. 46 voice_turn cases, with new stacked-/exit-marker coverage)
- `cargo fmt --all -- --check` ✅ / `cargo clippy --workspace --features api` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)