### PR TITLE
feat(memory): PR-2 capture layer — prompt segments, memory_note tool, read-side refresh

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -2,6 +2,13 @@
   "provider": "anthropic",
   "model": "claude-sonnet-4-20250514",
 
+  "memory": {
+    "max_inject_tokens": 2500,
+    "refresh": {
+      "enabled": false
+    }
+  },
+
   "sub_providers": [
     {
       "key": "cheap",

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -748,6 +748,12 @@ impl Agent {
                 self.tools.reset_spawn_only_invoked();
                 self.reset_loop_detected_recently();
 
+                // Refresh provider-backed prompt segments (e.g. the memory
+                // block when MEMORY.md changed on disk) before composing.
+                // No-op unless providers are registered; providers keep the
+                // unchanged path to a single stat.
+                self.refresh_prompt_segments().await;
+
                 // Build the system prompt via the shared helper in
                 // execution.rs so conversation + task loops compose the same
                 // prompt. This is where realtime sensor summary gets appended

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -11,6 +11,7 @@ mod loop_runner;
 pub mod loop_state;
 pub mod memory;
 mod message_repair;
+pub mod prompt_segments;
 pub mod realtime;
 pub mod rich_output;
 mod streaming;
@@ -24,6 +25,8 @@ use std::sync::{Arc, RwLock};
 use octos_core::{AgentId, Message, SessionScope, TokenUsage};
 use octos_llm::{EmbeddingProvider, LlmProvider, ProviderMetadata};
 use octos_memory::EpisodeStore;
+
+pub use prompt_segments::PromptSegmentProvider;
 
 use crate::file_state_cache::FileStateCache;
 use crate::hooks::{HookContext, HookExecutor};
@@ -260,8 +263,12 @@ pub struct Agent {
     pub(super) memory: Arc<EpisodeStore>,
     /// Embedding provider for hybrid memory search.
     pub(super) embedder: Option<Arc<dyn EmbeddingProvider>>,
-    /// System prompt for this agent (RwLock for hot-reload support).
-    pub(super) system_prompt: RwLock<String>,
+    /// System prompt for this agent, as ordered segments (RwLock for
+    /// hot-reload support). See [`prompt_segments::PromptSegments`].
+    pub(super) system_prompt: RwLock<prompt_segments::PromptSegments>,
+    /// Providers that refresh named prompt segments between turns
+    /// (e.g. the memory block). Run by [`Agent::refresh_prompt_segments`].
+    pub(super) segment_providers: RwLock<Vec<Arc<dyn PromptSegmentProvider>>>,
     /// Agent configuration.
     pub(super) config: AgentConfig,
     /// Progress reporter (RwLock for interior-mutable swap without &mut self).
@@ -430,7 +437,8 @@ impl Agent {
             tools,
             memory,
             embedder: None,
-            system_prompt: RwLock::new(system_prompt),
+            system_prompt: RwLock::new(prompt_segments::PromptSegments::from_base(system_prompt)),
+            segment_providers: RwLock::new(Vec::new()),
             config: AgentConfig::default(),
             reporter: RwLock::new(Arc::new(SilentReporter)),
             hooks: None,
@@ -501,7 +509,8 @@ impl Agent {
             tools,
             memory,
             embedder: None,
-            system_prompt: RwLock::new(system_prompt),
+            system_prompt: RwLock::new(prompt_segments::PromptSegments::from_base(system_prompt)),
+            segment_providers: RwLock::new(Vec::new()),
             config: AgentConfig::default(),
             reporter: RwLock::new(Arc::new(SilentReporter)),
             hooks: None,
@@ -645,10 +654,10 @@ impl Agent {
         // A poisoned lock means a prior holder panicked, but the String
         // data itself is still valid and overwritten here.
         if let Some(ref wp) = config.worker_prompt {
-            *self
-                .system_prompt
+            self.system_prompt
                 .write()
-                .unwrap_or_else(|e| e.into_inner()) = wp.clone();
+                .unwrap_or_else(|e| e.into_inner())
+                .replace_all(wp.clone());
         }
         self.config = config;
         self
@@ -1010,30 +1019,97 @@ impl Agent {
     }
 
     /// Override the system prompt (e.g. for gateway mode).
+    ///
+    /// Full replace: drops any named segments (re-set them afterwards if
+    /// still wanted).
     pub fn with_system_prompt(self, prompt: String) -> Self {
-        *self.system_prompt.write().unwrap_or_else(|e| {
-            tracing::warn!("system prompt lock was poisoned, recovering");
-            e.into_inner()
-        }) = prompt;
+        self.system_prompt
+            .write()
+            .unwrap_or_else(|e| {
+                tracing::warn!("system prompt lock was poisoned, recovering");
+                e.into_inner()
+            })
+            .replace_all(prompt);
         self
     }
 
     /// Append additional content to the current system prompt (e.g. bootstrap files).
     pub fn append_system_prompt(&self, extra: &str) {
+        self.system_prompt
+            .write()
+            .unwrap_or_else(|e| {
+                tracing::warn!("system prompt lock was poisoned, recovering");
+                e.into_inner()
+            })
+            .append(extra);
+    }
+
+    /// Insert (first call) or replace in place (later calls) a named prompt
+    /// segment such as the memory block. The segment keeps its insertion
+    /// position across replacements, so bootstrap-before / skills-after
+    /// ordering is preserved when the content refreshes.
+    pub fn set_prompt_segment(&self, name: &str, content: String) {
+        self.system_prompt
+            .write()
+            .unwrap_or_else(|e| {
+                tracing::warn!("system prompt lock was poisoned, recovering");
+                e.into_inner()
+            })
+            .set_named(name, content);
+    }
+
+    /// Register a provider that refreshes a named segment between turns.
+    pub fn add_prompt_segment_provider(&self, provider: Arc<dyn PromptSegmentProvider>) {
+        self.segment_providers
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(provider);
+    }
+
+    /// Run all registered segment providers, applying any changed content.
+    ///
+    /// Called by the conversation loop at turn start; a no-op when no
+    /// providers are registered, and providers keep the unchanged path
+    /// cheap (typically one stat).
+    pub async fn refresh_prompt_segments(&self) {
+        let providers: Vec<Arc<dyn PromptSegmentProvider>> = self
+            .segment_providers
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        if providers.is_empty() {
+            return;
+        }
+        let mut updates = Vec::new();
+        for provider in providers {
+            if let Some(content) = provider.refresh().await {
+                updates.push((provider.segment_name().to_string(), content));
+            }
+        }
+        if updates.is_empty() {
+            return;
+        }
         let mut guard = self.system_prompt.write().unwrap_or_else(|e| {
             tracing::warn!("system prompt lock was poisoned, recovering");
             e.into_inner()
         });
-        guard.push_str("\n\n");
-        guard.push_str(extra);
+        for (name, content) in updates {
+            guard.set_named(&name, content);
+        }
     }
 
     /// Update the system prompt at runtime (hot-reload).
+    ///
+    /// Full replace: drops any named segments (re-set them afterwards if
+    /// still wanted).
     pub fn set_system_prompt(&self, prompt: String) {
-        *self.system_prompt.write().unwrap_or_else(|e| {
-            tracing::warn!("system prompt lock was poisoned, recovering");
-            e.into_inner()
-        }) = prompt;
+        self.system_prompt
+            .write()
+            .unwrap_or_else(|e| {
+                tracing::warn!("system prompt lock was poisoned, recovering");
+                e.into_inner()
+            })
+            .replace_all(prompt);
     }
 
     /// The LLM model ID in use.
@@ -1135,7 +1211,7 @@ impl Agent {
         self.system_prompt
             .read()
             .unwrap_or_else(|e| e.into_inner())
-            .clone()
+            .render()
     }
 
     /// Whether the loop-detector warning has fired since the last reset.

--- a/crates/octos-agent/src/agent/prompt_segments.rs
+++ b/crates/octos-agent/src/agent/prompt_segments.rs
@@ -1,0 +1,214 @@
+//! Ordered system-prompt segments.
+//!
+//! The system prompt is a sequence of segments rendered by concatenation.
+//! Two kinds exist:
+//!
+//! - **Anonymous** segments carry the legacy append stream: every
+//!   [`PromptSegments::append`] writes `"\n\n" + text` into the current
+//!   anonymous tail, so a prompt built purely from `append` calls renders
+//!   byte-identically to the old single-`String` implementation.
+//! - **Named** segments are replace-in-place slots (e.g. `"memory"`).
+//!   They keep their insertion position when their content is refreshed,
+//!   which is what lets a long-lived session see an updated memory block
+//!   without disturbing the bootstrap-before / skills-after ordering.
+//!
+//! An `append` issued after a named segment starts a fresh anonymous tail
+//! rather than mutating the named slot, so later appends never get wiped
+//! by a segment refresh.
+
+/// Provider for a named prompt segment that can refresh between turns
+/// (e.g. the memory block re-read when `MEMORY.md` changes on disk).
+///
+/// [`crate::Agent::refresh_prompt_segments`] runs every registered
+/// provider at conversation-turn start.
+#[async_trait::async_trait]
+pub trait PromptSegmentProvider: Send + Sync {
+    /// Name of the segment this provider maintains (e.g. `"memory"`).
+    fn segment_name(&self) -> &str;
+
+    /// Return `Some(content)` when the segment changed since the last call
+    /// (including the first call); `None` when unchanged. Implementations
+    /// must keep the unchanged path cheap — typically a single `stat`.
+    async fn refresh(&self) -> Option<String>;
+}
+
+/// One prompt segment: optional name + raw content.
+///
+/// Anonymous segments store their bytes exactly as rendered (including any
+/// leading `"\n\n"` from `append`). Named segments store bare content; the
+/// renderer adds the `"\n\n"` separator so replacements can't corrupt
+/// spacing.
+#[derive(Debug, Clone)]
+struct PromptSegment {
+    name: Option<String>,
+    content: String,
+}
+
+/// Ordered segment list backing the agent system prompt.
+///
+/// Public for visibility reasons only (the `Agent.system_prompt` field
+/// names it); construct and mutate exclusively through `Agent` methods.
+#[derive(Debug, Clone)]
+pub struct PromptSegments {
+    segments: Vec<PromptSegment>,
+}
+
+impl PromptSegments {
+    /// A prompt consisting of a single anonymous base segment.
+    pub(super) fn from_base(base: String) -> Self {
+        Self {
+            segments: vec![PromptSegment {
+                name: None,
+                content: base,
+            }],
+        }
+    }
+
+    /// Replace the WHOLE prompt with a single anonymous base segment.
+    ///
+    /// This is the semantic of the legacy `set_system_prompt` /
+    /// `with_system_prompt` full-replace: named segments are dropped and
+    /// must be re-set by the caller afterwards if still wanted.
+    pub(super) fn replace_all(&mut self, prompt: String) {
+        self.segments = vec![PromptSegment {
+            name: None,
+            content: prompt,
+        }];
+    }
+
+    /// Append to the current anonymous tail (legacy `append_system_prompt`
+    /// semantics: `"\n\n"` separator + text). Starts a new anonymous
+    /// segment when the tail is named, so named slots stay replaceable.
+    pub(super) fn append(&mut self, extra: &str) {
+        match self.segments.last_mut() {
+            Some(seg) if seg.name.is_none() => {
+                seg.content.push_str("\n\n");
+                seg.content.push_str(extra);
+            }
+            _ => self.segments.push(PromptSegment {
+                name: None,
+                content: format!("\n\n{extra}"),
+            }),
+        }
+    }
+
+    /// Insert (first call) or replace in place (subsequent calls) the named
+    /// segment. Content is stored bare; the renderer emits a `"\n\n"`
+    /// separator before non-first, non-empty segments. Setting empty
+    /// content effectively hides the segment while keeping its position.
+    pub(super) fn set_named(&mut self, name: &str, content: String) {
+        if let Some(seg) = self
+            .segments
+            .iter_mut()
+            .find(|seg| seg.name.as_deref() == Some(name))
+        {
+            seg.content = content;
+        } else {
+            self.segments.push(PromptSegment {
+                name: Some(name.to_string()),
+                content,
+            });
+        }
+    }
+
+    /// Render the full prompt.
+    pub(super) fn render(&self) -> String {
+        let mut out = String::new();
+        for seg in &self.segments {
+            if seg.content.is_empty() {
+                continue;
+            }
+            match seg.name {
+                // Anonymous content carries its own separators verbatim.
+                None => out.push_str(&seg.content),
+                // Named content gets a separator unless it opens the prompt.
+                Some(_) => {
+                    if !out.is_empty() {
+                        out.push_str("\n\n");
+                    }
+                    out.push_str(&seg.content);
+                }
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The load-bearing property: a prompt built only with base + appends
+    /// renders byte-identically to the legacy single-String implementation.
+    #[test]
+    fn should_render_identically_to_legacy_string_when_only_appends() {
+        let mut legacy = String::from("base prompt");
+        let mut segs = PromptSegments::from_base("base prompt".to_string());
+        for extra in ["bootstrap", "memory block", "skill fragment"] {
+            legacy.push_str("\n\n");
+            legacy.push_str(extra);
+            segs.append(extra);
+        }
+        assert_eq!(segs.render(), legacy);
+    }
+
+    #[test]
+    fn should_render_identically_when_memory_becomes_named_segment() {
+        // Legacy: base + append(bootstrap) + append(memory) + append(skills)
+        let legacy = "base\n\nbootstrap\n\nmemory v1\n\nskills";
+        let mut segs = PromptSegments::from_base("base".to_string());
+        segs.append("bootstrap");
+        segs.set_named("memory", "memory v1".to_string());
+        segs.append("skills");
+        assert_eq!(segs.render(), legacy);
+    }
+
+    #[test]
+    fn should_replace_in_place_when_named_segment_refreshed() {
+        let mut segs = PromptSegments::from_base("base".to_string());
+        segs.append("bootstrap");
+        segs.set_named("memory", "memory v1".to_string());
+        segs.append("skills");
+
+        segs.set_named("memory", "memory v2".to_string());
+        assert_eq!(segs.render(), "base\n\nbootstrap\n\nmemory v2\n\nskills");
+    }
+
+    #[test]
+    fn should_start_new_anonymous_tail_when_appending_after_named() {
+        let mut segs = PromptSegments::from_base("base".to_string());
+        segs.set_named("memory", "m".to_string());
+        segs.append("after");
+        // Refresh must not eat the append.
+        segs.set_named("memory", "M".to_string());
+        assert_eq!(segs.render(), "base\n\nM\n\nafter");
+    }
+
+    #[test]
+    fn should_hide_named_segment_when_content_empty() {
+        let mut segs = PromptSegments::from_base("base".to_string());
+        segs.set_named("memory", String::new());
+        segs.append("after");
+        assert_eq!(segs.render(), "base\n\nafter");
+        // ...and it can come back in position later.
+        segs.set_named("memory", "mem".to_string());
+        assert_eq!(segs.render(), "base\n\nmem\n\nafter");
+    }
+
+    #[test]
+    fn should_drop_named_segments_when_replace_all() {
+        let mut segs = PromptSegments::from_base("base".to_string());
+        segs.set_named("memory", "mem".to_string());
+        segs.replace_all("fresh full prompt".to_string());
+        assert_eq!(segs.render(), "fresh full prompt");
+    }
+
+    #[test]
+    fn should_keep_legacy_bytes_when_base_is_empty() {
+        // Legacy behavior: append onto an empty prompt still emits the
+        // leading separator.
+        let mut segs = PromptSegments::from_base(String::new());
+        segs.append("only content");
+        assert_eq!(segs.render(), "\n\nonly content");
+    }
+}

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -30,6 +30,7 @@ pub mod hooks;
 pub mod loop_detect;
 pub mod mcp;
 pub mod mcp_server;
+pub mod memory_segment;
 pub mod permissions;
 pub mod plugins;
 pub mod policy;
@@ -71,8 +72,8 @@ pub use abi_schema::{
 };
 pub use agent::{
     Agent, AgentConfig, ConversationResponse, DEFAULT_SESSION_TIMEOUT_SECS,
-    DEFAULT_TOOL_TIMEOUT_SECS, DEFAULT_WORKER_PROMPT, MAX_TOOL_TIMEOUT_SECS, RealtimeController,
-    TASK_REPORTER, TokenTracker,
+    DEFAULT_TOOL_TIMEOUT_SECS, DEFAULT_WORKER_PROMPT, MAX_TOOL_TIMEOUT_SECS, PromptSegmentProvider,
+    RealtimeController, TASK_REPORTER, TokenTracker,
     loop_state::{
         LoopDecision, LoopRetryCounters, LoopRetryLimits, LoopRetryState, OCTOS_LOOP_RETRY_TOTAL,
         SHELL_SPIRAL_VARIANT,
@@ -130,6 +131,9 @@ pub use hooks::{
     HookConfig, HookContext, HookEvent, HookExecutor, HookPayload, HookPayloadEnricher, HookResult,
 };
 pub use mcp::{McpClient, McpServerConfig};
+pub use memory_segment::{
+    MEMORY_CAPTURE_POLICY, MEMORY_SEGMENT_NAME, MemorySegmentProvider, compose_memory_segment,
+};
 pub use permissions::{InvalidSafetyTier, SafetyTier};
 pub use plugins::{PluginLoadOptions, PluginLoadResult, PluginLoader, SynthesisConfig};
 pub use policy::{
@@ -174,13 +178,13 @@ pub use tools::{
     DelegateTool, DelegationEvent, DelegationOutcome, DepthBudget, DiffEditTool,
     DispatchContextContract, DispatchOutcome, DispatchRequest, DispatchResponse, EditFileTool,
     GlobTool, GrepTool, HttpMcpAgent, ListDirTool, MAX_DEPTH, MakeTypeEntry, ManageSkillsTool,
-    McpAgentBackend, McpAgentBackendConfig, MessageTool, MofaDescribeContentTypeTool, MofaMakeTool,
-    PolicyDecision, ReadFileTool, ReadTaskOutputTool, RecallMemoryTool, RobotToolRegistry,
-    SaveMemoryTool, SendAppCardTool, SendFileTool, SharedBackend, ShellTool, SpawnTool,
-    StdioMcpAgent, SynthesizeResearchTool, Tool, ToolApprovalDecision, ToolApprovalRequest,
-    ToolApprovalRequester, ToolConfigStore, ToolPolicy, ToolRegistry, ToolResult,
-    TurnAttachmentContext, UserQuestionOutcome, UserQuestionRequest, UserQuestionRequester,
-    WebFetchTool, WebSearchTool, WriteFileTool,
+    McpAgentBackend, McpAgentBackendConfig, MemoryNoteTool, MessageTool,
+    MofaDescribeContentTypeTool, MofaMakeTool, PolicyDecision, ReadFileTool, ReadTaskOutputTool,
+    RecallMemoryTool, RobotToolRegistry, SaveMemoryTool, SendAppCardTool, SendFileTool,
+    SharedBackend, ShellTool, SpawnTool, StdioMcpAgent, SynthesizeResearchTool, Tool,
+    ToolApprovalDecision, ToolApprovalRequest, ToolApprovalRequester, ToolConfigStore, ToolPolicy,
+    ToolRegistry, ToolResult, TurnAttachmentContext, UserQuestionOutcome, UserQuestionRequest,
+    UserQuestionRequester, WebFetchTool, WebSearchTool, WriteFileTool,
     admin::{AdminApiContext, register_admin_api_tools},
     build_backend_from_config, build_delegated_child_policy, build_dispatch_event_payload,
     dispatch_with_metrics, install_robot_registry, keep_tool_in_slides_session,

--- a/crates/octos-agent/src/memory_segment.rs
+++ b/crates/octos-agent/src/memory_segment.rs
@@ -1,0 +1,180 @@
+//! Memory prompt-segment provider: keeps the injected memory block fresh.
+//!
+//! Registered on conversation agents when `memory.refresh.enabled` is on.
+//! [`crate::Agent::refresh_prompt_segments`] calls [`MemorySegmentProvider::refresh`]
+//! at every turn start; the provider re-renders the block only when
+//! `MEMORY.md` changed on disk (mtime+len) or the local date rolled over
+//! (daily-note windows shift) — the unchanged path is a single `stat`.
+
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use octos_memory::MemoryStore;
+
+use crate::agent::PromptSegmentProvider;
+
+/// Name of the named prompt segment carrying the memory block.
+pub const MEMORY_SEGMENT_NAME: &str = "memory";
+
+/// Capture-policy block appended to the memory segment when the
+/// memory-refresh feature is enabled. Shared by the chat path (via
+/// [`MemorySegmentProvider`]) and the gateway prompt builder so both
+/// surfaces teach the same rules.
+pub const MEMORY_CAPTURE_POLICY: &str = "## Memory Capture\n\
+Your Long-term Memory above may be stale — prefer fresh evidence from this \
+conversation when they conflict, and say so when a consequential answer relies \
+on possibly-stale memory. Capture durable observations with the `memory_note` \
+tool (notes are consolidated later; MOST TURNS NEED NO NOTE):\n\
+- The user explicitly asks to remember/forget/update something -> \
+memory_note(kind=\"user_request\") quoting their request.\n\
+- This conversation contradicts a Long-term Memory entry -> \
+memory_note(kind=\"correction\"), with replaces_id set to the entry's id when one is shown.\n\
+- You learned a durable preference, workflow, or environment fact -> \
+memory_note(kind=\"fact\") — only if a future conversation would plausibly go \
+better for knowing it.\n\
+Never edit files under the memory directory with file tools; `memory_note` is \
+the only memory write path.";
+
+/// Change fingerprint for the memory block inputs.
+#[derive(PartialEq, Eq, Clone)]
+struct Fingerprint {
+    /// (mtime, len) of MEMORY.md; `None` when the file doesn't exist.
+    memory_md: Option<(SystemTime, u64)>,
+    /// Local date — daily-note windows shift at midnight.
+    date: String,
+}
+
+/// [`PromptSegmentProvider`] for the `"memory"` segment.
+pub struct MemorySegmentProvider {
+    store: Arc<MemoryStore>,
+    max_inject_tokens: usize,
+    include_capture_policy: bool,
+    last: tokio::sync::Mutex<Option<Fingerprint>>,
+}
+
+impl MemorySegmentProvider {
+    pub fn new(
+        store: Arc<MemoryStore>,
+        max_inject_tokens: usize,
+        include_capture_policy: bool,
+    ) -> Self {
+        Self {
+            store,
+            max_inject_tokens,
+            include_capture_policy,
+            last: tokio::sync::Mutex::new(None),
+        }
+    }
+
+    async fn fingerprint(&self) -> Fingerprint {
+        let memory_md = tokio::fs::metadata(self.store.memory_md_path())
+            .await
+            .ok()
+            .and_then(|m| m.modified().ok().map(|t| (t, m.len())));
+        Fingerprint {
+            memory_md,
+            date: chrono::Local::now().format("%Y-%m-%d").to_string(),
+        }
+    }
+
+    /// Render the full segment content (memory block + optional policy).
+    pub async fn render(&self) -> String {
+        let memory_ctx = self
+            .store
+            .get_injectable_context(self.max_inject_tokens)
+            .await;
+        compose_memory_segment(&memory_ctx, self.include_capture_policy)
+    }
+}
+
+/// Compose the memory segment from the rendered block + optional capture
+/// policy. Shared with the gateway prompt builder so both paths emit the
+/// same bytes.
+pub fn compose_memory_segment(memory_ctx: &str, include_capture_policy: bool) -> String {
+    match (memory_ctx.is_empty(), include_capture_policy) {
+        (true, false) => String::new(),
+        (true, true) => MEMORY_CAPTURE_POLICY.to_string(),
+        (false, false) => memory_ctx.to_string(),
+        (false, true) => format!("{memory_ctx}\n\n{MEMORY_CAPTURE_POLICY}"),
+    }
+}
+
+#[async_trait::async_trait]
+impl PromptSegmentProvider for MemorySegmentProvider {
+    fn segment_name(&self) -> &str {
+        MEMORY_SEGMENT_NAME
+    }
+
+    async fn refresh(&self) -> Option<String> {
+        let current = self.fingerprint().await;
+        {
+            let mut last = self.last.lock().await;
+            if last.as_ref() == Some(&current) {
+                return None;
+            }
+            *last = Some(current);
+        }
+        Some(self.render().await)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn should_render_on_first_refresh_then_stat_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        store.write_long_term("a durable fact").await.unwrap();
+
+        let provider = MemorySegmentProvider::new(store, 2500, false);
+        let first = provider.refresh().await;
+        assert!(first.is_some_and(|c| c.contains("a durable fact")));
+        // Unchanged file → no re-render.
+        assert!(provider.refresh().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn should_re_render_when_memory_md_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        store.write_long_term("version one!").await.unwrap();
+
+        let provider = MemorySegmentProvider::new(store.clone(), 2500, false);
+        assert!(provider.refresh().await.is_some());
+        assert!(provider.refresh().await.is_none());
+
+        store
+            .write_long_term("version two, longer content")
+            .await
+            .unwrap();
+        let refreshed = provider.refresh().await;
+        assert!(refreshed.is_some_and(|c| c.contains("version two")));
+    }
+
+    #[tokio::test]
+    async fn should_include_policy_when_capture_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+
+        // Empty memory + capture on → policy alone.
+        let provider = MemorySegmentProvider::new(store.clone(), 2500, true);
+        let content = provider.refresh().await.expect("first refresh renders");
+        assert!(content.contains("## Memory Capture"));
+        assert!(content.contains("memory_note"));
+
+        // Empty memory + capture off → empty segment.
+        let provider_off = MemorySegmentProvider::new(store, 2500, false);
+        assert_eq!(provider_off.refresh().await, Some(String::new()));
+    }
+
+    #[test]
+    fn should_compose_segment_in_all_four_shapes() {
+        assert_eq!(compose_memory_segment("", false), "");
+        assert_eq!(compose_memory_segment("", true), MEMORY_CAPTURE_POLICY);
+        assert_eq!(compose_memory_segment("mem", false), "mem");
+        let both = compose_memory_segment("mem", true);
+        assert!(both.starts_with("mem\n\n## Memory Capture"));
+    }
+}

--- a/crates/octos-agent/src/memory_segment.rs
+++ b/crates/octos-agent/src/memory_segment.rs
@@ -2,9 +2,11 @@
 //!
 //! Registered on conversation agents when `memory.refresh.enabled` is on.
 //! [`crate::Agent::refresh_prompt_segments`] calls [`MemorySegmentProvider::refresh`]
-//! at every turn start; the provider re-renders the block only when
-//! `MEMORY.md` changed on disk (mtime+len) or the local date rolled over
-//! (daily-note windows shift) — the unchanged path is a single `stat`.
+//! at every turn start; the provider re-renders the block only when one of
+//! the injected sources changed: `MEMORY.md` (mtime+len), today's daily
+//! note (mtime+len), the bank entities directory (mtime — entity writes
+//! rename into it), or the local date rolled over (daily-note windows
+//! shift). The unchanged path is three stats, no reads.
 
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -35,11 +37,17 @@ better for knowing it.\n\
 Never edit files under the memory directory with file tools; `memory_note` is \
 the only memory write path.";
 
-/// Change fingerprint for the memory block inputs.
+/// Change fingerprint over every source that feeds the injected block.
 #[derive(PartialEq, Eq, Clone)]
 struct Fingerprint {
     /// (mtime, len) of MEMORY.md; `None` when the file doesn't exist.
     memory_md: Option<(SystemTime, u64)>,
+    /// (mtime, len) of today's daily note (append_today writes land here).
+    today_note: Option<(SystemTime, u64)>,
+    /// mtime of `bank/entities/` — save_memory's atomic rename and `.prev`
+    /// copy both bump the directory mtime, so entity edits are caught
+    /// without stat-ing every entity file.
+    bank_dir: Option<SystemTime>,
     /// Local date — daily-note windows shift at midnight.
     date: String,
 }
@@ -67,12 +75,20 @@ impl MemorySegmentProvider {
     }
 
     async fn fingerprint(&self) -> Fingerprint {
-        let memory_md = tokio::fs::metadata(self.store.memory_md_path())
+        async fn stat_file(path: std::path::PathBuf) -> Option<(SystemTime, u64)> {
+            let meta = tokio::fs::metadata(path).await.ok()?;
+            meta.modified().ok().map(|t| (t, meta.len()))
+        }
+        let memory_md = stat_file(self.store.memory_md_path()).await;
+        let today_note = stat_file(self.store.today_note_path()).await;
+        let bank_dir = tokio::fs::metadata(self.store.bank_entities_dir())
             .await
             .ok()
-            .and_then(|m| m.modified().ok().map(|t| (t, m.len())));
+            .and_then(|m| m.modified().ok());
         Fingerprint {
             memory_md,
+            today_note,
+            bank_dir,
             date: chrono::Local::now().format("%Y-%m-%d").to_string(),
         }
     }
@@ -167,6 +183,43 @@ mod tests {
         // Empty memory + capture off → empty segment.
         let provider_off = MemorySegmentProvider::new(store, 2500, false);
         assert_eq!(provider_off.refresh().await, Some(String::new()));
+    }
+
+    #[tokio::test]
+    async fn should_re_render_when_bank_entity_or_today_note_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        store.write_long_term("stable long-term").await.unwrap();
+
+        let provider = MemorySegmentProvider::new(store.clone(), 2500, false);
+        assert!(provider.refresh().await.is_some());
+        assert!(provider.refresh().await.is_none());
+
+        // save_memory-style bank write must invalidate the fingerprint.
+        store
+            .write_entity(
+                "city",
+                "# city
+
+user lives in Vancouver
+",
+            )
+            .await
+            .unwrap();
+        let after_bank = provider.refresh().await;
+        assert!(
+            after_bank.is_some_and(|c| c.contains("Vancouver")),
+            "bank entity write must refresh the injected block"
+        );
+        assert!(provider.refresh().await.is_none());
+
+        // append_today must invalidate it too.
+        store.append_today("learned something today").await.unwrap();
+        let after_today = provider.refresh().await;
+        assert!(
+            after_today.is_some_and(|c| c.contains("learned something today")),
+            "today-note append must refresh the injected block"
+        );
     }
 
     #[test]

--- a/crates/octos-agent/src/tools/memory_note.rs
+++ b/crates/octos-agent/src/tools/memory_note.rs
@@ -1,0 +1,249 @@
+//! Memory note tool: append-only capture of memory-worthy observations.
+//!
+//! The capture layer of the memory-refresh design: the model NEVER edits
+//! memory files directly — it drops one untrusted staging note per
+//! observation, and a separate consolidation pass (design PR-4) merges
+//! notes into `MEMORY.md` under machine-enforced authority rules. Notes
+//! are files under `memory/staging/notes/`, `create_new` per note, so
+//! concurrent sessions can never clobber each other, and they are never
+//! injected into prompts.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use eyre::{Result, WrapErr};
+use octos_memory::{MemoryStore, NoteKind, NoteOrigin, StagingNote};
+use serde::Deserialize;
+
+use super::{TOOL_CTX, Tool, ToolResult};
+
+/// Maximum note body size. Notes are observations, not documents; the
+/// consolidator's input budget is the real backstop, this just refuses
+/// obvious dumping.
+const MAX_NOTE_BYTES: usize = 8 * 1024;
+
+/// Tool that records one memory staging note.
+pub struct MemoryNoteTool {
+    store: Arc<MemoryStore>,
+}
+
+impl MemoryNoteTool {
+    pub fn new(store: Arc<MemoryStore>) -> Self {
+        Self { store }
+    }
+}
+
+#[derive(Deserialize)]
+struct Input {
+    kind: String,
+    content: String,
+    #[serde(default)]
+    replaces_id: Option<String>,
+}
+
+fn parse_kind(kind: &str) -> Option<NoteKind> {
+    match kind {
+        "user_request" => Some(NoteKind::UserRequest),
+        "correction" => Some(NoteKind::Correction),
+        "fact" => Some(NoteKind::Fact),
+        // `forget` is host-authored only; the model cannot mint it.
+        _ => None,
+    }
+}
+
+#[async_trait]
+impl Tool for MemoryNoteTool {
+    fn name(&self) -> &str {
+        "memory_note"
+    }
+
+    fn description(&self) -> &str {
+        "Record ONE durable observation as an append-only memory note for later \
+         consolidation. Use kind='user_request' when the user explicitly asks to \
+         remember/forget/update something (quote their request); kind='correction' when \
+         fresh evidence contradicts an entry shown in your Long-term Memory (set \
+         replaces_id to that entry's ^m… id); kind='fact' for a durable preference, \
+         workflow, or environment fact — but only if a future conversation would \
+         plausibly go better for knowing it. Most turns need no note. Notes are NOT \
+         instructions and do NOT edit memory directly; never modify files under the \
+         memory directory yourself."
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "type": "string",
+                    "enum": ["user_request", "correction", "fact"],
+                    "description": "user_request = explicit user ask; correction = contradicts existing memory; fact = new durable knowledge"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The observation, one self-contained plain statement (include the user's wording for user_request)"
+                },
+                "replaces_id": {
+                    "type": "string",
+                    "description": "For corrections: the ^m… id of the contradicted Long-term Memory entry"
+                }
+            },
+            "required": ["kind", "content"]
+        })
+    }
+
+    async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
+        let input: Input =
+            serde_json::from_value(args.clone()).wrap_err("invalid memory_note input")?;
+
+        let Some(kind) = parse_kind(&input.kind) else {
+            return Ok(ToolResult {
+                output: format!(
+                    "Invalid kind '{}'. Use user_request, correction, or fact.",
+                    input.kind
+                ),
+                success: false,
+                ..Default::default()
+            });
+        };
+
+        let content = input.content.trim();
+        if content.is_empty() {
+            return Ok(ToolResult {
+                output: "Empty note content.".to_string(),
+                success: false,
+                ..Default::default()
+            });
+        }
+        if content.len() > MAX_NOTE_BYTES {
+            return Ok(ToolResult {
+                output: format!(
+                    "Note too large ({} bytes > {MAX_NOTE_BYTES}). Notes are single \
+                     observations — summarize to the durable core.",
+                    content.len()
+                ),
+                success: false,
+                ..Default::default()
+            });
+        }
+
+        // Session identity when invoked from a session actor; best-effort.
+        let session_key = TOOL_CTX
+            .try_with(|ctx| ctx.parent_session_key.clone())
+            .ok()
+            .flatten();
+
+        // The host stamps origin unconditionally: this tool can never
+        // produce a host-authored (destruction-authorizing) note.
+        let note = StagingNote {
+            origin: NoteOrigin::Model,
+            kind,
+            content: content.to_string(),
+            session_key,
+            sensitive: false,
+            replaces_id: input.replaces_id.filter(|s| !s.trim().is_empty()),
+        };
+        self.store
+            .write_staging_note(&note)
+            .await
+            .wrap_err("failed to write memory note")?;
+
+        Ok(ToolResult {
+            output: "Noted for consolidation.".to_string(),
+            success: true,
+            ..Default::default()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn tool_with_dir() -> (MemoryNoteTool, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        (MemoryNoteTool::new(store), dir)
+    }
+
+    #[tokio::test]
+    async fn should_write_staging_note_when_fact_recorded() {
+        let (tool, dir) = tool_with_dir().await;
+        let result = tool
+            .execute(&serde_json::json!({"kind": "fact", "content": "prefers dark mode"}))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert_eq!(result.output, "Noted for consolidation.");
+
+        let notes_dir = dir.path().join("memory/staging/notes");
+        let mut entries = tokio::fs::read_dir(&notes_dir).await.unwrap();
+        let entry = entries.next_entry().await.unwrap().expect("one note file");
+        let text = tokio::fs::read_to_string(entry.path()).await.unwrap();
+        assert!(text.contains("origin: model"));
+        assert!(text.contains("kind: fact"));
+        assert!(text.contains("prefers dark mode"));
+    }
+
+    #[tokio::test]
+    async fn should_reject_forget_kind_when_model_calls() {
+        let (tool, _dir) = tool_with_dir().await;
+        let result = tool
+            .execute(&serde_json::json!({"kind": "forget", "content": "x"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.output.contains("Invalid kind"));
+    }
+
+    #[tokio::test]
+    async fn should_record_replaces_id_when_correction() {
+        let (tool, dir) = tool_with_dir().await;
+        let result = tool
+            .execute(&serde_json::json!({
+                "kind": "correction",
+                "content": "user moved to Seattle",
+                "replaces_id": "^m4k2ab"
+            }))
+            .await
+            .unwrap();
+        assert!(result.success);
+
+        let notes_dir = dir.path().join("memory/staging/notes");
+        let mut entries = tokio::fs::read_dir(&notes_dir).await.unwrap();
+        let entry = entries.next_entry().await.unwrap().unwrap();
+        let text = tokio::fs::read_to_string(entry.path()).await.unwrap();
+        assert!(text.contains("replaces_id: \"^m4k2ab\""));
+    }
+
+    #[tokio::test]
+    async fn should_reject_empty_and_oversized_content() {
+        let (tool, _dir) = tool_with_dir().await;
+        let empty = tool
+            .execute(&serde_json::json!({"kind": "fact", "content": "   "}))
+            .await
+            .unwrap();
+        assert!(!empty.success);
+
+        let big = "x".repeat(MAX_NOTE_BYTES + 1);
+        let oversized = tool
+            .execute(&serde_json::json!({"kind": "fact", "content": big}))
+            .await
+            .unwrap();
+        assert!(!oversized.success);
+        assert!(oversized.output.contains("too large"));
+    }
+
+    #[test]
+    fn should_expose_only_model_kinds_in_schema() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let (tool, _dir) = rt.block_on(tool_with_dir());
+        let schema = tool.input_schema();
+        let kinds: Vec<&str> = schema["properties"]["kind"]["enum"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(kinds, vec!["user_request", "correction", "fact"]);
+    }
+}

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -754,6 +754,7 @@ pub mod http;
 pub mod list_dir;
 pub mod manage_skills;
 pub mod mcp_agent;
+pub mod memory_note;
 pub mod message;
 pub mod read_file;
 pub mod read_task_output;
@@ -812,6 +813,7 @@ pub use mcp_agent::{
     StdioMcpAgent, build_backend_from_config, build_dispatch_event_payload, dispatch_with_metrics,
     record_dispatch,
 };
+pub use memory_note::MemoryNoteTool;
 pub use message::MessageTool;
 pub use read_file::ReadFileTool;
 pub use read_task_output::ReadTaskOutputTool;

--- a/crates/octos-agent/src/tools/policy.rs
+++ b/crates/octos-agent/src/tools/policy.rs
@@ -205,7 +205,7 @@ pub const TOOL_GROUPS: &[ToolGroupInfo] = &[
     ToolGroupInfo {
         name: "group:memory",
         description: "Long-term memory: save and recall knowledge across sessions",
-        tools: &["recall_memory", "save_memory"],
+        tools: &["recall_memory", "save_memory", "memory_note"],
     },
     ToolGroupInfo {
         name: "group:research",
@@ -252,6 +252,7 @@ pub const TOOL_GROUPS: &[ToolGroupInfo] = &[
             "send_message",
             "message",
             "save_memory",
+            "memory_note",
             "execute_code",
         ],
     },

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -309,6 +309,11 @@ impl ChatCommand {
         );
         tools.register(octos_agent::RecallMemoryTool::new(memory_store.clone()));
         tools.register(octos_agent::SaveMemoryTool::new(memory_store.clone()));
+        let memory_refresh_enabled =
+            crate::config::MemoryConfig::refresh_enabled(config.memory.as_ref());
+        if memory_refresh_enabled {
+            tools.register(octos_agent::MemoryNoteTool::new(memory_store.clone()));
+        }
 
         // Register MCP tools
         if !config.mcp_servers.is_empty() {
@@ -606,12 +611,24 @@ impl ChatCommand {
         }
 
         // Inject the token-capped memory block (long-term memory + daily
-        // notes + bank summary; omissions are disclosed to the model).
+        // notes + bank summary; omissions are disclosed to the model) as a
+        // replaceable named segment between bootstrap and skill fragments.
+        // With memory refresh on, the capture policy rides the same segment
+        // and a provider re-renders it when MEMORY.md changes on disk or
+        // the date rolls over (one stat per turn otherwise).
         let max_inject =
             crate::config::MemoryConfig::effective_max_inject_tokens(config.memory.as_ref());
         let memory_ctx = memory_store.get_injectable_context(max_inject).await;
-        if !memory_ctx.is_empty() {
-            agent.append_system_prompt(&memory_ctx);
+        agent.set_prompt_segment(
+            octos_agent::MEMORY_SEGMENT_NAME,
+            octos_agent::compose_memory_segment(&memory_ctx, memory_refresh_enabled),
+        );
+        if memory_refresh_enabled {
+            agent.add_prompt_segment_provider(Arc::new(octos_agent::MemorySegmentProvider::new(
+                memory_store.clone(),
+                max_inject,
+                true,
+            )));
         }
 
         // Inject skill prompt fragments

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -1096,6 +1096,9 @@ impl GatewayRuntime {
             // Memory bank tools
             tools.register(octos_agent::RecallMemoryTool::new(memory_store.clone()));
             tools.register(octos_agent::SaveMemoryTool::new(memory_store.clone()));
+            if crate::config::MemoryConfig::refresh_enabled(config.memory.as_ref()) {
+                tools.register(octos_agent::MemoryNoteTool::new(memory_store.clone()));
+            }
 
             // Runtime model switching tool
             tools.register(crate::tools::SwitchModelTool::new(
@@ -1125,6 +1128,8 @@ impl GatewayRuntime {
         // Build system prompt (always the full prompt with persona, memory, skills)
         let max_inject_tokens =
             crate::config::MemoryConfig::effective_max_inject_tokens(config.memory.as_ref());
+        let memory_refresh_enabled =
+            crate::config::MemoryConfig::refresh_enabled(config.memory.as_ref());
         let system_prompt = build_system_prompt(
             gw_config.system_prompt.as_deref(),
             &data_dir,
@@ -1133,6 +1138,7 @@ impl GatewayRuntime {
             &skills_loader,
             &tool_config,
             max_inject_tokens,
+            memory_refresh_enabled,
         )
         .await;
 
@@ -1621,6 +1627,7 @@ impl GatewayRuntime {
             let tool_config_p = tool_config.clone();
             let indicators = status_indicators.clone();
             let max_inject_p = max_inject_tokens;
+            let memory_refresh_p = memory_refresh_enabled;
             persona_service.start(
                 move |_persona_text| {
                     // Rebuild the full system prompt with the new persona and hot-update
@@ -1640,6 +1647,7 @@ impl GatewayRuntime {
                             &sl,
                             &tc,
                             max_inject_p,
+                            memory_refresh_p,
                         )
                         .await;
                         *prompt_lock.write().unwrap_or_else(|e| e.into_inner()) = new_prompt;

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -582,6 +582,9 @@ impl ProfileActorFactoryBuilder {
             if mem.max_inject_tokens.is_none() {
                 mem.max_inject_tokens = host.max_inject_tokens;
             }
+            if mem.refresh.is_none() {
+                mem.refresh = host.refresh.clone();
+            }
         }
         let (llm, provider_name, adaptive_router, llm_strong) =
             build_llm_stack(&profile_config, self.no_retry)?;
@@ -597,6 +600,8 @@ impl ProfileActorFactoryBuilder {
         let max_inject_tokens = crate::config::MemoryConfig::effective_max_inject_tokens(
             profile_config.memory.as_ref(),
         );
+        let memory_refresh_enabled =
+            crate::config::MemoryConfig::refresh_enabled(profile_config.memory.as_ref());
         let mut system_prompt = build_system_prompt(
             effective_profile.config.gateway.system_prompt.as_deref(),
             &profile_data_dir,
@@ -605,6 +610,7 @@ impl ProfileActorFactoryBuilder {
             &skills_loader,
             &self.tool_config,
             max_inject_tokens,
+            memory_refresh_enabled,
         )
         .await;
         for fragment in &self.plugin_prompt_fragments {
@@ -738,6 +744,9 @@ impl ProfileActorFactoryBuilder {
                 self.memory_store.clone(),
             ));
             tools.register(octos_agent::SaveMemoryTool::new(self.memory_store.clone()));
+            if memory_refresh_enabled {
+                tools.register(octos_agent::MemoryNoteTool::new(self.memory_store.clone()));
+            }
             if let Some(ref policy) = profile_config.tool_policy {
                 tools.apply_policy(policy);
             }

--- a/crates/octos-cli/src/commands/gateway/prompt.rs
+++ b/crates/octos-cli/src/commands/gateway/prompt.rs
@@ -21,6 +21,7 @@ pub async fn build_system_prompt(
     skills_loader: &SkillsLoader,
     tool_config: &octos_agent::ToolConfigStore,
     max_inject_tokens: usize,
+    memory_capture_policy: bool,
 ) -> String {
     let compiled = include_str!("../../prompts/gateway_default.txt");
     let runtime = super::super::load_prompt("gateway", compiled);
@@ -64,11 +65,13 @@ pub async fn build_system_prompt(
     }
 
     // Append the token-capped memory block (long-term memory + daily notes
-    // + bank summary; omissions are disclosed to the model).
+    // + bank summary; omissions are disclosed to the model), plus the
+    // capture-policy teaching block when memory refresh is enabled.
     let memory_ctx = memory_store.get_injectable_context(max_inject_tokens).await;
-    if !memory_ctx.is_empty() {
+    let memory_segment = octos_agent::compose_memory_segment(&memory_ctx, memory_capture_policy);
+    if !memory_segment.is_empty() {
         prompt.push_str("\n\n");
-        prompt.push_str(&memory_ctx);
+        prompt.push_str(&memory_segment);
     }
 
     // Append always-on skills

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -530,7 +530,10 @@ impl ServeCommand {
                 .with_host_plugins_require_signed(config.plugins.require_signed)
                 .with_host_max_inject_tokens(
                     config.memory.as_ref().and_then(|m| m.max_inject_tokens),
-                ),
+                )
+                .with_host_memory_refresh_enabled(crate::config::MemoryConfig::refresh_enabled(
+                    config.memory.as_ref(),
+                )),
         );
         process_manager.set_self_ref();
 

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -537,6 +537,21 @@ pub struct MemoryConfig {
     /// notes) and omissions are disclosed to the model with a marker.
     #[serde(default)]
     pub max_inject_tokens: Option<usize>,
+
+    /// Automatic memory refreshing (capture + consolidation pipeline).
+    #[serde(default)]
+    pub refresh: Option<MemoryRefreshConfig>,
+}
+
+/// Automatic memory-refresh settings. Default OFF: when disabled there is
+/// no `memory_note` tool, no capture policy in the prompt, and no
+/// per-turn memory re-read — behavior is identical to before the feature
+/// existed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct MemoryRefreshConfig {
+    /// Master switch for the capture layer + read-side refresh.
+    #[serde(default)]
+    pub enabled: bool,
 }
 
 impl MemoryConfig {
@@ -545,6 +560,13 @@ impl MemoryConfig {
         config
             .and_then(|m| m.max_inject_tokens)
             .unwrap_or(octos_memory::DEFAULT_MAX_INJECT_TOKENS)
+    }
+
+    /// Whether automatic memory refreshing (capture + read refresh) is on.
+    pub fn refresh_enabled(config: Option<&MemoryConfig>) -> bool {
+        config
+            .and_then(|m| m.refresh.as_ref())
+            .is_some_and(|r| r.enabled)
     }
 }
 
@@ -1098,16 +1120,34 @@ fn merge_env_memory_policy(config: &mut Config) {
         .memory
         .as_ref()
         .and_then(|m| m.max_inject_tokens)
-        .is_some()
+        .is_none()
     {
-        return;
+        if let Ok(v) = std::env::var("OCTOS_MEMORY_MAX_INJECT_TOKENS") {
+            if let Ok(n) = v.trim().parse::<usize>() {
+                config
+                    .memory
+                    .get_or_insert_with(Default::default)
+                    .max_inject_tokens = Some(n);
+            }
+        }
     }
-    if let Ok(v) = std::env::var("OCTOS_MEMORY_MAX_INJECT_TOKENS") {
-        if let Ok(n) = v.trim().parse::<usize>() {
-            config
-                .memory
-                .get_or_insert_with(Default::default)
-                .max_inject_tokens = Some(n);
+    // Same field-level rule for the refresh switch: the env only fills the
+    // gap when the loaded config says nothing about `memory.refresh`.
+    if config
+        .memory
+        .as_ref()
+        .and_then(|m| m.refresh.as_ref())
+        .is_none()
+    {
+        if let Ok(v) = std::env::var("OCTOS_MEMORY_REFRESH_ENABLED") {
+            let on = matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            );
+            if on {
+                config.memory.get_or_insert_with(Default::default).refresh =
+                    Some(MemoryRefreshConfig { enabled: true });
+            }
         }
     }
 }
@@ -2667,5 +2707,29 @@ mod tests {
             }));
         assert_eq!(overridden.tts_provider, "cloud");
         assert_eq!(overridden.cloud.unwrap().appid.as_deref(), Some("42"));
+    }
+
+    // --- memory refresh flag ---
+
+    #[test]
+    fn should_default_refresh_off_when_memory_absent_or_empty() {
+        assert!(!MemoryConfig::refresh_enabled(None));
+        let empty: MemoryConfig = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(!MemoryConfig::refresh_enabled(Some(&empty)));
+        let refresh_empty: MemoryConfig =
+            serde_json::from_value(serde_json::json!({"refresh": {}})).unwrap();
+        assert!(!MemoryConfig::refresh_enabled(Some(&refresh_empty)));
+    }
+
+    #[test]
+    fn should_enable_refresh_when_config_sets_it() {
+        let cfg: MemoryConfig =
+            serde_json::from_value(serde_json::json!({"refresh": {"enabled": true}})).unwrap();
+        assert!(MemoryConfig::refresh_enabled(Some(&cfg)));
+        // max_inject_tokens keeps its default independently.
+        assert_eq!(
+            MemoryConfig::effective_max_inject_tokens(Some(&cfg)),
+            octos_memory::DEFAULT_MAX_INJECT_TOKENS
+        );
     }
 }

--- a/crates/octos-cli/src/process_manager.rs
+++ b/crates/octos-cli/src/process_manager.rs
@@ -450,11 +450,23 @@ impl ProcessManager {
         if self.host_plugins_require_signed {
             cmd.env("OCTOS_PLUGINS_REQUIRE_SIGNED", "1");
         }
-        if let Some(n) = self.host_max_inject_tokens {
-            cmd.env("OCTOS_MEMORY_MAX_INJECT_TOKENS", n.to_string());
+        // Set-or-CLEAR: `Command` inherits the parent environment, so when
+        // the host does not forward a memory setting we must remove any
+        // inherited value — otherwise a stale env var from the serve
+        // process's own environment would re-enable a feature the host
+        // config explicitly turned off.
+        match self.host_max_inject_tokens {
+            Some(n) => {
+                cmd.env("OCTOS_MEMORY_MAX_INJECT_TOKENS", n.to_string());
+            }
+            None => {
+                cmd.env_remove("OCTOS_MEMORY_MAX_INJECT_TOKENS");
+            }
         }
         if self.host_memory_refresh_enabled {
             cmd.env("OCTOS_MEMORY_REFRESH_ENABLED", "1");
+        } else {
+            cmd.env_remove("OCTOS_MEMORY_REFRESH_ENABLED");
         }
 
         tracing::debug!(profile = %profile.id, "start: spawning gateway subprocess");

--- a/crates/octos-cli/src/process_manager.rs
+++ b/crates/octos-cli/src/process_manager.rs
@@ -57,6 +57,9 @@ pub struct ProcessManager {
     /// via `OCTOS_MEMORY_MAX_INJECT_TOKENS` (field-level: a profile's own
     /// explicit value wins; the env only fills the gap).
     host_max_inject_tokens: Option<usize>,
+    /// Host-level `memory.refresh.enabled` forwarded via
+    /// `OCTOS_MEMORY_REFRESH_ENABLED` under the same field-level rule.
+    host_memory_refresh_enabled: bool,
 }
 
 struct GatewayProcess {
@@ -140,6 +143,7 @@ impl ProcessManager {
             self_ref: std::sync::Mutex::new(None),
             host_plugins_require_signed: false,
             host_max_inject_tokens: None,
+            host_memory_refresh_enabled: false,
         }
     }
 
@@ -157,6 +161,13 @@ impl ProcessManager {
     /// the memory block inherit the host injection budget.
     pub fn with_host_max_inject_tokens(mut self, max_inject_tokens: Option<usize>) -> Self {
         self.host_max_inject_tokens = max_inject_tokens;
+        self
+    }
+
+    /// Mirror the host's `memory.refresh.enabled` onto spawned gateways via
+    /// `OCTOS_MEMORY_REFRESH_ENABLED` (field-level: profile value wins).
+    pub fn with_host_memory_refresh_enabled(mut self, enabled: bool) -> Self {
+        self.host_memory_refresh_enabled = enabled;
         self
     }
 
@@ -334,15 +345,17 @@ impl ProcessManager {
                                 );
                                 continue;
                             }
-                            // The host memory budget env is equally
+                            // The host memory envs are equally
                             // host-reserved: a parent profile must not
-                            // impersonate it toward sub-accounts.
-                            if key.eq_ignore_ascii_case("OCTOS_MEMORY_MAX_INJECT_TOKENS") {
+                            // impersonate them toward sub-accounts.
+                            if key.eq_ignore_ascii_case("OCTOS_MEMORY_MAX_INJECT_TOKENS")
+                                || key.eq_ignore_ascii_case("OCTOS_MEMORY_REFRESH_ENABLED")
+                            {
                                 tracing::warn!(
                                     profile = %profile.id,
                                     parent = %parent_id,
                                     var = %key,
-                                    "skipping parent env var that would override host memory budget"
+                                    "skipping parent env var that would override host memory settings"
                                 );
                                 continue;
                             }
@@ -413,14 +426,16 @@ impl ProcessManager {
                 );
                 continue;
             }
-            // Same reservation for the host memory budget: profiles override
-            // it via their own `memory` config block, not by spoofing the
-            // host-controlled env var.
-            if key.eq_ignore_ascii_case("OCTOS_MEMORY_MAX_INJECT_TOKENS") {
+            // Same reservation for the host memory settings: profiles
+            // override them via their own `memory` config block, not by
+            // spoofing the host-controlled env vars.
+            if key.eq_ignore_ascii_case("OCTOS_MEMORY_MAX_INJECT_TOKENS")
+                || key.eq_ignore_ascii_case("OCTOS_MEMORY_REFRESH_ENABLED")
+            {
                 tracing::warn!(
                     profile = %profile.id,
                     var = %key,
-                    "skipping profile env var that would override host memory budget"
+                    "skipping profile env var that would override host memory settings"
                 );
                 continue;
             }
@@ -437,6 +452,9 @@ impl ProcessManager {
         }
         if let Some(n) = self.host_max_inject_tokens {
             cmd.env("OCTOS_MEMORY_MAX_INJECT_TOKENS", n.to_string());
+        }
+        if self.host_memory_refresh_enabled {
+            cmd.env("OCTOS_MEMORY_REFRESH_ENABLED", "1");
         }
 
         tracing::debug!(profile = %profile.id, "start: spawning gateway subprocess");

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -449,6 +449,9 @@ impl ProfileRuntime {
             if mem.max_inject_tokens.is_none() {
                 mem.max_inject_tokens = host.max_inject_tokens;
             }
+            if mem.refresh.is_none() {
+                mem.refresh = host.refresh.clone();
+            }
         }
 
         // Step 2: resolve the provider name. `config_from_profile`
@@ -712,6 +715,9 @@ impl ProfileRuntime {
         // session inherits the same memory_store.
         tools.register(octos_agent::RecallMemoryTool::new(memory_store.clone()));
         tools.register(octos_agent::SaveMemoryTool::new(memory_store.clone()));
+        if crate::config::MemoryConfig::refresh_enabled(config.memory.as_ref()) {
+            tools.register(octos_agent::MemoryNoteTool::new(memory_store.clone()));
+        }
 
         // REG-7 follow-up: register `run_pipeline` at profile scope so
         // the serve path (`/api/sessions/*`, UI Protocol WS) exposes
@@ -934,6 +940,8 @@ impl ProfileRuntime {
         let skills_loader = build_account_skills_loader(data_dir);
         let max_inject_tokens =
             crate::config::MemoryConfig::effective_max_inject_tokens(config.memory.as_ref());
+        let memory_refresh_enabled =
+            crate::config::MemoryConfig::refresh_enabled(config.memory.as_ref());
         let mut system_prompt = build_system_prompt(
             profile.config.gateway.system_prompt.as_deref(),
             data_dir,
@@ -942,6 +950,7 @@ impl ProfileRuntime {
             &skills_loader,
             &tool_config,
             max_inject_tokens,
+            memory_refresh_enabled,
         )
         .await;
         for fragment in &plugin_result.prompt_fragments {

--- a/crates/octos-memory/src/lib.rs
+++ b/crates/octos-memory/src/lib.rs
@@ -11,5 +11,5 @@ mod store;
 
 pub use episode::{Episode, EpisodeOutcome};
 pub use hybrid_search::{HybridIndex, HybridScore};
-pub use memory_store::{DEFAULT_MAX_INJECT_TOKENS, MemoryStore};
+pub use memory_store::{DEFAULT_MAX_INJECT_TOKENS, MemoryStore, NoteKind, NoteOrigin, StagingNote};
 pub use store::EpisodeStore;

--- a/crates/octos-memory/src/memory_store.rs
+++ b/crates/octos-memory/src/memory_store.rs
@@ -154,6 +154,17 @@ impl MemoryStore {
         self.memory_dir.join("MEMORY.md")
     }
 
+    /// Path to today's daily-note file (for cheap change detection).
+    pub fn today_note_path(&self) -> PathBuf {
+        self.today_path()
+    }
+
+    /// Path to the bank entities directory (for cheap change detection:
+    /// entity writes rename/copy into this directory, bumping its mtime).
+    pub fn bank_entities_dir(&self) -> PathBuf {
+        self.bank_dir()
+    }
+
     /// Read long-term memory (`MEMORY.md`). Returns empty string if missing.
     pub async fn read_long_term(&self) -> Result<String> {
         let path = self.memory_dir.join("MEMORY.md");

--- a/crates/octos-memory/src/memory_store.rs
+++ b/crates/octos-memory/src/memory_store.rs
@@ -149,6 +149,11 @@ impl MemoryStore {
         Ok(Self { memory_dir })
     }
 
+    /// Path to `MEMORY.md` (for cheap change detection by callers).
+    pub fn memory_md_path(&self) -> PathBuf {
+        self.memory_dir.join("MEMORY.md")
+    }
+
     /// Read long-term memory (`MEMORY.md`). Returns empty string if missing.
     pub async fn read_long_term(&self) -> Result<String> {
         let path = self.memory_dir.join("MEMORY.md");
@@ -491,6 +496,156 @@ impl MemoryStore {
     fn today_path(&self) -> PathBuf {
         let date = chrono::Local::now().format("%Y-%m-%d").to_string();
         self.memory_dir.join(format!("{date}.md"))
+    }
+
+    // --- Staging notes (memory-refresh capture layer) ---
+
+    /// Path to `staging/notes/`.
+    fn staging_notes_dir(&self) -> PathBuf {
+        self.memory_dir.join("staging").join("notes")
+    }
+
+    /// Write one append-only staging note; returns its path.
+    ///
+    /// Notes are the capture layer of the memory-refresh design: untrusted
+    /// input for the consolidation pass (design PR-4), NEVER injected into
+    /// prompts. One `create_new` file per note — concurrent sessions can
+    /// never clobber each other. The note id is the uuidv7 filename stem.
+    pub async fn write_staging_note(&self, note: &StagingNote) -> Result<PathBuf> {
+        let dir = self.staging_notes_dir();
+        tokio::fs::create_dir_all(&dir)
+            .await
+            .wrap_err("failed to create staging notes directory")?;
+
+        let slug_source: String = note.content.chars().take(48).collect();
+        let file_name = format!(
+            "{}-{}.md",
+            uuid::Uuid::now_v7().simple(),
+            octos_core::safe_filename(slug_source.trim())
+        );
+        let path = dir.join(file_name);
+        let rendered = note.render();
+
+        let mut file = tokio::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&path)
+            .await
+            .wrap_err("failed to create staging note (name collision?)")?;
+        {
+            use tokio::io::AsyncWriteExt;
+            file.write_all(rendered.as_bytes())
+                .await
+                .wrap_err("failed to write staging note")?;
+            file.flush()
+                .await
+                .wrap_err("failed to flush staging note")?;
+        }
+        Ok(path)
+    }
+
+    /// Number of pending staging notes (for status surfacing).
+    pub async fn count_staging_notes(&self) -> usize {
+        let mut count = 0;
+        if let Ok(mut entries) = tokio::fs::read_dir(self.staging_notes_dir()).await {
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                if entry.path().extension().is_some_and(|e| e == "md") {
+                    count += 1;
+                }
+            }
+        }
+        count
+    }
+}
+
+/// Who authored a staging note. `Host` notes come from paths with no model
+/// in the loop (slash command / CLI) and are the only notes that can later
+/// authorize destructive memory operations; the `memory_note` tool always
+/// stamps `Model`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoteOrigin {
+    Model,
+    Host,
+}
+
+impl NoteOrigin {
+    fn as_str(self) -> &'static str {
+        match self {
+            NoteOrigin::Model => "model",
+            NoteOrigin::Host => "host",
+        }
+    }
+}
+
+/// What a staging note captures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoteKind {
+    /// The user explicitly asked to remember/forget/update something
+    /// (recorded by the model; still untrusted).
+    UserRequest,
+    /// Fresh evidence contradicts an existing memory entry.
+    Correction,
+    /// Durable knowledge the model judged worth keeping.
+    Fact,
+    /// A host-authored forget request (never writable by the model).
+    Forget,
+}
+
+impl NoteKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            NoteKind::UserRequest => "user_request",
+            NoteKind::Correction => "correction",
+            NoteKind::Fact => "fact",
+            NoteKind::Forget => "forget",
+        }
+    }
+}
+
+/// A capture-layer staging note awaiting consolidation.
+#[derive(Debug, Clone)]
+pub struct StagingNote {
+    pub origin: NoteOrigin,
+    pub kind: NoteKind,
+    pub content: String,
+    /// Session the note was captured in, when known.
+    pub session_key: Option<String>,
+    /// Marks a host forget note as sensitive (hard-delete path in PR-4).
+    pub sensitive: bool,
+    /// Stable id (`^m…`) of the MEMORY.md entry this note contradicts.
+    pub replaces_id: Option<String>,
+}
+
+impl StagingNote {
+    /// Render as frontmatter + body. String values are JSON-encoded so
+    /// multi-line / CJK / quote-bearing content can't corrupt the header.
+    fn render(&self) -> String {
+        let mut fm = String::from("---\n");
+        fm.push_str(&format!("origin: {}\n", self.origin.as_str()));
+        fm.push_str(&format!("kind: {}\n", self.kind.as_str()));
+        fm.push_str(&format!(
+            "created_at: {}\n",
+            chrono::Utc::now().to_rfc3339()
+        ));
+        if let Some(key) = &self.session_key {
+            fm.push_str(&format!(
+                "session_key: {}\n",
+                serde_json::to_string(key).unwrap_or_default()
+            ));
+        }
+        if self.sensitive {
+            fm.push_str("sensitive: true\n");
+        }
+        if let Some(id) = &self.replaces_id {
+            fm.push_str(&format!(
+                "replaces_id: {}\n",
+                serde_json::to_string(id).unwrap_or_default()
+            ));
+        }
+        fm.push_str("---\n\n");
+        fm.push_str(&self.content);
+        fm.push('\n');
+        fm
     }
 }
 
@@ -1045,6 +1200,83 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = MemoryStore::open(dir.path()).await.unwrap();
         assert_eq!(store.get_injectable_context(2500).await, "");
+    }
+
+    // --- staging notes ---
+
+    fn fact_note(content: &str) -> StagingNote {
+        StagingNote {
+            origin: NoteOrigin::Model,
+            kind: NoteKind::Fact,
+            content: content.to_string(),
+            session_key: Some("tg:123".to_string()),
+            sensitive: false,
+            replaces_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn should_write_frontmatter_and_body_when_staging_note() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = MemoryStore::open(dir.path()).await.unwrap();
+
+        let mut note = fact_note("user prefers dark mode");
+        note.replaces_id = Some("^m4k2ab".to_string());
+        let path = store.write_staging_note(&note).await.unwrap();
+
+        let text = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(text.starts_with("---\n"));
+        assert!(text.contains("origin: model"));
+        assert!(text.contains("kind: fact"));
+        assert!(text.contains("session_key: \"tg:123\""));
+        assert!(text.contains("replaces_id: \"^m4k2ab\""));
+        assert!(text.ends_with("user prefers dark mode\n"));
+        assert!(!text.contains("sensitive"));
+    }
+
+    #[tokio::test]
+    async fn should_create_distinct_files_when_notes_have_same_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = MemoryStore::open(dir.path()).await.unwrap();
+
+        let note = fact_note("duplicate content");
+        let a = store.write_staging_note(&note).await.unwrap();
+        let b = store.write_staging_note(&note).await.unwrap();
+        assert_ne!(a, b);
+        assert_eq!(store.count_staging_notes().await, 2);
+    }
+
+    #[tokio::test]
+    async fn should_handle_cjk_content_when_naming_staging_note() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = MemoryStore::open(dir.path()).await.unwrap();
+
+        let note = fact_note("用户偏好深色模式，且住在温哥华");
+        let path = store.write_staging_note(&note).await.unwrap();
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        assert!(name.len() <= 255, "filename too long: {name}");
+        let text = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(text.contains("用户偏好深色模式"));
+    }
+
+    #[tokio::test]
+    async fn should_mark_sensitive_when_host_forget_note() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = MemoryStore::open(dir.path()).await.unwrap();
+
+        let note = StagingNote {
+            origin: NoteOrigin::Host,
+            kind: NoteKind::Forget,
+            content: "forget my wifi password".to_string(),
+            session_key: None,
+            sensitive: true,
+            replaces_id: None,
+        };
+        let path = store.write_staging_note(&note).await.unwrap();
+        let text = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(text.contains("origin: host"));
+        assert!(text.contains("kind: forget"));
+        assert!(text.contains("sensitive: true"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Second slice of the 7-round codex-reviewed memory-refresh design (PR-1 was #1543). Everything here is behind `memory.refresh.enabled` (default **off** — zero behavior change when disabled; the segment refactor itself is byte-identical by construction and snapshot-locked).

## What

**Structural prompt segments** (`octos-agent`): the agent system prompt becomes an ordered segment list. `append_system_prompt` keeps its exact legacy semantics (anonymous tail, `\n\n` + text — byte-identical rendering locked by tests); new `set_prompt_segment(name, content)` gives named replace-in-place slots that keep their insertion position, so the memory block can refresh without disturbing bootstrap-before / skills-after ordering. Appends issued after a named segment start a fresh anonymous tail so refreshes can never eat them. `set/with_system_prompt` remain full-replace.

**Read-side refresh**: `PromptSegmentProvider` + `Agent::refresh_prompt_segments()` run at conversation-turn start. `MemorySegmentProvider` re-renders the memory block only when `MEMORY.md` (mtime+len) changed or the local date rolled over — the unchanged path is one stat per turn. Long-lived chat sessions now see updated memory same-day instead of construction-time state. (Gateway/serve read-refresh rides the follow-up prompt-parts refactor — their prompts flow as flat strings through `ActorFactory`/`SessionRuntime`; gateway memory already re-reads on persona rebuilds, so its staleness is bounded today.)

**`memory_note` capture tool**: the model records durable observations as append-only notes — `kind = user_request | correction | fact`, optional `replaces_id` — one `create_new` file per note under `memory/staging/notes/` (uuidv7 + `safe_filename`, JSON-encoded frontmatter values). The trust model from the design is machine-enforced from day one: the tool stamps `origin: model` unconditionally, cannot mint `kind=forget` (host-authored only), and notes are **never injected into prompts** — they are untrusted staging for the PR-4 consolidator. `memory_note` joins `group:memory` and the `group:delegated` child deny list.

**Capture policy** (`MEMORY_CAPTURE_POLICY`, shared const): rides the memory segment on chat and the gateway prompt builder — explicit-ask rule for `user_request`, contradiction → `correction` with `replaces_id`, the codex-style no-op gate ("most turns need no note"), staleness disclosure, and a hard rule against editing memory files with file tools.

**Config/propagation**: `memory.refresh.enabled` follows the exact host-propagation discipline PR-1 established for `max_inject_tokens`: `OCTOS_MEMORY_REFRESH_ENABLED` forwarded by `ProcessManager` (spoof-guarded in both the profile-env and parent-env loops), field-level `merge_env_memory_policy` fill, and field-by-field host merges in `bootstrap_with_host_plugins` and `ProfileActorFactoryBuilder`.

## Tests

22 new unit tests across segments (render identity vs legacy string, replace-in-place, append-after-named survival, empty-hide), provider (fingerprint stat-only path, change/date re-render, policy composition), tool (origin stamping, forget rejection, replaces_id, size/empty guards), staging notes (frontmatter, create_new collision, CJK naming, sensitive host notes), and config. Full suites green in a clean worktree: octos-agent 2043, octos-cli 1923 (+api), octos-memory 86, octos-core 299.

## Design lineage

Implements Layers 1 + 4 of the v5/v6/v7 design (codex rounds 1–7 → all-green). Next: PR-3 extraction sweep (flock service, snapshot watermarks, `export_transcript`), then PR-4 consolidation (ops DSL with id-exact destructive authority).