### PR TITLE
fix(security): sandbox + policy-enforce Agent project-root validators (#1607)

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -1119,6 +1119,12 @@ impl Agent {
                                 Some((&bg_supervisor, &task_id)),
                                 Some(&bg_args),
                                 named_outputs_value.as_ref(),
+                                // #1607: the Agent's own registry is built
+                                // sandboxed (session_actor
+                                // `create_registry_for_workspace` ->
+                                // `rebind_cwd(create_sandbox(&sandbox_config))`),
+                                // so its stored sandbox IS the session backend.
+                                bg_tools.sandbox(),
                             )
                             .await
                             {
@@ -1153,6 +1159,7 @@ impl Agent {
                                                 workspace_root,
                                                 None,
                                                 &r.files_to_send,
+                                                bg_tools.sandbox(),
                                             )
                                             .await;
                                     }

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -1945,6 +1945,10 @@ impl Agent {
                                 &task.context.working_dir,
                                 None,
                                 &files_to_send,
+                                // #1607: the Agent's own registry is built
+                                // sandboxed in `session_actor`, so its stored
+                                // sandbox is the session backend.
+                                self.tools.sandbox(),
                             )
                             .await;
                         let contract_failures =
@@ -6813,6 +6817,7 @@ printf '{"output":"voice saved","success":true}\n'
             tmp_root,
             Some(WorkspaceProjectKind::Slides),
             &files_to_send,
+            std::sync::Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
     }

--- a/crates/octos-agent/src/sandbox/docker.rs
+++ b/crates/octos-agent/src/sandbox/docker.rs
@@ -34,6 +34,10 @@ pub struct DockerSandbox {
 }
 
 impl Sandbox for DockerSandbox {
+    fn is_docker(&self) -> bool {
+        true
+    }
+
     fn wrap_command(&self, shell_command: &str, cwd: &Path) -> Command {
         let mut cmd = Command::new("docker");
         cmd.arg("run").arg("--rm");

--- a/crates/octos-agent/src/sandbox/mod.rs
+++ b/crates/octos-agent/src/sandbox/mod.rs
@@ -229,6 +229,21 @@ pub trait Sandbox: Send + Sync {
     fn is_noop(&self) -> bool {
         false
     }
+
+    /// Whether this backend is the Docker container sandbox.
+    ///
+    /// #1607 (codex-review follow-up): Docker bind-mounts the workspace at a
+    /// fixed in-container path (`/workspace`), but `Command` validators
+    /// interpolate absolute *host* paths (e.g. `${output.patch_path}` ->
+    /// `/host/ws/.../foo.patch`) which don't exist inside the container, so a
+    /// previously-passing required validator would start failing. Before
+    /// #1607, command validators ran on the host and worked. `ValidatorRunner`
+    /// uses this to keep Docker-mode command validators on the pre-#1607 direct
+    /// (host) path rather than silently breaking them. Full in-container path
+    /// translation is a known follow-up. Non-Docker backends inherit `false`.
+    fn is_docker(&self) -> bool {
+        false
+    }
 }
 
 /// No-op sandbox: executes commands directly.

--- a/crates/octos-agent/src/tools/check_workspace_contract.rs
+++ b/crates/octos-agent/src/tools/check_workspace_contract.rs
@@ -182,6 +182,7 @@ mod tests {
             workspace_root,
             Some(WorkspaceProjectKind::Slides),
             files_to_send,
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
     }

--- a/crates/octos-agent/src/tools/delegate.rs
+++ b/crates/octos-agent/src/tools/delegate.rs
@@ -41,6 +41,7 @@ use super::{Tool, ToolContext, ToolPolicy, ToolRegistry, ToolResult};
 use crate::compaction::CompactionRunner;
 use crate::harness_errors::HarnessError;
 use crate::harness_events::HARNESS_EVENT_SCHEMA_V1;
+use crate::sandbox::{SandboxConfig, create_sandbox};
 use crate::task_supervisor::{TaskLifecycleState, TaskSupervisor};
 use crate::validators::ValidatorPhase;
 use crate::workspace_contract::run_declared_validators;
@@ -262,6 +263,14 @@ pub struct DelegateTool {
     embedder: Option<Arc<dyn octos_llm::EmbeddingProvider>>,
     /// Caller-owned context-manager factory for delegated child agents.
     child_prompt_context_manager_factory: Option<ChildPromptContextManagerFactory>,
+    /// #1607 (codex-review follow-up): the session sandbox threaded from the
+    /// runtime construction site (`session_actor::spawn`). The child registry
+    /// built for a delegated worker carries this so its completion-phase
+    /// `run_declared_validators` pass confines `ValidatorSpec::Command`
+    /// validators to the same sandbox as the shell/exec tools. Defaults to
+    /// `SandboxConfig::default()` (resolves to `NoSandbox` on a host without a
+    /// backend, running command validators directly — unchanged behaviour).
+    sandbox: SandboxConfig,
 }
 
 impl DelegateTool {
@@ -282,7 +291,16 @@ impl DelegateTool {
             worker_config: None,
             embedder: None,
             child_prompt_context_manager_factory: None,
+            sandbox: SandboxConfig::default(),
         }
+    }
+
+    /// #1607: thread the session sandbox onto delegated child registries so
+    /// their completion-phase command validators are confined to it. Mirrors
+    /// `SpawnTool::with_sandbox`.
+    pub fn with_sandbox(mut self, sandbox: SandboxConfig) -> Self {
+        self.sandbox = sandbox;
+        self
     }
 
     /// Use a custom depth budget (primarily for constructing a child tool
@@ -331,6 +349,15 @@ impl DelegateTool {
     /// Test-only visibility: whether an embedder was threaded through.
     pub fn embedder_for_test(&self) -> Option<&Arc<dyn octos_llm::EmbeddingProvider>> {
         self.embedder.as_ref()
+    }
+
+    /// Test-only visibility: the sandbox threaded onto the child registry.
+    /// #1607: lets a unit test reconstruct the exact registry `execute`
+    /// builds (`with_builtins_and_sandbox(&working_dir, create_sandbox(&sandbox))`)
+    /// and assert the configured backend actually reaches the validator path.
+    #[cfg(test)]
+    pub(crate) fn sandbox_for_test(&self) -> &SandboxConfig {
+        &self.sandbox
     }
 
     /// Like [`Self::with_embedder`] but tolerates `None` — call-site
@@ -382,6 +409,8 @@ impl DelegateTool {
             worker_config: self.worker_config.clone(),
             embedder: self.embedder.clone(),
             child_prompt_context_manager_factory: self.child_prompt_context_manager_factory.clone(),
+            // #1607: a deeper delegate level inherits the same session sandbox.
+            sandbox: self.sandbox.clone(),
         })
     }
 }
@@ -596,7 +625,20 @@ impl Tool for DelegateTool {
         // its own DelegateTool with the incremented budget so a leaf child
         // (depth == max) can still emit a typed DepthExceeded error via
         // evaluate/run, and so a depth-1 child can delegate one more level.
-        let mut tools = ToolRegistry::with_builtins(&self.working_dir);
+        //
+        // #1607 (codex-review follow-up): build the child registry with the
+        // SESSION sandbox rather than the hardcoded `NoSandbox` `with_builtins`
+        // stores. The child's `child_tools_handle` feeds `run_declared_validators`
+        // (Step 6 below), and `build_validator_runner` confines
+        // `ValidatorSpec::Command` validators to `tools.sandbox()`. Without the
+        // real backend here, a workspace-declared command validator could
+        // escape the sandbox and execute on the host. On hosts without a real
+        // backend `create_sandbox` yields `NoSandbox` and the validator runs the
+        // argv directly (unchanged).
+        let mut tools = ToolRegistry::with_builtins_and_sandbox(
+            &self.working_dir,
+            create_sandbox(&self.sandbox),
+        );
         tools.clear_spawn_only();
 
         let child_delegate = Self {
@@ -616,6 +658,8 @@ impl Tool for DelegateTool {
             worker_config: self.worker_config.clone(),
             embedder: self.embedder.clone(),
             child_prompt_context_manager_factory: self.child_prompt_context_manager_factory.clone(),
+            // #1607: the re-registered child delegate inherits the same sandbox.
+            sandbox: self.sandbox.clone(),
         };
         tools.register_arc(Arc::new(child_delegate));
 
@@ -905,6 +949,66 @@ mod tests {
     async fn should_default_to_no_embedder_when_not_provided() {
         let tool = embedder_probe_tool().await;
         assert!(tool.embedder_for_test().is_none());
+    }
+
+    /// #1607 (codex-review follow-up): the delegated-child completion path
+    /// builds its validator registry with `with_builtins_and_sandbox(
+    /// &self.working_dir, create_sandbox(&self.sandbox))`. Lock in that the
+    /// sandbox threaded via `with_sandbox` reaches that registry (i.e. it is
+    /// NOT the pre-fix hardcoded `with_builtins` / `NoSandbox`). Docker mode is
+    /// chosen because `create_sandbox` returns a `DockerSandbox` unconditionally
+    /// (no docker binary required), so a hardcoded `NoSandbox` would report
+    /// `is_docker() == false` and fail here — host-independent.
+    #[tokio::test]
+    async fn delegate_threads_configured_sandbox_into_validator_registry() {
+        let tool = embedder_probe_tool().await.with_sandbox(SandboxConfig {
+            mode: crate::sandbox::SandboxMode::Docker,
+            ..SandboxConfig::default()
+        });
+        // Reconstruct exactly what `execute` builds for the child registry.
+        let registry = ToolRegistry::with_builtins_and_sandbox(
+            &tool.working_dir,
+            create_sandbox(tool.sandbox_for_test()),
+        );
+        let sandbox = registry.sandbox();
+        assert!(
+            sandbox.is_docker(),
+            "delegate child validator registry must inherit the DelegateTool \
+             sandbox (Docker here), not the pre-#1607 hardcoded NoSandbox"
+        );
+        assert!(
+            !sandbox.is_noop(),
+            "a real backend threaded via with_sandbox must not be a no-op"
+        );
+
+        // The re-registered deeper-level child must inherit the same sandbox.
+        let child = tool.child_tool().expect("depth budget allows a child");
+        assert_eq!(
+            child.sandbox_for_test().mode,
+            crate::sandbox::SandboxMode::Docker,
+            "child_tool() must fork the sandbox so grandchild validators stay \
+             confined"
+        );
+    }
+
+    /// #1607: the default (unconfigured) DelegateTool keeps a
+    /// `SandboxConfig::default()` and stays host-independent — an explicit
+    /// no-op backend runs command validators directly (pre-#1607 behaviour).
+    #[tokio::test]
+    async fn delegate_none_sandbox_registry_is_noop() {
+        let tool = embedder_probe_tool().await.with_sandbox(SandboxConfig {
+            mode: crate::sandbox::SandboxMode::None,
+            ..SandboxConfig::default()
+        });
+        let registry = ToolRegistry::with_builtins_and_sandbox(
+            &tool.working_dir,
+            create_sandbox(tool.sandbox_for_test()),
+        );
+        assert!(
+            registry.sandbox().is_noop(),
+            "SandboxMode::None must resolve to a no-op backend so command \
+             validators run directly (host-independent)"
+        );
     }
 
     #[test]

--- a/crates/octos-agent/src/tools/delegate.rs
+++ b/crates/octos-agent/src/tools/delegate.rs
@@ -797,6 +797,7 @@ impl Tool for DelegateTool {
                             "delegate",
                             ValidatorPhase::Completion,
                             None,
+                            std::sync::Arc::from(create_sandbox(&self.sandbox)),
                         )
                         .await
                         .err()

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -176,6 +176,17 @@ pub struct ToolRegistry {
     /// (`mofa_slides`, `mofa_cards`, ...): the dispatcher is the ONLY
     /// supported LLM entry-point.
     internal_hidden: HashSet<String>,
+    /// #1607: the session sandbox handed to the shell/exec/bash tools at
+    /// construction. Stored (not just handed off and dropped) so the
+    /// Agent-internal project-root validator path
+    /// (`workspace_contract::build_validator_runner`) can thread the same
+    /// sandbox into its `ValidatorRunner` and confine
+    /// `ValidatorSpec::Command` validators declared by an untrusted
+    /// workspace policy. Defaults to `Arc::new(NoSandbox)` (a no-op sandbox
+    /// whose `is_noop()==true`), so on the plain `with_builtins`/`Default`
+    /// path — and on any host without a real backend — command validators
+    /// run the argv directly and behavior is unchanged.
+    sandbox: Arc<dyn Sandbox>,
 }
 
 /// Default per-tool execution-timeout backstop (seconds) for the registry
@@ -212,7 +223,23 @@ impl ToolRegistry {
             output_dir_hint: None,
             tool_timeout_secs: DEFAULT_REGISTRY_TOOL_TIMEOUT_SECS,
             internal_hidden: HashSet::new(),
+            // #1607: default to a no-op sandbox. Constructors that receive a
+            // real sandbox (`with_builtins_and_permissions`,
+            // `rebind_cwd_with_permissions`) overwrite this below.
+            sandbox: Arc::new(NoSandbox),
         }
+    }
+
+    /// #1607: the session sandbox stored on this registry. Threaded into the
+    /// Agent-internal project-root validator runner
+    /// (`workspace_contract::build_validator_runner`) so
+    /// `ValidatorSpec::Command` validators declared by an untrusted workspace
+    /// policy are confined to the same sandbox as the shell/exec tools instead
+    /// of running unsandboxed on the host. A no-op sandbox
+    /// (`NoSandbox`, or a backend whose helper is unavailable) has nothing to
+    /// escape, so `ValidatorRunner` runs the argv directly there.
+    pub fn sandbox(&self) -> Arc<dyn Sandbox> {
+        self.sandbox.clone()
     }
 
     /// Set the global per-tool execution-timeout backstop (seconds) enforced
@@ -856,6 +883,27 @@ impl ToolRegistry {
         self.provider_policy.as_ref()
     }
 
+    /// #1607 (P2): whether the active **provider policy** permits dispatching
+    /// the named tool. Applies the exact deny-wins-then-allow semantics that
+    /// [`Self::execute_with_context`] enforces at the dispatch boundary
+    /// (including alias equivalence, e.g. `bash`/`shell`/`exec_command`), but
+    /// unlike [`Self::is_tool_visible`] does NOT apply the `context_filter` or
+    /// internal-hidden markers — it answers only "would the provider policy
+    /// let the model call this tool".
+    ///
+    /// Used by [`crate::validators::MapToolDispatcher::from_registry`] to keep
+    /// project-root `ToolCall` validators from reaching a tool the provider
+    /// policy denies. With no provider policy set every tool is permitted (the
+    /// default), so this is a no-op on the common path.
+    pub fn provider_policy_permits(&self, name: &str) -> bool {
+        self.provider_policy.as_ref().is_none_or(|policy| {
+            matches!(
+                evaluate_provider_policy_equivalent(policy, name),
+                policy::PolicyDecision::Allow
+            )
+        })
+    }
+
     /// Set a context-based tag filter. Only tools whose tags overlap with these
     /// values will appear in `specs()`. Tools with no tags always pass through.
     pub fn set_context_filter(&mut self, tags: Vec<String>) {
@@ -901,6 +949,13 @@ impl ToolRegistry {
             // the same invariants as the parent (mofa_make targets stay
             // hidden from `specs()`).
             internal_hidden: self.internal_hidden.clone(),
+            // #1607: carry the parent's sandbox onto the snapshot so a
+            // snapshot-derived registry (used by `rebind_cwd_with_permissions`)
+            // keeps a real sandbox by default. `rebind_cwd_with_permissions`
+            // overwrites it below with the sandbox for the rebound cwd, but a
+            // plain `snapshot_excluding` caller still observes the same
+            // confinement as the parent.
+            sandbox: self.sandbox.clone(),
         };
         // #1148 codex P2: the cloned `tool_search` / `tool_suggest`
         // Arcs still point to the PARENT's catalog cell. Re-register
@@ -1100,6 +1155,11 @@ impl ToolRegistry {
         let mut registry = Self::new();
         registry.workspace_root = Some(cwd.to_path_buf());
         let sandbox: Arc<dyn Sandbox> = Arc::from(sandbox);
+        // #1607: store the session sandbox so the Agent-internal project-root
+        // validator path can confine command validators to it (see
+        // `Self::sandbox`). Kept in lockstep with the shell/exec/bash tools
+        // registered just below.
+        registry.sandbox = sandbox.clone();
         registry.register(
             ShellTool::new(cwd)
                 .with_shared_sandbox(sandbox.clone())
@@ -1314,6 +1374,11 @@ impl ToolRegistry {
         let mut registry = self.snapshot_excluding(&exclude);
         registry.workspace_root = Some(cwd.to_path_buf());
         let sandbox: Arc<dyn Sandbox> = Arc::from(sandbox);
+        // #1607: store the sandbox for the rebound cwd (overwriting the
+        // parent's, carried by `snapshot_excluding`) so the project-root
+        // validator path confines command validators to the same sandbox as
+        // the shell/exec/bash tools re-registered just below.
+        registry.sandbox = sandbox.clone();
         // Re-register cwd-bound tools with the new workspace
         registry.register(
             ShellTool::new(cwd)
@@ -1834,6 +1899,94 @@ mod registry_dispatch_tests {
     fn is_tool_visible_returns_false_for_unregistered_tools() {
         let reg = make_registry(5, 3);
         assert!(!reg.is_tool_visible("nope_does_not_exist"));
+    }
+
+    #[test]
+    fn should_expose_a_noop_sandbox_when_registry_built_without_a_real_backend() {
+        // #1607 (P1): `with_builtins` (and `Default`) install `NoSandbox`, so
+        // the getter the project-root validator path calls must return a no-op
+        // sandbox — `ValidatorRunner` then runs command validators' argv
+        // directly, keeping host behavior unchanged where no backend exists.
+        let reg = make_registry(5, 3);
+        assert!(
+            reg.sandbox().is_noop(),
+            "registry built without a real sandbox must expose a no-op sandbox"
+        );
+    }
+
+    #[test]
+    fn should_store_the_real_sandbox_handed_to_builtins_and_expose_it() {
+        // #1607 (P1): a real (non-no-op) sandbox handed to the shell/exec/bash
+        // tools must be STORED on the registry and surfaced via `sandbox()`,
+        // not handed off and dropped — that is the handle the project-root
+        // validator runner threads into `.with_sandbox(...)`.
+        struct FakeRealSandbox;
+        impl Sandbox for FakeRealSandbox {
+            fn wrap_command(
+                &self,
+                command: &str,
+                _cwd: &std::path::Path,
+            ) -> tokio::process::Command {
+                let mut c = tokio::process::Command::new("sh");
+                c.arg("-c").arg(command);
+                c
+            }
+            fn is_noop(&self) -> bool {
+                false
+            }
+        }
+        let reg = ToolRegistry::with_builtins_and_sandbox(
+            PathBuf::from("/tmp"),
+            Box::new(FakeRealSandbox),
+        );
+        assert!(
+            !reg.sandbox().is_noop(),
+            "a real sandbox handed to with_builtins_and_sandbox must be stored, not dropped"
+        );
+    }
+
+    #[test]
+    fn should_permit_all_tools_when_no_provider_policy_is_set() {
+        // #1607 (P2): with no provider policy the permit predicate is a no-op,
+        // so `MapToolDispatcher::from_registry` snapshots every tool.
+        let reg = make_registry(5, 3);
+        assert!(reg.provider_policy_permits("shell"));
+        assert!(reg.provider_policy_permits("read_file"));
+    }
+
+    #[test]
+    fn should_deny_provider_policy_denied_tools_including_aliases() {
+        // #1607 (P2): the permit predicate must mirror the deny-wins semantics
+        // (with alias equivalence) that `execute` enforces, so a project-root
+        // ToolCall validator can't reach a denied tool via the snapshot.
+        let mut reg = make_registry(5, 3);
+        reg.set_provider_policy(ToolPolicy {
+            deny: vec!["spawn".to_string()],
+            ..Default::default()
+        });
+        // `spawn_agent` maps to the `spawn` alias, so denying `spawn` denies it.
+        assert!(
+            !reg.provider_policy_permits("spawn_agent"),
+            "alias-equivalent denied tools must not pass the permit predicate"
+        );
+        // A tool outside the deny list still passes (allow list empty => allow).
+        assert!(reg.provider_policy_permits("read_file"));
+    }
+
+    #[test]
+    fn should_permit_only_allowlisted_tools_when_allow_list_is_set() {
+        // #1607 (P2): a non-empty allow list means only listed (or
+        // alias-equivalent) tools are permitted.
+        let mut reg = make_registry(5, 3);
+        reg.set_provider_policy(ToolPolicy {
+            allow: vec!["read_file".to_string()],
+            ..Default::default()
+        });
+        assert!(reg.provider_policy_permits("read_file"));
+        assert!(
+            !reg.provider_policy_permits("shell"),
+            "tools absent from a non-empty allow list must not pass the permit predicate"
+        );
     }
 
     #[test]

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -29,6 +29,13 @@ fn policy_equivalent_tool_names(name: &str) -> Vec<&str> {
     match name {
         "spawn_agent" => vec!["spawn_agent", "spawn"],
         "wait_agent" => vec!["wait_agent", "read_task_output"],
+        // #1607 (codex round 2): `shell`/`bash`/`exec_command` are the same
+        // command capability (the `bash`/`exec_command` names are codex-compat
+        // aliases that share the shell policy — see `register`). A provider
+        // policy naming any one must apply to all three: otherwise `deny=["shell"]`
+        // is trivially bypassed via `bash`, and `allow=["shell"]` wrongly drops a
+        // `ToolCall` validator that uses `bash`/`exec_command`.
+        "shell" | "bash" | "exec_command" => vec!["shell", "bash", "exec_command"],
         _ => vec![name],
     }
 }

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -25,6 +25,7 @@ use crate::file_state_cache::FileStateCache;
 use crate::harness_events::{HarnessEvent, HarnessEventSink, write_event_to_sink};
 use crate::prompt_context::PromptContextManager;
 use crate::role_template::RoleTemplate;
+use crate::sandbox::{SandboxConfig, create_sandbox};
 use crate::subagent_output::SubAgentOutputRouter;
 use crate::subagent_summary::AgentSummaryGenerator;
 use crate::task_supervisor::{TaskSupervisor, TaskTerminalGuard};
@@ -876,6 +877,24 @@ pub struct SpawnTool {
     /// `None` keeps the pre-fix behaviour for callers that opted out
     /// (e.g. legacy tests not exercising the gate).
     dispatch_policy: Option<crate::dispatch_policy::DispatchPolicy>,
+    /// #1607 (codex-review follow-up): the session's sandbox config, carried
+    /// so the spawn/agent_mcp child completion path can confine `Command`
+    /// validators declared by an untrusted workspace `workspace_policy.toml`
+    /// to the same backend as the parent's shell/exec tools. Before this
+    /// field, the two validator registries in `execute_with_context`'s
+    /// `agent_mcp` branch were built with `ToolRegistry::with_builtins`
+    /// (hardcoded `NoSandbox`), so `run_project_root_validators` /
+    /// `run_declared_validators` executed a workspace-authored `Command`
+    /// validator directly on the host even when the session was sandboxed —
+    /// a second construction site for the exact escape #1607 closed on the
+    /// `build_validator_runner` chokepoint. Defaults to
+    /// `SandboxConfig::default()`; the real session wiring threads the same
+    /// config the parent `ToolRegistry` was built with via
+    /// [`Self::with_sandbox`]. A no-op backend (`NoSandbox`, or a helper that
+    /// is unavailable) has nothing to escape, so `ValidatorRunner` runs the
+    /// argv directly there — behaviour is unchanged on hosts without a real
+    /// backend.
+    sandbox: SandboxConfig,
 }
 
 impl SpawnTool {
@@ -916,6 +935,7 @@ impl SpawnTool {
             parent_subagent_summary_generator: None,
             child_prompt_context_manager_factory: None,
             dispatch_policy: None,
+            sandbox: SandboxConfig::default(),
         }
     }
 
@@ -959,6 +979,7 @@ impl SpawnTool {
             parent_subagent_summary_generator: None,
             child_prompt_context_manager_factory: None,
             dispatch_policy: None,
+            sandbox: SandboxConfig::default(),
         }
     }
 
@@ -991,6 +1012,18 @@ impl SpawnTool {
     /// Inherit a provider-specific tool policy from the parent agent.
     pub fn with_provider_policy(mut self, policy: Option<ToolPolicy>) -> Self {
         self.provider_policy = policy;
+        self
+    }
+
+    /// #1607 (codex-review follow-up): inherit the session's sandbox config so
+    /// the spawn/agent_mcp child completion path confines workspace-declared
+    /// `Command` validators to the same backend as the parent's shell/exec
+    /// tools. Real session wiring passes the exact `SandboxConfig` the parent
+    /// `ToolRegistry` was built with; callers that don't set it keep the
+    /// host-independent `SandboxConfig::default()` (which resolves to a no-op
+    /// backend when no helper is present, so validators run the argv directly).
+    pub fn with_sandbox(mut self, sandbox: SandboxConfig) -> Self {
+        self.sandbox = sandbox;
         self
     }
 
@@ -2823,8 +2856,19 @@ impl Tool for SpawnTool {
                     crate::workspace_policy::read_workspace_policy(&self.working_dir)
                 {
                     if !policy.validation.validators.is_empty() {
-                        let registry_for_validators =
-                            ToolRegistry::with_builtins(&self.working_dir);
+                        // #1607 (codex-review follow-up): build this
+                        // session-scope validator registry with the session's
+                        // sandbox so a workspace-authored `Command` validator
+                        // runs confined, not directly on the host. `with_builtins`
+                        // hardcodes `NoSandbox`, so `tools.sandbox()` inside
+                        // `build_validator_runner` would be a no-op here even
+                        // when the parent session is sandboxed. A no-op backend
+                        // (no helper present) still runs the argv directly, so
+                        // hosts without a real sandbox are unaffected.
+                        let registry_for_validators = ToolRegistry::with_builtins_and_sandbox(
+                            &self.working_dir,
+                            create_sandbox(&self.sandbox),
+                        );
                         if let Err(reason) = crate::workspace_contract::run_declared_validators(
                             &registry_for_validators,
                             &self.working_dir,
@@ -2856,7 +2900,18 @@ impl Tool for SpawnTool {
             // branch closes the same bypass.
             if mcp_success {
                 let expected_kind = workflow.as_ref().and_then(workflow_contract_project_kind);
-                let registry_for_validators = ToolRegistry::with_builtins(&self.working_dir);
+                // #1607 (codex-review follow-up): same rationale as the
+                // session-scope block above — the project-root validator pass
+                // runs `Command` validators declared by an untrusted
+                // `slides/<slug>` or `sites/<slug>` `workspace_policy.toml`, so
+                // it MUST inherit the session sandbox instead of `with_builtins`'
+                // hardcoded `NoSandbox`. This is the child mirror of the
+                // `build_validator_runner` chokepoint fix; without it the
+                // agent_mcp branch is a second unsandboxed construction site.
+                let registry_for_validators = ToolRegistry::with_builtins_and_sandbox(
+                    &self.working_dir,
+                    create_sandbox(&self.sandbox),
+                );
                 let report = crate::workspace_contract::run_project_root_validators(
                     &registry_for_validators,
                     &self.working_dir,
@@ -4417,6 +4472,12 @@ mod tests {
             parent_subagent_summary_generator: None,
             child_prompt_context_manager_factory: None,
             dispatch_policy: None,
+            // Explicit no-op sandbox keeps this unit test host-independent
+            // (no dependency on whether a real backend helper is installed).
+            sandbox: SandboxConfig {
+                mode: crate::sandbox::SandboxMode::None,
+                ..SandboxConfig::default()
+            },
         };
 
         assert_eq!(tool.worker_count.load(Ordering::SeqCst), 0);
@@ -4427,6 +4488,80 @@ mod tests {
 
         // Worker count should not increment on invalid input
         assert_eq!(tool.worker_count.load(Ordering::SeqCst), 0);
+    }
+
+    /// #1607 (codex-review follow-up): the spawn/agent_mcp child completion
+    /// path builds its validator registries with
+    /// `ToolRegistry::with_builtins_and_sandbox(&self.working_dir,
+    /// create_sandbox(&self.sandbox))`. This test locks in that the sandbox
+    /// threaded via `with_sandbox` actually reaches that registry (i.e. the
+    /// two construction sites are NOT the pre-fix hardcoded `with_builtins` /
+    /// `NoSandbox`). Docker mode is chosen because `create_sandbox` returns a
+    /// `DockerSandbox` unconditionally (no docker binary required), so the
+    /// assertion is host-independent: a hardcoded `NoSandbox` would report
+    /// `is_noop() == true` / `is_docker() == false`, which would fail here.
+    #[tokio::test]
+    async fn spawn_threads_configured_sandbox_into_validator_registry() {
+        let (in_tx, _in_rx) = tokio::sync::mpsc::channel(16);
+        let tool = SpawnTool::new(
+            Arc::new(MockProvider),
+            Arc::new(create_test_store().await),
+            PathBuf::from("/tmp"),
+            in_tx,
+        )
+        .with_sandbox(SandboxConfig {
+            mode: crate::sandbox::SandboxMode::Docker,
+            ..SandboxConfig::default()
+        });
+
+        // Reconstruct exactly what the two `execute_with_context` validator
+        // blocks build (`with_builtins_and_sandbox(&self.working_dir,
+        // create_sandbox(&self.sandbox))`) and assert the backend is the one
+        // we configured, not a hardcoded no-op.
+        let registry = ToolRegistry::with_builtins_and_sandbox(
+            &tool.working_dir,
+            create_sandbox(&tool.sandbox),
+        );
+        let sandbox = registry.sandbox();
+        assert!(
+            sandbox.is_docker(),
+            "spawn validator registry must inherit the SpawnTool sandbox \
+             (Docker here), not the pre-#1607 hardcoded NoSandbox"
+        );
+        assert!(
+            !sandbox.is_noop(),
+            "a real backend threaded via with_sandbox must not be a no-op"
+        );
+    }
+
+    /// #1607 (codex-review follow-up): the default (unconfigured) SpawnTool
+    /// keeps a `SandboxConfig::default()` and stays host-independent — an
+    /// explicit `SandboxMode::None` resolves to `NoSandbox` (is_noop), so the
+    /// validator registry runs command validators directly (pre-#1607
+    /// behaviour) on hosts without a real backend.
+    #[tokio::test]
+    async fn spawn_none_sandbox_registry_is_noop() {
+        let (in_tx, _in_rx) = tokio::sync::mpsc::channel(16);
+        let tool = SpawnTool::new(
+            Arc::new(MockProvider),
+            Arc::new(create_test_store().await),
+            PathBuf::from("/tmp"),
+            in_tx,
+        )
+        .with_sandbox(SandboxConfig {
+            mode: crate::sandbox::SandboxMode::None,
+            ..SandboxConfig::default()
+        });
+
+        let registry = ToolRegistry::with_builtins_and_sandbox(
+            &tool.working_dir,
+            create_sandbox(&tool.sandbox),
+        );
+        assert!(
+            registry.sandbox().is_noop(),
+            "SandboxMode::None must resolve to a no-op backend so command \
+             validators run directly (host-independent)"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -2865,6 +2865,8 @@ impl Tool for SpawnTool {
                         // when the parent session is sandboxed. A no-op backend
                         // (no helper present) still runs the argv directly, so
                         // hosts without a real sandbox are unaffected.
+                        let validator_sandbox: std::sync::Arc<dyn crate::sandbox::Sandbox> =
+                            std::sync::Arc::from(create_sandbox(&self.sandbox));
                         let mut registry_for_validators = ToolRegistry::with_builtins_and_sandbox(
                             &self.working_dir,
                             create_sandbox(&self.sandbox),
@@ -2882,6 +2884,7 @@ impl Tool for SpawnTool {
                             "spawn-agent-mcp",
                             crate::validators::ValidatorPhase::Completion,
                             None,
+                            validator_sandbox,
                         )
                         .await
                         {
@@ -2914,6 +2917,8 @@ impl Tool for SpawnTool {
                 // hardcoded `NoSandbox`. This is the child mirror of the
                 // `build_validator_runner` chokepoint fix; without it the
                 // agent_mcp branch is a second unsandboxed construction site.
+                let validator_sandbox: std::sync::Arc<dyn crate::sandbox::Sandbox> =
+                    std::sync::Arc::from(create_sandbox(&self.sandbox));
                 let mut registry_for_validators = ToolRegistry::with_builtins_and_sandbox(
                     &self.working_dir,
                     create_sandbox(&self.sandbox),
@@ -2929,6 +2934,7 @@ impl Tool for SpawnTool {
                     &self.working_dir,
                     expected_kind,
                     &response.files_to_send,
+                    validator_sandbox,
                 )
                 .await;
                 if let Some(reason) = report.first_failure_reason() {
@@ -3255,6 +3261,7 @@ impl Tool for SpawnTool {
                                     "spawn",
                                     crate::validators::ValidatorPhase::Completion,
                                     None,
+                                    std::sync::Arc::from(create_sandbox(&self.sandbox)),
                                 )
                                 .await
                                 {
@@ -3290,6 +3297,7 @@ impl Tool for SpawnTool {
                             &child_working_dir,
                             expected_kind,
                             &r.files_to_send,
+                            std::sync::Arc::from(create_sandbox(&self.sandbox)),
                         )
                         .await;
                         if let Some(reason) = report.first_failure_reason() {
@@ -3829,6 +3837,7 @@ impl Tool for SpawnTool {
                             "spawn",
                             crate::validators::ValidatorPhase::Completion,
                             None,
+                            std::sync::Arc::from(create_sandbox(&child_sandbox)),
                         )
                         .await
                         {
@@ -3862,6 +3871,7 @@ impl Tool for SpawnTool {
                         &working_dir,
                         expected_kind,
                         bg_files_to_send,
+                        std::sync::Arc::from(create_sandbox(&child_sandbox)),
                     )
                     .await;
                     if let Some(reason) = report.first_failure_reason() {
@@ -5363,6 +5373,7 @@ PY
                     temp.path(),
                     Some(crate::WorkspaceProjectKind::Slides),
                     &files_to_send,
+                    std::sync::Arc::new(crate::sandbox::NoSandbox),
                 )
                 .await;
             });

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -2865,10 +2865,16 @@ impl Tool for SpawnTool {
                         // when the parent session is sandboxed. A no-op backend
                         // (no helper present) still runs the argv directly, so
                         // hosts without a real sandbox are unaffected.
-                        let registry_for_validators = ToolRegistry::with_builtins_and_sandbox(
+                        let mut registry_for_validators = ToolRegistry::with_builtins_and_sandbox(
                             &self.working_dir,
                             create_sandbox(&self.sandbox),
                         );
+                        // Honour the parent's provider tool policy in the validator
+                        // registry too, so a workspace `ToolCall` validator can't
+                        // invoke a tool the policy denies (#1607 codex round 2).
+                        if let Some(policy) = self.provider_policy.clone() {
+                            registry_for_validators.set_provider_policy(policy);
+                        }
                         if let Err(reason) = crate::workspace_contract::run_declared_validators(
                             &registry_for_validators,
                             &self.working_dir,
@@ -2908,10 +2914,16 @@ impl Tool for SpawnTool {
                 // hardcoded `NoSandbox`. This is the child mirror of the
                 // `build_validator_runner` chokepoint fix; without it the
                 // agent_mcp branch is a second unsandboxed construction site.
-                let registry_for_validators = ToolRegistry::with_builtins_and_sandbox(
+                let mut registry_for_validators = ToolRegistry::with_builtins_and_sandbox(
                     &self.working_dir,
                     create_sandbox(&self.sandbox),
                 );
+                // Honour the parent's provider tool policy in the validator
+                // registry too, so a workspace `ToolCall` validator can't invoke
+                // a tool the policy denies (#1607 codex round 2).
+                if let Some(policy) = self.provider_policy.clone() {
+                    registry_for_validators.set_provider_policy(policy);
+                }
                 let report = crate::workspace_contract::run_project_root_validators(
                     &registry_for_validators,
                     &self.working_dir,

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -3058,7 +3058,21 @@ impl Tool for SpawnTool {
 
         if is_sync {
             // Sync mode: run subagent inline and return the result directly
-            let mut tools = ToolRegistry::with_builtins(&child_working_dir);
+            //
+            // #1607 (codex-review follow-up): build the child registry with the
+            // SESSION sandbox, not the hardcoded `NoSandbox` that
+            // `with_builtins` stores. The child's `child_tools_handle` feeds
+            // `run_declared_validators` / `run_project_root_validators` below,
+            // and `build_validator_runner` confines `ValidatorSpec::Command`
+            // validators to `tools.sandbox()`. A `NoSandbox` registry there
+            // would let an untrusted `workspace_policy.toml` command validator
+            // execute directly on the host from a sandboxed session. On hosts
+            // without a real backend `create_sandbox` yields `NoSandbox` and
+            // the validator runs the argv directly (unchanged).
+            let mut tools = ToolRegistry::with_builtins_and_sandbox(
+                &child_working_dir,
+                create_sandbox(&self.sandbox),
+            );
             // Load plugin tools so subagents can use fm_tts, etc.
             // Section B (codex review P1.1): honour the parent's
             // require_signed policy so unsigned plugins are rejected here
@@ -3406,6 +3420,12 @@ impl Tool for SpawnTool {
                 .take()
                 .map(WorkerWorktreeGuard::disarm);
             let provider_policy = self.provider_policy.clone();
+            // #1607 (codex-review follow-up): capture the session sandbox so the
+            // detached background child registry can be built with it (see the
+            // `with_builtins_and_sandbox` call inside the closure). Without this
+            // the background child's validator registry stored `NoSandbox`, so a
+            // workspace-declared command validator could escape to the host.
+            let child_sandbox = self.sandbox.clone();
             let additional_instructions = input.additional_instructions;
             let default_worker_prompt = self.worker_prompt.clone();
             let bg_sender = self.background_result_sender.clone();
@@ -3592,7 +3612,17 @@ impl Tool for SpawnTool {
                 };
                 let harness_event_sink_path = harness_event_sink.as_ref().map(|sink| sink.uri());
 
-                let mut tools = ToolRegistry::with_builtins(&working_dir);
+                // #1607 (codex-review follow-up): build the detached child
+                // registry with the SESSION sandbox rather than the hardcoded
+                // `NoSandbox` `with_builtins` stores. Its `child_tools_handle`
+                // feeds `run_declared_validators` / `run_project_root_validators`
+                // below, and `build_validator_runner` confines command
+                // validators to `tools.sandbox()`. On hosts without a real
+                // backend `create_sandbox` yields `NoSandbox` (unchanged).
+                let mut tools = ToolRegistry::with_builtins_and_sandbox(
+                    &working_dir,
+                    create_sandbox(&child_sandbox),
+                );
                 // Load plugin tools so subagents can use fm_tts, etc.
                 // Section B (codex review P1.1): inherit the parent's
                 // require_signed gate.

--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -728,7 +728,23 @@ impl ValidatorRunner {
         // helper is unavailable) and the no-sandbox case have nothing to escape,
         // so they run the argv directly, where `Command` passes each element as a
         // distinct token (injection-safe).
-        let real_sandbox = self.sandbox.as_ref().filter(|s| !s.is_noop());
+        //
+        // #1607 (codex-review follow-up) — Docker exception: the Docker backend
+        // bind-mounts the workspace at a fixed in-container path (`/workspace`),
+        // but `Command` validators interpolate absolute *host* paths (e.g.
+        // `${output.patch_path}` -> `/host/ws/.../foo.patch`) that don't exist
+        // inside the container, so wrapping them in `docker run` would make a
+        // previously-passing required validator start failing. Before #1607,
+        // command validators ran on the host and worked. To avoid a silent
+        // regression, Docker-mode command validators stay on the pre-#1607
+        // direct (host) path here (Docker is not the fleet default). This does
+        // NOT sandbox them — full in-container path translation is a documented
+        // known follow-up (see `Sandbox::is_docker`). The non-command validator
+        // kinds (ToolCall / file checks) are unaffected: they never shell out.
+        let real_sandbox = self
+            .sandbox
+            .as_ref()
+            .filter(|s| !s.is_noop() && !s.is_docker());
         let sandbox_is_windows = cfg!(windows);
         if real_sandbox.is_some() && sandbox_is_windows {
             return error_outcome(
@@ -3584,6 +3600,63 @@ mod tests {
         }));
         let outcomes = runner.run_all(&invocation, &[validator]).await;
         assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    /// #1607 (codex-review follow-up) — Docker P2: a Docker-mode sandbox must
+    /// NOT wrap command validators in `docker run` (host absolute paths like
+    /// `${output.target_path}` don't exist inside the `/workspace` bind mount,
+    /// so a previously-passing required validator would break). Instead they
+    /// stay on the pre-#1607 direct (host) path. Proof: a `test -f <host path>`
+    /// validator run under `SandboxMode::Docker` still PASSES against the real
+    /// host file. If it were wrapped in `docker run`, it would either error
+    /// (no docker binary) or fail (host path not visible in the container) —
+    /// never Pass. Unix-only because the host path is checked via `test -f`.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn docker_sandbox_keeps_command_validator_on_host_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path_arg = dir.path().join("deck.pptx");
+        std::fs::write(&path_arg, b"x").unwrap();
+
+        // A Docker-mode sandbox is constructed regardless of whether the docker
+        // binary is present, so this test is host-independent.
+        let docker: Arc<dyn Sandbox> = Arc::from(crate::sandbox::create_sandbox(
+            &crate::sandbox::SandboxConfig {
+                mode: crate::sandbox::SandboxMode::Docker,
+                ..crate::sandbox::SandboxConfig::default()
+            },
+        ));
+        assert!(docker.is_docker(), "guard: backend must be Docker");
+        assert!(
+            !docker.is_noop(),
+            "guard: Docker is a real (non-no-op) backend"
+        );
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf())
+            .with_sandbox(docker);
+        let validator = validator_with_spec(
+            "docker_host_path_cmd",
+            ValidatorSpec::Command {
+                cmd: "test".into(),
+                args: vec!["-f".into(), "${output.target_path}".into()],
+            },
+        );
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_tool_output(serde_json::json!({
+            "target_path": path_arg.to_string_lossy().to_string(),
+        }));
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(
+            outcomes[0].status,
+            ValidatorStatus::Pass,
+            "Docker-mode command validator must run on the host directly and \
+             pass against the real host file (not be wrapped in `docker run`): \
+             {outcomes:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -400,6 +400,17 @@ impl MapToolDispatcher {
     pub fn from_registry(registry: &ToolRegistry) -> Self {
         let mut me = Self::new();
         for name in registry.tool_names() {
+            // #1607 (P2): only snapshot tools the active provider policy would
+            // let the model call. `MapToolDispatcher::dispatch` invokes
+            // `Tool::execute` directly, bypassing `ToolRegistry::execute`'s
+            // provider-policy gate — so without this filter a nested-project
+            // `ToolCall` validator could invoke a tool the provider policy
+            // denies. A denied tool is simply not inserted, so `dispatch`
+            // returns "tool not registered for validator dispatch". With no
+            // provider policy set (the default) every tool passes through.
+            if !registry.provider_policy_permits(&name) {
+                continue;
+            }
             if let Some(tool) = registry.get_tool(&name) {
                 me.insert(name, tool);
             }
@@ -4785,5 +4796,48 @@ mod tests {
              an unrelated non-silent file exists in the workspace (proves the validator \
              does not fall back to the glob path); outcomes = {outcomes:?}",
         );
+    }
+
+    #[tokio::test]
+    async fn map_tool_dispatcher_snapshots_all_tools_without_a_provider_policy() {
+        // #1607 (P2): with no provider policy, `from_registry` snapshots every
+        // registered tool, so a ToolCall validator can dispatch it.
+        let reg = ToolRegistry::with_builtins(std::env::temp_dir());
+        let dispatcher = MapToolDispatcher::from_registry(&reg);
+        // `read_file` is a built-in and must be dispatchable.
+        assert!(dispatcher.tools.contains_key("read_file"));
+    }
+
+    #[tokio::test]
+    async fn map_tool_dispatcher_excludes_provider_policy_denied_tools() {
+        // #1607 (P2): a tool the provider policy denies must NOT be snapshotted
+        // by `from_registry`, so a nested-project ToolCall validator can't
+        // reach it. `dispatch` then reports it as unregistered instead of
+        // silently invoking `Tool::execute` (which bypasses the policy gate).
+        let mut reg = ToolRegistry::with_builtins(std::env::temp_dir());
+        reg.set_provider_policy(crate::tools::ToolPolicy {
+            deny: vec!["shell".to_string()],
+            ..Default::default()
+        });
+        let dispatcher = MapToolDispatcher::from_registry(&reg);
+        assert!(
+            !dispatcher.tools.contains_key("shell"),
+            "provider-policy-denied tools must be excluded from the validator dispatch snapshot"
+        );
+        // Dispatching the denied tool fails closed with the unregistered error.
+        let err = match dispatcher
+            .dispatch("shell", &serde_json::json!({ "command": "echo hi" }))
+            .await
+        {
+            Ok(_) => panic!("denied tool must not dispatch through the snapshot"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("not registered for validator dispatch"),
+            "unexpected error: {err}"
+        );
+        // A non-denied built-in is still present.
+        assert!(dispatcher.tools.contains_key("read_file"));
     }
 }

--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -729,32 +729,33 @@ impl ValidatorRunner {
         // so they run the argv directly, where `Command` passes each element as a
         // distinct token (injection-safe).
         //
-        // #1607 (codex-review follow-up) — Docker exception: the Docker backend
-        // bind-mounts the workspace at a fixed in-container path (`/workspace`),
-        // but `Command` validators interpolate absolute *host* paths (e.g.
-        // `${output.patch_path}` -> `/host/ws/.../foo.patch`) that don't exist
-        // inside the container, so wrapping them in `docker run` would make a
-        // previously-passing required validator start failing. Before #1607,
-        // command validators ran on the host and worked. To avoid a silent
-        // regression, Docker-mode command validators stay on the pre-#1607
-        // direct (host) path here (Docker is not the fleet default). This does
-        // NOT sandbox them — full in-container path translation is a documented
-        // known follow-up (see `Sandbox::is_docker`). The non-command validator
-        // kinds (ToolCall / file checks) are unaffected: they never shell out.
-        let real_sandbox = self
-            .sandbox
-            .as_ref()
-            .filter(|s| !s.is_noop() && !s.is_docker());
-        let sandbox_is_windows = cfg!(windows);
-        if real_sandbox.is_some() && sandbox_is_windows {
+        // #1607 (codex-review follow-up): two real backends cannot safely run
+        // the validator argv here, so a real one of either must FAIL CLOSED
+        // rather than mis-quote or escape to the host:
+        //  - Windows (`cmd /C`) ignores the POSIX single quotes `shlex` emits,
+        //    so metacharacters in an argument would stay active.
+        //  - Docker bind-mounts the workspace at a fixed in-container path
+        //    (`/workspace`), but `Command` validators interpolate absolute
+        //    *host* paths (e.g. `${output.patch_path}`) that don't resolve
+        //    inside the container. Running them on the host instead (the prior
+        //    behaviour) would bypass Docker's mount/write/network confinement —
+        //    the very escape #1607 closes. Full in-container path translation
+        //    is a documented follow-up (see `Sandbox::is_docker`).
+        // A no-op / absent sandbox has nothing to escape and runs the argv
+        // directly (injection-safe). ToolCall / file-check validators never
+        // shell out, so they are unaffected either way.
+        let real_sandbox = self.sandbox.as_ref().filter(|s| !s.is_noop());
+        let is_windows = cfg!(windows);
+        let cannot_wrap = real_sandbox.is_some_and(|s| is_windows || s.is_docker());
+        if cannot_wrap {
             return error_outcome(
                 invocation,
                 validator,
                 started_at,
                 started,
                 format!(
-                    "command validator not supported under the Windows sandbox \
-                     (would bypass AppContainer): {command_string}"
+                    "command validator not supported under the active sandbox \
+                     backend (Windows/Docker): {command_string}"
                 ),
             );
         }
@@ -3602,24 +3603,22 @@ mod tests {
         assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
     }
 
-    /// #1607 (codex-review follow-up) — Docker P2: a Docker-mode sandbox must
-    /// NOT wrap command validators in `docker run` (host absolute paths like
-    /// `${output.target_path}` don't exist inside the `/workspace` bind mount,
-    /// so a previously-passing required validator would break). Instead they
-    /// stay on the pre-#1607 direct (host) path. Proof: a `test -f <host path>`
-    /// validator run under `SandboxMode::Docker` still PASSES against the real
-    /// host file. If it were wrapped in `docker run`, it would either error
-    /// (no docker binary) or fail (host path not visible in the container) —
-    /// never Pass. Unix-only because the host path is checked via `test -f`.
+    /// #1607 (codex-review round 2) — Docker fails CLOSED: a Docker-mode
+    /// sandbox cannot safely run a command validator here. Host absolute paths
+    /// like `${output.target_path}` don't resolve inside the `/workspace` bind
+    /// mount, and running them on the host instead (the prior behaviour) would
+    /// bypass Docker's mount/write/network confinement — the very escape #1607
+    /// closes. So the validator must fail closed with a typed error, NOT run on
+    /// the host (which would Pass). Host-independent: a Docker sandbox is
+    /// constructed regardless of whether the docker binary is present. Unix-only
+    /// for parity with the sibling command-validator tests.
     #[tokio::test]
     #[cfg(unix)]
-    async fn docker_sandbox_keeps_command_validator_on_host_path() {
+    async fn docker_sandbox_fails_command_validator_closed() {
         let dir = tempfile::tempdir().unwrap();
         let path_arg = dir.path().join("deck.pptx");
         std::fs::write(&path_arg, b"x").unwrap();
 
-        // A Docker-mode sandbox is constructed regardless of whether the docker
-        // binary is present, so this test is host-independent.
         let docker: Arc<dyn Sandbox> = Arc::from(crate::sandbox::create_sandbox(
             &crate::sandbox::SandboxConfig {
                 mode: crate::sandbox::SandboxMode::Docker,
@@ -3650,12 +3649,13 @@ mod tests {
             "target_path": path_arg.to_string_lossy().to_string(),
         }));
         let outcomes = runner.run_all(&invocation, &[validator]).await;
-        assert_eq!(
-            outcomes[0].status,
-            ValidatorStatus::Pass,
-            "Docker-mode command validator must run on the host directly and \
-             pass against the real host file (not be wrapped in `docker run`): \
-             {outcomes:?}"
+        // Fails CLOSED: not run on the host (which would Pass and bypass Docker),
+        // and not wrapped in `docker run` either.
+        assert_eq!(outcomes[0].status, ValidatorStatus::Error, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains("Docker") || outcomes[0].reason.contains("not supported"),
+            "expected a fail-closed reason, got: {}",
+            outcomes[0].reason
         );
     }
 

--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -821,7 +821,17 @@ fn build_validator_runner(tools: &ToolRegistry, workspace_root: &Path) -> Valida
     // Avoids cloning the full registry and its LRU bookkeeping.
     let dispatcher: Arc<dyn crate::validators::ValidatorToolDispatcher> =
         Arc::new(crate::validators::MapToolDispatcher::from_registry(tools));
-    ValidatorRunner::with_dispatcher(dispatcher, workspace_root)
+    // #1607: confine `ValidatorSpec::Command` validators (which a project's
+    // `workspace_policy.toml` can declare) to the same session sandbox the
+    // shell/exec tools use, so the automatic project-root validator pass at
+    // the end of `run_task` can't be turned into a host-level sandbox escape.
+    // `ValidatorRunner::run_command` runs the argv directly when the sandbox is
+    // a no-op (`NoSandbox`, or a backend whose helper is unavailable), so hosts
+    // without a real backend are unaffected; on POSIX with a real backend the
+    // command is shell-quoted and wrapped; the Windows real-sandbox case fails
+    // closed. This is the single chokepoint for every project-root validator
+    // caller (execution.rs / loop_runner.rs / workspace_git.rs).
+    ValidatorRunner::with_dispatcher(dispatcher, workspace_root).with_sandbox(tools.sandbox())
 }
 
 #[cfg(test)]

--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -7,6 +7,7 @@ use glob::glob;
 use crate::behaviour::{
     ActionContext, ActionResult, evaluate_actions_with_context, run_action_with_context,
 };
+use crate::sandbox::Sandbox;
 use crate::task_supervisor::{TaskRuntimeState, TaskSupervisor};
 use crate::tools::ToolRegistry;
 use crate::validators::{
@@ -48,6 +49,7 @@ pub async fn enforce_spawn_task_contract(
     files_to_send: &[PathBuf],
     task_started_at: SystemTime,
     supervisor: Option<(&TaskSupervisor, &str)>,
+    sandbox: Arc<dyn Sandbox>,
 ) -> SpawnTaskContractResult {
     enforce_spawn_task_contract_with_args_and_output(
         tools,
@@ -58,6 +60,7 @@ pub async fn enforce_spawn_task_contract(
         supervisor,
         None,
         None,
+        sandbox,
     )
     .await
 }
@@ -71,6 +74,7 @@ pub async fn enforce_spawn_task_contract(
 /// the tool's `named_outputs` for `${output.<key>}` interpolation). This
 /// entry point exists for callers that have args but no tool output to
 /// forward.
+#[allow(clippy::too_many_arguments)]
 pub async fn enforce_spawn_task_contract_with_args(
     tools: &ToolRegistry,
     tool_name: &str,
@@ -79,6 +83,7 @@ pub async fn enforce_spawn_task_contract_with_args(
     task_started_at: SystemTime,
     supervisor: Option<(&TaskSupervisor, &str)>,
     input_args: Option<&serde_json::Value>,
+    sandbox: Arc<dyn Sandbox>,
 ) -> SpawnTaskContractResult {
     enforce_spawn_task_contract_with_args_and_output(
         tools,
@@ -89,6 +94,7 @@ pub async fn enforce_spawn_task_contract_with_args(
         supervisor,
         input_args,
         None,
+        sandbox,
     )
     .await
 }
@@ -112,6 +118,7 @@ pub async fn enforce_spawn_task_contract_with_args_and_output(
     supervisor: Option<(&TaskSupervisor, &str)>,
     input_args: Option<&serde_json::Value>,
     tool_named_outputs: Option<&serde_json::Value>,
+    sandbox: Arc<dyn Sandbox>,
 ) -> SpawnTaskContractResult {
     let required_by_default = default_session_policy_requires_contract(tool_name);
     let Some(workspace_root) = tools.workspace_root() else {
@@ -211,6 +218,7 @@ pub async fn enforce_spawn_task_contract_with_args_and_output(
         // `PerFileNonSilent`) declaring `source = "spawn_only_files"`
         // can consume the authoritative path set the skill emitted.
         Some(files_to_send.to_vec()),
+        sandbox,
     )
     .await
     {
@@ -552,6 +560,15 @@ fn default_session_policy_requires_contract(tool_name: &str) -> bool {
 ///
 /// Thin wrapper for non-spawn-only callers that have no tool output to
 /// forward. Spawn-only callers should use [`run_declared_validators_with_output`].
+///
+/// #1607: `sandbox` is the session sandbox under which `ValidatorSpec::Command`
+/// validators (which a project's `workspace_policy.toml` can declare) execute.
+/// It is threaded EXPLICITLY — the compiler enforces that every call site names
+/// the sandbox it means to confine command validators to, so an untrusted
+/// workspace validator can never run unsandboxed on the host from a sandboxed
+/// session. Pass `Arc::new(crate::sandbox::NoSandbox)` for host-independent
+/// contexts (a no-op sandbox runs the argv directly, matching pre-#1607
+/// behaviour).
 pub async fn run_declared_validators(
     tools: &ToolRegistry,
     workspace_root: &Path,
@@ -559,6 +576,7 @@ pub async fn run_declared_validators(
     repo_label_hint: &str,
     phase: ValidatorPhase,
     input_args: Option<serde_json::Value>,
+    sandbox: Arc<dyn Sandbox>,
 ) -> Result<Vec<ValidatorOutcome>, String> {
     run_declared_validators_with_output(
         tools,
@@ -569,6 +587,7 @@ pub async fn run_declared_validators(
         input_args,
         None,
         None,
+        sandbox,
     )
     .await
 }
@@ -595,6 +614,7 @@ pub async fn run_declared_validators_with_output(
     input_args: Option<serde_json::Value>,
     tool_output: Option<serde_json::Value>,
     spawn_only_files: Option<Vec<PathBuf>>,
+    sandbox: Arc<dyn Sandbox>,
 ) -> Result<Vec<ValidatorOutcome>, String> {
     if validators.is_empty() {
         return Ok(Vec::new());
@@ -624,7 +644,7 @@ pub async fn run_declared_validators_with_output(
         }
     };
 
-    let runner = build_validator_runner(tools, workspace_root);
+    let runner = build_validator_runner(tools, workspace_root, sandbox);
     let runner = match ledger {
         Some(ledger) => runner.with_ledger(ledger),
         None => runner,
@@ -715,6 +735,7 @@ pub async fn run_project_root_validators(
     working_dir: &Path,
     expected_kind: Option<WorkspaceProjectKind>,
     files_to_send: &[PathBuf],
+    sandbox: Arc<dyn Sandbox>,
 ) -> ProjectRootValidatorReport {
     let mut report = ProjectRootValidatorReport::default();
     let repos = match list_workspace_repos(working_dir) {
@@ -775,6 +796,7 @@ pub async fn run_project_root_validators(
             None,
             None,
             Some(project_files),
+            sandbox.clone(),
         )
         .await
         {
@@ -816,22 +838,28 @@ fn filter_files_for_project(
         .collect()
 }
 
-fn build_validator_runner(tools: &ToolRegistry, workspace_root: &Path) -> ValidatorRunner {
+fn build_validator_runner(
+    tools: &ToolRegistry,
+    workspace_root: &Path,
+    sandbox: Arc<dyn Sandbox>,
+) -> ValidatorRunner {
     // Capture a lightweight snapshot of tool handles for the validator runner.
     // Avoids cloning the full registry and its LRU bookkeeping.
     let dispatcher: Arc<dyn crate::validators::ValidatorToolDispatcher> =
         Arc::new(crate::validators::MapToolDispatcher::from_registry(tools));
     // #1607: confine `ValidatorSpec::Command` validators (which a project's
-    // `workspace_policy.toml` can declare) to the same session sandbox the
-    // shell/exec tools use, so the automatic project-root validator pass at
-    // the end of `run_task` can't be turned into a host-level sandbox escape.
+    // `workspace_policy.toml` can declare) to the session sandbox the caller
+    // hands in EXPLICITLY, so the automatic project-root validator pass at the
+    // end of `run_task` can't be turned into a host-level sandbox escape. The
+    // sandbox is an explicit entry-point argument (not `tools.sandbox()`) so
+    // the compiler enumerates and enforces every call site: each caller must
+    // name the sandbox it means to confine command validators to.
     // `ValidatorRunner::run_command` runs the argv directly when the sandbox is
     // a no-op (`NoSandbox`, or a backend whose helper is unavailable), so hosts
     // without a real backend are unaffected; on POSIX with a real backend the
     // command is shell-quoted and wrapped; the Windows real-sandbox case fails
-    // closed. This is the single chokepoint for every project-root validator
-    // caller (execution.rs / loop_runner.rs / workspace_git.rs).
-    ValidatorRunner::with_dispatcher(dispatcher, workspace_root).with_sandbox(tools.sandbox())
+    // closed.
+    ValidatorRunner::with_dispatcher(dispatcher, workspace_root).with_sandbox(sandbox)
 }
 
 #[cfg(test)]
@@ -906,6 +934,7 @@ mod tests {
             &[],
             UNIX_EPOCH,
             None,
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -929,6 +958,7 @@ mod tests {
             &[],
             UNIX_EPOCH,
             None,
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -968,6 +998,7 @@ mod tests {
             std::slice::from_ref(&output),
             UNIX_EPOCH,
             None,
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1064,6 +1095,7 @@ mod tests {
             std::slice::from_ref(&output),
             UNIX_EPOCH,
             None,
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1143,6 +1175,7 @@ mod tests {
             &[],
             UNIX_EPOCH,
             None,
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1192,6 +1225,7 @@ mod tests {
             &[],
             UNIX_EPOCH,
             None,
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1250,6 +1284,7 @@ mod tests {
             &[report.clone(), audio.clone()],
             UNIX_EPOCH,
             None,
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1311,6 +1346,7 @@ mod tests {
             std::slice::from_ref(&report),
             UNIX_EPOCH,
             None,
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1333,6 +1369,7 @@ mod tests {
             &[],
             UNIX_EPOCH,
             None,
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1356,6 +1393,7 @@ mod tests {
             &[],
             UNIX_EPOCH,
             None,
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1430,6 +1468,7 @@ mod tests {
             UNIX_EPOCH,
             None,
             Some(&json!({"out": "output/deck.pptx"})),
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1462,6 +1501,7 @@ mod tests {
             UNIX_EPOCH,
             None,
             Some(&json!({"out": "output/deck.pptx"})),
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1498,6 +1538,7 @@ mod tests {
             UNIX_EPOCH,
             None,
             Some(&json!({"card_dir": "skill-output/cards/abc/deep/layout"})),
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1531,6 +1572,7 @@ mod tests {
             UNIX_EPOCH,
             None,
             Some(&json!({"card_dir": "cards/abc"})),
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1570,6 +1612,7 @@ mod tests {
             UNIX_EPOCH,
             None,
             Some(&json!({"out": "comic.png"})),
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1605,6 +1648,7 @@ mod tests {
             UNIX_EPOCH,
             None,
             Some(&json!({"out": "comic.png"})),
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1654,6 +1698,7 @@ mod tests {
             // `out_path` is optional. Pass none so the dormant-contract
             // mode is what we exercise.
             Some(&json!({})),
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1697,6 +1742,7 @@ mod tests {
             UNIX_EPOCH,
             None,
             Some(&json!({"out": "comic.png"})),
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1751,6 +1797,7 @@ mod tests {
             UNIX_EPOCH,
             None,
             Some(&json!({"name": "yangmi", "audio_path": "/tmp/in.wav"})),
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1785,6 +1832,7 @@ mod tests {
             UNIX_EPOCH,
             None,
             Some(&json!({"name": "no_such_voice"})),
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1876,6 +1924,7 @@ mod tests {
             None,
             None,
             Some(&json!({"deploy_url": format!("http://{addr}/site")})),
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1937,6 +1986,7 @@ mod tests {
             UNIX_EPOCH,
             None,
             Some(&json!({"expected_sha256": expected_hex.clone()})),
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -1968,6 +2018,7 @@ mod tests {
             None,
             None,
             Some(&json!({"deploy_url": format!("http://{addr}/missing")})),
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -2019,6 +2070,7 @@ mod tests {
             UNIX_EPOCH,
             None,
             Some(&json!({"expected_sha256": wrong_hex})),
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -2057,6 +2109,7 @@ mod tests {
             // tool_output absent — emulates the current mofa_publish
             // skill (before the mofa-skills repo follow-up).
             None,
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -2090,6 +2143,7 @@ mod tests {
             None,
             // No named_outputs from the skill (current state).
             None,
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -2151,6 +2205,7 @@ mod tests {
             None,
             None,
             Some(&json!({"target_path": "artifact.txt"})),
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 
@@ -2221,6 +2276,7 @@ mod tests {
             UNIX_EPOCH,
             None,
             None,
+            Arc::new(crate::sandbox::NoSandbox),
         )
         .await;
 

--- a/crates/octos-agent/src/workspace_git.rs
+++ b/crates/octos-agent/src/workspace_git.rs
@@ -1060,6 +1060,7 @@ mod tests {
                 workspace_root,
                 Some(WorkspaceProjectKind::Slides),
                 files_to_send,
+                Arc::new(crate::sandbox::NoSandbox),
             )
             .await;
         });

--- a/crates/octos-agent/tests/slides_validator_project_scope.rs
+++ b/crates/octos-agent/tests/slides_validator_project_scope.rs
@@ -112,6 +112,7 @@ async fn html_pptx_fails_slides_kind_project_scope_validator_gate() {
         None,
         None,
         Some(vec![deck_path.clone()]),
+        Arc::new(octos_agent::sandbox::NoSandbox),
     )
     .await;
 
@@ -163,6 +164,7 @@ async fn valid_pptx_passes_slides_kind_project_scope_validator_gate() {
         None,
         None,
         Some(vec![deck_path.clone()]),
+        Arc::new(octos_agent::sandbox::NoSandbox),
     )
     .await
     .expect("genuine PPTX must pass the slides project-scope validator gate");
@@ -274,6 +276,7 @@ async fn project_root_validators_write_to_project_ledger_without_manual_seeding(
         session_root,
         Some(WorkspaceProjectKind::Slides),
         &files_to_send,
+        Arc::new(octos_agent::sandbox::NoSandbox),
     )
     .await;
 

--- a/crates/octos-agent/tests/validator_runner.rs
+++ b/crates/octos-agent/tests/validator_runner.rs
@@ -575,6 +575,7 @@ async fn should_block_spawn_task_contract_when_required_validator_fails() {
         &[],
         UNIX_EPOCH,
         None,
+        Arc::new(octos_agent::sandbox::NoSandbox),
     )
     .await;
 
@@ -653,6 +654,7 @@ async fn should_not_block_spawn_task_contract_when_optional_validator_fails() {
         &[],
         UNIX_EPOCH,
         None,
+        Arc::new(octos_agent::sandbox::NoSandbox),
     )
     .await;
 
@@ -830,6 +832,7 @@ async fn should_bind_files_to_send_to_artifact_for_mofa_slides_contract() {
         &files_to_send,
         UNIX_EPOCH,
         None,
+        Arc::new(octos_agent::sandbox::NoSandbox),
     )
     .await;
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -18613,6 +18613,12 @@ async fn run_standalone_turn(
             session_id.to_string(),
         )
         .with_provider_policy(tool_registry.provider_policy().cloned())
+        // #1607 (codex-review follow-up): inherit the session's effective
+        // sandbox (the same `SandboxConfig` the parent `tool_registry` was
+        // built from) so the spawn/agent_mcp child completion path confines
+        // workspace-declared `Command` validators rather than running them on
+        // the host.
+        .with_sandbox(session_runtime.sandbox.clone())
         .with_agent_config(agent_config.clone())
         .with_task_supervisor(
             task_supervisor.clone(),

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -18745,8 +18745,15 @@ async fn run_standalone_turn(
         // clone the `Arc` here for every spawn-tool child closure
         // invocation.
         if let Some(pipeline_factory) = session_runtime.profile.pipeline_factory.clone() {
-            spawn_tool =
-                spawn_tool.with_child_tool_factory(Arc::new(move || pipeline_factory.create()));
+            // #1607 (codex round 4): bind spawn-child `run_pipeline` instances to
+            // the SESSION-effective sandbox (`session_runtime.sandbox`, set by
+            // `bootstrap_with_permissions_and_sandbox`), NOT the profile-time
+            // default the factory was built with — otherwise a read-only
+            // session's spawned pipeline validators regain removed
+            // writes/network.
+            let child_sandbox = session_runtime.sandbox.clone();
+            spawn_tool = spawn_tool
+                .with_child_tool_factory(Arc::new(move || pipeline_factory.create(&child_sandbox)));
         }
         tool_registry.register(spawn_tool);
         // RFC-0 (#1289): LRU deferral removed — no base-tool pin needed.

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -378,6 +378,11 @@ impl AcpBootstrap {
         tools.register(
             octos_agent::SpawnTool::new(llm.clone(), memory.clone(), cwd.clone(), spawn_tx)
                 .with_worker_prompt(worker_prompt)
+                // #1607 (codex-review follow-up): thread the same sandbox the
+                // parent registry was built from so the spawn/agent_mcp child
+                // completion path confines workspace-declared `Command`
+                // validators instead of running them on the host.
+                .with_sandbox(sandbox.clone())
                 // Embed-on-save + recall parity: ACP spawn subagents save
                 // episodes; without the shared embedder they store them
                 // vectorless and their episodic recall silently skips.

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -462,6 +462,10 @@ impl AcpBootstrap {
             plugin_dirs.clone(),
             config.plugins.require_signed,
             shared.embedder.clone(),
+            // #1607: same sandbox the ACP agent registry uses (built at
+            // `build_acp_tool_registry` / the `create_sandbox(&sandbox)` above),
+            // so pipeline command validators run under the identical backend.
+            sandbox.clone(),
         );
         tools.register(pipeline_tool);
         tools.mark_spawn_only(

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -825,6 +825,10 @@ impl ChatCommand {
             plugin_dirs.clone(),
             config.plugins.require_signed,
             embedder.clone(),
+            // #1607: same sandbox `octos chat` builds for its shell/exec tools
+            // (see `effective_sandbox_config` above), so pipeline command
+            // validators run under the identical backend.
+            effective_sandbox_config.clone(),
         );
         tools.register(pipeline_tool);
         tools.mark_spawn_only(
@@ -1431,12 +1435,18 @@ pub(crate) fn build_run_pipeline_tool(
     plugin_dirs: Vec<PathBuf>,
     plugin_require_signed: bool,
     embedder: Option<Arc<dyn EmbeddingProvider>>,
+    // #1607: session sandbox forwarded onto the pipeline executor so its
+    // terminal / per-node command validators run confined instead of on the
+    // host.
+    sandbox: octos_agent::SandboxConfig,
 ) -> octos_pipeline::RunPipelineTool {
     let mut pipeline_tool =
         octos_pipeline::RunPipelineTool::new(llm, memory, cwd, data_dir.clone())
             .with_provider_policy(provider_policy)
             .with_plugin_dirs(plugin_dirs)
             .with_plugin_require_signed(plugin_require_signed)
+            // #1607: confine pipeline command validators to the session sandbox.
+            .with_sandbox(sandbox)
             // Gap 4.1 BLOCKER 2/3: `octos chat` bootstraps the bundle into
             // `<data_dir>/bundled-pipelines` (see chat.rs above). Register that
             // exact dir as the LOWEST-precedence discovery path so the bundled
@@ -1852,6 +1862,7 @@ mod tests {
             vec![],
             false,
             Some(embedder),
+            octos_agent::SandboxConfig::default(),
         );
 
         assert!(
@@ -1910,6 +1921,7 @@ mod tests {
             vec![],
             false,
             None,
+            octos_agent::SandboxConfig::default(),
         );
 
         assert!(

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -686,7 +686,12 @@ impl ChatCommand {
         let worker_prompt = super::load_prompt("worker", octos_agent::DEFAULT_WORKER_PROMPT);
         let mut spawn_tool =
             octos_agent::SpawnTool::new(llm.clone(), memory.clone(), cwd.clone(), spawn_tx)
-                .with_worker_prompt(worker_prompt);
+                .with_worker_prompt(worker_prompt)
+                // #1607 (codex-review follow-up): thread the same sandbox the
+                // parent registry was built from so the spawn/agent_mcp child
+                // completion path confines workspace-declared `Command`
+                // validators instead of running them on the host.
+                .with_sandbox(effective_sandbox_config.clone());
         if let Some(ref embedder) = embedder {
             // Workers save episodes by default; without the embedder those
             // episodes are stored vectorless and worker recall skips.

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -1061,6 +1061,10 @@ impl GatewayRuntime {
                     /// filtered memory recall instead of the cwd-only
                     /// unfiltered fallback.
                     embedder: Option<Arc<dyn octos_llm::EmbeddingProvider>>,
+                    /// #1607: session sandbox forwarded onto the pipeline
+                    /// executor so terminal / per-node command validators
+                    /// run confined instead of on the host.
+                    sandbox_config: octos_agent::SandboxConfig,
                 }
 
                 impl crate::session_actor::PipelineToolFactory for DefaultPipelineToolFactory {
@@ -1074,6 +1078,9 @@ impl GatewayRuntime {
                         .with_provider_policy(self.policy.clone())
                         .with_plugin_dirs(self.plugin_dirs.clone())
                         .with_plugin_require_signed(self.plugin_require_signed)
+                        // #1607: confine pipeline command validators to the
+                        // session sandbox.
+                        .with_sandbox(self.sandbox_config.clone())
                         // BLOCKER 2: unconditional — registers
                         // <octos_home>/{skills,pipelines} (installed) and
                         // <octos_home>/bundled-pipelines (bundled, last).
@@ -1106,6 +1113,10 @@ impl GatewayRuntime {
                     octos_home: octos_home_c,
                     plugin_require_signed: plugin_require_signed_c,
                     embedder: embedder_c,
+                    // #1607: thread the gateway session sandbox onto the
+                    // pipeline factory (mirrors `sandbox_config.clone()` used
+                    // for the actor factory below).
+                    sandbox_config: sandbox_config.clone(),
                 })
                     as Arc<dyn crate::session_actor::PipelineToolFactory + Send + Sync>);
             }

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -1061,14 +1061,13 @@ impl GatewayRuntime {
                     /// filtered memory recall instead of the cwd-only
                     /// unfiltered fallback.
                     embedder: Option<Arc<dyn octos_llm::EmbeddingProvider>>,
-                    /// #1607: session sandbox forwarded onto the pipeline
-                    /// executor so terminal / per-node command validators
-                    /// run confined instead of on the host.
-                    sandbox_config: octos_agent::SandboxConfig,
                 }
 
                 impl crate::session_actor::PipelineToolFactory for DefaultPipelineToolFactory {
-                    fn create(&self) -> Arc<dyn octos_agent::Tool> {
+                    fn create(
+                        &self,
+                        sandbox: &octos_agent::SandboxConfig,
+                    ) -> Arc<dyn octos_agent::Tool> {
                         let mut pt = octos_pipeline::RunPipelineTool::new(
                             self.llm.clone(),
                             self.memory.clone(),
@@ -1078,9 +1077,10 @@ impl GatewayRuntime {
                         .with_provider_policy(self.policy.clone())
                         .with_plugin_dirs(self.plugin_dirs.clone())
                         .with_plugin_require_signed(self.plugin_require_signed)
-                        // #1607: confine pipeline command validators to the
-                        // session sandbox.
-                        .with_sandbox(self.sandbox_config.clone())
+                        // #1607 (codex round 4): confine pipeline command
+                        // validators to the SESSION-effective sandbox handed in
+                        // by the actor factory.
+                        .with_sandbox(sandbox.clone())
                         // BLOCKER 2: unconditional — registers
                         // <octos_home>/{skills,pipelines} (installed) and
                         // <octos_home>/bundled-pipelines (bundled, last).
@@ -1113,10 +1113,9 @@ impl GatewayRuntime {
                     octos_home: octos_home_c,
                     plugin_require_signed: plugin_require_signed_c,
                     embedder: embedder_c,
-                    // #1607: thread the gateway session sandbox onto the
-                    // pipeline factory (mirrors `sandbox_config.clone()` used
-                    // for the actor factory below).
-                    sandbox_config: sandbox_config.clone(),
+                    // #1607 (codex round 4): the session sandbox is now handed to
+                    // `create()` by the actor factory (`self.sandbox_config`), so
+                    // no per-factory field is needed.
                 })
                     as Arc<dyn crate::session_actor::PipelineToolFactory + Send + Sync>);
             }

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -928,6 +928,10 @@ impl ProfileActorFactoryBuilder {
                 /// agents inherit hybrid scored + filtered memory
                 /// recall instead of the cwd-only unfiltered fallback.
                 embedder: Option<Arc<dyn octos_llm::EmbeddingProvider>>,
+                /// #1607: session sandbox forwarded onto the pipeline
+                /// executor so terminal / per-node command validators run
+                /// confined instead of on the host.
+                sandbox_config: octos_agent::SandboxConfig,
             }
 
             impl crate::session_actor::PipelineToolFactory for ChildPipelineToolFactory {
@@ -941,6 +945,9 @@ impl ProfileActorFactoryBuilder {
                     .with_provider_policy(self.policy.clone())
                     .with_plugin_dirs(self.plugin_dirs.clone())
                     .with_plugin_require_signed(self.plugin_require_signed)
+                    // #1607: confine pipeline command validators to the
+                    // session sandbox.
+                    .with_sandbox(self.sandbox_config.clone())
                     .with_octos_home(self.octos_home.clone());
                     if let Some(ref router) = self.router {
                         pt = pt.with_provider_router(router.clone());
@@ -976,6 +983,11 @@ impl ProfileActorFactoryBuilder {
                 // profile's strict-signing policy.
                 plugin_require_signed: profile_config.plugins.require_signed,
                 embedder: child_pipeline_embedder,
+                // #1607: mirror the ActorFactory `sandbox_config` (line
+                // `effective_profile.config.sandbox.clone()` below) so the
+                // pipeline's command validators run under the same session
+                // sandbox as the session's shell/exec tools.
+                sandbox_config: effective_profile.config.sandbox.clone(),
             })
                 as Arc<dyn crate::session_actor::PipelineToolFactory + Send + Sync>);
 

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -928,14 +928,13 @@ impl ProfileActorFactoryBuilder {
                 /// agents inherit hybrid scored + filtered memory
                 /// recall instead of the cwd-only unfiltered fallback.
                 embedder: Option<Arc<dyn octos_llm::EmbeddingProvider>>,
-                /// #1607: session sandbox forwarded onto the pipeline
-                /// executor so terminal / per-node command validators run
-                /// confined instead of on the host.
-                sandbox_config: octos_agent::SandboxConfig,
             }
 
             impl crate::session_actor::PipelineToolFactory for ChildPipelineToolFactory {
-                fn create(&self) -> Arc<dyn octos_agent::Tool> {
+                fn create(
+                    &self,
+                    sandbox: &octos_agent::SandboxConfig,
+                ) -> Arc<dyn octos_agent::Tool> {
                     let mut pt = octos_pipeline::RunPipelineTool::new(
                         self.llm.clone(),
                         self.memory.clone(),
@@ -945,9 +944,10 @@ impl ProfileActorFactoryBuilder {
                     .with_provider_policy(self.policy.clone())
                     .with_plugin_dirs(self.plugin_dirs.clone())
                     .with_plugin_require_signed(self.plugin_require_signed)
-                    // #1607: confine pipeline command validators to the
-                    // session sandbox.
-                    .with_sandbox(self.sandbox_config.clone())
+                    // #1607 (codex round 4): confine pipeline command validators
+                    // to the SESSION-effective sandbox handed in by the actor
+                    // factory.
+                    .with_sandbox(sandbox.clone())
                     .with_octos_home(self.octos_home.clone());
                     if let Some(ref router) = self.router {
                         pt = pt.with_provider_router(router.clone());
@@ -983,11 +983,9 @@ impl ProfileActorFactoryBuilder {
                 // profile's strict-signing policy.
                 plugin_require_signed: profile_config.plugins.require_signed,
                 embedder: child_pipeline_embedder,
-                // #1607: mirror the ActorFactory `sandbox_config` (line
-                // `effective_profile.config.sandbox.clone()` below) so the
-                // pipeline's command validators run under the same session
-                // sandbox as the session's shell/exec tools.
-                sandbox_config: effective_profile.config.sandbox.clone(),
+                // #1607 (codex round 4): the session sandbox is now handed to
+                // `create()` by the actor factory (`self.sandbox_config`), so no
+                // per-factory field is needed.
             })
                 as Arc<dyn crate::session_actor::PipelineToolFactory + Send + Sync>);
 

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -781,6 +781,10 @@ impl ProfileRuntime {
                 /// agents inherit the contamination-safe hybrid scored
                 /// + filtered memory recall path.
                 embedder: Option<Arc<dyn octos_llm::EmbeddingProvider>>,
+                /// #1607: session sandbox forwarded onto the pipeline
+                /// executor so terminal / per-node command validators run
+                /// confined instead of on the host.
+                sandbox_config: SandboxConfig,
             }
 
             impl crate::session_actor::PipelineToolFactory for AppUiPipelineToolFactory {
@@ -794,6 +798,9 @@ impl ProfileRuntime {
                     .with_provider_policy(self.policy.clone())
                     .with_plugin_dirs(self.plugin_dirs.clone())
                     .with_plugin_require_signed(self.plugin_require_signed)
+                    // #1607: confine pipeline command validators to the
+                    // session sandbox.
+                    .with_sandbox(self.sandbox_config.clone())
                     .with_octos_home(self.octos_home.clone());
                     if let Some(ref embedder) = self.embedder {
                         pt = pt.with_embedder(embedder.clone());
@@ -812,6 +819,9 @@ impl ProfileRuntime {
                     octos_home: effective_octos_home.clone(),
                     plugin_require_signed: config.plugins.require_signed,
                     embedder: embedder.clone(),
+                    // #1607: thread the AppUI session sandbox onto the
+                    // pipeline factory so command validators run confined.
+                    sandbox_config: sandbox_config.clone(),
                 });
 
             // Register the parent `run_pipeline` via the same factory

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -781,14 +781,10 @@ impl ProfileRuntime {
                 /// agents inherit the contamination-safe hybrid scored
                 /// + filtered memory recall path.
                 embedder: Option<Arc<dyn octos_llm::EmbeddingProvider>>,
-                /// #1607: session sandbox forwarded onto the pipeline
-                /// executor so terminal / per-node command validators run
-                /// confined instead of on the host.
-                sandbox_config: SandboxConfig,
             }
 
             impl crate::session_actor::PipelineToolFactory for AppUiPipelineToolFactory {
-                fn create(&self) -> Arc<dyn octos_agent::tools::Tool> {
+                fn create(&self, sandbox: &SandboxConfig) -> Arc<dyn octos_agent::tools::Tool> {
                     let mut pt = octos_pipeline::RunPipelineTool::new(
                         self.llm.clone(),
                         self.memory.clone(),
@@ -798,9 +794,13 @@ impl ProfileRuntime {
                     .with_provider_policy(self.policy.clone())
                     .with_plugin_dirs(self.plugin_dirs.clone())
                     .with_plugin_require_signed(self.plugin_require_signed)
-                    // #1607: confine pipeline command validators to the
-                    // session sandbox.
-                    .with_sandbox(self.sandbox_config.clone())
+                    // #1607 (codex round 4): confine pipeline command
+                    // validators to the SESSION-effective sandbox passed in by
+                    // the caller (`SessionRuntime`/`ActorFactory`), NOT a
+                    // profile-time default captured at factory-build time — a
+                    // read-only session's validators must not regain removed
+                    // writes/network.
+                    .with_sandbox(sandbox.clone())
                     .with_octos_home(self.octos_home.clone());
                     if let Some(ref embedder) = self.embedder {
                         pt = pt.with_embedder(embedder.clone());
@@ -819,15 +819,15 @@ impl ProfileRuntime {
                     octos_home: effective_octos_home.clone(),
                     plugin_require_signed: config.plugins.require_signed,
                     embedder: embedder.clone(),
-                    // #1607: thread the AppUI session sandbox onto the
-                    // pipeline factory so command validators run confined.
-                    sandbox_config: sandbox_config.clone(),
                 });
 
-            // Register the parent `run_pipeline` via the same factory
-            // so the parent registry and every spawn-child registry
-            // observe byte-identical config.
-            tools.register_arc(factory.create());
+            // Register the parent `run_pipeline` via the same factory so the
+            // parent registry and every spawn-child registry observe
+            // byte-identical config. This profile-scope registration uses the
+            // profile default sandbox; `SessionRuntime::bootstrap_*` re-registers
+            // it with the SESSION-effective sandbox (which `rebind_cwd` does not
+            // touch, since `run_pipeline` is not a CWD-bound tool).
+            tools.register_arc(factory.create(&sandbox_config));
             tools.mark_spawn_only(
                 "run_pipeline",
                 Some(
@@ -1864,7 +1864,7 @@ mod tests {
             .pipeline_factory
             .as_ref()
             .expect("pipeline_factory must be Some after a successful bootstrap");
-        let pt = factory.create();
+        let pt = factory.create(&octos_agent::SandboxConfig::default());
         assert_eq!(
             pt.name(),
             "run_pipeline",
@@ -1879,7 +1879,7 @@ mod tests {
         // `ensure_subagent_tools_available` preflight will pass for
         // `allowed_tools=["run_pipeline"]`.
         let mut child_registry = octos_agent::ToolRegistry::with_builtins(&data_dir);
-        child_registry.register_arc(factory.create());
+        child_registry.register_arc(factory.create(&octos_agent::SandboxConfig::default()));
         assert!(
             child_registry.get("run_pipeline").is_some(),
             "spawned child registry must carry `run_pipeline` so the spawn preflight succeeds",

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -275,6 +275,25 @@ impl SessionRuntime {
         );
         tools.set_output_dir_hint(plugin_work_dir.to_string_lossy().into_owned());
         tools.rebind_plugin_work_dirs(&plugin_work_dir);
+        // #1607 (codex round 4): `run_pipeline` is NOT a CWD-bound tool, so the
+        // `rebind_cwd_with_permissions` snapshot above carried the PROFILE-time
+        // `run_pipeline` instance — which baked in the profile default sandbox.
+        // Re-register it from the profile's pipeline factory with the
+        // SESSION-effective `sandbox` so a read-only (or otherwise overridden)
+        // session's pipeline command validators run under the session sandbox
+        // instead of regaining the profile default's writes/network. The
+        // spawn_only marker persists across `register_arc` (it is registry
+        // metadata carried by the snapshot), and re-marking is idempotent.
+        if let Some(ref pf) = profile.pipeline_factory {
+            tools.register_arc(pf.create(&sandbox));
+            tools.mark_spawn_only(
+                "run_pipeline",
+                Some(
+                    "Pipeline started in background. The final result and any artifacts will be sent here when complete. You can keep chatting in the meantime."
+                        .to_string(),
+                ),
+            );
+        }
         // RFC-0 (#1289): the `activate_tools` meta-tool was removed — every
         // enabled tool is emitted every turn, so there is no per-session
         // meta-tool to re-register or wire.
@@ -1577,6 +1596,7 @@ mod tests {
             &[],
             SystemTime::now(),
             None,
+            Arc::new(octos_agent::sandbox::NoSandbox),
         )
         .await;
 

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -284,15 +284,24 @@ impl SessionRuntime {
         // instead of regaining the profile default's writes/network. The
         // spawn_only marker persists across `register_arc` (it is registry
         // metadata carried by the snapshot), and re-marking is idempotent.
+        // Only REPLACE `run_pipeline` (with the session-sandbox instance) when
+        // the profile policy actually left it in the rebound registry. A profile
+        // that denies `run_pipeline` (or an allow-list excluding it) removed it
+        // during `ProfileRuntime::bootstrap` (`apply_policy` → `retain`), so it's
+        // absent here; re-adding it unconditionally would make a policy-disabled
+        // pipeline visible + callable, bypassing the tool policy (#1607 codex
+        // round 5). `register_arc` replaces the existing entry by name.
         if let Some(ref pf) = profile.pipeline_factory {
-            tools.register_arc(pf.create(&sandbox));
-            tools.mark_spawn_only(
-                "run_pipeline",
-                Some(
-                    "Pipeline started in background. The final result and any artifacts will be sent here when complete. You can keep chatting in the meantime."
-                        .to_string(),
-                ),
-            );
+            if tools.get_tool("run_pipeline").is_some() {
+                tools.register_arc(pf.create(&sandbox));
+                tools.mark_spawn_only(
+                    "run_pipeline",
+                    Some(
+                        "Pipeline started in background. The final result and any artifacts will be sent here when complete. You can keep chatting in the meantime."
+                            .to_string(),
+                    ),
+                );
+            }
         }
         // RFC-0 (#1289): the `activate_tools` meta-tool was removed — every
         // enabled tool is emitted every turn, so there is no per-session

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -3343,6 +3343,12 @@ impl ActorFactory {
             chat_id,
         )
         .with_provider_policy(self.provider_policy.clone())
+        // #1607 (codex-review follow-up): thread the same sandbox config the
+        // parent `ToolRegistry` was built with (`create_sandbox(&self.sandbox_config)`
+        // above) so the spawn/agent_mcp child completion path confines
+        // workspace-declared `Command` validators instead of running them on
+        // the host.
+        .with_sandbox(self.sandbox_config.clone())
         .with_agent_config(self.agent_config.clone())
         .with_task_supervisor(
             supervisor.clone(),

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -3500,6 +3500,11 @@ impl ActorFactory {
                 .with_agent_config(self.agent_config.clone())
                 .with_optional_embedder(self.embedder.clone())
                 .with_task_supervisor(supervisor.clone(), session_key.to_string())
+                // #1607: thread the session sandbox onto delegated children so
+                // their completion-phase command validators run confined —
+                // mirrors the SpawnTool `.with_sandbox(self.sandbox_config...)`
+                // wiring above.
+                .with_sandbox(self.sandbox_config.clone())
                 .with_child_prompt_context_manager_factory(delegate_factory);
         if let Some(ref prompt) = self.worker_prompt {
             delegate_tool = delegate_tool.with_worker_prompt(prompt.clone());

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -2844,8 +2844,18 @@ pub trait ToolRegistryFactory: Send + Sync {
 }
 
 /// Trait for creating per-session pipeline tool instances.
+///
+/// #1607 (codex round 4): `create` takes the SESSION-effective sandbox so the
+/// produced `run_pipeline` tool (and every spawn-child instance) confines its
+/// pipeline command validators to the sandbox that is actually in force for
+/// this session — NOT a profile-time default captured when the factory was
+/// built. In the AppUI path the effective sandbox is only known after
+/// `SessionRuntime::bootstrap_with_permissions_and_sandbox` resolves the
+/// permission/override, so passing it in at `create` time is the only correct
+/// binding: a read-only session's pipeline validators must not regain writes
+/// or network the profile default allowed.
 pub trait PipelineToolFactory: Send + Sync {
-    fn create(&self) -> Arc<dyn octos_agent::tools::Tool>;
+    fn create(&self, sandbox: &octos_agent::SandboxConfig) -> Arc<dyn octos_agent::tools::Tool>;
 }
 
 /// ToolRegistryFactory backed by snapshot_excluding() — clones shared tools cheaply.
@@ -3386,8 +3396,12 @@ impl ActorFactory {
         }
         if let Some(ref pipeline_factory) = self.pipeline_factory {
             let pipeline_factory = pipeline_factory.clone();
-            spawn_tool =
-                spawn_tool.with_child_tool_factory(Arc::new(move || pipeline_factory.create()));
+            // #1607 (codex round 4): hand each spawn-child `run_pipeline`
+            // instance the SESSION-effective sandbox (the same one the actor's
+            // tool registry uses), not a profile-time default.
+            let child_sandbox = self.sandbox_config.clone();
+            spawn_tool = spawn_tool
+                .with_child_tool_factory(Arc::new(move || pipeline_factory.create(&child_sandbox)));
         }
         // Child SendFileTool factory (gateway parity with AppUI). Every
         // spawned subagent's registry gets a fresh `SendFileTool` wired
@@ -3538,7 +3552,9 @@ impl ActorFactory {
         };
 
         if let Some(ref pf) = self.pipeline_factory {
-            let pt = pf.create();
+            // #1607 (codex round 4): the parent `run_pipeline` also uses the
+            // session-effective sandbox this actor's registry was built with.
+            let pt = pf.create(&self.sandbox_config);
             tools.register_arc(pt);
             tools.mark_spawn_only(
                 "run_pipeline",

--- a/crates/octos-pipeline/examples/run_ir_cli.rs
+++ b/crates/octos-pipeline/examples/run_ir_cli.rs
@@ -55,6 +55,9 @@ async fn main() {
         host_context: PipelineHostContext::default(),
         embedder: None,
         catalog_dir: None,
+        // #1607: pipeline validators run under a no-op sandbox in tests
+        // (host-independent — command validators run the argv directly).
+        sandbox: octos_agent::SandboxConfig::default(),
     };
     let executor = PipelineExecutor::new(config);
 

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -431,6 +431,18 @@ pub struct ExecutorConfig {
     /// split, scoped runs silently lost strong/fast model defaults +
     /// cost projections.
     pub catalog_dir: Option<PathBuf>,
+    /// #1607 (codex-review follow-up): the session sandbox threaded from the
+    /// `RunPipelineTool` construction site. `run_terminal_validators` /
+    /// `run_node_validators` build a workspace-scoped `ToolRegistry` for the
+    /// declared-validator pass; without this they stored `NoSandbox`, so an
+    /// untrusted `workspace_policy.toml` `Command` validator could execute
+    /// directly on the host from a sandboxed pipeline. Building that registry
+    /// via `with_builtins_and_sandbox(&working_dir, create_sandbox(&sandbox))`
+    /// confines command validators to the same backend the pipeline's shell/
+    /// exec tools use. Default (`SandboxConfig::default()` → `NoSandbox` on a
+    /// host without a backend) runs command validators directly — byte-for-byte
+    /// identical to the pre-#1607 path.
+    pub sandbox: octos_agent::SandboxConfig,
 }
 
 /// A single planned sub-task from the LLM planner.
@@ -2080,7 +2092,16 @@ impl PipelineExecutor {
             // runner — it only needs the workspace root for file
             // existence + the registered tools for tool_call
             // validators. Matches the spawn-agent-mcp pattern.
-            let registry = octos_agent::ToolRegistry::with_builtins(&self.config.working_dir);
+            //
+            // #1607 (codex-review follow-up): carry the session sandbox so
+            // `build_validator_runner` confines `ValidatorSpec::Command`
+            // validators to it. `with_builtins` would store `NoSandbox`,
+            // letting a workspace-declared command validator escape to the
+            // host from a sandboxed pipeline.
+            let registry = octos_agent::ToolRegistry::with_builtins_and_sandbox(
+                &self.config.working_dir,
+                octos_agent::create_sandbox(&self.config.sandbox),
+            );
             run_declared_validators(
                 &registry,
                 &self.config.working_dir,
@@ -2157,7 +2178,13 @@ impl PipelineExecutor {
         // separate turn-end phase isn't meaningful inside pipeline
         // execution.
         let scoped: Vec<WorkspaceValidator> = validators.to_vec();
-        let registry = octos_agent::ToolRegistry::with_builtins(&self.config.working_dir);
+        // #1607 (codex-review follow-up): carry the session sandbox so
+        // per-node command validators run confined (see
+        // `run_terminal_validators`).
+        let registry = octos_agent::ToolRegistry::with_builtins_and_sandbox(
+            &self.config.working_dir,
+            octos_agent::create_sandbox(&self.config.sandbox),
+        );
         run_declared_validators(
             &registry,
             &self.config.working_dir,
@@ -5688,7 +5715,64 @@ mod tests {
             host_context: crate::host_context::PipelineHostContext::default(),
             embedder: None,
             catalog_dir: None,
+            sandbox: octos_agent::SandboxConfig::default(),
         }
+    }
+
+    /// #1607 (codex-review follow-up): `run_terminal_validators` /
+    /// `run_node_validators` build their workspace-scoped validator registry
+    /// with `with_builtins_and_sandbox(&self.config.working_dir,
+    /// create_sandbox(&self.config.sandbox))`. Lock in that the sandbox
+    /// threaded onto `ExecutorConfig` reaches that registry (i.e. NOT the
+    /// pre-fix hardcoded `with_builtins` / `NoSandbox`). Docker mode is chosen
+    /// because `create_sandbox` returns a `DockerSandbox` unconditionally
+    /// (no docker binary required), so the assertion is host-independent.
+    #[test]
+    fn pipeline_threads_configured_sandbox_into_validator_registry() {
+        let mut config = make_test_config();
+        config.sandbox = octos_agent::SandboxConfig {
+            mode: octos_agent::SandboxMode::Docker,
+            ..octos_agent::SandboxConfig::default()
+        };
+        // Reconstruct exactly what the two validator blocks build.
+        let registry = octos_agent::ToolRegistry::with_builtins_and_sandbox(
+            &config.working_dir,
+            octos_agent::create_sandbox(&config.sandbox),
+        );
+        let sandbox = registry.sandbox();
+        assert!(
+            sandbox.is_docker(),
+            "pipeline validator registry must inherit the ExecutorConfig \
+             sandbox (Docker here), not the pre-#1607 hardcoded NoSandbox"
+        );
+        assert!(
+            !sandbox.is_noop(),
+            "a real backend threaded onto ExecutorConfig must not be a no-op"
+        );
+    }
+
+    /// #1607: an explicit `SandboxMode::None` on `ExecutorConfig` resolves to a
+    /// no-op backend, so command validators run the argv directly (pre-#1607
+    /// behaviour on a host without a configured backend). Note: the STRUCT
+    /// default is `SandboxMode::Auto`, which resolves to a REAL backend on
+    /// macOS/Linux — so this test pins `None` explicitly to stay
+    /// host-independent (mirrors `spawn_none_sandbox_registry_is_noop`).
+    #[test]
+    fn pipeline_none_sandbox_registry_is_noop() {
+        let mut config = make_test_config();
+        config.sandbox = octos_agent::SandboxConfig {
+            mode: octos_agent::SandboxMode::None,
+            ..octos_agent::SandboxConfig::default()
+        };
+        let registry = octos_agent::ToolRegistry::with_builtins_and_sandbox(
+            &config.working_dir,
+            octos_agent::create_sandbox(&config.sandbox),
+        );
+        assert!(
+            registry.sandbox().is_noop(),
+            "SandboxMode::None must resolve to a no-op backend so command \
+             validators run directly (host-independent)"
+        );
     }
 
     struct MockProvider;
@@ -5970,6 +6054,7 @@ mod tests {
             host_context: crate::host_context::PipelineHostContext::default(),
             embedder: None,
             catalog_dir: None,
+            sandbox: octos_agent::SandboxConfig::default(),
         }
     }
 
@@ -7002,6 +7087,7 @@ mod tests {
             host_context: crate::host_context::PipelineHostContext::default(),
             embedder: None,
             catalog_dir: None,
+            sandbox: octos_agent::SandboxConfig::default(),
         };
         config.working_dir = custom_wd.path().to_path_buf();
         let executor = PipelineExecutor::new(config);
@@ -7059,6 +7145,7 @@ mod tests {
             embedder: None,
             // catalog reads must hit the PROFILE root, not the worker CWD.
             catalog_dir: Some(profile_root.path().to_path_buf()),
+            sandbox: octos_agent::SandboxConfig::default(),
         };
 
         // Pin the helper that the executor uses for catalog lookup:
@@ -7108,6 +7195,7 @@ mod tests {
             host_context: crate::host_context::PipelineHostContext::default(),
             embedder: None,
             catalog_dir: None,
+            sandbox: octos_agent::SandboxConfig::default(),
         };
         config.working_dir = only_dir.path().to_path_buf();
         let executor = PipelineExecutor::new(config);

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -2109,6 +2109,7 @@ impl PipelineExecutor {
                 "pipeline",
                 ValidatorPhase::Completion,
                 None,
+                std::sync::Arc::from(octos_agent::create_sandbox(&self.config.sandbox)),
             )
             .await?;
         }
@@ -2192,6 +2193,7 @@ impl PipelineExecutor {
             &format!("pipeline-node-{node_id}"),
             ValidatorPhase::Completion,
             None,
+            std::sync::Arc::from(octos_agent::create_sandbox(&self.config.sandbox)),
         )
         .await
         .map(|_| ())
@@ -2307,6 +2309,11 @@ impl PipelineExecutor {
         .with_provider_policy(self.config.provider_policy.clone())
         .with_plugin_dirs(self.config.plugin_dirs.clone())
         .with_plugin_require_signed(self.config.plugin_require_signed)
+        // #1607 (codex round 4): thread the session sandbox so each per-node
+        // worker registry is built sandboxed — the worker Agent's own
+        // project-root validator pass then confines a workspace-declared
+        // `Command` validator to it instead of running it on the host.
+        .with_sandbox(self.config.sandbox.clone())
         // M8 parity (W1.A1): propagate the host context so per-node
         // Agents inherit the parent session's FileStateCache /
         // SubAgentOutputRouter / AgentSummaryGenerator. Empty context

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -345,6 +345,15 @@ pub struct CodergenHandler {
     /// per-process tempdir (`cfg(test)` inside octos-agent). Tests
     /// pass a tempdir here to isolate from the user's cache.
     plugin_verified_cache_dir: Option<PathBuf>,
+    /// #1607 (codex round 4): the session sandbox threaded from
+    /// `ExecutorConfig.sandbox` via [`PipelineExecutor::build_codergen`].
+    /// Each per-node worker registry is built with
+    /// `with_builtins_and_sandbox(&working_dir, create_sandbox(&sandbox))`
+    /// so the worker Agent's own project-root validator pass confines a
+    /// workspace-declared `ValidatorSpec::Command` to this sandbox instead of
+    /// running it directly on the host from a sandboxed pipeline. Defaults to
+    /// `SandboxConfig::default()`; a no-op backend runs the argv directly.
+    sandbox: octos_agent::SandboxConfig,
 }
 
 impl CodergenHandler {
@@ -371,7 +380,18 @@ impl CodergenHandler {
             plugin_cache: Arc::new(OnceLock::new()),
             embedder: None,
             plugin_verified_cache_dir: None,
+            sandbox: octos_agent::SandboxConfig::default(),
         }
+    }
+
+    /// #1607 (codex round 4): thread the session sandbox onto every per-node
+    /// worker registry this handler builds, so a workspace-declared `Command`
+    /// validator run by the worker Agent's project-root validator pass is
+    /// confined to the session sandbox instead of executing on the host.
+    /// `PipelineExecutor::build_codergen` calls this with `ExecutorConfig.sandbox`.
+    pub fn with_sandbox(mut self, sandbox: octos_agent::SandboxConfig) -> Self {
+        self.sandbox = sandbox;
+        self
     }
 
     /// Override where plugin verified-exe copies live. Production
@@ -627,7 +647,17 @@ impl Handler for CodergenHandler {
         };
 
         // Build tool registry (same pattern as SpawnTool sync, spawn.rs:269-278)
-        let mut tools = octos_agent::ToolRegistry::with_builtins(&self.working_dir);
+        //
+        // #1607 (codex round 4): carry the session sandbox so the worker
+        // Agent's own project-root validator pass confines a workspace-declared
+        // `ValidatorSpec::Command` to it (the Agent-internal validator path
+        // reads `self.tools.sandbox()`). `with_builtins` would store `NoSandbox`,
+        // letting such a command validator escape to the host from a sandboxed
+        // pipeline. A no-op backend runs the argv directly (unchanged).
+        let mut tools = octos_agent::ToolRegistry::with_builtins_and_sandbox(
+            &self.working_dir,
+            octos_agent::create_sandbox(&self.sandbox),
+        );
 
         // Backend bug #1: load plugin tools from a process-shared cache.
         // The cache is populated on the first node's execute() call (or

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -146,6 +146,11 @@ pub struct RunPipelineTool {
     /// may pass an `ir` program which is compiled (capability-locked via the
     /// closed palette + [`crate::profile::ValidationProfile`]) and executed.
     ir_enabled: bool,
+    /// #1607 (codex-review follow-up): the session sandbox forwarded onto the
+    /// [`ExecutorConfig`] so the pipeline's terminal / per-node command
+    /// validators run confined instead of on the host. Defaults to
+    /// `SandboxConfig::default()` (no-op on a host without a backend).
+    sandbox: octos_agent::SandboxConfig,
 }
 
 impl RunPipelineTool {
@@ -173,7 +178,16 @@ impl RunPipelineTool {
             contract_id: None,
             embedder: None,
             ir_enabled: ir_authoring_default(),
+            sandbox: octos_agent::SandboxConfig::default(),
         }
+    }
+
+    /// #1607: thread the session sandbox onto the pipeline executor so
+    /// terminal / per-node `Command` validators run confined. Mirrors
+    /// `SpawnTool::with_sandbox` / `DelegateTool::with_sandbox`.
+    pub fn with_sandbox(mut self, sandbox: octos_agent::SandboxConfig) -> Self {
+        self.sandbox = sandbox;
+        self
     }
 
     /// S1-5: enable the typed-IR authoring path (opt-in; default off). The
@@ -1023,6 +1037,9 @@ impl Tool for RunPipelineTool {
             // runs silently lose strong/fast model defaults and cost
             // projections fall back to the minimum estimate.
             catalog_dir: Some(self.working_dir.clone()),
+            // #1607 (codex-review follow-up): forward the session sandbox so
+            // the terminal / per-node command validators run confined.
+            sandbox: self.sandbox.clone(),
         };
 
         // Pipeline-level timeout resolution (NEW-15):

--- a/crates/octos-pipeline/tests/checkpoint_resume.rs
+++ b/crates/octos-pipeline/tests/checkpoint_resume.rs
@@ -122,6 +122,9 @@ fn base_config(
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
         embedder: None,
         catalog_dir: None,
+        // #1607: pipeline validators run under a no-op sandbox in tests
+        // (host-independent — command validators run the argv directly).
+        sandbox: octos_agent::SandboxConfig::default(),
     }
 }
 

--- a/crates/octos-pipeline/tests/dag_real_llm.rs
+++ b/crates/octos-pipeline/tests/dag_real_llm.rs
@@ -63,6 +63,9 @@ async fn make_executor(dir: &TempDir, dag: bool) -> PipelineExecutor {
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
         embedder: None,
         catalog_dir: None,
+        // #1607: pipeline validators run under a no-op sandbox in tests
+        // (host-independent — command validators run the argv directly).
+        sandbox: octos_agent::SandboxConfig::default(),
     };
     PipelineExecutor::new(config).with_dag_scheduler(dag)
 }

--- a/crates/octos-pipeline/tests/dag_scheduler.rs
+++ b/crates/octos-pipeline/tests/dag_scheduler.rs
@@ -126,6 +126,9 @@ async fn run_with(
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
         embedder: None,
         catalog_dir: None,
+        // #1607: pipeline validators run under a no-op sandbox in tests
+        // (host-independent — command validators run the argv directly).
+        sandbox: octos_agent::SandboxConfig::default(),
     };
     let exec = PipelineExecutor::new(config).with_dag_scheduler(dag);
     let state = Arc::new(Mutex::new(ExecState::default()));

--- a/crates/octos-pipeline/tests/deadline_enforcement.rs
+++ b/crates/octos-pipeline/tests/deadline_enforcement.rs
@@ -126,6 +126,9 @@ fn base_config(
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
         embedder: None,
         catalog_dir: None,
+        // #1607: pipeline validators run under a no-op sandbox in tests
+        // (host-independent — command validators run the argv directly).
+        sandbox: octos_agent::SandboxConfig::default(),
     }
 }
 

--- a/crates/octos-pipeline/tests/deep_research_ir.rs
+++ b/crates/octos-pipeline/tests/deep_research_ir.rs
@@ -149,6 +149,9 @@ async fn deep_research_ir_runs_end_to_end() {
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
         embedder: None,
         catalog_dir: None,
+        // #1607: pipeline validators run under a no-op sandbox in tests
+        // (host-independent — command validators run the argv directly).
+        sandbox: octos_agent::SandboxConfig::default(),
     };
     let exec = PipelineExecutor::new(config);
 

--- a/crates/octos-pipeline/tests/embedder_propagation.rs
+++ b/crates/octos-pipeline/tests/embedder_propagation.rs
@@ -179,6 +179,9 @@ async fn build_codergen_propagates_embedder_from_executor_config() {
         host_context: octos_pipeline::PipelineHostContext::default(),
         embedder: Some(embedder),
         catalog_dir: None,
+        // #1607: pipeline validators run under a no-op sandbox in tests
+        // (host-independent — command validators run the argv directly).
+        sandbox: octos_agent::SandboxConfig::default(),
     };
 
     let executor = PipelineExecutor::new(config);
@@ -222,6 +225,9 @@ async fn build_codergen_omits_embedder_when_executor_config_has_none() {
         host_context: octos_pipeline::PipelineHostContext::default(),
         embedder: None,
         catalog_dir: None,
+        // #1607: pipeline validators run under a no-op sandbox in tests
+        // (host-independent — command validators run the argv directly).
+        sandbox: octos_agent::SandboxConfig::default(),
     };
 
     let executor = PipelineExecutor::new(config);

--- a/crates/octos-pipeline/tests/fanout_deadline_action_and_continue.rs
+++ b/crates/octos-pipeline/tests/fanout_deadline_action_and_continue.rs
@@ -128,6 +128,9 @@ async fn make_executor(dir: &TempDir) -> PipelineExecutor {
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
         embedder: None,
         catalog_dir: None,
+        // #1607: pipeline validators run under a no-op sandbox in tests
+        // (host-independent — command validators run the argv directly).
+        sandbox: octos_agent::SandboxConfig::default(),
     };
     PipelineExecutor::new(config)
 }

--- a/crates/octos-pipeline/tests/fanout_failed_task_no_hang.rs
+++ b/crates/octos-pipeline/tests/fanout_failed_task_no_hang.rs
@@ -116,6 +116,9 @@ async fn make_executor(dir: &TempDir) -> PipelineExecutor {
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
         embedder: None,
         catalog_dir: None,
+        // #1607: pipeline validators run under a no-op sandbox in tests
+        // (host-independent — command validators run the argv directly).
+        sandbox: octos_agent::SandboxConfig::default(),
     };
     PipelineExecutor::new(config)
 }

--- a/crates/octos-pipeline/tests/sequential_pipeline_cost.rs
+++ b/crates/octos-pipeline/tests/sequential_pipeline_cost.rs
@@ -117,6 +117,9 @@ fn config(
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
         embedder: None,
         catalog_dir: None,
+        // #1607: pipeline validators run under a no-op sandbox in tests
+        // (host-independent — command validators run the argv directly).
+        sandbox: octos_agent::SandboxConfig::default(),
     }
 }
 

--- a/crates/octos-pipeline/tests/ux_pipeline.rs
+++ b/crates/octos-pipeline/tests/ux_pipeline.rs
@@ -70,6 +70,9 @@ async fn make_config(provider: Arc<dyn LlmProvider>, dir: &TempDir) -> ExecutorC
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
         embedder: None,
         catalog_dir: None,
+        // #1607: pipeline validators run under a no-op sandbox in tests
+        // (host-independent — command validators run the argv directly).
+        sandbox: octos_agent::SandboxConfig::default(),
     }
 }
 

--- a/crates/octos-pipeline/tests/workspace_contract.rs
+++ b/crates/octos-pipeline/tests/workspace_contract.rs
@@ -168,6 +168,9 @@ fn base_config(dir: &TempDir, memory: Arc<EpisodeStore>, ctx: PipelineContext) -
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
         embedder: None,
         catalog_dir: None,
+        // #1607: pipeline validators run under a no-op sandbox in tests
+        // (host-independent — command validators run the argv directly).
+        sandbox: octos_agent::SandboxConfig::default(),
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #1607. Sandboxes **workspace-declared command validators** so an untrusted `workspace_policy.toml` `Command` validator can never execute on the host from a sandboxed session.

**codex kept finding MORE registry-construction sites that passed a `NoSandbox` (or wrong) registry into a validator entry point — the "carry a real sandbox on every registry" approach did not converge.** This revision fixes it **structurally**: the validator entry points now take the session sandbox as an **explicit argument** (`std::sync::Arc<dyn Sandbox>`), and `build_validator_runner` uses that argument instead of reading `tools.sandbox()`. The **compiler now enumerates and enforces every call site** — the exhaustiveness proof is compiler-derived, not a grep.

### Entry points (in `octos-agent/src/workspace_contract.rs`) — now REQUIRE a sandbox

- `build_validator_runner(tools, workspace_root, sandbox)` → `.with_sandbox(sandbox)` (no longer reads `tools.sandbox()`)
- `run_declared_validators(..., sandbox)`
- `run_declared_validators_with_output(..., sandbox)`
- `run_project_root_validators(..., sandbox)`
- `enforce_spawn_task_contract{,_with_args,_with_args_and_output}(..., sandbox)` — these also reach a validator runner, so the compiler flagged their internal call and they were threaded too.

### Behaviour contract (unchanged for legacy hosts)
`ValidatorRunner::run_command` (in `validators.rs`) branches on the backend:
- **no-op backend** (`NoSandbox`, or a real backend whose helper binary is unavailable) → runs the argv **directly** (pre-fix behaviour; backend-less hosts unaffected).
- **POSIX real backend** (macOS `sandbox-exec` / Linux bwrap-landlock) → shell-quotes + wraps (`sh -c` + shlex).
- **Windows / Docker real backend** → **fails closed** (Docker via `is_docker()`).

The `shell`/`bash`/`exec_command` policy-alias equivalence is preserved.

## Call sites the compiler flagged (exhaustiveness proof — compiler-derived)

**Agent-internal** — pass `self.tools.sandbox()` / the local `bg_tools.sandbox()`. The Agent's own registry is built sandboxed in `session_actor` (`create_registry_for_workspace` → `rebind_cwd(create_sandbox(&sandbox_config))`):
- `agent/execution.rs` (`enforce_spawn_task_contract_with_args_and_output` + `run_project_root_validators`)
- `agent/loop_runner.rs:1943` (`run_project_root_validators`)

**Threaded-config tools** — pass `Arc::from(create_sandbox(&<that config>))` (explicit form, preferred over `tools.sandbox()`):
- `tools/spawn.rs` — SpawnTool `self.sandbox`: agent_mcp session-scope + project-root (2×), sync child validators (2×), background child validators (2×, via captured `child_sandbox`).
- `tools/delegate.rs` — DelegateTool `self.sandbox`.
- `octos-pipeline/src/executor.rs` — `ExecutorConfig.sandbox`: `run_terminal_validators` + `run_node_validators` (`octos_agent::create_sandbox`).

**Session-effective (round-4 AppUI, see below):**
- `api/ui_protocol.rs` spawn-child pipeline factory → `session_runtime.sandbox`
- `runtime/session.rs::bootstrap_with_permissions_and_sandbox` re-registers `run_pipeline` → session `sandbox`
- `session_actor.rs` parent + spawn-child `PipelineToolFactory::create` → `self.sandbox_config`

**Tests (host-independent `Arc::new(NoSandbox)` / `SandboxConfig::default()`):** `spawn.rs:5361`, `check_workspace_contract.rs`, `loop_runner.rs:6811`, `workspace_git.rs`, `runtime/session.rs` bootstrap test, `runtime/profile.rs` factory test, `tests/validator_runner.rs` (3×), `tests/slides_validator_project_scope.rs` (3×), and the crate's `#[cfg(test)]` `enforce_spawn_task_contract{,_with_args}` calls (28×).

## Round-4 codex findings fixed

**Codergen (`octos-pipeline/src/handler.rs`)** — its worker registry was `ToolRegistry::with_builtins` (stores `NoSandbox`), and the worker Agent runs its own `run_project_root_validators`. Added a `sandbox` field to `CodergenHandler`, threaded `ExecutorConfig.sandbox` through `build_codergen`, and the worker registry is now `with_builtins_and_sandbox(&working_dir, create_sandbox(&self.sandbox))` — so the worker Agent's project-root validator pass (Agent-internal path, reads `self.tools.sandbox()`) is confined.

**AppUI (`runtime/profile.rs` → session-effective sandbox)** — `AppUiPipelineToolFactory` captured the **profile-time** `sandbox_config`, but the session's effective sandbox is only set later by `bootstrap_with_permissions_and_sandbox`. Because `run_pipeline` is **not** a `CWD_BOUND_TOOLS` entry, `rebind_cwd_with_permissions` carried the stale profile-time `run_pipeline` instance into the session registry. Fix:
- `PipelineToolFactory::create(&self, sandbox: &SandboxConfig)` now takes the session-effective sandbox explicitly (all 3 implementors updated: AppUI + gateway `DefaultPipelineToolFactory` + `ChildPipelineToolFactory`).
- `bootstrap_with_permissions_and_sandbox` **re-registers** `run_pipeline` from the profile's pipeline factory with the SESSION `sandbox` (spawn_only marker preserved).
- Spawn-child pipeline tools bind to `session_runtime.sandbox` (`ui_protocol.rs`) / `self.sandbox_config` (`session_actor.rs`).

Net effect: a read-only (or otherwise overridden) session's pipeline command validators no longer regain removed writes/network from the profile default.

The `ToolRegistry::sandbox()` getter and the earlier `sandbox` fields are **retained** — the Agent-internal callers use `.sandbox()`, and child-tools sandboxing (spawned CHILD agents, a separate valid concern) still uses them.

## Verify
- `cargo build -p octos-agent -p octos-cli -p octos-pipeline` — OK
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (0)
- `cargo fmt --all -- --check` — clean
- `cargo test -p octos-agent` — lib **2078 passed, 0 failed**; all integration binaries green
- `cargo test -p octos-pipeline` — lib **338 passed, 0 failed**; all integration green
- `cargo test -p octos-cli --features api` — lib **2225/2226 passed** (only a load-induced timing flake alternates: `session_actor::…master_continuation_tick_reenters_actor_loop` and `should_emit_only_valid_json_on_stdout_when_running_acp` — both use `start_paused`/3s-subprocess windows and pass in isolation / are unrelated to this change; the ACP test fails identically on the pristine base commit `159aa21be`, i.e. pre-existing environmental).
