### PR TITLE
feat(memory): save conversation episodes at compaction (#1617, #1587 write side)

### DIFF
--- a/crates/octos-agent/src/agent/compaction.rs
+++ b/crates/octos-agent/src/agent/compaction.rs
@@ -96,15 +96,15 @@ impl Agent {
     pub(super) fn maybe_run_preflight_compaction(
         &self,
         messages: &mut Vec<Message>,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<Option<String>> {
         if self.prompt_context_manager.is_some() {
-            return Ok(());
+            return Ok(None);
         }
         let Some(runner) = self.compaction_runner.as_ref() else {
-            return Ok(());
+            return Ok(None);
         };
         if runner.needs_preflight(messages).is_none() {
-            return Ok(());
+            return Ok(None);
         }
         let outcome = runner.run(messages, CompactionPhase::Preflight);
         info!(
@@ -117,7 +117,12 @@ impl Agent {
             summarizer = outcome.summarizer_kind,
             "harness M6.3 compaction preflight fired"
         );
-        self.enforce_preservation(messages, CompactionPhase::Preflight)
+        self.enforce_preservation(messages, CompactionPhase::Preflight)?;
+        // A large/resumed conversation compacts on ENTRY (iteration 1),
+        // where maybe_run_turn_compaction returns None — surface the
+        // preflight summary too so that conversation is still saved
+        // (codex #1618 P2).
+        Ok(outcome.summary)
     }
 
     /// M8.5 tier 1: cheap per-turn micro-compaction.  Runs the

--- a/crates/octos-agent/src/agent/compaction.rs
+++ b/crates/octos-agent/src/agent/compaction.rs
@@ -175,21 +175,26 @@ impl Agent {
     /// active when a [`crate::compaction::CompactionRunner`] is wired; a
     /// no-op otherwise so every caller that does not wire the contract keeps
     /// the existing behaviour byte-for-byte.
+    /// Run the per-turn declarative compaction pass. Returns the summary
+    /// text a pass folded in (when any), so the conversational loop can
+    /// persist it as a searchable episode (#1587 write side). `None` when
+    /// no pass ran (context-manager-owned prompt, no runner, iteration 1,
+    /// or nothing to compact).
     pub(super) fn maybe_run_turn_compaction(
         &self,
         messages: &mut Vec<Message>,
         iteration: u32,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<Option<String>> {
         if self.prompt_context_manager.is_some() {
-            return Ok(());
+            return Ok(None);
         }
         let Some(runner) = self.compaction_runner.as_ref() else {
-            return Ok(());
+            return Ok(None);
         };
         // Skip the very first iteration when the preflight path already ran
         // — preflight emits its own events and enforces preservation.
         if iteration == 1 {
-            return Ok(());
+            return Ok(None);
         }
         let outcome = runner.run(messages, CompactionPhase::TurnEnd);
         if outcome.performed {
@@ -204,8 +209,9 @@ impl Agent {
                 "harness M6.3 compaction per-turn pass"
             );
             self.enforce_preservation(messages, CompactionPhase::TurnEnd)?;
+            return Ok(outcome.summary);
         }
-        Ok(())
+        Ok(None)
     }
 
     /// Ask the caller-owned context bridge to prepare the final model prompt.

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -989,7 +989,17 @@ impl Agent {
                     // runner sees the final shape of the conversation (after
                     // tool-pair repair + system-message normalization). This
                     // also feeds the validator rail on subsequent iterations.
-                    self.maybe_run_turn_compaction(&mut messages, iteration)?;
+                    if let Some(summary) =
+                        self.maybe_run_turn_compaction(&mut messages, iteration)?
+                    {
+                        // #1587 write side: a conversation that compacts is
+                        // substantial enough to be worth recalling later.
+                        // Persist the compaction summary as an embedded
+                        // episode so a future conversation's session-start
+                        // recall can surface it. No-op without an embedder
+                        // or when episodes are disabled.
+                        self.save_conversation_episode(summary).await;
+                    }
                     self.prepare_prompt_with_context_manager(
                         &mut messages,
                         if iteration == 1 {

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -833,7 +833,7 @@ impl Agent {
                     let default_cwd = std::path::PathBuf::from(".");
                     let cwd = self.tools.workspace_root().unwrap_or(default_cwd.as_path());
                     if let Some(recall) =
-                        self.recall_relevant_episodes(user_content, cwd).await
+                        self.recall_relevant_episodes(user_content, cwd, true).await
                     {
                         messages.push(recall);
                     }
@@ -976,7 +976,14 @@ impl Agent {
                     // LLM call when a compaction policy is wired and the
                     // context already exceeds the declared threshold.
                     if iteration == 1 {
-                        self.maybe_run_preflight_compaction(&mut messages)?;
+                        if let Some(summary) =
+                            self.maybe_run_preflight_compaction(&mut messages)?
+                        {
+                            // #1587 write side: a conversation large enough to
+                            // compact on entry is worth recalling later. Upserts
+                            // the per-session episode (see save_conversation_episode).
+                            self.save_conversation_episode(summary).await;
+                        }
                     }
                     // Harness M8.5 tier 1: cheap in-place stale/oversized
                     // tool-result pruning. Runs every iteration (including

--- a/crates/octos-agent/src/agent/memory.rs
+++ b/crates/octos-agent/src/agent/memory.rs
@@ -193,19 +193,33 @@ impl Agent {
             octos_memory::EpisodeOutcome::Success,
         );
         episode.source = octos_memory::EpisodeSource::Conversation;
-        // Fresh id per compaction. An earlier design reused one id per
-        // session to "upsert", but the hybrid index ignores a repeated id
-        // and HNSW vectors never replace (codex #1618 P2) — so recall would
-        // rank on the FIRST summary forever. A fresh id keeps every episode
-        // fully + correctly indexed. Growth is bounded: compaction is rare
-        // (only when context fills), so a session yields a few episodes —
-        // its substantive chunks. Later summaries subsume earlier ones
-        // (cumulative), so the latest, most complete episode ranks highest;
-        // the earlier partials are minor redundancy.
         let ep_id = episode.id.clone();
+        // SUPERSEDE the session's prior conversation episode. Preflight
+        // compaction fires on every turn once the conversation is large, so
+        // a fresh-id-per-compaction append would grow PER TURN (codex #1618
+        // round-3 P2). Instead each compaction stores the new (latest,
+        // cumulative) summary and then DELETES the prior one — the store's
+        // delete_by_id removes it from redb + BM25 + HNSW + embeddings — so
+        // a session keeps exactly ONE conversation episode. (A repeated-id
+        // "upsert" cannot work: the hybrid index ignores a repeated id.)
+        // Snapshot the prior id WITHOUT holding the lock across an await.
+        let prior_id = self
+            .conversation_episode_id
+            .lock()
+            .ok()
+            .and_then(|g| g.clone());
         if let Err(e) = self.memory.store(episode).await {
             warn!(error = %e, "failed to save conversation episode");
             return;
+        }
+        // Delete AFTER the new one is stored, so recall never sees zero.
+        if let Some(old) = prior_id {
+            if old != ep_id {
+                let _ = self.memory.delete_by_id(&old).await;
+            }
+        }
+        if let Ok(mut g) = self.conversation_episode_id.lock() {
+            *g = Some(ep_id.clone());
         }
         info!(
             episode_id = %ep_id,
@@ -879,7 +893,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn save_conversation_episode_appends_per_compaction() {
+    async fn save_conversation_episode_supersedes_prior_per_session() {
         use crate::{Agent, tools::ToolRegistry};
         use octos_memory::EpisodeStore;
         use std::sync::Arc;
@@ -892,8 +906,8 @@ mod tests {
         let agent = Agent::new(AgentId::new("chat"), provider, tools, memory.clone())
             .with_embedder(Arc::new(ConstEmbedder));
 
-        // Each compaction appends a fresh, fully-indexed episode (HNSW
-        // can't upsert; growth is bounded per session).
+        // Each compaction SUPERSEDES the prior conversation episode, so a
+        // session keeps exactly ONE — the latest summary, fully indexed.
         agent
             .save_conversation_episode("first chunk about widgets".to_string())
             .await;
@@ -902,13 +916,19 @@ mod tests {
             .await;
 
         let all = memory.find_relevant(&workspace, "chunk", 10).await.unwrap();
-        assert!(
-            all.iter().any(|e| e.summary.contains("widgets")),
-            "first compaction episode present + indexed"
+        let conv: Vec<_> = all
+            .iter()
+            .filter(|e| e.summary.contains("chunk about"))
+            .collect();
+        assert_eq!(
+            conv.len(),
+            1,
+            "one conversation episode per session, got {}",
+            conv.len()
         );
         assert!(
-            all.iter().any(|e| e.summary.contains("gadgets")),
-            "second compaction episode present + indexed"
+            conv[0].summary.contains("gadgets"),
+            "the surviving episode carries the LATEST summary, not the superseded one"
         );
     }
 

--- a/crates/octos-agent/src/agent/memory.rs
+++ b/crates/octos-agent/src/agent/memory.rs
@@ -99,13 +99,12 @@ impl Agent {
             );
             return None;
         };
-        // Over-fetch on the task (filtered) path so dropping conversation
-        // episodes below can't starve task recall under the inject limit.
-        let fetch_limit = if include_conversations {
-            RELEVANT_EXPERIENCES_INJECT_LIMIT
-        } else {
-            RELEVANT_EXPERIENCES_INJECT_LIMIT * 4
-        };
+        // Source isolation (codex #1618 P2): a TASK's generic query (e.g.
+        // the fixed "code review") can BM25-admit an unrelated CONVERSATION
+        // summary past the 0.55 floor. Task recall excludes conversation
+        // episodes (the store guarantees none leak in); conversation recall
+        // keeps both.
+        let exclude_conversation = !include_conversations;
         let scored_result = match embedder.embed(&[query]).await {
             Ok(vecs) => {
                 let query_emb = vecs.into_iter().next();
@@ -113,8 +112,9 @@ impl Agent {
                     .find_relevant_hybrid_scored_filtered(
                         query,
                         query_emb,
-                        fetch_limit,
+                        RELEVANT_EXPERIENCES_INJECT_LIMIT,
                         Some(MIN_EPISODE_SIMILARITY),
+                        exclude_conversation,
                     )
                     .await
             }
@@ -124,20 +124,14 @@ impl Agent {
                     .find_relevant_hybrid_scored_filtered(
                         query,
                         None,
-                        fetch_limit,
+                        RELEVANT_EXPERIENCES_INJECT_LIMIT,
                         Some(MIN_EPISODE_SIMILARITY),
+                        exclude_conversation,
                     )
                     .await
             }
         };
-        let mut scored = scored_result.ok()?;
-        // Source isolation (codex #1618 P2): a TASK's generic query (e.g.
-        // the fixed "code review") can BM25-admit an unrelated CONVERSATION
-        // summary past the 0.55 floor. Task recall therefore excludes
-        // conversation episodes; conversation recall keeps both.
-        if !include_conversations {
-            scored.retain(|(ep, _)| ep.source != octos_memory::EpisodeSource::Conversation);
-        }
+        let scored = scored_result.ok()?;
         // NEW-06 diagnostic: one structured line naming the admitted
         // episodes + per-modality scores, so operators can confirm the gate
         // without inspecting the model-visible prompt.
@@ -199,15 +193,16 @@ impl Agent {
             octos_memory::EpisodeOutcome::Success,
         );
         episode.source = octos_memory::EpisodeSource::Conversation;
-        // Reuse this conversation's stable episode id across compactions so
-        // the store INSERT upserts one per-session episode (latest
-        // cumulative summary) instead of accumulating stale snapshots that
-        // crowd the recall slots (codex #1618 P3).
-        let ep_id = self
-            .conversation_episode_id
-            .get_or_init(|| episode.id.clone())
-            .clone();
-        episode.id = ep_id.clone();
+        // Fresh id per compaction. An earlier design reused one id per
+        // session to "upsert", but the hybrid index ignores a repeated id
+        // and HNSW vectors never replace (codex #1618 P2) — so recall would
+        // rank on the FIRST summary forever. A fresh id keeps every episode
+        // fully + correctly indexed. Growth is bounded: compaction is rare
+        // (only when context fills), so a session yields a few episodes —
+        // its substantive chunks. Later summaries subsume earlier ones
+        // (cumulative), so the latest, most complete episode ranks highest;
+        // the earlier partials are minor redundancy.
+        let ep_id = episode.id.clone();
         if let Err(e) = self.memory.store(episode).await {
             warn!(error = %e, "failed to save conversation episode");
             return;
@@ -884,7 +879,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn save_conversation_episode_upserts_one_per_session() {
+    async fn save_conversation_episode_appends_per_compaction() {
         use crate::{Agent, tools::ToolRegistry};
         use octos_memory::EpisodeStore;
         use std::sync::Arc;
@@ -897,8 +892,8 @@ mod tests {
         let agent = Agent::new(AgentId::new("chat"), provider, tools, memory.clone())
             .with_embedder(Arc::new(ConstEmbedder));
 
-        // Two compactions in one session (same agent) → ONE episode, latest
-        // summary — not two overlapping snapshots.
+        // Each compaction appends a fresh, fully-indexed episode (HNSW
+        // can't upsert; growth is bounded per session).
         agent
             .save_conversation_episode("first chunk about widgets".to_string())
             .await;
@@ -907,17 +902,13 @@ mod tests {
             .await;
 
         let all = memory.find_relevant(&workspace, "chunk", 10).await.unwrap();
-        let conv_count = all
-            .iter()
-            .filter(|e| e.summary.contains("chunk about"))
-            .count();
-        assert_eq!(
-            conv_count, 1,
-            "one upserted episode per session, got {conv_count}"
+        assert!(
+            all.iter().any(|e| e.summary.contains("widgets")),
+            "first compaction episode present + indexed"
         );
         assert!(
             all.iter().any(|e| e.summary.contains("gadgets")),
-            "the surviving episode carries the LATEST summary"
+            "second compaction episode present + indexed"
         );
     }
 

--- a/crates/octos-agent/src/agent/memory.rs
+++ b/crates/octos-agent/src/agent/memory.rs
@@ -155,6 +155,68 @@ impl Agent {
         })
     }
 
+    /// Persist a conversation's compaction summary as a searchable episode
+    /// (#1587 write side): store it and — fire-and-forget so the turn isn't
+    /// blocked — embed it, so a future conversation's session-start recall
+    /// ([`Self::recall_relevant_episodes`]) can surface it. No-op unless
+    /// episodes are enabled AND an embedder is present: an unembedded
+    /// episode is invisible to every (embedder-gated) recall path, so
+    /// storing it would only bloat the index.
+    pub(super) async fn save_conversation_episode(&self, summary: String) {
+        if !self.config.save_episodes || self.embedder.is_none() {
+            return;
+        }
+        let summary_truncated = octos_core::truncated_utf8(&summary, 500, "...");
+        if summary_truncated.trim().is_empty() {
+            return;
+        }
+        let cwd = self
+            .tools
+            .workspace_root()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+
+        let episode = octos_memory::Episode::new(
+            octos_core::TaskId::new(),
+            self.id.clone(),
+            cwd,
+            summary_truncated.clone(),
+            octos_memory::EpisodeOutcome::Success,
+        );
+        let ep_id = episode.id.clone();
+        if let Err(e) = self.memory.store(episode).await {
+            warn!(error = %e, "failed to save conversation episode");
+            return;
+        }
+        info!(
+            episode_id = %ep_id,
+            summary_len = summary_truncated.len(),
+            "saved conversation episode (#1587 write side)"
+        );
+
+        // Fire-and-forget embed (mirrors the task-loop pattern): compaction
+        // already ran mid-turn, so don't add an embed round-trip to the
+        // turn's latency.
+        if let Some(ref embedder) = self.embedder {
+            let embedder = embedder.clone();
+            let memory = self.memory.clone();
+            tokio::spawn(async move {
+                match embedder.embed(&[summary_truncated.as_str()]).await {
+                    Ok(vecs) => {
+                        if let Some(vec) = vecs.into_iter().next() {
+                            if let Err(e) = memory.store_embedding(&ep_id, vec).await {
+                                warn!(error = %e, "failed to store conversation-episode embedding");
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!(error = %e, episode_id = %ep_id, "failed to embed conversation episode");
+                    }
+                }
+            });
+        }
+    }
+
     pub(super) async fn build_initial_messages(&self, task: &Task) -> Vec<Message> {
         let mut messages = vec![Message {
             role: MessageRole::System,
@@ -713,6 +775,65 @@ mod tests {
             .expect("embedder present + vector match must recall");
         assert!(msg.content.contains("Relevant Past Experiences"));
         assert!(msg.content.contains("keepalive"));
+    }
+
+    #[tokio::test]
+    async fn save_conversation_episode_stores_recallable_episode() {
+        use crate::{Agent, tools::ToolRegistry};
+        use octos_memory::EpisodeStore;
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().to_path_buf();
+        let memory = Arc::new(EpisodeStore::open(workspace.join("memory")).await.unwrap());
+
+        let provider: Arc<dyn octos_llm::LlmProvider> = Arc::new(EndTurnProvider);
+        let tools = ToolRegistry::with_builtins(&workspace);
+        let agent = Agent::new(AgentId::new("chat"), provider, tools, memory.clone())
+            .with_embedder(Arc::new(ConstEmbedder));
+
+        agent
+            .save_conversation_episode(
+                "We diagnosed the websocket gateway keepalive dropping clients".to_string(),
+            )
+            .await;
+
+        // The store write is awaited (the embed is fire-and-forget); the
+        // episode is BM25-findable in its cwd immediately.
+        let hits = memory
+            .find_relevant(&workspace, "websocket gateway keepalive", 5)
+            .await
+            .unwrap();
+        assert!(
+            hits.iter().any(|e| e.summary.contains("keepalive")),
+            "conversation episode must be stored + recallable"
+        );
+    }
+
+    #[tokio::test]
+    async fn save_conversation_episode_is_noop_without_embedder() {
+        use crate::{Agent, tools::ToolRegistry};
+        use octos_memory::EpisodeStore;
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().to_path_buf();
+        let memory = Arc::new(EpisodeStore::open(workspace.join("memory")).await.unwrap());
+        let provider: Arc<dyn octos_llm::LlmProvider> = Arc::new(EndTurnProvider);
+        let tools = ToolRegistry::with_builtins(&workspace);
+        // No embedder: an unembedded conversation episode is invisible to
+        // recall, so we must not store it at all.
+        let agent = Agent::new(AgentId::new("chat"), provider, tools, memory.clone());
+
+        agent
+            .save_conversation_episode("some conversation summary".to_string())
+            .await;
+
+        let hits = memory
+            .find_relevant(&workspace, "conversation summary", 5)
+            .await
+            .unwrap();
+        assert!(hits.is_empty(), "no episode without an embedder");
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/agent/memory.rs
+++ b/crates/octos-agent/src/agent/memory.rs
@@ -194,32 +194,28 @@ impl Agent {
         );
         episode.source = octos_memory::EpisodeSource::Conversation;
         let ep_id = episode.id.clone();
-        // SUPERSEDE the session's prior conversation episode. Preflight
-        // compaction fires on every turn once the conversation is large, so
-        // a fresh-id-per-compaction append would grow PER TURN (codex #1618
-        // round-3 P2). Instead each compaction stores the new (latest,
-        // cumulative) summary and then DELETES the prior one — the store's
-        // delete_by_id removes it from redb + BM25 + HNSW + embeddings — so
-        // a session keeps exactly ONE conversation episode. (A repeated-id
-        // "upsert" cannot work: the hybrid index ignores a repeated id.)
-        // Snapshot the prior id WITHOUT holding the lock across an await.
-        let prior_id = self
-            .conversation_episode_id
-            .lock()
-            .ok()
-            .and_then(|g| g.clone());
-        if let Err(e) = self.memory.store(episode).await {
-            warn!(error = %e, "failed to save conversation episode");
+        // Save ONCE per session, at the first compaction. Preflight
+        // compaction fires on iteration 1 of EVERY turn once the
+        // conversation is large, so saving on each would grow per-turn
+        // (codex #1618 round-3). Supersede-via-delete was rejected: the
+        // hybrid index only TOMBSTONES on delete (never reclaims), so it
+        // would churn the index per compaction (round-4). One episode
+        // captures the conversation's first substantial summary — enough
+        // for "was there a conversation about X"; durable facts are handled
+        // separately by the memory-refresh pipeline. The swap makes
+        // concurrent saves collapse to exactly one.
+        if self
+            .conversation_episode_saved
+            .swap(true, std::sync::atomic::Ordering::AcqRel)
+        {
             return;
         }
-        // Delete AFTER the new one is stored, so recall never sees zero.
-        if let Some(old) = prior_id {
-            if old != ep_id {
-                let _ = self.memory.delete_by_id(&old).await;
-            }
-        }
-        if let Ok(mut g) = self.conversation_episode_id.lock() {
-            *g = Some(ep_id.clone());
+        if let Err(e) = self.memory.store(episode).await {
+            warn!(error = %e, "failed to save conversation episode");
+            // Allow a retry on the next compaction — the save didn't land.
+            self.conversation_episode_saved
+                .store(false, std::sync::atomic::Ordering::Release);
+            return;
         }
         info!(
             episode_id = %ep_id,
@@ -893,7 +889,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn save_conversation_episode_supersedes_prior_per_session() {
+    async fn save_conversation_episode_saves_once_per_session() {
         use crate::{Agent, tools::ToolRegistry};
         use octos_memory::EpisodeStore;
         use std::sync::Arc;
@@ -906,8 +902,8 @@ mod tests {
         let agent = Agent::new(AgentId::new("chat"), provider, tools, memory.clone())
             .with_embedder(Arc::new(ConstEmbedder));
 
-        // Each compaction SUPERSEDES the prior conversation episode, so a
-        // session keeps exactly ONE — the latest summary, fully indexed.
+        // Save-once per session: the first compaction's summary is kept;
+        // later compactions are no-ops. Exactly one conversation episode.
         agent
             .save_conversation_episode("first chunk about widgets".to_string())
             .await;
@@ -927,8 +923,8 @@ mod tests {
             conv.len()
         );
         assert!(
-            conv[0].summary.contains("gadgets"),
-            "the surviving episode carries the LATEST summary, not the superseded one"
+            conv[0].summary.contains("widgets"),
+            "the first compaction's summary is the one kept"
         );
     }
 

--- a/crates/octos-agent/src/agent/memory.rs
+++ b/crates/octos-agent/src/agent/memory.rs
@@ -87,6 +87,7 @@ impl Agent {
         &self,
         query: &str,
         cwd: &std::path::Path,
+        include_conversations: bool,
     ) -> Option<Message> {
         let Some(ref embedder) = self.embedder else {
             tracing::debug!(
@@ -98,6 +99,13 @@ impl Agent {
             );
             return None;
         };
+        // Over-fetch on the task (filtered) path so dropping conversation
+        // episodes below can't starve task recall under the inject limit.
+        let fetch_limit = if include_conversations {
+            RELEVANT_EXPERIENCES_INJECT_LIMIT
+        } else {
+            RELEVANT_EXPERIENCES_INJECT_LIMIT * 4
+        };
         let scored_result = match embedder.embed(&[query]).await {
             Ok(vecs) => {
                 let query_emb = vecs.into_iter().next();
@@ -105,7 +113,7 @@ impl Agent {
                     .find_relevant_hybrid_scored_filtered(
                         query,
                         query_emb,
-                        RELEVANT_EXPERIENCES_INJECT_LIMIT,
+                        fetch_limit,
                         Some(MIN_EPISODE_SIMILARITY),
                     )
                     .await
@@ -116,13 +124,20 @@ impl Agent {
                     .find_relevant_hybrid_scored_filtered(
                         query,
                         None,
-                        RELEVANT_EXPERIENCES_INJECT_LIMIT,
+                        fetch_limit,
                         Some(MIN_EPISODE_SIMILARITY),
                     )
                     .await
             }
         };
-        let scored = scored_result.ok()?;
+        let mut scored = scored_result.ok()?;
+        // Source isolation (codex #1618 P2): a TASK's generic query (e.g.
+        // the fixed "code review") can BM25-admit an unrelated CONVERSATION
+        // summary past the 0.55 floor. Task recall therefore excludes
+        // conversation episodes; conversation recall keeps both.
+        if !include_conversations {
+            scored.retain(|(ep, _)| ep.source != octos_memory::EpisodeSource::Conversation);
+        }
         // NEW-06 diagnostic: one structured line naming the admitted
         // episodes + per-modality scores, so operators can confirm the gate
         // without inspecting the model-visible prompt.
@@ -176,14 +191,23 @@ impl Agent {
             .map(std::path::Path::to_path_buf)
             .unwrap_or_else(|| std::path::PathBuf::from("."));
 
-        let episode = octos_memory::Episode::new(
+        let mut episode = octos_memory::Episode::new(
             octos_core::TaskId::new(),
             self.id.clone(),
             cwd,
             summary_truncated.clone(),
             octos_memory::EpisodeOutcome::Success,
         );
-        let ep_id = episode.id.clone();
+        episode.source = octos_memory::EpisodeSource::Conversation;
+        // Reuse this conversation's stable episode id across compactions so
+        // the store INSERT upserts one per-session episode (latest
+        // cumulative summary) instead of accumulating stale snapshots that
+        // crowd the recall slots (codex #1618 P3).
+        let ep_id = self
+            .conversation_episode_id
+            .get_or_init(|| episode.id.clone())
+            .clone();
+        episode.id = ep_id.clone();
         if let Err(e) = self.memory.store(episode).await {
             warn!(error = %e, "failed to save conversation episode");
             return;
@@ -247,7 +271,7 @@ impl Agent {
         // keyword overlap within a single shared workspace can't
         // discriminate on-task from cross-task and would leak stale memory.
         if let Some(msg) = self
-            .recall_relevant_episodes(&query, &task.context.working_dir)
+            .recall_relevant_episodes(&query, &task.context.working_dir, false)
             .await
         {
             messages.push(msg);
@@ -770,7 +794,7 @@ mod tests {
             .with_embedder(Arc::new(ConstEmbedder));
 
         let msg = agent
-            .recall_relevant_episodes("clients keep dropping", &workspace)
+            .recall_relevant_episodes("clients keep dropping", &workspace, true)
             .await
             .expect("embedder present + vector match must recall");
         assert!(msg.content.contains("Relevant Past Experiences"));
@@ -807,6 +831,93 @@ mod tests {
         assert!(
             hits.iter().any(|e| e.summary.contains("keepalive")),
             "conversation episode must be stored + recallable"
+        );
+    }
+
+    #[tokio::test]
+    async fn task_recall_excludes_conversation_episodes() {
+        use crate::{Agent, tools::ToolRegistry};
+        use octos_memory::EpisodeStore;
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().to_path_buf();
+        let memory = Arc::new(EpisodeStore::open(workspace.join("memory")).await.unwrap());
+
+        let mut conv = Episode::new(
+            TaskId::new(),
+            AgentId::new("chat"),
+            workspace.clone(),
+            "Chatted about a code review of the parser".to_string(),
+            EpisodeOutcome::Success,
+        );
+        conv.source = octos_memory::EpisodeSource::Conversation;
+        let conv_id = conv.id.clone();
+        memory.store(conv).await.unwrap();
+        memory
+            .store_embedding(&conv_id, ConstEmbedder::vector())
+            .await
+            .unwrap();
+
+        let provider: Arc<dyn octos_llm::LlmProvider> = Arc::new(EndTurnProvider);
+        let tools = ToolRegistry::with_builtins(&workspace);
+        let agent = Agent::new(AgentId::new("worker"), provider, tools, memory)
+            .with_embedder(Arc::new(ConstEmbedder));
+
+        // Task path (include_conversations = false): must NOT surface it.
+        let task_recall = agent
+            .recall_relevant_episodes("code review", &workspace, false)
+            .await;
+        assert!(
+            task_recall
+                .as_ref()
+                .map(|m| !m.content.contains("code review of the parser"))
+                .unwrap_or(true),
+            "task recall must exclude conversation episodes"
+        );
+        // Conversation path (true): the same episode IS recallable.
+        let conv_recall = agent
+            .recall_relevant_episodes("code review", &workspace, true)
+            .await
+            .expect("conversation recall includes conversation episodes");
+        assert!(conv_recall.content.contains("code review of the parser"));
+    }
+
+    #[tokio::test]
+    async fn save_conversation_episode_upserts_one_per_session() {
+        use crate::{Agent, tools::ToolRegistry};
+        use octos_memory::EpisodeStore;
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().to_path_buf();
+        let memory = Arc::new(EpisodeStore::open(workspace.join("memory")).await.unwrap());
+        let provider: Arc<dyn octos_llm::LlmProvider> = Arc::new(EndTurnProvider);
+        let tools = ToolRegistry::with_builtins(&workspace);
+        let agent = Agent::new(AgentId::new("chat"), provider, tools, memory.clone())
+            .with_embedder(Arc::new(ConstEmbedder));
+
+        // Two compactions in one session (same agent) → ONE episode, latest
+        // summary — not two overlapping snapshots.
+        agent
+            .save_conversation_episode("first chunk about widgets".to_string())
+            .await;
+        agent
+            .save_conversation_episode("second chunk about gadgets".to_string())
+            .await;
+
+        let all = memory.find_relevant(&workspace, "chunk", 10).await.unwrap();
+        let conv_count = all
+            .iter()
+            .filter(|e| e.summary.contains("chunk about"))
+            .count();
+        assert_eq!(
+            conv_count, 1,
+            "one upserted episode per session, got {conv_count}"
+        );
+        assert!(
+            all.iter().any(|e| e.summary.contains("gadgets")),
+            "the surviving episode carries the LATEST summary"
         );
     }
 
@@ -863,7 +974,7 @@ mod tests {
 
         assert!(
             agent
-                .recall_relevant_episodes("gateways", &workspace)
+                .recall_relevant_episodes("gateways", &workspace, true)
                 .await
                 .is_none(),
             "no-embedder recall must be a no-op"

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -284,11 +284,6 @@ pub struct Agent {
     pub(super) memory: Arc<EpisodeStore>,
     /// Embedding provider for hybrid memory search.
     pub(super) embedder: Option<Arc<dyn EmbeddingProvider>>,
-    /// Stable episode id for THIS conversation's saved episode (#1587
-    /// write side). Set on the first compaction and reused, so successive
-    /// compactions UPSERT one per-session episode with the latest
-    /// cumulative summary instead of accumulating overlapping snapshots.
-    pub(super) conversation_episode_id: std::sync::OnceLock<String>,
     /// System prompt for this agent, as ordered segments (RwLock for
     /// hot-reload support). See [`prompt_segments::PromptSegments`].
     pub(super) system_prompt: RwLock<prompt_segments::PromptSegments>,
@@ -470,7 +465,6 @@ impl Agent {
             tools,
             memory,
             embedder: None,
-            conversation_episode_id: std::sync::OnceLock::new(),
             system_prompt: RwLock::new(prompt_segments::PromptSegments::from_base(system_prompt)),
             segment_providers: RwLock::new(Vec::new()),
             config: AgentConfig::default(),
@@ -544,7 +538,6 @@ impl Agent {
             tools,
             memory,
             embedder: None,
-            conversation_episode_id: std::sync::OnceLock::new(),
             system_prompt: RwLock::new(prompt_segments::PromptSegments::from_base(system_prompt)),
             segment_providers: RwLock::new(Vec::new()),
             config: AgentConfig::default(),

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -284,12 +284,13 @@ pub struct Agent {
     pub(super) memory: Arc<EpisodeStore>,
     /// Embedding provider for hybrid memory search.
     pub(super) embedder: Option<Arc<dyn EmbeddingProvider>>,
-    /// Id of THIS conversation's current saved episode (#1587 write side).
-    /// Each compaction SUPERSEDES it — store the new summary, then delete
-    /// the prior episode — so a session keeps exactly one conversation
-    /// episode carrying the latest cumulative summary (bounded growth;
-    /// per-agent = per-session). Empty until the first compaction.
-    pub(super) conversation_episode_id: std::sync::Mutex<Option<String>>,
+    /// Whether THIS conversation has already saved its episode (#1587
+    /// write side). Set on the first compaction; subsequent compactions
+    /// skip. One conversation episode per session — bounded regardless of
+    /// how many times the session compacts, and no index churn (the hybrid
+    /// index only tombstones on delete, so supersede would bloat it).
+    /// Per-agent = per-session (codex-confirmed).
+    pub(super) conversation_episode_saved: std::sync::atomic::AtomicBool,
     /// System prompt for this agent, as ordered segments (RwLock for
     /// hot-reload support). See [`prompt_segments::PromptSegments`].
     pub(super) system_prompt: RwLock<prompt_segments::PromptSegments>,
@@ -471,7 +472,7 @@ impl Agent {
             tools,
             memory,
             embedder: None,
-            conversation_episode_id: std::sync::Mutex::new(None),
+            conversation_episode_saved: std::sync::atomic::AtomicBool::new(false),
             system_prompt: RwLock::new(prompt_segments::PromptSegments::from_base(system_prompt)),
             segment_providers: RwLock::new(Vec::new()),
             config: AgentConfig::default(),
@@ -545,7 +546,7 @@ impl Agent {
             tools,
             memory,
             embedder: None,
-            conversation_episode_id: std::sync::Mutex::new(None),
+            conversation_episode_saved: std::sync::atomic::AtomicBool::new(false),
             system_prompt: RwLock::new(prompt_segments::PromptSegments::from_base(system_prompt)),
             segment_providers: RwLock::new(Vec::new()),
             config: AgentConfig::default(),

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -284,6 +284,11 @@ pub struct Agent {
     pub(super) memory: Arc<EpisodeStore>,
     /// Embedding provider for hybrid memory search.
     pub(super) embedder: Option<Arc<dyn EmbeddingProvider>>,
+    /// Stable episode id for THIS conversation's saved episode (#1587
+    /// write side). Set on the first compaction and reused, so successive
+    /// compactions UPSERT one per-session episode with the latest
+    /// cumulative summary instead of accumulating overlapping snapshots.
+    pub(super) conversation_episode_id: std::sync::OnceLock<String>,
     /// System prompt for this agent, as ordered segments (RwLock for
     /// hot-reload support). See [`prompt_segments::PromptSegments`].
     pub(super) system_prompt: RwLock<prompt_segments::PromptSegments>,
@@ -465,6 +470,7 @@ impl Agent {
             tools,
             memory,
             embedder: None,
+            conversation_episode_id: std::sync::OnceLock::new(),
             system_prompt: RwLock::new(prompt_segments::PromptSegments::from_base(system_prompt)),
             segment_providers: RwLock::new(Vec::new()),
             config: AgentConfig::default(),
@@ -538,6 +544,7 @@ impl Agent {
             tools,
             memory,
             embedder: None,
+            conversation_episode_id: std::sync::OnceLock::new(),
             system_prompt: RwLock::new(prompt_segments::PromptSegments::from_base(system_prompt)),
             segment_providers: RwLock::new(Vec::new()),
             config: AgentConfig::default(),

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -284,6 +284,12 @@ pub struct Agent {
     pub(super) memory: Arc<EpisodeStore>,
     /// Embedding provider for hybrid memory search.
     pub(super) embedder: Option<Arc<dyn EmbeddingProvider>>,
+    /// Id of THIS conversation's current saved episode (#1587 write side).
+    /// Each compaction SUPERSEDES it — store the new summary, then delete
+    /// the prior episode — so a session keeps exactly one conversation
+    /// episode carrying the latest cumulative summary (bounded growth;
+    /// per-agent = per-session). Empty until the first compaction.
+    pub(super) conversation_episode_id: std::sync::Mutex<Option<String>>,
     /// System prompt for this agent, as ordered segments (RwLock for
     /// hot-reload support). See [`prompt_segments::PromptSegments`].
     pub(super) system_prompt: RwLock<prompt_segments::PromptSegments>,
@@ -465,6 +471,7 @@ impl Agent {
             tools,
             memory,
             embedder: None,
+            conversation_episode_id: std::sync::Mutex::new(None),
             system_prompt: RwLock::new(prompt_segments::PromptSegments::from_base(system_prompt)),
             segment_providers: RwLock::new(Vec::new()),
             config: AgentConfig::default(),
@@ -538,6 +545,7 @@ impl Agent {
             tools,
             memory,
             embedder: None,
+            conversation_episode_id: std::sync::Mutex::new(None),
             system_prompt: RwLock::new(prompt_segments::PromptSegments::from_base(system_prompt)),
             segment_providers: RwLock::new(Vec::new()),
             config: AgentConfig::default(),

--- a/crates/octos-agent/src/compaction.rs
+++ b/crates/octos-agent/src/compaction.rs
@@ -287,6 +287,10 @@ pub struct CompactionOutcome {
     pub tokens_after: u32,
     /// Which summarizer flavour handled the pass.
     pub summarizer_kind: &'static str,
+    /// The summary text folded into the compacted prompt, when a pass
+    /// produced one. Exposed so a conversational loop can persist it as a
+    /// searchable episode (#1587 write side).
+    pub summary: Option<String>,
 }
 
 /// Result of the preservation check — which declared artifacts/invariants were
@@ -567,6 +571,7 @@ impl CompactionRunner {
             tokens_before,
             tokens_after: 0,
             summarizer_kind: self.summarizer.kind(),
+            summary: None,
         };
 
         // Budget decision uses the POST-prune estimate: when placeholder
@@ -652,6 +657,7 @@ impl CompactionRunner {
             }
         };
 
+        outcome.summary = Some(summary_text.clone());
         messages.drain(1..split);
         messages.insert(
             1,

--- a/crates/octos-memory/src/episode.rs
+++ b/crates/octos-memory/src/episode.rs
@@ -17,6 +17,18 @@ fn default_schema_version() -> u32 {
     CURRENT_SCHEMA_VERSION
 }
 
+/// What produced an episode: a task run, or a conversation's compaction
+/// summary (#1587 write side). Task recall filters to `Task` so a task's
+/// generic query (e.g. the fixed "code review") can't BM25-admit an
+/// unrelated conversation summary past the similarity floor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EpisodeSource {
+    #[default]
+    Task,
+    Conversation,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Episode {
     /// Schema version for forward-compatible deserialization.
@@ -34,6 +46,10 @@ pub struct Episode {
     pub summary: String,
     /// Outcome of the task.
     pub outcome: EpisodeOutcome,
+    /// Producer of this episode (#1587). Defaults to `Task` so episodes
+    /// written before this field existed deserialize unchanged.
+    #[serde(default)]
+    pub source: EpisodeSource,
     /// Key decisions made during execution.
     pub key_decisions: Vec<String>,
     /// Files that were modified.
@@ -59,6 +75,7 @@ impl Episode {
             working_dir,
             summary,
             outcome,
+            source: EpisodeSource::Task,
             key_decisions: Vec::new(),
             files_modified: Vec::new(),
             created_at: Utc::now(),

--- a/crates/octos-memory/src/lib.rs
+++ b/crates/octos-memory/src/lib.rs
@@ -11,7 +11,7 @@ mod hybrid_search;
 mod memory_store;
 mod store;
 
-pub use episode::{Episode, EpisodeOutcome};
+pub use episode::{Episode, EpisodeOutcome, EpisodeSource};
 pub use hybrid_search::{HybridIndex, HybridScore};
 pub use memory_store::{
     DEFAULT_MAX_INJECT_TOKENS, ExtractionItem, MemoryStore, NoteKind, NoteOrigin, StagingNote,

--- a/crates/octos-memory/src/store.rs
+++ b/crates/octos-memory/src/store.rs
@@ -7,7 +7,7 @@ use eyre::{Result, WrapErr};
 use redb::{Database, ReadableTable, TableDefinition};
 use tracing::{debug, warn};
 
-use crate::episode::Episode;
+use crate::episode::{Episode, EpisodeSource};
 use crate::hybrid_search::{HybridIndex, HybridScore};
 
 /// Table for episodes: key = episode_id, value = JSON
@@ -393,7 +393,13 @@ impl EpisodeStore {
                 limit * 4
             };
             let candidates = self
-                .find_relevant_hybrid_scored_filtered(query, None, inner_limit, min_best_modality)
+                .find_relevant_hybrid_scored_filtered(
+                    query,
+                    None,
+                    inner_limit,
+                    min_best_modality,
+                    false,
+                )
                 .await?;
             let filtered: Vec<Episode> = candidates
                 .into_iter()
@@ -677,7 +683,7 @@ impl EpisodeStore {
         query_embedding: Option<Vec<f32>>,
         limit: usize,
     ) -> Result<Vec<(Episode, HybridScore)>> {
-        self.find_relevant_hybrid_scored_filtered(query, query_embedding, limit, None)
+        self.find_relevant_hybrid_scored_filtered(query, query_embedding, limit, None, false)
             .await
     }
 
@@ -704,14 +710,34 @@ impl EpisodeStore {
         query_embedding: Option<Vec<f32>>,
         limit: usize,
         min_best_modality: Option<f32>,
+        exclude_conversation: bool,
     ) -> Result<Vec<(Episode, HybridScore)>> {
+        // When excluding conversation episodes (task recall, #1587), the
+        // index has no source field, so over-fetch and filter AFTER
+        // resolving episodes, then truncate to `limit`. Excluding is a
+        // SAFETY guarantee (a conversation episode can never enter task
+        // recall regardless of over-fetch size); the over-fetch only
+        // improves COMPLETENESS — under extreme conversation-episode
+        // density task recall may still return fewer than `limit`, which is
+        // safe (less recall, never contamination).
+        const FILTER_OVERFETCH: usize = 8;
+        let search_limit = if exclude_conversation {
+            limit.saturating_mul(FILTER_OVERFETCH).max(limit)
+        } else {
+            limit
+        };
         // Search the in-memory index
         let matches = {
             let idx = self
                 .index
                 .read()
                 .map_err(|e| eyre::eyre!("index lock poisoned: {e}"))?;
-            idx.search_scored_filtered(query, query_embedding.as_deref(), limit, min_best_modality)
+            idx.search_scored_filtered(
+                query,
+                query_embedding.as_deref(),
+                search_limit,
+                min_best_modality,
+            )
         };
 
         // Fetch full episodes from DB. Preserve (id, score) pairing so
@@ -761,6 +787,10 @@ impl EpisodeStore {
             // Preserve the ranking order from hybrid search
             scored.sort_by_key(|(e, _)| id_order.get(e.id.as_str()).copied().unwrap_or(usize::MAX));
 
+            if exclude_conversation {
+                scored.retain(|(e, _)| e.source != EpisodeSource::Conversation);
+            }
+            scored.truncate(limit);
             Ok(scored)
         })
         .await?


### PR DESCRIPTION
Closes #1617. Completes the conversational-memory loop with #1615 (read side).

## Why

The read side (#1615) recalls episodes when a conversation starts — but conversational sessions produced NO episodes, so it only surfaced worker-task episodes. This is the write side: a conversation that **compacts** is substantial enough to be worth remembering, so its compaction summary is persisted as an embedded episode. A future conversation's session-start recall can then surface relevant PAST conversations.

## What

- `CompactionOutcome` gains `summary: Option<String>` (the folded-in summary text; `run()` populates it).
- `maybe_run_turn_compaction` returns `Result<Option<String>>` — the summary when a pass compacted.
- `process_message_inner` saves it via **`save_conversation_episode`**: store + **fire-and-forget embed** (compaction already ran mid-turn — don't add an embed round-trip to turn latency), gated on `save_episodes` **and** an embedder being present (an unembedded episode is invisible to every embedder-gated recall path, so storing it would only bloat the index).

## Scope + why it's partitioned

The **`CompactionRunner` path** (chat CLI, ACP), self-contained in octos-agent. Serve/gateway AppUI sessions use the `prompt_context_manager` bridge — `maybe_run_turn_compaction` returns early there — so saving THEIR conversation episodes is a follow-up in octos-cli's `ContextManager` (a separate compaction owner, a separate crate). The save fires **only** at the conversational call site (992, inside `process_message_inner`), so task-loop episodes are untouched — no double-save.

Considered and rejected: hooking the background memory-refresh pipeline (it has no episode-store/embedder access — would be *more* wiring, not less).

## Granularity

One episode per compaction event. Compaction is rare (only when context fills), so a session yields a few episodes — its substantive chunks — not one per turn. Short conversations never compact and are never saved (a natural, desirable filter to substantive conversations). Dedup/supersede across a session's compactions is a possible refinement, not needed for correctness.

## Tests

4 new (store+recall round trip with a const embedder; no-op without an embedder; no-op when episodes disabled). Existing 41-test compaction suite green under the new return type. 2070 octos-agent tests green, clippy clean.