### PR TITLE
fix(context): stop post-compaction transcript duplication, rollback ledger resurrection, tool-call mispairing

### DIFF
--- a/crates/octos-agent/src/agent/loop_compaction.rs
+++ b/crates/octos-agent/src/agent/loop_compaction.rs
@@ -44,7 +44,14 @@ pub(crate) fn prepare_conversation_messages(
     if synthesize_missing_tool_results(messages) {
         turn.record_repair(LoopRepairReason::MissingToolResultsSynthesized);
     }
-    if truncate_old_tool_results(messages) {
+    // With a caller-owned ContextManager the bridge replaces the vector with
+    // its canonical frame before the model call, so this truncation cannot
+    // affect the final prompt — but it mutates frame-derived rows (the
+    // envelope's model-visible content is bounded at 4096 bytes, above the
+    // 800-char cut here) and breaks the bridge's contiguous coverage match,
+    // which then re-records the whole conversation as duplicates. Tool-output
+    // bounding is the ContextManager's job there (ToolOutputPolicy).
+    if agent.prompt_context_manager.is_none() && truncate_old_tool_results(messages) {
         turn.record_repair(LoopRepairReason::OldToolResultsTruncated);
     }
     if normalize_tool_call_ids(messages) {
@@ -311,6 +318,47 @@ mod tests {
                 .repair_reasons()
                 .contains(&LoopRepairReason::ContextTrimmed),
             "legacy ContextTrimmed repair should stay absent when ContextManager owns prompt compaction"
+        );
+    }
+
+    /// A caller-owned ContextManager bridge replaces the loop's prompt
+    /// vector with its canonical frame anyway, so the legacy 800-char
+    /// old-tool-result truncation has no effect on the final prompt — but it
+    /// DOES mutate the frame-derived vector before the bridge's coverage
+    /// matcher compares it against the frame (ToolOutputEnvelope emits up to
+    /// 4096 bytes), which broke the contiguous window match and re-recorded
+    /// the whole conversation as source-less duplicates every turn.
+    #[tokio::test]
+    async fn context_managed_agent_skips_old_tool_result_truncation() {
+        let (_dir, agent) = setup_agent(1_000_000).await;
+        let agent = agent.with_prompt_context_manager(Arc::new(NoopPromptContextManager));
+        let mut turn = LoopTurnState::new(Instant::now());
+        let old_tool_output = "z".repeat(2_000);
+        let mut messages = vec![
+            sys("prompt"),
+            user("old question"),
+            assistant_with_tools(&["call_old"]),
+            tool_result_msg("call_old", &old_tool_output),
+            assistant("old answer"),
+            user("current question"),
+        ];
+
+        prepare_conversation_messages(&agent, &mut messages, &mut turn);
+
+        let tool = messages
+            .iter()
+            .find(|m| m.tool_call_id.as_deref() == Some("call_old"))
+            .expect("old tool result still present");
+        assert_eq!(
+            tool.content, old_tool_output,
+            "ContextManager-owned sessions must not run the legacy old-tool-result \
+             truncation before the context bridge — it breaks bridge coverage matching"
+        );
+        assert!(
+            !turn
+                .repair_reasons()
+                .contains(&LoopRepairReason::OldToolResultsTruncated),
+            "OldToolResultsTruncated repair must stay absent when ContextManager owns prompt compaction"
         );
     }
 

--- a/crates/octos-agent/src/agent/message_repair.rs
+++ b/crates/octos-agent/src/agent/message_repair.rs
@@ -83,6 +83,22 @@ fn normalize_one_id(id: &str) -> String {
     format!("call_{stripped}")
 }
 
+/// Normalize a single provider tool-call id into the loop's canonical form —
+/// the same rewrite [`normalize_tool_call_ids`] applies across a prompt
+/// vector (empty ids pass through untouched, exactly like the vector pass,
+/// which only maps non-empty ids).
+///
+/// Public so transcript recorders (the CLI `ContextManager`) can normalize at
+/// record time: the durable transcript must be id-identical with the prompt
+/// vector after the loop's rewrite, or exact-match coverage comparison between
+/// the two re-records the conversation as duplicates.
+pub fn normalize_tool_call_id(id: &str) -> String {
+    if id.is_empty() {
+        return String::new();
+    }
+    normalize_one_id(id)
+}
+
 /// Merge all system messages into the first one so providers that require a
 /// single leading system message (e.g. Qwen) don't reject the request.
 ///
@@ -522,6 +538,35 @@ pub(crate) fn truncate_old_tool_results(messages: &mut [Message]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The public single-id normalizer must agree with the vector pass
+    /// (`normalize_tool_call_ids`) on every id class — transcript recorders
+    /// rely on that equivalence for exact-id coverage matching.
+    #[test]
+    fn normalize_tool_call_id_matches_vector_pass_semantics() {
+        // Already-normal forms pass through.
+        assert_eq!(normalize_tool_call_id("call_abc"), "call_abc");
+        assert_eq!(normalize_tool_call_id("fc_abc"), "fc_abc");
+        // Known provider prefixes are stripped then call_-prefixed.
+        assert_eq!(normalize_tool_call_id("toolu_abc"), "call_abc");
+        assert_eq!(normalize_tool_call_id("chatcmpl-abc"), "call_abc");
+        // Moonshot's `call_function_*` already starts with `call_`, so BOTH
+        // the vector pass and this wrapper leave it untouched (the
+        // `call_function_` strip is unreachable for it) — equivalence with
+        // the vector pass is the property that matters here.
+        assert_eq!(
+            normalize_tool_call_id("call_function_abc"),
+            "call_function_abc"
+        );
+        // Unknown forms (e.g. sanitized kimi ids) get the prefix verbatim.
+        assert_eq!(
+            normalize_tool_call_id("functions_shell_0"),
+            "call_functions_shell_0"
+        );
+        // Empty ids pass through untouched, exactly like the vector pass
+        // (its id map only collects non-empty ids).
+        assert_eq!(normalize_tool_call_id(""), "");
+    }
 
     fn sys(content: &str) -> Message {
         Message {

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -33,6 +33,7 @@ use crate::session::{SessionLimits, SessionUsage};
 use crate::tools::ToolRegistry;
 use verifier::AgentVerifierConfig;
 
+pub use message_repair::normalize_tool_call_id;
 pub use realtime::RealtimeController;
 
 tokio::task_local! {

--- a/crates/octos-agent/src/compaction.rs
+++ b/crates/octos-agent/src/compaction.rs
@@ -569,11 +569,16 @@ impl CompactionRunner {
             summarizer_kind: self.summarizer.kind(),
         };
 
-        if tokens_before <= budget {
+        // Budget decision uses the POST-prune estimate: when placeholder
+        // pruning alone brought the conversation under budget, summarizing
+        // old messages would discard context for no budget reason.
+        // `tokens_before` (pre-prune) is preserved on the outcome for
+        // reporting.
+        let tokens_after_prune: u32 = messages.iter().map(estimate_message_tokens).sum();
+        if tokens_after_prune <= budget {
             // Nothing to summarise — only the pruning step ran.
-            let tokens_after: u32 = messages.iter().map(estimate_message_tokens).sum();
-            outcome.tokens_after = tokens_after;
-            self.emit_phase_event(phase, "complete", tokens_after);
+            outcome.tokens_after = tokens_after_prune;
+            self.emit_phase_event(phase, "complete", tokens_after_prune);
             return outcome;
         }
 
@@ -1254,6 +1259,61 @@ mod tests {
         let mut messages = vec![user_msg("hi")];
         let outcome = runner.run(&mut messages, CompactionPhase::OnDemand);
         assert!(!outcome.performed);
+    }
+
+    /// When the tool-result pruning pass alone brings the conversation under
+    /// the token budget, the runner must not go on to summarize/drop old
+    /// messages based on the stale pre-prune estimate — that discards
+    /// conversational context for no budget reason.
+    #[test]
+    fn runner_skips_summary_when_prune_brings_under_budget() {
+        let policy = CompactionPolicy {
+            token_budget: 1_000,
+            prune_tool_results_after_turns: Some(1),
+            ..Default::default()
+        };
+        let runner = CompactionRunner::new(policy);
+        let mut messages = vec![system_msg("sys prompt")];
+        // Turn 1 carries a huge, stale tool result (pruned to a placeholder).
+        messages.push(user_msg("old question"));
+        messages.push(assistant_tool_call("shell", "tc_old"));
+        messages.push(tool_result("tc_old", &"x".repeat(8_000)));
+        // 6 more modest turns so the post-prune total sits between
+        // budget/2 and budget (the recent-boundary walk engages, so a
+        // stale over-budget decision WOULD summarize old turns).
+        for index in 0..6 {
+            messages.push(user_msg(&format!(
+                "question {index} {}",
+                "detail ".repeat(30)
+            )));
+            messages.push(assistant_msg(&format!(
+                "answer {index} {}",
+                "reply ".repeat(30)
+            )));
+        }
+        let message_count_before = messages.len();
+
+        let outcome = runner.run(&mut messages, CompactionPhase::OnDemand);
+
+        assert!(
+            outcome.tool_results_replaced >= 1,
+            "the stale tool result should be pruned"
+        );
+        assert_eq!(
+            outcome.messages_dropped, 0,
+            "pruning already satisfied the budget; no messages may be summarized away"
+        );
+        assert_eq!(
+            messages.len(),
+            message_count_before,
+            "no summary row should be inserted and no messages drained"
+        );
+        assert!(
+            !messages
+                .iter()
+                .any(|m| m.content.contains("Conversation Summary")),
+            "no extractive summary should be generated"
+        );
     }
 
     #[test]

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -78,6 +78,7 @@ pub use agent::{
         SHELL_SPIRAL_VARIANT,
     },
     memory::MIN_EPISODE_SIMILARITY,
+    normalize_tool_call_id,
     realtime::{
         AgentError, Heartbeat, HeartbeatState, RealtimeConfig, RealtimeHookEnricher,
         SensorContextInjector, SensorSnapshot, SensorSource,

--- a/crates/octos-cli/src/api/context_manager.rs
+++ b/crates/octos-cli/src/api/context_manager.rs
@@ -10,6 +10,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Component, Path, PathBuf};
 
 use chrono::Utc;
+use octos_agent::normalize_tool_call_id;
 use octos_core::{Message, MessageRole, ToolCall};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -467,6 +468,13 @@ fn context_ledger_artifact_path(data_dir: &Path, artifact_ref: &str) -> Result<P
 fn persist_tool_output_artifacts(data_dir: &Path, manager: &ContextManager) -> Result<(), String> {
     for (artifact_ref, bytes) in &manager.tool_output_artifacts {
         let path = context_ledger_artifact_path(data_dir, artifact_ref)?;
+        // Artifacts are content-addressed (sha256 in the ref), so an existing
+        // file is already current. Skipping it keeps snapshot persistence
+        // (which runs on every message commit) from rewriting every artifact
+        // the session has ever produced.
+        if path.exists() {
+            continue;
+        }
         atomic_write_bytes(&path, bytes)?;
     }
     Ok(())
@@ -630,6 +638,36 @@ fn remove_all_visual_markers(s: &str) -> String {
     out
 }
 
+/// Normalize raw provider tool-call ids on items IMPORTED from a persisted
+/// snapshot or a forked parent. Record-time normalization only covers
+/// freshly-recorded messages; a snapshot persisted by a pre-normalization
+/// daemon can carry raw ids (`toolu_*`, sanitized kimi ids, …) that would
+/// re-introduce the frame/vector id mismatch the record-time pass exists to
+/// prevent. No-op for already-normal ids.
+fn normalize_imported_tool_call_ids(items: Vec<TranscriptItem>) -> Vec<TranscriptItem> {
+    items
+        .into_iter()
+        .map(|mut item| {
+            match &mut item.kind {
+                TranscriptItemKind::AssistantToolCall { call_id, .. } => {
+                    let normalized = normalize_tool_call_id(call_id);
+                    if *call_id != normalized {
+                        *call_id = normalized;
+                    }
+                }
+                TranscriptItemKind::ToolOutput { envelope } => {
+                    let normalized = normalize_tool_call_id(&envelope.tool_call_id);
+                    if envelope.tool_call_id != normalized {
+                        envelope.tool_call_id = normalized;
+                    }
+                }
+                _ => {}
+            }
+            item
+        })
+        .collect()
+}
+
 /// #1477: scrub the in-band `[[VISUAL:...]]` directive from items IMPORTED from
 /// a persisted snapshot or a forked parent. The record-time sanitizer in
 /// `record_message_with_source_ref` only covers freshly-recorded messages; items
@@ -716,8 +754,9 @@ impl ContextManager {
             .collect();
         // #1477: a forked parent's items bypass `record_message_with_source_ref`,
         // so scrub any in-band visual marker here too (see
-        // `sanitize_imported_visual_markers`).
-        let items = sanitize_imported_visual_markers(items);
+        // `sanitize_imported_visual_markers`) and normalize legacy raw
+        // tool-call ids for the same reason.
+        let items = normalize_imported_tool_call_ids(sanitize_imported_visual_markers(items));
         let next_item_seq = items
             .iter()
             .filter_map(|item| {
@@ -830,8 +869,9 @@ impl ContextManager {
         // `context_ledger_covers_history` will happily Load such a snapshot
         // instead of rebuilding — so `for_prompt` would re-emit the marker to
         // the model. Scrub it at the import boundary, the snapshot-side
-        // complement to the record-time sanitizer.
-        let items = sanitize_imported_visual_markers(items);
+        // complement to the record-time sanitizer. Same for legacy raw
+        // tool-call ids, which must import in the loop's normalized form.
+        let items = normalize_imported_tool_call_ids(sanitize_imported_visual_markers(items));
         let next_item_seq = items
             .iter()
             .filter_map(|item| item.id.as_str().strip_prefix("ctxitem_"))
@@ -1013,7 +1053,14 @@ impl ContextManager {
                 for tool_call in message.tool_calls.iter().flatten() {
                     ids.push(self.record_item_with_source_ref(
                         TranscriptItemKind::AssistantToolCall {
-                            call_id: tool_call.id.clone(),
+                            // Record-time normalization: the loop rewrites
+                            // provider ids (`toolu_*`, sanitized kimi ids, …)
+                            // to the canonical `call_` form in the prompt
+                            // vector; the transcript must store the same form
+                            // or the bridge's exact-id coverage comparison
+                            // breaks (the CompactAndRetry path records before
+                            // the loop's normalize pass runs).
+                            call_id: normalize_tool_call_id(&tool_call.id),
                             name: tool_call.name.clone(),
                             arguments: tool_call.arguments.clone(),
                         },
@@ -1052,6 +1099,10 @@ impl ContextManager {
             }
             MessageRole::Tool => {
                 if let Some(tool_call_id) = message.tool_call_id.as_ref() {
+                    // Lookup + record under the loop's canonical id form —
+                    // stored AssistantToolCall items are normalized at
+                    // record time.
+                    let tool_call_id = normalize_tool_call_id(tool_call_id);
                     // #982: resolve the real tool_name from a prior
                     // AssistantToolCall transcript entry instead of
                     // burning the placeholder "unknown" into the
@@ -1060,7 +1111,7 @@ impl ContextManager {
                     // tool output, which means the envelope must carry
                     // the same tool_name the LLM saw.
                     let tool_name = self
-                        .tool_name_for_call_id(tool_call_id)
+                        .tool_name_for_call_id(&tool_call_id)
                         .unwrap_or_else(|| "unknown".to_owned());
                     ids.push(self.record_tool_output_with_source_ref(
                         tool_call_id,
@@ -1105,7 +1156,9 @@ impl ContextManager {
         raw_output: &str,
         source_ref: Option<TranscriptSourceRef>,
     ) -> TranscriptItemId {
-        let tool_call_id = tool_call_id.into();
+        // Same record-time normalization as `AssistantToolCall` recording —
+        // outputs must pair with calls under the loop's canonical id form.
+        let tool_call_id = normalize_tool_call_id(&tool_call_id.into());
         let raw_sha256 = sha256_prefixed(raw_output.as_bytes());
         let original_bytes = raw_output.len();
         let (model_visible_content, truncation_reason) = truncate_utf8(
@@ -1320,8 +1373,12 @@ impl ContextManager {
         let mut repaired_item_ids = Vec::new();
         let mut synthetic_item_ids = Vec::new();
         let mut truncated_item_ids = Vec::new();
-        let mut emitted_tool_calls = HashSet::new();
-        let mut emitted_tool_outputs = HashSet::new();
+        // Tool outputs are consumed by TRANSCRIPT ITEM ID, not by
+        // tool_call_id: index-based provider ids (kimi `functions.foo:0`,
+        // vllm `call_0`) legitimately repeat across turns, so a call must
+        // pair with the first unconsumed output at or after its own
+        // position rather than the first id match anywhere.
+        let mut consumed_tool_outputs: HashSet<TranscriptItemId> = HashSet::new();
         let mut index = 0;
 
         while index < self.items.len() {
@@ -1363,6 +1420,7 @@ impl ContextManager {
                     index += 1;
                 }
                 TranscriptItemKind::AssistantToolCall { .. } => {
+                    let group_start = index;
                     let mut source_item_ids = Vec::new();
                     let mut call_ids = Vec::new();
                     let mut calls = Vec::new();
@@ -1376,7 +1434,6 @@ impl ContextManager {
                         else {
                             break;
                         };
-                        emitted_tool_calls.insert(call_id.clone());
                         source_item_ids.push(item.id.clone());
                         call_ids.push(call_id.clone());
                         calls.push(ToolCall {
@@ -1409,17 +1466,40 @@ impl ContextManager {
                     ));
 
                     for call_id in call_ids {
-                        if let Some((tool_item_id, envelope)) =
-                            self.items.iter().find_map(|candidate| {
+                        // Positional pairing: the first UNCONSUMED output with
+                        // this call_id at or after the call group's own
+                        // position. Recording order guarantees outputs follow
+                        // their call, so an id reused by a later turn cannot
+                        // steal this group's output (and vice versa). The
+                        // search additionally stops at the NEXT call carrying
+                        // the same id: when THIS group's output is missing
+                        // entirely, it must synthesize rather than steal the
+                        // output that positionally belongs to that later call.
+                        let next_same_id_call = self.items[index..]
+                            .iter()
+                            .position(|candidate| {
+                                matches!(
+                                    &candidate.kind,
+                                    TranscriptItemKind::AssistantToolCall { call_id: later, .. }
+                                        if later == &call_id
+                                )
+                            })
+                            .map(|offset| index + offset)
+                            .unwrap_or(self.items.len());
+                        if let Some((tool_item_id, envelope)) = self.items
+                            [group_start..next_same_id_call]
+                            .iter()
+                            .find_map(|candidate| {
                                 let TranscriptItemKind::ToolOutput { envelope } = &candidate.kind
                                 else {
                                     return None;
                                 };
-                                (envelope.tool_call_id == call_id)
-                                    .then_some((candidate.id.clone(), envelope))
+                                (envelope.tool_call_id == call_id
+                                    && !consumed_tool_outputs.contains(&candidate.id))
+                                .then_some((candidate.id.clone(), envelope))
                             })
                         {
-                            emitted_tool_outputs.insert(call_id.clone());
+                            consumed_tool_outputs.insert(tool_item_id.clone());
                             let mut msg =
                                 message(MessageRole::Tool, envelope.model_visible_content.clone());
                             msg.tool_call_id = Some(call_id.clone());
@@ -1446,24 +1526,14 @@ impl ContextManager {
                         }
                     }
                 }
-                TranscriptItemKind::ToolOutput { envelope } => {
-                    if emitted_tool_outputs.contains(&envelope.tool_call_id) {
-                        index += 1;
-                        continue;
-                    }
-                    if emitted_tool_calls.contains(&envelope.tool_call_id) {
-                        let mut msg =
-                            message(MessageRole::Tool, envelope.model_visible_content.clone());
-                        msg.tool_call_id = Some(envelope.tool_call_id.clone());
-                        entries.push(PromptMessageEntry::tool_output(
-                            msg,
-                            item.id.clone(),
-                            envelope.tool_call_id.clone(),
-                        ));
-                        if envelope.truncation_reason.is_some() {
-                            truncated_item_ids.push(item.id.clone());
-                        }
-                    } else {
+                TranscriptItemKind::ToolOutput { .. } => {
+                    // Consumed outputs were already emitted adjacent to their
+                    // call group above. Anything else is an orphan (no call
+                    // recorded before it) or a surplus output for a call
+                    // already satisfied by an earlier item (duplicate provider
+                    // call ids) — emitting it would attach a second Tool row
+                    // for the same call_id, so drop it with evidence.
+                    if !consumed_tool_outputs.contains(&item.id) {
                         dropped_item_ids.push(item.id.clone());
                     }
                     index += 1;
@@ -1507,9 +1577,17 @@ impl ContextManager {
                     index += 1;
                 }
                 TranscriptItemKind::CompactionSummary { summary, .. } => {
+                    // User, not System: the agent loop's
+                    // `normalize_system_messages` rewrites every non-leading
+                    // System row before the prompt bridge compares this frame
+                    // against the loop vector, and any rewrite breaks the
+                    // bridge's contiguous coverage window (wholesale
+                    // re-recording of the transcript). A User row passes
+                    // through the loop untouched; the entry stays protected so
+                    // prompt trimming can never drop the summary.
                     entries.push(PromptMessageEntry::protected(
                         message(
-                            MessageRole::System,
+                            MessageRole::User,
                             format!("[Conversation summary]\n{summary}"),
                         ),
                         item.id.clone(),
@@ -1794,9 +1872,11 @@ fn first_removable_prompt_group(entries: &[PromptMessageEntry]) -> Option<(usize
         // target, and dropping the live request (e.g. a voice turn whose
         // protected compaction summary already fills the budget) would leave the
         // model answering nothing. See `voice_cap_keeps_current_request_*`.
+        // Protected User rows (e.g. the compaction summary) are context, not a
+        // later live request — they must not license trimming the current one.
         let has_later_user = entries[start + 1..]
             .iter()
-            .any(|entry| matches!(entry.message.role, MessageRole::User));
+            .any(|entry| !entry.protected && matches!(entry.message.role, MessageRole::User));
         if !has_later_user {
             return None;
         }
@@ -2088,15 +2168,15 @@ mod tests {
     #[test]
     fn prompt_normalization_synthesizes_missing_tool_output_and_drops_orphan() {
         let mut manager = ContextManager::new("s", None);
-        manager.record_message(&assistant_tool_call("call-1"));
-        manager.record_tool_output("orphan", "shell", "orphan output");
+        manager.record_message(&assistant_tool_call("call_1"));
+        manager.record_tool_output("call_orphan", "shell", "orphan output");
 
         let frame = manager.for_prompt(&PromptBuildPolicy::default());
 
         assert_eq!(frame.messages.len(), 2);
         assert_eq!(frame.messages[0].role, MessageRole::Assistant);
         assert_eq!(frame.messages[1].role, MessageRole::Tool);
-        assert_eq!(frame.messages[1].tool_call_id.as_deref(), Some("call-1"));
+        assert_eq!(frame.messages[1].tool_call_id.as_deref(), Some("call_1"));
         assert!(frame.messages[1].content.contains("missing"));
         assert_eq!(frame.report.synthetic_item_ids.len(), 1);
         assert_eq!(frame.report.dropped_item_ids.len(), 1);
@@ -2180,6 +2260,259 @@ mod tests {
         assert!(
             !prompt.messages.iter().any(|m| m.content.contains("VISUAL")),
             "post-compaction prompt (incl. System summary) must be marker-free"
+        );
+    }
+
+    /// Tool-output artifacts are content-addressed (`tool-output/<sha>.txt`),
+    /// so an existing file is by definition current. Re-writing every
+    /// accumulated artifact on every snapshot persist turns each message
+    /// commit into O(session tool outputs) file writes.
+    #[test]
+    fn persist_skips_existing_content_addressed_artifacts() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let session_id = "coding:local:artifact-skip";
+        let mut manager = ContextManager::new(session_id, None);
+        manager.record_message(&assistant_tool_call("call_1"));
+        // Oversized output -> raw artifact sidecar.
+        manager.record_tool_output("call_1", "shell", &"y".repeat(20 * 1024));
+        persist_context_manager_snapshot(temp.path(), session_id, &manager).expect("first persist");
+
+        let artifact_ref = manager
+            .items()
+            .iter()
+            .find_map(|item| match &item.kind {
+                TranscriptItemKind::ToolOutput { envelope } => envelope.raw_artifact_ref.clone(),
+                _ => None,
+            })
+            .expect("raw artifact ref recorded");
+        let artifact_path = context_ledger_artifact_path(temp.path(), &artifact_ref)
+            .expect("artifact path resolves");
+        assert!(artifact_path.exists(), "first persist writes the artifact");
+
+        // Plant a sentinel: a second persist must SKIP the existing
+        // content-addressed file rather than rewrite it.
+        std::fs::write(&artifact_path, b"sentinel").expect("plant sentinel");
+        persist_context_manager_snapshot(temp.path(), session_id, &manager)
+            .expect("second persist");
+        assert_eq!(
+            std::fs::read(&artifact_path).expect("read artifact"),
+            b"sentinel",
+            "second persist must not rewrite an existing content-addressed artifact"
+        );
+    }
+
+    /// Index-based provider tool-call ids (kimi `functions.foo:0`, vllm
+    /// `call_0`) repeat the SAME `tool_call_id` in every assistant turn.
+    /// Pairing a call with the first matching output anywhere in the
+    /// transcript attaches turn 1's output to every later call and silently
+    /// drops the later real outputs. Pairing must be positional: each call
+    /// consumes the first unconsumed output at or after its own position.
+    #[test]
+    fn for_prompt_pairs_reused_tool_call_ids_positionally() {
+        let mut manager = ContextManager::new("s", None);
+        manager.record_message(&Message::user("first question"));
+        manager.record_message(&assistant_tool_call("call_0"));
+        manager.record_tool_output("call_0", "shell", "output for turn one");
+        manager.record_message(&Message::assistant("answer one"));
+        manager.record_message(&Message::user("second question"));
+        manager.record_message(&assistant_tool_call("call_0"));
+        manager.record_tool_output("call_0", "shell", "output for turn two");
+        manager.record_message(&Message::assistant("answer two"));
+
+        let frame = manager.for_prompt(&PromptBuildPolicy::default());
+
+        let tool_outputs: Vec<&Message> = frame
+            .messages
+            .iter()
+            .filter(|m| m.role == MessageRole::Tool)
+            .collect();
+        assert_eq!(
+            tool_outputs.len(),
+            2,
+            "both real tool outputs must reach the prompt: {:#?}",
+            frame.messages
+        );
+        assert!(
+            tool_outputs[0].content.contains("turn one"),
+            "first call must pair with the first output (got {:?})",
+            tool_outputs[0].content
+        );
+        assert!(
+            tool_outputs[1].content.contains("turn two"),
+            "second call must pair with its own output, not a duplicate of turn one (got {:?})",
+            tool_outputs[1].content
+        );
+        assert!(
+            frame.report.synthetic_item_ids.is_empty(),
+            "no synthetic outputs should be fabricated when real outputs exist"
+        );
+        assert!(
+            frame.report.dropped_item_ids.is_empty(),
+            "no real output should be dropped when each call has exactly one output"
+        );
+    }
+
+    /// The agent loop's `normalize_tool_call_ids` rewrites provider ids
+    /// (`toolu_*`, kimi-style `functions_foo_0`, ...) to the canonical
+    /// `call_` form in the prompt vector before every model call. The
+    /// transcript must record ids in the SAME form, or the bridge's exact
+    /// coverage comparison between frame and vector re-records the
+    /// conversation as duplicates (raw ids can reach recording via the
+    /// CompactAndRetry path, which runs the bridge without the loop's
+    /// normalize pass).
+    #[test]
+    fn records_provider_tool_call_ids_in_loop_normal_form() {
+        let mut manager = ContextManager::new("s", None);
+        let mut msg = Message::assistant("");
+        msg.tool_calls = Some(vec![ToolCall {
+            id: "toolu_abc123".to_owned(),
+            name: "shell".to_owned(),
+            arguments: json!({}),
+            metadata: None,
+        }]);
+        manager.record_message(&msg);
+        manager.record_tool_output("toolu_abc123", "shell", "raw provider id output");
+
+        let frame = manager.for_prompt(&PromptBuildPolicy::default());
+        let call_row = frame
+            .messages
+            .iter()
+            .find(|m| m.tool_calls.is_some())
+            .expect("call row present");
+        assert_eq!(
+            call_row.tool_calls.as_ref().unwrap()[0].id,
+            "call_abc123",
+            "recorded call id must match the loop's normalized form"
+        );
+        let tool_row = frame
+            .messages
+            .iter()
+            .find(|m| m.role == MessageRole::Tool)
+            .expect("tool row present");
+        assert_eq!(
+            tool_row.tool_call_id.as_deref(),
+            Some("call_abc123"),
+            "recorded output id must match the loop's normalized form"
+        );
+        assert!(
+            tool_row.content.contains("raw provider id output"),
+            "call/output pairing must survive normalization"
+        );
+    }
+
+    /// Snapshots persisted by a pre-normalization daemon can hold raw
+    /// provider ids; importing them verbatim would re-introduce the
+    /// frame/vector id mismatch. The import boundary must normalize.
+    #[test]
+    fn from_snapshot_normalizes_legacy_raw_tool_call_ids() {
+        let mut manager = ContextManager::new("s", None);
+        let mut msg = Message::assistant("");
+        msg.tool_calls = Some(vec![ToolCall {
+            id: "toolu_legacy".to_owned(),
+            name: "shell".to_owned(),
+            arguments: json!({}),
+            metadata: None,
+        }]);
+        manager.record_message(&msg);
+        manager.record_tool_output("toolu_legacy", "shell", "legacy output");
+        let mut snapshot = manager.snapshot();
+        // Simulate a pre-fix snapshot by reverting the stored ids to the raw
+        // provider form.
+        for item in snapshot.items.iter_mut() {
+            match &mut item.kind {
+                TranscriptItemKind::AssistantToolCall { call_id, .. } => {
+                    *call_id = "toolu_legacy".to_owned();
+                }
+                TranscriptItemKind::ToolOutput { envelope } => {
+                    envelope.tool_call_id = "toolu_legacy".to_owned();
+                }
+                _ => {}
+            }
+        }
+
+        let loaded = ContextManager::from_snapshot(snapshot);
+        let frame = loaded.for_prompt(&PromptBuildPolicy::default());
+        let tool_row = frame
+            .messages
+            .iter()
+            .find(|m| m.role == MessageRole::Tool)
+            .expect("tool row present");
+        assert_eq!(
+            tool_row.tool_call_id.as_deref(),
+            Some("call_legacy"),
+            "imported raw ids must be normalized at the snapshot boundary"
+        );
+        assert!(tool_row.content.contains("legacy output"));
+    }
+
+    /// Companion to the positional-pairing test: when an EARLIER call with a
+    /// reused id never got an output, it must synthesize — not steal the
+    /// output that positionally belongs to a LATER call with the same id.
+    #[test]
+    fn for_prompt_does_not_steal_later_output_for_missing_earlier_reused_id() {
+        let mut manager = ContextManager::new("s", None);
+        manager.record_message(&Message::user("first question"));
+        // This call's output was never recorded (tool aborted).
+        manager.record_message(&assistant_tool_call("call_0"));
+        manager.record_message(&Message::assistant("gave up"));
+        manager.record_message(&Message::user("second question"));
+        manager.record_message(&assistant_tool_call("call_0"));
+        manager.record_tool_output("call_0", "shell", "output for turn two");
+
+        let frame = manager.for_prompt(&PromptBuildPolicy::default());
+
+        let tool_rows: Vec<&Message> = frame
+            .messages
+            .iter()
+            .filter(|m| m.role == MessageRole::Tool)
+            .collect();
+        assert_eq!(tool_rows.len(), 2, "one synthetic + one real output");
+        assert!(
+            tool_rows[0].content.contains("missing"),
+            "earlier missing-output call must synthesize, got {:?}",
+            tool_rows[0].content
+        );
+        assert!(
+            tool_rows[1].content.contains("turn two"),
+            "later call keeps its own output, got {:?}",
+            tool_rows[1].content
+        );
+        assert_eq!(frame.report.synthetic_item_ids.len(), 1);
+        assert!(
+            frame.report.dropped_item_ids.is_empty(),
+            "the real output must not be dropped: {:?}",
+            frame.report.dropped_item_ids
+        );
+    }
+
+    /// The agent loop's `normalize_system_messages` runs BEFORE the prompt
+    /// bridge and rewrites any non-leading System row (context rows like
+    /// `[Conversation summary]` are converted to User, instruction rows are
+    /// merged into `messages[0]`). A System-role summary row therefore
+    /// guarantees the bridge's contiguous coverage window match fails on the
+    /// first post-compaction turn, and the whole conversation is re-recorded
+    /// as source-less duplicates. Emit the summary as a protected User row so
+    /// the loop's normalization leaves it byte-identical.
+    #[test]
+    fn for_prompt_emits_compaction_summary_as_user_row() {
+        let mut manager = ContextManager::new("s", None);
+        for index in 0..6 {
+            manager.record_message(&Message::user(format!("u{index}")));
+            manager.record_message(&Message::assistant(format!("a{index}")));
+        }
+        manager.install_compaction_summary("older turns summarized", 2);
+
+        let frame = manager.for_prompt(&PromptBuildPolicy::default());
+        let summary_row = frame
+            .messages
+            .iter()
+            .find(|m| m.content.contains("[Conversation summary]"))
+            .expect("summary row present");
+        assert_eq!(
+            summary_row.role,
+            MessageRole::User,
+            "compaction summary must render as a User row so the agent loop's \
+             system normalization cannot mutate it out of the bridge coverage window"
         );
     }
 
@@ -2293,21 +2626,21 @@ mod tests {
         let mut assistant = Message::assistant("I'll inspect both directories.");
         assistant.tool_calls = Some(vec![
             ToolCall {
-                id: "call-a".into(),
+                id: "call_a".into(),
                 name: "list_dir".into(),
                 arguments: json!({"path": "/tmp/a"}),
                 metadata: None,
             },
             ToolCall {
-                id: "call-b".into(),
+                id: "call_b".into(),
                 name: "list_dir".into(),
                 arguments: json!({"path": "/tmp/b"}),
                 metadata: None,
             },
         ]);
         manager.record_message(&assistant);
-        manager.record_tool_output("call-a", "list_dir", "Error: missing a");
-        manager.record_tool_output("call-b", "list_dir", "Error: missing b");
+        manager.record_tool_output("call_a", "list_dir", "Error: missing a");
+        manager.record_tool_output("call_b", "list_dir", "Error: missing b");
 
         let frame = manager.for_prompt(&PromptBuildPolicy::default());
 
@@ -2319,12 +2652,12 @@ mod tests {
             .as_ref()
             .expect("assistant message must keep tool calls");
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].id, "call-a");
-        assert_eq!(calls[1].id, "call-b");
+        assert_eq!(calls[0].id, "call_a");
+        assert_eq!(calls[1].id, "call_b");
         assert_eq!(frame.messages[1].role, MessageRole::Tool);
-        assert_eq!(frame.messages[1].tool_call_id.as_deref(), Some("call-a"));
+        assert_eq!(frame.messages[1].tool_call_id.as_deref(), Some("call_a"));
         assert_eq!(frame.messages[2].role, MessageRole::Tool);
-        assert_eq!(frame.messages[2].tool_call_id.as_deref(), Some("call-b"));
+        assert_eq!(frame.messages[2].tool_call_id.as_deref(), Some("call_b"));
         assert!(frame.report.synthetic_item_ids.is_empty());
         assert!(frame.report.dropped_item_ids.is_empty());
     }
@@ -2337,7 +2670,7 @@ mod tests {
             model_visible_max_bytes: 10,
         };
         let mut manager = ContextManager::new("s", None).with_tool_output_policy(policy);
-        manager.record_tool_output("call-1", "shell", "0123456789abcdef");
+        manager.record_tool_output("call_1", "shell", "0123456789abcdef");
 
         let envelope = match &manager.items()[0].kind {
             TranscriptItemKind::ToolOutput { envelope } => envelope,
@@ -2361,7 +2694,7 @@ mod tests {
                 .starts_with("tool-output/sha256:")
         );
         let preview = envelope.ui_preview.as_ref().expect("ui preview link");
-        assert_eq!(preview.preview_ref, "appui/tool-output-preview/call-1");
+        assert_eq!(preview.preview_ref, "appui/tool-output-preview/call_1");
         assert_eq!(preview.content, envelope.model_visible_content);
         assert_eq!(preview.bytes, preview.content.len());
         assert!(envelope.raw_sha256.starts_with("sha256:"));
@@ -2373,11 +2706,11 @@ mod tests {
         // tool_name "unknown" into the envelope. The envelope now resolves
         // the real name from a prior AssistantToolCall transcript entry.
         let mut manager = ContextManager::new("s", None);
-        manager.record_message(&assistant_tool_call("call-7"));
+        manager.record_message(&assistant_tool_call("call_7"));
         let tool_message = {
             let mut message = Message::assistant("");
             message.role = MessageRole::Tool;
-            message.tool_call_id = Some("call-7".to_owned());
+            message.tool_call_id = Some("call_7".to_owned());
             message.content = "output for call-7".into();
             message
         };
@@ -2391,7 +2724,7 @@ mod tests {
                 _ => None,
             })
             .expect("recorded tool output");
-        assert_eq!(envelope.tool_call_id, "call-7");
+        assert_eq!(envelope.tool_call_id, "call_7");
         assert_eq!(envelope.tool_name, "shell");
     }
 
@@ -2402,12 +2735,12 @@ mod tests {
         // on its own. Verify the post-probe patch-up still wires the real
         // tool_name onto the merged envelope.
         let mut manager = ContextManager::new("s", None);
-        manager.record_persisted_message(&assistant_tool_call("call-9"), 0);
+        manager.record_persisted_message(&assistant_tool_call("call_9"), 0);
 
         let tool_message = {
             let mut message = Message::assistant("");
             message.role = MessageRole::Tool;
-            message.tool_call_id = Some("call-9".to_owned());
+            message.tool_call_id = Some("call_9".to_owned());
             message.content = "merged output for call-9".into();
             message
         };
@@ -2837,8 +3170,8 @@ mod tests {
             model_visible_max_bytes: 10,
         };
         let mut manager = ContextManager::new(session_id, None).with_tool_output_policy(policy);
-        manager.record_message(&assistant_tool_call("call-1"));
-        manager.record_tool_output("call-1", "shell", "0123456789abcdef");
+        manager.record_message(&assistant_tool_call("call_1"));
+        manager.record_tool_output("call_1", "shell", "0123456789abcdef");
 
         let envelope = match &manager.items()[1].kind {
             TranscriptItemKind::ToolOutput { envelope } => envelope,
@@ -2865,7 +3198,7 @@ mod tests {
             std::fs::read_to_string(&artifact_path).expect("read sidecar"),
             "0123456789abcdef"
         );
-        assert_eq!(preview_ref, "appui/tool-output-preview/call-1");
+        assert_eq!(preview_ref, "appui/tool-output-preview/call_1");
 
         let loaded = load_context_manager_snapshot(temp.path(), session_id)
             .expect("load snapshot")
@@ -2894,8 +3227,8 @@ mod tests {
         let mut manager = ContextManager::new("s", None).with_tool_output_policy(policy);
         manager.record_message(&Message::system("system"));
         manager.record_message(&Message::user("recent user"));
-        manager.record_message(&assistant_tool_call("call-pressure"));
-        let tool_item_id = manager.record_tool_output("call-pressure", "shell", &"x".repeat(200));
+        manager.record_message(&assistant_tool_call("call_pressure"));
+        let tool_item_id = manager.record_tool_output("call_pressure", "shell", &"x".repeat(200));
 
         let frame = manager.for_prompt(&PromptBuildPolicy {
             max_prompt_token_estimate: Some(40),
@@ -2962,8 +3295,8 @@ mod tests {
         let mut assistant = Message::assistant("done");
         assistant.reasoning_content = Some("private reasoning".into());
         manager.record_message(&assistant);
-        manager.record_message(&assistant_tool_call("call-1"));
-        manager.record_tool_output("call-1", "shell", "secret tool output");
+        manager.record_message(&assistant_tool_call("call_1"));
+        manager.record_tool_output("call_1", "shell", "secret tool output");
         manager.record_item(
             TranscriptItemKind::ContextInjection {
                 label: "parent".into(),

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2307,27 +2307,29 @@ impl PromptContextManager for AppUiPromptContextBridge {
         if let Some(system) = runtime_system {
             // Re-apply the agent's runtime System prompt. Two cases:
             //
-            //   a) `frame.messages` leads with a System message
-            //      (e.g. a `[Conversation summary]` emitted by
-            //      `for_prompt`'s compaction path —
-            //      `context_manager.rs:1159`). Concatenate the runtime
-            //      System CONTENT into that existing System rather
-            //      than inserting a second one. We do this in-place to
-            //      avoid producing two consecutive `System` messages
-            //      because `normalize_system_messages` runs BEFORE
-            //      this bridge (`loop_compaction.rs:35`) — anything we
-            //      emit here goes straight to the provider, and
-            //      multi-System payloads are rejected by Anthropic
-            //      (single `system` field) and other providers.
+            //   a) `frame.messages` leads with a System message.
+            //      Concatenate the runtime System CONTENT into that
+            //      existing System rather than inserting a second one.
+            //      We do this in-place to avoid producing two
+            //      consecutive `System` messages because
+            //      `normalize_system_messages` runs BEFORE this bridge
+            //      (`loop_compaction.rs:35`) — anything we emit here
+            //      goes straight to the provider, and multi-System
+            //      payloads are rejected by Anthropic (single `system`
+            //      field) and other providers. Since compaction
+            //      summaries render as protected User rows (see
+            //      `for_prompt`'s CompactionSummary arm), this arm is
+            //      effectively a legacy guard.
             //
-            //   b) `frame.messages` does not lead with a System.
-            //      Insert the runtime System at index 0.
+            //   b) `frame.messages` does not lead with a System (the
+            //      normal case, including post-compaction where the
+            //      frame leads with the User-role summary). Insert the
+            //      runtime System at index 0.
             //
             // Safe to merge unconditionally because
             // `record_message_with_source_ref` early-returns for
             // `System` role (`context_manager.rs:752`) so the frame
-            // can only contain compaction summaries or no System at
-            // all — never the runtime System itself.
+            // never contains the runtime System itself.
             match messages.first_mut() {
                 Some(first) if first.role == MessageRole::System => {
                     let existing = std::mem::take(&mut first.content);
@@ -12343,7 +12345,33 @@ async fn handle_session_rollback(
                 return;
             }
         };
+        let data_dir = sessions_guard.data_dir();
         let session = sessions_guard.get_or_create(&params.session_id).await;
+        // Rebuild + persist the context ledger from the trimmed history.
+        // The ledger coverage check (`context_ledger_covers_history`) is a
+        // high-watermark `>=` — deliberately tolerant of bounded history
+        // slices — so a pre-rollback snapshot still "covers" the shrunken
+        // history and would be Loaded verbatim on the next turn, feeding the
+        // rolled-back turns straight back into the model prompt. Mirrors
+        // `reset_context_manager_from_history` on the session-actor path.
+        let mut rebuilt_context = crate::context_manager::ContextManager::from_session_history(
+            params.session_id.to_string(),
+            None,
+            &session.messages,
+        );
+        rebuilt_context.set_recovery_state(crate::context_manager::ContextRecoveryState::Rebuilt);
+        if let Err(error) = crate::context_manager::persist_context_manager_snapshot(
+            &data_dir,
+            &params.session_id.to_string(),
+            &rebuilt_context,
+        ) {
+            warn!(
+                session = %params.session_id,
+                %error,
+                "session/rollback: failed to persist rebuilt context ledger"
+            );
+        }
+        publish_appui_context_status(&params.session_id, &rebuilt_context);
         // Same message projection as `handle_session_hydrate` for a
         // non-negotiated client: seqs are the trimmed transcript's indices.
         let messages = session
@@ -35709,6 +35737,82 @@ ignore = []
             );
             assert!(session.messages.iter().all(|m| m.content != "turn 3"));
         }
+    }
+
+    /// A stale context ledger must not resurrect rolled-back turns. The
+    /// ledger coverage check is a high-watermark `>=` (deliberately
+    /// slice-tolerant, because turn paths pass bounded history slices), so
+    /// after a rollback shrinks durable history a pre-rollback ledger still
+    /// "covers" it, gets Loaded verbatim, and the next model prompt would
+    /// contain the very turns the user rewound away. `session/rollback` must
+    /// rebuild + persist the context ledger from the trimmed history.
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_rollback_rebuilds_context_ledger() {
+        let session_id = SessionKey("local:rollback-ctx-ledger".into());
+        let (state, _tmp) = prg_state_with_persisted_turns(&session_id, 3).await;
+        // Persist a pre-rollback context ledger exactly like a prior turn's
+        // prompt path would have.
+        let data_dir = {
+            let sessions = state.sessions.as_ref().expect("sessions store");
+            let mut guard = sessions.lock().await;
+            let data_dir = guard.data_dir();
+            let history = guard.get_or_create(&session_id).await.messages.clone();
+            let manager = crate::context_manager::ContextManager::from_session_history(
+                session_id.to_string(),
+                None,
+                &history,
+            );
+            crate::context_manager::persist_context_manager_snapshot(
+                &data_dir,
+                &session_id.to_string(),
+                &manager,
+            )
+            .expect("persist pre-rollback ledger");
+            data_dir
+        };
+        let active_turns = active_turns_registry();
+        let ledger = event_ledger(&state).await;
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        handle_session_rollback(
+            &ws,
+            &state,
+            &ledger,
+            &active_turns,
+            None,
+            None,
+            "rb-ctx".into(),
+            SessionRollbackParams {
+                session_id: session_id.clone(),
+                num_turns: 1,
+            },
+        )
+        .await;
+        let _ = recv_rpc_json(&mut rx).await;
+
+        // The next turn loads the ledger against the TRIMMED history; the
+        // dropped turn must not be visible in the resulting prompt frame.
+        let trimmed = {
+            let sessions = state.sessions.as_ref().expect("sessions store");
+            let mut guard = sessions.lock().await;
+            guard.get_or_create(&session_id).await.messages.clone()
+        };
+        assert!(trimmed.iter().all(|m| m.content != "turn 3"));
+        let (loaded, _status) = crate::context_manager::load_or_rebuild_context_manager(
+            &data_dir,
+            session_id.to_string(),
+            None,
+            &trimmed,
+        );
+        let frame = loaded.for_prompt(&crate::context_manager::PromptBuildPolicy::default());
+        assert!(
+            !frame
+                .messages
+                .iter()
+                .any(|m| m.content.contains("turn 3") || m.content.contains("reply 3")),
+            "rolled-back turns must not resurrect through a stale context ledger: {:#?}",
+            frame.messages
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -706,13 +706,14 @@ impl PromptContextManager for SessionActorPromptContextBridge {
                 .any(|(left, right)| !prompt_message_matches(left, right));
         *messages = frame.messages;
         if let Some(system) = runtime_system {
-            // Merge in place when the frame leads with a System (e.g.
-            // compaction summary). `normalize_system_messages` runs
-            // BEFORE this bridge in the agent loop
-            // (`loop_compaction.rs:35`), so multi-System payloads
-            // produced here would reach the provider unmerged.
-            // Anthropic in particular rejects them outright. See the
-            // AppUI analogue in `api::ui_protocol::AppUiPromptContextBridge::prepare_prompt`
+            // Merge in place when the frame leads with a System (legacy
+            // guard — compaction summaries now render as protected User
+            // rows). `normalize_system_messages` runs BEFORE this bridge
+            // in the agent loop (`loop_compaction.rs:35`), so
+            // multi-System payloads produced here would reach the
+            // provider unmerged. Anthropic in particular rejects them
+            // outright. See the AppUI analogue in
+            // `api::ui_protocol::AppUiPromptContextBridge::prepare_prompt`
             // for the rationale.
             match messages.first_mut() {
                 Some(first) if first.role == MessageRole::System => {
@@ -9821,6 +9822,106 @@ mod tests {
             crate::context_manager::context_ledger_path(dir.path(), &session_key.to_string())
                 .exists(),
             "prompt-context preparation should persist the canonical context ledger"
+        );
+    }
+
+    /// Post-compaction coverage regression: the agent loop runs
+    /// `normalize_system_messages` BEFORE the bridge, converting any
+    /// non-leading `[Conversation summary]` System row into a
+    /// `[System note] ` User row. When the frame emitted that summary as a
+    /// System row, the bridge's contiguous coverage window never matched
+    /// again after the first compaction, and every TurnStart re-recorded the
+    /// entire retained conversation as source-less duplicates. The frame now
+    /// emits the summary as a User row, which the loop leaves untouched, so
+    /// TurnStart must record exactly ONE new item (the current user turn).
+    #[test]
+    fn session_actor_prompt_context_bridge_covers_frame_after_compaction() {
+        let session_key = SessionKey::new("cli", "context-post-compaction-coverage");
+        let history: Vec<Message> = (0..6)
+            .flat_map(|index| {
+                vec![
+                    test_message(MessageRole::User, format!("user turn {index}")),
+                    test_message(MessageRole::Assistant, format!("assistant turn {index}")),
+                ]
+            })
+            .collect();
+        let mut manager =
+            ContextManager::from_session_history(session_key.to_string(), None, &history);
+        manager.install_compaction_summary("older turns summarized", 4);
+        let item_count_before = manager.items().len();
+        let manager = Arc::new(StdMutex::new(manager));
+        let dir = tempfile::TempDir::new().unwrap();
+        let bridge = SessionActorPromptContextBridge::new(
+            session_key.clone(),
+            dir.path().to_path_buf(),
+            manager.clone(),
+        );
+
+        let request = PromptContextRequest {
+            phase: PromptContextPhase::TurnStart,
+            iteration: 1,
+            provider_name: "test".to_string(),
+            model_id: "large-context".to_string(),
+            context_window: 16_000,
+        };
+        // Build the turn-start vector the way the agent loop does: runtime
+        // System + the manager's own frame + the new user turn...
+        let frame_messages = {
+            let guard = manager.lock().unwrap_or_else(|e| e.into_inner());
+            guard
+                .for_prompt(&SessionActorPromptContextBridge::prompt_policy(&request))
+                .messages
+        };
+        let mut prompt = vec![test_message(MessageRole::System, "runtime system")];
+        prompt.extend(frame_messages);
+        prompt.push(test_message(MessageRole::User, "current request"));
+        // ...then apply the `normalize_system_messages` conversion rule that
+        // runs before the bridge (message_repair.rs): non-leading context
+        // System rows become `[System note] ` User rows. A User-role summary
+        // frame row makes this a no-op; a System-role regression would be
+        // rewritten here and blow the coverage window below.
+        for message in prompt.iter_mut().skip(1) {
+            if message.role == MessageRole::System
+                && (message.content.starts_with("[Conversation summary]")
+                    || message.content.starts_with("[Background task"))
+            {
+                message.role = MessageRole::User;
+                message.content = format!("[System note] {}", message.content);
+            }
+        }
+
+        let report = bridge
+            .prepare_prompt(request, &mut prompt)
+            .expect("context manager bridge should prepare prompt");
+
+        assert!(
+            !report.compaction_performed,
+            "small post-compaction transcript must not re-compact"
+        );
+        let item_count_after = manager
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .items()
+            .len();
+        assert_eq!(
+            item_count_after,
+            item_count_before + 1,
+            "TurnStart must record exactly the current user turn; anything more \
+             means the frame failed coverage and was re-recorded as duplicates"
+        );
+        assert!(
+            prompt
+                .iter()
+                .any(|message| message.content.contains("[Conversation summary]")),
+            "summary must still reach the model prompt"
+        );
+        assert_eq!(
+            prompt
+                .iter()
+                .filter(|message| message.content == "user turn 4")
+                .count(),
+            1,
+            "retained history must not be duplicated in the outgoing prompt"
         );
     }
 

--- a/crates/octos-memory/src/hybrid_search.rs
+++ b/crates/octos-memory/src/hybrid_search.rs
@@ -182,19 +182,33 @@ impl HybridIndex {
             return; // Already indexed
         }
 
-        // HNSW capacity warnings
-        let at_capacity = self.ids.len() >= HNSW_CAPACITY;
-        if at_capacity {
-            tracing::warn!(
-                "HNSW index at capacity ({HNSW_CAPACITY}), indexing {episode_id} in BM25 only — consider rebuilding with a larger capacity"
-            );
-        } else if self.ids.len() >= HNSW_CAPACITY * 80 / 100 {
-            tracing::warn!(
-                "HNSW index at {}% capacity ({}/{}) — consider rebuilding with a larger capacity",
-                self.ids.len() * 100 / HNSW_CAPACITY,
-                self.ids.len(),
-                HNSW_CAPACITY
-            );
+        // HNSW capacity gate. Count actual HNSW points (parity with
+        // `add_embedding`), not total indexed docs: BM25-only and tombstoned
+        // docs occupy `ids` without occupying HNSW slots, so a doc-count gate
+        // would silently stop vectorizing every new episode once the store
+        // passes 10k docs even with an empty vector index.
+        let hnsw_points = self
+            .hnsw
+            .as_ref()
+            .map(|hnsw| hnsw.get_nb_point())
+            .unwrap_or(0);
+        let at_capacity = hnsw_points >= HNSW_CAPACITY;
+        // Capacity warnings only concern inserts that would actually touch
+        // HNSW — a BM25-only insert neither consumes nor is affected by
+        // vector-slot pressure.
+        if embedding.is_some() {
+            if at_capacity {
+                tracing::warn!(
+                    "HNSW index at capacity ({HNSW_CAPACITY}), indexing {episode_id} in BM25 only — consider rebuilding with a larger capacity"
+                );
+            } else if hnsw_points >= HNSW_CAPACITY * 80 / 100 {
+                tracing::warn!(
+                    "HNSW index at {}% capacity ({}/{}) — consider rebuilding with a larger capacity",
+                    hnsw_points * 100 / HNSW_CAPACITY,
+                    hnsw_points,
+                    HNSW_CAPACITY
+                );
+            }
         }
 
         let doc_idx = self.ids.len();
@@ -746,6 +760,35 @@ mod tests {
             index.hnsw.as_ref().map(|h| h.get_nb_point()),
             Some(HNSW_CAPACITY),
             "HNSW point count must NOT grow past capacity — saturation invariant for vector_fetch_count"
+        );
+    }
+
+    #[test]
+    fn insert_vectorizes_when_hnsw_has_room_despite_many_bm25_docs() {
+        // The insert-side HNSW gate must count actual HNSW points (like
+        // `add_embedding` does), not total indexed docs: a store can exceed
+        // HNSW_CAPACITY in BM25-only docs while the vector index is empty.
+        // Gating on doc count silently stops vectorizing new episodes for
+        // any >10k-episode store even though HNSW has full capacity left.
+        let mut index = HybridIndex::new(4);
+        for i in 0..HNSW_CAPACITY {
+            index.insert(&format!("bm25-{i}"), "text", None);
+        }
+        index.insert("with-embedding", "vector text", Some(&[1.0, 0.0, 0.0, 0.0]));
+
+        let idx = index
+            .ids
+            .iter()
+            .position(|id| id == "with-embedding")
+            .expect("doc indexed");
+        assert!(
+            index.has_embedding[idx],
+            "insert must vectorize when the HNSW index itself has room"
+        );
+        assert_eq!(
+            index.hnsw.as_ref().map(|h| h.get_nb_point()),
+            Some(1),
+            "the embedding must actually land in HNSW"
         );
     }
 

--- a/crates/octos-memory/src/memory_store.rs
+++ b/crates/octos-memory/src/memory_store.rs
@@ -271,28 +271,29 @@ fn extract_abstract(content: &str) -> String {
 }
 
 /// Strip YAML frontmatter (`---` delimited), returning only the body.
+///
+/// Both fences must be bare `---` lines: `---abc` is not an opener, `----`
+/// is a horizontal rule rather than a closing fence, and an empty
+/// frontmatter block (`---\n---\n`) strips cleanly.
 fn strip_frontmatter(content: &str) -> &str {
     let trimmed = content.trim_start();
-    if !trimmed.starts_with("---") {
+    let Some(after_opener) = trimmed.strip_prefix("---") else {
         return content;
+    };
+    let Some(rest) = after_opener
+        .strip_prefix("\r\n")
+        .or_else(|| after_opener.strip_prefix('\n'))
+    else {
+        return content;
+    };
+    let mut offset = 0;
+    for line in rest.split_inclusive('\n') {
+        if line.trim_end_matches(['\r', '\n']) == "---" {
+            return &rest[offset + line.len()..];
+        }
+        offset += line.len();
     }
-    let after_first = &trimmed[3..];
-    // Skip past the first newline after opening ---
-    let after_first = after_first
-        .strip_prefix('\r')
-        .unwrap_or(after_first)
-        .strip_prefix('\n')
-        .unwrap_or(after_first);
-    if let Some(end) = after_first.find("\n---") {
-        let body_start = end + 4; // skip "\n---"
-        after_first[body_start..]
-            .strip_prefix('\r')
-            .unwrap_or(&after_first[body_start..])
-            .strip_prefix('\n')
-            .unwrap_or(&after_first[body_start..])
-    } else {
-        content
-    }
+    content
 }
 
 #[cfg(test)]
@@ -438,6 +439,35 @@ mod tests {
     fn test_strip_frontmatter_no_frontmatter() {
         let content = "Just plain text.";
         assert_eq!(strip_frontmatter(content), content);
+    }
+
+    #[test]
+    fn test_strip_frontmatter_empty_frontmatter() {
+        assert_eq!(strip_frontmatter("---\n---\nBody here."), "Body here.");
+    }
+
+    #[test]
+    fn test_strip_frontmatter_requires_bare_opener_line() {
+        // "---abc" is a plain text line, not a frontmatter fence.
+        let content = "---abc\nnot frontmatter\n---\nBody";
+        assert_eq!(strip_frontmatter(content), content);
+    }
+
+    #[test]
+    fn test_strip_frontmatter_ignores_longer_dash_runs() {
+        // A "----" line is a horizontal rule / typo, not a closing fence.
+        let content = "---\nname: x\n----\nBody";
+        assert_eq!(strip_frontmatter(content), content);
+    }
+
+    #[test]
+    fn test_strip_frontmatter_crlf() {
+        assert_eq!(strip_frontmatter("---\r\nname: x\r\n---\r\nBody"), "Body");
+    }
+
+    #[test]
+    fn test_strip_frontmatter_closing_fence_at_eof() {
+        assert_eq!(strip_frontmatter("---\nname: x\n---"), "");
     }
 
     #[tokio::test]

--- a/crates/octos-memory/src/store.rs
+++ b/crates/octos-memory/src/store.rs
@@ -22,6 +22,40 @@ const EMBEDDINGS_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("emb
 /// Default embedding dimension (OpenAI text-embedding-3-small).
 const DEFAULT_DIMENSION: usize = 1536;
 
+/// Parse a cwd-index JSON array of episode IDs. On corrupt JSON, salvage any
+/// quoted strings that look like episode IDs instead of silently replacing
+/// the list with an empty one (which would orphan every other episode
+/// indexed under that cwd). Shared by the store, scan, and delete paths so
+/// corruption handling stays consistent.
+fn parse_episode_ids_with_salvage(raw: &str) -> Vec<String> {
+    match serde_json::from_str(raw) {
+        Ok(ids) => ids,
+        Err(e) => {
+            warn!(
+                "failed to parse cwd index JSON ({} bytes): {e}; attempting salvage",
+                raw.len()
+            );
+            let salvaged: Vec<String> = raw
+                .split('"')
+                .enumerate()
+                .filter_map(|(i, s)| {
+                    // Odd indices are inside quotes in valid JSON arrays
+                    if i % 2 == 1 && !s.is_empty() && !s.contains(['[', ']', ',']) {
+                        Some(s.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            warn!(
+                "salvaged {} episode IDs from corrupted index",
+                salvaged.len()
+            );
+            salvaged
+        }
+    }
+}
+
 /// Store for episodes using redb (pure Rust embedded database).
 ///
 /// # Degraded mode
@@ -252,29 +286,7 @@ impl EpisodeStore {
                 let mut index = write_txn.open_table(CWD_INDEX_TABLE)?;
                 let existing: Vec<String> = index
                     .get(cwd.as_str())?
-                    .map(|v| match serde_json::from_str(v.value()) {
-                        Ok(val) => val,
-                        Err(e) => {
-                            // Don't replace with empty Vec — try to salvage by
-                            // extracting any quoted strings that look like episode IDs.
-                            let raw = v.value();
-                            warn!("failed to parse cwd index JSON ({} bytes): {e}; attempting salvage", raw.len());
-                            let salvaged: Vec<String> = raw
-                                .split('"')
-                                .enumerate()
-                                .filter_map(|(i, s)| {
-                                    // Odd indices are inside quotes in valid JSON arrays
-                                    if i % 2 == 1 && !s.is_empty() && !s.contains(['[', ']', ',']) {
-                                        Some(s.to_string())
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .collect();
-                            warn!("salvaged {} episode IDs from corrupted index", salvaged.len());
-                            salvaged
-                        }
-                    })
+                    .map(|v| parse_episode_ids_with_salvage(v.value()))
                     .unwrap_or_default();
 
                 let mut ids = existing;
@@ -442,23 +454,7 @@ impl EpisodeStore {
             // Get episode IDs for this cwd
             let episode_ids: Vec<String> = index_table
                 .get(cwd_str.as_str())?
-                .map(|v| match serde_json::from_str(v.value()) {
-                    Ok(val) => val,
-                    Err(e) => {
-                        let raw = v.value();
-                        warn!("failed to parse episode index JSON ({} bytes): {e}; attempting salvage", raw.len());
-                        raw.split('"')
-                            .enumerate()
-                            .filter_map(|(i, s)| {
-                                if i % 2 == 1 && !s.is_empty() && !s.contains(['[', ']', ',']) {
-                                    Some(s.to_string())
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect()
-                    }
-                })
+                .map(|v| parse_episode_ids_with_salvage(v.value()))
                 .unwrap_or_default();
 
             // Tokenize query consistently (#127): split on non-alphanumeric, filter short tokens
@@ -584,11 +580,14 @@ impl EpisodeStore {
                     if let Ok(episode) = serde_json::from_str::<Episode>(old_json.value()) {
                         let cwd = episode.working_dir.to_string_lossy().to_string();
                         let mut cwd_index = write_txn.open_table(CWD_INDEX_TABLE)?;
-                        // Read and drop the immutable borrow before mutating
-                        let existing: Option<Vec<String>> =
-                            cwd_index.get(cwd.as_str())?.map(|ids_json| {
-                                serde_json::from_str(ids_json.value()).unwrap_or_default()
-                            });
+                        // Read and drop the immutable borrow before mutating.
+                        // Salvage on corrupt JSON (parity with `store`):
+                        // defaulting to an empty list here would remove the
+                        // whole cwd entry and orphan every other episode
+                        // indexed under it.
+                        let existing: Option<Vec<String>> = cwd_index
+                            .get(cwd.as_str())?
+                            .map(|ids_json| parse_episode_ids_with_salvage(ids_json.value()));
                         if let Some(mut ids) = existing {
                             ids.retain(|id| id != &ep_id);
                             if ids.is_empty() {
@@ -781,6 +780,76 @@ mod tests {
             summary.into(),
             EpisodeOutcome::Success,
         )
+    }
+
+    #[test]
+    fn parse_episode_ids_salvages_corrupt_json() {
+        // Valid JSON parses normally.
+        assert_eq!(
+            parse_episode_ids_with_salvage(r#"["ep-1","ep-2"]"#),
+            vec!["ep-1".to_string(), "ep-2".to_string()]
+        );
+        // Corrupt JSON (truncated array) salvages the quoted IDs instead of
+        // silently dropping the list — the pre-fix `delete_by_id` behavior
+        // would have emptied the cwd index and orphaned ep-1/ep-2.
+        assert_eq!(
+            parse_episode_ids_with_salvage(r#"["ep-1","ep-2""#),
+            vec!["ep-1".to_string(), "ep-2".to_string()]
+        );
+    }
+
+    /// End-to-end pin for the delete-path salvage: corrupt the on-disk cwd
+    /// index, delete ONE episode, and assert the other episode's ID survives
+    /// in the index. Pre-fix, `delete_by_id` parsed the corrupt JSON with
+    /// `unwrap_or_default()`, saw an empty list, and removed the whole cwd
+    /// entry — orphaning every other episode indexed under that cwd.
+    #[tokio::test]
+    async fn delete_by_id_salvages_corrupt_cwd_index_and_keeps_other_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let (id_keep, id_delete);
+        {
+            let store = EpisodeStore::open(dir.path()).await.unwrap();
+            let keeper = make_episode("keeper episode", "/proj");
+            let doomed = make_episode("doomed episode", "/proj");
+            id_keep = keeper.id.clone();
+            id_delete = doomed.id.clone();
+            store.store(keeper).await.unwrap();
+            store.store(doomed).await.unwrap();
+        } // drop the store to release the redb lock
+
+        // Corrupt the cwd index: truncated JSON array (no closing bracket).
+        {
+            let db = Database::create(dir.path().join("episodes.redb")).unwrap();
+            let txn = db.begin_write().unwrap();
+            {
+                let mut table = txn.open_table(CWD_INDEX_TABLE).unwrap();
+                let corrupt = format!("[\"{id_keep}\",\"{id_delete}\"");
+                table.insert("/proj", corrupt.as_str()).unwrap();
+            }
+            txn.commit().unwrap();
+        }
+
+        {
+            let store = EpisodeStore::open(dir.path()).await.unwrap();
+            assert!(store.delete_by_id(&id_delete).await.unwrap());
+        }
+
+        // Inspect the index directly: the keeper must have been salvaged.
+        let db = Database::create(dir.path().join("episodes.redb")).unwrap();
+        let txn = db.begin_read().unwrap();
+        let table = txn.open_table(CWD_INDEX_TABLE).unwrap();
+        let raw = table
+            .get("/proj")
+            .unwrap()
+            .expect("cwd entry must survive when it still lists episodes")
+            .value()
+            .to_string();
+        let ids: Vec<String> = serde_json::from_str(&raw).expect("rewritten index is valid JSON");
+        assert_eq!(
+            ids,
+            vec![id_keep.clone()],
+            "keeper must remain indexed after deleting through a corrupt cwd index"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Deep systematic review of the context continuous-compaction + memory subsystems against `docs/OCTOS_CONTEXT_MANAGER_GAP_CONTRACT.md` / `M16_CONTEXT_MANAGER_PSEUDOCODE.md`. 11 bugs fixed, 3 of them production-critical, every fix landed test-first.

### Production-critical

1. **Post-compaction transcript duplication churn.** The loop's `normalize_system_messages` converted `for_prompt`'s System `[Conversation summary]` row to a User row, and `truncate_old_tool_results` (800-char cap) mutated 4KB envelope rows — either broke the prompt bridge's contiguous coverage-window match, so `record_prompt_messages_not_covered_by_context` re-recorded the entire conversation as source-less duplicates on **every post-compaction turn** (context bloat + compaction churn). Fix: the compaction summary renders as a **protected User row**, and the legacy truncation is skipped for bridge-managed agents (its output was already discarded by frame replacement; it only poisoned coverage).
2. **`session/rollback` resurrection through the context ledger.** The rollback handler never touched the persisted ledger; `context_ledger_covers_history` is a slice-tolerant high-watermark `>=`, so the stale ledger stayed `Loaded` and the next prompt contained the turns the user had just rewound away. Fix: rollback rebuilds the ContextManager from the trimmed history, persists the snapshot, refreshes the status store.
3. **Duplicate `tool_call_id` mispairing in `for_prompt`.** Pairing used first-id-match over the whole transcript; providers with index-style ids (kimi `functions.foo:0`, vllm `call_0`) reuse ids across turns, so later calls got turn-1's output and the real later outputs silently vanished. Fix: positional pairing (consume by transcript item id, search from the call group, bounded at the next same-id call so a missing output synthesizes instead of stealing). Plus record-time + import-time id normalization (`octos_agent::normalize_tool_call_id`) so ledger ids always match the loop-normalized vector — raw ids could reach recording via the `CompactAndRetry` path, which runs the bridge before the loop's normalize pass.

### Additional fixes

- `CompactionRunner::run` budget decision now uses the post-prune estimate (stale pre-prune count caused needless summarization).
- `persist_tool_output_artifacts` skips existing content-addressed files (was O(session tool outputs) rewrites per message commit).
- Prompt trimming: protected User rows no longer count as a "later live request".
- `HybridIndex::insert` gates HNSW capacity on `get_nb_point()` like `add_embedding` (doc-count gating froze vectorization for >10k-episode stores).
- `EpisodeStore::delete_by_id` salvages corrupt cwd-index JSON (parity with `store()`) instead of orphaning sibling episodes.
- `MemoryStore::strip_frontmatter` line-based fence parsing (empty frontmatter, `---abc` opener, `----` fence, CRLF, EOF fence).

## Verification

- TDD: each fix has a regression test that failed before the fix (17 new tests).
- `cargo test --workspace`: 2090 passed / 0 failed; `cargo test -p octos-cli --features api --lib`: 1888 passed; api `--no-run` compile gate, clippy, fmt all clean.
- codex review: 4 rounds on this exact diff (findings verification -> diff review -> follow-up review -> final confirmation); final verdict mergeable, no remaining P1/P2.
- Live smoke on mini4 against real DeepSeek (`serve --stdio`, forced `OCTOS_CONTEXT_COMPACT_THRESHOLD_TOKENS=400`): flat item counts under repeated compaction (no duplication), ledger rebuilt after rollback with the model answering from the surviving turn only, exact tool-output pairing with normalized ids — 21/21 probe assertions passed.

## Deferred follow-ups (documented, out of scope)

- Bounded-slice ledger coverage semantics (>50-message sessions can hide ledger-missing rows, e.g. background-delivered assistant messages).
- Telescoping of prior summaries under repeated extractive compaction.
- Token-estimator inconsistencies (tool-call arguments uncounted in frame estimates).
- System-role session rows (approval outcomes / background notices) invisible to the manager.