### PR TITLE
fix(serve): close 2 P1 cross-tenant leaks (agent/list bare-session, router RPC scope)

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -1972,9 +1972,23 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
                     .is_none_or(|session_id| session_controls_target(session_id, &agent.session_id))
             })
             .filter(|agent| {
-                request.connection_profile_id.is_none()
-                    || agent.profile_id == scoped_profile_id
-                    || agent.session_id.profile_id().is_none()
+                // Scope by the agent's OWNER profile, exactly like the read
+                // path (`ensure_agent_control_scope`, which forbids
+                // `agent.profile_id != profile_id`). An unscoped (admin,
+                // `connection_profile_id == None`) connection sees every
+                // agent. A profile-scoped connection sees only agents it owns.
+                //
+                // P1 fix: the removed `|| agent.session_id.profile_id().is_none()`
+                // clause admitted EVERY bare-session (profile-less) agent to
+                // EVERY scoped connection. Because a bare session whose spawn
+                // did not thread a runtime profile resolves to `MAIN_PROFILE_ID`
+                // ("_main"), that leaked a `_main`/other-tenant agent's
+                // output_tail / task / cwd (see `autonomy_agent_json`) to a
+                // tenant-B connection — while the read RPCs would forbid the
+                // same agent. A bare-session agent owned by the caller already
+                // matches on `agent.profile_id == scoped_profile_id`; one that
+                // does not is out of scope and must not appear.
+                request.connection_profile_id.is_none() || agent.profile_id == scoped_profile_id
             })
             .map(autonomy_agent_json)
             .collect::<Vec<_>>();
@@ -6409,6 +6423,106 @@ mod tests {
             .expect("agent list");
         assert_eq!(result["agents"].as_array().expect("agents").len(), 1);
         assert_eq!(result["agents"][0]["agent_id"], json!("agent-b"));
+    }
+
+    #[test]
+    fn list_agents_does_not_leak_bare_session_agents_across_tenants() {
+        // P1: the old `agent.session_id.profile_id().is_none()` clause admitted
+        // EVERY bare-session (profile-less) agent to EVERY profile-scoped
+        // connection. A bare session whose spawn threaded no runtime profile
+        // resolves to `MAIN_PROFILE_ID` ("_main"), so tenant-B saw a `_main`
+        // agent's output_tail / task / cwd — even though the read path
+        // (`ensure_agent_control_scope`) would forbid the same agent.
+        let orchestrator = InProcessAgentOrchestrator::default();
+
+        // Bare-session agent owned by "_main".
+        let mut bare = sample_agent("bare-main", MAIN_PROFILE_ID);
+        bare.session_id = SessionKey::new("api", "bare-chat");
+        assert!(
+            bare.session_id.profile_id().is_none(),
+            "precondition: session must be profile-less"
+        );
+        // A genuine tenant-B agent.
+        let owned = sample_agent("owned-b", "tenant-b");
+
+        orchestrator
+            .state()
+            .agents
+            .insert(bare.agent_id.clone(), bare);
+        orchestrator
+            .state()
+            .agents
+            .insert(owned.agent_id.clone(), owned);
+
+        let result = orchestrator
+            .list_agents(AgentListRequest {
+                session_id: None,
+                profile_id: "tenant-b".into(),
+                connection_profile_id: Some("tenant-b".into()),
+            })
+            .expect("agent list");
+        let ids: Vec<&str> = result["agents"]
+            .as_array()
+            .expect("agents")
+            .iter()
+            .filter_map(|a| a["agent_id"].as_str())
+            .collect();
+        assert!(ids.contains(&"owned-b"), "tenant-B must see its own agent");
+        assert!(
+            !ids.contains(&"bare-main"),
+            "tenant-B must NOT see a _main bare-session agent (cross-tenant leak)"
+        );
+    }
+
+    #[test]
+    fn list_agents_main_scoped_connection_still_sees_its_bare_session_agents() {
+        // Removing the leaky clause must not hide a connection's OWN
+        // bare-session agents: a `_main`-scoped connection still matches a
+        // `_main`-owned bare agent via `agent.profile_id == scoped_profile_id`.
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let mut bare = sample_agent("bare-main", MAIN_PROFILE_ID);
+        bare.session_id = SessionKey::new("api", "bare-chat");
+
+        orchestrator
+            .state()
+            .agents
+            .insert(bare.agent_id.clone(), bare);
+
+        let result = orchestrator
+            .list_agents(AgentListRequest {
+                session_id: None,
+                profile_id: MAIN_PROFILE_ID.into(),
+                connection_profile_id: Some(MAIN_PROFILE_ID.into()),
+            })
+            .expect("agent list");
+        let agents = result["agents"].as_array().expect("agents");
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0]["agent_id"], json!("bare-main"));
+    }
+
+    #[test]
+    fn list_agents_unscoped_admin_still_sees_bare_session_agents() {
+        // An unscoped (admin, `connection_profile_id == None`) connection is
+        // authorized for every profile and still sees bare-session agents.
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let mut bare = sample_agent("bare-main", MAIN_PROFILE_ID);
+        bare.session_id = SessionKey::new("api", "bare-chat");
+
+        orchestrator
+            .state()
+            .agents
+            .insert(bare.agent_id.clone(), bare);
+
+        let result = orchestrator
+            .list_agents(AgentListRequest {
+                session_id: None,
+                profile_id: MAIN_PROFILE_ID.into(),
+                connection_profile_id: None,
+            })
+            .expect("agent list");
+        let agents = result["agents"].as_array().expect("agents");
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0]["agent_id"], json!("bare-main"));
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -14461,18 +14461,13 @@ fn resolve_router_for_session(
     connection_profile_id: Option<&str>,
     routed_profile_id: Option<&str>,
 ) -> Result<Option<Arc<octos_llm::AdaptiveRouter>>, RpcError> {
-    // Tenant-scope gate (P1): an authenticated (profile-scoped) connection may
-    // only reach the router of its OWN profile. Without this, the
-    // `session_id.profile_id()`-first precedence below lets a tenant-B
-    // connection pass a `session_id` that embeds tenant-A's profile and
-    // resolve — then `set_mode` mutate / `get_metrics` read — tenant-A's
-    // `AdaptiveRouter`. `validate_session_scope` rejects a session_id whose
-    // embedded profile differs from the connection's authenticated profile;
-    // an unscoped (admin, `None`) connection is authorized for every profile
-    // and passes through, matching every other mutating RPC handler. Placing
-    // the check inside the shared resolver protects BOTH router handlers by
+    // Tenant-scope gate (P1). Without it the `session_id.profile_id()`-first
+    // precedence below lets a tenant-B connection pass a `session_id` that
+    // embeds tenant-A's profile and resolve — then `set_mode` mutate /
+    // `get_metrics` read — tenant-A's `AdaptiveRouter`. Placing the check
+    // inside the shared resolver protects BOTH router handlers by
     // construction.
-    validate_session_scope(session_id, None, connection_profile_id)?;
+    authorize_router_session_scope(session_id, connection_profile_id, routed_profile_id)?;
     let active_profile_id = session_id
         .profile_id()
         .map(ToOwned::to_owned)
@@ -14481,6 +14476,50 @@ fn resolve_router_for_session(
         resolve_session_profile_runtime(state, active_profile_id.as_deref())
             .and_then(|profile_runtime| profile_runtime.adaptive_router.clone()),
     )
+}
+
+/// Tenant-scope gate for the router RPCs.
+///
+/// A hosted WS connection is authorized for its own authenticated
+/// `connection_profile_id` AND — on a per-tenant subdomain — the
+/// `routed_profile_id` that `is_authorized_for_profile` already cleared at
+/// upgrade time (an admin / parent account operating a tenant it owns; a
+/// forged `Host` for an unauthorized tenant 403s before this point, so a
+/// present `routed_profile_id` is always trustworthy). A `session_id` whose
+/// embedded profile is EITHER is in scope; a different tenant is rejected.
+///
+/// - An unscoped connection (`connection_profile_id == None` — bootstrap
+///   admin token / local solo) is authorized for every profile.
+/// - A bare (profile-less) `session_id` is authorized under the connection's
+///   auth, matching `validate_authenticated_session_scope`'s `None` arm.
+///
+/// This is deliberately a touch more permissive than the bare
+/// `validate_session_scope(session_id, None, connection_profile_id)` other
+/// handlers use (it also honours `routed_profile_id`): a router RPC on a
+/// hosted subdomain must not regress the authorized admin/parent access that
+/// existed before this gate landed, while a genuine cross-tenant `session_id`
+/// (matching neither authorized profile) is still rejected. `authenticated_
+/// scope_mismatch_error` tags the rejection `auth_scope_violation` so the
+/// handler emits the same 1008 close the other scope checks do.
+fn authorize_router_session_scope(
+    session_id: &SessionKey,
+    connection_profile_id: Option<&str>,
+    routed_profile_id: Option<&str>,
+) -> Result<(), RpcError> {
+    let Some(connection_profile_id) = connection_profile_id else {
+        return Ok(());
+    };
+    let Some(session_profile) = session_id.profile_id() else {
+        return Ok(());
+    };
+    if session_profile == connection_profile_id || routed_profile_id == Some(session_profile) {
+        return Ok(());
+    }
+    Err(authenticated_scope_mismatch_error(
+        "session_id is outside the authorized profile scope",
+        connection_profile_id,
+        Some(session_profile),
+    ))
 }
 
 /// Wave4-A handler for `router/set_mode`. Parses `params.mode` into the
@@ -29695,6 +29734,44 @@ ignore = []
         let resolved = resolve_router_for_session(&state, &session_a, None, None)
             .expect("admin connection must pass the gate");
         assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn resolve_router_for_session_allows_authorized_routed_profile() {
+        // Codex P2: an OTP-admin / parent connection authorized for a tenant
+        // subdomain carries `connection_profile_id == <its own user id>` and
+        // `routed_profile_id == <tenant>` (is_authorized_for_profile cleared it
+        // at upgrade). The gate must NOT reject a session_id embedding the
+        // routed tenant — that access is authorized and predates the gate.
+        let state = Arc::new(AppState::empty_for_tests());
+        let tenant_session = SessionKey::with_profile("tenant-b", "api", "chat-1");
+        let resolved = resolve_router_for_session(
+            &state,
+            &tenant_session,
+            Some("admin-user"), // connection == the admin's own user id
+            Some("tenant-b"),   // routed == the authorized tenant subdomain
+        )
+        .expect("authorized routed profile must pass the gate");
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn resolve_router_for_session_rejects_tenant_outside_routed_and_connection() {
+        // Even WITH a routed profile present, a session_id embedding a third
+        // tenant (neither the connection's own id nor the authorized routed
+        // tenant) is still rejected — the union does not become allow-any.
+        let state = Arc::new(AppState::empty_for_tests());
+        let other = SessionKey::with_profile("tenant-c", "api", "chat-1");
+        let error = match resolve_router_for_session(
+            &state,
+            &other,
+            Some("admin-user"),
+            Some("tenant-b"),
+        ) {
+            Err(error) => error,
+            Ok(_) => panic!("a third-tenant session_id must be rejected"),
+        };
+        assert!(is_auth_scope_violation(&error));
     }
 
     /// Codex BLOCK regression (2026-05-13): with the writer channel at

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -4488,10 +4488,26 @@ async fn ui_protocol_connection(
                 .await;
             }
             UiCommand::RouterSetMode(params) => {
-                handle_router_set_mode(&ws, &state, routed_profile_id, id, params).await;
+                handle_router_set_mode(
+                    &ws,
+                    &state,
+                    connection_profile_id,
+                    routed_profile_id,
+                    id,
+                    params,
+                )
+                .await;
             }
             UiCommand::RouterGetMetrics(params) => {
-                handle_router_get_metrics(&ws, &state, routed_profile_id, id, params).await;
+                handle_router_get_metrics(
+                    &ws,
+                    &state,
+                    connection_profile_id,
+                    routed_profile_id,
+                    id,
+                    params,
+                )
+                .await;
             }
         }
     }
@@ -5040,9 +5056,16 @@ where
                 .await;
             }
             UiCommand::RouterSetMode(params) => {
+                // stdio is a local single-user transport with no authenticated
+                // tenant scope, so `connection_profile_id` is `None` (no
+                // cross-tenant enforcement); `connection_profile_id_owned`
+                // remains the resolution fallback. Only the hosted WS path,
+                // which carries an authenticated `connection_profile_id`,
+                // enforces the tenant gate.
                 handle_router_set_mode(
                     &ws,
                     &state,
+                    None,
                     connection_profile_id_owned.as_deref(),
                     id,
                     params,
@@ -5053,6 +5076,7 @@ where
                 handle_router_get_metrics(
                     &ws,
                     &state,
+                    None,
                     connection_profile_id_owned.as_deref(),
                     id,
                     params,
@@ -14434,14 +14458,29 @@ fn task_cancel_rpc_error(task_id: &TaskId, error: octos_agent::TaskCancelError) 
 fn resolve_router_for_session(
     state: &Arc<AppState>,
     session_id: &SessionKey,
+    connection_profile_id: Option<&str>,
     routed_profile_id: Option<&str>,
-) -> Option<Arc<octos_llm::AdaptiveRouter>> {
+) -> Result<Option<Arc<octos_llm::AdaptiveRouter>>, RpcError> {
+    // Tenant-scope gate (P1): an authenticated (profile-scoped) connection may
+    // only reach the router of its OWN profile. Without this, the
+    // `session_id.profile_id()`-first precedence below lets a tenant-B
+    // connection pass a `session_id` that embeds tenant-A's profile and
+    // resolve — then `set_mode` mutate / `get_metrics` read — tenant-A's
+    // `AdaptiveRouter`. `validate_session_scope` rejects a session_id whose
+    // embedded profile differs from the connection's authenticated profile;
+    // an unscoped (admin, `None`) connection is authorized for every profile
+    // and passes through, matching every other mutating RPC handler. Placing
+    // the check inside the shared resolver protects BOTH router handlers by
+    // construction.
+    validate_session_scope(session_id, None, connection_profile_id)?;
     let active_profile_id = session_id
         .profile_id()
         .map(ToOwned::to_owned)
         .or_else(|| routed_profile_id.map(ToOwned::to_owned));
-    let profile_runtime = resolve_session_profile_runtime(state, active_profile_id.as_deref())?;
-    profile_runtime.adaptive_router.clone()
+    Ok(
+        resolve_session_profile_runtime(state, active_profile_id.as_deref())
+            .and_then(|profile_runtime| profile_runtime.adaptive_router.clone()),
+    )
 }
 
 /// Wave4-A handler for `router/set_mode`. Parses `params.mode` into the
@@ -14454,6 +14493,7 @@ fn resolve_router_for_session(
 async fn handle_router_set_mode(
     ws: &WsConnection,
     state: &Arc<AppState>,
+    connection_profile_id: Option<&str>,
     routed_profile_id: Option<&str>,
     id: String,
     params: octos_core::ui_protocol::RouterSetModeParams,
@@ -14474,17 +14514,30 @@ async fn handle_router_set_mode(
             return;
         }
     };
-    let Some(router) = resolve_router_for_session(state, &params.session_id, routed_profile_id)
-    else {
-        let _ = send_rpc_error(
-            ws,
-            Some(id),
-            RpcError::invalid_params(format!(
-                "{method}: no adaptive router attached to this session"
-            ))
-            .with_data(json!({ "kind": "runtime_unavailable" })),
-        );
-        return;
+    let router = match resolve_router_for_session(
+        state,
+        &params.session_id,
+        connection_profile_id,
+        routed_profile_id,
+    ) {
+        Ok(Some(router)) => router,
+        Ok(None) => {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::invalid_params(format!(
+                    "{method}: no adaptive router attached to this session"
+                ))
+                .with_data(json!({ "kind": "runtime_unavailable" })),
+            );
+            return;
+        }
+        // Cross-tenant session_id on a profile-scoped connection: reject
+        // before touching another tenant's router.
+        Err(error) => {
+            send_scope_error(ws, id, error);
+            return;
+        }
     };
     router.set_mode(mode);
     let result = octos_core::ui_protocol::RouterSetModeResult { mode: params.mode };
@@ -14508,22 +14561,36 @@ async fn handle_router_set_mode(
 async fn handle_router_get_metrics(
     ws: &WsConnection,
     state: &Arc<AppState>,
+    connection_profile_id: Option<&str>,
     routed_profile_id: Option<&str>,
     id: String,
     params: octos_core::ui_protocol::RouterGetMetricsParams,
 ) {
     let method = octos_core::ui_protocol::methods::ROUTER_GET_METRICS;
-    let Some(router) = resolve_router_for_session(state, &params.session_id, routed_profile_id)
-    else {
-        let _ = send_rpc_error(
-            ws,
-            Some(id),
-            RpcError::invalid_params(format!(
-                "{method}: no adaptive router attached to this session"
-            ))
-            .with_data(json!({ "kind": "runtime_unavailable" })),
-        );
-        return;
+    let router = match resolve_router_for_session(
+        state,
+        &params.session_id,
+        connection_profile_id,
+        routed_profile_id,
+    ) {
+        Ok(Some(router)) => router,
+        Ok(None) => {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::invalid_params(format!(
+                    "{method}: no adaptive router attached to this session"
+                ))
+                .with_data(json!({ "kind": "runtime_unavailable" })),
+            );
+            return;
+        }
+        // Cross-tenant session_id on a profile-scoped connection: reject
+        // before reading another tenant's router metrics.
+        Err(error) => {
+            send_scope_error(ws, id, error);
+            return;
+        }
     };
     let status = router.adaptive_status();
     let result = octos_core::ui_protocol::RouterGetMetricsResult {
@@ -29585,6 +29652,49 @@ ignore = []
         // Drop the sender side so a pending recv resolves promptly; instead,
         // poll once with no wait to confirm the queue is empty.
         assert!(rx.try_recv().is_err(), "no close frame expected");
+    }
+
+    #[test]
+    fn resolve_router_for_session_rejects_cross_tenant_session_id() {
+        // P1: a profile-scoped (tenant-B) connection must not resolve — and so
+        // must not be able to `set_mode` / read metrics on — a router for a
+        // `session_id` that embeds tenant-A's profile. The tenant gate fires
+        // BEFORE any ProfileRuntime lookup, so an empty test state suffices to
+        // prove the rejection. Without the gate this returned `Ok(None)` (and
+        // the handler would go on to resolve tenant-A's runtime).
+        let state = Arc::new(AppState::empty_for_tests());
+        let session_a = SessionKey::with_profile("tenant-a", "api", "chat-1");
+        // `AdaptiveRouter` is not `Debug`, so `.expect_err` on the `Ok` type
+        // does not compile — match instead.
+        let error = match resolve_router_for_session(&state, &session_a, Some("tenant-b"), None) {
+            Err(error) => error,
+            Ok(_) => panic!("cross-tenant router access must be rejected"),
+        };
+        assert!(is_auth_scope_violation(&error));
+    }
+
+    #[test]
+    fn resolve_router_for_session_allows_same_tenant() {
+        // Same-tenant scope passes the gate; with no ProfileRuntime registered
+        // in the empty test state the router resolves to `None` (`Ok(None)`) —
+        // NOT an error. Proves the gate is scope-only, not a blanket denial.
+        let state = Arc::new(AppState::empty_for_tests());
+        let session_a = SessionKey::with_profile("tenant-a", "api", "chat-1");
+        let resolved = resolve_router_for_session(&state, &session_a, Some("tenant-a"), None)
+            .expect("same-tenant scope must pass the gate");
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn resolve_router_for_session_admin_connection_is_unscoped() {
+        // An unscoped (admin, `connection_profile_id == None`) connection is
+        // authorized for every profile — it passes the gate for any
+        // `session_id`, matching every other mutating RPC handler.
+        let state = Arc::new(AppState::empty_for_tests());
+        let session_a = SessionKey::with_profile("tenant-a", "api", "chat-1");
+        let resolved = resolve_router_for_session(&state, &session_a, None, None)
+            .expect("admin connection must pass the gate");
+        assert!(resolved.is_none());
     }
 
     /// Codex BLOCK regression (2026-05-13): with the writer channel at


### PR DESCRIPTION
Closes 2 of the P1 tenant-isolation findings from the 2026-07 review (#1529).

## P1 — `agent/list` bare-session cross-tenant leak
`InProcessAgentOrchestrator::list_agents` admitted **every** profile-less ("bare") agent to **every** profile-scoped connection via `agent.session_id.profile_id().is_none()`. A bare session whose spawn threaded no runtime profile resolves to `MAIN_PROFILE_ID` (`_main`), so a tenant-B connection saw a `_main`/other-tenant agent's `output_tail` / task / `cwd` (`autonomy_agent_json`) — even though the **read** path (`ensure_agent_control_scope`, which forbids `agent.profile_id != profile_id`) would reject the same agent.

**Fix:** drop the clause so `list` scopes by `agent.profile_id` exactly, matching `read`. A caller's own bare agent still matches on `agent.profile_id`; an unscoped admin connection still sees everything.

## P1 — `router/set_mode` + `router/get_metrics` scope bypass
`resolve_router_for_session` trusted the client-supplied `session_id`'s embedded profile (`session_id.profile_id()` first) and never ran the tenant gate, so a tenant-B connection could pass a `session_id` embedding tenant-A's profile and **flip** (`set_mode`) or **read** (`get_metrics`) tenant-A's `AdaptiveRouter`.

**Fix:** a tenant-scope gate inside the shared resolver (now returns `Result`) protects **both** handlers by construction. The WS path passes its authenticated `connection_profile_id`; the local stdio path stays unscoped (`None`) exactly as before.

### Codex-review follow-up (2nd commit)
Codex flagged that validating solely against `connection_profile_id` would regress **authorized** access: on a hosted per-tenant subdomain an OTP-admin or parent account has `connection_profile_id == its own user id` while `routed_profile_id == the tenant it owns` (cleared by `is_authorized_for_profile` at upgrade). `authorize_router_session_scope` now allows a `session_id` whose profile matches **either** the connection's own profile **or** the authorized `routed_profile_id`; a genuine third-tenant `session_id` is still rejected with the same `auth_scope_violation` / 1008 close.

## Tests (TDD, RED-verified)
- `list_agents_does_not_leak_bare_session_agents_across_tenants`, `..._main_scoped_connection_still_sees_its_bare_session_agents`, `..._unscoped_admin_still_sees_bare_session_agents`
- `resolve_router_for_session_{rejects_cross_tenant_session_id, allows_same_tenant, admin_connection_is_unscoped, allows_authorized_routed_profile, rejects_tenant_outside_routed_and_connection}`

RED confirmed by neutralizing each guard (both leak tests fail with the exact cross-tenant assertion). `cargo test -p octos-cli --features api` scope/router/agent_orchestrator suites green. Codex-reviewed per commit (both passes clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)