### PR TITLE
ci: unbreak main — drop stale activate_tools_regression step + fmt from #1578

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
       fail-fast: false
       matrix:
         # `lib` runs `--lib` only. `integration` runs `--tests` (every
-        # integration test binary, including activate_tools_regression).
+        # integration test binary).
         # Splitting these onto separate runners means each gets a fresh
         # 16GB allocation and neither inherits residual RAM from the
         # other's compile phase.
@@ -307,12 +307,6 @@ jobs:
         # comfortably within the runner's 6h budget.
         run: cargo test -p octos-agent --tests -- --test-threads=1
 
-      # Co-located in the integration job so it reuses the warm octos-agent
-      # integration test build cache (activate_tools_regression is itself an
-      # integration test binary). Skipped in the lib job.
-      - name: activate_tools regression tests
-        if: matrix.test-mode == 'integration'
-        run: cargo test -p octos-agent --test activate_tools_regression -- --nocapture
 
   test-octos-cli:
     runs-on: ubuntu-latest

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -176,9 +176,9 @@ pub use task_supervisor::{
     TaskSupervisor, TerminalEvent, TerminalOutcome, parse_alternatives,
 };
 pub use tools::{
-    AskUserQuestionTool, BackgroundResultKind, BackgroundResultPayload,
-    BrowserTool, CheckBackgroundTasksTool, CheckWorkspaceContractTool, ConcurrencyClass,
-    ConfigureToolTool, DEFAULT_DISPATCH_TIMEOUT_SECS, DEFAULT_HTTP_CONNECT_TIMEOUT_SECS,
+    AskUserQuestionTool, BackgroundResultKind, BackgroundResultPayload, BrowserTool,
+    CheckBackgroundTasksTool, CheckWorkspaceContractTool, ConcurrencyClass, ConfigureToolTool,
+    DEFAULT_DISPATCH_TIMEOUT_SECS, DEFAULT_HTTP_CONNECT_TIMEOUT_SECS,
     DEFAULT_HTTP_READ_TIMEOUT_SECS, DELEGATED_DENY_GROUP, DELEGATION_METRIC, DeepSearchTool,
     DelegateTool, DelegationEvent, DelegationOutcome, DepthBudget, DiffEditTool,
     DispatchContextContract, DispatchOutcome, DispatchRequest, DispatchResponse, EditFileTool,

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -18,10 +18,10 @@ use super::{
     ApplyPatchTool, AskUserQuestionTool, BrowserTool, CheckWorkspaceContractTool, CloseAgentTool,
     ConfigureToolTool, DiffEditTool, EditFileTool, ExecCommandTool, GlobTool, GrepTool,
     ImageGenerationTool, ListDirTool, ReadFileTool, RequestUserInputTool, ResumeAgentTool,
-    SendInputTool, ShellTool, SpawnAgentTool, Tool, ToolCatalogEntry, ToolConfigStore,
-    ToolResult, ToolSearchTool, ToolSuggestTool, UpdatePlanTool, ViewImageTool,
-    WaitAgentTool, WebFetchTool, WebSearchTool, WorkspaceDiffTool, WorkspaceLogTool,
-    WorkspaceShowTool, WriteFileTool, WriteStdinTool,
+    SendInputTool, ShellTool, SpawnAgentTool, Tool, ToolCatalogEntry, ToolConfigStore, ToolResult,
+    ToolSearchTool, ToolSuggestTool, UpdatePlanTool, ViewImageTool, WaitAgentTool, WebFetchTool,
+    WebSearchTool, WorkspaceDiffTool, WorkspaceLogTool, WorkspaceShowTool, WriteFileTool,
+    WriteStdinTool,
 };
 use crate::sandbox::{NoSandbox, Sandbox};
 

--- a/crates/octos-agent/tests/tiered_compaction_loop.rs
+++ b/crates/octos-agent/tests/tiered_compaction_loop.rs
@@ -163,7 +163,7 @@ async fn tier1_shrinks_50kb_tool_result_to_placeholder_on_next_iteration() {
             .content
             .starts_with(octos_agent::compaction::TOOL_RESULT_PLACEHOLDER_PREFIX),
         "tier 1 did not shrink the 50KB tool result: {:?}",
-        &tool_msg.content.chars().take(80).collect::<String>()
+        tool_msg.content.chars().take(80).collect::<String>()
     );
     assert!(
         tool_msg.content.len() < 1_000,

--- a/crates/octos-cli/src/commands/gateway/message_preprocessing.rs
+++ b/crates/octos-cli/src/commands/gateway/message_preprocessing.rs
@@ -415,14 +415,14 @@ pub fn resolve_reply_target(
             .metadata
             .get("deliver_to_channel")
             .and_then(|v| v.as_str())
-            .and_then(|s| if s.is_empty() { None } else { Some(s) })
+            .filter(|s| !s.is_empty())
             .unwrap_or(default_cron_channel)
             .to_string();
         let cid = inbound
             .metadata
             .get("deliver_to_chat_id")
             .and_then(|v| v.as_str())
-            .and_then(|s| if s.is_empty() { None } else { Some(s) })
+            .filter(|s| !s.is_empty())
             .unwrap_or_else(|| {
                 if !default_cron_chat_id.is_empty() {
                     default_cron_chat_id


### PR DESCRIPTION
#1578 (RFC-0 LRU tool-deferral removal, 172fb2be6) was merged before its CI completed and broke main twice over:

1. **Integration job**: it deleted `crates/octos-agent/tests/activate_tools_regression.rs` but left the ci.yml step running `cargo test -p octos-agent --test activate_tools_regression` → cargo exit 101 (no such target) on main and every PR since. Step + comment references removed.
2. **check job**: unformatted tool-import blocks (octos-agent `lib.rs`/`tools/registry.rs`) fail `cargo fmt --all -- --check` at the job's first step (the 24s failures). `cargo fmt` applied.

Evidence: 4 PRs (#1555/#1222/#1224/#1504) all failing exactly `check` (24s, fmt diff in log) + `test-octos-agent (integration)` (cargo 101 listing available targets) since 172fb2be6 landed; reruns reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)