### PR TITLE
feat(memory): automatic memory is DEFAULT-ON

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,11 +1,10 @@
 {
   "provider": "anthropic",
   "model": "claude-sonnet-4-20250514",
-
   "memory": {
     "max_inject_tokens": 2500,
     "refresh": {
-      "enabled": false,
+      "enabled": true,
       "extract_model": null,
       "min_idle_minutes": 30,
       "max_session_age_days": 10,
@@ -22,7 +21,6 @@
       "pending_confirm_days": 7
     }
   },
-
   "sub_providers": [
     {
       "key": "cheap",

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -267,6 +267,10 @@ pub struct AppState {
     /// configs never set) is the primary defence; the handlers additionally
     /// reject any request carrying proxy-forwarding headers.
     pub solo_login_enabled: bool,
+    /// Resolved HOST-level memory policy (top-level config). Threaded into
+    /// lazily-bootstrapped profile runtimes so a host opt-out of memory
+    /// refresh (DEFAULT-ON) also binds profiles created after startup.
+    pub host_memory: Option<crate::config::MemoryConfig>,
     /// Whether the admin shell endpoint is enabled (default: false).
     pub allow_admin_shell: bool,
     /// Content catalog manager for per-profile file indexing.
@@ -386,6 +390,7 @@ impl AppState {
             frps_port: None,
             deployment_mode: crate::config::DeploymentMode::Local,
             solo_login_enabled: false,
+            host_memory: None,
             allow_admin_shell: false,
             content_catalog_mgr: None,
             swarm_state: None,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -9782,11 +9782,17 @@ async fn ensure_session_profile_runtime(
     }
 
     let profile_data_dir = store.resolve_data_dir(&profile);
-    let runtime = crate::runtime::ProfileRuntime::bootstrap(
+    // Lazily-created profiles must honour host-level policy too — without
+    // host_memory, a host opt-out of (default-on) memory refresh would not
+    // bind profiles created after startup.
+    let runtime = crate::runtime::ProfileRuntime::bootstrap_with_host_plugins(
         &profile,
         &profile_data_dir,
         Some(store.octos_home_dir()),
         crate::runtime::BootstrapRole::Serve,
+        None,
+        None,
+        state.host_memory.as_ref(),
     )
     .await
     .map_err(|error| {

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -577,15 +577,10 @@ impl ProfileActorFactoryBuilder {
         }
         // Host memory settings apply field-by-field when the child profile
         // doesn't override them (same pattern as bootstrap_with_host_plugins).
-        if let Some(host) = self.host_memory.as_ref() {
-            let mem = profile_config.memory.get_or_insert_with(Default::default);
-            if mem.max_inject_tokens.is_none() {
-                mem.max_inject_tokens = host.max_inject_tokens;
-            }
-            if mem.refresh.is_none() {
-                mem.refresh = host.refresh.clone();
-            }
-        }
+        crate::config::merge_host_memory_into_profile(
+            &mut profile_config.memory,
+            self.host_memory.as_ref(),
+        );
         let (llm, provider_name, adaptive_router, llm_strong) =
             build_llm_stack(&profile_config, self.no_retry)?;
         let llm_for_compaction = llm.clone();

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -714,6 +714,7 @@ impl ServeCommand {
                 .or_else(|| std::env::var("FRPS_SERVER").ok()),
             frps_port: std::env::var("FRPS_PORT").ok().and_then(|p| p.parse().ok()),
             deployment_mode: config.mode.clone(),
+            host_memory: config.memory.clone(),
             solo_login_enabled: self.solo
                 || std::env::var("OCTOS_SOLO_LOGIN")
                     .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -550,9 +550,11 @@ pub struct MemoryConfig {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct MemoryRefreshConfig {
     /// Master switch for the capture layer + read-side refresh + the
-    /// background extraction sweep.
+    /// background extraction sweep. DEFAULT-ON: `None` means enabled —
+    /// automatic memory is the product behavior; set `false` (or
+    /// `OCTOS_MEMORY_REFRESH_ENABLED=0`) to opt out.
     #[serde(default)]
-    pub enabled: bool,
+    pub enabled: Option<bool>,
 
     /// Model key for the extraction pass (unset → the profile's provider).
     #[serde(default)]
@@ -649,10 +651,13 @@ impl MemoryConfig {
     }
 
     /// Whether automatic memory refreshing (capture + read refresh) is on.
+    /// DEFAULT-ON: an absent memory/refresh block (or an unset `enabled`)
+    /// means enabled; only an explicit `false` opts out.
     pub fn refresh_enabled(config: Option<&MemoryConfig>) -> bool {
         config
             .and_then(|m| m.refresh.as_ref())
-            .is_some_and(|r| r.enabled)
+            .and_then(|r| r.enabled)
+            .unwrap_or(true)
     }
 }
 
@@ -1218,11 +1223,17 @@ fn merge_env_memory_policy(config: &mut Config) {
         }
     }
     // Same field-level rule for the refresh switch: the env only fills the
-    // gap when the loaded config says nothing about `memory.refresh`.
+    // gap when the loaded config says nothing about `memory.refresh.enabled`
+    // (block absent OR the tri-state left unset). With the DEFAULT-ON
+    // semantics the OFF direction matters most: a host that disabled
+    // memory mirrors `OCTOS_MEMORY_REFRESH_ENABLED=0` to spawned
+    // subprocesses, and that must beat the child's default-on. An explicit
+    // `enabled` in the config file still wins over the env.
     if config
         .memory
         .as_ref()
         .and_then(|m| m.refresh.as_ref())
+        .and_then(|r| r.enabled)
         .is_none()
     {
         if let Ok(v) = std::env::var("OCTOS_MEMORY_REFRESH_ENABLED") {
@@ -1230,13 +1241,12 @@ fn merge_env_memory_policy(config: &mut Config) {
                 v.trim().to_ascii_lowercase().as_str(),
                 "1" | "true" | "yes" | "on"
             );
-            if on {
-                config.memory.get_or_insert_with(Default::default).refresh =
-                    Some(MemoryRefreshConfig {
-                        enabled: true,
-                        ..Default::default()
-                    });
-            }
+            config
+                .memory
+                .get_or_insert_with(Default::default)
+                .refresh
+                .get_or_insert_with(Default::default)
+                .enabled = Some(on);
         }
     }
 }
@@ -2801,24 +2811,59 @@ mod tests {
     // --- memory refresh flag ---
 
     #[test]
-    fn should_default_refresh_off_when_memory_absent_or_empty() {
-        assert!(!MemoryConfig::refresh_enabled(None));
+    fn should_default_refresh_on_when_memory_absent_or_empty() {
+        // DEFAULT-ON: automatic memory is the product behavior; absence of
+        // config means enabled.
+        assert!(MemoryConfig::refresh_enabled(None));
         let empty: MemoryConfig = serde_json::from_value(serde_json::json!({})).unwrap();
-        assert!(!MemoryConfig::refresh_enabled(Some(&empty)));
+        assert!(MemoryConfig::refresh_enabled(Some(&empty)));
         let refresh_empty: MemoryConfig =
             serde_json::from_value(serde_json::json!({"refresh": {}})).unwrap();
-        assert!(!MemoryConfig::refresh_enabled(Some(&refresh_empty)));
+        assert!(MemoryConfig::refresh_enabled(Some(&refresh_empty)));
     }
 
     #[test]
-    fn should_enable_refresh_when_config_sets_it() {
-        let cfg: MemoryConfig =
+    fn should_disable_refresh_only_when_explicitly_false() {
+        let off: MemoryConfig =
+            serde_json::from_value(serde_json::json!({"refresh": {"enabled": false}})).unwrap();
+        assert!(!MemoryConfig::refresh_enabled(Some(&off)));
+        let on: MemoryConfig =
             serde_json::from_value(serde_json::json!({"refresh": {"enabled": true}})).unwrap();
-        assert!(MemoryConfig::refresh_enabled(Some(&cfg)));
+        assert!(MemoryConfig::refresh_enabled(Some(&on)));
         // max_inject_tokens keeps its default independently.
         assert_eq!(
-            MemoryConfig::effective_max_inject_tokens(Some(&cfg)),
+            MemoryConfig::effective_max_inject_tokens(Some(&on)),
             octos_memory::DEFAULT_MAX_INJECT_TOKENS
         );
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn should_let_env_disable_refresh_when_config_silent() {
+        // Host mirroring: OCTOS_MEMORY_REFRESH_ENABLED=0 must beat the
+        // child's default-on when the config file says nothing.
+        let prev = std::env::var("OCTOS_MEMORY_REFRESH_ENABLED").ok();
+        unsafe { std::env::set_var("OCTOS_MEMORY_REFRESH_ENABLED", "0") };
+
+        let mut config = Config::default();
+        merge_env_memory_policy(&mut config);
+        assert!(!MemoryConfig::refresh_enabled(config.memory.as_ref()));
+
+        // An explicit config value wins over the env.
+        let mut explicit = Config::default();
+        explicit.memory = Some(MemoryConfig {
+            refresh: Some(MemoryRefreshConfig {
+                enabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        merge_env_memory_policy(&mut explicit);
+        assert!(MemoryConfig::refresh_enabled(explicit.memory.as_ref()));
+
+        match prev {
+            Some(v) => unsafe { std::env::set_var("OCTOS_MEMORY_REFRESH_ENABLED", v) },
+            None => unsafe { std::env::remove_var("OCTOS_MEMORY_REFRESH_ENABLED") },
+        }
     }
 }

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -661,6 +661,34 @@ impl MemoryConfig {
     }
 }
 
+/// Field-level host→profile memory inheritance (in-process runtimes: the
+/// profile bootstrap and the actor factory). A profile that says nothing
+/// inherits the host block wholesale; a profile block present only for
+/// knobs (tri-state `enabled` unset) still inherits the host's
+/// enabled/disabled decision — under DEFAULT-ON semantics dropping it
+/// would bypass a host-level opt-out.
+pub fn merge_host_memory_into_profile(
+    config: &mut Option<MemoryConfig>,
+    host_memory: Option<&MemoryConfig>,
+) {
+    let Some(host) = host_memory else {
+        return;
+    };
+    let mem = config.get_or_insert_with(Default::default);
+    if mem.max_inject_tokens.is_none() {
+        mem.max_inject_tokens = host.max_inject_tokens;
+    }
+    if mem.refresh.is_none() {
+        mem.refresh = host.refresh.clone();
+    } else if let (Some(profile_refresh), Some(host_refresh)) =
+        (mem.refresh.as_mut(), host.refresh.as_ref())
+    {
+        if profile_refresh.enabled.is_none() {
+            profile_refresh.enabled = host_refresh.enabled;
+        }
+    }
+}
+
 /// Email sending configuration for the `send_email` tool.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EmailConfig {
@@ -2835,6 +2863,48 @@ mod tests {
             MemoryConfig::effective_max_inject_tokens(Some(&on)),
             octos_memory::DEFAULT_MAX_INJECT_TOKENS
         );
+    }
+
+    #[test]
+    fn should_inherit_host_opt_out_when_profile_refresh_is_knobs_only() {
+        // Host explicitly disabled; profile block exists only for knobs.
+        let host = MemoryConfig {
+            refresh: Some(MemoryRefreshConfig {
+                enabled: Some(false),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut profile = Some(MemoryConfig {
+            refresh: Some(MemoryRefreshConfig {
+                min_idle_minutes: Some(5),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        merge_host_memory_into_profile(&mut profile, Some(&host));
+        assert!(
+            !MemoryConfig::refresh_enabled(profile.as_ref()),
+            "knobs-only profile blocks must inherit the host opt-out"
+        );
+        // The profile's own knob survives the merge.
+        assert_eq!(profile.unwrap().refresh.unwrap().min_idle_minutes, Some(5));
+
+        // An explicit profile decision beats the host.
+        let mut explicit = Some(MemoryConfig {
+            refresh: Some(MemoryRefreshConfig {
+                enabled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        merge_host_memory_into_profile(&mut explicit, Some(&host));
+        assert!(MemoryConfig::refresh_enabled(explicit.as_ref()));
+
+        // Absent profile memory inherits the host block wholesale.
+        let mut absent: Option<MemoryConfig> = None;
+        merge_host_memory_into_profile(&mut absent, Some(&host));
+        assert!(!MemoryConfig::refresh_enabled(absent.as_ref()));
     }
 
     #[test]

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -1265,16 +1265,30 @@ fn merge_env_memory_policy(config: &mut Config) {
         .is_none()
     {
         if let Ok(v) = std::env::var("OCTOS_MEMORY_REFRESH_ENABLED") {
-            let on = matches!(
-                v.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            );
-            config
-                .memory
-                .get_or_insert_with(Default::default)
-                .refresh
-                .get_or_insert_with(Default::default)
-                .enabled = Some(on);
+            // Recognized values only — an empty or misspelled variable
+            // (easy in shell/Docker) must not silently opt out of the
+            // default-on behavior.
+            let parsed = match v.trim().to_ascii_lowercase().as_str() {
+                "1" | "true" | "yes" | "on" => Some(true),
+                "0" | "false" | "no" | "off" => Some(false),
+                other => {
+                    if !other.is_empty() {
+                        tracing::warn!(
+                            value = %v,
+                            "ignoring unrecognized OCTOS_MEMORY_REFRESH_ENABLED"
+                        );
+                    }
+                    None
+                }
+            };
+            if let Some(on) = parsed {
+                config
+                    .memory
+                    .get_or_insert_with(Default::default)
+                    .refresh
+                    .get_or_insert_with(Default::default)
+                    .enabled = Some(on);
+            }
         }
     }
 }
@@ -2930,6 +2944,17 @@ mod tests {
         });
         merge_env_memory_policy(&mut explicit);
         assert!(MemoryConfig::refresh_enabled(explicit.memory.as_ref()));
+
+        // Malformed/empty values leave the default-on untouched.
+        for bad in ["", "banana"] {
+            unsafe { std::env::set_var("OCTOS_MEMORY_REFRESH_ENABLED", bad) };
+            let mut silent = Config::default();
+            merge_env_memory_policy(&mut silent);
+            assert!(
+                MemoryConfig::refresh_enabled(silent.memory.as_ref()),
+                "unrecognized env value {bad:?} must not opt out"
+            );
+        }
 
         match prev {
             Some(v) => unsafe { std::env::set_var("OCTOS_MEMORY_REFRESH_ENABLED", v) },

--- a/crates/octos-cli/src/process_manager.rs
+++ b/crates/octos-cli/src/process_manager.rs
@@ -143,7 +143,9 @@ impl ProcessManager {
             self_ref: std::sync::Mutex::new(None),
             host_plugins_require_signed: false,
             host_max_inject_tokens: None,
-            host_memory_refresh_enabled: false,
+            // Matches the product default (memory refresh DEFAULT-ON);
+            // serve overwrites from the resolved host config.
+            host_memory_refresh_enabled: true,
         }
     }
 
@@ -466,7 +468,10 @@ impl ProcessManager {
         if self.host_memory_refresh_enabled {
             cmd.env("OCTOS_MEMORY_REFRESH_ENABLED", "1");
         } else {
-            cmd.env_remove("OCTOS_MEMORY_REFRESH_ENABLED");
+            // DEFAULT-ON semantics: an absent var means enabled, so a
+            // disabled host must mirror an explicit OFF — env_remove would
+            // let the child fall back to on.
+            cmd.env("OCTOS_MEMORY_REFRESH_ENABLED", "0");
         }
 
         tracing::debug!(profile = %profile.id, "start: spawning gateway subprocess");

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -449,15 +449,7 @@ impl ProfileRuntime {
         // override them (same host-default pattern as plugins/voice). A
         // profile serialized with an empty `memory: {}` block must still
         // inherit the host budget.
-        if let Some(host) = host_memory {
-            let mem = config.memory.get_or_insert_with(Default::default);
-            if mem.max_inject_tokens.is_none() {
-                mem.max_inject_tokens = host.max_inject_tokens;
-            }
-            if mem.refresh.is_none() {
-                mem.refresh = host.refresh.clone();
-            }
-        }
+        crate::config::merge_host_memory_into_profile(&mut config.memory, host_memory);
 
         // Step 2: resolve the provider name. `config_from_profile`
         // populates `provider`/`model` from `llm.primary` when set,


### PR DESCRIPTION
Flips `memory.refresh.enabled` to a tri-state with **default ON**: automatic memory (capture → extraction → consolidation → read-refresh) runs out of the box; an explicit `false` or `OCTOS_MEMORY_REFRESH_ENABLED=0` opts out. Daily budgets bound the cost.

Threaded through the env-merge (both directions when config is silent; explicit config wins) and ProcessManager host-mirroring (a disabled host now exports an explicit `=0` — `env_remove` would let children fall back to on). Example config updated.

Follows the mini5 soak that validated the full pipeline live (#1553, #1554).

🤖 Generated with [Claude Code](https://claude.com/claude-code)