### PR TITLE
fix(autonomy): self-paced/maintenance loops become schedulable; reply-less fires reschedule

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -2496,12 +2496,32 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
             mode: parsed.mode,
             interval_seconds: parsed.interval_seconds,
             status: "active".into(),
-            next_run_at_ms: parsed.interval_seconds.and_then(|seconds| {
-                i64::try_from(seconds)
-                    .ok()
-                    .and_then(|seconds| seconds.checked_mul(1_000))
-                    .and_then(|delay_ms| now.checked_add(delay_ms))
-            }),
+            // A fresh loop MUST carry a schedule cue or the due-scan never
+            // visits it. Fixed loops schedule now+interval (unchanged).
+            // Self-paced and maintenance loops previously started at
+            // `next_run_at_ms: None`, which the due-scan skips forever — so
+            // `/loop <prompt>` and bare `/loop` NEVER fired without a manual
+            // `loop/fire_now` (the model can only pick its
+            // `<<loop-next-in: …>>` delay after a first fire that never
+            // came). Give them the default self-paced delay as an initial
+            // cue: schedulable, model-paced thereafter. (Deliberately NOT
+            // due-now — a due-now first fire races a client that also seeds
+            // with `loop/fire_now`, enqueuing two first turns; the spec's
+            // "immediately fires once" is a separate follow-up that should
+            // enqueue the first fire from `create` itself.)
+            next_run_at_ms: parsed
+                .interval_seconds
+                .and_then(|seconds| {
+                    i64::try_from(seconds)
+                        .ok()
+                        .and_then(|seconds| seconds.checked_mul(1_000))
+                })
+                .or_else(|| {
+                    i64::try_from(SELF_PACED_DEFAULT_DELAY_SECONDS)
+                        .ok()
+                        .and_then(|seconds| seconds.checked_mul(1_000))
+                })
+                .and_then(|delay_ms| now.checked_add(delay_ms)),
             last_run_at_ms: None,
             expires_at_ms: now + LOOP_MAX_AGE_DAYS * 24 * 60 * 60 * 1_000,
             created_at_ms: now,
@@ -8681,6 +8701,68 @@ mod tests {
             drained[0].metadata.get("prompt").map(String::as_str),
             Some("check build health")
         );
+    }
+
+    /// UPCR-2026-021: "`/loop 5m /foo` creates a fixed loop and immediately
+    /// fires once", and a self-paced loop needs an INITIAL fire for the
+    /// model to select a delay at all. Every freshly created loop must be
+    /// due immediately — previously fixed loops waited a full interval and
+    /// self-paced/maintenance (`next_run_at_ms: None`) NEVER fired without
+    /// a manual `loop/fire_now`.
+    #[test]
+    fn created_loops_carry_a_schedule_cue_for_every_mode() {
+        // Every mode must get a non-None `next_run_at_ms` at create time or
+        // the due-scan never visits it. Self-paced and maintenance loops
+        // previously started at None and NEVER fired without a manual
+        // fire_now; they now schedule at the default self-paced delay (not
+        // due-now — that would race a client that also seeds fire_now).
+        // Fixed loops keep now+interval.
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let cases: [(&str, Option<u64>, Option<&str>, Option<&str>); 3] = [
+            (
+                "fixed",
+                Some(120),
+                Some("check builds"),
+                Some("fixed_interval"),
+            ),
+            (
+                "selfpaced",
+                None,
+                Some("tend the garden"),
+                Some("self_paced"),
+            ),
+            ("maintenance", None, None, Some("maintenance")),
+        ];
+        for (tag, interval, prompt, mode) in cases {
+            let session_id =
+                SessionKey::with_profile("tenant-a", "api", &format!("loop-cue-{tag}"));
+            let created = orchestrator
+                .create_loop(LoopCreateRequest {
+                    session_id: session_id.clone(),
+                    profile_id: "tenant-a".into(),
+                    prompt: prompt.map(str::to_owned),
+                    command: None,
+                    interval_seconds: interval,
+                    mode: mode.map(str::to_owned),
+                })
+                .expect("create loop");
+            let loop_id = created["loop_id"].as_str().expect("loop id").to_owned();
+            let state = orchestrator.state();
+            let loop_record = state.loops.get(&loop_id).expect("loop record");
+            let next = loop_record
+                .next_run_at_ms
+                .unwrap_or_else(|| panic!("{tag}: new loop must carry a schedule cue, not None"));
+            assert!(
+                next > now_ms(),
+                "{tag}: the cue is in the future (fixed=+interval, self-paced/maintenance=+default delay), not due-now (next={next})"
+            );
+            // The scheduled cue is bounded by the mode's expected delay.
+            let expected_ms = interval.unwrap_or(SELF_PACED_DEFAULT_DELAY_SECONDS) as i64 * 1_000;
+            assert!(
+                next <= now_ms() + expected_ms + 5_000,
+                "{tag}: cue within the expected delay window"
+            );
+        }
     }
 
     /// #1128 codex P1 acceptance: self-paced loops whose `next_run_at_ms`

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -17158,7 +17158,14 @@ fn appui_loop_assistant_reply_for_self_paced(
     match captured_response_content {
         Some(content) if !content.is_empty() => Some(content.to_owned()),
         Some(_) => None,
-        None => history_fallback,
+        // No capture (interrupt / agent error before EndTurn): use the
+        // history reply if present, else `Some("")`. Returning `Some("")`
+        // for a true no-reply is deliberate — the empty reply carries no
+        // `<<loop-next-in: …>>` sentinel, so `apply_self_paced_response`
+        // stamps the DEFAULT delay. The old `None` here parked the loop at
+        // `next_run_at_ms: None`, which the due-scan never visits again —
+        // one interrupted turn silently killed the loop.
+        None => Some(history_fallback.unwrap_or_default()),
     }
 }
 
@@ -24396,6 +24403,19 @@ mod tests {
         assert_eq!(
             blank_capture, None,
             "empty captured content must not stamp a default-delay reschedule via history fallback"
+        );
+
+        // A fire with NO capture and NO history reply (interrupt / agent
+        // error before anything persisted) must still reschedule: the
+        // picker yields an empty reply, which carries no sentinel, so the
+        // orchestrator stamps the DEFAULT delay. The old `None` here parked
+        // the loop at `next_run_at_ms: None` — permanently dead after one
+        // interrupted turn.
+        let reply_less = appui_loop_assistant_reply_for_self_paced(None, None);
+        assert_eq!(
+            reply_less.as_deref(),
+            Some(""),
+            "a reply-less fire must reschedule with the default delay, not kill the loop"
         );
     }
 

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -4854,19 +4854,35 @@ impl SessionActor {
                         .last()
                         .map(|(_, message)| message.content.clone())
                 };
-                if let Some(reply) = assistant_reply {
-                    if let Err(err) = default_agent_orchestrator().apply_self_paced_response(
-                        &loop_id,
-                        &profile_id,
-                        &reply,
-                    ) {
-                        info!(
-                            session = %self.session_key,
-                            loop_id = %loop_id,
-                            error = %err.message,
-                            "apply_self_paced_response skipped"
-                        );
-                    }
+                // A reply-less fire (interrupt / agent error / empty content)
+                // still reschedules: the empty reply carries no
+                // `<<loop-next-in: …>>` sentinel, so the orchestrator applies
+                // the DEFAULT self-paced delay. Skipping here parked the loop
+                // at `next_run_at_ms: None`, which the due-scan never visits
+                // again — one failed turn silently killed the loop.
+                //
+                // Deliberate divergence from the AppUI path (codex round-1):
+                // AppUI captures the EndTurn payload and can distinguish a
+                // DELIBERATE blank reply (skip, #1134 contract) from a true
+                // no-reply (reschedule). This path has no capture —
+                // `process_inbound` doesn't persist empty assistant content
+                // and the history scan filters empties — so blank and error
+                // are indistinguishable here, and liveness wins: a blank
+                // loop turn retries at the default delay instead of dying.
+                // An explicit model stop should be a sentinel (follow-up),
+                // not an unpersistable blank.
+                let reply = assistant_reply.unwrap_or_default();
+                if let Err(err) = default_agent_orchestrator().apply_self_paced_response(
+                    &loop_id,
+                    &profile_id,
+                    &reply,
+                ) {
+                    info!(
+                        session = %self.session_key,
+                        loop_id = %loop_id,
+                        error = %err.message,
+                        "apply_self_paced_response skipped"
+                    );
                 }
             }
             default_agent_orchestrator().mark_continuation_completed(


### PR DESCRIPTION
Self-paced and maintenance loops were created with next_run_at_ms: None → the due-scan skips them forever, so /loop <prompt> and bare /loop NEVER fired without a manual fire_now. They now carry a schedule cue (self-paced/maintenance = now+default delay; fixed = now+interval, unchanged). A reply-less fire (interrupt/error) no longer parks the loop at None — it reschedules at the default delay. Complementary to #1523 (which parks RESTORED loops on solo boot). codex-clean; live-smoked (a fixed loop auto-fired end-to-end). Immediate-first-fire + resume-revival deferred as follow-ups (create/fire_now race). 1893 api tests.