### PR TITLE
feat(session): resume + rewind server support (session/rollback RPC, JSONL rollback marker, session/list updated_at)

### DIFF
--- a/crates/octos-bus/src/resume_policy.rs
+++ b/crates/octos-bus/src/resume_policy.rs
@@ -471,6 +471,73 @@ fn is_whitespace_only_assistant(msg: &Message) -> bool {
     true
 }
 
+/// Count the number of distinct user turns in `messages`.
+///
+/// A "user turn" is the message group sharing one `User` message's
+/// [`Message::thread_id`] (M8.10 thread grouping). System messages and the
+/// assistant/tool replies that inherit a turn's thread_id never start a new
+/// turn, so the count equals the number of distinct thread_ids rooted by a
+/// `User` message.
+pub(crate) fn count_user_turns(messages: &[Message]) -> u32 {
+    let mut seen: HashSet<&str> = HashSet::new();
+    let mut count = 0_u32;
+    for msg in messages {
+        if matches!(msg.role, MessageRole::User) {
+            if let Some(tid) = msg.thread_id.as_deref() {
+                if seen.insert(tid) {
+                    count = count.saturating_add(1);
+                }
+            }
+        }
+    }
+    count
+}
+
+/// Drop the last `n` user turns from `messages` in place, returning the number
+/// of turns actually removed (clamped to the transcript's turn count).
+///
+/// A user turn is the set of messages sharing one `User` message's
+/// [`Message::thread_id`] (M8.10). Removing the last `n` turns deletes those
+/// groups' user + assistant + tool messages — i.e. everything from the
+/// `n`-from-last user message onward. Leading `System` messages and any
+/// compaction-summary `System` message carry `thread_id == None`, are never
+/// part of a user turn, and always survive; dropping every user turn therefore
+/// returns the transcript to its pre-first-user state.
+///
+/// Deterministic and idempotent when driven by the append-only rollback marker:
+/// applied at the marker's position in the JSONL log, replaying the same log
+/// always yields the same trimmed transcript. `n == 0` is a no-op.
+pub(crate) fn drop_last_n_user_turns(messages: &mut Vec<Message>, n: u32) -> u32 {
+    if n == 0 {
+        return 0;
+    }
+    // Ordered, distinct thread_ids rooted by a `User` message.
+    let mut user_threads: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for msg in messages.iter() {
+        if matches!(msg.role, MessageRole::User) {
+            if let Some(tid) = msg.thread_id.clone() {
+                if seen.insert(tid.clone()) {
+                    user_threads.push(tid);
+                }
+            }
+        }
+    }
+    let drop_count = (n as usize).min(user_threads.len());
+    if drop_count == 0 {
+        return 0;
+    }
+    let to_drop: HashSet<String> = user_threads
+        .split_off(user_threads.len() - drop_count)
+        .into_iter()
+        .collect();
+    messages.retain(|msg| match msg.thread_id.as_deref() {
+        Some(tid) => !to_drop.contains(tid),
+        None => true,
+    });
+    drop_count as u32
+}
+
 /// Pass 4: collect content-replacement refs from tool results.
 ///
 /// Scans every tool-role message for file paths. Heuristic: parse the tool
@@ -1185,5 +1252,106 @@ mod tests {
         assert_eq!(outcome.messages.len(), 0);
         assert_eq!(outcome.report.input_len, 0);
         assert_eq!(outcome.report.output_len, 0);
+    }
+
+    fn user_in_thread(content: &str, thread: &str) -> Message {
+        let mut msg = user(content);
+        msg.client_message_id = Some(thread.into());
+        msg.thread_id = Some(thread.into());
+        msg
+    }
+
+    fn assistant_in_thread(content: &str, thread: &str) -> Message {
+        let mut msg = assistant_text(content);
+        msg.thread_id = Some(thread.into());
+        msg
+    }
+
+    fn system_msg(content: &str) -> Message {
+        let mut msg = user(content);
+        msg.role = MessageRole::System;
+        msg.client_message_id = None;
+        msg.thread_id = None;
+        msg
+    }
+
+    /// Build a 3-user-turn transcript with a leading system prompt.
+    fn three_turn_transcript() -> Vec<Message> {
+        vec![
+            system_msg("you are octos"),
+            user_in_thread("turn 1", "t1"),
+            assistant_in_thread("reply 1", "t1"),
+            user_in_thread("turn 2", "t2"),
+            assistant_in_thread("reply 2", "t2"),
+            user_in_thread("turn 3", "t3"),
+            assistant_in_thread("reply 3", "t3"),
+        ]
+    }
+
+    #[test]
+    fn drop_last_user_turn_removes_only_final_turn() {
+        let mut messages = three_turn_transcript();
+        let dropped = drop_last_n_user_turns(&mut messages, 1);
+        assert_eq!(dropped, 1);
+        // System + turns 1 & 2 survive; turn 3's user+assistant are gone.
+        assert_eq!(count_user_turns(&messages), 2);
+        assert_eq!(
+            messages
+                .iter()
+                .map(|m| m.content.clone())
+                .collect::<Vec<_>>(),
+            vec![
+                "you are octos".to_string(),
+                "turn 1".into(),
+                "reply 1".into(),
+                "turn 2".into(),
+                "reply 2".into(),
+            ]
+        );
+    }
+
+    #[test]
+    fn drop_more_turns_than_exist_returns_to_pre_first_user_state() {
+        let mut messages = three_turn_transcript();
+        // n greater than the turn count clamps to 3 and leaves only the
+        // leading system message (the pre-first-user prefix).
+        let dropped = drop_last_n_user_turns(&mut messages, 9);
+        assert_eq!(dropped, 3);
+        assert_eq!(count_user_turns(&messages), 0);
+        assert_eq!(messages.len(), 1);
+        assert!(matches!(messages[0].role, MessageRole::System));
+    }
+
+    #[test]
+    fn drop_preserves_interleaved_summary_system_message() {
+        // A compaction-summary System message (thread_id == None) sitting
+        // after turn 1 must survive a rollback of the last turn.
+        let mut messages = vec![
+            system_msg("base prompt"),
+            user_in_thread("turn 1", "t1"),
+            assistant_in_thread("reply 1", "t1"),
+            system_msg("summary of earlier context"),
+            user_in_thread("turn 2", "t2"),
+            assistant_in_thread("reply 2", "t2"),
+        ];
+        let dropped = drop_last_n_user_turns(&mut messages, 1);
+        assert_eq!(dropped, 1);
+        assert_eq!(count_user_turns(&messages), 1);
+        // Both system messages survive.
+        assert_eq!(
+            messages
+                .iter()
+                .filter(|m| matches!(m.role, MessageRole::System))
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn drop_zero_turns_is_noop() {
+        let mut messages = three_turn_transcript();
+        let before = messages.len();
+        assert_eq!(drop_last_n_user_turns(&mut messages, 0), 0);
+        assert_eq!(messages.len(), before);
     }
 }

--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -358,6 +358,65 @@ pub(crate) fn synthesize_thread_ids(messages: &mut [Message]) {
     }
 }
 
+/// Append-only control records interleaved with `Message` lines in a session
+/// JSONL. Discriminated on `kind` so [`assemble_session_messages`] can tell
+/// them apart from `Message` rows — a persisted [`Message`] never carries a
+/// `kind` field, and an internally-tagged control record has no `role`, so the
+/// two decode paths are mutually exclusive.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum SessionControlRecord {
+    /// Conversation-only rewind marker: drop the last `num_turns` user turns
+    /// from the transcript accumulated up to this point in the log. Written by
+    /// [`SessionManager::rollback_last_n_user_turns`] and replayed on every
+    /// load (append-only, never a truncation).
+    Rollback { num_turns: u32, at: DateTime<Utc> },
+}
+
+/// Serialize a rollback control record to its single-line JSONL form.
+fn rollback_marker_line(num_turns: u32) -> Result<String> {
+    let record = SessionControlRecord::Rollback {
+        num_turns,
+        at: Utc::now(),
+    };
+    Ok(serde_json::to_string(&record)?)
+}
+
+/// Assemble the ordered `Message` list from a session JSONL's post-meta lines,
+/// applying any interleaved [`SessionControlRecord`] at its position in the
+/// log.
+///
+/// Control lines are recognized before the `Message` decode (they carry a
+/// `kind` discriminator a `Message` never has) and are NOT parsed as messages.
+/// A `rollback` record drops the last N user turns accumulated *so far* —
+/// applying it positionally (rather than after the whole file) is what makes
+/// rewind-then-continue survive a reload: turns appended after the marker are
+/// kept, turns before it are trimmed. `thread_id`s are synthesized for legacy
+/// rows before each drop and once at the end, so a file without any control
+/// record assembles exactly as it did pre-marker (a single synthesize pass over
+/// the full transcript).
+fn assemble_session_messages<'a>(lines: impl Iterator<Item = &'a str>) -> Vec<Message> {
+    let mut messages: Vec<Message> = Vec::new();
+    for line in lines.filter(|line| !line.trim().is_empty()) {
+        if let Ok(control) = serde_json::from_str::<SessionControlRecord>(line) {
+            match control {
+                SessionControlRecord::Rollback { num_turns, .. } => {
+                    synthesize_thread_ids(&mut messages);
+                    crate::resume_policy::drop_last_n_user_turns(&mut messages, num_turns);
+                }
+            }
+            continue;
+        }
+        if let Ok(message) = serde_json::from_str::<Message>(line) {
+            messages.push(message);
+        }
+        // Unparseable lines are skipped, matching the prior
+        // `filter_map(|line| serde_json::from_str(line).ok())` behavior.
+    }
+    synthesize_thread_ids(&mut messages);
+    messages
+}
+
 fn record_session_persist(outcome: &'static str) {
     counter!(
         "octos_session_persist_total",
@@ -685,6 +744,12 @@ const DEFAULT_MAX_SESSIONS: usize = 1000;
 /// Maximum session file size we'll load (10 MB). Prevents OOM on corrupted/adversarial files.
 const MAX_SESSION_FILE_SIZE: u64 = 10 * 1024 * 1024;
 
+/// One row of the title/recency session listing:
+/// `(session_key, message_count, title, updated_at)`. `title` and `updated_at`
+/// are `None` for legacy files that pre-date those meta fields (with `updated_at`
+/// falling back to the JSONL mtime when available).
+pub type SessionTitleMetaRow = (String, usize, Option<String>, Option<DateTime<Utc>>);
+
 /// Manages sessions with in-memory LRU cache and JSONL disk persistence.
 ///
 /// Uses `lru::LruCache` for O(1) get/put with automatic eviction of the
@@ -736,6 +801,9 @@ impl SessionManager {
     /// `GET /sessions` endpoint to surface server-authoritative titles.
     pub fn list_sessions_with_title(&self) -> Vec<(String, usize, Option<String>)> {
         self.list_sessions_inner_with_title(false)
+            .into_iter()
+            .map(|(id, count, title, _updated_at)| (id, count, title))
+            .collect()
     }
 
     /// List only top-level sessions — those whose topic is empty (the
@@ -758,38 +826,60 @@ impl SessionManager {
     /// pre-#617 sessions).
     pub fn list_top_level_sessions_with_title(&self) -> Vec<(String, usize, Option<String>)> {
         self.list_sessions_inner_with_title(true)
+            .into_iter()
+            .map(|(id, count, title, _updated_at)| (id, count, title))
+            .collect()
+    }
+
+    /// Like [`Self::list_top_level_sessions_with_title`] but also returns each
+    /// session's recency timestamp — `SessionMeta.updated_at`, or the JSONL
+    /// file's mtime when the meta line is missing/unparseable, or `None` when
+    /// neither is available. Backs the `updated_at` field on the WS
+    /// `session/list` RPC so clients can sort by recency.
+    pub fn list_top_level_sessions_with_meta(&self) -> Vec<SessionTitleMetaRow> {
+        self.list_sessions_inner_with_title(true)
     }
 
     fn list_sessions_inner_with_title(
         &self,
         skip_internal_topics: bool,
-    ) -> Vec<(String, usize, Option<String>)> {
+    ) -> Vec<SessionTitleMetaRow> {
         // Reuse the path discovery from list_sessions_inner, but read each
         // file's first line to extract the title alongside the line count.
         let mut seen = std::collections::HashSet::new();
         let mut result = Vec::new();
 
-        let push_with_title =
-            |path: &Path,
-             session_key: String,
-             seen: &mut std::collections::HashSet<String>,
-             out: &mut Vec<(String, usize, Option<String>)>| {
-                if seen.contains(&session_key) {
-                    return;
-                }
-                // Read just the first line for metadata; fall back to count_lines
-                // for the message count.
-                let title = std::fs::read_to_string(path).ok().and_then(|content| {
+        let push_with_title = |path: &Path,
+                               session_key: String,
+                               seen: &mut std::collections::HashSet<String>,
+                               out: &mut Vec<SessionTitleMetaRow>| {
+            if seen.contains(&session_key) {
+                return;
+            }
+            // Read just the first line for metadata (title + updated_at);
+            // fall back to count_lines for the message count.
+            let (title, updated_at) = std::fs::read_to_string(path)
+                .ok()
+                .and_then(|content| {
                     content
                         .lines()
                         .next()
                         .and_then(|first| serde_json::from_str::<SessionMeta>(first).ok())
-                        .and_then(|meta| meta.title)
-                });
-                let count = Self::count_lines(path);
-                seen.insert(session_key.clone());
-                out.push((session_key, count, title));
-            };
+                })
+                .map(|meta| (meta.title, Some(meta.updated_at)))
+                .unwrap_or((None, None));
+            // Cheap recency fallback when the meta line is missing or
+            // unparseable: the JSONL file's own mtime.
+            let updated_at = updated_at.or_else(|| {
+                std::fs::metadata(path)
+                    .ok()
+                    .and_then(|meta| meta.modified().ok())
+                    .map(DateTime::<Utc>::from)
+            });
+            let count = Self::count_lines(path);
+            seen.insert(session_key.clone());
+            out.push((session_key, count, title, updated_at));
+        };
 
         if let Ok(entries) = std::fs::read_dir(&self.sessions_dir) {
             for entry in entries.flatten() {
@@ -1225,14 +1315,11 @@ impl SessionManager {
                     return None;
                 }
 
-                let mut messages: Vec<Message> = lines
-                    .filter(|line| !line.trim().is_empty())
-                    .filter_map(|line| serde_json::from_str(line).ok())
-                    .collect();
-
-                // M8.10 PR #1: synthesize `thread_id` for legacy rows
-                // (pre-field). In-memory only.
-                synthesize_thread_ids(&mut messages);
+                // Assemble messages, applying any append-only rollback control
+                // records at their position in the log and gap-filling legacy
+                // `thread_id`s in-memory (M8.10). Files without control records
+                // parse identically to the prior single-pass load.
+                let messages = assemble_session_messages(lines);
 
                 Some(Session {
                     key: key.clone(),
@@ -1590,6 +1677,93 @@ impl SessionManager {
     /// stale post-write reads.
     pub fn invalidate_cache(&mut self, key: &SessionKey) {
         self.cache.pop(&key.0);
+    }
+
+    /// Roll back the last `num_turns` user turns for `key` (conversation-only
+    /// rewind): append an idempotent rollback marker to the session JSONL and
+    /// trim the in-memory transcript to match. Returns the number of user turns
+    /// actually dropped, clamped to the session's turn count.
+    ///
+    /// The marker is appended to the same on-disk file that holds the session's
+    /// messages (per-user layout preferred, legacy flat as fallback), so both
+    /// [`Self::load_from_disk`] and the per-user `SessionHandle` load path
+    /// replay the drop at the marker's log position on the next load. This is
+    /// what keeps the trim durable without truncating history. `num_turns == 0`
+    /// is a defensive no-op (the handler rejects it as `invalid_params`).
+    ///
+    /// Conversation-only: no git, worktree, or workspace file state is touched.
+    pub async fn rollback_last_n_user_turns(
+        &mut self,
+        key: &SessionKey,
+        num_turns: u32,
+    ) -> Result<u32> {
+        // Ensure the session is resident so the trim reflects the full
+        // (merged) on-disk transcript.
+        let _ = self.get_or_create(key).await;
+        let dropped = {
+            let session = self
+                .cache
+                .peek(&key.0)
+                .ok_or_else(|| eyre::eyre!("session not in cache after get_or_create: {key}"))?;
+            num_turns.min(crate::resume_policy::count_user_turns(&session.messages))
+        };
+        if dropped == 0 {
+            return Ok(0);
+        }
+        // Durable first: append the append-only marker to disk so a crash
+        // between here and the in-memory trim still replays identically on the
+        // next load.
+        self.append_rollback_marker(key, num_turns).await?;
+        // Trim the in-memory mirror to match the persisted state so the next
+        // turn continues from the trimmed transcript.
+        if let Some(session) = self.cache.get_mut(&key.0) {
+            crate::resume_policy::drop_last_n_user_turns(&mut session.messages, num_turns);
+            session.updated_at = Utc::now();
+        }
+        Ok(dropped)
+    }
+
+    /// Append a rollback control line to the on-disk JSONL for `key`. Chooses
+    /// the per-user layout file when present, else the legacy flat file; when
+    /// neither exists there is nothing on disk to trim on reload, so the append
+    /// is skipped (the in-memory trim is authoritative for a cache-only
+    /// session).
+    async fn append_rollback_marker(&self, key: &SessionKey, num_turns: u32) -> Result<()> {
+        let flat_path = self.session_path(key);
+        let base_key = key.base_key();
+        let encoded_base = encode_path_component(base_key);
+        let topic = key.topic().unwrap_or("default");
+        let encoded_topic = encode_path_component(topic);
+        let per_user_path = self
+            .sessions_dir
+            .parent()
+            .unwrap_or(&self.sessions_dir)
+            .join("users")
+            .join(&encoded_base)
+            .join("sessions")
+            .join(format!("{encoded_topic}.jsonl"));
+
+        // Co-locate the marker with the messages so `load_from_disk`'s per-file
+        // fold applies the drop against the right transcript: per-user
+        // (canonical) wins, then legacy flat.
+        let target = if per_user_path.exists() {
+            per_user_path
+        } else if flat_path.exists() {
+            flat_path
+        } else {
+            return Ok(());
+        };
+
+        let line = rollback_marker_line(num_turns)?;
+        tokio::task::spawn_blocking(move || {
+            use std::io::Write;
+            let mut file = std::fs::OpenOptions::new().append(true).open(&target)?;
+            writeln!(file, "{line}")?;
+            Ok::<_, eyre::Report>(())
+        })
+        .await
+        .map_err(|e| eyre::eyre!("spawn_blocking join error: {e}"))??;
+        Ok(())
     }
 
     /// Scan the per-user layout for every JSONL belonging to `base_key` and
@@ -2338,14 +2512,10 @@ impl SessionHandle {
             return None;
         }
 
-        let mut messages: Vec<Message> = lines
-            .filter(|line| !line.trim().is_empty())
-            .filter_map(|line| serde_json::from_str(line).ok())
-            .collect();
-
-        // M8.10 PR #1: synthesize `thread_id` for legacy rows that pre-date
-        // the field. In-memory only — nothing is rewritten on load.
-        synthesize_thread_ids(&mut messages);
+        // Assemble messages, replaying any append-only rollback control
+        // records at their log position so a rewind survives a per-user
+        // reload too (this path backs the next turn's `SessionHandle::open`).
+        let messages = assemble_session_messages(lines);
 
         debug!(key = %key, messages = messages.len(), "Loaded session from disk");
 
@@ -2824,6 +2994,51 @@ mod tests {
             assert_eq!(session.messages.len(), 2);
             assert_eq!(session.messages[0].content, "saved");
             assert_eq!(session.messages[1].content, "reply");
+        }
+    }
+
+    #[tokio::test]
+    async fn rollback_last_n_user_turns_trims_and_survives_reload() {
+        let tmp = TempDir::new().unwrap();
+        let key = SessionKey::new("cli", "rollback-rt");
+
+        {
+            let mut mgr = SessionManager::open(tmp.path()).unwrap();
+            // Seed 3 user turns (user + assistant each) with persisted
+            // thread_ids so the drop can group them.
+            for n in 1..=3 {
+                let tid = format!("t{n}");
+                let mut user = make_message(MessageRole::User, &format!("turn {n}"));
+                user.client_message_id = Some(tid.clone());
+                user.thread_id = Some(tid.clone());
+                mgr.add_message(&key, user).await.unwrap();
+                let mut asst = make_message(MessageRole::Assistant, &format!("reply {n}"));
+                asst.thread_id = Some(tid.clone());
+                mgr.add_message(&key, asst).await.unwrap();
+            }
+
+            // Roll back the last user turn: appends the marker + trims memory.
+            let dropped = mgr.rollback_last_n_user_turns(&key, 1).await.unwrap();
+            assert_eq!(dropped, 1);
+
+            let session = mgr.get_or_create(&key).await;
+            assert_eq!(session.messages.len(), 4, "turns 1 & 2 remain in memory");
+            assert!(session.messages.iter().all(|m| m.content != "turn 3"));
+            assert!(session.messages.iter().all(|m| m.content != "reply 3"));
+        }
+
+        // A fresh manager reloads from disk; the append-only marker replays the
+        // trim (NOT a truncation — the dropped rows are still on disk).
+        {
+            let mut reload = SessionManager::open(tmp.path()).unwrap();
+            let session = reload.get_or_create(&key).await;
+            let contents: Vec<&String> = session.messages.iter().map(|m| &m.content).collect();
+            assert_eq!(
+                session.messages.len(),
+                4,
+                "rollback marker must survive reload; got {contents:?}"
+            );
+            assert!(session.messages.iter().all(|m| m.content != "turn 3"));
         }
     }
 
@@ -3456,6 +3671,38 @@ mod tests {
         let top = mgr.list_top_level_sessions();
         let ids: Vec<&str> = top.iter().map(|(id, _)| id.as_str()).collect();
         assert_eq!(ids, vec!["api:web-tasks"], "got {top:?}");
+    }
+
+    #[test]
+    fn list_top_level_sessions_with_meta_surfaces_updated_at() {
+        use chrono::TimeZone;
+        let tmp = TempDir::new().unwrap();
+        let mgr = SessionManager::open(tmp.path()).unwrap();
+
+        let user_dir = tmp.path().join("users/cli%3Ameta-recency/sessions");
+        std::fs::create_dir_all(&user_dir).unwrap();
+
+        let updated = Utc.with_ymd_and_hms(2026, 6, 30, 8, 15, 0).unwrap();
+        let meta = serde_json::json!({
+            "schema_version": 1,
+            "session_key": "cli:meta-recency",
+            "title": "Recency Chat",
+            "created_at": Utc.with_ymd_and_hms(2026, 6, 30, 8, 0, 0).unwrap(),
+            "updated_at": updated,
+        });
+        std::fs::write(
+            user_dir.join("default.jsonl"),
+            format!("{}\n", serde_json::to_string(&meta).unwrap()),
+        )
+        .unwrap();
+
+        let rows = mgr.list_top_level_sessions_with_meta();
+        let row = rows
+            .iter()
+            .find(|(id, ..)| id == "cli:meta-recency")
+            .expect("session present");
+        assert_eq!(row.2.as_deref(), Some("Recency Chat"));
+        assert_eq!(row.3, Some(updated), "updated_at read from SessionMeta");
     }
 
     /// Regression guard for the O(N) hang. With 5 000 synthetic

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -561,6 +561,11 @@ pub struct SessionInfo {
     /// the client should fall back to deriving a title from message content.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    /// Recency timestamp (RFC3339) — `SessionMeta.updated_at`, or the JSONL
+    /// file mtime as a cheap fallback. Lets the TUI sort the session list by
+    /// most-recently-touched. None when neither source is available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
 }
 
 fn is_internal_api_session_id(id: &str) -> bool {
@@ -636,9 +641,9 @@ pub async fn list_sessions(
         let existing: std::collections::HashSet<String> =
             all.iter().map(|s| s.id.clone()).collect();
         all.extend(
-            sess.list_top_level_sessions_with_title()
+            sess.list_top_level_sessions_with_meta()
                 .into_iter()
-                .filter_map(|(id, count, title)| {
+                .filter_map(|(id, count, title, updated_at)| {
                     let chat_id = id.strip_prefix(&prefix)?;
                     if is_internal_api_session_id(chat_id) {
                         return None;
@@ -650,6 +655,7 @@ pub async fn list_sessions(
                         id: chat_id.to_string(),
                         message_count: count,
                         title,
+                        updated_at: updated_at.map(|dt| dt.to_rfc3339()),
                     })
                 }),
         );
@@ -715,9 +721,9 @@ fn list_profile_sessions(profile_data_dir: &std::path::Path) -> Vec<SessionInfo>
     let Ok(mgr) = octos_bus::SessionManager::open(profile_data_dir) else {
         return Vec::new();
     };
-    mgr.list_top_level_sessions_with_title()
+    mgr.list_top_level_sessions_with_meta()
         .into_iter()
-        .filter_map(|(id, count, title)| {
+        .filter_map(|(id, count, title, updated_at)| {
             if is_internal_api_session_id(&id) {
                 return None;
             }
@@ -725,6 +731,7 @@ fn list_profile_sessions(profile_data_dir: &std::path::Path) -> Vec<SessionInfo>
                 id,
                 message_count: count,
                 title,
+                updated_at: updated_at.map(|dt| dt.to_rfc3339()),
             })
         })
         .collect()
@@ -3949,6 +3956,7 @@ mod tests {
             id: "test-session".into(),
             message_count: 42,
             title: None,
+            updated_at: None,
         };
         let json = serde_json::to_value(&info).unwrap();
         assert_eq!(json["id"], "test-session");
@@ -3956,6 +3964,10 @@ mod tests {
         assert!(
             json.get("title").is_none(),
             "None title must be omitted from JSON"
+        );
+        assert!(
+            json.get("updated_at").is_none(),
+            "None updated_at must be omitted from JSON"
         );
     }
 
@@ -3965,9 +3977,22 @@ mod tests {
             id: "test-session".into(),
             message_count: 7,
             title: Some("My Pinned Chat".into()),
+            updated_at: None,
         };
         let json = serde_json::to_value(&info).unwrap();
         assert_eq!(json["title"], "My Pinned Chat");
+    }
+
+    #[test]
+    fn session_info_serialize_includes_updated_at() {
+        let info = SessionInfo {
+            id: "test-session".into(),
+            message_count: 3,
+            title: None,
+            updated_at: Some("2026-07-02T12:00:00+00:00".into()),
+        };
+        let json = serde_json::to_value(&info).unwrap();
+        assert_eq!(json["updated_at"], "2026-07-02T12:00:00+00:00");
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -36,31 +36,31 @@ use octos_core::ui_protocol::{
     SESSION_MESSAGES_PAGE_MAX_LIMIT, SESSION_MESSAGES_PAGE_MAX_OFFSET, SESSION_TITLE_SET_MAX_CHARS,
     SessionDeleteParams, SessionFilesListParams, SessionHydrateParams, SessionHydrateResult,
     SessionListParams, SessionMessagesPageParams, SessionOpenParams, SessionOpenResult,
-    SessionOpened, SessionOrchestrationEvent, SessionSnapshotParams, SessionStatusGetParams,
-    SessionTasksListParams, SessionTitleSetParams, SessionWorkspaceGetParams,
-    SystemStatusGetParams, TaskArtifactListParams, TaskArtifactListResult, TaskArtifactReadParams,
-    TaskArtifactReadResult, TaskArtifactRecord, TaskCancelParams, TaskCancelResult, TaskListEntry,
-    TaskListParams, TaskListResult, TaskOutputDeltaEvent, TaskRestartFromNodeParams,
-    TaskRestartFromNodeResult, TaskRuntimeState as UiTaskRuntimeState, TaskUpdatedEvent,
-    ThreadGraphEntry, ThreadGraphGetParams, ThreadGraphGetResult, ToolCompletedEvent,
-    ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent, TurnErrorEvent, TurnId,
-    TurnInterruptParams, TurnInterruptResult, TurnLifecycleState, TurnSessionResult,
-    TurnSpawnCompleteEvent, TurnStartParams, TurnStateGetParams, TurnStateGetResult,
-    UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1, UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1,
-    UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1, UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1,
-    UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1, UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1,
-    UI_PROTOCOL_FEATURE_CONTEXT_LIFECYCLE_V1, UI_PROTOCOL_FEATURE_FILE_ATTACHED_V1,
-    UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1, UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
-    UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1, UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
-    UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1, UI_PROTOCOL_FEATURE_REVIEW_START_V1,
-    UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1, UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1,
-    UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1, UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1,
-    UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1, UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1,
-    UI_PROTOCOL_FEATURE_USER_QUESTION_V1, UiAgentRecord, UiArtifactPaneItem,
-    UiArtifactPaneSnapshot, UiCommand, UiContextCompactionRecord, UiContextNormalizationReport,
-    UiContextState, UiCursor, UiFileMutationNotice, UiGitHistoryItem, UiGitPaneSnapshot,
-    UiGitStatusItem, UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation, UiProgressEvent,
-    UiProgressMetadata, UiProtocolCapabilities, UiRpcResult, UiWorkspacePaneEntry,
+    SessionOpened, SessionOrchestrationEvent, SessionRollbackParams, SessionRollbackResult,
+    SessionSnapshotParams, SessionStatusGetParams, SessionTasksListParams, SessionTitleSetParams,
+    SessionWorkspaceGetParams, SystemStatusGetParams, TaskArtifactListParams,
+    TaskArtifactListResult, TaskArtifactReadParams, TaskArtifactReadResult, TaskArtifactRecord,
+    TaskCancelParams, TaskCancelResult, TaskListEntry, TaskListParams, TaskListResult,
+    TaskOutputDeltaEvent, TaskRestartFromNodeParams, TaskRestartFromNodeResult,
+    TaskRuntimeState as UiTaskRuntimeState, TaskUpdatedEvent, ThreadGraphEntry,
+    ThreadGraphGetParams, ThreadGraphGetResult, ToolCompletedEvent, ToolProgressEvent,
+    ToolStartedEvent, TurnCompletedEvent, TurnErrorEvent, TurnId, TurnInterruptParams,
+    TurnInterruptResult, TurnLifecycleState, TurnSessionResult, TurnSpawnCompleteEvent,
+    TurnStartParams, TurnStateGetParams, TurnStateGetResult, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
+    UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1, UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1,
+    UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1, UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1,
+    UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1, UI_PROTOCOL_FEATURE_CONTEXT_LIFECYCLE_V1,
+    UI_PROTOCOL_FEATURE_FILE_ATTACHED_V1, UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1,
+    UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1, UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1,
+    UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1, UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1,
+    UI_PROTOCOL_FEATURE_REVIEW_START_V1, UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1,
+    UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1, UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
+    UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1, UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1,
+    UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1, UI_PROTOCOL_FEATURE_USER_QUESTION_V1, UiAgentRecord,
+    UiArtifactPaneItem, UiArtifactPaneSnapshot, UiCommand, UiContextCompactionRecord,
+    UiContextNormalizationReport, UiContextState, UiCursor, UiFileMutationNotice, UiGitHistoryItem,
+    UiGitPaneSnapshot, UiGitStatusItem, UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation,
+    UiProgressEvent, UiProgressMetadata, UiProtocolCapabilities, UiRpcResult, UiWorkspacePaneEntry,
     UiWorkspacePaneSnapshot, UnsupportedCapabilityReport, UserQuestionRequestedEvent,
     UserQuestionRespondParams, approval_cancelled_reasons, approval_kinds, hydrate_sections,
     progress_kinds, thread_status,
@@ -4268,6 +4268,19 @@ async fn ui_protocol_connection(
                 )
                 .await;
             }
+            UiCommand::SessionRollback(params) => {
+                handle_session_rollback(
+                    &ws,
+                    &state,
+                    &ledger,
+                    &active_turns,
+                    connection_profile_id,
+                    routed_profile_id,
+                    id,
+                    params,
+                )
+                .await;
+            }
             UiCommand::ThreadGraphGet(params) => {
                 handle_thread_graph_get(
                     &ws,
@@ -4824,6 +4837,19 @@ where
                     connection_profile_id_owned.as_deref(),
                     None,
                     features,
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::SessionRollback(params) => {
+                handle_session_rollback(
+                    &ws,
+                    &state,
+                    &ledger,
+                    &active_turns,
+                    connection_profile_id_owned.as_deref(),
+                    None,
                     id,
                     params,
                 )
@@ -8211,6 +8237,7 @@ fn validate_session_ingress_command_scope(
         UiCommand::TaskArtifactList(params) => params.session_id.clone(),
         UiCommand::TaskArtifactRead(params) => params.session_id.clone(),
         UiCommand::SessionHydrate(params) => params.session_id.clone(),
+        UiCommand::SessionRollback(params) => params.session_id.clone(),
         UiCommand::ThreadGraphGet(params) => params.session_id.clone(),
         UiCommand::TurnStateGet(params) => params.session_id.clone(),
         UiCommand::SessionSnapshot(params) => {
@@ -12201,6 +12228,166 @@ async fn handle_session_hydrate(
         octos_core::ui_protocol::methods::SESSION_HYDRATE,
         result,
     );
+}
+
+/// `session/rollback` — conversation-only rewind. Drops the last `num_turns`
+/// user turns from the session (persisted + in-memory), persists an idempotent
+/// append-only marker, and returns the trimmed thread projected exactly like
+/// `session/hydrate` (messages + threads + turns + cursor).
+///
+/// Scoped / resolved identically to [`handle_session_hydrate`]. Rejected when a
+/// turn is in progress for the session (rewinding under an active turn would
+/// race the writer). NOTHING outside the conversation transcript is touched —
+/// no git, worktree, or workspace file state.
+#[allow(clippy::too_many_arguments)]
+async fn handle_session_rollback(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    ledger: &Arc<UiProtocolLedger>,
+    active_turns: &SharedActiveTurns,
+    connection_profile_id: Option<&str>,
+    routed_profile_id: Option<&str>,
+    id: String,
+    params: SessionRollbackParams,
+) {
+    let method = octos_core::ui_protocol::methods::SESSION_ROLLBACK;
+    if let Err(error) = validate_session_scope(&params.session_id, None, connection_profile_id) {
+        send_scope_error(ws, id, error);
+        return;
+    }
+    // `num_turns` must be >= 1 — a zero-turn rollback is a no-op the client
+    // should never send.
+    if params.num_turns < 1 {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            RpcError::invalid_params(format!("{method}: num_turns must be >= 1"))
+                .with_data(json!({ "kind": "invalid_num_turns" })),
+        );
+        return;
+    }
+
+    // Snapshot the ledger once for the trimmed-thread projection's cursor +
+    // turn overlay (mirrors the hydrate handler).
+    let (replayed, head_cursor) = match ledger.snapshot_with_cursor(&params.session_id, None) {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+            return;
+        }
+    };
+
+    let Some(sessions) = resolve_sessions_for_lookup(
+        state,
+        connection_profile_id,
+        routed_profile_id,
+        &params.session_id,
+    )
+    .await
+    else {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            runtime_unavailable_error("Sessions not available"),
+        );
+        return;
+    };
+
+    // Guard: refuse to rewind while a turn is in flight for this session.
+    // Detected via the same process-global active-turn registry the
+    // turn/hydrate handlers consult. Checked before taking the sessions lock so
+    // we never hold two locks at once.
+    if active_turn_sessions(active_turns)
+        .await
+        .contains(&params.session_id)
+    {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            RpcError::invalid_params(format!(
+                "{method}: a turn is in progress; interrupt it before rolling back"
+            ))
+            .with_data(json!({ "kind": "turn_in_progress" })),
+        );
+        return;
+    }
+
+    // Apply the rollback (marker + in-memory trim) and project the trimmed
+    // thread while holding the sessions lock, so the projection reflects the
+    // post-trim snapshot.
+    let (dropped_turns, messages, threads, orphans) = {
+        let mut sessions_guard = sessions.lock().await;
+        // Reject unknown sessions per the hydrate error model — we do NOT
+        // auto-create on rollback.
+        if !sessions_guard.session_known(&params.session_id) {
+            drop(sessions_guard);
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::unknown_session(params.session_id.0.clone()),
+            );
+            return;
+        }
+        let dropped_turns = match sessions_guard
+            .rollback_last_n_user_turns(&params.session_id, params.num_turns)
+            .await
+        {
+            Ok(dropped) => dropped,
+            Err(error) => {
+                drop(sessions_guard);
+                let _ = send_rpc_error(
+                    ws,
+                    Some(id),
+                    RpcError::internal_error(format!("{method}: {error}")),
+                );
+                return;
+            }
+        };
+        let session = sessions_guard.get_or_create(&params.session_id).await;
+        // Same message projection as `handle_session_hydrate` for a
+        // non-negotiated client: seqs are the trimmed transcript's indices.
+        let messages = session
+            .messages
+            .iter()
+            .enumerate()
+            .map(|(seq, msg)| HydratedMessage {
+                seq: seq as u64,
+                role: msg.role.as_str().to_owned(),
+                content: msg.content.clone(),
+                turn_id: None,
+                thread_id: msg.thread_id.clone(),
+                client_message_id: msg.client_message_id.clone(),
+                persisted_at: msg.timestamp,
+                message_id: None,
+                source: None,
+                media: msg.media.clone(),
+            })
+            .collect::<Vec<_>>();
+        let (threads, orphans) = build_thread_graph_entries(session);
+        (dropped_turns, messages, threads, orphans)
+    };
+    let _ = orphans;
+
+    // Turn projection reuses the exact hydrate helper over the trimmed threads.
+    let turns = collect_session_turns(&params.session_id, active_turns, &replayed, &threads).await;
+
+    let thread = SessionHydrateResult {
+        session_id: params.session_id.clone(),
+        cursor: head_cursor,
+        context: None,
+        context_state: None,
+        messages: Some(messages),
+        threads: Some(threads),
+        turns: Some(turns),
+        pending_approvals: None,
+        pending_questions: None,
+        replayed_envelopes: None,
+    };
+    let result = SessionRollbackResult {
+        dropped_turns,
+        thread,
+    };
+    send_serialized_rpc_result(ws, id, method, result);
 }
 
 /// Per UPCR-2026-010: lift the in-memory thread partition onto the wire.
@@ -23313,6 +23500,7 @@ mod tests {
                 "node_id": "design",
             }),
             methods::SESSION_HYDRATE => json!({ "session_id": session_id }),
+            methods::SESSION_ROLLBACK => json!({ "session_id": session_id, "num_turns": 1 }),
             methods::THREAD_GRAPH_GET => json!({ "session_id": session_id }),
             methods::TURN_STATE_GET => json!({
                 "session_id": session_id,
@@ -35364,6 +35552,226 @@ ignore = []
             thread_id: Some("cmid-user-1".into()),
             timestamp: now + chrono::Duration::milliseconds(10),
         });
+    }
+
+    /// Open a disk-backed `SessionManager` and persist `turns` user turns
+    /// (user + assistant each, thread-grouped) so `session/rollback` has a real
+    /// JSONL to append its marker to and reload from. Returns the state plus the
+    /// live `TempDir` — the caller must keep it alive for the test's duration.
+    async fn prg_state_with_persisted_turns(
+        session_id: &SessionKey,
+        turns: usize,
+    ) -> (Arc<AppState>, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let manager = octos_bus::SessionManager::open(tmp.path()).expect("session manager open");
+        let manager = Arc::new(tokio::sync::Mutex::new(manager));
+        {
+            let mut guard = manager.lock().await;
+            for n in 1..=turns {
+                let tid = format!("t{n}");
+                let now = Utc::now() + chrono::Duration::milliseconds((n as i64) * 2);
+                let user = Message {
+                    role: MessageRole::User,
+                    content: format!("turn {n}"),
+                    media: vec![],
+                    tool_calls: None,
+                    tool_call_id: None,
+                    reasoning_content: None,
+                    client_message_id: Some(tid.clone()),
+                    thread_id: Some(tid.clone()),
+                    timestamp: now,
+                };
+                guard
+                    .add_message(session_id, user)
+                    .await
+                    .expect("persist user");
+                let asst = Message {
+                    role: MessageRole::Assistant,
+                    content: format!("reply {n}"),
+                    media: vec![],
+                    tool_calls: None,
+                    tool_call_id: None,
+                    reasoning_content: None,
+                    client_message_id: None,
+                    thread_id: Some(tid.clone()),
+                    timestamp: now + chrono::Duration::milliseconds(1),
+                };
+                guard
+                    .add_message(session_id, asst)
+                    .await
+                    .expect("persist assistant");
+            }
+        }
+        let state = Arc::new(AppState {
+            sessions: Some(manager),
+            ..AppState::empty_for_tests()
+        });
+        (state, tmp)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_rollback_drops_last_turn_and_returns_trimmed_thread() {
+        let session_id = SessionKey("local:rollback-1".into());
+        let (state, _tmp) = prg_state_with_persisted_turns(&session_id, 3).await;
+        let active_turns = active_turns_registry();
+        let ledger = event_ledger(&state).await;
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        handle_session_rollback(
+            &ws,
+            &state,
+            &ledger,
+            &active_turns,
+            None,
+            None,
+            "rb1".into(),
+            SessionRollbackParams {
+                session_id: session_id.clone(),
+                num_turns: 1,
+            },
+        )
+        .await;
+
+        let frame = recv_rpc_json(&mut rx).await;
+        assert_eq!(frame["id"], "rb1");
+        let result = &frame["result"];
+        assert_eq!(result["dropped_turns"], 1);
+        let thread = &result["thread"];
+        assert_eq!(thread["session_id"], session_id.to_string());
+        assert!(thread["cursor"].is_object());
+        let messages = thread["messages"].as_array().expect("messages array");
+        assert_eq!(
+            messages.len(),
+            4,
+            "turns 1 & 2 remain after dropping turn 3"
+        );
+        assert!(messages.iter().all(|m| m["content"] != "turn 3"));
+        assert!(messages.iter().all(|m| m["content"] != "reply 3"));
+        let threads = thread["threads"].as_array().expect("threads array");
+        assert_eq!(threads.len(), 2);
+        assert!(thread["turns"].is_array());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_rollback_survives_reload_from_disk() {
+        let session_id = SessionKey("local:rollback-reload".into());
+        let (state, _tmp) = prg_state_with_persisted_turns(&session_id, 3).await;
+        let active_turns = active_turns_registry();
+        let ledger = event_ledger(&state).await;
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        handle_session_rollback(
+            &ws,
+            &state,
+            &ledger,
+            &active_turns,
+            None,
+            None,
+            "rb2".into(),
+            SessionRollbackParams {
+                session_id: session_id.clone(),
+                num_turns: 1,
+            },
+        )
+        .await;
+        let _ = recv_rpc_json(&mut rx).await;
+
+        // Evict the cache and reload from disk: the append-only marker replays
+        // the trim (it was persisted, not truncated).
+        {
+            let sessions = state.sessions.as_ref().expect("sessions store");
+            let mut guard = sessions.lock().await;
+            guard.invalidate_cache(&session_id);
+            let session = guard.get_or_create(&session_id).await;
+            assert_eq!(
+                session.messages.len(),
+                4,
+                "rollback marker must survive a disk reload"
+            );
+            assert!(session.messages.iter().all(|m| m.content != "turn 3"));
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_rollback_rejects_when_turn_in_progress() {
+        let session_id = SessionKey("local:rollback-busy".into());
+        let (state, _tmp) = prg_state_with_persisted_turns(&session_id, 3).await;
+        let active_turns = active_turns_registry();
+        // Insert a synthetic in-flight turn, exactly as handle_turn_start would.
+        let (interrupt_tx, _interrupt_rx) = mpsc::channel::<()>(1);
+        let dummy_handle = tokio::spawn(async {});
+        {
+            let mut guard = active_turns.lock().await;
+            guard.insert(
+                session_id.clone(),
+                ActiveTurn {
+                    turn_id: TurnId::new(),
+                    state: Arc::new(TokioMutex::new(TurnState::Active)),
+                    interrupt_tx: Arc::new(TokioMutex::new(Some(interrupt_tx))),
+                    abort: dummy_handle.abort_handle(),
+                },
+            );
+        }
+        let ledger = event_ledger(&state).await;
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        handle_session_rollback(
+            &ws,
+            &state,
+            &ledger,
+            &active_turns,
+            None,
+            None,
+            "rb3".into(),
+            SessionRollbackParams {
+                session_id: session_id.clone(),
+                num_turns: 1,
+            },
+        )
+        .await;
+
+        let frame = recv_rpc_json(&mut rx).await;
+        assert!(
+            frame.get("error").is_some(),
+            "rollback under an active turn must error: {frame}"
+        );
+        assert_eq!(frame["error"]["data"]["kind"], "turn_in_progress");
+        // The transcript must be untouched (6 messages = 3 turns).
+        {
+            let sessions = state.sessions.as_ref().expect("sessions store");
+            let mut guard = sessions.lock().await;
+            let session = guard.get_or_create(&session_id).await;
+            assert_eq!(session.messages.len(), 6, "no trim under an active turn");
+        }
+        active_turns.lock().await.remove(&session_id);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_rollback_rejects_zero_num_turns() {
+        let session_id = SessionKey("local:rollback-zero".into());
+        let (state, _tmp) = prg_state_with_persisted_turns(&session_id, 2).await;
+        let active_turns = active_turns_registry();
+        let ledger = event_ledger(&state).await;
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        handle_session_rollback(
+            &ws,
+            &state,
+            &ledger,
+            &active_turns,
+            None,
+            None,
+            "rb0".into(),
+            SessionRollbackParams {
+                session_id: session_id.clone(),
+                num_turns: 0,
+            },
+        )
+        .await;
+
+        let frame = recv_rpc_json(&mut rx).await;
+        assert!(frame.get("error").is_some(), "num_turns=0 must be rejected");
+        assert_eq!(frame["error"]["data"]["kind"], "invalid_num_turns");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -962,6 +962,10 @@ pub mod methods {
 
     /// UPCR-2026-009 `session/hydrate` — authoritative chat-state reload.
     pub const SESSION_HYDRATE: &str = "session/hydrate";
+    /// `session/rollback` — drop the last N user turns (conversation-only
+    /// rewind), persist an idempotent append-only marker, and return the
+    /// trimmed hydrated thread. MUTATING: changes persisted session state.
+    pub const SESSION_ROLLBACK: &str = "session/rollback";
     /// UPCR-2026-010 `thread/graph/get` — thread partition for the session.
     pub const THREAD_GRAPH_GET: &str = "thread/graph/get";
     /// UPCR-2026-011 `turn/state/get` — turn lifecycle introspection.
@@ -1183,6 +1187,7 @@ pub const UI_PROTOCOL_COMMAND_METHODS: &[&str] = &[
     methods::TASK_RESTART_FROM_NODE,
     methods::TASK_OUTPUT_READ,
     methods::SESSION_HYDRATE,
+    methods::SESSION_ROLLBACK,
     methods::THREAD_GRAPH_GET,
     methods::TURN_STATE_GET,
     methods::AGENT_LIST,
@@ -1282,6 +1287,7 @@ pub const UI_PROTOCOL_FIRST_SERVER_METHODS: &[&str] = &[
     methods::TASK_RESTART_FROM_NODE,
     methods::TASK_OUTPUT_READ,
     methods::SESSION_HYDRATE,
+    methods::SESSION_ROLLBACK,
     methods::THREAD_GRAPH_GET,
     methods::TURN_STATE_GET,
     methods::AGENT_LIST,
@@ -1675,6 +1681,7 @@ pub enum UiResultKind {
     TaskArtifactList,
     TaskArtifactRead,
     SessionHydrate,
+    SessionRollback,
     ThreadGraphGet,
     TurnStateGet,
     UnsupportedCapability,
@@ -1698,6 +1705,7 @@ pub fn first_server_result_kind_for_method(method: &str) -> Option<UiResultKind>
         methods::TASK_ARTIFACT_LIST => Some(UiResultKind::TaskArtifactList),
         methods::TASK_ARTIFACT_READ => Some(UiResultKind::TaskArtifactRead),
         methods::SESSION_HYDRATE => Some(UiResultKind::SessionHydrate),
+        methods::SESSION_ROLLBACK => Some(UiResultKind::SessionRollback),
         methods::THREAD_GRAPH_GET => Some(UiResultKind::ThreadGraphGet),
         methods::TURN_STATE_GET => Some(UiResultKind::TurnStateGet),
         _ => None,
@@ -2705,6 +2713,24 @@ pub struct SessionHydrateResult {
     pub replayed_envelopes: Option<Vec<TurnSpawnCompleteEvent>>,
 }
 
+/// Params for `session/rollback` — conversation-only rewind. Drops the last
+/// `num_turns` user turns from the session (persisted + in-memory). `num_turns`
+/// must be `>= 1`; the server rejects `0` with `invalid_params`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionRollbackParams {
+    pub session_id: SessionKey,
+    pub num_turns: u32,
+}
+
+/// Result for `session/rollback`. `dropped_turns` is the number of user turns
+/// actually removed (clamped to the session's turn count), and `thread` is the
+/// trimmed session projected via the same shape as `session/hydrate`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionRollbackResult {
+    pub dropped_turns: u32,
+    pub thread: SessionHydrateResult,
+}
+
 // ----- UPCR-2026-010 `thread/graph/get` -----
 
 /// Params for `thread/graph/get` (UPCR-2026-010).
@@ -3583,6 +3609,7 @@ pub enum UiCommand {
     TaskArtifactList(TaskArtifactListParams),
     TaskArtifactRead(TaskArtifactReadParams),
     SessionHydrate(SessionHydrateParams),
+    SessionRollback(SessionRollbackParams),
     ThreadGraphGet(ThreadGraphGetParams),
     TurnStateGet(TurnStateGetParams),
     // ---- M12 Phase D-1 auxiliary REST → WS frames ----
@@ -3624,6 +3651,7 @@ impl UiCommand {
             Self::TaskArtifactList(_) => methods::TASK_ARTIFACT_LIST,
             Self::TaskArtifactRead(_) => methods::TASK_ARTIFACT_READ,
             Self::SessionHydrate(_) => methods::SESSION_HYDRATE,
+            Self::SessionRollback(_) => methods::SESSION_ROLLBACK,
             Self::ThreadGraphGet(_) => methods::THREAD_GRAPH_GET,
             Self::TurnStateGet(_) => methods::TURN_STATE_GET,
             Self::SessionList(_) => methods::SESSION_LIST,
@@ -3667,6 +3695,7 @@ impl UiCommand {
             Self::TaskArtifactList(params) => serde_json::to_value(params),
             Self::TaskArtifactRead(params) => serde_json::to_value(params),
             Self::SessionHydrate(params) => serde_json::to_value(params),
+            Self::SessionRollback(params) => serde_json::to_value(params),
             Self::ThreadGraphGet(params) => serde_json::to_value(params),
             Self::TurnStateGet(params) => serde_json::to_value(params),
             Self::SessionList(params) => serde_json::to_value(params),
@@ -3736,6 +3765,7 @@ impl UiCommand {
                 Ok(Self::TaskArtifactRead(decode_params(method, params)?))
             }
             methods::SESSION_HYDRATE => Ok(Self::SessionHydrate(decode_params(method, params)?)),
+            methods::SESSION_ROLLBACK => Ok(Self::SessionRollback(decode_params(method, params)?)),
             methods::THREAD_GRAPH_GET => Ok(Self::ThreadGraphGet(decode_params(method, params)?)),
             methods::TURN_STATE_GET => Ok(Self::TurnStateGet(decode_params(method, params)?)),
             methods::SESSION_LIST => Ok(Self::SessionList(decode_optional_params(method, params)?)),
@@ -4079,6 +4109,7 @@ pub enum UiRpcResult {
     TaskArtifactList(TaskArtifactListResult),
     TaskArtifactRead(TaskArtifactReadResult),
     SessionHydrate(SessionHydrateResult),
+    SessionRollback(SessionRollbackResult),
     ThreadGraphGet(ThreadGraphGetResult),
     TurnStateGet(TurnStateGetResult),
     UnsupportedCapability(UnsupportedCapabilityResult),
@@ -4103,6 +4134,7 @@ impl UiRpcResult {
             Self::TaskArtifactList(_) => UiResultKind::TaskArtifactList,
             Self::TaskArtifactRead(_) => UiResultKind::TaskArtifactRead,
             Self::SessionHydrate(_) => UiResultKind::SessionHydrate,
+            Self::SessionRollback(_) => UiResultKind::SessionRollback,
             Self::ThreadGraphGet(_) => UiResultKind::ThreadGraphGet,
             Self::TurnStateGet(_) => UiResultKind::TurnStateGet,
             Self::UnsupportedCapability(_) => UiResultKind::UnsupportedCapability,
@@ -4127,6 +4159,7 @@ impl UiRpcResult {
             Self::TaskArtifactList(_) => Some(methods::TASK_ARTIFACT_LIST),
             Self::TaskArtifactRead(_) => Some(methods::TASK_ARTIFACT_READ),
             Self::SessionHydrate(_) => Some(methods::SESSION_HYDRATE),
+            Self::SessionRollback(_) => Some(methods::SESSION_ROLLBACK),
             Self::ThreadGraphGet(_) => Some(methods::THREAD_GRAPH_GET),
             Self::TurnStateGet(_) => Some(methods::TURN_STATE_GET),
             Self::UnsupportedCapability(result) => Some(result.unsupported.method.as_str()),
@@ -4151,6 +4184,7 @@ impl UiRpcResult {
             Self::TaskArtifactList(result) => serde_json::to_value(result),
             Self::TaskArtifactRead(result) => serde_json::to_value(result),
             Self::SessionHydrate(result) => serde_json::to_value(result),
+            Self::SessionRollback(result) => serde_json::to_value(result),
             Self::ThreadGraphGet(result) => serde_json::to_value(result),
             Self::TurnStateGet(result) => serde_json::to_value(result),
             Self::UnsupportedCapability(result) => serde_json::to_value(result),
@@ -4206,6 +4240,7 @@ impl UiRpcResult {
                 Ok(Self::TaskArtifactRead(decode_result(method, result)?))
             }
             methods::SESSION_HYDRATE => Ok(Self::SessionHydrate(decode_result(method, result)?)),
+            methods::SESSION_ROLLBACK => Ok(Self::SessionRollback(decode_result(method, result)?)),
             methods::THREAD_GRAPH_GET => Ok(Self::ThreadGraphGet(decode_result(method, result)?)),
             methods::TURN_STATE_GET => Ok(Self::TurnStateGet(decode_result(method, result)?)),
             _ => Err(RpcError::method_not_found(method)),
@@ -6744,6 +6779,7 @@ mod tests {
                 "task/restart_from_node",
                 "task/output/read",
                 "session/hydrate",
+                "session/rollback",
                 "thread/graph/get",
                 "turn/state/get",
                 "agent/list",
@@ -6845,6 +6881,7 @@ mod tests {
                 "task/restart_from_node",
                 "task/output/read",
                 "session/hydrate",
+                "session/rollback",
                 "thread/graph/get",
                 "turn/state/get",
                 "agent/list",
@@ -6918,6 +6955,7 @@ mod tests {
                     "task/restart_from_node",
                     "task/output/read",
                     "session/hydrate",
+                    "session/rollback",
                     "thread/graph/get",
                     "turn/state/get",
                     "agent/list",
@@ -9809,6 +9847,62 @@ mod tests {
         assert!(!object.contains_key("pending_questions"));
         // Bug C: a non-negotiated client never sees the new field.
         assert!(!object.contains_key("replayed_envelopes"));
+    }
+
+    #[test]
+    fn golden_session_rollback_params_serde() {
+        let params = SessionRollbackParams {
+            session_id: sample_session_id(),
+            num_turns: 2,
+        };
+        let value = serde_json::to_value(&params).expect("serialize rollback params");
+        assert_eq!(value, json!({ "session_id": "local:demo", "num_turns": 2 }));
+        let parsed: SessionRollbackParams =
+            serde_json::from_value(value).expect("deserialize rollback params");
+        assert_eq!(parsed, params);
+    }
+
+    #[test]
+    fn session_rollback_command_and_result_round_trip() {
+        // Command decodes from its wire method name.
+        let command = UiCommand::SessionRollback(SessionRollbackParams {
+            session_id: sample_session_id(),
+            num_turns: 1,
+        });
+        assert_eq!(command.method(), methods::SESSION_ROLLBACK);
+        let request = command.clone().into_rpc_request("r1").expect("encode");
+        assert_eq!(request.method, methods::SESSION_ROLLBACK);
+        let decoded = UiCommand::from_rpc_request(request).expect("decode command");
+        assert_eq!(decoded, command);
+
+        // Result carries the trimmed hydrate projection and round-trips through
+        // the method-keyed decode path.
+        let result = SessionRollbackResult {
+            dropped_turns: 1,
+            thread: SessionHydrateResult {
+                session_id: sample_session_id(),
+                cursor: sample_cursor(),
+                context: None,
+                context_state: None,
+                messages: Some(vec![]),
+                threads: None,
+                turns: None,
+                pending_approvals: None,
+                pending_questions: None,
+                replayed_envelopes: None,
+            },
+        };
+        let wire = UiRpcResult::SessionRollback(result.clone());
+        assert_eq!(wire.method(), Some(methods::SESSION_ROLLBACK));
+        assert_eq!(wire.kind(), UiResultKind::SessionRollback);
+        let value = wire.into_result_value().expect("encode result");
+        let decoded =
+            UiRpcResult::from_method_and_result(methods::SESSION_ROLLBACK, value).expect("decode");
+        assert_eq!(decoded, UiRpcResult::SessionRollback(result));
+        assert_eq!(
+            first_server_result_kind_for_method(methods::SESSION_ROLLBACK),
+            Some(UiResultKind::SessionRollback)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Server-side support for session **resume** and **rewind** in the UI Protocol, consumed by the octos-tui `/resume` and `/rewind` pickers.

- **`session/rollback` RPC** (octos-core `ui_protocol.rs`, octos-cli `ui_protocol.rs` + `handlers.rs`): drop the last N user turns from a session and re-hydrate the trimmed thread.
- **JSONL rollback marker + `drop_last_n_user_turns`** (octos-bus `session.rs`): durable rollback recorded as a marker line; reload applies the marker to reconstruct the trimmed transcript.
- **`updated_at` on `session/list`** (octos-bus `session.rs`): sessions carry a recency timestamp so clients can order the resume picker by most-recent.
- New `octos-bus/src/resume_policy.rs` helper.

## Verification

Build + test verified prior to landing. This is the first half of a two-repo change; octos-tui then bumps its `octos-core` git-dep to the merged commit and adds the `/resume` + `/rewind` pickers.