### PR TITLE
test(pipeline): robust send_file sandbox-escape test (audit finding F1)

### DIFF
--- a/crates/octos-pipeline/tests/ux_pipeline.rs
+++ b/crates/octos-pipeline/tests/ux_pipeline.rs
@@ -716,12 +716,49 @@ async fn test_06_send_file_sandbox_escape() {
     use octos_agent::tools::SendFileTool;
 
     let sandbox = TempDir::new().unwrap();
+
+    // The "secret" must live OUTSIDE every root `SendFileTool` allowlists.
+    // That set is { base_dir, /tmp, upload_root, extra_allowed_dirs } — and
+    // /tmp is allowlisted UNCONDITIONALLY (skill outputs land there). So the
+    // escape target cannot sit under /tmp; if it does, the send is *correctly*
+    // permitted and asserting `!success` tests the wrong thing. This bit us
+    // when the repo/cwd lived under /tmp (audit finding F1): the old test put
+    // the secret under `current_dir()`, which was inside the /tmp allowlist,
+    // so the tool rightly allowed it and the test failed spuriously.
+    //
+    // Anchor the outside dir to the first candidate proven not under /tmp
+    // (HOME, then the crate source dir); skip if the whole environment is
+    // /tmp-rooted (nothing is genuinely "outside" then).
+    let tmp_canon =
+        std::fs::canonicalize("/tmp").unwrap_or_else(|_| std::path::PathBuf::from("/tmp"));
+    let is_under_tmp = |p: &std::path::Path| {
+        std::fs::canonicalize(p)
+            .map(|c| c.starts_with(&tmp_canon))
+            .unwrap_or(true)
+    };
+    let outside_root = [
+        std::env::var_os("HOME").map(std::path::PathBuf::from),
+        Some(std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))),
+    ]
+    .into_iter()
+    .flatten()
+    .find(|p| p.exists() && !is_under_tmp(p));
+
+    let Some(outside_root) = outside_root else {
+        eprintln!(
+            "[sandbox-abs] SKIP: no filesystem root outside the /tmp allowlist \
+             in this environment (repo/HOME both under /tmp); the escape guard \
+             is exercised by the traversal case in CI where the repo is not /tmp-rooted"
+        );
+        return;
+    };
+
     let outside = tempfile::Builder::new()
         .prefix("octos-pipeline-send-file-outside-")
-        .tempdir_in(std::env::current_dir().unwrap())
+        .tempdir_in(&outside_root)
         .unwrap();
 
-    // Create a "secret" file outside the sandbox
+    // Create a "secret" file outside the sandbox (and outside /tmp).
     let secret = outside.path().join("credentials.json");
     std::fs::write(&secret, r#"{"api_key": "sk-secret"}"#).unwrap();
 

--- a/crates/octos-pipeline/tests/ux_pipeline.rs
+++ b/crates/octos-pipeline/tests/ux_pipeline.rs
@@ -736,27 +736,32 @@ async fn test_06_send_file_sandbox_escape() {
             .map(|c| c.starts_with(&tmp_canon))
             .unwrap_or(true)
     };
-    let outside_root = [
+    // Probe candidate roots by actually creating the temp dir — a root may be
+    // non-/tmp yet unwritable (sandboxed / read-only-HOME CI), so selection
+    // must not commit to it before the create succeeds (codex review).
+    let outside = [
         std::env::var_os("HOME").map(std::path::PathBuf::from),
         Some(std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))),
     ]
     .into_iter()
     .flatten()
-    .find(|p| p.exists() && !is_under_tmp(p));
+    .filter(|p| p.exists() && !is_under_tmp(p))
+    .find_map(|root| {
+        tempfile::Builder::new()
+            .prefix("octos-pipeline-send-file-outside-")
+            .tempdir_in(&root)
+            .ok()
+    });
 
-    let Some(outside_root) = outside_root else {
+    let Some(outside) = outside else {
         eprintln!(
-            "[sandbox-abs] SKIP: no filesystem root outside the /tmp allowlist \
-             in this environment (repo/HOME both under /tmp); the escape guard \
-             is exercised by the traversal case in CI where the repo is not /tmp-rooted"
+            "[sandbox-abs] SKIP: no writable filesystem root outside the /tmp \
+             allowlist in this environment (repo/HOME both under /tmp or \
+             unwritable); the escape guard is exercised in CI where the repo \
+             is not /tmp-rooted"
         );
         return;
     };
-
-    let outside = tempfile::Builder::new()
-        .prefix("octos-pipeline-send-file-outside-")
-        .tempdir_in(&outside_root)
-        .unwrap();
 
     // Create a "secret" file outside the sandbox (and outside /tmp).
     let secret = outside.path().join("credentials.json");


### PR DESCRIPTION
Found during the tri-repo feature audit (Phase 1 testing). The full octos workspace suite had exactly **one** failure — `test_06_send_file_sandbox_escape` — and it is **not a product defect**: `SendFileTool` unconditionally allowlists `/tmp` (skill outputs land there), but the test created its "outside-the-sandbox" secret under `std::env::current_dir()`. When the repo/cwd is under `/tmp` (CI/scratch builds), that "outside" file is *inside* the `/tmp` allowlist, so the tool correctly permits the send and the `!success` assertion fails — a false sandbox-escape alarm.

Proof it's environment-only: the same test **passes from `~/home/octos`** and **failed from `/tmp/…`**.

Fix: anchor the outside dir to the first root proven not under `/tmp` (HOME → crate source dir); honest skip only if the entire environment is `/tmp`-rooted. Verified passing from **both** a `/tmp`-rooted checkout (previously red) and a normal checkout; full `ux_pipeline` suite 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)