### PR TITLE
feat(session): session/fork RPC — branch a session with copied history

### DIFF
--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -1903,6 +1903,14 @@ impl SessionManager {
     /// Serialises on the per-key persist lock so the whole-file rewrite
     /// cannot interleave with (and erase) a canonical locked append or a
     /// concurrent `SessionHandle` rewrite of the same key.
+    /// The directory session files persist under — the on-disk
+    /// collision domain for fork child keys (serve scopes its fork
+    /// reservations by it; two managers over the same dir CAN collide,
+    /// two different profiles' dirs cannot).
+    pub fn sessions_dir(&self) -> &std::path::Path {
+        &self.sessions_dir
+    }
+
     pub async fn rewrite(&self, key: &SessionKey) -> Result<()> {
         let lock = persist_lock_for(key);
         let _guard = lock.lock().await;
@@ -3977,11 +3985,8 @@ mod tests {
         assert_eq!(child.messages[2].content, "msg4");
     }
 
-    #[cfg(unix)]
     #[tokio::test]
     async fn test_fork_failed_write_leaves_no_ghost_child() {
-        use std::os::unix::fs::PermissionsExt;
-
         let tmp = TempDir::new().unwrap();
         let mut mgr = SessionManager::open(tmp.path()).unwrap();
         let parent = SessionKey::new("cli", "ghost-parent");
@@ -3989,15 +3994,18 @@ mod tests {
             .await
             .unwrap();
 
-        // Make the sessions dir unwritable so the child rewrite fails.
+        // Replace the sessions DIR with a regular FILE: creating the
+        // child's jsonl under it fails with ENOTDIR for EVERY euid —
+        // unlike a 0o555 mode, which root bypasses (codex #1613 r2).
         let sessions_dir = tmp.path().join("sessions");
-        let live = std::fs::metadata(&sessions_dir).unwrap().permissions();
-        std::fs::set_permissions(&sessions_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+        std::fs::remove_dir_all(&sessions_dir).unwrap();
+        std::fs::write(&sessions_dir, b"not a directory").unwrap();
 
         let result = mgr.fork(&parent, "ghost-child", 1).await;
-        // Restore before asserting so the tempdir can clean up even on
-        // a failed assertion.
-        std::fs::set_permissions(&sessions_dir, live).unwrap();
+        // Restore the real directory before asserting so the retry leg
+        // below can succeed.
+        std::fs::remove_file(&sessions_dir).unwrap();
+        std::fs::create_dir_all(&sessions_dir).unwrap();
 
         assert!(result.is_err(), "fork must surface the failed write");
         assert!(

--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -1969,9 +1969,9 @@ impl SessionManager {
     ) -> Result<SessionKey> {
         let parent = self.get_or_create(parent_key).await;
         let messages: Vec<Message> = parent.get_history(copy_messages).to_vec();
-        // Derive channel from parent key (format: "channel:chat_id")
-        let channel = parent_key.0.split(':').next().unwrap_or("cli");
-        let new_key = SessionKey::new(channel, new_chat_id);
+        // Shared derivation rule (SessionKey::fork_child): profile +
+        // channel preserved, raw SPA parents yield raw children.
+        let new_key = parent_key.fork_child(new_chat_id);
 
         let now = Utc::now();
         let session = Session {
@@ -1987,7 +1987,14 @@ impl SessionManager {
             updated_at: now,
         };
         self.cache.put(new_key.0.clone(), session);
-        self.rewrite(&new_key).await?;
+        if let Err(error) = self.rewrite(&new_key).await {
+            // A failed write must not leave a cache-resident ghost:
+            // `session_known` would keep answering true for a child
+            // that was never durably created, wedging retries on
+            // `child_exists` (codex #1613 P2).
+            self.cache.pop(&new_key.0);
+            return Err(error);
+        }
 
         debug!(
             parent = %parent_key,
@@ -3968,6 +3975,38 @@ mod tests {
         assert_eq!(child.messages.len(), 3);
         assert_eq!(child.messages[0].content, "msg2");
         assert_eq!(child.messages[2].content, "msg4");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_fork_failed_write_leaves_no_ghost_child() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let mut mgr = SessionManager::open(tmp.path()).unwrap();
+        let parent = SessionKey::new("cli", "ghost-parent");
+        mgr.add_message(&parent, make_message(MessageRole::User, "hello"))
+            .await
+            .unwrap();
+
+        // Make the sessions dir unwritable so the child rewrite fails.
+        let sessions_dir = tmp.path().join("sessions");
+        let live = std::fs::metadata(&sessions_dir).unwrap().permissions();
+        std::fs::set_permissions(&sessions_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let result = mgr.fork(&parent, "ghost-child", 1).await;
+        // Restore before asserting so the tempdir can clean up even on
+        // a failed assertion.
+        std::fs::set_permissions(&sessions_dir, live).unwrap();
+
+        assert!(result.is_err(), "fork must surface the failed write");
+        assert!(
+            !mgr.session_known(&SessionKey::new("cli", "ghost-child")),
+            "failed fork must not leave a cache-resident ghost child"
+        );
+        // And a retry once storage recovers succeeds.
+        let retried = mgr.fork(&parent, "ghost-child", 1).await.unwrap();
+        assert_eq!(retried, SessionKey::new("cli", "ghost-child"));
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -676,8 +676,12 @@ pub async fn verify(
                     .await
             }
             Some(RootLoginTarget::Allowlisted) => {
+                // Allowlist provenance authorizes claiming a
+                // pre-provisioned profile under the derived id — the
+                // profile probe must not bump the invitee to `<id>-1`
+                // (codex #1613 r7 P1).
                 auth_mgr
-                    .verify_otp_with_registration(&requested_email, &req.code, true)
+                    .verify_otp_with_authorized_claim(&requested_email, &req.code)
                     .await
             }
             None if auth_mgr.allow_self_registration() => {

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -4386,6 +4386,17 @@ async fn ui_protocol_connection(
                 )
                 .await;
             }
+            UiCommand::SessionFork(params) => {
+                handle_session_fork(
+                    &ws,
+                    &state,
+                    connection_profile_id,
+                    routed_profile_id,
+                    id,
+                    params,
+                )
+                .await;
+            }
             UiCommand::ThreadGraphGet(params) => {
                 handle_thread_graph_get(
                     &ws,
@@ -5028,6 +5039,17 @@ where
                     &state,
                     &ledger,
                     &active_turns,
+                    connection_profile_id_owned.as_deref(),
+                    None,
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::SessionFork(params) => {
+                handle_session_fork(
+                    &ws,
+                    &state,
                     connection_profile_id_owned.as_deref(),
                     None,
                     id,
@@ -8527,6 +8549,7 @@ fn session_ingress_callable_method(method: &str) -> bool {
             | octos_core::ui_protocol::methods::CONTENT_LIST
             | octos_core::ui_protocol::methods::CONTENT_DELETE
             | octos_core::ui_protocol::methods::CONTENT_BULK_DELETE
+            | octos_core::ui_protocol::methods::SESSION_FORK
     )
 }
 
@@ -8549,7 +8572,8 @@ fn validate_session_ingress_command_scope(
         | UiCommand::SystemStatusGet(_)
         | UiCommand::ContentList(_)
         | UiCommand::ContentDelete(_)
-        | UiCommand::ContentBulkDelete(_) => {
+        | UiCommand::ContentBulkDelete(_)
+        | UiCommand::SessionFork(_) => {
             return Err(RpcError::invalid_request(
                 "session ingress credentials may only call session-scoped methods",
             ));
@@ -12851,6 +12875,117 @@ async fn handle_session_rollback(
     let result = SessionRollbackResult {
         dropped_turns,
         thread,
+    };
+    send_serialized_rpc_result(ws, id, method, result);
+}
+
+/// `session/fork` — branch a NEW session off an existing one, copying
+/// the tail of its history (web parity P3: the book's documented fork
+/// affordance had no wire surface for the SPA; `SessionManager::fork`
+/// existed but had no production caller). MUTATING: writes the child
+/// session (parent tracked via `parent_key`).
+async fn handle_session_fork(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    connection_profile_id: Option<&str>,
+    routed_profile_id: Option<&str>,
+    id: String,
+    params: octos_core::ui_protocol::SessionForkParams,
+) {
+    let method = octos_core::ui_protocol::methods::SESSION_FORK;
+    if let Err(error) = validate_session_scope(&params.session_id, None, connection_profile_id) {
+        send_scope_error(ws, id, error);
+        return;
+    }
+    // The child chat-id becomes a filesystem path component and a wire
+    // session key half — hold it to the same charset as topic names.
+    if let Err(reason) = octos_bus::validate_topic_name(&params.new_chat_id) {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            RpcError::invalid_params(format!("{method}: invalid new_chat_id: {reason}"))
+                .with_data(json!({ "kind": "invalid_new_chat_id" })),
+        );
+        return;
+    }
+
+    let Some(sessions) = resolve_sessions_for_lookup(
+        state,
+        connection_profile_id,
+        routed_profile_id,
+        &params.session_id,
+    )
+    .await
+    else {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            runtime_unavailable_error("Sessions not available"),
+        );
+        return;
+    };
+
+    let (new_key, copied) = {
+        let mut sessions_guard = sessions.lock().await;
+        // Mirror rollback's error model: fork of an unknown session is
+        // an error, not an auto-create.
+        if !sessions_guard.session_known(&params.session_id) {
+            drop(sessions_guard);
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::unknown_session(params.session_id.0.clone()),
+            );
+            return;
+        }
+        // Refuse to clobber an existing session under the child key. The
+        // candidate key MUST be derived exactly as `SessionManager::fork`
+        // derives it (naive first-segment split), or the pre-check would
+        // guard a different key than the one fork writes.
+        let channel = params.session_id.0.split(':').next().unwrap_or("cli");
+        let candidate = SessionKey::new(channel, &params.new_chat_id);
+        if sessions_guard.session_known(&candidate) {
+            drop(sessions_guard);
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::invalid_params(format!(
+                    "{method}: a session already exists for '{candidate}'"
+                ))
+                .with_data(json!({ "kind": "child_exists" })),
+            );
+            return;
+        }
+        // Absent copy_messages → the FULL parent history.
+        let copy = params
+            .copy_messages
+            .map(|n| n as usize)
+            .unwrap_or(usize::MAX);
+        let copied_upper = {
+            let parent = sessions_guard.get_or_create(&params.session_id).await;
+            parent.messages.len().min(copy)
+        };
+        match sessions_guard
+            .fork(&params.session_id, &params.new_chat_id, copy)
+            .await
+        {
+            Ok(new_key) => (new_key, copied_upper as u32),
+            Err(error) => {
+                drop(sessions_guard);
+                let _ = send_rpc_error(
+                    ws,
+                    Some(id),
+                    RpcError::internal_error(format!("{method}: {error}")),
+                );
+                return;
+            }
+        }
+    };
+
+    let result = octos_core::ui_protocol::SessionForkResult {
+        new_session_id: new_key,
+        parent_session_id: params.session_id,
+        copied_messages: copied,
     };
     send_serialized_rpc_result(ws, id, method, result);
 }
@@ -24307,6 +24442,10 @@ mod tests {
                 "session_id": session_id.to_string(),
                 "title": "Dispatch parity",
             }),
+            methods::SESSION_FORK => json!({
+                "session_id": session_id,
+                "new_chat_id": "probe-fork-child",
+            }),
             methods::CONTENT_DELETE => json!({ "id": "content-1" }),
             methods::CONTENT_BULK_DELETE => json!({ "ids": ["content-1"] }),
             methods::ROUTER_SET_MODE => json!({
@@ -33146,6 +33285,7 @@ ignore = []
             octos_core::ui_protocol::methods::CONTENT_LIST,
             octos_core::ui_protocol::methods::CONTENT_DELETE,
             octos_core::ui_protocol::methods::CONTENT_BULK_DELETE,
+            octos_core::ui_protocol::methods::SESSION_FORK,
         ] {
             assert!(
                 !session_ingress_callable_method(m),
@@ -37148,6 +37288,216 @@ ignore = []
             !turn_ids.contains(&turn_drop.0.to_string()),
             "dropped turn 2 must be excluded from thread.turns; got {turn_ids:?}"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_fork_copies_full_history_by_default() {
+        let session_id = SessionKey("local:fork-parent".into());
+        // 3 turns -> 6 messages persisted on the parent.
+        let (state, _tmp) = prg_state_with_persisted_turns(&session_id, 3).await;
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        handle_session_fork(
+            &ws,
+            &state,
+            None,
+            None,
+            "fk1".into(),
+            octos_core::ui_protocol::SessionForkParams {
+                session_id: session_id.clone(),
+                new_chat_id: "fork-child".into(),
+                copy_messages: None,
+            },
+        )
+        .await;
+
+        let frame = recv_rpc_json(&mut rx).await;
+        assert_eq!(frame["id"], "fk1");
+        let result = &frame["result"];
+        assert_eq!(result["new_session_id"], "local:fork-child");
+        assert_eq!(result["parent_session_id"], session_id.to_string());
+        assert_eq!(result["copied_messages"], 6);
+
+        // The child must exist on the manager, carry parent lineage, and
+        // hold the full copied history.
+        let sessions = state.sessions.as_ref().expect("sessions");
+        let mut guard = sessions.lock().await;
+        let child_key = SessionKey("local:fork-child".into());
+        assert!(
+            guard.session_known(&child_key),
+            "child session must persist"
+        );
+        let child = guard.get_or_create(&child_key).await;
+        assert_eq!(child.parent_key.as_ref(), Some(&session_id));
+        assert_eq!(child.messages.len(), 6);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_fork_copies_only_requested_tail() {
+        let session_id = SessionKey("local:fork-tail".into());
+        let (state, _tmp) = prg_state_with_persisted_turns(&session_id, 3).await;
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        handle_session_fork(
+            &ws,
+            &state,
+            None,
+            None,
+            "fk2".into(),
+            octos_core::ui_protocol::SessionForkParams {
+                session_id: session_id.clone(),
+                new_chat_id: "tail-child".into(),
+                copy_messages: Some(2),
+            },
+        )
+        .await;
+
+        let frame = recv_rpc_json(&mut rx).await;
+        assert_eq!(frame["result"]["copied_messages"], 2);
+        let sessions = state.sessions.as_ref().expect("sessions");
+        let mut guard = sessions.lock().await;
+        let child = guard
+            .get_or_create(&SessionKey("local:tail-child".into()))
+            .await;
+        assert_eq!(child.messages.len(), 2);
+        // Tail = the LAST turn (user + assistant of turn 3).
+        assert_eq!(child.messages[0].content, "turn 3");
+        assert_eq!(child.messages[1].content, "reply 3");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_fork_unknown_session_errors() {
+        let seeded = SessionKey("local:fork-seeded".into());
+        let (state, _tmp) = prg_state_with_persisted_turns(&seeded, 1).await;
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        handle_session_fork(
+            &ws,
+            &state,
+            None,
+            None,
+            "fk3".into(),
+            octos_core::ui_protocol::SessionForkParams {
+                session_id: SessionKey("local:never-created".into()),
+                new_chat_id: "child".into(),
+                copy_messages: None,
+            },
+        )
+        .await;
+
+        let frame = recv_rpc_json(&mut rx).await;
+        assert!(
+            frame.get("error").is_some(),
+            "fork of an unknown session must error, not auto-create"
+        );
+        // Fork must NOT have created either session as a side effect.
+        let sessions = state.sessions.as_ref().expect("sessions");
+        let mut guard = sessions.lock().await;
+        assert!(!guard.session_known(&SessionKey("local:never-created".into())));
+        assert!(!guard.session_known(&SessionKey("local:child".into())));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_fork_refuses_existing_child_key() {
+        let session_id = SessionKey("local:fork-clobber".into());
+        let (state, _tmp) = prg_state_with_persisted_turns(&session_id, 2).await;
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        for id in ["fka", "fkb"] {
+            handle_session_fork(
+                &ws,
+                &state,
+                None,
+                None,
+                id.into(),
+                octos_core::ui_protocol::SessionForkParams {
+                    session_id: session_id.clone(),
+                    new_chat_id: "same-child".into(),
+                    copy_messages: None,
+                },
+            )
+            .await;
+        }
+
+        let first = recv_rpc_json(&mut rx).await;
+        assert!(first.get("result").is_some(), "first fork succeeds");
+        let second = recv_rpc_json(&mut rx).await;
+        assert_eq!(
+            second["error"]["data"]["kind"], "child_exists",
+            "second fork onto the same child key must refuse, not clobber"
+        );
+
+        // The child's history must be the FIRST fork's copy, untouched.
+        let sessions = state.sessions.as_ref().expect("sessions");
+        let mut guard = sessions.lock().await;
+        let child = guard
+            .get_or_create(&SessionKey("local:same-child".into()))
+            .await;
+        assert_eq!(child.messages.len(), 4);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_fork_rejects_invalid_chat_id() {
+        let session_id = SessionKey("local:fork-badname".into());
+        let (state, _tmp) = prg_state_with_persisted_turns(&session_id, 1).await;
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        handle_session_fork(
+            &ws,
+            &state,
+            None,
+            None,
+            "fk4".into(),
+            octos_core::ui_protocol::SessionForkParams {
+                session_id: session_id.clone(),
+                new_chat_id: "../escape".into(),
+                copy_messages: None,
+            },
+        )
+        .await;
+
+        let frame = recv_rpc_json(&mut rx).await;
+        assert_eq!(frame["error"]["data"]["kind"], "invalid_new_chat_id");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_fork_enforces_connection_scope() {
+        // A profile-PREFIXED session id names another tenant's scope
+        // outright; a connection bound to "tenant-b" must be refused.
+        // (Un-prefixed ids are accepted by SPA convention — isolation for
+        // those comes from per-profile runtime resolution.)
+        let session_id = SessionKey("tenant-a:local:fork-scope".into());
+        let (state, _tmp) = prg_state_with_persisted_turns(&session_id, 1).await;
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        handle_session_fork(
+            &ws,
+            &state,
+            Some("tenant-b"),
+            None,
+            "fk5".into(),
+            octos_core::ui_protocol::SessionForkParams {
+                session_id: session_id.clone(),
+                new_chat_id: "stolen".into(),
+                copy_messages: None,
+            },
+        )
+        .await;
+
+        // Scope violations close 1008-first (see
+        // send_scope_error_closes_with_1008_on_authenticated_mismatch).
+        let first = rx.recv().await.expect("close frame");
+        match first {
+            axum::extract::ws::Message::Close(Some(frame)) => {
+                assert_eq!(frame.code, 1008);
+            }
+            other => panic!("expected 1008 close on cross-scope fork, got {other:?}"),
+        }
+        // And the fork must NOT have happened.
+        let sessions = state.sessions.as_ref().expect("sessions");
+        let mut guard = sessions.lock().await;
+        assert!(!guard.session_known(&SessionKey("tenant-a:local:stolen".into())));
+        assert!(!guard.session_known(&SessionKey("local:stolen".into())));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -12903,7 +12903,14 @@ impl ForkReservation {
     /// `None` when another fork to the same child key in the same
     /// sessions dir is in flight.
     fn try_acquire(sessions_dir: &Path, child_key: &SessionKey) -> Option<Self> {
-        let key = (sessions_dir.to_path_buf(), child_key.0.clone());
+        // Canonicalized: two managers can reach one on-disk dir through
+        // different spellings (`..` segments, symlinked data_dir
+        // overrides) — distinct PathBufs would defeat the reservation
+        // (codex #1613 r3). The dir exists (the manager created it), so
+        // canonicalize only fails on races — fall back to the raw path.
+        let dir =
+            std::fs::canonicalize(sessions_dir).unwrap_or_else(|_| sessions_dir.to_path_buf());
+        let key = (dir, child_key.0.clone());
         let mut set = fork_reservations()
             .lock()
             .unwrap_or_else(|e| e.into_inner());

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -12879,6 +12879,41 @@ async fn handle_session_rollback(
     send_serialized_rpc_result(ws, id, method, result);
 }
 
+/// Process-global in-flight fork child-key reservations. Two forks
+/// from DIFFERENT parents resolve different per-session
+/// `SessionManager`s, so a manager-local existence check cannot see
+/// the other fork mid-write — the later rewrite would silently
+/// overwrite the earlier child (codex #1613 P2). One serve process
+/// owns a profile's sessions dir, so a process-global set suffices.
+fn fork_reservations() -> &'static std::sync::Mutex<std::collections::HashSet<String>> {
+    static RESERVATIONS: OnceLock<std::sync::Mutex<std::collections::HashSet<String>>> =
+        OnceLock::new();
+    RESERVATIONS.get_or_init(Default::default)
+}
+
+/// RAII reservation on a fork child key — released on every exit path.
+struct ForkReservation(String);
+
+impl ForkReservation {
+    /// `None` when another fork to the same child key is in flight.
+    fn try_acquire(child_key: &SessionKey) -> Option<Self> {
+        let mut set = fork_reservations()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set.insert(child_key.0.clone())
+            .then(|| Self(child_key.0.clone()))
+    }
+}
+
+impl Drop for ForkReservation {
+    fn drop(&mut self) {
+        let mut set = fork_reservations()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set.remove(&self.0);
+    }
+}
+
 /// `session/fork` — branch a NEW session off an existing one, copying
 /// the tail of its history (web parity P3: the book's documented fork
 /// affordance had no wire surface for the SPA; `SessionManager::fork`
@@ -12925,6 +12960,22 @@ async fn handle_session_fork(
         return;
     };
 
+    // Reserve the child key across the whole check-then-write: the
+    // durable `session_known` check below cannot see a concurrent
+    // fork's child until its write lands (RAII — released on return).
+    let candidate_key = params.session_id.fork_child(&params.new_chat_id);
+    let Some(_reservation) = ForkReservation::try_acquire(&candidate_key) else {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            RpcError::invalid_params(format!(
+                "{method}: a fork to '{candidate_key}' is already in flight"
+            ))
+            .with_data(json!({ "kind": "child_exists" })),
+        );
+        return;
+    };
+
     let (new_key, copied) = {
         let mut sessions_guard = sessions.lock().await;
         // Mirror rollback's error model: fork of an unknown session is
@@ -12938,12 +12989,10 @@ async fn handle_session_fork(
             );
             return;
         }
-        // Refuse to clobber an existing session under the child key. The
-        // candidate key MUST be derived exactly as `SessionManager::fork`
-        // derives it (naive first-segment split), or the pre-check would
-        // guard a different key than the one fork writes.
-        let channel = params.session_id.0.split(':').next().unwrap_or("cli");
-        let candidate = SessionKey::new(channel, &params.new_chat_id);
+        // Refuse to clobber an existing session under the child key.
+        // `SessionKey::fork_child` is the SAME rule `SessionManager::fork`
+        // applies, so the pre-check guards exactly the key fork writes.
+        let candidate = params.session_id.fork_child(&params.new_chat_id);
         if sessions_guard.session_known(&candidate) {
             drop(sessions_guard);
             let _ = send_rpc_error(
@@ -37458,6 +37507,108 @@ ignore = []
 
         let frame = recv_rpc_json(&mut rx).await;
         assert_eq!(frame["error"]["data"]["kind"], "invalid_new_chat_id");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_fork_raw_spa_parent_yields_raw_child() {
+        // codex #1613 P1: a raw SPA handle ("web-123") must NOT be
+        // treated as a channel — the child is a raw handle too, not
+        // "web-123:kid" (excluded from the raw REST fallbacks).
+        let session_id = SessionKey("web-123".into());
+        let (state, _tmp) = prg_state_with_persisted_turns(&session_id, 1).await;
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        handle_session_fork(
+            &ws,
+            &state,
+            None,
+            None,
+            "fk-raw".into(),
+            octos_core::ui_protocol::SessionForkParams {
+                session_id: session_id.clone(),
+                new_chat_id: "web-456".into(),
+                copy_messages: None,
+            },
+        )
+        .await;
+
+        let frame = recv_rpc_json(&mut rx).await;
+        assert_eq!(frame["result"]["new_session_id"], "web-456");
+        let sessions = state.sessions.as_ref().expect("sessions");
+        let mut guard = sessions.lock().await;
+        assert!(guard.session_known(&SessionKey("web-456".into())));
+        assert!(
+            !guard.session_known(&SessionKey("web-123:web-456".into())),
+            "the naive channel-split key must not exist"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn session_fork_concurrent_same_child_one_wins() {
+        // codex #1613 P2: two forks from DIFFERENT parents racing to
+        // the same child key — exactly one may win; the loser must not
+        // silently overwrite the winner's copied history.
+        let parent_a = SessionKey("local:race-a".into());
+        let parent_b = SessionKey("local:race-b".into());
+        let (state, _tmp) = prg_state_with_persisted_turns(&parent_a, 1).await;
+        {
+            // Seed the second parent on the same manager.
+            let sessions = state.sessions.as_ref().expect("sessions");
+            let mut guard = sessions.lock().await;
+            let now = Utc::now();
+            let msg = Message {
+                role: MessageRole::User,
+                content: "b says".into(),
+                media: vec![],
+                tool_calls: None,
+                tool_call_id: None,
+                reasoning_content: None,
+                client_message_id: None,
+                thread_id: None,
+                timestamp: now,
+            };
+            guard.add_message(&parent_b, msg).await.expect("seed b");
+        }
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        let fork = |parent: SessionKey, id: &str| {
+            let ws = &ws;
+            let state = &state;
+            let id = id.to_string();
+            async move {
+                handle_session_fork(
+                    ws,
+                    state,
+                    None,
+                    None,
+                    id,
+                    octos_core::ui_protocol::SessionForkParams {
+                        session_id: parent,
+                        new_chat_id: "contested".into(),
+                        copy_messages: None,
+                    },
+                )
+                .await;
+            }
+        };
+        tokio::join!(
+            fork(parent_a.clone(), "fk-a"),
+            fork(parent_b.clone(), "fk-b")
+        );
+
+        let first = recv_rpc_json(&mut rx).await;
+        let second = recv_rpc_json(&mut rx).await;
+        let oks = [&first, &second]
+            .iter()
+            .filter(|f| f.get("result").is_some())
+            .count();
+        assert_eq!(oks, 1, "exactly one fork wins: {first} / {second}");
+        let loser = if first.get("error").is_some() {
+            &first
+        } else {
+            &second
+        };
+        assert_eq!(loser["error"]["data"]["kind"], "child_exists");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -12883,25 +12883,31 @@ async fn handle_session_rollback(
 /// from DIFFERENT parents resolve different per-session
 /// `SessionManager`s, so a manager-local existence check cannot see
 /// the other fork mid-write — the later rewrite would silently
-/// overwrite the earlier child (codex #1613 P2). One serve process
-/// owns a profile's sessions dir, so a process-global set suffices.
-fn fork_reservations() -> &'static std::sync::Mutex<std::collections::HashSet<String>> {
-    static RESERVATIONS: OnceLock<std::sync::Mutex<std::collections::HashSet<String>>> =
+/// overwrite the earlier child (codex #1613 P2). Keyed by
+/// `(sessions_dir, child key)`: the sessions DIR is the on-disk
+/// collision domain — same-profile managers share it and must
+/// mutually exclude, while different profiles' identical child keys
+/// name different files and must NOT reject each other (codex #1613
+/// r2). One serve process owns a profile's sessions dir, so a
+/// process-global set suffices.
+fn fork_reservations() -> &'static std::sync::Mutex<std::collections::HashSet<(PathBuf, String)>> {
+    static RESERVATIONS: OnceLock<std::sync::Mutex<std::collections::HashSet<(PathBuf, String)>>> =
         OnceLock::new();
     RESERVATIONS.get_or_init(Default::default)
 }
 
 /// RAII reservation on a fork child key — released on every exit path.
-struct ForkReservation(String);
+struct ForkReservation((PathBuf, String));
 
 impl ForkReservation {
-    /// `None` when another fork to the same child key is in flight.
-    fn try_acquire(child_key: &SessionKey) -> Option<Self> {
+    /// `None` when another fork to the same child key in the same
+    /// sessions dir is in flight.
+    fn try_acquire(sessions_dir: &Path, child_key: &SessionKey) -> Option<Self> {
+        let key = (sessions_dir.to_path_buf(), child_key.0.clone());
         let mut set = fork_reservations()
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        set.insert(child_key.0.clone())
-            .then(|| Self(child_key.0.clone()))
+        set.insert(key.clone()).then(|| Self(key))
     }
 }
 
@@ -12960,24 +12966,28 @@ async fn handle_session_fork(
         return;
     };
 
-    // Reserve the child key across the whole check-then-write: the
-    // durable `session_known` check below cannot see a concurrent
-    // fork's child until its write lands (RAII — released on return).
-    let candidate_key = params.session_id.fork_child(&params.new_chat_id);
-    let Some(_reservation) = ForkReservation::try_acquire(&candidate_key) else {
-        let _ = send_rpc_error(
-            ws,
-            Some(id),
-            RpcError::invalid_params(format!(
-                "{method}: a fork to '{candidate_key}' is already in flight"
-            ))
-            .with_data(json!({ "kind": "child_exists" })),
-        );
-        return;
-    };
-
     let (new_key, copied) = {
         let mut sessions_guard = sessions.lock().await;
+        // Reserve the child key across the whole check-then-write: the
+        // durable `session_known` check below cannot see a concurrent
+        // fork's child (a DIFFERENT parent's manager) until its write
+        // lands. Scoped to this manager's sessions dir — the on-disk
+        // collision domain (RAII — released on return).
+        let candidate_key = params.session_id.fork_child(&params.new_chat_id);
+        let Some(_reservation) =
+            ForkReservation::try_acquire(sessions_guard.sessions_dir(), &candidate_key)
+        else {
+            drop(sessions_guard);
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::invalid_params(format!(
+                    "{method}: a fork to '{candidate_key}' is already in flight"
+                ))
+                .with_data(json!({ "kind": "child_exists" })),
+            );
+            return;
+        };
         // Mirror rollback's error model: fork of an unknown session is
         // an error, not an auto-create.
         if !sessions_guard.session_known(&params.session_id) {
@@ -37507,6 +37517,29 @@ ignore = []
 
         let frame = recv_rpc_json(&mut rx).await;
         assert_eq!(frame["error"]["data"]["kind"], "invalid_new_chat_id");
+    }
+
+    #[test]
+    fn fork_reservations_scope_by_sessions_dir() {
+        // codex #1613 r2: identical child keys in DIFFERENT profiles'
+        // sessions dirs name different files — they must not exclude
+        // each other. Same dir + same key must.
+        let child = SessionKey("local:contested".into());
+        let dir_a = std::path::Path::new("/tmp/profile-a/sessions");
+        let dir_b = std::path::Path::new("/tmp/profile-b/sessions");
+
+        let a = ForkReservation::try_acquire(dir_a, &child).expect("dir A reserves");
+        let b = ForkReservation::try_acquire(dir_b, &child);
+        assert!(b.is_some(), "different sessions dir must not collide");
+        assert!(
+            ForkReservation::try_acquire(dir_a, &child).is_none(),
+            "same dir + same child key must exclude"
+        );
+        drop(a);
+        assert!(
+            ForkReservation::try_acquire(dir_a, &child).is_some(),
+            "released reservation must be reacquirable"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -6027,6 +6027,18 @@ fn normalize_local_username(username: &str) -> Result<String, RpcError> {
             "normalized username must be 1-64 characters",
         ));
     }
+    // The username becomes BOTH the user id and the profile id.
+    // Profile ids reject reserved channel names (ambiguous session
+    // keys — see profiles::validate_profile_id), so reject here BEFORE
+    // any record persists: previously the user record was saved first
+    // and only the later profile save failed, leaving a valid user
+    // with no usable profile (codex #1613 r5).
+    if octos_core::is_reserved_channel_name(&normalized) {
+        return Err(local_profile_error(
+            "profile_local_invalid_username",
+            "username must not be a reserved channel name (e.g. api, slack, line)",
+        ));
+    }
     Ok(normalized)
 }
 
@@ -25404,6 +25416,26 @@ mod tests {
         assert_eq!(
             invalid.data.as_ref().and_then(|data| data.get("kind")),
             Some(&json!("profile_local_invalid_username"))
+        );
+
+        // codex #1613 r5: a reserved channel-name username must be
+        // rejected BEFORE any record persists. Previously the user
+        // record was saved and only the later profile save failed,
+        // leaving a valid user with no usable profile.
+        let reserved = create_or_get_local_solo_profile(
+            &state,
+            local_profile_params("Ada Lovelace", "api", "api@example.com"),
+        )
+        .expect_err("reserved channel-name username");
+        assert_eq!(reserved.code, rpc_error_codes::INVALID_PARAMS);
+        assert_eq!(
+            reserved.data.as_ref().and_then(|data| data.get("kind")),
+            Some(&json!("profile_local_invalid_username"))
+        );
+        let users = state.user_store.as_ref().expect("user store");
+        assert!(
+            users.get("api").unwrap().is_none(),
+            "no user record may persist for a rejected reserved username"
         );
 
         let tenant_state = AppState {

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -571,7 +571,16 @@ impl ServeCommand {
             };
             let mut mgr = crate::otp::AuthManager::new(auth_config.clone(), user_store.clone())
                 .with_sessions_path(data_dir.join("auth_sessions.json"))
-                .with_data_dir(data_dir.clone());
+                .with_data_dir(data_dir.clone())
+                // Registration id generation must treat an existing
+                // PROFILE file as taken, or a generated id claims an
+                // admin-created-but-unclaimed profile (codex #1613 r6).
+                // Raw path probe, not get(): corrupt or quarantined
+                // profile json still counts as occupied.
+                .with_id_taken_probe({
+                    let ps = profile_store.clone();
+                    std::sync::Arc::new(move |id: &str| ps.profile_path(id).exists())
+                });
 
             if let Some(password) = derived_profile_password {
                 mgr = mgr.with_smtp_password(password);

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -574,12 +574,16 @@ impl ServeCommand {
                 .with_data_dir(data_dir.clone())
                 // Registration id generation must treat an existing
                 // PROFILE file as taken, or a generated id claims an
-                // admin-created-but-unclaimed profile (codex #1613 r6).
-                // Raw path probe, not get(): corrupt or quarantined
-                // profile json still counts as occupied.
+                // admin-created-but-unclaimed profile (codex #1613
+                // r6/r8). Policy lives on the store — see
+                // id_reserved_for_registration: anonymous claims never
+                // pass a file; authorized (allowlist) claims pass only
+                // a cleanly-loadable record.
                 .with_id_taken_probe({
                     let ps = profile_store.clone();
-                    std::sync::Arc::new(move |id: &str| ps.profile_path(id).exists())
+                    std::sync::Arc::new(move |id: &str, authorized: bool| {
+                        ps.id_reserved_for_registration(id, authorized)
+                    })
                 });
 
             if let Some(password) = derived_profile_password {

--- a/crates/octos-cli/src/otp.rs
+++ b/crates/octos-cli/src/otp.rs
@@ -93,6 +93,10 @@ pub struct TestEmail {
     pub html: String,
 }
 
+/// `(candidate_id, authorized_for_candidate) -> taken`. See
+/// [`AuthManager::with_id_taken_probe`].
+pub type IdTakenProbe = Arc<dyn Fn(&str, bool) -> bool + Send + Sync>;
+
 /// OTP and session manager with optional disk persistence.
 pub struct AuthManager {
     pending_otps: RwLock<HashMap<String, PendingOtp>>,
@@ -113,12 +117,18 @@ pub struct AuthManager {
     pub static_tokens: Vec<String>,
     user_store: Arc<UserStore>,
     /// Optional probe for registration ids that are taken OUTSIDE the
-    /// user store. The serve bootstrap wires this to profile-file
-    /// existence so a generated id can never claim an admin-created
-    /// (but unclaimed) profile: /api/auth/verify treats an existing
-    /// profile under the new user's id as that user's own (codex
-    /// #1613 r6). `None` (tests, solo) checks the user store only.
-    id_taken_probe: Option<Arc<dyn Fn(&str) -> bool + Send + Sync>>,
+    /// user store — `(candidate, authorized_for_candidate) -> taken`.
+    /// The serve bootstrap wires this to
+    /// `ProfileStore::id_reserved_for_registration`, so a generated id
+    /// can never claim an admin-created (but unclaimed) profile:
+    /// /api/auth/verify treats an existing profile under the new
+    /// user's id as that user's own (codex #1613 r6). The `authorized`
+    /// flag is true ONLY for the exact allowlist-derived id (suffix
+    /// candidates from collisions carry no authorization — r8 P1),
+    /// and even then the store keeps unloadable records reserved so a
+    /// claim can't clobber a corrupt profile file (r8 P2). `None`
+    /// (tests, solo) checks the user store only.
+    id_taken_probe: Option<IdTakenProbe>,
     /// Path to persist sessions. `None` = in-memory only (tests).
     sessions_path: Option<PathBuf>,
     /// Data directory used to load the SMTP password from `smtp_secret.json`.
@@ -164,8 +174,8 @@ impl AuthManager {
     }
 
     /// Attach the external id-taken probe used by registration id
-    /// generation (see the field docs — codex #1613 r6).
-    pub fn with_id_taken_probe(mut self, probe: Arc<dyn Fn(&str) -> bool + Send + Sync>) -> Self {
+    /// generation (see the field docs — codex #1613 r6/r8).
+    pub fn with_id_taken_probe(mut self, probe: IdTakenProbe) -> Self {
         self.id_taken_probe = Some(probe);
         self
     }
@@ -507,23 +517,27 @@ impl AuthManager {
                 let id = crate::user_store::email_to_user_id(&email_lower);
                 let mut final_id = id.clone();
                 let mut suffix = 1u32;
-                // A candidate is taken when a user row exists OR — for
-                // ANONYMOUS registration only — the bootstrap probe
-                // says the id is occupied elsewhere (a profile file on
-                // disk): self-registration must never claim an
-                // admin-created-but-unclaimed profile, or
+                // A candidate is taken when a user row exists OR the
+                // bootstrap probe says the id is occupied elsewhere (a
+                // profile file on disk): self-registration must never
+                // claim an admin-created-but-unclaimed profile, or
                 // /api/auth/verify hands the existing profile to the
-                // new user (codex #1613 r6). Authorized claims
-                // (allowlist provenance) skip the probe so an invitee
-                // KEEPS their pre-provisioned profile instead of being
-                // bumped to `<id>-1` (codex #1613 r7 P1).
+                // new user (codex #1613 r6). Allowlist provenance
+                // authorizes claiming ONLY the exact derived id — an
+                // invitee keeps their pre-provisioned profile (r7 P1)
+                // — but a suffix candidate minted after a collision
+                // carries no such authorization, or the invitee would
+                // silently absorb some OTHER unclaimed profile
+                // (`alice-1`, r8 P1). The probe itself still reserves
+                // unloadable records even for authorized claims
+                // (r8 P2 — see id_reserved_for_registration).
                 loop {
                     let user_taken = self.user_store.get(&final_id)?.is_some();
-                    let probe_taken = !authorized_claim
-                        && self
-                            .id_taken_probe
-                            .as_ref()
-                            .is_some_and(|probe| probe(&final_id));
+                    let candidate_authorized = authorized_claim && final_id == id;
+                    let probe_taken = self
+                        .id_taken_probe
+                        .as_ref()
+                        .is_some_and(|probe| probe(&final_id, candidate_authorized));
                     if !user_taken && !probe_taken {
                         break;
                     }
@@ -1169,7 +1183,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
         let mgr = AuthManager::new(None, user_store.clone())
-            .with_id_taken_probe(Arc::new(|id: &str| id == "api-user"));
+            .with_id_taken_probe(Arc::new(|id: &str, _authorized: bool| id == "api-user"));
         mgr.set_allow_self_registration(true);
         mgr.send_otp("api@example.com").await.unwrap();
         let code = {
@@ -1201,8 +1215,14 @@ mod tests {
         // self-registration only.
         let dir = tempfile::tempdir().unwrap();
         let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
-        let mgr = AuthManager::new(None, user_store.clone())
-            .with_id_taken_probe(Arc::new(|id: &str| id == "alice"));
+        let mgr = AuthManager::new(None, user_store.clone()).with_id_taken_probe(Arc::new(
+            |id: &str, authorized: bool| {
+                // Loadable pre-provisioned profile: reserved from
+                // anonymous registration, claimable with allowlist
+                // authorization (mirrors id_reserved_for_registration).
+                id == "alice" && !authorized
+            },
+        ));
         mgr.send_otp_with_registration("alice@example.com", true)
             .await
             .unwrap();
@@ -1227,6 +1247,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn should_probe_suffix_candidates_even_for_authorized_claims() {
+        // codex #1613 r8 P1: allowlist authorization covers the exact
+        // DERIVED id only. When that id collides with another account's
+        // user row, the suffix candidates are ordinary generated ids —
+        // an unclaimed `alice-1` profile must not be silently absorbed
+        // by the invitee.
+        let dir = tempfile::tempdir().unwrap();
+        let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
+        // `alice` belongs to a DIFFERENT account.
+        user_store
+            .save(&crate::user_store::User {
+                id: "alice".into(),
+                email: "other-alice@corp.example".into(),
+                name: "Other Alice".into(),
+                role: UserRole::User,
+                created_at: Utc::now(),
+                last_login_at: None,
+            })
+            .unwrap();
+        let mgr = AuthManager::new(None, user_store.clone()).with_id_taken_probe(Arc::new(
+            |id: &str, authorized: bool| match id {
+                // Pre-provisioned loadable profile for the derived id —
+                // claimable only WITH authorization (moot here: the
+                // user-row collision advances first)…
+                "alice" => !authorized,
+                // …and an unrelated unclaimed profile on the first
+                // suffix, which carries NO authorization.
+                "alice-1" => true,
+                _ => false,
+            },
+        ));
+        mgr.send_otp_with_registration("alice@new.example", true)
+            .await
+            .unwrap();
+        let code = {
+            let otps = mgr.pending_otps.read().await;
+            otps.get("alice@new.example").unwrap().code.clone()
+        };
+
+        let token = mgr
+            .verify_otp_with_authorized_claim("alice@new.example", &code)
+            .await
+            .unwrap();
+        assert!(token.is_some());
+        let user = user_store
+            .get_by_email("alice@new.example")
+            .unwrap()
+            .expect("registration must create a user");
+        assert_eq!(
+            user.id, "alice-2",
+            "suffix candidates must be probed even under an authorized claim"
+        );
+    }
+
+    #[tokio::test]
     async fn should_keep_suffixed_ids_within_the_slug_limit() {
         // codex #1613 r7 P2: a 63-char local part maps to a 63-char id;
         // appending `-1` produced a 65-char candidate that
@@ -1239,8 +1314,9 @@ mod tests {
         let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
         let base_id = crate::user_store::email_to_user_id(&email);
         assert_eq!(base_id.len(), 63, "fixture must sit at the slug limit");
-        let mgr = AuthManager::new(None, user_store.clone())
-            .with_id_taken_probe(Arc::new(move |id: &str| id == "a".repeat(63)));
+        let mgr = AuthManager::new(None, user_store.clone()).with_id_taken_probe(Arc::new(
+            move |id: &str, _authorized: bool| id == "a".repeat(63),
+        ));
         mgr.set_allow_self_registration(true);
         mgr.send_otp(&email).await.unwrap();
         let code = {

--- a/crates/octos-cli/src/otp.rs
+++ b/crates/octos-cli/src/otp.rs
@@ -112,6 +112,13 @@ pub struct AuthManager {
     /// Static tokens that bypass OTP (for E2E testing).
     pub static_tokens: Vec<String>,
     user_store: Arc<UserStore>,
+    /// Optional probe for registration ids that are taken OUTSIDE the
+    /// user store. The serve bootstrap wires this to profile-file
+    /// existence so a generated id can never claim an admin-created
+    /// (but unclaimed) profile: /api/auth/verify treats an existing
+    /// profile under the new user's id as that user's own (codex
+    /// #1613 r6). `None` (tests, solo) checks the user store only.
+    id_taken_probe: Option<Arc<dyn Fn(&str) -> bool + Send + Sync>>,
     /// Path to persist sessions. `None` = in-memory only (tests).
     sessions_path: Option<PathBuf>,
     /// Data directory used to load the SMTP password from `smtp_secret.json`.
@@ -143,6 +150,7 @@ impl AuthManager {
             user_store,
             sessions_path: None,
             data_dir: None,
+            id_taken_probe: None,
             #[cfg(test)]
             sent_emails: RwLock::new(Vec::new()),
         }
@@ -152,6 +160,13 @@ impl AuthManager {
     /// from `{data_dir}/smtp_secret.json` in preference to the env var.
     pub fn with_data_dir(mut self, data_dir: PathBuf) -> Self {
         self.data_dir = Some(data_dir);
+        self
+    }
+
+    /// Attach the external id-taken probe used by registration id
+    /// generation (see the field docs — codex #1613 r6).
+    pub fn with_id_taken_probe(mut self, probe: Arc<dyn Fn(&str) -> bool + Send + Sync>) -> Self {
+        self.id_taken_probe = Some(probe);
         self
     }
 
@@ -462,7 +477,23 @@ impl AuthManager {
                 let id = crate::user_store::email_to_user_id(&email_lower);
                 let mut final_id = id.clone();
                 let mut suffix = 1u32;
-                while self.user_store.get(&final_id)?.is_some() {
+                // A candidate is taken when a user row exists OR the
+                // bootstrap probe says the id is occupied elsewhere
+                // (a profile file on disk). Anonymous self-registration
+                // must never claim an admin-created-but-unclaimed
+                // profile — /api/auth/verify would hand the existing
+                // profile to the new user (codex #1613 r6). Explicitly
+                // provisioned flows (allowlist / registered users)
+                // authorize their claim and don't pass through here.
+                loop {
+                    let user_taken = self.user_store.get(&final_id)?.is_some();
+                    let probe_taken = self
+                        .id_taken_probe
+                        .as_ref()
+                        .is_some_and(|probe| probe(&final_id));
+                    if !user_taken && !probe_taken {
+                        break;
+                    }
                     final_id = format!("{id}-{suffix}");
                     suffix += 1;
                 }
@@ -1078,6 +1109,41 @@ mod tests {
         let user = user_store.get_by_email("newuser@example.com").unwrap();
         assert!(user.is_some());
         assert_eq!(user.unwrap().id, "newuser");
+    }
+
+    #[tokio::test]
+    async fn should_skip_probe_taken_ids_when_generating_registration_ids() {
+        // codex #1613 r6: the collision loop only consulted the USER
+        // store, so a generated id could claim an admin-created (but
+        // unclaimed) PROFILE: with self-registration on, api@… became
+        // user `api-user` (reserved-name disambiguation), and
+        // /api/auth/verify then treated the existing api-user profile
+        // as that user's own — granting an anonymous registrant an
+        // admin-provisioned profile. The serve bootstrap now wires a
+        // probe (profile-file existence); a probe-taken candidate
+        // advances to the next suffix.
+        let dir = tempfile::tempdir().unwrap();
+        let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
+        let mgr = AuthManager::new(None, user_store.clone())
+            .with_id_taken_probe(Arc::new(|id: &str| id == "api-user"));
+        mgr.set_allow_self_registration(true);
+        mgr.send_otp("api@example.com").await.unwrap();
+        let code = {
+            let otps = mgr.pending_otps.read().await;
+            otps.get("api@example.com").unwrap().code.clone()
+        };
+
+        let token = mgr.verify_otp("api@example.com", &code).await.unwrap();
+        assert!(token.is_some());
+
+        let user = user_store
+            .get_by_email("api@example.com")
+            .unwrap()
+            .expect("registration must create a user");
+        assert_eq!(
+            user.id, "api-user-1",
+            "a probe-taken id (existing profile) must not be claimed"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/otp.rs
+++ b/crates/octos-cli/src/otp.rs
@@ -447,11 +447,41 @@ impl AuthManager {
             .await
     }
 
+    /// Verify with ANONYMOUS registration semantics: a generated id
+    /// must not claim an existing-but-unclaimed profile (the
+    /// `id_taken_probe` applies — codex #1613 r6).
     pub async fn verify_otp_with_registration(
         &self,
         email: &str,
         code: &str,
         allow_registration: bool,
+    ) -> Result<Option<String>> {
+        self.verify_otp_registration_inner(email, code, allow_registration, false)
+            .await
+    }
+
+    /// Verify with AUTHORIZED-CLAIM semantics (codex #1613 r7 P1): the
+    /// caller has explicit provenance — an allowlist entry — that this
+    /// email is entitled to its derived id, so an existing unclaimed
+    /// profile under that id is the invitee's pre-provisioned profile,
+    /// not a squat target. The profile probe is skipped; user-row
+    /// collisions still advance the suffix (a user row means the id
+    /// belongs to a DIFFERENT account).
+    pub async fn verify_otp_with_authorized_claim(
+        &self,
+        email: &str,
+        code: &str,
+    ) -> Result<Option<String>> {
+        self.verify_otp_registration_inner(email, code, true, true)
+            .await
+    }
+
+    async fn verify_otp_registration_inner(
+        &self,
+        email: &str,
+        code: &str,
+        allow_registration: bool,
+        authorized_claim: bool,
     ) -> Result<Option<String>> {
         let email_lower = email.to_lowercase();
         let now = Utc::now();
@@ -477,24 +507,38 @@ impl AuthManager {
                 let id = crate::user_store::email_to_user_id(&email_lower);
                 let mut final_id = id.clone();
                 let mut suffix = 1u32;
-                // A candidate is taken when a user row exists OR the
-                // bootstrap probe says the id is occupied elsewhere
-                // (a profile file on disk). Anonymous self-registration
-                // must never claim an admin-created-but-unclaimed
-                // profile — /api/auth/verify would hand the existing
-                // profile to the new user (codex #1613 r6). Explicitly
-                // provisioned flows (allowlist / registered users)
-                // authorize their claim and don't pass through here.
+                // A candidate is taken when a user row exists OR — for
+                // ANONYMOUS registration only — the bootstrap probe
+                // says the id is occupied elsewhere (a profile file on
+                // disk): self-registration must never claim an
+                // admin-created-but-unclaimed profile, or
+                // /api/auth/verify hands the existing profile to the
+                // new user (codex #1613 r6). Authorized claims
+                // (allowlist provenance) skip the probe so an invitee
+                // KEEPS their pre-provisioned profile instead of being
+                // bumped to `<id>-1` (codex #1613 r7 P1).
                 loop {
                     let user_taken = self.user_store.get(&final_id)?.is_some();
-                    let probe_taken = self
-                        .id_taken_probe
-                        .as_ref()
-                        .is_some_and(|probe| probe(&final_id));
+                    let probe_taken = !authorized_claim
+                        && self
+                            .id_taken_probe
+                            .as_ref()
+                            .is_some_and(|probe| probe(&final_id));
                     if !user_taken && !probe_taken {
                         break;
                     }
-                    final_id = format!("{id}-{suffix}");
+                    // Reserve room for `-N` within the 63-char slug
+                    // budget (matching email_to_user_id's own cap): a
+                    // 63-char base id would otherwise mint a 65-char
+                    // candidate that validate_user_id rejects, failing
+                    // a VALID OTP with a generic error (codex #1613
+                    // r7 P2). Trailing hyphens from the cut are
+                    // trimmed so the candidate stays slug-shaped.
+                    let suffix_str = suffix.to_string();
+                    let max_base = 63usize.saturating_sub(suffix_str.len() + 1);
+                    let base: String = id.chars().take(max_base).collect();
+                    let base = base.trim_end_matches('-');
+                    final_id = format!("{base}-{suffix_str}");
                     suffix += 1;
                 }
                 let new_user = crate::user_store::User {
@@ -1143,6 +1187,85 @@ mod tests {
         assert_eq!(
             user.id, "api-user-1",
             "a probe-taken id (existing profile) must not be claimed"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_let_authorized_claims_take_probe_taken_ids() {
+        // codex #1613 r7 P1: an admin pre-creates profile `alice` and
+        // allowlists alice@example.com. That flow routes through the
+        // registration path with ALLOWLIST provenance — the profile
+        // probe must NOT bump the invitee to `alice-1` (which would
+        // strand the pre-provisioned profile and record the allowlist
+        // claim under the wrong id). The probe guards ANONYMOUS
+        // self-registration only.
+        let dir = tempfile::tempdir().unwrap();
+        let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
+        let mgr = AuthManager::new(None, user_store.clone())
+            .with_id_taken_probe(Arc::new(|id: &str| id == "alice"));
+        mgr.send_otp_with_registration("alice@example.com", true)
+            .await
+            .unwrap();
+        let code = {
+            let otps = mgr.pending_otps.read().await;
+            otps.get("alice@example.com").unwrap().code.clone()
+        };
+
+        let token = mgr
+            .verify_otp_with_authorized_claim("alice@example.com", &code)
+            .await
+            .unwrap();
+        assert!(token.is_some());
+        let user = user_store
+            .get_by_email("alice@example.com")
+            .unwrap()
+            .expect("allowlisted registration must create the user");
+        assert_eq!(
+            user.id, "alice",
+            "an authorized claim must keep the pre-provisioned id"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_keep_suffixed_ids_within_the_slug_limit() {
+        // codex #1613 r7 P2: a 63-char local part maps to a 63-char id;
+        // appending `-1` produced a 65-char candidate that
+        // validate_user_id rejects, so a VALID OTP failed with a
+        // generic error instead of registering. Suffixed candidates
+        // must reserve space for `-N`.
+        let long_local = "a".repeat(63);
+        let email = format!("{long_local}@example.com");
+        let dir = tempfile::tempdir().unwrap();
+        let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
+        let base_id = crate::user_store::email_to_user_id(&email);
+        assert_eq!(base_id.len(), 63, "fixture must sit at the slug limit");
+        let mgr = AuthManager::new(None, user_store.clone())
+            .with_id_taken_probe(Arc::new(move |id: &str| id == "a".repeat(63)));
+        mgr.set_allow_self_registration(true);
+        mgr.send_otp(&email).await.unwrap();
+        let code = {
+            let otps = mgr.pending_otps.read().await;
+            otps.get(&email).unwrap().code.clone()
+        };
+
+        let token = mgr
+            .verify_otp(&email, &code)
+            .await
+            .expect("suffixing at the limit must not error");
+        assert!(token.is_some());
+        let user = user_store
+            .get_by_email(&email)
+            .unwrap()
+            .expect("registration must create a user");
+        assert!(
+            user.id.len() <= 63,
+            "suffixed id must stay within the slug limit, got {} chars",
+            user.id.len()
+        );
+        assert!(
+            user.id.ends_with("-1"),
+            "collision must advance to the -1 suffix, got {}",
+            user.id
         );
     }
 

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1369,6 +1369,9 @@ impl ProfileStore {
     ///   channel-name id) stays reserved: the verify path's
     ///   auto-create treats a `get` error as "no profile" and would
     ///   OVERWRITE the file with a default profile (r8 P2).
+    // The only non-test caller (the serve bootstrap) is api-gated; the
+    // policy itself stays unconditional next to the store it guards.
+    #[cfg_attr(not(feature = "api"), allow(dead_code))]
     pub(crate) fn id_reserved_for_registration(&self, id: &str, authorized: bool) -> bool {
         if !self.profile_path(id).exists() {
             return false;

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1737,6 +1737,15 @@ fn validate_profile_id(id: &str) -> Result<()> {
     if id.starts_with('-') || id.ends_with('-') {
         bail!("profile ID must not start or end with a hyphen");
     }
+    // Reserve session-key channel names: a profile id equal to a
+    // channel (`api`, `slack`, `line`, …) makes the profiled key
+    // `{id}:{channel}:{chat}` indistinguishable from a bare
+    // `{channel}:{chat}` under `split_base_key`, mis-scoping the
+    // session everywhere (profile_id/channel/chat_id) — and forking it
+    // would persist a wrongly-scoped child (codex #1613 r4).
+    if octos_core::is_reserved_channel_name(id) {
+        bail!("profile ID must not be a reserved channel name (e.g. api, slack, line)");
+    }
     Ok(())
 }
 
@@ -2363,6 +2372,11 @@ mod tests {
         assert!(validate_profile_id("user123").is_ok());
         assert!(validate_profile_id("").is_err());
         assert!(validate_profile_id("-bad").is_err());
+        // Channel names are reserved (codex #1613 r4): a profile named
+        // after a channel makes profiled session keys ambiguous.
+        assert!(validate_profile_id("api").is_err());
+        assert!(validate_profile_id("slack").is_err());
+        assert!(validate_profile_id("line").is_err());
         assert!(validate_profile_id("bad-").is_err());
         assert!(validate_profile_id("UPPER").is_err());
         assert!(validate_profile_id("has space").is_err());
@@ -2375,7 +2389,8 @@ mod tests {
         let store = ProfileStore::open(dir.path()).unwrap();
 
         let profile = UserProfile {
-            id: "test".into(),
+            // Not "test" — a reserved channel name (codex #1613 r4).
+            id: "test-bot".into(),
             name: "Test Bot".into(),
             enabled: true,
             data_dir: None,
@@ -2406,16 +2421,16 @@ mod tests {
         };
 
         store.save(&profile).unwrap();
-        let loaded = store.get("test").unwrap().unwrap();
-        assert_eq!(loaded.id, "test");
+        let loaded = store.get("test-bot").unwrap().unwrap();
+        assert_eq!(loaded.id, "test-bot");
         assert_eq!(loaded.name, "Test Bot");
         assert!(loaded.enabled);
 
         let profiles = store.list().unwrap();
         assert_eq!(profiles.len(), 1);
 
-        assert!(store.delete("test").unwrap());
-        assert!(store.get("test").unwrap().is_none());
+        assert!(store.delete("test-bot").unwrap());
+        assert!(store.get("test-bot").unwrap().is_none());
     }
 
     #[test]

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1356,6 +1356,29 @@ impl ProfileStore {
         self.profiles_dir.join(format!("{id}.json"))
     }
 
+    /// Registration-id reservation policy (codex #1613 r6/r8), wired
+    /// into `AuthManager::with_id_taken_probe` by the serve bootstrap:
+    /// `(candidate, authorized) -> taken`.
+    ///
+    /// - No profile file → free for anyone.
+    /// - File exists, ANONYMOUS registration → taken: a generated id
+    ///   must never claim an admin-created-but-unclaimed profile (r6).
+    /// - File exists, AUTHORIZED claim (allowlist provenance for this
+    ///   exact derived id) → claimable ONLY when the record loads
+    ///   cleanly. An unloadable file (corrupt json, quarantined
+    ///   channel-name id) stays reserved: the verify path's
+    ///   auto-create treats a `get` error as "no profile" and would
+    ///   OVERWRITE the file with a default profile (r8 P2).
+    pub(crate) fn id_reserved_for_registration(&self, id: &str, authorized: bool) -> bool {
+        if !self.profile_path(id).exists() {
+            return false;
+        }
+        if !authorized {
+            return true;
+        }
+        !matches!(self.get(id), Ok(Some(_)))
+    }
+
     /// Return the parent directory of the profiles dir (i.e. the octos home dir).
     pub fn octos_home_dir(&self) -> &Path {
         self.profiles_dir.parent().unwrap_or(&self.profiles_dir)
@@ -2445,6 +2468,44 @@ mod tests {
         // Shape checks still shared with profile ids.
         assert!(validate_public_subdomain("-bad").is_err());
         assert!(validate_public_subdomain("UPPER").is_err());
+    }
+
+    #[test]
+    fn registration_reservation_tracks_loadability() {
+        // codex #1613 r6/r8: the probe behind AuthManager's generated-
+        // id loop. Anonymous registration never claims an existing
+        // file; an authorized (allowlist) claim passes only a
+        // cleanly-loadable record — a corrupt file stays reserved, or
+        // the verify path's auto-create (get error → None → save)
+        // would overwrite it with a default profile (r8 P2).
+        let dir = tempfile::tempdir().unwrap();
+        let store = ProfileStore::open(dir.path()).unwrap();
+
+        // Absent: free for anyone.
+        assert!(!store.id_reserved_for_registration("ghost", false));
+        assert!(!store.id_reserved_for_registration("ghost", true));
+
+        // Loadable pre-provisioned profile: reserved from anonymous,
+        // claimable with authorization.
+        let invitee = UserProfile {
+            id: "invitee".into(),
+            name: "Invitee".into(),
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig::default(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        store.save(&invitee).unwrap();
+        assert!(store.id_reserved_for_registration("invitee", false));
+        assert!(!store.id_reserved_for_registration("invitee", true));
+
+        // Corrupt record: reserved from EVERYONE.
+        std::fs::write(store.profile_path("mangled"), "{not json").unwrap();
+        assert!(store.id_reserved_for_registration("mangled", false));
+        assert!(store.id_reserved_for_registration("mangled", true));
     }
 
     #[test]

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1185,6 +1185,23 @@ impl ProfileStore {
                 match std::fs::read_to_string(&path) {
                     Ok(content) => match serde_json::from_str::<UserProfile>(&content) {
                         Ok(mut profile) => {
+                            // Quarantine legacy records that predate the
+                            // channel-name reservation (codex #1613 r5):
+                            // a profile id equal to a channel produces
+                            // ambiguous session keys, so it must not
+                            // handle sessions. Skipping (same precedent
+                            // as unparsable JSON above) keeps one legacy
+                            // record from bricking the deployment; the
+                            // warning tells the operator to rename it.
+                            if octos_core::is_reserved_channel_name(&profile.id) {
+                                tracing::warn!(
+                                    path = %path.display(),
+                                    id = %profile.id,
+                                    "skipping profile whose id is a reserved channel name; \
+                                     rename the profile (its session keys are ambiguous)"
+                                );
+                                continue;
+                            }
                             profile.config.normalize_llm_contract();
                             profiles.push(profile);
                         }
@@ -1212,6 +1229,20 @@ impl ProfileStore {
             .wrap_err_with(|| format!("failed to read profile: {id}"))?;
         let mut profile: UserProfile = serde_json::from_str(&content)
             .wrap_err_with(|| format!("failed to parse profile: {id}"))?;
+        // Fail fast on legacy records that predate the channel-name
+        // reservation (codex #1613 r5): a channel-named profile
+        // produces ambiguous session keys (`api:telegram:123` parses as
+        // a bare channel key), so it must not handle sessions. The
+        // error names the fix instead of letting the record limp along.
+        if octos_core::is_reserved_channel_name(&profile.id) {
+            bail!(
+                "profile '{}' uses a reserved channel name as its id and cannot be loaded; \
+                 rename the profile file and its `id` field (e.g. `{}-bot`) — channel-named \
+                 profiles produce ambiguous session keys",
+                profile.id,
+                profile.id
+            );
+        }
         profile.config.normalize_llm_contract();
         Ok(Some(profile))
     }
@@ -1526,7 +1557,13 @@ pub fn resolve_effective_profile(
 }
 
 fn validate_public_subdomain(slug: &str) -> Result<()> {
-    validate_profile_id(slug)?;
+    // Only the SHAPE is shared with profile ids. The channel-name
+    // reservation does NOT apply here: a public subdomain never
+    // occupies the SessionKey profile segment (it resolves to the
+    // owning profile's real id), so `slack`/`telegram`/`line` remain
+    // valid slugs (codex #1613 r5 P2). The subdomain namespace keeps
+    // its own reserved list below.
+    validate_slug_shape(slug, "public subdomain")?;
     if matches!(slug, "www" | "app" | "admin" | "api" | "crew" | "octos") {
         bail!("public subdomain '{slug}' is reserved");
     }
@@ -1723,26 +1760,35 @@ fn restore_masked_optional_secret(new_value: &mut Option<String>, old_value: &Op
     }
 }
 
-/// Validate a profile ID (slug format).
-fn validate_profile_id(id: &str) -> Result<()> {
-    if id.is_empty() || id.len() > 64 {
-        bail!("profile ID must be 1-64 characters");
+/// Shared slug shape check for profile IDs and public subdomains:
+/// 1-64 chars, lowercase alphanumerics and hyphens, no edge hyphens.
+fn validate_slug_shape(value: &str, what: &str) -> Result<()> {
+    if value.is_empty() || value.len() > 64 {
+        bail!("{what} must be 1-64 characters");
     }
-    if !id
+    if !value
         .bytes()
         .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
     {
-        bail!("profile ID must contain only lowercase letters, digits, and hyphens");
+        bail!("{what} must contain only lowercase letters, digits, and hyphens");
     }
-    if id.starts_with('-') || id.ends_with('-') {
-        bail!("profile ID must not start or end with a hyphen");
+    if value.starts_with('-') || value.ends_with('-') {
+        bail!("{what} must not start or end with a hyphen");
     }
+    Ok(())
+}
+
+/// Validate a profile ID (slug format).
+fn validate_profile_id(id: &str) -> Result<()> {
+    validate_slug_shape(id, "profile ID")?;
     // Reserve session-key channel names: a profile id equal to a
     // channel (`api`, `slack`, `line`, …) makes the profiled key
     // `{id}:{channel}:{chat}` indistinguishable from a bare
     // `{channel}:{chat}` under `split_base_key`, mis-scoping the
     // session everywhere (profile_id/channel/chat_id) — and forking it
-    // would persist a wrongly-scoped child (codex #1613 r4).
+    // would persist a wrongly-scoped child (codex #1613 r4). This
+    // reservation applies ONLY to profile ids — see
+    // validate_public_subdomain (codex #1613 r5 P2).
     if octos_core::is_reserved_channel_name(id) {
         bail!("profile ID must not be a reserved channel name (e.g. api, slack, line)");
     }
@@ -2381,6 +2427,85 @@ mod tests {
         assert!(validate_profile_id("UPPER").is_err());
         assert!(validate_profile_id("has space").is_err());
         assert!(validate_profile_id("a".repeat(65).as_str()).is_err());
+    }
+
+    #[test]
+    fn should_allow_channel_named_public_subdomains() {
+        // codex #1613 r5 P2: the channel-name reservation exists to keep
+        // the SessionKey PROFILE segment unambiguous. A public subdomain
+        // never occupies that segment (it resolves to the owning
+        // profile's real id), so channel names stay valid slugs here.
+        assert!(validate_public_subdomain("slack").is_ok());
+        assert!(validate_public_subdomain("telegram").is_ok());
+        assert!(validate_public_subdomain("line").is_ok());
+        // The subdomain namespace keeps its OWN reserved list.
+        assert!(validate_public_subdomain("api").is_err());
+        assert!(validate_public_subdomain("www").is_err());
+        assert!(validate_public_subdomain("admin").is_err());
+        // Shape checks still shared with profile ids.
+        assert!(validate_public_subdomain("-bad").is_err());
+        assert!(validate_public_subdomain("UPPER").is_err());
+    }
+
+    #[test]
+    fn should_quarantine_legacy_channel_named_profiles_on_load() {
+        // codex #1613 r5 P1: profiles created BEFORE the channel-name
+        // reservation bypass save-time validation forever — an existing
+        // `profiles/api.json` would keep producing `api:<channel>:<chat>`
+        // keys that `split_base_key` mis-parses (profile dropped,
+        // mis-scoped forks). Loading must fail fast instead: `get`
+        // errors with rename guidance, `list` skips the record (same
+        // precedent as unparsable profile JSON) so one legacy record
+        // cannot brick a multi-profile deployment.
+        let dir = tempfile::tempdir().unwrap();
+        let store = ProfileStore::open(dir.path()).unwrap();
+
+        // Plant the legacy record directly on disk, bypassing save().
+        let legacy = serde_json::json!({
+            "id": "api",
+            "name": "Legacy Api",
+            "enabled": true,
+            "created_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-01T00:00:00Z",
+            "config": {}
+        });
+        std::fs::write(
+            store.profile_path("api"),
+            serde_json::to_string_pretty(&legacy).unwrap(),
+        )
+        .unwrap();
+
+        // A healthy profile sits alongside it.
+        let healthy = UserProfile {
+            id: "alice".into(),
+            name: "Alice".into(),
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig::default(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        store.save(&healthy).unwrap();
+
+        let err = store
+            .get("api")
+            .expect_err("channel-named legacy profile must fail fast on get");
+        assert!(
+            err.to_string().contains("reserved channel name"),
+            "error must explain the rename requirement, got: {err}"
+        );
+
+        let listed = store.list().unwrap();
+        assert!(
+            listed.iter().any(|p| p.id == "alice"),
+            "healthy profiles must survive a legacy record"
+        );
+        assert!(
+            !listed.iter().any(|p| p.id == "api"),
+            "channel-named legacy profile must be skipped from list()"
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/user_store.rs
+++ b/crates/octos-cli/src/user_store.rs
@@ -184,13 +184,26 @@ pub fn email_to_user_id(email: &str) -> String {
     while result.ends_with('-') {
         result.pop();
     }
-    if result.is_empty() {
+    let id = if result.is_empty() {
         "user".into()
     } else if !result.starts_with(|c: char| c.is_ascii_alphanumeric()) {
         // Ensure the slug starts with an alphanumeric character
         format!("u{result}")
     } else {
         result
+    };
+    // The user id doubles as the auto-created profile id, and profile
+    // ids reject reserved channel names (they make profiled session
+    // keys ambiguous — see validate_profile_id). Disambiguate at the
+    // mint so provisioning never persists a user whose profile can't
+    // be created (codex #1613 r5): `api@…` → `api-user`. Reserved
+    // names are short registry words, so the suffix stays within the
+    // 64-char slug limit; the registration collision loop appends
+    // `-N` if `api-user` is taken.
+    if octos_core::is_reserved_channel_name(&id) {
+        format!("{id}-user")
+    } else {
+        id
     }
 }
 
@@ -234,6 +247,23 @@ mod tests {
         assert_eq!(email_to_user_id("Bob.Smith@corp.co"), "bob-smith");
         assert_eq!(email_to_user_id("user+tag@test.com"), "user-tag");
         assert_eq!(email_to_user_id("...@test.com"), "user");
+    }
+
+    #[test]
+    fn should_disambiguate_reserved_channel_names_when_minting_user_ids() {
+        // codex #1613 r5: the user id doubles as the auto-created
+        // profile id, and profile ids reject reserved channel names
+        // (ambiguous session keys). Provisioning must therefore never
+        // MINT one: `api@example.com` used to become user `api`, get
+        // persisted, and then dead-end when the profile save was
+        // rejected — a valid login with no usable profile.
+        assert_eq!(email_to_user_id("api@example.com"), "api-user");
+        assert_eq!(email_to_user_id("slack@corp.co"), "slack-user");
+        assert_eq!(email_to_user_id("line@corp.co"), "line-user");
+        // Non-reserved local parts are untouched.
+        assert_eq!(email_to_user_id("apiteam@example.com"), "apiteam");
+        // The disambiguated id passes user-id validation.
+        assert!(validate_user_id("api-user").is_ok());
     }
 
     #[test]

--- a/crates/octos-core/src/lib.rs
+++ b/crates/octos-core/src/lib.rs
@@ -35,7 +35,7 @@ pub use task::{
 };
 pub use types::{
     AgentId, ClientMessageId, EpisodeRef, IdentityError, IdentityKind, MAIN_PROFILE_ID, Message,
-    MessageRole, SessionKey, TaskId, ThreadId, ToolCall, TurnId,
+    MessageRole, SessionKey, TaskId, ThreadId, ToolCall, TurnId, is_reserved_channel_name,
 };
 pub use ui_protocol::{EventEnvelope, TurnContext};
 pub use utils::{

--- a/crates/octos-core/src/types.rs
+++ b/crates/octos-core/src/types.rs
@@ -555,6 +555,25 @@ impl SessionKey {
         self.split_base_key().0
     }
 
+    /// Child key for a fork: the parent's profile + channel with a new
+    /// chat id (topic dropped — the child is a fresh conversation). A
+    /// raw colon-less parent — the SPA's opaque per-tab handles
+    /// (`web-123`) — yields a raw child: treating the whole raw id as a
+    /// channel would mint `web-123:<id>` keys, which the raw REST
+    /// resume/title/delete fallbacks intentionally exclude. Single
+    /// source of truth for `SessionManager::fork` AND the serve-side
+    /// pre-checks (codex #1613 P1: two derivations drifted).
+    pub fn fork_child(&self, new_chat_id: &str) -> SessionKey {
+        if !self.base_key().contains(':') {
+            return SessionKey(new_chat_id.to_string());
+        }
+        let (profile, channel, _chat) = self.split_base_key();
+        match profile {
+            Some(profile) => SessionKey(format!("{profile}:{channel}:{new_chat_id}")),
+            None => SessionKey(format!("{channel}:{new_chat_id}")),
+        }
+    }
+
     /// Channel name: `"telegram:12345#foo"` → `"telegram"`.
     pub fn channel(&self) -> &str {
         self.split_base_key().1
@@ -598,6 +617,39 @@ impl std::fmt::Display for SessionKey {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fork_child_preserves_profile_and_channel() {
+        // channel:chat parent
+        assert_eq!(
+            SessionKey("local:parent".into()).fork_child("kid").0,
+            "local:kid"
+        );
+        // profile:channel:chat parent keeps BOTH prefixes
+        assert_eq!(
+            SessionKey("tenant:api:parent".into()).fork_child("kid").0,
+            "tenant:api:kid"
+        );
+        // raw SPA handle (no colon) yields a raw child — NOT
+        // "web-123:kid", which the raw REST fallbacks exclude
+        assert_eq!(
+            SessionKey("web-123".into()).fork_child("web-456").0,
+            "web-456"
+        );
+        // topic parents fork off the base conversation, topic dropped
+        assert_eq!(
+            SessionKey("local:parent#research".into())
+                .fork_child("kid")
+                .0,
+            "local:kid"
+        );
+        assert_eq!(
+            SessionKey("web-123#research".into())
+                .fork_child("web-456")
+                .0,
+            "web-456"
+        );
+    }
 
     #[test]
     fn test_task_id_unique() {

--- a/crates/octos-core/src/types.rs
+++ b/crates/octos-core/src/types.rs
@@ -555,26 +555,30 @@ impl SessionKey {
         self.split_base_key().0
     }
 
-    /// Child key for a fork: the parent's ENTIRE key prefix with a new
+    /// Child key for a fork: the parent's profile + channel with a new
     /// chat id (topic dropped — the child is a fresh conversation). A
     /// raw colon-less parent — the SPA's opaque per-tab handles
     /// (`web-123`) — yields a raw child: treating the whole raw id as a
     /// channel would mint `web-123:<id>` keys, which the raw REST
     /// resume/title/delete fallbacks intentionally exclude.
     ///
-    /// Deliberately NOT built on `split_base_key`: its channel
-    /// allowlist omits feature-gated channels (`wechat`, `line`, …),
-    /// which would silently drop the channel from
-    /// `tenant:wechat:parent` (codex #1613 r2). Replacing the last
-    /// `:`-segment preserves whatever profile/channel shape the parent
-    /// has, unambiguously. (Chat ids are colon-free by construction —
-    /// `validate_topic_name` enforces the child's, and every channel
-    /// mints colon-free parents.) Single source of truth for
+    /// Built on `split_base_key`, the same profile/channel boundary the
+    /// rest of the key parsing uses. A last-segment replacement is NOT
+    /// equivalent: chat ids can contain colons (Matrix rooms —
+    /// `matrix:!room:localhost`), so only the registry-backed parse
+    /// places the boundary correctly for both colon chat ids and
+    /// `{profile}:{channel}:{chat}` keys (codex #1613 r2+r3; the
+    /// registry gap for feature-gated channels is fixed in
+    /// `is_channel_name`). Single source of truth for
     /// `SessionManager::fork` AND the serve-side pre-checks.
     pub fn fork_child(&self, new_chat_id: &str) -> SessionKey {
-        match self.base_key().rsplit_once(':') {
-            None => SessionKey(new_chat_id.to_string()),
-            Some((prefix, _chat_id)) => SessionKey(format!("{prefix}:{new_chat_id}")),
+        if !self.base_key().contains(':') {
+            return SessionKey(new_chat_id.to_string());
+        }
+        let (profile, channel, _chat) = self.split_base_key();
+        match profile {
+            Some(profile) => SessionKey(format!("{profile}:{channel}:{new_chat_id}")),
+            None => SessionKey(format!("{channel}:{new_chat_id}")),
         }
     }
 
@@ -598,6 +602,7 @@ fn is_channel_name(value: &str) -> bool {
             | "discord"
             | "email"
             | "feishu"
+            | "line"
             | "local"
             | "matrix"
             | "qq-bot"
@@ -606,6 +611,7 @@ fn is_channel_name(value: &str) -> bool {
             | "telegram"
             | "test"
             | "twilio"
+            | "wechat"
             | "wecom"
             | "wecom-bot"
             | "whatsapp"
@@ -634,13 +640,21 @@ mod tests {
             SessionKey("tenant:api:parent".into()).fork_child("kid").0,
             "tenant:api:kid"
         );
-        // feature-gated channels (outside is_channel_name's allowlist)
-        // keep their shape too — the derivation is registry-independent
+        // feature-gated channels parse correctly now that the registry
+        // includes them (wechat/line were missing pre-#1613)
         assert_eq!(
             SessionKey("tenant:wechat:parent".into())
                 .fork_child("kid")
                 .0,
             "tenant:wechat:kid"
+        );
+        // colon-bearing chat ids (Matrix rooms) must be REPLACED whole,
+        // not treated as extra prefix segments
+        assert_eq!(
+            SessionKey("matrix:!room:localhost".into())
+                .fork_child("kid")
+                .0,
+            "matrix:kid"
         );
         // raw SPA handle (no colon) yields a raw child — NOT
         // "web-123:kid", which the raw REST fallbacks exclude

--- a/crates/octos-core/src/types.rs
+++ b/crates/octos-core/src/types.rs
@@ -555,22 +555,26 @@ impl SessionKey {
         self.split_base_key().0
     }
 
-    /// Child key for a fork: the parent's profile + channel with a new
+    /// Child key for a fork: the parent's ENTIRE key prefix with a new
     /// chat id (topic dropped — the child is a fresh conversation). A
     /// raw colon-less parent — the SPA's opaque per-tab handles
     /// (`web-123`) — yields a raw child: treating the whole raw id as a
     /// channel would mint `web-123:<id>` keys, which the raw REST
-    /// resume/title/delete fallbacks intentionally exclude. Single
-    /// source of truth for `SessionManager::fork` AND the serve-side
-    /// pre-checks (codex #1613 P1: two derivations drifted).
+    /// resume/title/delete fallbacks intentionally exclude.
+    ///
+    /// Deliberately NOT built on `split_base_key`: its channel
+    /// allowlist omits feature-gated channels (`wechat`, `line`, …),
+    /// which would silently drop the channel from
+    /// `tenant:wechat:parent` (codex #1613 r2). Replacing the last
+    /// `:`-segment preserves whatever profile/channel shape the parent
+    /// has, unambiguously. (Chat ids are colon-free by construction —
+    /// `validate_topic_name` enforces the child's, and every channel
+    /// mints colon-free parents.) Single source of truth for
+    /// `SessionManager::fork` AND the serve-side pre-checks.
     pub fn fork_child(&self, new_chat_id: &str) -> SessionKey {
-        if !self.base_key().contains(':') {
-            return SessionKey(new_chat_id.to_string());
-        }
-        let (profile, channel, _chat) = self.split_base_key();
-        match profile {
-            Some(profile) => SessionKey(format!("{profile}:{channel}:{new_chat_id}")),
-            None => SessionKey(format!("{channel}:{new_chat_id}")),
+        match self.base_key().rsplit_once(':') {
+            None => SessionKey(new_chat_id.to_string()),
+            Some((prefix, _chat_id)) => SessionKey(format!("{prefix}:{new_chat_id}")),
         }
     }
 
@@ -629,6 +633,14 @@ mod tests {
         assert_eq!(
             SessionKey("tenant:api:parent".into()).fork_child("kid").0,
             "tenant:api:kid"
+        );
+        // feature-gated channels (outside is_channel_name's allowlist)
+        // keep their shape too — the derivation is registry-independent
+        assert_eq!(
+            SessionKey("tenant:wechat:parent".into())
+                .fork_child("kid")
+                .0,
+            "tenant:wechat:kid"
         );
         // raw SPA handle (no colon) yields a raw child — NOT
         // "web-123:kid", which the raw REST fallbacks exclude

--- a/crates/octos-core/src/types.rs
+++ b/crates/octos-core/src/types.rs
@@ -593,6 +593,17 @@ impl SessionKey {
     }
 }
 
+/// Whether `value` is a registered session-key channel name (the
+/// middle segment of a `{channel}:{chat}` or `{profile}:{channel}:{chat}`
+/// key). Exposed so profile-ID validation can REJECT ids that collide
+/// with a channel name: such an id makes `profile:channel:chat`
+/// indistinguishable from `channel:chat_with_colons`, which
+/// `split_base_key` (and thus `profile_id`/`channel`/`fork_child`)
+/// would misparse (codex #1613 r4).
+pub fn is_reserved_channel_name(value: &str) -> bool {
+    is_channel_name(value)
+}
+
 fn is_channel_name(value: &str) -> bool {
     matches!(
         value,

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -974,6 +974,10 @@ pub mod methods {
     /// rewind), persist an idempotent append-only marker, and return the
     /// trimmed hydrated thread. MUTATING: changes persisted session state.
     pub const SESSION_ROLLBACK: &str = "session/rollback";
+    /// `session/fork` — create a NEW session copying the tail of an
+    /// existing one (`SessionManager::fork`; parent tracked via
+    /// `parent_key`). MUTATING: writes the child session to disk.
+    pub const SESSION_FORK: &str = "session/fork";
     /// UPCR-2026-010 `thread/graph/get` — thread partition for the session.
     pub const THREAD_GRAPH_GET: &str = "thread/graph/get";
     /// UPCR-2026-011 `turn/state/get` — turn lifecycle introspection.
@@ -1201,6 +1205,7 @@ pub const UI_PROTOCOL_COMMAND_METHODS: &[&str] = &[
     methods::TASK_OUTPUT_READ,
     methods::SESSION_HYDRATE,
     methods::SESSION_ROLLBACK,
+    methods::SESSION_FORK,
     methods::THREAD_GRAPH_GET,
     methods::TURN_STATE_GET,
     methods::AGENT_LIST,
@@ -1303,6 +1308,7 @@ pub const UI_PROTOCOL_FIRST_SERVER_METHODS: &[&str] = &[
     methods::TASK_OUTPUT_READ,
     methods::SESSION_HYDRATE,
     methods::SESSION_ROLLBACK,
+    methods::SESSION_FORK,
     methods::THREAD_GRAPH_GET,
     methods::TURN_STATE_GET,
     methods::AGENT_LIST,
@@ -1697,6 +1703,7 @@ pub enum UiResultKind {
     TaskArtifactRead,
     SessionHydrate,
     SessionRollback,
+    SessionFork,
     ThreadGraphGet,
     TurnStateGet,
     UnsupportedCapability,
@@ -1721,6 +1728,7 @@ pub fn first_server_result_kind_for_method(method: &str) -> Option<UiResultKind>
         methods::TASK_ARTIFACT_READ => Some(UiResultKind::TaskArtifactRead),
         methods::SESSION_HYDRATE => Some(UiResultKind::SessionHydrate),
         methods::SESSION_ROLLBACK => Some(UiResultKind::SessionRollback),
+        methods::SESSION_FORK => Some(UiResultKind::SessionFork),
         methods::THREAD_GRAPH_GET => Some(UiResultKind::ThreadGraphGet),
         methods::TURN_STATE_GET => Some(UiResultKind::TurnStateGet),
         _ => None,
@@ -2760,6 +2768,28 @@ pub struct SessionRollbackResult {
     pub thread: SessionHydrateResult,
 }
 
+/// Params for `session/fork`: branch a new session off `session_id`,
+/// copying the last `copy_messages` messages (absent → the FULL
+/// history). `new_chat_id` becomes the child's chat id; the channel is
+/// derived from the parent key (`channel:chat_id`), matching
+/// `SessionManager::fork`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionForkParams {
+    pub session_id: SessionKey,
+    pub new_chat_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub copy_messages: Option<u32>,
+}
+
+/// Result for `session/fork`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionForkResult {
+    pub new_session_id: SessionKey,
+    pub parent_session_id: SessionKey,
+    /// Messages actually copied into the child.
+    pub copied_messages: u32,
+}
+
 // ----- UPCR-2026-010 `thread/graph/get` -----
 
 /// Params for `thread/graph/get` (UPCR-2026-010).
@@ -3639,6 +3669,7 @@ pub enum UiCommand {
     TaskArtifactRead(TaskArtifactReadParams),
     SessionHydrate(SessionHydrateParams),
     SessionRollback(SessionRollbackParams),
+    SessionFork(SessionForkParams),
     ThreadGraphGet(ThreadGraphGetParams),
     TurnStateGet(TurnStateGetParams),
     // ---- M12 Phase D-1 auxiliary REST → WS frames ----
@@ -3681,6 +3712,7 @@ impl UiCommand {
             Self::TaskArtifactRead(_) => methods::TASK_ARTIFACT_READ,
             Self::SessionHydrate(_) => methods::SESSION_HYDRATE,
             Self::SessionRollback(_) => methods::SESSION_ROLLBACK,
+            Self::SessionFork(_) => methods::SESSION_FORK,
             Self::ThreadGraphGet(_) => methods::THREAD_GRAPH_GET,
             Self::TurnStateGet(_) => methods::TURN_STATE_GET,
             Self::SessionList(_) => methods::SESSION_LIST,
@@ -3725,6 +3757,7 @@ impl UiCommand {
             Self::TaskArtifactRead(params) => serde_json::to_value(params),
             Self::SessionHydrate(params) => serde_json::to_value(params),
             Self::SessionRollback(params) => serde_json::to_value(params),
+            Self::SessionFork(params) => serde_json::to_value(params),
             Self::ThreadGraphGet(params) => serde_json::to_value(params),
             Self::TurnStateGet(params) => serde_json::to_value(params),
             Self::SessionList(params) => serde_json::to_value(params),
@@ -3795,6 +3828,7 @@ impl UiCommand {
             }
             methods::SESSION_HYDRATE => Ok(Self::SessionHydrate(decode_params(method, params)?)),
             methods::SESSION_ROLLBACK => Ok(Self::SessionRollback(decode_params(method, params)?)),
+            methods::SESSION_FORK => Ok(Self::SessionFork(decode_params(method, params)?)),
             methods::THREAD_GRAPH_GET => Ok(Self::ThreadGraphGet(decode_params(method, params)?)),
             methods::TURN_STATE_GET => Ok(Self::TurnStateGet(decode_params(method, params)?)),
             methods::SESSION_LIST => Ok(Self::SessionList(decode_optional_params(method, params)?)),
@@ -4139,6 +4173,7 @@ pub enum UiRpcResult {
     TaskArtifactRead(TaskArtifactReadResult),
     SessionHydrate(SessionHydrateResult),
     SessionRollback(SessionRollbackResult),
+    SessionFork(SessionForkResult),
     ThreadGraphGet(ThreadGraphGetResult),
     TurnStateGet(TurnStateGetResult),
     UnsupportedCapability(UnsupportedCapabilityResult),
@@ -4164,6 +4199,7 @@ impl UiRpcResult {
             Self::TaskArtifactRead(_) => UiResultKind::TaskArtifactRead,
             Self::SessionHydrate(_) => UiResultKind::SessionHydrate,
             Self::SessionRollback(_) => UiResultKind::SessionRollback,
+            Self::SessionFork(_) => UiResultKind::SessionFork,
             Self::ThreadGraphGet(_) => UiResultKind::ThreadGraphGet,
             Self::TurnStateGet(_) => UiResultKind::TurnStateGet,
             Self::UnsupportedCapability(_) => UiResultKind::UnsupportedCapability,
@@ -4189,6 +4225,7 @@ impl UiRpcResult {
             Self::TaskArtifactRead(_) => Some(methods::TASK_ARTIFACT_READ),
             Self::SessionHydrate(_) => Some(methods::SESSION_HYDRATE),
             Self::SessionRollback(_) => Some(methods::SESSION_ROLLBACK),
+            Self::SessionFork(_) => Some(methods::SESSION_FORK),
             Self::ThreadGraphGet(_) => Some(methods::THREAD_GRAPH_GET),
             Self::TurnStateGet(_) => Some(methods::TURN_STATE_GET),
             Self::UnsupportedCapability(result) => Some(result.unsupported.method.as_str()),
@@ -4214,6 +4251,7 @@ impl UiRpcResult {
             Self::TaskArtifactRead(result) => serde_json::to_value(result),
             Self::SessionHydrate(result) => serde_json::to_value(result),
             Self::SessionRollback(result) => serde_json::to_value(result),
+            Self::SessionFork(result) => serde_json::to_value(result),
             Self::ThreadGraphGet(result) => serde_json::to_value(result),
             Self::TurnStateGet(result) => serde_json::to_value(result),
             Self::UnsupportedCapability(result) => serde_json::to_value(result),
@@ -4270,6 +4308,7 @@ impl UiRpcResult {
             }
             methods::SESSION_HYDRATE => Ok(Self::SessionHydrate(decode_result(method, result)?)),
             methods::SESSION_ROLLBACK => Ok(Self::SessionRollback(decode_result(method, result)?)),
+            methods::SESSION_FORK => Ok(Self::SessionFork(decode_result(method, result)?)),
             methods::THREAD_GRAPH_GET => Ok(Self::ThreadGraphGet(decode_result(method, result)?)),
             methods::TURN_STATE_GET => Ok(Self::TurnStateGet(decode_result(method, result)?)),
             _ => Err(RpcError::method_not_found(method)),
@@ -6865,6 +6904,7 @@ mod tests {
                 "task/output/read",
                 "session/hydrate",
                 "session/rollback",
+                "session/fork",
                 "thread/graph/get",
                 "turn/state/get",
                 "agent/list",
@@ -6969,6 +7009,7 @@ mod tests {
                 "task/output/read",
                 "session/hydrate",
                 "session/rollback",
+                "session/fork",
                 "thread/graph/get",
                 "turn/state/get",
                 "agent/list",
@@ -7043,6 +7084,7 @@ mod tests {
                     "task/output/read",
                     "session/hydrate",
                     "session/rollback",
+                    "session/fork",
                     "thread/graph/get",
                     "turn/state/get",
                     "agent/list",


### PR DESCRIPTION
## Summary

Web parity P3 item 8 (~/home/octos-audit/WEB-PARITY-2026-07-10.md): the book documents session forking and `SessionManager::fork` has existed since the /new command work (parent_key lineage, tail-copy) — but it had **no production caller**. The SPA's `/new` is topic scaffolding only. This lifts fork onto the UI Protocol wire so the web sidebar can offer "branch from here".

- **octos-core**: `session/fork` method const + `SessionForkParams{session_id, new_chat_id, copy_messages?}` / `SessionForkResult{new_session_id, parent_session_id, copied_messages}`, wired through `UiCommand`/`UiRpcResult`/`UiResultKind`; both golden wire-contract fixtures updated.
- **serve (`handle_session_fork`)**: scope-validated (1008-close on cross-profile key); `new_chat_id` held to the topic-name charset (it becomes a path component + wire key half); refuses unknown parents (error, no auto-create); refuses clobbering an existing child key (`child_exists`) — the candidate key is derived exactly as `SessionManager::fork` derives it; absent `copy_messages` copies the FULL parent history, bounded tail otherwise.
- **session-ingress**: `session/fork` is denied + filtered from advertised caps for ingress credentials — fork creates a NEW session, outside a single-session credential's scope.

## Tests
6 new handler tests (default full copy + lineage, bounded tail, unknown parent, child-clobber refusal, invalid chat id, cross-scope 1008) + ingress deny-list coverage; golden contract tests updated. `cargo test -p octos-cli --lib --features api`: 2225 passed. `cargo test -p octos-core`: 304 passed. clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)