### PR TITLE
fix(clippy): allow too_many_arguments on build_system_prompt (unblock CI)

### DIFF
--- a/crates/octos-cli/src/commands/gateway/prompt.rs
+++ b/crates/octos-cli/src/commands/gateway/prompt.rs
@@ -13,6 +13,11 @@ use crate::persona_service::PersonaService;
 /// daily notes + bank summary combined); use
 /// [`crate::config::MemoryConfig::effective_max_inject_tokens`] to resolve it
 /// from config.
+// These are the cohesive set of bootstrap inputs a system prompt is composed
+// from (persona base, data/project dirs, memory + skills sources, and the two
+// resolved memory knobs); they don't group into a smaller, meaningful sub-type,
+// so the arg count is expected here.
+#[allow(clippy::too_many_arguments)]
 pub async fn build_system_prompt(
     base: Option<&str>,
     data_dir: &Path,


### PR DESCRIPTION
## Summary

Unblocks CI (red on `main`): `cargo clippy --workspace --all-targets -- -D warnings` fails on `build_system_prompt` — it has 8 args (`too_many_arguments`, 8/7) after `memory_capture_policy` was added, with no override. This blocks **every** open PR's CI, not just one.

Fix: add `#[allow(clippy::too_many_arguments)]` (clippy's own recommended override) with a comment. These 8 are a cohesive set of prompt-bootstrap inputs (persona base, data/project dirs, memory + skills sources, two resolved memory knobs) that don't factor into a smaller meaningful sub-type; a struct wrapper across the 4 gateway-bootstrap call sites would add churn/risk in load-bearing startup code for no behavior benefit.

Behavior-preserving; no call sites touched. `cargo clippy --workspace --all-targets -- -D warnings` now clean.
