### PR TITLE
docs(readme-zh): 在 Zed 中使用 octos（ACP）

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -39,6 +39,34 @@ export ANTHROPIC_API_KEY=your-key-here
 octos chat
 ```
 
+## 在 Zed 中使用 octos（ACP）
+
+`octos acp` 让 octos 成为一个 **ACP（[Agent Client Protocol](https://agentclientprotocol.com)）服务器**，可被 [Zed](https://zed.dev) 等 ACP 编辑器作为一等的编码 Agent 驱动——具备与 `octos chat` 相同的能力：你的工具 + 沙箱、长期记忆 + `MEMORY.md` 注入、技能/插件、MCP、hooks、上下文压缩、提供者故障转移。
+
+**1. 配置提供者凭据。** 推荐 `octos auth login --provider deepseek`（存入 `auth.json`，不依赖环境变量）。Dock 启动的 Zed 不会继承你 shell 的环境变量，若想用 API key 环境变量，请写进下面的 `env` 块。
+
+**2. 在 Zed 设置中注册 octos**（`~/.config/zed/settings.json`，或运行 *zed: open settings*）。若 `octos` 在 `PATH` 中可用则用 `"command": "octos"`，否则填 `which octos` 的绝对路径（Dock 启动的 Zed 的 `PATH` 很精简，可能找不到裸 `octos`）：
+
+```jsonc
+{
+  "agent_servers": {
+    "Octos": {
+      "command": "octos",
+      "args": ["acp", "--provider", "deepseek", "--model", "deepseek-chat"],
+      "env": {}
+    }
+  }
+}
+```
+
+**3. 在 Zed 中使用。** 先**打开一个文件夹**（外部 Agent 需要工作区，否则 Agent 面板只显示 *"Open Project"*），打开 **Agent 面板**（右侧停靠栏），点击 **＋ New Thread** 下拉（或按 `⌥⌘⇧N`），选择 **Octos**，然后输入提示词。octos 会运行完整 Agent 循环，并把工具、思考与结果流式返回 Zed，还会通过你的 `MEMORY.md` 跨轮次记忆。
+
+> **找不到 Octos？** 它在 **＋ New Thread** 菜单（外部 Agent）里，**不在** `⋯` → *MCP / Context Servers* 列表中（那是另一个功能）。修改 `agent_servers` 后请用 `Cmd-Q` 彻底退出并重开 Zed 以重新加载配置。
+
+> **当前限制：** 交互式工具审批提示与 `ask_user_question` 暂未透传到编辑器——octos 以自身（非交互）审批策略运行工具，而非 ACP 的 `session/request_permission`，因此在 `octos chat` 中会暂停等待审批的工具，在 Zed 中不会向你提示。其余能力一致。
+
+标志与 `octos chat` 一致：`--provider`、`--model`、`--base-url`、`--config`、`--data-dir`、`--cwd`、`--profile`、`--max-iterations`。Zed 通过 `session/new` 传入每会话工作目录，octos 以此作为工具、技能与文件系统作用域的根。
+
 ## 文档
 
 📖 **[完整文档](https://octos-org.github.io/octos/zh/)** — 安装、配置、频道、提供者、记忆、技能、高级功能等。


### PR DESCRIPTION
Adds the ACP / Zed setup walkthrough to the Chinese README (README-zh.md), mirroring the English 'Use octos in Zed (ACP)' section merged in #1566 — including the interactive-approval parity caveat and the New-Thread-picker (not MCP list) gotcha. Docs-only.