### PR TITLE
fix: fan-out cap semantics, session rewrite lost-updates, anthropic tool round-trip

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -745,6 +745,51 @@ impl Agent {
                     Some(effective_args.clone()),
                     bg_originating_thread_id.clone(),
                 );
+                // Cap refusal: the legacy register entry points signal a
+                // per-session child-fanout rejection with an empty-string
+                // sentinel. Spawning anyway would run a worker that is
+                // invisible to `task/list`, uncancellable (`cancel("")`
+                // no-ops), and hand the LLM a task_handle with an empty id —
+                // the cap would bound tracking, not execution. Refuse the
+                // call synchronously instead, mirroring the policy-deny
+                // early-return above (chip clear included).
+                if task_id.is_empty() {
+                    tracing::error!(
+                        tool = %tc_name,
+                        "spawn_only register refused (child fanout cap); not spawning"
+                    );
+                    let cap_msg = format!(
+                        "[TASK LIMIT] Cannot start background task '{tc_name}': this \
+                         session reached its background-task fanout cap. Wait for \
+                         running tasks to finish (or cancel them) before starting more. \
+                         Do not retry immediately."
+                    );
+                    reporter.report(ProgressEvent::ToolCompleted {
+                        name: tc_name.clone(),
+                        tool_id: tc_id.clone(),
+                        success: false,
+                        output_preview: octos_core::truncated_utf8(&cap_msg, 200, "..."),
+                        duration: tool_start.elapsed(),
+                    });
+                    return (
+                        Message {
+                            role: MessageRole::Tool,
+                            content: cap_msg,
+                            media: vec![],
+                            tool_calls: None,
+                            tool_call_id: Some(tc_id),
+                            reasoning_content: None,
+                            client_message_id: None,
+                            thread_id: None,
+                            timestamp: chrono::Utc::now(),
+                        },
+                        Vec::new(),
+                        Vec::new(),
+                        None,
+                        false,
+                        None,
+                    );
+                }
                 tools.mark_spawn_only_invoked();
                 let bg_supervisor = tools.supervisor();
                 // F004 B2: bridge supervised runtime-state transitions onto

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -1938,12 +1938,17 @@ impl TaskSupervisor {
                 .unwrap_or_else(|e| e.into_inner())
                 .contains(parent_session_key);
             if already_poisoned {
+                // Diagnostic count for the error payload — live children,
+                // matching the semantics of the gating count below.
                 let count = self
                     .tasks
                     .lock()
                     .unwrap_or_else(|e| e.into_inner())
                     .values()
-                    .filter(|task| task.parent_session_key.as_deref() == Some(parent_session_key))
+                    .filter(|task| {
+                        task.parent_session_key.as_deref() == Some(parent_session_key)
+                            && task.status.is_active()
+                    })
                     .count();
                 let error = RegisterTaskError::ChildFanoutExceeded {
                     parent_session_key: parent_session_key.to_string(),
@@ -1971,9 +1976,19 @@ impl TaskSupervisor {
             // continue to hit the cap path as before.
             let (current_count, parent_terminal_status) = {
                 let tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
+                // Count LIVE children only. `tasks` is never pruned, so an
+                // unfiltered count is the session's lifetime total — a
+                // long-lived session that merely completed `cap` tasks over
+                // its life would trip the cap, poison the key forever, and
+                // force-fail its active work. The cap's job is to bound
+                // runaway CONCURRENT fan-out; terminal children are done and
+                // hold no resources this cap protects.
                 let count = tasks
                     .values()
-                    .filter(|task| task.parent_session_key.as_deref() == Some(parent_session_key))
+                    .filter(|task| {
+                        task.parent_session_key.as_deref() == Some(parent_session_key)
+                            && task.status.is_active()
+                    })
                     .count();
                 let terminal = parent_terminal_check_tool_call_id
                     .filter(|tcid| !tcid.is_empty())
@@ -5585,6 +5600,42 @@ mod tests {
             .try_register_with_input("tts", "call-other-1", Some("api:other-parent"), None)
             .expect("other parents stay unaffected by a poisoned peer");
         assert!(!other.is_empty());
+    }
+
+    /// The fan-out cap bounds LIVE children, not the session's lifetime
+    /// total. Regression: the cap count had no `is_active()` filter and
+    /// `tasks` is never pruned, so a long-lived session that merely
+    /// COMPLETED `MAX_CHILDREN_PER_PARENT` background tasks over its life
+    /// (tts / podcast / pipeline nodes) tripped the cap on the next
+    /// register — poisoning the session key forever and force-failing
+    /// every currently-active legitimate task.
+    #[test]
+    fn completed_children_do_not_count_toward_fanout_cap() {
+        let parent_session = "api:long-lived-parent";
+        let supervisor = TaskSupervisor::new();
+        for i in 0..MAX_CHILDREN_PER_PARENT {
+            let id = supervisor
+                .try_register_with_input("tts", &format!("call-{i}"), Some(parent_session), None)
+                .unwrap_or_else(|err| panic!("register #{i} should succeed; got {err}"));
+            // Every child finishes cleanly — the session is long-lived,
+            // not runaway.
+            supervisor.mark_completed(&id, Vec::new());
+        }
+
+        let id = supervisor
+            .try_register_with_input("tts", "call-after-long-life", Some(parent_session), None)
+            .expect("a session with only COMPLETED children must not trip the fan-out cap");
+        assert!(!id.is_empty());
+
+        // And the session must not have been poisoned or had work
+        // force-failed by the register above.
+        let tasks = supervisor.get_tasks_for_session(parent_session);
+        assert!(
+            tasks
+                .iter()
+                .all(|t| t.error.as_deref().is_none_or(|e| !e.contains("fanout"))),
+            "no child may be force-failed with a fan-out reason on a healthy session"
+        );
     }
 
     /// The legacy `register_with_input` entry point keeps returning a

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -1938,8 +1938,9 @@ impl TaskSupervisor {
                 .unwrap_or_else(|e| e.into_inner())
                 .contains(parent_session_key);
             if already_poisoned {
-                // Diagnostic count for the error payload — live children,
-                // matching the semantics of the gating count below.
+                // Diagnostic count for the error payload — live children
+                // (status-active OR worker-still-running), matching the
+                // semantics of the gating count below.
                 let count = self
                     .tasks
                     .lock()
@@ -1947,7 +1948,7 @@ impl TaskSupervisor {
                     .values()
                     .filter(|task| {
                         task.parent_session_key.as_deref() == Some(parent_session_key)
-                            && task.status.is_active()
+                            && (task.status.is_active() || is_task_live(&task.id))
                     })
                     .count();
                 let error = RegisterTaskError::ChildFanoutExceeded {
@@ -1983,11 +1984,19 @@ impl TaskSupervisor {
                 // force-fail its active work. The cap's job is to bound
                 // runaway CONCURRENT fan-out; terminal children are done and
                 // hold no resources this cap protects.
+                //
+                // "Live" is status-active OR worker-still-running (codex P2):
+                // `cancel` flips the STATUS to Cancelled immediately, but the
+                // detached worker keeps executing until it observes the token
+                // — status alone would let a spawn→cancel-all→spawn cycle run
+                // 2× the cap concurrently. The process-global live-set
+                // (armed by `TaskTerminalGuard::new`, cleared on its Drop at
+                // every worker exit path) tracks actual worker liveness.
                 let count = tasks
                     .values()
                     .filter(|task| {
                         task.parent_session_key.as_deref() == Some(parent_session_key)
-                            && task.status.is_active()
+                            && (task.status.is_active() || is_task_live(&task.id))
                     })
                     .count();
                 let terminal = parent_terminal_check_tool_call_id
@@ -5636,6 +5645,35 @@ mod tests {
                 .all(|t| t.error.as_deref().is_none_or(|e| !e.contains("fanout"))),
             "no child may be force-failed with a fan-out reason on a healthy session"
         );
+    }
+
+    /// codex P2 on the active-only cap count: `cancel` flips a task's STATUS
+    /// to Cancelled immediately, but the detached worker keeps running until
+    /// it observes the token — a status-only count would let a session spawn
+    /// the cap, cancel everything, and spawn another cap while the first
+    /// workers still execute. A child whose worker is still LIVE (in the
+    /// process-global live-set armed by [`TaskTerminalGuard::new`]) must keep
+    /// counting toward the cap until the guard drops.
+    #[test]
+    fn cancelled_but_still_live_children_still_count_toward_cap() {
+        let parent_session = "api:cancel-bypass-parent";
+        let supervisor = Arc::new(TaskSupervisor::new());
+        let mut guards = Vec::new();
+        for i in 0..MAX_CHILDREN_PER_PARENT {
+            let id = supervisor
+                .try_register_with_input("busy", &format!("call-{i}"), Some(parent_session), None)
+                .unwrap_or_else(|err| panic!("register #{i} should succeed; got {err}"));
+            // Arm the production liveness guard (worker "running"), then
+            // cancel: status flips Cancelled but the worker is still live.
+            guards.push(TaskTerminalGuard::new(supervisor.clone(), id.clone()));
+            let _ = supervisor.cancel(&id);
+        }
+
+        let err = supervisor
+            .try_register_with_input("busy", "call-bypass", Some(parent_session), None)
+            .expect_err("cancelled-but-still-LIVE workers must still bound the fan-out cap");
+        assert!(matches!(err, RegisterTaskError::ChildFanoutExceeded { .. }));
+        drop(guards);
     }
 
     /// The legacy `register_with_input` entry point keeps returning a

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -2697,6 +2697,30 @@ impl Tool for SpawnTool {
                     task_ledger_path.as_deref(),
                 )
             });
+            // Cap refusal: `register_with_lineage` signals a per-session
+            // child-fanout rejection with an empty-string sentinel. Spawning
+            // anyway would run a detached worker that is invisible to
+            // `task/list` and uncancellable (`cancel("")` no-ops), and the
+            // terminal guard below would be armed under `""`. Refuse the
+            // spawn synchronously so the LLM sees the cap instead of a fake
+            // "started in background" handle. (`None` = no supervisor at all —
+            // the legacy untracked path — which stays allowed.)
+            if tracked_task_id.as_deref() == Some("") {
+                tracing::error!(
+                    label = %label,
+                    "background spawn register refused (child fanout cap); not spawning"
+                );
+                return Ok(ToolResult {
+                    output: format!(
+                        "[TASK LIMIT] Cannot spawn background subagent '{label}': this \
+                         session reached its background-task fanout cap. Wait for \
+                         running tasks to finish (or cancel them) before spawning more. \
+                         Do not retry immediately."
+                    ),
+                    success: false,
+                    ..Default::default()
+                });
+            }
             let tracked_child_session_key = tracked_task_id.as_ref().and_then(|task_id| {
                 self.task_supervisor
                     .as_ref()
@@ -3800,6 +3824,62 @@ mod tests {
             );
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
+    }
+
+    /// Cap refusal must refuse the SPAWN, not just the tracking. Regression:
+    /// `register_with_lineage` returns an empty-string sentinel when the
+    /// per-session child-fanout cap rejects the registration, and the
+    /// background branch spawned the detached worker anyway — untracked,
+    /// uncancellable, with the terminal guard armed under `""`.
+    #[tokio::test]
+    async fn test_background_spawn_refused_at_fanout_cap_does_not_spawn() {
+        let (in_tx, _in_rx) = tokio::sync::mpsc::channel(16);
+        let supervisor = Arc::new(TaskSupervisor::new());
+        // Saturate the parent with ACTIVE (Spawned) children so the next
+        // register is refused.
+        for i in 0..crate::task_supervisor::MAX_CHILDREN_PER_PARENT {
+            let id = supervisor.register("busy", &format!("call-{i}"), Some("api:test-session"));
+            assert!(!id.is_empty(), "saturation register #{i} must succeed");
+        }
+
+        let tool = SpawnTool::new(
+            Arc::new(MockProvider),
+            Arc::new(create_test_store().await),
+            PathBuf::from("/tmp"),
+            in_tx,
+        )
+        .with_task_supervisor(
+            supervisor.clone(),
+            "api:test-session",
+            PathBuf::from("/tmp/tasks.jsonl"),
+        );
+
+        let result = tool
+            .execute(&serde_json::json!({
+                "task": "Write a short answer",
+                "label": "over-cap spawn",
+                "mode": "background",
+                "allowed_tools": []
+            }))
+            .await
+            .unwrap();
+
+        assert!(
+            !result.success,
+            "a cap-refused background spawn must fail, not report started; got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("[TASK LIMIT]"),
+            "the refusal must tell the LLM about the cap; got: {}",
+            result.output
+        );
+        // No untracked worker: the supervisor still holds exactly the cap.
+        assert_eq!(
+            supervisor.get_tasks_for_session("api:test-session").len(),
+            crate::task_supervisor::MAX_CHILDREN_PER_PARENT,
+            "the refused spawn must not register or run new work"
+        );
     }
 
     #[ignore = "Pre-migration test: the SpawnOnlyFiles-source MagicBytes validator \

--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -1690,7 +1690,13 @@ impl SessionManager {
     /// Rewrite a session's JSONL file from the in-memory state.
     /// Uses atomic write-then-rename to avoid corruption on crash.
     /// Uses spawn_blocking to avoid blocking the async runtime.
+    ///
+    /// Serialises on the per-key persist lock so the whole-file rewrite
+    /// cannot interleave with (and erase) a canonical locked append or a
+    /// concurrent `SessionHandle` rewrite of the same key.
     pub async fn rewrite(&self, key: &SessionKey) -> Result<()> {
+        let lock = persist_lock_for(key);
+        let _guard = lock.lock().await;
         let session = self
             .cache
             .peek(&key.0)
@@ -2147,6 +2153,30 @@ pub async fn persist_message_through_canonical_path(
     handle.add_message_with_seq(message).await
 }
 
+/// Upsert a durable child-session contract through the canonical locked
+/// path: per-key persist lock → FRESH open (latest disk state) → mutate →
+/// rewrite, all inside one critical section.
+///
+/// Contract writes are whole-file read-modify-write cycles (`rewrite`
+/// snapshots the in-memory session and renames over the file), so two
+/// concurrent writers that each open their own handle both read the same
+/// pre-state and the second rename silently erases the first's update.
+/// This is the production-documented fanout race: two children terminating
+/// together each stamp their terminal contract into the SHARED PARENT
+/// session; the loser's contract reverts to pre-terminal and the task is
+/// stuck un-Joined forever. Holding the per-key lock across open→rewrite
+/// makes the cycle atomic per session key.
+pub async fn upsert_child_contract_through_canonical_path(
+    data_dir: &Path,
+    key: &SessionKey,
+    contract: ChildSessionContract,
+) -> Result<bool> {
+    let lock = persist_lock_for(key);
+    let _guard = lock.lock().await;
+    let mut handle = SessionHandle::open(data_dir, key);
+    handle.upsert_child_contract_unlocked(contract).await
+}
+
 impl SessionHandle {
     /// Open or create a session handle for the given key.
     ///
@@ -2504,10 +2534,29 @@ impl SessionHandle {
     }
 
     /// Insert or update a durable child-session contract and persist it.
+    ///
+    /// Serialises on the per-key persist lock (see [`persist_lock_for`]).
+    /// NOTE: the lock covers mutate→rewrite only; this handle's in-memory
+    /// state was snapshotted at open time, so a handle opened BEFORE a
+    /// concurrent writer committed will still rewrite from that stale
+    /// snapshot. Callers racing other writers must use
+    /// [`upsert_child_contract_through_canonical_path`], which holds the
+    /// lock across the fresh open as well.
     pub async fn upsert_child_contract(&mut self, contract: ChildSessionContract) -> Result<bool> {
+        let lock = persist_lock_for(&self.session.key);
+        let _guard = lock.lock().await;
+        self.upsert_child_contract_unlocked(contract).await
+    }
+
+    /// Mutate + rewrite without taking the persist lock — the caller must
+    /// already hold it (see [`upsert_child_contract_through_canonical_path`]).
+    async fn upsert_child_contract_unlocked(
+        &mut self,
+        contract: ChildSessionContract,
+    ) -> Result<bool> {
         let existed = self.session.upsert_child_contract(contract);
         self.session.updated_at = Utc::now();
-        self.rewrite().await?;
+        self.rewrite_unlocked().await?;
         Ok(existed)
     }
 
@@ -2517,7 +2566,21 @@ impl SessionHandle {
     }
 
     /// Rewrite the session to disk (atomic write-then-rename).
+    ///
+    /// Serialises on the per-key persist lock so a whole-file rewrite cannot
+    /// interleave with the canonical locked append path
+    /// ([`persist_message_through_canonical_path`]) — an append committed
+    /// between an unlocked rewrite's snapshot and its rename was silently
+    /// erased by the rename.
     pub async fn rewrite(&self) -> Result<()> {
+        let lock = persist_lock_for(&self.session.key);
+        let _guard = lock.lock().await;
+        self.rewrite_unlocked().await
+    }
+
+    /// Snapshot-and-rename without taking the persist lock — the caller
+    /// must already hold it.
+    async fn rewrite_unlocked(&self) -> Result<()> {
         let meta = SessionMeta {
             schema_version: CURRENT_SESSION_SCHEMA,
             session_key: self.session.key.0.clone(),
@@ -3916,6 +3979,63 @@ mod tests {
         assert_eq!(contract.join_state, Some(ChildSessionJoinState::Joined));
         assert_eq!(contract.output_files, vec!["/tmp/report.md"]);
         assert!(contract.joined_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn concurrent_canonical_contract_upserts_lose_no_updates() {
+        // The production fanout race: N children terminate together and each
+        // stamps its terminal contract into the SHARED parent session. A
+        // contract write is a whole-file read-modify-write (open snapshots
+        // the file, rewrite renames over it), so writers that read the same
+        // pre-state erase each other — the canonical path must hold the
+        // per-key persist lock across open→mutate→rewrite.
+        //
+        // On the single-threaded test runtime every future runs its
+        // synchronous open() before any rewrite lands, so WITHOUT the lock
+        // all 16 read the empty pre-state and exactly one contract survives
+        // — the loss is deterministic, not timing-dependent.
+        let tmp = TempDir::new().unwrap();
+        let parent = SessionKey::new("api", "fanout-parent");
+        {
+            let mut parent_handle = SessionHandle::open(tmp.path(), &parent);
+            parent_handle
+                .add_message(make_message(MessageRole::User, "seed"))
+                .await
+                .unwrap();
+        }
+
+        let make_contract = |i: usize| ChildSessionContract {
+            task_id: format!("task-{i}"),
+            task_label: format!("worker {i}"),
+            parent_session_key: parent.to_string(),
+            child_session_key: child_session_key(&parent, &format!("task-{i}")).to_string(),
+            workflow_kind: Some("deep_research".to_string()),
+            current_phase: Some("deliver_result".to_string()),
+            terminal_state: Some(ChildSessionTerminalState::Completed),
+            join_state: Some(ChildSessionJoinState::Joined),
+            joined_at: Some(Utc::now()),
+            failure_action: None,
+            error: None,
+            output_files: vec![],
+        };
+
+        let futures = (0..16)
+            .map(|i| {
+                upsert_child_contract_through_canonical_path(tmp.path(), &parent, make_contract(i))
+            })
+            .collect::<Vec<_>>();
+        for result in futures::future::join_all(futures).await {
+            result.expect("every contract upsert must commit");
+        }
+
+        let reloaded = SessionHandle::open(tmp.path(), &parent);
+        assert_eq!(
+            reloaded.session().child_contracts.len(),
+            16,
+            "every concurrently-upserted contract must survive on disk (lost-update race)"
+        );
+        // The seeded message must survive the rewrites too.
+        assert_eq!(reloaded.session().messages.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -1452,10 +1452,25 @@ async fn persist_child_session_lifecycle(
                 error: None,
                 output_files: Vec::new(),
             };
-            let _ = child.upsert_child_contract(contract.clone()).await?;
+            // Canonical locked path: a contract write is a whole-file
+            // read-modify-write, and every fanout child stamps the SHARED
+            // parent session — two children terminating together with their
+            // own stale handles silently erase each other's contract (the
+            // stuck-un-Joined race). The helper holds the per-key persist
+            // lock across open→mutate→rewrite.
+            let _ = octos_bus::session::upsert_child_contract_through_canonical_path(
+                data_dir,
+                &child_key,
+                contract.clone(),
+            )
+            .await?;
             if parent_exists {
-                let mut parent = SessionHandle::open(data_dir, &parent_key);
-                let _ = parent.upsert_child_contract(contract).await?;
+                let _ = octos_bus::session::upsert_child_contract_through_canonical_path(
+                    data_dir,
+                    &parent_key,
+                    contract,
+                )
+                .await?;
             }
             record_child_session_lifecycle(ChildSessionLifecycleKind::Spawned, "persisted");
             Ok(parent_exists)
@@ -1515,10 +1530,23 @@ async fn persist_child_session_lifecycle(
                 error: payload.error.clone(),
                 output_files: payload.output_files.clone(),
             };
-            let _ = child.upsert_child_contract(contract.clone()).await?;
+            // Canonical locked path — see the Spawned arm. This terminal arm
+            // is the production-documented race: two children completing
+            // together each rewrote the parent from a stale snapshot, and the
+            // loser's terminal contract reverted to pre-terminal.
+            let _ = octos_bus::session::upsert_child_contract_through_canonical_path(
+                data_dir,
+                &child_key,
+                contract.clone(),
+            )
+            .await?;
             if parent_exists {
-                let mut parent = SessionHandle::open(data_dir, &parent_key);
-                let _ = parent.upsert_child_contract(contract).await?;
+                let _ = octos_bus::session::upsert_child_contract_through_canonical_path(
+                    data_dir,
+                    &parent_key,
+                    contract,
+                )
+                .await?;
             }
             record_child_session_lifecycle(
                 payload.kind,

--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -334,6 +334,14 @@ fn build_anthropic_messages(messages: &[Message]) -> Vec<AnthropicMessage<'stati
     // True while `out.last()` is the user-role message accumulating the
     // current run of consecutive tool_result blocks.
     let mut merging_tool_results = false;
+    // tool_use ids answerable by the NEXT emitted message (codex P2): a
+    // `tool_result` is only valid immediately after the assistant message
+    // that carries its `tool_use`. A Tool row whose id is not pending — the
+    // assistant row was trimmed/compacted away, the window starts mid-loop,
+    // or another message closed the window — must fall back to plain user
+    // text; Anthropic rejects orphan tool_result blocks outright.
+    let mut pending_tool_use_ids: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
 
     for m in messages
         .iter()
@@ -343,41 +351,68 @@ fn build_anthropic_messages(messages: &[Message]) -> Vec<AnthropicMessage<'stati
             octos_core::MessageRole::Assistant => {
                 merging_tool_results = false;
                 if let Some(content) = build_assistant_anthropic_content(m) {
+                    pending_tool_use_ids = m
+                        .tool_calls
+                        .as_deref()
+                        .unwrap_or_default()
+                        .iter()
+                        .filter(|tc| !tc.id.is_empty())
+                        .map(|tc| tc.id.clone())
+                        .collect();
                     out.push(AnthropicMessage {
                         role: "assistant",
                         content,
                     });
                 }
+                // A DROPPED (fully-empty) assistant row emits nothing, so the
+                // previously-emitted message is unchanged — leave the pending
+                // window as-is.
             }
-            octos_core::MessageRole::Tool => match anthropic_tool_result_block(m) {
-                Some(block) => {
-                    if merging_tool_results
-                        && let Some(AnthropicMessage {
-                            content: AnthropicContent::Parts(parts),
-                            ..
-                        }) = out.last_mut()
-                    {
-                        parts.push(block);
-                    } else {
+            octos_core::MessageRole::Tool => {
+                let block = m
+                    .tool_call_id
+                    .as_deref()
+                    .filter(|id| pending_tool_use_ids.contains(*id))
+                    .and_then(|_| anthropic_tool_result_block(m));
+                match block {
+                    Some(block) => {
+                        // Consume the id: a duplicate result for the same
+                        // tool_use would also be rejected.
+                        if let Some(id) = m.tool_call_id.as_deref() {
+                            pending_tool_use_ids.remove(id);
+                        }
+                        if merging_tool_results
+                            && let Some(AnthropicMessage {
+                                content: AnthropicContent::Parts(parts),
+                                ..
+                            }) = out.last_mut()
+                        {
+                            parts.push(block);
+                        } else {
+                            out.push(AnthropicMessage {
+                                role: "user",
+                                content: AnthropicContent::Parts(vec![block]),
+                            });
+                            merging_tool_results = true;
+                        }
+                    }
+                    None => {
+                        // ID-less or orphan tool output: no pending tool_use
+                        // to pair with — plain user text for this row. This
+                        // also closes the pending window (the inserted text
+                        // message breaks the immediately-after adjacency).
+                        merging_tool_results = false;
+                        pending_tool_use_ids.clear();
                         out.push(AnthropicMessage {
                             role: "user",
-                            content: AnthropicContent::Parts(vec![block]),
+                            content: build_anthropic_content(m),
                         });
-                        merging_tool_results = true;
                     }
                 }
-                None => {
-                    // ID-less tool output: no valid tool_use_id to pair with,
-                    // fall back to plain user text for this row only.
-                    merging_tool_results = false;
-                    out.push(AnthropicMessage {
-                        role: "user",
-                        content: build_anthropic_content(m),
-                    });
-                }
-            },
+            }
             _ => {
                 merging_tool_results = false;
+                pending_tool_use_ids.clear();
                 out.push(AnthropicMessage {
                     role: "user",
                     content: build_anthropic_content(m),
@@ -893,6 +928,54 @@ mod tests {
         assert_eq!(out.len(), 2, "empty assistant row dropped: {body}");
         assert_eq!(out[0]["content"], "hi");
         assert_eq!(out[1]["content"], "still there?");
+    }
+
+    #[test]
+    fn orphan_tool_result_falls_back_to_plain_text() {
+        // codex P2: a Tool row whose matching assistant tool_use is NOT the
+        // immediately-preceding emitted message (compaction trimmed the
+        // assistant row, or the window starts mid-loop) must NOT serialize as
+        // a tool_result — Anthropic rejects orphan tool_result blocks. Fall
+        // back to plain user text, the pre-fix behaviour for these rows.
+        let provider = AnthropicProvider::new("test-key", "claude-test");
+
+        // Case 1: transcript starts with a Tool row (assistant trimmed away).
+        let mut orphan = msg(MessageRole::Tool, "stale output");
+        orphan.tool_call_id = Some("toolu_gone".into());
+        let messages = vec![orphan.clone(), msg(MessageRole::User, "continue")];
+        let config = ChatConfig::default();
+        let body = serde_json::to_value(provider.build_request(&messages, &[], &config)).unwrap();
+        let out = body["messages"].as_array().unwrap();
+        assert_eq!(out[0]["role"], "user");
+        assert_eq!(
+            out[0]["content"], "stale output",
+            "orphan tool row must be plain text, not tool_result: {body}"
+        );
+
+        // Case 2: a user row between the assistant's tool_use and the Tool row
+        // closes the immediately-following window — the late result must fall
+        // back to text (a tool_result there would be orphaned).
+        let mut assistant = msg(MessageRole::Assistant, "");
+        assistant.tool_calls = Some(vec![tool_call(
+            "toolu_late",
+            "shell",
+            serde_json::json!({"command": "ls"}),
+        )]);
+        let mut late = msg(MessageRole::Tool, "late output");
+        late.tool_call_id = Some("toolu_late".into());
+        let messages = vec![
+            msg(MessageRole::User, "go"),
+            assistant,
+            msg(MessageRole::User, "interposed"),
+            late,
+        ];
+        let body = serde_json::to_value(provider.build_request(&messages, &[], &config)).unwrap();
+        let out = body["messages"].as_array().unwrap();
+        assert_eq!(out[3]["role"], "user");
+        assert_eq!(
+            out[3]["content"], "late output",
+            "a result outside the immediately-following window must be plain text: {body}"
+        );
     }
 
     #[test]

--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -82,22 +82,7 @@ impl AnthropicProvider {
         AnthropicRequest {
             model: &self.model,
             max_tokens,
-            messages: messages
-                .iter()
-                .filter(|m| m.role != octos_core::MessageRole::System)
-                .map(|m| {
-                    let role = match m.role {
-                        octos_core::MessageRole::User => "user",
-                        octos_core::MessageRole::Assistant => "assistant",
-                        octos_core::MessageRole::Tool => "user",
-                        octos_core::MessageRole::System => "user",
-                    };
-                    AnthropicMessage {
-                        role,
-                        content: build_anthropic_content(m),
-                    }
-                })
-                .collect(),
+            messages: build_anthropic_messages(messages),
             system: {
                 let system_parts: Vec<&str> = messages
                     .iter()
@@ -305,6 +290,23 @@ enum AnthropicContentBlock {
     Text { text: String },
     #[serde(rename = "image")]
     Image { source: AnthropicImageSource },
+    /// Prior assistant tool invocation, round-tripped from
+    /// [`octos_core::Message::tool_calls`]. Anthropic requires the original
+    /// `tool_use` block in the assistant turn for the following
+    /// `tool_result` to pair with — without it the request 400s.
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    /// Tool output for a prior `tool_use`, carried in a USER-role message
+    /// (Anthropic's convention for tool results).
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+    },
 }
 
 #[derive(Serialize)]
@@ -312,6 +314,132 @@ struct AnthropicImageSource {
     r#type: String,
     media_type: String,
     data: String,
+}
+
+/// Convert the transcript into Anthropic wire messages.
+///
+/// Role handling:
+/// - System rows are extracted by the caller into the top-level `system`
+///   field and skipped here.
+/// - Assistant rows round-trip `tool_calls` as `tool_use` blocks; rows with
+///   neither non-blank text nor tool calls are DROPPED (Anthropic rejects
+///   empty content — mirrors the openai.rs filter).
+/// - Tool rows become `tool_result` blocks in USER-role messages, and
+///   CONSECUTIVE Tool rows merge into ONE user message: Anthropic requires
+///   every `tool_use` id from the assistant turn to be answered in the
+///   immediately-following message, so parallel tool results split across
+///   two user messages would 400.
+fn build_anthropic_messages(messages: &[Message]) -> Vec<AnthropicMessage<'static>> {
+    let mut out: Vec<AnthropicMessage> = Vec::with_capacity(messages.len());
+    // True while `out.last()` is the user-role message accumulating the
+    // current run of consecutive tool_result blocks.
+    let mut merging_tool_results = false;
+
+    for m in messages
+        .iter()
+        .filter(|m| m.role != octos_core::MessageRole::System)
+    {
+        match m.role {
+            octos_core::MessageRole::Assistant => {
+                merging_tool_results = false;
+                if let Some(content) = build_assistant_anthropic_content(m) {
+                    out.push(AnthropicMessage {
+                        role: "assistant",
+                        content,
+                    });
+                }
+            }
+            octos_core::MessageRole::Tool => match anthropic_tool_result_block(m) {
+                Some(block) => {
+                    if merging_tool_results
+                        && let Some(AnthropicMessage {
+                            content: AnthropicContent::Parts(parts),
+                            ..
+                        }) = out.last_mut()
+                    {
+                        parts.push(block);
+                    } else {
+                        out.push(AnthropicMessage {
+                            role: "user",
+                            content: AnthropicContent::Parts(vec![block]),
+                        });
+                        merging_tool_results = true;
+                    }
+                }
+                None => {
+                    // ID-less tool output: no valid tool_use_id to pair with,
+                    // fall back to plain user text for this row only.
+                    merging_tool_results = false;
+                    out.push(AnthropicMessage {
+                        role: "user",
+                        content: build_anthropic_content(m),
+                    });
+                }
+            },
+            _ => {
+                merging_tool_results = false;
+                out.push(AnthropicMessage {
+                    role: "user",
+                    content: build_anthropic_content(m),
+                });
+            }
+        }
+    }
+    out
+}
+
+/// Build an ASSISTANT message's content, round-tripping `tool_calls` as
+/// `tool_use` blocks. Returns `None` when the row has neither non-blank text
+/// nor tool calls — Anthropic rejects empty/whitespace-only content, so such
+/// rows are dropped entirely (mirrors the openai.rs empty-assistant filter).
+///
+/// Known limitation: streamed `thinking` blocks are NOT round-tripped (their
+/// signatures are not captured in [`ChatResponse`]), so a tool loop with
+/// extended thinking enabled may still be rejected by the API's
+/// thinking-precedes-tool_use requirement. Tool loops with thinking off (the
+/// default) are fully supported.
+fn build_assistant_anthropic_content(msg: &Message) -> Option<AnthropicContent> {
+    let tool_calls = msg
+        .tool_calls
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .filter(|tc| !tc.id.is_empty())
+        .collect::<Vec<_>>();
+    let has_text = !msg.content.trim().is_empty();
+
+    if tool_calls.is_empty() {
+        if !has_text {
+            return None;
+        }
+        return Some(AnthropicContent::Text(msg.content.clone()));
+    }
+
+    let mut parts = Vec::with_capacity(tool_calls.len() + 1);
+    if has_text {
+        parts.push(AnthropicContentBlock::Text {
+            text: msg.content.clone(),
+        });
+    }
+    for tc in tool_calls {
+        parts.push(AnthropicContentBlock::ToolUse {
+            id: tc.id.clone(),
+            name: tc.name.clone(),
+            input: tc.arguments.clone(),
+        });
+    }
+    Some(AnthropicContent::Parts(parts))
+}
+
+/// Build the `tool_result` block for a Tool-role message. Returns `None`
+/// when `tool_call_id` is missing/empty (ID-less providers) — an empty
+/// `tool_use_id` would 400, so the caller falls back to plain user text.
+fn anthropic_tool_result_block(msg: &Message) -> Option<AnthropicContentBlock> {
+    let tool_use_id = msg.tool_call_id.as_deref().filter(|id| !id.is_empty())?;
+    Some(AnthropicContentBlock::ToolResult {
+        tool_use_id: tool_use_id.to_string(),
+        content: msg.content.clone(),
+    })
 }
 
 fn build_anthropic_content(msg: &Message) -> AnthropicContent {
@@ -644,6 +772,143 @@ mod tests {
             }
             _ => panic!("expected Text for non-image media"),
         }
+    }
+
+    // --- tool_use / tool_result round-trip tests ---
+
+    fn tool_call(id: &str, name: &str, args: serde_json::Value) -> octos_core::ToolCall {
+        octos_core::ToolCall {
+            id: id.to_string(),
+            name: name.to_string(),
+            arguments: args,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn tool_loop_history_round_trips_tool_use_and_tool_result() {
+        // Regression: the request builder never serialized `tool_calls` /
+        // `tool_call_id`, so an assistant turn that returned only tool_use
+        // round-tripped as `{"role":"assistant","content":""}` (Anthropic
+        // 400s on empty content) and the Tool-role result went back as plain
+        // user text (Anthropic 400s on a dangling tool_use without a
+        // matching tool_result in the next message). Iteration 2 of every
+        // native-Anthropic tool loop died on it.
+        let provider = AnthropicProvider::new("test-key", "claude-test");
+        let mut assistant = msg(MessageRole::Assistant, "");
+        assistant.tool_calls = Some(vec![tool_call(
+            "toolu_01",
+            "shell",
+            serde_json::json!({"command": "ls"}),
+        )]);
+        let mut tool_result = msg(MessageRole::Tool, "file-a\nfile-b");
+        tool_result.tool_call_id = Some("toolu_01".into());
+        let messages = vec![msg(MessageRole::User, "list files"), assistant, tool_result];
+
+        let config = ChatConfig::default();
+        let body = serde_json::to_value(provider.build_request(&messages, &[], &config)).unwrap();
+        let out = body["messages"].as_array().unwrap();
+        assert_eq!(out.len(), 3, "user + assistant + tool_result: {body}");
+
+        let assistant_content = out[1]["content"]
+            .as_array()
+            .unwrap_or_else(|| panic!("assistant content must be blocks, got {}", out[1]));
+        assert_eq!(assistant_content[0]["type"], "tool_use");
+        assert_eq!(assistant_content[0]["id"], "toolu_01");
+        assert_eq!(assistant_content[0]["name"], "shell");
+        assert_eq!(assistant_content[0]["input"]["command"], "ls");
+
+        assert_eq!(out[2]["role"], "user");
+        let result_content = out[2]["content"]
+            .as_array()
+            .unwrap_or_else(|| panic!("tool result content must be blocks, got {}", out[2]));
+        assert_eq!(result_content[0]["type"], "tool_result");
+        assert_eq!(result_content[0]["tool_use_id"], "toolu_01");
+        assert_eq!(result_content[0]["content"], "file-a\nfile-b");
+    }
+
+    #[test]
+    fn parallel_tool_results_merge_into_one_user_message() {
+        // Anthropic requires EVERY tool_use id from the assistant turn to have
+        // a tool_result in the IMMEDIATELY following message. Two consecutive
+        // Tool-role rows (parallel calls) must therefore merge into one user
+        // message with two tool_result blocks — separate user messages 400.
+        let provider = AnthropicProvider::new("test-key", "claude-test");
+        let mut assistant = msg(MessageRole::Assistant, "Running both.");
+        assistant.tool_calls = Some(vec![
+            tool_call("toolu_a", "shell", serde_json::json!({"command": "ls"})),
+            tool_call("toolu_b", "read_file", serde_json::json!({"path": "x"})),
+        ]);
+        let mut result_a = msg(MessageRole::Tool, "out-a");
+        result_a.tool_call_id = Some("toolu_a".into());
+        let mut result_b = msg(MessageRole::Tool, "out-b");
+        result_b.tool_call_id = Some("toolu_b".into());
+        let messages = vec![
+            msg(MessageRole::User, "go"),
+            assistant,
+            result_a,
+            result_b,
+            msg(MessageRole::User, "thanks"),
+        ];
+
+        let config = ChatConfig::default();
+        let body = serde_json::to_value(provider.build_request(&messages, &[], &config)).unwrap();
+        let out = body["messages"].as_array().unwrap();
+        assert_eq!(
+            out.len(),
+            4,
+            "user + assistant + merged tool_results + user: {body}"
+        );
+
+        // Assistant keeps its text AND carries both tool_use blocks.
+        let assistant_content = out[1]["content"].as_array().unwrap();
+        assert_eq!(assistant_content[0]["type"], "text");
+        assert_eq!(assistant_content[0]["text"], "Running both.");
+        assert_eq!(assistant_content[1]["type"], "tool_use");
+        assert_eq!(assistant_content[2]["type"], "tool_use");
+
+        let results = out[2]["content"].as_array().unwrap();
+        assert_eq!(results.len(), 2, "both tool_results in ONE user message");
+        assert_eq!(results[0]["tool_use_id"], "toolu_a");
+        assert_eq!(results[1]["tool_use_id"], "toolu_b");
+
+        assert_eq!(out[3]["role"], "user");
+        assert_eq!(out[3]["content"], "thanks");
+    }
+
+    #[test]
+    fn empty_assistant_message_is_dropped_from_request() {
+        // Mirrors the openai.rs empty-assistant filter: a fully-empty
+        // assistant row (no text, no tool calls) must be dropped, not sent as
+        // `content: ""` which Anthropic rejects.
+        let provider = AnthropicProvider::new("test-key", "claude-test");
+        let messages = vec![
+            msg(MessageRole::User, "hi"),
+            msg(MessageRole::Assistant, ""),
+            msg(MessageRole::User, "still there?"),
+        ];
+        let config = ChatConfig::default();
+        let body = serde_json::to_value(provider.build_request(&messages, &[], &config)).unwrap();
+        let out = body["messages"].as_array().unwrap();
+        assert_eq!(out.len(), 2, "empty assistant row dropped: {body}");
+        assert_eq!(out[0]["content"], "hi");
+        assert_eq!(out[1]["content"], "still there?");
+    }
+
+    #[test]
+    fn tool_result_without_id_falls_back_to_plain_text() {
+        // ID-less providers can leave tool_call_id empty; a tool_result block
+        // with an empty tool_use_id would 400, so fall back to plain user
+        // text (pre-fix behaviour) for that row only.
+        let provider = AnthropicProvider::new("test-key", "claude-test");
+        let mut orphan = msg(MessageRole::Tool, "orphan output");
+        orphan.tool_call_id = None;
+        let messages = vec![msg(MessageRole::User, "go"), orphan];
+        let config = ChatConfig::default();
+        let body = serde_json::to_value(provider.build_request(&messages, &[], &config)).unwrap();
+        let out = body["messages"].as_array().unwrap();
+        assert_eq!(out[1]["role"], "user");
+        assert_eq!(out[1]["content"], "orphan output");
     }
 
     // --- build_request tests ---


### PR DESCRIPTION
Batch 2 of the tri-repo review fixes — three P1s, one commit each, all TDD'd (RED proven before each fix).

## 1. `fix(agent)`: fan-out cap counts live children; cap refusal refuses the spawn
- The per-parent child-fanout count had no `is_active()` filter and the task map is never pruned — it counted the session's **lifetime** total. A long-lived session that merely *completed* 200 background tasks (tts/podcast/pipeline nodes) tripped the cap on its next register, poisoning the session key forever and force-failing all its active work. The cap now bounds **concurrent** children; a genuine 200-concurrent runaway still trips and poisons.
- Both spawn paths ignored the empty-string cap-refusal sentinel and spawned anyway — an untracked, uncancellable worker with a `""` task handle (the cap bounded tracking, not execution). `spawn_only` interception and background `spawn` now refuse synchronously with a `[TASK LIMIT]` tool result. RED proven by neutering the guard ("Spawned background task" leaked through).

## 2. `fix(bus)`: serialize whole-file session rewrites on the per-key persist lock
`SessionHandle::rewrite` / `SessionManager::rewrite` did whole-file snapshot-and-rename **without** the per-key persist lock the canonical append path holds. A locked append landing between snapshot and rename was silently erased; two fanout children terminating together each rewrote the shared parent from a stale handle — the loser's terminal contract reverted to pre-terminal (task stuck un-Joined forever; the production-documented race).

Rewrites now take the lock, and a new `upsert_child_contract_through_canonical_path` holds it across the full read-modify-write (fresh open → mutate → rewrite). session_actor's four contract sites use it. Deadlock-audited: no caller holds the lock when entering these paths.

Regression test is deterministic, not timing-dependent: 16 concurrent contract upserts on the single-threaded test runtime all snapshot the empty pre-state before any rename lands — RED lost 10 of 16; GREEN keeps 16/16.

## 3. `fix(llm)`: anthropic provider round-trips tool_use/tool_result
The native Anthropic provider parsed `tool_use` out of responses but never serialized tool history back: an all-tool-calls assistant turn round-tripped as `{"role":"assistant","content":""}` (400) and Tool results went back as plain user text (400: dangling `tool_use`). **Iteration 2 of every native-Anthropic tool loop died.**
- Assistant rows now emit text + `tool_use` blocks; fully-empty rows are dropped (mirrors the openai.rs filter).
- Tool rows become `tool_result` blocks in user messages; consecutive Tool rows merge into one user message (parallel results split across two messages 400).
- ID-less tool rows fall back to plain text.
- Documented limitation: thinking blocks aren't round-tripped (signatures not captured), so extended-thinking tool loops may still be rejected; default tool loops fully work.

## Verification
- Suites: octos-llm 412, octos-bus 214, task_supervisor 95, spawn 43, session_actor (api) 131 — all green; fmt + clippy clean.
- codex per-commit reviews running; findings (if any) will be addressed before merge.