### PR TITLE
feat(protocol): tool-card fidelity on projection envelopes (args + output previews)

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -2219,11 +2219,16 @@ form).
 
 #### `tool_start`
 Tool invocation begun. The projection opens a tool-call card keyed on
-`tool_call_id`.
+`tool_call_id`. `arguments_preview` (optional) is a compact
+`key: value` echo of the call arguments, server-bounded to 700 chars
+(UTF-8-safe) — display fidelity for the card, not a replayable
+argument record. Omitted for argument-less calls and for envelopes
+persisted before the field existed.
 
 ```json
 { "type": "tool_start",
-  "data": { "tool_call_id": "tc-1", "name": "shell" } }
+  "data": { "tool_call_id": "tc-1", "name": "shell",
+            "arguments_preview": "command: \"cargo test\"" } }
 ```
 
 #### `tool_progress`
@@ -2239,11 +2244,18 @@ the projection appends in `seq` order.
 Tool invocation finished. `error` is set iff `status === "error"`;
 omitted on the wire when null. `reason` is an optional human-readable
 detail field, primarily populated for `skipped` and `aborted` outcomes
-(see below); omitted on the wire when null.
+(see below); omitted on the wire when null. `output_preview` (optional)
+carries the first lines of the tool result, server-bounded to
+2048 chars (UTF-8-safe) — the result excerpt under the tool card; the
+`error` field is bounded the same way. `duration_ms` (optional) is the
+call's wall-clock duration. Both are omitted for envelopes persisted
+before the fields existed.
 
 ```json
 { "type": "tool_end",
-  "data": { "tool_call_id": "tc-1", "status": "complete" } }
+  "data": { "tool_call_id": "tc-1", "status": "complete",
+            "output_preview": "test result: ok. 815 passed",
+            "duration_ms": 4321 } }
 ```
 
 ```json

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -534,6 +534,7 @@ impl Agent {
             reporter.report(ProgressEvent::ToolStarted {
                 name: tc_name.clone(),
                 tool_id: tc_id.clone(),
+                arguments: Some(tc_args.clone()),
             });
 
             // Before-tool hook: may deny or modify args

--- a/crates/octos-agent/src/progress.rs
+++ b/crates/octos-agent/src/progress.rs
@@ -67,7 +67,14 @@ pub enum ProgressEvent {
     Response { content: String, iteration: u32 },
 
     /// Agent is calling a tool.
-    ToolStarted { name: String, tool_id: String },
+    ToolStarted {
+        name: String,
+        tool_id: String,
+        /// The call arguments as requested by the LLM (pre-hook). Carried so
+        /// downstream projections (UI protocol tool cards, envelope
+        /// `arguments_preview`) can echo what the tool was asked to do.
+        arguments: Option<serde_json::Value>,
+    },
 
     /// Mid-execution progress from a tool (e.g., stderr line from binary plugin).
     ToolProgress {
@@ -308,7 +315,7 @@ impl ProgressReporter for ConsoleReporter {
                 use std::io::Write;
                 let _ = std::io::stdout().flush();
             }
-            ProgressEvent::ToolStarted { name, tool_id: _ } => {
+            ProgressEvent::ToolStarted { name, .. } => {
                 print!(
                     "\r{} {}",
                     self.yellow("⚙"),

--- a/crates/octos-cli/src/api/events.rs
+++ b/crates/octos-cli/src/api/events.rs
@@ -79,25 +79,44 @@ pub(crate) fn event_to_json(event: &ProgressEvent, thread_id: Option<&str>) -> s
                 "task_id": task_id,
             })
         }
-        ProgressEvent::ToolStarted { name, tool_id } => {
-            serde_json::json!({
+        ProgressEvent::ToolStarted {
+            name,
+            tool_id,
+            arguments,
+        } => {
+            let mut value = serde_json::json!({
                 "type": "tool_start",
                 "tool": name,
                 "tool_call_id": tool_id,
-            })
+            });
+            // Additive: carried so the UI-protocol mapper (`map_tool_start`)
+            // and the envelope `arguments_preview` can echo the call.
+            if let Some(arguments) = arguments {
+                value["arguments"] = arguments.clone();
+            }
+            value
         }
         ProgressEvent::ToolCompleted {
             name,
             tool_id,
             success,
-            ..
+            output_preview,
+            duration,
         } => {
-            serde_json::json!({
+            let mut value = serde_json::json!({
                 "type": "tool_end",
                 "tool": name,
                 "tool_call_id": tool_id,
                 "success": success,
-            })
+                "duration_ms": duration.as_millis() as u64,
+            });
+            // Additive: the mapper (`map_tool_end`) lifts these onto
+            // `ToolCompletedEvent` so tool cards and envelope previews can
+            // show the result excerpt.
+            if !output_preview.is_empty() {
+                value["output_preview"] = serde_json::json!(output_preview);
+            }
+            value
         }
         ProgressEvent::ToolProgress {
             name,
@@ -243,11 +262,28 @@ mod tests {
         let event = ProgressEvent::ToolStarted {
             name: "shell".into(),
             tool_id: "t1".into(),
+            arguments: None,
         };
         let json = event_to_json(&event, None);
         assert_eq!(json["type"], "tool_start");
         assert_eq!(json["tool"], "shell");
         assert_eq!(json["tool_call_id"], "t1");
+        // No-args calls omit the field entirely (additive wire).
+        assert!(json.get("arguments").is_none());
+    }
+
+    #[test]
+    fn event_to_json_tool_started_carries_arguments() {
+        // The fidelity route: arguments must survive Progress→JSON so the
+        // UI-protocol mapper (`map_tool_start`) and the envelope
+        // `arguments_preview` can echo the call.
+        let event = ProgressEvent::ToolStarted {
+            name: "shell".into(),
+            tool_id: "t1".into(),
+            arguments: Some(serde_json::json!({"command": "cargo test"})),
+        };
+        let json = event_to_json(&event, None);
+        assert_eq!(json["arguments"]["command"], "cargo test");
     }
 
     #[test]
@@ -264,6 +300,10 @@ mod tests {
         assert_eq!(json["tool"], "read_file");
         assert_eq!(json["tool_call_id"], "t2");
         assert_eq!(json["success"], true);
+        // Fidelity route: preview + duration survive Progress→JSON for the
+        // mapper (`map_tool_end`) and the envelope `output_preview`.
+        assert_eq!(json["output_preview"], "contents");
+        assert_eq!(json["duration_ms"], 42);
     }
 
     #[test]
@@ -433,6 +473,7 @@ mod tests {
                 ProgressEvent::ToolStarted {
                     name: "shell".into(),
                     tool_id: "t1".into(),
+                    arguments: None,
                 },
                 "tool_start",
             ),

--- a/crates/octos-cli/src/api/events.rs
+++ b/crates/octos-cli/src/api/events.rs
@@ -112,9 +112,16 @@ pub(crate) fn event_to_json(event: &ProgressEvent, thread_id: Option<&str>) -> s
             });
             // Additive: the mapper (`map_tool_end`) lifts these onto
             // `ToolCompletedEvent` so tool cards and envelope previews can
-            // show the result excerpt.
+            // show the result excerpt. Bounded HERE — the chokepoint feeding
+            // both the durable notification ledger and the envelope lane —
+            // because producers are not trustworthy about size (a failing
+            // tool emits unbounded `e.to_string()`).
             if !output_preview.is_empty() {
-                value["output_preview"] = serde_json::json!(output_preview);
+                value["output_preview"] = serde_json::json!(octos_core::truncated_utf8(
+                    output_preview,
+                    octos_core::ui_protocol::ENVELOPE_TOOL_OUTPUT_PREVIEW_MAX,
+                    "…",
+                ));
             }
             value
         }
@@ -304,6 +311,27 @@ mod tests {
         // mapper (`map_tool_end`) and the envelope `output_preview`.
         assert_eq!(json["output_preview"], "contents");
         assert_eq!(json["duration_ms"], 42);
+    }
+
+    #[test]
+    fn event_to_json_bounds_giant_output_preview() {
+        // A failing tool emits unbounded `e.to_string()` — this serializer is
+        // the chokepoint before the durable ledger + envelope lane.
+        let event = ProgressEvent::ToolCompleted {
+            name: "shell".into(),
+            tool_id: "t9".into(),
+            success: false,
+            output_preview: "é".repeat(9000),
+            duration: Duration::from_millis(1),
+        };
+        let json = event_to_json(&event, None);
+        let preview = json["output_preview"].as_str().expect("preview");
+        assert!(
+            preview.chars().count()
+                <= octos_core::ui_protocol::ENVELOPE_TOOL_OUTPUT_PREVIEW_MAX + 1,
+            "preview must be bounded, got {} chars",
+            preview.chars().count()
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -21277,6 +21277,28 @@ async fn try_emit_terminal(
 ///
 /// `Skipped` and `Aborted` variants require future signal sources
 /// (deadline-skip plumbing, interrupt propagation) and are NOT
+/// Compact preview of a tool call's arguments for envelope display, bounded
+/// to [`octos_core::ui_protocol::ENVELOPE_TOOL_ARGUMENTS_PREVIEW_MAX`].
+/// Object arguments render as `key: value` pairs (`command: "cargo test",
+/// timeout: 30`) — the human `shell(…)` reading, not raw JSON braces. This is
+/// display fidelity only; the full arguments stay on the live
+/// `ToolStarted` notification and in the agent transcript.
+fn envelope_tool_arguments_preview(arguments: &Value) -> String {
+    let rendered = match arguments {
+        Value::Object(map) => map
+            .iter()
+            .map(|(key, value)| format!("{key}: {value}"))
+            .collect::<Vec<_>>()
+            .join(", "),
+        other => other.to_string(),
+    };
+    octos_core::truncated_utf8(
+        &rendered,
+        octos_core::ui_protocol::ENVELOPE_TOOL_ARGUMENTS_PREVIEW_MAX,
+        "…",
+    )
+}
+
 /// reachable through `ToolCompleted` today.
 fn emit_envelope_for_legacy_notification(
     ledger: &UiProtocolLedger,
@@ -21305,6 +21327,13 @@ fn emit_envelope_for_legacy_notification(
                 Payload::ToolStart {
                     tool_call_id: event.tool_call_id.clone(),
                     name: event.tool_name.clone(),
+                    // Display fidelity for the tool card (`shell(cd … && …)`),
+                    // bounded so a 1MB tool-arg blob never lands in every
+                    // persisted envelope + hydrate replay.
+                    arguments_preview: event
+                        .arguments
+                        .as_ref()
+                        .map(envelope_tool_arguments_preview),
                 },
                 None,
             ),
@@ -21337,6 +21366,18 @@ fn emit_envelope_for_legacy_notification(
                         status,
                         error,
                         reason: None,
+                        // Result excerpt for the `⎿ …` line under the card.
+                        // `ToolCompletedEvent.output_preview` is already a
+                        // preview upstream; re-bound defensively so ledger
+                        // growth is capped no matter what the emitter sent.
+                        output_preview: event.output_preview.as_deref().map(|preview| {
+                            octos_core::truncated_utf8(
+                                preview,
+                                octos_core::ui_protocol::ENVELOPE_TOOL_OUTPUT_PREVIEW_MAX,
+                                "…",
+                            )
+                        }),
+                        duration_ms: event.duration_ms,
                     },
                     None,
                 )
@@ -37707,6 +37748,7 @@ ignore = []
             Payload::ToolStart {
                 tool_call_id: "tc-shell-1".into(),
                 name: "shell".into(),
+                arguments_preview: None,
             },
             None,
         );
@@ -39408,6 +39450,90 @@ ignore = []
     /// the helper that wires the dual-emit
     /// (`emit_envelope_for_legacy_notification`) so a future refactor
     /// can't silently drop a variant from the dual surface.
+    #[test]
+    fn emit_envelope_carries_tool_fidelity_previews() {
+        // The tool-card fidelity lane: ToolStarted.arguments →
+        // ToolStart.arguments_preview (key: value rendering, bounded) and
+        // ToolCompleted.output_preview/duration_ms → ToolEnd (re-bounded).
+        let ledger = UiProtocolLedger::new(32);
+        let session_id = SessionKey("local:fidelity-emit".into());
+        let turn_id = TurnId::new();
+
+        let giant = "æ".repeat(9000);
+        emit_envelope_for_legacy_notification(
+            &ledger,
+            &session_id,
+            &UiNotification::ToolStarted(ToolStartedEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_id.clone(),
+                tool_call_id: "tc-fid".into(),
+                tool_name: "shell".into(),
+                arguments: Some(serde_json::json!({
+                    "command": "cargo test",
+                    "blob": giant,
+                })),
+            }),
+        );
+        emit_envelope_for_legacy_notification(
+            &ledger,
+            &session_id,
+            &UiNotification::ToolCompleted(ToolCompletedEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_id.clone(),
+                tool_call_id: "tc-fid".into(),
+                tool_name: "shell".into(),
+                success: Some(true),
+                output_preview: Some("test result: ok. 815 passed".into()),
+                duration_ms: Some(4321),
+            }),
+        );
+
+        let baseline = UiCursor {
+            stream: session_id.0.clone(),
+            seq: 0,
+        };
+        let replay = ledger.replay_after(&session_id, Some(&baseline)).unwrap();
+        let payloads: Vec<&Payload> = replay
+            .iter()
+            .filter_map(|e| match &e.event {
+                UiProtocolLedgerEvent::Notification(UiNotification::Envelope(env)) => {
+                    Some(&env.envelope.payload)
+                }
+                _ => None,
+            })
+            .collect();
+
+        let Some(Payload::ToolStart {
+            arguments_preview: Some(preview),
+            ..
+        }) = payloads.first()
+        else {
+            panic!("expected enriched ToolStart, got {payloads:?}");
+        };
+        assert!(
+            preview.contains("command: \"cargo test\""),
+            "object args render as key: value pairs, got {preview}"
+        );
+        assert!(
+            preview.chars().count()
+                <= octos_core::ui_protocol::ENVELOPE_TOOL_ARGUMENTS_PREVIEW_MAX + 1,
+            "arguments preview must be bounded (UTF-8-safe), got {} chars",
+            preview.chars().count()
+        );
+        let Some(Payload::ToolEnd {
+            output_preview: Some(output),
+            duration_ms: Some(duration),
+            ..
+        }) = payloads.get(1)
+        else {
+            panic!("expected enriched ToolEnd, got {payloads:?}");
+        };
+        assert_eq!(output, "test result: ok. 815 passed");
+        assert_eq!(*duration, 4321);
+    }
+
     #[test]
     fn emit_envelope_for_legacy_notification_covers_every_progress_variant() {
         let ledger = UiProtocolLedger::new(32);

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -21356,7 +21356,16 @@ fn emit_envelope_for_legacy_notification(
                     Some(false) => EnvelopeToolEndStatus::Error,
                 };
                 let error = match status {
-                    EnvelopeToolEndStatus::Error => event.output_preview.clone(),
+                    // Bounded like `output_preview`: the error source can be
+                    // arbitrary-length tool output, and this string lands in
+                    // the durable ledger + every hydrate replay.
+                    EnvelopeToolEndStatus::Error => event.output_preview.as_deref().map(|s| {
+                        octos_core::truncated_utf8(
+                            s,
+                            octos_core::ui_protocol::ENVELOPE_TOOL_OUTPUT_PREVIEW_MAX,
+                            "…",
+                        )
+                    }),
                     _ => None,
                 };
                 (

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -21333,7 +21333,10 @@ fn emit_envelope_for_legacy_notification(
                     arguments_preview: event
                         .arguments
                         .as_ref()
-                        .map(envelope_tool_arguments_preview),
+                        .map(envelope_tool_arguments_preview)
+                        // `{}` args render as "" — the spec says omit, not
+                        // empty-string.
+                        .filter(|preview| !preview.is_empty()),
                 },
                 None,
             ),
@@ -39541,6 +39544,39 @@ ignore = []
         };
         assert_eq!(output, "test result: ok. 815 passed");
         assert_eq!(*duration, 4321);
+
+        // `{}` arguments render empty — spec says OMIT, not empty-string.
+        emit_envelope_for_legacy_notification(
+            &ledger,
+            &session_id,
+            &UiNotification::ToolStarted(ToolStartedEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_id.clone(),
+                tool_call_id: "tc-empty".into(),
+                tool_name: "noop".into(),
+                arguments: Some(serde_json::json!({})),
+            }),
+        );
+        let replay = ledger.replay_after(&session_id, Some(&baseline)).unwrap();
+        let empty_start = replay
+            .iter()
+            .filter_map(|e| match &e.event {
+                UiProtocolLedgerEvent::Notification(UiNotification::Envelope(env)) => {
+                    match &env.envelope.payload {
+                        Payload::ToolStart {
+                            tool_call_id,
+                            arguments_preview,
+                            ..
+                        } if tool_call_id == "tc-empty" => Some(arguments_preview.clone()),
+                        _ => None,
+                    }
+                }
+                _ => None,
+            })
+            .next()
+            .expect("tc-empty envelope present");
+        assert_eq!(empty_start, None, "empty args must omit the preview");
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol_alpha2_bridge.rs
+++ b/crates/octos-cli/src/api/ui_protocol_alpha2_bridge.rs
@@ -189,6 +189,7 @@ mod tests {
         reporter.report(ProgressEvent::ToolStarted {
             name: "shell".into(),
             tool_id: "call_x".into(),
+            arguments: None,
         });
 
         // Inner reporter receives both events.

--- a/crates/octos-cli/src/api/ui_protocol_alpha4_bridge.rs
+++ b/crates/octos-cli/src/api/ui_protocol_alpha4_bridge.rs
@@ -429,6 +429,7 @@ mod tests {
         reporter.report(ProgressEvent::ToolStarted {
             name: "shell".into(),
             tool_id: "call-1".into(),
+            arguments: None,
         });
         reporter.report(ProgressEvent::ToolCompleted {
             name: "shell".into(),

--- a/crates/octos-cli/src/api/ui_protocol_progress.rs
+++ b/crates/octos-cli/src/api/ui_protocol_progress.rs
@@ -414,7 +414,15 @@ fn map_tool_end(context: &ProgressMappingContext, event: &Value) -> UiProgressMa
             tool_call_id,
             tool_name,
             success: bool_field(event, &["success"]),
-            output_preview: string_field(event, &["output_preview"]),
+            // Raw progress JSON can come from arbitrary producers (binary
+            // plugins); bound before this lands in the durable ledger.
+            output_preview: string_field(event, &["output_preview"]).map(|preview| {
+                octos_core::truncated_utf8(
+                    &preview,
+                    octos_core::ui_protocol::ENVELOPE_TOOL_OUTPUT_PREVIEW_MAX,
+                    "…",
+                )
+            }),
             duration_ms: u64_field(event, &["duration_ms", "elapsed_ms"]),
         })],
         status: Some(UiProgressStatus::new(context, metadata)),
@@ -776,6 +784,32 @@ mod tests {
         );
         assert_eq!(mapping.status, None);
         assert_eq!(mapping.warning, None);
+    }
+
+    #[test]
+    fn ui_protocol_progress_bounds_tool_end_preview_from_raw_json() {
+        // Raw progress JSON can come from arbitrary producers (binary
+        // plugins) — the mapper must bound before the durable ledger.
+        let mapping = map_progress_json(
+            &context(),
+            &json!({
+                "type": "tool_end",
+                "tool": "shell",
+                "tool_call_id": "call-9",
+                "success": false,
+                "output_preview": "x".repeat(9000),
+            }),
+        );
+        let [UiNotification::ToolCompleted(completed)] = mapping.notifications.as_slice() else {
+            panic!("expected tool completed notification");
+        };
+        let preview = completed.output_preview.as_deref().expect("preview");
+        assert!(
+            preview.chars().count()
+                <= octos_core::ui_protocol::ENVELOPE_TOOL_OUTPUT_PREVIEW_MAX + 1,
+            "mapper must bound raw-JSON previews, got {} chars",
+            preview.chars().count()
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -1276,7 +1276,7 @@ pub(crate) fn progress_event_to_acp(event: &ProgressEvent) -> Option<SessionUpda
         ProgressEvent::ReasoningChunk { text, .. } => Some(SessionUpdate::AgentThoughtChunk(
             ContentChunk::new(ContentBlock::from(text.clone())),
         )),
-        ProgressEvent::ToolStarted { name, tool_id } => {
+        ProgressEvent::ToolStarted { name, tool_id, .. } => {
             let call = ToolCall::new(tool_id.clone(), name.clone())
                 .kind(tool_kind_for(name))
                 .status(ToolCallStatus::InProgress);
@@ -1524,6 +1524,7 @@ mod tests {
         let ev = ProgressEvent::ToolStarted {
             name: "shell".into(),
             tool_id: "call-1".into(),
+            arguments: None,
         };
         let update = progress_event_to_acp(&ev).expect("tool start maps to a tool call");
         match update {

--- a/crates/octos-cli/src/memory_consolidate/ops.rs
+++ b/crates/octos-cli/src/memory_consolidate/ops.rs
@@ -919,8 +919,10 @@ mod tests {
     fn should_reject_update_when_content_guard_flags_new_text() {
         // A qualifying host note grants edit authority, so the failure below
         // can only come from the CONTENT gate — not the authority gate.
-        let mut fx = Fixture::default();
-        fx.notes = vec![note("n1", "host", "user_request", "tabs pref changed")];
+        let fx = Fixture {
+            notes: vec![note("n1", "host", "user_request", "tabs pref changed")],
+            ..Fixture::default()
+        };
         let err = fx
             .validate(&output(
                 vec![Op::Update {

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -111,6 +111,7 @@ impl ProgressReporter for ChannelStreamReporter {
             ProgressEvent::ToolStarted {
                 ref name,
                 ref tool_id,
+                ..
             } => {
                 // Also send raw SSE for web client status indicators
                 let mut payload = serde_json::json!({
@@ -962,6 +963,7 @@ mod tests {
         reporter.report(ProgressEvent::ToolStarted {
             name: "shell".into(),
             tool_id: "t1".into(),
+            arguments: None,
         });
         reporter.report(ProgressEvent::ToolCompleted {
             name: "shell".into(),

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -3389,6 +3389,16 @@ pub struct FileRef {
     pub size_bytes: u64,
 }
 
+/// Bound for [`Payload::ToolStart::arguments_preview`]: enough for a
+/// meaningful `shell(cd … && cargo test …)` argument echo without letting a
+/// 1MB tool-arg blob into every persisted envelope + hydrate replay.
+pub const ENVELOPE_TOOL_ARGUMENTS_PREVIEW_MAX: usize = 700;
+
+/// Bound for [`Payload::ToolEnd::output_preview`]: a screenful of result
+/// excerpt for the tool card, not the full output (which stays in the
+/// transcript/tool message).
+pub const ENVELOPE_TOOL_OUTPUT_PREVIEW_MAX: usize = 2048;
+
 /// Sealed tagged union of payloads carried by the M9-γ projection
 /// envelope. Each variant carries everything the projection needs;
 /// the projection function is `(committed_log) → ChatViewModel` and
@@ -3453,7 +3463,17 @@ pub enum Payload {
     AssistantPersisted { text: String, meta: MessageMeta },
     /// Tool invocation begun. The projection opens a tool-call card
     /// keyed on `tool_call_id`.
-    ToolStart { tool_call_id: String, name: String },
+    ToolStart {
+        tool_call_id: String,
+        name: String,
+        /// Compact JSON of the call arguments, UTF-8-truncated to
+        /// [`ENVELOPE_TOOL_ARGUMENTS_PREVIEW_MAX`] — display fidelity for
+        /// tool cards (`shell(cd … && cargo test)`), NOT a replayable
+        /// argument record. `None` on argument-less calls and on
+        /// envelopes persisted before this field existed.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        arguments_preview: Option<String>,
+    },
     /// Tool emitted a progress message. Idempotent per `(tool_call_id,
     /// seq)`; the projection appends in `seq` order.
     ToolProgress {
@@ -3471,6 +3491,15 @@ pub enum Payload {
         error: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         reason: Option<String>,
+        /// First lines of the tool result, UTF-8-truncated to
+        /// [`ENVELOPE_TOOL_OUTPUT_PREVIEW_MAX`] — the `⎿ …` result excerpt
+        /// under the card. `None` for output-less tools and on envelopes
+        /// persisted before this field existed.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        output_preview: Option<String>,
+        /// Wall-clock duration of the call, when the emitter tracked it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        duration_ms: Option<u64>,
     },
     /// File attached to the current thread (e.g. `.md` report from
     /// `deep_search` or `.mp3` from `fm_tts`). The projection adds the
@@ -11232,12 +11261,94 @@ mod tests {
     }
 
     #[test]
+    fn golden_envelope_tool_fidelity_round_trip_and_legacy_decode() {
+        // Enriched shape: arguments/output previews + duration survive the
+        // wire round-trip.
+        let start = envelope(
+            4,
+            Payload::ToolStart {
+                tool_call_id: "tc-1".into(),
+                name: "shell".into(),
+                arguments_preview: Some("command: \"cargo test\"".into()),
+            },
+        );
+        let end = envelope(
+            5,
+            Payload::ToolEnd {
+                tool_call_id: "tc-1".into(),
+                status: EnvelopeToolEndStatus::Complete,
+                error: None,
+                reason: None,
+                output_preview: Some("test result: ok. 815 passed".into()),
+                duration_ms: Some(1234),
+            },
+        );
+        for env in [start, end] {
+            let value = serde_json::to_value(&env).expect("serialize");
+            let parsed: Envelope = serde_json::from_value(value).expect("deserialize");
+            assert_eq!(parsed, env);
+        }
+
+        // Legacy wire (envelopes persisted before the fidelity fields
+        // existed) must still decode — fields default to None. Build the
+        // legacy shape by stripping the new keys from a modern envelope so
+        // the fixture tracks the real tag/content encoding.
+        let strip = |env: &Envelope, keys: &[&str]| -> Envelope {
+            let mut value = serde_json::to_value(env).expect("serialize");
+            let data = value["payload"]["data"]
+                .as_object_mut()
+                .expect("payload data object");
+            for key in keys {
+                data.remove(*key);
+            }
+            serde_json::from_value(value).expect("legacy envelope decodes")
+        };
+        let start = envelope(
+            8,
+            Payload::ToolStart {
+                tool_call_id: "tc-9".into(),
+                name: "read_file".into(),
+                arguments_preview: Some("path: \"x\"".into()),
+            },
+        );
+        match strip(&start, &["arguments_preview"]).payload {
+            Payload::ToolStart {
+                arguments_preview, ..
+            } => assert_eq!(arguments_preview, None),
+            other => panic!("expected ToolStart, got {other:?}"),
+        }
+        let end = envelope(
+            9,
+            Payload::ToolEnd {
+                tool_call_id: "tc-9".into(),
+                status: EnvelopeToolEndStatus::Complete,
+                error: None,
+                reason: None,
+                output_preview: Some("ok".into()),
+                duration_ms: Some(1),
+            },
+        );
+        match strip(&end, &["output_preview", "duration_ms"]).payload {
+            Payload::ToolEnd {
+                output_preview,
+                duration_ms,
+                ..
+            } => {
+                assert_eq!(output_preview, None);
+                assert_eq!(duration_ms, None);
+            }
+            other => panic!("expected ToolEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn golden_envelope_tool_start_progress_end_round_trip() {
         let start = envelope(
             4,
             Payload::ToolStart {
                 tool_call_id: "tc-1".into(),
                 name: "shell".into(),
+                arguments_preview: None,
             },
         );
         let progress = envelope(
@@ -11254,6 +11365,8 @@ mod tests {
                 status: EnvelopeToolEndStatus::Complete,
                 error: None,
                 reason: None,
+                output_preview: None,
+                duration_ms: None,
             },
         );
         let end_err = envelope(
@@ -11263,6 +11376,8 @@ mod tests {
                 status: EnvelopeToolEndStatus::Error,
                 error: Some("boom".into()),
                 reason: None,
+                output_preview: None,
+                duration_ms: None,
             },
         );
 
@@ -11309,6 +11424,8 @@ mod tests {
                 status: EnvelopeToolEndStatus::Skipped,
                 error: None,
                 reason: Some("deadline elapsed before tool started".into()),
+                output_preview: None,
+                duration_ms: None,
             },
         );
         let aborted = envelope(
@@ -11318,6 +11435,8 @@ mod tests {
                 status: EnvelopeToolEndStatus::Aborted,
                 error: None,
                 reason: Some("user issued turn/interrupt".into()),
+                output_preview: None,
+                duration_ms: None,
             },
         );
         for (env, expected_status) in [(&skipped, "skipped"), (&aborted, "aborted")] {

--- a/crates/octos-web/src/runtime/ui-protocol-types.ts
+++ b/crates/octos-web/src/runtime/ui-protocol-types.ts
@@ -143,7 +143,14 @@ interface AssistantPersistedPayload {
 
 interface ToolStartPayload {
   type: 'tool_start';
-  data: { tool_call_id: string; name: string };
+  data: {
+    tool_call_id: string;
+    name: string;
+    /** Compact `key: value` echo of the call arguments, server-bounded
+     *  (700 chars). Omitted for argument-less calls and envelopes persisted
+     *  before the field existed. */
+    arguments_preview?: string;
+  };
 }
 
 interface ToolProgressPayload {
@@ -163,6 +170,12 @@ interface ToolEndPayload {
      *  (user `turn/interrupt`, system cancellation) outcomes. Omitted
      *  on the wire when null. */
     reason?: string;
+    /** First lines of the tool result, server-bounded (2048 chars) — the
+     *  `⎿ …` excerpt under the tool card. Omitted for output-less tools and
+     *  envelopes persisted before the field existed. */
+    output_preview?: string;
+    /** Wall-clock duration of the call, when the emitter tracked it. */
+    duration_ms?: number;
   };
 }
 


### PR DESCRIPTION
The projection envelope lane dropped the tool-call detail the live events already carry: `ToolStarted.arguments` and `ToolCompleted.output_preview`/`duration_ms` never reached `Payload::ToolStart`/`ToolEnd`. Anything rendering from envelopes — including the #1515 `session/hydrate.replayed_tool_envelopes` lane — could show only `shell → failed`, with no argument echo or result excerpt, e.g. after a TUI restart.

**Change**
- `Payload::ToolStart` += `arguments_preview: Option<String>` — compact `key: value` rendering of the call args, UTF-8-truncated to `ENVELOPE_TOOL_ARGUMENTS_PREVIEW_MAX` (700) so a 1MB tool-arg blob never lands in every persisted envelope + hydrate payload.
- `Payload::ToolEnd` += `output_preview: Option<String>` (re-bounded to `ENVELOPE_TOOL_OUTPUT_PREVIEW_MAX`, 2048) and `duration_ms: Option<u64>`.
- `emit_envelope_for_legacy_notification` populates all three from the event fields.

**Compat**: fields are `serde(default, skip_serializing_if)` — legacy persisted envelopes decode to `None`; legacy clients ignore the new keys; wire is byte-identical when fields are absent.

**Tests**: golden enriched round-trip + stripped-legacy decode (tracks the real tag/content encoding); emit test pins key:value rendering, UTF-8-safe bounding of a 9000-char multibyte blob, and output/duration passthrough. Full workspace clippy `-D warnings` clean.

Client adoption (octos-tui) follows separately; the SPA can pick the fields up whenever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)