### PR TITLE
fix(profile): clippy field_reassign_with_default in test helper (unbreak main check)

### DIFF
--- a/crates/octos-cli/src/commands/profile.rs
+++ b/crates/octos-cli/src/commands/profile.rs
@@ -297,10 +297,12 @@ mod tests {
     use super::*;
 
     fn config_with_provider() -> Config {
-        let mut config = Config::default();
-        config.provider = Some("deepseek".into());
-        config.model = Some("deepseek-v4-pro".into());
-        config.api_key_env = Some("DEEPSEEK_API_KEY".into());
+        let mut config = Config {
+            provider: Some("deepseek".into()),
+            model: Some("deepseek-v4-pro".into()),
+            api_key_env: Some("DEEPSEEK_API_KEY".into()),
+            ..Config::default()
+        };
         config
             .env_vars
             .insert("DEEPSEEK_API_KEY".into(), "sk-test-key".into());


### PR DESCRIPTION
main's `check` job (Linux clippy `--all-targets -D warnings`) fails at `crates/octos-cli/src/commands/profile.rs:300` — the `config_with_provider` test helper from the #1569 squash trips `field_reassign_with_default`. The squash landed before its refreshed CI run completed, so this was never caught on the PR (#1574 merged on top the same way; its branch CI failed with the same single inherited error + the known flaky ACP cancel test, nothing new).

Every open PR's `check` job fails against current main until this lands — proof: #1250's fresh run (main-merged tree, unrelated spawn-only diff) fails at exactly this line.

Fix: struct init with `..Config::default()`. Test-code only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)