### PR TITLE
docs(readme): fold API-key capture into octos init (EN + 中文)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -66,7 +66,7 @@ octos init                           # 选择提供者与模型，并粘贴该�
 }
 ```
 
-> `args` 中的 `--provider`/`--model` 必须与第 1–2 步配置的提供者一致（本指南以 DeepSeek 为例）。`octos acp` 会从你的 `octos init` 配置继承其余字段——`base_url`、`api_type`、`api_key_env`——因此用 `deepseek` 参数指向另一个已配置的提供者会把错误的 key/端点发出去，导致会话失败。
+> `args` 中的 `--provider`/`--model` 必须与第 1 步配置的提供者一致（本指南以 DeepSeek 为例）。`octos acp` 会从你的 `octos init` 配置继承其余字段——`base_url`、`api_type`、`api_key_env`——因此用 `deepseek` 参数指向另一个已配置的提供者会把错误的 key/端点发出去，导致会话失败。
 
 **3. 在 Zed 中使用。** 先**打开一个文件夹**（外部 Agent 需要工作区，否则 Agent 面板只显示 *"Open Project"*），打开 **Agent 面板**（右侧停靠栏），点击 **＋ New Thread** 下拉（或按 `⌥⌘⇧N`），选择 **Octos**，然后输入提示词。octos 会运行完整 Agent 循环，并把工具、思考与结果流式返回 Zed，还会通过你的 `MEMORY.md` 跨轮次记忆。
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -47,12 +47,12 @@ octos chat
 
 ```bash
 npm install -g @octos-org/octos      # 或用 Homebrew / 从源码构建（见快速开始）
-octos init                           # 选择提供者与模型——本指南以 DeepSeek 为例
+octos init                           # 选择提供者与模型，并粘贴该提供者的 API key
 ```
 
-**2. 配置 DeepSeek API key。** 运行 `octos auth login --provider deepseek`，**在提示时粘贴你的 key**（从 DeepSeek 平台获取）。它会安全存入 `auth.json`，且不依赖环境变量（`octos acp` 与 `octos chat` 一样解析 LLM）。Dock 启动的 Zed 不会继承你 shell 的环境变量，若想用环境变量传 key，请写进下面的 `env` 块。
+`octos init` 会引导你选择提供者与模型（本指南以 **DeepSeek** 为例），并提示你**粘贴该提供者的 API key**——安全存入 `auth.json`，且不依赖环境变量（`octos acp` 与 `octos chat` 一样解析 LLM）。按 Enter 跳过了？之后可用 `octos auth login --provider deepseek` 补上。Dock 启动的 Zed 不会继承你 shell 的环境变量，若想用环境变量传 key，请写进下面的 `env` 块。
 
-**3. 在 Zed 设置中注册 octos**（`~/.config/zed/settings.json`，或运行 *zed: open settings*）。若 `octos` 在 `PATH` 中可用则用 `"command": "octos"`，否则填 `which octos` 的绝对路径（Dock 启动的 Zed 的 `PATH` 很精简，可能找不到裸 `octos`）：
+**2. 在 Zed 设置中注册 octos**（`~/.config/zed/settings.json`，或运行 *zed: open settings*）。若 `octos` 在 `PATH` 中可用则用 `"command": "octos"`，否则填 `which octos` 的绝对路径（Dock 启动的 Zed 的 `PATH` 很精简，可能找不到裸 `octos`）：
 
 ```jsonc
 {
@@ -68,7 +68,7 @@ octos init                           # 选择提供者与模型——本指南�
 
 > `args` 中的 `--provider`/`--model` 必须与第 1–2 步配置的提供者一致（本指南以 DeepSeek 为例）。`octos acp` 会从你的 `octos init` 配置继承其余字段——`base_url`、`api_type`、`api_key_env`——因此用 `deepseek` 参数指向另一个已配置的提供者会把错误的 key/端点发出去，导致会话失败。
 
-**4. 在 Zed 中使用。** 先**打开一个文件夹**（外部 Agent 需要工作区，否则 Agent 面板只显示 *"Open Project"*），打开 **Agent 面板**（右侧停靠栏），点击 **＋ New Thread** 下拉（或按 `⌥⌘⇧N`），选择 **Octos**，然后输入提示词。octos 会运行完整 Agent 循环，并把工具、思考与结果流式返回 Zed，还会通过你的 `MEMORY.md` 跨轮次记忆。
+**3. 在 Zed 中使用。** 先**打开一个文件夹**（外部 Agent 需要工作区，否则 Agent 面板只显示 *"Open Project"*），打开 **Agent 面板**（右侧停靠栏），点击 **＋ New Thread** 下拉（或按 `⌥⌘⇧N`），选择 **Octos**，然后输入提示词。octos 会运行完整 Agent 循环，并把工具、思考与结果流式返回 Zed，还会通过你的 `MEMORY.md` 跨轮次记忆。
 
 > **找不到 Octos？** 它在 **＋ New Thread** 菜单（外部 Agent）里，**不在** `⋯` → *MCP / Context Servers* 列表中（那是另一个功能）。修改 `agent_servers` 后请用 `Cmd-Q` 彻底退出并重开 Zed 以重新加载配置。
 

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ octos init                           # pick a provider + model, then paste that 
 }
 ```
 
-> The `--provider`/`--model` in `args` must match the provider you set up in steps 1–2 (this guide uses DeepSeek). `octos acp` inherits the rest — `base_url`, `api_type`, `api_key_env` — from your `octos init` config, so pointing `deepseek` args at a differently-configured provider sends the wrong key/endpoint and the session fails.
+> The `--provider`/`--model` in `args` must match the provider you set up in step 1 (this guide uses DeepSeek). `octos acp` inherits the rest — `base_url`, `api_type`, `api_key_env` — from your `octos init` config, so pointing `deepseek` args at a differently-configured provider sends the wrong key/endpoint and the session fails.
 
 **3. Play with it in Zed.**
 - **Open a folder** — external agents need a workspace (with none open, the Agent Panel just shows *"Open Project"*).

--- a/README.md
+++ b/README.md
@@ -445,12 +445,12 @@ Interactive clients talk to `octos serve` over **UI Protocol v1** — a JSON-RPC
 
 ```bash
 npm install -g @octos-org/octos      # or Homebrew / build from source — see Start here
-octos init                           # pick a provider + model — this guide uses DeepSeek
+octos init                           # pick a provider + model, then paste that provider's API key
 ```
 
-**2. Provide your DeepSeek API key.** Run `octos auth login --provider deepseek` and **paste your key when prompted** (get one from the DeepSeek platform). It's stored securely in `auth.json` and read regardless of environment (`octos acp` resolves its LLM exactly like `octos chat`). A Dock-launched Zed does **not** inherit your shell's env vars, so if you'd rather pass the key by env var, put it in the `env` block below instead.
+`octos init` walks you through choosing a provider + model (this guide uses **DeepSeek**) and then prompts you to **paste that provider's API key** — stored securely in `auth.json` and read regardless of environment (`octos acp` resolves its LLM exactly like `octos chat`). Pressed Enter to skip it? Add the key later with `octos auth login --provider deepseek`. A Dock-launched Zed does **not** inherit your shell's env vars, so if you'd rather pass the key by an env var, put it in the `env` block below instead.
 
-**3. Register octos as an agent server** in Zed's settings (`~/.config/zed/settings.json`, or run *zed: open settings*). Use `"command": "octos"` if it's on your `PATH`, or the absolute path from `which octos` — a Dock-launched Zed has a minimal `PATH` and may not find a bare `octos`:
+**2. Register octos as an agent server** in Zed's settings (`~/.config/zed/settings.json`, or run *zed: open settings*). Use `"command": "octos"` if it's on your `PATH`, or the absolute path from `which octos` — a Dock-launched Zed has a minimal `PATH` and may not find a bare `octos`:
 
 ```jsonc
 {
@@ -466,7 +466,7 @@ octos init                           # pick a provider + model — this guide us
 
 > The `--provider`/`--model` in `args` must match the provider you set up in steps 1–2 (this guide uses DeepSeek). `octos acp` inherits the rest — `base_url`, `api_type`, `api_key_env` — from your `octos init` config, so pointing `deepseek` args at a differently-configured provider sends the wrong key/endpoint and the session fails.
 
-**4. Play with it in Zed.**
+**3. Play with it in Zed.**
 - **Open a folder** — external agents need a workspace (with none open, the Agent Panel just shows *"Open Project"*).
 - Open the **Agent Panel** (right dock), click the **＋ New Thread** dropdown (or press `⌥⌘⇧N`), and choose **Octos**.
 - Type a prompt. octos runs the agent loop and streams tools, thinking, and results back into Zed — and it remembers across turns via your `MEMORY.md`.


### PR DESCRIPTION
`octos init` (interactive) already prompts to paste the provider's API key and stores it in the auth store (#1541/#1542) — same as `octos auth login`. The ACP/Zed walkthrough had a redundant separate 'run octos auth login' step; fold it into the `octos init` step (auth login kept only as the skip-recovery fallback), and renumber. Docs-only, both READMEs.