### PR TITLE
docs(readme): install + init + API-key steps in the ACP/Zed walkthrough (EN + 中文)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -43,9 +43,16 @@ octos chat
 
 `octos acp` 让 octos 成为一个 **ACP（[Agent Client Protocol](https://agentclientprotocol.com)）服务器**，可被 [Zed](https://zed.dev) 等 ACP 编辑器作为一等的编码 Agent 驱动——具备与 `octos chat` 相同的能力：你的工具 + 沙箱、长期记忆 + `MEMORY.md` 注入、技能/插件、MCP、hooks、上下文压缩、提供者故障转移。
 
-**1. 配置提供者凭据。** 推荐 `octos auth login --provider deepseek`（存入 `auth.json`，不依赖环境变量）。Dock 启动的 Zed 不会继承你 shell 的环境变量，若想用 API key 环境变量，请写进下面的 `env` 块。
+**1. 安装 octos 并初始化**（若尚未安装——完整安装方式见 [English README 的 Start here](README.md#start-here)）：
 
-**2. 在 Zed 设置中注册 octos**（`~/.config/zed/settings.json`，或运行 *zed: open settings*）。若 `octos` 在 `PATH` 中可用则用 `"command": "octos"`，否则填 `which octos` 的绝对路径（Dock 启动的 Zed 的 `PATH` 很精简，可能找不到裸 `octos`）：
+```bash
+npm install -g @octos-org/octos      # 或用 Homebrew / 从源码构建（见快速开始）
+octos init                           # 交互式：选择提供者与模型
+```
+
+**2. 配置 DeepSeek API key。** 运行 `octos auth login --provider deepseek`，**在提示时粘贴你的 key**（从 DeepSeek 平台获取）。它会安全存入 `auth.json`，且不依赖环境变量（`octos acp` 与 `octos chat` 一样解析 LLM）。Dock 启动的 Zed 不会继承你 shell 的环境变量，若想用环境变量传 key，请写进下面的 `env` 块。
+
+**3. 在 Zed 设置中注册 octos**（`~/.config/zed/settings.json`，或运行 *zed: open settings*）。若 `octos` 在 `PATH` 中可用则用 `"command": "octos"`，否则填 `which octos` 的绝对路径（Dock 启动的 Zed 的 `PATH` 很精简，可能找不到裸 `octos`）：
 
 ```jsonc
 {
@@ -59,7 +66,7 @@ octos chat
 }
 ```
 
-**3. 在 Zed 中使用。** 先**打开一个文件夹**（外部 Agent 需要工作区，否则 Agent 面板只显示 *"Open Project"*），打开 **Agent 面板**（右侧停靠栏），点击 **＋ New Thread** 下拉（或按 `⌥⌘⇧N`），选择 **Octos**，然后输入提示词。octos 会运行完整 Agent 循环，并把工具、思考与结果流式返回 Zed，还会通过你的 `MEMORY.md` 跨轮次记忆。
+**4. 在 Zed 中使用。** 先**打开一个文件夹**（外部 Agent 需要工作区，否则 Agent 面板只显示 *"Open Project"*），打开 **Agent 面板**（右侧停靠栏），点击 **＋ New Thread** 下拉（或按 `⌥⌘⇧N`），选择 **Octos**，然后输入提示词。octos 会运行完整 Agent 循环，并把工具、思考与结果流式返回 Zed，还会通过你的 `MEMORY.md` 跨轮次记忆。
 
 > **找不到 Octos？** 它在 **＋ New Thread** 菜单（外部 Agent）里，**不在** `⋯` → *MCP / Context Servers* 列表中（那是另一个功能）。修改 `agent_servers` 后请用 `Cmd-Q` 彻底退出并重开 Zed 以重新加载配置。
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -47,7 +47,7 @@ octos chat
 
 ```bash
 npm install -g @octos-org/octos      # 或用 Homebrew / 从源码构建（见快速开始）
-octos init                           # 交互式：选择提供者与模型
+octos init                           # 选择提供者与模型——本指南以 DeepSeek 为例
 ```
 
 **2. 配置 DeepSeek API key。** 运行 `octos auth login --provider deepseek`，**在提示时粘贴你的 key**（从 DeepSeek 平台获取）。它会安全存入 `auth.json`，且不依赖环境变量（`octos acp` 与 `octos chat` 一样解析 LLM）。Dock 启动的 Zed 不会继承你 shell 的环境变量，若想用环境变量传 key，请写进下面的 `env` 块。
@@ -65,6 +65,8 @@ octos init                           # 交互式：选择提供者与模型
   }
 }
 ```
+
+> `args` 中的 `--provider`/`--model` 必须与第 1–2 步配置的提供者一致（本指南以 DeepSeek 为例）。`octos acp` 会从你的 `octos init` 配置继承其余字段——`base_url`、`api_type`、`api_key_env`——因此用 `deepseek` 参数指向另一个已配置的提供者会把错误的 key/端点发出去，导致会话失败。
 
 **4. 在 Zed 中使用。** 先**打开一个文件夹**（外部 Agent 需要工作区，否则 Agent 面板只显示 *"Open Project"*），打开 **Agent 面板**（右侧停靠栏），点击 **＋ New Thread** 下拉（或按 `⌥⌘⇧N`），选择 **Octos**，然后输入提示词。octos 会运行完整 Agent 循环，并把工具、思考与结果流式返回 Zed，还会通过你的 `MEMORY.md` 跨轮次记忆。
 

--- a/README.md
+++ b/README.md
@@ -441,9 +441,16 @@ Interactive clients talk to `octos serve` over **UI Protocol v1** — a JSON-RPC
 
 > **One gap today:** interactive tool-approval prompts and `ask_user_question` aren't surfaced to the editor yet — octos runs tools under its own (non-interactive) approval policy rather than ACP `session/request_permission`, so a tool that would pause for approval in `octos chat` won't prompt you in Zed. Everything else matches.
 
-**1. Give the agent a provider credential.** Easiest is `octos auth login --provider deepseek` — it's stored in `auth.json` and read regardless of environment (`octos acp` resolves its LLM exactly like `octos chat`). A Dock-launched Zed does **not** inherit your shell's env vars, so if you'd rather pass an API key by env var, put it in the `env` block below.
+**1. Install octos and initialize it** (skip if you already have it — see [Start here](#start-here) for all install options):
 
-**2. Register octos as an agent server** in Zed's settings (`~/.config/zed/settings.json`, or run *zed: open settings*). Use `"command": "octos"` if it's on your `PATH`, or the absolute path from `which octos` — a Dock-launched Zed has a minimal `PATH` and may not find a bare `octos`:
+```bash
+npm install -g @octos-org/octos      # or Homebrew / build from source — see Start here
+octos init                           # interactive: pick a provider + model
+```
+
+**2. Provide your DeepSeek API key.** Run `octos auth login --provider deepseek` and **paste your key when prompted** (get one from the DeepSeek platform). It's stored securely in `auth.json` and read regardless of environment (`octos acp` resolves its LLM exactly like `octos chat`). A Dock-launched Zed does **not** inherit your shell's env vars, so if you'd rather pass the key by env var, put it in the `env` block below instead.
+
+**3. Register octos as an agent server** in Zed's settings (`~/.config/zed/settings.json`, or run *zed: open settings*). Use `"command": "octos"` if it's on your `PATH`, or the absolute path from `which octos` — a Dock-launched Zed has a minimal `PATH` and may not find a bare `octos`:
 
 ```jsonc
 {
@@ -457,7 +464,7 @@ Interactive clients talk to `octos serve` over **UI Protocol v1** — a JSON-RPC
 }
 ```
 
-**3. Play with it in Zed.**
+**4. Play with it in Zed.**
 - **Open a folder** — external agents need a workspace (with none open, the Agent Panel just shows *"Open Project"*).
 - Open the **Agent Panel** (right dock), click the **＋ New Thread** dropdown (or press `⌥⌘⇧N`), and choose **Octos**.
 - Type a prompt. octos runs the agent loop and streams tools, thinking, and results back into Zed — and it remembers across turns via your `MEMORY.md`.

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ Interactive clients talk to `octos serve` over **UI Protocol v1** — a JSON-RPC
 
 ```bash
 npm install -g @octos-org/octos      # or Homebrew / build from source — see Start here
-octos init                           # interactive: pick a provider + model
+octos init                           # pick a provider + model — this guide uses DeepSeek
 ```
 
 **2. Provide your DeepSeek API key.** Run `octos auth login --provider deepseek` and **paste your key when prompted** (get one from the DeepSeek platform). It's stored securely in `auth.json` and read regardless of environment (`octos acp` resolves its LLM exactly like `octos chat`). A Dock-launched Zed does **not** inherit your shell's env vars, so if you'd rather pass the key by env var, put it in the `env` block below instead.
@@ -463,6 +463,8 @@ octos init                           # interactive: pick a provider + model
   }
 }
 ```
+
+> The `--provider`/`--model` in `args` must match the provider you set up in steps 1–2 (this guide uses DeepSeek). `octos acp` inherits the rest — `base_url`, `api_type`, `api_key_env` — from your `octos init` config, so pointing `deepseek` args at a differently-configured provider sends the wrong key/endpoint and the session fails.
 
 **4. Play with it in Zed.**
 - **Open a folder** — external agents need a workspace (with none open, the Agent Panel just shows *"Open Project"*).


### PR DESCRIPTION
The Zed/ACP section assumed octos was already installed + initialized and jumped to `auth login`/`agent_servers`. Adds explicit prerequisite steps to both READMEs: install octos, `octos init`, then provide the DeepSeek key via `octos auth login --provider deepseek` (paste when prompted). Docs-only.