### PR TITLE
feat(memory): per-session memory segments for serve and gateway agents

### DIFF
--- a/crates/octos-agent/src/agent/prompt_segments.rs
+++ b/crates/octos-agent/src/agent/prompt_segments.rs
@@ -211,4 +211,23 @@ mod tests {
         segs.append("only content");
         assert_eq!(segs.render(), "\n\nonly content");
     }
+
+    #[test]
+    fn reserved_empty_named_slot_keeps_position_when_filled_later() {
+        // The session-actor pattern: base → reserve empty named slot →
+        // append tail → (turn-start refresh) fill the slot. The filled
+        // content must land BETWEEN base and tail, and the empty slot
+        // must render as nothing meanwhile.
+        let mut segs = PromptSegments::from_base("BASE".to_string());
+        segs.set_named("memory", String::new());
+        segs.append("TAIL");
+        assert_eq!(segs.render(), "BASE\n\nTAIL");
+
+        segs.set_named("memory", "MEMORY".to_string());
+        let rendered = segs.render();
+        let b = rendered.find("BASE").unwrap();
+        let m = rendered.find("MEMORY").unwrap();
+        let t = rendered.find("TAIL").unwrap();
+        assert!(b < m && m < t, "order must be base→memory→tail: {rendered}");
+    }
 }

--- a/crates/octos-agent/src/memory_segment.rs
+++ b/crates/octos-agent/src/memory_segment.rs
@@ -57,6 +57,8 @@ pub struct MemorySegmentProvider {
     store: Arc<MemoryStore>,
     max_inject_tokens: usize,
     include_capture_policy: bool,
+    /// See [`Self::static_snapshot`]: first render only, no re-reads.
+    static_after_first: bool,
     last: tokio::sync::Mutex<Option<Fingerprint>>,
 }
 
@@ -70,8 +72,19 @@ impl MemorySegmentProvider {
             store,
             max_inject_tokens,
             include_capture_policy,
+            static_after_first: false,
             last: tokio::sync::Mutex::new(None),
         }
+    }
+
+    /// Snapshot mode: render ONCE (the first turn-start refresh) and never
+    /// re-render. Used when `memory.refresh.enabled = false` — the config
+    /// contract there is "no per-turn memory re-read", but agents built by
+    /// synchronous factories (session actors) still need their initial
+    /// memory block seeded through the provider path.
+    pub fn static_snapshot(mut self) -> Self {
+        self.static_after_first = true;
+        self
     }
 
     async fn fingerprint(&self) -> Fingerprint {
@@ -122,6 +135,17 @@ impl PromptSegmentProvider for MemorySegmentProvider {
     }
 
     async fn refresh(&self) -> Option<String> {
+        if self.static_after_first {
+            let mut last = self.last.lock().await;
+            if last.is_some() {
+                return None;
+            }
+            // Any non-None marker: the fingerprint is irrelevant in
+            // snapshot mode — one render, then silence.
+            *last = Some(self.fingerprint().await);
+            drop(last);
+            return Some(self.render().await);
+        }
         let current = self.fingerprint().await;
         {
             let mut last = self.last.lock().await;

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -40093,6 +40093,8 @@ ignore = []
             system_prompt: "test-system-prompt".to_string(),
             memory,
             memory_store,
+            memory_inject_tokens: 2500,
+            memory_refresh_enabled: false,
             memory_refresh: None,
             tool_config,
             cron_service: None,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -40100,6 +40100,10 @@ ignore = []
             review_config: None,
             human_approval_rules: None,
             system_prompt: "test-system-prompt".to_string(),
+            prompt_parts: crate::commands::gateway::prompt::GatewayPromptParts {
+                pre_memory: "test-system-prompt".to_string(),
+                post_memory: String::new(),
+            },
             memory,
             memory_store,
             memory_inject_tokens: 2500,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -15971,6 +15971,11 @@ async fn run_native_code_review_turn(
     let memory_store = session_runtime.profile.memory.clone();
     let tools = Arc::new(session_runtime.tools.snapshot_excluding(&[]));
     let agent_config = session_runtime.agent.agent_config();
+    // UPCR follow-up to #1561: refresh named prompt segments (memory) on
+    // the cached session agent BEFORE snapshotting — WS turns build a
+    // fresh request agent from this snapshot and never run the cached
+    // agent's own turn-start refresh.
+    session_runtime.agent.refresh_prompt_segments().await;
     let system_prompt_base = session_runtime.agent.system_prompt_snapshot();
     let review_dispatch_policy = Arc::new(octos_agent::DispatchPolicy::from_agent_gates(
         profile_runtime.tool_policy.clone(),
@@ -17694,6 +17699,10 @@ async fn run_standalone_turn(
     // dynamic context — none of which the session prompt should
     // supplant. The session prompt is workflow-specific guidance that
     // augments rather than replaces.
+    // Same refresh-before-snapshot rule as the review path: the cached
+    // agent's memory segment must be current before the per-turn agent
+    // clones its prompt.
+    session_runtime.agent.refresh_prompt_segments().await;
     let agent_snapshot = session_runtime.agent.system_prompt_snapshot();
     let system_prompt_base = match session_id.topic().and_then(|topic| {
         crate::project_templates::read_session_prompt(&session_runtime.profile.data_dir, topic)

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -176,7 +176,7 @@ pub(super) struct GatewayRuntime {
     active_sessions: Arc<RwLock<ActiveSessionStore>>,
 
     // Config / hot-reload
-    system_prompt: Arc<std::sync::RwLock<String>>,
+    system_prompt: Arc<std::sync::RwLock<crate::commands::gateway::prompt::GatewayPromptParts>>,
     max_history: Arc<AtomicUsize>,
     config_rx: tokio::sync::watch::Receiver<Option<ConfigChange>>,
     tool_config: Arc<octos_agent::ToolConfigStore>,
@@ -1169,16 +1169,15 @@ impl GatewayRuntime {
         )
         .await;
 
-        // Append skill prompt fragments
-        let system_prompt = if plugin_result.prompt_fragments.is_empty() {
-            system_prompt
-        } else {
-            let mut prompt = system_prompt;
+        // Append skill prompt fragments (post-memory tail: fragments came
+        // after the memory slot pre-refactor too).
+        let system_prompt = {
+            let mut parts = system_prompt;
             for fragment in &plugin_result.prompt_fragments {
-                prompt.push_str("\n\n");
-                prompt.push_str(fragment);
+                parts.post_memory.push_str("\n\n");
+                parts.post_memory.push_str(fragment);
             }
-            prompt
+            parts
         };
 
         // Shared system prompt for hot-reload (factory reads this at actor spawn time)
@@ -1779,10 +1778,13 @@ impl GatewayRuntime {
                             max_history: new_max,
                         } => {
                             if let Some(prompt) = system_prompt {
-                                *self
-                                    .system_prompt
+                                // A hot-reloaded config prompt replaces the
+                                // PRE-memory half only; the built post half
+                                // (skills/tool prefs) stays.
+                                self.system_prompt
                                     .write()
-                                    .unwrap_or_else(|e| e.into_inner()) = prompt;
+                                    .unwrap_or_else(|e| e.into_inner())
+                                    .pre_memory = prompt;
                                 info!(
                                     "System prompt updated via hot-reload (new actors will use it)"
                                 );

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -1164,11 +1164,8 @@ impl GatewayRuntime {
             gw_config.system_prompt.as_deref(),
             &data_dir,
             &project_dir,
-            &memory_store,
             &skills_loader,
             &tool_config,
-            max_inject_tokens,
-            memory_refresh_enabled,
         )
         .await;
 
@@ -1339,6 +1336,8 @@ impl GatewayRuntime {
             llm: llm.clone(),
             llm_for_compaction: llm_for_compaction.clone(),
             memory: memory.clone(),
+            memory_inject_tokens: max_inject_tokens,
+            memory_refresh_enabled,
             system_prompt: system_prompt.clone(),
             hooks,
             hook_context_template,
@@ -1653,33 +1652,20 @@ impl GatewayRuntime {
             let base_prompt = gw_config.system_prompt.clone();
             let data_dir_p = data_dir.clone();
             let project_dir_p = project_dir.clone();
-            let memory_store_p = memory_store.clone();
             let tool_config_p = tool_config.clone();
             let indicators = status_indicators.clone();
-            let max_inject_p = max_inject_tokens;
-            let memory_refresh_p = memory_refresh_enabled;
             persona_service.start(
                 move |_persona_text| {
                     // Rebuild the full system prompt with the new persona and hot-update
                     let base = base_prompt.clone();
                     let dd = data_dir_p.clone();
                     let pd = project_dir_p.clone();
-                    let ms = memory_store_p.clone();
                     let tc = tool_config_p.clone();
                     let prompt_lock = system_prompt_for_persona.clone();
                     tokio::spawn(async move {
                         let sl = crate::skills_scope::build_account_skills_loader(&dd);
-                        let new_prompt = build_system_prompt(
-                            base.as_deref(),
-                            &dd,
-                            &pd,
-                            &ms,
-                            &sl,
-                            &tc,
-                            max_inject_p,
-                            memory_refresh_p,
-                        )
-                        .await;
+                        let new_prompt =
+                            build_system_prompt(base.as_deref(), &dd, &pd, &sl, &tc).await;
                         *prompt_lock.write().unwrap_or_else(|e| e.into_inner()) = new_prompt;
                         info!("system prompt updated with new persona");
                     });

--- a/crates/octos-cli/src/commands/gateway/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/mod.rs
@@ -7,7 +7,7 @@ mod gateway_runtime;
 mod matrix_integration;
 mod message_preprocessing;
 pub(crate) mod profile_factory;
-mod prompt;
+pub mod prompt;
 pub(crate) mod session_ui;
 mod skills_handler;
 

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -606,8 +606,8 @@ impl ProfileActorFactoryBuilder {
         )
         .await;
         for fragment in &self.plugin_prompt_fragments {
-            system_prompt.push_str("\n\n");
-            system_prompt.push_str(fragment);
+            system_prompt.post_memory.push_str("\n\n");
+            system_prompt.post_memory.push_str(fragment);
         }
         let mut pipeline_factory = self.pipeline_factory.clone();
         let mut provider_policy = self.provider_policy.clone();
@@ -936,8 +936,8 @@ impl ProfileActorFactoryBuilder {
 
         if !child_plugin_prompt_fragments.is_empty() {
             for fragment in &child_plugin_prompt_fragments {
-                system_prompt.push_str("\n\n");
-                system_prompt.push_str(fragment);
+                system_prompt.post_memory.push_str("\n\n");
+                system_prompt.post_memory.push_str(fragment);
             }
         }
 

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -601,11 +601,8 @@ impl ProfileActorFactoryBuilder {
             effective_profile.config.gateway.system_prompt.as_deref(),
             &profile_data_dir,
             &self.project_dir,
-            &self.memory_store,
             &skills_loader,
             &self.tool_config,
-            max_inject_tokens,
-            memory_refresh_enabled,
         )
         .await;
         for fragment in &self.plugin_prompt_fragments {
@@ -961,6 +958,8 @@ impl ProfileActorFactoryBuilder {
             llm: llm.clone(),
             llm_for_compaction,
             memory: self.memory.clone(),
+            memory_inject_tokens: max_inject_tokens,
+            memory_refresh_enabled,
             system_prompt: Arc::new(std::sync::RwLock::new(system_prompt)),
             hooks,
             hook_context_template: Some(HookContext {

--- a/crates/octos-cli/src/commands/gateway/prompt.rs
+++ b/crates/octos-cli/src/commands/gateway/prompt.rs
@@ -17,13 +17,37 @@ use crate::persona_service::PersonaService;
 // resolved memory knobs); they don't group into a smaller, meaningful sub-type,
 // so the arg count is expected here.
 #[allow(clippy::too_many_arguments)]
+/// The base system prompt split at the memory slot. Memory is injected as
+/// a NAMED per-agent prompt segment BETWEEN these halves (the pre-refactor
+/// order was `…bootstrap/soul → memory → skills/tool prefs`; keeping the
+/// slot preserves prompt precedence — persisted user memory must not
+/// override the skill/tool guidance that always followed it).
+#[derive(Debug, Clone, Default)]
+pub struct GatewayPromptParts {
+    /// Everything before the memory slot (base, date, platform, persona,
+    /// bootstrap files, soul).
+    pub pre_memory: String,
+    /// Everything after it (active skills, skills summary, tool prefs).
+    pub post_memory: String,
+}
+
+impl GatewayPromptParts {
+    /// The joined prompt WITHOUT a memory block — for read-only consumers
+    /// (length logging, tests) that don't build agents.
+    pub fn joined(&self) -> String {
+        let mut out = self.pre_memory.clone();
+        out.push_str(&self.post_memory);
+        out
+    }
+}
+
 pub async fn build_system_prompt(
     base: Option<&str>,
     data_dir: &Path,
     project_dir: &Path,
     skills_loader: &SkillsLoader,
     tool_config: &octos_agent::ToolConfigStore,
-) -> String {
+) -> GatewayPromptParts {
     let compiled = include_str!("../../prompts/gateway_default.txt");
     let runtime = super::super::load_prompt("gateway", compiled);
     let mut prompt = base.unwrap_or(&runtime).to_string();
@@ -65,13 +89,13 @@ pub async fn build_system_prompt(
         prompt.push_str(&user_soul);
     }
 
+    // ---- memory slot ----------------------------------------------------
     // Memory is NOT inlined here anymore: every model call flows through a
     // per-session `octos_agent::Agent`, which owns the memory as a named
     // prompt segment refreshed at each turn start (chat.rs pattern —
     // fingerprint stat per turn). Inlining it in this base String froze it
-    // at build time: serve profiles bootstrapped before any consolidation
-    // carried an empty block forever, and gateway staleness was bounded
-    // only by the 6-hour persona tick.
+    // at build time. The split preserves the slot's POSITION.
+    let pre_memory = std::mem::take(&mut prompt);
 
     // Append always-on skills
     if let Ok(always_names) = skills_loader.get_always_skills().await {
@@ -100,7 +124,10 @@ pub async fn build_system_prompt(
         prompt.push_str(&config_summary);
     }
 
-    prompt
+    GatewayPromptParts {
+        pre_memory,
+        post_memory: prompt,
+    }
 }
 
 /// Extract a string value from channel settings JSON, with a default fallback.

--- a/crates/octos-cli/src/commands/gateway/prompt.rs
+++ b/crates/octos-cli/src/commands/gateway/prompt.rs
@@ -3,7 +3,6 @@
 use std::path::Path;
 
 use octos_agent::SkillsLoader;
-use octos_memory::MemoryStore;
 
 use crate::persona_service::PersonaService;
 
@@ -22,11 +21,8 @@ pub async fn build_system_prompt(
     base: Option<&str>,
     data_dir: &Path,
     project_dir: &Path,
-    memory_store: &MemoryStore,
     skills_loader: &SkillsLoader,
     tool_config: &octos_agent::ToolConfigStore,
-    max_inject_tokens: usize,
-    memory_capture_policy: bool,
 ) -> String {
     let compiled = include_str!("../../prompts/gateway_default.txt");
     let runtime = super::super::load_prompt("gateway", compiled);
@@ -69,15 +65,13 @@ pub async fn build_system_prompt(
         prompt.push_str(&user_soul);
     }
 
-    // Append the token-capped memory block (long-term memory + daily notes
-    // + bank summary; omissions are disclosed to the model), plus the
-    // capture-policy teaching block when memory refresh is enabled.
-    let memory_ctx = memory_store.get_injectable_context(max_inject_tokens).await;
-    let memory_segment = octos_agent::compose_memory_segment(&memory_ctx, memory_capture_policy);
-    if !memory_segment.is_empty() {
-        prompt.push_str("\n\n");
-        prompt.push_str(&memory_segment);
-    }
+    // Memory is NOT inlined here anymore: every model call flows through a
+    // per-session `octos_agent::Agent`, which owns the memory as a named
+    // prompt segment refreshed at each turn start (chat.rs pattern —
+    // fingerprint stat per turn). Inlining it in this base String froze it
+    // at build time: serve profiles bootstrapped before any consolidation
+    // carried an empty block forever, and gateway staleness was bounded
+    // only by the 6-hour persona tick.
 
     // Append always-on skills
     if let Ok(always_names) = skills_loader.get_always_skills().await {

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -2929,6 +2929,9 @@ mod tests {
     fn should_let_env_disable_refresh_when_config_silent() {
         // Host mirroring: OCTOS_MEMORY_REFRESH_ENABLED=0 must beat the
         // child's default-on when the config file says nothing.
+        // Serialized: process-env mutation races every parallel test that
+        // loads a Config (same rule as the HOME-mutating tests).
+        let _g = HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prev = std::env::var("OCTOS_MEMORY_REFRESH_ENABLED").ok();
         unsafe { std::env::set_var("OCTOS_MEMORY_REFRESH_ENABLED", "0") };
 

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -603,6 +603,10 @@ mod tests {
             review_config: None,
             human_approval_rules: None,
             system_prompt: "test-system-prompt".to_string(),
+            prompt_parts: crate::commands::gateway::prompt::GatewayPromptParts {
+                pre_memory: "test-system-prompt".to_string(),
+                post_memory: String::new(),
+            },
             memory,
             memory_store,
             memory_inject_tokens: 2500,

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -605,6 +605,8 @@ mod tests {
             system_prompt: "test-system-prompt".to_string(),
             memory,
             memory_store,
+            memory_inject_tokens: 2500,
+            memory_refresh_enabled: false,
             memory_refresh: None,
             tool_config,
             cron_service: None,

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -251,6 +251,11 @@ pub struct ProfileRuntime {
     /// Long-lived [`MemoryStore`] (MEMORY.md + daily notes + recent
     /// memories window) for this profile.
     pub memory_store: Arc<MemoryStore>,
+    /// Resolved `memory.max_inject_tokens` for per-session memory segments.
+    pub memory_inject_tokens: usize,
+    /// Resolved `memory.refresh.enabled` — gates the capture-policy text in
+    /// the memory segment and the per-turn refresh provider.
+    pub memory_refresh_enabled: bool,
     /// Background memory-refresh sweep (extraction over idle sessions).
     /// `Some` only when `memory.refresh.enabled` and this process won the
     /// profile's refresh lock; dropping the runtime stops the sweep and
@@ -943,11 +948,8 @@ impl ProfileRuntime {
             profile.config.gateway.system_prompt.as_deref(),
             data_dir,
             data_dir,
-            &memory_store,
             &skills_loader,
             &tool_config,
-            max_inject_tokens,
-            memory_refresh_enabled,
         )
         .await;
         for fragment in &plugin_result.prompt_fragments {
@@ -1055,6 +1057,8 @@ impl ProfileRuntime {
                 .as_ref()
                 .map(|policy| policy.to_runtime_rules()),
             system_prompt,
+            memory_inject_tokens: max_inject_tokens,
+            memory_refresh_enabled,
             memory,
             memory_store,
             memory_refresh,

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -221,6 +221,10 @@ pub struct ProfileRuntime {
     /// the heavy work (memory context, skills summary, bootstrap
     /// files) off the per-request hot path.
     pub system_prompt: String,
+    /// The same prompt split at the memory slot — per-session agents
+    /// compose `pre → [memory segment] → post` to keep the pre-refactor
+    /// precedence (memory before skills/tool guidance).
+    pub prompt_parts: crate::commands::gateway::prompt::GatewayPromptParts,
 
     /// Hook configurations contributed by loaded plugins (skill
     /// manifests can declare `before_tool_call` / `after_tool_call` /
@@ -944,7 +948,7 @@ impl ProfileRuntime {
             crate::config::MemoryConfig::effective_max_inject_tokens(config.memory.as_ref());
         let memory_refresh_enabled =
             crate::config::MemoryConfig::refresh_enabled(config.memory.as_ref());
-        let mut system_prompt = build_system_prompt(
+        let mut prompt_parts = build_system_prompt(
             profile.config.gateway.system_prompt.as_deref(),
             data_dir,
             data_dir,
@@ -953,9 +957,11 @@ impl ProfileRuntime {
         )
         .await;
         for fragment in &plugin_result.prompt_fragments {
-            system_prompt.push_str("\n\n");
-            system_prompt.push_str(fragment);
+            prompt_parts.post_memory.push_str("\n\n");
+            prompt_parts.post_memory.push_str(fragment);
         }
+        let system_prompt = prompt_parts.joined();
+        let prompt_parts_for_runtime = prompt_parts.clone();
 
         // M11-F regression fix REG-3: assemble the lifecycle hook
         // executor once per profile and propagate the `Arc` onto every
@@ -1057,6 +1063,7 @@ impl ProfileRuntime {
                 .as_ref()
                 .map(|policy| policy.to_runtime_rules()),
             system_prompt,
+            prompt_parts: prompt_parts_for_runtime,
             memory_inject_tokens: max_inject_tokens,
             memory_refresh_enabled,
             memory,

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -495,7 +495,7 @@ impl SessionRuntime {
         // line, the agent's prompt would fall back to the
         // `Agent::new_shared` default and the LLM would lose its
         // skill-aware routing.
-        .with_system_prompt(profile.system_prompt.clone())
+        .with_system_prompt(profile.prompt_parts.pre_memory.clone())
         .with_file_state_cache(file_state_cache)
         .with_subagent_output_router(subagent_output_router)
         .with_subagent_summary_generator(subagent_summary_generator)
@@ -534,6 +534,11 @@ impl SessionRuntime {
                 profile.memory_inject_tokens,
                 true,
             )));
+        }
+        // Post-memory half AFTER the named segment — the pre-refactor
+        // order (memory before skills/tool guidance).
+        if !profile.prompt_parts.post_memory.is_empty() {
+            agent.append_system_prompt(&profile.prompt_parts.post_memory);
         }
 
         // M11-F regression fix REG-3: propagate the profile-scope
@@ -844,6 +849,10 @@ mod tests {
             plugin_hooks: Vec::new(),
             review_config: None,
             human_approval_rules: None,
+            prompt_parts: crate::commands::gateway::prompt::GatewayPromptParts {
+                pre_memory: system_prompt.clone(),
+                post_memory: String::new(),
+            },
             system_prompt,
             memory,
             memory_store,
@@ -908,6 +917,44 @@ mod tests {
             prompt.contains("Friday again"),
             "read-refresh must pick up post-bootstrap consolidations: {prompt}"
         );
+    }
+
+    #[tokio::test]
+    async fn memory_segment_keeps_pre_skills_slot() {
+        // codex round-3 P2: the memory block must keep its pre-refactor
+        // position — after bootstrap/soul, BEFORE the skills/tool-prefs
+        // half — or persisted user memory gains precedence over guidance
+        // that always followed it.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        std::fs::create_dir_all(data_dir.join("memory")).unwrap();
+        std::fs::write(
+            data_dir.join("memory/MEMORY.md"),
+            "A very durable fact. (updated: 2026-07-09) ^mvvvvvv\n",
+        )
+        .unwrap();
+        let profile = make_profile(data_dir.clone()).await;
+
+        let rt = SessionRuntime::bootstrap(&profile, SessionKey::new("appui", "order"), None)
+            .await
+            .expect("bootstrap");
+        rt.agent.refresh_prompt_segments().await;
+        let prompt = rt.agent.system_prompt_snapshot();
+        let memory_pos = prompt
+            .find("A very durable fact")
+            .expect("memory segment present");
+        if let Some(tool_prefs_pos) = prompt.find("## Tool Preferences") {
+            assert!(
+                memory_pos < tool_prefs_pos,
+                "memory must precede the tool-prefs half: mem={memory_pos} prefs={tool_prefs_pos}"
+            );
+        }
+        if let Some(skills_pos) = prompt.find("## Available Skills") {
+            assert!(
+                memory_pos < skills_pos,
+                "memory must precede the skills half: mem={memory_pos} skills={skills_pos}"
+            );
+        }
     }
 
     #[tokio::test]
@@ -1472,6 +1519,10 @@ mod tests {
             review_config: None,
             human_approval_rules: None,
             system_prompt: "test-system-prompt".to_string(),
+            prompt_parts: crate::commands::gateway::prompt::GatewayPromptParts {
+                pre_memory: "test-system-prompt".to_string(),
+                post_memory: String::new(),
+            },
             memory,
             memory_store,
             memory_inject_tokens: 2500,
@@ -1530,6 +1581,10 @@ mod tests {
             review_config: None,
             human_approval_rules: None,
             system_prompt: "test-system-prompt".to_string(),
+            prompt_parts: crate::commands::gateway::prompt::GatewayPromptParts {
+                pre_memory: "test-system-prompt".to_string(),
+                post_memory: String::new(),
+            },
             memory,
             memory_store,
             memory_inject_tokens: 2500,
@@ -1616,6 +1671,10 @@ mod tests {
             review_config: None,
             human_approval_rules: None,
             system_prompt: "test-system-prompt".to_string(),
+            prompt_parts: crate::commands::gateway::prompt::GatewayPromptParts {
+                pre_memory: "test-system-prompt".to_string(),
+                post_memory: String::new(),
+            },
             memory,
             memory_store,
             memory_inject_tokens: 2500,

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -509,6 +509,30 @@ impl SessionRuntime {
             agent = agent.with_session_scope(scope);
         }
 
+        // Memory rides the per-session agent as a NAMED prompt segment
+        // (chat.rs pattern) instead of being frozen into the profile's
+        // bootstrap prompt String: serve profiles bootstrapped before any
+        // consolidation carried an empty block forever (the model then
+        // fabricates a "memory bank" when asked). The provider re-renders
+        // the segment at each turn start when MEMORY.md / daily notes /
+        // bank change on disk (one fingerprint stat per turn otherwise).
+        let memory_ctx = profile
+            .memory_store
+            .get_injectable_context(profile.memory_inject_tokens)
+            .await;
+        agent.set_prompt_segment(
+            octos_agent::MEMORY_SEGMENT_NAME,
+            octos_agent::compose_memory_segment(&memory_ctx, profile.memory_refresh_enabled),
+        );
+        // Refresh is unconditional — reading CURRENT memory each turn is
+        // correct even when the capture layer is opted out; the flag only
+        // controls the capture-policy teaching text inside the segment.
+        agent.add_prompt_segment_provider(Arc::new(octos_agent::MemorySegmentProvider::new(
+            profile.memory_store.clone(),
+            profile.memory_inject_tokens,
+            profile.memory_refresh_enabled,
+        )));
+
         // M11-F regression fix REG-3: propagate the profile-scope
         // [`octos_agent::HookExecutor`] onto the per-session agent.
         // `ProfileRuntime::bootstrap` assembled it once from
@@ -820,6 +844,8 @@ mod tests {
             system_prompt,
             memory,
             memory_store,
+            memory_inject_tokens: 2500,
+            memory_refresh_enabled: false,
             memory_refresh: None,
             tool_config,
             cron_service: None,
@@ -836,6 +862,49 @@ mod tests {
     ) -> Arc<ProfileRuntime> {
         make_profile_with_prompt_and_sandbox(data_dir, "test-system-prompt".to_string(), sandbox)
             .await
+    }
+
+    #[tokio::test]
+    async fn session_agent_renders_fresh_memory_segment() {
+        // Serve sessions read MEMORY.md via the per-session agent's NAMED
+        // segment + turn-start refresh — NOT a value frozen into the
+        // profile bootstrap prompt (which fabricated-memory bugs came
+        // from). Consolidations landing AFTER the session was created
+        // must be visible on the next refresh.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        std::fs::create_dir_all(data_dir.join("memory")).unwrap();
+        std::fs::write(
+            data_dir.join("memory/MEMORY.md"),
+            "Deploy day is Monday. (updated: 2026-07-08) ^mvzercg\n",
+        )
+        .unwrap();
+        let profile = make_profile(data_dir.clone()).await;
+
+        let rt = SessionRuntime::bootstrap(&profile, SessionKey::new("appui", "mem"), None)
+            .await
+            .expect("bootstrap");
+        rt.agent.refresh_prompt_segments().await;
+        let prompt = rt.agent.system_prompt_snapshot();
+        assert!(
+            prompt.contains("Deploy day is Monday"),
+            "session agent must inject MEMORY.md: {prompt}"
+        );
+
+        // A consolidation AFTER session creation becomes visible on the
+        // next turn-start refresh (fingerprint change).
+        std::fs::write(
+            data_dir.join("memory/MEMORY.md"),
+            "Deploy day is Friday again. (updated: 2026-07-09) ^mvzercg\n",
+        )
+        .unwrap();
+        rt.agent.refresh_prompt_segments().await;
+        let prompt = rt.agent.system_prompt_snapshot();
+        assert!(
+            prompt.contains("Friday again"),
+            "read-refresh must pick up post-bootstrap consolidations: {prompt}"
+        );
     }
 
     #[tokio::test]
@@ -1402,6 +1471,8 @@ mod tests {
             system_prompt: "test-system-prompt".to_string(),
             memory,
             memory_store,
+            memory_inject_tokens: 2500,
+            memory_refresh_enabled: false,
             memory_refresh: None,
             tool_config,
             cron_service: None,
@@ -1458,6 +1529,8 @@ mod tests {
             system_prompt: "test-system-prompt".to_string(),
             memory,
             memory_store,
+            memory_inject_tokens: 2500,
+            memory_refresh_enabled: false,
             memory_refresh: None,
             tool_config,
             cron_service: None,
@@ -1542,6 +1615,8 @@ mod tests {
             system_prompt: "test-system-prompt".to_string(),
             memory,
             memory_store,
+            memory_inject_tokens: 2500,
+            memory_refresh_enabled: false,
             memory_refresh: None,
             tool_config,
             cron_service: None,

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -524,14 +524,17 @@ impl SessionRuntime {
             octos_agent::MEMORY_SEGMENT_NAME,
             octos_agent::compose_memory_segment(&memory_ctx, profile.memory_refresh_enabled),
         );
-        // Refresh is unconditional — reading CURRENT memory each turn is
-        // correct even when the capture layer is opted out; the flag only
-        // controls the capture-policy teaching text inside the segment.
-        agent.add_prompt_segment_provider(Arc::new(octos_agent::MemorySegmentProvider::new(
-            profile.memory_store.clone(),
-            profile.memory_inject_tokens,
-            profile.memory_refresh_enabled,
-        )));
+        // Contract parity with chat.rs: `memory.refresh.enabled = false`
+        // means NO per-turn memory re-read — the segment stays as seeded
+        // at session bootstrap. Default-on makes disabled an explicit
+        // opt-out.
+        if profile.memory_refresh_enabled {
+            agent.add_prompt_segment_provider(Arc::new(octos_agent::MemorySegmentProvider::new(
+                profile.memory_store.clone(),
+                profile.memory_inject_tokens,
+                true,
+            )));
+        }
 
         // M11-F regression fix REG-3: propagate the profile-scope
         // [`octos_agent::HookExecutor`] onto the per-session agent.
@@ -845,7 +848,7 @@ mod tests {
             memory,
             memory_store,
             memory_inject_tokens: 2500,
-            memory_refresh_enabled: false,
+            memory_refresh_enabled: true,
             memory_refresh: None,
             tool_config,
             cron_service: None,
@@ -1472,7 +1475,7 @@ mod tests {
             memory,
             memory_store,
             memory_inject_tokens: 2500,
-            memory_refresh_enabled: false,
+            memory_refresh_enabled: true,
             memory_refresh: None,
             tool_config,
             cron_service: None,
@@ -1530,7 +1533,7 @@ mod tests {
             memory,
             memory_store,
             memory_inject_tokens: 2500,
-            memory_refresh_enabled: false,
+            memory_refresh_enabled: true,
             memory_refresh: None,
             tool_config,
             cron_service: None,
@@ -1616,7 +1619,7 @@ mod tests {
             memory,
             memory_store,
             memory_inject_tokens: 2500,
-            memory_refresh_enabled: false,
+            memory_refresh_enabled: true,
             memory_refresh: None,
             tool_config,
             cron_service: None,

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -2734,7 +2734,7 @@ pub struct ActorFactory {
     /// Strong-only provider chain for slides sessions (kimi + deepseek + minimax).
     pub llm_strong: Arc<dyn LlmProvider>,
     pub memory: Arc<EpisodeStore>,
-    pub system_prompt: Arc<std::sync::RwLock<String>>,
+    pub system_prompt: Arc<std::sync::RwLock<crate::commands::gateway::prompt::GatewayPromptParts>>,
     pub hooks: Option<Arc<HookExecutor>>,
     pub hook_context_template: Option<HookContext>,
     /// Data directory for creating per-actor SessionHandle instances.
@@ -3649,14 +3649,25 @@ impl ActorFactory {
         };
         let agent_id = AgentId::new(format!("session-{}", session_key));
         let has_deferred = tools.has_deferred();
-        let mut system_prompt = system_prompt_override.unwrap_or_else(|| {
-            self.system_prompt
-                .read()
-                .unwrap_or_else(|e| e.into_inner())
-                .clone()
-        });
+        // Pre/post-memory split: the memory segment must keep its
+        // pre-refactor slot (after bootstrap/soul, BEFORE skills/tool
+        // guidance) — see GatewayPromptParts. Per-session tails (slides
+        // availability, deferred-tools teaching) belong to the post half.
+        let (mut system_prompt, mut post_memory_tail) = match system_prompt_override {
+            // An override replaces the whole base prompt; memory still
+            // takes the slot right after it.
+            Some(override_prompt) => (override_prompt, String::new()),
+            None => {
+                let parts = self
+                    .system_prompt
+                    .read()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .clone();
+                (parts.pre_memory, parts.post_memory)
+            }
+        };
         if is_slides && !slides_generation_available {
-            system_prompt.push_str(
+            post_memory_tail.push_str(
                 "\n\n## Slides Generation Availability\n\n\
                  `mofa_slides` is not available on this host. You may still design and edit slide projects, \
                  but you must tell the user that PPTX/image generation is unavailable here. \
@@ -3675,8 +3686,9 @@ impl ActorFactory {
                 }
             }
             let template = include_str!("../../octos-agent/src/prompts/deferred_tools.txt");
-            system_prompt.push_str(&template.replace("{tool_list}", &tool_names.join(", ")));
+            post_memory_tail.push_str(&template.replace("{tool_list}", &tool_names.join(", ")));
         }
+        let _ = &mut system_prompt;
 
         // M8 fix-first item 8 (gap 2): build a per-actor
         // AgentSummaryGenerator now that the supervisor handle and the
@@ -3766,6 +3778,11 @@ impl ActorFactory {
                 provider.static_snapshot()
             };
             agent.add_prompt_segment_provider(Arc::new(provider));
+        }
+        // Post-memory half (skills, tool prefs, per-session tails) lands
+        // AFTER the named memory segment — the pre-refactor order.
+        if !post_memory_tail.is_empty() {
+            agent.append_system_prompt(&post_memory_tail);
         }
 
         if let Some(ref embedder) = self.embedder {
@@ -15058,7 +15075,12 @@ mod tests {
             memory,
             memory_inject_tokens: 2500,
             memory_refresh_enabled: true,
-            system_prompt: Arc::new(std::sync::RwLock::new("default prompt".to_string())),
+            system_prompt: Arc::new(std::sync::RwLock::new(
+                crate::commands::gateway::prompt::GatewayPromptParts {
+                    pre_memory: "default prompt".to_string(),
+                    post_memory: String::new(),
+                },
+            )),
             hooks: None,
             hook_context_template: None,
             data_dir: dir.path().to_path_buf(),

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -3767,6 +3767,11 @@ impl ActorFactory {
         // mode: one render, then silence — parity with the old
         // inlined-at-build behavior, minus the staleness.
         if let Some(ref memory_store) = self.memory_store {
+            // RESERVE the named slot before the post tail lands: set_named
+            // on a missing segment APPENDS, so without this the provider's
+            // first refresh would place memory AFTER the tail
+            // (pre → post → memory). Empty segments render as nothing.
+            agent.set_prompt_segment(octos_agent::MEMORY_SEGMENT_NAME, String::new());
             let provider = octos_agent::MemorySegmentProvider::new(
                 memory_store.clone(),
                 self.memory_inject_tokens,

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -2790,6 +2790,11 @@ pub struct ActorFactory {
     /// Memory store for saving long-form outputs (research reports) to the
     /// memory bank so only a summary is injected into session context.
     pub memory_store: Option<Arc<MemoryStore>>,
+    /// Resolved `memory.max_inject_tokens` for per-session memory segments.
+    /// Paired with `memory_store`; `memory_refresh_enabled` gates the
+    /// capture-policy text and the per-turn refresh provider.
+    pub memory_inject_tokens: usize,
+    pub memory_refresh_enabled: bool,
     /// Profile id (= tenant id in [`SessionScope::multi_tenant`]). Used
     /// to construct a per-session [`SessionScope`] when spawning gateway
     /// session actors. `None` for the top-level admin factory (the
@@ -3735,6 +3740,25 @@ impl ActorFactory {
             agent = agent.with_session_scope(scope);
         }
 
+        // Memory as a NAMED per-agent prompt segment (chat.rs pattern):
+        // the factory's base prompt String no longer inlines it, so both
+        // gateway channel actors and serve WS/stdio actors read a fresh
+        // block each turn instead of whatever was on disk at
+        // build_system_prompt time (gateway persona tick = 6h; serve
+        // profile bootstrap = forever). This builder is synchronous, so
+        // the segment is not pre-seeded: the provider composes it during
+        // the turn-start refresh, which runs BEFORE the first model call.
+        // Registered unconditionally — with refresh disabled the segment
+        // still renders (without the capture-policy text); it only
+        // re-renders when the fingerprint changes.
+        if let Some(ref memory_store) = self.memory_store {
+            agent.add_prompt_segment_provider(Arc::new(octos_agent::MemorySegmentProvider::new(
+                memory_store.clone(),
+                self.memory_inject_tokens,
+                self.memory_refresh_enabled,
+            )));
+        }
+
         if let Some(ref embedder) = self.embedder {
             agent = agent.with_embedder(embedder.clone());
         }
@@ -3821,6 +3845,8 @@ impl ActorFactory {
             adaptive_router: self.adaptive_router.clone(),
             lane_routing: self.lane_routing.clone(),
             memory_store: self.memory_store.clone(),
+            memory_inject_tokens: self.memory_inject_tokens,
+            memory_refresh_enabled: self.memory_refresh_enabled,
             usage_profile_id: self
                 .profile_id
                 .clone()
@@ -4327,6 +4353,9 @@ struct SessionActor {
     lane_routing: Option<octos_llm::LaneRoutingConfig>,
     /// Memory store for saving long research reports out-of-band.
     memory_store: Option<Arc<MemoryStore>>,
+    /// Resolved memory-segment knobs (from the factory's profile config).
+    memory_inject_tokens: usize,
+    memory_refresh_enabled: bool,
     /// Active overflow task counter for concurrency limiting.
     active_overflow_tasks: Arc<std::sync::atomic::AtomicU32>,
     /// Cancellation flag for in-flight overflow tasks.
@@ -11719,6 +11748,8 @@ mod tests {
             adaptive_router,
             lane_routing: None,
             memory_store: None,
+            memory_inject_tokens: 2500,
+            memory_refresh_enabled: false,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
@@ -11800,6 +11831,8 @@ mod tests {
             adaptive_router: None,
             lane_routing: None,
             memory_store: None,
+            memory_inject_tokens: 2500,
+            memory_refresh_enabled: false,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
@@ -12066,6 +12099,8 @@ mod tests {
             adaptive_router: None,
             lane_routing: None,
             memory_store: None,
+            memory_inject_tokens: 2500,
+            memory_refresh_enabled: false,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
@@ -12200,6 +12235,8 @@ mod tests {
             adaptive_router: None,
             lane_routing: None,
             memory_store: None,
+            memory_inject_tokens: 2500,
+            memory_refresh_enabled: false,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
@@ -12330,6 +12367,8 @@ mod tests {
             adaptive_router: None,
             lane_routing: None,
             memory_store: None,
+            memory_inject_tokens: 2500,
+            memory_refresh_enabled: false,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
@@ -12432,6 +12471,8 @@ mod tests {
             adaptive_router: Some(router),
             lane_routing: None,
             memory_store: None,
+            memory_inject_tokens: 2500,
+            memory_refresh_enabled: false,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
@@ -12533,6 +12574,8 @@ mod tests {
             adaptive_router: Some(router),
             lane_routing: None,
             memory_store: None,
+            memory_inject_tokens: 2500,
+            memory_refresh_enabled: false,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
@@ -15051,6 +15094,8 @@ mod tests {
             adaptive_router: None,
             lane_routing: None,
             memory_store: None,
+            memory_inject_tokens: 2500,
+            memory_refresh_enabled: false,
             profile_id: None,
             plugin_dirs: Vec::new(),
             plugin_extra_env: Vec::new(),
@@ -17958,6 +18003,8 @@ mod tests {
             adaptive_router: None,
             lane_routing: None,
             memory_store: None,
+            memory_inject_tokens: 2500,
+            memory_refresh_enabled: false,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -3748,19 +3748,24 @@ impl ActorFactory {
         // profile bootstrap = forever). This builder is synchronous, so
         // the segment is not pre-seeded: the provider composes it during
         // the turn-start refresh, which runs BEFORE the first model call.
-        // Contract parity with chat.rs: registration is gated on
-        // `memory.refresh.enabled` — disabled means NO per-turn memory
-        // re-read (default-on makes disabled an explicit opt-out).
-        if self.memory_refresh_enabled {
-            if let Some(ref memory_store) = self.memory_store {
-                agent.add_prompt_segment_provider(Arc::new(
-                    octos_agent::MemorySegmentProvider::new(
-                        memory_store.clone(),
-                        self.memory_inject_tokens,
-                        true,
-                    ),
-                ));
-            }
+        // The provider is ALWAYS registered — this synchronous builder
+        // cannot pre-seed the segment, so the provider's first turn-start
+        // refresh is what injects memory at all. The refresh-disabled
+        // contract ("no per-turn memory re-read") is honored via snapshot
+        // mode: one render, then silence — parity with the old
+        // inlined-at-build behavior, minus the staleness.
+        if let Some(ref memory_store) = self.memory_store {
+            let provider = octos_agent::MemorySegmentProvider::new(
+                memory_store.clone(),
+                self.memory_inject_tokens,
+                self.memory_refresh_enabled,
+            );
+            let provider = if self.memory_refresh_enabled {
+                provider
+            } else {
+                provider.static_snapshot()
+            };
+            agent.add_prompt_segment_provider(Arc::new(provider));
         }
 
         if let Some(ref embedder) = self.embedder {
@@ -3849,8 +3854,6 @@ impl ActorFactory {
             adaptive_router: self.adaptive_router.clone(),
             lane_routing: self.lane_routing.clone(),
             memory_store: self.memory_store.clone(),
-            memory_inject_tokens: self.memory_inject_tokens,
-            memory_refresh_enabled: self.memory_refresh_enabled,
             usage_profile_id: self
                 .profile_id
                 .clone()
@@ -4357,9 +4360,6 @@ struct SessionActor {
     lane_routing: Option<octos_llm::LaneRoutingConfig>,
     /// Memory store for saving long research reports out-of-band.
     memory_store: Option<Arc<MemoryStore>>,
-    /// Resolved memory-segment knobs (from the factory's profile config).
-    memory_inject_tokens: usize,
-    memory_refresh_enabled: bool,
     /// Active overflow task counter for concurrency limiting.
     active_overflow_tasks: Arc<std::sync::atomic::AtomicU32>,
     /// Cancellation flag for in-flight overflow tasks.
@@ -11752,8 +11752,6 @@ mod tests {
             adaptive_router,
             lane_routing: None,
             memory_store: None,
-            memory_inject_tokens: 2500,
-            memory_refresh_enabled: false,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
@@ -11835,8 +11833,6 @@ mod tests {
             adaptive_router: None,
             lane_routing: None,
             memory_store: None,
-            memory_inject_tokens: 2500,
-            memory_refresh_enabled: false,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
@@ -12103,8 +12099,6 @@ mod tests {
             adaptive_router: None,
             lane_routing: None,
             memory_store: None,
-            memory_inject_tokens: 2500,
-            memory_refresh_enabled: false,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
@@ -12239,8 +12233,6 @@ mod tests {
             adaptive_router: None,
             lane_routing: None,
             memory_store: None,
-            memory_inject_tokens: 2500,
-            memory_refresh_enabled: false,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
@@ -12371,8 +12363,6 @@ mod tests {
             adaptive_router: None,
             lane_routing: None,
             memory_store: None,
-            memory_inject_tokens: 2500,
-            memory_refresh_enabled: false,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
@@ -12475,8 +12465,6 @@ mod tests {
             adaptive_router: Some(router),
             lane_routing: None,
             memory_store: None,
-            memory_inject_tokens: 2500,
-            memory_refresh_enabled: false,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
@@ -12578,8 +12566,6 @@ mod tests {
             adaptive_router: Some(router),
             lane_routing: None,
             memory_store: None,
-            memory_inject_tokens: 2500,
-            memory_refresh_enabled: false,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
@@ -15070,6 +15056,8 @@ mod tests {
             llm_for_compaction: provider.clone(),
             llm_strong: provider.clone(),
             memory,
+            memory_inject_tokens: 2500,
+            memory_refresh_enabled: true,
             system_prompt: Arc::new(std::sync::RwLock::new("default prompt".to_string())),
             hooks: None,
             hook_context_template: None,
@@ -15098,8 +15086,6 @@ mod tests {
             adaptive_router: None,
             lane_routing: None,
             memory_store: None,
-            memory_inject_tokens: 2500,
-            memory_refresh_enabled: false,
             profile_id: None,
             plugin_dirs: Vec::new(),
             plugin_extra_env: Vec::new(),
@@ -18007,8 +17993,6 @@ mod tests {
             adaptive_router: None,
             lane_routing: None,
             memory_store: None,
-            memory_inject_tokens: 2500,
-            memory_refresh_enabled: false,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -3748,15 +3748,19 @@ impl ActorFactory {
         // profile bootstrap = forever). This builder is synchronous, so
         // the segment is not pre-seeded: the provider composes it during
         // the turn-start refresh, which runs BEFORE the first model call.
-        // Registered unconditionally — with refresh disabled the segment
-        // still renders (without the capture-policy text); it only
-        // re-renders when the fingerprint changes.
-        if let Some(ref memory_store) = self.memory_store {
-            agent.add_prompt_segment_provider(Arc::new(octos_agent::MemorySegmentProvider::new(
-                memory_store.clone(),
-                self.memory_inject_tokens,
-                self.memory_refresh_enabled,
-            )));
+        // Contract parity with chat.rs: registration is gated on
+        // `memory.refresh.enabled` — disabled means NO per-turn memory
+        // re-read (default-on makes disabled an explicit opt-out).
+        if self.memory_refresh_enabled {
+            if let Some(ref memory_store) = self.memory_store {
+                agent.add_prompt_segment_provider(Arc::new(
+                    octos_agent::MemorySegmentProvider::new(
+                        memory_store.clone(),
+                        self.memory_inject_tokens,
+                        true,
+                    ),
+                ));
+            }
         }
 
         if let Some(ref embedder) = self.embedder {

--- a/crates/octos-cli/tests/coding_multi_session.rs
+++ b/crates/octos-cli/tests/coding_multi_session.rs
@@ -217,6 +217,8 @@ async fn make_m11g_profile(profile_id: &str, data_dir: &std::path::Path) -> Arc<
         voice: octos_cli::config::VoiceConfig::default(),
         memory,
         memory_store,
+        memory_inject_tokens: 2500,
+        memory_refresh_enabled: false,
         memory_refresh: None,
         tool_config,
         cron_service: None,

--- a/crates/octos-cli/tests/coding_multi_session.rs
+++ b/crates/octos-cli/tests/coding_multi_session.rs
@@ -214,6 +214,10 @@ async fn make_m11g_profile(profile_id: &str, data_dir: &std::path::Path) -> Arc<
         review_config: None,
         human_approval_rules: None,
         system_prompt: "test-system-prompt".to_string(),
+        prompt_parts: octos_cli::commands::gateway::prompt::GatewayPromptParts {
+            pre_memory: "test-system-prompt".to_string(),
+            post_memory: String::new(),
+        },
         voice: octos_cli::config::VoiceConfig::default(),
         memory,
         memory_store,


### PR DESCRIPTION
Fixes the two read-side memory gaps found in the wiring audit:

1. **Serve sessions (TUI/web) froze memory at profile-bootstrap time** — a profile bootstrapped before any consolidation carried an empty block forever (models then fabricate a memory bank when asked; reproduced live on mini5). 
2. **Gateway staleness was bounded only by the 6-hour persona tick.**

Every per-session Agent now owns memory as a NAMED prompt segment with the turn-start refresh provider (chat.rs pattern); `build_system_prompt` no longer inlines the block. Provider registration is unconditional — the refresh flag only gates the capture-policy text. Also serializes the #1556 env test on the shared env lock (recurring suite flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)