### PR TITLE
fix(security): harden the mcp-serve sandbox (fail-closed, tool policy, sandboxed validators)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4293,6 +4293,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "shlex",
  "similar",
  "symphonia",
  "tar",

--- a/crates/octos-agent/Cargo.toml
+++ b/crates/octos-agent/Cargo.toml
@@ -26,6 +26,9 @@ tracing = { workspace = true }
 metrics = { workspace = true }
 glob = { workspace = true }
 globset = { workspace = true }
+# Shell-quote validator argv when wrapping command validators for a POSIX
+# sandbox (so `sh -c` reconstructs the exact argv rather than word-splitting).
+shlex = "1"
 which = { workspace = true }
 regex = { workspace = true }
 ignore = { workspace = true }

--- a/crates/octos-agent/src/sandbox/mod.rs
+++ b/crates/octos-agent/src/sandbox/mod.rs
@@ -221,12 +221,24 @@ pub enum SandboxMode {
 pub trait Sandbox: Send + Sync {
     /// Wrap a shell command string into a sandboxed `Command`.
     fn wrap_command(&self, shell_command: &str, cwd: &Path) -> Command;
+
+    /// Whether this sandbox provides no confinement (runs commands directly).
+    /// Lets callers that require confinement (e.g. the `mcp-serve` server path)
+    /// fail closed when `SandboxMode::Auto` resolves to no backend. Real
+    /// backends inherit the default `false`.
+    fn is_noop(&self) -> bool {
+        false
+    }
 }
 
 /// No-op sandbox: executes commands directly.
 pub struct NoSandbox;
 
 impl Sandbox for NoSandbox {
+    fn is_noop(&self) -> bool {
+        true
+    }
+
     fn wrap_command(&self, shell_command: &str, cwd: &Path) -> Command {
         #[cfg(windows)]
         {
@@ -632,5 +644,42 @@ mod tests {
         assert_eq!(prog, "cmd");
         #[cfg(not(windows))]
         assert_eq!(prog, "sh");
+    }
+
+    // --- is_noop contract (fail-closed callers depend on this) ---
+
+    #[test]
+    fn no_sandbox_reports_noop() {
+        // The `mcp-serve` fail-closed check and the validator direct-argv path
+        // both key off `is_noop()`. NoSandbox provides zero confinement, so it
+        // must report `true`; the trait default (real backends) is `false`.
+        assert!(
+            NoSandbox.is_noop(),
+            "NoSandbox must report is_noop() == true"
+        );
+    }
+
+    #[test]
+    fn disabled_and_none_modes_yield_noop_sandbox() {
+        // Both an explicitly-disabled sandbox and `mode = none` must resolve to
+        // a no-op backend, so a fail-closed caller can distinguish "operator
+        // opted out" (respect it) from "wanted a sandbox, none available"
+        // (refuse). This is host-independent.
+        for config in [
+            SandboxConfig {
+                enabled: false,
+                ..SandboxConfig::default()
+            },
+            SandboxConfig {
+                enabled: true,
+                mode: SandboxMode::None,
+                ..SandboxConfig::default()
+            },
+        ] {
+            assert!(
+                create_sandbox(&config).is_noop(),
+                "config {config:?} must produce a no-op sandbox"
+            );
+        }
     }
 }

--- a/crates/octos-agent/src/sandbox/windows.rs
+++ b/crates/octos-agent/src/sandbox/windows.rs
@@ -45,6 +45,18 @@ const WINDOWS_READ_ALLOW_PATHS: &[&str] = &[
 ];
 
 impl Sandbox for AppContainerSandbox {
+    /// Report no-op enforcement when the `octos-sandbox` helper is unavailable.
+    ///
+    /// Without the helper, [`Self::wrap_command`] falls back to an unsandboxed
+    /// `cmd /C`, so the AppContainer provides no confinement. Surfacing that as
+    /// `is_noop() == true` lets fail-closed callers (e.g. the `mcp-serve` path)
+    /// refuse to run tools rather than silently executing host commands under a
+    /// configured-but-inert sandbox — matching how the Linux Landlock backend
+    /// refuses when its helper is missing.
+    fn is_noop(&self) -> bool {
+        find_sandbox_helper().is_none()
+    }
+
     fn wrap_command(&self, shell_command: &str, cwd: &Path) -> Command {
         // Find the helper binary next to our own executable
         let helper = find_sandbox_helper();

--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -33,6 +33,7 @@ use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use crate::policy::{CommandPolicy, Decision, SafePolicy};
+use crate::sandbox::Sandbox;
 use crate::subprocess_env::{EnvAllowlist, sanitize_command_env};
 use crate::tools::{ToolRegistry, ToolResult};
 use crate::workspace_policy::{
@@ -430,6 +431,12 @@ pub struct ValidatorRunner {
     evidence_root: PathBuf,
     policy: Arc<dyn CommandPolicy>,
     ledger: Option<ValidatorLedger>,
+    /// Optional sandbox for **command** validators (which shell out). When set,
+    /// each command validator is wrapped via [`Sandbox::wrap_command`] so an
+    /// untrusted workspace `.octos-workspace.toml` can't run unsandboxed host
+    /// commands post-turn. `None` = run directly (current default; trusted
+    /// callers). Opted into on the `mcp-serve` path.
+    sandbox: Option<Arc<dyn Sandbox>>,
 }
 
 impl std::fmt::Debug for ValidatorRunner {
@@ -460,12 +467,21 @@ impl ValidatorRunner {
             evidence_root,
             policy: Arc::new(SafePolicy::default()),
             ledger: None,
+            sandbox: None,
         }
     }
 
     /// Override the directory where evidence files are written.
     pub fn with_evidence_root(mut self, path: impl Into<PathBuf>) -> Self {
         self.evidence_root = path.into();
+        self
+    }
+
+    /// Run **command** validators under `sandbox` (wraps each via
+    /// [`Sandbox::wrap_command`]). Used by callers that must confine
+    /// workspace-declared command validators (e.g. `mcp-serve`).
+    pub fn with_sandbox(mut self, sandbox: Arc<dyn Sandbox>) -> Self {
+        self.sandbox = Some(sandbox);
         self
     }
 
@@ -691,10 +707,47 @@ impl ValidatorRunner {
             }
         }
 
-        let mut command = Command::new(&resolved_cmd);
+        // Only shell-wrap the validator through the sandbox when it provides real
+        // confinement *and* the platform's sandbox shell is POSIX `sh -c`, where
+        // the `shlex` quoting below is correct. A no-op sandbox (e.g. NoSandbox,
+        // or a backend whose helper is unavailable) has nothing to escape, and on
+        // Windows the backends shell out via `cmd /C` — which ignores the POSIX
+        // single quotes `shlex` emits, leaving metacharacters in an argument
+        // active. Both cases fall through to running the argv directly, where
+        // `Command` passes each element as a distinct token so a caller-influenced
+        // argument cannot inject shell metacharacters.
+        let sandbox_shell_is_posix = cfg!(not(windows));
+        let mut command = match &self.sandbox {
+            Some(sandbox) if sandbox_shell_is_posix && !sandbox.is_noop() => {
+                // wrap_command runs the string via `sh -c`, so shell-quote each
+                // argv element (build_command_string above is unquoted — it's
+                // only for the SafePolicy display/check). Otherwise `sh -c "sh -c
+                // exit 1"`-style validators would word-split and mis-report.
+                let quoted = match shlex::try_join(
+                    std::iter::once(resolved_cmd.as_str())
+                        .chain(resolved_args.iter().map(String::as_str)),
+                ) {
+                    Ok(q) => q,
+                    Err(_) => {
+                        return error_outcome(
+                            invocation,
+                            validator,
+                            started_at,
+                            started,
+                            format!("command validator contains a NUL byte: {command_string}"),
+                        );
+                    }
+                };
+                sandbox.wrap_command(&quoted, &invocation.workspace_root)
+            }
+            _ => {
+                let mut c = Command::new(&resolved_cmd);
+                c.args(&resolved_args)
+                    .current_dir(&invocation.workspace_root);
+                c
+            }
+        };
         command
-            .args(&resolved_args)
-            .current_dir(&invocation.workspace_root)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .stdin(Stdio::null());

--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -707,18 +707,32 @@ impl ValidatorRunner {
             }
         }
 
-        // Only shell-wrap the validator through the sandbox when it provides real
-        // confinement *and* the platform's sandbox shell is POSIX `sh -c`, where
-        // the `shlex` quoting below is correct. A no-op sandbox (e.g. NoSandbox,
-        // or a backend whose helper is unavailable) has nothing to escape, and on
-        // Windows the backends shell out via `cmd /C` — which ignores the POSIX
-        // single quotes `shlex` emits, leaving metacharacters in an argument
-        // active. Both cases fall through to running the argv directly, where
-        // `Command` passes each element as a distinct token so a caller-influenced
-        // argument cannot inject shell metacharacters.
-        let sandbox_shell_is_posix = cfg!(not(windows));
-        let mut command = match &self.sandbox {
-            Some(sandbox) if sandbox_shell_is_posix && !sandbox.is_noop() => {
+        // A configured, real (non-no-op) sandbox means the validator MUST run
+        // inside it. On POSIX the backend runs via `sh -c`, so we shell-quote the
+        // argv with `shlex`. On Windows the backends shell out via `cmd /C`, for
+        // which there is no safe POSIX argv wrapping here — and a workspace policy
+        // can name an arbitrary executable, not merely inject an argument — so
+        // running the argv directly would *bypass* the sandbox. Fail closed there
+        // rather than escape it. A no-op sandbox (NoSandbox, or a backend whose
+        // helper is unavailable) and the no-sandbox case have nothing to escape,
+        // so they run the argv directly, where `Command` passes each element as a
+        // distinct token (injection-safe).
+        let real_sandbox = self.sandbox.as_ref().filter(|s| !s.is_noop());
+        let sandbox_is_windows = cfg!(windows);
+        if real_sandbox.is_some() && sandbox_is_windows {
+            return error_outcome(
+                invocation,
+                validator,
+                started_at,
+                started,
+                format!(
+                    "command validator not supported under the Windows sandbox \
+                     (would bypass AppContainer): {command_string}"
+                ),
+            );
+        }
+        let mut command = match real_sandbox {
+            Some(sandbox) => {
                 // wrap_command runs the string via `sh -c`, so shell-quote each
                 // argv element (build_command_string above is unquoted — it's
                 // only for the SafePolicy display/check). Otherwise `sh -c "sh -c
@@ -740,7 +754,7 @@ impl ValidatorRunner {
                 };
                 sandbox.wrap_command(&quoted, &invocation.workspace_root)
             }
-            _ => {
+            None => {
                 let mut c = Command::new(&resolved_cmd);
                 c.args(&resolved_args)
                     .current_dir(&invocation.workspace_root);

--- a/crates/octos-cli/src/commands/mcp_serve.rs
+++ b/crates/octos-cli/src/commands/mcp_serve.rs
@@ -33,6 +33,7 @@
 //! `contract_failed:`, `artifact_missing:`, `session_failed:`) so outer
 //! orchestrators can branch on category without scraping English text.
 
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -48,7 +49,10 @@ use octos_agent::task_supervisor::{TaskLifecycleState, TaskSupervisor};
 use octos_agent::validators::{
     ValidatorInvocation, ValidatorPhase, ValidatorRunner, run_workspace_validators,
 };
-use octos_agent::{Agent, AgentConfig, HarnessEvent, SandboxConfig, ToolRegistry, create_sandbox};
+use octos_agent::{
+    Agent, AgentConfig, ApprovalPolicy, EffectivePermissions, HarnessEvent, SandboxConfig,
+    SandboxMode, ToolPolicy, ToolRegistry, create_sandbox,
+};
 use octos_core::{AgentId, Task, TaskContext, TaskKind};
 use octos_llm::LlmProvider;
 use octos_memory::EpisodeStore;
@@ -118,11 +122,28 @@ impl McpServeCommand {
             Config::load_with_context(&cwd, &ctx)?
         };
 
-        // Capture the sandbox policy before `config` is moved into the LLM
-        // factory. The per-session tool registry uses it to confine
-        // shell/exec/file tools to the workspace (see the security note on
-        // `RealSessionDispatch`).
+        // Capture the sandbox + tool-policy config before `config` is moved into
+        // the LLM factory. The per-session tool registry uses the sandbox to
+        // confine shell/exec/file tools to the workspace and the policies so an
+        // external caller gets no looser a tool surface than local chat (see the
+        // security note on `RealSessionDispatch`).
         let sandbox = config.sandbox.clone();
+        let tool_policy = config.tool_policy.clone();
+        let tool_policy_by_provider = config.tool_policy_by_provider.clone();
+        // Resolved for the per-provider policy fallback (model id wins at
+        // session time). Matches chat: explicit `provider`, else inferred from
+        // the configured model.
+        let provider_name = config
+            .provider
+            .clone()
+            .or_else(|| {
+                config
+                    .model
+                    .as_deref()
+                    .and_then(crate::config::detect_provider)
+                    .map(str::to_string)
+            })
+            .unwrap_or_default();
         let factory = AgentLlmFactory::from_config(config)
             .wrap_err("failed to build LLM factory from config")?;
         let dispatch_config = SessionDispatchConfig {
@@ -130,6 +151,9 @@ impl McpServeCommand {
             data_dir: data_dir.clone(),
             max_iterations: 20,
             sandbox,
+            tool_policy,
+            tool_policy_by_provider,
+            provider_name,
         };
         let dispatch: Arc<dyn McpSessionDispatch> =
             Arc::new(RealSessionDispatch::new(dispatch_config, factory));
@@ -310,15 +334,41 @@ pub struct SessionDispatchConfig {
     /// [`SandboxMode::Auto`](octos_agent::SandboxMode) via
     /// [`SandboxConfig::default`].
     pub sandbox: SandboxConfig,
+    /// Operator-configured global tool deny/allow policy. Applied to the
+    /// MCP-served registry so a server that denies e.g. `shell`/`bash` locally
+    /// doesn't re-expose those tools to an external caller (parity with chat).
+    pub tool_policy: Option<ToolPolicy>,
+    /// Full per-provider tool-policy map (config `tool_policy_by_provider`),
+    /// resolved per session against the built provider's `model_id()` — with a
+    /// fallback to [`Self::provider_name`] — so a model-scoped deny is honoured
+    /// even when the config relies on a provider default model.
+    pub tool_policy_by_provider: HashMap<String, ToolPolicy>,
+    /// Configured provider name, the fallback key when resolving the
+    /// per-provider tool policy (model id wins over provider name).
+    pub provider_name: String,
 }
 
 impl SessionDispatchConfig {
-    /// Build the sandbox backend for this session's tool registry. Auto mode
-    /// resolves to `sandbox-exec` on macOS / `bwrap` on Linux and falls back
-    /// to `NoSandbox` only when no backend is available (matching chat and
-    /// gateway).
-    fn sandbox_backend(&self) -> Box<dyn octos_agent::Sandbox> {
-        create_sandbox(&self.sandbox)
+    /// Build the sandbox backend for this session's tool registry, applying the
+    /// MCP approval posture first. Returns the effective [`SandboxConfig`] and
+    /// the constructed backend so the caller can fail closed when a sandbox was
+    /// requested but no backend is available on this host.
+    ///
+    /// The MCP-served agent runs under [`ApprovalPolicy::Never`]: there is no
+    /// interactive approver in server mode, so any tool call that would prompt
+    /// fails at the tool boundary rather than silently proceeding. Auto mode
+    /// resolves to `sandbox-exec` on macOS / `bwrap` on Linux.
+    fn sandbox_backend(&self) -> (SandboxConfig, Box<dyn octos_agent::Sandbox>) {
+        let permissions = self.permissions();
+        let effective = permissions.apply_to_sandbox(&self.sandbox);
+        let backend = create_sandbox(&effective);
+        (effective, backend)
+    }
+
+    /// The MCP-served agent's effective permissions: workspace-write, but with
+    /// a fail-closed approval policy (no interactive approver exists server-side).
+    fn permissions(&self) -> EffectivePermissions {
+        EffectivePermissions::workspace_write().with_approval_policy(ApprovalPolicy::Never)
     }
 }
 
@@ -467,10 +517,49 @@ impl McpSessionDispatch for RealSessionDispatch {
         // `shell`/`exec_command` to read, write, or execute anywhere the octos
         // process could (the M7.2 session-dispatch RCE). The OS sandbox
         // restricts writes to `cwd`.
-        let tools = Arc::new(ToolRegistry::with_builtins_and_sandbox(
-            &self.config.cwd,
-            self.config.sandbox_backend(),
-        ));
+        let permissions = self.config.permissions();
+        let (effective_sandbox_config, sandbox) = self.config.sandbox_backend();
+        // Fail closed: unlike local chat/gateway (where the human runs their own
+        // commands), the mcp-serve caller is only parent-trusted (stdio) or
+        // bearer-token authenticated (http). If the operator wanted a sandbox but
+        // this host has no backend (Auto → NoSandbox), refuse the session rather
+        // than silently running an external caller's tools unsandboxed. An
+        // explicit `sandbox.mode = "none"` opt-out is respected.
+        if effective_sandbox_config.enabled
+            && effective_sandbox_config.mode != SandboxMode::None
+            && sandbox.is_noop()
+        {
+            return Err(McpServerError::SessionFailed(
+                "session_failed: no sandbox backend available on this host; refusing to run \
+                 tools unsandboxed on the mcp-serve path (set sandbox.mode = \"none\" to opt out)"
+                    .to_string(),
+            ));
+        }
+        let mut registry =
+            ToolRegistry::with_builtins_and_permissions(&self.config.cwd, sandbox, permissions);
+        // Apply the operator's global tool deny/allow policy (parity with chat)
+        // so a server that denies command tools doesn't re-expose them, then the
+        // model-scoped policy resolved against the provider we actually built
+        // (`llm.model_id()` — not the raw config model, which is empty when only
+        // a provider is configured, so a policy keyed to the provider default
+        // model would otherwise be skipped).
+        if let Some(policy) = &self.config.tool_policy {
+            registry.apply_policy(policy);
+        }
+        let provider_policy = self
+            .config
+            .tool_policy_by_provider
+            .get(llm.model_id())
+            .or_else(|| {
+                self.config
+                    .tool_policy_by_provider
+                    .get(&self.config.provider_name)
+            })
+            .cloned();
+        if let Some(policy) = provider_policy {
+            registry.set_provider_policy(policy);
+        }
+        let tools = Arc::new(registry);
         let agent_config = AgentConfig {
             max_iterations: self.config.max_iterations,
             // Skip episode persistence — MCP sessions are short-lived and
@@ -556,7 +645,13 @@ impl McpSessionDispatch for RealSessionDispatch {
         // defined. Results are surfaced via `validator_results` so MCP
         // callers see the same typed outcomes the local spawn pipeline
         // records in its ledger. Missing policy → empty vec (not an error).
-        let validator_results = run_completion_validators(&self.config.cwd, contract, &tools).await;
+        let validator_results = run_completion_validators(
+            &self.config.cwd,
+            contract,
+            &tools,
+            &effective_sandbox_config,
+        )
+        .await;
 
         // Resolve the contract artifact. Precedence:
         //   1. Explicit `expected_artifact` from the MCP input.
@@ -669,6 +764,7 @@ async fn run_completion_validators(
     workspace_root: &std::path::Path,
     contract: &str,
     tools: &Arc<ToolRegistry>,
+    sandbox: &SandboxConfig,
 ) -> Vec<Value> {
     let Ok(Some(policy)) = octos_agent::read_workspace_policy(workspace_root) else {
         return Vec::new();
@@ -676,7 +772,12 @@ async fn run_completion_validators(
     if policy.validation.validators.is_empty() {
         return Vec::new();
     }
-    let runner = ValidatorRunner::new(tools.clone(), workspace_root);
+    // Run workspace command validators *through* the same sandbox the agent's
+    // tools use — otherwise a workspace-declared completion command would be an
+    // unsandboxed host-exec escape on the mcp-serve path (the validator runner
+    // routes no-op sandboxes to a direct, injection-safe argv exec).
+    let runner = ValidatorRunner::new(tools.clone(), workspace_root)
+        .with_sandbox(Arc::from(create_sandbox(sandbox)));
     let invocation = ValidatorInvocation {
         phase: ValidatorPhase::Completion,
         workspace_root: workspace_root.to_path_buf(),
@@ -766,6 +867,9 @@ mod tests {
             data_dir: std::env::temp_dir(),
             max_iterations: 4,
             sandbox,
+            tool_policy: None,
+            tool_policy_by_provider: HashMap::new(),
+            provider_name: String::new(),
         };
 
         // A disabled policy must produce a pass-through backend, proving the
@@ -776,6 +880,7 @@ mod tests {
         });
         let program = disabled
             .sandbox_backend()
+            .1
             .wrap_command("true", std::path::Path::new("."))
             .as_std()
             .get_program()

--- a/crates/octos-cli/tests/mcp_serve_integration.rs
+++ b/crates/octos-cli/tests/mcp_serve_integration.rs
@@ -23,9 +23,9 @@
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use octos_agent::SandboxConfig;
 use octos_agent::mcp_server::{McpSessionDispatch, SessionLifecycleObserver};
 use octos_agent::task_supervisor::TaskLifecycleState;
+use octos_agent::{SandboxConfig, SandboxMode};
 use octos_cli::commands::mcp_serve::{AgentLlmFactory, RealSessionDispatch, SessionDispatchConfig};
 use octos_core::{Message, ToolCall};
 use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, TokenUsage, ToolSpec};
@@ -139,7 +139,19 @@ struct DispatchHarness {
 
 impl DispatchHarness {
     fn build(provider: Arc<dyn LlmProvider>, workspace: TempDir) -> Self {
-        Self::build_with_sandbox(provider, workspace, SandboxConfig::default())
+        // Opt out of the sandbox for the scripted success/lifecycle paths so the
+        // mcp-serve fail-closed no-backend check is host-independent (CI runners
+        // have no bwrap/sandbox-exec). Confinement is exercised separately by
+        // `should_block_shell_write_outside_workspace_via_sandbox`, which opts
+        // into a real backend and self-skips when none is available.
+        Self::build_with_sandbox(
+            provider,
+            workspace,
+            SandboxConfig {
+                mode: SandboxMode::None,
+                ..SandboxConfig::default()
+            },
+        )
     }
 
     fn build_with_sandbox(
@@ -155,6 +167,9 @@ impl DispatchHarness {
             data_dir,
             max_iterations: 4,
             sandbox,
+            tool_policy: None,
+            tool_policy_by_provider: Default::default(),
+            provider_name: String::new(),
         };
         Self {
             dispatch: RealSessionDispatch::new_for_test(config, factory),
@@ -597,7 +612,10 @@ async fn should_block_shell_write_outside_workspace_via_sandbox() {
         }),
         end_turn("attempted the writes"),
     ]);
-    let harness = DispatchHarness::build(provider, workspace);
+    // Opt into a real backend (Auto) — this test asserts OS-level confinement,
+    // and self-skipped above when Auto resolves to NoSandbox on this host.
+    let harness =
+        DispatchHarness::build_with_sandbox(provider, workspace, SandboxConfig::default());
     let observer = RecordingObserver::new();
 
     // Outcome may be Ready or Failed depending on artifact resolution; the


### PR DESCRIPTION
## Summary

Hardens the sandbox fix **#1604** landed for the `run_octos_session` RCE (**#1597**). #1604 confines the MCP-served agent's tools via `with_builtins_and_sandbox(Auto)` — the core fix — but an external MCP caller is only parent-trusted (stdio) or bearer-token authenticated (http), never fully trusted like a local chat user, and several gaps remained. This PR closes them.

> Rebased onto #1604; this is a pure hardening delta on top of it.

## What this adds on top of #1604

- **Fail closed on the mcp-serve path.** `Auto` falls back to `NoSandbox` when a host has no backend (e.g. Linux without `bwrap`, or Windows without the `octos-sandbox` helper) — which leaves the RCE open there. Unlike chat/gateway (where the human runs their own commands), the mcp-serve session now **refuses to start** when a sandbox was requested but no backend is available. An explicit `sandbox.mode = "none"` opt-out is respected. *(Deliberate divergence from chat/gateway — flagged here for review.)*
- **Fail-closed approval policy.** Tools run under `EffectivePermissions::workspace_write().with_approval_policy(Never)`. There is no interactive approver in server mode, so any tool call that would prompt fails at the boundary instead of silently proceeding (parity with local chat).
- **Honour operator tool policy.** The global `tool_policy` and the per-provider policy are applied to the MCP registry, so a server that denies `shell`/`bash` locally doesn't re-expose them to an external caller. The per-provider policy is resolved **per session against the built provider's `model_id()`**, so a policy keyed to a provider's *default* model is honoured.
- **Sandbox completion-command validators.** #1604 left `ValidatorRunner` running workspace command validators **unsandboxed**. They now run *through* the sandbox (`sh -c` + `shlex` argv quoting on POSIX). No-op sandboxes and Windows (`cmd /C`, which ignores POSIX quoting) run the argv **directly** via `Command`, so a caller-influenced argument cannot inject shell metacharacters.
- **Windows fail-closed.** `AppContainerSandbox::is_noop()` reports `true` when the `octos-sandbox` helper is unavailable (its `wrap_command` otherwise falls back to unsandboxed `cmd /C`), so the fail-closed check refuses the session — mirroring the Linux Landlock backend.

## Tests

- New `is_noop` contract unit tests (NoSandbox + disabled/none modes → no-op) — the fail-closed check depends on this.
- Scripted mcp-serve dispatch tests opt out of the sandbox (`mode = none`) so the no-backend fail-closed check is host-independent; the shell-escape regression (`should_block_shell_write_outside_workspace_via_sandbox`) opts into a real backend and self-skips when none is available.
- `octos-agent` sandbox + validators suites, `mcp_serve` unit + integration suites all green; `cargo build` / `clippy --all-targets -D warnings` / `fmt` clean.

## Review

Hardened across four `codex review` rounds (fail-closed sandbox → apply tool policy → sandbox validators → argv quoting → per-provider policy → Windows AppContainer + provider-default model). One of the swarm/mcp-serve findings tracked in #1597–#1602.