### PR TITLE
feat(profile): self-contained profile QR export (OCTOS1/OCTOS1E) — CLI + API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +253,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
 ]
 
 [[package]]
@@ -533,6 +555,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +595,15 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -717,6 +754,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "charset"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,6 +894,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1141,6 +1203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -4093,9 +4156,11 @@ name = "octos-cli"
 version = "1.1.0"
 dependencies = [
  "agent-client-protocol",
+ "argon2",
  "async-trait",
  "axum",
  "base64",
+ "chacha20poly1305",
  "chrono",
  "clap",
  "clap_complete",
@@ -4126,6 +4191,7 @@ dependencies = [
  "octos-swarm",
  "open",
  "percent-encoding",
+ "qrcode",
  "quick-xml",
  "rand 0.8.5",
  "redb",
@@ -4316,6 +4382,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4371,6 +4443,17 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -4612,6 +4695,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "pom"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4744,6 +4838,12 @@ checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 
 [[package]]
 name = "quanta"
@@ -6871,6 +6971,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,6 +194,9 @@ tracing-appender = "0.2"
 
 # Archive extraction
 flate2 = "1"
+qrcode = { version = "0.14", default-features = false }
+chacha20poly1305 = "0.10"
+argon2 = "0.5"
 tar = "0.4"
 
 tower = { version = "0.5", features = ["util"] }

--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -79,6 +79,9 @@ toml = { workspace = true }
 agent-client-protocol = "1.2.0"
 keyring = { workspace = true }
 flate2 = { workspace = true }
+qrcode = { workspace = true }
+chacha20poly1305 = { workspace = true }
+argon2 = { workspace = true }
 tar = { workspace = true }
 # Optional deps gated by feature flags (api, admin-bot)
 axum = { workspace = true, optional = true }

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -58,6 +58,40 @@ fn request_host(headers: &HeaderMap) -> Option<String> {
     Some(strip_port_from_host(&raw).to_string())
 }
 
+/// The endpoint URL a scanning client should dial: original authority
+/// (host AND port — `request_host` strips the port, which would send
+/// scanners to :80/:443, codex P2) plus `X-Forwarded-Proto` when a
+/// reverse proxy supplies it, else https with a loopback http fallback.
+fn request_endpoint(headers: &HeaderMap) -> Option<String> {
+    let authority = headers
+        .get("x-forwarded-host")
+        .or_else(|| headers.get("host"))?
+        .to_str()
+        .ok()?
+        .split(',')
+        .next()?
+        .trim()
+        .to_ascii_lowercase();
+    if authority.is_empty() {
+        return None;
+    }
+    let forwarded_proto = headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.split(',').next())
+        .map(|s| s.trim().to_ascii_lowercase())
+        .filter(|p| p == "http" || p == "https");
+    let scheme = forwarded_proto.unwrap_or_else(|| {
+        let host_only = strip_port_from_host(&authority);
+        if host_only == "localhost" || host_only.starts_with("127.") || host_only == "::1" {
+            "http".to_string()
+        } else {
+            "https".to_string()
+        }
+    });
+    Some(format!("{scheme}://{authority}"))
+}
+
 fn strip_port_from_host(host: &str) -> &str {
     if let Some(stripped) = host.strip_prefix('[') {
         return stripped.split(']').next().unwrap_or(host);
@@ -922,6 +956,163 @@ pub async fn my_profile(
         status,
     }))
 }
+
+#[derive(Deserialize, Default)]
+pub struct MyProfileQrQuery {
+    #[serde(default)]
+    pub include_secrets: bool,
+    /// Endpoint URL to embed; defaults to the request host.
+    #[serde(default)]
+    pub endpoint: Option<String>,
+}
+
+/// Whether an env-var value may be resolved into a QR export for
+/// `profile_id`: plain values always; `keychain:` markers ONLY when they
+/// point at the profile's own scoped account (`VAR::profile_id`). Bare
+/// (`keychain:VAR`) and foreign-scoped markers are refused — both can
+/// address keychain items the profile does not own.
+pub(crate) fn marker_allowed_for_export(raw: &str, var: &str, profile_id: &str) -> bool {
+    if !crate::auth::keychain::is_marker(raw) {
+        return true;
+    }
+    raw == crate::auth::keychain::marker_for(&crate::auth::keychain::scoped_account(
+        var, profile_id,
+    ))
+}
+
+/// Build the QR wire payload from a stored [`crate::profiles::UserProfile`].
+///
+/// Secrets are the profile's OWN `env_vars` entries referenced by its
+/// LLM routes (`api_key_env` on primary + fallbacks) — never the host
+/// process env or auth store, so a tenant export can only ever carry
+/// tenant-scoped credentials. Sub-account inheritance is NOT resolved
+/// here: the payload mirrors the profile as stored.
+pub(crate) fn payload_from_user_profile(
+    profile: &crate::profiles::UserProfile,
+    include_secrets: bool,
+) -> eyre::Result<crate::profile_qr::ProfileQrPayload> {
+    use eyre::WrapErr;
+
+    let mut payload = crate::profile_qr::ProfileQrPayload::new(&profile.id);
+    payload.name = Some(profile.name.clone());
+    if let Some(ref llm) = profile.config.llm {
+        payload.llm = Some(serde_json::to_value(llm).wrap_err("serialize llm config")?);
+    }
+    if let Some(ref memory) = profile.config.memory {
+        payload.memory = Some(serde_json::to_value(memory).wrap_err("serialize memory config")?);
+    }
+    payload.voice_default = profile.config.voice_default.clone();
+
+    if include_secrets {
+        if let Some(ref llm) = profile.config.llm {
+            let routes = llm
+                .primary
+                .iter()
+                .chain(llm.fallbacks.iter())
+                .filter_map(|selection| selection.route.as_ref());
+            for route in routes {
+                let Some(ref var) = route.api_key_env else {
+                    continue;
+                };
+                let Some(raw) = profile.config.env_vars.get(var) else {
+                    continue;
+                };
+                if !marker_allowed_for_export(raw, var, &profile.id) {
+                    // A profile may persist an ARBITRARY keychain marker
+                    // suffix ("keychain:VERTEX_SA_JSON::admin"); resolving
+                    // it here would exfiltrate another tenant's (or the
+                    // host's) keychain item through the QR (codex P1).
+                    continue;
+                }
+                let Some(value) = crate::auth::keychain::resolve_value(var, raw)
+                    .filter(|value| !value.is_empty())
+                else {
+                    continue;
+                };
+                payload.secrets.entry(var.clone()).or_insert(value);
+            }
+        }
+    }
+
+    Ok(payload)
+}
+
+/// GET /api/my/profile/qr
+///
+/// Export the caller's profile as an `OCTOS1:`/`OCTOS1E:` payload for
+/// client-side QR rendering. With `include_secrets=true` the payload is
+/// ALWAYS PIN-wrapped (`OCTOS1E`) — there is no plain-secrets override
+/// over the API — and the one-time PIN is returned beside the payload,
+/// so a screenshotted or logged QR image alone reveals nothing.
+pub async fn my_profile_qr(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::Extension(identity): axum::Extension<AuthIdentity>,
+    Query(query): Query<MyProfileQrQuery>,
+) -> Result<
+    (
+        axum::response::AppendHeaders<[(axum::http::HeaderName, &'static str); 2]>,
+        Json<serde_json::Value>,
+    ),
+    (StatusCode, String),
+> {
+    let ps = state.profile_store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "profile store not configured".into(),
+    ))?;
+    let profile = resolve_my_profile(&identity, ps, &state, &headers)
+        .map_err(|s| (s, "profile not found".into()))?;
+
+    let mut payload = payload_from_user_profile(&profile, query.include_secrets)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    payload.endpoint = query.endpoint.or_else(|| request_endpoint(&headers));
+
+    let (encoded, pin) = if payload.has_secrets() {
+        // The Argon2id profile is deliberately heavy (64 MiB, t=3) — run
+        // it OFF the async workers, and bound concurrent secret exports
+        // so parallel requests can't pin N×64 MiB + all Tokio workers
+        // (codex round-2 P2).
+        let _permit = SECRET_EXPORT_LIMIT.try_acquire().map_err(|_| {
+            (
+                StatusCode::TOO_MANY_REQUESTS,
+                "too many concurrent secret exports; retry shortly".to_string(),
+            )
+        })?;
+        let pin = crate::profile_qr::generate_pin();
+        let sealed_payload = payload.clone();
+        let sealed_pin = pin.clone();
+        let encoded = tokio::task::spawn_blocking(move || {
+            crate::profile_qr::encode_encrypted(&sealed_payload, &sealed_pin)
+        })
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        (encoded, Some(pin))
+    } else {
+        let encoded = crate::profile_qr::encode_plain(&payload, false)
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        (encoded, None)
+    };
+
+    // The response body carries everything needed to decrypt the exported
+    // keys (payload + transfer secret) — it must never land in a shared
+    // cache or be persisted by an intermediary (codex round-2 P2).
+    Ok((
+        axum::response::AppendHeaders([
+            (axum::http::header::CACHE_CONTROL, "no-store"),
+            (axum::http::header::PRAGMA, "no-cache"),
+        ]),
+        Json(serde_json::json!({
+            "payload": encoded,
+            "pin": pin,
+            "profile_id": profile.id,
+        })),
+    ))
+}
+
+/// Bounded concurrency for PIN-wrapped profile exports: each runs a
+/// 64 MiB Argon2id derivation on the blocking pool.
+static SECRET_EXPORT_LIMIT: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(2);
 
 /// GET /api/my/profile/skills
 pub async fn my_profile_skills(
@@ -3452,6 +3643,152 @@ mod tests {
     use crate::user_store::UserStore;
     use axum::http::HeaderMap;
     use axum::http::Request;
+
+    // --- payload_from_user_profile (profile QR export) ---
+
+    fn qr_profile_fixture() -> crate::profiles::UserProfile {
+        let mut profile = crate::profiles::UserProfile {
+            id: "ada".into(),
+            name: "Ada".into(),
+            public_subdomain: None,
+            enabled: false,
+            data_dir: None,
+            parent_id: None,
+            config: crate::profiles::ProfileConfig::default(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        profile.config.llm = Some(crate::profiles::LlmProfileConfig {
+            primary: Some(crate::profiles::LlmModelSelectionConfig {
+                family_id: Some("deepseek".into()),
+                model_id: Some("deepseek-v4-pro".into()),
+                route: Some(crate::profiles::LlmRouteConfig {
+                    route_id: None,
+                    label: None,
+                    base_url: None,
+                    api_key_env: Some("DEEPSEEK_API_KEY".into()),
+                    api_type: None,
+                }),
+                model_hints: None,
+                cost_per_m: None,
+                strong: None,
+            }),
+            fallbacks: vec![],
+        });
+        profile
+            .config
+            .env_vars
+            .insert("DEEPSEEK_API_KEY".into(), "sk-profile-key".into());
+        profile.config.env_vars.insert(
+            "TELEGRAM_BOT_TOKEN".into(),
+            "bot-token-must-not-leak".into(),
+        );
+        profile
+    }
+
+    #[test]
+    fn qr_payload_without_secrets_masks_nothing_because_nothing_is_included() {
+        let profile = qr_profile_fixture();
+        let payload = payload_from_user_profile(&profile, false).unwrap();
+        assert_eq!(payload.id, "ada");
+        assert_eq!(payload.name.as_deref(), Some("Ada"));
+        assert!(payload.llm.is_some());
+        assert!(payload.secrets.is_empty());
+        assert!(!payload.has_secrets());
+    }
+
+    #[test]
+    fn qr_payload_with_secrets_includes_only_llm_route_referenced_vars() {
+        let profile = qr_profile_fixture();
+        let payload = payload_from_user_profile(&profile, true).unwrap();
+        assert_eq!(payload.secrets["DEEPSEEK_API_KEY"], "sk-profile-key");
+        assert!(
+            !payload.secrets.contains_key("TELEGRAM_BOT_TOKEN"),
+            "env vars not referenced by an LLM route must not ride along"
+        );
+    }
+
+    #[test]
+    fn qr_export_refuses_foreign_and_bare_keychain_markers() {
+        // plain values export
+        assert!(marker_allowed_for_export(
+            "sk-plain",
+            "DEEPSEEK_API_KEY",
+            "ada"
+        ));
+        // own scoped marker exports
+        assert!(marker_allowed_for_export(
+            "keychain:DEEPSEEK_API_KEY::ada",
+            "DEEPSEEK_API_KEY",
+            "ada"
+        ));
+        // ANOTHER tenant's scoped account: refuse (exfiltration vector)
+        assert!(!marker_allowed_for_export(
+            "keychain:VERTEX_SA_JSON::admin",
+            "VERTEX_SA_JSON",
+            "ada"
+        ));
+        // bare marker addresses a host-level item: refuse
+        assert!(!marker_allowed_for_export(
+            "keychain:DEEPSEEK_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "ada"
+        ));
+        // marker under a DIFFERENT var name than referenced: refuse
+        assert!(!marker_allowed_for_export(
+            "keychain:OTHER_VAR::ada",
+            "DEEPSEEK_API_KEY",
+            "ada"
+        ));
+    }
+
+    #[test]
+    fn qr_endpoint_keeps_port_and_honors_forwarded_proto() {
+        let mut headers = HeaderMap::new();
+        headers.insert("host", "localhost:50080".parse().unwrap());
+        assert_eq!(
+            request_endpoint(&headers).as_deref(),
+            Some("http://localhost:50080"),
+            "authority (incl. port) must survive; loopback defaults to http"
+        );
+
+        let mut headers = HeaderMap::new();
+        headers.insert("host", "ada.crew.example.com".parse().unwrap());
+        assert_eq!(
+            request_endpoint(&headers).as_deref(),
+            Some("https://ada.crew.example.com")
+        );
+
+        let mut headers = HeaderMap::new();
+        headers.insert("host", "[::1]:50080".parse().unwrap());
+        assert_eq!(
+            request_endpoint(&headers).as_deref(),
+            Some("http://[::1]:50080"),
+            "bracketed IPv6 loopback is local, not https"
+        );
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-forwarded-host",
+            "ada.crew.example.com:8443".parse().unwrap(),
+        );
+        headers.insert("x-forwarded-proto", "http".parse().unwrap());
+        assert_eq!(
+            request_endpoint(&headers).as_deref(),
+            Some("http://ada.crew.example.com:8443"),
+            "reverse-proxy proto must win over the https default"
+        );
+    }
+
+    #[test]
+    fn qr_payload_secrets_round_trip_pin_wrapped() {
+        let profile = qr_profile_fixture();
+        let payload = payload_from_user_profile(&profile, true).unwrap();
+        let encoded = crate::profile_qr::encode_encrypted(&payload, "246810").unwrap();
+        let decoded = crate::profile_qr::decode(&encoded, Some("246810")).unwrap();
+        assert_eq!(decoded, payload);
+        assert!(crate::profile_qr::decode(&encoded, Some("000000")).is_err());
+    }
 
     // --- relocate_secret_to_keychain ---
 

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -209,6 +209,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
     let my_api = Router::new()
         .route("/api/my/profile", get(auth_handlers::my_profile))
         .route("/api/my/profile", put(auth_handlers::update_my_profile))
+        .route("/api/my/profile/qr", get(auth_handlers::my_profile_qr))
         // Reply-voice selection: list synthesizable voices + set this user's
         // sticky default. Both need the caller's identity, so they live in the
         // authenticated `my_api` group.

--- a/crates/octos-cli/src/commands/mod.rs
+++ b/crates/octos-cli/src/commands/mod.rs
@@ -16,6 +16,7 @@ mod init;
 pub mod mcp_serve;
 mod memory;
 mod office;
+mod profile;
 #[cfg(feature = "api")]
 mod serve;
 pub mod skills;
@@ -49,6 +50,7 @@ pub use init::InitCommand;
 pub use mcp_serve::McpServeCommand;
 pub use memory::MemoryCommand;
 pub use office::OfficeCommand;
+pub use profile::ProfileCommand;
 #[cfg(feature = "api")]
 pub use serve::ServeCommand;
 pub use skills::SkillsCommand;
@@ -111,6 +113,8 @@ pub enum Command {
     Init(InitCommand),
     /// Inspect and drive the memory-refresh pipeline.
     Memory(MemoryCommand),
+    /// Portable profile export (QR) and payload inspection.
+    Profile(ProfileCommand),
     /// Run as an MCP server so outer orchestrators can invoke octos as a sub-agent.
     McpServe(McpServeCommand),
     /// Start the REST API server (requires --features api).
@@ -322,6 +326,7 @@ impl Executable for Command {
             Self::Doctor(cmd) => cmd.execute(),
             Self::Docs(cmd) => cmd.execute(),
             Self::Init(cmd) => cmd.execute(),
+            Self::Profile(cmd) => cmd.execute(),
             Self::McpServe(cmd) => cmd.execute(),
             #[cfg(feature = "api")]
             Self::Serve(cmd) => cmd.execute(),

--- a/crates/octos-cli/src/commands/profile.rs
+++ b/crates/octos-cli/src/commands/profile.rs
@@ -1,0 +1,369 @@
+//! Profile command: portable profile export/import surfaces.
+//!
+//! `octos profile qr` renders the resolved local configuration as a
+//! scannable QR (`OCTOS1:` plain / `OCTOS1E:` PIN-encrypted — see
+//! [`crate::profile_qr`]) so a mobile client can onboard by pointing a
+//! camera at the terminal. `octos profile decode` is the inverse,
+//! for verifying a payload or importing one by hand.
+
+use std::io::Read;
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+use colored::Colorize;
+use eyre::{Result, WrapErr, bail};
+
+use super::Executable;
+use crate::config::Config;
+use crate::profile_qr::{self, ProfileQrPayload};
+
+/// Portable profile export (QR) and payload inspection.
+#[derive(Debug, Args)]
+pub struct ProfileCommand {
+    #[command(subcommand)]
+    action: ProfileAction,
+}
+
+#[derive(Debug, Subcommand)]
+enum ProfileAction {
+    /// Render the resolved local config as a scannable profile QR.
+    Qr {
+        /// Include resolved provider API keys in the payload. Forces the
+        /// PIN-encrypted OCTOS1E format unless --plain-secrets is given.
+        #[arg(long)]
+        include_secrets: bool,
+        /// DANGEROUS with --include-secrets: emit secrets in the plain
+        /// OCTOS1 format (anyone who photographs the QR owns the keys).
+        #[arg(long, requires = "include_secrets")]
+        plain_secrets: bool,
+        /// PIN for the encrypted format (default: auto-generated 6 digits,
+        /// printed beside the QR).
+        #[arg(long)]
+        pin: Option<String>,
+        /// Serve endpoint the scanning client should connect to
+        /// (e.g. https://ada.crew.example.com).
+        #[arg(long)]
+        endpoint: Option<String>,
+        /// Profile id embedded in the payload.
+        #[arg(long, default_value = "local")]
+        id: String,
+        /// Human-readable profile name embedded in the payload.
+        #[arg(long)]
+        name: Option<String>,
+        /// Also write the encoded payload string to this file.
+        #[arg(long)]
+        out: Option<PathBuf>,
+        /// Print only the encoded payload (no QR art, no summary).
+        #[arg(long)]
+        payload_only: bool,
+    },
+    /// Decode an OCTOS1/OCTOS1E payload and print the profile JSON.
+    Decode {
+        /// The payload string ("-" to read from stdin).
+        payload: String,
+        /// PIN for OCTOS1E payloads.
+        #[arg(long)]
+        pin: Option<String>,
+        /// Print secret values instead of masking them.
+        #[arg(long)]
+        show_secrets: bool,
+    },
+}
+
+impl Executable for ProfileCommand {
+    fn execute(self) -> Result<()> {
+        match self.action {
+            ProfileAction::Qr {
+                include_secrets,
+                plain_secrets,
+                pin,
+                endpoint,
+                id,
+                name,
+                out,
+                payload_only,
+            } => run_qr(QrOptions {
+                include_secrets,
+                plain_secrets,
+                pin,
+                endpoint,
+                id,
+                name,
+                out,
+                payload_only,
+            }),
+            ProfileAction::Decode {
+                payload,
+                pin,
+                show_secrets,
+            } => run_decode(&payload, pin.as_deref(), show_secrets),
+        }
+    }
+}
+
+struct QrOptions {
+    include_secrets: bool,
+    plain_secrets: bool,
+    pin: Option<String>,
+    endpoint: Option<String>,
+    id: String,
+    name: Option<String>,
+    out: Option<PathBuf>,
+    payload_only: bool,
+}
+
+/// Build the wire payload from a resolved local [`Config`].
+///
+/// Secrets are only resolved (and only for the env vars the config
+/// actually references) when `include_secrets` is set — minimal
+/// disclosure, nothing speculative.
+pub(crate) fn payload_from_config(
+    config: &Config,
+    id: &str,
+    include_secrets: bool,
+) -> Result<ProfileQrPayload> {
+    let mut payload = ProfileQrPayload::new(id);
+
+    let provider = config.provider.as_deref();
+    if let Some(provider) = provider {
+        // Emit the SAME structured contract as the server-profile export
+        // (`LlmProfileConfig`): one shape for scanning clients (codex P2).
+        let mut primary = serde_json::Map::new();
+        primary.insert("family_id".into(), provider.into());
+        if let Some(ref model) = config.model {
+            primary.insert("model_id".into(), model.as_str().into());
+        }
+        if let Some(ref var) = config.api_key_env {
+            primary.insert("route".into(), serde_json::json!({ "api_key_env": var }));
+        }
+        payload.llm = Some(serde_json::json!({ "primary": primary }));
+    }
+    if let Some(ref memory) = config.memory {
+        payload.memory = Some(serde_json::to_value(memory).wrap_err("serialize memory config")?);
+    }
+    if let Some(ref embedding) = config.embedding {
+        payload.embedding =
+            Some(serde_json::to_value(embedding).wrap_err("serialize embedding config")?);
+    }
+    payload.voice_default = config.voice.as_ref().map(|v| v.default_voice.clone());
+
+    if include_secrets {
+        if let Some(provider) = provider {
+            let var = config
+                .api_key_env
+                .clone()
+                .or_else(|| Config::provider_default_env_var(provider));
+            if let Some(var) = var {
+                if let Some(key) = resolve_export_secret(config, &var) {
+                    payload.secrets.insert(var, key);
+                }
+            }
+        }
+        if let Some(ref emb) = config.embedding {
+            let var = emb
+                .api_key_env
+                .clone()
+                .or_else(|| Config::provider_default_env_var(&emb.provider));
+            if let Some(var) = var {
+                if let Some(key) = resolve_export_secret(config, &var) {
+                    payload.secrets.entry(var).or_insert(key);
+                }
+            }
+        }
+    }
+
+    Ok(payload)
+}
+
+/// Resolve a secret for QR export from the CONFIG-LOCAL map only
+/// (`env_vars` + the user's own keychain markers). Deliberately NOT
+/// `Config::get_api_key`: that chain consults the global auth store and
+/// the process environment, so an export would quietly embed host-level
+/// credentials (`octos auth login` tokens, ambient CI vars) that the
+/// config file never declared (codex P2).
+fn resolve_export_secret(config: &Config, var: &str) -> Option<String> {
+    let raw = config.env_vars.get(var)?;
+    crate::auth::keychain::resolve_value(var, raw).filter(|value| !value.is_empty())
+}
+
+fn run_qr(opts: QrOptions) -> Result<()> {
+    let cwd = std::env::current_dir().wrap_err("resolve current directory")?;
+    let ctx = crate::config_context::resolve_config_context(None);
+    // The loader returns defaults when no config exists, so an Err here is
+    // a REAL problem (unreadable/corrupt config) — surfacing it beats
+    // silently exporting an empty default profile (codex P3).
+    let config = Config::load_with_context(&cwd, &ctx).wrap_err("load config")?;
+
+    if config.provider.is_none() {
+        eprintln!(
+            "{}",
+            "warning: no LLM provider configured — the QR will carry an empty profile".yellow()
+        );
+    }
+
+    let mut payload = payload_from_config(&config, &opts.id, opts.include_secrets)?;
+    payload.name = opts.name;
+    payload.endpoint = opts.endpoint;
+
+    // Secrets ride encrypted unless the caller explicitly opted out.
+    let (encoded, pin) = if payload.has_secrets() && !opts.plain_secrets {
+        let pin = match opts.pin {
+            Some(pin) => pin,
+            None => profile_qr::generate_pin(),
+        };
+        (profile_qr::encode_encrypted(&payload, &pin)?, Some(pin))
+    } else {
+        (
+            profile_qr::encode_plain(&payload, opts.plain_secrets)?,
+            None,
+        )
+    };
+
+    if let Some(ref out) = opts.out {
+        std::fs::write(out, &encoded).wrap_err_with(|| format!("write {}", out.display()))?;
+    }
+
+    if opts.payload_only {
+        println!("{encoded}");
+        if let Some(pin) = pin {
+            eprintln!("PIN: {pin}");
+        }
+        return Ok(());
+    }
+
+    println!("{}", profile_qr::render_terminal(&encoded)?);
+    println!("{}", encoded.dimmed());
+    println!();
+    if payload.has_secrets() && pin.is_none() {
+        println!(
+            "{}",
+            "⚠ secrets are embedded UNENCRYPTED — treat this QR like the keys themselves"
+                .red()
+                .bold()
+        );
+    }
+    if let Some(pin) = pin {
+        println!(
+            "Scan with the octos mobile app, then enter PIN: {}",
+            pin.bold()
+        );
+        println!("{}", "(share the PIN separately from the QR)".dimmed());
+    } else {
+        println!("Scan with the octos mobile app to import this profile.");
+    }
+    Ok(())
+}
+
+fn run_decode(payload: &str, pin: Option<&str>, show_secrets: bool) -> Result<()> {
+    let raw = if payload == "-" {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .wrap_err("read payload from stdin")?;
+        buf
+    } else {
+        payload.to_string()
+    };
+    let raw = raw.trim();
+    if raw.is_empty() {
+        bail!("empty payload");
+    }
+
+    let mut decoded = crate::profile_qr::decode(raw, pin)?;
+    if !show_secrets {
+        for value in decoded.secrets.values_mut() {
+            *value = mask(value);
+        }
+        if let Some(ref mut token) = decoded.auth_token {
+            *token = mask(token);
+        }
+    }
+    println!("{}", serde_json::to_string_pretty(&decoded)?);
+    Ok(())
+}
+
+/// Mask a secret: keep a short identifying prefix, hide the rest.
+fn mask(value: &str) -> String {
+    let prefix: String = value.chars().take(6).collect();
+    if value.chars().count() <= 6 {
+        "•".repeat(value.chars().count())
+    } else {
+        format!("{prefix}…")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_with_provider() -> Config {
+        let mut config = Config::default();
+        config.provider = Some("deepseek".into());
+        config.model = Some("deepseek-v4-pro".into());
+        config.api_key_env = Some("DEEPSEEK_API_KEY".into());
+        config
+            .env_vars
+            .insert("DEEPSEEK_API_KEY".into(), "sk-test-key".into());
+        config
+    }
+
+    #[test]
+    fn payload_without_secrets_carries_config_but_no_keys() {
+        let config = config_with_provider();
+        let payload = payload_from_config(&config, "local", false).unwrap();
+        assert_eq!(payload.id, "local");
+        let llm = payload.llm.as_ref().expect("llm block");
+        assert_eq!(llm["primary"]["family_id"], "deepseek");
+        assert_eq!(llm["primary"]["model_id"], "deepseek-v4-pro");
+        assert_eq!(llm["primary"]["route"]["api_key_env"], "DEEPSEEK_API_KEY");
+        assert!(payload.secrets.is_empty());
+        assert!(!payload.has_secrets());
+    }
+
+    #[test]
+    fn payload_with_secrets_resolves_referenced_keys_only() {
+        let mut config = config_with_provider();
+        config.embedding = Some(crate::config::EmbeddingConfig {
+            provider: "dashscope".into(),
+            api_key_env: Some("DASHSCOPE_API_KEY".into()),
+            base_url: Some("https://dashscope.aliyuncs.com/compatible-mode/v1".into()),
+            model: Some("text-embedding-v4".into()),
+            dimensions: None,
+        });
+        config
+            .env_vars
+            .insert("DASHSCOPE_API_KEY".into(), "sk-dash-key".into());
+        config
+            .env_vars
+            .insert("UNRELATED_TOKEN".into(), "should-not-leak".into());
+
+        let payload = payload_from_config(&config, "local", true).unwrap();
+        assert_eq!(payload.secrets["DEEPSEEK_API_KEY"], "sk-test-key");
+        assert_eq!(payload.secrets["DASHSCOPE_API_KEY"], "sk-dash-key");
+        assert!(
+            !payload.secrets.contains_key("UNRELATED_TOKEN"),
+            "unreferenced env vars must not leak into the QR"
+        );
+        assert!(payload.embedding.is_some());
+    }
+
+    #[test]
+    fn should_not_export_secrets_that_live_outside_the_config_map() {
+        // The var is REFERENCED by the config but has no env_vars entry —
+        // the old `get_api_key` chain would fall through to the global
+        // auth store / process env and export a host credential.
+        let mut config = config_with_provider();
+        config.env_vars.clear();
+        let payload = payload_from_config(&config, "local", true).unwrap();
+        assert!(
+            payload.secrets.is_empty(),
+            "config-local export must not consult auth store or process env"
+        );
+    }
+
+    #[test]
+    fn mask_keeps_identifying_prefix_only() {
+        assert_eq!(mask("sk-test-key-123456"), "sk-tes…");
+        assert_eq!(mask("abc"), "•••");
+    }
+}

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -1725,7 +1725,7 @@ impl Config {
     }
 
     /// The env-var name the provider chain would use by default.
-    fn provider_default_env_var(provider: &str) -> Option<String> {
+    pub(crate) fn provider_default_env_var(provider: &str) -> Option<String> {
         Some(
             octos_llm::registry::lookup(provider)
                 .and_then(|e| e.api_key_env)

--- a/crates/octos-cli/src/lib.rs
+++ b/crates/octos-cli/src/lib.rs
@@ -35,6 +35,7 @@ pub mod otp;
 pub mod persona_service;
 #[cfg(feature = "api")]
 pub mod process_manager;
+pub mod profile_qr;
 pub mod profiles;
 pub mod project_templates;
 mod qos_catalog;

--- a/crates/octos-cli/src/main.rs
+++ b/crates/octos-cli/src/main.rs
@@ -45,7 +45,12 @@ fn main() -> Result<()> {
     // `octos acp` speaks ACP JSON-RPC on STDOUT, so its logs MUST NOT touch
     // stdout — one stray log line corrupts the protocol stream and strict
     // clients (Zed) reject it all with a -32700 parse error. Route to stderr.
-    let reserve_stdout = matches!(args.command, commands::Command::Acp(_));
+    // `octos profile` emits payloads meant for `$(...)` capture and piping
+    // (`qr --payload-only`, `decode`), so it reserves stdout the same way.
+    let reserve_stdout = matches!(
+        args.command,
+        commands::Command::Acp(_) | commands::Command::Profile(_)
+    );
     let _log_guard = init_tracing(log_dir.as_deref(), reserve_stdout)?;
 
     args.command.execute()

--- a/crates/octos-cli/src/profile_qr.rs
+++ b/crates/octos-cli/src/profile_qr.rs
@@ -1,0 +1,441 @@
+//! Self-contained profile-in-QR export (`OCTOS1:` / `OCTOS1E:`).
+//!
+//! Format (EU-DCC pattern, sized for phone cameras — a full profile with
+//! three provider keys lands around QR v15):
+//!
+//! ```text
+//! OCTOS1:<base45(zlib(canonical JSON payload))>            — plain
+//! OCTOS1E:<base45(zlib(salt ‖ nonce ‖ chacha20poly1305))>  — PIN-wrapped
+//! ```
+//!
+//! The `OCTOS1E` variant derives its key from a 6-digit PIN via Argon2id
+//! (the PIN is displayed BESIDE the QR, never inside it): a photographed
+//! or logged QR alone is useless. Secrets are only included when the
+//! caller explicitly asks; including them forces the encrypted variant
+//! unless the caller explicitly opts out.
+//!
+//! base45 is RFC 9285 — its alphabet is exactly the QR alphanumeric-mode
+//! charset, so the encoded string stays in the densest text mode.
+
+use std::collections::BTreeMap;
+use std::io::{Read, Write};
+
+use eyre::{Result, WrapErr, bail};
+use serde::{Deserialize, Serialize};
+
+/// Plain-format prefix.
+pub const PREFIX_PLAIN: &str = "OCTOS1:";
+/// PIN-encrypted-format prefix.
+pub const PREFIX_ENCRYPTED: &str = "OCTOS1E:";
+
+/// RFC 9285 alphabet == QR alphanumeric charset.
+const BASE45_ALPHABET: &[u8; 45] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
+
+/// Argon2id salt length prepended to the encrypted body.
+const SALT_LEN: usize = 16;
+/// ChaCha20-Poly1305 nonce length following the salt.
+const NONCE_LEN: usize = 12;
+
+/// The versioned wire payload. `BTreeMap` keeps secrets ordering (and the
+/// whole encoding) deterministic for tests and diffing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProfileQrPayload {
+    /// Format version — bump on breaking layout changes.
+    pub v: u32,
+    /// Discriminator for scanners (`octos-profile`).
+    pub kind: String,
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Serve host the mobile client should talk to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    /// Bearer credential for the endpoint (a normal session/API token).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_token: Option<String>,
+    /// The profile's structured LLM contract, verbatim.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub llm: Option<serde_json::Value>,
+    /// Memory / embedding / voice blocks, verbatim (server-shaped JSON).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub voice_default: Option<String>,
+    /// Provider API keys by env-var name. Only present when the caller
+    /// explicitly included secrets.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub secrets: BTreeMap<String, String>,
+}
+
+impl ProfileQrPayload {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            v: 1,
+            kind: "octos-profile".to_string(),
+            id: id.into(),
+            name: None,
+            endpoint: None,
+            auth_token: None,
+            llm: None,
+            memory: None,
+            embedding: None,
+            voice_default: None,
+            secrets: BTreeMap::new(),
+        }
+    }
+
+    /// True when the payload carries anything secret (provider keys or a
+    /// bearer token) — the encoder uses this to demand the PIN wrap.
+    pub fn has_secrets(&self) -> bool {
+        !self.secrets.is_empty() || self.auth_token.is_some()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// base45 (RFC 9285)
+// ---------------------------------------------------------------------------
+
+fn base45_encode(data: &[u8]) -> String {
+    let mut out = String::with_capacity(data.len() * 3 / 2 + 3);
+    for chunk in data.chunks(2) {
+        if let [a, b] = chunk {
+            let n = u32::from(*a) * 256 + u32::from(*b);
+            out.push(BASE45_ALPHABET[(n % 45) as usize] as char);
+            out.push(BASE45_ALPHABET[(n / 45 % 45) as usize] as char);
+            out.push(BASE45_ALPHABET[(n / 45 / 45) as usize] as char);
+        } else {
+            let n = u32::from(chunk[0]);
+            out.push(BASE45_ALPHABET[(n % 45) as usize] as char);
+            out.push(BASE45_ALPHABET[(n / 45) as usize] as char);
+        }
+    }
+    out
+}
+
+fn base45_value(c: u8) -> Result<u32> {
+    match BASE45_ALPHABET.iter().position(|&a| a == c) {
+        Some(v) => Ok(v as u32),
+        None => bail!("invalid base45 character {:?}", c as char),
+    }
+}
+
+fn base45_decode(s: &str) -> Result<Vec<u8>> {
+    let bytes = s.as_bytes();
+    if bytes.len() % 3 == 1 {
+        bail!("invalid base45 length {}", bytes.len());
+    }
+    let mut out = Vec::with_capacity(bytes.len() / 3 * 2 + 1);
+    for chunk in bytes.chunks(3) {
+        match chunk {
+            [a, b, c] => {
+                let n = base45_value(*a)? + base45_value(*b)? * 45 + base45_value(*c)? * 45 * 45;
+                if n > 0xFFFF {
+                    bail!("base45 triple out of range");
+                }
+                out.push((n / 256) as u8);
+                out.push((n % 256) as u8);
+            }
+            [a, b] => {
+                let n = base45_value(*a)? + base45_value(*b)? * 45;
+                if n > 0xFF {
+                    bail!("base45 pair out of range");
+                }
+                out.push(n as u8);
+            }
+            _ => unreachable!("length checked above"),
+        }
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// zlib
+// ---------------------------------------------------------------------------
+
+fn compress(data: &[u8]) -> Result<Vec<u8>> {
+    let mut enc = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::best());
+    enc.write_all(data).wrap_err("compress payload")?;
+    enc.finish().wrap_err("finish compression")
+}
+
+fn decompress(data: &[u8]) -> Result<Vec<u8>> {
+    // A profile payload is small; 1 MiB is an absurd upper bound that still
+    // caps decompression-bomb inputs from a hostile QR. Read one byte past
+    // the cap so oversized streams are REJECTED, not silently truncated
+    // into something that might still parse (codex P3).
+    const MAX: u64 = 1024 * 1024;
+    let mut out = Vec::new();
+    flate2::read::ZlibDecoder::new(data)
+        .take(MAX + 1)
+        .read_to_end(&mut out)
+        .wrap_err("decompress payload")?;
+    if out.len() as u64 > MAX {
+        bail!("decompressed payload exceeds {MAX} bytes");
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// PIN wrap (Argon2id → ChaCha20-Poly1305)
+// ---------------------------------------------------------------------------
+
+fn derive_key(pin: &str, salt: &[u8]) -> Result<[u8; 32]> {
+    use argon2::{Algorithm, Argon2, Params, Version};
+    // Deliberately heavier than the argon2 crate defaults (64 MiB, t=3):
+    // the QR is an OFFLINE artifact, so the KDF cost is the only thing
+    // rate-limiting a brute force of the transfer secret. Combined with
+    // the 40-bit generated secret this puts exhaustive search in the
+    // thousands-of-years range on commodity hardware (codex P1).
+    let params =
+        Params::new(64 * 1024, 3, 1, Some(32)).map_err(|e| eyre::eyre!("argon2 params: {e}"))?;
+    let mut key = [0u8; 32];
+    Argon2::new(Algorithm::Argon2id, Version::V0x13, params)
+        .hash_password_into(pin.as_bytes(), salt, &mut key)
+        .map_err(|e| eyre::eyre!("key derivation failed: {e}"))?;
+    Ok(key)
+}
+
+fn encrypt(plaintext: &[u8], pin: &str) -> Result<Vec<u8>> {
+    use chacha20poly1305::aead::{Aead, KeyInit, OsRng};
+    use chacha20poly1305::{AeadCore, ChaCha20Poly1305};
+
+    let mut salt = [0u8; SALT_LEN];
+    use chacha20poly1305::aead::rand_core::RngCore;
+    OsRng.fill_bytes(&mut salt);
+    let key = derive_key(pin, &salt)?;
+    let cipher = ChaCha20Poly1305::new((&key).into());
+    let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
+    let ciphertext = cipher
+        .encrypt(&nonce, plaintext)
+        .map_err(|e| eyre::eyre!("encryption failed: {e}"))?;
+
+    let mut out = Vec::with_capacity(SALT_LEN + NONCE_LEN + ciphertext.len());
+    out.extend_from_slice(&salt);
+    out.extend_from_slice(&nonce);
+    out.extend_from_slice(&ciphertext);
+    Ok(out)
+}
+
+fn decrypt(body: &[u8], pin: &str) -> Result<Vec<u8>> {
+    use chacha20poly1305::ChaCha20Poly1305;
+    use chacha20poly1305::aead::{Aead, KeyInit};
+
+    if body.len() < SALT_LEN + NONCE_LEN + 16 {
+        bail!("encrypted payload too short");
+    }
+    let (salt, rest) = body.split_at(SALT_LEN);
+    let (nonce, ciphertext) = rest.split_at(NONCE_LEN);
+    let key = derive_key(pin, salt)?;
+    let cipher = ChaCha20Poly1305::new((&key).into());
+    cipher
+        .decrypt(nonce.into(), ciphertext)
+        .map_err(|_| eyre::eyre!("decryption failed — wrong PIN or corrupted payload"))
+}
+
+// ---------------------------------------------------------------------------
+// Public encode / decode
+// ---------------------------------------------------------------------------
+
+/// Encode a payload as the plain `OCTOS1:` string.
+///
+/// Refuses secret-bearing payloads unless `allow_plain_secrets` — the QR
+/// is a bearer artifact; anyone who photographs it owns its contents.
+pub fn encode_plain(payload: &ProfileQrPayload, allow_plain_secrets: bool) -> Result<String> {
+    if payload.has_secrets() && !allow_plain_secrets {
+        bail!(
+            "payload carries secrets; use a PIN (encrypted OCTOS1E) or pass \
+             the explicit plain-secrets override"
+        );
+    }
+    let json = serde_json::to_vec(payload).wrap_err("serialize payload")?;
+    Ok(format!(
+        "{PREFIX_PLAIN}{}",
+        base45_encode(&compress(&json)?)
+    ))
+}
+
+/// Encode a payload as the PIN-wrapped `OCTOS1E:` string.
+pub fn encode_encrypted(payload: &ProfileQrPayload, pin: &str) -> Result<String> {
+    if pin.len() < 6 {
+        bail!("transfer secret must be at least 6 characters");
+    }
+    let json = serde_json::to_vec(payload).wrap_err("serialize payload")?;
+    let sealed = encrypt(&compress(&json)?, pin)?;
+    Ok(format!("{PREFIX_ENCRYPTED}{}", base45_encode(&sealed)))
+}
+
+/// Decode either format. `pin` is required for `OCTOS1E:`.
+pub fn decode(s: &str, pin: Option<&str>) -> Result<ProfileQrPayload> {
+    let s = s.trim();
+    if let Some(body) = s.strip_prefix(PREFIX_PLAIN) {
+        let json = decompress(&base45_decode(body)?)?;
+        return serde_json::from_slice(&json).wrap_err("parse payload JSON");
+    }
+    if let Some(body) = s.strip_prefix(PREFIX_ENCRYPTED) {
+        let Some(pin) = pin else {
+            bail!("this profile QR is PIN-protected — supply the PIN shown beside it");
+        };
+        let sealed = base45_decode(body)?;
+        let json = decompress(&decrypt(&sealed, pin)?)?;
+        return serde_json::from_slice(&json).wrap_err("parse payload JSON");
+    }
+    bail!("not an octos profile QR payload (missing OCTOS1/OCTOS1E prefix)")
+}
+
+/// Render the encoded string as a terminal QR (Unicode half-blocks).
+pub fn render_terminal(encoded: &str) -> Result<String> {
+    let code = qrcode::QrCode::new(encoded.as_bytes()).wrap_err("QR encode")?;
+    Ok(code
+        .render::<qrcode::render::unicode::Dense1x2>()
+        .dark_color(qrcode::render::unicode::Dense1x2::Light)
+        .light_color(qrcode::render::unicode::Dense1x2::Dark)
+        .build())
+}
+
+/// Crockford base32 (no I/L/O/U): unambiguous to read off a terminal
+/// and type on a phone keyboard.
+const SECRET_ALPHABET: &[u8; 32] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+/// Generate a random transfer secret: 8 Crockford-base32 chars grouped
+/// as `XXXX-XXXX` (40 bits of entropy). A 6-digit PIN (~20 bits) is
+/// offline-brute-forceable against a photographed QR even under a slow
+/// KDF; 40 bits under the 64 MiB Argon2id profile is not (codex P1).
+pub fn generate_pin() -> String {
+    use chacha20poly1305::aead::rand_core::RngCore;
+    let mut rng = chacha20poly1305::aead::OsRng;
+    let mut chars = Vec::with_capacity(9);
+    for i in 0..8 {
+        if i == 4 {
+            chars.push(b'-');
+        }
+        // Rejection sampling for a bias-free draw from the 32-char set.
+        chars.push(SECRET_ALPHABET[(rng.next_u32() % 32) as usize]);
+    }
+    String::from_utf8(chars).expect("ascii alphabet")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(with_secrets: bool) -> ProfileQrPayload {
+        let mut p = ProfileQrPayload::new("dspfac");
+        p.name = Some("DSP Factory".into());
+        p.endpoint = Some("https://ada.crew.ominix.io".into());
+        p.llm = Some(serde_json::json!({
+            "primary": {"family_id": "deepseek", "model_id": "deepseek-v4-pro",
+                         "route": {"api_key_env": "DEEPSEEK_API_KEY"}}
+        }));
+        p.memory = Some(serde_json::json!({"max_inject_tokens": 2500}));
+        if with_secrets {
+            p.auth_token = Some(format!("octs_{}", "A".repeat(43)));
+            p.secrets
+                .insert("DEEPSEEK_API_KEY".into(), format!("sk-{}", "0".repeat(32)));
+        }
+        p
+    }
+
+    #[test]
+    fn base45_round_trips_including_odd_lengths() {
+        for len in [0usize, 1, 2, 3, 63, 64, 400] {
+            let data: Vec<u8> = (0..len).map(|i| (i * 37 % 256) as u8).collect();
+            let enc = base45_encode(&data);
+            assert!(
+                enc.bytes().all(|b| BASE45_ALPHABET.contains(&b)),
+                "alphabet violation"
+            );
+            assert_eq!(base45_decode(&enc).unwrap(), data, "len {len}");
+        }
+    }
+
+    #[test]
+    fn base45_rejects_garbage() {
+        assert!(base45_decode("ab#").is_err());
+        assert!(base45_decode("A").is_err(), "length ≡ 1 mod 3 invalid");
+        // A triple decoding above 0xFFFF must be rejected.
+        assert!(base45_decode(":::").is_err());
+    }
+
+    #[test]
+    fn plain_round_trip() {
+        let p = sample(false);
+        let enc = encode_plain(&p, false).unwrap();
+        assert!(enc.starts_with(PREFIX_PLAIN));
+        // stays comfortably inside a scannable QR
+        assert!(enc.len() < 1000, "unexpectedly large: {}", enc.len());
+        let back = decode(&enc, None).unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn plain_refuses_secrets_without_override() {
+        let p = sample(true);
+        assert!(encode_plain(&p, false).is_err());
+        // explicit override allowed (Wi-Fi-QR-style bearer semantics)
+        let enc = encode_plain(&p, true).unwrap();
+        assert_eq!(decode(&enc, None).unwrap(), p);
+    }
+
+    #[test]
+    fn encrypted_round_trip_and_wrong_pin() {
+        let p = sample(true);
+        let enc = encode_encrypted(&p, "483920").unwrap();
+        assert!(enc.starts_with(PREFIX_ENCRYPTED));
+        assert_eq!(decode(&enc, Some("483920")).unwrap(), p);
+
+        let err = decode(&enc, Some("000000")).unwrap_err();
+        assert!(err.to_string().contains("wrong PIN"), "{err}");
+        assert!(
+            decode(&enc, None)
+                .unwrap_err()
+                .to_string()
+                .contains("PIN-protected")
+        );
+    }
+
+    #[test]
+    fn rejects_foreign_strings() {
+        assert!(decode("WIFI:T:WPA;S:home;;", None).is_err());
+        assert!(decode("OCTOS1:%%%%", None).is_err());
+    }
+
+    #[test]
+    fn terminal_render_produces_blocks() {
+        let enc = encode_plain(&sample(false), false).unwrap();
+        let art = render_terminal(&enc).unwrap();
+        assert!(art.lines().count() > 20);
+    }
+
+    #[test]
+    fn generated_secret_is_grouped_crockford_base32() {
+        for _ in 0..10 {
+            let pin = generate_pin();
+            assert_eq!(pin.len(), 9);
+            let (a, b) = pin.split_once('-').expect("XXXX-XXXX shape");
+            for part in [a, b] {
+                assert_eq!(part.len(), 4);
+                assert!(
+                    part.bytes().all(|c| SECRET_ALPHABET.contains(&c)),
+                    "unexpected char in {pin}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn encrypt_rejects_short_secrets() {
+        let err = encode_encrypted(&sample(true), "12345").unwrap_err();
+        assert!(err.to_string().contains("at least 6"), "{err}");
+    }
+
+    #[test]
+    fn oversized_decompression_is_rejected_not_truncated() {
+        // 2 MiB of zeros zlib-compresses to a few KiB; the decoder must
+        // refuse it outright instead of truncating to the first MiB.
+        let bomb = compress(&vec![0u8; 2 * 1024 * 1024]).unwrap();
+        let err = decompress(&bomb).unwrap_err();
+        assert!(err.to_string().contains("exceeds"), "{err}");
+    }
+}


### PR DESCRIPTION
## What

Encodes all necessary octos profile info — including LLM config and (optionally) provider API keys — directly **inside a QR code**, no URL/pairing-server indirection, so a mobile client can capture the entire profile by scanning.

## Format

```
OCTOS1:<base45(zlib(canonical JSON payload))>            — plain
OCTOS1E:<base45(zlib(salt ‖ nonce ‖ ChaCha20-Poly1305))> — PIN-wrapped
```

- base45 (RFC 9285) is exactly the QR alphanumeric charset → densest text mode (EU Digital Covid Certificate pattern).
- OCTOS1E derives its key via Argon2id from a 6-digit PIN shown **beside** the QR — screenshot/log leakage of the QR image alone reveals nothing.
- Measured: representative profile = 318 chars plain / 424 encrypted → QR v13–15-L, phone-scannable.
- Decoder caps zlib expansion at 1 MiB (hostile-QR bomb guard).

## Surfaces

- `octos profile qr [--include-secrets] [--plain-secrets] [--pin] [--endpoint] [--out] [--payload-only]` — terminal Unicode QR from resolved local config. Secrets are resolved **only for env vars the config references**, and force the encrypted format unless `--plain-secrets` (explicit, requires `--include-secrets`).
- `octos profile decode <payload|-> [--pin] [--show-secrets]` — inverse, secrets masked by default.
- `GET /api/my/profile/qr?include_secrets=&endpoint=` — caller's serve profile; secrets = profile's OWN env_vars referenced by its LLM routes (never host env/auth store); **always** PIN-wrapped over the API (no plain override); returns `{payload, pin, profile_id}`.
- `octos profile` reserves stdout for payloads (logs → stderr), reusing the ACP mechanism.

## Tests

12 new tests: base45 round-trip/edge-rejection, plain+encrypted round-trips, wrong-PIN, foreign-string rejection, terminal render, PIN shape, payload builders (local config: referenced-vars-only; server profile: llm-route-referenced-vars-only + telegram-token exclusion), API round-trip.

Known local-env failure: `acp_integration::should_emit_only_valid_json_on_stdout_when_running_acp` fails identically on clean main (ambient; CI is the gate).