### PR TITLE
feat(memory): loadable long-term registry — two-tier read path (#1588)

### DIFF
--- a/crates/octos-agent/src/memory_segment.rs
+++ b/crates/octos-agent/src/memory_segment.rs
@@ -31,7 +31,12 @@ the claim is memory-derived and may be stale, and offer to re-check.\n\
 do NOT re-ask the user for facts memory already answers.\n\
 - Prefer fresh evidence from THIS conversation over memory when they \
 conflict.\n\
-- Never present an unverified memory-derived fact as confirmed-current.";
+- Never present an unverified memory-derived fact as confirmed-current.\n\
+- What is shown above may be a SUMMARY: memory-bank abstracts and a \
+budget-truncated registry. Load the full detail on demand with \
+`recall_memory` — an entity name for its page, or \"MEMORY\" for the \
+complete long-term registry — instead of guessing when a needed detail \
+is not in the summary.";
 
 /// Capture-policy block appended to the memory segment when the
 /// memory-refresh feature is enabled. Shared by the chat path (via

--- a/crates/octos-agent/src/tools/recall_memory.rs
+++ b/crates/octos-agent/src/tools/recall_memory.rs
@@ -44,8 +44,13 @@ fn to_slug(name: &str) -> String {
 /// targeted retrieval the schema never offered (codex #1608 P2). Paging
 /// makes the whole registry reachable page by page.
 fn render_registry_page(registry: &str, page: usize) -> String {
+    // Headroom covers the pager marker appended after slicing (~75 bytes)
+    // with generous slack, so every rendered page stays STRICTLY under the
+    // outer truncate_head_tail limit — a too-tight margin let a full page +
+    // marker + disclosure exceed it and re-trigger the silent middle-loss
+    // (codex #1608 round-3 P1).
     let limit = octos_core::tool_output_limit("recall_memory");
-    let budget = limit.saturating_sub(200).max(1);
+    let budget = limit.saturating_sub(512).max(1);
 
     // Build page ranges at newline boundaries (always char-safe), each
     // <= budget bytes. A pathological newline-free run is cut at a char
@@ -117,6 +122,11 @@ impl Tool for RecallMemoryTool {
                 "name": {
                     "type": "string",
                     "description": "Entity name (e.g. 'octos', 'yuechen'), or 'MEMORY' for the full long-term registry"
+                },
+                "page": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "0-based page for a large 'MEMORY' registry load; follow the 'page=N' hint in the page marker. Ignored for entity names."
                 }
             },
             "required": ["name"]
@@ -130,23 +140,33 @@ impl Tool for RecallMemoryTool {
         // Tier-2 registry load: the injected long-term memory is capped to a
         // token budget, so "MEMORY" (and aliases) returns the full MEMORY.md.
         if octos_memory::is_reserved_memory_name(&input.name) {
-            let registry = self.store.read_long_term().await?;
-            let mut output = if registry.trim().is_empty() {
+            // Prepend any PRE-UPGRADE bank entity whose name is now reserved:
+            // new writes under these names are refused, but legacy files
+            // would otherwise be shadowed by the alias and unreadable. Folding
+            // their content into the paged text makes it reachable, size-safe
+            // (the pager bounds it), and case/space-variant-aware since
+            // list_entities returns the actual on-disk stems (codex #1608 P2).
+            let mut full = String::new();
+            if let Ok(entities) = self.store.list_entities().await {
+                for (name, _) in entities
+                    .iter()
+                    .filter(|(n, _)| octos_memory::is_reserved_memory_name(n))
+                {
+                    if let Ok(Some(content)) = self.store.read_entity(name).await {
+                        full.push_str(&format!(
+                            "## Legacy bank entity \"{name}\" (shadowed by the registry \
+                             alias; rename via save_memory to address it directly)\n{content}\n\n"
+                        ));
+                    }
+                }
+            }
+            full.push_str(&self.store.read_long_term().await?);
+
+            let output = if full.trim().is_empty() {
                 "The long-term memory registry (MEMORY.md) is empty.".to_string()
             } else {
-                render_registry_page(&registry, input.page.unwrap_or(0))
+                render_registry_page(&full, input.page.unwrap_or(0))
             };
-            // Legacy-collision disclosure: new writes under a reserved name
-            // are refused, but a pre-upgrade bank entity may still exist and
-            // is now shadowed by this alias — point the model at it rather
-            // than losing it silently (codex #1608 P2).
-            if let Ok(Some(_)) = self.store.read_entity(&to_slug(&input.name)).await {
-                output.push_str(&format!(
-                    "\n\n_[note: a legacy bank entity named \"{}\" is shadowed by the \
-                     registry alias; rename it via save_memory to read it]_",
-                    to_slug(&input.name)
-                ));
-            }
             return Ok(ToolResult {
                 output,
                 success: true,
@@ -350,20 +370,35 @@ mod tests {
     async fn should_disclose_legacy_entity_shadowed_by_registry_alias() {
         let dir = tempfile::tempdir().unwrap();
         let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
-        store.write_long_term("A fact. ^maaaaaa").await.unwrap();
-        // Simulate a pre-upgrade entity literally named "memory" (writes are
-        // refused now, so seed it at the store to mimic legacy data).
         store
-            .write_entity_raw("memory", "# memory\nlegacy page")
-            .await;
+            .write_long_term("A registry fact. ^maaaaaa")
+            .await
+            .unwrap();
+        // Simulate a pre-upgrade entity literally named "memory" (writes are
+        // refused now) by seeding the bank file directly on disk. Layout:
+        // <data_dir>/memory/bank/entities/<name>.md.
+        let bank = dir.path().join("memory").join("bank").join("entities");
+        std::fs::create_dir_all(&bank).unwrap();
+        std::fs::write(bank.join("memory.md"), "# memory\nlegacy page body").unwrap();
         let tool = RecallMemoryTool::new(store);
 
         let result = tool
             .execute(&serde_json::json!({ "name": "MEMORY" }))
             .await
             .unwrap();
+        // The legacy entity's CONTENT is folded in and reachable, not noted.
         assert!(
-            result.output.contains("legacy bank entity"),
+            result.output.contains("Legacy bank entity"),
+            "{}",
+            result.output
+        );
+        assert!(
+            result.output.contains("legacy page body"),
+            "{}",
+            result.output
+        );
+        assert!(
+            result.output.contains("A registry fact."),
             "{}",
             result.output
         );

--- a/crates/octos-agent/src/tools/recall_memory.rs
+++ b/crates/octos-agent/src/tools/recall_memory.rs
@@ -23,6 +23,11 @@ impl RecallMemoryTool {
 #[derive(Deserialize)]
 struct Input {
     name: String,
+    /// Optional 0-based page for the paged registry load (`name="MEMORY"`
+    /// when the registry exceeds the tool-output limit). Ignored for bank
+    /// entities.
+    #[serde(default)]
+    page: Option<usize>,
 }
 
 /// Normalize an entity name into a slug: trim, lowercase, spaces to hyphens.
@@ -30,26 +35,66 @@ fn to_slug(name: &str) -> String {
     name.trim().to_lowercase().replace(' ', "-")
 }
 
-/// Cap the registry to just under the tool-output limit at an ENTRY
-/// (line) boundary, appending a visible disclosure. The generic tool
-/// truncation (`truncate_head_tail`, 0.7) would otherwise drop the
-/// MIDDLE of a large `MEMORY.md` SILENTLY, recreating the very
-/// unrecoverable-tail problem this tool exists to solve (codex #1608 P2).
-fn cap_registry(registry: &str) -> String {
+/// Split the registry into byte-safe, line-aligned pages each just under
+/// the tool-output limit, and render the requested page with a truthful
+/// pager marker. The generic tool truncation (`truncate_head_tail`, 0.7)
+/// would otherwise SILENTLY drop the middle of a large `MEMORY.md`,
+/// recreating the unrecoverable-tail problem this tool exists to solve —
+/// and a one-shot cap left the tail unreachable, over-promising a
+/// targeted retrieval the schema never offered (codex #1608 P2). Paging
+/// makes the whole registry reachable page by page.
+fn render_registry_page(registry: &str, page: usize) -> String {
     let limit = octos_core::tool_output_limit("recall_memory");
-    // Leave headroom for the marker so our output stays under the outer cap.
-    let budget = limit.saturating_sub(160);
-    if registry.len() <= budget {
-        return registry.to_string();
+    let budget = limit.saturating_sub(200).max(1);
+
+    // Build page ranges at newline boundaries (always char-safe), each
+    // <= budget bytes. A pathological newline-free run is cut at a char
+    // boundary so slicing can never panic mid-codepoint.
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    let mut start = 0usize;
+    while start < registry.len() {
+        let mut end = (start + budget).min(registry.len());
+        while end > start && !registry.is_char_boundary(end) {
+            end -= 1;
+        }
+        if end < registry.len() {
+            if let Some(nl) = registry[start..end].rfind('\n') {
+                end = start + nl + 1;
+            }
+        }
+        if end == start {
+            // Single codepoint wider than the budget: advance one char.
+            end = registry[start..]
+                .char_indices()
+                .nth(1)
+                .map(|(i, _)| start + i)
+                .unwrap_or(registry.len());
+        }
+        ranges.push((start, end));
+        start = end;
     }
-    let cut = registry[..budget].rfind('\n').unwrap_or(budget);
-    let omitted = registry.len() - cut;
-    format!(
-        "{}\n\n_[registry truncated to fit the tool-output limit — {omitted} more \
-         bytes on disk; ask for a specific entry by its ^m id or narrow your \
-         query]_",
-        &registry[..cut]
-    )
+
+    let total = ranges.len().max(1);
+    let page = page.min(total - 1);
+    let (s0, e0) = ranges.get(page).copied().unwrap_or((0, registry.len()));
+    let mut out = registry[s0..e0].to_string();
+    if total > 1 {
+        let more = if page + 1 < total {
+            format!(
+                " — more: call recall_memory(name=\"MEMORY\", page={})",
+                page + 1
+            )
+        } else {
+            String::new()
+        };
+        out.push_str(&format!(
+            "\n\n_[registry page {}/{}{}]_",
+            page + 1,
+            total,
+            more
+        ));
+    }
+    out
 }
 
 #[async_trait]
@@ -86,11 +131,22 @@ impl Tool for RecallMemoryTool {
         // token budget, so "MEMORY" (and aliases) returns the full MEMORY.md.
         if octos_memory::is_reserved_memory_name(&input.name) {
             let registry = self.store.read_long_term().await?;
-            let output = if registry.trim().is_empty() {
+            let mut output = if registry.trim().is_empty() {
                 "The long-term memory registry (MEMORY.md) is empty.".to_string()
             } else {
-                cap_registry(&registry)
+                render_registry_page(&registry, input.page.unwrap_or(0))
             };
+            // Legacy-collision disclosure: new writes under a reserved name
+            // are refused, but a pre-upgrade bank entity may still exist and
+            // is now shadowed by this alias — point the model at it rather
+            // than losing it silently (codex #1608 P2).
+            if let Ok(Some(_)) = self.store.read_entity(&to_slug(&input.name)).await {
+                output.push_str(&format!(
+                    "\n\n_[note: a legacy bank entity named \"{}\" is shadowed by the \
+                     registry alias; rename it via save_memory to read it]_",
+                    to_slug(&input.name)
+                ));
+            }
             return Ok(ToolResult {
                 output,
                 success: true,
@@ -234,12 +290,51 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_disclose_truncation_when_registry_exceeds_tool_limit() {
+    async fn should_page_registry_when_it_exceeds_tool_limit() {
         let dir = tempfile::tempdir().unwrap();
         let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
-        // Build a registry larger than the recall_memory output limit.
         let limit = octos_core::tool_output_limit("recall_memory");
-        let big = "Fact line that is reasonably long. ^maaaaaa\n".repeat(limit / 20);
+        // Distinct per-line content so pages are verifiably different.
+        let big: String = (0..(limit / 20))
+            .map(|i| format!("Fact number {i} recorded for the record. ^maaaaaa\n"))
+            .collect();
+        store.write_long_term(&big).await.unwrap();
+        let tool = RecallMemoryTool::new(store.clone());
+
+        let p0 = tool
+            .execute(&serde_json::json!({ "name": "MEMORY" }))
+            .await
+            .unwrap();
+        assert!(p0.success);
+        assert!(
+            p0.output.len() <= limit,
+            "page must stay under the tool cap so the outer truncation is a no-op"
+        );
+        assert!(
+            p0.output.contains("registry page 1/"),
+            "pager marker present"
+        );
+        assert!(p0.output.contains("page=1"), "points at the next page");
+
+        let p1 = tool
+            .execute(&serde_json::json!({ "name": "MEMORY", "page": 1 }))
+            .await
+            .unwrap();
+        assert!(p1.success);
+        assert_ne!(
+            p0.output, p1.output,
+            "page 1 must return different entries than page 0 (tail reachable)"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_not_panic_on_multibyte_registry_at_the_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        let limit = octos_core::tool_output_limit("recall_memory");
+        // CJK is 3 bytes/char — a naive byte slice at `budget` would land
+        // mid-codepoint and panic.
+        let big = "记忆条目：这是一条中文记录。^maaaaaa\n".repeat(limit / 30);
         store.write_long_term(&big).await.unwrap();
         let tool = RecallMemoryTool::new(store);
 
@@ -247,14 +342,30 @@ mod tests {
             .execute(&serde_json::json!({ "name": "MEMORY" }))
             .await
             .unwrap();
-        assert!(result.success);
+        assert!(result.success, "multibyte registry must not error");
+        assert!(result.output.len() <= limit);
+    }
+
+    #[tokio::test]
+    async fn should_disclose_legacy_entity_shadowed_by_registry_alias() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        store.write_long_term("A fact. ^maaaaaa").await.unwrap();
+        // Simulate a pre-upgrade entity literally named "memory" (writes are
+        // refused now, so seed it at the store to mimic legacy data).
+        store
+            .write_entity_raw("memory", "# memory\nlegacy page")
+            .await;
+        let tool = RecallMemoryTool::new(store);
+
+        let result = tool
+            .execute(&serde_json::json!({ "name": "MEMORY" }))
+            .await
+            .unwrap();
         assert!(
-            result.output.len() <= limit,
-            "output must stay under the tool cap so the outer truncation is a no-op"
-        );
-        assert!(
-            result.output.contains("registry truncated to fit"),
-            "truncation must be disclosed, not silent"
+            result.output.contains("legacy bank entity"),
+            "{}",
+            result.output
         );
     }
 

--- a/crates/octos-agent/src/tools/recall_memory.rs
+++ b/crates/octos-agent/src/tools/recall_memory.rs
@@ -30,6 +30,17 @@ fn to_slug(name: &str) -> String {
     name.trim().to_lowercase().replace(' ', "-")
 }
 
+/// Reserved names that resolve to the whole long-term MEMORY.md registry
+/// rather than a memory-bank entity page (#1588 two-tier: the injected
+/// registry is budget-truncated, so the model must be able to pull the
+/// full thing on demand). Matched case-insensitively after trim.
+fn is_registry_alias(name: &str) -> bool {
+    matches!(
+        name.trim().to_lowercase().as_str(),
+        "memory" | "memory.md" | "registry" | "long-term memory" | "long-term-memory"
+    )
+}
+
 #[async_trait]
 impl Tool for RecallMemoryTool {
     fn name(&self) -> &str {
@@ -37,8 +48,10 @@ impl Tool for RecallMemoryTool {
     }
 
     fn description(&self) -> &str {
-        "Load the full content of a memory bank entity by name. \
-         Use the entity names shown in the Memory Bank section of the system prompt."
+        "Load full memory detail on demand. Pass a memory-bank entity name \
+         (as shown in the Memory Bank section) for its page, or \"MEMORY\" \
+         for the complete long-term registry when the injected memory is a \
+         budget-truncated summary and you need an entry that isn't shown."
     }
 
     fn input_schema(&self) -> serde_json::Value {
@@ -47,7 +60,7 @@ impl Tool for RecallMemoryTool {
             "properties": {
                 "name": {
                     "type": "string",
-                    "description": "Entity name (e.g. 'octos', 'yuechen')"
+                    "description": "Entity name (e.g. 'octos', 'yuechen'), or 'MEMORY' for the full long-term registry"
                 }
             },
             "required": ["name"]
@@ -57,6 +70,21 @@ impl Tool for RecallMemoryTool {
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
         let input: Input =
             serde_json::from_value(args.clone()).wrap_err("invalid recall_memory input")?;
+
+        // Tier-2 registry load: the injected long-term memory is capped to a
+        // token budget, so "MEMORY" (and aliases) returns the full MEMORY.md.
+        if is_registry_alias(&input.name) {
+            let registry = self.store.read_long_term().await?;
+            return Ok(ToolResult {
+                output: if registry.trim().is_empty() {
+                    "The long-term memory registry (MEMORY.md) is empty.".to_string()
+                } else {
+                    registry
+                },
+                success: true,
+                ..Default::default()
+            });
+        }
 
         let slug = to_slug(&input.name);
 
@@ -150,5 +178,60 @@ mod tests {
         let props = schema["properties"].as_object().unwrap();
         assert!(props.contains_key("name"));
         assert_eq!(props["name"]["type"], "string");
+    }
+
+    #[test]
+    fn registry_aliases_match_case_and_form_insensitively() {
+        for name in [
+            "MEMORY",
+            "memory",
+            " Memory.md ",
+            "registry",
+            "long-term memory",
+        ] {
+            assert!(
+                is_registry_alias(name),
+                "{name:?} should be a registry alias"
+            );
+        }
+        for name in ["octos", "yuechen", "memories", "mem"] {
+            assert!(
+                !is_registry_alias(name),
+                "{name:?} is a bank entity, not the registry"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn should_load_full_registry_when_name_is_memory() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        store
+            .write_long_term("Fact one. ^maaaaaa\nFact two. ^mbbbbbb")
+            .await
+            .unwrap();
+        let tool = RecallMemoryTool::new(store);
+
+        let result = tool
+            .execute(&serde_json::json!({ "name": "MEMORY" }))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("Fact one."));
+        assert!(result.output.contains("Fact two."));
+    }
+
+    #[tokio::test]
+    async fn should_report_empty_registry_gracefully() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        let tool = RecallMemoryTool::new(store);
+
+        let result = tool
+            .execute(&serde_json::json!({ "name": "registry" }))
+            .await
+            .unwrap();
+        assert!(result.success, "empty registry is not an error");
+        assert!(result.output.contains("empty"));
     }
 }

--- a/crates/octos-agent/src/tools/recall_memory.rs
+++ b/crates/octos-agent/src/tools/recall_memory.rs
@@ -30,14 +30,25 @@ fn to_slug(name: &str) -> String {
     name.trim().to_lowercase().replace(' ', "-")
 }
 
-/// Reserved names that resolve to the whole long-term MEMORY.md registry
-/// rather than a memory-bank entity page (#1588 two-tier: the injected
-/// registry is budget-truncated, so the model must be able to pull the
-/// full thing on demand). Matched case-insensitively after trim.
-fn is_registry_alias(name: &str) -> bool {
-    matches!(
-        name.trim().to_lowercase().as_str(),
-        "memory" | "memory.md" | "registry" | "long-term memory" | "long-term-memory"
+/// Cap the registry to just under the tool-output limit at an ENTRY
+/// (line) boundary, appending a visible disclosure. The generic tool
+/// truncation (`truncate_head_tail`, 0.7) would otherwise drop the
+/// MIDDLE of a large `MEMORY.md` SILENTLY, recreating the very
+/// unrecoverable-tail problem this tool exists to solve (codex #1608 P2).
+fn cap_registry(registry: &str) -> String {
+    let limit = octos_core::tool_output_limit("recall_memory");
+    // Leave headroom for the marker so our output stays under the outer cap.
+    let budget = limit.saturating_sub(160);
+    if registry.len() <= budget {
+        return registry.to_string();
+    }
+    let cut = registry[..budget].rfind('\n').unwrap_or(budget);
+    let omitted = registry.len() - cut;
+    format!(
+        "{}\n\n_[registry truncated to fit the tool-output limit — {omitted} more \
+         bytes on disk; ask for a specific entry by its ^m id or narrow your \
+         query]_",
+        &registry[..cut]
     )
 }
 
@@ -73,14 +84,15 @@ impl Tool for RecallMemoryTool {
 
         // Tier-2 registry load: the injected long-term memory is capped to a
         // token budget, so "MEMORY" (and aliases) returns the full MEMORY.md.
-        if is_registry_alias(&input.name) {
+        if octos_memory::is_reserved_memory_name(&input.name) {
             let registry = self.store.read_long_term().await?;
+            let output = if registry.trim().is_empty() {
+                "The long-term memory registry (MEMORY.md) is empty.".to_string()
+            } else {
+                cap_registry(&registry)
+            };
             return Ok(ToolResult {
-                output: if registry.trim().is_empty() {
-                    "The long-term memory registry (MEMORY.md) is empty.".to_string()
-                } else {
-                    registry
-                },
+                output,
                 success: true,
                 ..Default::default()
             });
@@ -190,13 +202,13 @@ mod tests {
             "long-term memory",
         ] {
             assert!(
-                is_registry_alias(name),
+                octos_memory::is_reserved_memory_name(name),
                 "{name:?} should be a registry alias"
             );
         }
         for name in ["octos", "yuechen", "memories", "mem"] {
             assert!(
-                !is_registry_alias(name),
+                !octos_memory::is_reserved_memory_name(name),
                 "{name:?} is a bank entity, not the registry"
             );
         }
@@ -219,6 +231,31 @@ mod tests {
         assert!(result.success);
         assert!(result.output.contains("Fact one."));
         assert!(result.output.contains("Fact two."));
+    }
+
+    #[tokio::test]
+    async fn should_disclose_truncation_when_registry_exceeds_tool_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        // Build a registry larger than the recall_memory output limit.
+        let limit = octos_core::tool_output_limit("recall_memory");
+        let big = "Fact line that is reasonably long. ^maaaaaa\n".repeat(limit / 20);
+        store.write_long_term(&big).await.unwrap();
+        let tool = RecallMemoryTool::new(store);
+
+        let result = tool
+            .execute(&serde_json::json!({ "name": "MEMORY" }))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(
+            result.output.len() <= limit,
+            "output must stay under the tool cap so the outer truncation is a no-op"
+        );
+        assert!(
+            result.output.contains("registry truncated to fit"),
+            "truncation must be disclosed, not silent"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/save_memory.rs
+++ b/crates/octos-agent/src/tools/save_memory.rs
@@ -94,6 +94,22 @@ impl Tool for SaveMemoryTool {
             });
         }
 
+        // Names reserved for recall_memory's registry load must not become
+        // bank entities — recall_memory would resolve them to MEMORY.md and
+        // the entity would be permanently unreachable (codex #1608 P2).
+        if octos_memory::is_reserved_memory_name(&input.name)
+            || octos_memory::is_reserved_memory_name(&slug)
+        {
+            return Ok(ToolResult {
+                output: format!(
+                    "'{slug}' is reserved (recall_memory uses it for the full registry). \
+                     Choose a different entity name."
+                ),
+                success: false,
+                ..Default::default()
+            });
+        }
+
         // Write-time threat gate (#1585): entity pages are loaded into the
         // prompt via recall_memory and the memory-bank index; refuse content
         // that reads as instruction-override / exfiltration.
@@ -137,6 +153,27 @@ mod tests {
     use super::*;
 
     // --- content guard (#1585) ---
+
+    #[tokio::test]
+    async fn should_reject_reserved_registry_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(MemoryStore::open(dir.path()).await.unwrap());
+        let tool = SaveMemoryTool::new(store.clone());
+        for name in ["MEMORY", "memory", "registry", "long-term memory"] {
+            let result = tool
+                .execute(&serde_json::json!({ "name": name, "content": "# x\nbenign" }))
+                .await
+                .unwrap();
+            assert!(!result.success, "{name:?} must be rejected");
+            assert!(result.output.contains("reserved"), "{}", result.output);
+        }
+        // a normal name still saves
+        let ok = tool
+            .execute(&serde_json::json!({ "name": "memories-of-summer", "content": "# x\nbenign" }))
+            .await
+            .unwrap();
+        assert!(ok.success, "{}", ok.output);
+    }
 
     #[tokio::test]
     async fn should_refuse_save_when_content_guard_flags_it() {

--- a/crates/octos-memory/src/lib.rs
+++ b/crates/octos-memory/src/lib.rs
@@ -15,6 +15,6 @@ pub use episode::{Episode, EpisodeOutcome};
 pub use hybrid_search::{HybridIndex, HybridScore};
 pub use memory_store::{
     DEFAULT_MAX_INJECT_TOKENS, ExtractionItem, MemoryStore, NoteKind, NoteOrigin, StagingNote,
-    estimate_tokens, is_valid_entry_id,
+    estimate_tokens, is_reserved_memory_name, is_valid_entry_id,
 };
 pub use store::{DEFAULT_DIMENSION as EPISODIC_INDEX_DIMENSION, EpisodeStore};

--- a/crates/octos-memory/src/memory_store.rs
+++ b/crates/octos-memory/src/memory_store.rs
@@ -751,6 +751,20 @@ pub fn is_valid_entry_id(s: &str) -> bool {
     rest.len() == 6 && rest.chars().all(|c| matches!(c, 'a'..='z' | '2'..='7'))
 }
 
+/// Names reserved for `recall_memory`'s long-term-registry load (#1588).
+/// `recall_memory` resolves these to the whole `MEMORY.md` instead of a
+/// bank entity, so `save_memory` must REFUSE them — otherwise a bank
+/// entity named "memory" is created but forever shadowed by the alias
+/// and can never be recalled (codex #1608 P2). Matched on the trimmed,
+/// lowercased name; the space and hyphen forms are both listed so the
+/// check works on raw names and slugs alike.
+pub fn is_reserved_memory_name(name: &str) -> bool {
+    matches!(
+        name.trim().to_lowercase().as_str(),
+        "memory" | "memory.md" | "registry" | "long-term memory" | "long-term-memory"
+    )
+}
+
 /// A capture-layer staging note awaiting consolidation.
 #[derive(Debug, Clone)]
 pub struct StagingNote {

--- a/crates/octos-memory/src/memory_store.rs
+++ b/crates/octos-memory/src/memory_store.rs
@@ -431,16 +431,6 @@ impl MemoryStore {
             .wrap_err("failed to create memory bank directory")
     }
 
-    /// Write an entity file directly, bypassing every `write_entity` gate.
-    /// For tests/migration fixtures that must seed data the normal path now
-    /// refuses (e.g. a pre-upgrade entity under a reserved registry name).
-    #[doc(hidden)]
-    pub async fn write_entity_raw(&self, slug: &str, content: &str) {
-        self.ensure_bank_dir().await.expect("bank dir");
-        let path = self.bank_dir().join(format!("{slug}.md"));
-        tokio::fs::write(&path, content).await.expect("seed entity");
-    }
-
     /// List all entity files, returning `(slug, abstract_line)` pairs sorted by name.
     pub async fn list_entities(&self) -> Result<Vec<(String, String)>> {
         let dir = self.bank_dir();

--- a/crates/octos-memory/src/memory_store.rs
+++ b/crates/octos-memory/src/memory_store.rs
@@ -431,6 +431,16 @@ impl MemoryStore {
             .wrap_err("failed to create memory bank directory")
     }
 
+    /// Write an entity file directly, bypassing every `write_entity` gate.
+    /// For tests/migration fixtures that must seed data the normal path now
+    /// refuses (e.g. a pre-upgrade entity under a reserved registry name).
+    #[doc(hidden)]
+    pub async fn write_entity_raw(&self, slug: &str, content: &str) {
+        self.ensure_bank_dir().await.expect("bank dir");
+        let path = self.bank_dir().join(format!("{slug}.md"));
+        tokio::fs::write(&path, content).await.expect("seed entity");
+    }
+
     /// List all entity files, returning `(slug, abstract_line)` pairs sorted by name.
     pub async fn list_entities(&self) -> Result<Vec<(String, String)>> {
         let dir = self.bank_dir();
@@ -495,6 +505,14 @@ impl MemoryStore {
         // unlisted, unrecallable, yet reported as saved (codex round-3 P3).
         if name.trim_matches(['-', '_', ' ']).is_empty() {
             eyre::bail!("memory entity name must not be empty");
+        }
+        // Reserved registry names are refused at the BOUNDARY, not just in
+        // the save_memory tool: session_actor banks background reports via
+        // write_entity with a task-label slug, so a task named "Memory"
+        // would otherwise create an entity that recall_memory permanently
+        // shadows with the registry (#1608 P2).
+        if is_reserved_memory_name(name) {
+            eyre::bail!("memory entity name '{name}' is reserved for the long-term registry");
         }
         // Scan the SANITIZED name+abstract row exactly as it will render in
         // the bank index: name and content pass separately, but the row
@@ -1707,6 +1725,25 @@ mod tests {
                 "{name:?} must be refused"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn should_reject_reserved_registry_names_at_the_write_boundary() {
+        // #1608 P2: session_actor banks reports via write_entity with a
+        // task-label slug, bypassing the save_memory tool check — the
+        // boundary must refuse the reserved names too.
+        let dir = tempfile::tempdir().unwrap();
+        let store = MemoryStore::open(dir.path()).await.unwrap();
+        for name in ["memory", "registry", "long-term-memory"] {
+            assert!(
+                store.write_entity(name, "# x\nbody").await.is_err(),
+                "{name:?} must be refused at the boundary"
+            );
+        }
+        store
+            .write_entity("weekly-report", "# x\nbody")
+            .await
+            .expect("a normal report name still banks");
     }
 
     #[tokio::test]

--- a/crates/octos-memory/src/memory_store.rs
+++ b/crates/octos-memory/src/memory_store.rs
@@ -347,10 +347,11 @@ impl MemoryStore {
                 budget = 0;
                 if kept.is_empty() {
                     sections.long_term = String::new();
-                    omitted.push("long-term memory".to_string());
+                    omitted
+                        .push("long-term memory (load with recall_memory(\"MEMORY\"))".to_string());
                 } else {
                     sections.long_term = format!(
-                        "{kept}\n\n_[long-term memory truncated to fit the context budget — full MEMORY.md on disk]_"
+                        "{kept}\n\n_[long-term memory truncated to fit the context budget — load the complete registry on demand with recall_memory(\"MEMORY\")]_"
                     );
                 }
             }
@@ -1453,6 +1454,12 @@ mod tests {
         assert!(ctx.contains("first entry"));
         assert!(!ctx.contains(&big_para));
         assert!(ctx.contains("long-term memory truncated"));
+        // #1588 two-tier: the truncation marker must point the model at the
+        // tool that loads the full registry, not just say it's "on disk".
+        assert!(
+            ctx.contains("recall_memory(\"MEMORY\")"),
+            "truncation marker must name the registry-load affordance: {ctx}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #1588.

## Context (scope is narrower than the issue sketch)

The comparative review flagged octos as "one-tier" vs codex's summary + searchable-registry split. On inspection the **memory bank is already two-tier** (abstracts injected by `get_bank_summary`, full pages via `recall_memory`), and octos's `MEMORY.md` is compact one-liner-per-fact rather than codex's large searchable file. So the real residual is a single concrete gap:

**`MEMORY.md` had no read tool.** When it exceeded the injection token budget it was paragraph-truncated, and the dropped tail was invisible AND unrecoverable — there was no way for the model to get it back.

## What

- `recall_memory` accepts the reserved name **"MEMORY"** (+ aliases `memory.md`, `registry`, `long-term memory`) → returns the full `MEMORY.md`. A budget-truncated summary is no longer lossy.
- The truncation marker now names that affordance (`recall_memory("MEMORY")`) instead of the dead-end "full MEMORY.md on disk".
- Read-path guidance (`MEMORY_USE_GUIDANCE`, #1589) teaches that injected memory may be a summary and to load full detail on demand rather than guess.

## Deliberately out of scope

A separate consolidation-maintained `memory_summary.md` artifact (codex-faithful): octos `MEMORY.md` is already one-liner-per-fact, so the compact form IS the summary tier — a second artifact would only add drift. Noted as a follow-up if entries ever grow bodies.

## Tests

4 new: registry-alias matching (case/form-insensitive, bank names excluded), full-registry load, empty-registry graceful, and the truncation marker names the tool. octos-memory 115, octos-agent 2057, clippy clean.