### PR TITLE
feat(hydrate): surface persisted reasoning_content on hydrated messages

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -12555,6 +12555,14 @@ async fn handle_session_hydrate(
                             persisted_at: msg.timestamp,
                             message_id,
                             source,
+                            // The store persists reasoning; without this the
+                            // "· reasoning" block vanishes on every client
+                            // restart. Same gate as message_id/source.
+                            reasoning_content: if expose_message_id {
+                                msg.reasoning_content.clone()
+                            } else {
+                                None
+                            },
                             // P1.3 fix: surface canonical-ledger media so a
                             // client reconnecting after a disconnect can
                             // re-render the same `.md` / `.mp3` / `.pptx`
@@ -12805,6 +12813,7 @@ async fn handle_session_rollback(
                 persisted_at: msg.timestamp,
                 message_id: None,
                 source: None,
+                reasoning_content: None,
                 media: msg.media.clone(),
             })
             .collect::<Vec<_>>();
@@ -37679,7 +37688,10 @@ ignore = []
                 media: vec!["research/_report.md".into()],
                 tool_calls: None,
                 tool_call_id: None,
-                reasoning_content: None,
+                // Persisted thinking text — must survive into the hydrated
+                // row for negotiated clients (the "· reasoning" block used
+                // to vanish on every client restart).
+                reasoning_content: Some("I should summarize the findings.".into()),
                 client_message_id: None,
                 thread_id: Some("cmid-user-1".into()),
                 timestamp: spawn_ack_ts,
@@ -37820,6 +37832,19 @@ ignore = []
             .expect("seq=1 companion row");
         assert_eq!(companion_row["source"], "background");
         assert_eq!(spawn_ack_row["source"], "background");
+        // Negotiated hydrate carries the persisted reasoning so the
+        // "· reasoning" block survives a client restart.
+        assert_eq!(
+            spawn_ack_row["reasoning_content"], "I should summarize the findings.",
+            "hydrated row must surface persisted reasoning_content"
+        );
+        assert!(
+            companion_row
+                .get("reasoning_content")
+                .map(|v| v.is_null())
+                .unwrap_or(true),
+            "rows without reasoning omit the field"
+        );
         let user_row = messages_new
             .iter()
             .find(|m| m["seq"] == 0)

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -2580,6 +2580,14 @@ pub struct HydratedMessage {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub client_message_id: Option<String>,
     pub persisted_at: DateTime<Utc>,
+    /// Reasoning/thinking text captured for this message (#1502), when the
+    /// provider emitted it. Surfaced on hydrate so the "· reasoning" block
+    /// survives a client restart instead of silently vanishing — the store
+    /// has persisted it all along. Gated on `event.spawn_complete.v1` like
+    /// `message_id`/`source`, so non-negotiated clients keep the pre-fix
+    /// wire byte-identical.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
     /// Stable per-row identity, derived from `(session_id, seq,
     /// timestamp_nanos)` — identical to what
     /// [`MessagePersistedEvent::message_id`] and
@@ -9917,6 +9925,7 @@ mod tests {
                 message_id: Some("local:demo:17:1700000000000000000".into()),
                 source: Some("user".into()),
                 media: vec![],
+                reasoning_content: None,
             }]),
             threads: Some(vec![ThreadGraphEntry {
                 thread_id: "thread-1".into(),


### PR DESCRIPTION
Reasoning blocks render live and are persisted in the session store (#1502), but `HydratedMessage` never carried `reasoning_content` — so every client restart rebuilt the transcript without them. Validated end-to-end before the fix: live turn renders the `· reasoning` block → session JSONL contains `reasoning_content` → rehydrated transcript silently drops it.

**Change**: `HydratedMessage.reasoning_content: Option<String>` (serde default + skip), populated on the hydrate message projection under the same `event.spawn_complete.v1` gate as `message_id`/`source` (non-negotiated wire stays byte-identical; stdio negotiates the feature by default). The rollback projection keeps `None` like its other negotiated-only fields.

**Tests**: negotiated-hydrate test extended — a seeded message with reasoning surfaces it on the hydrated row; rows without reasoning omit the field. Full workspace clippy `-D warnings` + fmt clean.

TUI consumption lands separately (one-line mapping in the hydrate seeder; renderer already displays `reasoning_content`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)