### PR TITLE
feat(dashboard): admin-mode profile list + create shortcut (reimplements #1213)

### DIFF
--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -178,7 +178,19 @@ export const api = {
     offset?: number
   }) => request<AdminAuditResponse>(queryPath('/audit', params ?? {})),
 
-  listProfiles: () => request<ProfileResponse[]>('/profiles'),
+  listProfiles: (params?: { offset?: number; limit?: number }) =>
+    request<ProfileResponse[]>(queryPath('/profiles', params ?? {})),
+
+  // Fetch every profile page (the endpoint defaults to limit=100).
+  listAllProfiles: async (): Promise<ProfileResponse[]> => {
+    const pageSize = 100
+    const all: ProfileResponse[] = []
+    for (let offset = 0; ; offset += pageSize) {
+      const page = await api.listProfiles({ offset, limit: pageSize })
+      all.push(...page)
+      if (page.length < pageSize) return all
+    }
+  },
 
   getProfile: (id: string) => request<ProfileResponse>(`/profiles/${id}`),
 

--- a/dashboard/src/pages/AdminBotPage.test.tsx
+++ b/dashboard/src/pages/AdminBotPage.test.tsx
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
 import AdminBotPage from './AdminBotPage'
+import type { ProfileResponse } from '../types'
 
 const mockMonitorStatus = vi.fn()
+const mockListProfiles = vi.fn()
 const mockToggleWatchdog = vi.fn()
 const mockToggleAlerts = vi.fn()
 const mockUpdateProfileMonitor = vi.fn()
@@ -12,6 +15,7 @@ const mockToast = vi.fn()
 vi.mock('../api', () => ({
   api: {
     monitorStatus: () => mockMonitorStatus(),
+    listProfiles: () => mockListProfiles(),
     toggleWatchdog: (enabled: boolean) => mockToggleWatchdog(enabled),
     toggleAlerts: (enabled: boolean) => mockToggleAlerts(enabled),
     updateProfileMonitor: (
@@ -35,12 +39,53 @@ const alpha = {
   alerts_override: false,
 }
 
+function profile(
+  id: string,
+  name: string,
+  adminMode: boolean,
+  running: boolean,
+): ProfileResponse {
+  return {
+    id,
+    name,
+    enabled: true,
+    data_dir: null,
+    parent_id: null,
+    public_subdomain: null,
+    config: {
+      channels: [],
+      gateway: {},
+      env_vars: {},
+      admin_mode: adminMode,
+    },
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-01T00:00:00Z',
+    status: {
+      running,
+      pid: running ? 123 : null,
+      started_at: running ? '2026-05-01T00:00:00Z' : null,
+      uptime_secs: running ? 30 : null,
+    },
+    email: null,
+  }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/admin-bot']}>
+      <AdminBotPage />
+    </MemoryRouter>,
+  )
+}
+
 beforeEach(() => {
   mockMonitorStatus.mockReset()
+  mockListProfiles.mockReset()
   mockToggleWatchdog.mockReset()
   mockToggleAlerts.mockReset()
   mockUpdateProfileMonitor.mockReset()
   mockToast.mockReset()
+  mockListProfiles.mockResolvedValue([])
 })
 
 describe('AdminBotPage', () => {
@@ -51,7 +96,7 @@ describe('AdminBotPage', () => {
       profiles: [alpha],
     })
 
-    render(<AdminBotPage />)
+    renderPage()
 
     expect(await screen.findByText('Alpha')).toBeInTheDocument()
     expect(screen.getByText('alpha')).toBeInTheDocument()
@@ -72,7 +117,7 @@ describe('AdminBotPage', () => {
       watchdog_override: false,
     })
 
-    render(<AdminBotPage />)
+    renderPage()
 
     const watchdogSelect = (await screen.findAllByRole('combobox'))[0]
     await user.selectOptions(watchdogSelect, 'disabled')
@@ -84,5 +129,47 @@ describe('AdminBotPage', () => {
       expect(screen.getAllByText('Effective: disabled')).toHaveLength(2)
     })
     expect(mockToggleWatchdog).not.toHaveBeenCalled()
+  })
+
+  it('lists admin-mode profiles and highlights the running admin bot', async () => {
+    mockMonitorStatus.mockResolvedValue({
+      watchdog_enabled: true,
+      alerts_enabled: false,
+      profiles: [],
+    })
+    mockListProfiles.mockResolvedValue([
+      profile('ops-admin', 'Ops Admin', true, true),
+      profile('backup-admin', 'Backup Admin', true, false),
+      profile('regular-user', 'Regular User', false, true),
+    ])
+
+    renderPage()
+
+    expect(await screen.findAllByText('Ops Admin')).toHaveLength(2)
+    expect(screen.getByText('Backup Admin')).toBeInTheDocument()
+    expect(screen.queryByText('Regular User')).not.toBeInTheDocument()
+    expect(screen.getByText('Running')).toBeInTheDocument()
+    expect(screen.getByText('Stopped')).toBeInTheDocument()
+    expect(screen.getByText('Active admin bot:')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Create admin profile' })).toHaveAttribute(
+      'href',
+      '/profiles/new?adminMode=true',
+    )
+  })
+
+  it('shows an empty state when no admin-mode profile exists', async () => {
+    mockMonitorStatus.mockResolvedValue({
+      watchdog_enabled: true,
+      alerts_enabled: false,
+      profiles: [],
+    })
+    mockListProfiles.mockResolvedValue([
+      profile('regular-user', 'Regular User', false, true),
+    ])
+
+    renderPage()
+
+    expect(await screen.findByText('No admin-mode profiles found.')).toBeInTheDocument()
+    expect(screen.getByText('None running')).toBeInTheDocument()
   })
 })

--- a/dashboard/src/pages/AdminBotPage.test.tsx
+++ b/dashboard/src/pages/AdminBotPage.test.tsx
@@ -16,6 +16,8 @@ vi.mock('../api', () => ({
   api: {
     monitorStatus: () => mockMonitorStatus(),
     listProfiles: () => mockListProfiles(),
+    // The page loads all pages; in tests one mocked page is the whole set.
+    listAllProfiles: () => mockListProfiles(),
     toggleWatchdog: (enabled: boolean) => mockToggleWatchdog(enabled),
     toggleAlerts: (enabled: boolean) => mockToggleAlerts(enabled),
     updateProfileMonitor: (

--- a/dashboard/src/pages/AdminBotPage.tsx
+++ b/dashboard/src/pages/AdminBotPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Link } from 'react-router-dom'
 import { api } from '../api'
+import StatusBadge from '../components/StatusBadge'
 import { useToast } from '../components/Toast'
 import type { MonitorProfileStatus, MonitorStatus, ProfileResponse } from '../types'
 
@@ -23,7 +24,9 @@ export default function AdminBotPage() {
     try {
       const [monitor, profileList] = await Promise.all([
         api.monitorStatus().catch(() => EMPTY_MONITOR_STATUS),
-        api.listProfiles(),
+        // All pages — admin profiles past the first page (limit=100)
+        // must not silently vanish from this list.
+        api.listAllProfiles(),
       ])
       setMonitorStatus({ ...EMPTY_MONITOR_STATUS, ...monitor, profiles: monitor.profiles ?? [] })
       setProfiles(profileList)
@@ -199,15 +202,12 @@ export default function AdminBotPage() {
                   </Link>
                   <p className="text-xs text-gray-500 font-mono mt-1 truncate">{profile.id}</p>
                 </div>
-                <span
-                  className={`shrink-0 inline-flex px-2 py-0.5 text-[10px] font-medium rounded-full ${
-                    profile.status.running
-                      ? 'bg-green-500/15 text-green-400'
-                      : 'bg-gray-500/15 text-gray-400'
-                  }`}
-                >
-                  {profile.status.running ? 'Running' : 'Stopped'}
-                </span>
+                <StatusBadge
+                  className="shrink-0"
+                  running={profile.status.running}
+                  status={profile.status.status}
+                  error={profile.status.error ?? null}
+                />
               </div>
             ))}
           </div>

--- a/dashboard/src/pages/AdminBotPage.tsx
+++ b/dashboard/src/pages/AdminBotPage.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback } from 'react'
+import { Link } from 'react-router-dom'
 import { api } from '../api'
 import { useToast } from '../components/Toast'
-import type { MonitorProfileStatus, MonitorStatus } from '../types'
+import type { MonitorProfileStatus, MonitorStatus, ProfileResponse } from '../types'
 
 type MonitorOverride = 'inherit' | 'enabled' | 'disabled'
 
@@ -16,11 +17,16 @@ export default function AdminBotPage() {
   const [loading, setLoading] = useState(true)
   const [savingProfileId, setSavingProfileId] = useState<string | null>(null)
   const [monitorStatus, setMonitorStatus] = useState<MonitorStatus>(EMPTY_MONITOR_STATUS)
+  const [profiles, setProfiles] = useState<ProfileResponse[]>([])
 
   const loadData = useCallback(async () => {
     try {
-      const monitor = await api.monitorStatus().catch(() => EMPTY_MONITOR_STATUS)
+      const [monitor, profileList] = await Promise.all([
+        api.monitorStatus().catch(() => EMPTY_MONITOR_STATUS),
+        api.listProfiles(),
+      ])
       setMonitorStatus({ ...EMPTY_MONITOR_STATUS, ...monitor, profiles: monitor.profiles ?? [] })
+      setProfiles(profileList)
     } catch (e: any) {
       toast(e.message, 'error')
     } finally {
@@ -79,6 +85,9 @@ export default function AdminBotPage() {
       </div>
     )
   }
+
+  const adminProfiles = profiles.filter((profile) => profile.config.admin_mode)
+  const activeAdminProfile = adminProfiles.find((profile) => profile.status.running)
 
   return (
     <div className="max-w-5xl">
@@ -159,12 +168,54 @@ export default function AdminBotPage() {
       </div>
 
       <div className="bg-surface rounded-xl border border-gray-700/50 p-5">
-        <h2 className="text-sm font-semibold text-white mb-2">Admin Bot Profile</h2>
-        <p className="text-sm text-gray-400">
-          To set up an admin bot, create a regular profile and enable <strong className="text-white">Admin Mode</strong> in
-          its settings. Admin mode restricts the gateway to admin-only tools (profile management,
-          monitoring, logs) and uses a built-in admin system prompt.
-        </p>
+        <div className="flex items-center justify-between gap-3 mb-4">
+          <div>
+            <h2 className="text-sm font-semibold text-white">Admin Bot Profile</h2>
+            <p className="text-xs text-gray-500 mt-1">
+              Active admin bot:{' '}
+              <span className={activeAdminProfile ? 'text-green-400' : 'text-gray-400'}>
+                {activeAdminProfile ? activeAdminProfile.name : 'None running'}
+              </span>
+            </p>
+          </div>
+          <Link
+            to="/profiles/new?adminMode=true"
+            className="shrink-0 px-3 py-2 text-xs font-medium rounded-lg bg-accent text-white hover:bg-accent-light transition"
+          >
+            Create admin profile
+          </Link>
+        </div>
+
+        {adminProfiles.length > 0 ? (
+          <div className="divide-y divide-gray-700/50">
+            {adminProfiles.map((profile) => (
+              <div key={profile.id} className="flex items-center justify-between gap-3 py-3 first:pt-0 last:pb-0">
+                <div className="min-w-0">
+                  <Link
+                    to={`/profile/${profile.id}`}
+                    className="text-sm font-medium text-white hover:text-accent transition"
+                  >
+                    {profile.name}
+                  </Link>
+                  <p className="text-xs text-gray-500 font-mono mt-1 truncate">{profile.id}</p>
+                </div>
+                <span
+                  className={`shrink-0 inline-flex px-2 py-0.5 text-[10px] font-medium rounded-full ${
+                    profile.status.running
+                      ? 'bg-green-500/15 text-green-400'
+                      : 'bg-gray-500/15 text-gray-400'
+                  }`}
+                >
+                  {profile.status.running ? 'Running' : 'Stopped'}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed border-gray-700/70 px-4 py-5 text-sm text-gray-400">
+            No admin-mode profiles found.
+          </div>
+        )}
       </div>
     </div>
   )

--- a/dashboard/src/pages/NewProfile.test.tsx
+++ b/dashboard/src/pages/NewProfile.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import NewProfile from './NewProfile'
+
+const mockCreateProfile = vi.fn()
+const mockToast = vi.fn()
+
+vi.mock('../api', () => ({
+  api: {
+    createProfile: (data: unknown) => mockCreateProfile(data),
+  },
+}))
+
+vi.mock('../components/Toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}))
+
+function renderNewProfile(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/profiles/new" element={<NewProfile />} />
+        <Route path="/profile/:id" element={<div>Profile created page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockCreateProfile.mockReset()
+  mockToast.mockReset()
+  mockCreateProfile.mockResolvedValue({})
+})
+
+describe('NewProfile admin mode shortcut', () => {
+  it('preselects admin mode from the query string and submits admin config', async () => {
+    const user = userEvent.setup()
+    renderNewProfile('/profiles/new?adminMode=true')
+
+    expect(screen.getByRole('checkbox', { name: 'Admin Mode' })).toBeChecked()
+
+    await user.type(screen.getAllByPlaceholderText('alice-bot')[0], 'ops-admin')
+    await user.type(screen.getByPlaceholderText("Alice's Bot"), 'Ops Admin')
+    await user.click(screen.getByRole('button', { name: 'Create Profile' }))
+
+    await waitFor(() => {
+      expect(mockCreateProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'ops-admin',
+          name: 'Ops Admin',
+          config: expect.objectContaining({
+            admin_mode: true,
+            channels: [],
+            gateway: {},
+            env_vars: {},
+          }),
+        }),
+      )
+    })
+  })
+
+  it('leaves admin mode off by default and omits config from the request', async () => {
+    const user = userEvent.setup()
+    renderNewProfile('/profiles/new')
+
+    expect(screen.getByRole('checkbox', { name: 'Admin Mode' })).not.toBeChecked()
+
+    await user.type(screen.getAllByPlaceholderText('alice-bot')[0], 'plain-bot')
+    await user.type(screen.getByPlaceholderText("Alice's Bot"), 'Plain Bot')
+    await user.click(screen.getByRole('button', { name: 'Create Profile' }))
+
+    await waitFor(() => {
+      expect(mockCreateProfile).toHaveBeenCalledWith({
+        id: 'plain-bot',
+        name: 'Plain Bot',
+        public_subdomain: null,
+        enabled: true,
+      })
+    })
+  })
+})

--- a/dashboard/src/pages/NewProfile.tsx
+++ b/dashboard/src/pages/NewProfile.tsx
@@ -1,16 +1,19 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useToast } from '../components/Toast'
 import { api } from '../api'
 
 export default function NewProfile() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const { toast } = useToast()
+  const adminModeRequested = searchParams.get('adminMode') === 'true'
   const [loading, setLoading] = useState(false)
   const [id, setId] = useState('')
   const [name, setName] = useState('')
   const [publicSubdomain, setPublicSubdomain] = useState('')
   const [enabled, setEnabled] = useState(true)
+  const [adminMode, setAdminMode] = useState(adminModeRequested)
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -21,6 +24,16 @@ export default function NewProfile() {
         name,
         public_subdomain: publicSubdomain.trim() || null,
         enabled,
+        ...(adminMode
+          ? {
+              config: {
+                channels: [],
+                gateway: {},
+                env_vars: {},
+                admin_mode: true,
+              },
+            }
+          : {}),
       })
       toast('Profile created')
       navigate(`/profile/${id}`)
@@ -91,6 +104,17 @@ export default function NewProfile() {
                 className="w-4 h-4 rounded bg-surface-dark border-gray-600 text-accent focus:ring-accent"
               />
               <span className="text-sm text-gray-400">Auto-start gateway when server starts</span>
+            </label>
+          </div>
+          <div>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={adminMode}
+                onChange={(e) => setAdminMode(e.target.checked)}
+                className="w-4 h-4 rounded bg-surface-dark border-gray-600 text-accent focus:ring-accent"
+              />
+              <span className="text-sm text-gray-400">Admin Mode</span>
             </label>
           </div>
           <div className="flex justify-end gap-3 pt-4 border-t border-gray-700/50">


### PR DESCRIPTION
## Summary

Fresh re-implementation of #1213 ("feat(dashboard): show admin bot profiles") on current `main`. #1213's target page was rewritten by #1241 (`6e44b86ef`, per-profile monitor overrides), so this lands the same feature adapted to the post-#1241 Monitor & Watchdog page instead of rebasing the old branch. #1213 stays open as the spec reference.

- Replace the static "Admin Bot Profile" copy at the bottom of `AdminBotPage` with a live list of profiles where `config.admin_mode` is set, each with a Running/Stopped status badge (from `profile.status.running`) and a link to the profile page.
- Show the currently running admin bot inline ("Active admin bot: …"), with an empty state when no admin-mode profile exists.
- Add a "Create admin profile" shortcut to `/profiles/new?adminMode=true`; `NewProfile` gains an Admin Mode checkbox preselected from that query param and submits `config: { channels: [], gateway: {}, env_vars: {}, admin_mode: true }` when checked.
- Extend `AdminBotPage` tests (renders now wrapped in `MemoryRouter` for the new links) and add `NewProfile` tests covering the shortcut and the default (no-config) submit.

Dashboard-only: no Rust files touched. The monitor override toggles from #1241 are untouched.

Closes #425

## Validation

Run in an isolated worktree off `origin/main` (`65486dadb`):

- `npm ci` (dashboard)
- `npx tsc -b` — clean
- `npm test` (vitest) — 12 files / 54 tests passed, including the new `AdminBotPage` and `NewProfile` cases
- `./scripts/build-dashboard.sh` from repo root — built and synced to `crates/octos-cli/static/admin` (gitignored; no artifacts committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
