### PR TITLE
fix(memory): delta extraction — consumed transcript turns are never re-fed

### DIFF
--- a/crates/octos-cli/src/memory_refresh/service.rs
+++ b/crates/octos-cli/src/memory_refresh/service.rs
@@ -93,13 +93,17 @@ pub(crate) struct RefreshState {
     /// Per session key: the file snapshots actually READ last time.
     #[serde(default)]
     pub watermarks: std::collections::BTreeMap<String, Vec<FileSnap>>,
-    /// Per session key: transcript messages already CONSUMED by extraction.
-    /// Later sweeps feed only the delta — re-reading history would
-    /// re-learn facts the user has since hard-deleted (they are gone from
-    /// CURRENT MEMORY, so the "do not re-extract" instruction cannot see
-    /// them) and would re-spend tokens on every old turn.
+    /// Per session key: (transcript messages CONSUMED, total session-file
+    /// bytes at consume time). Later sweeps feed only the delta —
+    /// re-reading history would re-learn facts the user has since
+    /// hard-deleted (they are gone from CURRENT MEMORY, so the "do not
+    /// re-extract" instruction cannot see them) and would re-spend tokens
+    /// on every old turn. The byte total detects REWRITES (fork /
+    /// truncation / replacement): any shrink resets the cursor; a
+    /// same-or-longer rewrite with equal message count is the same
+    /// residual the (mtime,len) watermark design already accepts.
     #[serde(default)]
-    pub extracted_counts: std::collections::BTreeMap<String, usize>,
+    pub extracted_counts: std::collections::BTreeMap<String, (usize, u64)>,
     /// Per session key: consecutive extraction failures (skip at cap).
     #[serde(default)]
     pub failures: std::collections::BTreeMap<String, u32>,
@@ -429,6 +433,7 @@ pub(crate) async fn run_extraction_pass(
             break;
         }
         let key = session.key.clone();
+        let total_bytes: u64 = snaps.iter().map(|s| s.len).sum();
         let outcome = extract_one_session(
             &manager,
             memory_store,
@@ -436,6 +441,7 @@ pub(crate) async fn run_extraction_pass(
             knobs,
             &key,
             newest,
+            total_bytes,
             &mut state,
         )
         .await;
@@ -647,28 +653,37 @@ async fn extract_one_session(
     knobs: &RefreshKnobs,
     key: &octos_core::SessionKey,
     newest: SystemTime,
+    total_bytes: u64,
     state: &mut RefreshState,
 ) -> Result<bool> {
     let Some(transcript) = manager.export_transcript(key).await else {
         // Unreadable/empty: nothing to extract; not an error.
         return Ok(false);
     };
-    // Delta extraction: skip messages consumed by earlier sweeps. A
-    // SHORTER transcript means the session file was rewritten (fork,
-    // truncation) — start over from the top.
+    // Delta extraction: skip messages consumed by earlier sweeps. The
+    // cursor is valid only for a GROWN file with at least as many
+    // messages — a shorter transcript OR shrunken byte total means the
+    // session was rewritten (fork, truncation, replacement): start over.
     let prior = state
         .extracted_counts
         .get(&key.0)
         .copied()
-        .filter(|&n| n <= transcript.len())
+        .filter(|&(n, bytes)| n <= transcript.len() && bytes <= total_bytes)
+        .map(|(n, _)| n)
         .unwrap_or(0);
-    let fresh = &transcript[prior..];
-    let lines = build_input_lines(fresh);
+    // Build lines over the FULL transcript (tool-call names for result
+    // filtering can live in already-consumed messages), then keep only
+    // the fresh indices. Labels keep original indices, so evidence
+    // validation is unaffected.
+    let lines: Vec<_> = build_input_lines(&transcript)
+        .into_iter()
+        .filter(|l| l.idx >= prior)
+        .collect();
     if lines.is_empty() {
         // Nothing extractable in the delta; remember we consumed it.
         state
             .extracted_counts
-            .insert(key.0.clone(), transcript.len());
+            .insert(key.0.clone(), (transcript.len(), total_bytes));
         return Ok(false);
     }
     let rendered = render_transcript(
@@ -737,19 +752,24 @@ async fn extract_one_session(
     let parsed = parse_extraction_response(&raw)
         .map_err(|e| eyre::eyre!("extraction output was not valid JSON: {e}"))?;
     let items = validate_items(parsed, &lines, &session_date.format("%Y-%m-%d").to_string());
-    // The delta is consumed whichever way this run ends now — advancing on
-    // the no-op path too is what stops old turns from being re-fed (and
-    // re-charged) on every later sweep.
-    state
-        .extracted_counts
-        .insert(key.0.clone(), transcript.len());
     if items.is_empty() {
-        // The no-op gate firing is the expected common case.
+        // The no-op gate firing is the expected common case — the delta
+        // was consumed (nothing worth staging), so advance the cursor or
+        // these turns would be re-fed and re-charged every later sweep.
+        state
+            .extracted_counts
+            .insert(key.0.clone(), (transcript.len(), total_bytes));
         return Ok(false);
     }
     memory_store
         .write_staging_extraction(Some(&key.0), provider.model_id(), &items)
         .await?;
+    // Only now is the extraction durable — advancing earlier would let a
+    // failed write mark these turns consumed and the retry would skip
+    // them forever.
+    state
+        .extracted_counts
+        .insert(key.0.clone(), (transcript.len(), total_bytes));
     Ok(true)
 }
 
@@ -1469,6 +1489,47 @@ mod tests {
         assert!(
             !transcript_part.contains("oolong"),
             "already-consumed turns must not be re-fed: {transcript_part}"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_reset_cursor_when_session_rewritten() {
+        // A cleared/recreated session whose byte total SHRANK must reset
+        // the cursor — a stale count would silently skip the new content.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        seed_session(
+            dir.path(),
+            "api:501",
+            "a very long opening statement that pads the first transcript with bytes",
+        )
+        .await;
+
+        let provider = ScriptedProvider {
+            response: r#"{"items":[]}"#.to_string(),
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            prompts: std::sync::Mutex::new(Vec::new()),
+        };
+        let knobs = knobs_for_test();
+        run_extraction_pass(dir.path(), &store, &provider, &knobs)
+            .await
+            .unwrap();
+
+        // Replace the session with SHORTER different content.
+        let mut mgr = SessionManager::open(dir.path()).unwrap();
+        let key = SessionKey("api:501".to_string());
+        mgr.clear(&key).await.unwrap();
+        drop(mgr);
+        seed_session(dir.path(), "api:501", "my cat is Miso").await;
+        provider.prompts.lock().unwrap().clear();
+
+        run_extraction_pass(dir.path(), &store, &provider, &knobs)
+            .await
+            .unwrap();
+        let prompts = provider.prompts.lock().unwrap().concat();
+        assert!(
+            prompts.contains("Miso"),
+            "rewritten session must re-extract from the top: {prompts}"
         );
     }
 

--- a/crates/octos-cli/src/memory_refresh/service.rs
+++ b/crates/octos-cli/src/memory_refresh/service.rs
@@ -374,19 +374,9 @@ pub(crate) async fn run_extraction_pass(
     let mut state = RefreshState::load(&state_path);
     state.roll_date(&chrono::Local::now().format("%Y-%m-%d").to_string());
 
-    if state.extractions_today >= knobs.max_extractions_per_day
-        || state.tokens_today >= knobs.max_daily_tokens
-    {
-        report.skipped_budget = true;
-        state.save(&state_path)?;
-        return Ok(report);
-    }
-
     let manager = SessionManager::open(data_dir).wrap_err("failed to open session manager")?;
     let now = SystemTime::now();
 
-    // Eligible = user-facing, idle long enough, young enough, and changed
-    // since the snapshots we last read.
     // Pre-upgrade cursor backfill — INDEPENDENT of extraction eligibility
     // (idle windows, age caps, budgets): a watermarked session without a
     // cursor was fully consumed by a pre-cursor sweep; stamp it before
@@ -421,6 +411,20 @@ pub(crate) async fn run_extraction_pass(
             }
         }
     }
+
+    // The budget gates PROVIDER work only — the no-provider backfill above
+    // must run even on capped passes, or an append before the budget reset
+    // would re-feed the whole pre-upgrade history.
+    if state.extractions_today >= knobs.max_extractions_per_day
+        || state.tokens_today >= knobs.max_daily_tokens
+    {
+        report.skipped_budget = true;
+        state.save(&state_path)?;
+        return Ok(report);
+    }
+
+    // Eligible = user-facing, idle long enough, young enough, and changed
+    // since the snapshots we last read.
 
     let mut candidates: Vec<(octos_bus::AnalysisSession, Vec<FileSnap>, SystemTime)> = Vec::new();
     for session in manager.list_for_analysis() {
@@ -1738,6 +1742,39 @@ mod tests {
         assert!(
             state.extracted_counts.contains_key("api:504"),
             "backfill is independent of extraction eligibility: {:?}",
+            state.extracted_counts
+        );
+    }
+
+    #[tokio::test]
+    async fn should_backfill_cursor_even_when_budget_exhausted() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        seed_session(dir.path(), "api:505", "pre-upgrade fact").await;
+
+        let provider = ScriptedProvider {
+            response: r#"{"items":[]}"#.to_string(),
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            prompts: std::sync::Mutex::new(Vec::new()),
+        };
+        let knobs = knobs_for_test();
+        run_extraction_pass(dir.path(), &store, &provider, &knobs)
+            .await
+            .unwrap();
+        // Pre-upgrade state + exhausted budget.
+        let state_path = dir.path().join("memory").join("refresh_state.json");
+        let mut state = RefreshState::load(&state_path);
+        state.extracted_counts.clear();
+        state.extractions_today = knobs.max_extractions_per_day;
+        state.save(&state_path).unwrap();
+
+        run_extraction_pass(dir.path(), &store, &provider, &knobs)
+            .await
+            .unwrap();
+        let state = RefreshState::load(&state_path);
+        assert!(
+            state.extracted_counts.contains_key("api:505"),
+            "the no-provider backfill must run on capped passes: {:?}",
             state.extracted_counts
         );
     }

--- a/crates/octos-cli/src/memory_refresh/service.rs
+++ b/crates/octos-cli/src/memory_refresh/service.rs
@@ -423,11 +423,18 @@ pub(crate) async fn run_extraction_pass(
             // extracted by the old code.
             if !state.extracted_counts.contains_key(&session.key.0) {
                 if let Some(transcript) = manager.export_transcript(&session.key).await {
-                    let fp = transcript_prefix_fingerprint(&transcript, transcript.len());
-                    state
-                        .extracted_counts
-                        .insert(session.key.0.clone(), (transcript.len(), fp));
-                    state.save(&state_path)?;
+                    // Pre-read snapshot rule (same as the watermark
+                    // advance): a turn appended DURING this read would be
+                    // stamped consumed without extraction and skipped
+                    // forever. Leave the cursor unset; the changed file
+                    // makes the session a candidate next pass.
+                    if snapshots_current(&snaps) {
+                        let fp = transcript_prefix_fingerprint(&transcript, transcript.len());
+                        state
+                            .extracted_counts
+                            .insert(session.key.0.clone(), (transcript.len(), fp));
+                        state.save(&state_path)?;
+                    }
                 }
             }
             continue;

--- a/crates/octos-cli/src/memory_refresh/service.rs
+++ b/crates/octos-cli/src/memory_refresh/service.rs
@@ -387,6 +387,41 @@ pub(crate) async fn run_extraction_pass(
 
     // Eligible = user-facing, idle long enough, young enough, and changed
     // since the snapshots we last read.
+    // Pre-upgrade cursor backfill — INDEPENDENT of extraction eligibility
+    // (idle windows, age caps, budgets): a watermarked session without a
+    // cursor was fully consumed by a pre-cursor sweep; stamp it before
+    // anything can make the session a candidate, or its next append would
+    // fall back to prior=0 and re-feed the whole history. Sessions whose
+    // files already changed since the old watermark accept a one-time
+    // full re-read (we cannot know the consumed prefix).
+    for session in manager.list_for_analysis() {
+        if session.internal || session.files.is_empty() {
+            continue;
+        }
+        if state.extracted_counts.contains_key(&session.key.0) {
+            continue;
+        }
+        let snaps: Vec<FileSnap> = session
+            .files
+            .iter()
+            .map(|f| FileSnap::of(&f.path, f.modified, f.len))
+            .collect();
+        if state.watermarks.get(&session.key.0) != Some(&snaps) {
+            continue;
+        }
+        if let Some(transcript) = manager.export_transcript(&session.key).await {
+            // Pre-read snapshot rule: a turn appended DURING this read
+            // would be stamped consumed without extraction.
+            if snapshots_current(&snaps) {
+                let fp = transcript_prefix_fingerprint(&transcript, transcript.len());
+                state
+                    .extracted_counts
+                    .insert(session.key.0.clone(), (transcript.len(), fp));
+                state.save(&state_path)?;
+            }
+        }
+    }
+
     let mut candidates: Vec<(octos_bus::AnalysisSession, Vec<FileSnap>, SystemTime)> = Vec::new();
     for session in manager.list_for_analysis() {
         if session.internal || session.files.is_empty() {
@@ -415,28 +450,6 @@ pub(crate) async fn run_extraction_pass(
             .map(|f| FileSnap::of(&f.path, f.modified, f.len))
             .collect();
         if state.watermarks.get(&session.key.0) == Some(&snaps) {
-            // Pre-upgrade backfill: this session was fully consumed by a
-            // sweep from BEFORE delta cursors existed. Without a cursor,
-            // the next append would fall back to prior=0 and re-feed the
-            // whole history (re-learning facts deleted since). Stamp the
-            // cursor now, without extraction — that content was already
-            // extracted by the old code.
-            if !state.extracted_counts.contains_key(&session.key.0) {
-                if let Some(transcript) = manager.export_transcript(&session.key).await {
-                    // Pre-read snapshot rule (same as the watermark
-                    // advance): a turn appended DURING this read would be
-                    // stamped consumed without extraction and skipped
-                    // forever. Leave the cursor unset; the changed file
-                    // makes the session a candidate next pass.
-                    if snapshots_current(&snaps) {
-                        let fp = transcript_prefix_fingerprint(&transcript, transcript.len());
-                        state
-                            .extracted_counts
-                            .insert(session.key.0.clone(), (transcript.len(), fp));
-                        state.save(&state_path)?;
-                    }
-                }
-            }
             continue;
         }
         candidates.push((session, snaps, newest));
@@ -671,9 +684,27 @@ fn transcript_prefix_fingerprint(transcript: &[(usize, Message)], n: usize) -> S
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     for (_, msg) in &transcript[..n.min(transcript.len())] {
+        // Every field build_input_lines consumes: rewrites that change
+        // only tool linkage (rollback/migration) must invalidate the
+        // cursor too, or a changed sanitized prefix would be skipped.
         hasher.update(msg.role.as_str().as_bytes());
         hasher.update([0u8]);
         hasher.update(msg.content.as_bytes());
+        hasher.update([0u8]);
+        if let Some(id) = &msg.tool_call_id {
+            hasher.update(id.as_bytes());
+        }
+        hasher.update([0u8]);
+        if let Some(calls) = &msg.tool_calls {
+            for call in calls {
+                hasher.update(call.id.as_bytes());
+                hasher.update([1u8]);
+                hasher.update(call.name.as_bytes());
+                hasher.update([1u8]);
+                hasher.update(call.arguments.to_string().as_bytes());
+                hasher.update([1u8]);
+            }
+        }
         hasher.update([0x1e]);
     }
     format!("{:x}", hasher.finalize())
@@ -1668,6 +1699,46 @@ mod tests {
         assert!(
             transcript_part.contains("fish") && !transcript_part.contains("oolong"),
             "post-backfill append is delta-only: {transcript_part}"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_backfill_cursor_even_when_session_not_extraction_eligible() {
+        // The backfill must not depend on idle windows: a pre-upgrade
+        // session that is TOO FRESH for extraction still gets its cursor
+        // stamped, so an append right after upgrade feeds only the delta.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        seed_session(dir.path(), "api:504", "pre-upgrade fact: tea is oolong").await;
+
+        let provider = ScriptedProvider {
+            response: r#"{"items":[]}"#.to_string(),
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            prompts: std::sync::Mutex::new(Vec::new()),
+        };
+        // First pass with normal knobs consumes the session + watermark.
+        let knobs = knobs_for_test();
+        run_extraction_pass(dir.path(), &store, &provider, &knobs)
+            .await
+            .unwrap();
+        // Simulate pre-upgrade state: cursor dropped, watermark kept.
+        let state_path = dir.path().join("memory").join("refresh_state.json");
+        let mut state = RefreshState::load(&state_path);
+        state.extracted_counts.clear();
+        state.save(&state_path).unwrap();
+
+        // Pass with a LONG idle requirement: the session is not
+        // extraction-eligible, but the backfill must still stamp it.
+        let mut strict = knobs_for_test();
+        strict.min_idle = std::time::Duration::from_secs(3600);
+        run_extraction_pass(dir.path(), &store, &provider, &strict)
+            .await
+            .unwrap();
+        let state = RefreshState::load(&state_path);
+        assert!(
+            state.extracted_counts.contains_key("api:504"),
+            "backfill is independent of extraction eligibility: {:?}",
+            state.extracted_counts
         );
     }
 

--- a/crates/octos-cli/src/memory_refresh/service.rs
+++ b/crates/octos-cli/src/memory_refresh/service.rs
@@ -93,6 +93,13 @@ pub(crate) struct RefreshState {
     /// Per session key: the file snapshots actually READ last time.
     #[serde(default)]
     pub watermarks: std::collections::BTreeMap<String, Vec<FileSnap>>,
+    /// Per session key: transcript messages already CONSUMED by extraction.
+    /// Later sweeps feed only the delta — re-reading history would
+    /// re-learn facts the user has since hard-deleted (they are gone from
+    /// CURRENT MEMORY, so the "do not re-extract" instruction cannot see
+    /// them) and would re-spend tokens on every old turn.
+    #[serde(default)]
+    pub extracted_counts: std::collections::BTreeMap<String, usize>,
     /// Per session key: consecutive extraction failures (skip at cap).
     #[serde(default)]
     pub failures: std::collections::BTreeMap<String, u32>,
@@ -646,8 +653,22 @@ async fn extract_one_session(
         // Unreadable/empty: nothing to extract; not an error.
         return Ok(false);
     };
-    let lines = build_input_lines(&transcript);
+    // Delta extraction: skip messages consumed by earlier sweeps. A
+    // SHORTER transcript means the session file was rewritten (fork,
+    // truncation) — start over from the top.
+    let prior = state
+        .extracted_counts
+        .get(&key.0)
+        .copied()
+        .filter(|&n| n <= transcript.len())
+        .unwrap_or(0);
+    let fresh = &transcript[prior..];
+    let lines = build_input_lines(fresh);
     if lines.is_empty() {
+        // Nothing extractable in the delta; remember we consumed it.
+        state
+            .extracted_counts
+            .insert(key.0.clone(), transcript.len());
         return Ok(false);
     }
     let rendered = render_transcript(
@@ -716,6 +737,12 @@ async fn extract_one_session(
     let parsed = parse_extraction_response(&raw)
         .map_err(|e| eyre::eyre!("extraction output was not valid JSON: {e}"))?;
     let items = validate_items(parsed, &lines, &session_date.format("%Y-%m-%d").to_string());
+    // The delta is consumed whichever way this run ends now — advancing on
+    // the no-op path too is what stops old turns from being re-fed (and
+    // re-charged) on every later sweep.
+    state
+        .extracted_counts
+        .insert(key.0.clone(), transcript.len());
     if items.is_empty() {
         // The no-op gate firing is the expected common case.
         return Ok(false);
@@ -735,17 +762,22 @@ mod tests {
     struct ScriptedProvider {
         response: String,
         calls: std::sync::atomic::AtomicUsize,
+        prompts: std::sync::Mutex<Vec<String>>,
     }
 
     #[async_trait::async_trait]
     impl LlmProvider for ScriptedProvider {
         async fn chat(
             &self,
-            _messages: &[Message],
+            messages: &[Message],
             _tools: &[ToolSpec],
             _config: &ChatConfig,
         ) -> eyre::Result<ChatResponse> {
             self.calls.fetch_add(1, Ordering::SeqCst);
+            self.prompts
+                .lock()
+                .unwrap()
+                .extend(messages.iter().map(|m| m.content.clone()));
             Ok(ChatResponse {
                 content: Some(self.response.clone()),
                 reasoning_content: None,
@@ -817,6 +849,7 @@ mod tests {
                 r#"{"items":[{"kind":"fact","content":"lives in Vancouver","evidence":[0]}]}"#
                     .to_string(),
             calls: std::sync::atomic::AtomicUsize::new(0),
+            prompts: std::sync::Mutex::new(Vec::new()),
         };
         let knobs = knobs_for_test();
         let report = run_extraction_pass(dir.path(), &store, &provider, &knobs)
@@ -844,6 +877,7 @@ mod tests {
         let provider = ScriptedProvider {
             response: r#"{"items":[]}"#.to_string(),
             calls: std::sync::atomic::AtomicUsize::new(0),
+            prompts: std::sync::Mutex::new(Vec::new()),
         };
         let report = run_extraction_pass(dir.path(), &store, &provider, &knobs_for_test())
             .await
@@ -874,6 +908,7 @@ mod tests {
         let provider = ScriptedProvider {
             response: r#"{"items":[]}"#.to_string(),
             calls: std::sync::atomic::AtomicUsize::new(0),
+            prompts: std::sync::Mutex::new(Vec::new()),
         };
         let report = run_extraction_pass(dir.path(), &store, &provider, &knobs_for_test())
             .await
@@ -899,6 +934,7 @@ mod tests {
         let provider = ScriptedProvider {
             response: "NOT JSON AT ALL".to_string(),
             calls: std::sync::atomic::AtomicUsize::new(0),
+            prompts: std::sync::Mutex::new(Vec::new()),
         };
         let knobs = knobs_for_test();
         for _ in 0..MAX_SESSION_FAILURES {
@@ -985,6 +1021,7 @@ mod tests {
                 r#"{"items":[{"kind":"fact","content":"lives in Vancouver","evidence":[0]}]}"#
                     .to_string(),
             calls: std::sync::atomic::AtomicUsize::new(0),
+            prompts: std::sync::Mutex::new(Vec::new()),
         };
         let knobs = knobs_for_test();
         let report = run_extraction_pass(dir.path(), &store, &extract, &knobs)
@@ -1271,6 +1308,7 @@ mod tests {
         let extract = ScriptedProvider {
             response: "NOT JSON".to_string(),
             calls: std::sync::atomic::AtomicUsize::new(0),
+            prompts: std::sync::Mutex::new(Vec::new()),
         };
         let notes_dir = dir.path().join("memory/staging/notes");
         let note_name = std::fs::read_dir(&notes_dir)
@@ -1380,6 +1418,57 @@ mod tests {
             state.tokens_today >= 1_000,
             "the consumed staging payload must be charged (pre-capture): {}",
             state.tokens_today
+        );
+    }
+
+    #[tokio::test]
+    async fn should_extract_only_delta_when_session_grows() {
+        // A fact stated BEFORE the first sweep must not be re-fed to the
+        // extractor after later turns move the watermark — re-reading
+        // history re-learns facts the user may have hard-deleted since.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        seed_session(dir.path(), "api:500", "my favorite tea is oolong").await;
+
+        let provider = ScriptedProvider {
+            response: r#"{"items":[]}"#.to_string(),
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            prompts: std::sync::Mutex::new(Vec::new()),
+        };
+        let knobs = knobs_for_test();
+        run_extraction_pass(dir.path(), &store, &provider, &knobs)
+            .await
+            .unwrap();
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+        assert!(
+            provider.prompts.lock().unwrap().concat().contains("oolong"),
+            "first sweep reads the full transcript"
+        );
+
+        // The session grows by one new exchange.
+        seed_session(dir.path(), "api:500", "my staging server is maple").await;
+        provider.prompts.lock().unwrap().clear();
+
+        run_extraction_pass(dir.path(), &store, &provider, &knobs)
+            .await
+            .unwrap();
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
+        let second = provider.prompts.lock().unwrap().concat();
+        assert!(
+            second.contains("maple"),
+            "the new turn is extracted: {second}"
+        );
+        // The old statement may appear in CURRENT MEMORY context but must
+        // not appear in the TRANSCRIPT slice. Assert on the transcript
+        // portion only.
+        let transcript_part = second
+            .split("TRANSCRIPT of session")
+            .nth(1)
+            .unwrap_or("")
+            .to_string();
+        assert!(
+            !transcript_part.contains("oolong"),
+            "already-consumed turns must not be re-fed: {transcript_part}"
         );
     }
 

--- a/crates/octos-cli/src/memory_refresh/service.rs
+++ b/crates/octos-cli/src/memory_refresh/service.rs
@@ -482,10 +482,14 @@ pub(crate) async fn run_extraction_pass(
         )
         .await;
         match outcome {
-            Ok(wrote) => {
+            Ok(outcome) => {
                 state.failures.remove(&key.0);
-                state.extractions_today += 1;
-                if wrote {
+                // The extraction-call budget counts PROVIDER calls; empty
+                // deltas (filtered-only changes) are free.
+                if outcome.called_provider {
+                    state.extractions_today += 1;
+                }
+                if outcome.wrote {
                     report.extracted += 1;
                 }
                 // Advance the watermark ONLY if the files did not change
@@ -682,6 +686,15 @@ fn snapshots_current(snaps: &[FileSnap]) -> bool {
 }
 
 /// Extract one session; returns Ok(true) when a staging artifact was written.
+/// What one session's extraction attempt did — the CALLER charges the
+/// daily extraction budget only when a provider call actually happened
+/// (empty deltas and unreadable sessions are free).
+#[derive(Debug, Clone, Copy, Default)]
+struct ExtractOutcome {
+    called_provider: bool,
+    wrote: bool,
+}
+
 /// Stable fingerprint of the first `n` transcript messages — the delta
 /// cursor's validity check. Any change below the cursor resets it.
 fn transcript_prefix_fingerprint(transcript: &[(usize, Message)], n: usize) -> String {
@@ -722,10 +735,10 @@ async fn extract_one_session(
     key: &octos_core::SessionKey,
     newest: SystemTime,
     state: &mut RefreshState,
-) -> Result<bool> {
+) -> Result<ExtractOutcome> {
     let Some(transcript) = manager.export_transcript(key).await else {
         // Unreadable/empty: nothing to extract; not an error.
-        return Ok(false);
+        return Ok(ExtractOutcome::default());
     };
     // Delta extraction: skip messages consumed by earlier sweeps. The
     // cursor is valid only when the consumed PREFIX is byte-identical —
@@ -756,7 +769,7 @@ async fn extract_one_session(
                 transcript_prefix_fingerprint(&transcript, transcript.len()),
             ),
         );
-        return Ok(false);
+        return Ok(ExtractOutcome::default());
     }
     let rendered = render_transcript(
         &lines,
@@ -835,7 +848,10 @@ async fn extract_one_session(
                 transcript_prefix_fingerprint(&transcript, transcript.len()),
             ),
         );
-        return Ok(false);
+        return Ok(ExtractOutcome {
+            called_provider: true,
+            wrote: false,
+        });
     }
     memory_store
         .write_staging_extraction(Some(&key.0), provider.model_id(), &items)
@@ -850,7 +866,10 @@ async fn extract_one_session(
             transcript_prefix_fingerprint(&transcript, transcript.len()),
         ),
     );
-    Ok(true)
+    Ok(ExtractOutcome {
+        called_provider: true,
+        wrote: true,
+    })
 }
 
 #[cfg(test)]
@@ -1776,6 +1795,60 @@ mod tests {
             state.extracted_counts.contains_key("api:505"),
             "the no-provider backfill must run on capped passes: {:?}",
             state.extracted_counts
+        );
+    }
+
+    #[tokio::test]
+    async fn should_not_charge_extraction_budget_for_empty_delta() {
+        // A session whose only change is filtered content (e.g. a bare
+        // system row) produces an empty delta — no provider call, no
+        // budget charge.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        seed_session(dir.path(), "api:506", "a real user fact").await;
+
+        let provider = ScriptedProvider {
+            response: r#"{"items":[]}"#.to_string(),
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            prompts: std::sync::Mutex::new(Vec::new()),
+        };
+        let knobs = knobs_for_test();
+        run_extraction_pass(dir.path(), &store, &provider, &knobs)
+            .await
+            .unwrap();
+        let state_path = dir.path().join("memory").join("refresh_state.json");
+        let before = RefreshState::load(&state_path).extractions_today;
+
+        // Append a SYSTEM message: build_input_lines drops it, so the
+        // delta is empty.
+        let mut mgr = SessionManager::open(dir.path()).unwrap();
+        let key = SessionKey("api:506".to_string());
+        let msg = octos_core::Message {
+            role: MessageRole::System,
+            content: "internal marker".to_string(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: None,
+            timestamp: chrono::Utc::now(),
+        };
+        mgr.add_message(&key, msg).await.unwrap();
+        drop(mgr);
+
+        run_extraction_pass(dir.path(), &store, &provider, &knobs)
+            .await
+            .unwrap();
+        let state = RefreshState::load(&state_path);
+        assert_eq!(
+            state.extractions_today, before,
+            "empty deltas must not burn the extraction-call budget"
+        );
+        assert_eq!(
+            provider.calls.load(Ordering::SeqCst),
+            1,
+            "no second provider call"
         );
     }
 

--- a/crates/octos-cli/src/memory_refresh/service.rs
+++ b/crates/octos-cli/src/memory_refresh/service.rs
@@ -93,17 +93,16 @@ pub(crate) struct RefreshState {
     /// Per session key: the file snapshots actually READ last time.
     #[serde(default)]
     pub watermarks: std::collections::BTreeMap<String, Vec<FileSnap>>,
-    /// Per session key: (transcript messages CONSUMED, total session-file
-    /// bytes at consume time). Later sweeps feed only the delta —
-    /// re-reading history would re-learn facts the user has since
-    /// hard-deleted (they are gone from CURRENT MEMORY, so the "do not
-    /// re-extract" instruction cannot see them) and would re-spend tokens
-    /// on every old turn. The byte total detects REWRITES (fork /
-    /// truncation / replacement): any shrink resets the cursor; a
-    /// same-or-longer rewrite with equal message count is the same
-    /// residual the (mtime,len) watermark design already accepts.
+    /// Per session key: (transcript messages CONSUMED, fingerprint of that
+    /// consumed prefix). Later sweeps feed only the delta — re-reading
+    /// history would re-learn facts the user has since hard-deleted (they
+    /// are gone from CURRENT MEMORY, so the "do not re-extract"
+    /// instruction cannot see them) and would re-spend tokens on every
+    /// old turn. The FINGERPRINT (not file bytes) detects rewrites:
+    /// rollback-and-continue can grow the file while replacing folded
+    /// messages below the cursor — any prefix change resets it.
     #[serde(default)]
-    pub extracted_counts: std::collections::BTreeMap<String, (usize, u64)>,
+    pub extracted_counts: std::collections::BTreeMap<String, (usize, String)>,
     /// Per session key: consecutive extraction failures (skip at cap).
     #[serde(default)]
     pub failures: std::collections::BTreeMap<String, u32>,
@@ -416,6 +415,21 @@ pub(crate) async fn run_extraction_pass(
             .map(|f| FileSnap::of(&f.path, f.modified, f.len))
             .collect();
         if state.watermarks.get(&session.key.0) == Some(&snaps) {
+            // Pre-upgrade backfill: this session was fully consumed by a
+            // sweep from BEFORE delta cursors existed. Without a cursor,
+            // the next append would fall back to prior=0 and re-feed the
+            // whole history (re-learning facts deleted since). Stamp the
+            // cursor now, without extraction — that content was already
+            // extracted by the old code.
+            if !state.extracted_counts.contains_key(&session.key.0) {
+                if let Some(transcript) = manager.export_transcript(&session.key).await {
+                    let fp = transcript_prefix_fingerprint(&transcript, transcript.len());
+                    state
+                        .extracted_counts
+                        .insert(session.key.0.clone(), (transcript.len(), fp));
+                    state.save(&state_path)?;
+                }
+            }
             continue;
         }
         candidates.push((session, snaps, newest));
@@ -433,7 +447,6 @@ pub(crate) async fn run_extraction_pass(
             break;
         }
         let key = session.key.clone();
-        let total_bytes: u64 = snaps.iter().map(|s| s.len).sum();
         let outcome = extract_one_session(
             &manager,
             memory_store,
@@ -441,7 +454,6 @@ pub(crate) async fn run_extraction_pass(
             knobs,
             &key,
             newest,
-            total_bytes,
             &mut state,
         )
         .await;
@@ -646,6 +658,20 @@ fn snapshots_current(snaps: &[FileSnap]) -> bool {
 }
 
 /// Extract one session; returns Ok(true) when a staging artifact was written.
+/// Stable fingerprint of the first `n` transcript messages — the delta
+/// cursor's validity check. Any change below the cursor resets it.
+fn transcript_prefix_fingerprint(transcript: &[(usize, Message)], n: usize) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    for (_, msg) in &transcript[..n.min(transcript.len())] {
+        hasher.update(msg.role.as_str().as_bytes());
+        hasher.update([0u8]);
+        hasher.update(msg.content.as_bytes());
+        hasher.update([0x1e]);
+    }
+    format!("{:x}", hasher.finalize())
+}
+
 async fn extract_one_session(
     manager: &SessionManager,
     memory_store: &Arc<MemoryStore>,
@@ -653,7 +679,6 @@ async fn extract_one_session(
     knobs: &RefreshKnobs,
     key: &octos_core::SessionKey,
     newest: SystemTime,
-    total_bytes: u64,
     state: &mut RefreshState,
 ) -> Result<bool> {
     let Some(transcript) = manager.export_transcript(key).await else {
@@ -661,15 +686,16 @@ async fn extract_one_session(
         return Ok(false);
     };
     // Delta extraction: skip messages consumed by earlier sweeps. The
-    // cursor is valid only for a GROWN file with at least as many
-    // messages — a shorter transcript OR shrunken byte total means the
-    // session was rewritten (fork, truncation, replacement): start over.
+    // cursor is valid only when the consumed PREFIX is byte-identical —
+    // fork/truncation/rollback-and-continue all change it and reset the
+    // cursor to a full re-read.
     let prior = state
         .extracted_counts
         .get(&key.0)
-        .copied()
-        .filter(|&(n, bytes)| n <= transcript.len() && bytes <= total_bytes)
-        .map(|(n, _)| n)
+        .filter(|(n, fp)| {
+            *n <= transcript.len() && *fp == transcript_prefix_fingerprint(&transcript, *n)
+        })
+        .map(|(n, _)| *n)
         .unwrap_or(0);
     // Build lines over the FULL transcript (tool-call names for result
     // filtering can live in already-consumed messages), then keep only
@@ -681,9 +707,13 @@ async fn extract_one_session(
         .collect();
     if lines.is_empty() {
         // Nothing extractable in the delta; remember we consumed it.
-        state
-            .extracted_counts
-            .insert(key.0.clone(), (transcript.len(), total_bytes));
+        state.extracted_counts.insert(
+            key.0.clone(),
+            (
+                transcript.len(),
+                transcript_prefix_fingerprint(&transcript, transcript.len()),
+            ),
+        );
         return Ok(false);
     }
     let rendered = render_transcript(
@@ -756,9 +786,13 @@ async fn extract_one_session(
         // The no-op gate firing is the expected common case — the delta
         // was consumed (nothing worth staging), so advance the cursor or
         // these turns would be re-fed and re-charged every later sweep.
-        state
-            .extracted_counts
-            .insert(key.0.clone(), (transcript.len(), total_bytes));
+        state.extracted_counts.insert(
+            key.0.clone(),
+            (
+                transcript.len(),
+                transcript_prefix_fingerprint(&transcript, transcript.len()),
+            ),
+        );
         return Ok(false);
     }
     memory_store
@@ -767,9 +801,13 @@ async fn extract_one_session(
     // Only now is the extraction durable — advancing earlier would let a
     // failed write mark these turns consumed and the retry would skip
     // them forever.
-    state
-        .extracted_counts
-        .insert(key.0.clone(), (transcript.len(), total_bytes));
+    state.extracted_counts.insert(
+        key.0.clone(),
+        (
+            transcript.len(),
+            transcript_prefix_fingerprint(&transcript, transcript.len()),
+        ),
+    );
     Ok(true)
 }
 
@@ -1530,6 +1568,99 @@ mod tests {
         assert!(
             prompts.contains("Miso"),
             "rewritten session must re-extract from the top: {prompts}"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_reset_cursor_when_prefix_rewritten_but_longer() {
+        // Rollback-and-continue: the transcript ends up AT LEAST as long
+        // with different content below the cursor. Byte/length checks
+        // can't see it — the prefix fingerprint must.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        seed_session(dir.path(), "api:502", "original statement one").await;
+
+        let provider = ScriptedProvider {
+            response: r#"{"items":[]}"#.to_string(),
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            prompts: std::sync::Mutex::new(Vec::new()),
+        };
+        let knobs = knobs_for_test();
+        run_extraction_pass(dir.path(), &store, &provider, &knobs)
+            .await
+            .unwrap();
+
+        // Replace with DIFFERENT content of the same+greater length.
+        let mut mgr = SessionManager::open(dir.path()).unwrap();
+        let key = SessionKey("api:502".to_string());
+        mgr.clear(&key).await.unwrap();
+        drop(mgr);
+        seed_session(dir.path(), "api:502", "replacement statement alpha").await;
+        seed_session(dir.path(), "api:502", "replacement statement beta").await;
+        provider.prompts.lock().unwrap().clear();
+
+        run_extraction_pass(dir.path(), &store, &provider, &knobs)
+            .await
+            .unwrap();
+        let prompts = provider.prompts.lock().unwrap().concat();
+        assert!(
+            prompts.contains("replacement statement alpha"),
+            "rewritten prefix must reset the cursor: {prompts}"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_backfill_cursor_for_pre_upgrade_watermarks() {
+        // A session fully consumed by a pre-cursor sweep (watermark set,
+        // no cursor) must get a cursor stamped WITHOUT re-extraction, so
+        // the next append feeds only the delta.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        seed_session(dir.path(), "api:503", "ancient fact: tea is oolong").await;
+
+        let provider = ScriptedProvider {
+            response: r#"{"items":[]}"#.to_string(),
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            prompts: std::sync::Mutex::new(Vec::new()),
+        };
+        let knobs = knobs_for_test();
+        run_extraction_pass(dir.path(), &store, &provider, &knobs)
+            .await
+            .unwrap();
+
+        // Simulate the pre-upgrade state: watermark kept, cursor dropped.
+        let state_path = dir.path().join("memory").join("refresh_state.json");
+        let mut state = RefreshState::load(&state_path);
+        state.extracted_counts.clear();
+        state.save(&state_path).unwrap();
+
+        // Clean pass (watermark matches): backfills without extraction.
+        run_extraction_pass(dir.path(), &store, &provider, &knobs)
+            .await
+            .unwrap();
+        let state = RefreshState::load(&state_path);
+        assert!(
+            state.extracted_counts.contains_key("api:503"),
+            "cursor backfilled on the clean pass: {:?}",
+            state.extracted_counts
+        );
+        assert_eq!(
+            provider.calls.load(Ordering::SeqCst),
+            1,
+            "no extra extraction"
+        );
+
+        // The next append feeds only the delta.
+        seed_session(dir.path(), "api:503", "new fact: shell is fish").await;
+        provider.prompts.lock().unwrap().clear();
+        run_extraction_pass(dir.path(), &store, &provider, &knobs)
+            .await
+            .unwrap();
+        let prompts = provider.prompts.lock().unwrap().concat();
+        let transcript_part = prompts.split("TRANSCRIPT of session").nth(1).unwrap_or("");
+        assert!(
+            transcript_part.contains("fish") && !transcript_part.contains("oolong"),
+            "post-backfill append is delta-only: {transcript_part}"
         );
     }
 


### PR DESCRIPTION
## Soak finding (mini5, live serve + DeepSeek)

Hard-deleting a fact (`octos memory forget --id`) and then continuing the conversation brought the fact **back**: the next turn moved the session watermark, extraction re-read the WHOLE transcript, and the original statement — no longer in CURRENT MEMORY, so the "do not re-extract" instruction could not see it — was re-learned under a fresh id. Re-reading history also re-spent tokens on old turns at every sweep.

## Fix

`RefreshState.extracted_counts` (session key → transcript messages already consumed); `extract_one_session` slices the export after that count and advances it on both success exits (staged write AND the no-op gate). A shorter transcript than the count = session rewritten (fork/truncation) → full re-read. Existing states deserialize with empty counts (one-time full read post-upgrade).

Verified live on mini5 after the fix (see soak notes) + regression test asserting the second sweep's transcript slice excludes already-consumed turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)