### PR TITLE
feat(api): user-scoped /api/my/cron list + enable toggle

### DIFF
--- a/crates/octos-bus/src/cron_service.rs
+++ b/crates/octos-bus/src/cron_service.rs
@@ -491,47 +491,66 @@ impl CronService {
         // reserved — codex #1612 r3). Run the WHOLE section on the
         // blocking pool so its fs write never occupies a tokio worker,
         // even on a slow/full/network FS or a one-worker runtime
-        // (codex #1612 r4 P1). The blocking task self-holds an Arc, so
-        // it completes even if this on_timer future is aborted mid-tick.
+        // (codex #1612 r4 P1).
+        //
+        // The reserve→deliver→re-arm chain runs as ONE DETACHED task
+        // (codex #1612 r5 P1). This on_timer future runs inside the
+        // armed timer task, and EVERY schedule mutation (add_job /
+        // remove_job / enable_job) calls arm_timer, which aborts that
+        // task. If delivery lived here, an abort landing after the
+        // blocking reservation committed but before (or during) the bus
+        // sends would swallow the firing: the reservation already
+        // advanced+persisted next_run, so the re-armed timer sees a
+        // future-dated job and silently skips the occurrence. Detached,
+        // an abort only ever cancels the SLEEP between ticks — a tick
+        // that has begun always finishes reserve → deliver → re-arm.
+        // Overlap is safe by construction: reservation is atomic under
+        // the store lock, so a concurrent tick finds nothing due.
+        // Shutdown does not leak the unit: execute_job races each send
+        // against shutdown_notify, and arm_timer no-ops once `running`
+        // is false.
         let this = std::sync::Arc::clone(self);
-        let due_jobs: Vec<CronJob> = tokio::task::spawn_blocking(move || {
-            let mut store = this.store.lock().unwrap_or_else(|e| e.into_inner());
-            let mut due = Vec::new();
-            let mut to_delete = Vec::new();
+        tokio::spawn(async move {
+            let reserve = std::sync::Arc::clone(&this);
+            let due_jobs: Vec<CronJob> = tokio::task::spawn_blocking(move || {
+                let mut store = reserve.store.lock().unwrap_or_else(|e| e.into_inner());
+                let mut due = Vec::new();
+                let mut to_delete = Vec::new();
 
-            for stored_job in &mut store.jobs {
-                if !stored_job.is_due(now_ms) {
-                    continue;
+                for stored_job in &mut store.jobs {
+                    if !stored_job.is_due(now_ms) {
+                        continue;
+                    }
+                    due.push(stored_job.clone());
+
+                    stored_job.state.last_run_at_ms = Some(now_ms);
+                    stored_job.state.last_status = Some("ok".into());
+
+                    if stored_job.delete_after_run {
+                        to_delete.push(stored_job.id.clone());
+                    } else {
+                        stored_job.compute_next_run(now_ms);
+                    }
                 }
-                due.push(stored_job.clone());
 
-                stored_job.state.last_run_at_ms = Some(now_ms);
-                stored_job.state.last_status = Some("ok".into());
-
-                if stored_job.delete_after_run {
-                    to_delete.push(stored_job.id.clone());
-                } else {
-                    stored_job.compute_next_run(now_ms);
+                store.jobs.retain(|j| !to_delete.contains(&j.id));
+                // A failed write is logged and the tick proceeds —
+                // next_run stays advanced in memory, so no double-fire;
+                // the file catches up on the next successful persist.
+                if let Err(e) = persist_store_locked(&reserve.store_path, &store) {
+                    tracing::warn!("failed to save cron store: {e}");
                 }
+                due
+            })
+            .await
+            .unwrap_or_default();
+
+            for job in &due_jobs {
+                this.execute_job(job).await;
             }
 
-            store.jobs.retain(|j| !to_delete.contains(&j.id));
-            // A failed write is logged and the tick proceeds — next_run
-            // stays advanced in memory, so no double-fire; the file
-            // catches up on the next successful persist.
-            if let Err(e) = persist_store_locked(&this.store_path, &store) {
-                tracing::warn!("failed to save cron store: {e}");
-            }
-            due
-        })
-        .await
-        .unwrap_or_default();
-
-        for job in &due_jobs {
-            self.execute_job(job).await;
-        }
-
-        self.arm_timer();
+            this.arm_timer();
+        });
     }
 
     /// Fire a single job by sending an InboundMessage into the bus.
@@ -554,8 +573,34 @@ impl CronService {
             origin: octos_core::MessageOrigin::ExternalUser,
         };
 
-        if let Err(e) = self.inbound_tx.send(msg).await {
-            warn!(error = %e, job_id = %job.id, "failed to send cron message to bus");
+        // The delivery unit is detached (not abort-targeted), so a
+        // shutdown can no longer cancel an in-flight send by aborting
+        // the timer task. Race the send against the shutdown notify —
+        // check-then-select, same missed-notify-proof ordering as the
+        // sleeper in arm_timer: register the waiter FIRST, then check
+        // `running`, so a shutdown that fires before registration is
+        // caught by the flag and one that fires after wakes the select.
+        // Without this, a full bus channel whose receiver stopped
+        // draining at shutdown would park the send forever, pinning the
+        // service Arc. Dropping the delivery on shutdown matches the
+        // old abort semantics: the reservation stays advanced, so the
+        // occurrence is skipped, never double-fired.
+        let notified = self.shutdown_notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+        if !self.running.load(Ordering::Relaxed) {
+            warn!(job_id = %job.id, "cron service stopped; dropping cron delivery");
+            return;
+        }
+        tokio::select! {
+            res = self.inbound_tx.send(msg) => {
+                if let Err(e) = res {
+                    warn!(error = %e, job_id = %job.id, "failed to send cron message to bus");
+                }
+            }
+            _ = &mut notified => {
+                warn!(job_id = %job.id, "cron service shut down during delivery; dropping cron message");
+            }
         }
     }
 }
@@ -1165,6 +1210,126 @@ mod tests {
                 "job {id} must have its next occurrence scheduled, got {next:?}"
             );
         }
+
+        service.stop().await;
+    }
+
+    /// codex #1612 r5 P1: a routine schedule mutation must never swallow
+    /// a firing whose reservation already committed.
+    ///
+    /// The tick is reserve-then-fire: the blocking critical section
+    /// advances `next_run_at_ms` and persists, and only then does the
+    /// task deliver to the bus. Every mutation (`add_job` / `remove_job`
+    /// / `enable_job`) calls `arm_timer`, which ABORTS the armed timer
+    /// task. If delivery lives in that abortable future, an abort
+    /// landing after the reservation committed but before (or during)
+    /// the bus send kills the delivery — and the re-armed timer sees
+    /// the advanced next_run and silently skips the occurrence.
+    ///
+    /// Deterministic interleaving: the bus channel (capacity 1) is
+    /// PRE-FILLED, so the tick's send is guaranteed parked (or not yet
+    /// polled) — it cannot complete before the test drains. We wait for
+    /// the reservation to commit (next_run advanced), let a concurrent
+    /// `add_job` abort the timer task, PROVE the task is dead, and only
+    /// then drain: the reserved fire must still arrive, because the
+    /// reserve→deliver→re-arm unit is detached and no abort can sever
+    /// a committed reservation from its delivery.
+    #[tokio::test]
+    async fn should_deliver_reserved_fire_when_rearm_aborts_timer_mid_tick() {
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, mut rx) = mpsc::channel::<InboundMessage>(1);
+        let service =
+            std::sync::Arc::new(CronService::new(dir.path().join("cron.json"), tx.clone()));
+
+        let payload = |msg: &str| CronPayload {
+            message: msg.into(),
+            deliver: false,
+            channel: None,
+            chat_id: None,
+        };
+
+        // Fill the channel BEFORE the timer can fire: the tick's send
+        // parks until the test drains.
+        tx.try_send(InboundMessage {
+            channel: "system".into(),
+            sender_id: "test".into(),
+            chat_id: "plug".into(),
+            content: "plug".into(),
+            timestamp: Utc::now(),
+            media: vec![],
+            metadata: serde_json::Value::Null,
+            message_id: None,
+            origin: octos_core::MessageOrigin::ExternalUser,
+        })
+        .expect("pre-fill send must succeed on an empty capacity-1 channel");
+
+        // Added while stopped, then backdated so it is due immediately.
+        let job = service
+            .add_job(
+                "reserved".into(),
+                CronSchedule::Every { every_ms: 60_000 },
+                payload("reserved fire"),
+            )
+            .unwrap();
+        let past_ms = Utc::now().timestamp_millis() - 60_000;
+        {
+            let mut store = service.store.lock().unwrap();
+            store.jobs[0].state.next_run_at_ms = Some(past_ms);
+        }
+
+        service.start();
+
+        // The reservation has committed once next_run is advanced past
+        // the backdated value; delivery is parked on the full channel.
+        wait_until("reservation committed (next_run advanced)", || {
+            service
+                .list_jobs()
+                .first()
+                .and_then(|j| j.state.next_run_at_ms)
+                .is_some_and(|t| t > past_ms)
+        })
+        .await;
+
+        // Capture the armed timer task, then let a routine mutation
+        // re-arm (and thus abort) it.
+        let timer_abort = {
+            let guard = service.timer_handle.lock().await;
+            guard
+                .as_ref()
+                .expect("timer task must be armed")
+                .abort_handle()
+        };
+        service
+            .add_job(
+                "unrelated".into(),
+                CronSchedule::Every { every_ms: 600_000 },
+                payload("unrelated"),
+            )
+            .unwrap();
+
+        // Only drain once the abort has provably landed, so delivery
+        // cannot win by racing ahead of the abort.
+        wait_until("timer task aborted by the re-arm", || {
+            timer_abort.is_finished()
+        })
+        .await;
+
+        // Drain the plug, then the reserved fire MUST arrive.
+        let plug = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("plug message must be readable")
+            .expect("bus channel closed unexpectedly");
+        assert_eq!(plug.content, "plug");
+
+        let fired = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect(
+                "reserved fire must be delivered even though a schedule mutation \
+                 aborted the timer task after the reservation committed",
+            )
+            .expect("bus channel closed unexpectedly");
+        assert_eq!(fired.chat_id, job.id);
+        assert_eq!(fired.content, "reserved fire");
 
         service.stop().await;
     }

--- a/crates/octos-bus/src/cron_service.rs
+++ b/crates/octos-bus/src/cron_service.rs
@@ -247,6 +247,65 @@ impl CronService {
         found
     }
 
+    /// Enable/disable a job with RECONCILIATION + durable persistence:
+    /// under one store-lock hold, re-read `cron.json` into memory
+    /// (adopting writes from other owners — a gateway child that ran
+    /// and exited, CLI edits), apply the toggle with `enable_job`'s
+    /// next-run semantics, and persist — propagating save failures
+    /// instead of logging them away.
+    ///
+    /// This exists for the serve-side `/api/my/cron` toggle: the
+    /// long-lived ProfileRuntime service's in-memory store can be
+    /// arbitrarily stale w.r.t. the file, and blindly persisting the
+    /// stale store would erase other owners' jobs (codex #1612 r2).
+    /// `Ok(None)` = job not found; `Err` = persistence failed (the
+    /// in-memory store keeps the reloaded + toggled state either way —
+    /// strictly fresher than what it held before).
+    pub fn toggle_job_reconciling(
+        self: &std::sync::Arc<Self>,
+        id: &str,
+        enabled: bool,
+    ) -> Result<Option<CronJob>> {
+        let (found, json) = {
+            let now_ms = Utc::now().timestamp_millis();
+            let mut store = self.store.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(fresh) = load_store(&self.store_path) {
+                *store = fresh;
+            }
+            let found = if let Some(job) = store.jobs.iter_mut().find(|j| j.id == id) {
+                job.enabled = enabled;
+                if enabled {
+                    job.compute_next_run(now_ms);
+                } else {
+                    job.state.next_run_at_ms = None;
+                }
+                Some(job.clone())
+            } else {
+                None
+            };
+            let json = if found.is_some() {
+                Some(
+                    serde_json::to_string_pretty(&*store)
+                        .wrap_err("failed to serialize cron store")?,
+                )
+            } else {
+                None
+            };
+            (found, json)
+        };
+
+        if let Some(json) = json {
+            // Same tmp+rename pattern as save_store, but serialized
+            // under the caller's coordination (the serve mutation lock).
+            let tmp_path = self.store_path.with_extension("tmp");
+            std::fs::write(&tmp_path, &json).wrap_err("failed to write cron store temp")?;
+            std::fs::rename(&tmp_path, &self.store_path).wrap_err("failed to rename cron store")?;
+            self.arm_timer();
+        }
+
+        Ok(found)
+    }
+
     /// Arm a timer for the earliest due job.
     fn arm_timer(self: &std::sync::Arc<Self>) {
         if !self.running.load(Ordering::Relaxed) {

--- a/crates/octos-bus/src/cron_service.rs
+++ b/crates/octos-bus/src/cron_service.rs
@@ -485,8 +485,17 @@ impl CronService {
         // re-fired and its next occurrence stays scheduled — cron
         // semantics reserve the NEXT slot regardless of this fire's
         // outcome.
-        let due_jobs: Vec<CronJob> = {
-            let mut store = self.store.lock().unwrap_or_else(|e| e.into_inner());
+        // The reserve+advance+persist critical section is SYNCHRONOUS
+        // (std Mutex + std::fs write) and must stay atomic to keep the
+        // persistence invariant (persist under the same lock hold that
+        // reserved — codex #1612 r3). Run the WHOLE section on the
+        // blocking pool so its fs write never occupies a tokio worker,
+        // even on a slow/full/network FS or a one-worker runtime
+        // (codex #1612 r4 P1). The blocking task self-holds an Arc, so
+        // it completes even if this on_timer future is aborted mid-tick.
+        let this = std::sync::Arc::clone(self);
+        let due_jobs: Vec<CronJob> = tokio::task::spawn_blocking(move || {
+            let mut store = this.store.lock().unwrap_or_else(|e| e.into_inner());
             let mut due = Vec::new();
             let mut to_delete = Vec::new();
 
@@ -507,20 +516,16 @@ impl CronService {
             }
 
             store.jobs.retain(|j| !to_delete.contains(&j.id));
-            // Persist the advance in the SAME critical section that
-            // reserved it (persistence invariant): the old post-fire
-            // async save left a window where memory was ahead of the
-            // file, and any concurrent reload-based reconciliation
-            // could revert the advance and re-arm a past-due fire
-            // (codex #1612 r3). A failed write is logged and the tick
-            // proceeds — next_run stays advanced in memory, so no
-            // double-fire; the file catches up on the next successful
-            // persist.
-            if let Err(e) = persist_store_locked(&self.store_path, &store) {
+            // A failed write is logged and the tick proceeds — next_run
+            // stays advanced in memory, so no double-fire; the file
+            // catches up on the next successful persist.
+            if let Err(e) = persist_store_locked(&this.store_path, &store) {
                 tracing::warn!("failed to save cron store: {e}");
             }
             due
-        };
+        })
+        .await
+        .unwrap_or_default();
 
         for job in &due_jobs {
             self.execute_job(job).await;
@@ -562,14 +567,31 @@ impl CronService {
 /// stale snapshot (codex #1612 r3). Unique temp names keep
 /// out-of-process writers from colliding on a shared `cron.tmp`.
 fn persist_store_locked(store_path: &Path, store: &CronStore) -> Result<()> {
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let json = serde_json::to_string_pretty(store).wrap_err("failed to serialize cron store")?;
+    write_cron_json_atomic(store_path, &json)
+}
+
+/// Process-global temp-name sequence, shared by EVERY cron writer
+/// (`CronService::persist_store_locked` AND the serve-side file toggle
+/// in `cron_panel.rs`), so no two writers can pick the same
+/// `cron.tmp-<pid>-<seq>` path and consume each other's temp file
+/// (codex #1612 r4 P2).
+static CRON_TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Serialize-free atomic replace of `cron.json`: write to a unique temp
+/// then rename. The ONLY cron writer primitive — every mutation path
+/// and the serve-side file toggle route through it (shared temp
+/// sequence, consistent cleanup). Partial temp files are removed on
+/// BOTH the write and rename error paths so repeated failures cannot
+/// accumulate orphans (codex #1612 r4 P2).
+pub fn write_cron_json_atomic(store_path: &Path, json: &str) -> Result<()> {
     let tmp_path = store_path.with_extension(format!(
         "tmp-{}-{}",
         std::process::id(),
-        TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        CRON_TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
     ));
-    if let Err(error) = std::fs::write(&tmp_path, &json) {
+    if let Err(error) = std::fs::write(&tmp_path, json) {
+        let _ = std::fs::remove_file(&tmp_path);
         return Err(eyre::Report::new(error).wrap_err("failed to write cron store temp"));
     }
     if let Err(error) = std::fs::rename(&tmp_path, store_path) {

--- a/crates/octos-bus/src/cron_service.rs
+++ b/crates/octos-bus/src/cron_service.rs
@@ -171,11 +171,17 @@ impl CronService {
         let result = job.clone();
 
         {
+            // Mutate + persist under ONE lock hold (persistence
+            // invariant — see persist_store_locked). Roll the push back
+            // on a failed write so memory never diverges from the file.
             let mut store = self.store.lock().unwrap_or_else(|e| e.into_inner());
             store.jobs.push(job);
+            if let Err(error) = persist_store_locked(&self.store_path, &store) {
+                store.jobs.retain(|j| j.id != id);
+                return Err(error);
+            }
         }
 
-        self.save_store()?;
         self.arm_timer();
 
         debug!(id = %id, "added cron job");
@@ -186,15 +192,30 @@ impl CronService {
     pub fn remove_job(self: &std::sync::Arc<Self>, id: &str) -> bool {
         let removed = {
             let mut store = self.store.lock().unwrap_or_else(|e| e.into_inner());
-            let before = store.jobs.len();
-            store.jobs.retain(|j| j.id != id);
-            store.jobs.len() < before
+            let mut extracted = Vec::new();
+            let mut kept = Vec::with_capacity(store.jobs.len());
+            for job in store.jobs.drain(..) {
+                if job.id == id {
+                    extracted.push(job);
+                } else {
+                    kept.push(job);
+                }
+            }
+            store.jobs = kept;
+            if extracted.is_empty() {
+                false
+            } else if let Err(e) = persist_store_locked(&self.store_path, &store) {
+                // Failed write: put the job back so memory matches the
+                // file (persistence invariant), and report not-removed.
+                store.jobs.extend(extracted);
+                tracing::warn!("failed to save cron store: {e}");
+                false
+            } else {
+                true
+            }
         };
 
         if removed {
-            if let Err(e) = self.save_store() {
-                tracing::warn!("failed to save cron store: {e}");
-            }
             self.arm_timer();
             debug!(id = %id, "removed cron job");
         }
@@ -224,22 +245,29 @@ impl CronService {
             let now_ms = Utc::now().timestamp_millis();
             let mut store = self.store.lock().unwrap_or_else(|e| e.into_inner());
             if let Some(job) = store.jobs.iter_mut().find(|j| j.id == id) {
+                let prior = job.clone();
                 job.enabled = enabled;
                 if enabled {
                     job.compute_next_run(now_ms);
                 } else {
                     job.state.next_run_at_ms = None;
                 }
-                true
+                if let Err(e) = persist_store_locked(&self.store_path, &store) {
+                    // Failed write: revert so memory matches the file.
+                    if let Some(job) = store.jobs.iter_mut().find(|j| j.id == id) {
+                        *job = prior;
+                    }
+                    tracing::warn!("failed to save cron store: {e}");
+                    false
+                } else {
+                    true
+                }
             } else {
                 false
             }
         };
 
         if found {
-            if let Err(e) = self.save_store() {
-                tracing::warn!("failed to save cron store: {e}");
-            }
             self.arm_timer();
             debug!(id = %id, enabled = %enabled, "toggled cron job");
         }
@@ -266,12 +294,19 @@ impl CronService {
         id: &str,
         enabled: bool,
     ) -> Result<Option<CronJob>> {
-        let (found, json) = {
+        let found = {
             let now_ms = Utc::now().timestamp_millis();
+            // Reload + toggle + persist under ONE lock hold. Every other
+            // mutation persists before releasing this lock (persistence
+            // invariant — see persist_store_locked), so the file we
+            // reload is never behind unflushed memory, and nothing can
+            // interleave between our reload and our write (codex #1612
+            // r3 — both P1s).
             let mut store = self.store.lock().unwrap_or_else(|e| e.into_inner());
             if let Some(fresh) = load_store(&self.store_path) {
                 *store = fresh;
             }
+            let prior = store.jobs.clone();
             let found = if let Some(job) = store.jobs.iter_mut().find(|j| j.id == id) {
                 job.enabled = enabled;
                 if enabled {
@@ -283,26 +318,19 @@ impl CronService {
             } else {
                 None
             };
-            let json = if found.is_some() {
-                Some(
-                    serde_json::to_string_pretty(&*store)
-                        .wrap_err("failed to serialize cron store")?,
-                )
-            } else {
-                None
-            };
-            (found, json)
+            if found.is_some()
+                && let Err(error) = persist_store_locked(&self.store_path, &store)
+            {
+                // Failed write: revert so memory matches the file.
+                store.jobs = prior;
+                return Err(error);
+            }
+            found
         };
 
-        if let Some(json) = json {
-            // Same tmp+rename pattern as save_store, but serialized
-            // under the caller's coordination (the serve mutation lock).
-            let tmp_path = self.store_path.with_extension("tmp");
-            std::fs::write(&tmp_path, &json).wrap_err("failed to write cron store temp")?;
-            std::fs::rename(&tmp_path, &self.store_path).wrap_err("failed to rename cron store")?;
+        if found.is_some() {
             self.arm_timer();
         }
-
         Ok(found)
     }
 
@@ -479,6 +507,18 @@ impl CronService {
             }
 
             store.jobs.retain(|j| !to_delete.contains(&j.id));
+            // Persist the advance in the SAME critical section that
+            // reserved it (persistence invariant): the old post-fire
+            // async save left a window where memory was ahead of the
+            // file, and any concurrent reload-based reconciliation
+            // could revert the advance and re-arm a past-due fire
+            // (codex #1612 r3). A failed write is logged and the tick
+            // proceeds — next_run stays advanced in memory, so no
+            // double-fire; the file catches up on the next successful
+            // persist.
+            if let Err(e) = persist_store_locked(&self.store_path, &store) {
+                tracing::warn!("failed to save cron store: {e}");
+            }
             due
         };
 
@@ -486,9 +526,6 @@ impl CronService {
             self.execute_job(job).await;
         }
 
-        if let Err(e) = self.save_store_async().await {
-            tracing::warn!("failed to save cron store: {e}");
-        }
         self.arm_timer();
     }
 
@@ -516,37 +553,30 @@ impl CronService {
             warn!(error = %e, job_id = %job.id, "failed to send cron message to bus");
         }
     }
+}
 
-    fn save_store(&self) -> Result<()> {
-        let store = self.store.lock().unwrap_or_else(|e| e.into_inner());
-        let json =
-            serde_json::to_string_pretty(&*store).wrap_err("failed to serialize cron store")?;
-        let tmp_path = self.store_path.with_extension("tmp");
-        std::fs::write(&tmp_path, &json).wrap_err("failed to write cron store temp")?;
-        std::fs::rename(&tmp_path, &self.store_path).wrap_err("failed to rename cron store")?;
-        Ok(())
+/// Serialize + atomically replace `cron.json`. The caller MUST hold the
+/// store lock for the whole call — that is the service's persistence
+/// invariant (every mutation persists before releasing the lock), which
+/// keeps memory and file in lockstep so no writer can interleave a
+/// stale snapshot (codex #1612 r3). Unique temp names keep
+/// out-of-process writers from colliding on a shared `cron.tmp`.
+fn persist_store_locked(store_path: &Path, store: &CronStore) -> Result<()> {
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let json = serde_json::to_string_pretty(store).wrap_err("failed to serialize cron store")?;
+    let tmp_path = store_path.with_extension(format!(
+        "tmp-{}-{}",
+        std::process::id(),
+        TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    if let Err(error) = std::fs::write(&tmp_path, &json) {
+        return Err(eyre::Report::new(error).wrap_err("failed to write cron store temp"));
     }
-
-    /// Async version of save_store that uses spawn_blocking to avoid blocking
-    /// the tokio runtime thread.
-    async fn save_store_async(&self) -> Result<()> {
-        let json = {
-            let store = self.store.lock().unwrap_or_else(|e| e.into_inner());
-            serde_json::to_string_pretty(&*store).wrap_err("failed to serialize cron store")?
-        };
-        let tmp_path = self.store_path.with_extension("tmp");
-        let store_path = self.store_path.clone();
-
-        tokio::task::spawn_blocking(move || {
-            std::fs::write(&tmp_path, &json).wrap_err("failed to write cron store temp")?;
-            std::fs::rename(&tmp_path, &store_path).wrap_err("failed to rename cron store")?;
-            Ok::<_, eyre::Report>(())
-        })
-        .await
-        .map_err(|e| eyre::eyre!("spawn_blocking join error: {e}"))??;
-
-        Ok(())
+    if let Err(error) = std::fs::rename(&tmp_path, store_path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(eyre::Report::new(error).wrap_err("failed to rename cron store"));
     }
+    Ok(())
 }
 
 fn load_store(path: &Path) -> Option<CronStore> {
@@ -599,6 +629,70 @@ mod tests {
         let (tx, rx) = mpsc::channel(64);
         let service = std::sync::Arc::new(CronService::new(dir.join("cron.json"), tx));
         (service, rx)
+    }
+
+    #[test]
+    fn concurrent_adds_and_reconciling_toggles_lose_nothing() {
+        // codex #1612 r3: every mutation persists before releasing the
+        // store lock, so a reload-based reconcile can never revert an
+        // unflushed add, and no writer can interleave a stale snapshot
+        // between another's serialize and rename. 8 adds racing 8
+        // reconciling toggles must land ALL adds in the file.
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, _rx) = mpsc::channel(64);
+        let service = std::sync::Arc::new(CronService::new(dir.path().join("cron.json"), tx));
+        let seeded = service
+            .add_job(
+                "seed".into(),
+                CronSchedule::Every { every_ms: 60_000 },
+                CronPayload {
+                    message: "m".into(),
+                    deliver: false,
+                    channel: None,
+                    chat_id: None,
+                },
+            )
+            .unwrap();
+
+        let mut handles = Vec::new();
+        for i in 0..8 {
+            let svc = std::sync::Arc::clone(&service);
+            handles.push(std::thread::spawn(move || {
+                svc.add_job(
+                    format!("racer-{i}"),
+                    CronSchedule::Every { every_ms: 60_000 },
+                    CronPayload {
+                        message: "m".into(),
+                        deliver: false,
+                        channel: None,
+                        chat_id: None,
+                    },
+                )
+                .unwrap();
+            }));
+            let svc = std::sync::Arc::clone(&service);
+            let seed_id = seeded.id.clone();
+            handles.push(std::thread::spawn(move || {
+                svc.toggle_job_reconciling(&seed_id, i % 2 == 0)
+                    .unwrap()
+                    .expect("seed job present");
+            }));
+        }
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let file: CronStore =
+            serde_json::from_str(&std::fs::read_to_string(dir.path().join("cron.json")).unwrap())
+                .unwrap();
+        assert_eq!(
+            file.jobs.len(),
+            9,
+            "all 8 racing adds + the seed must survive: {:?}",
+            file.jobs.iter().map(|j| j.name.clone()).collect::<Vec<_>>()
+        );
+        // And memory agrees with the file (persistence invariant).
+        assert_eq!(service.list_all_jobs().len(), 9);
     }
 
     #[tokio::test]

--- a/crates/octos-bus/src/cron_service.rs
+++ b/crates/octos-bus/src/cron_service.rs
@@ -585,6 +585,14 @@ impl CronService {
         // service Arc. Dropping the delivery on shutdown matches the
         // old abort semantics: the reservation stays advanced, so the
         // occurrence is skipped, never double-fired.
+        //
+        // `biased` with the notify arm FIRST (codex #1612 r6 P2): when
+        // shutdown lands between the `running` check and the select's
+        // first poll, BOTH arms are ready (the bus may have capacity).
+        // An unbiased select! randomizes the winner, so the send could
+        // deliver a cron message after the service stopped — the old
+        // abort semantics never allowed that. Biased polling makes
+        // cancellation take precedence deterministically.
         let notified = self.shutdown_notify.notified();
         tokio::pin!(notified);
         notified.as_mut().enable();
@@ -593,13 +601,14 @@ impl CronService {
             return;
         }
         tokio::select! {
+            biased;
+            _ = &mut notified => {
+                warn!(job_id = %job.id, "cron service shut down during delivery; dropping cron message");
+            }
             res = self.inbound_tx.send(msg) => {
                 if let Err(e) = res {
                     warn!(error = %e, job_id = %job.id, "failed to send cron message to bus");
                 }
-            }
-            _ = &mut notified => {
-                warn!(job_id = %job.id, "cron service shut down during delivery; dropping cron message");
             }
         }
     }

--- a/crates/octos-bus/src/lib.rs
+++ b/crates/octos-bus/src/lib.rs
@@ -52,7 +52,7 @@ pub mod whatsapp_channel;
 pub use bus::{AgentHandle, BusPublisher, create_bus};
 pub use channel::{Channel, ChannelHealth, ChannelManager};
 pub use cli_channel::CliChannel;
-pub use cron_service::CronService;
+pub use cron_service::{CronService, write_cron_json_atomic};
 pub use cron_types::{CronJob, CronPayload, CronSchedule, CronStore};
 pub use dedup::MessageDedup;
 pub use heartbeat::HeartbeatService;

--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -3646,7 +3646,7 @@ pub async fn read_session(
 
 /// Truncate a string to max_len chars, appending "..." if truncated.
 /// Safe for multi-byte UTF-8 (truncates at char boundary).
-fn truncate_str(s: &str, max_len: usize) -> String {
+pub(crate) fn truncate_str(s: &str, max_len: usize) -> String {
     if s.chars().count() <= max_len {
         s.to_string()
     } else {

--- a/crates/octos-cli/src/api/cron_panel.rs
+++ b/crates/octos-cli/src/api/cron_panel.rs
@@ -1,0 +1,415 @@
+//! `/api/my/cron*` — user-scoped cron viewer + enable toggle (web
+//! parity audit P3 item 7: the book documents scheduled tasks, but the
+//! dashboard had no cron surface at all — only the admin-token
+//! `GET /api/admin/profiles/{id}/cron` list).
+//!
+//! Runtime-ownership constraint that shapes this API: cron jobs
+//! EXECUTE inside a profile's gateway process, whose `CronService`
+//! holds `cron.json` in memory and rewrites the whole file on its own
+//! events (job state updates after every run). A serve-side file edit
+//! while that process runs is a silent lost-update waiting to happen —
+//! so the toggle endpoint REFUSES with `409 {reason:
+//! "gateway_running"}` while the profile gateway is up, and the SPA
+//! offers the existing stop/start controls next to it. When the
+//! gateway is stopped the file is the single source of truth and the
+//! toggle applies atomically (tmp + rename, the service's own
+//! pattern), taking effect on next start.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path as AxumPath, State};
+use axum::http::{HeaderMap, StatusCode};
+use chrono::Utc;
+use serde::Deserialize;
+
+use super::AppState;
+use super::router::AuthIdentity;
+use crate::api::auth_handlers::resolve_my_profile_id;
+
+/// Render one job in the same shape the admin list uses, so the SPA
+/// can share a row component between the two surfaces.
+fn job_json(j: &octos_bus::CronJob, now_ms: i64) -> serde_json::Value {
+    let next_in = j.state.next_run_at_ms.map(|t| {
+        let secs = (t - now_ms) / 1000;
+        if secs < 0 {
+            "overdue".to_string()
+        } else if secs < 60 {
+            format!("{secs}s")
+        } else if secs < 3600 {
+            format!("{}m", secs / 60)
+        } else {
+            format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+        }
+    });
+    let last_run = j.state.last_run_at_ms.map(|t| {
+        chrono::DateTime::from_timestamp_millis(t)
+            .map(|dt| dt.to_rfc3339())
+            .unwrap_or_default()
+    });
+    serde_json::json!({
+        "id": j.id,
+        "name": j.name,
+        "enabled": j.enabled,
+        "schedule": serde_json::to_value(&j.schedule).unwrap_or_default(),
+        "message": crate::api::admin::truncate_str(&j.payload.message, 100),
+        "channel": j.payload.channel,
+        "last_run": last_run,
+        "last_status": j.state.last_status,
+        "next_in": next_in,
+        "timezone": j.timezone,
+    })
+}
+
+fn cron_path_for(data_dir: &Path) -> PathBuf {
+    data_dir.join("cron.json")
+}
+
+/// Whether the profile's gateway process is currently running (the
+/// cron store's runtime owner). `None` process manager (solo serve,
+/// tests) means nothing can own the file → not running.
+async fn gateway_running(state: &AppState, profile_id: &str) -> bool {
+    match state.process_manager.as_ref() {
+        Some(pm) => pm.status(profile_id).await.running,
+        None => false,
+    }
+}
+
+/// GET /api/my/cron
+pub async fn my_cron(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::Extension(identity): axum::Extension<AuthIdentity>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let ps = state
+        .profile_store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let profile_id = resolve_my_profile_id(&identity, ps, &state, &headers)?;
+    let profile = ps
+        .get(&profile_id)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
+    let cron_path = cron_path_for(&ps.resolve_data_dir(&profile));
+
+    let running = gateway_running(&state, &profile_id).await;
+    let store = match read_cron_store(&cron_path).await {
+        Ok(Some(store)) => store,
+        Ok(None) => {
+            return Ok(Json(serde_json::json!({
+                "ok": true,
+                "count": 0,
+                "jobs": [],
+                "gateway_running": running,
+            })));
+        }
+        Err(status) => return Err(status),
+    };
+
+    let now_ms = Utc::now().timestamp_millis();
+    let jobs: Vec<serde_json::Value> = store.jobs.iter().map(|j| job_json(j, now_ms)).collect();
+    Ok(Json(serde_json::json!({
+        "ok": true,
+        "count": jobs.len(),
+        "jobs": jobs,
+        "gateway_running": running,
+    })))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ToggleBody {
+    pub enabled: bool,
+}
+
+/// Outcome of the pure file-level toggle (kept handler-free so the
+/// mutation semantics are unit-testable without a ProcessManager).
+#[derive(Debug, PartialEq)]
+pub(crate) enum ToggleError {
+    NotFound,
+    Io,
+}
+
+/// Flip `enabled` for one job in `cron.json`, atomically (tmp +
+/// rename — the CronService's own persistence pattern). Caller is
+/// responsible for the gateway-not-running guard.
+pub(crate) async fn apply_cron_toggle(
+    cron_path: &Path,
+    job_id: &str,
+    enabled: bool,
+) -> Result<octos_bus::CronJob, ToggleError> {
+    let content = match tokio::fs::read_to_string(cron_path).await {
+        Ok(content) => content,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Err(ToggleError::NotFound),
+        Err(_) => return Err(ToggleError::Io),
+    };
+    let mut store: octos_bus::CronStore =
+        serde_json::from_str(&content).map_err(|_| ToggleError::Io)?;
+    let job = store
+        .jobs
+        .iter_mut()
+        .find(|j| j.id == job_id)
+        .ok_or(ToggleError::NotFound)?;
+    job.enabled = enabled;
+    let updated = job.clone();
+    let json = serde_json::to_string_pretty(&store).map_err(|_| ToggleError::Io)?;
+    let tmp_path = cron_path.with_extension("tmp");
+    tokio::fs::write(&tmp_path, &json)
+        .await
+        .map_err(|_| ToggleError::Io)?;
+    tokio::fs::rename(&tmp_path, cron_path)
+        .await
+        .map_err(|_| ToggleError::Io)?;
+    Ok(updated)
+}
+
+/// PUT /api/my/cron/{job_id}/enabled
+pub async fn set_my_cron_enabled(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::Extension(identity): axum::Extension<AuthIdentity>,
+    AxumPath(job_id): AxumPath<String>,
+    Json(body): Json<ToggleBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let err = |status: StatusCode, reason: &str| {
+        (
+            status,
+            Json(serde_json::json!({ "ok": false, "reason": reason })),
+        )
+    };
+
+    let ps = state
+        .profile_store
+        .as_ref()
+        .ok_or_else(|| err(StatusCode::SERVICE_UNAVAILABLE, "profiles_unavailable"))?;
+    let profile_id = resolve_my_profile_id(&identity, ps, &state, &headers)
+        .map_err(|status| err(status, "auth"))?;
+    let profile = ps
+        .get(&profile_id)
+        .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "profile_read_failed"))?
+        .ok_or_else(|| err(StatusCode::NOT_FOUND, "profile_not_found"))?;
+
+    // The gateway process owns cron.json while it runs (its CronService
+    // rewrites the file wholesale on its own schedule); a concurrent
+    // edit here would be silently lost. Refuse and let the SPA route
+    // the user through the stop/start controls.
+    if gateway_running(&state, &profile_id).await {
+        return Err(err(StatusCode::CONFLICT, "gateway_running"));
+    }
+
+    let cron_path = cron_path_for(&ps.resolve_data_dir(&profile));
+    match apply_cron_toggle(&cron_path, &job_id, body.enabled).await {
+        Ok(job) => {
+            let now_ms = Utc::now().timestamp_millis();
+            Ok(Json(serde_json::json!({
+                "ok": true,
+                "job": job_json(&job, now_ms),
+            })))
+        }
+        Err(ToggleError::NotFound) => Err(err(StatusCode::NOT_FOUND, "job_not_found")),
+        Err(ToggleError::Io) => Err(err(StatusCode::INTERNAL_SERVER_ERROR, "cron_store_io")),
+    }
+}
+
+/// Read + parse `cron.json`; `Ok(None)` when the file does not exist.
+async fn read_cron_store(cron_path: &Path) -> Result<Option<octos_bus::CronStore>, StatusCode> {
+    let content = match tokio::fs::read_to_string(cron_path).await {
+        Ok(content) => content,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
+    };
+    serde_json::from_str(&content)
+        .map(Some)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::profiles::ProfileStore;
+    use crate::user_store::UserRole;
+
+    fn make_user_profile(id: &str) -> crate::profiles::UserProfile {
+        crate::profiles::UserProfile {
+            id: id.into(),
+            name: id.into(),
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: crate::profiles::ProfileConfig::default(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    fn temp_state() -> (tempfile::TempDir, Arc<AppState>, Arc<ProfileStore>) {
+        let dir = tempfile::tempdir().unwrap();
+        let profile_store = Arc::new(ProfileStore::open(dir.path()).unwrap());
+        let state = Arc::new(AppState {
+            profile_store: Some(profile_store.clone()),
+            ..AppState::empty_for_tests()
+        });
+        (dir, state, profile_store)
+    }
+
+    fn user_identity(id: &str) -> axum::Extension<AuthIdentity> {
+        axum::Extension(AuthIdentity::User {
+            id: id.into(),
+            role: UserRole::User,
+        })
+    }
+
+    fn make_job(id: &str, enabled: bool) -> octos_bus::CronJob {
+        octos_bus::CronJob {
+            id: id.into(),
+            name: format!("job {id}"),
+            enabled,
+            schedule: octos_bus::CronSchedule::Every {
+                every_ms: 1_800_000,
+            },
+            payload: octos_bus::CronPayload {
+                message: "check the queue".into(),
+                deliver: false,
+                channel: Some("system".into()),
+                chat_id: None,
+            },
+            state: Default::default(),
+            created_at_ms: 1,
+            delete_after_run: false,
+            timezone: None,
+        }
+    }
+
+    async fn seed_cron(
+        ps: &ProfileStore,
+        profile: &crate::profiles::UserProfile,
+        jobs: Vec<octos_bus::CronJob>,
+    ) -> PathBuf {
+        let data_dir = ps.resolve_data_dir(profile);
+        tokio::fs::create_dir_all(&data_dir).await.unwrap();
+        let path = cron_path_for(&data_dir);
+        let store = octos_bus::CronStore { version: 1, jobs };
+        tokio::fs::write(&path, serde_json::to_string_pretty(&store).unwrap())
+            .await
+            .unwrap();
+        path
+    }
+
+    #[tokio::test]
+    async fn my_cron_lists_zero_state_without_file() {
+        let (_dir, state, ps) = temp_state();
+        ps.save(&make_user_profile("tenant")).unwrap();
+        let Json(resp) = my_cron(State(state), HeaderMap::new(), user_identity("tenant"))
+            .await
+            .unwrap();
+        assert_eq!(resp["ok"], true);
+        assert_eq!(resp["count"], 0);
+        assert_eq!(resp["gateway_running"], false);
+    }
+
+    #[tokio::test]
+    async fn my_cron_lists_jobs_in_admin_shape() {
+        let (_dir, state, ps) = temp_state();
+        let profile = make_user_profile("tenant2");
+        ps.save(&profile).unwrap();
+        seed_cron(
+            &ps,
+            &profile,
+            vec![make_job("aa11", true), make_job("bb22", false)],
+        )
+        .await;
+
+        let Json(resp) = my_cron(State(state), HeaderMap::new(), user_identity("tenant2"))
+            .await
+            .unwrap();
+        assert_eq!(resp["count"], 2);
+        assert_eq!(resp["jobs"][0]["id"], "aa11");
+        assert_eq!(resp["jobs"][0]["enabled"], true);
+        assert_eq!(resp["jobs"][1]["enabled"], false);
+        assert_eq!(resp["jobs"][0]["message"], "check the queue");
+    }
+
+    #[tokio::test]
+    async fn toggle_flips_and_persists_atomically() {
+        let (_dir, state, ps) = temp_state();
+        let profile = make_user_profile("tenant3");
+        ps.save(&profile).unwrap();
+        let path = seed_cron(&ps, &profile, vec![make_job("aa11", true)]).await;
+
+        let Json(resp) = set_my_cron_enabled(
+            State(state),
+            HeaderMap::new(),
+            user_identity("tenant3"),
+            AxumPath("aa11".into()),
+            Json(ToggleBody { enabled: false }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp["ok"], true);
+        assert_eq!(resp["job"]["enabled"], false);
+
+        // Persisted: a fresh read of cron.json reflects the flip and
+        // the store shape (version + full job records) survived.
+        let content = tokio::fs::read_to_string(&path).await.unwrap();
+        let store: octos_bus::CronStore = serde_json::from_str(&content).unwrap();
+        assert_eq!(store.version, 1);
+        assert_eq!(store.jobs.len(), 1);
+        assert!(!store.jobs[0].enabled);
+        assert_eq!(store.jobs[0].payload.message, "check the queue");
+    }
+
+    #[tokio::test]
+    async fn toggle_404s_on_unknown_job_and_missing_store() {
+        let (_dir, state, ps) = temp_state();
+        let profile = make_user_profile("tenant4");
+        ps.save(&profile).unwrap();
+
+        // No cron.json at all.
+        let missing_store = set_my_cron_enabled(
+            State(state.clone()),
+            HeaderMap::new(),
+            user_identity("tenant4"),
+            AxumPath("aa11".into()),
+            Json(ToggleBody { enabled: false }),
+        )
+        .await;
+        assert_eq!(
+            missing_store.err().map(|(s, _)| s),
+            Some(StatusCode::NOT_FOUND)
+        );
+
+        // Store exists but the id doesn't.
+        seed_cron(&ps, &profile, vec![make_job("aa11", true)]).await;
+        let unknown = set_my_cron_enabled(
+            State(state),
+            HeaderMap::new(),
+            user_identity("tenant4"),
+            AxumPath("zz99".into()),
+            Json(ToggleBody { enabled: false }),
+        )
+        .await;
+        assert_eq!(unknown.err().map(|(s, _)| s), Some(StatusCode::NOT_FOUND));
+    }
+
+    #[tokio::test]
+    async fn apply_cron_toggle_is_scoped_to_the_addressed_job() {
+        // Pure file-level core: flipping one job leaves siblings alone.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cron.json");
+        let store = octos_bus::CronStore {
+            version: 1,
+            jobs: vec![make_job("one", true), make_job("two", true)],
+        };
+        tokio::fs::write(&path, serde_json::to_string(&store).unwrap())
+            .await
+            .unwrap();
+
+        let updated = apply_cron_toggle(&path, "two", false).await.unwrap();
+        assert_eq!(updated.id, "two");
+        let reread: octos_bus::CronStore =
+            serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
+        assert!(reread.jobs[0].enabled, "sibling job must be untouched");
+        assert!(!reread.jobs[1].enabled);
+    }
+}

--- a/crates/octos-cli/src/api/cron_panel.rs
+++ b/crates/octos-cli/src/api/cron_panel.rs
@@ -3,18 +3,29 @@
 //! dashboard had no cron surface at all — only the admin-token
 //! `GET /api/admin/profiles/{id}/cron` list).
 //!
-//! Runtime-ownership constraint that shapes this API: cron jobs
-//! EXECUTE inside a profile's gateway process, whose `CronService`
-//! holds `cron.json` in memory and rewrites the whole file on its own
-//! events (job state updates after every run). A serve-side file edit
-//! while that process runs is a silent lost-update waiting to happen —
-//! so the toggle endpoint REFUSES with `409 {reason:
-//! "gateway_running"}` while the profile gateway is up, and the SPA
-//! offers the existing stop/start controls next to it. When the
-//! gateway is stopped the file is the single source of truth and the
-//! toggle applies atomically (tmp + rename, the service's own
-//! pattern), taking effect on next start.
-
+//! Runtime-ownership constraint that shapes this API: `cron.json` has
+//! up to three writers, and a bare file edit races all of them (each
+//! holds the store in memory and rewrites the whole file on its own
+//! events):
+//!
+//! 1. **The serve-side `ProfileRuntime`'s own `CronService`** (started
+//!    for enabled profiles with an LLM). When one is live we route the
+//!    toggle THROUGH it (`CronService::enable_job` — mutates the
+//!    in-memory store, persists, recomputes `next_run_at_ms`, re-arms
+//!    the timer), so there is no drift by construction.
+//! 2. **A spawned gateway child process.** Its `CronService` lives in
+//!    another process we cannot call into — the toggle REFUSES with
+//!    `409 {reason: "gateway_running"}` and the SPA routes the user
+//!    through the existing stop/start controls.
+//! 3. **Nobody** — the file is the source of truth and the toggle
+//!    applies atomically (unique tmp + rename), mirroring
+//!    `enable_job`'s next-run semantics so a later `CronService::start`
+//!    (which only recomputes jobs whose next run is `None`) does not
+//!    fire a stale deadline.
+//!
+//! All serve-side mutations are serialized behind a process-wide lock
+//! (concurrent PUTs would otherwise race the read-modify-write and drop
+//! one another's changes). Residual race documented on the lock.
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -22,6 +33,7 @@ use axum::Json;
 use axum::extract::{Path as AxumPath, State};
 use axum::http::{HeaderMap, StatusCode};
 use chrono::Utc;
+use octos_bus::CronService;
 use serde::Deserialize;
 
 use super::AppState;
@@ -66,15 +78,38 @@ fn cron_path_for(data_dir: &Path) -> PathBuf {
     data_dir.join("cron.json")
 }
 
-/// Whether the profile's gateway process is currently running (the
-/// cron store's runtime owner). `None` process manager (solo serve,
-/// tests) means nothing can own the file → not running.
+/// Whether the profile's gateway CHILD PROCESS is currently running.
+/// That process's `CronService` owns `cron.json` from another address
+/// space we cannot coordinate with — the toggle refuses while it runs.
+/// `None` process manager (solo serve, tests) means no child exists.
 async fn gateway_running(state: &AppState, profile_id: &str) -> bool {
     match state.process_manager.as_ref() {
         Some(pm) => pm.status(profile_id).await.running,
         None => false,
     }
 }
+
+/// The serve-process-local `CronService` for this profile, if one is
+/// live (enabled top-level profile with an LLM gets one on its
+/// `ProfileRuntime`). Mutations MUST route through it when present —
+/// it holds the store in memory and its next save would silently
+/// overwrite a bare file edit.
+fn live_cron_service(state: &AppState, profile_id: &str) -> Option<Arc<CronService>> {
+    crate::api::ui_protocol::resolve_session_profile_runtime(state, Some(profile_id))
+        .and_then(|runtime| runtime.cron_service.clone())
+}
+
+/// Serializes every serve-side cron mutation (in-process, across all
+/// profiles — toggles are rare enough that one lock is fine).
+///
+/// Residual race, accepted + documented: a `ProfileRuntime` can
+/// bootstrap CONCURRENTLY with a file-path toggle (its `CronService`
+/// loads `cron.json` in `new()`), in which case a load that
+/// interleaves our read-modify-write can hold the pre-toggle store and
+/// persist it later. We shrink the window by re-resolving the live
+/// service inside the lock; closing it fully needs a cross-owner
+/// lifecycle lock that does not exist today.
+static CRON_MUTATION_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 /// GET /api/my/cron
 pub async fn my_cron(
@@ -94,21 +129,20 @@ pub async fn my_cron(
     let cron_path = cron_path_for(&ps.resolve_data_dir(&profile));
 
     let running = gateway_running(&state, &profile_id).await;
-    let store = match read_cron_store(&cron_path).await {
-        Ok(Some(store)) => store,
-        Ok(None) => {
-            return Ok(Json(serde_json::json!({
-                "ok": true,
-                "count": 0,
-                "jobs": [],
-                "gateway_running": running,
-            })));
+    // Prefer the live service's view — it is what the toggle path will
+    // mutate, and it is fresher than the file between persists.
+    let jobs = if let Some(svc) = live_cron_service(&state, &profile_id) {
+        svc.list_all_jobs()
+    } else {
+        match read_cron_store(&cron_path).await {
+            Ok(Some(store)) => store.jobs,
+            Ok(None) => Vec::new(),
+            Err(status) => return Err(status),
         }
-        Err(status) => return Err(status),
     };
 
     let now_ms = Utc::now().timestamp_millis();
-    let jobs: Vec<serde_json::Value> = store.jobs.iter().map(|j| job_json(j, now_ms)).collect();
+    let jobs: Vec<serde_json::Value> = jobs.iter().map(|j| job_json(j, now_ms)).collect();
     Ok(Json(serde_json::json!({
         "ok": true,
         "count": jobs.len(),
@@ -130,9 +164,13 @@ pub(crate) enum ToggleError {
     Io,
 }
 
-/// Flip `enabled` for one job in `cron.json`, atomically (tmp +
-/// rename — the CronService's own persistence pattern). Caller is
-/// responsible for the gateway-not-running guard.
+/// Flip `enabled` for one job in `cron.json`, atomically (unique tmp +
+/// rename). Mirrors `CronService::enable_job`'s state semantics:
+/// disabling clears `next_run_at_ms` (a stale deadline would fire
+/// immediately on re-enable + restart, because `CronService::start`
+/// only recomputes jobs whose next run is `None`), enabling recomputes
+/// it from now. Caller is responsible for owner coordination
+/// (gateway-not-running guard + `CRON_MUTATION_LOCK`).
 pub(crate) async fn apply_cron_toggle(
     cron_path: &Path,
     job_id: &str,
@@ -151,16 +189,52 @@ pub(crate) async fn apply_cron_toggle(
         .find(|j| j.id == job_id)
         .ok_or(ToggleError::NotFound)?;
     job.enabled = enabled;
+    if enabled {
+        job.compute_next_run(Utc::now().timestamp_millis());
+    } else {
+        job.state.next_run_at_ms = None;
+    }
     let updated = job.clone();
     let json = serde_json::to_string_pretty(&store).map_err(|_| ToggleError::Io)?;
-    let tmp_path = cron_path.with_extension("tmp");
-    tokio::fs::write(&tmp_path, &json)
-        .await
-        .map_err(|_| ToggleError::Io)?;
-    tokio::fs::rename(&tmp_path, cron_path)
-        .await
-        .map_err(|_| ToggleError::Io)?;
+    // Unique per-write temp name: a concurrent writer using a shared
+    // `cron.tmp` could rename OUR content away (or fail on a vanished
+    // temp file). The mutation lock already serializes serve-side
+    // writers; the unique name additionally keeps any out-of-process
+    // writer from colliding on the temp path itself.
+    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let tmp_path = cron_path.with_extension(format!(
+        "tmp-{}-{}",
+        std::process::id(),
+        TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    if tokio::fs::write(&tmp_path, &json).await.is_err() {
+        return Err(ToggleError::Io);
+    }
+    if tokio::fs::rename(&tmp_path, cron_path).await.is_err() {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(ToggleError::Io);
+    }
     Ok(updated)
+}
+
+/// Route the toggle through a live `CronService` (it owns the store:
+/// persists, recomputes next-run, re-arms its timer). Split from the
+/// handler so the service path is unit-testable without a
+/// `ProfileRuntime`.
+pub(crate) fn toggle_via_service(
+    svc: &Arc<CronService>,
+    job_id: &str,
+    enabled: bool,
+) -> Result<octos_bus::CronJob, ToggleError> {
+    if !svc.enable_job(job_id, enabled) {
+        return Err(ToggleError::NotFound);
+    }
+    svc.list_all_jobs()
+        .into_iter()
+        .find(|j| j.id == job_id)
+        // Present a beat ago under the store lock; racing deletion is
+        // the only way to lose it. Treat as gone.
+        .ok_or(ToggleError::NotFound)
 }
 
 /// PUT /api/my/cron/{job_id}/enabled
@@ -189,16 +263,24 @@ pub async fn set_my_cron_enabled(
         .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "profile_read_failed"))?
         .ok_or_else(|| err(StatusCode::NOT_FOUND, "profile_not_found"))?;
 
-    // The gateway process owns cron.json while it runs (its CronService
-    // rewrites the file wholesale on its own schedule); a concurrent
-    // edit here would be silently lost. Refuse and let the SPA route
-    // the user through the stop/start controls.
+    // A spawned gateway child owns cron.json from another process; we
+    // can neither call into it nor safely edit under it. Refuse and let
+    // the SPA route the user through the stop/start controls.
     if gateway_running(&state, &profile_id).await {
         return Err(err(StatusCode::CONFLICT, "gateway_running"));
     }
 
-    let cron_path = cron_path_for(&ps.resolve_data_dir(&profile));
-    match apply_cron_toggle(&cron_path, &job_id, body.enabled).await {
+    let _mutation = CRON_MUTATION_LOCK.lock().await;
+    // Resolved INSIDE the lock: a runtime that came up while we waited
+    // must be routed through, not written under.
+    let outcome = if let Some(svc) = live_cron_service(&state, &profile_id) {
+        toggle_via_service(&svc, &job_id, body.enabled)
+    } else {
+        let cron_path = cron_path_for(&ps.resolve_data_dir(&profile));
+        apply_cron_toggle(&cron_path, &job_id, body.enabled).await
+    };
+
+    match outcome {
         Ok(job) => {
             let now_ms = Utc::now().timestamp_millis();
             Ok(Json(serde_json::json!({
@@ -411,5 +493,109 @@ mod tests {
             serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
         assert!(reread.jobs[0].enabled, "sibling job must be untouched");
         assert!(!reread.jobs[1].enabled);
+    }
+
+    #[tokio::test]
+    async fn apply_cron_toggle_matches_cron_service_next_run_semantics() {
+        // Disabling clears a stale deadline; re-enabling recomputes it.
+        // (CronService::start only recomputes jobs whose next run is
+        // None — a stale next_run_at_ms would fire immediately.)
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cron.json");
+        let mut job = make_job("one", true);
+        job.state.next_run_at_ms = Some(123); // long past
+        let store = octos_bus::CronStore {
+            version: 1,
+            jobs: vec![job],
+        };
+        tokio::fs::write(&path, serde_json::to_string(&store).unwrap())
+            .await
+            .unwrap();
+
+        let disabled = apply_cron_toggle(&path, "one", false).await.unwrap();
+        assert_eq!(disabled.state.next_run_at_ms, None);
+        let reread: octos_bus::CronStore =
+            serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
+        assert_eq!(reread.jobs[0].state.next_run_at_ms, None);
+
+        let enabled = apply_cron_toggle(&path, "one", true).await.unwrap();
+        let now_ms = Utc::now().timestamp_millis();
+        let next = enabled.state.next_run_at_ms.expect("recomputed next run");
+        assert!(
+            next > now_ms,
+            "every-30m job must be scheduled in the future, got {next} vs now {now_ms}"
+        );
+    }
+
+    #[tokio::test]
+    async fn toggle_via_service_routes_through_the_owning_store() {
+        // The service path: enable_job mutates the IN-MEMORY store and
+        // persists — the file reflects the flip without us touching it.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cron.json");
+        let mut job = make_job("svc1", true);
+        job.state.next_run_at_ms = Some(123);
+        let store = octos_bus::CronStore {
+            version: 1,
+            jobs: vec![job],
+        };
+        tokio::fs::write(&path, serde_json::to_string(&store).unwrap())
+            .await
+            .unwrap();
+
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let svc = Arc::new(CronService::new(&path, tx));
+
+        let toggled = toggle_via_service(&svc, "svc1", false).unwrap();
+        assert!(!toggled.enabled);
+        assert_eq!(toggled.state.next_run_at_ms, None, "deadline cleared");
+        let reread: octos_bus::CronStore =
+            serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
+        assert!(!reread.jobs[0].enabled, "service persisted the flip");
+
+        assert!(matches!(
+            toggle_via_service(&svc, "nope", false),
+            Err(ToggleError::NotFound)
+        ));
+    }
+
+    #[tokio::test]
+    async fn concurrent_toggles_both_persist() {
+        // Two PUTs for DIFFERENT jobs racing: without serialization one
+        // read-modify-write can swallow the other. Both flips must land.
+        let (_dir, state, ps) = temp_state();
+        let profile = make_user_profile("tenant5");
+        ps.save(&profile).unwrap();
+        let path = seed_cron(
+            &ps,
+            &profile,
+            vec![make_job("one", true), make_job("two", true)],
+        )
+        .await;
+
+        let (a, b) = tokio::join!(
+            set_my_cron_enabled(
+                State(state.clone()),
+                HeaderMap::new(),
+                user_identity("tenant5"),
+                AxumPath("one".into()),
+                Json(ToggleBody { enabled: false }),
+            ),
+            set_my_cron_enabled(
+                State(state.clone()),
+                HeaderMap::new(),
+                user_identity("tenant5"),
+                AxumPath("two".into()),
+                Json(ToggleBody { enabled: false }),
+            )
+        );
+        assert!(a.is_ok() && b.is_ok());
+
+        let reread: octos_bus::CronStore =
+            serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
+        assert!(
+            reread.jobs.iter().all(|j| !j.enabled),
+            "both flips must survive: {reread:?}"
+        );
     }
 }

--- a/crates/octos-cli/src/api/cron_panel.rs
+++ b/crates/octos-cli/src/api/cron_panel.rs
@@ -202,24 +202,16 @@ pub(crate) async fn apply_cron_toggle(
     }
     let updated = job.clone();
     let json = serde_json::to_string_pretty(&store).map_err(|_| ToggleError::Io)?;
-    // Unique per-write temp name: a concurrent writer using a shared
-    // `cron.tmp` could rename OUR content away (or fail on a vanished
-    // temp file). The mutation lock already serializes serve-side
-    // writers; the unique name additionally keeps any out-of-process
-    // writer from colliding on the temp path itself.
-    static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let tmp_path = cron_path.with_extension(format!(
-        "tmp-{}-{}",
-        std::process::id(),
-        TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-    ));
-    if tokio::fs::write(&tmp_path, &json).await.is_err() {
-        return Err(ToggleError::Io);
-    }
-    if tokio::fs::rename(&tmp_path, cron_path).await.is_err() {
-        let _ = tokio::fs::remove_file(&tmp_path).await;
-        return Err(ToggleError::Io);
-    }
+    // Route through the SAME atomic writer CronService uses — one
+    // shared process-global temp-name sequence, so this file path and
+    // a live service can never pick the same cron.tmp-<pid>-<seq> and
+    // consume each other's temp file (codex #1612 r4 P2). Runs on the
+    // blocking pool (it is synchronous fs I/O).
+    let cron_path = cron_path.to_path_buf();
+    tokio::task::spawn_blocking(move || octos_bus::write_cron_json_atomic(&cron_path, &json))
+        .await
+        .map_err(|_| ToggleError::Io)?
+        .map_err(|_| ToggleError::Io)?;
     Ok(updated)
 }
 

--- a/crates/octos-cli/src/api/cron_panel.rs
+++ b/crates/octos-cli/src/api/cron_panel.rs
@@ -9,19 +9,28 @@
 //! events):
 //!
 //! 1. **The serve-side `ProfileRuntime`'s own `CronService`** (started
-//!    for enabled profiles with an LLM). When one is live we route the
-//!    toggle THROUGH it (`CronService::enable_job` — mutates the
-//!    in-memory store, persists, recomputes `next_run_at_ms`, re-arms
-//!    the timer), so there is no drift by construction.
+//!    for enabled profiles with an LLM). Its in-memory store can be
+//!    ARBITRARILY STALE w.r.t. the file (a gateway child may have run
+//!    and written since it loaded), so the toggle routes through
+//!    `CronService::toggle_job_reconciling`: reload-from-disk +
+//!    toggle + persist under ONE store-lock hold — adopting other
+//!    owners' writes instead of erasing them, and propagating
+//!    persistence failures (codex #1612 r2).
 //! 2. **A spawned gateway child process.** Its `CronService` lives in
 //!    another process we cannot call into — the toggle REFUSES with
-//!    `409 {reason: "gateway_running"}` and the SPA routes the user
-//!    through the existing stop/start controls.
+//!    `409 {reason: "gateway_running"}` (re-checked INSIDE the
+//!    mutation lock) and the SPA routes the user through the existing
+//!    stop/start controls.
 //! 3. **Nobody** — the file is the source of truth and the toggle
 //!    applies atomically (unique tmp + rename), mirroring
 //!    `enable_job`'s next-run semantics so a later `CronService::start`
 //!    (which only recomputes jobs whose next run is `None`) does not
 //!    fire a stale deadline.
+//!
+//! Reads (`GET /api/my/cron`) always come from the FILE: every owner
+//! persists synchronously after each mutation, so the file is the one
+//! view that is never staler than its most recent writer — unlike the
+//! parent service's memory (codex #1612 r2 P1).
 //!
 //! All serve-side mutations are serialized behind a process-wide lock
 //! (concurrent PUTs would otherwise race the read-modify-write and drop
@@ -129,16 +138,13 @@ pub async fn my_cron(
     let cron_path = cron_path_for(&ps.resolve_data_dir(&profile));
 
     let running = gateway_running(&state, &profile_id).await;
-    // Prefer the live service's view — it is what the toggle path will
-    // mutate, and it is fresher than the file between persists.
-    let jobs = if let Some(svc) = live_cron_service(&state, &profile_id) {
-        svc.list_all_jobs()
-    } else {
-        match read_cron_store(&cron_path).await {
-            Ok(Some(store)) => store.jobs,
-            Ok(None) => Vec::new(),
-            Err(status) => return Err(status),
-        }
+    // The FILE is the freshest honest view: every owner persists
+    // synchronously after each mutation, while the parent service's
+    // memory can predate a gateway child's whole lifetime.
+    let jobs = match read_cron_store(&cron_path).await {
+        Ok(Some(store)) => store.jobs,
+        Ok(None) => Vec::new(),
+        Err(status) => return Err(status),
     };
 
     let now_ms = Utc::now().timestamp_millis();
@@ -217,24 +223,22 @@ pub(crate) async fn apply_cron_toggle(
     Ok(updated)
 }
 
-/// Route the toggle through a live `CronService` (it owns the store:
-/// persists, recomputes next-run, re-arms its timer). Split from the
-/// handler so the service path is unit-testable without a
-/// `ProfileRuntime`.
+/// Route the toggle through a live `CronService` with reconciliation:
+/// reload-from-disk + toggle + persist under one store-lock hold, so a
+/// stale parent service ADOPTS other owners' writes instead of erasing
+/// them, and save failures surface as errors instead of `ok: true`
+/// (codex #1612 r2). Split from the handler so the service path is
+/// unit-testable without a `ProfileRuntime`.
 pub(crate) fn toggle_via_service(
     svc: &Arc<CronService>,
     job_id: &str,
     enabled: bool,
 ) -> Result<octos_bus::CronJob, ToggleError> {
-    if !svc.enable_job(job_id, enabled) {
-        return Err(ToggleError::NotFound);
+    match svc.toggle_job_reconciling(job_id, enabled) {
+        Ok(Some(job)) => Ok(job),
+        Ok(None) => Err(ToggleError::NotFound),
+        Err(_) => Err(ToggleError::Io),
     }
-    svc.list_all_jobs()
-        .into_iter()
-        .find(|j| j.id == job_id)
-        // Present a beat ago under the store lock; racing deletion is
-        // the only way to lose it. Treat as gone.
-        .ok_or(ToggleError::NotFound)
 }
 
 /// PUT /api/my/cron/{job_id}/enabled
@@ -263,16 +267,16 @@ pub async fn set_my_cron_enabled(
         .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "profile_read_failed"))?
         .ok_or_else(|| err(StatusCode::NOT_FOUND, "profile_not_found"))?;
 
-    // A spawned gateway child owns cron.json from another process; we
-    // can neither call into it nor safely edit under it. Refuse and let
+    let _mutation = CRON_MUTATION_LOCK.lock().await;
+    // Ownership checked INSIDE the lock: a gateway child (or a
+    // ProfileRuntime) that came up while we queued behind another
+    // toggle must be respected, not written under (codex #1612 r2 P2).
+    // A spawned child owns cron.json from another process; we can
+    // neither call into it nor safely edit under it — refuse and let
     // the SPA route the user through the stop/start controls.
     if gateway_running(&state, &profile_id).await {
         return Err(err(StatusCode::CONFLICT, "gateway_running"));
     }
-
-    let _mutation = CRON_MUTATION_LOCK.lock().await;
-    // Resolved INSIDE the lock: a runtime that came up while we waited
-    // must be routed through, not written under.
     let outcome = if let Some(svc) = live_cron_service(&state, &profile_id) {
         toggle_via_service(&svc, &job_id, body.enabled)
     } else {
@@ -524,6 +528,79 @@ mod tests {
         assert!(
             next > now_ms,
             "every-30m job must be scheduled in the future, got {next} vs now {now_ms}"
+        );
+    }
+
+    #[tokio::test]
+    async fn toggle_via_service_adopts_external_writes_instead_of_erasing_them() {
+        // codex #1612 r2 P1: the parent service's memory can predate a
+        // gateway child's whole lifetime. A toggle routed through it
+        // must ADOPT the file's current jobs, not persist its stale
+        // memory over them.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cron.json");
+        let store = octos_bus::CronStore {
+            version: 1,
+            jobs: vec![make_job("old", true)],
+        };
+        tokio::fs::write(&path, serde_json::to_string(&store).unwrap())
+            .await
+            .unwrap();
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        // Service loads {old} into memory…
+        let svc = Arc::new(CronService::new(&path, tx));
+        // …then an external owner (gateway child / CLI) rewrites the
+        // file with an ADDITIONAL job.
+        let external = octos_bus::CronStore {
+            version: 1,
+            jobs: vec![make_job("old", true), make_job("child-added", true)],
+        };
+        tokio::fs::write(&path, serde_json::to_string(&external).unwrap())
+            .await
+            .unwrap();
+
+        // Toggling through the service must see child-added AND keep it.
+        let toggled = toggle_via_service(&svc, "child-added", false).unwrap();
+        assert!(!toggled.enabled);
+        let reread: octos_bus::CronStore =
+            serde_json::from_str(&tokio::fs::read_to_string(&path).await.unwrap()).unwrap();
+        assert_eq!(reread.jobs.len(), 2, "child-added must survive: {reread:?}");
+        assert!(reread.jobs.iter().any(|j| j.id == "old" && j.enabled));
+        assert!(
+            reread
+                .jobs
+                .iter()
+                .any(|j| j.id == "child-added" && !j.enabled)
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn toggle_via_service_surfaces_persistence_failures() {
+        // codex #1612 r2 P2: enable_job swallowed save errors and
+        // reported ok. The reconciling path must propagate them.
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cron.json");
+        let store = octos_bus::CronStore {
+            version: 1,
+            jobs: vec![make_job("one", true)],
+        };
+        tokio::fs::write(&path, serde_json::to_string(&store).unwrap())
+            .await
+            .unwrap();
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let svc = Arc::new(CronService::new(&path, tx));
+
+        let live = std::fs::metadata(dir.path()).unwrap().permissions();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
+        let outcome = toggle_via_service(&svc, "one", false);
+        std::fs::set_permissions(dir.path(), live).unwrap();
+
+        assert!(
+            matches!(outcome, Err(ToggleError::Io)),
+            "failed persistence must not report ok: {outcome:?}"
         );
     }
 

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod agent_orchestrator;
 pub mod auth_handlers;
 mod bilibili;
 pub(crate) mod coding_tool_contract;
+mod cron_panel;
 mod events;
 mod events_harness;
 mod frps_plugin;

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -16,6 +16,7 @@ use super::admin_audit;
 use super::admin_setup;
 use super::auth_handlers;
 use super::bilibili;
+use super::cron_panel;
 use super::events_harness;
 use super::frps_plugin;
 use super::handlers;
@@ -217,6 +218,13 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/my/voice", put(auth_handlers::set_my_voice))
         // Per-tenant voice-assistant pre-flight: ASR + LLM + (route-aware) TTS.
         .route("/api/voice/readiness", get(auth_handlers::voice_readiness))
+        // Cron panel (web parity P3): user-scoped schedule list + the
+        // enable toggle (409 while the profile gateway owns cron.json).
+        .route("/api/my/cron", get(cron_panel::my_cron))
+        .route(
+            "/api/my/cron/{job_id}/enabled",
+            put(cron_panel::set_my_cron_enabled),
+        )
         .route("/api/my/soul", get(auth_handlers::my_soul))
         .route("/api/my/soul", put(auth_handlers::update_my_soul))
         .route("/api/my/soul", delete(auth_handlers::delete_my_soul))


### PR DESCRIPTION
Server half of web-parity P3 item 7 (cron list/toggle in settings). The octos-web settings tab consumes these.

## Endpoints
- `GET /api/my/cron` → `{ok, count, jobs[…admin-list shape…], gateway_running}`
- `PUT /api/my/cron/{job_id}/enabled` `{enabled}` → `{ok, job}` | `404 job_not_found` | `409 {reason: gateway_running}`

## Why the 409
Cron jobs execute inside the profile's **gateway process**; its `CronService` holds `cron.json` in memory and rewrites the file wholesale on its own events (per-run state updates). A serve-side edit while it runs is a silent lost-update — so the toggle only applies while the gateway is stopped (atomic tmp+rename, the service's own persistence pattern) and the SPA routes through the existing stop/start controls otherwise. A gateway-side control channel is the correct long-term fix and out of scope here.

## Gates
5 unit tests (zero-state, admin-shape list, flip+persist, 404s, sibling isolation); `cargo test -p octos-cli --features api` compiles; fmt/clippy clean on the new module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)