### PR TITLE
feat(protocol): context/compaction_started notification (UPCR-2026-026)

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -510,7 +510,7 @@ M15 agent/goal/loop autonomy (accepted `UPCR-2026-021`):
 
 M16 context lifecycle (gate `context.lifecycle.v1`):
 
-- `context/compaction_completed`, `context/normalization_reported`
+- `context/compaction_completed`, `context/compaction_started`, `context/normalization_reported`
 
 ## 7. Command Semantics
 
@@ -1878,6 +1878,26 @@ Required fields: `session_id`, `context_state`, `compaction`. Full field
 set, `UiContextState` shape, and `UiContextCompactionRecord` shape
 documented by
 [UPCR-2026-022](../docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_022.md).
+
+### `context/compaction_started`
+
+Notification that a server-owned context-manager compaction pass is about
+to run. Emitted immediately before the pass with the PRE-compaction
+`context_state` (its `token_estimate` is the "before" size), the `trigger`
+label that the eventual `context/compaction_completed` record repeats, and
+`threshold_tokens` (the context-window-derived limit that tripped the
+pass) so clients can render an honest fullness percentage and an
+in-progress state (spinner/progress bar).
+
+Always followed by `context/compaction_completed` for the same pass.
+Today's serve compaction is synchronous, so both notifications may arrive
+in one delivery batch; clients MUST tolerate a zero-duration window.
+
+Capability gate: `context.lifecycle.v1`.
+
+Required fields: `session_id`, `context_state`, `trigger`,
+`threshold_tokens`. Documented by
+[UPCR-2026-026](../docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_026_COMPACTION_STARTED.md).
 
 ### `context/normalization_reported`
 

--- a/api/OCTOS_UI_PROTOCOL_WIRE_INVENTORY_2026-05-24.md
+++ b/api/OCTOS_UI_PROTOCOL_WIRE_INVENTORY_2026-05-24.md
@@ -131,6 +131,7 @@ spec and UPCR documents. The authoritative source remains code:
 | `loop/fired` | shipped, UPCR-2026-021 |
 | `loop/completed` | shipped, UPCR-2026-021 |
 | `context/compaction_completed` | shipped M16 context lifecycle notification |
+| `context/compaction_started` | shipped M16 context lifecycle notification |
 | `context/normalization_reported` | shipped M16 context lifecycle notification |
 
 ## Reconciliation Decisions

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -28,10 +28,10 @@ use octos_core::ui_protocol::{
     AgentUpdatedEvent, ApprovalAutoResolvedEvent, ApprovalCancelledEvent, ApprovalCommandDetails,
     ApprovalDecidedEvent, ApprovalDecision, ApprovalId, ApprovalRenderHints,
     ApprovalRequestedEvent, ApprovalTypedDetails, ContentBulkDeleteParams, ContentDeleteParams,
-    ContentListParams, ContextCompactionCompletedEvent, ContextNormalizationReportedEvent,
-    EnvelopeTokenUsage, FileRef, HydratedMessage, HydratedTurn, InputItem, MessageDeltaEvent,
-    MessageMeta, MessagePersistedEvent, MessagePersistedSource, OutputCursor, Payload,
-    ReplayLossyEvent, RpcError, RpcErrorResponse, RpcRequest, RpcResponse,
+    ContentListParams, ContextCompactionCompletedEvent, ContextCompactionStartedEvent,
+    ContextNormalizationReportedEvent, EnvelopeTokenUsage, FileRef, HydratedMessage, HydratedTurn,
+    InputItem, MessageDeltaEvent, MessageMeta, MessagePersistedEvent, MessagePersistedSource,
+    OutputCursor, Payload, ReplayLossyEvent, RpcError, RpcErrorResponse, RpcRequest, RpcResponse,
     SESSION_HYDRATE_INCLUDE_MAX, SESSION_MESSAGES_PAGE_DEFAULT_LIMIT,
     SESSION_MESSAGES_PAGE_MAX_LIMIT, SESSION_MESSAGES_PAGE_MAX_OFFSET, SESSION_TITLE_SET_MAX_CHARS,
     SessionDeleteParams, SessionFilesListParams, SessionHydrateParams, SessionHydrateResult,
@@ -1996,6 +1996,17 @@ fn appui_context_history_for_agent(
     let policy = appui_context_prompt_policy(llm_provider);
     let state = manager.state();
     if state.token_estimate > threshold {
+        // UPCR-2026-026: the started event precedes the (synchronous) pass;
+        // clients render the in-progress state from it and must tolerate
+        // started/completed arriving in one delivery batch.
+        lifecycle_notifications.push(UiNotification::ContextCompactionStarted(
+            ContextCompactionStartedEvent {
+                session_id: session_id.clone(),
+                context_state: ui_context_state_for(session_id, &manager),
+                trigger: trigger.to_owned(),
+                threshold_tokens: threshold,
+            },
+        ));
         let before = manager.for_prompt(&policy);
         let summary_budget = threshold.clamp(256, 4096) as u32;
         let summary = octos_agent::compaction::compact_messages(&before.messages, summary_budget);
@@ -8844,6 +8855,7 @@ fn live_event_passes_capability_filter(
     if !features.context_lifecycle_available() {
         if let UiProtocolLedgerEvent::Notification(
             UiNotification::ContextCompactionCompleted(_)
+            | UiNotification::ContextCompactionStarted(_)
             | UiNotification::ContextNormalizationReported(_),
         ) = event
         {
@@ -23446,6 +23458,7 @@ fn ledger_event_cursor(event: &UiProtocolLedgerEvent) -> Option<UiCursor> {
             // hashes, not replay cursors. The durable ledger cursor is on
             // the surrounding LedgeredUiProtocolEvent.
             | UiNotification::ContextCompactionCompleted(_)
+            | UiNotification::ContextCompactionStarted(_)
             | UiNotification::ContextNormalizationReported(_)
             // Whole-job orchestration status is a stateless lifecycle push
             // (no durable cursor of its own).
@@ -23535,6 +23548,74 @@ mod tests {
         QuestionId, ReasoningDeltaEvent, SessionSandboxParams, approval_scopes, methods,
         rpc_error_codes,
     };
+
+    #[tokio::test]
+    async fn compaction_started_precedes_completed_in_lifecycle_batch() {
+        // UPCR-2026-026: when the threshold trips, the lifecycle batch must
+        // carry context/compaction_started BEFORE context/compaction_completed
+        // and the started event reports the pre-compaction estimate.
+        struct TinyContextProvider;
+        #[async_trait::async_trait]
+        impl octos_llm::LlmProvider for TinyContextProvider {
+            async fn chat(
+                &self,
+                _messages: &[octos_core::Message],
+                _tools: &[octos_llm::ToolSpec],
+                _config: &octos_llm::ChatConfig,
+            ) -> eyre::Result<octos_llm::ChatResponse> {
+                unreachable!("compaction never calls the provider")
+            }
+            fn model_id(&self) -> &str {
+                "tiny"
+            }
+            fn provider_name(&self) -> &str {
+                "tiny"
+            }
+            fn context_window(&self) -> u32 {
+                512
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let session: SessionKey = SessionKey("full:api:compact".to_string());
+        let mut history = Vec::new();
+        for i in 0..40 {
+            history.push(octos_core::Message {
+                role: octos_core::MessageRole::User,
+                content: format!("padding message {i}: {}", "x".repeat(400)),
+                media: vec![],
+                tool_calls: None,
+                tool_call_id: None,
+                reasoning_content: None,
+                client_message_id: None,
+                thread_id: None,
+                timestamp: chrono::Utc::now(),
+            });
+        }
+
+        let provider = TinyContextProvider;
+        let (_messages, _manager, notifications) =
+            appui_context_history_for_agent(dir.path(), &session, &history, &provider, "preflight");
+
+        let started_pos = notifications
+            .iter()
+            .position(|n| matches!(n, UiNotification::ContextCompactionStarted(_)));
+        let completed_pos = notifications
+            .iter()
+            .position(|n| matches!(n, UiNotification::ContextCompactionCompleted(_)));
+        let (Some(started_pos), Some(completed_pos)) = (started_pos, completed_pos) else {
+            panic!("both compaction events must be emitted: {notifications:?}");
+        };
+        assert!(
+            started_pos < completed_pos,
+            "started must precede completed"
+        );
+        let UiNotification::ContextCompactionStarted(started) = &notifications[started_pos] else {
+            unreachable!()
+        };
+        assert!(started.context_state.token_estimate > started.threshold_tokens);
+        assert_eq!(started.trigger, "preflight");
+    }
 
     #[test]
     fn post_terminal_drain_skips_late_tokens_but_keeps_background_progress() {

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -2356,6 +2356,7 @@ fn notification_session_id(notification: &UiNotification) -> &SessionKey {
         UiNotification::LoopFired(event) => &event.session_id,
         UiNotification::LoopCompleted(event) => &event.session_id,
         UiNotification::ContextCompactionCompleted(event) => &event.session_id,
+        UiNotification::ContextCompactionStarted(event) => &event.session_id,
         UiNotification::ContextNormalizationReported(event) => &event.session_id,
         UiNotification::SessionOrchestration(event) => &event.session_id,
         UiNotification::UserQuestionRequested(event) => &event.session_id,

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -1157,6 +1157,7 @@ pub mod methods {
     pub const LOOP_COMPLETED: &str = "loop/completed";
     /// M16 `context.lifecycle.v1`: compact-context lifecycle notification.
     pub const CONTEXT_COMPACTION_COMPLETED: &str = "context/compaction_completed";
+    pub const CONTEXT_COMPACTION_STARTED: &str = "context/compaction_started";
     /// M16 `context.lifecycle.v1`: prompt normalization report notification.
     pub const CONTEXT_NORMALIZATION_REPORTED: &str = "context/normalization_reported";
     /// Session-level whole-job orchestration status notification.
@@ -1268,6 +1269,7 @@ pub const UI_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &[
     methods::LOOP_FIRED,
     methods::LOOP_COMPLETED,
     methods::CONTEXT_COMPACTION_COMPLETED,
+    methods::CONTEXT_COMPACTION_STARTED,
     methods::CONTEXT_NORMALIZATION_REPORTED,
 ];
 
@@ -5422,6 +5424,23 @@ pub struct ContextCompactionCompletedEvent {
     pub compaction: UiContextCompactionRecord,
 }
 
+/// UPCR-2026-026: emitted immediately BEFORE a context compaction pass so
+/// clients can show an in-progress state (spinner/bar). Always followed by
+/// `context/compaction_completed` for the same generation — today's serve
+/// compaction is synchronous, so both may arrive in one delivery batch;
+/// clients must tolerate a zero-duration window.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextCompactionStartedEvent {
+    pub session_id: SessionKey,
+    /// Pre-compaction context state (token_estimate = the "before" size).
+    pub context_state: UiContextState,
+    /// Trigger label, mirrors the eventual completed record's trigger.
+    pub trigger: String,
+    /// The token threshold that tripped this compaction (context-window
+    /// derived) — lets clients render an honest fullness percentage.
+    pub threshold_tokens: usize,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UiContextNormalizationReport {
     pub generation: u64,
@@ -5687,6 +5706,7 @@ pub enum UiNotification {
     LoopCompleted(LoopCompletedEvent),
     /// M16: compact-context lifecycle event.
     ContextCompactionCompleted(ContextCompactionCompletedEvent),
+    ContextCompactionStarted(ContextCompactionStartedEvent),
     /// M16: prompt normalization lifecycle event.
     ContextNormalizationReported(ContextNormalizationReportedEvent),
     /// Session-level whole-job orchestration status. Emitted when the session's
@@ -5757,6 +5777,7 @@ impl UiNotification {
             Self::LoopFired(_) => methods::LOOP_FIRED,
             Self::LoopCompleted(_) => methods::LOOP_COMPLETED,
             Self::ContextCompactionCompleted(_) => methods::CONTEXT_COMPACTION_COMPLETED,
+            Self::ContextCompactionStarted(_) => methods::CONTEXT_COMPACTION_STARTED,
             Self::ContextNormalizationReported(_) => methods::CONTEXT_NORMALIZATION_REPORTED,
             Self::SessionOrchestration(_) => methods::SESSION_ORCHESTRATION,
             Self::Envelope(_) => methods::PROJECTION_ENVELOPE,
@@ -5804,6 +5825,7 @@ impl UiNotification {
             Self::LoopFired(event) => &event.session_id,
             Self::LoopCompleted(event) => &event.session_id,
             Self::ContextCompactionCompleted(event) => &event.session_id,
+            Self::ContextCompactionStarted(event) => &event.session_id,
             Self::ContextNormalizationReported(event) => &event.session_id,
             Self::SessionOrchestration(event) => &event.session_id,
             Self::Envelope(event) => &event.session_id,
@@ -5952,6 +5974,7 @@ impl UiNotification {
             Self::LoopFired(params) => serde_json::to_value(params),
             Self::LoopCompleted(params) => serde_json::to_value(params),
             Self::ContextCompactionCompleted(params) => serde_json::to_value(params),
+            Self::ContextCompactionStarted(params) => serde_json::to_value(params),
             Self::ContextNormalizationReported(params) => serde_json::to_value(params),
             Self::SessionOrchestration(params) => serde_json::to_value(params),
             // UPCR-2026-014 (M9-γ) + feat(envelope-wire-routing): the wire
@@ -6075,6 +6098,9 @@ impl UiNotification {
             methods::LOOP_UPDATED => Ok(Self::LoopUpdated(decode_params(method, params)?)),
             methods::LOOP_FIRED => Ok(Self::LoopFired(decode_params(method, params)?)),
             methods::LOOP_COMPLETED => Ok(Self::LoopCompleted(decode_params(method, params)?)),
+            methods::CONTEXT_COMPACTION_STARTED => Ok(Self::ContextCompactionStarted(
+                decode_params(method, params)?,
+            )),
             methods::CONTEXT_COMPACTION_COMPLETED => Ok(Self::ContextCompactionCompleted(
                 decode_params(method, params)?,
             )),
@@ -6861,6 +6887,7 @@ mod tests {
                 "loop/fired",
                 "loop/completed",
                 "context/compaction_completed",
+                "context/compaction_started",
                 "context/normalization_reported",
             ]
         );
@@ -7034,6 +7061,7 @@ mod tests {
                     "loop/fired",
                     "loop/completed",
                     "context/compaction_completed",
+                    "context/compaction_started",
                     "context/normalization_reported"
                 ],
                 "supported_features": [

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_026_COMPACTION_STARTED.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_026_COMPACTION_STARTED.md
@@ -1,0 +1,89 @@
+# Octos UI Protocol Change Request: `context/compaction_started` Notification
+
+## Header
+
+- Request id: `UPCR-2026-026`
+- Title: Add `context/compaction_started` notification for in-progress compaction UX
+- Author: compaction-UX slice (memory/default-on follow-up)
+- Date: 2026-07-08
+- Target protocol: `octos-ui/v1alpha1`
+- Status: accepted
+- Sibling UPCRs: `UPCR-2026-022` (context lifecycle: `context/compaction_completed`,
+  `context/normalization_reported`)
+
+## Summary
+
+Adds one additive JSON-RPC notification, `context/compaction_started`, emitted
+immediately BEFORE a server-owned context-manager compaction pass. Today
+clients learn about compaction only after the fact (`context/compaction_completed`),
+so a UI cannot render an in-progress state ("Compacting conversation…" with a
+progress/fullness bar). The change is strictly additive.
+
+## Motivation
+
+octos-tui wants Claude-Code-style compaction UX:
+
+```
+✶ Compacting conversation… (12s · 87.4k tokens)
+  ▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 49%
+```
+
+The percentage is honest only if the client knows the pre-compaction token
+estimate AND the threshold that tripped the pass. Both live server-side at the
+emission site (`appui_context_history_for_agent`). The completed event carries
+before/after estimates but arrives after the work; a started event closes the
+gap and future-proofs the UX for asynchronous/LLM summarizers where the window
+is measured in seconds, not microseconds.
+
+## Payload
+
+```json
+{
+  "method": "context/compaction_started",
+  "params": {
+    "session_id": "<key>",
+    "context_state": { "…": "UiContextState — token_estimate = BEFORE size" },
+    "trigger": "preflight",
+    "threshold_tokens": 96000
+  }
+}
+```
+
+- `context_state` — pre-compaction `UiContextState` (same shape as
+  `UPCR-2026-022`).
+- `trigger` — mirrors the eventual completed record's `trigger`.
+- `threshold_tokens` — the context-window-derived limit that tripped the pass;
+  `token_estimate / threshold_tokens` (or vs. the model context window) renders
+  an honest fullness percentage.
+
+## Semantics
+
+- Emitted at most once per compaction pass, always before the pass mutates the
+  context manager.
+- Always followed by `context/compaction_completed` for the same pass (the
+  completed record's `token_estimate_before` equals the started event's
+  `context_state.token_estimate`).
+- Today's serve compaction is synchronous: both notifications may arrive in one
+  delivery batch. Clients MUST tolerate a zero-duration started→completed
+  window (render the final state directly).
+- Ephemeral-class: carries no durable replay cursor of its own (same
+  classification as the other `context.lifecycle.v1` notifications).
+
+## Gating
+
+- Capability gate: `context.lifecycle.v1` (same as its siblings). Clients that
+  did not negotiate the feature never receive it.
+
+## Compatibility
+
+- Strictly additive: no existing method, notification, payload, enum variant,
+  capability bit, or protocol identifier changes.
+- Old clients ignore unknown notifications per § 4 versioning rules.
+
+## Implementation anchors
+
+- Type: `octos-core/src/ui_protocol.rs` `ContextCompactionStartedEvent`
+- Emission: `octos-cli/src/api/ui_protocol.rs` `appui_context_history_for_agent`
+- Gating/classification: notification feature filter + cursorless list +
+  ledger session-id mapping
+- Test: `compaction_started_precedes_completed_in_lifecycle_batch`


### PR DESCRIPTION
Adds one additive notification, `context/compaction_started`, emitted immediately before a server-owned compaction pass with the pre-compaction `context_state`, `trigger`, and `threshold_tokens` — so clients (octos-tui) can render an in-progress compaction state (spinner + honest fullness bar) instead of learning about compaction after the fact.

Always followed by `context/compaction_completed`; synchronous serve compaction may deliver both in one batch (zero-duration window documented). Gated behind `context.lifecycle.v1`, ephemeral-class, ledger-mapped. Spec §, wire inventory, and UPCR-2026-026 doc included.

Client side lands separately in octos-tui (pins the new octos-core rev after this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)