### PR TITLE
feat(acp): Agent Client Protocol support — full chat-parity octos acp stdio agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent-client-protocol"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882b815ffa67b023e1b40e7ea3bab3f05869654e8565d6811870c5545285e1d3"
+dependencies = [
+ "agent-client-protocol-derive",
+ "agent-client-protocol-schema",
+ "async-process",
+ "blocking",
+ "futures",
+ "futures-concurrency",
+ "rustc-hash",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "shell-words",
+ "tracing",
+ "uuid",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5ca63f112bd2459bcaf9eda0683b9ba95fc3b5e5fdd9036ca941c6a09345b1"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06679e1542356341f4550ccfb16338b64f37f6af70de2105446ef6fbb078234c"
+dependencies = [
+ "anyhow",
+ "derive_more 2.1.1",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum",
+ "tracing",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +323,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +584,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -871,6 +1012,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,9 +1169,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1029,11 +1179,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -1043,9 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -1167,7 +1316,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl 2.1.1",
 ]
 
 [[package]]
@@ -1178,6 +1336,20 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
  "syn",
  "unicode-xid",
 ]
@@ -1513,6 +1685,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1592,25 +1770,38 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
 ]
 
 [[package]]
-name = "futures-core"
-version = "0.3.31"
+name = "futures-concurrency"
+version = "7.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1619,15 +1810,28 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1636,15 +1840,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -1654,9 +1858,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1666,7 +1870,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -3889,6 +4092,7 @@ dependencies = [
 name = "octos-cli"
 version = "1.1.0"
 dependencies = [
+ "agent-client-protocol",
  "async-trait",
  "axum",
  "base64",
@@ -4364,6 +4568,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4380,6 +4595,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4992,6 +5221,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5163,8 +5401,21 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -5295,6 +5546,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "send-email"
 version = "1.0.0"
 dependencies = [
@@ -5345,11 +5602,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.12.1",
  "itoa",
  "memchr",
  "serde",
@@ -5391,11 +5660,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5410,9 +5680,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5694,6 +5964,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ The full CLI surface (see `octos help`):
 | `auth` / `account` / `admin` | provider login (OAuth/PKCE), sub-accounts, tenant & tunnel admin |
 | `channels` / `cron` / `skills` | messaging channels, scheduled jobs, skill install/remove |
 | `mcp-serve` | run octos as an MCP server, so outer orchestrators can drive it as a sub-agent |
+| `acp` | run octos as an [Agent Client Protocol](https://agentclientprotocol.com) agent over stdio, so editors like Zed drive it as their coding agent |
 | `office` | PPTX/DOCX/XLSX manipulation from the shell |
 | `update` / `clean` / `completions` / `docs` | release check, cache cleanup, shell completions, doc generation |
 
@@ -430,6 +431,29 @@ Interactive clients talk to `octos serve` over **UI Protocol v1** — a JSON-RPC
 - **[octos-web](https://github.com/octos-org/octos-web)** — the browser client: chat, voice/video, studio, slides, and sites. A build is embedded in the server binary at `/app/`, so `octos serve` works with zero extra deploys. (The admin dashboard is a separate SPA, embedded at `/admin/`.)
 - **[octos-tui](https://github.com/octos-org/octos-tui)** — the terminal client. Connects to a running server over WebSocket, or spawns `octos serve --stdio` as its own private backend.
 - **`octos mcp-serve`** — the inverse direction: octos as an MCP server, callable as a sub-agent from outer orchestrators.
+- **`octos acp`** — the editor-facing direction: octos as an **[Agent Client Protocol](https://agentclientprotocol.com) (ACP)** agent over stdio, so ACP-speaking editors (Zed and others) run octos as their coding agent — it shows up in the editor's agent picker alongside Claude Code and Gemini CLI. See [Use octos in Zed](#use-octos-in-zed-acp).
+
+### Use octos in Zed (ACP)
+
+`octos acp` speaks [ACP](https://agentclientprotocol.com) — the same protocol Zed uses for external agents — so Zed can run octos as its coding agent, with the full agent loop (tools, memory, streaming).
+
+1. **Give the agent a provider credential.** Easiest is `octos auth login --provider deepseek` — stored in `auth.json` and read regardless of environment; `octos acp` resolves its LLM exactly like `octos chat`. Note a Dock-launched Zed does **not** inherit your shell's env vars, so if you'd rather pass an API key by env var, put it in the `env` block below instead of relying on the shell.
+2. **Register octos** in Zed's settings (`~/.config/zed/settings.json`, or *zed: open settings* from the command palette). Use `"command": "octos"` if it's on your PATH, or the absolute path from `which octos` — a Dock-launched Zed has a minimal PATH and may not find a bare `octos`:
+
+   ```jsonc
+   {
+     "agent_servers": {
+       "Octos": {
+         "command": "octos",
+         "args": ["acp", "--provider", "deepseek", "--model", "deepseek-chat"],
+         "env": {}
+       }
+     }
+   }
+   ```
+3. **Start a thread.** Open a folder (external agents need a workspace), open the **Agent Panel**, click the **＋ New Thread** dropdown (`⌥⌘⇧N`), and choose **Octos**. Type a prompt — octos runs the loop and streams its work back into Zed.
+
+Flags mirror `octos chat`: `--provider`, `--model`, `--base-url`, `--config`, `--data-dir`, `--cwd`, `--profile`, and `--max-iterations` (default 20). Zed sends a per-session working directory with `session/new` that takes precedence over `--cwd`.
 
 ## Documentation
 

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -378,6 +378,17 @@ type OnFailureCallback = Box<dyn Fn(&SpawnOnlyFailureSignal) + Send + Sync>;
 /// Terminal outcome carried by a [`TerminalEvent`]. Distinguishes the
 /// success path (→ `ChildCompleted` re-entry) from the failure path
 /// (→ recovery re-entry, prompt-selected on `synth_ack_emitted`).
+//
+// `large_enum_variant`: the `Failed` variant carries a
+// [`SpawnOnlyFailureSignal`], which holds a `serde_json::Value`
+// (`tool_input`). When any workspace crate enables serde_json's
+// `preserve_order` feature (the `octos acp` bridge's `agent-client-protocol`
+// dependency requires it, and Cargo unifies features workspace-wide),
+// `Value::Object` switches from `BTreeMap` to `IndexMap` and the struct grows
+// past the lint's threshold. Boxing the payload here would ripple through the
+// `pub` API and every match site for a terminal (cold) event; the size
+// difference is immaterial on this non-hot path, so we allow it instead.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TerminalOutcome {
     /// Task reached `Completed`. Drives the autonomous `ChildCompleted`

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -1222,8 +1222,9 @@ impl ToolRegistry {
             .add_base_tools(names);
     }
 
-    /// Record that a tool was used (called from execute()).
-    fn record_usage(&self, name: &str) {
+    /// Record that a tool was used. Called from `execute()`; public so tool
+    /// lifecycle (alongside `tick`/`auto_evict`) can be driven in tests.
+    pub fn record_usage(&self, name: &str) {
         self.lifecycle
             .lock()
             .unwrap_or_else(|e| e.into_inner())

--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -71,6 +71,12 @@ base64 = { workspace = true }
 # `octos_agent::workspace_policy::WorkspacePolicy` as the canonical schema
 # and only needs the `toml` deserializer entry point here.
 toml = { workspace = true }
+# `octos acp` speaks the Agent Client Protocol (Zed editor <-> agent standard)
+# over stdio. The official Rust SDK provides the JSON-RPC framing, the schema
+# types (initialize/session-new/prompt/cancel + session/update notifications),
+# and the connection runtime; `acp.rs` implements the agent side on top of the
+# existing octos agent loop. Pinned to the published 1.2.0 line.
+agent-client-protocol = "1.2.0"
 keyring = { workspace = true }
 flate2 = { workspace = true }
 tar = { workspace = true }

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -1478,17 +1478,19 @@ mod tests {
         // ("done") must NOT be persisted into history, so the fresh second turn's
         // chat() must not see it. Without the `!cancelled` guard, the partial
         // reply leaks into the next prompt's context.
+        //
+        // Select the fresh turn by the "second" user prompt it carries — a
+        // cancelled first turn may retry (stream fallback while the shutdown flag
+        // is set), so it is NOT necessarily snapshot index 1 (codex round-4).
         let snapshots = seen.lock().await;
+        let fresh = snapshots
+            .iter()
+            .find(|snap| snap.iter().any(|c| c.contains("second")))
+            .expect("the fresh second prompt must have reached the LLM");
         assert!(
-            snapshots.len() >= 2,
-            "both turns reached the LLM: {} calls",
-            snapshots.len()
-        );
-        assert!(
-            !snapshots[1].iter().any(|c| c.contains("done")),
+            !fresh.iter().any(|c| c.contains("done")),
             "the cancelled turn's aborted assistant reply must NOT persist into the \
-             next prompt's history; turn-2 messages: {:?}",
-            snapshots[1]
+             fresh prompt's history; fresh-turn messages: {fresh:?}"
         );
     }
 }

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -594,6 +594,23 @@ impl SessionAgentFactory for ConfigAgentFactory {
     }
 
     async fn build(&self, cwd: PathBuf) -> Result<(Arc<Agent>, Arc<AtomicBool>)> {
+        // Normalize the client-supplied cwd (resolve `..` + symlinks) up front so
+        // the per-cwd cache key is stable and the session scope's `..`-rejecting
+        // resolvers accept normal relative reads like `read_file("Cargo.toml")`
+        // (codex P2). Falls back to an absolutized path if the dir doesn't exist.
+        let cwd = match std::fs::canonicalize(&cwd) {
+            Ok(c) => c,
+            Err(_) => {
+                if cwd.is_absolute() {
+                    cwd
+                } else if let Ok(d) = std::env::current_dir() {
+                    d.join(&cwd)
+                } else {
+                    cwd
+                }
+            }
+        };
+
         // Process-global stores (provider chain, redb episode store, memory) built
         // once, lazily, on the first session.
         let shared = self
@@ -639,20 +656,15 @@ impl SessionAgentFactory for ConfigAgentFactory {
 
         // Per-session filesystem scope (codex P1): contain file tools + plugins to
         // cwd, with skill read-zones so `read_file` reaches SKILL.md references.
-        let absolute_cwd = if cwd.is_absolute() {
-            cwd.clone()
-        } else {
-            std::env::current_dir()
-                .map(|d| d.join(&cwd))
-                .unwrap_or_else(|_| cwd.clone())
-        };
-        let session_scope = SessionScope::solo(absolute_cwd.clone(), Vec::new())
+        // `cwd` is already normalized above, so the scope's resolvers accept
+        // relative reads.
+        let session_scope = SessionScope::solo(cwd.clone(), Vec::new())
             .ok()
             .map(|base| {
                 base.with_skill_read_zones(b.skill_read_zones.clone())
                     .unwrap_or_else(|_| {
-                        SessionScope::solo(absolute_cwd.clone(), Vec::new())
-                            .expect("absolutized cwd is valid")
+                        SessionScope::solo(cwd.clone(), Vec::new())
+                            .expect("normalized cwd is valid")
                     })
             });
 

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -1,0 +1,1048 @@
+//! `octos acp`: run octos as an [Agent Client Protocol][acp] (ACP) agent over
+//! stdin/stdout so ACP clients (Zed, and other editors/CLIs that speak ACP) can
+//! drive the octos agent loop.
+//!
+//! [acp]: https://agentclientprotocol.com/
+//!
+//! ## Shape
+//!
+//! The official `agent-client-protocol` crate (v1.2.0) does **not** expose a
+//! single "implement these methods" trait. Instead you build an
+//! [`agent_client_protocol::Agent`] role via its builder, registering one
+//! `on_receive_request` / `on_receive_notification` handler per ACP message
+//! type, then hand the builder a stdio transport and let its runtime drive the
+//! JSON-RPC framing:
+//!
+//! ```ignore
+//! Agent.builder()
+//!     .on_receive_request(handle_initialize, on_receive_request!())
+//!     .on_receive_request(handle_new_session, on_receive_request!())
+//!     .on_receive_request(handle_prompt, on_receive_request!())
+//!     .on_receive_notification(handle_cancel, on_receive_notification!())
+//!     .connect_to(Stdio::new())
+//!     .await
+//! ```
+//!
+//! Dispatch is by the request's Rust type: registering a handler for
+//! [`InitializeRequest`] wires the `"initialize"` method, `NewSessionRequest`
+//! wires `"session/new"`, `PromptRequest` wires `"session/prompt"`,
+//! `CancelNotification` wires the `"session/cancel"` notification, and so on.
+//!
+//! Each handler receives a `Responder<Resp>` (call `.respond(resp)` to reply)
+//! and a `ConnectionTo<Client>` (`cx`) on which we push streaming
+//! [`SessionNotification`]s (`session/update`) back to the client.
+//!
+//! ## Bridge
+//!
+//! `new_session` builds a real octos [`Agent`] (LLM provider + a
+//! [`ToolRegistry`] rooted at the requested cwd + episodic memory) and stores
+//! it in a session map keyed by the ACP [`SessionId`]. `prompt` extracts the
+//! text from the ACP content blocks, runs [`Agent::process_message`] with an
+//! [`AcpProgressReporter`] that forwards each [`ProgressEvent`] to the client as
+//! a `session/update`, and returns the ACP [`StopReason`].
+//!
+//! Cancellation: the prompt turn runs in a task spawned off the dispatch loop
+//! (`ConnectionTo::spawn`) so an interleaved `session/cancel` notification is
+//! processed WHILE the turn is in flight. `session/cancel` flips the agent's
+//! shared `Arc<AtomicBool>` shutdown flag (wired via `Agent::with_shutdown`),
+//! which aborts the running loop at its next checkpoint; the turn then responds
+//! with [`StopReason::Cancelled`].
+//!
+//! Permissions: octos runs its own tools through its own approval path; we
+//! surface them to the client as ACP `tool_call` / `tool_call_update` records
+//! but do not block on ACP `session/request_permission` in v1.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use clap::Args;
+use eyre::{Result, WrapErr};
+
+use agent_client_protocol::schema::v1::{
+    AgentCapabilities, CancelNotification, ContentBlock, ContentChunk, InitializeRequest,
+    InitializeResponse, LoadSessionRequest, LoadSessionResponse, NewSessionRequest,
+    NewSessionResponse, PromptCapabilities, PromptRequest, PromptResponse, SessionId,
+    SessionNotification, SessionUpdate, StopReason, ToolCall, ToolCallContent, ToolCallStatus,
+    ToolCallUpdate, ToolCallUpdateFields,
+};
+use agent_client_protocol::{
+    Agent as AcpAgentRole, Client, ConnectionTo, Error as AcpError, Stdio, on_receive_notification,
+    on_receive_request,
+};
+
+use octos_agent::{
+    Agent, AgentConfig, ProgressEvent, ProgressReporter, ToolRegistry, create_sandbox,
+};
+use octos_core::AgentId;
+use octos_llm::{LlmProvider, RetryProvider};
+use octos_memory::EpisodeStore;
+use tokio::sync::Mutex;
+
+use super::Executable;
+use crate::config::Config;
+
+/// Run octos as an ACP (Agent Client Protocol) agent over stdin/stdout.
+///
+/// ACP clients (Zed and other editors) spawn this process and drive it via
+/// JSON-RPC on stdio. Provider/model/profile flags mirror `octos chat` so the
+/// ACP agent resolves an LLM the same way.
+#[derive(Debug, Args)]
+pub struct AcpCommand {
+    /// Working directory the agent's tools are rooted at (defaults to the
+    /// current directory). Note: ACP clients also send a `cwd` with
+    /// `session/new`; that per-session value takes precedence when present.
+    #[arg(short, long)]
+    pub cwd: Option<PathBuf>,
+
+    /// Data directory for episodes/memory (defaults to $OCTOS_HOME or ~/.octos).
+    #[arg(long)]
+    pub data_dir: Option<PathBuf>,
+
+    /// Path to config file.
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+
+    /// LLM provider to use (overrides config).
+    #[arg(long)]
+    pub provider: Option<String>,
+
+    /// Model to use (overrides config).
+    #[arg(long)]
+    pub model: Option<String>,
+
+    /// Custom base URL for the API endpoint (overrides config).
+    #[arg(long)]
+    pub base_url: Option<String>,
+
+    /// Maximum tool-call iterations per prompt turn.
+    #[arg(long, default_value = "20")]
+    pub max_iterations: u32,
+
+    /// Runtime profile hint (accepted for parity with `octos chat`; the ACP
+    /// bridge builds a minimal agent and does not apply profile tool filters).
+    #[arg(long)]
+    pub profile: Option<String>,
+}
+
+impl Executable for AcpCommand {
+    fn execute(self) -> Result<()> {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .thread_stack_size(8 * 1024 * 1024) // deep agent futures need a big stack
+            .build()
+            .wrap_err("failed to create tokio runtime")?
+            .block_on(self.run_async())
+    }
+}
+
+/// Everything a spawned prompt turn needs, shared behind the session map.
+struct AcpSession {
+    agent: Arc<Agent>,
+    /// Conversation history accumulated across prompt turns in this session.
+    history: Mutex<Vec<octos_core::Message>>,
+    /// Flipped to `true` by a `session/cancel` notification; the agent's
+    /// shutdown flag is shared so the in-flight loop aborts.
+    shutdown: Arc<AtomicBool>,
+}
+
+/// Builds a fresh octos [`Agent`] per ACP `session/new`.
+///
+/// A trait (rather than a concrete type) so the integration test can inject a
+/// `MockLlm`-backed agent without a real provider/config, while production uses
+/// [`ConfigAgentFactory`] which resolves an LLM exactly like `octos chat`.
+#[async_trait::async_trait]
+trait SessionAgentFactory: Send + Sync {
+    /// The cwd to fall back to when the client sends an empty `session/new` cwd.
+    fn default_cwd(&self) -> &std::path::Path;
+
+    /// Build a runnable agent rooted at `cwd`, returning it plus the shared
+    /// shutdown flag wired into it (flipped on `session/cancel`).
+    async fn build(&self, cwd: PathBuf) -> Result<(Arc<Agent>, Arc<AtomicBool>)>;
+}
+
+/// Production agent factory: resolves the LLM provider + tools + memory the same
+/// way `octos chat` does, minus the profile/plugin/pipeline bootstrap so the ACP
+/// entrypoint stays self-contained.
+struct ConfigAgentFactory {
+    config: Config,
+    provider_name: String,
+    model: Option<String>,
+    base_url: Option<String>,
+    data_dir: PathBuf,
+    default_cwd: PathBuf,
+    max_iterations: u32,
+}
+
+#[async_trait::async_trait]
+impl SessionAgentFactory for ConfigAgentFactory {
+    fn default_cwd(&self) -> &std::path::Path {
+        &self.default_cwd
+    }
+
+    async fn build(&self, cwd: PathBuf) -> Result<(Arc<Agent>, Arc<AtomicBool>)> {
+        // Provider resolution mirrors `chat.rs`: base provider -> RetryProvider.
+        let base_provider: Arc<dyn LlmProvider> = super::chat::create_provider(
+            &self.provider_name,
+            &self.config,
+            self.model.clone(),
+            self.base_url.clone(),
+        )?;
+        let llm: Arc<dyn LlmProvider> = Arc::new(RetryProvider::new(base_provider));
+
+        let memory = Arc::new(
+            EpisodeStore::open(&self.data_dir)
+                .await
+                .wrap_err("failed to open episode store")?,
+        );
+
+        let sandbox = create_sandbox(&self.config.sandbox);
+        let tools = ToolRegistry::with_builtins_and_sandbox(&cwd, sandbox);
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let agent = Agent::new(AgentId::new("acp"), llm, tools, memory)
+            .with_config(AgentConfig {
+                max_iterations: self.max_iterations,
+                ..AgentConfig::default()
+            })
+            .with_shutdown(shutdown.clone());
+
+        Ok((Arc::new(agent), shutdown))
+    }
+}
+
+/// Map of ACP session id -> live octos session.
+type SessionMap = Arc<Mutex<HashMap<SessionId, Arc<AcpSession>>>>;
+
+/// Assemble the ACP [`Agent`](AcpAgentRole) builder with all handlers wired and
+/// drive it over `transport` until the connection closes.
+///
+/// Production passes [`Stdio::new()`]; the integration test passes an in-process
+/// client [`Builder`](agent_client_protocol::Builder) (which implements
+/// `ConnectTo<Agent>`), so the same handler wiring is exercised without any OS
+/// pipes or subprocess.
+async fn spawn_acp_agent(
+    factory: Arc<dyn SessionAgentFactory>,
+    sessions: SessionMap,
+    transport: impl agent_client_protocol::ConnectTo<AcpAgentRole> + 'static,
+) -> std::result::Result<(), AcpError> {
+    let factory_for_new = factory.clone();
+    let sessions_for_new = sessions.clone();
+    let sessions_for_prompt = sessions.clone();
+    let sessions_for_cancel = sessions;
+
+    AcpAgentRole
+        .builder()
+        .name("octos-acp")
+        // initialize: advertise capabilities.
+        .on_receive_request(
+            async move |req: InitializeRequest, responder, _cx: ConnectionTo<Client>| {
+                responder.respond(build_initialize_response(&req))
+            },
+            on_receive_request!(),
+        )
+        // authenticate: octos auth is env/config-key based; no interactive auth.
+        // We advertise zero auth methods at initialize, so a spec-abiding client
+        // never calls this; if one does, succeed.
+        .on_receive_request(
+            async move |_req: agent_client_protocol::schema::v1::AuthenticateRequest,
+                        responder,
+                        _cx: ConnectionTo<Client>| {
+                responder.respond(agent_client_protocol::schema::v1::AuthenticateResponse::new())
+            },
+            on_receive_request!(),
+        )
+        // session/new: build an octos agent rooted at the client's cwd.
+        .on_receive_request(
+            async move |req: NewSessionRequest, responder, _cx: ConnectionTo<Client>| {
+                match handle_new_session(factory_for_new.as_ref(), &sessions_for_new, req).await {
+                    Ok(resp) => responder.respond(resp),
+                    Err(err) => responder.respond_with_error(err),
+                }
+            },
+            on_receive_request!(),
+        )
+        // session/prompt: run a turn, stream session/update, return stop reason.
+        // The turn runs in a spawned task (off the dispatch loop) so an
+        // interleaved `session/cancel` notification can be processed WHILE the
+        // turn is in flight; the `responder` is moved into that task and fires
+        // when the turn actually completes.
+        .on_receive_request(
+            async move |req: PromptRequest,
+                        responder: agent_client_protocol::Responder<PromptResponse>,
+                        cx: ConnectionTo<Client>| {
+                handle_prompt(&sessions_for_prompt, req, cx, responder)
+            },
+            on_receive_request!(),
+        )
+        // session/cancel: abort the in-flight turn for that session.
+        .on_receive_notification(
+            async move |notif: CancelNotification, _cx: ConnectionTo<Client>| {
+                handle_cancel(&sessions_for_cancel, notif).await;
+                Ok(())
+            },
+            on_receive_notification!(),
+        )
+        .connect_to(transport)
+        .await
+}
+
+/// Test-support factory that wraps a caller-supplied [`LlmProvider`] (e.g. a
+/// `MockLlm`) so the end-to-end ACP integration test can drive the real handler
+/// wiring without a network-backed provider or on-disk config.
+///
+/// Not for production use — production goes through [`ConfigAgentFactory`].
+#[doc(hidden)]
+pub struct TestAgentFactory {
+    llm: Arc<dyn LlmProvider>,
+    memory_dir: PathBuf,
+    default_cwd: PathBuf,
+}
+
+#[doc(hidden)]
+impl TestAgentFactory {
+    /// Build a factory that hands every session an agent backed by `llm`, with
+    /// episodic memory in `memory_dir` and tools rooted at `default_cwd`.
+    pub fn new(llm: Arc<dyn LlmProvider>, memory_dir: PathBuf, default_cwd: PathBuf) -> Self {
+        Self {
+            llm,
+            memory_dir,
+            default_cwd,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl SessionAgentFactory for TestAgentFactory {
+    fn default_cwd(&self) -> &std::path::Path {
+        &self.default_cwd
+    }
+
+    async fn build(&self, cwd: PathBuf) -> Result<(Arc<Agent>, Arc<AtomicBool>)> {
+        let memory = Arc::new(EpisodeStore::open(&self.memory_dir).await?);
+        let tools = ToolRegistry::with_builtins_and_sandbox(
+            &cwd,
+            create_sandbox(&octos_agent::SandboxConfig::default()),
+        );
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let agent = Agent::new(AgentId::new("acp-test"), self.llm.clone(), tools, memory)
+            .with_shutdown(shutdown.clone());
+        Ok((Arc::new(agent), shutdown))
+    }
+}
+
+/// Test-support transport: the octos ACP **agent** exposed as a
+/// `ConnectTo<Client>` so an in-process ACP client can use it directly as its
+/// transport (no OS pipes, no subprocess, no network).
+///
+/// The `agent-client-protocol` runtime treats one endpoint as the "transport"
+/// for the other; the agent side is `ConnectTo<Client>` (since `Client` is the
+/// `Agent` role's counterpart). The integration test does:
+///
+/// ```ignore
+/// Client.builder()
+///     .on_receive_notification(record_updates, ...)
+///     .connect_with(OctosAcpAgentTransport::new(factory), |conn| async {
+///         conn.send_request(InitializeRequest::new(V1)).block_task().await?;
+///         // session/new, session/prompt, assert stop reason ...
+///     })
+///     .await
+/// ```
+#[doc(hidden)]
+pub struct OctosAcpAgentTransport {
+    factory: TestAgentFactory,
+}
+
+#[doc(hidden)]
+impl OctosAcpAgentTransport {
+    /// Wrap a [`TestAgentFactory`] so it can serve one in-process ACP client.
+    pub fn new(factory: TestAgentFactory) -> Self {
+        Self { factory }
+    }
+}
+
+impl agent_client_protocol::ConnectTo<Client> for OctosAcpAgentTransport {
+    async fn connect_to(
+        self,
+        client: impl agent_client_protocol::ConnectTo<AcpAgentRole> + 'static,
+    ) -> std::result::Result<(), AcpError> {
+        let sessions: SessionMap = Arc::new(Mutex::new(HashMap::new()));
+        spawn_acp_agent(Arc::new(self.factory), sessions, client).await
+    }
+}
+
+impl AcpCommand {
+    async fn run_async(self) -> Result<()> {
+        // Resolve config the same way `octos chat` does.
+        let cwd = match &self.cwd {
+            Some(c) => c.clone(),
+            None => std::env::current_dir().wrap_err("failed to get current directory")?,
+        };
+        let ctx = super::resolve_command_context(self.data_dir.clone())?;
+        let data_dir = ctx.data_dir.clone();
+        let config = if let Some(config_path) = &self.config {
+            Config::from_file(config_path)?
+        } else {
+            Config::load_with_context(&cwd, &ctx)?
+        };
+
+        let model = self.model.clone().or(config.model.clone());
+        let base_url = self.base_url.clone().or(config.base_url.clone());
+        let provider_name = self
+            .provider
+            .clone()
+            .or(config.provider.clone())
+            .or_else(|| {
+                model
+                    .as_deref()
+                    .and_then(crate::config::detect_provider)
+                    .map(String::from)
+            })
+            .ok_or_else(|| {
+                eyre::eyre!(
+                    "no LLM provider configured. Run `octos init` or set provider in config.json"
+                )
+            })?;
+
+        let factory: Arc<dyn SessionAgentFactory> = Arc::new(ConfigAgentFactory {
+            config,
+            provider_name,
+            model,
+            base_url,
+            data_dir,
+            default_cwd: cwd,
+            max_iterations: self.max_iterations,
+        });
+
+        let sessions: SessionMap = Arc::new(Mutex::new(HashMap::new()));
+
+        // Drive the ACP agent over stdio until the client disconnects.
+        spawn_acp_agent(factory, sessions, Stdio::new())
+            .await
+            .map_err(|e| eyre::eyre!("ACP connection ended with error: {e}"))
+    }
+}
+
+/// Build the `initialize` response advertising octos's agent capabilities.
+///
+/// Echoes the client's requested protocol version (per ACP the agent replies
+/// with a version it supports; we mirror V1's behaviour by echoing the client
+/// version, which the crate's `InitializeResponse::new` takes directly).
+fn build_initialize_response(req: &InitializeRequest) -> InitializeResponse {
+    // Prompt capabilities: octos consumes plain text prompt blocks today.
+    // Image/audio/embedded-context are left false (v1 extracts text only).
+    let prompt = PromptCapabilities::new();
+    let caps = AgentCapabilities::new()
+        // We accept `session/load` no better than `session/new` today, so do
+        // NOT advertise loadSession (leave it false / default).
+        .prompt_capabilities(prompt);
+    InitializeResponse::new(req.protocol_version).agent_capabilities(caps)
+}
+
+/// Handle `session/new`: build a fresh octos agent and register it.
+async fn handle_new_session(
+    factory: &dyn SessionAgentFactory,
+    sessions: &SessionMap,
+    req: NewSessionRequest,
+) -> std::result::Result<NewSessionResponse, AcpError> {
+    // MCP servers requested by the client are ignored in v1 (logged only).
+    if !req.mcp_servers.is_empty() {
+        tracing::info!(
+            count = req.mcp_servers.len(),
+            "ACP session/new requested MCP servers; ignored in v1 (octos runs its own tools)"
+        );
+    }
+
+    let cwd = if req.cwd.as_os_str().is_empty() {
+        factory.default_cwd().to_path_buf()
+    } else {
+        req.cwd.clone()
+    };
+
+    let (agent, shutdown) = factory
+        .build(cwd)
+        .await
+        .map_err(|e| agent_client_protocol::util::internal_error(format!("build agent: {e}")))?;
+
+    let session_id = new_session_id();
+    let session = Arc::new(AcpSession {
+        agent,
+        history: Mutex::new(Vec::new()),
+        shutdown,
+    });
+    sessions.lock().await.insert(session_id.clone(), session);
+
+    Ok(NewSessionResponse::new(session_id))
+}
+
+/// Handle `session/prompt`: spawn a turn off the dispatch loop, stream
+/// `session/update`s to the client, and fire `responder` with the ACP stop
+/// reason once the turn completes.
+///
+/// Returns immediately (marking the request handled) so the dispatch loop stays
+/// free to process an interleaved `session/cancel` while the turn runs. The
+/// actual JSON-RPC response is sent from the spawned task via `responder`.
+fn handle_prompt(
+    sessions: &SessionMap,
+    req: PromptRequest,
+    cx: ConnectionTo<Client>,
+    responder: agent_client_protocol::Responder<PromptResponse>,
+) -> std::result::Result<(), AcpError> {
+    // Look up the session synchronously (try_lock avoids awaiting in the
+    // dispatch loop; the map is only briefly held by session/new + cancel).
+    let session = {
+        let map = match sessions.try_lock() {
+            Ok(map) => map,
+            // Contended (a session/new or cancel is mid-flight): fall back to a
+            // blocking lock inside the spawn instead. Rare; keep it simple by
+            // cloning the Arc<Mutex> and resolving in the task below.
+            Err(_) => {
+                let sessions = sessions.clone();
+                let session_id = req.session_id.clone();
+                return cx.clone().spawn(run_prompt_turn_deferred(
+                    sessions, session_id, req, cx, responder,
+                ));
+            }
+        };
+        map.get(&req.session_id).cloned()
+    };
+
+    let Some(session) = session else {
+        return responder.respond_with_error(agent_client_protocol::util::internal_error(format!(
+            "unknown session id: {}",
+            req.session_id.0
+        )));
+    };
+
+    cx.clone()
+        .spawn(run_prompt_turn(session, req, cx, responder))
+}
+
+/// Resolve the session from the map inside the spawned task (used only when the
+/// session map was contended at handler time), then run the turn.
+async fn run_prompt_turn_deferred(
+    sessions: SessionMap,
+    session_id: SessionId,
+    req: PromptRequest,
+    cx: ConnectionTo<Client>,
+    responder: agent_client_protocol::Responder<PromptResponse>,
+) -> std::result::Result<(), AcpError> {
+    let session = {
+        let map = sessions.lock().await;
+        map.get(&session_id).cloned()
+    };
+    match session {
+        Some(session) => run_prompt_turn(session, req, cx, responder).await,
+        None => responder.respond_with_error(agent_client_protocol::util::internal_error(format!(
+            "unknown session id: {}",
+            session_id.0
+        ))),
+    }
+}
+
+/// The actual prompt turn: attach a streaming reporter, run the octos agent
+/// loop, persist history, and respond with the ACP stop reason.
+async fn run_prompt_turn(
+    session: Arc<AcpSession>,
+    req: PromptRequest,
+    cx: ConnectionTo<Client>,
+    responder: agent_client_protocol::Responder<PromptResponse>,
+) -> std::result::Result<(), AcpError> {
+    // Fresh turn: clear any stale cancel flag from a previous cancelled turn.
+    session.shutdown.store(false, Ordering::Release);
+
+    let user_text = extract_prompt_text(&req.prompt);
+    let history = { session.history.lock().await.clone() };
+
+    // Attach a per-turn reporter that streams `session/update` to this client.
+    // `set_reporter` takes `&self` (RwLock interior mutability) precisely so the
+    // agent can stay behind an `Arc` across turns.
+    let reporter: Arc<dyn ProgressReporter> =
+        Arc::new(AcpProgressReporter::new(req.session_id.clone(), cx));
+    session.agent.set_reporter(reporter);
+
+    let outcome = session
+        .agent
+        .process_message(&user_text, &history, vec![])
+        .await;
+
+    let cancelled = session.shutdown.load(Ordering::Acquire);
+    let response = match outcome {
+        Ok(resp) => {
+            // Persist the full turn (user + assistant + tool messages) so the
+            // next prompt sees the context.
+            {
+                let mut h = session.history.lock().await;
+                *h = resp.messages.clone();
+            }
+            // Distinguish a client-driven cancel from a natural end-of-turn.
+            let stop_reason = if cancelled {
+                StopReason::Cancelled
+            } else {
+                StopReason::EndTurn
+            };
+            PromptResponse::new(stop_reason)
+        }
+        Err(err) => {
+            // If the turn ended because we were cancelled, report Cancelled
+            // rather than surfacing an error frame.
+            if cancelled {
+                PromptResponse::new(StopReason::Cancelled)
+            } else {
+                return responder.respond_with_error(agent_client_protocol::util::internal_error(
+                    format!("prompt turn failed: {err}"),
+                ));
+            }
+        }
+    };
+    responder.respond(response)
+}
+
+/// Handle `session/cancel`: abort the in-flight turn for the given session.
+///
+/// octos exposes a shared `Arc<AtomicBool>` shutdown flag on the agent (set via
+/// `Agent::with_shutdown`); flipping it aborts the running loop at its next
+/// checkpoint. Unknown session ids are ignored (the client may race a cancel
+/// against session teardown).
+async fn handle_cancel(sessions: &SessionMap, notif: CancelNotification) {
+    let map = sessions.lock().await;
+    if let Some(session) = map.get(&notif.session_id) {
+        session.shutdown.store(true, Ordering::Release);
+        tracing::info!(session_id = %notif.session_id.0, "ACP session/cancel: aborting turn");
+    } else {
+        tracing::debug!(
+            session_id = %notif.session_id.0,
+            "ACP session/cancel for unknown session; ignoring"
+        );
+    }
+}
+
+/// Handle `session/load` — NOT supported in v1: octos does not persist ACP
+/// sessions across process restarts. Kept as a documented stub so the intent is
+/// explicit; not wired into the builder (an unregistered method returns
+/// `method_not_found` automatically).
+#[allow(dead_code)]
+fn handle_load_session_unsupported(
+    _req: LoadSessionRequest,
+) -> std::result::Result<LoadSessionResponse, AcpError> {
+    Err(AcpError::method_not_found())
+}
+
+/// Generate a fresh, unique ACP session id.
+fn new_session_id() -> SessionId {
+    SessionId::new(format!("octos-{}", uuid::Uuid::new_v4()))
+}
+
+/// Extract the plain text from a prompt's ACP content blocks.
+///
+/// octos's agent loop consumes a single text prompt; we concatenate the text of
+/// every `ContentBlock::Text` (and the text payload of embedded text
+/// resources), joining multiple blocks with newlines. Non-text blocks (image,
+/// audio, resource links) are skipped in v1 — we advertise text-only prompt
+/// capabilities at `initialize`.
+fn extract_prompt_text(blocks: &[ContentBlock]) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    for block in blocks {
+        match block {
+            ContentBlock::Text(t) => parts.push(t.text.clone()),
+            ContentBlock::Resource(r) => {
+                if let agent_client_protocol::schema::v1::EmbeddedResourceResource::TextResourceContents(tr) =
+                    &r.resource
+                {
+                    parts.push(tr.text.clone());
+                }
+            }
+            // Non-text blocks (image, audio, resource links) and any future
+            // variants are not consumed by the text-only agent loop. `ContentBlock`
+            // is `#[non_exhaustive]`, so a catch-all is required.
+            _ => {}
+        }
+    }
+    parts.join("\n")
+}
+
+/// Translate a single octos [`ProgressEvent`] into the ACP [`SessionUpdate`]
+/// that should be streamed to the client, or `None` if the event has no ACP
+/// projection.
+///
+/// This is the pure, side-effect-free core of the streaming bridge — unit
+/// tested without any live connection.
+///
+/// Mapping:
+/// - `StreamChunk` / `Response`   -> `AgentMessageChunk` (assistant text)
+/// - `ReasoningChunk`             -> `AgentThoughtChunk` (thinking)
+/// - `ToolStarted`                -> `ToolCall` (status = InProgress)
+/// - `ToolCompleted`              -> `ToolCallUpdate` (Completed/Failed + output)
+/// - everything else              -> `None`
+pub(crate) fn progress_event_to_acp(event: &ProgressEvent) -> Option<SessionUpdate> {
+    match event {
+        ProgressEvent::StreamChunk { text, .. } => Some(SessionUpdate::AgentMessageChunk(
+            ContentChunk::new(ContentBlock::from(text.clone())),
+        )),
+        ProgressEvent::Response { content, .. } => Some(SessionUpdate::AgentMessageChunk(
+            ContentChunk::new(ContentBlock::from(content.clone())),
+        )),
+        ProgressEvent::ReasoningChunk { text, .. } => Some(SessionUpdate::AgentThoughtChunk(
+            ContentChunk::new(ContentBlock::from(text.clone())),
+        )),
+        ProgressEvent::ToolStarted { name, tool_id } => {
+            let call = ToolCall::new(tool_id.clone(), name.clone())
+                .kind(tool_kind_for(name))
+                .status(ToolCallStatus::InProgress);
+            Some(SessionUpdate::ToolCall(call))
+        }
+        ProgressEvent::ToolCompleted {
+            tool_id,
+            success,
+            output_preview,
+            ..
+        } => {
+            let status = if *success {
+                ToolCallStatus::Completed
+            } else {
+                ToolCallStatus::Failed
+            };
+            let mut fields = ToolCallUpdateFields::new().status(status);
+            if !output_preview.is_empty() {
+                let content: ToolCallContent =
+                    ToolCallContent::from(ContentBlock::from(output_preview.clone()));
+                fields = fields.content(vec![content]);
+            }
+            Some(SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+                tool_id.clone(),
+                fields,
+            )))
+        }
+        // No ACP projection: lifecycle/bookkeeping/token/cost events.
+        _ => None,
+    }
+}
+
+/// Best-effort mapping from an octos tool name to an ACP [`ToolKind`] so clients
+/// can render an appropriate icon. Unknown tools fall back to `Other`.
+fn tool_kind_for(name: &str) -> agent_client_protocol::schema::v1::ToolKind {
+    use agent_client_protocol::schema::v1::ToolKind;
+    match name {
+        "read_file" | "list_dir" => ToolKind::Read,
+        "write_file" | "edit_file" => ToolKind::Edit,
+        "glob" | "grep" => ToolKind::Search,
+        "shell" => ToolKind::Execute,
+        "web_search" | "web_fetch" => ToolKind::Fetch,
+        _ => ToolKind::Other,
+    }
+}
+
+/// A [`ProgressReporter`] that forwards octos agent progress to an ACP client as
+/// `session/update` notifications on the connection.
+///
+/// The translation itself lives in [`progress_event_to_acp`]; this type just
+/// wraps it with the connection handle and session id and fires the
+/// notification (best-effort — a send failure is logged, never fatal to the
+/// turn).
+struct AcpProgressReporter {
+    session_id: SessionId,
+    cx: ConnectionTo<Client>,
+    /// Whether any streaming `StreamChunk` was already forwarded this turn. The
+    /// agent loop emits streaming deltas AND a final full `Response` carrying the
+    /// same text; forwarding both makes an ACP client render the assistant
+    /// message twice, so once we've streamed, the final `Response` is dropped.
+    streamed: std::sync::atomic::AtomicBool,
+}
+
+impl AcpProgressReporter {
+    fn new(session_id: SessionId, cx: ConnectionTo<Client>) -> Self {
+        Self {
+            session_id,
+            cx,
+            streamed: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+}
+
+impl ProgressReporter for AcpProgressReporter {
+    fn report(&self, event: ProgressEvent) {
+        if let Some(update) = project_progress_event_deduped(&event, &self.streamed) {
+            let notif = SessionNotification::new(self.session_id.clone(), update);
+            if let Err(err) = self.cx.send_notification(notif) {
+                tracing::warn!(error = %err, "failed to send ACP session/update");
+            }
+        }
+    }
+}
+
+/// Stateful wrapper over [`progress_event_to_acp`] that de-duplicates assistant
+/// text: a `StreamChunk` marks the turn as streamed; a subsequent full
+/// `Response` (which repeats the streamed text) is then dropped so ACP clients
+/// don't render the message twice. A `Response` with NO prior streaming (a
+/// non-streaming provider) is still forwarded. `streamed` is per-turn (the
+/// reporter is constructed per prompt).
+pub(crate) fn project_progress_event_deduped(
+    event: &ProgressEvent,
+    streamed: &std::sync::atomic::AtomicBool,
+) -> Option<SessionUpdate> {
+    use std::sync::atomic::Ordering;
+    match event {
+        ProgressEvent::StreamChunk { .. } => streamed.store(true, Ordering::Relaxed),
+        ProgressEvent::Response { .. } if streamed.load(Ordering::Relaxed) => return None,
+        _ => {}
+    }
+    progress_event_to_acp(event)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agent_client_protocol::schema::ProtocolVersion;
+    use octos_agent::SilentReporter;
+    use std::time::Duration;
+
+    fn text_of_chunk(update: &SessionUpdate) -> Option<&str> {
+        match update {
+            SessionUpdate::AgentMessageChunk(c) | SessionUpdate::AgentThoughtChunk(c) => {
+                match &c.content {
+                    ContentBlock::Text(t) => Some(&t.text),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn should_map_stream_chunk_to_agent_message_chunk_when_streaming_text() {
+        let ev = ProgressEvent::StreamChunk {
+            text: "hello world".into(),
+            iteration: 1,
+        };
+        let update = progress_event_to_acp(&ev).expect("stream chunk maps to an update");
+        assert!(matches!(update, SessionUpdate::AgentMessageChunk(_)));
+        assert_eq!(text_of_chunk(&update), Some("hello world"));
+    }
+
+    #[test]
+    fn should_map_response_to_agent_message_chunk_when_non_streamed() {
+        let ev = ProgressEvent::Response {
+            content: "final answer".into(),
+            iteration: 1,
+        };
+        let update = progress_event_to_acp(&ev).expect("response maps to an update");
+        assert!(matches!(update, SessionUpdate::AgentMessageChunk(_)));
+        assert_eq!(text_of_chunk(&update), Some("final answer"));
+    }
+
+    #[test]
+    fn should_drop_final_response_when_text_was_already_streamed() {
+        // Live-test regression: the agent loop emits streaming deltas AND a final
+        // full `Response` with the same text. Forwarding both doubles the message
+        // in an ACP client. Once a StreamChunk is seen, the trailing Response is
+        // dropped; a Response with no prior streaming is still forwarded.
+        use std::sync::atomic::AtomicBool;
+        let streamed = AtomicBool::new(false);
+
+        let chunk = ProgressEvent::StreamChunk {
+            text: "final answer".into(),
+            iteration: 1,
+        };
+        assert!(
+            matches!(
+                project_progress_event_deduped(&chunk, &streamed),
+                Some(SessionUpdate::AgentMessageChunk(_))
+            ),
+            "stream chunk is forwarded and marks the turn streamed"
+        );
+
+        let response = ProgressEvent::Response {
+            content: "final answer".into(),
+            iteration: 1,
+        };
+        assert!(
+            project_progress_event_deduped(&response, &streamed).is_none(),
+            "the duplicate final Response must be dropped after streaming"
+        );
+
+        // A Response with NO prior streaming (non-streaming provider) still emits.
+        let fresh = AtomicBool::new(false);
+        assert!(
+            matches!(
+                project_progress_event_deduped(&response, &fresh),
+                Some(SessionUpdate::AgentMessageChunk(_))
+            ),
+            "a Response without prior streaming is forwarded"
+        );
+    }
+
+    #[test]
+    fn should_map_reasoning_chunk_to_agent_thought_chunk_when_thinking() {
+        let ev = ProgressEvent::ReasoningChunk {
+            text: "let me think".into(),
+            iteration: 2,
+        };
+        let update = progress_event_to_acp(&ev).expect("reasoning maps to a thought update");
+        assert!(matches!(update, SessionUpdate::AgentThoughtChunk(_)));
+        assert_eq!(text_of_chunk(&update), Some("let me think"));
+    }
+
+    #[test]
+    fn should_map_tool_started_to_tool_call_in_progress_when_tool_begins() {
+        let ev = ProgressEvent::ToolStarted {
+            name: "shell".into(),
+            tool_id: "call-1".into(),
+        };
+        let update = progress_event_to_acp(&ev).expect("tool start maps to a tool call");
+        match update {
+            SessionUpdate::ToolCall(call) => {
+                assert_eq!(call.tool_call_id.0.as_ref(), "call-1");
+                assert_eq!(call.title, "shell");
+                assert!(matches!(call.status, ToolCallStatus::InProgress));
+                assert!(matches!(
+                    call.kind,
+                    agent_client_protocol::schema::v1::ToolKind::Execute
+                ));
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_map_tool_completed_success_to_completed_update_with_output() {
+        let ev = ProgressEvent::ToolCompleted {
+            name: "read_file".into(),
+            tool_id: "call-2".into(),
+            success: true,
+            output_preview: "file contents".into(),
+            duration: Duration::from_millis(5),
+        };
+        let update = progress_event_to_acp(&ev).expect("tool completion maps to an update");
+        match update {
+            SessionUpdate::ToolCallUpdate(u) => {
+                assert_eq!(u.tool_call_id.0.as_ref(), "call-2");
+                assert!(matches!(u.fields.status, Some(ToolCallStatus::Completed)));
+                let content = u.fields.content.expect("output content present");
+                assert_eq!(content.len(), 1);
+                match &content[0] {
+                    ToolCallContent::Content(c) => match &c.content {
+                        ContentBlock::Text(t) => assert_eq!(t.text, "file contents"),
+                        other => panic!("expected text content, got {other:?}"),
+                    },
+                    other => panic!("expected Content variant, got {other:?}"),
+                }
+            }
+            other => panic!("expected ToolCallUpdate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_map_tool_completed_failure_to_failed_status() {
+        let ev = ProgressEvent::ToolCompleted {
+            name: "shell".into(),
+            tool_id: "call-3".into(),
+            success: false,
+            output_preview: String::new(),
+            duration: Duration::from_millis(1),
+        };
+        let update = progress_event_to_acp(&ev).expect("failed tool maps to an update");
+        match update {
+            SessionUpdate::ToolCallUpdate(u) => {
+                assert!(matches!(u.fields.status, Some(ToolCallStatus::Failed)));
+                // Empty output_preview must not emit a content vec.
+                assert!(u.fields.content.is_none());
+            }
+            other => panic!("expected ToolCallUpdate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_return_none_for_lifecycle_events_without_acp_projection() {
+        // A representative sample of events that must not stream to the client.
+        let cases = [
+            ProgressEvent::TaskStarted {
+                task_id: "t".into(),
+            },
+            ProgressEvent::Thinking { iteration: 1 },
+            ProgressEvent::TokenUsage {
+                input_tokens: 10,
+                output_tokens: 20,
+            },
+            ProgressEvent::StreamDone { iteration: 1 },
+            ProgressEvent::TaskCompleted {
+                success: true,
+                iterations: 1,
+                duration: Duration::from_millis(1),
+            },
+        ];
+        for ev in cases {
+            assert!(
+                progress_event_to_acp(&ev).is_none(),
+                "event {ev:?} must have no ACP projection"
+            );
+        }
+    }
+
+    #[test]
+    fn should_extract_and_join_text_blocks_when_prompt_has_multiple_blocks() {
+        use agent_client_protocol::schema::v1::{ImageContent, TextContent};
+        let blocks = vec![
+            ContentBlock::Text(TextContent::new("first line")),
+            // An image block must be skipped, not crash.
+            ContentBlock::Image(ImageContent::new("base64data", "image/png")),
+            ContentBlock::Text(TextContent::new("second line")),
+        ];
+        let text = extract_prompt_text(&blocks);
+        assert_eq!(text, "first line\nsecond line");
+    }
+
+    #[test]
+    fn should_extract_text_from_embedded_text_resource() {
+        use agent_client_protocol::schema::v1::{
+            EmbeddedResource, EmbeddedResourceResource, TextResourceContents,
+        };
+        let blocks = vec![ContentBlock::Resource(EmbeddedResource::new(
+            EmbeddedResourceResource::TextResourceContents(TextResourceContents::new(
+                "resource body",
+                "file:///tmp/x.txt",
+            )),
+        ))];
+        assert_eq!(extract_prompt_text(&blocks), "resource body");
+    }
+
+    #[test]
+    fn should_extract_from_string_convertible_block_via_from_impl() {
+        // The crate provides `From<Into<String>> for ContentBlock` (Text). This
+        // is the ergonomic path used by the reporter mapping above.
+        let block: ContentBlock = "just text".into();
+        assert_eq!(
+            extract_prompt_text(std::slice::from_ref(&block)),
+            "just text"
+        );
+    }
+
+    #[test]
+    fn should_build_initialize_response_echoing_protocol_version_and_advertising_text_prompt() {
+        let req = InitializeRequest::new(ProtocolVersion::V1);
+        let resp = build_initialize_response(&req);
+        assert_eq!(resp.protocol_version, ProtocolVersion::V1);
+        // Text-only prompt capabilities: image/audio/embedded_context all false.
+        assert!(!resp.agent_capabilities.prompt_capabilities.image);
+        assert!(!resp.agent_capabilities.prompt_capabilities.audio);
+        // We do not advertise loadSession in v1.
+        assert!(!resp.agent_capabilities.load_session);
+    }
+
+    #[test]
+    fn should_generate_unique_session_ids() {
+        let a = new_session_id();
+        let b = new_session_id();
+        assert_ne!(a.0, b.0, "session ids must be unique");
+        assert!(a.0.starts_with("octos-"));
+    }
+
+    /// A no-op reporter is a valid `ProgressReporter`; this pins that the
+    /// silent path (used when a turn runs without a live ACP connection, e.g.
+    /// in unit tests) compiles and does nothing.
+    #[test]
+    fn should_accept_silent_reporter_as_progress_reporter() {
+        let reporter: Arc<dyn ProgressReporter> = Arc::new(SilentReporter);
+        reporter.report(ProgressEvent::Thinking { iteration: 1 });
+    }
+}

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -609,7 +609,32 @@ async fn run_prompt_turn(
             // and the agent would forget context after the second prompt.
             {
                 let mut h = session.history.lock().await;
+                let assistant_reply = resp.content.clone();
                 h.extend(resp.messages);
+                // For a plain-text turn, `resp.messages` carries the user row but
+                // NOT the final assistant text (that is streamed live via
+                // `content`). Persist it explicitly so later prompts can refer
+                // back to what the agent SAID — mirroring the chat REPL, which
+                // also pushes `response.content` as an assistant message. Guard
+                // against double-append for turns where messages already ends
+                // with that assistant reply.
+                let already_persisted = matches!(
+                    h.last(),
+                    Some(last) if last.role == octos_core::MessageRole::Assistant && last.content == assistant_reply
+                );
+                if !assistant_reply.is_empty() && !already_persisted {
+                    h.push(octos_core::Message {
+                        role: octos_core::MessageRole::Assistant,
+                        content: assistant_reply,
+                        media: vec![],
+                        tool_calls: None,
+                        tool_call_id: None,
+                        reasoning_content: None,
+                        client_message_id: None,
+                        thread_id: None,
+                        timestamp: chrono::Utc::now(),
+                    });
+                }
             }
             // Distinguish a client-driven cancel from a natural end-of-turn.
             let stop_reason = if cancelled {

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -426,10 +426,15 @@ impl AcpCommand {
 
 /// Build the `initialize` response advertising octos's agent capabilities.
 ///
-/// Echoes the client's requested protocol version (per ACP the agent replies
-/// with a version it supports; we mirror V1's behaviour by echoing the client
-/// version, which the crate's `InitializeResponse::new` takes directly).
+/// Per ACP the agent must reply with a protocol version it actually supports —
+/// NOT whatever the client requested. This handler implements v1 only, so we
+/// echo the client's version only when it is a version we support (V1);
+/// otherwise (a newer/unknown version) we reply with the latest version we do
+/// support (`ProtocolVersion::LATEST`, currently V1) rather than falsely
+/// advertising support for the requested one.
 fn build_initialize_response(req: &InitializeRequest) -> InitializeResponse {
+    use agent_client_protocol::schema::ProtocolVersion;
+
     // Prompt capabilities: octos consumes plain text prompt blocks today.
     // Image/audio/embedded-context are left false (v1 extracts text only).
     let prompt = PromptCapabilities::new();
@@ -437,7 +442,13 @@ fn build_initialize_response(req: &InitializeRequest) -> InitializeResponse {
         // We accept `session/load` no better than `session/new` today, so do
         // NOT advertise loadSession (leave it false / default).
         .prompt_capabilities(prompt);
-    InitializeResponse::new(req.protocol_version).agent_capabilities(caps)
+
+    let negotiated = if req.protocol_version == ProtocolVersion::V1 {
+        req.protocol_version
+    } else {
+        ProtocolVersion::LATEST
+    };
+    InitializeResponse::new(negotiated).agent_capabilities(caps)
 }
 
 /// Handle `session/new`: build a fresh octos agent and register it.
@@ -515,6 +526,13 @@ fn handle_prompt(
         )));
     };
 
+    // Clear any stale cancel flag from a previous cancelled turn SYNCHRONOUSLY
+    // on the dispatch loop, before spawning the turn. The turn runs in a
+    // spawned task, so any `session/cancel` dispatched AFTER this handler
+    // returns (i.e. for THIS turn) must win — resetting here (not inside the
+    // spawned task) guarantees a later cancel's `store(true)` is not clobbered.
+    session.shutdown.store(false, Ordering::Release);
+
     cx.clone()
         .spawn(run_prompt_turn(session, req, cx, responder))
 }
@@ -533,7 +551,17 @@ async fn run_prompt_turn_deferred(
         map.get(&session_id).cloned()
     };
     match session {
-        Some(session) => run_prompt_turn(session, req, cx, responder).await,
+        Some(session) => {
+            // Reset the stale cancel flag before running the turn. This path is
+            // rare (taken only when the session map was contended at handler
+            // time), and unlike `handle_prompt` the reset here happens inside
+            // the spawned task rather than synchronously on the dispatch loop —
+            // so a `session/cancel` racing the very first poll could still be
+            // clobbered. Best-effort for the contended path; the common path
+            // (`handle_prompt`) resets synchronously and closes the race.
+            session.shutdown.store(false, Ordering::Release);
+            run_prompt_turn(session, req, cx, responder).await
+        }
         None => responder.respond_with_error(agent_client_protocol::util::internal_error(format!(
             "unknown session id: {}",
             session_id.0
@@ -549,9 +577,11 @@ async fn run_prompt_turn(
     cx: ConnectionTo<Client>,
     responder: agent_client_protocol::Responder<PromptResponse>,
 ) -> std::result::Result<(), AcpError> {
-    // Fresh turn: clear any stale cancel flag from a previous cancelled turn.
-    session.shutdown.store(false, Ordering::Release);
-
+    // NOTE: the stale-cancel-flag reset does NOT happen here. It is done
+    // synchronously on the dispatch loop in `handle_prompt` (and in
+    // `run_prompt_turn_deferred` for the rare contended path) BEFORE this turn
+    // is spawned, so a `session/cancel` dispatched for this turn correctly wins
+    // instead of being clobbered by a reset in this spawned task.
     let user_text = extract_prompt_text(&req.prompt);
     let history = { session.history.lock().await.clone() };
 
@@ -570,11 +600,16 @@ async fn run_prompt_turn(
     let cancelled = session.shutdown.load(Ordering::Acquire);
     let response = match outcome {
         Ok(resp) => {
-            // Persist the full turn (user + assistant + tool messages) so the
-            // next prompt sees the context.
+            // Persist this turn's messages (user + assistant + tool messages).
+            // `ConversationResponse.messages` is THIS-TURN-ONLY (the user
+            // message at front + the assistant/tool messages produced this
+            // turn); it does NOT include prior history. The stored history
+            // still holds the earlier turns (we only cloned it above, never
+            // cleared it), so APPEND — replacing would drop every earlier turn
+            // and the agent would forget context after the second prompt.
             {
                 let mut h = session.history.lock().await;
-                *h = resp.messages.clone();
+                h.extend(resp.messages);
             }
             // Distinguish a client-driven cancel from a natural end-of-turn.
             let stop_reason = if cancelled {
@@ -638,9 +673,12 @@ fn new_session_id() -> SessionId {
 ///
 /// octos's agent loop consumes a single text prompt; we concatenate the text of
 /// every `ContentBlock::Text` (and the text payload of embedded text
-/// resources), joining multiple blocks with newlines. Non-text blocks (image,
-/// audio, resource links) are skipped in v1 — we advertise text-only prompt
-/// capabilities at `initialize`.
+/// resources), joining multiple blocks with newlines. `ContentBlock::ResourceLink`
+/// is BASELINE ACP prompt content (file/context attachments), so we surface each
+/// link as a `[Resource: <title|name> (<uri>)]` reference (plus its description on
+/// the next line, if any) rather than dropping it. Binary non-text blocks (image,
+/// audio) are still skipped in v1 — we advertise text-only prompt capabilities at
+/// `initialize`.
 fn extract_prompt_text(blocks: &[ContentBlock]) -> String {
     let mut parts: Vec<String> = Vec::new();
     for block in blocks {
@@ -653,8 +691,20 @@ fn extract_prompt_text(blocks: &[ContentBlock]) -> String {
                     parts.push(tr.text.clone());
                 }
             }
-            // Non-text blocks (image, audio, resource links) and any future
-            // variants are not consumed by the text-only agent loop. `ContentBlock`
+            // Resource links are baseline ACP prompt content (file/context
+            // attachments). Surface the reference as usable context text so a
+            // prompt made entirely of links still reaches octos with content.
+            ContentBlock::ResourceLink(link) => {
+                let label = link.title.as_deref().unwrap_or(&link.name);
+                let mut part = format!("[Resource: {label} ({})]", link.uri);
+                if let Some(desc) = &link.description {
+                    part.push('\n');
+                    part.push_str(desc);
+                }
+                parts.push(part);
+            }
+            // Remaining non-text blocks (image, audio) and any future variants
+            // are not consumed by the text-only agent loop. `ContentBlock`
             // is `#[non_exhaustive]`, so a catch-all is required.
             _ => {}
         }
@@ -1007,6 +1057,40 @@ mod tests {
     }
 
     #[test]
+    fn should_include_resource_link_reference_when_prompt_has_resource_link() {
+        use agent_client_protocol::schema::v1::ResourceLink;
+        // A resource link with a title + description: the reference (title +
+        // uri) and the description must both surface in the extracted text.
+        let link = ResourceLink::new("main.rs", "file:///repo/src/main.rs")
+            .title("Main entrypoint")
+            .description("The program entrypoint");
+        let blocks = vec![ContentBlock::ResourceLink(link)];
+        let text = extract_prompt_text(&blocks);
+        assert!(
+            text.contains("file:///repo/src/main.rs"),
+            "resource-link uri must be surfaced; got {text:?}"
+        );
+        assert!(
+            text.contains("Main entrypoint"),
+            "resource-link title must be surfaced; got {text:?}"
+        );
+        assert!(
+            text.contains("The program entrypoint"),
+            "resource-link description must be surfaced; got {text:?}"
+        );
+    }
+
+    #[test]
+    fn should_use_resource_link_name_when_title_absent() {
+        use agent_client_protocol::schema::v1::ResourceLink;
+        // No title -> fall back to the link name; no description -> single line.
+        let link = ResourceLink::new("notes.txt", "file:///repo/notes.txt");
+        let blocks = vec![ContentBlock::ResourceLink(link)];
+        let text = extract_prompt_text(&blocks);
+        assert_eq!(text, "[Resource: notes.txt (file:///repo/notes.txt)]");
+    }
+
+    #[test]
     fn should_extract_from_string_convertible_block_via_from_impl() {
         // The crate provides `From<Into<String>> for ContentBlock` (Text). This
         // is the ergonomic path used by the reporter mapping above.
@@ -1021,12 +1105,27 @@ mod tests {
     fn should_build_initialize_response_echoing_protocol_version_and_advertising_text_prompt() {
         let req = InitializeRequest::new(ProtocolVersion::V1);
         let resp = build_initialize_response(&req);
+        // We support V1, so a V1 request is echoed back as V1.
         assert_eq!(resp.protocol_version, ProtocolVersion::V1);
         // Text-only prompt capabilities: image/audio/embedded_context all false.
         assert!(!resp.agent_capabilities.prompt_capabilities.image);
         assert!(!resp.agent_capabilities.prompt_capabilities.audio);
         // We do not advertise loadSession in v1.
         assert!(!resp.agent_capabilities.load_session);
+    }
+
+    #[test]
+    fn should_downgrade_to_latest_supported_version_when_client_requests_newer() {
+        // A client requesting a newer/unsupported protocol version must NOT get
+        // that version echoed back (that would falsely advertise support this
+        // v1-only handler doesn't implement). We reply with the latest version
+        // we actually support (`ProtocolVersion::LATEST`, currently V1).
+        let newer = ProtocolVersion::from(2u16);
+        assert_ne!(newer, ProtocolVersion::V1, "sanity: 2 is not V1");
+        let req = InitializeRequest::new(newer);
+        let resp = build_initialize_response(&req);
+        assert_eq!(resp.protocol_version, ProtocolVersion::LATEST);
+        assert_eq!(resp.protocol_version, ProtocolVersion::V1);
     }
 
     #[test]
@@ -1044,5 +1143,297 @@ mod tests {
     fn should_accept_silent_reporter_as_progress_reporter() {
         let reporter: Arc<dyn ProgressReporter> = Arc::new(SilentReporter);
         reporter.report(ProgressEvent::Thinking { iteration: 1 });
+    }
+
+    // ---- Cancellation-race coverage (Fix: move the stale-flag reset onto the
+    // dispatch loop). These drive the REAL handler wiring in-process (the same
+    // `spawn_acp_agent` `octos acp` uses), so the reset relocation from
+    // `run_prompt_turn` to `handle_prompt` is exercised end to end. ----
+
+    /// A `MockLlm` whose FIRST `chat()` blocks on a barrier until the test
+    /// releases it (announcing entry first), so the test can deliver a
+    /// `session/cancel` while the turn is genuinely in flight. Later calls
+    /// return immediately. Always returns `EndTurn` — the turn's `Cancelled`
+    /// outcome must come from the shutdown flag surviving into the turn, not
+    /// from the LLM.
+    struct BarrierLlm {
+        calls: std::sync::atomic::AtomicUsize,
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl octos_llm::LlmProvider for BarrierLlm {
+        async fn chat(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            let n = self.calls.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                // Announce that the turn is executing, then wait for the test
+                // to deliver the cancel and release us.
+                self.entered.notify_one();
+                self.release.notified().await;
+            }
+            Ok(octos_llm::ChatResponse {
+                content: Some("done".to_string()),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: octos_llm::TokenUsage::default(),
+                provider_index: None,
+            })
+        }
+        fn provider_name(&self) -> &str {
+            "barrier-mock"
+        }
+        fn model_id(&self) -> &str {
+            "barrier-1"
+        }
+    }
+
+    /// Factory that hands every session an agent backed by a caller-supplied
+    /// `LlmProvider` (so we can inject the `BarrierLlm`). Mirrors
+    /// `TestAgentFactory` but takes the provider by `Arc` so the barrier
+    /// handles are shared with the test.
+    struct InjectedLlmFactory {
+        llm: Arc<dyn octos_llm::LlmProvider>,
+        memory_dir: PathBuf,
+        default_cwd: PathBuf,
+    }
+
+    #[async_trait::async_trait]
+    impl SessionAgentFactory for InjectedLlmFactory {
+        fn default_cwd(&self) -> &std::path::Path {
+            &self.default_cwd
+        }
+        async fn build(&self, cwd: PathBuf) -> Result<(Arc<Agent>, Arc<AtomicBool>)> {
+            let memory = Arc::new(EpisodeStore::open(&self.memory_dir).await?);
+            let tools = ToolRegistry::with_builtins_and_sandbox(
+                &cwd,
+                create_sandbox(&octos_agent::SandboxConfig::default()),
+            );
+            let shutdown = Arc::new(AtomicBool::new(false));
+            let agent = Agent::new(
+                AgentId::new("acp-cancel-test"),
+                self.llm.clone(),
+                tools,
+                memory,
+            )
+            .with_shutdown(shutdown.clone());
+            Ok((Arc::new(agent), shutdown))
+        }
+    }
+
+    /// Test transport: expose the octos ACP agent (backed by `factory`) as a
+    /// `ConnectTo<Client>` so an in-process client can drive it.
+    struct CancelTestTransport {
+        factory: InjectedLlmFactory,
+    }
+
+    impl agent_client_protocol::ConnectTo<Client> for CancelTestTransport {
+        async fn connect_to(
+            self,
+            client: impl agent_client_protocol::ConnectTo<AcpAgentRole> + 'static,
+        ) -> std::result::Result<(), AcpError> {
+            let sessions: SessionMap = Arc::new(Mutex::new(HashMap::new()));
+            spawn_acp_agent(Arc::new(self.factory), sessions, client).await
+        }
+    }
+
+    /// A `session/cancel` delivered WHILE the turn is in flight must yield
+    /// `StopReason::Cancelled`. With the reset moved onto the dispatch loop
+    /// (`handle_prompt`), the cancel that arrives after the prompt is accepted
+    /// sets the flag and it survives into the turn, which reports `Cancelled`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn should_report_cancelled_when_session_cancel_arrives_during_turn() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cwd = tmp.path().to_path_buf();
+        let memory_dir = tmp.path().join("memory");
+        std::fs::create_dir_all(&memory_dir).unwrap();
+
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let llm: Arc<dyn octos_llm::LlmProvider> = Arc::new(BarrierLlm {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            entered: entered.clone(),
+            release: release.clone(),
+        });
+        let transport = CancelTestTransport {
+            factory: InjectedLlmFactory {
+                llm,
+                memory_dir,
+                default_cwd: cwd.clone(),
+            },
+        };
+
+        let stop_reason: Arc<Mutex<Option<StopReason>>> = Arc::new(Mutex::new(None));
+        let stop_for_main = stop_reason.clone();
+        let prompt_cwd = cwd.clone();
+
+        Client
+            .builder()
+            .name("octos-acp-cancel-client")
+            .on_receive_notification(
+                async move |_notif: SessionNotification, _cx: ConnectionTo<AcpAgentRole>| Ok(()),
+                on_receive_notification!(),
+            )
+            .connect_with(
+                transport,
+                |connection: ConnectionTo<AcpAgentRole>| async move {
+                    connection
+                        .send_request(InitializeRequest::new(
+                            agent_client_protocol::schema::ProtocolVersion::V1,
+                        ))
+                        .block_task()
+                        .await?;
+                    let new_session = connection
+                        .send_request(NewSessionRequest::new(prompt_cwd.clone()))
+                        .block_task()
+                        .await?;
+                    let session_id = new_session.session_id;
+
+                    // Concurrently: once the turn is executing, deliver a cancel,
+                    // then release the barrier so the LLM call returns.
+                    let cancel_conn = connection.clone();
+                    let cancel_sid = session_id.clone();
+                    let canceller = tokio::spawn(async move {
+                        entered.notified().await;
+                        cancel_conn
+                            .send_notification(CancelNotification::new(cancel_sid))
+                            .expect("send cancel");
+                        release.notify_one();
+                    });
+
+                    let prompt = connection
+                        .send_request(PromptRequest::new(
+                            session_id.clone(),
+                            vec![ContentBlock::Text(
+                                agent_client_protocol::schema::v1::TextContent::new("hello"),
+                            )],
+                        ))
+                        .block_task()
+                        .await?;
+                    canceller.await.expect("canceller joins");
+                    *stop_for_main.lock().await = Some(prompt.stop_reason);
+                    Ok(())
+                },
+            )
+            .await
+            .expect("ACP client run completes");
+
+        let got = *stop_reason.lock().await;
+        assert!(
+            matches!(got, Some(StopReason::Cancelled)),
+            "cancel during the turn must yield Cancelled, got {got:?}"
+        );
+    }
+
+    /// After a turn is cancelled, a FRESH prompt on the same session (no cancel)
+    /// must return `EndTurn` — proving the stale-flag reset was RELOCATED onto
+    /// `handle_prompt` (run before each turn spawns), not simply deleted. If the
+    /// reset were gone entirely, the stale `true` from the cancelled turn would
+    /// leak and wrongly report `Cancelled` again.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn should_report_end_turn_for_fresh_prompt_after_prior_turn_was_cancelled() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cwd = tmp.path().to_path_buf();
+        let memory_dir = tmp.path().join("memory");
+        std::fs::create_dir_all(&memory_dir).unwrap();
+
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let llm: Arc<dyn octos_llm::LlmProvider> = Arc::new(BarrierLlm {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            entered: entered.clone(),
+            release: release.clone(),
+        });
+        let transport = CancelTestTransport {
+            factory: InjectedLlmFactory {
+                llm,
+                memory_dir,
+                default_cwd: cwd.clone(),
+            },
+        };
+
+        let second_stop: Arc<Mutex<Option<StopReason>>> = Arc::new(Mutex::new(None));
+        let second_for_main = second_stop.clone();
+        let prompt_cwd = cwd.clone();
+
+        Client
+            .builder()
+            .name("octos-acp-cancel-then-fresh-client")
+            .on_receive_notification(
+                async move |_notif: SessionNotification, _cx: ConnectionTo<AcpAgentRole>| Ok(()),
+                on_receive_notification!(),
+            )
+            .connect_with(
+                transport,
+                |connection: ConnectionTo<AcpAgentRole>| async move {
+                    connection
+                        .send_request(InitializeRequest::new(
+                            agent_client_protocol::schema::ProtocolVersion::V1,
+                        ))
+                        .block_task()
+                        .await?;
+                    let new_session = connection
+                        .send_request(NewSessionRequest::new(prompt_cwd.clone()))
+                        .block_task()
+                        .await?;
+                    let session_id = new_session.session_id;
+
+                    // Turn 1: cancel it mid-flight (as in the test above).
+                    let cancel_conn = connection.clone();
+                    let cancel_sid = session_id.clone();
+                    let canceller = tokio::spawn(async move {
+                        entered.notified().await;
+                        cancel_conn
+                            .send_notification(CancelNotification::new(cancel_sid))
+                            .expect("send cancel");
+                        release.notify_one();
+                    });
+                    let first = connection
+                        .send_request(PromptRequest::new(
+                            session_id.clone(),
+                            vec![ContentBlock::Text(
+                                agent_client_protocol::schema::v1::TextContent::new("first"),
+                            )],
+                        ))
+                        .block_task()
+                        .await?;
+                    canceller.await.expect("canceller joins");
+                    assert!(
+                        matches!(first.stop_reason, StopReason::Cancelled),
+                        "sanity: turn 1 should be Cancelled, got {:?}",
+                        first.stop_reason
+                    );
+
+                    // Turn 2: no cancel. The BarrierLlm only blocks its FIRST call,
+                    // so this returns immediately. Must be EndTurn — the stale flag
+                    // from turn 1 must have been reset before turn 2 spawned.
+                    let second = connection
+                        .send_request(PromptRequest::new(
+                            session_id.clone(),
+                            vec![ContentBlock::Text(
+                                agent_client_protocol::schema::v1::TextContent::new("second"),
+                            )],
+                        ))
+                        .block_task()
+                        .await?;
+                    *second_for_main.lock().await = Some(second.stop_reason);
+                    Ok(())
+                },
+            )
+            .await
+            .expect("ACP client run completes");
+
+        let got = *second_stop.lock().await;
+        assert!(
+            matches!(got, Some(StopReason::EndTurn)),
+            "fresh prompt after a cancelled turn must be EndTurn (reset relocated, \
+             not deleted), got {got:?}"
+        );
     }
 }

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -76,8 +76,8 @@ use octos_agent::{
     Agent, AgentConfig, ProgressEvent, ProgressReporter, ToolRegistry, create_sandbox,
 };
 use octos_core::AgentId;
-use octos_llm::{LlmProvider, RetryProvider};
-use octos_memory::EpisodeStore;
+use octos_llm::{EmbeddingProvider, LlmProvider};
+use octos_memory::{EpisodeStore, MemoryStore};
 use tokio::sync::Mutex;
 
 use super::Executable;
@@ -162,19 +162,6 @@ trait SessionAgentFactory: Send + Sync {
     async fn build(&self, cwd: PathBuf) -> Result<(Arc<Agent>, Arc<AtomicBool>)>;
 }
 
-/// Production agent factory: resolves the LLM provider + tools + memory the same
-/// way `octos chat` does, minus the profile/plugin/pipeline bootstrap so the ACP
-/// entrypoint stays self-contained.
-struct ConfigAgentFactory {
-    config: Config,
-    provider_name: String,
-    model: Option<String>,
-    base_url: Option<String>,
-    data_dir: PathBuf,
-    default_cwd: PathBuf,
-    max_iterations: u32,
-}
-
 /// Core tools pinned as LRU "base" tools so the agent never auto-evicts them
 /// mid-session. The registry keeps only `max_active` (15) tools visible and
 /// evicts the least-recently-used non-base tools after they sit idle for
@@ -209,6 +196,360 @@ fn build_acp_tool_registry(
     tools
 }
 
+/// Register the long-term memory-bank tools (recall/save, plus the refresh
+/// capture tool when memory-refresh is enabled). Shared by the production
+/// assembler and the unit test so both exercise the same wiring.
+fn register_memory_bank(
+    tools: &mut ToolRegistry,
+    memory_store: &Arc<MemoryStore>,
+    refresh_enabled: bool,
+) {
+    tools.register(octos_agent::RecallMemoryTool::new(memory_store.clone()));
+    tools.register(octos_agent::SaveMemoryTool::new(memory_store.clone()));
+    if refresh_enabled {
+        tools.register(octos_agent::MemoryNoteTool::new(memory_store.clone()));
+    }
+}
+
+/// Apply every registry-narrowing filter LAST, in the same order as `octos chat`:
+/// config tool policy -> context tag filter -> provider policy -> resolved
+/// profile envelope. Shared by the production assembler and the unit test.
+fn finalize_tool_registry(
+    tools: &mut ToolRegistry,
+    config: &Config,
+    provider_name: &str,
+    model_id: &str,
+    profile: &octos_agent::profile::ProfileDefinition,
+) {
+    if let Some(policy) = &config.tool_policy {
+        tools.apply_policy(policy);
+    }
+    if !config.context_filter.is_empty() {
+        tools.set_context_filter(config.context_filter.clone());
+    }
+    if let Some(policy) = super::chat::resolve_provider_policy(config, provider_name, model_id) {
+        tools.set_provider_policy(policy);
+    }
+    // M8.3: profile narrowing runs AFTER every other filter (spawn_only preserved).
+    profile.apply_to_registry(tools);
+}
+
+/// Process-wide state assembled ONCE at `octos acp` startup and shared behind an
+/// `Arc` across every ACP `session/new`. Mirrors what `octos chat` builds for its
+/// single embedded agent — failover provider chain, episodic + long-term memory,
+/// the full tool registry (builtins + plugins + MCP + memory-bank + pipeline +
+/// policy + profile), embedder, system prompt, hooks, and compaction — so ACP is
+/// as capable as `octos chat` / a serve session. The expensive work (provider
+/// chain, plugin scan, MCP spawn, memory stores, redb episode store opened
+/// exactly once) happens here; per-session work in [`ConfigAgentFactory::build`]
+/// is only the cheap cwd rebind + agent construction.
+struct AcpBootstrap {
+    llm: Arc<dyn LlmProvider>,
+    memory: Arc<EpisodeStore>,
+    memory_store: Arc<MemoryStore>,
+    embedder: Option<Arc<dyn EmbeddingProvider>>,
+    /// Base registry template — NOT bound to a session cwd. Each session clones +
+    /// rebinds it via `rebind_cwd_with_permissions`.
+    tool_specs: Arc<ToolRegistry>,
+    sandbox: octos_agent::SandboxConfig,
+    /// System-prompt override from the profile template (None = keep the agent's
+    /// built-in default). Bootstrap files + memory segment are attached per session.
+    profile_system_prompt: Option<String>,
+    plugin_prompt_fragments: Vec<String>,
+    hook_executor: Option<Arc<octos_agent::HookExecutor>>,
+    agent_definitions: Arc<octos_agent::agents::AgentDefinitions>,
+    profile: Arc<octos_agent::profile::ProfileDefinition>,
+    agent_config: AgentConfig,
+    compaction: Option<(
+        Arc<octos_agent::compaction::CompactionRunner>,
+        octos_agent::WorkspacePolicy,
+    )>,
+    memory_refresh_enabled: bool,
+    max_inject_tokens: usize,
+    data_dir: PathBuf,
+}
+
+impl AcpBootstrap {
+    /// Assemble the full shared agent stack. Mirrors `octos chat`'s `run_async`
+    /// (crates/octos-cli/src/commands/chat.rs) step-for-step, minus the console
+    /// reporter / Ctrl-C / single-message REPL bits. All diagnostics go to stderr
+    /// (never stdout — ACP speaks JSON-RPC there).
+    #[allow(clippy::too_many_arguments)]
+    async fn build(
+        config: Config,
+        provider_name: String,
+        model: Option<String>,
+        base_url: Option<String>,
+        data_dir: PathBuf,
+        cwd: PathBuf,
+        max_iterations: u32,
+        profile_arg: &Option<String>,
+    ) -> Result<Self> {
+        // --- LLM provider (failover chain, same canonical helper serve/gateway use) ---
+        let base_provider: Arc<dyn LlmProvider> =
+            super::chat::create_provider(&provider_name, &config, model, base_url)?;
+        let model_id = base_provider.model_id().to_string();
+        let bundle = crate::qos_catalog::build_adaptive_provider_chain(
+            base_provider,
+            &config,
+            &data_dir,
+            /* no_retry */ false,
+            crate::qos_catalog::ExporterMode::Spawn,
+        );
+        let llm = bundle.llm.clone();
+
+        // --- memory (episodic + long-term) ---
+        let memory = Arc::new(
+            EpisodeStore::open(&data_dir)
+                .await
+                .wrap_err("failed to open episode store")?,
+        );
+        let memory_store = Arc::new(
+            MemoryStore::open(&data_dir)
+                .await
+                .wrap_err("failed to open memory store")?,
+        );
+        let memory_refresh_enabled =
+            crate::config::MemoryConfig::refresh_enabled(config.memory.as_ref());
+        let max_inject_tokens =
+            crate::config::MemoryConfig::effective_max_inject_tokens(config.memory.as_ref());
+
+        // --- profile (resolved now; applied to the registry LAST via finalize) ---
+        let (profile, profile_source_label) = super::chat::resolve_profile(profile_arg)?;
+        tracing::info!(
+            "profile resolved: name={} source={}",
+            profile.name,
+            profile_source_label
+        );
+
+        // --- tool registry ---
+        let sandbox = config.sandbox.clone();
+        let mut tools = ToolRegistry::with_builtins_and_sandbox(&cwd, create_sandbox(&sandbox));
+        tools.set_base_tools(ACP_BASE_TOOLS.iter().copied());
+
+        let tool_config = Arc::new(
+            octos_agent::ToolConfigStore::open(&data_dir)
+                .await
+                .wrap_err("failed to open tool config store")?,
+        );
+        tools.inject_tool_config(tool_config.clone());
+        if let Some(gw) = &config.gateway {
+            if let Some(secs) = gw.browser_timeout_secs {
+                tools.register(
+                    octos_agent::BrowserTool::with_timeout(std::time::Duration::from_secs(secs))
+                        .with_config(tool_config.clone()),
+                );
+            }
+        }
+
+        // spawn (sync sub-agents; background delivery is a dummy channel) + research synth
+        let (spawn_tx, _spawn_rx) = tokio::sync::mpsc::channel(1);
+        let worker_prompt = super::load_prompt("worker", octos_agent::DEFAULT_WORKER_PROMPT);
+        tools.register(
+            octos_agent::SpawnTool::new(llm.clone(), memory.clone(), cwd.clone(), spawn_tx)
+                .with_worker_prompt(worker_prompt),
+        );
+        tools.register(octos_agent::SynthesizeResearchTool::new(
+            llm.clone(),
+            data_dir.clone(),
+        ));
+
+        // long-term memory bank tools
+        register_memory_bank(&mut tools, &memory_store, memory_refresh_enabled);
+
+        // MCP tools declared in config
+        if !config.mcp_servers.is_empty() {
+            match octos_agent::McpClient::start(&config.mcp_servers).await {
+                Ok(client) => client.register_tools(&mut tools),
+                Err(e) => eprintln!("Warning: MCP initialization failed: {e}"),
+            }
+        }
+
+        // Bootstrap bundled app-skills / platform-skills / pipelines BEFORE plugin load.
+        let project_dir = cwd.join(".octos");
+        let n = octos_agent::bootstrap::bootstrap_bundled_skills(&project_dir);
+        if n > 0 {
+            eprintln!("Bootstrapped {n} app-skills");
+        }
+        let n = octos_agent::bootstrap::bootstrap_platform_skills(&project_dir);
+        if n > 0 {
+            eprintln!("Bootstrapped {n} platform skills");
+        }
+        let n = octos_agent::bootstrap::bootstrap_bundled_pipelines(&data_dir);
+        if n > 0 {
+            eprintln!("Bootstrapped {n} bundled pipelines");
+        }
+
+        // Load plugins/skills (binary-protocol + HTTP tool discovery).
+        let plugin_dirs = Config::plugin_dirs_from_project(&cwd.join(".octos"));
+        let mut plugin_result = octos_agent::PluginLoadResult::default();
+        if !plugin_dirs.is_empty() {
+            match octos_agent::PluginLoader::load_into_with_options(
+                &mut tools,
+                &plugin_dirs,
+                &[],
+                octos_agent::PluginLoadOptions {
+                    work_dir: None,
+                    synthesis_config: None,
+                    require_signed: config.plugins.require_signed,
+                    verified_cache_dir: None,
+                },
+            ) {
+                Ok(result) => plugin_result = result,
+                Err(e) => eprintln!("Warning: plugin loading failed: {e}"),
+            }
+            octos_agent::plugins::register_http_skills_on_startup(&mut tools, &plugin_dirs)
+                .await
+                .wrap_err("HTTP tool discovery failed at agent boot")?;
+        }
+        if !plugin_result.mcp_servers.is_empty() {
+            match octos_agent::McpClient::start(&plugin_result.mcp_servers).await {
+                Ok(client) => client.register_tools(&mut tools),
+                Err(e) => eprintln!("Warning: skill MCP initialization failed: {e}"),
+            }
+        }
+
+        // Pipeline tool (DOT workflows), embedder-aware, marked spawn_only.
+        let pipeline_tool = super::chat::build_run_pipeline_tool(
+            llm.clone(),
+            memory.clone(),
+            cwd.clone(),
+            data_dir.clone(),
+            tools.provider_policy().cloned(),
+            plugin_dirs.clone(),
+            config.plugins.require_signed,
+            super::chat::create_embedder(&config),
+        );
+        tools.register(pipeline_tool);
+        tools.mark_spawn_only(
+            "run_pipeline",
+            Some(
+                "Pipeline started in background. The final result and any artifacts will be sent here when complete."
+                    .to_string(),
+            ),
+        );
+
+        // Policy + context filter + provider policy + profile narrowing (LAST).
+        finalize_tool_registry(&mut tools, &config, &provider_name, &model_id, &profile);
+
+        // Sub-agent manifests from `<cwd>/agents/` layered on the built-ins.
+        let agents_dir = cwd.join("agents");
+        let agent_definitions = match octos_agent::agents::AgentDefinitions::load_dir(&agents_dir) {
+            Ok(defs) => Arc::new(defs),
+            Err(err) => {
+                eprintln!(
+                    "Warning: failed to load agent manifests from {}: {err}",
+                    agents_dir.display()
+                );
+                Arc::new(octos_agent::agents::AgentDefinitions::with_builtins())
+            }
+        };
+        profile
+            .validate_against_registry(&agent_definitions)
+            .wrap_err("profile references missing agent_definition ids")?;
+
+        let embedder = super::chat::create_embedder(&config);
+
+        // System-prompt override from the profile template (bootstrap files +
+        // memory segment are attached per session in `build`, since they are
+        // cwd-specific / live-refreshing).
+        let profile_system_prompt = profile
+            .system_prompt_template
+            .as_ref()
+            .and_then(|tpl| super::load_profile_prompt_template(&profile.name, tpl));
+
+        // Hooks (config + skill-declared).
+        let mut all_hooks = config.hooks.clone();
+        all_hooks.extend(plugin_result.hooks.clone());
+        let hook_executor = if all_hooks.is_empty() {
+            None
+        } else {
+            Some(Arc::new(octos_agent::HookExecutor::new(all_hooks)))
+        };
+
+        // Declarative compaction runner from the cwd's workspace policy.
+        let compaction = match octos_agent::read_workspace_policy(&cwd) {
+            Ok(Some(ws)) => {
+                if let Some(cp) = ws.compaction.clone() {
+                    let runner = match cp.summarizer {
+                        octos_agent::CompactionSummarizerKind::LlmIterative => {
+                            octos_agent::compaction::CompactionRunner::with_provider(
+                                cp,
+                                llm.clone(),
+                            )
+                        }
+                        octos_agent::CompactionSummarizerKind::Extractive => {
+                            octos_agent::compaction::CompactionRunner::new(cp)
+                        }
+                    }
+                    .with_workspace_policy(&ws);
+                    Some((Arc::new(runner), ws))
+                } else {
+                    None
+                }
+            }
+            Ok(None) => None,
+            Err(error) => {
+                eprintln!("Warning: failed to read workspace policy for compaction: {error}");
+                None
+            }
+        };
+
+        let agent_config = AgentConfig {
+            max_iterations,
+            save_episodes: true,
+            chat_max_tokens: config.gateway.as_ref().and_then(|g| g.max_output_tokens),
+            reasoning_effort: config.gateway.as_ref().and_then(|g| g.reasoning_effort),
+            ..Default::default()
+        };
+
+        // NOTE(acp): the background `MemoryRefreshService` (auto-sweep of MEMORY.md)
+        // is intentionally NOT started here. The memory-bank tools + MEMORY.md
+        // injection above already give recall/save/capture (chat parity). The
+        // long-running sweep is a serve-only concern (flock-arbitrated); enable it
+        // later behind `memory.refresh.enabled` if wanted.
+
+        let profile = Arc::new(profile);
+
+        Ok(Self {
+            llm,
+            memory,
+            memory_store,
+            embedder,
+            tool_specs: Arc::new(tools),
+            sandbox,
+            profile_system_prompt,
+            plugin_prompt_fragments: plugin_result.prompt_fragments,
+            hook_executor,
+            agent_definitions,
+            profile,
+            agent_config,
+            compaction,
+            memory_refresh_enabled,
+            max_inject_tokens,
+            data_dir,
+        })
+    }
+}
+
+/// Production agent factory: holds the raw config inputs plus a lazily-built
+/// shared [`AcpBootstrap`]. The heavy assembly runs ONCE on the first
+/// `session/new` (using the client's real project cwd); every session then only
+/// does a cheap cwd rebind. Building lazily keeps `initialize` cheap and turns a
+/// misconfiguration (e.g. missing provider key) into a `session/new` error
+/// response rather than a startup crash before the ACP handshake.
+struct ConfigAgentFactory {
+    config: Config,
+    provider_name: String,
+    model: Option<String>,
+    base_url: Option<String>,
+    data_dir: PathBuf,
+    default_cwd: PathBuf,
+    max_iterations: u32,
+    profile: Option<String>,
+    bootstrap: tokio::sync::OnceCell<Arc<AcpBootstrap>>,
+}
+
 #[async_trait::async_trait]
 impl SessionAgentFactory for ConfigAgentFactory {
     fn default_cwd(&self) -> &std::path::Path {
@@ -216,30 +557,96 @@ impl SessionAgentFactory for ConfigAgentFactory {
     }
 
     async fn build(&self, cwd: PathBuf) -> Result<(Arc<Agent>, Arc<AtomicBool>)> {
-        // Provider resolution mirrors `chat.rs`: base provider -> RetryProvider.
-        let base_provider: Arc<dyn LlmProvider> = super::chat::create_provider(
-            &self.provider_name,
-            &self.config,
-            self.model.clone(),
-            self.base_url.clone(),
-        )?;
-        let llm: Arc<dyn LlmProvider> = Arc::new(RetryProvider::new(base_provider));
-
-        let memory = Arc::new(
-            EpisodeStore::open(&self.data_dir)
+        // Assemble the shared stack once, lazily, on the first session (using the
+        // client's real project cwd for plugins/skills/policy/system-prompt).
+        let b = self
+            .bootstrap
+            .get_or_try_init(|| async {
+                AcpBootstrap::build(
+                    self.config.clone(),
+                    self.provider_name.clone(),
+                    self.model.clone(),
+                    self.base_url.clone(),
+                    self.data_dir.clone(),
+                    cwd.clone(),
+                    self.max_iterations,
+                    &self.profile,
+                )
                 .await
-                .wrap_err("failed to open episode store")?,
+                .map(Arc::new)
+            })
+            .await?
+            .clone();
+
+        // Per-session: rebind the shared base registry to the client's cwd so the
+        // cwd-bound tools (shell/read_file/…) run against the client's repo, and
+        // give this session its own Arc-able registry.
+        let tools = b.tool_specs.rebind_cwd_with_permissions(
+            &cwd,
+            create_sandbox(&b.sandbox),
+            octos_agent::EffectivePermissions::workspace_write(),
         );
 
-        let tools = build_acp_tool_registry(&cwd, &self.config.sandbox);
+        // Per-session sub-agent output routing + file-state cache (cheap).
+        let subagent_output_router = Arc::new(octos_agent::SubAgentOutputRouter::new(
+            b.data_dir.join("subagent-outputs"),
+        ));
+        let supervisor_for_summary = (*tools.supervisor()).clone();
+        let subagent_summary_generator = Arc::new(octos_agent::AgentSummaryGenerator::new(
+            b.llm.clone(),
+            subagent_output_router.clone(),
+            supervisor_for_summary,
+        ));
 
         let shutdown = Arc::new(AtomicBool::new(false));
-        let agent = Agent::new(AgentId::new("acp"), llm, tools, memory)
-            .with_config(AgentConfig {
-                max_iterations: self.max_iterations,
-                ..AgentConfig::default()
-            })
+        let mut agent = Agent::new(AgentId::new("acp"), b.llm.clone(), tools, b.memory.clone())
+            .with_config(b.agent_config.clone())
+            .with_agent_definitions(b.agent_definitions.clone())
+            .with_profile(b.profile.clone())
+            .with_file_state_cache(Arc::new(octos_agent::FileStateCache::new()))
+            .with_subagent_output_router(subagent_output_router)
+            .with_subagent_summary_generator(subagent_summary_generator)
             .with_shutdown(shutdown.clone());
+        if let Some(embedder) = &b.embedder {
+            agent = agent.with_embedder(embedder.clone());
+        }
+        if let Some(hooks) = &b.hook_executor {
+            agent = agent.with_hooks(hooks.clone());
+        }
+        if let Some((runner, ws)) = &b.compaction {
+            agent = agent
+                .with_compaction_runner(runner.clone())
+                .with_compaction_workspace(ws.clone());
+        }
+
+        // System prompt: profile template (opt) + bootstrap files (per-cwd) +
+        // token-capped MEMORY.md segment (+ live provider when refresh on) + skill
+        // fragments — mirrors `octos chat`.
+        if let Some(sp) = &b.profile_system_prompt {
+            agent.set_system_prompt(sp.clone());
+        }
+        let bootstrap_files = super::load_bootstrap_files(&cwd.join(".octos"));
+        if !bootstrap_files.is_empty() {
+            agent.append_system_prompt(&bootstrap_files);
+        }
+        let memory_ctx = b
+            .memory_store
+            .get_injectable_context(b.max_inject_tokens)
+            .await;
+        agent.set_prompt_segment(
+            octos_agent::MEMORY_SEGMENT_NAME,
+            octos_agent::compose_memory_segment(&memory_ctx, b.memory_refresh_enabled),
+        );
+        if b.memory_refresh_enabled {
+            agent.add_prompt_segment_provider(Arc::new(octos_agent::MemorySegmentProvider::new(
+                b.memory_store.clone(),
+                b.max_inject_tokens,
+                true,
+            )));
+        }
+        for fragment in &b.plugin_prompt_fragments {
+            agent.append_system_prompt(fragment);
+        }
 
         Ok((Arc::new(agent), shutdown))
     }
@@ -435,6 +842,9 @@ impl AcpCommand {
                 )
             })?;
 
+        // The full shared agent stack (provider chain, memory, plugins, MCP,
+        // hooks, system prompt, compaction) is assembled lazily on the first
+        // `session/new` — see `ConfigAgentFactory`.
         let factory: Arc<dyn SessionAgentFactory> = Arc::new(ConfigAgentFactory {
             config,
             provider_name,
@@ -443,6 +853,8 @@ impl AcpCommand {
             data_dir,
             default_cwd: cwd,
             max_iterations: self.max_iterations,
+            profile: self.profile.clone(),
+            bootstrap: tokio::sync::OnceCell::new(),
         });
 
         let sessions: SessionMap = Arc::new(Mutex::new(HashMap::new()));
@@ -901,6 +1313,35 @@ pub(crate) fn project_progress_event_deduped(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The ACP assembler wires the long-term memory bank (chat parity), so the
+    /// agent is no longer a bare-builtins skeleton. Exercises the real
+    /// `register_memory_bank` helper the production `AcpBootstrap` uses. Offline:
+    /// `MemoryStore::open` is local (no network / no provider key).
+    #[tokio::test]
+    async fn should_register_memory_bank_tools_in_acp_assembly() {
+        let dir = std::env::temp_dir().join(format!("octos-acp-membank-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = Arc::new(MemoryStore::open(&dir).await.expect("open memory store"));
+
+        let mut tools = ToolRegistry::with_builtins_and_sandbox(
+            &dir,
+            create_sandbox(&octos_agent::SandboxConfig::default()),
+        );
+        assert!(
+            !tools.is_tool_visible("recall_memory"),
+            "baseline builtins should not carry the long-term memory bank"
+        );
+        register_memory_bank(&mut tools, &store, /* refresh_enabled */ true);
+        for t in ["recall_memory", "save_memory", "memory_note"] {
+            assert!(
+                tools.is_tool_visible(t),
+                "{t} must be registered by the ACP memory-bank wiring"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     /// Regression: a long ACP session that keeps using file/search tools while
     /// never touching the exec tools must not lose `shell`/`exec_command`/

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -617,12 +617,15 @@ async fn run_prompt_turn(
                 // back to what the agent SAID — mirroring the chat REPL, which
                 // also pushes `response.content` as an assistant message. Guard
                 // against double-append for turns where messages already ends
-                // with that assistant reply.
+                // with that assistant reply. Skip entirely on a CANCELLED turn:
+                // `content` there is a partial/aborted stream, and persisting it
+                // would condition the next prompt on a reply the client never
+                // completed.
                 let already_persisted = matches!(
                     h.last(),
                     Some(last) if last.role == octos_core::MessageRole::Assistant && last.content == assistant_reply
                 );
-                if !assistant_reply.is_empty() && !already_persisted {
+                if !cancelled && !assistant_reply.is_empty() && !already_persisted {
                     h.push(octos_core::Message {
                         role: octos_core::MessageRole::Assistant,
                         content: assistant_reply,
@@ -1185,16 +1188,23 @@ mod tests {
         calls: std::sync::atomic::AtomicUsize,
         entered: Arc<tokio::sync::Notify>,
         release: Arc<tokio::sync::Notify>,
+        /// One entry per `chat()` call: the `content` of every incoming message,
+        /// so a test can assert what history a later turn was handed.
+        seen: Arc<Mutex<Vec<Vec<String>>>>,
     }
 
     #[async_trait::async_trait]
     impl octos_llm::LlmProvider for BarrierLlm {
         async fn chat(
             &self,
-            _messages: &[octos_core::Message],
+            messages: &[octos_core::Message],
             _tools: &[octos_llm::ToolSpec],
             _config: &octos_llm::ChatConfig,
         ) -> eyre::Result<octos_llm::ChatResponse> {
+            self.seen
+                .lock()
+                .await
+                .push(messages.iter().map(|m| m.content.clone()).collect());
             let n = self.calls.fetch_add(1, Ordering::SeqCst);
             if n == 0 {
                 // Announce that the turn is executing, then wait for the test
@@ -1285,6 +1295,7 @@ mod tests {
             calls: std::sync::atomic::AtomicUsize::new(0),
             entered: entered.clone(),
             release: release.clone(),
+            seen: Arc::new(Mutex::new(Vec::new())),
         });
         let transport = CancelTestTransport {
             factory: InjectedLlmFactory {
@@ -1370,10 +1381,12 @@ mod tests {
 
         let entered = Arc::new(tokio::sync::Notify::new());
         let release = Arc::new(tokio::sync::Notify::new());
+        let seen: Arc<Mutex<Vec<Vec<String>>>> = Arc::new(Mutex::new(Vec::new()));
         let llm: Arc<dyn octos_llm::LlmProvider> = Arc::new(BarrierLlm {
             calls: std::sync::atomic::AtomicUsize::new(0),
             entered: entered.clone(),
             release: release.clone(),
+            seen: seen.clone(),
         });
         let transport = CancelTestTransport {
             factory: InjectedLlmFactory {
@@ -1459,6 +1472,23 @@ mod tests {
             matches!(got, Some(StopReason::EndTurn)),
             "fresh prompt after a cancelled turn must be EndTurn (reset relocated, \
              not deleted), got {got:?}"
+        );
+
+        // codex round-3 regression: the CANCELLED turn's aborted assistant reply
+        // ("done") must NOT be persisted into history, so the fresh second turn's
+        // chat() must not see it. Without the `!cancelled` guard, the partial
+        // reply leaks into the next prompt's context.
+        let snapshots = seen.lock().await;
+        assert!(
+            snapshots.len() >= 2,
+            "both turns reached the LLM: {} calls",
+            snapshots.len()
+        );
+        assert!(
+            !snapshots[1].iter().any(|c| c.contains("done")),
+            "the cancelled turn's aborted assistant reply must NOT persist into the \
+             next prompt's history; turn-2 messages: {:?}",
+            snapshots[1]
         );
     }
 }

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -75,7 +75,7 @@ use agent_client_protocol::{
 use octos_agent::{
     Agent, AgentConfig, ProgressEvent, ProgressReporter, ToolRegistry, create_sandbox,
 };
-use octos_core::AgentId;
+use octos_core::{AgentId, SessionScope, canonicalize_skill_read_zones};
 use octos_llm::{EmbeddingProvider, LlmProvider};
 use octos_memory::{EpisodeStore, MemoryStore};
 use tokio::sync::Mutex;
@@ -234,22 +234,34 @@ fn finalize_tool_registry(
     profile.apply_to_registry(tools);
 }
 
-/// Process-wide state assembled ONCE at `octos acp` startup and shared behind an
-/// `Arc` across every ACP `session/new`. Mirrors what `octos chat` builds for its
-/// single embedded agent — failover provider chain, episodic + long-term memory,
-/// the full tool registry (builtins + plugins + MCP + memory-bank + pipeline +
-/// policy + profile), embedder, system prompt, hooks, and compaction — so ACP is
-/// as capable as `octos chat` / a serve session. The expensive work (provider
-/// chain, plugin scan, MCP spawn, memory stores, redb episode store opened
-/// exactly once) happens here; per-session work in [`ConfigAgentFactory::build`]
-/// is only the cheap cwd rebind + agent construction.
-struct AcpBootstrap {
+/// Process-global, **cwd-independent** state, assembled ONCE per `octos acp`
+/// process (lazily, on the first `session/new`). The redb episode store is a
+/// single-writer resource, so it must live here — never rebuilt per cwd. Also
+/// carries the raw `Config` + resolved provider identity so per-cwd registries
+/// (which DO depend on cwd) can be built on top.
+struct AcpSharedStores {
     llm: Arc<dyn LlmProvider>,
     memory: Arc<EpisodeStore>,
     memory_store: Arc<MemoryStore>,
     embedder: Option<Arc<dyn EmbeddingProvider>>,
-    /// Base registry template — NOT bound to a session cwd. Each session clones +
-    /// rebinds it via `rebind_cwd_with_permissions`.
+    agent_config: AgentConfig,
+    memory_refresh_enabled: bool,
+    max_inject_tokens: usize,
+    data_dir: PathBuf,
+    config: Config,
+    provider_name: String,
+    model_id: String,
+}
+
+/// Per-cwd assembled state, cached per distinct `session/new` cwd (so a second
+/// project handled by the same process gets its OWN skills/agents/scope instead
+/// of the first cwd's). Holds the tool registry (plugins/MCP/skills rooted at
+/// THIS cwd), profile, agent defs, hooks, compaction, and the canonicalized
+/// skill dirs used to build the per-session filesystem `SessionScope`. Mirrors
+/// what `octos chat` assembles for its single embedded agent.
+struct AcpBootstrap {
+    /// Base registry template for this cwd. Each session clones + rebinds it via
+    /// `rebind_cwd_with_permissions`.
     tool_specs: Arc<ToolRegistry>,
     sandbox: octos_agent::SandboxConfig,
     /// System-prompt override from the profile template (None = keep the agent's
@@ -259,21 +271,17 @@ struct AcpBootstrap {
     hook_executor: Option<Arc<octos_agent::HookExecutor>>,
     agent_definitions: Arc<octos_agent::agents::AgentDefinitions>,
     profile: Arc<octos_agent::profile::ProfileDefinition>,
-    agent_config: AgentConfig,
     compaction: Option<(
         Arc<octos_agent::compaction::CompactionRunner>,
         octos_agent::WorkspacePolicy,
     )>,
-    memory_refresh_enabled: bool,
-    max_inject_tokens: usize,
-    data_dir: PathBuf,
+    /// Canonicalized skill dirs → `SessionScope` skill-read zones (fail-closed).
+    skill_read_zones: Vec<PathBuf>,
 }
 
-impl AcpBootstrap {
-    /// Assemble the full shared agent stack. Mirrors `octos chat`'s `run_async`
-    /// (crates/octos-cli/src/commands/chat.rs) step-for-step, minus the console
-    /// reporter / Ctrl-C / single-message REPL bits. All diagnostics go to stderr
-    /// (never stdout — ACP speaks JSON-RPC there).
+impl AcpSharedStores {
+    /// Open the process-global stores + build the failover provider chain. Runs
+    /// exactly once; the redb episode store is opened here and never re-opened.
     #[allow(clippy::too_many_arguments)]
     async fn build(
         config: Config,
@@ -281,11 +289,8 @@ impl AcpBootstrap {
         model: Option<String>,
         base_url: Option<String>,
         data_dir: PathBuf,
-        cwd: PathBuf,
         max_iterations: u32,
-        profile_arg: &Option<String>,
     ) -> Result<Self> {
-        // --- LLM provider (failover chain, same canonical helper serve/gateway use) ---
         let base_provider: Arc<dyn LlmProvider> =
             super::chat::create_provider(&provider_name, &config, model, base_url)?;
         let model_id = base_provider.model_id().to_string();
@@ -298,7 +303,6 @@ impl AcpBootstrap {
         );
         let llm = bundle.llm.clone();
 
-        // --- memory (episodic + long-term) ---
         let memory = Arc::new(
             EpisodeStore::open(&data_dir)
                 .await
@@ -309,10 +313,59 @@ impl AcpBootstrap {
                 .await
                 .wrap_err("failed to open memory store")?,
         );
+        let embedder = super::chat::create_embedder(&config);
         let memory_refresh_enabled =
             crate::config::MemoryConfig::refresh_enabled(config.memory.as_ref());
         let max_inject_tokens =
             crate::config::MemoryConfig::effective_max_inject_tokens(config.memory.as_ref());
+        let agent_config = AgentConfig {
+            max_iterations,
+            save_episodes: true,
+            chat_max_tokens: config.gateway.as_ref().and_then(|g| g.max_output_tokens),
+            reasoning_effort: config.gateway.as_ref().and_then(|g| g.reasoning_effort),
+            ..Default::default()
+        };
+
+        // NOTE(acp): the background `MemoryRefreshService` (auto-sweep of MEMORY.md)
+        // is intentionally NOT started. The memory-bank tools + MEMORY.md injection
+        // already give recall/save/capture (chat parity); the long-running sweep is
+        // a serve-only concern (flock-arbitrated), enable later behind config.
+
+        Ok(Self {
+            llm,
+            memory,
+            memory_store,
+            embedder,
+            agent_config,
+            memory_refresh_enabled,
+            max_inject_tokens,
+            data_dir,
+            config,
+            provider_name,
+            model_id,
+        })
+    }
+}
+
+impl AcpBootstrap {
+    /// Assemble the per-cwd agent state (tool registry rooted at `cwd`, profile,
+    /// agents, hooks, compaction, skill read-zones) on top of the process-global
+    /// [`AcpSharedStores`]. Mirrors `octos chat`'s assembly; the owned aliases
+    /// below keep the body identical. Diagnostics go to stderr (ACP owns stdout).
+    async fn build(
+        shared: &AcpSharedStores,
+        cwd: PathBuf,
+        profile_arg: &Option<String>,
+    ) -> Result<Self> {
+        // Owned aliases so the assembly body reads exactly like `octos chat`.
+        let config = shared.config.clone();
+        let data_dir = shared.data_dir.clone();
+        let llm = shared.llm.clone();
+        let memory = shared.memory.clone();
+        let memory_store = shared.memory_store.clone();
+        let memory_refresh_enabled = shared.memory_refresh_enabled;
+        let provider_name = shared.provider_name.clone();
+        let model_id = shared.model_id.clone();
 
         // --- profile (resolved now; applied to the registry LAST via finalize) ---
         let (profile, profile_source_label) = super::chat::resolve_profile(profile_arg)?;
@@ -389,7 +442,9 @@ impl AcpBootstrap {
                 &plugin_dirs,
                 &[],
                 octos_agent::PluginLoadOptions {
-                    work_dir: None,
+                    // P1 (codex): plugins execute in the SESSION cwd, not the
+                    // ACP process launch dir.
+                    work_dir: Some(cwd.as_path()),
                     synthesis_config: None,
                     require_signed: config.plugins.require_signed,
                     verified_cache_dir: None,
@@ -415,10 +470,12 @@ impl AcpBootstrap {
             memory.clone(),
             cwd.clone(),
             data_dir.clone(),
-            tools.provider_policy().cloned(),
+            // P3 (codex): resolve provider policy NOW (finalize runs later) so
+            // pipeline workers inherit tool_policy_by_provider denials.
+            super::chat::resolve_provider_policy(&config, &provider_name, &model_id),
             plugin_dirs.clone(),
             config.plugins.require_signed,
-            super::chat::create_embedder(&config),
+            shared.embedder.clone(),
         );
         tools.register(pipeline_tool);
         tools.mark_spawn_only(
@@ -447,8 +504,6 @@ impl AcpBootstrap {
         profile
             .validate_against_registry(&agent_definitions)
             .wrap_err("profile references missing agent_definition ids")?;
-
-        let embedder = super::chat::create_embedder(&config);
 
         // System-prompt override from the profile template (bootstrap files +
         // memory segment are attached per session in `build`, since they are
@@ -495,49 +550,30 @@ impl AcpBootstrap {
             }
         };
 
-        let agent_config = AgentConfig {
-            max_iterations,
-            save_episodes: true,
-            chat_max_tokens: config.gateway.as_ref().and_then(|g| g.max_output_tokens),
-            reasoning_effort: config.gateway.as_ref().and_then(|g| g.reasoning_effort),
-            ..Default::default()
-        };
-
-        // NOTE(acp): the background `MemoryRefreshService` (auto-sweep of MEMORY.md)
-        // is intentionally NOT started here. The memory-bank tools + MEMORY.md
-        // injection above already give recall/save/capture (chat parity). The
-        // long-running sweep is a serve-only concern (flock-arbitrated); enable it
-        // later behind `memory.refresh.enabled` if wanted.
-
-        let profile = Arc::new(profile);
+        // Canonicalized skill dirs → per-session `SessionScope` read-zones (P1).
+        let skill_read_zones = canonicalize_skill_read_zones(&plugin_dirs);
 
         Ok(Self {
-            llm,
-            memory,
-            memory_store,
-            embedder,
             tool_specs: Arc::new(tools),
             sandbox,
             profile_system_prompt,
             plugin_prompt_fragments: plugin_result.prompt_fragments,
             hook_executor,
             agent_definitions,
-            profile,
-            agent_config,
+            profile: Arc::new(profile),
             compaction,
-            memory_refresh_enabled,
-            max_inject_tokens,
-            data_dir,
+            skill_read_zones,
         })
     }
 }
 
-/// Production agent factory: holds the raw config inputs plus a lazily-built
-/// shared [`AcpBootstrap`]. The heavy assembly runs ONCE on the first
-/// `session/new` (using the client's real project cwd); every session then only
-/// does a cheap cwd rebind. Building lazily keeps `initialize` cheap and turns a
-/// misconfiguration (e.g. missing provider key) into a `session/new` error
-/// response rather than a startup crash before the ACP handshake.
+/// Production agent factory: raw config inputs + a lazily-built process-global
+/// [`AcpSharedStores`] and a per-cwd cache of [`AcpBootstrap`]. The shared stores
+/// (provider chain, redb episode store, memory) build ONCE on the first
+/// `session/new`; each distinct session cwd builds its own tool
+/// registry/plugins/agents/scope on top. Lazy build keeps `initialize` cheap and
+/// turns a misconfiguration (e.g. missing provider key) into a `session/new`
+/// error rather than a startup crash before the ACP handshake.
 struct ConfigAgentFactory {
     config: Config,
     provider_name: String,
@@ -547,7 +583,8 @@ struct ConfigAgentFactory {
     default_cwd: PathBuf,
     max_iterations: u32,
     profile: Option<String>,
-    bootstrap: tokio::sync::OnceCell<Arc<AcpBootstrap>>,
+    shared: tokio::sync::OnceCell<Arc<AcpSharedStores>>,
+    cwd_cache: Mutex<HashMap<PathBuf, Arc<AcpBootstrap>>>,
 }
 
 #[async_trait::async_trait]
@@ -557,20 +594,18 @@ impl SessionAgentFactory for ConfigAgentFactory {
     }
 
     async fn build(&self, cwd: PathBuf) -> Result<(Arc<Agent>, Arc<AtomicBool>)> {
-        // Assemble the shared stack once, lazily, on the first session (using the
-        // client's real project cwd for plugins/skills/policy/system-prompt).
-        let b = self
-            .bootstrap
+        // Process-global stores (provider chain, redb episode store, memory) built
+        // once, lazily, on the first session.
+        let shared = self
+            .shared
             .get_or_try_init(|| async {
-                AcpBootstrap::build(
+                AcpSharedStores::build(
                     self.config.clone(),
                     self.provider_name.clone(),
                     self.model.clone(),
                     self.base_url.clone(),
                     self.data_dir.clone(),
-                    cwd.clone(),
                     self.max_iterations,
-                    &self.profile,
                 )
                 .await
                 .map(Arc::new)
@@ -578,36 +613,78 @@ impl SessionAgentFactory for ConfigAgentFactory {
             .await?
             .clone();
 
-        // Per-session: rebind the shared base registry to the client's cwd so the
-        // cwd-bound tools (shell/read_file/…) run against the client's repo, and
-        // give this session its own Arc-able registry.
+        // Per-cwd assembled state (plugins/agents/hooks/compaction/scope rooted at
+        // THIS cwd), cached so a second project handled by the same process gets
+        // its own skills/agents/scope instead of the first cwd's (codex P2).
+        let b = {
+            let mut cache = self.cwd_cache.lock().await;
+            if let Some(existing) = cache.get(&cwd) {
+                existing.clone()
+            } else {
+                let built =
+                    Arc::new(AcpBootstrap::build(&shared, cwd.clone(), &self.profile).await?);
+                cache.insert(cwd.clone(), built.clone());
+                built
+            }
+        };
+
+        // Per-session: rebind this cwd's base registry so the cwd-bound tools
+        // (shell/read_file/…) run against the client's repo, and give this session
+        // its own Arc-able registry.
         let tools = b.tool_specs.rebind_cwd_with_permissions(
             &cwd,
             create_sandbox(&b.sandbox),
             octos_agent::EffectivePermissions::workspace_write(),
         );
 
+        // Per-session filesystem scope (codex P1): contain file tools + plugins to
+        // cwd, with skill read-zones so `read_file` reaches SKILL.md references.
+        let absolute_cwd = if cwd.is_absolute() {
+            cwd.clone()
+        } else {
+            std::env::current_dir()
+                .map(|d| d.join(&cwd))
+                .unwrap_or_else(|_| cwd.clone())
+        };
+        let session_scope = SessionScope::solo(absolute_cwd.clone(), Vec::new())
+            .ok()
+            .map(|base| {
+                base.with_skill_read_zones(b.skill_read_zones.clone())
+                    .unwrap_or_else(|_| {
+                        SessionScope::solo(absolute_cwd.clone(), Vec::new())
+                            .expect("absolutized cwd is valid")
+                    })
+            });
+
         // Per-session sub-agent output routing + file-state cache (cheap).
         let subagent_output_router = Arc::new(octos_agent::SubAgentOutputRouter::new(
-            b.data_dir.join("subagent-outputs"),
+            shared.data_dir.join("subagent-outputs"),
         ));
         let supervisor_for_summary = (*tools.supervisor()).clone();
         let subagent_summary_generator = Arc::new(octos_agent::AgentSummaryGenerator::new(
-            b.llm.clone(),
+            shared.llm.clone(),
             subagent_output_router.clone(),
             supervisor_for_summary,
         ));
 
         let shutdown = Arc::new(AtomicBool::new(false));
-        let mut agent = Agent::new(AgentId::new("acp"), b.llm.clone(), tools, b.memory.clone())
-            .with_config(b.agent_config.clone())
-            .with_agent_definitions(b.agent_definitions.clone())
-            .with_profile(b.profile.clone())
-            .with_file_state_cache(Arc::new(octos_agent::FileStateCache::new()))
-            .with_subagent_output_router(subagent_output_router)
-            .with_subagent_summary_generator(subagent_summary_generator)
-            .with_shutdown(shutdown.clone());
-        if let Some(embedder) = &b.embedder {
+        let mut agent = Agent::new(
+            AgentId::new("acp"),
+            shared.llm.clone(),
+            tools,
+            shared.memory.clone(),
+        )
+        .with_config(shared.agent_config.clone())
+        .with_agent_definitions(b.agent_definitions.clone())
+        .with_profile(b.profile.clone())
+        .with_file_state_cache(Arc::new(octos_agent::FileStateCache::new()))
+        .with_subagent_output_router(subagent_output_router)
+        .with_subagent_summary_generator(subagent_summary_generator)
+        .with_shutdown(shutdown.clone());
+        if let Some(scope) = session_scope {
+            agent = agent.with_session_scope(Arc::new(scope));
+        }
+        if let Some(embedder) = &shared.embedder {
             agent = agent.with_embedder(embedder.clone());
         }
         if let Some(hooks) = &b.hook_executor {
@@ -629,18 +706,18 @@ impl SessionAgentFactory for ConfigAgentFactory {
         if !bootstrap_files.is_empty() {
             agent.append_system_prompt(&bootstrap_files);
         }
-        let memory_ctx = b
+        let memory_ctx = shared
             .memory_store
-            .get_injectable_context(b.max_inject_tokens)
+            .get_injectable_context(shared.max_inject_tokens)
             .await;
         agent.set_prompt_segment(
             octos_agent::MEMORY_SEGMENT_NAME,
-            octos_agent::compose_memory_segment(&memory_ctx, b.memory_refresh_enabled),
+            octos_agent::compose_memory_segment(&memory_ctx, shared.memory_refresh_enabled),
         );
-        if b.memory_refresh_enabled {
+        if shared.memory_refresh_enabled {
             agent.add_prompt_segment_provider(Arc::new(octos_agent::MemorySegmentProvider::new(
-                b.memory_store.clone(),
-                b.max_inject_tokens,
+                shared.memory_store.clone(),
+                shared.max_inject_tokens,
                 true,
             )));
         }
@@ -854,7 +931,8 @@ impl AcpCommand {
             default_cwd: cwd,
             max_iterations: self.max_iterations,
             profile: self.profile.clone(),
-            bootstrap: tokio::sync::OnceCell::new(),
+            shared: tokio::sync::OnceCell::new(),
+            cwd_cache: Mutex::new(HashMap::new()),
         });
 
         let sessions: SessionMap = Arc::new(Mutex::new(HashMap::new()));

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -175,6 +175,40 @@ struct ConfigAgentFactory {
     max_iterations: u32,
 }
 
+/// Core tools pinned as LRU "base" tools so the agent never auto-evicts them
+/// mid-session. The registry keeps only `max_active` (15) tools visible and
+/// evicts the least-recently-used non-base tools after they sit idle for
+/// `idle_threshold` iterations. Without pinning, the command-execution tools
+/// (`shell`/`exec_command`/`bash`) get evicted once the model spends a stretch
+/// on file/search tools — and the agent then silently loses the ability to run
+/// a script (observed live driving octos from Zed: the model fell back to
+/// `web_search`/`request_user_input` instead of executing a command). Mirrors
+/// the base set the gateway/profile runtimes pin.
+const ACP_BASE_TOOLS: &[&str] = &[
+    "shell",
+    "exec_command",
+    "bash",
+    "read_file",
+    "write_file",
+    "edit_file",
+    "apply_patch",
+    "list_dir",
+    "glob",
+    "grep",
+];
+
+/// Build the tool registry shared by every ACP session: built-ins rooted at
+/// `cwd` under `sandbox_config`, with the core coding tools pinned as base
+/// tools (see [`ACP_BASE_TOOLS`]) so they survive LRU eviction.
+fn build_acp_tool_registry(
+    cwd: &std::path::Path,
+    sandbox_config: &octos_agent::SandboxConfig,
+) -> ToolRegistry {
+    let mut tools = ToolRegistry::with_builtins_and_sandbox(cwd, create_sandbox(sandbox_config));
+    tools.set_base_tools(ACP_BASE_TOOLS.iter().copied());
+    tools
+}
+
 #[async_trait::async_trait]
 impl SessionAgentFactory for ConfigAgentFactory {
     fn default_cwd(&self) -> &std::path::Path {
@@ -197,8 +231,7 @@ impl SessionAgentFactory for ConfigAgentFactory {
                 .wrap_err("failed to open episode store")?,
         );
 
-        let sandbox = create_sandbox(&self.config.sandbox);
-        let tools = ToolRegistry::with_builtins_and_sandbox(&cwd, sandbox);
+        let tools = build_acp_tool_registry(&cwd, &self.config.sandbox);
 
         let shutdown = Arc::new(AtomicBool::new(false));
         let agent = Agent::new(AgentId::new("acp"), llm, tools, memory)
@@ -321,10 +354,7 @@ impl SessionAgentFactory for TestAgentFactory {
 
     async fn build(&self, cwd: PathBuf) -> Result<(Arc<Agent>, Arc<AtomicBool>)> {
         let memory = Arc::new(EpisodeStore::open(&self.memory_dir).await?);
-        let tools = ToolRegistry::with_builtins_and_sandbox(
-            &cwd,
-            create_sandbox(&octos_agent::SandboxConfig::default()),
-        );
+        let tools = build_acp_tool_registry(&cwd, &octos_agent::SandboxConfig::default());
         let shutdown = Arc::new(AtomicBool::new(false));
         let agent = Agent::new(AgentId::new("acp-test"), self.llm.clone(), tools, memory)
             .with_shutdown(shutdown.clone());
@@ -871,6 +901,49 @@ pub(crate) fn project_progress_event_deduped(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression: a long ACP session that keeps using file/search tools while
+    /// never touching the exec tools must not lose `shell`/`exec_command`/
+    /// `bash` to LRU eviction (`max_active` = 15). Before they were pinned as
+    /// base tools they got evicted after `idle_threshold` idle iterations and
+    /// the agent silently lost the ability to run scripts — observed live
+    /// driving octos from Zed (the model flailed on `web_search` /
+    /// `request_user_input` instead of running a command).
+    #[test]
+    fn should_keep_exec_tools_visible_when_long_session_only_uses_file_tools() {
+        let reg = build_acp_tool_registry(
+            std::path::Path::new("."),
+            &octos_agent::SandboxConfig::default(),
+        );
+        for t in ["shell", "exec_command", "bash"] {
+            assert!(
+                reg.is_tool_visible(t),
+                "{t} should be present at construction"
+            );
+        }
+        // Drive many turns that only ever use non-exec tools, applying LRU
+        // eviction each turn exactly as the agent loop does.
+        for _ in 0..12 {
+            reg.tick();
+            for used in [
+                "read_file",
+                "edit_file",
+                "grep",
+                "list_dir",
+                "glob",
+                "write_file",
+            ] {
+                reg.record_usage(used);
+            }
+            reg.auto_evict();
+        }
+        for t in ["shell", "exec_command", "bash"] {
+            assert!(
+                reg.is_tool_visible(t),
+                "{t} must survive LRU eviction across a long ACP session"
+            );
+        }
+    }
     use agent_client_protocol::schema::ProtocolVersion;
     use octos_agent::SilentReporter;
     use std::time::Duration;

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -53,6 +53,16 @@ use super::matrix_integration::*;
 
 const PROFILE_PROMPT_CACHE_CAP: usize = 128;
 
+// `large_enum_variant`: the `Inbound` variant carries an
+// `octos_core::InboundMessage`, which holds `serde_json::Value` fields. When a
+// workspace crate enables serde_json's `preserve_order` feature (the `octos acp`
+// bridge's `agent-client-protocol` dependency requires it, and Cargo unifies
+// features workspace-wide), `Value::Object` switches from `BTreeMap` to
+// `IndexMap` and this enum grows past the lint threshold. This event is
+// constructed once per inbound message on a channel-bounded path where the size
+// delta is immaterial; boxing would churn every construction/match site for no
+// real benefit, so we allow it.
+#[allow(clippy::large_enum_variant)]
 enum GatewayLoopEvent {
     Wake,
     Shutdown,

--- a/crates/octos-cli/src/commands/mod.rs
+++ b/crates/octos-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 //! CLI commands for octos.
 
 mod account;
+mod acp;
 mod admin;
 mod auth;
 mod channels;
@@ -27,6 +28,13 @@ use clap::{Parser, Subcommand};
 use eyre::Result;
 
 pub use account::AccountCommand;
+pub use acp::AcpCommand;
+// Test-support seam for the `octos acp` bridge: the end-to-end integration test
+// in `crates/octos-cli/tests/acp_integration.rs` drives the real ACP handler
+// wiring with a `MockLlm`-backed agent over an in-process transport. Hidden
+// from docs; not part of the stable surface.
+#[doc(hidden)]
+pub use acp::{OctosAcpAgentTransport, TestAgentFactory};
 pub use admin::AdminCommand;
 pub use auth::AuthCommand;
 pub use channels::ChannelsCommand;
@@ -83,6 +91,8 @@ fn version_string() -> &'static str {
 pub enum Command {
     /// Manage sub-accounts under profiles.
     Account(AccountCommand),
+    /// Run as an Agent Client Protocol (ACP) agent over stdio (Zed, etc.).
+    Acp(AcpCommand),
     /// Admin commands for tenant and tunnel management.
     Admin(AdminCommand),
     /// Manage authentication for LLM providers.
@@ -303,6 +313,7 @@ impl Executable for Command {
     fn execute(self) -> Result<()> {
         match self {
             Self::Account(cmd) => cmd.execute(),
+            Self::Acp(cmd) => cmd.execute(),
             Self::Admin(cmd) => cmd.execute(),
             Self::Auth(cmd) => cmd.execute(),
             Self::Channels(cmd) => cmd.execute(),

--- a/crates/octos-cli/src/main.rs
+++ b/crates/octos-cli/src/main.rs
@@ -41,8 +41,12 @@ fn main() -> Result<()> {
         log_dir = Some(dir);
     }
 
-    // Initialize tracing (with optional rolling file output for serve)
-    let _log_guard = init_tracing(log_dir.as_deref())?;
+    // Initialize tracing (with optional rolling file output for serve).
+    // `octos acp` speaks ACP JSON-RPC on STDOUT, so its logs MUST NOT touch
+    // stdout — one stray log line corrupts the protocol stream and strict
+    // clients (Zed) reject it all with a -32700 parse error. Route to stderr.
+    let reserve_stdout = matches!(args.command, commands::Command::Acp(_));
+    let _log_guard = init_tracing(log_dir.as_deref(), reserve_stdout)?;
 
     args.command.execute()
 }
@@ -54,6 +58,7 @@ fn main() -> Result<()> {
 /// the last 7 days.  The returned guard must be held for the program lifetime.
 fn init_tracing(
     log_dir: Option<&std::path::Path>,
+    reserve_stdout: bool,
 ) -> Result<Option<tracing_appender::non_blocking::WorkerGuard>> {
     use std::io::IsTerminal as _;
     use tracing_subscriber::fmt::writer::{BoxMakeWriter, MakeWriterExt};
@@ -122,6 +127,13 @@ fn init_tracing(
 
         Ok(Some(guard))
     } else {
+        // `octos acp` reserves stdout for the JSON-RPC protocol → its logs go to
+        // stderr. Every other no-log-dir command keeps the historical stdout.
+        let writer: BoxMakeWriter = if reserve_stdout {
+            BoxMakeWriter::new(std::io::stderr)
+        } else {
+            BoxMakeWriter::new(std::io::stdout)
+        };
         if json_logs {
             tracing_subscriber::registry()
                 .with(
@@ -129,7 +141,8 @@ fn init_tracing(
                         .json()
                         .with_target(true)
                         .with_span_list(true)
-                        .with_current_span(true),
+                        .with_current_span(true)
+                        .with_writer(writer),
                 )
                 .with(filter)
                 .init();
@@ -139,7 +152,8 @@ fn init_tracing(
                     fmt::layer()
                         .with_target(false)
                         .with_thread_ids(false)
-                        .compact(),
+                        .compact()
+                        .with_writer(writer),
                 )
                 .with(filter)
                 .init();

--- a/crates/octos-cli/tests/acp_integration.rs
+++ b/crates/octos-cli/tests/acp_integration.rs
@@ -362,6 +362,15 @@ fn should_emit_only_valid_json_on_stdout_when_running_acp() {
     use std::process::{Command, Stdio};
 
     let tmp = tempfile::tempdir().expect("tempdir");
+    // Fully isolate the child from the developer/CI account: its data, config,
+    // and auth dirs resolve to temp subdirs so the test can neither read nor
+    // mutate real user state (codex). A fresh config home also still exercises
+    // startup logging under RUST_LOG=info, so a stdout leak would surface.
+    let home = tmp.path().join("home");
+    let config = tmp.path().join("config");
+    let data = tmp.path().join("data");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&config).unwrap();
     let mut child = Command::new(env!("CARGO_BIN_EXE_octos"))
         .args([
             "acp",
@@ -373,6 +382,9 @@ fn should_emit_only_valid_json_on_stdout_when_running_acp() {
             tmp.path().to_str().unwrap(),
         ])
         .env("RUST_LOG", "info") // force startup logging so a leak would show
+        .env("HOME", &home)
+        .env("OCTOS_HOME", &data)
+        .env("OCTOS_CONFIG_DIR", &config)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -406,6 +418,7 @@ fn should_emit_only_valid_json_on_stdout_when_running_acp() {
     });
     std::thread::sleep(std::time::Duration::from_secs(3));
     let _ = child.kill();
+    let _ = child.wait(); // reap the child so it can't linger as a zombie
     let lines = handle.join().unwrap_or_default();
 
     assert!(

--- a/crates/octos-cli/tests/acp_integration.rs
+++ b/crates/octos-cli/tests/acp_integration.rs
@@ -349,3 +349,72 @@ async fn should_accumulate_conversation_history_across_multiple_prompts() {
         snapshots[2].len()
     );
 }
+
+/// Regression: `octos acp` speaks ACP JSON-RPC on stdout, so NOTHING else may be
+/// written there — a single stray log line makes strict clients (Zed) reject the
+/// whole stream with a `-32700` parse error. octos's tracing previously defaulted
+/// to stdout for no-log-dir commands; this drives the REAL binary through
+/// `initialize` + `session/new` (which loads config → emits startup logs) and
+/// asserts every stdout line is valid JSON.
+#[test]
+fn should_emit_only_valid_json_on_stdout_when_running_acp() {
+    use std::io::{BufRead, BufReader, Write};
+    use std::process::{Command, Stdio};
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_octos"))
+        .args([
+            "acp",
+            "--provider",
+            "deepseek",
+            "--model",
+            "deepseek-chat",
+            "--cwd",
+            tmp.path().to_str().unwrap(),
+        ])
+        .env("RUST_LOG", "info") // force startup logging so a leak would show
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn octos acp");
+
+    let mut stdin = child.stdin.take().unwrap();
+    // initialize + session/new — the latter triggers config load (the logs that
+    // used to leak). No LLM call, so no provider key is needed.
+    stdin
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":1,\"clientCapabilities\":{}}}\n")
+        .unwrap();
+    stdin
+        .write_all(format!("{{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/new\",\"params\":{{\"cwd\":\"{}\",\"mcpServers\":[]}}}}\n", tmp.path().to_str().unwrap()).as_bytes())
+        .unwrap();
+    stdin.flush().unwrap();
+
+    // Read stdout in a thread; stop after a couple of responses or a short wait.
+    let stdout = child.stdout.take().unwrap();
+    let handle = std::thread::spawn(move || {
+        let mut lines = Vec::new();
+        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+            if !line.trim().is_empty() {
+                lines.push(line);
+            }
+            if lines.len() >= 2 {
+                break;
+            }
+        }
+        lines
+    });
+    std::thread::sleep(std::time::Duration::from_secs(3));
+    let _ = child.kill();
+    let lines = handle.join().unwrap_or_default();
+
+    assert!(
+        !lines.is_empty(),
+        "octos acp should have emitted at least the initialize/session responses on stdout"
+    );
+    for line in &lines {
+        serde_json::from_str::<serde_json::Value>(line).unwrap_or_else(|e| {
+            panic!("non-JSON line on the ACP stdout stream (would -32700 in Zed): {line:?} ({e})")
+        });
+    }
+}

--- a/crates/octos-cli/tests/acp_integration.rs
+++ b/crates/octos-cli/tests/acp_integration.rs
@@ -323,8 +323,24 @@ async fn should_accumulate_conversation_history_across_multiple_prompts() {
     );
     assert!(t3.contains("USER_THREE"), "turn 3 sees its own user msg");
 
-    // The accumulated history the LLM receives grows every turn (one extra
-    // user message per turn): [sys, u1] -> [sys, u1, u2] -> [sys, u1, u2, u3].
+    // codex round-2 regression: the ASSISTANT reply must also persist. A
+    // text-only turn carries the final reply in `resp.content`, NOT in
+    // `resp.messages`, so without explicitly persisting it the agent remembers
+    // what the USER said but not what IT answered. Turns 2 and 3 must see turn
+    // 1's assistant reply ("ASSISTANT_ONE").
+    assert!(
+        blob(1).contains("ASSISTANT_ONE"),
+        "turn 2 must see turn 1's ASSISTANT reply; assistant text not persisted. turn-2 messages: {:?}",
+        snapshots[1]
+    );
+    assert!(
+        t3.contains("ASSISTANT_ONE") && t3.contains("ASSISTANT_TWO"),
+        "turn 3 must see the assistant replies from turns 1 and 2. turn-3 messages: {:?}",
+        snapshots[2]
+    );
+
+    // The accumulated history the LLM receives grows every turn (user + assistant
+    // per turn): [sys, u1] -> [sys, u1, a1, u2] -> [sys, u1, a1, u2, a2, u3].
     assert!(
         snapshots[0].len() < snapshots[1].len() && snapshots[1].len() < snapshots[2].len(),
         "incoming message count must grow across turns: {} < {} < {}",

--- a/crates/octos-cli/tests/acp_integration.rs
+++ b/crates/octos-cli/tests/acp_integration.rs
@@ -1,0 +1,162 @@
+//! End-to-end integration test for the `octos acp` bridge.
+//!
+//! Drives the real ACP agent (the exact handler wiring `octos acp` uses) with a
+//! `MockLlm` — a canned [`LlmProvider`] that returns a fixed assistant reply —
+//! through the full `initialize -> session/new -> session/prompt` round-trip,
+//! and asserts the streamed `session/update` sequence plus the final stop
+//! reason.
+//!
+//! No network, no subprocess, no OS pipes: the ACP client and the octos ACP
+//! agent are wired together **in-process**. [`OctosAcpAgentTransport`] exposes
+//! the octos agent as a `ConnectTo<Client>` transport; the client's
+//! `connect_with` closure drives the protocol while the agent's handlers run in
+//! the background — all on one tokio runtime, exchanging typed JSON-RPC messages
+//! directly.
+
+use std::sync::Arc;
+
+use agent_client_protocol::schema::ProtocolVersion;
+use agent_client_protocol::schema::v1::{
+    ContentBlock, InitializeRequest, NewSessionRequest, PromptRequest, SessionNotification,
+    SessionUpdate, StopReason, TextContent,
+};
+use agent_client_protocol::{Client, ConnectionTo};
+
+use async_trait::async_trait;
+use octos_cli::commands::{OctosAcpAgentTransport, TestAgentFactory};
+use tokio::sync::Mutex;
+
+/// A canned LLM that always returns the same assistant text and ends the turn —
+/// mirrors the `MockLlm` pattern from `chat.rs`'s unit tests.
+struct MockLlm {
+    reply: String,
+}
+
+#[async_trait]
+impl octos_llm::LlmProvider for MockLlm {
+    async fn chat(
+        &self,
+        _messages: &[octos_core::Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &octos_llm::ChatConfig,
+    ) -> eyre::Result<octos_llm::ChatResponse> {
+        Ok(octos_llm::ChatResponse {
+            content: Some(self.reply.clone()),
+            reasoning_content: None,
+            tool_calls: vec![],
+            stop_reason: octos_llm::StopReason::EndTurn,
+            usage: octos_llm::TokenUsage::default(),
+            provider_index: None,
+        })
+    }
+
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+
+    fn model_id(&self) -> &str {
+        "mock-1"
+    }
+}
+
+/// Pull the text out of an assistant-message `session/update`, if that's what it
+/// is.
+fn agent_message_text(update: &SessionUpdate) -> Option<String> {
+    match update {
+        SessionUpdate::AgentMessageChunk(chunk) => match &chunk.content {
+            ContentBlock::Text(t) => Some(t.text.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_stream_assistant_message_and_end_turn_when_driven_through_acp_initialize_new_session_prompt()
+ {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cwd = tmp.path().to_path_buf();
+    let memory_dir = tmp.path().join("memory");
+    std::fs::create_dir_all(&memory_dir).unwrap();
+
+    let reply = "Hello from octos ACP";
+    let llm: Arc<dyn octos_llm::LlmProvider> = Arc::new(MockLlm {
+        reply: reply.to_string(),
+    });
+    let factory = TestAgentFactory::new(llm, memory_dir, cwd.clone());
+    let transport = OctosAcpAgentTransport::new(factory);
+
+    // Records every `session/update` the agent streams to the client.
+    let updates: Arc<Mutex<Vec<SessionUpdate>>> = Arc::new(Mutex::new(Vec::new()));
+    let updates_for_handler = updates.clone();
+
+    // The captured stop reason from the prompt turn.
+    let stop_reason: Arc<Mutex<Option<StopReason>>> = Arc::new(Mutex::new(None));
+    let stop_reason_for_main = stop_reason.clone();
+
+    let prompt_cwd = cwd.clone();
+
+    // Build the in-process ACP CLIENT and drive the protocol from its
+    // `connect_with` closure. The octos ACP agent is the transport.
+    let client_result = Client
+        .builder()
+        .name("octos-acp-test-client")
+        .on_receive_notification(
+            async move |notif: SessionNotification,
+                        _cx: ConnectionTo<agent_client_protocol::Agent>| {
+                updates_for_handler.lock().await.push(notif.update);
+                Ok(())
+            },
+            agent_client_protocol::on_receive_notification!(),
+        )
+        .connect_with(
+            transport,
+            |connection: ConnectionTo<agent_client_protocol::Agent>| async move {
+                // 1) initialize
+                let init = connection
+                    .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                    .block_task()
+                    .await?;
+                assert_eq!(init.protocol_version, ProtocolVersion::V1);
+                // octos advertises text-only prompt capabilities.
+                assert!(!init.agent_capabilities.prompt_capabilities.image);
+
+                // 2) session/new
+                let new_session = connection
+                    .send_request(NewSessionRequest::new(prompt_cwd.clone()))
+                    .block_task()
+                    .await?;
+                let session_id = new_session.session_id;
+
+                // 3) session/prompt
+                let prompt = connection
+                    .send_request(PromptRequest::new(
+                        session_id.clone(),
+                        vec![ContentBlock::Text(TextContent::new("hello"))],
+                    ))
+                    .block_task()
+                    .await?;
+
+                *stop_reason_for_main.lock().await = Some(prompt.stop_reason);
+                Ok(())
+            },
+        )
+        .await;
+
+    client_result.expect("ACP client run should complete cleanly");
+
+    // The turn ended naturally. `StopReason` is `Copy`, so deref instead of clone.
+    let got_stop = *stop_reason.lock().await;
+    assert!(
+        matches!(got_stop, Some(StopReason::EndTurn)),
+        "expected StopReason::EndTurn, got {got_stop:?}"
+    );
+
+    // The assistant's canned reply was streamed as an AgentMessageChunk.
+    let recorded = updates.lock().await;
+    let assistant_texts: Vec<String> = recorded.iter().filter_map(agent_message_text).collect();
+    assert!(
+        assistant_texts.iter().any(|t| t.contains(reply)),
+        "expected an AgentMessageChunk containing {reply:?}; recorded updates: {recorded:?}"
+    );
+}

--- a/crates/octos-cli/tests/acp_integration.rs
+++ b/crates/octos-cli/tests/acp_integration.rs
@@ -59,6 +59,56 @@ impl octos_llm::LlmProvider for MockLlm {
     }
 }
 
+/// A `MockLlm` that returns a per-call assistant reply and records, for every
+/// `chat()` call, the full set of message *contents* it was handed (system +
+/// accumulated history + the current user turn). The integration test inspects
+/// these snapshots to prove multi-turn history accumulates across prompts.
+struct RecordingLlm {
+    /// One entry per `chat()` call: the `content` of every incoming message.
+    seen: Arc<Mutex<Vec<Vec<String>>>>,
+    /// Assistant reply text keyed by call index (0-based); falls back to a
+    /// generic reply if the call index is beyond the vec.
+    replies: Vec<String>,
+    calls: std::sync::atomic::AtomicUsize,
+}
+
+#[async_trait]
+impl octos_llm::LlmProvider for RecordingLlm {
+    async fn chat(
+        &self,
+        messages: &[octos_core::Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &octos_llm::ChatConfig,
+    ) -> eyre::Result<octos_llm::ChatResponse> {
+        let idx = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.seen
+            .lock()
+            .await
+            .push(messages.iter().map(|m| m.content.clone()).collect());
+        let reply = self
+            .replies
+            .get(idx)
+            .cloned()
+            .unwrap_or_else(|| format!("reply-{idx}"));
+        Ok(octos_llm::ChatResponse {
+            content: Some(reply),
+            reasoning_content: None,
+            tool_calls: vec![],
+            stop_reason: octos_llm::StopReason::EndTurn,
+            usage: octos_llm::TokenUsage::default(),
+            provider_index: None,
+        })
+    }
+
+    fn provider_name(&self) -> &str {
+        "recording-mock"
+    }
+
+    fn model_id(&self) -> &str {
+        "recording-1"
+    }
+}
+
 /// Pull the text out of an assistant-message `session/update`, if that's what it
 /// is.
 fn agent_message_text(update: &SessionUpdate) -> Option<String> {
@@ -158,5 +208,128 @@ async fn should_stream_assistant_message_and_end_turn_when_driven_through_acp_in
     assert!(
         assistant_texts.iter().any(|t| t.contains(reply)),
         "expected an AgentMessageChunk containing {reply:?}; recorded updates: {recorded:?}"
+    );
+}
+
+/// Multi-turn history must ACCUMULATE across prompts: turn N's `process_message`
+/// must see the messages from all earlier turns. This is driven over the real
+/// ACP handler wiring (`initialize -> session/new -> prompt x3`) with a
+/// `RecordingLlm` that snapshots the messages it is handed each turn.
+///
+/// `ConversationResponse.messages` for a text-only (no-tool) `EndTurn` is just
+/// the turn's user message (the assistant's final text is streamed live and
+/// carried in `content`, not re-persisted as a history `Message`), so history
+/// accumulation is observable via the USER turns surviving.
+///
+/// The buggy `*h = resp.messages` (replace) only surfaces from the THIRD turn:
+/// after turn 1 the stored history is [user1] and after turn 2 it is REPLACED
+/// by [user2], dropping user1 — so turn 3 would no longer see user1. A
+/// two-prompt drive can't catch it (turn 2 still sees user1 under the bug); we
+/// therefore drive three prompts and assert turn 3 still sees user1, and that
+/// the incoming message count grows every turn.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_accumulate_conversation_history_across_multiple_prompts() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cwd = tmp.path().to_path_buf();
+    let memory_dir = tmp.path().join("memory");
+    std::fs::create_dir_all(&memory_dir).unwrap();
+
+    // Distinct, greppable replies so we can assert turn-1 content survives.
+    let seen: Arc<Mutex<Vec<Vec<String>>>> = Arc::new(Mutex::new(Vec::new()));
+    let llm: Arc<dyn octos_llm::LlmProvider> = Arc::new(RecordingLlm {
+        seen: seen.clone(),
+        replies: vec![
+            "ASSISTANT_ONE".to_string(),
+            "ASSISTANT_TWO".to_string(),
+            "ASSISTANT_THREE".to_string(),
+        ],
+        calls: std::sync::atomic::AtomicUsize::new(0),
+    });
+    let factory = TestAgentFactory::new(llm, memory_dir, cwd.clone());
+    let transport = OctosAcpAgentTransport::new(factory);
+
+    let prompt_cwd = cwd.clone();
+
+    Client
+        .builder()
+        .name("octos-acp-history-client")
+        .on_receive_notification(
+            async move |_notif: SessionNotification,
+                        _cx: ConnectionTo<agent_client_protocol::Agent>| { Ok(()) },
+            agent_client_protocol::on_receive_notification!(),
+        )
+        .connect_with(
+            transport,
+            |connection: ConnectionTo<agent_client_protocol::Agent>| async move {
+                connection
+                    .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                    .block_task()
+                    .await?;
+                let new_session = connection
+                    .send_request(NewSessionRequest::new(prompt_cwd.clone()))
+                    .block_task()
+                    .await?;
+                let session_id = new_session.session_id;
+
+                for user in ["USER_ONE", "USER_TWO", "USER_THREE"] {
+                    let prompt = connection
+                        .send_request(PromptRequest::new(
+                            session_id.clone(),
+                            vec![ContentBlock::Text(TextContent::new(user))],
+                        ))
+                        .block_task()
+                        .await?;
+                    assert!(
+                        matches!(prompt.stop_reason, StopReason::EndTurn),
+                        "each turn should EndTurn; got {:?}",
+                        prompt.stop_reason
+                    );
+                }
+                Ok(())
+            },
+        )
+        .await
+        .expect("ACP client run should complete cleanly");
+
+    let snapshots = seen.lock().await;
+    assert_eq!(
+        snapshots.len(),
+        3,
+        "exactly one chat() call per prompt turn"
+    );
+
+    // Flatten each turn's incoming messages into one blob for content checks.
+    let blob = |i: usize| snapshots[i].join("\n");
+
+    // Turn 1 sees only turn-1's user prompt (no prior turns).
+    assert!(blob(0).contains("USER_ONE"), "turn 1 sees its own user msg");
+    assert!(
+        !blob(0).contains("USER_TWO"),
+        "turn 1 cannot see a future turn's user msg"
+    );
+
+    // Turn 3 MUST still see turn-1's user prompt — the core regression:
+    // replacing (instead of appending) history drops user1 by turn 3.
+    let t3 = blob(2);
+    assert!(
+        t3.contains("USER_ONE"),
+        "turn 3 must still see turn 1's user msg; history was dropped. turn-3 messages: {:?}",
+        snapshots[2]
+    );
+    assert!(
+        t3.contains("USER_TWO"),
+        "turn 3 must also see turn 2's user msg. turn-3 messages: {:?}",
+        snapshots[2]
+    );
+    assert!(t3.contains("USER_THREE"), "turn 3 sees its own user msg");
+
+    // The accumulated history the LLM receives grows every turn (one extra
+    // user message per turn): [sys, u1] -> [sys, u1, u2] -> [sys, u1, u2, u3].
+    assert!(
+        snapshots[0].len() < snapshots[1].len() && snapshots[1].len() < snapshots[2].len(),
+        "incoming message count must grow across turns: {} < {} < {}",
+        snapshots[0].len(),
+        snapshots[1].len(),
+        snapshots[2].len()
     );
 }


### PR DESCRIPTION
## Summary

Adds **Agent Client Protocol (ACP)** support: `octos acp` runs octos as an ACP agent over stdio (JSON-RPC), so ACP-speaking editors (Zed and others) drive the full octos agent loop as their coding agent. Built on the `agent-client-protocol` crate. This branch is the complete arc — from initial support through **full capability parity with `octos chat`**.

## What's included (10 commits)

**Core ACP bridge** (`crates/octos-cli/src/commands/acp.rs`)
- `octos acp`: initialize / session·new / session·prompt / session·cancel handlers over JSONL stdio (builder + typed-dispatch)
- Streaming `AcpProgressReporter` maps octos `ProgressEvent` → ACP `session/update` (message/thought chunks, tool_call / tool_call_update)
- Per-session history; cancel via a shared `Arc<AtomicBool>`; the prompt turn runs off the dispatch loop so cancel lands mid-flight

**Correctness fixes (codex-reviewed)**
- Multi-turn history accumulation; cancel-race; ResourceLink prompt blocks; protocol-version clamp; assistant reply persisted from `resp.content`; cancelled-turn partial reply not persisted
- **stdout purity**: ACP tracing → stderr (stdout is the JSON-RPC channel; a leaked log line made Zed reject the stream with `-32700`)
- **LRU exec-tool fix**: pin `shell`/`exec_command`/`bash` + core file tools as base so a long session can't LRU-evict the ability to run scripts

**Full parity with `octos chat`** (final commit)
- New `AcpBootstrap` assembles the same stack chat.rs builds, reusing the identical leaf helpers: failover provider chain, long-term memory (MemoryStore + recall/save/note tools + MEMORY.md injection), embedder, plugins/skills + MCP, hooks, pipeline tool, tool/provider policy + `--profile`, agent definitions, sub-agent output routing, compaction
- Built lazily (`OnceCell`) on the first `session/new` using the client's real project cwd → `initialize` stays cheap, a misconfig surfaces as a `session/new` error (not a startup crash), redb episode store opens once; per-session build is just a cheap cwd rebind + `with_shutdown`

**Docs**: README "Use octos in Zed (ACP)" section.

## Testing
- Unit + integration (`tests/acp_integration.rs`) incl. a stdout-purity binary test; regression tests for exec-tool pinning and memory-bank wiring
- Full `octos-cli` suite green (**709+ passed, 0 failed**); clippy `-D warnings` + fmt clean
- Live-verified end-to-end against real Zed and a scripted ACP client: multi-turn agentic sessions, tool execution, MEMORY.md recall, cancel

## Deferred (noted in code)
Background `MemoryRefreshService` auto-sweep (off pending review); `SessionScope::solo`; ACP `session/request_permission` (octos uses its own approval), `session/load`, image/audio prompt blocks.

## Try it in Zed
`~/.config/zed/settings.json`:
```jsonc
{ "agent_servers": { "Octos": { "command": "octos", "args": ["acp","--provider","deepseek","--model","deepseek-chat"], "env": {} } } }
```
Open a folder → Agent Panel → ＋ New Thread (⌥⌘⇧N) → **Octos**.
