### PR TITLE
fix(session): rollback correctness across mixed layout + list recency + trimmed turns

### DIFF
--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -1415,10 +1415,12 @@ impl SessionManager {
                     let mut items: Vec<SessionTimelineItem> = Vec::with_capacity(
                         flat_timeline.len().saturating_add(per_user_timeline.len()),
                     );
-                    let mut seen = std::collections::HashSet::new();
+                    let mut seen: std::collections::HashMap<String, usize> =
+                        std::collections::HashMap::new();
 
                     for item in flat_timeline.into_iter().chain(per_user_timeline) {
-                        match &item {
+                        match item {
+                            SessionTimelineItem::Rollback { .. } => items.push(item),
                             SessionTimelineItem::Message(message) => {
                                 // The dedup fingerprint must be synthesis-INDEPENDENT: a
                                 // legacy flat row (no persisted `thread_id`) and its
@@ -1428,20 +1430,43 @@ impl SessionManager {
                                 // logical message. `thread_id` is only synthesized later
                                 // in `fold_session_timeline`, and neither field is content
                                 // identity, so normalize both to `None` before
-                                // fingerprinting. Otherwise the two copies fingerprint
+                                // fingerprinting — else the two copies fingerprint
                                 // differently, both survive, and a partial-migration
                                 // (stale flat + per-user) session doubles on reload.
-                                let mut ident = message.as_ref().clone();
+                                let mut ident = (*message).clone();
                                 ident.thread_id = None;
                                 ident.client_message_id = None;
                                 let Ok(fingerprint) = serde_json::to_string(&ident) else {
                                     continue;
                                 };
-                                if seen.insert(fingerprint) {
-                                    items.push(item);
+                                // On a cross-layout dup, keep the RICHER copy: the
+                                // migrated per-user row carries the canonical
+                                // thread_id/client_message_id the legacy flat row lacks,
+                                // so hydrate/thread projections resolve the real IDs on
+                                // reload rather than the flat row's missing/synthesized
+                                // ones (flat is processed first, so without this the
+                                // stale row would win).
+                                let richness = message.thread_id.is_some() as u8
+                                    + message.client_message_id.is_some() as u8;
+                                match seen.get(&fingerprint).copied() {
+                                    None => {
+                                        seen.insert(fingerprint, items.len());
+                                        items.push(SessionTimelineItem::Message(message));
+                                    }
+                                    Some(idx) => {
+                                        let kept = match &items[idx] {
+                                            SessionTimelineItem::Message(existing) => {
+                                                existing.thread_id.is_some() as u8
+                                                    + existing.client_message_id.is_some() as u8
+                                            }
+                                            SessionTimelineItem::Rollback { .. } => u8::MAX,
+                                        };
+                                        if richness > kept {
+                                            items[idx] = SessionTimelineItem::Message(message);
+                                        }
+                                    }
                                 }
                             }
-                            SessionTimelineItem::Rollback { .. } => items.push(item),
                         }
                     }
                     // Stable sort: preserves flat-before-per-user order for
@@ -3266,7 +3291,9 @@ mod tests {
         // Same logical rows (identical role/content/timestamp). The flat copy has
         // NO thread_id (legacy); the per-user copy carries a synthesized thread_id
         // (migrated) — the only serialized difference between the two.
-        let row = |content: &str, offset: i64, thread_id: Option<&str>| {
+        // ids = Some((thread_id, client_message_id)) for the migrated per-user
+        // copy; None for the legacy flat copy (which carries neither).
+        let row = |content: &str, offset: i64, ids: Option<(&str, &str)>| {
             let role = if content.starts_with("turn") {
                 MessageRole::User
             } else {
@@ -3274,7 +3301,12 @@ mod tests {
             };
             let mut m = make_message(role, content);
             m.timestamp = base + chrono::Duration::milliseconds(offset);
-            m.thread_id = thread_id.map(|s| s.to_string());
+            let (tid, cmid) = match ids {
+                Some((t, c)) => (Some(t.to_string()), Some(c.to_string())),
+                None => (None, None),
+            };
+            m.thread_id = tid;
+            m.client_message_id = cmid;
             m
         };
         let meta = |updated_ms: i64| {
@@ -3312,8 +3344,8 @@ mod tests {
             format!(
                 "{}\n{}\n{}\n",
                 serde_json::to_string(&meta(2)).unwrap(),
-                serde_json::to_string(&row("turn 1", 0, Some("t1"))).unwrap(),
-                serde_json::to_string(&row("reply 1", 1, Some("t1"))).unwrap(),
+                serde_json::to_string(&row("turn 1", 0, Some(("t1", "cmid-turn1")))).unwrap(),
+                serde_json::to_string(&row("reply 1", 1, Some(("t1", "cmid-reply1")))).unwrap(),
             ),
         )
         .unwrap();
@@ -3334,6 +3366,18 @@ mod tests {
                 .count(),
             1,
             "migrated 'turn 1' must appear exactly once: {contents:?}"
+        );
+        // The RICHER per-user copy must win the dedup, so its canonical
+        // client_message_id survives (not the flat row's None).
+        let turn1 = session
+            .messages
+            .iter()
+            .find(|m| m.content == "turn 1")
+            .expect("turn 1 present");
+        assert_eq!(
+            turn1.client_message_id.as_deref(),
+            Some("cmid-turn1"),
+            "dedup must keep the canonical per-user row's client_message_id"
         );
     }
 

--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -382,39 +382,78 @@ fn rollback_marker_line(num_turns: u32) -> Result<String> {
     Ok(serde_json::to_string(&record)?)
 }
 
-/// Assemble the ordered `Message` list from a session JSONL's post-meta lines,
-/// applying any interleaved [`SessionControlRecord`] at its position in the
-/// log.
+/// One ordered item in a session JSONL's post-meta timeline: a persisted
+/// [`Message`] or an append-only rollback control marker. Parsing keeps the two
+/// interleaved in log order so the marker can be replayed positionally — by log
+/// order within a single file ([`fold_session_timeline`]) or by timestamp after
+/// a flat + per-user merge (in [`SessionManager::load_from_disk`]).
+///
+/// `Message` is boxed so the small `Rollback` variant does not inflate every
+/// element of a session-length `Vec` (clippy `large_enum_variant`).
+enum SessionTimelineItem {
+    Message(Box<Message>),
+    Rollback { num_turns: u32, at: DateTime<Utc> },
+}
+
+/// Parse a session JSONL's post-meta lines into an ordered timeline WITHOUT
+/// applying any rollback drop.
 ///
 /// Control lines are recognized before the `Message` decode (they carry a
 /// `kind` discriminator a `Message` never has) and are NOT parsed as messages.
-/// A `rollback` record drops the last N user turns accumulated *so far* —
-/// applying it positionally (rather than after the whole file) is what makes
-/// rewind-then-continue survive a reload: turns appended after the marker are
-/// kept, turns before it are trimmed. `thread_id`s are synthesized for legacy
-/// rows before each drop and once at the end, so a file without any control
-/// record assembles exactly as it did pre-marker (a single synthesize pass over
-/// the full transcript).
-fn assemble_session_messages<'a>(lines: impl Iterator<Item = &'a str>) -> Vec<Message> {
-    let mut messages: Vec<Message> = Vec::new();
+/// Unparseable lines are skipped, matching the prior
+/// `filter_map(|line| serde_json::from_str(line).ok())` behavior. The rollback
+/// drop is deferred to [`fold_session_timeline`] so the merge path in
+/// [`SessionManager::load_from_disk`] can apply markers against the combined
+/// flat + per-user transcript rather than one file in isolation.
+fn parse_session_timeline<'a>(lines: impl Iterator<Item = &'a str>) -> Vec<SessionTimelineItem> {
+    let mut timeline: Vec<SessionTimelineItem> = Vec::new();
     for line in lines.filter(|line| !line.trim().is_empty()) {
         if let Ok(control) = serde_json::from_str::<SessionControlRecord>(line) {
             match control {
-                SessionControlRecord::Rollback { num_turns, .. } => {
-                    synthesize_thread_ids(&mut messages);
-                    crate::resume_policy::drop_last_n_user_turns(&mut messages, num_turns);
+                SessionControlRecord::Rollback { num_turns, at } => {
+                    timeline.push(SessionTimelineItem::Rollback { num_turns, at });
                 }
             }
             continue;
         }
         if let Ok(message) = serde_json::from_str::<Message>(line) {
-            messages.push(message);
+            timeline.push(SessionTimelineItem::Message(Box::new(message)));
         }
-        // Unparseable lines are skipped, matching the prior
-        // `filter_map(|line| serde_json::from_str(line).ok())` behavior.
+    }
+    timeline
+}
+
+/// Fold an ordered timeline into the trimmed `Message` list, replaying each
+/// rollback marker at its position.
+///
+/// A `rollback` record drops the last N user turns accumulated *so far* —
+/// applying it positionally (rather than after the whole timeline) is what makes
+/// rewind-then-continue survive a reload: turns appended after the marker are
+/// kept, turns before it are trimmed. `thread_id`s are synthesized for legacy
+/// rows before each drop and once at the end, so a timeline without any control
+/// record folds exactly as it did pre-marker (a single synthesize pass over the
+/// full transcript).
+fn fold_session_timeline(timeline: Vec<SessionTimelineItem>) -> Vec<Message> {
+    let mut messages: Vec<Message> = Vec::new();
+    for item in timeline {
+        match item {
+            SessionTimelineItem::Message(message) => messages.push(*message),
+            SessionTimelineItem::Rollback { num_turns, .. } => {
+                synthesize_thread_ids(&mut messages);
+                crate::resume_policy::drop_last_n_user_turns(&mut messages, num_turns);
+            }
+        }
     }
     synthesize_thread_ids(&mut messages);
     messages
+}
+
+/// Assemble the ordered `Message` list from a session JSONL's post-meta lines,
+/// applying any interleaved [`SessionControlRecord`] at its position in the
+/// log. Single-file convenience over [`parse_session_timeline`] +
+/// [`fold_session_timeline`].
+fn assemble_session_messages<'a>(lines: impl Iterator<Item = &'a str>) -> Vec<Message> {
+    fold_session_timeline(parse_session_timeline(lines))
 }
 
 fn record_session_persist(outcome: &'static str) {
@@ -858,7 +897,7 @@ impl SessionManager {
             }
             // Read just the first line for metadata (title + updated_at);
             // fall back to count_lines for the message count.
-            let (title, updated_at) = std::fs::read_to_string(path)
+            let (title, meta_updated_at) = std::fs::read_to_string(path)
                 .ok()
                 .and_then(|content| {
                     content
@@ -868,14 +907,21 @@ impl SessionManager {
                 })
                 .map(|meta| (meta.title, Some(meta.updated_at)))
                 .unwrap_or((None, None));
-            // Cheap recency fallback when the meta line is missing or
-            // unparseable: the JSONL file's own mtime.
-            let updated_at = updated_at.or_else(|| {
-                std::fs::metadata(path)
-                    .ok()
-                    .and_then(|meta| meta.modified().ok())
-                    .map(DateTime::<Utc>::from)
-            });
+            // Recency for the `session/list` sort. `SessionMeta.updated_at` is
+            // only rewritten on create / rename / summary rewrite — NOT on an
+            // ordinary message append — so an active chat's meta timestamp goes
+            // stale while its JSONL file mtime keeps advancing. Take the LATER
+            // of the two (codex P2) so recency tracks real writes; the file
+            // mtime alone also covers the missing / unparseable-meta case.
+            let file_mtime = std::fs::metadata(path)
+                .ok()
+                .and_then(|meta| meta.modified().ok())
+                .map(DateTime::<Utc>::from);
+            let updated_at = match (meta_updated_at, file_mtime) {
+                (Some(meta_at), Some(mtime)) => Some(meta_at.max(mtime)),
+                (Some(only), None) | (None, Some(only)) => Some(only),
+                (None, None) => None,
+            };
             let count = Self::count_lines(path);
             seen.insert(session_key.clone());
             out.push((session_key, count, title, updated_at));
@@ -1283,14 +1329,23 @@ impl SessionManager {
 
         let key_clone = key.clone();
         tokio::task::spawn_blocking(move || {
-            fn load_session_file(path: &Path, key: &SessionKey) -> Option<Session> {
+            // Parse a session file into its meta + an un-applied timeline
+            // (messages interleaved with rollback markers). The rollback drop
+            // is DEFERRED — the flat + per-user merge below applies markers
+            // against the COMBINED transcript, so a marker co-located with one
+            // layout still trims turns that live in the other (codex P1: a
+            // mixed flat/per-user layout must not resurrect rolled-back turns).
+            fn parse_session_file(
+                path: &Path,
+                key: &SessionKey,
+            ) -> Option<(SessionMeta, Vec<SessionTimelineItem>)> {
                 // Guard against oversized files to prevent OOM
-                if let Ok(meta) = std::fs::metadata(path) {
-                    if meta.len() > MAX_SESSION_FILE_SIZE {
+                if let Ok(file_meta) = std::fs::metadata(path) {
+                    if file_meta.len() > MAX_SESSION_FILE_SIZE {
                         warn!(
                             key = %key,
                             path = %path.display(),
-                            size = meta.len(),
+                            size = file_meta.len(),
                             limit = MAX_SESSION_FILE_SIZE,
                             "session file too large, skipping"
                         );
@@ -1315,13 +1370,17 @@ impl SessionManager {
                     return None;
                 }
 
-                // Assemble messages, applying any append-only rollback control
-                // records at their position in the log and gap-filling legacy
-                // `thread_id`s in-memory (M8.10). Files without control records
-                // parse identically to the prior single-pass load.
-                let messages = assemble_session_messages(lines);
+                Some((meta, parse_session_timeline(lines)))
+            }
 
-                Some(Session {
+            // Fold a single file's timeline into a `Session` (per-user only or
+            // legacy flat only — the marker application is unambiguous).
+            fn session_from(
+                meta: SessionMeta,
+                messages: Vec<Message>,
+                key: &SessionKey,
+            ) -> Session {
+                Session {
                     key: key.clone(),
                     parent_key: meta.parent_key.map(SessionKey),
                     topic: meta.topic,
@@ -1332,52 +1391,77 @@ impl SessionManager {
                     messages,
                     created_at: meta.created_at,
                     updated_at: meta.updated_at,
-                })
+                }
             }
 
             let flat = flat_path
                 .exists()
-                .then(|| load_session_file(&flat_path, &key_clone))
+                .then(|| parse_session_file(&flat_path, &key_clone))
                 .flatten();
             let per_user = per_user_path
                 .exists()
-                .then(|| load_session_file(&per_user_path, &key_clone))
+                .then(|| parse_session_file(&per_user_path, &key_clone))
                 .flatten();
 
             let merged = match (flat, per_user) {
-                (Some(flat), Some(per_user)) => {
-                    let mut merged_messages = Vec::with_capacity(
-                        flat.messages.len().saturating_add(per_user.messages.len()),
+                (Some((flat_meta, flat_timeline)), Some((per_user_meta, per_user_timeline))) => {
+                    // Merge the two timelines: dedup messages by fingerprint (a
+                    // message migrated into both layouts appears once), keep
+                    // EVERY rollback marker, then order by timestamp so each
+                    // marker lands after the messages it should trim
+                    // (message-before-marker on an exact tie). Folding the
+                    // combined, ordered timeline applies the drop across BOTH
+                    // files — the fix for the mixed-layout resurrection.
+                    let mut items: Vec<SessionTimelineItem> = Vec::with_capacity(
+                        flat_timeline.len().saturating_add(per_user_timeline.len()),
                     );
                     let mut seen = std::collections::HashSet::new();
 
-                    for message in flat.messages.into_iter().chain(per_user.messages) {
-                        let Ok(fingerprint) = serde_json::to_string(&message) else {
-                            continue;
-                        };
-                        if seen.insert(fingerprint) {
-                            merged_messages.push(message);
+                    for item in flat_timeline.into_iter().chain(per_user_timeline) {
+                        match &item {
+                            SessionTimelineItem::Message(message) => {
+                                let Ok(fingerprint) = serde_json::to_string(message.as_ref())
+                                else {
+                                    continue;
+                                };
+                                if seen.insert(fingerprint) {
+                                    items.push(item);
+                                }
+                            }
+                            SessionTimelineItem::Rollback { .. } => items.push(item),
                         }
                     }
-                    merged_messages.sort_by_key(|message| message.timestamp);
+                    // Stable sort: preserves flat-before-per-user order for
+                    // messages sharing a timestamp (matches the prior merge's
+                    // `sort_by_key(|m| m.timestamp)` stability).
+                    items.sort_by_key(|item| match item {
+                        SessionTimelineItem::Message(message) => (message.timestamp, 0u8),
+                        SessionTimelineItem::Rollback { at, .. } => (*at, 1u8),
+                    });
+                    let messages = fold_session_timeline(items);
 
                     Session {
                         key: key_clone.clone(),
-                        parent_key: per_user.parent_key.or(flat.parent_key),
-                        topic: per_user.topic.or(flat.topic),
-                        summary: per_user.summary.or(flat.summary),
-                        title: per_user.title.or(flat.title),
-                        title_manual: per_user.title_manual || flat.title_manual,
+                        parent_key: per_user_meta
+                            .parent_key
+                            .or(flat_meta.parent_key)
+                            .map(SessionKey),
+                        topic: per_user_meta.topic.or(flat_meta.topic),
+                        summary: per_user_meta.summary.or(flat_meta.summary),
+                        title: per_user_meta.title.or(flat_meta.title),
+                        title_manual: per_user_meta.title_manual || flat_meta.title_manual,
                         child_contracts: merge_child_contracts(
-                            flat.child_contracts,
-                            per_user.child_contracts,
+                            flat_meta.child_contracts,
+                            per_user_meta.child_contracts,
                         ),
-                        messages: merged_messages,
-                        created_at: flat.created_at.min(per_user.created_at),
-                        updated_at: flat.updated_at.max(per_user.updated_at),
+                        messages,
+                        created_at: flat_meta.created_at.min(per_user_meta.created_at),
+                        updated_at: flat_meta.updated_at.max(per_user_meta.updated_at),
                     }
                 }
-                (Some(session), None) | (None, Some(session)) => session,
+                (Some((meta, timeline)), None) | (None, Some((meta, timeline))) => {
+                    session_from(meta, fold_session_timeline(timeline), &key_clone)
+                }
                 (None, None) => return None,
             };
 
@@ -1743,9 +1827,11 @@ impl SessionManager {
             .join("sessions")
             .join(format!("{encoded_topic}.jsonl"));
 
-        // Co-locate the marker with the messages so `load_from_disk`'s per-file
-        // fold applies the drop against the right transcript: per-user
-        // (canonical) wins, then legacy flat.
+        // Write the marker to the canonical layout (per-user preferred, legacy
+        // flat as fallback). `load_from_disk` folds markers AFTER merging both
+        // layouts (by timestamp), so the drop trims the combined transcript
+        // even when the rolled-back turns live in the OTHER file — a
+        // single-file `SessionHandle::open` still applies it in log order.
         let target = if per_user_path.exists() {
             per_user_path
         } else if flat_path.exists() {
@@ -3042,6 +3128,116 @@ mod tests {
         }
     }
 
+    /// Codex P1: in a MIXED flat + per-user layout, the rollback marker is
+    /// co-located with ONE file (per-user preferred) but the drop is computed
+    /// over the MERGED transcript. If the rolled-back turns straddle the legacy
+    /// flat file, applying the marker per-file would resurrect them on the next
+    /// merge-load. The drop must be applied POST-MERGE.
+    #[tokio::test]
+    async fn rollback_trims_across_mixed_flat_and_per_user_layout_without_resurrection() {
+        let tmp = TempDir::new().unwrap();
+        let mut mgr = SessionManager::open(tmp.path()).unwrap();
+        let key = SessionKey::with_profile("dspfac", "api", "mixed-rollback");
+
+        // Flat turns are older (legacy); the per-user turn is newer. The
+        // rollback marker (appended at `Utc::now()`) sorts after all of them.
+        let base = Utc::now() - chrono::Duration::minutes(10);
+        let msg = |content: &str, tid: &str, offset: i64| {
+            let role = if content.starts_with("turn") {
+                MessageRole::User
+            } else {
+                MessageRole::Assistant
+            };
+            let mut m = make_message(role, content);
+            m.client_message_id = Some(tid.to_string());
+            m.thread_id = Some(tid.to_string());
+            m.timestamp = base + chrono::Duration::milliseconds(offset);
+            m
+        };
+
+        // Legacy flat file: turns 1 & 2.
+        let flat_meta = serde_json::json!({
+            "schema_version": 1,
+            "session_key": key.0,
+            "created_at": base,
+            "updated_at": base + chrono::Duration::milliseconds(3),
+        });
+        std::fs::create_dir_all(tmp.path().join("sessions")).unwrap();
+        std::fs::write(
+            mgr.session_path(&key),
+            format!(
+                "{}\n{}\n{}\n{}\n{}\n",
+                serde_json::to_string(&flat_meta).unwrap(),
+                serde_json::to_string(&msg("turn 1", "t1", 0)).unwrap(),
+                serde_json::to_string(&msg("reply 1", "t1", 1)).unwrap(),
+                serde_json::to_string(&msg("turn 2", "t2", 2)).unwrap(),
+                serde_json::to_string(&msg("reply 2", "t2", 3)).unwrap(),
+            ),
+        )
+        .unwrap();
+
+        // Per-user file: turn 3 only.
+        let encoded_base = encode_path_component(key.base_key());
+        let per_user_dir = tmp
+            .path()
+            .join("users")
+            .join(&encoded_base)
+            .join("sessions");
+        std::fs::create_dir_all(&per_user_dir).unwrap();
+        let per_user_meta = serde_json::json!({
+            "schema_version": 1,
+            "session_key": key.0,
+            "created_at": base + chrono::Duration::milliseconds(4),
+            "updated_at": base + chrono::Duration::milliseconds(5),
+        });
+        std::fs::write(
+            per_user_dir.join("default.jsonl"),
+            format!(
+                "{}\n{}\n{}\n",
+                serde_json::to_string(&per_user_meta).unwrap(),
+                serde_json::to_string(&msg("turn 3", "t3", 4)).unwrap(),
+                serde_json::to_string(&msg("reply 3", "t3", 5)).unwrap(),
+            ),
+        )
+        .unwrap();
+
+        // Merged load sees all 3 turns.
+        assert_eq!(
+            mgr.get_or_create(&key).await.messages.len(),
+            6,
+            "precondition: merged transcript = 3 turns (6 messages)"
+        );
+
+        // Roll back 2 turns: drops turn 3 (per-user) AND turn 2 (legacy flat).
+        // The marker lands in the per-user file (it exists) but must cover the
+        // flat turn on reload.
+        let dropped = mgr.rollback_last_n_user_turns(&key, 2).await.unwrap();
+        assert_eq!(dropped, 2);
+        {
+            let session = mgr.get_or_create(&key).await;
+            assert_eq!(session.messages.len(), 2, "in-memory: only turn 1 remains");
+            assert!(session.messages.iter().all(|m| m.content != "reply 2"));
+        }
+
+        // Reload from a FRESH manager (empty cache): load_from_disk re-merges
+        // flat + per-user and folds the marker post-merge. Turn 2 (flat) must
+        // NOT be resurrected.
+        let mut reload = SessionManager::open(tmp.path()).unwrap();
+        let session = reload.get_or_create(&key).await;
+        let contents: Vec<&String> = session.messages.iter().map(|m| &m.content).collect();
+        assert_eq!(
+            session.messages.len(),
+            2,
+            "turn 1 only after reload; got {contents:?}"
+        );
+        assert!(
+            session.messages.iter().all(|m| m.content != "turn 2"),
+            "turn 2 (legacy flat) must not resurrect after a merge-reload: {contents:?}"
+        );
+        assert!(session.messages.iter().all(|m| m.content != "turn 3"));
+        assert_eq!(session.messages[0].content, "turn 1");
+    }
+
     #[tokio::test]
     async fn test_session_manager_clear() {
         let tmp = TempDir::new().unwrap();
@@ -3702,7 +3898,57 @@ mod tests {
             .find(|(id, ..)| id == "cli:meta-recency")
             .expect("session present");
         assert_eq!(row.2.as_deref(), Some("Recency Chat"));
-        assert_eq!(row.3, Some(updated), "updated_at read from SessionMeta");
+        // Recency is `max(meta.updated_at, file mtime)` (codex P2). The file was
+        // just written, so its mtime dominates the older meta timestamp; the
+        // surfaced recency is therefore at least the meta value.
+        let recency = row.3.expect("updated_at present");
+        assert!(
+            recency >= updated,
+            "recency must be at least the meta.updated_at; got {recency}"
+        );
+    }
+
+    /// Codex P2: `SessionMeta.updated_at` is stamped once at creation and is
+    /// NOT rewritten on ordinary message appends, so `session/list` recency read
+    /// straight from meta goes stale for active chats. Appending a message must
+    /// advance the list recency — the surfaced timestamp has to track the file's
+    /// real last-write time (mtime), not the frozen meta value.
+    #[tokio::test]
+    async fn list_recency_advances_when_a_message_is_appended() {
+        let tmp = TempDir::new().unwrap();
+        let mut mgr = SessionManager::open(tmp.path()).unwrap();
+        let key = SessionKey::new("cli", "recency-append");
+
+        // Create the session: `meta.updated_at` is stamped here, once.
+        mgr.add_message(&key, make_message(MessageRole::User, "hi"))
+            .await
+            .unwrap();
+        let recency_before = mgr
+            .list_top_level_sessions_with_meta()
+            .into_iter()
+            .find(|(id, ..)| id == "cli:recency-append")
+            .and_then(|row| row.3)
+            .expect("recency present after create");
+
+        // Let the filesystem mtime clock advance, then append. The meta line
+        // (and its `updated_at`) is left untouched; only the file mtime moves.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        mgr.add_message(&key, make_message(MessageRole::Assistant, "there"))
+            .await
+            .unwrap();
+        let recency_after = mgr
+            .list_top_level_sessions_with_meta()
+            .into_iter()
+            .find(|(id, ..)| id == "cli:recency-append")
+            .and_then(|row| row.3)
+            .expect("recency present after append");
+
+        assert!(
+            recency_after > recency_before,
+            "appending a message must advance list recency; meta.updated_at is \
+             frozen at creation, so mtime must drive it — before={recency_before} \
+             after={recency_after}"
+        );
     }
 
     /// Regression guard for the O(N) hang. With 5 000 synthetic

--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -1420,8 +1420,21 @@ impl SessionManager {
                     for item in flat_timeline.into_iter().chain(per_user_timeline) {
                         match &item {
                             SessionTimelineItem::Message(message) => {
-                                let Ok(fingerprint) = serde_json::to_string(message.as_ref())
-                                else {
+                                // The dedup fingerprint must be synthesis-INDEPENDENT: a
+                                // legacy flat row (no persisted `thread_id`) and its
+                                // migrated per-user copy (a `thread_id` synthesized +
+                                // persisted by an earlier migration, possibly a
+                                // migration-added `client_message_id`) are the SAME
+                                // logical message. `thread_id` is only synthesized later
+                                // in `fold_session_timeline`, and neither field is content
+                                // identity, so normalize both to `None` before
+                                // fingerprinting. Otherwise the two copies fingerprint
+                                // differently, both survive, and a partial-migration
+                                // (stale flat + per-user) session doubles on reload.
+                                let mut ident = message.as_ref().clone();
+                                ident.thread_id = None;
+                                ident.client_message_id = None;
+                                let Ok(fingerprint) = serde_json::to_string(&ident) else {
                                     continue;
                                 };
                                 if seen.insert(fingerprint) {
@@ -3236,6 +3249,92 @@ mod tests {
         );
         assert!(session.messages.iter().all(|m| m.content != "turn 3"));
         assert_eq!(session.messages[0].content, "turn 1");
+    }
+
+    /// Codex follow-up on the P1 fix: the merge dedup fingerprint must be
+    /// synthesis-INDEPENDENT. A legacy flat row (no `thread_id`) and its migrated
+    /// per-user copy (a synthesized `thread_id`) are the SAME logical message;
+    /// fingerprinting the raw rows kept both and DOUBLED the transcript on reload
+    /// for partial-migration (stale flat + per-user) sessions.
+    #[tokio::test]
+    async fn mixed_layout_dedups_migrated_rows_despite_synthesized_thread_id() {
+        let tmp = TempDir::new().unwrap();
+        let mut mgr = SessionManager::open(tmp.path()).unwrap();
+        let key = SessionKey::with_profile("dspfac", "api", "partial-migration");
+
+        let base = Utc::now() - chrono::Duration::minutes(5);
+        // Same logical rows (identical role/content/timestamp). The flat copy has
+        // NO thread_id (legacy); the per-user copy carries a synthesized thread_id
+        // (migrated) — the only serialized difference between the two.
+        let row = |content: &str, offset: i64, thread_id: Option<&str>| {
+            let role = if content.starts_with("turn") {
+                MessageRole::User
+            } else {
+                MessageRole::Assistant
+            };
+            let mut m = make_message(role, content);
+            m.timestamp = base + chrono::Duration::milliseconds(offset);
+            m.thread_id = thread_id.map(|s| s.to_string());
+            m
+        };
+        let meta = |updated_ms: i64| {
+            serde_json::json!({
+                "schema_version": 1,
+                "session_key": key.0,
+                "created_at": base,
+                "updated_at": base + chrono::Duration::milliseconds(updated_ms),
+            })
+        };
+
+        // Legacy flat file: rows WITHOUT thread_id.
+        std::fs::create_dir_all(tmp.path().join("sessions")).unwrap();
+        std::fs::write(
+            mgr.session_path(&key),
+            format!(
+                "{}\n{}\n{}\n",
+                serde_json::to_string(&meta(1)).unwrap(),
+                serde_json::to_string(&row("turn 1", 0, None)).unwrap(),
+                serde_json::to_string(&row("reply 1", 1, None)).unwrap(),
+            ),
+        )
+        .unwrap();
+
+        // Per-user file: the SAME rows, but with synthesized thread_ids (migrated).
+        let encoded_base = encode_path_component(key.base_key());
+        let per_user_dir = tmp
+            .path()
+            .join("users")
+            .join(&encoded_base)
+            .join("sessions");
+        std::fs::create_dir_all(&per_user_dir).unwrap();
+        std::fs::write(
+            per_user_dir.join("default.jsonl"),
+            format!(
+                "{}\n{}\n{}\n",
+                serde_json::to_string(&meta(2)).unwrap(),
+                serde_json::to_string(&row("turn 1", 0, Some("t1"))).unwrap(),
+                serde_json::to_string(&row("reply 1", 1, Some("t1"))).unwrap(),
+            ),
+        )
+        .unwrap();
+
+        // First access on an empty cache re-merges both layouts from disk.
+        let session = mgr.get_or_create(&key).await;
+        let contents: Vec<&String> = session.messages.iter().map(|m| &m.content).collect();
+        assert_eq!(
+            session.messages.len(),
+            2,
+            "partial-migration session must dedup across layouts, not double: {contents:?}"
+        );
+        assert_eq!(
+            session
+                .messages
+                .iter()
+                .filter(|m| m.content == "turn 1")
+                .count(),
+            1,
+            "migrated 'turn 1' must appear exactly once: {contents:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -12369,7 +12369,26 @@ async fn handle_session_rollback(
     let _ = orphans;
 
     // Turn projection reuses the exact hydrate helper over the trimmed threads.
-    let turns = collect_session_turns(&params.session_id, active_turns, &replayed, &threads).await;
+    // The `replayed` snapshot was taken PRE-trim, so it still carries lifecycle
+    // + `message/persisted` events for the just-rolled-back turns. Scope the
+    // projected turns to the SURVIVING threads (codex P2): a turn belongs to the
+    // trimmed thread iff its `thread_id` — surfaced from the ledger's
+    // `message/persisted` rows — is still present among the trimmed threads.
+    // Without this, `thread.turns` would leak lifecycle state for dropped turns
+    // even though `messages`/`threads` are trimmed.
+    let surviving_thread_ids: std::collections::HashSet<&str> = threads
+        .iter()
+        .map(|entry| entry.thread_id.as_str())
+        .collect();
+    let turns = collect_session_turns(&params.session_id, active_turns, &replayed, &threads)
+        .await
+        .into_iter()
+        .filter(|turn| {
+            turn.thread_id
+                .as_deref()
+                .is_some_and(|thread_id| surviving_thread_ids.contains(thread_id))
+        })
+        .collect::<Vec<_>>();
 
     let thread = SessionHydrateResult {
         session_id: params.session_id.clone(),
@@ -35772,6 +35791,99 @@ ignore = []
         let frame = recv_rpc_json(&mut rx).await;
         assert!(frame.get("error").is_some(), "num_turns=0 must be rejected");
         assert_eq!(frame["error"]["data"]["kind"], "invalid_num_turns");
+    }
+
+    /// Codex P2: the ledger snapshot handed to `collect_session_turns` is taken
+    /// BEFORE the trim, so it still carries lifecycle + `message/persisted`
+    /// events for the rolled-back turns. The returned `thread.turns` must scope
+    /// to the SURVIVING threads — a dropped turn must not linger in the turn
+    /// projection even though its ledger rows persist.
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_rollback_excludes_dropped_turns_from_thread_turns() {
+        let session_id = SessionKey("local:rollback-turns-scope".into());
+        // Two persisted turns, thread-grouped under "t1" and "t2".
+        let (state, _tmp) = prg_state_with_persisted_turns(&session_id, 2).await;
+        let active_turns = active_turns_registry();
+        let ledger = event_ledger(&state).await;
+
+        // Full lifecycle for BOTH turns in the ledger, thread-linked to the
+        // persisted turns (thread_ids surfaced via `message/persisted.thread_id`
+        // are what `collect_session_turns` keys the projection on).
+        let turn_keep = TurnId::new(); // turn 1 -> thread "t1" (survives)
+        let turn_drop = TurnId::new(); // turn 2 -> thread "t2" (rolled back)
+        for (turn_id, thread_id, seq) in [(&turn_keep, "t1", 1_u64), (&turn_drop, "t2", 3_u64)] {
+            let _ = ledger.append_notification(UiNotification::TurnStarted(
+                octos_core::ui_protocol::TurnStartedEvent {
+                    session_id: session_id.clone(),
+                    turn_id: turn_id.clone(),
+                    timestamp: Utc::now(),
+                    topic: None,
+                },
+            ));
+            let _ = ledger.append_notification(UiNotification::MessagePersisted(
+                MessagePersistedEvent {
+                    session_id: session_id.clone(),
+                    topic: None,
+                    turn_id: Some(turn_id.clone()),
+                    thread_id: Some(thread_id.to_string()),
+                    seq,
+                    role: "user".into(),
+                    message_id: format!("{}:{seq}:0", session_id.0),
+                    client_message_id: None,
+                    source: MessagePersistedSource::User,
+                    cursor: UiCursor {
+                        stream: session_id.0.clone(),
+                        seq,
+                    },
+                    persisted_at: Utc::now(),
+                    media: vec![],
+                    content: None,
+                },
+            ));
+            let _ = ledger.append_notification(UiNotification::TurnCompleted(TurnCompletedEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_id.clone(),
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            }));
+        }
+
+        let (ws, mut rx) = ws_connection_for_test(8);
+        handle_session_rollback(
+            &ws,
+            &state,
+            &ledger,
+            &active_turns,
+            None,
+            None,
+            "rb-scope".into(),
+            SessionRollbackParams {
+                session_id: session_id.clone(),
+                num_turns: 1,
+            },
+        )
+        .await;
+
+        let frame = recv_rpc_json(&mut rx).await;
+        assert_eq!(frame["result"]["dropped_turns"], 1);
+        let turns = frame["result"]["thread"]["turns"]
+            .as_array()
+            .expect("turns array");
+        let turn_ids: Vec<String> = turns
+            .iter()
+            .filter_map(|turn| turn["turn_id"].as_str().map(str::to_owned))
+            .collect();
+        assert!(
+            turn_ids.contains(&turn_keep.0.to_string()),
+            "surviving turn 1 must remain in thread.turns; got {turn_ids:?}"
+        );
+        assert!(
+            !turn_ids.contains(&turn_drop.0.to_string()),
+            "dropped turn 2 must be excluded from thread.turns; got {turn_ids:?}"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
Three codex-review follow-ups on the just-merged session/rollback feature (#1516). Each fix ships a RED→GREEN regression test.

## [P1] Rollback resurrection in mixed flat + per-user layouts
`crates/octos-bus/src/session.rs`

The rollback marker is co-located with **one** file (per-user preferred), but the drop is computed over the **merged** transcript. When some rolled-back turns live in the legacy flat file, `load_from_disk` applied the marker only to the per-user half and then merged the untouched flat rows back — **resurrecting** the rewound turns on reload.

**Fix:** split parsing from marker application — `parse_session_timeline` (messages + markers, un-applied) and `fold_session_timeline` (replays each marker positionally). `load_from_disk` now folds the drop **after merging both layouts** (ordered by timestamp, message-before-marker on a tie), so a marker in one file still trims turns that live in the other. Single-file load paths (`SessionHandle::open` / per-user- or flat-only) fold in log order exactly as before. `assemble_session_messages` is now a thin `fold(parse(..))` wrapper (unchanged single-file behavior).

## [P2] `session/list` stale recency
`crates/octos-bus/src/session.rs`

`SessionMeta.updated_at` is stamped once at creation and is **not** rewritten on ordinary appends (`append_to_disk` only writes the meta line when the file is new), so active chats sorted stale while only the file mtime advanced.

**Fix:** list recency = `max(meta.updated_at, file mtime)` — tracks real writes cheaply; mtime alone still covers the missing/unparseable-meta case.

## [P2] Dropped turns leak into the rollback thread projection
`crates/octos-cli/src/api/ui_protocol.rs`

`handle_session_rollback` snapshots the ledger **before** the trim, then passed that unfiltered snapshot to `collect_session_turns` — so lifecycle + `message/persisted` events for the just-dropped turns still appeared in `thread.turns` even though `messages`/`threads` were trimmed.

**Fix:** scope the projected turns to the surviving threads. A turn belongs to the trimmed thread iff its `thread_id` (surfaced from the ledger's `message/persisted` rows) is still present among the trimmed threads. (`ThreadGraphEntry.turn_id` is always `None` today, so the link goes through `thread_id`, not `turn_id`.)

## Tests (each verified RED without the fix, GREEN with it)
- `octos-bus`: `rollback_trims_across_mixed_flat_and_per_user_layout_without_resurrection`
- `octos-bus`: `list_recency_advances_when_a_message_is_appended`
- `octos-cli`: `session_rollback_excludes_dropped_turns_from_thread_turns`

The existing `list_top_level_sessions_with_meta_surfaces_updated_at` was updated to the corrected `max(meta, mtime)` semantics (asserts recency ≥ the meta value + title surfaced).

## Gates
- `cargo build -p octos-core -p octos-bus -p octos-cli` — ok
- `cargo test -p octos-bus` — 206 lib + integration, ok
- `cargo test -p octos-cli --features api` — 1880 lib + integration, ok
- `cargo clippy --workspace` (+ `-p octos-cli --features api`) — clean
- `cargo fmt --all -- --check` — clean