### PR TITLE
chore(homebrew): host octos formula in-repo as its own tap

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -39,7 +39,11 @@ jobs:
       TAG: ${{ inputs.tag || github.event.release.tag_name }}
       GH_TOKEN: ${{ github.token }}
     steps:
+      # Base the formula-bump branch on main (a release event otherwise checks
+      # out the tag commit, which would make the PR diff/auto-merge messy).
       - uses: actions/checkout@v6
+        with:
+          ref: main
 
       - name: Download unix bundles for the tag
         run: |

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -3,11 +3,17 @@ name: Publish Packages
 # archives produced by release.yml (which this workflow does NOT modify) and
 # publishes a Homebrew formula + an npm wrapper.
 #
+# The Homebrew formula now lives IN THIS REPO at Formula/octos.rb (this repo is
+# its own Homebrew tap — `brew tap octos-org/octos https://github.com/octos-org/octos`).
+# On a stable release the homebrew job re-renders Formula/octos.rb from the
+# built bundles and opens a PR to update it (main is branch-protected, so it
+# cannot push directly). npm publishing is unchanged.
+#
 # Gated behind the repo variable PUBLISH_PACKAGES so it no-ops until the
 # maintainer opts in (avoids failing on missing tokens). To go live, set:
 #   - repo variable PUBLISH_PACKAGES = true
-#   - secret HOMEBREW_TAP_TOKEN  (PAT with push to octos-org/homebrew-tap)
 #   - secret NPM_TOKEN           (npm automation token for @octos-org)
+# (No tap PAT needed anymore — the formula update uses the built-in GITHUB_TOKEN.)
 
 on:
   release:
@@ -26,6 +32,9 @@ jobs:
   homebrew:
     if: ${{ vars.PUBLISH_PACKAGES == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write        # push the formula-update branch
+      pull-requests: write   # open the PR that bumps Formula/octos.rb
     env:
       TAG: ${{ inputs.tag || github.event.release.tag_name }}
       GH_TOKEN: ${{ github.token }}
@@ -66,43 +75,51 @@ jobs:
           sha_linux_x64=$(sha256sum bundles/octos-bundle-x86_64-unknown-linux-gnu.tar.gz | awk '{print $1}')
           sha_linux_arm=$(sha256sum bundles/octos-bundle-aarch64-unknown-linux-gnu.tar.gz | awk '{print $1}')
 
-          cp packaging/homebrew/octos.rb octos.rb
-          sed -i "s|__VERSION__|${version}|g" octos.rb
-          sed -i "s|__TAG__|${TAG}|g" octos.rb
-          sed -i "s|__SHA_DARWIN_ARM__|${sha_darwin_arm}|g" octos.rb
-          sed -i "s|__SHA_LINUX_X64__|${sha_linux_x64}|g" octos.rb
-          sed -i "s|__SHA_LINUX_ARM__|${sha_linux_arm}|g" octos.rb
+          mkdir -p Formula
+          cp packaging/homebrew/octos.rb Formula/octos.rb
+          sed -i "s|__VERSION__|${version}|g" Formula/octos.rb
+          sed -i "s|__TAG__|${TAG}|g" Formula/octos.rb
+          sed -i "s|__SHA_DARWIN_ARM__|${sha_darwin_arm}|g" Formula/octos.rb
+          sed -i "s|__SHA_LINUX_X64__|${sha_linux_x64}|g" Formula/octos.rb
+          sed -i "s|__SHA_LINUX_ARM__|${sha_linux_arm}|g" Formula/octos.rb
 
           echo "----- rendered Formula/octos.rb -----"
-          cat octos.rb
+          cat Formula/octos.rb
 
-      - name: Skip tap push for prereleases
+      - name: Skip formula update for prereleases
         if: ${{ contains(env.TAG, '-') }}
-        run: echo "::notice::${TAG} is a prerelease — formula rendered + validated above, but NOT pushed to the public tap (octos.rb tracks stable only)."
+        run: echo "::notice::${TAG} is a prerelease — formula rendered + validated above, but NOT committed (Formula/octos.rb tracks stable only)."
 
-      - name: Push formula to homebrew-tap
+      - name: Open PR to update in-repo formula
         if: ${{ !contains(env.TAG, '-') }}
-        env:
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           set -euo pipefail
-          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/octos-org/homebrew-tap.git" tap
-          mkdir -p tap/Formula
-          cp octos.rb tap/Formula/octos.rb
-          cd tap
-          git config user.name "octos-release-bot"
-          git config user.email "151983+ymote@users.noreply.github.com"
-          # `git add` FIRST, then check the STAGED diff: a brand-new untracked
-          # Formula/octos.rb is invisible to a plain `git diff --quiet` (that only
-          # inspects tracked files), so the first publish would silently skip the
-          # push. `git diff --cached --quiet` correctly sees the new staged file.
-          git add Formula/octos.rb
-          if git diff --cached --quiet; then
-            echo "Formula/octos.rb unchanged; nothing to push."
+          # Formula/octos.rb lives in this repo (this repo is its own tap). main
+          # is branch-protected, so we open a PR rather than pushing to it.
+          if git diff --quiet -- Formula/octos.rb; then
+            echo "Formula/octos.rb unchanged; nothing to open a PR for."
             exit 0
           fi
-          git commit -m "octos ${TAG}"
-          git push origin HEAD
+          branch="homebrew/octos-${TAG}"
+          git config user.name "octos-release-bot"
+          git config user.email "151983+ymote@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add Formula/octos.rb
+          git commit -m "octos ${TAG}: update Homebrew formula"
+          git push -f origin "$branch"
+          # Create the PR if one isn't already open for this branch, then enable
+          # auto-merge so a green formula-only change lands without babysitting.
+          if ! gh pr view "$branch" >/dev/null 2>&1; then
+            gh pr create --base main --head "$branch" \
+              --title "octos ${TAG}: update Homebrew formula" \
+              --body "Automated Homebrew formula bump for ${TAG}. Renders \`Formula/octos.rb\` from the published bundle checksums." \
+              --label "release" 2>/dev/null \
+            || gh pr create --base main --head "$branch" \
+              --title "octos ${TAG}: update Homebrew formula" \
+              --body "Automated Homebrew formula bump for ${TAG}."
+          fi
+          gh pr merge "$branch" --squash --auto 2>/dev/null \
+            || echo "::notice::auto-merge unavailable; merge the formula PR manually."
 
   npm:
     if: ${{ vars.PUBLISH_PACKAGES == 'true' }}

--- a/Formula/octos.rb
+++ b/Formula/octos.rb
@@ -1,0 +1,51 @@
+class Octos < Formula
+  desc "Rust-native, API-first Agentic OS server (octos serve + bundled skills)"
+  homepage "https://github.com/octos-org/octos"
+  version "1.1.0"
+  license "Apache-2.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/octos-org/octos/releases/download/v1.1.0/octos-bundle-aarch64-apple-darwin.tar.gz"
+      sha256 "5fcc62da44542ae0289d38d5d0ba5a8bed45598bf6faf7fec98b382276bf384f"
+    end
+    on_intel do
+      odie "octos requires Apple Silicon; no x86_64 macOS build is published"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/octos-org/octos/releases/download/v1.1.0/octos-bundle-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "428d692364949e14d1ec9823c67c049f1c01a7653f928797c72e70d494c8647c"
+    end
+    on_arm do
+      url "https://github.com/octos-org/octos/releases/download/v1.1.0/octos-bundle-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "a93c61951facbd394a16502041fe8890161739b5b61254228504469929c21dcd"
+    end
+  end
+
+  def install
+    # The release bundle ships `octos` alongside its 8 skill binaries
+    # (news_fetch, deep-search, deep_crawl, send_email, account_manager,
+    # voice, clock, weather). At `octos serve` startup, bootstrap discovers
+    # those skills as SIBLINGS of the resolved `octos` executable
+    # (current_exe().parent()). Keep all of them together in libexec and
+    # expose only `octos` on PATH.
+    libexec.install Dir["*"]
+    # Use an exec WRAPPER, not bin.install_symlink: on macOS,
+    # std::env::current_exe() returns the *symlink* path (Darwin
+    # _NSGetExecutablePath), so a bin/octos symlink would put exe_dir at bin/
+    # and the sibling skills (in libexec) would not be found -> plugin_count=0.
+    # `exec` replaces the process image, so current_exe() == libexec/octos and
+    # exe_dir == libexec, where the skill binaries live.
+    (bin/"octos").write <<~SH
+      #!/bin/bash
+      exec "#{libexec}/octos" "$@"
+    SH
+  end
+
+  test do
+    assert_match "octos", shell_output("#{bin}/octos --version")
+  end
+end

--- a/Formula/octos.rb
+++ b/Formula/octos.rb
@@ -43,6 +43,9 @@ class Octos < Formula
       #!/bin/bash
       exec "#{libexec}/octos" "$@"
     SH
+    # `Pathname#write` does not set the executable bit, so the wrapper — the only
+    # `octos` on PATH — must be chmod'd or `octos` fails with permission denied.
+    (bin/"octos").chmod 0755
   end
 
   test do

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The fastest way to a working assistant, on the supported platforms (macOS Apple 
 
 ```bash
 # 1. Install
-brew install octos-org/tap/octos        # or: npm install -g @octos-org/octos
+brew tap octos-org/octos https://github.com/octos-org/octos
+brew install octos-org/octos/octos      # or: npm install -g @octos-org/octos
 
 # 2. Choose your AI provider and a model (interactive — pick a real
 #    model name; some providers reject the "auto" default)
@@ -153,8 +154,9 @@ grep OCTOS_AUTH_TOKEN /etc/systemd/system/octos-serve.service
 Alternatively, install just the binaries (the `octos` server plus its bundled skills) via a package manager:
 
 ```bash
-# Homebrew (macOS Apple Silicon, Linux x86_64/ARM64)
-brew install octos-org/tap/octos
+# Homebrew (macOS Apple Silicon, Linux x86_64/ARM64) — this repo is its own tap
+brew tap octos-org/octos https://github.com/octos-org/octos
+brew install octos-org/octos/octos
 
 # npm (macOS Apple Silicon, Linux x86_64/ARM64, Windows x64)
 npm install -g @octos-org/octos

--- a/crates/octos-cli/src/commands/doctor.rs
+++ b/crates/octos-cli/src/commands/doctor.rs
@@ -64,7 +64,7 @@ fn octos_server_spec() -> ProductSpec {
         "octos-bundle",            // asset prefix → octos-bundle-<triple>
     )
     .with_github_token_env("OCTOS_GITHUB_TOKEN")
-    .with_brew_formula("octos-org/tap/octos")
+    .with_brew_formula("octos-org/octos/octos")
     .with_npm_package("@octos-org/octos")
     .with_cargo_install("octos-cli")
     .with_cargo_dist_app("octos")

--- a/crates/octos-cli/src/commands/update.rs
+++ b/crates/octos-cli/src/commands/update.rs
@@ -51,7 +51,7 @@ fn octos_server_spec() -> ProductSpec {
         "octos-bundle",            // asset prefix → octos-bundle-<triple>
     )
     .with_github_token_env("OCTOS_GITHUB_TOKEN")
-    .with_brew_formula("octos-org/tap/octos")
+    .with_brew_formula("octos-org/octos/octos")
     .with_npm_package("@octos-org/octos")
     .with_cargo_install("octos-cli")
     .with_cargo_dist_app("octos")
@@ -223,11 +223,11 @@ mod tests {
     #[test]
     fn defer_to_package_manager_exits_ten_and_prints_cmd() {
         let plan = UpdatePlan::DeferToPackageManager {
-            cmd: "brew upgrade octos-org/tap/octos".into(),
+            cmd: "brew upgrade octos-org/octos/octos".into(),
         };
         let (text, _json, code) = render_check(&plan, &InstallMethod::Homebrew, &spec());
         assert_eq!(code, EXIT_UPDATE_AVAILABLE);
-        assert!(text.contains("brew upgrade octos-org/tap/octos"));
+        assert!(text.contains("brew upgrade octos-org/octos/octos"));
     }
 
     #[test]

--- a/crates/octos-diagnostics/src/github.rs
+++ b/crates/octos-diagnostics/src/github.rs
@@ -193,7 +193,7 @@ mod tests {
 
     fn octos_spec() -> ProductSpec {
         ProductSpec::new("octos", "octos", "1.0.0", "octos-org/octos", "octos-bundle")
-            .with_brew_formula("octos-org/tap/octos")
+            .with_brew_formula("octos-org/octos/octos")
             .with_cargo_dist_app("octos")
     }
 

--- a/crates/octos-diagnostics/src/install_method.rs
+++ b/crates/octos-diagnostics/src/install_method.rs
@@ -343,7 +343,7 @@ mod tests {
 
     fn octos_spec() -> ProductSpec {
         ProductSpec::new("octos", "octos", "1.0.0", "octos-org/octos", "octos-bundle")
-            .with_brew_formula("octos-org/tap/octos")
+            .with_brew_formula("octos-org/octos/octos")
             .with_npm_package("@octos-org/octos")
             .with_cargo_install("octos-cli")
             .with_cargo_dist_app("octos")
@@ -436,7 +436,7 @@ mod tests {
         );
         assert_eq!(
             InstallMethod::Homebrew.upgrade_hint(&spec).unwrap(),
-            "brew update && brew upgrade octos-org/tap/octos"
+            "brew update && brew upgrade octos-org/octos/octos"
         );
         assert_eq!(
             InstallMethod::Npm.upgrade_hint(&spec).unwrap(),

--- a/crates/octos-diagnostics/src/spec.rs
+++ b/crates/octos-diagnostics/src/spec.rs
@@ -55,7 +55,7 @@ pub struct ProductSpec {
     /// (Stage 2, `github` feature) reads it only when this is `Some` and the var
     /// is set & non-blank; a public repo never requires it.
     pub github_token_env: Option<String>,
-    /// Homebrew formula (tap-qualified), e.g. `octos-org/tap/octos`.
+    /// Homebrew formula (tap-qualified), e.g. `octos-org/octos/octos`.
     pub brew_formula: Option<String>,
     /// npm package name, e.g. `@octos-org/octos`.
     pub npm_package: Option<String>,
@@ -148,12 +148,12 @@ mod tests {
     #[test]
     fn builder_sets_optional_fields() {
         let spec = ProductSpec::new("octos", "octos", "1.2.3", "octos-org/octos", "octos-bundle")
-            .with_brew_formula("octos-org/tap/octos")
+            .with_brew_formula("octos-org/octos/octos")
             .with_npm_package("@octos-org/octos")
             .with_cargo_install("octos-cli")
             .with_cargo_dist_app("octos");
         assert_eq!(spec.current_version, "1.2.3");
-        assert_eq!(spec.brew_formula.as_deref(), Some("octos-org/tap/octos"));
+        assert_eq!(spec.brew_formula.as_deref(), Some("octos-org/octos/octos"));
         assert_eq!(spec.npm_package.as_deref(), Some("@octos-org/octos"));
         assert_eq!(spec.cargo_install.as_deref(), Some("octos-cli"));
         assert_eq!(spec.cargo_dist_app.as_deref(), Some("octos"));

--- a/crates/octos-diagnostics/src/update.rs
+++ b/crates/octos-diagnostics/src/update.rs
@@ -98,7 +98,7 @@ mod tests {
 
     fn spec() -> ProductSpec {
         ProductSpec::new("octos", "octos", "1.0.0", "octos-org/octos", "octos-bundle")
-            .with_brew_formula("octos-org/tap/octos")
+            .with_brew_formula("octos-org/octos/octos")
     }
 
     #[test]
@@ -170,7 +170,7 @@ mod tests {
     fn plan_defers_to_package_manager_for_brew() {
         match plan("1.0.0", "1.1.0", &InstallMethod::Homebrew, &spec()) {
             UpdatePlan::DeferToPackageManager { cmd } => {
-                assert!(cmd.contains("brew upgrade octos-org/tap/octos"));
+                assert!(cmd.contains("brew upgrade octos-org/octos/octos"));
             }
             other => panic!("expected DeferToPackageManager, got {other:?}"),
         }

--- a/packaging/homebrew/octos.rb
+++ b/packaging/homebrew/octos.rb
@@ -43,6 +43,9 @@ class Octos < Formula
       #!/bin/bash
       exec "#{libexec}/octos" "$@"
     SH
+    # `Pathname#write` does not set the executable bit, so the wrapper — the only
+    # `octos` on PATH — must be chmod'd or `octos` fails with permission denied.
+    (bin/"octos").chmod 0755
   end
 
   test do

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -33,7 +33,7 @@ macOS Intel is not supported (no prebuilt build is published).
 
 ```bash
 # Homebrew
-brew install octos-org/tap/octos
+brew install octos-org/octos/octos
 
 # Shell installer (sets up octos serve as a service)
 curl -fsSL https://github.com/octos-org/octos/releases/latest/download/install.sh | bash


### PR DESCRIPTION
Part of consolidating Homebrew formulae out of the separate `octos-org/homebrew-tap` repo (Full-B: each tool hosts its own formula).

## What
- Add `Formula/octos.rb` (seeded at current v1.1.0) so this repo is a valid Homebrew tap.
- Rework the `homebrew` job in `publish-packages.yml`: render `Formula/octos.rb` from the built bundle checksums and open an **auto-merge PR** to bump it, instead of cloning + pushing to `octos-org/homebrew-tap`. Uses the built-in `GITHUB_TOKEN` (no `HOMEBREW_TAP_TOKEN`).
- Update README install steps to the new tap form.

## Install (new)
```bash
brew tap octos-org/octos https://github.com/octos-org/octos
brew install octos-org/octos/octos
```

## Notes / tradeoffs (accepted)
- The old short `brew install octos-org/tap/octos` **breaks** — GitHub only resolves the short `user/tap` form for repos named `homebrew-*`, so a full-URL tap is required. Existing users must re-tap.
- Because `main` is branch-protected, each release now produces a small formula-bump PR (auto-merge enabled) rather than a direct push — one accepted bit of friction vs. the old unprotected tap.
- `octos-org/homebrew-tap` should be archived only **after** this + the octos-tui counterpart land (separate PR).