### PR TITLE
feat(voice): per-profile cloud TTS route + credentials

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -19167,6 +19167,7 @@ async fn run_standalone_turn(
             &session_runtime.profile.voice.default_voice,
         );
         let w_provider = session_runtime.profile.voice.tts_provider.clone();
+        let w_cloud = session_runtime.profile.voice.cloud.clone();
         let handle = tokio::spawn(async move {
             let mut n: usize = 0;
             while let Some(sentence) = rx.recv().await {
@@ -19174,6 +19175,7 @@ async fn run_standalone_turn(
                     &sentence,
                     &w_voice,
                     &w_provider,
+                    w_cloud.as_ref(),
                     &w_dir,
                 )
                 .await
@@ -19876,9 +19878,10 @@ async fn run_standalone_turn(
                 &session_runtime.profile.voice.default_voice,
             );
             let provider = session_runtime.profile.voice.tts_provider.as_str();
+            let cloud = session_runtime.profile.voice.cloud.as_ref();
             let reply_audio_dir = session_runtime.workspace_root.as_path();
             if let Some(audio_path) =
-                crate::api::voice_turn::synthesize_reply(reply, &voice, provider, reply_audio_dir)
+                crate::api::voice_turn::synthesize_reply(reply, &voice, provider, cloud, reply_audio_dir)
                     .await
             {
                 // Deliver via the EXISTING file/attached carrier. Emit the

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -19880,9 +19880,14 @@ async fn run_standalone_turn(
             let provider = session_runtime.profile.voice.tts_provider.as_str();
             let cloud = session_runtime.profile.voice.cloud.as_ref();
             let reply_audio_dir = session_runtime.workspace_root.as_path();
-            if let Some(audio_path) =
-                crate::api::voice_turn::synthesize_reply(reply, &voice, provider, cloud, reply_audio_dir)
-                    .await
+            if let Some(audio_path) = crate::api::voice_turn::synthesize_reply(
+                reply,
+                &voice,
+                provider,
+                cloud,
+                reply_audio_dir,
+            )
+            .await
             {
                 // Deliver via the EXISTING file/attached carrier. Emit the
                 // WORKSPACE-RELATIVE filename, NOT the absolute path:

--- a/crates/octos-cli/src/api/voice_turn.rs
+++ b/crates/octos-cli/src/api/voice_turn.rs
@@ -757,8 +757,15 @@ fn build_volcano(
 /// Resolve a Volcano config from typed per-profile cloud settings + env token.
 fn resolve_volcano(cloud: Option<&CloudTtsConfig>) -> Option<VolcanoTts> {
     let env = |k: &str| std::env::var(k).ok();
+    // Token precedence: the runtime-resolved per-profile token (from `env_vars`,
+    // set by `ProfileRuntime::bootstrap`) wins; fall back to the process env for
+    // legacy pure-`export` setups.
+    let token = cloud
+        .and_then(|c| c.token.clone())
+        .filter(|s| !s.is_empty())
+        .or_else(|| env("VOLC_TTS_TOKEN"));
     build_volcano(
-        env("VOLC_TTS_TOKEN"),
+        token,
         cloud,
         env("VOLC_TTS_APPID"),
         env("VOLC_TTS_CLUSTER"),

--- a/crates/octos-cli/src/api/voice_turn.rs
+++ b/crates/octos-cli/src/api/voice_turn.rs
@@ -803,6 +803,20 @@ fn resolve_volcano(cloud: Option<&CloudTtsConfig>) -> Option<VolcanoTts> {
     )
 }
 
+/// HTTP client for Volcano TTS, with redirects DISABLED. Even though the
+/// endpoint is allowlisted to an HTTPS Volcano host, that host could still
+/// respond with a 3xx to an off-allowlist address; `reqwest` would otherwise
+/// follow it and 307/308 preserve the POST body — replaying the token to the
+/// redirect target. `Policy::none()` makes a redirect a terminal response we
+/// never follow, closing that exfiltration path.
+fn volcano_http_client() -> Option<reqwest::Client> {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .inspect_err(|e| tracing::warn!(error = %e, "voice_turn: volcano client build failed"))
+        .ok()
+}
+
 /// Synthesize via Volcano Engine HTTP TTS (non-streaming `operation:"query"`,
 /// returns base64 audio in JSON). Writes the decoded audio to `out_dir` and
 /// returns the path. `None` on any failure (caller falls back to ominix).
@@ -817,7 +831,7 @@ async fn synthesize_volcano(cfg: &VolcanoTts, text: &str, out_dir: &Path) -> Opt
         "request": { "reqid": reqid, "text": text, "operation": "query", "text_type": "plain" },
     });
 
-    let client = reqwest::Client::new();
+    let client = volcano_http_client()?;
     let resp = client
         .post(&cfg.endpoint)
         // Volcano's quirky scheme: literal "Bearer;" + token (semicolon, no space).
@@ -942,7 +956,10 @@ mod tests {
 
     #[test]
     fn should_return_none_when_token_missing() {
-        let cloud = CloudTtsConfig { appid: Some("1".into()), ..Default::default() };
+        let cloud = CloudTtsConfig {
+            appid: Some("1".into()),
+            ..Default::default()
+        };
         assert!(build_volcano(None, Some(&cloud), None, None, None, None, None).is_none());
     }
 
@@ -957,7 +974,10 @@ mod tests {
             Some("tok".into()),
             Some(&cloud),
             Some("envid".into()), // typed appid wins
-            None, None, None, None,
+            None,
+            None,
+            None,
+            None,
         )
         .unwrap();
         assert_eq!(v.appid, "typed");
@@ -1002,14 +1022,29 @@ mod tests {
             endpoint: Some("https://attacker.example/tts".into()),
             ..Default::default()
         };
-        assert!(build_volcano(Some("tok".into()), Some(&cloud), None, None, None, None, None).is_none());
+        assert!(
+            build_volcano(
+                Some("tok".into()),
+                Some(&cloud),
+                None,
+                None,
+                None,
+                None,
+                None
+            )
+            .is_none()
+        );
     }
 
     #[test]
     fn should_reject_http_volcano_endpoint() {
         // Even the right host over plain http is rejected (must be https).
-        assert!(!is_allowed_volcano_endpoint("http://openspeech.bytedance.com/api/v1/tts"));
-        assert!(!is_allowed_volcano_endpoint("https://evil.openspeech.bytedance.com.attacker.com/"));
+        assert!(!is_allowed_volcano_endpoint(
+            "http://openspeech.bytedance.com/api/v1/tts"
+        ));
+        assert!(!is_allowed_volcano_endpoint(
+            "https://evil.openspeech.bytedance.com.attacker.com/"
+        ));
         assert!(!is_allowed_volcano_endpoint("not a url"));
     }
 
@@ -1018,6 +1053,40 @@ mod tests {
         assert!(is_allowed_volcano_endpoint(
             "https://openspeech.bytedance.com/api/v1/tts"
         ));
+    }
+
+    #[tokio::test]
+    async fn volcano_client_does_not_follow_redirects() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        // A one-shot server that answers every connection with a 307 to another
+        // host. A client that followed redirects would replay the POST there;
+        // ours must instead surface the 307 as a terminal response.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                let mut buf = [0u8; 1024];
+                let _ = sock.read(&mut buf).await;
+                let resp = "HTTP/1.1 307 Temporary Redirect\r\n\
+                    Location: http://attacker.example/steal\r\n\
+                    Content-Length: 0\r\n\r\n";
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.flush().await;
+            }
+        });
+
+        let client = volcano_http_client().expect("client builds");
+        let resp = client
+            .post(format!("http://{addr}/"))
+            .body("token=secret")
+            .send()
+            .await
+            .expect("request completes");
+        assert_eq!(
+            resp.status().as_u16(),
+            307,
+            "redirects must NOT be followed (token would leak to the target)"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/voice_turn.rs
+++ b/crates/octos-cli/src/api/voice_turn.rs
@@ -824,11 +824,11 @@ async fn synthesize_volcano(cfg: &VolcanoTts, text: &str, out_dir: &Path) -> Opt
 }
 
 /// Synthesize a reply to an audio file, picking the TTS route from `provider`:
-/// - `"auto"`: cloud Volcano when `VOLC_TTS_*` env is configured, else
-///   on-device GPT-SoVITS.
-/// - `"volcano"`: force cloud Volcano; fall back to on-device sovits when the
-///   env is missing or the request fails.
-/// - `"sovits"` / `"qwen3"`: force the named on-device engine (no cloud).
+/// - `"auto"`: cloud Volcano when a token resolves, else on-device.
+/// - `"cloud"` (alias `"volcano"`): force cloud Volcano; falls back to
+///   on-device when the token/appid is missing or the request fails.
+/// - `"local"` (or any other value, incl. legacy `"sovits"`/`"qwen3"`):
+///   on-device synthesis using the default engine.
 ///
 /// `voice` is the on-device voice preset (voices.json); the cloud route uses
 /// its own `VOLC_TTS_VOICE` env instead. Returns `None` on failure.
@@ -861,8 +861,8 @@ pub(crate) async fn synthesize_reply(
             tracing::warn!("voice_turn: volcano TTS failed; falling back to ominix");
         } else if provider == "cloud" || provider == "volcano" {
             tracing::warn!(
-                "voice_turn: tts route=cloud but VOLC_TTS_TOKEN/appid missing; \
-                 falling back to on-device"
+                provider = %provider,
+                "voice_turn: tts cloud route but VOLC_TTS_TOKEN/appid missing; falling back to on-device"
             );
         }
     }
@@ -945,6 +945,7 @@ mod tests {
             Some("https://example/tts".into()),
         )
         .unwrap();
+        assert_eq!(v.token, "tok");
         assert_eq!(v.appid, "envid");
         assert_eq!(v.voice, "envvoice");
         assert_eq!(v.cluster, "clu");

--- a/crates/octos-cli/src/api/voice_turn.rs
+++ b/crates/octos-cli/src/api/voice_turn.rs
@@ -9,6 +9,8 @@ use std::path::{Path, PathBuf};
 use octos_core::{Message, MessageRole};
 use octos_llm::ominix::OminixClient;
 
+use crate::config::CloudTtsConfig;
+
 /// 解析 OminiX 服务基址（平台级，env 优先）。与 `api/admin.rs` 的同名 helper 等价；
 /// 抽到此处避免跨模块可见性问题。
 // TODO(later-tasks): remove dead_code allow once callers are wired up.
@@ -714,22 +716,56 @@ struct VolcanoTts {
     endpoint: String,
 }
 
-fn volcano_from_env() -> Option<VolcanoTts> {
-    let appid = std::env::var("VOLC_TTS_APPID")
-        .ok()
-        .filter(|s| !s.is_empty())?;
-    let token = std::env::var("VOLC_TTS_TOKEN")
-        .ok()
-        .filter(|s| !s.is_empty())?;
+/// Whether the route wants the cloud path. Legacy `volcano` aliases `cloud`.
+fn wants_cloud(provider: &str) -> bool {
+    matches!(provider, "auto" | "cloud" | "volcano")
+}
+
+/// Pure core: merge typed (non-secret) cloud config over env fallbacks, applying
+/// engine defaults. Requires a non-empty token AND a resolvable appid.
+fn build_volcano(
+    token: Option<String>,
+    cloud: Option<&CloudTtsConfig>,
+    env_appid: Option<String>,
+    env_cluster: Option<String>,
+    env_voice: Option<String>,
+    env_encoding: Option<String>,
+    env_endpoint: Option<String>,
+) -> Option<VolcanoTts> {
+    let token = token.filter(|s| !s.is_empty())?;
+    let pick = |typed: Option<&String>, env: Option<String>| -> Option<String> {
+        typed
+            .filter(|s| !s.is_empty())
+            .cloned()
+            .or_else(|| env.filter(|s| !s.is_empty()))
+    };
+    let appid = pick(cloud.and_then(|c| c.appid.as_ref()), env_appid)?;
     Some(VolcanoTts {
         appid,
         token,
-        cluster: std::env::var("VOLC_TTS_CLUSTER").unwrap_or_else(|_| "volcano_tts".to_string()),
-        voice: std::env::var("VOLC_TTS_VOICE").unwrap_or_else(|_| "BV001_streaming".to_string()),
-        encoding: std::env::var("VOLC_TTS_ENCODING").unwrap_or_else(|_| "mp3".to_string()),
-        endpoint: std::env::var("VOLC_TTS_ENDPOINT")
-            .unwrap_or_else(|_| "https://openspeech.bytedance.com/api/v1/tts".to_string()),
+        cluster: pick(cloud.and_then(|c| c.cluster.as_ref()), env_cluster)
+            .unwrap_or_else(|| "volcano_tts".to_string()),
+        voice: pick(cloud.and_then(|c| c.voice.as_ref()), env_voice)
+            .unwrap_or_else(|| "BV001_streaming".to_string()),
+        encoding: pick(cloud.and_then(|c| c.encoding.as_ref()), env_encoding)
+            .unwrap_or_else(|| "mp3".to_string()),
+        endpoint: pick(cloud.and_then(|c| c.endpoint.as_ref()), env_endpoint)
+            .unwrap_or_else(|| "https://openspeech.bytedance.com/api/v1/tts".to_string()),
     })
+}
+
+/// Resolve a Volcano config from typed per-profile cloud settings + env token.
+fn resolve_volcano(cloud: Option<&CloudTtsConfig>) -> Option<VolcanoTts> {
+    let env = |k: &str| std::env::var(k).ok();
+    build_volcano(
+        env("VOLC_TTS_TOKEN"),
+        cloud,
+        env("VOLC_TTS_APPID"),
+        env("VOLC_TTS_CLUSTER"),
+        env("VOLC_TTS_VOICE"),
+        env("VOLC_TTS_ENCODING"),
+        env("VOLC_TTS_ENDPOINT"),
+    )
 }
 
 /// Synthesize via Volcano Engine HTTP TTS (non-streaming `operation:"query"`,
@@ -800,6 +836,7 @@ pub(crate) async fn synthesize_reply(
     text: &str,
     voice: &str,
     provider: &str,
+    cloud: Option<&CloudTtsConfig>,
     out_dir: &Path,
 ) -> Option<PathBuf> {
     let speak = clean_for_tts(text);
@@ -812,30 +849,26 @@ pub(crate) async fn synthesize_reply(
     let tts_t = std::time::Instant::now();
     eprintln!("[TIMING] TTS_start epoch_ms={}", now_ms());
 
-    // Cloud route. "auto" uses cloud only when env is present; "volcano" forces
-    // it (still falls back to on-device on failure). Cloud is faster (no
+    // Cloud route. "auto" uses cloud only when env is present; "cloud"/"volcano"
+    // force it (still falls back to on-device on failure). Cloud is faster (no
     // on-device model reload) and higher quality when available.
-    let want_cloud = matches!(provider, "auto" | "volcano");
+    let want_cloud = wants_cloud(provider);
     if want_cloud {
-        if let Some(cfg) = volcano_from_env() {
+        if let Some(cfg) = resolve_volcano(cloud) {
             if let Some(path) = synthesize_volcano(&cfg, &speak, out_dir).await {
                 return Some(path);
             }
             tracing::warn!("voice_turn: volcano TTS failed; falling back to ominix");
-        } else if provider == "volcano" {
+        } else if provider == "cloud" || provider == "volcano" {
             tracing::warn!(
-                "voice_turn: tts_provider=volcano but VOLC_TTS_* env missing; \
-                 falling back to on-device sovits"
+                "voice_turn: tts route=cloud but VOLC_TTS_TOKEN/appid missing; \
+                 falling back to on-device"
             );
         }
     }
 
-    // On-device route. Forced engine for "sovits"/"qwen3"; sovits otherwise.
-    let engine = if provider == "qwen3" {
-        "qwen3"
-    } else {
-        "sovits"
-    };
+    // On-device route: always the default engine (no qwen3 UI split).
+    let engine = "sovits";
     let out_path = out_dir.join(format!("reply-{}.wav", uuid::Uuid::now_v7()));
     let client = OminixClient::new(&ominix_base_url());
     match client
@@ -860,11 +893,74 @@ pub(crate) async fn synthesize_reply(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::CloudTtsConfig;
+
+    #[test]
+    fn should_want_cloud_for_auto_cloud_and_legacy_volcano() {
+        for p in ["auto", "cloud", "volcano"] {
+            assert!(wants_cloud(p), "{p} should want cloud");
+        }
+        for p in ["local", "sovits", "qwen3", ""] {
+            assert!(!wants_cloud(p), "{p} should NOT want cloud");
+        }
+    }
+
+    #[test]
+    fn should_return_none_when_token_missing() {
+        let cloud = CloudTtsConfig { appid: Some("1".into()), ..Default::default() };
+        assert!(build_volcano(None, Some(&cloud), None, None, None, None, None).is_none());
+    }
+
+    #[test]
+    fn should_prefer_typed_cloud_over_env_and_apply_defaults() {
+        let cloud = CloudTtsConfig {
+            appid: Some("typed".into()),
+            voice: Some("BV700".into()),
+            ..Default::default()
+        };
+        let v = build_volcano(
+            Some("tok".into()),
+            Some(&cloud),
+            Some("envid".into()), // typed appid wins
+            None, None, None, None,
+        )
+        .unwrap();
+        assert_eq!(v.appid, "typed");
+        assert_eq!(v.voice, "BV700");
+        assert_eq!(v.cluster, "volcano_tts"); // default
+        assert_eq!(v.encoding, "mp3"); // default
+        assert_eq!(v.endpoint, "https://openspeech.bytedance.com/api/v1/tts");
+        assert_eq!(v.token, "tok");
+    }
+
+    #[test]
+    fn should_fall_back_to_env_when_cloud_none() {
+        let v = build_volcano(
+            Some("tok".into()),
+            None,
+            Some("envid".into()),
+            Some("clu".into()),
+            Some("envvoice".into()),
+            Some("wav".into()),
+            Some("https://example/tts".into()),
+        )
+        .unwrap();
+        assert_eq!(v.appid, "envid");
+        assert_eq!(v.voice, "envvoice");
+        assert_eq!(v.cluster, "clu");
+        assert_eq!(v.encoding, "wav");
+        assert_eq!(v.endpoint, "https://example/tts");
+    }
+
+    #[test]
+    fn should_return_none_when_no_appid_anywhere() {
+        assert!(build_volcano(Some("tok".into()), None, None, None, None, None, None).is_none());
+    }
 
     #[tokio::test]
     async fn synthesize_reply_returns_none_for_blank_text() {
         let dir = std::env::temp_dir();
-        let got = synthesize_reply("   ", "vivian", "auto", &dir).await;
+        let got = synthesize_reply("   ", "vivian", "auto", None, &dir).await;
         assert!(got.is_none());
     }
 

--- a/crates/octos-cli/src/api/voice_turn.rs
+++ b/crates/octos-cli/src/api/voice_turn.rs
@@ -740,6 +740,19 @@ fn build_volcano(
             .or_else(|| env.filter(|s| !s.is_empty()))
     };
     let appid = pick(cloud.and_then(|c| c.appid.as_ref()), env_appid)?;
+    let endpoint = pick(cloud.and_then(|c| c.endpoint.as_ref()), env_endpoint)
+        .unwrap_or_else(|| "https://openspeech.bytedance.com/api/v1/tts".to_string());
+    // The endpoint is partly tenant-controlled (per-profile `tts_cloud.endpoint`)
+    // and the token may be the host-global `VOLC_TTS_TOKEN`. Never send the token
+    // anywhere but an HTTPS Volcano host — otherwise a tenant could point the
+    // endpoint at an internal/attacker address and exfiltrate the token (SSRF).
+    if !is_allowed_volcano_endpoint(&endpoint) {
+        tracing::warn!(
+            endpoint = %endpoint,
+            "voice_turn: refusing cloud TTS — endpoint not in the HTTPS Volcano allowlist; token NOT sent"
+        );
+        return None;
+    }
     Some(VolcanoTts {
         appid,
         token,
@@ -749,9 +762,24 @@ fn build_volcano(
             .unwrap_or_else(|| "BV001_streaming".to_string()),
         encoding: pick(cloud.and_then(|c| c.encoding.as_ref()), env_encoding)
             .unwrap_or_else(|| "mp3".to_string()),
-        endpoint: pick(cloud.and_then(|c| c.endpoint.as_ref()), env_endpoint)
-            .unwrap_or_else(|| "https://openspeech.bytedance.com/api/v1/tts".to_string()),
+        endpoint,
     })
+}
+
+/// HTTPS Volcano TTS hosts the token may be sent to. Keep this tight — it is the
+/// SSRF / token-exfiltration boundary for the partly tenant-controlled endpoint.
+const VOLCANO_ALLOWED_HOSTS: &[&str] = &["openspeech.bytedance.com"];
+
+/// True only for an `https://` URL whose host is in [`VOLCANO_ALLOWED_HOSTS`].
+fn is_allowed_volcano_endpoint(endpoint: &str) -> bool {
+    match reqwest::Url::parse(endpoint) {
+        Ok(u) => {
+            u.scheme() == "https"
+                && u.host_str()
+                    .is_some_and(|h| VOLCANO_ALLOWED_HOSTS.contains(&h))
+        }
+        Err(_) => false,
+    }
 }
 
 /// Resolve a Volcano config from typed per-profile cloud settings + env token.
@@ -949,7 +977,7 @@ mod tests {
             Some("clu".into()),
             Some("envvoice".into()),
             Some("wav".into()),
-            Some("https://example/tts".into()),
+            Some("https://openspeech.bytedance.com/api/v1/tts".into()),
         )
         .unwrap();
         assert_eq!(v.token, "tok");
@@ -957,12 +985,39 @@ mod tests {
         assert_eq!(v.voice, "envvoice");
         assert_eq!(v.cluster, "clu");
         assert_eq!(v.encoding, "wav");
-        assert_eq!(v.endpoint, "https://example/tts");
+        assert_eq!(v.endpoint, "https://openspeech.bytedance.com/api/v1/tts");
     }
 
     #[test]
     fn should_return_none_when_no_appid_anywhere() {
         assert!(build_volcano(Some("tok".into()), None, None, None, None, None, None).is_none());
+    }
+
+    #[test]
+    fn should_reject_non_volcano_endpoint_to_prevent_ssrf() {
+        // A tenant-controlled endpoint pointing off the Volcano allowlist must
+        // never receive the token — build_volcano returns None.
+        let cloud = CloudTtsConfig {
+            appid: Some("1".into()),
+            endpoint: Some("https://attacker.example/tts".into()),
+            ..Default::default()
+        };
+        assert!(build_volcano(Some("tok".into()), Some(&cloud), None, None, None, None, None).is_none());
+    }
+
+    #[test]
+    fn should_reject_http_volcano_endpoint() {
+        // Even the right host over plain http is rejected (must be https).
+        assert!(!is_allowed_volcano_endpoint("http://openspeech.bytedance.com/api/v1/tts"));
+        assert!(!is_allowed_volcano_endpoint("https://evil.openspeech.bytedance.com.attacker.com/"));
+        assert!(!is_allowed_volcano_endpoint("not a url"));
+    }
+
+    #[test]
+    fn should_allow_default_volcano_endpoint() {
+        assert!(is_allowed_volcano_endpoint(
+            "https://openspeech.bytedance.com/api/v1/tts"
+        ));
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -561,11 +561,16 @@ pub struct EmailConfig {
     pub feishu_region: Option<String>,
 }
 
-/// Non-secret Volcano (cloud) TTS settings. The token is NEVER stored here —
-/// it lives in `env_vars["VOLC_TTS_TOKEN"]` so the shared masking/restore
-/// machinery covers it. Missing fields fall back to engine defaults at resolve
-/// time (see `voice_turn::resolve_volcano`).
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+/// Non-secret Volcano (cloud) TTS settings. The **persisted** secret (the API
+/// token) is NEVER stored here — it lives in `env_vars["VOLC_TTS_TOKEN"]` so the
+/// shared masking/restore machinery covers it. The `token` field below is a
+/// runtime-only carrier (`#[serde(skip)]`): `ProfileRuntime::bootstrap` resolves
+/// the token from the profile's `env_vars` and stashes it here so the in-process
+/// `serve` path (which, unlike the gateway worker, does not get `env_vars`
+/// injected into `std::env`) can authenticate. It is never serialized and the
+/// `Debug` impl redacts it. Missing non-secret fields fall back to engine
+/// defaults at resolve time (see `voice_turn::resolve_volcano`).
+#[derive(Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct CloudTtsConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub appid: Option<String>,
@@ -577,6 +582,23 @@ pub struct CloudTtsConfig {
     pub encoding: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub endpoint: Option<String>,
+    /// Runtime-only resolved API token (from `env_vars["VOLC_TTS_TOKEN"]`).
+    /// Never serialized; redacted in `Debug`.
+    #[serde(skip)]
+    pub token: Option<String>,
+}
+
+impl std::fmt::Debug for CloudTtsConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CloudTtsConfig")
+            .field("appid", &self.appid)
+            .field("voice", &self.voice)
+            .field("cluster", &self.cluster)
+            .field("encoding", &self.encoding)
+            .field("endpoint", &self.endpoint)
+            .field("token", &self.token.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
 }
 
 /// Voice (ASR/TTS) configuration for auto-transcription and auto-synthesis.
@@ -664,6 +686,34 @@ impl VoiceConfig {
     pub fn with_cloud_override(mut self, override_cloud: Option<&CloudTtsConfig>) -> Self {
         if let Some(c) = override_cloud {
             self.cloud = Some(c.clone());
+        }
+        self
+    }
+
+    /// Resolve the cloud-TTS API token from a profile's `env_vars`
+    /// (`VOLC_TTS_TOKEN`, keychain-aware) and stash it on `cloud.token`.
+    ///
+    /// This bridges the gap that the in-process `serve` path does not get the
+    /// profile's `env_vars` injected into `std::env` (only the gateway worker
+    /// does), so `voice_turn::resolve_volcano` can read the token from the
+    /// runtime config instead. No-op when there is no `cloud` config, when the
+    /// token is already set, or when `env_vars` has no (resolvable) token.
+    pub fn with_cloud_token_from_env(
+        mut self,
+        env_vars: &std::collections::HashMap<String, String>,
+    ) -> Self {
+        if let Some(cloud) = self.cloud.as_mut() {
+            if cloud.token.as_deref().unwrap_or("").is_empty() {
+                if let Some(raw) = env_vars.get("VOLC_TTS_TOKEN") {
+                    if let Some(resolved) =
+                        crate::auth::keychain::resolve_value("VOLC_TTS_TOKEN", raw)
+                    {
+                        if !resolved.is_empty() {
+                            cloud.token = Some(resolved);
+                        }
+                    }
+                }
+            }
         }
         self
     }
@@ -2488,6 +2538,52 @@ mod tests {
         assert_eq!(cloud.appid.as_deref(), Some("a"));
         assert_eq!(cloud.voice.as_deref(), Some("BV700"));
         assert_eq!(cloud.cluster, None);
+    }
+
+    #[test]
+    fn should_never_serialize_cloud_token() {
+        let cloud = CloudTtsConfig {
+            appid: Some("a".into()),
+            token: Some("supersecret".into()),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&cloud).unwrap();
+        assert!(!json.contains("token"), "token key must not serialize: {json}");
+        assert!(!json.contains("supersecret"), "token value must not leak: {json}");
+    }
+
+    #[test]
+    fn should_redact_cloud_token_in_debug() {
+        let cloud = CloudTtsConfig {
+            token: Some("supersecret".into()),
+            ..Default::default()
+        };
+        let dbg = format!("{cloud:?}");
+        assert!(!dbg.contains("supersecret"), "Debug must redact token: {dbg}");
+        assert!(dbg.contains("redacted"));
+    }
+
+    #[test]
+    fn should_resolve_cloud_token_from_env_vars() {
+        let mut env = std::collections::HashMap::new();
+        env.insert("VOLC_TTS_TOKEN".to_string(), "T-abc".to_string());
+        let vc = VoiceConfig {
+            cloud: Some(CloudTtsConfig {
+                appid: Some("1".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+        .with_cloud_token_from_env(&env);
+        assert_eq!(vc.cloud.unwrap().token.as_deref(), Some("T-abc"));
+    }
+
+    #[test]
+    fn should_not_resolve_cloud_token_when_no_cloud_config() {
+        let mut env = std::collections::HashMap::new();
+        env.insert("VOLC_TTS_TOKEN".to_string(), "T-abc".to_string());
+        let vc = VoiceConfig::default().with_cloud_token_from_env(&env);
+        assert!(vc.cloud.is_none());
     }
 
     #[test]

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -561,6 +561,24 @@ pub struct EmailConfig {
     pub feishu_region: Option<String>,
 }
 
+/// Non-secret Volcano (cloud) TTS settings. The token is NEVER stored here —
+/// it lives in `env_vars["VOLC_TTS_TOKEN"]` so the shared masking/restore
+/// machinery covers it. Missing fields fall back to engine defaults at resolve
+/// time (see `voice_turn::resolve_volcano`).
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct CloudTtsConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub appid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub voice: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cluster: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encoding: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+}
+
 /// Voice (ASR/TTS) configuration for auto-transcription and auto-synthesis.
 /// The OminiX API URL is a platform-wide setting via OMINIX_API_URL env var
 /// (default http://localhost:8080), NOT per-profile.
@@ -593,6 +611,11 @@ pub struct VoiceConfig {
     /// never read from config); this switch only selects the *route*.
     #[serde(default = "default_tts_provider")]
     pub tts_provider: String,
+    /// Non-secret cloud (Volcano) TTS settings. `None` → resolve entirely from
+    /// `VOLC_TTS_*` env (back-compat). Per-profile override via
+    /// `ProfileConfig.tts_cloud`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cloud: Option<CloudTtsConfig>,
 }
 
 impl Default for VoiceConfig {
@@ -604,6 +627,7 @@ impl Default for VoiceConfig {
             default_voice: default_voice_preset(),
             asr_language: None,
             tts_provider: default_tts_provider(),
+            cloud: None,
         }
     }
 }
@@ -619,6 +643,26 @@ impl VoiceConfig {
             if !v.is_empty() {
                 self.default_voice = v.to_string();
             }
+        }
+        self
+    }
+
+    /// Apply a per-profile TTS route override (`auto`/`local`/`cloud`). Empty /
+    /// `None` leaves the serve-level route untouched.
+    pub fn with_tts_provider_override(mut self, override_provider: Option<&str>) -> Self {
+        if let Some(p) = override_provider {
+            if !p.is_empty() {
+                self.tts_provider = p.to_string();
+            }
+        }
+        self
+    }
+
+    /// Apply a per-profile cloud-TTS settings override. `None` leaves the
+    /// serve-level (or env-fallback) settings untouched.
+    pub fn with_cloud_override(mut self, override_cloud: Option<&CloudTtsConfig>) -> Self {
+        if let Some(c) = override_cloud {
+            self.cloud = Some(c.clone());
         }
         self
     }
@@ -2411,5 +2455,37 @@ mod tests {
             base.with_default_voice_override(Some("")).default_voice,
             "doubao"
         );
+    }
+
+    #[test]
+    fn should_override_tts_provider_when_some_nonempty() {
+        let cfg = VoiceConfig::default().with_tts_provider_override(Some("cloud"));
+        assert_eq!(cfg.tts_provider, "cloud");
+    }
+
+    #[test]
+    fn should_keep_tts_provider_when_override_none_or_empty() {
+        let base = VoiceConfig::default();
+        let kept = base.clone().with_tts_provider_override(None);
+        assert_eq!(kept.tts_provider, base.tts_provider);
+        let kept2 = base.clone().with_tts_provider_override(Some(""));
+        assert_eq!(kept2.tts_provider, base.tts_provider);
+    }
+
+    #[test]
+    fn should_override_cloud_when_some() {
+        let cloud = CloudTtsConfig { appid: Some("123".into()), ..Default::default() };
+        let cfg = VoiceConfig::default().with_cloud_override(Some(&cloud));
+        assert_eq!(cfg.cloud.unwrap().appid.as_deref(), Some("123"));
+    }
+
+    #[test]
+    fn should_roundtrip_cloud_tts_config_serde() {
+        let json = r#"{ "cloud": { "appid": "a", "voice": "BV700" } }"#;
+        let cfg: VoiceConfig = serde_json::from_str(json).unwrap();
+        let cloud = cfg.cloud.unwrap();
+        assert_eq!(cloud.appid.as_deref(), Some("a"));
+        assert_eq!(cloud.voice.as_deref(), Some("BV700"));
+        assert_eq!(cloud.cluster, None);
     }
 }

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -600,15 +600,16 @@ pub struct VoiceConfig {
     #[serde(default)]
     pub asr_language: Option<String>,
     /// Which TTS route to use for synthesized replies:
-    /// - `"auto"` (default): cloud Volcano when the `VOLC_TTS_*` env is
-    ///   configured, otherwise the on-device GPT-SoVITS engine.
-    /// - `"volcano"`: force cloud Volcano (falls back to on-device sovits
-    ///   when the env is missing or the request fails).
-    /// - `"sovits"`: force the on-device GPT-SoVITS engine.
-    /// - `"qwen3"`: force the on-device Qwen3-TTS pool.
+    /// - `"auto"` (default): cloud when a token is configured, else on-device.
+    /// - `"local"`: force the on-device ominix-api engine.
+    /// - `"cloud"`: force cloud Volcano (falls back to on-device when the token
+    ///   is missing or the request fails).
     ///
-    /// Cloud credentials always come from `VOLC_TTS_*` env vars (secrets are
-    /// never read from config); this switch only selects the *route*.
+    /// Legacy aliases accepted for back-compat: `"volcano"` → `cloud`;
+    /// `"sovits"` / `"qwen3"` → `local`.
+    ///
+    /// Cloud credentials: the non-secret settings live in `cloud` (CloudTtsConfig);
+    /// the token is read from `VOLC_TTS_TOKEN` (never stored in config).
     #[serde(default = "default_tts_provider")]
     pub tts_provider: String,
     /// Non-secret cloud (Volcano) TTS settings. `None` → resolve entirely from

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -2489,4 +2489,17 @@ mod tests {
         assert_eq!(cloud.voice.as_deref(), Some("BV700"));
         assert_eq!(cloud.cluster, None);
     }
+
+    #[test]
+    fn should_overlay_profile_tts_provider_over_host_voice() {
+        let host = VoiceConfig { tts_provider: "auto".into(), ..Default::default() };
+        let overridden = host
+            .with_tts_provider_override(Some("cloud"))
+            .with_cloud_override(Some(&CloudTtsConfig {
+                appid: Some("42".into()),
+                ..Default::default()
+            }));
+        assert_eq!(overridden.tts_provider, "cloud");
+        assert_eq!(overridden.cloud.unwrap().appid.as_deref(), Some("42"));
+    }
 }

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -2525,7 +2525,10 @@ mod tests {
 
     #[test]
     fn should_override_cloud_when_some() {
-        let cloud = CloudTtsConfig { appid: Some("123".into()), ..Default::default() };
+        let cloud = CloudTtsConfig {
+            appid: Some("123".into()),
+            ..Default::default()
+        };
         let cfg = VoiceConfig::default().with_cloud_override(Some(&cloud));
         assert_eq!(cfg.cloud.unwrap().appid.as_deref(), Some("123"));
     }
@@ -2548,8 +2551,14 @@ mod tests {
             ..Default::default()
         };
         let json = serde_json::to_string(&cloud).unwrap();
-        assert!(!json.contains("token"), "token key must not serialize: {json}");
-        assert!(!json.contains("supersecret"), "token value must not leak: {json}");
+        assert!(
+            !json.contains("token"),
+            "token key must not serialize: {json}"
+        );
+        assert!(
+            !json.contains("supersecret"),
+            "token value must not leak: {json}"
+        );
     }
 
     #[test]
@@ -2559,7 +2568,10 @@ mod tests {
             ..Default::default()
         };
         let dbg = format!("{cloud:?}");
-        assert!(!dbg.contains("supersecret"), "Debug must redact token: {dbg}");
+        assert!(
+            !dbg.contains("supersecret"),
+            "Debug must redact token: {dbg}"
+        );
         assert!(dbg.contains("redacted"));
     }
 
@@ -2588,7 +2600,10 @@ mod tests {
 
     #[test]
     fn should_overlay_profile_tts_provider_over_host_voice() {
-        let host = VoiceConfig { tts_provider: "auto".into(), ..Default::default() };
+        let host = VoiceConfig {
+            tts_provider: "auto".into(),
+            ..Default::default()
+        };
         let overridden = host
             .with_tts_provider_override(Some("cloud"))
             .with_cloud_override(Some(&CloudTtsConfig {

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -4360,10 +4360,14 @@ mod tests {
 
     #[test]
     fn should_roundtrip_tts_provider_and_cloud_on_profile_config() {
-        let json = r#"{ "tts_provider": "cloud", "tts_cloud": { "appid": "999", "voice": "BV700" } }"#;
+        let json =
+            r#"{ "tts_provider": "cloud", "tts_cloud": { "appid": "999", "voice": "BV700" } }"#;
         let cfg: ProfileConfig = serde_json::from_str(json).unwrap();
         assert_eq!(cfg.tts_provider.as_deref(), Some("cloud"));
-        assert_eq!(cfg.tts_cloud.as_ref().unwrap().appid.as_deref(), Some("999"));
+        assert_eq!(
+            cfg.tts_cloud.as_ref().unwrap().appid.as_deref(),
+            Some("999")
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -11,7 +11,7 @@ use chrono::{DateTime, Utc};
 use eyre::{Result, WrapErr, bail};
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::config::{ChannelEntry, Config, FallbackModel, GatewayConfig};
+use crate::config::{ChannelEntry, CloudTtsConfig, Config, FallbackModel, GatewayConfig};
 
 pub const MAX_SUB_ACCOUNTS_PER_PARENT: usize = 10;
 
@@ -61,6 +61,15 @@ pub struct ProfileConfig {
     /// serve default. Set by `PUT /api/my/voice`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub voice_default: Option<String>,
+    /// Per-profile TTS route override (`auto`/`local`/`cloud`). `None` →
+    /// inherit the serve-level `VoiceConfig.tts_provider`. Applied in
+    /// `runtime/profile.rs` via `VoiceConfig::with_tts_provider_override`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tts_provider: Option<String>,
+    /// Per-profile non-secret cloud (Volcano) TTS settings. The token rides
+    /// `env_vars["VOLC_TTS_TOKEN"]`. `None` → inherit serve / env defaults.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tts_cloud: Option<CloudTtsConfig>,
     /// Coding review specialist template. When omitted, `/review`
     /// uses the server's built-in default specialists. Operators may
     /// configure this per profile to change the native reviewer fanout
@@ -4347,5 +4356,20 @@ mod tests {
         assert_eq!(settings["user_id"], "@bot:matrix.org");
         assert_eq!(settings["password"], "secret");
         assert_eq!(settings["device_name"], "octos-gw");
+    }
+
+    #[test]
+    fn should_roundtrip_tts_provider_and_cloud_on_profile_config() {
+        let json = r#"{ "tts_provider": "cloud", "tts_cloud": { "appid": "999", "voice": "BV700" } }"#;
+        let cfg: ProfileConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.tts_provider.as_deref(), Some("cloud"));
+        assert_eq!(cfg.tts_cloud.as_ref().unwrap().appid.as_deref(), Some("999"));
+    }
+
+    #[test]
+    fn should_default_tts_fields_to_none_when_absent() {
+        let cfg: ProfileConfig = serde_json::from_str("{}").unwrap();
+        assert!(cfg.tts_provider.is_none());
+        assert!(cfg.tts_cloud.is_none());
     }
 }

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -1021,15 +1021,18 @@ impl ProfileRuntime {
             // setting living on the top-level config.json, not on per-profile
             // JSON. `config_from_profile` drops it, so the caller (serve/gateway)
             // passes the host's `config.voice` here; fall back to defaults when
-            // absent. The *timbre* (`default_voice`), however, is per-tenant:
-            // overlay the profile's `voice_default` on top so each user keeps
-            // their own reply voice (set via `PUT /api/my/voice`).
+            // absent. Per-tenant settings (*timbre*, TTS route, cloud config) are
+            // overlaid: `voice_default` (reply voice via `PUT /api/my/voice`),
+            // `tts_provider` (route: auto/local/cloud), and `tts_cloud` (cloud
+            // credentials).
             voice: config
                 .voice
                 .clone()
                 .or_else(|| host_voice.cloned())
                 .unwrap_or_default()
-                .with_default_voice_override(profile.config.voice_default.as_deref()),
+                .with_default_voice_override(profile.config.voice_default.as_deref())
+                .with_tts_provider_override(profile.config.tts_provider.as_deref())
+                .with_cloud_override(profile.config.tts_cloud.as_ref()),
         }))
     }
 }

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -1032,7 +1032,8 @@ impl ProfileRuntime {
                 .unwrap_or_default()
                 .with_default_voice_override(profile.config.voice_default.as_deref())
                 .with_tts_provider_override(profile.config.tts_provider.as_deref())
-                .with_cloud_override(profile.config.tts_cloud.as_ref()),
+                .with_cloud_override(profile.config.tts_cloud.as_ref())
+                .with_cloud_token_from_env(&profile.config.env_vars),
         }))
     }
 }


### PR DESCRIPTION
## Summary

Adds per-profile voice TTS configuration so a profile can choose its synthesis route (`auto` / `local` / `cloud`) and supply Volcano (cloud) settings, instead of relying solely on process-level `VOLC_TTS_*` env vars. Pairs with the octos-web PR that adds the Settings → Voice tab.

## What changed

- **`CloudTtsConfig`** (`config.rs`): typed, non-secret cloud settings (`appid`, `voice`, `cluster`, `encoding`, `endpoint`) on `VoiceConfig`, plus `with_tts_provider_override` / `with_cloud_override` builders. The token is **not** stored here — see below.
- **`ProfileConfig`** (`profiles.rs`): per-profile `tts_provider` + `tts_cloud` overrides (`None` → inherit the serve-level default).
- **Runtime overlay** (`runtime/profile.rs`): `ProfileRuntime::bootstrap` overlays the per-profile route/cloud onto the host `VoiceConfig`.
- **Route mapping** (`voice_turn.rs`): `synthesize_reply` resolves `auto`/`local`/`cloud` (legacy `volcano`/`sovits`/`qwen3` accepted); on-device always uses the default engine.

## Token handling (works in `serve`, not just the gateway worker)

The voice turn runs in the `serve` process, which — unlike the per-profile gateway worker — does not get `env_vars` injected into `std::env`. `ProfileRuntime::bootstrap` now resolves `VOLC_TTS_TOKEN` from the profile's `env_vars` (keychain-aware) into a **runtime-only** `CloudTtsConfig.token` (`#[serde(skip)]`, redacted `Debug`); `resolve_volcano` prefers it and falls back to `std::env` for legacy pure-`export` setups. The token is never serialized and stays masked in API responses.

## Security hardening

- **SSRF / token-exfiltration guard:** the endpoint is partly tenant-controlled, so `build_volcano` refuses any endpoint that is not an HTTPS host on a Volcano allowlist — the token is never sent off-allowlist.
- **No redirect following:** the Volcano HTTP client uses `redirect::Policy::none()`, so an allowlisted host cannot 3xx the token-bearing POST to another address (307/308 preserve the body).

## Testing

- `cargo test -p octos-cli --features api voice_turn` — 43 passing, including endpoint-allowlist rejection (SSRF), redirect-not-followed, token precedence, and route mapping.
- `cargo fmt --all -- --check` passes.

## Deploy note

Voice synthesis runs in `serve` and the runtime is built at startup, so this requires a **rebuild + restart of `octos serve`** to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)