### PR TITLE
feat(embedding): model/dimensions config + honor api_key_env

### DIFF
--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -1059,6 +1059,15 @@ pub(crate) fn create_embedder(config: &Config) -> Option<Arc<dyn EmbeddingProvid
     let mut e = OpenAIEmbedder::new(key);
     if let Some(ref url) = cfg.base_url {
         e = e.with_base_url(url);
+    } else if !cfg.provider.eq_ignore_ascii_case("openai") {
+        // A non-openai provider without an explicit base_url falls back to
+        // the registry's default endpoint — otherwise the request goes to
+        // api.openai.com with the other provider's key/model (codex R8).
+        if let Some(url) =
+            octos_llm::registry::lookup(&cfg.provider).and_then(|e| e.default_base_url)
+        {
+            e = e.with_base_url(url);
+        }
     }
     if let Some(ref model) = cfg.model {
         e = e.with_model(model);

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -1048,10 +1048,22 @@ pub(crate) fn resolve_provider_policy(
 /// Create an embedding provider from config, if configured.
 pub(crate) fn create_embedder(config: &Config) -> Option<Arc<dyn EmbeddingProvider>> {
     let cfg = config.embedding.as_ref()?;
-    let key = config.get_api_key(&cfg.provider).ok()?;
+    // `api_key_env` was declared on EmbeddingConfig but never honored —
+    // it wins over the provider-default key lookup so an OpenAI-compatible
+    // endpoint (DashScope etc.) can use its own key variable.
+    let key = match cfg.api_key_env.as_deref() {
+        Some(var) => std::env::var(var).ok()?,
+        None => config.get_api_key(&cfg.provider).ok()?,
+    };
     let mut e = OpenAIEmbedder::new(key);
     if let Some(ref url) = cfg.base_url {
         e = e.with_base_url(url);
+    }
+    if let Some(ref model) = cfg.model {
+        e = e.with_model(model);
+    }
+    if let Some(dimensions) = cfg.dimensions {
+        e = e.with_dimensions(dimensions);
     }
     Some(Arc::new(e))
 }

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -1073,18 +1073,18 @@ pub(crate) fn create_embedder(config: &Config) -> Option<Arc<dyn EmbeddingProvid
             );
         }
         e = e.with_dimensions(dimensions);
-    } else if e.dimension() != octos_memory::EPISODIC_INDEX_DIMENSION {
-        // A model whose native size differs from the fixed index (e.g.
-        // text-embedding-3-large @3072, DashScope v4 @1024) would have
-        // every vector silently dropped to BM25-only. Pin the request to
-        // the index dimension (OpenAI-standard `dimensions` truncation;
-        // compatible providers accept it — ones that don't will error
-        // visibly at request time instead of degrading silently).
+    } else if cfg.model.is_some() {
+        // ANY custom model pins to the index dimension when `dimensions`
+        // is unset: the native-size table only knows OpenAI's models, so
+        // an unknown OpenAI-compatible model (DashScope v4 is natively
+        // 1024-d) would silently drop every vector to BM25-only. Known
+        // 1536-native models tolerate the explicit param; providers that
+        // reject it error visibly at request time instead of degrading
+        // silently. The no-model default keeps the legacy request shape.
         tracing::info!(
             model = %e.model(),
-            native = e.dimension(),
             pinned = octos_memory::EPISODIC_INDEX_DIMENSION,
-            "pinning embedding dimensions to the episodic index size"
+            "pinning custom embedding model to the episodic index dimension"
         );
         e = e.with_dimensions(octos_memory::EPISODIC_INDEX_DIMENSION as u32);
     }

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -1049,12 +1049,13 @@ pub(crate) fn resolve_provider_policy(
 pub(crate) fn create_embedder(config: &Config) -> Option<Arc<dyn EmbeddingProvider>> {
     let cfg = config.embedding.as_ref()?;
     // `api_key_env` was declared on EmbeddingConfig but never honored —
-    // it wins over the provider-default key lookup so an OpenAI-compatible
-    // endpoint (DashScope etc.) can use its own key variable.
-    let key = match cfg.api_key_env.as_deref() {
-        Some(var) => std::env::var(var).ok()?,
-        None => config.get_api_key(&cfg.provider).ok()?,
-    };
+    // it wins over the provider-default var name, resolving through the
+    // SAME credential chain as every other key (auth store, env_vars +
+    // keychain, process env), so `octos auth login` / config-stored keys
+    // keep working (codex P2).
+    let key = config
+        .get_api_key_with_env(&cfg.provider, cfg.api_key_env.as_deref())
+        .ok()?;
     let mut e = OpenAIEmbedder::new(key);
     if let Some(ref url) = cfg.base_url {
         e = e.with_base_url(url);

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -1064,7 +1064,29 @@ pub(crate) fn create_embedder(config: &Config) -> Option<Arc<dyn EmbeddingProvid
         e = e.with_model(model);
     }
     if let Some(dimensions) = cfg.dimensions {
+        if dimensions as usize != octos_memory::EPISODIC_INDEX_DIMENSION {
+            tracing::warn!(
+                dimensions,
+                index = octos_memory::EPISODIC_INDEX_DIMENSION,
+                "embedding.dimensions differs from the episodic index dimension — \
+                 vectors will be dropped to BM25-only"
+            );
+        }
         e = e.with_dimensions(dimensions);
+    } else if e.dimension() != octos_memory::EPISODIC_INDEX_DIMENSION {
+        // A model whose native size differs from the fixed index (e.g.
+        // text-embedding-3-large @3072, DashScope v4 @1024) would have
+        // every vector silently dropped to BM25-only. Pin the request to
+        // the index dimension (OpenAI-standard `dimensions` truncation;
+        // compatible providers accept it — ones that don't will error
+        // visibly at request time instead of degrading silently).
+        tracing::info!(
+            model = %e.model(),
+            native = e.dimension(),
+            pinned = octos_memory::EPISODIC_INDEX_DIMENSION,
+            "pinning embedding dimensions to the episodic index size"
+        );
+        e = e.with_dimensions(octos_memory::EPISODIC_INDEX_DIMENSION as u32);
     }
     Some(Arc::new(e))
 }

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -1081,8 +1081,12 @@ pub(crate) fn create_embedder(config: &Config) -> Option<Arc<dyn EmbeddingProvid
         // families we can't classify, warn loudly instead of degrading
         // silently — the native size is unknown and non-1536 vectors are
         // dropped to BM25-only.
+        // Exactly the families verified to accept `dimensions: 1536`:
+        // OpenAI 3-series (native 1536/3072, truncation supported) and
+        // DashScope text-embedding-v4 (64–2048, verified live). v3 caps
+        // below 1536 and would error — it falls to the warn path.
         let supports_dimensions =
-            model.starts_with("text-embedding-3") || model.starts_with("text-embedding-v");
+            model.starts_with("text-embedding-3") || model == "text-embedding-v4";
         if supports_dimensions {
             tracing::info!(
                 model = %e.model(),

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -1073,20 +1073,32 @@ pub(crate) fn create_embedder(config: &Config) -> Option<Arc<dyn EmbeddingProvid
             );
         }
         e = e.with_dimensions(dimensions);
-    } else if cfg.model.is_some() {
-        // ANY custom model pins to the index dimension when `dimensions`
-        // is unset: the native-size table only knows OpenAI's models, so
-        // an unknown OpenAI-compatible model (DashScope v4 is natively
-        // 1024-d) would silently drop every vector to BM25-only. Known
-        // 1536-native models tolerate the explicit param; providers that
-        // reject it error visibly at request time instead of degrading
-        // silently. The no-model default keeps the legacy request shape.
-        tracing::info!(
-            model = %e.model(),
-            pinned = octos_memory::EPISODIC_INDEX_DIMENSION,
-            "pinning custom embedding model to the episodic index dimension"
-        );
-        e = e.with_dimensions(octos_memory::EPISODIC_INDEX_DIMENSION as u32);
+    } else if let Some(model) = cfg.model.as_deref() {
+        // Auto-pin to the index dimension ONLY for families known to
+        // accept the OpenAI-standard `dimensions` field (OpenAI 3-series;
+        // DashScope text-embedding-v3/v4, natively 1024-d). Models that
+        // reject the field (ada-002) keep the legacy request shape; for
+        // families we can't classify, warn loudly instead of degrading
+        // silently — the native size is unknown and non-1536 vectors are
+        // dropped to BM25-only.
+        let supports_dimensions =
+            model.starts_with("text-embedding-3") || model.starts_with("text-embedding-v");
+        if supports_dimensions {
+            tracing::info!(
+                model = %e.model(),
+                pinned = octos_memory::EPISODIC_INDEX_DIMENSION,
+                "pinning custom embedding model to the episodic index dimension"
+            );
+            e = e.with_dimensions(octos_memory::EPISODIC_INDEX_DIMENSION as u32);
+        } else {
+            tracing::warn!(
+                model = %e.model(),
+                index = octos_memory::EPISODIC_INDEX_DIMENSION,
+                "custom embedding model without `dimensions`: native size unknown — \
+                 vectors that are not index-sized will be dropped to BM25-only; set \
+                 embedding.dimensions if the provider supports it"
+            );
+        }
     }
     Some(Arc::new(e))
 }

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -1699,6 +1699,17 @@ impl Config {
     }
 
     /// Get the API key: auth store first, then environment variable.
+    /// [`Self::get_api_key`] with an explicit env-var override (e.g. the
+    /// embedding block's `api_key_env`): resolves through the SAME chain —
+    /// secret registration, auth store, `env_vars` (keychain-resolved),
+    /// process env — instead of a bare `std::env::var` read.
+    pub fn get_api_key_with_env(&self, provider: &str, env_var: Option<&str>) -> Result<String> {
+        match env_var {
+            Some(var) => self.resolve_api_key(provider, var.to_string()),
+            None => self.get_api_key(provider),
+        }
+    }
+
     pub fn get_api_key(&self, provider: &str) -> Result<String> {
         // Resolve the env var name we expect to hold this provider's key, and
         // mark it as a secret FIRST — before any early return — so the
@@ -1716,6 +1727,12 @@ impl Config {
                 .map(String::from)
                 .unwrap_or_else(|| format!("{}_API_KEY", provider.to_uppercase()))
         });
+        self.resolve_api_key(provider, env_var)
+    }
+
+    /// Shared resolution body: auth store → env_vars (keychain) → process
+    /// env, with the var name secret-registered first.
+    fn resolve_api_key(&self, provider: &str, env_var: String) -> Result<String> {
         octos_agent::register_secret_env_names([env_var.as_str()]);
 
         // Check auth store first. Auth is GLOBAL: it lives under the resolver's
@@ -2892,6 +2909,21 @@ mod tests {
             MemoryConfig::effective_max_inject_tokens(Some(&on)),
             octos_memory::DEFAULT_MAX_INJECT_TOKENS
         );
+    }
+
+    #[test]
+    fn get_api_key_with_env_resolves_through_config_env_vars() {
+        // The override var must resolve through the same chain as normal
+        // keys — here via the config's env_vars map, NOT the process env.
+        let mut config = Config::default();
+        config.env_vars.insert(
+            "CUSTOM_EMBED_KEY".to_string(),
+            "from-config-map".to_string(),
+        );
+        let key = config
+            .get_api_key_with_env("openai", Some("CUSTOM_EMBED_KEY"))
+            .expect("resolves via env_vars map");
+        assert_eq!(key, "from-config-map");
     }
 
     #[test]

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -1705,9 +1705,27 @@ impl Config {
     /// process env — instead of a bare `std::env::var` read.
     pub fn get_api_key_with_env(&self, provider: &str, env_var: Option<&str>) -> Result<String> {
         match env_var {
-            Some(var) => self.resolve_api_key(provider, var.to_string()),
+            // An EXPLICIT var means "use this variable": the provider-
+            // scoped auth store must not win, or a stored `octos auth
+            // login -p openai` token would be sent to a custom
+            // OpenAI-compatible endpoint that the override targets.
+            Some(var) => self.resolve_env_var_only(var),
             None => self.get_api_key(provider),
         }
+    }
+
+    /// Resolve a key from an explicit env-var name WITHOUT provider-scoped
+    /// auth-store lookup: secret registration → `env_vars` map (keychain-
+    /// resolved) → process env.
+    fn resolve_env_var_only(&self, env_var: &str) -> Result<String> {
+        octos_agent::register_secret_env_names([env_var]);
+        if let Some(value) = self.env_vars.get(env_var).and_then(|value| {
+            crate::auth::keychain::resolve_value(env_var, value).filter(|value| !value.is_empty())
+        }) {
+            return Ok(value);
+        }
+        std::env::var(env_var)
+            .wrap_err_with(|| format!("{env_var} not set (explicit embedding api_key_env)"))
     }
 
     pub fn get_api_key(&self, provider: &str) -> Result<String> {
@@ -2908,6 +2926,31 @@ mod tests {
         assert_eq!(
             MemoryConfig::effective_max_inject_tokens(Some(&on)),
             octos_memory::DEFAULT_MAX_INJECT_TOKENS
+        );
+    }
+
+    #[test]
+    fn explicit_env_var_skips_provider_auth_store() {
+        // Even with provider-default resolution available, the explicit
+        // override must come from ITS variable only — never the
+        // provider-scoped auth store (codex R2: an OpenAI OAuth token
+        // must not be sent to a custom-endpoint embedder).
+        let mut config = Config::default();
+        config
+            .env_vars
+            .insert("DASH_EMBED_KEY".to_string(), "dash-key".to_string());
+        // Provider-default path would resolve something else entirely;
+        // the explicit var wins regardless.
+        let key = config
+            .get_api_key_with_env("openai", Some("DASH_EMBED_KEY"))
+            .expect("explicit var resolves");
+        assert_eq!(key, "dash-key");
+        // And a MISSING explicit var is an error — no silent fallback to
+        // the provider chain.
+        assert!(
+            config
+                .get_api_key_with_env("openai", Some("NOPE_MISSING_VAR"))
+                .is_err()
         );
     }
 

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -2975,10 +2975,29 @@ mod tests {
     }
 
     #[test]
+    #[allow(unsafe_code)]
     fn default_name_override_ignores_top_level_api_key_env() {
         // Mixed-provider config: primary provider pins the top-level
         // api_key_env to ITS key; the embedding override naming the
         // embedding provider's default var must still read THAT var.
+        // Auth-home isolated (codex R5): the default-name path consults
+        // the GLOBAL auth store first, so an ambient `octos auth login
+        // -p openai` on a dev/CI machine would shadow the env_vars
+        // assertion nondeterministically.
+        let _g = HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let original_home = std::env::var_os("HOME");
+        let original_octos_home = std::env::var_os("OCTOS_HOME");
+        let original_octos_config = std::env::var_os("OCTOS_CONFIG_DIR");
+        let original_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: serialized by HOME_ENV_LOCK; restored below.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::remove_var("OCTOS_HOME");
+            std::env::remove_var("OCTOS_CONFIG_DIR");
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+
         let mut config = Config::default();
         config.api_key_env = Some("ANTHROPIC_API_KEY".to_string());
         config
@@ -2987,11 +3006,31 @@ mod tests {
         config
             .env_vars
             .insert("OPENAI_API_KEY".to_string(), "openai-key".to_string());
-        let key = config
-            .get_api_key_with_env("openai", Some("OPENAI_API_KEY"))
-            .expect("resolves");
+        let key = config.get_api_key_with_env("openai", Some("OPENAI_API_KEY"));
+
+        // SAFETY: still inside HOME_ENV_LOCK.
+        unsafe {
+            match original_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match original_octos_home {
+                Some(v) => std::env::set_var("OCTOS_HOME", v),
+                None => std::env::remove_var("OCTOS_HOME"),
+            }
+            match original_octos_config {
+                Some(v) => std::env::set_var("OCTOS_CONFIG_DIR", v),
+                None => std::env::remove_var("OCTOS_CONFIG_DIR"),
+            }
+            match original_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+
         assert_eq!(
-            key, "openai-key",
+            key.expect("resolves"),
+            "openai-key",
             "must not read the primary provider's var"
         );
     }

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -1705,13 +1705,28 @@ impl Config {
     /// process env — instead of a bare `std::env::var` read.
     pub fn get_api_key_with_env(&self, provider: &str, env_var: Option<&str>) -> Result<String> {
         match env_var {
-            // An EXPLICIT var means "use this variable": the provider-
-            // scoped auth store must not win, or a stored `octos auth
-            // login -p openai` token would be sent to a custom
-            // OpenAI-compatible endpoint that the override targets.
-            Some(var) => self.resolve_env_var_only(var),
-            None => self.get_api_key(provider),
+            // A CUSTOM var means "use this variable": the provider-scoped
+            // auth store must not win, or a stored `octos auth login -p
+            // openai` token would be sent to the custom OpenAI-compatible
+            // endpoint the override targets. But when the override IS the
+            // provider's default var name (a redundant-but-legal config),
+            // the full provider chain — auth store included — still
+            // applies, preserving pre-existing login-based setups.
+            Some(var) if Some(var) != Self::provider_default_env_var(provider).as_deref() => {
+                self.resolve_env_var_only(var)
+            }
+            _ => self.get_api_key(provider),
         }
+    }
+
+    /// The env-var name the provider chain would use by default.
+    fn provider_default_env_var(provider: &str) -> Option<String> {
+        Some(
+            octos_llm::registry::lookup(provider)
+                .and_then(|e| e.api_key_env)
+                .map(String::from)
+                .unwrap_or_else(|| format!("{}_API_KEY", provider.to_uppercase())),
+        )
     }
 
     /// Resolve a key from an explicit env-var name WITHOUT provider-scoped
@@ -2952,6 +2967,23 @@ mod tests {
                 .get_api_key_with_env("openai", Some("NOPE_MISSING_VAR"))
                 .is_err()
         );
+    }
+
+    #[test]
+    fn provider_default_env_var_name_keeps_full_chain() {
+        // api_key_env set to the provider's OWN default name is redundant
+        // but legal — it must keep the full provider chain (auth store
+        // included), not the custom-var-only path. Here the chain falls
+        // through to env_vars, same as get_api_key would.
+        let mut config = Config::default();
+        config
+            .env_vars
+            .insert("OPENAI_API_KEY".to_string(), "from-chain".to_string());
+        let via_override = config
+            .get_api_key_with_env("openai", Some("OPENAI_API_KEY"))
+            .expect("resolves");
+        let via_default = config.get_api_key("openai").expect("resolves");
+        assert_eq!(via_override, via_default);
     }
 
     #[test]

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -521,6 +521,18 @@ pub struct EmbeddingConfig {
     /// Custom base URL for the embedding API.
     #[serde(default)]
     pub base_url: Option<String>,
+
+    /// Embedding model id (default: text-embedding-3-small). Set for
+    /// OpenAI-compatible providers with their own catalogs (e.g.
+    /// DashScope `text-embedding-v4`).
+    #[serde(default)]
+    pub model: Option<String>,
+
+    /// OpenAI-standard `dimensions` request field. The episodic HNSW
+    /// index is fixed at 1536 dims — set this when the model's native
+    /// output differs or its vectors are dropped to BM25-only.
+    #[serde(default)]
+    pub dimensions: Option<u32>,
 }
 
 fn default_embedding_provider() -> String {

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -1715,7 +1715,12 @@ impl Config {
             Some(var) if Some(var) != Self::provider_default_env_var(provider).as_deref() => {
                 self.resolve_env_var_only(var)
             }
-            _ => self.get_api_key(provider),
+            // Default-name override: the FULL chain (auth store included)
+            // but with THE GIVEN var — get_api_key would re-apply the
+            // top-level Config.api_key_env, which in mixed-provider
+            // configs points at the PRIMARY provider's key (codex R4).
+            Some(var) => self.resolve_api_key(provider, var.to_string()),
+            None => self.get_api_key(provider),
         }
     }
 
@@ -2966,6 +2971,28 @@ mod tests {
             config
                 .get_api_key_with_env("openai", Some("NOPE_MISSING_VAR"))
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn default_name_override_ignores_top_level_api_key_env() {
+        // Mixed-provider config: primary provider pins the top-level
+        // api_key_env to ITS key; the embedding override naming the
+        // embedding provider's default var must still read THAT var.
+        let mut config = Config::default();
+        config.api_key_env = Some("ANTHROPIC_API_KEY".to_string());
+        config
+            .env_vars
+            .insert("ANTHROPIC_API_KEY".to_string(), "anthropic-key".to_string());
+        config
+            .env_vars
+            .insert("OPENAI_API_KEY".to_string(), "openai-key".to_string());
+        let key = config
+            .get_api_key_with_env("openai", Some("OPENAI_API_KEY"))
+            .expect("resolves");
+        assert_eq!(
+            key, "openai-key",
+            "must not read the primary provider's var"
         );
     }
 

--- a/crates/octos-llm/src/embedding.rs
+++ b/crates/octos-llm/src/embedding.rs
@@ -55,6 +55,11 @@ impl OpenAIEmbedder {
         self
     }
 
+    /// The configured embedding model id.
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
     /// Set a custom base URL.
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = base_url.into();

--- a/crates/octos-llm/src/embedding.rs
+++ b/crates/octos-llm/src/embedding.rs
@@ -26,6 +26,7 @@ pub struct OpenAIEmbedder {
     api_key: SecretString,
     model: String,
     base_url: String,
+    dimensions: Option<u32>,
 }
 
 impl OpenAIEmbedder {
@@ -40,7 +41,18 @@ impl OpenAIEmbedder {
             api_key: SecretString::from(api_key.into()),
             model: "text-embedding-3-small".to_string(),
             base_url: "https://api.openai.com/v1".to_string(),
+            dimensions: None,
         }
+    }
+
+    /// Request a specific output dimension (OpenAI-standard `dimensions`
+    /// field). The episodic HNSW index is built at a fixed dimension
+    /// (1536 by default) — set this when the model's native size differs
+    /// (e.g. DashScope text-embedding-v4 defaults to 1024) or mismatched
+    /// vectors are dropped to BM25-only.
+    pub fn with_dimensions(mut self, dimensions: u32) -> Self {
+        self.dimensions = Some(dimensions);
+        self
     }
 
     /// Set a custom base URL.
@@ -60,6 +72,11 @@ impl OpenAIEmbedder {
 struct EmbeddingRequest<'a> {
     model: &'a str,
     input: &'a [&'a str],
+    /// OpenAI-standard optional output dimension (supported by
+    /// text-embedding-3-* and OpenAI-compatible providers like DashScope
+    /// text-embedding-v4). Skipped when unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dimensions: Option<u32>,
 }
 
 #[derive(Deserialize)]
@@ -79,6 +96,7 @@ impl EmbeddingProvider for OpenAIEmbedder {
         let body = EmbeddingRequest {
             model: &self.model,
             input: texts,
+            dimensions: self.dimensions,
         };
 
         let resp = self
@@ -126,9 +144,43 @@ mod tests {
         let req = EmbeddingRequest {
             model: "text-embedding-3-small",
             input: &texts,
+            dimensions: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["model"], "text-embedding-3-small");
         assert_eq!(json["input"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn request_serializes_dimensions_only_when_set() {
+        let without = EmbeddingRequest {
+            model: "text-embedding-3-small",
+            input: &["x"],
+            dimensions: None,
+        };
+        let json = serde_json::to_string(&without).unwrap();
+        assert!(
+            !json.contains("dimensions"),
+            "unset must be skipped: {json}"
+        );
+
+        let with = EmbeddingRequest {
+            model: "text-embedding-v4",
+            input: &["x"],
+            dimensions: Some(1536),
+        };
+        let json = serde_json::to_string(&with).unwrap();
+        assert!(json.contains("\"dimensions\":1536"), "{json}");
+    }
+
+    #[test]
+    fn builder_overrides_model_and_dimensions() {
+        let e = OpenAIEmbedder::new("k")
+            .with_base_url("https://dashscope.aliyuncs.com/compatible-mode/v1")
+            .with_model("text-embedding-v4")
+            .with_dimensions(1536);
+        assert_eq!(e.model, "text-embedding-v4");
+        assert_eq!(e.dimensions, Some(1536));
+        assert!(e.base_url.contains("compatible-mode"));
     }
 }

--- a/crates/octos-llm/src/embedding.rs
+++ b/crates/octos-llm/src/embedding.rs
@@ -127,6 +127,12 @@ impl EmbeddingProvider for OpenAIEmbedder {
     }
 
     fn dimension(&self) -> usize {
+        // An explicit requested dimension IS the output size (the API
+        // truncates/projects to it) — the model-default table only applies
+        // when unset. Consumers size indexes from this value.
+        if let Some(d) = self.dimensions {
+            return d as usize;
+        }
         match self.model.as_str() {
             "text-embedding-3-large" => 3072,
             _ => 1536, // text-embedding-3-small, ada-002
@@ -171,6 +177,19 @@ mod tests {
         };
         let json = serde_json::to_string(&with).unwrap();
         assert!(json.contains("\"dimensions\":1536"), "{json}");
+    }
+
+    #[test]
+    fn dimension_reflects_requested_dimensions() {
+        let default = OpenAIEmbedder::new("k");
+        assert_eq!(EmbeddingProvider::dimension(&default), 1536);
+        let large = OpenAIEmbedder::new("k").with_model("text-embedding-3-large");
+        assert_eq!(EmbeddingProvider::dimension(&large), 3072);
+        // Requested size wins over the model default table.
+        let pinned = OpenAIEmbedder::new("k")
+            .with_model("text-embedding-3-large")
+            .with_dimensions(1536);
+        assert_eq!(EmbeddingProvider::dimension(&pinned), 1536);
     }
 
     #[test]

--- a/crates/octos-memory/src/lib.rs
+++ b/crates/octos-memory/src/lib.rs
@@ -15,4 +15,4 @@ pub use memory_store::{
     DEFAULT_MAX_INJECT_TOKENS, ExtractionItem, MemoryStore, NoteKind, NoteOrigin, StagingNote,
     estimate_tokens,
 };
-pub use store::EpisodeStore;
+pub use store::{DEFAULT_DIMENSION as EPISODIC_INDEX_DIMENSION, EpisodeStore};

--- a/crates/octos-memory/src/store.rs
+++ b/crates/octos-memory/src/store.rs
@@ -19,8 +19,10 @@ const CWD_INDEX_TABLE: TableDefinition<&str, &str> = TableDefinition::new("cwd_i
 /// Table for episode embeddings: key = episode_id, value = bincode-serialized Vec<f32>
 const EMBEDDINGS_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("embeddings");
 
-/// Default embedding dimension (OpenAI text-embedding-3-small).
-const DEFAULT_DIMENSION: usize = 1536;
+/// Default embedding dimension (OpenAI text-embedding-3-small). Public:
+/// embedder configuration pins non-1536 models to this value so their
+/// vectors are not dropped by the fixed-dimension episodic index.
+pub const DEFAULT_DIMENSION: usize = 1536;
 
 /// Parse a cwd-index JSON array of episode IDs. On corrupt JSON, salvage any
 /// quoted strings that look like episode IDs instead of silently replacing


### PR DESCRIPTION
Minimal config surface to enable episodic vector recall on any OpenAI-compatible embeddings endpoint: `embedding.model`, `embedding.dimensions` (OpenAI-standard field, needed to pin non-1536 models to the HNSW index dimension), and `api_key_env` finally honored by `create_embedder`. Motivated by the mini5 embedding live test (user's OpenAI key is quota-exhausted; DashScope text-embedding-v4 @1536 verified working on the same code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)