### PR TITLE
fix(tools): 2 P1 subagent tool-safety findings (disallowed_tools allow-all, SSRF redirects)

### DIFF
--- a/crates/app-skills/deep-search/src/main.rs
+++ b/crates/app-skills/deep-search/src/main.rs
@@ -1725,24 +1725,94 @@ async fn fetch_pages_parallel(
     results.into_iter().flatten().collect()
 }
 
+/// Browser-like UA (some sites 403 non-browser agents).
+const FETCH_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+/// Max redirects followed by [`ssrf_safe_get`].
+const FETCH_MAX_REDIRECTS: usize = 10;
+
+/// GET a URL with SSRF re-validated + DNS-pinned on EVERY redirect hop.
+///
+/// The shared `reqwest::Client` follows redirects by default WITHOUT
+/// re-checking the target, so an allowed URL that 30x-redirects to a private
+/// host (169.254.169.254 / 10.x / …) would be fetched unchecked. This builds
+/// a per-hop client with auto-redirects disabled and DNS pinned to the
+/// validated addresses, and follows `Location` manually. Fails closed on DNS
+/// error. (This binary ships its own SSRF copy — it cannot depend on
+/// octos-agent's `ssrf::ssrf_safe_send`.)
+async fn ssrf_safe_get(url: &str) -> Result<reqwest::Response, String> {
+    let mut current = url.to_string();
+
+    for _ in 0..FETCH_MAX_REDIRECTS {
+        let parsed = url::Url::parse(&current).map_err(|_| "invalid URL".to_string())?;
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| "URL has no host".to_string())?
+            .to_string();
+        if is_private_host(&host) {
+            return Err("blocked: private/internal host".to_string());
+        }
+        let port = parsed.port_or_known_default().unwrap_or(443);
+        // Fail closed on DNS error (rebinding variant: fail at check time,
+        // succeed at fetch time).
+        let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((host.as_str(), port))
+            .await
+            .map_err(|e| format!("DNS resolution failed (fail-closed): {e}"))?
+            .collect();
+        for addr in &addrs {
+            if is_private_ip(&addr.ip()) {
+                return Err("blocked: host resolves to a private IP".to_string());
+            }
+        }
+
+        let mut builder = reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .user_agent(FETCH_USER_AGENT)
+            .redirect(reqwest::redirect::Policy::none());
+        for addr in &addrs {
+            builder = builder.resolve(&host, *addr);
+        }
+        let client = builder
+            .build()
+            .map_err(|e| format!("HTTP client error: {e}"))?;
+
+        let response = client
+            .get(&current)
+            .send()
+            .await
+            .map_err(|e| format!("fetch failed: {e}"))?;
+
+        if !response.status().is_redirection() {
+            return Ok(response);
+        }
+
+        let location = response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| "redirect with no Location header".to_string())?;
+        current = parsed
+            .join(location)
+            .map_err(|_| format!("invalid redirect URL: {location}"))?
+            .to_string();
+    }
+
+    Err(format!("too many redirects (max {FETCH_MAX_REDIRECTS})"))
+}
+
 async fn fetch_page(
-    client: &reqwest::Client,
+    _client: &reqwest::Client,
     url: &str,
     max_chars: usize,
 ) -> Result<(String, Vec<String>), String> {
-    if let Ok(parsed) = url::Url::parse(url) {
-        if let Some(host) = parsed.host_str() {
-            if is_private_host(host) {
-                return Ok((String::new(), vec![]));
-            }
-        }
-    }
-
-    let response = client
-        .get(url)
-        .send()
-        .await
-        .map_err(|e| format!("fetch failed: {e}"))?;
+    // Best-effort: an SSRF-blocked target (including a redirect hop to a
+    // private host) or any transport failure yields empty content, which
+    // `fetch_pages_parallel` skips. Redirects are re-validated per hop by
+    // `ssrf_safe_get` (the previous initial-host-only check let an allowed URL
+    // 302 to a private host through).
+    let response = match ssrf_safe_get(url).await {
+        Ok(response) => response,
+        Err(_) => return Ok((String::new(), vec![])),
+    };
     if !response.status().is_success() {
         return Err(format!("HTTP {}", response.status()));
     }

--- a/crates/app-skills/deep-search/src/main.rs
+++ b/crates/app-skills/deep-search/src/main.rs
@@ -1768,8 +1768,11 @@ async fn ssrf_safe_get(url: &str) -> Result<reqwest::Response, String> {
             .timeout(Duration::from_secs(15))
             .user_agent(FETCH_USER_AGENT)
             .redirect(reqwest::redirect::Policy::none());
-        for addr in &addrs {
-            builder = builder.resolve(&host, *addr);
+        // Pin ALL validated addresses at once: `resolve()` in a loop replaces
+        // the per-host override each call, pinning only the last address (and
+        // failing if it happens to be unreachable).
+        if !addrs.is_empty() {
+            builder = builder.resolve_to_addrs(&host, &addrs);
         }
         let client = builder
             .build()

--- a/crates/octos-agent/src/tools/browser.rs
+++ b/crates/octos-agent/src/tools/browser.rs
@@ -297,6 +297,15 @@ impl Tool for BrowserTool {
                     ..Default::default()
                 });
             }
+            // KNOWN RESIDUAL (tracked separately): this validates only the
+            // INITIAL navigation URL. Headless Chrome then follows HTTP 30x,
+            // <meta refresh>, and JS `location=` redirects internally with no
+            // per-hop SSRF re-check, so an allowed page that redirects to a
+            // private host is still reachable. Unlike the reqwest-based tools
+            // (deep_search / mcp_agent), the fix here needs CDP request
+            // interception (`Fetch.enable` / `Network.setRequestInterception`)
+            // to re-validate every navigation — a larger change that needs
+            // real-browser validation and is out of scope for this SSRF pass.
         }
 
         // Resolve timeout from config, falling back to constructor value

--- a/crates/octos-agent/src/tools/deep_search.rs
+++ b/crates/octos-agent/src/tools/deep_search.rs
@@ -224,20 +224,15 @@ fn emit_deep_research_progress(phase: &str, message: &str, progress: Option<f64>
 
 impl DeepSearchTool {
     async fn fetch_page(&self, url: &str, max_chars: usize) -> Result<String> {
-        // Best-effort fetch: an SSRF-blocked target (including a redirect hop
-        // to a private host) or any transport failure yields empty content,
-        // which the caller skips — one bad URL must not abort the batch.
-        Ok(self
-            .fetch_page_inner(url, max_chars)
-            .await
-            .unwrap_or_default())
-    }
-
-    async fn fetch_page_inner(&self, url: &str, max_chars: usize) -> Result<String> {
         // SSRF is re-validated on EVERY redirect hop (the initial-URL-only
         // check this replaced let an allowed URL 302 to 169.254.169.254 /
         // 10.x through). `ssrf_safe_send` disables auto-redirects, re-checks +
         // DNS-pins each hop, and re-issues the GET.
+        //
+        // Failures (SSRF-blocked, transport error, non-2xx, body-read) return
+        // Err so the caller's save loop records an error artifact for the
+        // skipped source — collapsing them to Ok("") would silently drop
+        // 403/500 pages from the research index.
         let response = super::ssrf::ssrf_safe_send(
             url,
             super::ssrf::SSRF_MAX_REDIRECTS,

--- a/crates/octos-agent/src/tools/deep_search.rs
+++ b/crates/octos-agent/src/tools/deep_search.rs
@@ -166,6 +166,7 @@ impl Tool for DeepSearchTool {
 
         let mut saved_count = 0u32;
         let mut saved_files = Vec::new();
+        let mut failed_files: Vec<String> = Vec::new();
         for (i, (url, page)) in urls.iter().zip(pages.iter()).enumerate() {
             let filename = format!("{:02}_{}.md", i + 1, host_slug(url));
             let filepath = dir.join(&filename);
@@ -192,8 +193,20 @@ impl Tool for DeepSearchTool {
                 }
                 Ok(_) => {}
                 Err(e) => {
+                    // `fetch_page` now propagates 403/500, transport, and
+                    // body-read failures (it no longer swallows them to an
+                    // empty string). Persist the error artifact AND surface it
+                    // in the returned index — otherwise a failed (or all-failed)
+                    // crawl hands the agent an index that silently omits the
+                    // source, with no path or reason to inspect.
                     let err_content = format!("---\nurl: {url}\nerror: {e}\n---\n");
                     let _ = tokio::fs::write(&filepath, &err_content).await;
+                    failed_files.push(format!("  - {} ({url}): {e}", filepath.display()));
+                    output.push_str(&format!("## Source [{}]: {url} — FETCH FAILED\n", i + 1));
+                    output.push_str(&format!(
+                        "_Error: {e}. Saved error artifact: {}_\n\n---\n\n",
+                        filepath.display()
+                    ));
                 }
             }
         }
@@ -204,6 +217,7 @@ impl Tool for DeepSearchTool {
             dir.display(),
             saved_files.join("\n")
         ));
+        output.push_str(&render_failed_sources_block(&failed_files));
 
         emit_deep_research_progress("completion", "Deep search complete", Some(1.0));
 
@@ -272,6 +286,22 @@ fn slugify(s: &str) -> String {
         }
     }
     slug.trim_matches('-').to_string()
+}
+
+/// Render the "failed sources" tail appended to the research index when one or
+/// more crawls fail. Each entry names the saved error-artifact path and the
+/// failure reason so the agent can locate and read it. Empty when nothing
+/// failed. Pure, so the failed-source surfacing is unit-testable without a
+/// live crawl.
+fn render_failed_sources_block(failed_files: &[String]) -> String {
+    if failed_files.is_empty() {
+        return String::new();
+    }
+    format!(
+        "\n{} source(s) failed to fetch (error artifacts saved for inspection):\n{}\n",
+        failed_files.len(),
+        failed_files.join("\n")
+    )
 }
 
 /// Extract a short slug from a URL's hostname.
@@ -365,6 +395,23 @@ mod tests {
     #[test]
     fn test_extract_urls_empty() {
         assert!(extract_urls("no urls here").is_empty());
+    }
+
+    #[test]
+    fn failed_sources_block_lists_path_and_reason_and_is_empty_when_none() {
+        // Codex P2: once `fetch_page` propagates fetch errors, a failed crawl
+        // must surface the saved error-artifact path AND the reason in the
+        // returned index — not silently omit the source. No failures → no tail.
+        assert!(render_failed_sources_block(&[]).is_empty());
+
+        let block = render_failed_sources_block(&[
+            "  - /r/01_example-com.md (https://example.com): HTTP 403".to_string(),
+            "  - /r/02_other-com.md (https://other.com): read body failed".to_string(),
+        ]);
+        assert!(block.contains("2 source(s) failed"), "block: {block}");
+        assert!(block.contains("/r/01_example-com.md"), "block: {block}");
+        assert!(block.contains("HTTP 403"), "block: {block}");
+        assert!(block.contains("https://other.com"), "block: {block}");
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/deep_search.rs
+++ b/crates/octos-agent/src/tools/deep_search.rs
@@ -9,7 +9,6 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use eyre::{Result, WrapErr};
-use reqwest::Client;
 use serde::Deserialize;
 
 use crate::harness_events::emit_registered_progress_event;
@@ -18,9 +17,14 @@ use crate::tools::TOOL_CTX;
 use super::web_search::WebSearchTool;
 use super::{Tool, ToolResult};
 
+/// Browser-like UA used for page fetches (some sites 403 non-browser agents).
+const DEEP_SEARCH_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
+/// Page-fetch timeout.
+const DEEP_SEARCH_FETCH_TIMEOUT: Duration = Duration::from_secs(15);
+
 pub struct DeepSearchTool {
     search: WebSearchTool,
-    client: Client,
     /// Research output base directory (e.g. ~/.octos/research/ or a sub-agent's research_dir).
     research_base: PathBuf,
 }
@@ -29,11 +33,6 @@ impl DeepSearchTool {
     pub fn new(research_base: impl Into<PathBuf>) -> Self {
         Self {
             search: WebSearchTool::new(),
-            client: Client::builder()
-                .timeout(Duration::from_secs(15))
-                .user_agent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
-                .build()
-                .unwrap_or_else(|_| Client::new()),
             research_base: research_base.into(),
         }
     }
@@ -225,24 +224,32 @@ fn emit_deep_research_progress(phase: &str, message: &str, progress: Option<f64>
 
 impl DeepSearchTool {
     async fn fetch_page(&self, url: &str, max_chars: usize) -> Result<String> {
-        // SSRF check
-        if let Ok(parsed) = reqwest::Url::parse(url) {
-            if let Some(host) = parsed.host_str() {
-                if super::ssrf::is_private_host(host) {
-                    return Ok(String::new());
-                }
-                let port = parsed.port_or_known_default().unwrap_or(443);
-                if let Ok(addrs) = tokio::net::lookup_host(format!("{host}:{port}")).await {
-                    for addr in addrs {
-                        if super::ssrf::is_private_ip(&addr.ip()) {
-                            return Ok(String::new());
-                        }
-                    }
-                }
-            }
-        }
+        // Best-effort fetch: an SSRF-blocked target (including a redirect hop
+        // to a private host) or any transport failure yields empty content,
+        // which the caller skips — one bad URL must not abort the batch.
+        Ok(self
+            .fetch_page_inner(url, max_chars)
+            .await
+            .unwrap_or_default())
+    }
 
-        let response = self.client.get(url).send().await.wrap_err("fetch failed")?;
+    async fn fetch_page_inner(&self, url: &str, max_chars: usize) -> Result<String> {
+        // SSRF is re-validated on EVERY redirect hop (the initial-URL-only
+        // check this replaced let an allowed URL 302 to 169.254.169.254 /
+        // 10.x through). `ssrf_safe_send` disables auto-redirects, re-checks +
+        // DNS-pins each hop, and re-issues the GET.
+        let response = super::ssrf::ssrf_safe_send(
+            url,
+            super::ssrf::SSRF_MAX_REDIRECTS,
+            |builder| {
+                builder
+                    .timeout(DEEP_SEARCH_FETCH_TIMEOUT)
+                    .user_agent(DEEP_SEARCH_USER_AGENT)
+            },
+            |client, current_url| client.get(current_url),
+        )
+        .await
+        .map_err(|e| eyre::eyre!("{e}"))?;
 
         if !response.status().is_success() {
             eyre::bail!("HTTP {}", response.status());

--- a/crates/octos-agent/src/tools/mcp_agent.rs
+++ b/crates/octos-agent/src/tools/mcp_agent.rs
@@ -860,7 +860,14 @@ impl HttpMcpAgent {
 
         let mut builder = reqwest::Client::builder()
             .connect_timeout(self.connect_timeout)
-            .read_timeout(self.read_timeout);
+            .read_timeout(self.read_timeout)
+            // SSRF: never auto-follow redirects. reqwest's default policy
+            // resolves + connects to redirect targets WITHOUT re-running the
+            // SSRF check, and the `.resolve()` pin below only covers the
+            // ORIGINAL host — so a 30x to 169.254.169.254 / 10.x would be
+            // followed unchecked. An MCP endpoint is a fixed JSON-RPC URL, so
+            // we fail closed on any redirect (see `send_request`).
+            .redirect(reqwest::redirect::Policy::none());
         for addr in &resolved_addrs {
             builder = builder.resolve(&host, *addr);
         }
@@ -930,6 +937,22 @@ impl HttpMcpAgent {
                 );
             }
         };
+
+        // Auto-redirects are disabled (see `dispatch_inner`): a 3xx here means
+        // the endpoint tried to redirect us to a target that would bypass the
+        // SSRF check. MCP endpoints are a stable URL, so fail closed rather
+        // than follow an unvalidated hop.
+        if resp.status().is_redirection() {
+            return DispatchResponse::failure(
+                DispatchOutcome::SsrfBlocked,
+                format!(
+                    "MCP remote endpoint '{}' returned redirect {}; refusing to \
+                     follow (redirect targets bypass SSRF validation)",
+                    self.url,
+                    resp.status(),
+                ),
+            );
+        }
 
         let status = resp.status();
         let text = match resp.text().await {

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -1454,6 +1454,28 @@ async fn maybe_generate_inline_research_podcast(
     }
 }
 
+/// The EFFECTIVE allow-list for the two consumers that cannot apply the local
+/// [`ToolPolicy`] deny-list: `allowed_tools` with every manifest-`disallowed`
+/// tool removed.
+///
+/// - The `agent_mcp` dispatch payload — the REMOTE agent runs its own tool
+///   loop and only ever sees this list, so an unfiltered list would grant it a
+///   manifest-forbidden tool (the local deny-list never reaches it).
+/// - The availability preflight — a manifest-forbidden tool must not gate the
+///   spawn on host availability, since the policy denies it regardless.
+///
+/// The in-process ToolPolicy path deliberately keeps the FULL `allowed_tools`
+/// and relies on deny-wins, so this helper must NOT be used to build that
+/// policy — doing so would lose the "deny also covers role-refilled tools"
+/// guarantee.
+fn effective_allowed_tools(allowed_tools: &[String], disallowed_tools: &[String]) -> Vec<String> {
+    allowed_tools
+        .iter()
+        .filter(|tool| !disallowed_tools.contains(tool))
+        .cloned()
+        .collect()
+}
+
 fn build_subagent_tool_policy(
     allowed_tools: Vec<String>,
     disallowed_tools: Vec<String>,
@@ -2021,6 +2043,14 @@ impl Tool for SpawnTool {
         };
 
         let allowed_tools = input.allowed_tools.clone();
+        // Effective allow-list = `allowed_tools` minus the manifest's
+        // `disallowed_tools`, for the two consumers that cannot apply the local
+        // deny-list policy: the `agent_mcp` dispatch payload (codex P1) and the
+        // availability preflight (codex P2). See [`effective_allowed_tools`].
+        // The local ToolPolicy path below keeps the FULL `allowed_tools` and
+        // relies on deny-wins.
+        let effective_allowed_tools =
+            effective_allowed_tools(&allowed_tools, &manifest_disallowed_tools);
         let workflow = input.workflow.clone();
         let is_sync = input.mode == "sync";
         let is_agent_mcp = input.backend == "agent_mcp";
@@ -2061,7 +2091,14 @@ impl Tool for SpawnTool {
                 "task": task_desc,
                 "label": label,
                 "role": input.role,
-                "allowed_tools": allowed_tools,
+                // The remote agent runs its own tool loop and never sees the
+                // local ToolPolicy, so hand it the already-pruned allow-list
+                // (deny-list applied) rather than the raw `allowed_tools`.
+                // Also forward `disallowed_tools` so a remote that honors an
+                // explicit deny-list can enforce it even if a role template
+                // there re-expands the allow-list.
+                "allowed_tools": effective_allowed_tools,
+                "disallowed_tools": manifest_disallowed_tools,
                 "workflow": workflow.clone(),
                 "additional_instructions": input.additional_instructions,
             });
@@ -2513,7 +2550,10 @@ impl Tool for SpawnTool {
             // tool; routing through a dispatcher adds latency without
             // value once we are already in a spawned context.
             tools.clear_internal_hidden();
-            ensure_subagent_tools_available(&tools, &allowed_tools)
+            // Preflight against the EFFECTIVE (post-deny) allow-list: a tool
+            // the manifest forbids must not gate the spawn on availability,
+            // since the policy below denies it regardless (codex P2).
+            ensure_subagent_tools_available(&tools, &effective_allowed_tools)
                 .map_err(|error| eyre::eyre!(error))?;
             let policy = build_subagent_tool_policy(
                 allowed_tools,
@@ -3025,8 +3065,12 @@ impl Tool for SpawnTool {
                 // dispatcher targets directly without going through
                 // `mofa_make`.
                 tools.clear_internal_hidden();
-                let availability_check = ensure_subagent_tools_available(&tools, &allowed_tools)
-                    .map_err(|error| eyre::eyre!(error));
+                // Preflight against the EFFECTIVE (post-deny) allow-list —
+                // mirror the sync path so a manifest-forbidden tool that is
+                // absent from this registry does not fail the spawn (codex P2).
+                let availability_check =
+                    ensure_subagent_tools_available(&tools, &effective_allowed_tools)
+                        .map_err(|error| eyre::eyre!(error));
                 let policy = build_subagent_tool_policy(
                     allowed_tools,
                     manifest_disallowed_tools,
@@ -5253,6 +5297,223 @@ PY
         );
         assert!(policy.is_allowed("read_file"));
         assert!(policy.is_allowed("edit_file"));
+    }
+
+    #[test]
+    fn effective_allowed_tools_prunes_manifest_disallowed_from_the_list() {
+        // Codex P1: the list handed to the agent_mcp dispatch payload (and the
+        // preflight) must be `allowed_tools` MINUS the manifest's disallowed
+        // tools — the remote agent never runs the local deny-list policy.
+        //
+        // Both-allowed-and-disallowed → nothing survives. (An empty list on
+        // the wire means "no explicit tools", NOT "allow all" — that inversion
+        // only bites the in-process ToolPolicy, which keeps the full list.)
+        assert!(
+            effective_allowed_tools(&["shell".to_string()], &["shell".to_string()]).is_empty(),
+            "a tool that is both allowed and disallowed must not reach the remote"
+        );
+        // Mixed: only the non-disallowed tool survives.
+        assert_eq!(
+            effective_allowed_tools(
+                &["read_file".to_string(), "shell".to_string()],
+                &["shell".to_string()],
+            ),
+            vec!["read_file".to_string()],
+        );
+        // No disallow → identity.
+        assert_eq!(
+            effective_allowed_tools(&["grep".to_string()], &[]),
+            vec!["grep".to_string()],
+        );
+    }
+
+    #[test]
+    fn preflight_does_not_reject_a_disallowed_but_unavailable_tool() {
+        // Codex P2: once `disallowed_tools` stopped pruning `allowed_tools`,
+        // the availability preflight (run on the FULL allow-list) would fail a
+        // spawn for a manifest-forbidden tool that isn't installed on the host
+        // — even though the policy denies it anyway. Preflighting the EFFECTIVE
+        // (post-deny) set fixes that.
+        let tools = ToolRegistry::with_builtins("/tmp");
+        let allowed = vec!["shell".to_string(), "podcast_generate".to_string()];
+        let disallowed = vec!["podcast_generate".to_string()];
+
+        // The OLD ordering (preflight on the raw allow-list) rejects the spawn
+        // because `podcast_generate` is not available on this host:
+        assert!(
+            ensure_subagent_tools_available(&tools, &allowed).is_err(),
+            "sanity: the unfiltered allow-list still trips the missing-tool guard"
+        );
+        // The FIX: preflight the EFFECTIVE set — the forbidden-and-missing tool
+        // is gone, so the otherwise-valid `shell`-only spawn is admitted.
+        let effective = effective_allowed_tools(&allowed, &disallowed);
+        ensure_subagent_tools_available(&tools, &effective)
+            .expect("a disallowed-and-missing tool must not fail the preflight");
+    }
+
+    #[tokio::test]
+    async fn agent_mcp_dispatch_payload_sends_effective_allow_list_not_the_raw_one() {
+        // Codex P1 (wiring guard): the `agent_mcp` dispatch payload is the ONLY
+        // tool list the remote agent ever sees — it never runs the local
+        // deny-list ToolPolicy. If the payload carried the RAW `allowed_tools`,
+        // a manifest that both allows and forbids `shell` would still grant the
+        // remote `shell`, bypassing the deny-list fix. Drive a real spawn
+        // through a recording backend and assert the payload carries the
+        // EFFECTIVE (post-deny) allow-list, plus the deny-list for a remote
+        // that can honor it.
+        use crate::tools::mcp_agent::McpAgentBackend;
+        use std::sync::Mutex;
+
+        struct RecordingBackend {
+            seen: Arc<Mutex<Option<serde_json::Value>>>,
+        }
+        #[async_trait]
+        impl McpAgentBackend for RecordingBackend {
+            fn backend_label(&self) -> &'static str {
+                "local"
+            }
+            fn endpoint_label(&self) -> String {
+                "recording".to_string()
+            }
+            async fn dispatch(&self, request: DispatchRequest) -> DispatchResponse {
+                *self.seen.lock().unwrap() = Some(request.task.clone());
+                DispatchResponse {
+                    outcome: DispatchOutcome::Success,
+                    output: "recorded".to_string(),
+                    files_to_send: Vec::new(),
+                    error: None,
+                    context_contract: None,
+                }
+            }
+        }
+
+        let mut registry = crate::agents::AgentDefinitions::new();
+        registry.insert(
+            "example",
+            crate::agents::AgentDefinition::from_json_str(
+                r#"{
+                    "name": "example",
+                    "version": 1,
+                    "tools": ["shell", "grep"],
+                    "disallowed_tools": ["shell"]
+                }"#,
+            )
+            .expect("parse manifest"),
+        );
+        let mut ctx = crate::tools::ToolContext::zero();
+        ctx.agent_definitions = Arc::new(registry);
+
+        let seen = Arc::new(Mutex::new(None));
+        let backend: SharedBackend = Arc::new(RecordingBackend { seen: seen.clone() });
+        let (in_tx, _in_rx) = tokio::sync::mpsc::channel(16);
+        let tool = SpawnTool::new(
+            Arc::new(MockProvider),
+            Arc::new(create_test_store().await),
+            PathBuf::from("/tmp"),
+            in_tx,
+        )
+        .with_mcp_agent_backend(backend, Some("run_task".to_string()));
+
+        // Return value is irrelevant (post-dispatch validation may FAIL the
+        // artifact) — the payload is captured at dispatch time, before any of
+        // that runs.
+        let _ = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "task": "do it",
+                    "agent_definition_id": "example",
+                    "allowed_tools": ["shell", "grep"],
+                    "backend": "agent_mcp",
+                    "mode": "sync"
+                }),
+            )
+            .await;
+
+        let payload = seen
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("the recording backend must have been dispatched to");
+        let allowed: Vec<&str> = payload
+            .get("allowed_tools")
+            .and_then(|v| v.as_array())
+            .expect("payload carries allowed_tools")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert_eq!(
+            allowed,
+            vec!["grep"],
+            "agent_mcp payload must send the EFFECTIVE allow-list (shell pruned), not the raw one"
+        );
+        // The deny-list is also forwarded so a remote that honors an explicit
+        // deny-list can enforce it even if a role template there re-expands.
+        let disallowed: Vec<&str> = payload
+            .get("disallowed_tools")
+            .and_then(|v| v.as_array())
+            .expect("payload carries disallowed_tools")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert_eq!(disallowed, vec!["shell"]);
+    }
+
+    #[tokio::test]
+    async fn sync_spawn_admits_a_disallowed_but_unavailable_tool_via_effective_preflight() {
+        // Codex P2 (wiring guard): the builtin sync spawn path preflights tool
+        // availability. Before the fix it checked the RAW allow-list, so a
+        // manifest that forbids an uninstalled tool (`podcast_generate`) failed
+        // the whole spawn with "required tool(s) not available" — even though
+        // the deny-list blocks that tool anyway. After the fix it preflights
+        // the EFFECTIVE set, so the otherwise-valid `shell`-only spawn runs.
+        let mut registry = crate::agents::AgentDefinitions::new();
+        registry.insert(
+            "forbids-missing",
+            crate::agents::AgentDefinition::from_json_str(
+                r#"{
+                    "name": "forbids-missing",
+                    "version": 1,
+                    "tools": ["shell", "podcast_generate"],
+                    "disallowed_tools": ["podcast_generate"]
+                }"#,
+            )
+            .expect("parse manifest"),
+        );
+        let mut ctx = crate::tools::ToolContext::zero();
+        ctx.agent_definitions = Arc::new(registry);
+
+        let (in_tx, _in_rx) = tokio::sync::mpsc::channel(16);
+        let tool = SpawnTool::new(
+            Arc::new(MockProvider),
+            Arc::new(create_test_store().await),
+            PathBuf::from("/tmp"),
+            in_tx,
+        );
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "task": "do it",
+                    "agent_definition_id": "forbids-missing",
+                    "allowed_tools": ["shell", "podcast_generate"],
+                    "mode": "sync"
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !result.output.contains("required tool(s) not available"),
+            "a disallowed-and-missing tool must not fail the sync spawn preflight; got: {}",
+            result.output
+        );
+        assert!(
+            result.success,
+            "the shell-only spawn should run to completion: {}",
+            result.output
+        );
     }
 
     #[test]

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -1469,9 +1469,21 @@ async fn maybe_generate_inline_research_podcast(
 /// policy — doing so would lose the "deny also covers role-refilled tools"
 /// guarantee.
 fn effective_allowed_tools(allowed_tools: &[String], disallowed_tools: &[String]) -> Vec<String> {
+    if disallowed_tools.is_empty() {
+        return allowed_tools.to_vec();
+    }
+    // Deny entries carry the same wildcard (`podcast_*`) and group
+    // (`group:runtime`) semantics ToolPolicy enforces locally — prune with a
+    // deny-only policy (empty allow = allow everything not denied) instead of
+    // exact matching, so the effective set agrees with what the local policy
+    // would actually deny.
+    let deny_only = ToolPolicy {
+        deny: disallowed_tools.to_vec(),
+        ..Default::default()
+    };
     allowed_tools
         .iter()
-        .filter(|tool| !disallowed_tools.contains(tool))
+        .filter(|tool| deny_only.is_allowed(tool))
         .cloned()
         .collect()
 }
@@ -5324,6 +5336,32 @@ PY
         assert_eq!(
             effective_allowed_tools(&["grep".to_string()], &[]),
             vec!["grep".to_string()],
+        );
+    }
+
+    #[test]
+    fn effective_allowed_tools_prunes_with_policy_semantics_not_exact_match() {
+        // Codex P2 (fold 2): `disallowed_tools` entries carry the same
+        // wildcard/group semantics ToolPolicy enforces locally. An exact
+        // `contains` prune would let `shell` (denied via `group:runtime`) or
+        // `podcast_generate` (denied via `podcast_*`) reach the agent_mcp
+        // payload and the preflight — re-opening the bypass for exactly the
+        // deny spellings the local policy honors.
+        assert_eq!(
+            effective_allowed_tools(
+                &["shell".to_string(), "read_file".to_string()],
+                &["group:runtime".to_string()],
+            ),
+            vec!["read_file".to_string()],
+            "a group deny entry must prune its member tools"
+        );
+        assert_eq!(
+            effective_allowed_tools(
+                &["podcast_generate".to_string(), "grep".to_string()],
+                &["podcast_*".to_string()],
+            ),
+            vec!["grep".to_string()],
+            "a wildcard deny entry must prune matching tools"
         );
     }
 

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -1009,20 +1009,24 @@ fn default_mode() -> String {
 /// Returns an error when the id is set but does not exist in the registry —
 /// that's almost always a typo, and silently ignoring it would erase the
 /// manifest's safety envelope.
-/// Layer an `agent_definition_id` manifest onto the inline [`Input`].
 ///
-/// Returns `true` when the manifest's `disallowed_tools` pruned a
-/// previously **non-empty** `allowed_tools` down to empty. That signal is
-/// load-bearing for the P1 guard at the call site: an empty `allowed_tools`
-/// is treated downstream ([`ToolPolicy`]) as "allow every tool not denied",
-/// so a prune-to-empty must NOT silently fall through to full access — see
-/// [`reject_disallow_inverted_allow_list`].
+/// Returns the manifest's `disallowed_tools` (empty when there is no manifest
+/// or it declares none). The caller feeds this to
+/// [`build_subagent_tool_policy`] as a **deny-list**, which is the ONLY
+/// correct way to enforce it: removing entries from `allowed_tools` (the
+/// prior approach) breaks two ways — an allow-list pruned to empty is read by
+/// [`ToolPolicy`] as "allow every tool not denied" (a privilege INVERSION),
+/// and a one-time prune cannot cover tools a role template adds afterwards
+/// (a role could re-introduce a manifest-forbidden tool). A deny entry wins
+/// over any allow (including role-provided ones) and never empties the
+/// allow-list, so `allow:[shell] + deny:[shell]` → no tools (correct) and
+/// `allow:[] + deny:[shell]` → all-except-shell (correct).
 fn apply_agent_definition(
     input: &mut Input,
     registry: &crate::agents::AgentDefinitions,
-) -> Result<bool> {
+) -> Result<Vec<String>> {
     let Some(id) = input.agent_definition_id.as_deref() else {
-        return Ok(false);
+        return Ok(Vec::new());
     };
     let def = registry.get(id).ok_or_else(|| {
         eyre::eyre!(
@@ -1032,25 +1036,14 @@ fn apply_agent_definition(
         )
     })?;
 
-    // Tool allow-list: manifest provides the default; inline takes
-    // precedence when it is non-empty. Manifest deny-list is merged into
-    // the inline `allowed_tools` as a removal step so a manifest that
-    // marks `shell` as disallowed cannot be re-enabled silently by
-    // inheriting the parent's default allow set.
+    // Tool allow-list: manifest provides the default; inline takes precedence
+    // when it is non-empty. The manifest's `disallowed_tools` is NOT applied
+    // here — it is returned and enforced as a policy deny-list so it also
+    // covers tools a role template contributes later (see the doc comment).
     if input.allowed_tools.is_empty() {
         input.allowed_tools = def.tools.clone();
     }
-    let mut disallow_emptied_allow_list = false;
-    if !def.disallowed_tools.is_empty() {
-        let had_allow_list = !input.allowed_tools.is_empty();
-        input
-            .allowed_tools
-            .retain(|name| !def.disallowed_tools.contains(name));
-        // A prune that consumes the ENTIRE allow-list is the dangerous case:
-        // the now-empty list would otherwise mean "allow all". Flag it so the
-        // caller can reject (unless a role template later refills the list).
-        disallow_emptied_allow_list = had_allow_list && input.allowed_tools.is_empty();
-    }
+    let disallowed_tools = def.disallowed_tools.clone();
 
     // Option-typed fields: manifest only applies when the inline slot is
     // None.
@@ -1081,38 +1074,7 @@ fn apply_agent_definition(
         );
     }
 
-    Ok(disallow_emptied_allow_list)
-}
-
-/// P1 guard: reject a spawn whose tool allow-list was pruned to empty by a
-/// manifest's `disallowed_tools`.
-///
-/// An empty `allowed_tools` is interpreted downstream by [`ToolPolicy`] as
-/// "allow every tool not explicitly denied" (see `policy.rs`: "Empty allow
-/// list = allow everything not denied"). So a manifest that lists, say,
-/// `tools: ["shell"]` + `disallowed_tools: ["shell"]` — or a caller that
-/// requests `allowed_tools: ["shell"]` against a manifest that forbids
-/// `shell` — would prune the allow-list to empty and thereby grant the
-/// subagent EVERY tool: the exact inverse of the intended restriction.
-///
-/// This is checked at the call site AFTER [`apply_role_template`], so a role
-/// template that legitimately refills the emptied list (leaving
-/// `allowed_tools` non-empty) is honoured and does not trip the guard.
-fn reject_disallow_inverted_allow_list(
-    input: &Input,
-    disallow_emptied_allow_list: bool,
-) -> Result<()> {
-    if disallow_emptied_allow_list && input.allowed_tools.is_empty() {
-        eyre::bail!(
-            "spawn: agent_definition_id '{}' disallows every tool in the \
-             allow-list (disallowed_tools pruned it to empty). An empty \
-             allow-list would grant the subagent ALL tools — the opposite of \
-             the intended restriction. Request at least one tool that is not \
-             in the manifest's disallowed_tools.",
-            input.agent_definition_id.as_deref().unwrap_or("?"),
-        );
-    }
-    Ok(())
+    Ok(disallowed_tools)
 }
 
 fn append_role_instructions(existing: Option<String>, role_prefix: &str) -> Option<String> {
@@ -1494,6 +1456,7 @@ async fn maybe_generate_inline_research_podcast(
 
 fn build_subagent_tool_policy(
     allowed_tools: Vec<String>,
+    disallowed_tools: Vec<String>,
     workflow: Option<&WorkflowMetadata>,
 ) -> ToolPolicy {
     let mut deny = vec!["spawn".to_string()];
@@ -1503,6 +1466,12 @@ fn build_subagent_tool_policy(
         // cannot double-deliver slides/site artifacts.
         deny.push("send_file".to_string());
     }
+    // A manifest's `disallowed_tools` is enforced here as a DENY-list. Deny
+    // wins over allow (see `ToolPolicy::evaluate`), so a forbidden tool is
+    // blocked even if it appears in `allow` (inline/manifest) OR was added by
+    // a role template — and, unlike an allow-list prune, this can never empty
+    // the allow-list into an accidental "allow all".
+    deny.extend(disallowed_tools);
     ToolPolicy {
         allow: allowed_tools,
         deny,
@@ -2032,13 +2001,12 @@ impl Tool for SpawnTool {
         // layer the manifest's fields onto the inline Input with "inline
         // wins" semantics. Unknown ids are a hard error — silently ignoring
         // them would let a typo erase the manifest's safety envelope.
-        let disallow_emptied_allow_list =
+        // The manifest's `disallowed_tools` becomes a policy DENY-list (below),
+        // not an allow-list prune — so it also covers tools a role template
+        // adds and can never invert an emptied allow-list into "allow all".
+        let manifest_disallowed_tools =
             apply_agent_definition(&mut input, ctx.agent_definitions.as_ref())?;
         let role_template = apply_role_template(&mut input)?;
-        // P1: a `disallowed_tools` prune that empties the allow-list must not
-        // invert into "allow all". Checked after the role template has had its
-        // chance to refill the list.
-        reject_disallow_inverted_allow_list(&input, disallow_emptied_allow_list)?;
 
         let worker_num = self.worker_count.fetch_add(1, Ordering::SeqCst);
         let worker_id = AgentId::new(format!("subagent-{worker_num}"));
@@ -2547,7 +2515,11 @@ impl Tool for SpawnTool {
             tools.clear_internal_hidden();
             ensure_subagent_tools_available(&tools, &allowed_tools)
                 .map_err(|error| eyre::eyre!(error))?;
-            let policy = build_subagent_tool_policy(allowed_tools, workflow.as_ref());
+            let policy = build_subagent_tool_policy(
+                allowed_tools,
+                manifest_disallowed_tools,
+                workflow.as_ref(),
+            );
             tools.apply_policy(&policy);
             if let Some(ref pp) = self.provider_policy {
                 tools.set_provider_policy(pp.clone());
@@ -3055,7 +3027,11 @@ impl Tool for SpawnTool {
                 tools.clear_internal_hidden();
                 let availability_check = ensure_subagent_tools_available(&tools, &allowed_tools)
                     .map_err(|error| eyre::eyre!(error));
-                let policy = build_subagent_tool_policy(allowed_tools, workflow_metadata.as_ref());
+                let policy = build_subagent_tool_policy(
+                    allowed_tools,
+                    manifest_disallowed_tools,
+                    workflow_metadata.as_ref(),
+                );
                 tools.apply_policy(&policy);
                 if let Some(pp) = provider_policy {
                     tools.set_provider_policy(pp);
@@ -4365,7 +4341,10 @@ mod tests {
             progress: None,
         };
 
-        let policy = build_subagent_tool_policy(workflow.allowed_tools.clone(), Some(&workflow));
+        // Workflow-node spawn: no agent-definition manifest, so no
+        // manifest-level disallowed_tools deny-list.
+        let policy =
+            build_subagent_tool_policy(workflow.allowed_tools.clone(), Vec::new(), Some(&workflow));
 
         assert!(policy.deny.contains(&"spawn".to_string()));
         assert!(policy.deny.contains(&"send_file".to_string()));
@@ -5170,10 +5149,11 @@ PY
     }
 
     #[test]
-    fn should_let_inline_allowed_tools_override_manifest_allowed_tools() {
-        // When inline `allowed_tools` is non-empty it replaces the manifest
-        // list outright. The manifest's disallowed_tools still prune the
-        // result so a manifest cannot be silently bypassed.
+    fn manifest_disallowed_tools_are_denied_by_policy_not_pruned_from_allow_list() {
+        // inline [shell, grep] + manifest disallowed [shell]. The allow-list is
+        // NOT mutated (shell stays); apply_agent_definition returns the
+        // disallowed list, which build_subagent_tool_policy enforces as a
+        // DENY. Deny wins over allow → shell blocked, grep allowed.
         let mut registry = crate::agents::AgentDefinitions::new();
         registry.insert(
             "example",
@@ -5193,24 +5173,28 @@ PY
             "agent_definition_id": "example",
             "allowed_tools": ["shell", "grep"]
         }));
-        let flagged = apply_agent_definition(&mut input, &registry).expect("apply");
+        let disallowed = apply_agent_definition(&mut input, &registry).expect("apply");
 
-        // Inline list is kept, but manifest's disallow pruned `shell`.
+        assert_eq!(disallowed, vec!["shell".to_string()]);
+        // Inline list is kept verbatim — disallow is NOT a prune anymore.
         assert!(input.allowed_tools.contains(&"grep".to_string()));
-        assert!(!input.allowed_tools.contains(&"shell".to_string()));
-        // `grep` survives, so the allow-list is NOT emptied — no inversion.
+        assert!(input.allowed_tools.contains(&"shell".to_string()));
+
+        let policy = build_subagent_tool_policy(input.allowed_tools.clone(), disallowed, None);
         assert!(
-            !flagged,
-            "a non-empty post-prune allow-list must not flag the inversion guard"
+            !policy.is_allowed("shell"),
+            "manifest-disallowed shell must be denied by policy"
         );
+        assert!(policy.is_allowed("grep"), "grep must remain allowed");
     }
 
     #[test]
-    fn disallowed_tools_pruning_allow_list_to_empty_is_rejected_not_allow_all() {
-        // P1: a manifest that disallows every tool in the allow-list prunes it
-        // to empty. An empty `allowed_tools` means "allow ALL tools" to
-        // `ToolPolicy`, so proceeding would grant the subagent every tool —
-        // the inverse of the restriction. The spawn must be rejected instead.
+    fn manifest_forbidding_its_only_tool_grants_no_tools_not_allow_all() {
+        // P1 (the original finding): manifest tools:[shell] + disallowed:[shell]
+        // with no inline and no role. The OLD retain emptied the allow-list,
+        // which ToolPolicy reads as "allow ALL". Now the allow-list keeps
+        // [shell] (filled from def.tools, NOT pruned) and shell is denied, so
+        // the effective tool set is EMPTY — never allow-all.
         let mut registry = crate::agents::AgentDefinitions::new();
         registry.insert(
             "shell-then-forbid-shell",
@@ -5225,71 +5209,50 @@ PY
             .expect("parse"),
         );
 
-        // Manifest-only path: def.tools=[shell] filled in, then pruned to empty.
         let mut input = parse_spawn_input(serde_json::json!({
             "task": "do it",
             "agent_definition_id": "shell-then-forbid-shell"
         }));
-        let flagged = apply_agent_definition(&mut input, &registry).expect("apply");
-        assert!(flagged, "prune-to-empty must be flagged");
-        assert!(
-            input.allowed_tools.is_empty(),
-            "precondition: allow-list empty"
-        );
+        let disallowed = apply_agent_definition(&mut input, &registry).expect("apply");
+        assert_eq!(disallowed, vec!["shell".to_string()]);
 
-        // With no role template to refill the list, the guard must reject.
-        let err = reject_disallow_inverted_allow_list(&input, flagged).unwrap_err();
-        let msg = format!("{err:#}");
+        let policy = build_subagent_tool_policy(input.allowed_tools.clone(), disallowed, None);
+        assert!(!policy.is_allowed("shell"), "the forbidden tool is denied");
+        // The critical anti-inversion assertions: NOT allow-all.
         assert!(
-            msg.contains("grant the subagent ALL tools"),
-            "error must explain the allow-all inversion; got: {msg}"
+            !policy.is_allowed("read_file"),
+            "must NOT fall through to allow-all"
+        );
+        assert!(
+            !policy.is_allowed("web_fetch"),
+            "must NOT fall through to allow-all"
         );
     }
 
     #[test]
-    fn inline_only_all_requested_tools_disallowed_is_rejected() {
-        // The same inversion via the INLINE path: the caller requests only
-        // tools the manifest forbids, pruning the allow-list to empty.
-        let mut registry = crate::agents::AgentDefinitions::new();
-        registry.insert(
-            "forbids-shell",
-            crate::agents::AgentDefinition::from_json_str(
-                r#"{
-                    "name": "forbids-shell",
-                    "version": 1,
-                    "tools": ["read_file"],
-                    "disallowed_tools": ["shell"]
-                }"#,
-            )
-            .expect("parse"),
+    fn role_refill_cannot_reintroduce_a_manifest_disallowed_tool() {
+        // Codex P1: a spawn that ALSO supplies a `role` used to re-fill the
+        // emptied allow-list with the role's tool budget, re-introducing a
+        // manifest-forbidden tool. Because disallowed_tools is now a policy
+        // deny (not a one-time allow-list prune), a role-provided tool that
+        // overlaps the deny-list is still blocked — deny wins over allow.
+        //
+        // Simulates the post-`apply_role_template` state: the allow-list has
+        // been refilled with the role's tools (including the forbidden one).
+        let role_refilled_allow = vec![
+            "shell".to_string(),
+            "read_file".to_string(),
+            "edit_file".to_string(),
+        ];
+        let manifest_disallowed = vec!["shell".to_string()];
+
+        let policy = build_subagent_tool_policy(role_refilled_allow, manifest_disallowed, None);
+        assert!(
+            !policy.is_allowed("shell"),
+            "a role-provided tool must still be denied by the manifest's disallowed_tools"
         );
-
-        let mut input = parse_spawn_input(serde_json::json!({
-            "task": "do it",
-            "agent_definition_id": "forbids-shell",
-            "allowed_tools": ["shell"]
-        }));
-        let flagged = apply_agent_definition(&mut input, &registry).expect("apply");
-        assert!(flagged);
-        assert!(reject_disallow_inverted_allow_list(&input, flagged).is_err());
-    }
-
-    #[test]
-    fn reject_disallow_inverted_allow_list_permits_non_empty_and_unflagged() {
-        // The guard fires ONLY on the flagged prune-to-empty case: a non-empty
-        // allow-list (e.g. a role template refilled it) or an unflagged input
-        // (empty by "inherit default" semantics, not by pruning) both pass.
-        let mut refilled = parse_spawn_input(serde_json::json!({
-            "task": "x",
-            "agent_definition_id": "some-def",
-            "allowed_tools": ["read_file"]
-        }));
-        assert!(reject_disallow_inverted_allow_list(&refilled, true).is_ok());
-
-        refilled.allowed_tools.clear();
-        // Empty but NOT flagged as a prune-to-empty → legitimate "inherit"
-        // path, not the inversion — must pass.
-        assert!(reject_disallow_inverted_allow_list(&refilled, false).is_ok());
+        assert!(policy.is_allowed("read_file"));
+        assert!(policy.is_allowed("edit_file"));
     }
 
     #[test]

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -1009,12 +1009,20 @@ fn default_mode() -> String {
 /// Returns an error when the id is set but does not exist in the registry —
 /// that's almost always a typo, and silently ignoring it would erase the
 /// manifest's safety envelope.
+/// Layer an `agent_definition_id` manifest onto the inline [`Input`].
+///
+/// Returns `true` when the manifest's `disallowed_tools` pruned a
+/// previously **non-empty** `allowed_tools` down to empty. That signal is
+/// load-bearing for the P1 guard at the call site: an empty `allowed_tools`
+/// is treated downstream ([`ToolPolicy`]) as "allow every tool not denied",
+/// so a prune-to-empty must NOT silently fall through to full access — see
+/// [`reject_disallow_inverted_allow_list`].
 fn apply_agent_definition(
     input: &mut Input,
     registry: &crate::agents::AgentDefinitions,
-) -> Result<()> {
+) -> Result<bool> {
     let Some(id) = input.agent_definition_id.as_deref() else {
-        return Ok(());
+        return Ok(false);
     };
     let def = registry.get(id).ok_or_else(|| {
         eyre::eyre!(
@@ -1032,10 +1040,16 @@ fn apply_agent_definition(
     if input.allowed_tools.is_empty() {
         input.allowed_tools = def.tools.clone();
     }
+    let mut disallow_emptied_allow_list = false;
     if !def.disallowed_tools.is_empty() {
+        let had_allow_list = !input.allowed_tools.is_empty();
         input
             .allowed_tools
             .retain(|name| !def.disallowed_tools.contains(name));
+        // A prune that consumes the ENTIRE allow-list is the dangerous case:
+        // the now-empty list would otherwise mean "allow all". Flag it so the
+        // caller can reject (unless a role template later refills the list).
+        disallow_emptied_allow_list = had_allow_list && input.allowed_tools.is_empty();
     }
 
     // Option-typed fields: manifest only applies when the inline slot is
@@ -1067,6 +1081,37 @@ fn apply_agent_definition(
         );
     }
 
+    Ok(disallow_emptied_allow_list)
+}
+
+/// P1 guard: reject a spawn whose tool allow-list was pruned to empty by a
+/// manifest's `disallowed_tools`.
+///
+/// An empty `allowed_tools` is interpreted downstream by [`ToolPolicy`] as
+/// "allow every tool not explicitly denied" (see `policy.rs`: "Empty allow
+/// list = allow everything not denied"). So a manifest that lists, say,
+/// `tools: ["shell"]` + `disallowed_tools: ["shell"]` — or a caller that
+/// requests `allowed_tools: ["shell"]` against a manifest that forbids
+/// `shell` — would prune the allow-list to empty and thereby grant the
+/// subagent EVERY tool: the exact inverse of the intended restriction.
+///
+/// This is checked at the call site AFTER [`apply_role_template`], so a role
+/// template that legitimately refills the emptied list (leaving
+/// `allowed_tools` non-empty) is honoured and does not trip the guard.
+fn reject_disallow_inverted_allow_list(
+    input: &Input,
+    disallow_emptied_allow_list: bool,
+) -> Result<()> {
+    if disallow_emptied_allow_list && input.allowed_tools.is_empty() {
+        eyre::bail!(
+            "spawn: agent_definition_id '{}' disallows every tool in the \
+             allow-list (disallowed_tools pruned it to empty). An empty \
+             allow-list would grant the subagent ALL tools — the opposite of \
+             the intended restriction. Request at least one tool that is not \
+             in the manifest's disallowed_tools.",
+            input.agent_definition_id.as_deref().unwrap_or("?"),
+        );
+    }
     Ok(())
 }
 
@@ -1987,8 +2032,13 @@ impl Tool for SpawnTool {
         // layer the manifest's fields onto the inline Input with "inline
         // wins" semantics. Unknown ids are a hard error — silently ignoring
         // them would let a typo erase the manifest's safety envelope.
-        apply_agent_definition(&mut input, ctx.agent_definitions.as_ref())?;
+        let disallow_emptied_allow_list =
+            apply_agent_definition(&mut input, ctx.agent_definitions.as_ref())?;
         let role_template = apply_role_template(&mut input)?;
+        // P1: a `disallowed_tools` prune that empties the allow-list must not
+        // invert into "allow all". Checked after the role template has had its
+        // chance to refill the list.
+        reject_disallow_inverted_allow_list(&input, disallow_emptied_allow_list)?;
 
         let worker_num = self.worker_count.fetch_add(1, Ordering::SeqCst);
         let worker_id = AgentId::new(format!("subagent-{worker_num}"));
@@ -5143,11 +5193,103 @@ PY
             "agent_definition_id": "example",
             "allowed_tools": ["shell", "grep"]
         }));
-        apply_agent_definition(&mut input, &registry).expect("apply");
+        let flagged = apply_agent_definition(&mut input, &registry).expect("apply");
 
         // Inline list is kept, but manifest's disallow pruned `shell`.
         assert!(input.allowed_tools.contains(&"grep".to_string()));
         assert!(!input.allowed_tools.contains(&"shell".to_string()));
+        // `grep` survives, so the allow-list is NOT emptied — no inversion.
+        assert!(
+            !flagged,
+            "a non-empty post-prune allow-list must not flag the inversion guard"
+        );
+    }
+
+    #[test]
+    fn disallowed_tools_pruning_allow_list_to_empty_is_rejected_not_allow_all() {
+        // P1: a manifest that disallows every tool in the allow-list prunes it
+        // to empty. An empty `allowed_tools` means "allow ALL tools" to
+        // `ToolPolicy`, so proceeding would grant the subagent every tool —
+        // the inverse of the restriction. The spawn must be rejected instead.
+        let mut registry = crate::agents::AgentDefinitions::new();
+        registry.insert(
+            "shell-then-forbid-shell",
+            crate::agents::AgentDefinition::from_json_str(
+                r#"{
+                    "name": "shell-then-forbid-shell",
+                    "version": 1,
+                    "tools": ["shell"],
+                    "disallowed_tools": ["shell"]
+                }"#,
+            )
+            .expect("parse"),
+        );
+
+        // Manifest-only path: def.tools=[shell] filled in, then pruned to empty.
+        let mut input = parse_spawn_input(serde_json::json!({
+            "task": "do it",
+            "agent_definition_id": "shell-then-forbid-shell"
+        }));
+        let flagged = apply_agent_definition(&mut input, &registry).expect("apply");
+        assert!(flagged, "prune-to-empty must be flagged");
+        assert!(
+            input.allowed_tools.is_empty(),
+            "precondition: allow-list empty"
+        );
+
+        // With no role template to refill the list, the guard must reject.
+        let err = reject_disallow_inverted_allow_list(&input, flagged).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("grant the subagent ALL tools"),
+            "error must explain the allow-all inversion; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn inline_only_all_requested_tools_disallowed_is_rejected() {
+        // The same inversion via the INLINE path: the caller requests only
+        // tools the manifest forbids, pruning the allow-list to empty.
+        let mut registry = crate::agents::AgentDefinitions::new();
+        registry.insert(
+            "forbids-shell",
+            crate::agents::AgentDefinition::from_json_str(
+                r#"{
+                    "name": "forbids-shell",
+                    "version": 1,
+                    "tools": ["read_file"],
+                    "disallowed_tools": ["shell"]
+                }"#,
+            )
+            .expect("parse"),
+        );
+
+        let mut input = parse_spawn_input(serde_json::json!({
+            "task": "do it",
+            "agent_definition_id": "forbids-shell",
+            "allowed_tools": ["shell"]
+        }));
+        let flagged = apply_agent_definition(&mut input, &registry).expect("apply");
+        assert!(flagged);
+        assert!(reject_disallow_inverted_allow_list(&input, flagged).is_err());
+    }
+
+    #[test]
+    fn reject_disallow_inverted_allow_list_permits_non_empty_and_unflagged() {
+        // The guard fires ONLY on the flagged prune-to-empty case: a non-empty
+        // allow-list (e.g. a role template refilled it) or an unflagged input
+        // (empty by "inherit default" semantics, not by pruning) both pass.
+        let mut refilled = parse_spawn_input(serde_json::json!({
+            "task": "x",
+            "agent_definition_id": "some-def",
+            "allowed_tools": ["read_file"]
+        }));
+        assert!(reject_disallow_inverted_allow_list(&refilled, true).is_ok());
+
+        refilled.allowed_tools.clear();
+        // Empty but NOT flagged as a prune-to-empty → legitimate "inherit"
+        // path, not the inversion — must pass.
+        assert!(reject_disallow_inverted_allow_list(&refilled, false).is_ok());
     }
 
     #[test]

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -1474,16 +1474,21 @@ fn effective_allowed_tools(allowed_tools: &[String], disallowed_tools: &[String]
     }
     // Deny entries carry the same wildcard (`podcast_*`) and group
     // (`group:runtime`) semantics ToolPolicy enforces locally — prune with a
-    // deny-only policy (empty allow = allow everything not denied) instead of
-    // exact matching, so the effective set agrees with what the local policy
-    // would actually deny.
+    // deny-only policy (empty allow = allow everything not denied) so the
+    // effective set agrees with what the local policy would actually deny.
     let deny_only = ToolPolicy {
         deny: disallowed_tools.to_vec(),
         ..Default::default()
     };
     allowed_tools
         .iter()
-        .filter(|tool| deny_only.is_allowed(tool))
+        // Exact-contains AND policy matching: the allow-list may itself carry
+        // a group/wildcard entry, and `entry_matches` expands a denied group
+        // only against CONCRETE member names (the group string is not a member
+        // of itself) — so `group:runtime` denied verbatim would survive pure
+        // policy filtering. Contains catches identical entries; the policy
+        // catches concrete tools covered by a group/wildcard deny.
+        .filter(|tool| !disallowed_tools.contains(tool) && deny_only.is_allowed(tool))
         .cloned()
         .collect()
 }
@@ -5362,6 +5367,31 @@ PY
             ),
             vec!["grep".to_string()],
             "a wildcard deny entry must prune matching tools"
+        );
+    }
+
+    #[test]
+    fn effective_allowed_tools_prunes_a_group_entry_denied_verbatim() {
+        // Codex P1 (fold 3): the allow-list may itself carry a group entry
+        // (`tools: ["group:runtime"]`). `entry_matches` expands a denied group
+        // only against CONCRETE member names — the group string is not a
+        // member of itself — so pure policy filtering lets the denied group
+        // survive into the agent_mcp payload / preflight. The exact-contains
+        // check must prune identical entries too (as the pre-policy-semantics
+        // code did).
+        assert_eq!(
+            effective_allowed_tools(
+                &["group:runtime".to_string(), "read_file".to_string()],
+                &["group:runtime".to_string()],
+            ),
+            vec!["read_file".to_string()],
+            "a group entry denied verbatim must not survive the prune"
+        );
+        // Same belt-and-braces for a verbatim wildcard entry.
+        assert_eq!(
+            effective_allowed_tools(&["podcast_*".to_string()], &["podcast_*".to_string()]),
+            Vec::<String>::new(),
+            "a wildcard entry denied verbatim must not survive the prune"
         );
     }
 

--- a/crates/octos-agent/src/tools/ssrf.rs
+++ b/crates/octos-agent/src/tools/ssrf.rs
@@ -122,8 +122,15 @@ where
         // Per-hop client: caller config, redirects OFF, DNS pinned.
         let mut builder =
             configure(reqwest::Client::builder()).redirect(reqwest::redirect::Policy::none());
-        for addr in &check.resolved_addrs {
-            builder = builder.resolve(&host, *addr);
+        // Pin ALL validated addresses in a SINGLE override. `resolve()` called
+        // in a loop REPLACES the entry each time (reqwest keys `dns_overrides`
+        // by host), so a loop would pin only the LAST address — and if that one
+        // is unreachable (e.g. an IPv6 answer on an IPv4-only host) the fetch
+        // fails even though another validated address would have worked.
+        // `resolve_to_addrs` installs the whole list at once. (Empty for a
+        // literal-IP host — leave reqwest's own resolution in place then.)
+        if !check.resolved_addrs.is_empty() {
+            builder = builder.resolve_to_addrs(&host, &check.resolved_addrs);
         }
         let client = builder
             .build()

--- a/crates/octos-agent/src/tools/ssrf.rs
+++ b/crates/octos-agent/src/tools/ssrf.rs
@@ -72,6 +72,87 @@ pub(crate) async fn check_ssrf(url: &str) -> Option<String> {
     check_ssrf_with_addrs(url).await.err()
 }
 
+/// Maximum redirects [`ssrf_safe_send`] follows before failing.
+pub(crate) const SSRF_MAX_REDIRECTS: usize = 10;
+
+/// Send an HTTP request with SSRF protection re-applied to EVERY hop.
+///
+/// Default reqwest redirect-following resolves and connects to redirect
+/// targets WITHOUT re-running the SSRF check, so an allowed public URL that
+/// 30x-redirects to `169.254.169.254` / `10.x` / any private host is
+/// followed unchecked. This helper closes that gap: it disables reqwest's
+/// automatic redirects and follows them manually, re-validating (and
+/// DNS-pinning) each hop.
+///
+/// For each hop it: validates + DNS-resolves the current URL (fail-closed on
+/// DNS error), builds a per-hop client with `redirect(Policy::none())` and
+/// `.resolve()` pinned to the validated addresses (defeats the DNS-rebinding
+/// TOCTOU between check and connect), then sends. A 3xx response with a
+/// `Location` header re-enters the loop against the resolved target; any
+/// other status returns the response.
+///
+/// - `configure` layers caller-specific base client config (timeouts,
+///   user-agent) onto the builder; the redirect policy and DNS pins are
+///   always applied on top and cannot be overridden.
+/// - `build_request` builds the per-hop request (method, body, headers)
+///   against the pinned client and current URL. It is invoked once per hop,
+///   so a POST body is re-sent on each redirect.
+pub(crate) async fn ssrf_safe_send<F, G>(
+    initial_url: &str,
+    max_redirects: usize,
+    configure: F,
+    build_request: G,
+) -> Result<reqwest::Response, String>
+where
+    F: Fn(reqwest::ClientBuilder) -> reqwest::ClientBuilder,
+    G: Fn(&reqwest::Client, &str) -> reqwest::RequestBuilder,
+{
+    let mut current_url = initial_url.to_string();
+
+    for _ in 0..max_redirects {
+        // Validate + resolve the CURRENT hop (fail-closed on DNS error).
+        let check = check_ssrf_with_addrs(&current_url).await?;
+
+        let parsed = reqwest::Url::parse(&current_url).map_err(|_| "Invalid URL".to_string())?;
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| "URL has no host".to_string())?
+            .to_string();
+
+        // Per-hop client: caller config, redirects OFF, DNS pinned.
+        let mut builder =
+            configure(reqwest::Client::builder()).redirect(reqwest::redirect::Policy::none());
+        for addr in &check.resolved_addrs {
+            builder = builder.resolve(&host, *addr);
+        }
+        let client = builder
+            .build()
+            .map_err(|e| format!("HTTP client error: {e}"))?;
+
+        let response = build_request(&client, &current_url)
+            .send()
+            .await
+            .map_err(|e| format!("request failed: {e}"))?;
+
+        if !response.status().is_redirection() {
+            return Ok(response);
+        }
+
+        let location = response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| "Redirect with no Location header".to_string())?;
+        // Resolve relative redirects against the current URL.
+        current_url = parsed
+            .join(location)
+            .map_err(|_| format!("Invalid redirect URL: {location}"))?
+            .to_string();
+    }
+
+    Err(format!("Too many redirects (max {max_redirects})"))
+}
+
 /// Check if a hostname is private/internal (string check + IP parse).
 pub fn is_private_host(host: &str) -> bool {
     let lower = host.to_ascii_lowercase();
@@ -289,6 +370,29 @@ mod tests {
         assert!(
             result.is_some(),
             "IPv4-mapped IPv6 private should be blocked"
+        );
+    }
+
+    // --- ssrf_safe_send tests ---
+
+    #[tokio::test]
+    async fn ssrf_safe_send_blocks_private_initial_url() {
+        // Every hop is SSRF-checked, including hop 0. A private initial URL is
+        // rejected BEFORE any socket is opened — the error is the SSRF "private"
+        // message, not a connection error (which is how this distinguishes a
+        // wired-in check from a check that was accidentally dropped from the
+        // loop).
+        let result = ssrf_safe_send(
+            "http://127.0.0.1:9/",
+            SSRF_MAX_REDIRECTS,
+            |builder| builder,
+            |client, url| client.get(url),
+        )
+        .await;
+        assert!(result.is_err(), "private initial URL must be blocked");
+        assert!(
+            result.unwrap_err().contains("private"),
+            "must be blocked by the SSRF check, not a connection error"
         );
     }
 }

--- a/crates/octos-agent/tests/mcp_agent_backend.rs
+++ b/crates/octos-agent/tests/mcp_agent_backend.rs
@@ -143,6 +143,40 @@ async fn boot_fake_http_server(
     (url, join)
 }
 
+/// Boot a tiny HTTP server that answers every request with a 302 redirect to
+/// `location`. Used to prove the HTTP MCP backend refuses to follow a
+/// redirect (whose target would bypass the SSRF check).
+async fn boot_fake_redirect_server(location: &str) -> (String, tokio::task::JoinHandle<()>) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local_addr");
+    let url = format!("http://{}/", addr);
+    let location = location.to_string();
+
+    let join = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            let location = location.clone();
+            tokio::spawn(async move {
+                let mut buf = vec![0_u8; 8192];
+                let _ =
+                    tokio::time::timeout(Duration::from_millis(500), socket.read(&mut buf)).await;
+                let response = format!(
+                    "HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.shutdown().await;
+            });
+        }
+    });
+    (url, join)
+}
+
 /// Spawn a unique task/session id pair so repeated test runs do not
 /// collide in the supervisor's ledger.
 fn unique_ids() -> (String, String) {
@@ -217,6 +251,46 @@ async fn should_dispatch_to_remote_mcp_agent_and_return_contract_artifact() {
     assert_eq!(
         response.files_to_send,
         vec![PathBuf::from("/tmp/remote.md")]
+    );
+}
+
+#[tokio::test]
+async fn remote_mcp_agent_refuses_to_follow_redirect() {
+    // P1 SSRF: reqwest's default redirect policy would resolve + connect to a
+    // redirect target WITHOUT re-running the SSRF check (and the DNS pin only
+    // covers the original host). The backend disables auto-redirects and fails
+    // closed on any 3xx — proven here with a live 302 → the AWS metadata IP.
+    let (url, join) = boot_fake_redirect_server("http://169.254.169.254/latest/meta-data/").await;
+
+    let config = McpAgentBackendConfig::Remote {
+        url,
+        auth_header: None,
+        extra_headers: HashMap::new(),
+        connect_timeout_secs: Some(2),
+        read_timeout_secs: Some(2),
+        dispatch_timeout_secs: Some(5),
+    };
+    let backend = HttpMcpAgent::from_config(&config)
+        .expect("build http backend")
+        .with_loopback_allowed_for_tests();
+    let response = backend
+        .dispatch(DispatchRequest::new(
+            "run_task",
+            serde_json::json!({"task": "hi"}),
+        ))
+        .await;
+    join.abort();
+
+    assert_eq!(
+        response.outcome,
+        DispatchOutcome::SsrfBlocked,
+        "a redirect must be refused (not followed to the unvalidated target); got: {}",
+        response.output
+    );
+    assert!(
+        response.output.contains("redirect"),
+        "error should explain the refused redirect; got: {}",
+        response.output
     );
 }
 


### PR DESCRIPTION
Closes 2 more P1 findings from the 2026-07 review (#1529). Sibling to #1530 (tenant isolation).

## P1 — `disallowed_tools` empties the allow-list → allow-all (`spawn.rs`)
`apply_agent_definition` applies a manifest's `disallowed_tools` as a `retain()` over `allowed_tools`. When the disallow-list covers **every** entry (manifest `tools:["shell"]` + `disallowed_tools:["shell"]`, or a caller requesting `allowed_tools:["shell"]` against a manifest that forbids `shell`), the retain leaves `allowed_tools` empty — and `ToolPolicy` treats an empty allow-list as **"allow every tool not denied"** (`policy.rs`). So a subagent meant to be *restricted* instead received the full tool set: the exact inverse of the restriction.

**Fix:** `apply_agent_definition` reports whether `disallowed_tools` pruned a previously non-empty allow-list to empty; the call site checks this **after** `apply_role_template` (so a role template that legitimately refills the list is honored) and rejects the spawn (`reject_disallow_inverted_allow_list`) rather than falling through to allow-all.

## P1 — SSRF not re-validated on redirects (`deep_search`, `mcp_agent`, +binary)
The outbound fetchers followed HTTP redirects with reqwest's default policy, which resolves + connects to each redirect target **without** re-running the SSRF check (and any DNS pin covered only the original host). An allowed public URL that 30x-redirects to `169.254.169.254` / `10.x` was followed unchecked. Only `web_fetch` had the correct per-hop loop, and it wasn't shared — which is what let the gap persist.

**Fix:**
- `ssrf.rs`: extracted the shared `ssrf_safe_send` helper — auto-redirects off; every hop re-runs `check_ssrf_with_addrs` (fail-closed on DNS error) + DNS-pins the per-hop client (defeats the check→connect rebinding TOCTOU) + follows `Location` manually. Generic over GET/POST.
- `deep_search` (in-process): `fetch_page` routes through `ssrf_safe_send`.
- `mcp_agent` (HTTP backend): a fixed JSON-RPC endpoint, so it **fails closed** — `redirect(Policy::none())` + a 3xx → `SsrfBlocked`.
- `app-skills/deep-search` binary: ships its own SSRF copy, so it gets an equivalent local per-hop revalidating + pinning loop.
- `browser.rs`: **known residual documented** — Chrome follows HTTP/meta/JS redirects internally with no per-hop re-check; closing it needs CDP request interception (`Fetch.enable`) + real-browser validation, tracked separately, out of scope here.

## Tests (TDD, RED-verified)
- `disallowed_tools_pruning_allow_list_to_empty_is_rejected_not_allow_all`, `inline_only_all_requested_tools_disallowed_is_rejected`, `reject_disallow_inverted_allow_list_permits_non_empty_and_unflagged` (RED: forcing the flag false fails "prune-to-empty must be flagged").
- `remote_mcp_agent_refuses_to_follow_redirect` drives a live 302 → the AWS metadata IP through the loopback-test harness → `SsrfBlocked` (RED: without the fix it falls through to `RemoteError`). `ssrf_safe_send_blocks_private_initial_url` proves the per-hop gate is wired into the loop.

`cargo test -p octos-agent` spawn/ssrf/mcp_agent/deep_search suites green; clippy + fmt clean. Codex-reviewed per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)