### PR TITLE
fix(agent): loop-detector fall-through + capture-buffer UTF-8 panic

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -854,7 +854,12 @@ impl Agent {
                 let mut loop_detector = LoopDetector::new(12);
                 let mut turn_ledger = self.new_turn_ledger();
 
-                loop {
+                // Labeled so the loop-detector recovery arms below can re-enter
+                // the AGENT loop (skip tool execution for this spiraling
+                // response), not merely the inner `for tc in &response.tool_calls`
+                // loop — an unlabeled `continue` there fell through to
+                // `handle_tool_use` and executed the spiraling tools anyway.
+                'agent_loop: loop {
                     if let Some(stop) = turn.check_budget(self, activity.as_ref()) {
                         let stop_iteration = turn.iteration();
                         if !self.try_budget_grace_call(
@@ -1138,7 +1143,7 @@ impl Agent {
                                                 warn!(
                                                     "shell spiral fired pre-execution; injected recovery notice into latest shell Tool and continuing for LLM summary"
                                                 );
-                                                continue;
+                                                continue 'agent_loop;
                                             }
                                         }
                                         let terminal_content = if matches!(
@@ -1213,7 +1218,7 @@ impl Agent {
                                             warn!(
                                                 "loop detected — injected synthetic tool results with warning and continuing for ONE more iteration"
                                             );
-                                            continue;
+                                            continue 'agent_loop;
                                         }
                                         Err(_) => {
                                             warn!(
@@ -6500,6 +6505,103 @@ printf '{"output":"voice saved","success":true}\n'
             total_calls >= 5,
             "expected at least 5 LLM calls (4 to trigger first detection + \
              1 recovery iteration); got {total_calls}"
+        );
+    }
+
+    /// LLM mock that always calls a named tool, so the loop detector fires
+    /// repeatedly on a tool whose EXECUTION count the test can observe.
+    struct CountingAlwaysNamedToolProvider {
+        calls: AtomicUsize,
+        tool_name: &'static str,
+    }
+
+    #[async_trait]
+    impl LlmProvider for CountingAlwaysNamedToolProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> Result<ChatResponse> {
+            self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+            Ok(ChatResponse {
+                content: None,
+                reasoning_content: None,
+                tool_calls: vec![ToolCall {
+                    id: "call_loopy".to_string(),
+                    name: self.tool_name.to_string(),
+                    arguments: serde_json::json!({}),
+                    metadata: None,
+                }],
+                stop_reason: StopReason::ToolUse,
+                usage: LlmTokenUsage::default(),
+                provider_index: None,
+            })
+        }
+
+        fn model_id(&self) -> &str {
+            "mock"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    #[tokio::test]
+    async fn loop_detected_first_fire_does_not_execute_the_spiraling_tool() {
+        // Regression: the loop-detector `continue` after injecting synthetic
+        // results must re-enter the AGENT loop, not merely the inner
+        // `for tc in &response.tool_calls` loop. When it bound to the `for`,
+        // control fell through to `handle_tool_use` and the spiraling tool
+        // EXECUTED anyway (extra side effects + a duplicate tool_call_id row),
+        // defeating the detector's "inject a warning, do NOT call the tools"
+        // contract.
+        //
+        // With the same-tool provider the detector trips on the 4th call, so:
+        //   - iterations 1..=3 execute the tool  (3 executions)
+        //   - iteration 4 (FIRST fire) injects synthetic results and re-enters
+        //     the loop WITHOUT executing
+        //   - iteration 5 (SECOND fire) terminates before executing
+        // ⇒ executions == total_llm_calls - 2. The buggy fall-through executed
+        // on the first-fire iteration too (executions == total_llm_calls - 1).
+        let dir = tempfile::tempdir().unwrap();
+        let exec_count = Arc::new(AtomicUsize::new(0));
+        let provider = Arc::new(CountingAlwaysNamedToolProvider {
+            calls: AtomicUsize::new(0),
+            tool_name: "loopy_tool",
+        });
+        let provider_arc: Arc<dyn LlmProvider> = provider.clone();
+        let mut tools = ToolRegistry::with_builtins(dir.path());
+        tools.register(CountingEchoTool {
+            name: "loopy_tool",
+            output: "looped",
+            calls: exec_count.clone(),
+        });
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let agent = Agent::new(AgentId::new("recover"), provider_arc, tools, memory).with_config(
+            crate::AgentConfig {
+                max_iterations: 30,
+                save_episodes: false,
+                ..Default::default()
+            },
+        );
+
+        let result = agent
+            .process_message("please loop", &[], vec![])
+            .await
+            .expect("process_message should return Ok even when the loop terminates");
+        assert_eq!(result.content, loop_detected_terminal_message());
+
+        let total_calls = provider.calls.load(AtomicOrdering::SeqCst);
+        let executions = exec_count.load(AtomicOrdering::SeqCst);
+        assert_eq!(
+            executions,
+            total_calls - 2,
+            "the spiraling tool must NOT execute on the first-fire (synthetic-\
+             injection) iteration; got {executions} executions across \
+             {total_calls} LLM calls (buggy fall-through would be {})",
+            total_calls - 1
         );
     }
 

--- a/crates/octos-agent/src/tools/coding_tools.rs
+++ b/crates/octos-agent/src/tools/coding_tools.rs
@@ -94,11 +94,27 @@ where
             guard.push_str("\n--- stderr ---\n");
         }
         guard.push_str(&chunk);
-        if guard.len() > MAX_CAPTURE_BYTES * 2 {
-            let keep_from = guard.len().saturating_sub(MAX_CAPTURE_BYTES);
-            let trimmed = guard[keep_from..].to_string();
-            *guard = format!("... (earlier output truncated)\n{trimmed}");
+        truncate_capture_in_place(&mut guard);
+    }
+}
+
+/// Trim an accumulating capture buffer to its last [`MAX_CAPTURE_BYTES`] once it
+/// grows past twice that, keeping the tail.
+///
+/// `len - MAX_CAPTURE_BYTES` is a raw BYTE offset that need not fall on a UTF-8
+/// char boundary — slicing there directly panics ("byte index N is not a char
+/// boundary") when a multibyte char (CJK/emoji) straddles it. Because this runs
+/// inside a `tokio::spawn`ed reader task, that panic silently kills the reader
+/// and the stream stops capturing. Advance the cut to the next char boundary
+/// first so the slice is always valid.
+fn truncate_capture_in_place(guard: &mut String) {
+    if guard.len() > MAX_CAPTURE_BYTES * 2 {
+        let mut keep_from = guard.len().saturating_sub(MAX_CAPTURE_BYTES);
+        while keep_from < guard.len() && !guard.is_char_boundary(keep_from) {
+            keep_from += 1;
         }
+        let trimmed = guard[keep_from..].to_string();
+        *guard = format!("... (earlier output truncated)\n{trimmed}");
     }
 }
 
@@ -3367,6 +3383,30 @@ fn catalog_score(entry: &ToolCatalogEntry, query: &str, tokens: &[String]) -> i3
 mod tests {
     use super::*;
     use crate::tools::ToolRegistry;
+
+    #[test]
+    fn truncate_capture_does_not_panic_on_multibyte_boundary() {
+        // Regression: `guard[len - MAX_CAPTURE_BYTES..]` sliced at a raw byte
+        // offset. A multibyte char straddling that offset panicked, silently
+        // killing the spawned reader task. Build a buffer whose cut point falls
+        // mid-'世' (3 bytes) and confirm the trim succeeds and stays valid UTF-8.
+        // An all-3-byte-char buffer: char boundaries are multiples of 3, and
+        // MAX_CAPTURE_BYTES (50_000) is not ≡ 0 (mod 3), so the raw cut offset
+        // `len - MAX_CAPTURE_BYTES` is guaranteed to fall mid-char.
+        let mut guard = "世".repeat(40_000); // 120_000 bytes, over the 2× trigger
+        let cut = guard.len().saturating_sub(MAX_CAPTURE_BYTES);
+        assert!(
+            !guard.is_char_boundary(cut),
+            "test precondition: the raw cut offset must fall mid-char"
+        );
+
+        truncate_capture_in_place(&mut guard); // must not panic
+        assert!(guard.starts_with("... (earlier output truncated)\n"));
+        assert!(
+            guard.contains('世'),
+            "the kept tail must remain valid UTF-8"
+        );
+    }
 
     const CODEX_P0: &[&str] = &[
         "apply_patch",


### PR DESCRIPTION
Two independent octos-agent runtime bugs surfaced by a code-review sweep and each confirmed against source + codex.

## 1. Loop-detector recovery `continue` bound to the wrong loop (P1)

In `loop_runner.rs`, the agent loop wraps a `for tc in &response.tool_calls` block that runs the loop detector *before* executing tools. Both recovery arms — the DiffLikeSuccess pre-execution shell arm and the synthetic-injection arm — ended with an **unlabeled** `continue`, which bound to the inner `for` loop, not the agent loop.

Consequence: after injecting the `[LOOP DETECTED]` synthetic tool results (or the shell-recovery notice), the `for` loop simply advanced/ended and control **fell through to `handle_tool_use`**, so the spiraling tools **executed anyway** — extra side effects plus a second assistant row carrying duplicate `tool_call_id`s. This defeats the detector's core contract ("inject a warning, do NOT call the tools").

Fix: label the agent loop `'agent_loop` and bind both recovery arms to `continue 'agent_loop`, so a detected spiral re-enters the agent loop (re-asks the LLM with the injected results) without executing the tools.

The existing end-to-end test (`loop_detected_first_fire_continues_then_second_fire_terminates`) passed straight through the bug because it only asserted the terminal message and LLM-call count, never whether the tool executed. Added `loop_detected_first_fire_does_not_execute_the_spiraling_tool`, which registers an execution-counting tool and asserts it does **not** run on the first-fire iteration (`executions == llm_calls - 2`, where the buggy fall-through gave `- 1`). Verified RED (4 vs 3) → GREEN.

## 2. Capture-buffer trim panics on a multibyte UTF-8 boundary (P2)

`exec_command`/`write_stdin` accumulate child output and trim to the last `MAX_CAPTURE_BYTES` once past 2×. The trim sliced `guard[len - MAX_CAPTURE_BYTES..]` at a **raw byte offset**; a CJK/emoji char straddling that offset panicked (`byte index N is not a char boundary`) inside the `tokio::spawn`ed reader task, silently killing capture for that stream.

Fix: extract `truncate_capture_in_place` and advance the cut to the next UTF-8 char boundary before slicing. Added `truncate_capture_does_not_panic_on_multibyte_boundary` (all-`世` buffer guarantees a mid-char cut).

## Verification
- Changed modules fully green: `loop_runner` 77 passed, `coding_tools` 60 passed.
- codex-reviewed: loop-detector relabel confirmed correct (both sites, no over-relabeling, label placement right).
- Pre-existing plugin-subprocess + DNS-resolution env test failures are unrelated to these files.