### PR TITLE
fix: the P2 backlog from the 2026-07 tri-repo review (#1529) — 17 verified P2s

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -2278,73 +2278,55 @@ impl Agent {
                 .collect();
 
             // UPCR-2026-023: a human-wait batch (`tool_timeout == None`) awaits
-            // `join_all` DIRECTLY, with no `tokio::time::timeout` wrap, so the
-            // human-wait tool task is never detached by a fired ceiling. It is
-            // unblocked by the user answering or by a turn interrupt/abort
-            // (which drains the pending question). All other batches keep the
-            // finite ceiling. `Ok(Vec<JoinResult>)` is mapped identically in
-            // both arms.
-            let join_outcome = match tool_timeout {
-                Some(dur) => tokio::time::timeout(dur, futures::future::join_all(handles))
+            // `join_all` DIRECTLY, with no timeout wrap, so the human-wait
+            // tool task is never detached by a fired ceiling. It is unblocked
+            // by the user answering or by a turn interrupt/abort (which drains
+            // the pending question).
+            //
+            // All other batches share ONE absolute deadline, but each handle
+            // is raced against it INDIVIDUALLY (`tokio::time::timeout_at`): a
+            // call that already resolved keeps its REAL result even when a
+            // sibling overruns the ceiling — only the still-pending calls get
+            // the synthetic "timed out" message (success=false, so the
+            // spawn_only synth-ack gate in loop_runner still suppresses the
+            // fabricated "Background work started" bubble for them). The
+            // previous shape — one `timeout()` wrapped around the whole
+            // `join_all` — dropped the joined future on expiry and fabricated
+            // a timeout message for EVERY call, discarding the real output of
+            // calls (including spawn_only acks) that had already completed.
+            // `timeout_at` polls the inner handle before the timer, so a
+            // handle that completed by the time we reach it yields its result
+            // even at/past the deadline. Timed-out tasks are NOT aborted —
+            // they keep running detached for cleanup, exactly as before.
+            match tool_timeout {
+                Some(dur) => {
+                    let deadline = tokio::time::Instant::now() + dur;
+                    let elapsed_secs = dur.as_secs();
+                    let mut results: Vec<ToolCallResult> =
+                        Vec::with_capacity(response.tool_calls.len());
+                    for (handle, tc) in handles.into_iter().zip(response.tool_calls.iter()) {
+                        match tokio::time::timeout_at(deadline, handle).await {
+                            Ok(Ok(result)) => results.push(result),
+                            Ok(Err(e)) => results.push(panic_result(tc, &e.to_string())),
+                            Err(_elapsed) => {
+                                tracing::error!(
+                                    timeout_secs = elapsed_secs,
+                                    tool = %tc.name,
+                                    tool_id = %tc.id,
+                                    "tool execution timed out -- spawned task continues running for cleanup"
+                                );
+                                results.push(timed_out_result(tc, elapsed_secs));
+                            }
+                        }
+                    }
+                    results
+                }
+                None => futures::future::join_all(handles)
                     .await
-                    .map_err(|_| ()),
-                None => Ok(futures::future::join_all(handles).await),
-            };
-
-            match join_outcome {
-                Ok(results) => results
                     .into_iter()
                     .zip(response.tool_calls.iter())
                     .map(|(r, tc)| r.unwrap_or_else(|e| panic_result(tc, &e.to_string())))
                     .collect(),
-                Err(()) => {
-                    // Only reachable when `tool_timeout` was `Some` (a `None`
-                    // human-wait batch always yields `Ok`), so the seconds are
-                    // present for the diagnostic / synthetic-result message.
-                    let elapsed_secs = tool_timeout_secs.unwrap_or(0);
-                    tracing::error!(
-                        timeout_secs = elapsed_secs,
-                        tool_count = response.tool_calls.len(),
-                        tools = %tool_names.join(", "),
-                        "tool execution timed out -- spawned tasks continue running for cleanup"
-                    );
-                    let messages: Vec<Message> = response
-                        .tool_calls
-                        .iter()
-                        .map(|tc| Message {
-                            role: MessageRole::Tool,
-                            content: format!(
-                                "Tool '{}' timed out after {} seconds",
-                                tc.name, elapsed_secs
-                            ),
-                            media: vec![],
-                            tool_calls: None,
-                            tool_call_id: Some(tc.id.clone()),
-                            reasoning_content: None,
-                            client_message_id: None,
-                            thread_id: None,
-                            timestamp: chrono::Utc::now(),
-                        })
-                        .collect();
-                    // Batch-wide timeout: every tool in the batch failed.
-                    // Surface the success bit (false for all) so the
-                    // spawn_only synth-ack gate in loop_runner can suppress
-                    // the fabricated "Background work started" bubble
-                    // without depending on content-prefix matching.
-                    let success_by_id: Vec<(String, bool)> = response
-                        .tool_calls
-                        .iter()
-                        .map(|tc| (tc.id.clone(), false))
-                        .collect();
-                    return Ok((
-                        messages,
-                        vec![],
-                        vec![],
-                        TokenUsage::default(),
-                        Vec::new(),
-                        success_by_id,
-                    ));
-                }
             }
         };
 
@@ -2488,27 +2470,7 @@ impl Agent {
                         tool_id = %tool_call.id,
                         "serial tool execution timed out"
                     );
-                    (
-                        Message {
-                            role: MessageRole::Tool,
-                            content: format!(
-                                "Tool '{}' timed out after {} seconds",
-                                tool_call.name, elapsed_secs
-                            ),
-                            media: vec![],
-                            tool_calls: None,
-                            tool_call_id: Some(tool_call.id.clone()),
-                            reasoning_content: None,
-                            client_message_id: None,
-                            thread_id: None,
-                            timestamp: chrono::Utc::now(),
-                        },
-                        Vec::new(),
-                        Vec::new(),
-                        None,
-                        false,
-                        None,
-                    )
+                    timed_out_result(tool_call, elapsed_secs)
                 }
             };
 
@@ -2536,6 +2498,36 @@ fn cancelled_result(tool_call: &octos_core::ToolCall) -> ToolCallResult {
             content: format!(
                 "Tool '{}' cancelled due to earlier sibling error in the same batch. Re-issue this call on the next turn if still needed.",
                 tool_call.name
+            ),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: Some(tool_call.id.clone()),
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: None,
+            timestamp: chrono::Utc::now(),
+        },
+        Vec::new(),
+        Vec::new(),
+        None,
+        false,
+        None,
+    )
+}
+
+/// Build a synthetic tool-result message for a call that was still pending
+/// when the batch deadline fired (parallel dispatch) or whose own wrap
+/// expired (serial dispatch). `success` is `false` so the spawn_only
+/// synth-ack gate in loop_runner can suppress the fabricated "Background
+/// work started" bubble without content-prefix matching. The spawned task
+/// itself is NOT aborted — it keeps running detached for cleanup.
+fn timed_out_result(tool_call: &octos_core::ToolCall, elapsed_secs: u64) -> ToolCallResult {
+    (
+        Message {
+            role: MessageRole::Tool,
+            content: format!(
+                "Tool '{}' timed out after {} seconds",
+                tool_call.name, elapsed_secs
             ),
             media: vec![],
             tool_calls: None,
@@ -2967,5 +2959,186 @@ mod tests {
             /* interactive_default */ 120,
         );
         assert_eq!(secs, Some(1800));
+    }
+
+    // ------------------------------------------------------------------
+    // Parallel batch timeout must NOT discard already-completed results.
+    // ------------------------------------------------------------------
+
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use octos_core::{AgentId, ToolCall};
+    use octos_llm::{
+        ChatConfig, ChatResponse, LlmProvider, StopReason, TokenUsage as LlmTokenUsage, ToolSpec,
+    };
+    use octos_memory::EpisodeStore;
+
+    use crate::agent::{Agent, AgentConfig};
+    use crate::tools::{Tool, ToolRegistry, ToolResult};
+
+    /// `execute_tools` never talks to the LLM, so the provider only has to
+    /// satisfy the trait bounds (mirrors loop_runner's `InertProvider`).
+    struct NoChatProvider;
+
+    #[async_trait]
+    impl LlmProvider for NoChatProvider {
+        async fn chat(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[ToolSpec],
+            _config: &ChatConfig,
+        ) -> eyre::Result<ChatResponse> {
+            unreachable!("execute_tools must not call the provider");
+        }
+
+        fn model_id(&self) -> &str {
+            "inert"
+        }
+
+        fn provider_name(&self) -> &str {
+            "inert"
+        }
+    }
+
+    /// Completes immediately with a distinctive real output.
+    struct InstantTool;
+
+    #[async_trait]
+    impl Tool for InstantTool {
+        fn name(&self) -> &str {
+            "fast_tool"
+        }
+
+        fn description(&self) -> &str {
+            "test tool that completes immediately"
+        }
+
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+
+        async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+            Ok(ToolResult {
+                output: "FAST_TOOL_REAL_OUTPUT".to_string(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    /// Sleeps far past the batch ceiling so the batch timeout always fires
+    /// while this call is still pending.
+    struct SleepingTool;
+
+    #[async_trait]
+    impl Tool for SleepingTool {
+        fn name(&self) -> &str {
+            "slow_tool"
+        }
+
+        fn description(&self) -> &str {
+            "test tool that outlives the batch timeout"
+        }
+
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+
+        async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+            tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+            Ok(ToolResult {
+                output: "SLOW_TOOL_REAL_OUTPUT".to_string(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    fn tool_call(id: &str, name: &str) -> ToolCall {
+        ToolCall {
+            id: id.to_string(),
+            name: name.to_string(),
+            arguments: serde_json::json!({}),
+            metadata: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn should_keep_completed_call_results_when_batch_timeout_fires() {
+        // Regression: the parallel dispatch used to wrap the WHOLE `join_all`
+        // in one `tokio::time::timeout`; when the ceiling fired, every call in
+        // the batch — including ones that had already resolved — was replaced
+        // by a synthetic "timed out" message, discarding real output.
+        let dir = tempfile::tempdir().unwrap();
+        let mut tools = ToolRegistry::new();
+        tools.register(InstantTool);
+        tools.register(SleepingTool);
+        let provider: Arc<dyn LlmProvider> = Arc::new(NoChatProvider);
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let agent = Agent::new(AgentId::new("batch-timeout"), provider, tools, memory).with_config(
+            AgentConfig {
+                // Neither test tool is in LONG_RUNNING_TOOLS and no call
+                // requests `timeout_secs`, so this 1s interactive default is
+                // the whole batch's ceiling (see compute_batch_timeout_secs).
+                default_interactive_tool_timeout_secs: 1,
+                tool_timeout_secs: 1,
+                save_episodes: false,
+                ..Default::default()
+            },
+        );
+
+        let response = ChatResponse {
+            content: None,
+            reasoning_content: None,
+            tool_calls: vec![
+                tool_call("call_fast", "fast_tool"),
+                tool_call("call_slow", "slow_tool"),
+            ],
+            stop_reason: StopReason::ToolUse,
+            usage: LlmTokenUsage::default(),
+            provider_index: None,
+        };
+
+        let (messages, _files_modified, _files_to_send, _tokens, _structured, success_by_id) =
+            agent
+                .execute_tools(&response)
+                .await
+                .expect("execute_tools must not error on a batch timeout");
+
+        // 1:1 mapping in LLM call order is preserved.
+        assert_eq!(messages.len(), 2, "one result message per tool call");
+        assert_eq!(messages[0].tool_call_id.as_deref(), Some("call_fast"));
+        assert_eq!(messages[1].tool_call_id.as_deref(), Some("call_slow"));
+
+        // The fast call COMPLETED before the ceiling fired: its REAL output
+        // must survive, not be overwritten by a fabricated timeout message.
+        assert!(
+            messages[0].content.contains("FAST_TOOL_REAL_OUTPUT"),
+            "completed call's real output was discarded: {:?}",
+            messages[0].content
+        );
+        assert!(
+            !messages[0].content.contains("timed out"),
+            "completed call must not carry a synthetic timeout message: {:?}",
+            messages[0].content
+        );
+
+        // The still-pending slow call gets the synthetic timeout message in
+        // the existing (pinned) format.
+        assert_eq!(
+            messages[1].content,
+            "Tool 'slow_tool' timed out after 1 seconds"
+        );
+
+        // Per-call success bits follow the same split.
+        assert!(
+            success_by_id.contains(&("call_fast".to_string(), true)),
+            "completed call must keep success=true: {success_by_id:?}"
+        );
+        assert!(
+            success_by_id.contains(&("call_slow".to_string(), false)),
+            "timed-out call must report success=false: {success_by_id:?}"
+        );
     }
 }

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -182,6 +182,18 @@ fn compute_batch_timeout_secs(
 /// Returns `None` when `files` is empty — the caller MUST suppress the
 /// follow-up notification in that case so we never persist an empty
 /// "produced files:" stub. Token-budget invariant (M10 Phase 4): paths
+/// Whether a Satisfied spawn_only contract's delivery counts as a FAILURE.
+///
+/// `delivery` encodes the background-notification outcome:
+/// - `None` — no background sender is wired (chat mode). The contract is
+///   Satisfied and there is simply nowhere to deliver the notification; this
+///   is NOT a failure. (The bug this fixes recorded it as Failed.)
+/// - `Some(true)` — a sender ran and persisted the result. Success.
+/// - `Some(false)` — a sender ran and genuinely failed to persist. Failure.
+fn satisfied_delivery_is_failure(delivery: Option<bool>) -> bool {
+    delivery == Some(false)
+}
+
 /// only, never file contents.
 ///
 /// `workspace_root`, when supplied, is used to convert absolute paths
@@ -1165,30 +1177,44 @@ impl Agent {
                                     } else {
                                         r.output.clone()
                                     };
-                                    let result_persisted = if let Some(ref sender) = bg_sender {
-                                        sender(BackgroundResultPayload {
-                                            task_label: bg_name.clone(),
-                                            content: bubble_content,
-                                            kind: BackgroundResultKind::Notification,
-                                            media: output_files.clone(),
-                                            envelope_media: vec![],
-                                            originating_thread_id: bg_originating_thread_id.clone(),
-                                            task_id: Some(task_id.clone()),
-                                            originating_client_message_id:
-                                                bg_originating_client_message_id.clone(),
-                                            tool_call_id: Some(bg_tc_id.clone()),
-                                            // C1 step 3: contract-Satisfied success path
-                                            // (mark_completed below).
-                                            terminal_status: Some(
-                                                crate::task_supervisor::TaskStatus::Completed,
-                                            ),
-                                        })
-                                        .await
+                                    // `None` = no background channel is wired
+                                    // (chat mode): the contract is Satisfied and
+                                    // there is simply nowhere to deliver the
+                                    // notification — that is NOT a failure.
+                                    // `Some(false)` = a sender ran and genuinely
+                                    // failed to persist. Keeping these apart
+                                    // stops a Satisfied chat-mode contract from
+                                    // being recorded as Failed.
+                                    let delivery = if let Some(ref sender) = bg_sender {
+                                        Some(
+                                            sender(BackgroundResultPayload {
+                                                task_label: bg_name.clone(),
+                                                content: bubble_content,
+                                                kind: BackgroundResultKind::Notification,
+                                                media: output_files.clone(),
+                                                envelope_media: vec![],
+                                                originating_thread_id: bg_originating_thread_id
+                                                    .clone(),
+                                                task_id: Some(task_id.clone()),
+                                                originating_client_message_id:
+                                                    bg_originating_client_message_id.clone(),
+                                                tool_call_id: Some(bg_tc_id.clone()),
+                                                // C1 step 3: contract-Satisfied success path
+                                                // (mark_completed below).
+                                                terminal_status: Some(
+                                                    crate::task_supervisor::TaskStatus::Completed,
+                                                ),
+                                            })
+                                            .await,
+                                        )
                                     } else {
-                                        false
+                                        None
                                     };
 
-                                    if result_persisted {
+                                    // A Satisfied contract is a success unless a
+                                    // wired sender actually failed to persist.
+                                    let delivery_failed = satisfied_delivery_is_failure(delivery);
+                                    if !delivery_failed {
                                         // Workspace contract already verified
                                         // the declared artifacts. Trust it —
                                         // the supervisor's job is to record
@@ -2571,8 +2597,29 @@ fn panic_result(tool_call: &octos_core::ToolCall, reason: &str) -> ToolCallResul
 mod tests {
     use super::{
         build_spawn_only_produced_files_message, relativize_workspace_path,
-        satisfied_completion_content, should_auto_send_tool_files,
+        satisfied_completion_content, satisfied_delivery_is_failure, should_auto_send_tool_files,
     };
+
+    #[test]
+    fn satisfied_contract_in_chat_mode_is_not_a_failure() {
+        // P2 (tri-repo #1529): a Satisfied spawn_only contract in chat mode
+        // (no background sender: delivery == None) was recorded as Failed
+        // because "no channel to notify" was conflated with "sender failed to
+        // persist". None and Some(true) are BOTH success; only Some(false) —
+        // a wired sender that actually failed — is a failure.
+        assert!(
+            !satisfied_delivery_is_failure(None),
+            "chat mode (no background sender) must not be a failure"
+        );
+        assert!(
+            !satisfied_delivery_is_failure(Some(true)),
+            "a delivered result is a success"
+        );
+        assert!(
+            satisfied_delivery_is_failure(Some(false)),
+            "a wired sender that failed to persist is a real failure"
+        );
+    }
 
     #[test]
     fn explicit_send_file_turn_suppresses_plugin_auto_send_for_other_tools() {

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -2698,9 +2698,22 @@ fn recover_shell_retry(
         .filter(|content| !is_successful_shell_output(content))
         .count();
 
-    shell_results
-        .iter()
-        .find(|content| is_diff_like_shell_output(content))
+    // Every recovery arm below is gated on `failed_shells` because this is a
+    // shell-SPIRAL detector: it only intervenes when the model is stuck
+    // retrying failing shell calls, not when it is deliberately running a
+    // streak of successful commands. DiffLikeSuccess must be gated too —
+    // otherwise a legitimate turn that runs `git diff`/`git show` >= threshold
+    // times (all exit 0) is short-circuited, surfacing the raw diff as the
+    // assistant answer and terminating the turn before the model can reply. A
+    // genuine stuck-on-identical-success loop is caught by the separate
+    // loop-detector, not here. `>= 1` mirrors the UsefulSuccess sibling.
+    (failed_shells >= 1)
+        .then(|| {
+            shell_results
+                .iter()
+                .find(|content| is_diff_like_shell_output(content))
+        })
+        .flatten()
         .map(|content| ShellRetryRecovery {
             kind: ShellRetryRecoveryKind::DiffLikeSuccess,
             content: strip_success_exit_suffix(content),
@@ -4489,6 +4502,54 @@ printf '{"output":"voice saved","success":true}\n'
         assert_eq!(recovered.kind, ShellRetryRecoveryKind::DiffLikeSuccess);
         assert!(recovered.content.contains("diff --git"));
         assert!(!recovered.content.contains("Exit code: 0"));
+    }
+
+    #[test]
+    fn recover_shell_retry_does_not_fire_diff_like_on_all_success_turn() {
+        // P2 (tri-repo #1529): DiffLikeSuccess used to fire whenever ANY recent
+        // shell result was diff-like, regardless of failures. A legitimate turn
+        // that runs `git diff` >= threshold times (all exit 0) is NOT a spiral
+        // and must NOT be short-circuited into surfacing the raw diff as the
+        // assistant answer. Build a 4-shell all-success diff streak and assert
+        // recovery does not fire.
+        let diff =
+            "diff --git a/x.rs b/x.rs\n--- a/x.rs\n+++ b/x.rs\n@@ -1 +1 @@\n-a\n+b\n\nExit code: 0";
+        let mut messages = vec![Message::user("show me every diff")];
+        for i in 0..4 {
+            let id = format!("call_diff_{i}");
+            messages.push(Message {
+                role: MessageRole::Assistant,
+                content: String::new(),
+                media: vec![],
+                tool_calls: Some(vec![ToolCall {
+                    id: id.clone(),
+                    name: "shell".into(),
+                    arguments: serde_json::json!({"command": "git diff"}),
+                    metadata: None,
+                }]),
+                tool_call_id: None,
+                reasoning_content: None,
+                client_message_id: None,
+                thread_id: None,
+                timestamp: chrono::Utc::now(),
+            });
+            messages.push(Message {
+                role: MessageRole::Tool,
+                content: diff.into(),
+                media: vec![],
+                tool_calls: None,
+                tool_call_id: Some(id),
+                reasoning_content: None,
+                client_message_id: None,
+                thread_id: None,
+                timestamp: chrono::Utc::now(),
+            });
+        }
+
+        assert!(
+            recover_shell_retry(&messages, 4).is_none(),
+            "an all-success diff streak must not trigger shell-spiral recovery"
+        );
     }
 
     #[test]

--- a/crates/octos-agent/src/tools/coding_tools.rs
+++ b/crates/octos-agent/src/tools/coding_tools.rs
@@ -652,6 +652,14 @@ impl ExecCommandTool {
             .clamp(1, MAX_EXEC_TIMEOUT_SECS);
         let mut cmd = self.sandbox.wrap_command(&command, &cwd);
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        // Put the child in its own process group so the timeout path can
+        // signal the WHOLE tree (wrapper shell + grandchildren) with a
+        // negative-PID kill — mirrors the `bash` tool path. Without this the
+        // negative-PID kill targets a group the child was never placed in, so
+        // a backgrounded `sleep` survives the timeout and can mutate the
+        // workspace after the tool has reported failure.
+        #[cfg(unix)]
+        cmd.process_group(0);
         sanitize_command_env(&mut cmd, &EnvAllowlist::empty());
         let child = match cmd.spawn() {
             Ok(child) => child,
@@ -663,6 +671,10 @@ impl ExecCommandTool {
                 });
             }
         };
+        // Capture the pid BEFORE `wait_with_output` consumes the child — the
+        // timeout arm needs it to kill the process tree (dropping the wait
+        // future does NOT kill a tokio child).
+        let child_pid = child.id();
         let result = timeout(Duration::from_secs(timeout_secs), child.wait_with_output()).await;
         match result {
             Ok(Ok(output)) => {
@@ -693,11 +705,19 @@ impl ExecCommandTool {
                 success: false,
                 ..Default::default()
             }),
-            Err(_) => Ok(ToolResult {
-                output: format!("Command timed out after {timeout_secs} seconds"),
-                success: false,
-                ..Default::default()
-            }),
+            Err(_) => {
+                // Dropping the wait future does NOT kill a tokio child, so
+                // the wrapper shell and any grandchildren keep running. Kill
+                // the whole process group/tree (SIGTERM → 500ms grace →
+                // SIGKILL on Unix, `taskkill /F /T` on Windows) — the same
+                // helper the `bash` tool uses.
+                kill_timed_out_child(child_pid).await;
+                Ok(ToolResult {
+                    output: format!("Command timed out after {timeout_secs} seconds"),
+                    success: false,
+                    ..Default::default()
+                })
+            }
         }
     }
 
@@ -5725,6 +5745,72 @@ mod tests {
         assert!(
             !sentinel.exists(),
             "child process must be killed on timeout — sentinel file at {} should NOT exist",
+            sentinel.display(),
+        );
+    }
+
+    /// P2 (tri-repo #1529): `exec_command`'s timeout path dropped the wait
+    /// future without killing the child, so the wrapper shell and any
+    /// grandchildren survived. Mirror of `bash_kills_grandchildren_...`: a
+    /// backgrounded grandchild touches a sentinel after a sleep longer than
+    /// the timeout; the process-group kill must stop it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn exec_command_kills_grandchildren_via_process_group_on_timeout() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let sentinel = temp.path().join("exec-grandchild-late.txt");
+        let sentinel_path = sentinel.to_string_lossy().into_owned();
+        let cmd = format!("(sleep 3; touch {sentinel_path}) & wait");
+        let registry = ToolRegistry::with_builtins(temp.path());
+        let started = std::time::Instant::now();
+        let result = registry
+            .execute("exec_command", &json!({ "cmd": cmd, "timeout_secs": 1 }))
+            .await
+            .expect("exec_command runs");
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(3),
+            "exec_command must return within the timeout window (got {:?})",
+            started.elapsed()
+        );
+        assert!(!result.success, "{}", result.output);
+        tokio::time::sleep(std::time::Duration::from_millis(4_000)).await;
+        assert!(
+            !sentinel.exists(),
+            "grandchild must be killed via the exec_command process group on \
+             timeout — sentinel at {} should NOT exist",
+            sentinel.display(),
+        );
+    }
+
+    /// P2 (tri-repo #1529): the direct-child variant of the above.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn exec_command_kills_child_process_on_timeout() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let sentinel = temp.path().join("exec-late-write.txt");
+        let sentinel_path = sentinel.to_string_lossy().into_owned();
+        let cmd = format!("sleep 3; touch {sentinel_path}");
+        let registry = ToolRegistry::with_builtins(temp.path());
+        let started = std::time::Instant::now();
+        let result = registry
+            .execute("exec_command", &json!({ "cmd": cmd, "timeout_secs": 1 }))
+            .await
+            .expect("exec_command runs");
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(3),
+            "exec_command must return within the timeout window (got {:?})",
+            started.elapsed()
+        );
+        assert!(!result.success, "{}", result.output);
+        assert!(
+            result.output.contains("timed out"),
+            "exec_command must report timeout; got: {}",
+            result.output,
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(4_000)).await;
+        assert!(
+            !sentinel.exists(),
+            "child must be killed on timeout — sentinel at {} should NOT exist",
             sentinel.display(),
         );
     }

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -1213,7 +1213,7 @@ pub fn is_symlink_error(e: &std::io::Error) -> bool {
 pub async fn read_no_follow(path: &Path) -> std::io::Result<String> {
     let path = path.to_owned();
     tokio::task::spawn_blocking(move || {
-        use std::io::Read;
+        use std::io::{Read, Seek, SeekFrom};
         let mut opts = std::fs::OpenOptions::new();
         opts.read(true);
         #[cfg(unix)]
@@ -1232,40 +1232,36 @@ pub async fn read_no_follow(path: &Path) -> std::io::Result<String> {
         }
         let mut file = opts.open(&path)?;
 
-        // Peek the first 5 bytes to detect a PDF (`%PDF-`). The symlink-safe
-        // open above is already done; the bytes we read here can't have
-        // followed a symlink. PDF content is binary so `read_to_string`
-        // would fail with a UTF-8 error — for those we route through
-        // `pdf-extract` to recover plain text. Pinned by the mini5 invoice
-        // upload regression (2026-05-12): the LLM couldn't summarize a PDF
-        // because read_to_string aborted immediately.
+        // Peek the first 5 bytes to detect a PDF (`%PDF-`). PDF content is
+        // binary so `read_to_string` would fail with a UTF-8 error — for
+        // those we route through `pdf-extract` to recover plain text. Pinned
+        // by the mini5 invoice upload regression (2026-05-12).
+        //
+        // Both branches read the REST from the SAME O_NOFOLLOW file
+        // descriptor (seek back to 0), never by re-opening the path. The
+        // previous PDF branch did `std::fs::read(&path)`, which follows
+        // symlinks and does no symlink re-check — a leaf swapped between the
+        // O_NOFOLLOW open (time-of-check) and that read (time-of-use) was
+        // followed, so an attacker could redirect the read to `/etc/passwd`
+        // or any file and feed its contents to the LLM. Reading from the
+        // held fd binds every byte to the inode we already validated.
         let mut magic = [0u8; 5];
-        match file.read(&mut magic) {
-            Ok(n) if n >= 5 && &magic == b"%PDF-" => {
-                // PDF detected — close the partial read, load whole bytes,
-                // hand to pdf-extract. Errors from extraction get wrapped
-                // as io::Error so callers see a single error type.
-                drop(file);
-                let bytes = std::fs::read(&path)?;
-                match pdf_extract::extract_text_from_mem(&bytes) {
-                    Ok(text) => Ok(text),
-                    Err(err) => Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("pdf extraction failed: {err}"),
-                    )),
-                }
+        let n = file.read(&mut magic)?;
+        file.seek(SeekFrom::Start(0))?;
+        if n >= 5 && &magic == b"%PDF-" {
+            let mut bytes = Vec::new();
+            file.read_to_end(&mut bytes)?;
+            match pdf_extract::extract_text_from_mem(&bytes) {
+                Ok(text) => Ok(text),
+                Err(err) => Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("pdf extraction failed: {err}"),
+                )),
             }
-            Ok(n) => {
-                // Not a PDF. Re-open at the start and read as UTF-8 text.
-                // (Seeking back works on regular files but we re-open for
-                // simplicity — the path is already known-safe.)
-                drop(file);
-                let mut file = opts.open(&path)?;
-                let mut content = String::with_capacity(n);
-                file.read_to_string(&mut content)?;
-                Ok(content)
-            }
-            Err(err) => Err(err),
+        } else {
+            let mut content = String::with_capacity(n);
+            file.read_to_string(&mut content)?;
+            Ok(content)
         }
     })
     .await
@@ -1389,6 +1385,45 @@ mod nofollow_tests {
 
         let err = read_no_follow(&link).await.unwrap_err();
         assert!(is_symlink_error(&err), "expected ELOOP, got: {err}");
+    }
+
+    #[tokio::test]
+    async fn test_read_no_follow_reads_full_content_from_held_fd() {
+        // P2 (tri-repo #1529): both branches now read the rest of the file
+        // from the ALREADY-OPEN O_NOFOLLOW fd (seek back to 0) instead of
+        // re-opening the path. This guards the seek: after the 5-byte magic
+        // peek, the full content — INCLUDING the first 5 bytes — must be
+        // returned. A missing `seek(0)` would drop the leading 5 bytes.
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("plain.txt");
+        let content = "HELLO, this plaintext must round-trip in full.";
+        std::fs::write(&file, content).unwrap();
+
+        let read = read_no_follow(&file).await.unwrap();
+        assert_eq!(read, content, "full content must be read from the held fd");
+    }
+
+    #[tokio::test]
+    async fn test_read_no_follow_pdf_reads_whole_file_from_fd_not_path() {
+        // The PDF branch previously did `std::fs::read(&path)` — a re-open by
+        // path that follows a symlink swapped in after the O_NOFOLLOW open
+        // (TOCTOU). It now reads the whole file (magic + body) from the held
+        // fd. A PDF whose body extends well past the 5-byte magic must reach
+        // the extractor in full: pdf-extract fails on this junk body with
+        // InvalidData (proving the whole buffer, not a 5-byte truncation, was
+        // handed over — an empty/short buffer would surface differently).
+        let dir = tempfile::TempDir::new().unwrap();
+        let pdf = dir.path().join("doc.pdf");
+        let mut bytes = b"%PDF-1.7\n".to_vec();
+        bytes.extend(std::iter::repeat_n(b'X', 4096));
+        std::fs::write(&pdf, &bytes).unwrap();
+
+        let err = read_no_follow(&pdf).await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("pdf extraction failed"),
+            "got: {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/ssrf.rs
+++ b/crates/octos-agent/src/tools/ssrf.rs
@@ -173,13 +173,32 @@ pub fn is_private_host(host: &str) -> bool {
 }
 
 /// Check if an IP address is in a private/internal range.
+/// SSRF-relevant IPv4 ranges that are NOT routable public internet but which
+/// `Ipv4Addr::is_private()`/`is_link_local()` do not cover. The std predicates
+/// for these (`is_shared`, `is_benchmarking`, `is_reserved`, …) are all
+/// nightly-only, so match the octets explicitly.
+fn is_special_purpose_v4(v4: &std::net::Ipv4Addr) -> bool {
+    let [a, b, ..] = v4.octets();
+    // Shared address space / CGNAT 100.64.0.0/10 (RFC 6598) — routes to ISP
+    // carrier-grade NAT infrastructure.
+    (a == 100 && (64..=127).contains(&b))
+        // IETF protocol assignments 192.0.0.0/24 (RFC 6890).
+        || v4.octets()[..3] == [192, 0, 0]
+        // Benchmarking 198.18.0.0/15 (RFC 2544).
+        || (a == 198 && (b == 18 || b == 19))
+        // Multicast 224.0.0.0/4 and reserved/future 240.0.0.0/4 (RFC 1112),
+        // plus the limited-broadcast 255.255.255.255 that 240/4 subsumes.
+        || a >= 224
+}
+
 pub fn is_private_ip(ip: &IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => {
-            v4.is_loopback()           // 127.0.0.0/8
-                || v4.is_private()     // 10/8, 172.16/12, 192.168/16
-                || v4.is_link_local()  // 169.254/16 (AWS metadata)
-                || v4.is_unspecified() // 0.0.0.0
+            v4.is_loopback()                 // 127.0.0.0/8
+                || v4.is_private()           // 10/8, 172.16/12, 192.168/16
+                || v4.is_link_local()        // 169.254/16 (AWS metadata)
+                || v4.is_unspecified()       // 0.0.0.0
+                || is_special_purpose_v4(v4) // CGNAT/benchmark/reserved/multicast
         }
         IpAddr::V6(v6) => {
             v6.is_loopback()           // ::1
@@ -192,13 +211,9 @@ pub fn is_private_ip(ip: &IpAddr) -> bool {
                 // Site-local fec0::/10 (deprecated RFC 3879, still routable)
                 || (v6.segments()[0] & 0xffc0) == 0xfec0
                 // IPv4-mapped ::ffff:x.x.x.x
-                || v6.to_ipv4_mapped().is_some_and(|v4| {
-                    v4.is_loopback() || v4.is_private() || v4.is_link_local() || v4.is_unspecified()
-                })
+                || v6.to_ipv4_mapped().is_some_and(|v4| is_private_ip(&IpAddr::V4(v4)))
                 // IPv4-compatible ::x.x.x.x (deprecated RFC 4291)
-                || v6.to_ipv4().is_some_and(|v4| {
-                    v4.is_loopback() || v4.is_private() || v4.is_link_local() || v4.is_unspecified()
-                })
+                || v6.to_ipv4().is_some_and(|v4| is_private_ip(&IpAddr::V4(v4)))
         }
     }
 }
@@ -303,6 +318,35 @@ mod tests {
         assert!(!is_private_host("1.1.1.1"));
         assert!(!is_private_host("example.com"));
         assert!(!is_private_host("2001:4860:4860::8888"));
+    }
+
+    #[test]
+    fn test_private_host_special_purpose_ranges() {
+        // CGNAT / shared address space (RFC 6598) — the carrier-grade-NAT
+        // range that routes to ISP infrastructure, previously un-blocked.
+        assert!(is_private_host("100.64.0.1"), "CGNAT low edge");
+        assert!(is_private_host("100.100.100.100"), "CGNAT middle");
+        assert!(is_private_host("100.127.255.255"), "CGNAT high edge");
+        // Just OUTSIDE the /10 must stay public (100.64/10 boundaries).
+        assert!(!is_private_host("100.63.255.255"), "below CGNAT is public");
+        assert!(!is_private_host("100.128.0.0"), "above CGNAT is public");
+        // IETF protocol assignments (RFC 6890) 192.0.0.0/24.
+        assert!(is_private_host("192.0.0.1"));
+        assert!(!is_private_host("192.0.1.1"), "192.0.1/24 is public");
+        // Benchmarking (RFC 2544) 198.18.0.0/15.
+        assert!(is_private_host("198.18.0.1"));
+        assert!(is_private_host("198.19.255.255"));
+        assert!(
+            !is_private_host("198.20.0.0"),
+            "above benchmarking is public"
+        );
+        // Reserved / future use (RFC 1112) 240.0.0.0/4 + limited broadcast.
+        assert!(is_private_host("240.0.0.1"));
+        assert!(is_private_host("255.255.255.255"));
+        // IPv4 multicast 224.0.0.0/4 as a literal host.
+        assert!(is_private_host("224.0.0.1"));
+        // Mapped/compat forms of CGNAT must be blocked too (defense in depth).
+        assert!(is_private_host("::ffff:100.64.0.1"), "mapped CGNAT");
     }
 
     #[test]

--- a/crates/octos-bus/src/cron_service.rs
+++ b/crates/octos-bus/src/cron_service.rs
@@ -379,40 +379,52 @@ impl CronService {
 
         let now_ms = Utc::now().timestamp_millis();
 
-        // Collect due jobs
+        // Reserve-then-fire: collect due jobs AND advance their schedule
+        // state in ONE synchronous critical section, BEFORE any await.
+        //
+        // The old fire-then-advance ordering double-fired: while
+        // `execute_job` was awaiting the bus send, the store still held
+        // the firing job's past-due `next_run_at_ms`. Any concurrent
+        // `arm_timer` (add_job / remove_job / enable_job) read that stale
+        // value, computed a zero delay, aborted this task mid-fire (so
+        // the advance below never ran), and spawned a zero-delay sleeper
+        // that re-collected the SAME still-due job and fired it again.
+        //
+        // Advancing under the same lock that collects means no other
+        // task can ever observe a job as due once it has been reserved
+        // for this tick: a concurrent arm_timer sees the post-advance
+        // (future) next_run and arms a future-dated timer. Even if this
+        // task is aborted before or during the sends, the job is not
+        // re-fired and its next occurrence stays scheduled — cron
+        // semantics reserve the NEXT slot regardless of this fire's
+        // outcome.
         let due_jobs: Vec<CronJob> = {
-            let store = self.store.lock().unwrap_or_else(|e| e.into_inner());
-            store
-                .jobs
-                .iter()
-                .filter(|j| j.is_due(now_ms))
-                .cloned()
-                .collect()
-        };
-
-        for job in &due_jobs {
-            self.execute_job(job).await;
-        }
-
-        // Update state
-        {
             let mut store = self.store.lock().unwrap_or_else(|e| e.into_inner());
+            let mut due = Vec::new();
             let mut to_delete = Vec::new();
 
             for stored_job in &mut store.jobs {
-                if due_jobs.iter().any(|d| d.id == stored_job.id) {
-                    stored_job.state.last_run_at_ms = Some(now_ms);
-                    stored_job.state.last_status = Some("ok".into());
+                if !stored_job.is_due(now_ms) {
+                    continue;
+                }
+                due.push(stored_job.clone());
 
-                    if stored_job.delete_after_run {
-                        to_delete.push(stored_job.id.clone());
-                    } else {
-                        stored_job.compute_next_run(now_ms);
-                    }
+                stored_job.state.last_run_at_ms = Some(now_ms);
+                stored_job.state.last_status = Some("ok".into());
+
+                if stored_job.delete_after_run {
+                    to_delete.push(stored_job.id.clone());
+                } else {
+                    stored_job.compute_next_run(now_ms);
                 }
             }
 
             store.jobs.retain(|j| !to_delete.contains(&j.id));
+            due
+        };
+
+        for job in &due_jobs {
+            self.execute_job(job).await;
         }
 
         if let Err(e) = self.save_store_async().await {
@@ -831,6 +843,155 @@ mod tests {
             )
             .unwrap();
         assert!(!every_job.delete_after_run);
+    }
+
+    /// Poll `cond` until true or panic after 5s. Condition-polling (not a
+    /// blind sleep): under-waiting is impossible, over-waiting is bounded.
+    async fn wait_until(what: &str, mut cond: impl FnMut() -> bool) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !cond() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for: {what}"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+    }
+
+    /// Regression: re-arming the timer while a job is mid-fire must not
+    /// fire that job a second time.
+    ///
+    /// Forcing the window deterministically: the bus channel has capacity
+    /// 1 and two jobs are due. `on_timer` collects both, `send(J1)`
+    /// succeeds (fire #1, fills the channel), `send(J2)` parks — holding
+    /// `on_timer` open BEFORE it advances `next_run_at_ms` (the buggy
+    /// fire-then-advance ordering). J1's stored `next_run_at_ms` is still
+    /// past-due, pinned for as long as the test leaves the channel full.
+    /// A concurrent `add_job` then runs `arm_timer`, which reads that
+    /// stale past-due value, computes delay 0, aborts the parked timer
+    /// task (killing it before the advance ever happens), and spawns a
+    /// zero-delay sleeper that re-collects the still-due J1 and fires it
+    /// AGAIN. The test only starts draining after the original timer
+    /// task is provably dead (`AbortHandle::is_finished`), so the
+    /// interleaving is fixed, not timing-dependent.
+    #[tokio::test]
+    async fn should_fire_due_job_exactly_once_when_rearm_races_mid_fire() {
+        let dir = tempfile::tempdir().unwrap();
+        // Capacity 1: first send succeeds, second send blocks.
+        let (tx, mut rx) = mpsc::channel::<InboundMessage>(1);
+        let service =
+            std::sync::Arc::new(CronService::new(dir.path().join("cron.json"), tx.clone()));
+
+        let payload = |msg: &str| CronPayload {
+            message: msg.into(),
+            deliver: false,
+            channel: None,
+            chat_id: None,
+        };
+
+        // Added while stopped, so arm_timer no-ops until start().
+        let j1 = service
+            .add_job(
+                "first".into(),
+                CronSchedule::Every { every_ms: 60_000 },
+                payload("a"),
+            )
+            .unwrap();
+        let j2 = service
+            .add_job(
+                "second".into(),
+                CronSchedule::Every { every_ms: 60_000 },
+                payload("b"),
+            )
+            .unwrap();
+
+        // Backdate both jobs (as if their interval elapsed) so they are
+        // due the moment the service starts.
+        let past_ms = Utc::now().timestamp_millis() - 60_000;
+        {
+            let mut store = service.store.lock().unwrap();
+            for job in store.jobs.iter_mut() {
+                job.state.next_run_at_ms = Some(past_ms);
+            }
+        }
+
+        service.start();
+
+        // J1's fire is in the channel (capacity 1 -> 0) and the timer
+        // task is parked on J2's send, mid-fire.
+        wait_until("first fire enqueued and timer parked mid-fire", || {
+            tx.capacity() == 0
+        })
+        .await;
+
+        // Capture the parked timer task so its death is observable.
+        let timer_abort = {
+            let guard = service.timer_handle.lock().await;
+            guard
+                .as_ref()
+                .expect("timer task must be armed while mid-fire")
+                .abort_handle()
+        };
+
+        // Concurrent schedule mutation mid-fire: add_job -> arm_timer.
+        service
+            .add_job(
+                "third".into(),
+                CronSchedule::Every { every_ms: 600_000 },
+                payload("c"),
+            )
+            .unwrap();
+
+        // Only drain once the original timer task is dead, so it can
+        // never resume and advance next_run itself: the double-fire
+        // ordering is forced, not raced.
+        wait_until("mid-fire timer task aborted by re-arm", || {
+            timer_abort.is_finished()
+        })
+        .await;
+
+        // Drain: first message must already be there; then collect until
+        // the bus goes quiet for 500ms.
+        let mut msgs = Vec::new();
+        let first = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("first fire must arrive")
+            .expect("bus channel closed unexpectedly");
+        msgs.push(first);
+        while let Ok(Some(msg)) =
+            tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv()).await
+        {
+            msgs.push(msg);
+        }
+
+        let j1_fires = msgs.iter().filter(|m| m.chat_id == j1.id).count();
+        assert_eq!(
+            j1_fires,
+            1,
+            "job {} must fire exactly once across a concurrent re-arm, got {} fires \
+             (fired messages: {:?})",
+            j1.id,
+            j1_fires,
+            msgs.iter().map(|m| m.chat_id.clone()).collect::<Vec<_>>()
+        );
+
+        // Requirement (2): the fired jobs' next occurrence is scheduled
+        // (advanced past the stale backdated value), not perpetually due.
+        let jobs = service.list_jobs();
+        for id in [&j1.id, &j2.id] {
+            let next = jobs
+                .iter()
+                .find(|j| &j.id == id)
+                .expect("job must still exist")
+                .state
+                .next_run_at_ms;
+            assert!(
+                next.is_some_and(|t| t > past_ms),
+                "job {id} must have its next occurrence scheduled, got {next:?}"
+            );
+        }
+
+        service.stop().await;
     }
 
     #[test]

--- a/crates/octos-bus/src/dedup.rs
+++ b/crates/octos-bus/src/dedup.rs
@@ -62,6 +62,17 @@ impl MessageDedup {
         }
     }
 
+    /// Remove an ID from the cache so a later delivery is treated as new.
+    ///
+    /// [`is_duplicate`](Self::is_duplicate) records an ID at check time. If
+    /// processing then fails and the platform will retry the same ID (e.g. a
+    /// Matrix transaction nacked with a non-2xx status), the entry must be
+    /// forgotten or the retry would be dropped as a duplicate.
+    pub fn forget(&self, id: &str) {
+        let mut cache = self.seen.lock().unwrap_or_else(|e| e.into_inner());
+        cache.pop(id);
+    }
+
     /// Number of entries currently in the cache.
     #[cfg(test)]
     fn len(&self) -> usize {
@@ -129,6 +140,16 @@ mod tests {
 
         // "a" was evicted, so it's no longer a duplicate
         assert!(!dedup.is_duplicate("a"));
+    }
+
+    #[test]
+    fn should_accept_id_again_after_forget() {
+        let dedup = MessageDedup::new();
+        assert!(!dedup.is_duplicate("msg-1"));
+        dedup.forget("msg-1");
+        // Forgotten — treated as new again, then deduped as usual.
+        assert!(!dedup.is_duplicate("msg-1"));
+        assert!(dedup.is_duplicate("msg-1"));
     }
 
     #[test]

--- a/crates/octos-bus/src/matrix_channel.rs
+++ b/crates/octos-bus/src/matrix_channel.rs
@@ -1402,8 +1402,19 @@ async fn handle_transaction(
         };
 
         if state.inbound_tx.send(inbound).await.is_err() {
-            warn!("inbound channel closed while processing Matrix transaction");
-            break;
+            warn!(
+                txn_id,
+                "inbound channel closed while processing Matrix transaction; \
+                 returning 500 so the homeserver retries"
+            );
+            // The dedup check above already recorded this txn_id as seen.
+            // Forget it so the homeserver's retry of the same transaction is
+            // accepted instead of being dropped as a duplicate. Events
+            // enqueued before this failure may be delivered again on retry —
+            // at-least-once beats acking a dropped message with 200 OK
+            // (which the appservice spec treats as "processed, never retry").
+            state.dedup.forget(&txn_id);
+            return (StatusCode::INTERNAL_SERVER_ERROR, "{}").into_response();
         }
     }
 
@@ -3918,6 +3929,86 @@ mod tests {
 
         let msg = inbound_rx.try_recv().unwrap();
         assert_eq!(msg.content, "retry should still deliver");
+    }
+
+    #[tokio::test]
+    async fn test_handle_transaction_enqueue_failure_returns_500_and_does_not_poison_txn_id() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use tower::ServiceExt;
+
+        // Close the inbound channel by dropping the receiver so every
+        // enqueue fails. The homeserver must NOT be told 200 OK (which
+        // means "processed, never retry") for a message we dropped.
+        let (closed_tx, closed_rx) = mpsc::channel::<InboundMessage>(16);
+        drop(closed_rx);
+
+        let state = make_test_state(closed_tx);
+        let dedup = state.dedup.clone();
+
+        let app = Router::new()
+            .route(
+                "/_matrix/app/v1/transactions/{txn_id}",
+                put(handle_transaction),
+            )
+            .with_state(state);
+
+        let body = json!({
+            "events": [{
+                "type": "m.room.message",
+                "sender": "@alice:elsewhere.org",
+                "room_id": "!room:localhost",
+                "event_id": "$ev_enqueue_fail",
+                "content": {
+                    "msgtype": "m.text",
+                    "body": "must not be acked when dropped"
+                }
+            }]
+        });
+
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/_matrix/app/v1/transactions/txn_enqueue_fail?access_token=test_token")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed enqueue must not be acked with 200 OK"
+        );
+
+        // The failed transaction must not be recorded as processed:
+        // the homeserver retries the same txn_id, and that retry must be
+        // accepted, not dropped as a duplicate. Simulate the retry against
+        // a healthy inbound channel sharing the same dedup cache.
+        let (retry_tx, mut retry_rx) = mpsc::channel::<InboundMessage>(16);
+        let mut retry_state = make_test_state(retry_tx);
+        retry_state.dedup = dedup;
+
+        let retry_app = Router::new()
+            .route(
+                "/_matrix/app/v1/transactions/{txn_id}",
+                put(handle_transaction),
+            )
+            .with_state(retry_state);
+
+        let retry_req = Request::builder()
+            .method("PUT")
+            .uri("/_matrix/app/v1/transactions/txn_enqueue_fail?access_token=test_token")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap();
+
+        let retry_resp = retry_app.oneshot(retry_req).await.unwrap();
+        assert_eq!(retry_resp.status(), StatusCode::OK);
+
+        let msg = retry_rx
+            .try_recv()
+            .expect("retried transaction must be delivered, not deduped");
+        assert_eq!(msg.content, "must not be acked when dropped");
     }
 
     #[tokio::test]

--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -1919,6 +1919,17 @@ impl SessionManager {
         // Ensure the session is resident so the trim reflects the full
         // (merged) on-disk transcript.
         let _ = self.get_or_create(key).await;
+        // Serialise the count-read + marker-append + trim under the per-key
+        // persist lock — the SAME lock the rewrite / canonical-append paths
+        // hold (#1528). Without it this read-then-append raced a concurrent
+        // `rewrite`, which snapshots the pre-marker message vec and renames
+        // over the file, silently ERASING the appended rollback marker; and a
+        // concurrent append could land between the turn-count read and the
+        // marker write, computing the marker's `num_turns` against a stale
+        // transcript. `append_rollback_marker` takes no lock itself, so
+        // holding it here does not re-enter.
+        let lock = persist_lock_for(key);
+        let _guard = lock.lock().await;
         let dropped = {
             let session = self
                 .cache

--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -21,13 +21,16 @@ const CURRENT_SESSION_SCHEMA: u32 = 1;
 /// `message/persisted` notification dispatches through.
 ///
 /// Strict-ordering invariant: `add_message_with_seq` calls observers
-/// synchronously after the in-memory append, with the registry global lock
-/// held in [`set_message_commit_observer`]. Two concurrent commits to the
-/// same session serialize on the `&mut self` borrow of `SessionManager` /
-/// `SessionHandle`, so observer fires preserve commit order per session.
+/// synchronously after the in-memory append. Two concurrent commits to the
+/// same session key serialize on the per-key persist lock (see
+/// `persist_lock_for`) — independent writers (separate `SessionHandle`s,
+/// the canonical persist helper, a `SessionManager`) all contend on the
+/// same lock, so observer fires preserve commit order per session.
 ///
-/// The seq passed to the observer is the row's index in `Session::messages`
-/// after the append (`messages.len() - 1`).
+/// The seq passed to the observer is the row's index in the durable
+/// transcript: on the `SessionHandle` path it is read back from the
+/// on-disk file under the persist lock; on the `SessionManager` path it is
+/// the merged in-memory mirror's `messages.len() - 1` after the append.
 ///
 /// Errors raised by an observer are logged and dropped: the durable commit
 /// has already happened, and the observer is best-effort fan-out for
@@ -1258,7 +1261,33 @@ impl SessionManager {
     }
 
     /// Add a message to a session, persist it, and return its committed sequence.
+    ///
+    /// Serialises on the per-key persist lock (see [`persist_lock_for`]) so a
+    /// concurrent writer on the same key cannot interleave between the disk
+    /// append and the seq derivation. The lock is NOT reentrant: a caller
+    /// that already holds it must use
+    /// [`Self::add_message_with_seq_unlocked`] instead.
     pub async fn add_message_with_seq(
+        &mut self,
+        key: &SessionKey,
+        message: Message,
+    ) -> Result<usize> {
+        let lock = persist_lock_for(key);
+        let _guard = lock.lock().await;
+        self.add_message_with_seq_unlocked(key, message).await
+    }
+
+    /// Append + seq derivation without taking the persist lock — the caller
+    /// must already hold it (see [`persist_lock_for`]).
+    ///
+    /// The committed seq is derived from this manager's in-memory mirror:
+    /// the manager's transcript is the MERGED flat + per-user view assembled
+    /// at load time (see [`Self::load_from_disk`]), so the merged mirror —
+    /// not a single file's row count — is the closest authority the manager
+    /// has. The lock still guarantees the append and the len-read are atomic
+    /// against every other locked writer (canonical appends, rewrites,
+    /// rollback markers) on the same key.
+    async fn add_message_with_seq_unlocked(
         &mut self,
         key: &SessionKey,
         mut message: Message,
@@ -2115,11 +2144,19 @@ pub struct SessionHandle {
 /// Without serialisation, both observe `len = N`, both append, both return
 /// `seq = N` — duplicate seqs that break watcher correlation.
 ///
-/// This map gives `persist_message_through_canonical_path` a per-key Tokio
-/// mutex so all writes for the same `SessionKey.0` serialise. The mutex is
-/// scoped to the session_key string (NOT the file path) so callers reaching
+/// This map gives `persist_message_through_canonical_path` — and every other
+/// session write path: `SessionManager::add_message_with_seq`,
+/// `SessionHandle::add_message_with_seq`, the `rewrite`s,
+/// `rollback_last_n_user_turns`, and the child-contract upserts — a per-key
+/// Tokio mutex so all writes for the same `SessionKey.0` serialise. The mutex
+/// is scoped to the session_key string (NOT the file path) so callers reaching
 /// the canonical per-user JSONL via different code paths still contend on
 /// the same lock.
+///
+/// The mutex is NOT reentrant. Methods that need to run inside an
+/// already-held lock use the `_unlocked` variants
+/// (`add_message_with_seq_unlocked`, `rewrite_unlocked`,
+/// `upsert_child_contract_unlocked`).
 ///
 /// Memory note: entries leak forever, one per active session_key. In a long-
 /// lived bus process this grows with active distinct sessions; given
@@ -2161,7 +2198,10 @@ pub async fn persist_message_through_canonical_path(
     let lock = persist_lock_for(key);
     let _guard = lock.lock().await;
     let mut handle = SessionHandle::open(data_dir, key);
-    handle.add_message_with_seq(message).await
+    // `_unlocked`: this function already holds the per-key persist lock and
+    // the tokio mutex is not reentrant — calling the locking
+    // `add_message_with_seq` here would deadlock.
+    handle.add_message_with_seq_unlocked(message).await
 }
 
 /// Upsert a durable child-session contract through the canonical locked
@@ -2480,7 +2520,23 @@ impl SessionHandle {
     }
 
     /// Add a message to the session, persist it, and return its committed sequence.
-    pub async fn add_message_with_seq(&mut self, mut message: Message) -> Result<usize> {
+    ///
+    /// Serialises on the per-key persist lock (see [`persist_lock_for`]) so a
+    /// concurrent writer on the same key — another `SessionHandle`, the
+    /// canonical [`persist_message_through_canonical_path`] helper, or a
+    /// rewrite — cannot interleave between the disk append and the seq
+    /// derivation. The lock is NOT reentrant: a caller that already holds it
+    /// (the canonical helper) must use
+    /// [`Self::add_message_with_seq_unlocked`] instead.
+    pub async fn add_message_with_seq(&mut self, message: Message) -> Result<usize> {
+        let lock = persist_lock_for(&self.session.key);
+        let _guard = lock.lock().await;
+        self.add_message_with_seq_unlocked(message).await
+    }
+
+    /// Append + seq derivation without taking the persist lock — the caller
+    /// must already hold it (see [`persist_message_through_canonical_path`]).
+    async fn add_message_with_seq_unlocked(&mut self, mut message: Message) -> Result<usize> {
         // Auto-derive title from first user message before persistence so the
         // first append_to_disk includes the title in the JSONL meta line.
         // Manual titles set via update_title elsewhere are preserved.
@@ -2523,7 +2579,32 @@ impl SessionHandle {
         self.session.messages.push(message.clone());
         self.session.updated_at = Utc::now();
         record_session_persist("committed");
-        let committed_seq = self.session.messages.len().saturating_sub(1);
+        // Derive the committed sequence from the ON-DISK transcript, not
+        // from this handle's in-memory mirror. The caller holds the per-key
+        // persist lock, so no other writer can append between our disk
+        // write and this read-back — but THIS handle's mirror may be stale
+        // relative to rows other writers committed after it was opened
+        // (e.g. a long-lived actor handle racing the canonical persist
+        // path). Two such writers each pushing onto their own stale mirror
+        // both returned the same seq for different durable rows.
+        // `load_from_file` runs the same assembly a reload uses (meta line
+        // + rollback-marker replay), so the returned seq is exactly the
+        // index the appended row has in the durable transcript; under the
+        // lock our row is the last one. Falls back to the mirror length if
+        // the read-back fails: the row already committed, and a post-commit
+        // read failure must not turn the call into an error.
+        let path = self.session_path();
+        let key = self.session.key.clone();
+        let disk_len = tokio::task::spawn_blocking(move || {
+            Self::load_from_file(&path, &key).map(|on_disk| on_disk.messages.len())
+        })
+        .await
+        .ok()
+        .flatten();
+        let committed_seq = match disk_len {
+            Some(len) if len > 0 => len - 1,
+            _ => self.session.messages.len().saturating_sub(1),
+        };
         // Post-commit observer fan-out: fires AFTER the disk write
         // returned Ok AND after the in-memory mirror was updated. A
         // commit failure (`append_to_disk` Err) returns above without
@@ -4047,6 +4128,80 @@ mod tests {
         );
         // The seeded message must survive the rewrites too.
         assert_eq!(reloaded.session().messages.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn should_assign_distinct_seqs_when_concurrent_appends_race_same_key() {
+        // Seq-assignment race: `SessionHandle::add_message_with_seq` derived
+        // the committed seq from its OWN in-memory mirror length, with no
+        // per-key serialisation between the disk append and the len read.
+        // Independent writers (direct pre-opened handles racing the canonical
+        // locked path) each hold a mirror snapshotted at the same pre-state,
+        // so they all compute the SAME seq for different durable rows.
+        //
+        // Determinism: the 8 direct handles are opened at the 1-message
+        // pre-state BEFORE the race starts. Each direct future appends its
+        // row and then pushes onto its own mirror — every one of those
+        // mirrors has len 1 regardless of blocking-pool timing, so WITHOUT
+        // the per-key lock + disk-derived seq all 8 direct writers return
+        // seq 1. The duplicate is deterministic, not timing-dependent.
+        let tmp = TempDir::new().unwrap();
+        let key = SessionKey::new("api", "seq-race");
+        {
+            let mut seed = SessionHandle::open(tmp.path(), &key);
+            seed.add_message(make_message(MessageRole::User, "seed"))
+                .await
+                .unwrap();
+        }
+
+        // 8 independent handles, each mirroring the seeded pre-state.
+        let mut direct_handles: Vec<SessionHandle> = (0..8)
+            .map(|_| SessionHandle::open(tmp.path(), &key))
+            .collect();
+        let direct_futures = direct_handles
+            .iter_mut()
+            .enumerate()
+            .map(|(i, handle)| {
+                let msg = make_message(MessageRole::User, &format!("direct-{i}"));
+                async move { handle.add_message_with_seq(msg).await }
+            })
+            .collect::<Vec<_>>();
+        // 8 canonical-path persists racing the direct handles on the same key.
+        let canonical_futures = (0..8)
+            .map(|i| {
+                persist_message_through_canonical_path(
+                    tmp.path(),
+                    &key,
+                    make_message(MessageRole::User, &format!("canonical-{i}")),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let (direct_seqs, canonical_seqs) = tokio::join!(
+            futures::future::join_all(direct_futures),
+            futures::future::join_all(canonical_futures),
+        );
+
+        let mut seqs = Vec::new();
+        for result in direct_seqs.into_iter().chain(canonical_seqs) {
+            seqs.push(result.expect("every concurrent append must commit"));
+        }
+
+        let unique: std::collections::BTreeSet<usize> = seqs.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            seqs.len(),
+            "concurrent appends to the same key must commit distinct seqs; got {seqs:?}"
+        );
+        let expected: std::collections::BTreeSet<usize> = (1..=16).collect();
+        assert_eq!(
+            unique, expected,
+            "committed seqs must form the contiguous set 1..=16; got {seqs:?}"
+        );
+
+        // Every row must be durably visible on a reload too.
+        let reloaded = SessionHandle::open(tmp.path(), &key);
+        assert_eq!(reloaded.session().messages.len(), 17);
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -2736,6 +2736,20 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
                     SystemTime::now(),
                 )
                 .with_loop_id(loop_id.clone())
+                // Identity-only dedupe key SHARED with the scheduled
+                // due-tick enqueue (`enqueue_due_loop_continuations`).
+                // The auto-derived key folds metadata in, and the two
+                // paths' metadata differs (`scheduled_for_ms`,
+                // resolved-vs-record maintenance prompt), so a manual
+                // fire_now racing the tick used to enqueue a SECOND
+                // LoopFire for the same due moment. With the shared
+                // key the later path collapses as a Duplicate while a
+                // fire is pending.
+                .with_dedupe_key(loop_fire_dedupe_key(
+                    "coding-autonomy",
+                    &profile_id,
+                    &loop_id,
+                ))
                 .with_metadata("prompt", resolved_prompt)
                 .with_metadata("prompt_source", prompt_source_label);
                 let outcome = enqueue_and_persist_continuation(&mut state, continuation);
@@ -3092,6 +3106,18 @@ fn enqueue_due_loop_continuations(
             MasterContinuationReason::LoopFire,
             SystemTime::now(),
         )
+        // Identity-only dedupe key SHARED with the manual fire_now
+        // enqueue (`control_loop` FireNow arm) so the two paths racing
+        // over one due moment collapse to ONE pending LoopFire instead
+        // of double-firing. `scheduled_for_ms` stays observability
+        // metadata below — it must NOT split the key, and distinct due
+        // moments still fire because a claimed key leaves
+        // `pending_by_key`.
+        .with_dedupe_key(loop_fire_dedupe_key(
+            "coding-autonomy",
+            &fire.profile_id,
+            &fire.loop_id,
+        ))
         .with_loop_id(fire.loop_id)
         .with_metadata("prompt", fire.prompt)
         .with_metadata("prompt_source", prompt_source_label)
@@ -3844,6 +3870,25 @@ fn enqueue_agent_terminal_continuations(
 /// strangler double-delivery or repeated terminal marks.
 fn child_completed_dedupe_key(group_id: &str, session_id: &str, agent_id: &str) -> String {
     format!("child/{group_id}/{session_id}/{agent_id}")
+}
+
+/// Explicit `LoopFire` dedupe key shared by BOTH enqueue paths — the
+/// manual `control_loop(FireNow)` arm and the scheduled
+/// `enqueue_due_loop_continuations` tick. Keyed ONLY on stable identity
+/// (group + profile + loop_id): the auto-derived `stable_dedupe_key`
+/// folds every metadata pair into the key, and the two paths' metadata
+/// deliberately differs (`scheduled_for_ms` exists only on the tick;
+/// maintenance loops resolve prompt / prompt_source at fire time vs the
+/// legacy "record" label), so a fire_now racing the tick used to MISS
+/// `pending_by_key` and enqueue a SECOND LoopFire — two turns for one
+/// due moment. The identity key makes whichever path lands second
+/// collapse as a Duplicate while a fire is pending-and-unclaimed.
+/// Distinct due moments are unaffected: LoopFire is not `External`, so
+/// a CLAIMED (drained) key leaves `pending_by_key` immediately and the
+/// next due moment re-enqueues freely (see the recently-claimed guard
+/// scoping in `master_continuation_scheduler.rs`).
+fn loop_fire_dedupe_key(group_id: &str, profile_id: &str, loop_id: &str) -> String {
+    format!("loop_fire/{group_id}/{profile_id}/{loop_id}")
 }
 
 fn agent_continuation_group_id(agent: &AutonomyAgentRecord) -> String {
@@ -8893,6 +8938,155 @@ mod tests {
             drained[0].metadata.get("prompt").map(String::as_str),
             Some("check build health")
         );
+    }
+
+    /// A manual `loop/fire_now` racing the scheduled due-tick must not
+    /// double-fire the loop. The two enqueue paths historically derived
+    /// DIFFERENT auto keys — the tick folds `scheduled_for_ms` into the
+    /// continuation metadata (and maintenance loops resolve a different
+    /// prompt / prompt_source at fire time) — so `pending_by_key` missed
+    /// and BOTH continuations queued: two LoopFire turns for one due
+    /// moment. Both paths must share one identity-only dedupe key so the
+    /// second enqueue collapses onto the pending fire.
+    #[test]
+    fn fire_now_racing_scheduled_due_tick_collapses_to_one_loop_fire() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "loop-firenow-race");
+        let created = orchestrator
+            .create_loop(LoopCreateRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                prompt: Some("check build health".into()),
+                command: None,
+                interval_seconds: Some(60),
+                mode: Some("fixed_interval".into()),
+            })
+            .expect("create loop");
+        let loop_id = created["loop_id"].as_str().expect("loop id").to_owned();
+        orchestrator.force_loop_due_for_test(&loop_id);
+
+        // The scheduled tick claims the due moment first…
+        let ticked = orchestrator.tick_due_loops_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+        );
+        assert_eq!(ticked, 1);
+
+        // …then the racing manual fire_now lands before the queued
+        // continuation is claimed. FireNow skips the schedule gate
+        // (`decide_fire` only applies `next_due` to `ScheduledDue`),
+        // so only the queue's dedupe stands between this and a
+        // second turn for the same due moment.
+        let fired = orchestrator
+            .control_loop(LoopControlRequest {
+                session_id: Some(session_id.clone()),
+                profile_id: "tenant-a".into(),
+                loop_id: loop_id.clone(),
+                kind: LoopControlKind::FireNow,
+            })
+            .expect("fire_now");
+        assert_eq!(
+            fired["fire"]["duplicate"].as_bool(),
+            Some(true),
+            "fire_now must collapse onto the pending scheduled fire, got: {fired}"
+        );
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_test(),
+            1,
+            "one due moment must enqueue exactly ONE LoopFire continuation"
+        );
+        // #1138 semantics extend across paths: the deduplicated
+        // fire must not burn the safety budget a second time.
+        assert_eq!(
+            orchestrator
+                .state()
+                .loops
+                .get(&loop_id)
+                .expect("loop record")
+                .fires_used,
+            1,
+            "a deduplicated fire_now must not increment fires_used"
+        );
+    }
+
+    /// Over-dedupe guard for the shared LoopFire key: the identity-only
+    /// key must only collapse enqueues while a fire is PENDING. Once the
+    /// pending continuation is claimed (drained), the key leaves
+    /// `pending_by_key` — LoopFire is not `External`, so no
+    /// recently-claimed guard applies — and the next genuine due
+    /// moment, scheduled or manual, must enqueue a fresh continuation.
+    #[test]
+    fn distinct_due_moments_still_enqueue_distinct_loop_fires() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "loop-distinct-fires");
+        let created = orchestrator
+            .create_loop(LoopCreateRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                prompt: Some("check build health".into()),
+                command: None,
+                interval_seconds: Some(60),
+                mode: Some("fixed_interval".into()),
+            })
+            .expect("create loop");
+        let loop_id = created["loop_id"].as_str().expect("loop id").to_owned();
+
+        // Due moment 1: scheduled tick queues, then the turn claims it.
+        orchestrator.force_loop_due_for_test(&loop_id);
+        assert_eq!(
+            orchestrator.tick_due_loops_for_session(
+                &session_id,
+                "tenant-a",
+                MasterContinuationRuntimeState::idle(),
+            ),
+            1
+        );
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        assert_eq!(drained.len(), 1);
+
+        // Due moment 2: a manual fire_now after the claim is a genuine
+        // new fire, not a duplicate of the already-claimed one.
+        let fired = orchestrator
+            .control_loop(LoopControlRequest {
+                session_id: Some(session_id.clone()),
+                profile_id: "tenant-a".into(),
+                loop_id: loop_id.clone(),
+                kind: LoopControlKind::FireNow,
+            })
+            .expect("fire_now");
+        assert_eq!(
+            fired["fire"]["duplicate"].as_bool(),
+            Some(false),
+            "fire_now after the prior fire was claimed must queue fresh, got: {fired}"
+        );
+        assert_eq!(orchestrator.pending_continuation_count_for_test(), 1);
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].reason, MasterContinuationReason::LoopFire);
+
+        // Due moment 3: the next scheduled tick also queues fresh.
+        orchestrator.force_loop_due_for_test(&loop_id);
+        assert_eq!(
+            orchestrator.tick_due_loops_for_session(
+                &session_id,
+                "tenant-a",
+                MasterContinuationRuntimeState::idle(),
+            ),
+            1,
+            "a later scheduled due moment must enqueue its own continuation"
+        );
+        assert_eq!(orchestrator.pending_continuation_count_for_test(), 1);
     }
 
     /// UPCR-2026-021: "`/loop 5m /foo` creates a fixed loop and immediately

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -2644,6 +2644,28 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
             }
             LoopControlKind::Resume => {
                 loop_record.status = "active".into();
+                // Re-arm the schedule if it was cleared. A self-paced /
+                // maintenance loop paused between its due-fire (which sets
+                // `next_run_at_ms = None`, agent_orchestrator ~3046) and the
+                // continuation that would re-stamp it (`apply_self_paced_
+                // response`) is left with `next_run_at_ms = None` — and BOTH
+                // due-scans (`due_loop_targets_with_filter` and
+                // `enqueue_due_loop_continuations`) skip a `None` next-run
+                // forever, so the resumed loop would never fire again.
+                // Re-arm to `now + interval` (or `now`, due immediately, for a
+                // pure self-paced loop with no interval) so resume always
+                // yields a schedulable loop. A still-valid future next-run is
+                // left untouched — resume respects the existing schedule.
+                if loop_record.next_run_at_ms.is_none() {
+                    loop_record.next_run_at_ms = Some(
+                        loop_record
+                            .interval_seconds
+                            .and_then(|seconds| i64::try_from(seconds).ok())
+                            .and_then(|seconds| seconds.checked_mul(1_000))
+                            .and_then(|delay_ms| now.checked_add(delay_ms))
+                            .unwrap_or(now),
+                    );
+                }
                 loop_record.updated_at_ms = now;
                 persist_loop_state_with_store(supervisor_store.as_ref(), loop_record);
                 Ok(json!({
@@ -6595,6 +6617,62 @@ mod tests {
         assert_eq!(
             err.data.expect("error data")["kind"],
             json!(kinds::LOOP_NOT_FOUND)
+        );
+    }
+
+    #[test]
+    fn resume_rearms_next_run_for_a_loop_interrupted_mid_fire() {
+        // P2 (tri-repo #1529): a self-paced loop paused between its due-fire
+        // (which sets next_run_at_ms = None) and the continuation that would
+        // re-stamp it is left unschedulable — both due-scans skip a None
+        // next-run. Resume must re-arm it.
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "loop-resume");
+        let created = orchestrator
+            .create_loop(LoopCreateRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                prompt: Some("keep going".into()),
+                command: None,
+                interval_seconds: None,
+                mode: Some("self_paced".into()),
+            })
+            .expect("create loop");
+        let loop_id = created["loop_id"].as_str().expect("loop id").to_owned();
+
+        // Simulate the interrupted-mid-fire state: next_run cleared, paused.
+        {
+            let mut state = orchestrator.state();
+            let record = state.loops.get_mut(&loop_id).expect("loop record");
+            record.next_run_at_ms = None;
+            record.status = "paused".into();
+        }
+
+        let resumed = orchestrator
+            .control_loop(LoopControlRequest {
+                loop_id: loop_id.clone(),
+                session_id: Some(session_id),
+                profile_id: "tenant-a".into(),
+                kind: LoopControlKind::Resume,
+            })
+            .expect("resume");
+        assert_eq!(resumed["status"], json!("active"));
+        assert!(
+            resumed["loop"]["next_run_at_ms"].is_i64(),
+            "resume must re-arm next_run_at_ms so the loop is schedulable again; got {}",
+            resumed["loop"]["next_run_at_ms"]
+        );
+
+        // And the re-armed loop is actually due (now, since it has no interval).
+        let due = orchestrator
+            .state()
+            .loops
+            .get(&loop_id)
+            .unwrap()
+            .next_run_at_ms;
+        assert!(
+            due.is_some_and(|n| n <= now_ms() + 1_000),
+            "re-armed to fire promptly"
         );
     }
 

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -1579,33 +1579,6 @@ impl InProcessAgentOrchestrator {
         self.state().in_flight_goal_sessions.contains(session_id)
     }
 
-    /// ATOMICALLY claim the in-flight marker for `session_id`: if it is not
-    /// already set, insert it and return a clearing guard; if another dispatch
-    /// already holds it, return `None`. The check-and-set happens under a
-    /// SINGLE state-lock acquisition, so — unlike a separate
-    /// `is_goal_dispatch_in_flight` check followed by a later mark — two
-    /// subsystems racing to claim the same session cannot both succeed
-    /// (#1529, codex re-review: the mark must be atomic with the claim to
-    /// close the check-then-mark window). The caller drains and runs the turn
-    /// while holding the guard; dropping it releases the marker.
-    pub(crate) fn try_goal_dispatch_in_flight_guard(
-        &'static self,
-        session_id: SessionKey,
-    ) -> Option<GoalDispatchInFlightGuard> {
-        {
-            let mut state = self.state();
-            if state.in_flight_goal_sessions.contains(&session_id) {
-                return None;
-            }
-            state.in_flight_goal_sessions.insert(session_id.clone());
-        }
-        Some(GoalDispatchInFlightGuard {
-            orchestrator: self,
-            session_id,
-            disarmed: false,
-        })
-    }
-
     /// #1140 codex P1 re-review #4 — RAII drop-guard for the
     /// in-flight marker. Use this from the AppUI tick path so the
     /// marker is cleared on ANY exit path (cancellation,
@@ -10644,36 +10617,67 @@ mod tests {
     }
 
     #[test]
-    fn try_goal_dispatch_in_flight_guard_claims_atomically_and_releases_on_drop() {
-        // P2 (tri-repo #1529, codex re-review): the claim must be atomic — a
-        // SECOND claimant while a turn is in flight must get None (so it skips
-        // instead of draining a concurrent turn), and dropping the guard must
-        // release the marker so the next dispatch can claim it. Uses the
-        // process-global singleton because the guard captures 'static self.
-        let orchestrator = default_agent_orchestrator();
-        let session_id = SessionKey::with_profile("tenant-a", "api", "try-claim-atomic");
-        orchestrator.clear_goal_dispatch_in_flight(&session_id);
+    fn setting_in_flight_before_drain_blocks_the_owner_due_goal_enqueue() {
+        // P1 (tri-repo #1529, codex re-review): `drain_ready_continuations_for
+        // _session` runs `enqueue_due_goal_continuations` internally, which
+        // skips any session already in `in_flight_goal_sessions`. So the
+        // marker must be set AFTER the drain (the actor's own due-goal enqueue
+        // must not be suppressed), not before — claiming before the drain
+        // wedged recurring session-actor goal dispatch. This pins the
+        // interaction: with the marker CLEAR the drain enqueues+returns the
+        // due goal continuation; with it pre-SET the drain returns nothing.
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "enqueue-not-blocked");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "recurring goal".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        // Drain the initial set_goal continuation so the session is idle, then
+        // age last_continued_at past the min-delay so the goal is due again.
+        let _ = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        if let Some(goal) = orchestrator.state().goals.get_mut(&session_id) {
+            goal.last_continued_at_ms = now_ms() - (GOAL_MIN_CONTINUATION_INTERVAL_MS * 2);
+        }
 
-        let first = orchestrator.try_goal_dispatch_in_flight_guard(session_id.clone());
-        assert!(first.is_some(), "the first claim must succeed");
-        assert!(orchestrator.is_goal_dispatch_in_flight(&session_id));
-        // A concurrent claimant is refused while the first holds the marker.
+        // Marker CLEAR: the drain enqueues the due goal continuation and pops it.
+        let with_clear_marker = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            1,
+        );
         assert!(
-            orchestrator
-                .try_goal_dispatch_in_flight_guard(session_id.clone())
-                .is_none(),
-            "a second claim while a turn is in flight must be refused"
+            !with_clear_marker.is_empty(),
+            "a due active goal must enqueue+drain a continuation when not in-flight"
         );
 
-        drop(first);
-        assert!(
-            !orchestrator.is_goal_dispatch_in_flight(&session_id),
-            "dropping the guard must release the marker"
+        // Re-age (the drain above stamped last_continued_at) and pre-SET the
+        // marker: now the internal enqueue is suppressed → nothing drains.
+        if let Some(goal) = orchestrator.state().goals.get_mut(&session_id) {
+            goal.last_continued_at_ms = now_ms() - (GOAL_MIN_CONTINUATION_INTERVAL_MS * 2);
+        }
+        orchestrator.mark_goal_dispatch_in_flight(&session_id);
+        let with_set_marker = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            1,
         );
-        // After release a fresh claim succeeds again.
-        let again = orchestrator.try_goal_dispatch_in_flight_guard(session_id.clone());
-        assert!(again.is_some(), "a claim after release must succeed");
-        drop(again);
-        orchestrator.clear_goal_dispatch_in_flight(&session_id);
+        assert!(
+            with_set_marker.is_empty(),
+            "pre-setting the marker suppresses the owner's due-goal enqueue \
+             (which is why the actor reads, not sets, before draining)"
+        );
     }
 }

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -1252,6 +1252,16 @@ impl InProcessAgentOrchestrator {
         Option<GoalDispatchInFlightGuard>,
     ) {
         let mut state = self.state();
+        // Defer ENTIRELY if a turn is already in flight for this session —
+        // before draining anything. The enqueue suppression only covers
+        // goal/loop DUE-scans; a pre-queued loop / ChildCompleted / External
+        // continuation would otherwise still be popped here, run concurrently
+        // with the other subsystem's turn, AND its returned guard's drop would
+        // clear that turn's marker (codex re-review). Checking first, under
+        // the same lock, makes the whole claim generation-safe.
+        if state.in_flight_goal_sessions.contains(session_id) {
+            return (Vec::new(), None);
+        }
         let kept = Self::drain_ready_continuations_locked(
             &mut state,
             session_id,
@@ -10810,6 +10820,75 @@ mod tests {
 
         drop(guard);
         assert!(!orchestrator.is_goal_dispatch_in_flight(&session_id));
+        orchestrator.clear_goal_dispatch_in_flight(&session_id);
+    }
+
+    #[test]
+    fn drain_and_claim_does_not_pop_a_pre_queued_continuation_while_in_flight() {
+        // P1 (tri-repo #1529, codex re-review): the enqueue suppression only
+        // covers DUE-scans; a LoopFire (or ChildCompleted / External) already
+        // QUEUED before the session was marked in-flight would still be popped
+        // by the drain, run concurrently with the other subsystem's turn, and
+        // its guard's drop would clear that turn's marker. The atomic
+        // drain-and-claim must DEFER entirely — pop nothing — while a turn is
+        // already in flight, leaving the queued item for the next dispatch.
+        let orchestrator = default_agent_orchestrator();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "pre-queued-defer");
+        orchestrator.clear_goal_dispatch_in_flight(&session_id);
+        let created = orchestrator
+            .create_loop(LoopCreateRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                prompt: Some("check health".into()),
+                command: None,
+                interval_seconds: Some(60),
+                mode: Some("fixed_interval".into()),
+            })
+            .expect("create loop");
+        let loop_id = created["loop_id"].as_str().expect("loop id").to_owned();
+        orchestrator.force_loop_due_for_test(&loop_id);
+        // Queue a LoopFire BEFORE marking in-flight.
+        let ticked = orchestrator.tick_due_loops_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+        );
+        assert_eq!(ticked, 1, "a due loop must queue one LoopFire");
+        let queued_before = orchestrator.pending_continuation_count_for_test();
+        assert!(queued_before >= 1);
+
+        // Now a turn is in flight (e.g. an AppUI goal turn on the same session).
+        orchestrator.mark_goal_dispatch_in_flight(&session_id);
+        let (drained, guard) = orchestrator.drain_and_claim_ready_continuation_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            1,
+        );
+        assert!(
+            drained.is_empty() && guard.is_none(),
+            "must defer — not pop the pre-queued LoopFire — while in flight"
+        );
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_test(),
+            queued_before,
+            "the pre-queued LoopFire must remain queued for the next dispatch"
+        );
+
+        // Clearing the marker lets the queued LoopFire drain normally.
+        orchestrator.clear_goal_dispatch_in_flight(&session_id);
+        let (drained_after, guard_after) = orchestrator
+            .drain_and_claim_ready_continuation_for_session(
+                &session_id,
+                "tenant-a",
+                MasterContinuationRuntimeState::idle(),
+                1,
+            );
+        assert!(
+            !drained_after.is_empty() && guard_after.is_some(),
+            "after the other turn ends, the queued LoopFire drains and claims"
+        );
+        drop(guard_after);
         orchestrator.clear_goal_dispatch_in_flight(&session_id);
     }
 }

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -1579,6 +1579,33 @@ impl InProcessAgentOrchestrator {
         self.state().in_flight_goal_sessions.contains(session_id)
     }
 
+    /// ATOMICALLY claim the in-flight marker for `session_id`: if it is not
+    /// already set, insert it and return a clearing guard; if another dispatch
+    /// already holds it, return `None`. The check-and-set happens under a
+    /// SINGLE state-lock acquisition, so — unlike a separate
+    /// `is_goal_dispatch_in_flight` check followed by a later mark — two
+    /// subsystems racing to claim the same session cannot both succeed
+    /// (#1529, codex re-review: the mark must be atomic with the claim to
+    /// close the check-then-mark window). The caller drains and runs the turn
+    /// while holding the guard; dropping it releases the marker.
+    pub(crate) fn try_goal_dispatch_in_flight_guard(
+        &'static self,
+        session_id: SessionKey,
+    ) -> Option<GoalDispatchInFlightGuard> {
+        {
+            let mut state = self.state();
+            if state.in_flight_goal_sessions.contains(&session_id) {
+                return None;
+            }
+            state.in_flight_goal_sessions.insert(session_id.clone());
+        }
+        Some(GoalDispatchInFlightGuard {
+            orchestrator: self,
+            session_id,
+            disarmed: false,
+        })
+    }
+
     /// #1140 codex P1 re-review #4 — RAII drop-guard for the
     /// in-flight marker. Use this from the AppUI tick path so the
     /// marker is cleared on ANY exit path (cancellation,
@@ -10614,5 +10641,39 @@ mod tests {
             !orchestrator.is_goal_dispatch_in_flight(&session_id),
             "clearing the marker must let dispatch resume"
         );
+    }
+
+    #[test]
+    fn try_goal_dispatch_in_flight_guard_claims_atomically_and_releases_on_drop() {
+        // P2 (tri-repo #1529, codex re-review): the claim must be atomic — a
+        // SECOND claimant while a turn is in flight must get None (so it skips
+        // instead of draining a concurrent turn), and dropping the guard must
+        // release the marker so the next dispatch can claim it. Uses the
+        // process-global singleton because the guard captures 'static self.
+        let orchestrator = default_agent_orchestrator();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "try-claim-atomic");
+        orchestrator.clear_goal_dispatch_in_flight(&session_id);
+
+        let first = orchestrator.try_goal_dispatch_in_flight_guard(session_id.clone());
+        assert!(first.is_some(), "the first claim must succeed");
+        assert!(orchestrator.is_goal_dispatch_in_flight(&session_id));
+        // A concurrent claimant is refused while the first holds the marker.
+        assert!(
+            orchestrator
+                .try_goal_dispatch_in_flight_guard(session_id.clone())
+                .is_none(),
+            "a second claim while a turn is in flight must be refused"
+        );
+
+        drop(first);
+        assert!(
+            !orchestrator.is_goal_dispatch_in_flight(&session_id),
+            "dropping the guard must release the marker"
+        );
+        // After release a fresh claim succeeds again.
+        let again = orchestrator.try_goal_dispatch_in_flight_guard(session_id.clone());
+        assert!(again.is_some(), "a claim after release must succeed");
+        drop(again);
+        orchestrator.clear_goal_dispatch_in_flight(&session_id);
     }
 }

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -1569,6 +1569,16 @@ impl InProcessAgentOrchestrator {
         self.state().in_flight_goal_sessions.remove(session_id);
     }
 
+    /// True when a continuation turn for `session_id` is currently in flight
+    /// (the in-flight marker is set). The due-scan already excludes such
+    /// sessions; this accessor lets a SECOND dispatch surface — the AppUI
+    /// serve tick — also skip a session whose continuation turn is running in
+    /// the session actor, closing the cross-subsystem drain race where both
+    /// spawn a concurrent turn on the same session (#1529).
+    pub(crate) fn is_goal_dispatch_in_flight(&self, session_id: &SessionKey) -> bool {
+        self.state().in_flight_goal_sessions.contains(session_id)
+    }
+
     /// #1140 codex P1 re-review #4 — RAII drop-guard for the
     /// in-flight marker. Use this from the AppUI tick path so the
     /// marker is cleared on ANY exit path (cancellation,
@@ -10578,6 +10588,31 @@ mod tests {
         assert!(
             due_after.iter().any(|(s, _)| s == &session_id),
             "after clearing in-flight, goal must be due again (got {due_after:?})",
+        );
+    }
+
+    #[test]
+    fn is_goal_dispatch_in_flight_reflects_mark_and_clear() {
+        // P2 (tri-repo #1529): the accessor the AppUI serve tick reads to skip
+        // a session whose continuation turn is already running in the session
+        // actor (which marks in-flight for the turn's duration). Closing the
+        // cross-subsystem drain race relies on this reflecting the marker set
+        // by mark_goal_dispatch_in_flight / the RAII guard.
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "in-flight-accessor");
+        assert!(
+            !orchestrator.is_goal_dispatch_in_flight(&session_id),
+            "a session with no in-flight turn must read false"
+        );
+        orchestrator.mark_goal_dispatch_in_flight(&session_id);
+        assert!(
+            orchestrator.is_goal_dispatch_in_flight(&session_id),
+            "a marked session must read true so the AppUI tick skips it"
+        );
+        orchestrator.clear_goal_dispatch_in_flight(&session_id);
+        assert!(
+            !orchestrator.is_goal_dispatch_in_flight(&session_id),
+            "clearing the marker must let dispatch resume"
         );
     }
 }

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -1219,8 +1219,74 @@ impl InProcessAgentOrchestrator {
         max_items: usize,
     ) -> Vec<QueuedMasterContinuation> {
         let mut state = self.state();
+        Self::drain_ready_continuations_locked(
+            &mut state,
+            session_id,
+            profile_id,
+            runtime_state,
+            max_items,
+        )
+    }
+
+    /// Atomic drain-and-claim for the cross-subsystem occupancy race (#1529).
+    /// Runs the enqueue + pop AND the in-flight claim under a SINGLE state
+    /// lock, returning the drained continuations plus a clearing guard when
+    /// anything was drained. This is the only way to claim without a race
+    /// window: setting the marker BEFORE the drain self-suppresses the
+    /// session's own due-goal enqueue (which skips in-flight sessions);
+    /// setting it AFTER the drain releases the lock in between, letting a
+    /// concurrent AppUI tick re-enqueue and spawn a duplicate turn for the
+    /// same due goal (both caught by codex re-review). Because the marker is
+    /// set in the same lock scope as the pop, once this returns a continuation
+    /// no other subsystem can re-enqueue for the session until the guard drops
+    /// at the end of the turn. A session already in-flight drains nothing (its
+    /// enqueue is suppressed) → the caller defers.
+    pub(crate) fn drain_and_claim_ready_continuation_for_session(
+        &'static self,
+        session_id: &SessionKey,
+        profile_id: &str,
+        runtime_state: MasterContinuationRuntimeState,
+        max_items: usize,
+    ) -> (
+        Vec<QueuedMasterContinuation>,
+        Option<GoalDispatchInFlightGuard>,
+    ) {
+        let mut state = self.state();
+        let kept = Self::drain_ready_continuations_locked(
+            &mut state,
+            session_id,
+            profile_id,
+            runtime_state,
+            max_items,
+        );
+        let guard = if kept.is_empty() {
+            None
+        } else {
+            state.in_flight_goal_sessions.insert(session_id.clone());
+            Some(GoalDispatchInFlightGuard {
+                orchestrator: self,
+                session_id: session_id.clone(),
+                disarmed: false,
+            })
+        };
+        (kept, guard)
+    }
+
+    /// Enqueue due continuations for `(session, profile)` and drain up to
+    /// `max_items` schedulable ones — the shared body of
+    /// [`Self::drain_ready_continuations_for_session`] and
+    /// [`Self::drain_and_claim_ready_continuation_for_session`], run under a
+    /// caller-held state lock so the latter can claim the in-flight marker
+    /// atomically with the pop.
+    fn drain_ready_continuations_locked(
+        state: &mut AutonomyRuntimeState,
+        session_id: &SessionKey,
+        profile_id: &str,
+        runtime_state: MasterContinuationRuntimeState,
+        max_items: usize,
+    ) -> Vec<QueuedMasterContinuation> {
         let now = now_ms();
-        enqueue_due_loop_continuations(&mut state, session_id, profile_id, runtime_state, now);
+        enqueue_due_loop_continuations(state, session_id, profile_id, runtime_state, now);
         // #1129 codex P1 follow-up: active goals whose
         // `last_continued_at_ms + GOAL_MIN_CONTINUATION_INTERVAL_MS`
         // is past must also be re-queued here. Previously the only
@@ -1228,7 +1294,7 @@ impl InProcessAgentOrchestrator {
         // (which had just stamped `last_continued_at_ms = now`,
         // tripping the min-delay gate), so an active goal only ran
         // its initial continuation and never recurred.
-        enqueue_due_goal_continuations(&mut state, session_id, profile_id, runtime_state, now);
+        enqueue_due_goal_continuations(state, session_id, profile_id, runtime_state, now);
         // #1150 codex P2 follow-up to #1145: `pending_continuation_is_schedulable`
         // gates which sessions `due_loop_targets` surfaces, but the
         // scheduler's drain pops by `(session_key, profile)` without
@@ -1268,7 +1334,7 @@ impl InProcessAgentOrchestrator {
                 break;
             }
             for item in drained {
-                if pending_continuation_is_schedulable(&state, &item) {
+                if pending_continuation_is_schedulable(&*state, &item) {
                     kept.push(item);
                 } else {
                     // #1159 codex P2 follow-up: only TOMBSTONE drops whose
@@ -1281,7 +1347,7 @@ impl InProcessAgentOrchestrator {
                     // same dedupe_key, and a Completed tombstone would
                     // make `upsert_continuation` silently drop the new
                     // Queued event because Completed outranks Queued.
-                    if stale_drop_should_tombstone(&state, &item)
+                    if stale_drop_should_tombstone(&*state, &item)
                         && let Some(store) = state.supervisor_store.as_ref()
                     {
                         let _ = store.record_continuation_completed(
@@ -10679,5 +10745,71 @@ mod tests {
             "pre-setting the marker suppresses the owner's due-goal enqueue \
              (which is why the actor reads, not sets, before draining)"
         );
+    }
+
+    #[test]
+    fn drain_and_claim_sets_marker_atomically_and_defers_when_already_in_flight() {
+        // P1 (tri-repo #1529, codex re-review): the actor drains AND claims the
+        // in-flight marker under ONE state lock. A due goal must (1) enqueue +
+        // drain (the claim does NOT suppress the owner's own enqueue, because
+        // the marker is set AFTER the pop in the same lock) and leave the
+        // marker SET via the returned guard; and (2) when the session is
+        // already in-flight, drain NOTHING and yield NO guard (defer).
+        let orchestrator = default_agent_orchestrator();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "drain-and-claim");
+        orchestrator.clear_goal_dispatch_in_flight(&session_id);
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "atomic claim goal".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let _ = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        if let Some(goal) = orchestrator.state().goals.get_mut(&session_id) {
+            goal.last_continued_at_ms = now_ms() - (GOAL_MIN_CONTINUATION_INTERVAL_MS * 2);
+        }
+
+        // (1) Due + not in-flight: drains a continuation AND claims the marker.
+        let (drained, guard) = orchestrator.drain_and_claim_ready_continuation_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            1,
+        );
+        assert!(!drained.is_empty(), "a due goal must drain a continuation");
+        assert!(guard.is_some(), "draining must claim the in-flight marker");
+        assert!(
+            orchestrator.is_goal_dispatch_in_flight(&session_id),
+            "the marker is set while the guard is held"
+        );
+
+        // (2) While in-flight, a concurrent drain-and-claim yields nothing and
+        // no guard — the second dispatcher defers instead of double-running.
+        if let Some(goal) = orchestrator.state().goals.get_mut(&session_id) {
+            goal.last_continued_at_ms = now_ms() - (GOAL_MIN_CONTINUATION_INTERVAL_MS * 2);
+        }
+        let (drained2, guard2) = orchestrator.drain_and_claim_ready_continuation_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            1,
+        );
+        assert!(
+            drained2.is_empty() && guard2.is_none(),
+            "an already-in-flight session must drain nothing and yield no guard"
+        );
+
+        drop(guard);
+        assert!(!orchestrator.is_goal_dispatch_in_flight(&session_id));
+        orchestrator.clear_goal_dispatch_in_flight(&session_id);
     }
 }

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -2014,6 +2014,39 @@ pub async fn serve_file(
     .await
 }
 
+/// Read a file's bytes through an `O_NOFOLLOW` open (Unix) so a symlink leaf
+/// swapped in after a path was validated cannot redirect the read. On
+/// non-Unix, re-checks `symlink_metadata` before reading (best-effort, still
+/// racy but matches the platform's capabilities). The blocking I/O runs on a
+/// blocking thread.
+async fn read_file_no_follow(path: std::path::PathBuf) -> std::io::Result<Vec<u8>> {
+    tokio::task::spawn_blocking(move || {
+        use std::io::Read;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.read(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.custom_flags(libc::O_NOFOLLOW);
+        }
+        #[cfg(not(unix))]
+        {
+            if path.symlink_metadata().is_ok_and(|m| m.is_symlink()) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "symlink rejected",
+                ));
+            }
+        }
+        let mut file = opts.open(&path)?;
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)?;
+        Ok(bytes)
+    })
+    .await
+    .unwrap_or_else(|e| Err(std::io::Error::other(e)))
+}
+
 async fn serve_file_impl(
     data_dir: &std::path::Path,
     filename: &str,
@@ -2026,7 +2059,14 @@ async fn serve_file_impl(
         return (StatusCode::FORBIDDEN, "access denied").into_response();
     };
 
-    let data = match tokio::fs::read(&path).await {
+    // Read through an O_NOFOLLOW open rather than `tokio::fs::read(&path)`:
+    // `resolve_scoped_download_path` canonicalizes + containment-checks the
+    // path, but the final read still races that check — a leaf swapped to a
+    // symlink after resolution (time-of-check) would be followed by a plain
+    // read (time-of-use), serving an off-tenant / out-of-workspace file
+    // (e.g. a symlink to /etc/passwd). O_NOFOLLOW makes the open fail closed
+    // on a symlink leaf.
+    let data = match read_file_no_follow(path.clone()).await {
         Ok(d) => d,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
     };
@@ -3984,6 +4024,42 @@ fn extract_bearer_from_request(headers: &HeaderMap) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn read_file_no_follow_reads_regular_file_bytes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("doc.pdf");
+        std::fs::write(&file, b"%PDF-1.7 body bytes").unwrap();
+        let bytes = read_file_no_follow(file).await.unwrap();
+        assert_eq!(bytes, b"%PDF-1.7 body bytes");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn read_file_no_follow_rejects_a_symlink_leaf() {
+        // P2 (tri-repo #1529): a served path whose leaf is a symlink (e.g.
+        // swapped in after resolve_scoped_download_path canonicalized it)
+        // must NOT be followed — O_NOFOLLOW fails the open closed instead of
+        // serving the off-tenant target.
+        let dir = tempfile::TempDir::new().unwrap();
+        let target = dir.path().join("secret.txt");
+        std::fs::write(&target, "off-tenant secret").unwrap();
+        let link = dir.path().join("served.pdf");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let err = read_file_no_follow(link).await.unwrap_err();
+        assert_ne!(
+            err.kind(),
+            std::io::ErrorKind::NotFound,
+            "the symlink leaf must be rejected at open, not silently followed"
+        );
+        // The target's content must never be returned.
+        assert!(
+            read_file_no_follow(dir.path().join("served.pdf"))
+                .await
+                .is_err()
+        );
+    }
 
     // Legacy `POST /api/chat` REST tests (chat_request_*, chat_response_*)
     // were retired with the handler in the cleanup follow-up to PR #908.

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -10661,6 +10661,15 @@ async fn maybe_spawn_appui_master_continuation_runner(
     if occupied {
         return false;
     }
+    // Cross-subsystem occupancy (#1529): a session actor draining a
+    // continuation turn for this session marks it in-flight but has no entry
+    // in this connection's `active_turns` map. Without this check the serve
+    // tick would drain + spawn a SECOND concurrent turn on the same session
+    // while the actor's turn runs. The actor clears the marker (RAII guard)
+    // when its turn ends, so the next tick re-dispatches normally.
+    if default_agent_orchestrator().is_goal_dispatch_in_flight(&session_id) {
+        return false;
+    }
 
     let runtime_state = MasterContinuationRuntimeState::idle().with_approval_pending(
         !contracts

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -4810,6 +4810,15 @@ impl SessionActor {
             .profile_id()
             .unwrap_or(MAIN_PROFILE_ID)
             .to_owned();
+        // Cross-subsystem occupancy (#1529): if a continuation turn for this
+        // session is already in flight elsewhere (the AppUI serve tick marks
+        // in-flight when IT dispatches a goal turn), don't drain a second one
+        // here. The queue pop is atomic so a single queued continuation can't
+        // double-run, but this also stops the actor from starting a turn
+        // concurrent with an AppUI turn already underway.
+        if default_agent_orchestrator().is_goal_dispatch_in_flight(&self.session_key) {
+            return false;
+        }
         let continuations = default_agent_orchestrator().drain_ready_continuations_for_session(
             &self.session_key,
             &profile_id,
@@ -4862,6 +4871,15 @@ impl SessionActor {
                 None
             };
             let synthetic = self.synthetic_master_continuation_inbound(&continuation);
+            // Cross-subsystem occupancy (#1529): mark this session in-flight
+            // for the duration of the continuation turn so a concurrent AppUI
+            // serve tick (`maybe_spawn_appui_master_continuation_runner`) and
+            // the due-scan both skip it — otherwise both drain + spawn a
+            // SECOND turn on the same session state. The RAII guard clears the
+            // marker on ANY exit (return / error / panic) at the end of this
+            // iteration, so the next tick re-dispatches normally.
+            let _in_flight_guard = default_agent_orchestrator()
+                .goal_dispatch_in_flight_guard(self.session_key.clone());
             self.process_inbound(synthetic, Vec::new(), Vec::new(), None)
                 .await;
             // If this fire was a self-paced or maintenance loop, peek at

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -4810,22 +4810,17 @@ impl SessionActor {
             .profile_id()
             .unwrap_or(MAIN_PROFILE_ID)
             .to_owned();
-        // Cross-subsystem occupancy (#1529): ATOMICALLY claim the in-flight
-        // marker BEFORE draining. If another dispatch (the AppUI serve tick,
-        // which marks in-flight for its goal turns) already holds it, skip.
-        // Claiming before the pop — under a single state lock — closes the
-        // check-then-mark window codex flagged: with the mark separated from
-        // the pop by an `.await` (the LoopFire history lookup below), a
-        // concurrent tick could drain a SECOND continuation and even set its
-        // own marker that this actor's guard would later clear. The guard is
-        // held across the drain AND the turn; it releases the marker on ANY
-        // exit (empty drain, return, error, panic), so the next tick
-        // re-dispatches normally.
-        let Some(_in_flight_guard) = default_agent_orchestrator()
-            .try_goal_dispatch_in_flight_guard(self.session_key.clone())
-        else {
+        // Cross-subsystem occupancy (#1529), reverse direction: if an AppUI
+        // serve tick already holds the in-flight marker for this session (it
+        // marks in-flight for its goal turns), defer — don't drain a second
+        // turn. This is a READ only: it does NOT set the marker, so the
+        // drain's internal `enqueue_due_goal_continuations` (which skips
+        // in-flight sessions) still enqueues the actor's own due goal turn
+        // (claiming the marker BEFORE the drain suppressed that enqueue and
+        // wedged recurring goal dispatch — codex re-review).
+        if default_agent_orchestrator().is_goal_dispatch_in_flight(&self.session_key) {
             return false;
-        };
+        }
         let continuations = default_agent_orchestrator().drain_ready_continuations_for_session(
             &self.session_key,
             &profile_id,
@@ -4840,6 +4835,16 @@ impl SessionActor {
                 reason = master_continuation_reason_name(&continuation.reason),
                 "draining queued master continuation into session actor"
             );
+            // Cross-subsystem occupancy (#1529), forward direction: mark
+            // in-flight AFTER the drain's enqueue+pop (so the actor's own
+            // due-goal enqueue above was NOT suppressed) but BEFORE the first
+            // await below (the LoopFire `pre_assistant_count` history lookup),
+            // held for the whole turn. This suppresses the AppUI due-scan and
+            // makes its drain skip while the turn runs, so the two subsystems
+            // can't spawn concurrent turns on this session. The RAII guard
+            // clears the marker on ANY exit at the end of this iteration.
+            let _in_flight_guard = default_agent_orchestrator()
+                .goal_dispatch_in_flight_guard(self.session_key.clone());
             // #1131 — `GoalWrapUp` is the final goal turn under
             // budget exhaustion. Treat it as a goal turn for runtime
             // accounting so per-turn elapsed time is still recorded;

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -4810,15 +4810,22 @@ impl SessionActor {
             .profile_id()
             .unwrap_or(MAIN_PROFILE_ID)
             .to_owned();
-        // Cross-subsystem occupancy (#1529): if a continuation turn for this
-        // session is already in flight elsewhere (the AppUI serve tick marks
-        // in-flight when IT dispatches a goal turn), don't drain a second one
-        // here. The queue pop is atomic so a single queued continuation can't
-        // double-run, but this also stops the actor from starting a turn
-        // concurrent with an AppUI turn already underway.
-        if default_agent_orchestrator().is_goal_dispatch_in_flight(&self.session_key) {
+        // Cross-subsystem occupancy (#1529): ATOMICALLY claim the in-flight
+        // marker BEFORE draining. If another dispatch (the AppUI serve tick,
+        // which marks in-flight for its goal turns) already holds it, skip.
+        // Claiming before the pop — under a single state lock — closes the
+        // check-then-mark window codex flagged: with the mark separated from
+        // the pop by an `.await` (the LoopFire history lookup below), a
+        // concurrent tick could drain a SECOND continuation and even set its
+        // own marker that this actor's guard would later clear. The guard is
+        // held across the drain AND the turn; it releases the marker on ANY
+        // exit (empty drain, return, error, panic), so the next tick
+        // re-dispatches normally.
+        let Some(_in_flight_guard) = default_agent_orchestrator()
+            .try_goal_dispatch_in_flight_guard(self.session_key.clone())
+        else {
             return false;
-        }
+        };
         let continuations = default_agent_orchestrator().drain_ready_continuations_for_session(
             &self.session_key,
             &profile_id,
@@ -4871,15 +4878,6 @@ impl SessionActor {
                 None
             };
             let synthetic = self.synthetic_master_continuation_inbound(&continuation);
-            // Cross-subsystem occupancy (#1529): mark this session in-flight
-            // for the duration of the continuation turn so a concurrent AppUI
-            // serve tick (`maybe_spawn_appui_master_continuation_runner`) and
-            // the due-scan both skip it — otherwise both drain + spawn a
-            // SECOND turn on the same session state. The RAII guard clears the
-            // marker on ANY exit (return / error / panic) at the end of this
-            // iteration, so the next tick re-dispatches normally.
-            let _in_flight_guard = default_agent_orchestrator()
-                .goal_dispatch_in_flight_guard(self.session_key.clone());
             self.process_inbound(synthetic, Vec::new(), Vec::new(), None)
                 .await;
             // If this fire was a self-paced or maintenance loop, peek at

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -11880,6 +11880,110 @@ mod tests {
         handle.abort();
     }
 
+    /// #1529 P2 — a goal continuation drained by the SESSION ACTOR must
+    /// charge the goal's `tokens_used` the turn's REAL token usage.
+    ///
+    /// End-to-end: an active goal enqueues a `GoalContinue` continuation;
+    /// the actor's periodic tick drains it into `process_inbound`, which
+    /// stamps `last_turn_total_tokens` from the LLM response's
+    /// input+output tokens; the post-turn hook
+    /// (`maybe_advance_goal_runtime_after_turn`) then passes that value to
+    /// `record_goal_turn`. Before the fix the hook passed a hardcoded 0,
+    /// so `tokens_used` never advanced on the CLI/session-actor path and
+    /// the token-budget gate never tripped.
+    ///
+    /// The goal is registered under `MAIN_PROFILE_ID` because the actor's
+    /// drain loop resolves its goal profile as
+    /// `session_key.profile_id().unwrap_or(MAIN_PROFILE_ID)` and the bare
+    /// `cli:{tag}` test key has no profile segment — `record_goal_turn`
+    /// silently no-ops on a profile mismatch.
+    #[cfg(feature = "api")]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn should_charge_goal_real_turn_tokens_when_actor_drains_goal_continuation() {
+        use crate::api::agent_orchestrator::{AgentOrchestrator, GoalSetRequest};
+
+        let dir = tempfile::TempDir::new().unwrap();
+        // `make_response` carries TokenUsage { input: 50, output: 10 } —
+        // the turn's real total is 60 tokens.
+        let provider = Arc::new(DelayedMockProvider::new(
+            "goal-token-test",
+            vec![(Duration::ZERO, make_response("advancing the goal"))],
+        ));
+        let (tx, _out_rx, handle, _session_mgr) =
+            setup_actor_with_mode(provider.clone(), QueueMode::Followup, None, false, &dir).await;
+        let session_id = test_session_key(dir.path());
+
+        let orchestrator = default_agent_orchestrator();
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: MAIN_PROFILE_ID.into(),
+                objective: "keep the build green".into(),
+                status: Some("active".into()),
+                token_budget: Some(50_000),
+                transition_actor: None,
+            })
+            .expect("set active goal");
+
+        // Pre-condition: nothing accounted before the actor runs the turn.
+        let (tokens_before, continuations_before, _) = orchestrator
+            .goal_counters_for_test(&session_id)
+            .expect("goal exists");
+        assert_eq!(tokens_before, 0);
+        assert_eq!(continuations_before, 0);
+
+        // Cross the actor's continuation tick so it drains the queued
+        // GoalContinue into process_inbound (which calls the provider).
+        for _ in 0..10 {
+            tokio::time::advance(Duration::from_millis(250)).await;
+            if provider.call_count.load(Ordering::Relaxed) > 0 {
+                break;
+            }
+        }
+        assert!(
+            provider.call_count.load(Ordering::Relaxed) > 0,
+            "periodic actor tick must drain the queued goal continuation into process_inbound"
+        );
+
+        // The post-turn accountant runs after process_inbound returns, and
+        // the tail of process_inbound does REAL blocking I/O (the session
+        // JSONL append runs on the spawn_blocking pool) that the paused
+        // virtual clock cannot fast-forward. Wait for it in small bounded
+        // REAL-time slices: each slice parks the runtime on the blocking
+        // pool, so the actor's I/O completion (a real wakeup) gets CPU
+        // time. Bounded at 500 x 2ms = 1s real time; typically a couple of
+        // slices suffice.
+        let mut counters = None;
+        for _ in 0..500 {
+            tokio::task::spawn_blocking(|| {
+                std::thread::sleep(Duration::from_millis(2));
+            })
+            .await
+            .unwrap();
+            let current = orchestrator
+                .goal_counters_for_test(&session_id)
+                .expect("goal still exists");
+            if current.1 >= 1 {
+                counters = Some(current);
+                break;
+            }
+        }
+        let (tokens_used, continuations_used, _window) =
+            counters.expect("goal turn must be recorded within the polling window");
+        assert_eq!(
+            continuations_used, 1,
+            "exactly one goal turn should be accounted"
+        );
+        assert_eq!(
+            tokens_used, 60,
+            "goal budget must be charged the turn's real usage \
+             (50 input + 10 output tokens), not a hardcoded 0"
+        );
+
+        drop(tx);
+        handle.abort();
+    }
+
     #[tokio::test]
     #[cfg(unix)]
     async fn test_session_actor_emits_resume_and_turn_end_hooks() {

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -4810,23 +4810,25 @@ impl SessionActor {
             .profile_id()
             .unwrap_or(MAIN_PROFILE_ID)
             .to_owned();
-        // Cross-subsystem occupancy (#1529), reverse direction: if an AppUI
-        // serve tick already holds the in-flight marker for this session (it
-        // marks in-flight for its goal turns), defer — don't drain a second
-        // turn. This is a READ only: it does NOT set the marker, so the
-        // drain's internal `enqueue_due_goal_continuations` (which skips
-        // in-flight sessions) still enqueues the actor's own due goal turn
-        // (claiming the marker BEFORE the drain suppressed that enqueue and
-        // wedged recurring goal dispatch — codex re-review).
-        if default_agent_orchestrator().is_goal_dispatch_in_flight(&self.session_key) {
-            return false;
-        }
-        let continuations = default_agent_orchestrator().drain_ready_continuations_for_session(
-            &self.session_key,
-            &profile_id,
-            runtime_state,
-            1,
-        );
+        // Cross-subsystem occupancy (#1529): drain AND claim the in-flight
+        // marker under a SINGLE state lock (see
+        // `drain_and_claim_ready_continuation_for_session`). This is the only
+        // race-free ordering — setting the marker before the drain
+        // self-suppresses the actor's own due-goal enqueue; setting it after
+        // the drain opens a window for a concurrent AppUI tick to re-enqueue
+        // and spawn a duplicate turn (both caught by codex re-review). A
+        // session already in-flight (an AppUI goal turn running) drains
+        // nothing and yields no guard, so the actor defers. The guard is held
+        // across the whole turn and clears the marker on ANY exit at the end
+        // of the loop iteration, suppressing the AppUI due-scan/drain until
+        // the turn completes.
+        let (continuations, _in_flight_guard) = default_agent_orchestrator()
+            .drain_and_claim_ready_continuation_for_session(
+                &self.session_key,
+                &profile_id,
+                runtime_state,
+                1,
+            );
         let drained = !continuations.is_empty();
         for continuation in continuations {
             info!(
@@ -4835,16 +4837,6 @@ impl SessionActor {
                 reason = master_continuation_reason_name(&continuation.reason),
                 "draining queued master continuation into session actor"
             );
-            // Cross-subsystem occupancy (#1529), forward direction: mark
-            // in-flight AFTER the drain's enqueue+pop (so the actor's own
-            // due-goal enqueue above was NOT suppressed) but BEFORE the first
-            // await below (the LoopFire `pre_assistant_count` history lookup),
-            // held for the whole turn. This suppresses the AppUI due-scan and
-            // makes its drain skip while the turn runs, so the two subsystems
-            // can't spawn concurrent turns on this session. The RAII guard
-            // clears the marker on ANY exit at the end of this iteration.
-            let _in_flight_guard = default_agent_orchestrator()
-                .goal_dispatch_in_flight_guard(self.session_key.clone());
             // #1131 — `GoalWrapUp` is the final goal turn under
             // budget exhaustion. Treat it as a goal turn for runtime
             // accounting so per-turn elapsed time is still recorded;

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -3843,6 +3843,7 @@ impl ActorFactory {
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
             consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
+            last_turn_total_tokens: 0,
         };
 
         // Spawn the outbound forwarding task — buffers messages from inactive sessions
@@ -4388,6 +4389,14 @@ struct SessionActor {
     /// cleared at the end. `None` outside command handling — `send_reply`
     /// then falls back to legacy behavior (stamping no thread_id).
     current_command_cmid: Option<String>,
+
+    /// Total tokens (input + output) attributed to the MOST RECENT turn run
+    /// by `process_inbound`. Set on every LLM turn; read by
+    /// `maybe_advance_goal_runtime_after_turn` so a goal continuation's token
+    /// budget is charged the turn's real usage instead of a hardcoded 0
+    /// (which let a goal recur past its token budget). Reset to 0 at the top
+    /// of each turn so a failed/no-response turn charges nothing.
+    last_turn_total_tokens: u64,
 }
 
 impl SessionActor {
@@ -4933,13 +4942,11 @@ impl SessionActor {
     /// continuation only when the runtime stays idle AND the per-goal
     /// policy still allows another fire.
     ///
-    /// Token tracking is wired through the goal record's `tokens_used`
-    /// only when the orchestrator-level `record_goal_turn` is called
-    /// with a non-zero `tokens_consumed`. The per-turn LLM token usage
-    /// is currently still attributed via existing audit paths; surfacing
-    /// it into this hook is a deliberate follow-up so the first
-    /// production cut closes the recurrence + budget-state-machine
-    /// bullets cleanly without restructuring `process_inbound`.
+    /// The goal record's `tokens_used` is charged this turn's real token
+    /// usage (`last_turn_total_tokens`, set by `process_inbound` from the LLM
+    /// response's input+output tokens — the same per-turn total the AppUI
+    /// dispatch path attributes). Passing 0 here previously let the token
+    /// budget gate never trip, so a goal recurred past its token budget.
     #[cfg(feature = "api")]
     async fn maybe_advance_goal_runtime_after_turn(
         &mut self,
@@ -4947,8 +4954,14 @@ impl SessionActor {
         goal_turn_start: Instant,
     ) {
         let elapsed_seconds = goal_turn_start.elapsed().as_secs();
+        let tokens_consumed = self.last_turn_total_tokens;
         let orchestrator = default_agent_orchestrator();
-        orchestrator.record_goal_turn(&self.session_key, profile_id, 0, elapsed_seconds);
+        orchestrator.record_goal_turn(
+            &self.session_key,
+            profile_id,
+            tokens_consumed,
+            elapsed_seconds,
+        );
         // Capture the most recent assistant turn's text content to feed
         // the completion-sentinel detector. Reading from the durable
         // session handle keeps the wiring narrow — `process_inbound`
@@ -8770,6 +8783,10 @@ impl SessionActor {
         attachment_media: Vec<String>,
         attachment_prompt: Option<String>,
     ) {
+        // Reset per-turn token accounting so a turn that fails / produces no
+        // response charges 0 to the goal budget (set to the real usage below
+        // once the LLM response is in hand).
+        self.last_turn_total_tokens = 0;
         // Consecutive-recovery cap reset
         // (feat/spawn-only-failure-feedback-loop): user-initiated turns
         // break the "recovery chain" — once the user re-engages we no
@@ -9112,6 +9129,11 @@ impl SessionActor {
         if let Ok(Ok(ref cr)) = result {
             self.record_usage_event(cr, client_message_id.as_deref(), None)
                 .await;
+            // Attribute this turn's real token usage so a goal continuation
+            // charges its budget correctly (read by
+            // `maybe_advance_goal_runtime_after_turn`).
+            self.last_turn_total_tokens = u64::from(cr.token_usage.input_tokens)
+                .saturating_add(u64::from(cr.token_usage.output_tokens));
         }
 
         match result {
@@ -11695,6 +11717,7 @@ mod tests {
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
             consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
+            last_turn_total_tokens: 0,
         };
 
         let handle = tokio::spawn(actor.run());
@@ -11775,6 +11798,7 @@ mod tests {
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
             consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
+            last_turn_total_tokens: 0,
         };
 
         let handle = tokio::spawn(actor.run());
@@ -11936,6 +11960,7 @@ mod tests {
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
             consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
+            last_turn_total_tokens: 0,
         };
 
         let handle = tokio::spawn(actor.run());
@@ -12069,6 +12094,7 @@ mod tests {
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
             consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
+            last_turn_total_tokens: 0,
         };
 
         let handle = tokio::spawn(actor.run());
@@ -12198,6 +12224,7 @@ mod tests {
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
             consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
+            last_turn_total_tokens: 0,
         };
 
         let handle = tokio::spawn(actor.run());
@@ -12299,6 +12326,7 @@ mod tests {
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
             consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
+            last_turn_total_tokens: 0,
         };
 
         let handle = tokio::spawn(actor.run());
@@ -12399,6 +12427,7 @@ mod tests {
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
             consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
+            last_turn_total_tokens: 0,
         };
 
         let handle = tokio::spawn(actor.run());
@@ -17823,6 +17852,7 @@ mod tests {
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
             consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
+            last_turn_total_tokens: 0,
             usage_ledger: None,
             usage_profile_id: "test-profile".to_string(),
         };

--- a/crates/octos-llm/src/failover.rs
+++ b/crates/octos-llm/src/failover.rs
@@ -5,6 +5,7 @@
 //! Each provider has a circuit breaker that degrades after repeated failures
 //! and resets on success.
 
+use std::future::Future;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
@@ -16,6 +17,7 @@ use octos_core::Message;
 use tracing::{info, warn};
 
 use crate::config::ChatConfig;
+use crate::error::LlmError;
 use crate::provider::LlmProvider;
 use crate::retry::RetryProvider;
 use crate::types::{ChatResponse, ChatStream, ProviderMetadata, StreamEvent, ToolSpec};
@@ -31,7 +33,9 @@ struct ProviderSlot {
 /// Tries providers in order, skipping degraded ones (failure count >= threshold).
 /// On retriable error, moves to the next provider. On success, resets the
 /// provider's failure count.
-/// Default wall-clock timeout for an entire `chat()` call across all providers.
+/// Default per-lane timeout for a single provider attempt (that provider's
+/// internal retries included). A lane that exceeds it is recorded as failed
+/// and the chain fails over to the next lane.
 const DEFAULT_MAX_REQUEST_DURATION: Duration = Duration::from_secs(120);
 
 pub struct ProviderChain {
@@ -41,7 +45,11 @@ pub struct ProviderChain {
     /// Index of the last provider that returned a successful response.
     /// Used by `report_late_failure` to penalize the correct provider.
     last_success_index: AtomicU32,
-    /// Wall-clock timeout for the entire chain (retry + failover included).
+    /// Per-lane wall-clock timeout for a single provider attempt (that
+    /// provider's internal retries included). A lane that hangs past it is
+    /// recorded as failed — so `pick_start` stops re-selecting it — and the
+    /// chain fails over. Total chain time is bounded by
+    /// `slots.len()` x this duration.
     max_request_duration: Option<Duration>,
 }
 
@@ -75,7 +83,8 @@ impl ProviderChain {
         self
     }
 
-    /// Set the wall-clock timeout for the entire chain. `None` disables the cap.
+    /// Set the per-lane timeout for a single provider attempt. `None`
+    /// disables the cap.
     pub fn with_max_request_duration(mut self, duration: Option<Duration>) -> Self {
         self.max_request_duration = duration;
         self
@@ -112,6 +121,32 @@ impl ProviderChain {
         }
     }
 
+    /// Await a single lane's request, capped by `max_request_duration`.
+    ///
+    /// A lane that exceeds the cap yields a typed `LlmErrorKind::Timeout`
+    /// error attributed to that lane. The caller's `Err` arm then treats it
+    /// like any other retriable failure: the lane's failure count is
+    /// incremented (so `pick_start` stops re-selecting a hung lane) and the
+    /// chain fails over to the next lane within the same call.
+    async fn with_lane_timeout<T>(
+        &self,
+        provider_name: &str,
+        fut: impl Future<Output = Result<T>>,
+    ) -> Result<T> {
+        match self.max_request_duration {
+            Some(dur) => match tokio::time::timeout(dur, fut).await {
+                Ok(result) => result,
+                Err(_) => Err(LlmError::timeout(format!(
+                    "no response after {:.0}s",
+                    dur.as_secs_f64()
+                ))
+                .with_provider(provider_name)
+                .into()),
+            },
+            None => fut.await,
+        }
+    }
+
     async fn chat_inner(
         &self,
         messages: &[Message],
@@ -130,7 +165,14 @@ impl ProviderChain {
                 continue;
             }
 
-            match slot.provider.chat(messages, tools, config).await {
+            let result = self
+                .with_lane_timeout(
+                    slot.provider.provider_name(),
+                    slot.provider.chat(messages, tools, config),
+                )
+                .await;
+
+            match result {
                 Ok(mut response) => {
                     self.record_success(idx);
                     response.provider_index = Some(idx);
@@ -184,16 +226,11 @@ impl LlmProvider for ProviderChain {
         tools: &[ToolSpec],
         config: &ChatConfig,
     ) -> Result<ChatResponse> {
-        let fut = self.chat_inner(messages, tools, config);
-        match self.max_request_duration {
-            Some(dur) => tokio::time::timeout(dur, fut).await.map_err(|_| {
-                eyre::eyre!(
-                    "ProviderChain timed out after {:.0}s (all retries + failovers)",
-                    dur.as_secs_f64()
-                )
-            })?,
-            None => fut.await,
-        }
+        // The per-lane timeout lives inside `chat_inner` (around each
+        // provider await) so a hung lane is attributed via
+        // `record_failure(idx)` and the chain can still fail over to a
+        // healthy lane within this same call.
+        self.chat_inner(messages, tools, config).await
     }
 
     async fn chat_stream(
@@ -213,7 +250,17 @@ impl LlmProvider for ProviderChain {
                 continue;
             }
 
-            match slot.provider.chat_stream(messages, tools, config).await {
+            // Cap stream *initialization* per lane; consuming the returned
+            // stream is unaffected. A hung init is recorded below and the
+            // chain fails over like any other retriable error.
+            let result = self
+                .with_lane_timeout(
+                    slot.provider.provider_name(),
+                    slot.provider.chat_stream(messages, tools, config),
+                )
+                .await;
+
+            match result {
                 Ok(stream) => {
                     self.record_success(idx);
                     return Ok(self.stream_with_provider_index(idx, stream));
@@ -322,6 +369,33 @@ mod tests {
 
         fn model_id(&self) -> &str {
             "success-model"
+        }
+
+        fn provider_name(&self) -> &str {
+            self.name
+        }
+    }
+
+    /// Provider whose `chat()` never resolves — simulates a hung lane
+    /// (e.g. a TCP connection that accepts but never responds).
+    struct HangingProvider {
+        name: &'static str,
+    }
+
+    #[async_trait]
+    impl LlmProvider for HangingProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            _config: &ChatConfig,
+        ) -> Result<ChatResponse> {
+            std::future::pending::<()>().await;
+            unreachable!("hanging provider never resolves")
+        }
+
+        fn model_id(&self) -> &str {
+            "hang-model"
         }
 
         fn provider_name(&self) -> &str {
@@ -439,5 +513,90 @@ mod tests {
 
         // Now should route to fallback (primary is degraded)
         assert_eq!(chain.provider_name(), "fallback");
+    }
+
+    #[tokio::test]
+    async fn should_failover_to_healthy_lane_when_chat_hangs() {
+        let chain = ProviderChain::new(vec![
+            Arc::new(HangingProvider { name: "hung" }),
+            Arc::new(SuccessProvider { name: "fallback" }),
+        ])
+        .with_max_request_duration(Some(Duration::from_millis(50)));
+
+        let result = chain
+            .chat(&[], &[], &ChatConfig::default())
+            .await
+            .expect("chain must fail over past the hung lane and succeed");
+        assert_eq!(result.content.as_deref(), Some("ok"));
+        assert_eq!(result.provider_index, Some(1));
+        assert_eq!(
+            chain.slots[0].failures.load(Ordering::Relaxed),
+            1,
+            "hung lane must be recorded as failed"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_skip_hung_lane_when_failure_threshold_crossed() {
+        let chain = ProviderChain::new(vec![
+            Arc::new(HangingProvider { name: "hung" }),
+            Arc::new(SuccessProvider { name: "fallback" }),
+        ])
+        .with_failure_threshold(2)
+        .with_max_request_duration(Some(Duration::from_millis(50)));
+
+        // Two hangs cross the threshold and degrade the lane.
+        let _ = chain.chat(&[], &[], &ChatConfig::default()).await;
+        let _ = chain.chat(&[], &[], &ChatConfig::default()).await;
+        assert!(
+            chain.slots[0].failures.load(Ordering::Relaxed) >= 2,
+            "each hang must increment the lane's failure count"
+        );
+
+        // pick_start must now skip the hung lane entirely.
+        assert_eq!(chain.provider_name(), "fallback");
+
+        // The next call goes straight to the healthy lane: no new timeout
+        // failure is recorded on the hung lane.
+        let before = chain.slots[0].failures.load(Ordering::Relaxed);
+        let result = chain
+            .chat(&[], &[], &ChatConfig::default())
+            .await
+            .expect("degraded lane must be skipped, healthy lane succeeds");
+        assert_eq!(result.provider_index, Some(1));
+        assert_eq!(
+            chain.slots[0].failures.load(Ordering::Relaxed),
+            before,
+            "degraded lane must not be re-awaited"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_failover_stream_init_when_chat_stream_hangs() {
+        let chain = ProviderChain::new(vec![
+            Arc::new(HangingProvider { name: "hung" }),
+            Arc::new(SuccessProvider { name: "fallback" }),
+        ])
+        .with_max_request_duration(Some(Duration::from_millis(50)));
+
+        // Guard with a generous outer timeout so a regression fails the
+        // test instead of hanging the suite forever.
+        let result = tokio::time::timeout(
+            Duration::from_secs(2),
+            chain.chat_stream(&[], &[], &ChatConfig::default()),
+        )
+        .await
+        .expect("chat_stream must not hang when a lane hangs");
+
+        let mut stream = result.expect("stream must fail over to the healthy lane");
+        assert_eq!(
+            chain.slots[0].failures.load(Ordering::Relaxed),
+            1,
+            "hung stream init must be recorded as failed"
+        );
+        match stream.next().await {
+            Some(StreamEvent::ProviderIndex(idx)) => assert_eq!(idx, 1),
+            other => panic!("expected ProviderIndex(1) first, got {other:?}"),
+        }
     }
 }

--- a/crates/octos-llm/src/retry.rs
+++ b/crates/octos-llm/src/retry.rs
@@ -216,8 +216,8 @@ impl RetryProvider {
 
     /// Extract a longer delay for rate-limit (429 TPM) errors.
     /// OpenAI errors include "Please try again in 29.159s" — parse that.
-    /// Falls back to 30s if unparseable.
-    fn rate_limit_delay(error: &eyre::Report) -> Option<Duration> {
+    /// Falls back to 30s if unparseable. Always clamped to `max_delay`.
+    fn rate_limit_delay(&self, error: &eyre::Report) -> Option<Duration> {
         let msg = error.to_string();
         // Only apply to rate-limit / TPM errors
         let msg_lower = msg.to_lowercase();
@@ -229,20 +229,36 @@ impl RetryProvider {
         {
             return None;
         }
-        // Try to parse "try again in Xs" or "try again in X.XXXs"
+        // Try to parse "try again in Xs" / "X.XXXs" / "Xms". The numeric run
+        // stops at the first unit letter; the UNIT that follows decides the
+        // scale. Consuming only the digits and assuming seconds turned a
+        // sub-second "try again in 906ms" hint into a ~15-minute sleep.
         if let Some(idx) = msg.find("try again in ") {
             let after = &msg[idx + "try again in ".len()..];
             let num_str: String = after
                 .chars()
                 .take_while(|c| c.is_ascii_digit() || *c == '.')
                 .collect();
-            if let Ok(secs) = num_str.parse::<f64>() {
-                // Add 1s buffer
-                return Some(Duration::from_secs_f64(secs + 1.0));
+            if let Ok(value) = num_str.parse::<f64>() {
+                // `num_str` is ASCII digits/'.', so its char len == byte len.
+                let unit = after[num_str.len()..].trim_start();
+                let base = if unit.starts_with("ms") {
+                    Duration::from_secs_f64(value / 1000.0)
+                } else {
+                    // "s", "sec", or a bare number → seconds (OpenAI/Anthropic
+                    // spell sub-second hints in ms, so a unit-less value is a
+                    // whole-second count).
+                    Duration::from_secs_f64(value)
+                };
+                // Add a 1s buffer, then clamp to `max_delay` so a large or
+                // malformed hint ("try again in 1800s") can't park the whole
+                // provider on a multi-minute sleep past the configured ceiling.
+                let delay = base.saturating_add(Duration::from_secs(1));
+                return Some(delay.min(self.config.max_delay));
             }
         }
-        // Fallback: wait 30s for TPM to reset
-        Some(Duration::from_secs(30))
+        // Fallback: wait 30s for TPM to reset (still clamped to max_delay).
+        Some(Duration::from_secs(30).min(self.config.max_delay))
     }
 }
 
@@ -264,7 +280,8 @@ impl LlmProvider for RetryProvider {
                 }
                 Err(e) => {
                     if attempt < self.config.max_retries && Self::is_retryable_error(&e) {
-                        let delay = Self::rate_limit_delay(&e)
+                        let delay = self
+                            .rate_limit_delay(&e)
                             .unwrap_or_else(|| self.calculate_delay(attempt));
                         warn!(
                             attempt = attempt + 1,
@@ -302,7 +319,8 @@ impl LlmProvider for RetryProvider {
                 }
                 Err(e) => {
                     if attempt < self.config.max_retries && Self::is_retryable_error(&e) {
-                        let delay = Self::rate_limit_delay(&e)
+                        let delay = self
+                            .rate_limit_delay(&e)
                             .unwrap_or_else(|| self.calculate_delay(attempt));
                         warn!(
                             attempt = attempt + 1,
@@ -517,28 +535,69 @@ mod tests {
         assert!(RetryProvider::should_failover(&err));
     }
 
+    /// A retry provider with a generous `max_delay` so the clamp does not
+    /// interfere with parse-scale assertions.
+    fn retry_provider_uncapped() -> RetryProvider {
+        RetryProvider {
+            inner: Arc::new(MockProvider),
+            config: RetryConfig {
+                max_delay: Duration::from_secs(3600),
+                ..RetryConfig::default()
+            },
+        }
+    }
+
     #[test]
     fn test_rate_limit_delay_parses_seconds() {
         let err = eyre::eyre!(
             "OpenAI API error: 429 Too Many Requests - Rate limit reached. Please try again in 29.159s"
         );
-        let delay = RetryProvider::rate_limit_delay(&err).unwrap();
+        let delay = retry_provider_uncapped().rate_limit_delay(&err).unwrap();
         // 29.159 + 1.0 buffer = ~30.159s
         assert!(delay.as_secs_f64() > 29.0 && delay.as_secs_f64() < 32.0);
+    }
+
+    #[test]
+    fn test_rate_limit_delay_parses_milliseconds() {
+        // "906ms" must be read as 0.906s, NOT 906s — the unit suffix decides
+        // the scale (the +1s buffer dominates the sub-second value).
+        let err =
+            eyre::eyre!("OpenAI API error: 429 Too Many Requests - Please try again in 906ms");
+        let delay = retry_provider_uncapped().rate_limit_delay(&err).unwrap();
+        assert!(
+            delay.as_secs_f64() > 1.0 && delay.as_secs_f64() < 2.5,
+            "906ms + 1s buffer must be ~1.9s, got {delay:?}"
+        );
+    }
+
+    #[test]
+    fn test_rate_limit_delay_clamps_to_max_delay() {
+        // A large (or malformed) hint cannot exceed the configured ceiling.
+        let provider = RetryProvider {
+            inner: Arc::new(MockProvider),
+            config: RetryConfig {
+                max_delay: Duration::from_secs(60),
+                ..RetryConfig::default()
+            },
+        };
+        let err =
+            eyre::eyre!("OpenAI API error: 429 Too Many Requests - Please try again in 1800s");
+        let delay = provider.rate_limit_delay(&err).unwrap();
+        assert_eq!(delay, Duration::from_secs(60), "must clamp to max_delay");
     }
 
     #[test]
     fn test_rate_limit_delay_fallback() {
         let err =
             eyre::eyre!("OpenAI API error: 429 Too Many Requests - tokens per min limit exceeded");
-        let delay = RetryProvider::rate_limit_delay(&err).unwrap();
+        let delay = retry_provider_uncapped().rate_limit_delay(&err).unwrap();
         assert_eq!(delay, Duration::from_secs(30));
     }
 
     #[test]
     fn test_rate_limit_delay_not_429() {
         let err = eyre::eyre!("OpenAI API error: 500 Internal Server Error");
-        assert!(RetryProvider::rate_limit_delay(&err).is_none());
+        assert!(retry_provider_uncapped().rate_limit_delay(&err).is_none());
     }
 
     #[test]

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -3274,9 +3274,17 @@ impl PipelineExecutor {
                     eyre::eyre!("codergen handler not found for dynamic_parallel workers")
                 })?;
 
-                // Execute all synthetic nodes concurrently
+                // Execute all synthetic nodes concurrently, capped by the
+                // same `max_parallel_workers` semaphore the static `Parallel`
+                // branch uses. The planner may yield more tasks than the
+                // limit; without this gate every synthetic worker would
+                // dispatch at once (the planner's `llm_semaphore` bounds
+                // concurrent LLM calls, not in-flight workers).
                 let total_workers = synthetic_nodes.len();
                 let completed_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+                let semaphore = Arc::new(tokio::sync::Semaphore::new(
+                    self.config.max_parallel_workers,
+                ));
                 let mut futures = Vec::new();
                 // coding-blue FA-7: same fan-out reservation pattern as
                 // the static Parallel branch — reserve per-worker up
@@ -3340,6 +3348,7 @@ impl PipelineExecutor {
                     // PANICS (the future unwinds; `join_all` surfaces the panic).
                     let dp_node_index = worker_idx + 1;
 
+                    let sem = semaphore.clone();
                     let pipeline_id = graph.id.clone();
                     let guard_label = worker_label.clone();
                     let guard_tid = task_id.clone();
@@ -3351,8 +3360,10 @@ impl PipelineExecutor {
                     // attempt bounded by `MAX_FANOUT_WORKER_SECS`.
                     let hook_executor = self.config.hook_executor.clone();
                     futures.push(async move {
+                        let _permit = sem.acquire().await.expect("semaphore closed");
                         // Arm the guard HERE — only once the future is actually
-                        // polled, guaranteeing a started/completed pair.
+                        // polled AND holds a worker permit, guaranteeing a
+                        // started/completed pair for a worker that actually ran.
                         let guard = NodeProgressGuard::arm(
                             &pipeline_id,
                             &guard_tid,
@@ -6343,6 +6354,132 @@ mod tests {
                 assert_eq!(*count, 0, "no workers should dispatch before the cap fires");
             }
         }
+    }
+
+    /// Planner provider for the dynamic fan-out concurrency test: returns a
+    /// JSON array of exactly 6 tasks so the `dynamic_parallel` node plans
+    /// MORE workers than `max_parallel_workers`.
+    struct SixTaskPlanner;
+
+    #[async_trait::async_trait]
+    impl LlmProvider for SixTaskPlanner {
+        async fn chat(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> Result<octos_llm::ChatResponse> {
+            Ok(octos_llm::ChatResponse {
+                content: Some(
+                    r#"[{"task":"t1","label":"T1"},{"task":"t2","label":"T2"},
+                        {"task":"t3","label":"T3"},{"task":"t4","label":"T4"},
+                        {"task":"t5","label":"T5"},{"task":"t6","label":"T6"}]"#
+                        .to_string(),
+                ),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: octos_llm::TokenUsage::default(),
+                provider_index: None,
+            })
+        }
+
+        fn model_id(&self) -> &str {
+            "mock-planner"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    /// Codergen stand-in that records the peak number of concurrently
+    /// executing fan-out workers: increment an in-flight counter on entry,
+    /// fold it into the running maximum, hold the slot across a real await,
+    /// decrement on exit.
+    struct ConcurrencyProbeHandler {
+        in_flight: Arc<AtomicUsize>,
+        max_in_flight: Arc<AtomicUsize>,
+        executed: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl Handler for ConcurrencyProbeHandler {
+        async fn execute(&self, node: &PipelineNode, _ctx: &HandlerContext) -> Result<NodeOutcome> {
+            let now = self.in_flight.fetch_add(1, AtomicOrdering::SeqCst) + 1;
+            self.max_in_flight.fetch_max(now, AtomicOrdering::SeqCst);
+            // Hold the slot across an await point. `join_all` polls every
+            // worker future once within microseconds, so 50ms guarantees all
+            // concurrently-dispatched workers pile up before the first exits
+            // — no racing needed for a deterministic peak.
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            self.in_flight.fetch_sub(1, AtomicOrdering::SeqCst);
+            self.executed.fetch_add(1, AtomicOrdering::SeqCst);
+            Ok(NodeOutcome {
+                node_id: node.id.clone(),
+                status: OutcomeStatus::Pass,
+                content: format!("{} done", node.id),
+                token_usage: TokenUsage::default(),
+                files_modified: vec![],
+            })
+        }
+    }
+
+    /// The dynamic fan-out must honor `max_parallel_workers` exactly like
+    /// the static `Parallel` branch. A planner that yields 6 tasks with
+    /// `max_parallel_workers = 2` may never have more than 2 workers
+    /// in flight at once.
+    #[tokio::test]
+    async fn should_cap_dynamic_parallel_worker_concurrency_when_planner_exceeds_limit() {
+        let mut config = make_capped_config(100).await;
+        config.default_provider = Arc::new(SixTaskPlanner);
+        config.max_parallel_workers = 2;
+        let executor = PipelineExecutor::new(config);
+
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let executed = Arc::new(AtomicUsize::new(0));
+
+        let mut handlers = HandlerRegistry::new();
+        handlers.register(
+            HandlerKind::Codergen,
+            Arc::new(ConcurrencyProbeHandler {
+                in_flight: in_flight.clone(),
+                max_in_flight: max_in_flight.clone(),
+                executed: executed.clone(),
+            }),
+        );
+        handlers.register(HandlerKind::DynamicParallel, Arc::new(NoopHandler));
+        handlers.register(HandlerKind::Noop, Arc::new(NoopHandler));
+
+        let dot = r#"
+            digraph t {
+                plan [handler="dynamic_parallel", converge="merge", prompt="plan"]
+                merge [handler="noop"]
+                plan -> merge
+            }
+        "#;
+
+        let result = executor
+            .run_with_handlers(dot, "seed", &serde_json::Map::new(), handlers)
+            .await
+            .expect("dynamic parallel pipeline should complete");
+        assert!(result.success);
+
+        // The planner JSON must have driven the fan-out (6 workers), not the
+        // 3-task fallback — otherwise the concurrency assertion below tests
+        // a weaker shape than intended.
+        assert_eq!(
+            executed.load(AtomicOrdering::SeqCst),
+            6,
+            "expected all 6 planned workers to run"
+        );
+        let peak = max_in_flight.load(AtomicOrdering::SeqCst);
+        assert!(
+            peak <= 2,
+            "dynamic_parallel fan-out must gate workers to max_parallel_workers=2, \
+             but {peak} ran concurrently"
+        );
     }
 
     /// Guard B sanity check: when the fan-out is below the cap the


### PR DESCRIPTION
Fixes the **P2 tier** of the 2026-07 tri-repo review backlog (octos-org/octos#1529) — 17 verified findings across security, LLM routing, the agent runtime, autonomy scheduling, session persistence, and the pipeline engine. Every fix is RED→GREEN (a failing test written/verified first, then the fix), and each was reviewed (per-commit codex or independent re-verification of agent-produced diffs).

## Fixes

**Security**
- **SSRF: block CGNAT + other non-routable IPv4 ranges** — `is_private_ip` missed 100.64.0.0/10 (RFC 6598) and adjacent benchmark/reserved/multicast ranges (std predicates are nightly-only → explicit octet checks). Mapped IPv6 forms covered via recursion.
- **PDF/file-serve O_NOFOLLOW TOCTOU** — `read_no_follow`'s PDF branch re-read by path (`std::fs::read`) after the O_NOFOLLOW open, following a swapped-in symlink; now reads from the held fd (seek-back). `serve_file_impl` served files via `tokio::fs::read` after canonicalize; now O_NOFOLLOW.

**LLM**
- **Retry-After unit + clamp** — `"906ms"` was read as 906s; now parses the unit and clamps to `max_delay`.
- **Failover hung-lane** — a lane that hangs to the 120s chain timeout was never recorded failed → re-picked forever; now a per-lane timeout records the failure and fails over in-call (stream-init too).

**Agent runtime**
- **exec_command timeout** — left the child tree running; now kills the process group (mirrors the bash tool).
- **Batch-timeout fabrication** — a parallel-batch timeout replaced every call's result with "timed out", discarding completed calls; now each handle is raced against one deadline so completed results survive.
- **DiffLikeSuccess** — shell-spiral recovery fired on all-success turns; now gated on a real failure.
- **Contract Satisfied→Failed** — a satisfied spawn_only contract in chat mode (no bg sender) was marked Failed; now distinguishes "no channel" from "delivery failed".

**Autonomy scheduling**
- **/loop resume** re-arms `next_run_at_ms` (an interrupted self-paced loop was unschedulable forever).
- **Goal budget** charges the turn's real token usage on the session-actor path (was hardcoded 0), with an end-to-end actor test.
- **fire_now double-fire** — a manual fire racing the scheduled tick enqueued two LoopFires (metadata-divergent dedupe keys); now a stable identity key.
- **Due-loop cross-subsystem race** — the session actor drained continuation turns without registering occupancy, so the AppUI serve tick double-dispatched; the actor now *atomically* claims the in-flight marker before draining and the AppUI drain respects it.

**Bus / persistence**
- **Matrix acks** — returned 200 (never-retry) on a buffered-or-failed enqueue; now 500 + un-records the txn id so the homeserver retries.
- **Cron re-arm double-fire** — fired before advancing next_run; now reserves the next run before firing.
- **Rollback marker** appended without the persist lock (a concurrent rewrite erased it); now under `persist_lock_for`.
- **Seq assignment** derived from a stale in-memory mirror → duplicate seqs; now atomic under the persist lock with a disk read-back.

**Pipeline**
- **dynamic_parallel** bypassed the `max_parallel_workers` semaphore; now gated like the static path.

## Verification
- octos-llm (418), octos-pipeline (336), octos-bus (217), octos-cli (1911, single-threaded) — all green.
- octos-agent green modulo the known env flakes (plugin-parallelism → pass single-threaded; two `.invalid`-resolver ssrf/DNS tests → pass in CI) — none touch these fixes; proven pre-existing.
- Six fixes were produced by isolated fix-agents; each diff was independently re-verified (read, applied, tested, neutered-to-RED) before landing.

Closes the P2 checkboxes in #1529 (P3 bonuses remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)