### PR TITLE
fix(clippy): unbreak main — fold Fixture default-reassign (rust-1.97)

### DIFF
--- a/crates/octos-cli/src/memory_consolidate/ops.rs
+++ b/crates/octos-cli/src/memory_consolidate/ops.rs
@@ -919,8 +919,10 @@ mod tests {
     fn should_reject_update_when_content_guard_flags_new_text() {
         // A qualifying host note grants edit authority, so the failure below
         // can only come from the CONTENT gate — not the authority gate.
-        let mut fx = Fixture::default();
-        fx.notes = vec![note("n1", "host", "user_request", "tabs pref changed")];
+        let fx = Fixture {
+            notes: vec![note("n1", "host", "user_request", "tabs pref changed")],
+            ..Default::default()
+        };
         let err = fx
             .validate(&output(
                 vec![Op::Update {


### PR DESCRIPTION
## Summary

Fix-forward to unbreak `main`. The write-time threat-guard merge (#15xx) added a `field_reassign_with_default` in a test fixture at `crates/octos-cli/src/memory_consolidate/ops.rs`:

```rust
let mut fx = Fixture::default();
fx.notes = vec![note("n1", "host", "user_request", "tabs pref changed")];
```

Under CI's `cargo clippy --workspace --all-targets -- -D warnings` (rust-1.97) this is a **hard error**, so the `check` job fails for **every PR that re-lints octos-cli**. It didn't fail on the introducing merge because octos-cli was cached-clean there; it surfaces on any cache-invalidating change.

Folded into the initializer per clippy's own suggestion:

```rust
let fx = Fixture {
    notes: vec![note("n1", "host", "user_request", "tabs pref changed")],
    ..Default::default()
};
```

Verified locally: `cargo clippy -p octos-cli --all-targets -- -D warnings` and `cargo fmt` clean after a forced re-lint. Test behavior unchanged.