### PR TITLE
feat(serve): stream + gate plan/updated notifications (PR 3/4)

### DIFF
--- a/crates/octos-cli/src/api/events.rs
+++ b/crates/octos-cli/src/api/events.rs
@@ -187,6 +187,9 @@ pub(crate) fn event_to_json(event: &ProgressEvent, thread_id: Option<&str>) -> s
         ProgressEvent::FileModified { path } => {
             serde_json::json!({"type": "file_modified", "path": path})
         }
+        ProgressEvent::PlanUpdated { plan } => {
+            serde_json::json!({"type": "plan_updated", "plan": plan})
+        }
         ProgressEvent::TokenUsage {
             input_tokens,
             output_tokens,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -52,19 +52,19 @@ use octos_core::ui_protocol::{
     UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1, UI_PROTOCOL_FEATURE_CONTEXT_LIFECYCLE_V1,
     UI_PROTOCOL_FEATURE_FILE_ATTACHED_V1, UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1,
     UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1, UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1,
-    UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1, UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1,
-    UI_PROTOCOL_FEATURE_REVIEW_START_V1, UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1,
-    UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1, UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
-    UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1, UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1,
-    UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1, UI_PROTOCOL_FEATURE_USER_QUESTION_V1,
-    UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1, UiAgentRecord, UiArtifactPaneItem, UiArtifactPaneSnapshot,
-    UiCommand, UiContextCompactionRecord, UiContextNormalizationReport, UiContextState, UiCursor,
-    UiFileMutationNotice, UiGitHistoryItem, UiGitPaneSnapshot, UiGitStatusItem, UiNotification,
-    UiPaneSnapshot, UiPaneSnapshotLimitation, UiProgressEvent, UiProgressMetadata,
-    UiProtocolCapabilities, UiRpcResult, UiWorkspacePaneEntry, UiWorkspacePaneSnapshot,
-    UnsupportedCapabilityReport, UserQuestionRequestedEvent, UserQuestionRespondParams,
-    VoiceAudioChunkEvent, approval_cancelled_reasons, approval_kinds, hydrate_sections,
-    progress_kinds, thread_status,
+    UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1, UI_PROTOCOL_FEATURE_PLAN_TODOS_V1,
+    UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1, UI_PROTOCOL_FEATURE_REVIEW_START_V1,
+    UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1, UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1,
+    UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1, UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1,
+    UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1, UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1,
+    UI_PROTOCOL_FEATURE_USER_QUESTION_V1, UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1, UiAgentRecord,
+    UiArtifactPaneItem, UiArtifactPaneSnapshot, UiCommand, UiContextCompactionRecord,
+    UiContextNormalizationReport, UiContextState, UiCursor, UiFileMutationNotice, UiGitHistoryItem,
+    UiGitPaneSnapshot, UiGitStatusItem, UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation,
+    UiProgressEvent, UiProgressMetadata, UiProtocolCapabilities, UiRpcResult, UiWorkspacePaneEntry,
+    UiWorkspacePaneSnapshot, UnsupportedCapabilityReport, UserQuestionRequestedEvent,
+    UserQuestionRespondParams, VoiceAudioChunkEvent, approval_cancelled_reasons, approval_kinds,
+    hydrate_sections, progress_kinds, thread_status,
 };
 use octos_core::{
     AgentId, InboundMessage, MAIN_PROFILE_ID, Message, MessageRole, SessionKey, TaskId,
@@ -1034,6 +1034,11 @@ struct ConnectionUiFeatures {
     /// progressive MSE playback; otherwise it falls back to whole-file
     /// `file/attached` audio.
     voice_audio: bool,
+    /// `plan.todos.v1` negotiated. When set, the server streams the
+    /// `update_plan` tool's checklist as `plan/updated` notifications and
+    /// replays the latest snapshot on `session/open`. Otherwise the plan rides
+    /// out only on the legacy `tool/completed` `structured_metadata` path.
+    plan_todos: bool,
     /// UPCR-2026-014 M9-γ `projection.envelope.v1` negotiated. When set,
     /// the client opts in to the canonical [`Envelope`] shape (spec
     /// § 14) for projected events. γ-1 wires capability negotiation
@@ -1125,6 +1130,7 @@ impl ConnectionUiFeatures {
             spawn_complete: has_ui_feature(headers, query, UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1),
             file_attached: has_ui_feature(headers, query, UI_PROTOCOL_FEATURE_FILE_ATTACHED_V1),
             voice_audio: has_ui_feature(headers, query, UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1),
+            plan_todos: has_ui_feature(headers, query, UI_PROTOCOL_FEATURE_PLAN_TODOS_V1),
             projection_envelope: has_ui_feature(
                 headers,
                 query,
@@ -1182,6 +1188,7 @@ impl ConnectionUiFeatures {
             spawn_complete: true,
             file_attached: true,
             voice_audio: true,
+            plan_todos: true,
             // Do NOT auto-enable `projection.envelope.v1` for stdio
             // connections. Legacy `turn/completed` is the turn-lifecycle
             // source for clients that do not consume `projection/envelope`
@@ -1235,6 +1242,7 @@ impl ConnectionUiFeatures {
             spawn_complete: has(UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1),
             file_attached: has(UI_PROTOCOL_FEATURE_FILE_ATTACHED_V1),
             voice_audio: has(UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1),
+            plan_todos: has(UI_PROTOCOL_FEATURE_PLAN_TODOS_V1),
             projection_envelope: has(UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1),
             auxiliary_rest_to_ws_v1: has(UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1),
             coding_autonomy_v1: has(UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1),
@@ -1301,6 +1309,9 @@ impl ConnectionUiFeatures {
         }
         if self.voice_audio {
             requested.push(UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1);
+        }
+        if self.plan_todos {
+            requested.push(UI_PROTOCOL_FEATURE_PLAN_TODOS_V1);
         }
         if self.projection_envelope {
             requested.push(UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1);
@@ -9256,6 +9267,15 @@ fn live_event_passes_capability_filter(
     // whole-file `file/attached` audio path.
     if !features.voice_audio {
         if let UiProtocolLedgerEvent::Notification(UiNotification::VoiceAudioChunk(_)) = event {
+            return false;
+        }
+    }
+    // `plan.todos.v1` gate: the model-authored plan checklist only reaches
+    // connections that negotiated it (and know how to render `plan/updated`).
+    // Applies on both the live broadcast and reconnect replay, since both
+    // routes call this filter.
+    if !features.plan_todos {
+        if let UiProtocolLedgerEvent::Notification(UiNotification::PlanUpdated(_)) = event {
             return false;
         }
     }
@@ -29531,6 +29551,7 @@ ignore = []
                 spawn_complete: false,
                 file_attached: false,
                 voice_audio: false,
+                plan_todos: false,
                 projection_envelope: false,
                 auxiliary_rest_to_ws_v1: false,
                 coding_autonomy_v1: false,
@@ -29595,6 +29616,7 @@ ignore = []
                 spawn_complete: false,
                 file_attached: false,
                 voice_audio: false,
+                plan_todos: false,
                 projection_envelope: false,
                 auxiliary_rest_to_ws_v1: false,
                 coding_autonomy_v1: false,
@@ -29704,6 +29726,7 @@ ignore = []
                 spawn_complete: false,
                 file_attached: false,
                 voice_audio: false,
+                plan_todos: false,
                 projection_envelope: false,
                 auxiliary_rest_to_ws_v1: false,
                 coding_autonomy_v1: false,
@@ -29768,6 +29791,7 @@ ignore = []
                 spawn_complete: false,
                 file_attached: false,
                 voice_audio: false,
+                plan_todos: false,
                 projection_envelope: false,
                 auxiliary_rest_to_ws_v1: false,
                 coding_autonomy_v1: false,
@@ -29825,6 +29849,7 @@ ignore = []
                 spawn_complete: false,
                 file_attached: false,
                 voice_audio: false,
+                plan_todos: false,
                 projection_envelope: false,
                 auxiliary_rest_to_ws_v1: false,
                 coding_autonomy_v1: false,
@@ -29925,6 +29950,7 @@ ignore = []
                 spawn_complete: false,
                 file_attached: false,
                 voice_audio: false,
+                plan_todos: false,
                 projection_envelope: false,
                 auxiliary_rest_to_ws_v1: false,
                 coding_autonomy_v1: false,
@@ -31828,6 +31854,33 @@ ignore = []
         );
     }
 
+    #[test]
+    fn plan_updated_gated_by_plan_todos_capability() {
+        use octos_core::ui_protocol::{PlanUpdatedEvent, UiPlanRecord};
+        let event =
+            UiProtocolLedgerEvent::Notification(UiNotification::PlanUpdated(PlanUpdatedEvent {
+                session_id: SessionKey("local:test".into()),
+                topic: None,
+                turn_id: None,
+                plan: UiPlanRecord {
+                    items: Vec::new(),
+                    title: None,
+                    updated_at_ms: 0,
+                },
+            }));
+        // A connection that did not negotiate plan.todos.v1 never receives it —
+        // on the live broadcast OR reconnect replay (both call this filter).
+        assert!(!live_event_passes_capability_filter(
+            &event,
+            ConnectionUiFeatures::default()
+        ));
+        let negotiated = ConnectionUiFeatures {
+            plan_todos: true,
+            ..Default::default()
+        };
+        assert!(live_event_passes_capability_filter(&event, negotiated));
+    }
+
     #[tokio::test]
     async fn session_open_does_not_duplicate_pending_question_already_in_cursor_replay() {
         // #3: a question already carried by the cursor replay window must not
@@ -32156,6 +32209,7 @@ ignore = []
                 spawn_complete: false,
                 file_attached: false,
                 voice_audio: false,
+                plan_todos: false,
                 projection_envelope: false,
                 auxiliary_rest_to_ws_v1: false,
                 coding_autonomy_v1: false,

--- a/crates/octos-cli/src/api/ui_protocol_progress.rs
+++ b/crates/octos-cli/src/api/ui_protocol_progress.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code)]
 
 use octos_core::ui_protocol::{
-    ApprovalId, ApprovalRequestedEvent, MessageDeltaEvent, ReasoningDeltaEvent,
+    ApprovalId, ApprovalRequestedEvent, MessageDeltaEvent, PlanUpdatedEvent, ReasoningDeltaEvent,
     TaskRuntimeState as UiTaskRuntimeState, TaskUpdatedEvent, ToolCompletedEvent,
     ToolProgressEvent, ToolStartedEvent, TurnId, UiFileMutationNotice, UiNotification,
-    UiProgressEvent, UiProgressMetadata, UiRetryBackoff, UiTokenCostUpdate, WarningEvent,
-    file_mutation_operations, progress_kinds,
+    UiPlanRecord, UiProgressEvent, UiProgressMetadata, UiRetryBackoff, UiTokenCostUpdate,
+    WarningEvent, file_mutation_operations, progress_kinds,
 };
 use octos_core::{SessionKey, TaskId};
 use serde_json::{Value, json};
@@ -105,6 +105,7 @@ pub(crate) fn map_progress_json(
         "tool_end" => map_tool_end(context, event),
         "task_started" => map_task_started(context, event),
         "task_updated" => map_task_updated(context, event),
+        "plan_updated" => map_plan_updated(context, event),
         "task_completed" => map_task_completed(context, event),
         "task_interrupted" => map_task_interrupted(context, event),
         "max_iterations_reached" => map_budget_stop(context, event, "max iterations reached"),
@@ -150,6 +151,32 @@ fn map_approval_requested(context: &ProgressMappingContext, event: &Value) -> Ui
             body,
         ),
     )])
+}
+
+fn map_plan_updated(context: &ProgressMappingContext, event: &Value) -> UiProgressMapping {
+    let Some(plan_value) = event.get("plan").cloned() else {
+        return UiProgressMapping::warning(
+            context,
+            "invalid_plan",
+            "plan_updated event is missing `plan`".to_string(),
+        );
+    };
+    let plan: UiPlanRecord = match serde_json::from_value(plan_value) {
+        Ok(plan) => plan,
+        Err(err) => {
+            return UiProgressMapping::warning(
+                context,
+                "invalid_plan",
+                format!("plan_updated `plan` did not deserialize: {err}"),
+            );
+        }
+    };
+    UiProgressMapping::notifications(vec![UiNotification::PlanUpdated(PlanUpdatedEvent {
+        session_id: context.session_id.clone(),
+        topic: None,
+        turn_id: Some(context.turn_id.clone()),
+        plan,
+    })])
 }
 
 fn map_task_started(context: &ProgressMappingContext, event: &Value) -> UiProgressMapping {
@@ -720,6 +747,46 @@ mod tests {
             panic!("expected message delta notification");
         };
         assert_eq!(delta.text, "hi");
+    }
+
+    #[test]
+    fn ui_protocol_progress_maps_plan_updated_to_notification() {
+        let mapping = map_progress_json(
+            &context(),
+            &json!({
+                "type": "plan_updated",
+                "plan": {
+                    "title": "Building memory panel…",
+                    "updated_at_ms": 42,
+                    "items": [
+                        { "id": "1", "title": "done", "status": "completed", "priority": "P3" },
+                        { "id": "2", "title": "active", "status": "in_progress" }
+                    ]
+                }
+            }),
+        );
+        assert_eq!(mapping.warning, None);
+        let [UiNotification::PlanUpdated(event)] = mapping.notifications.as_slice() else {
+            panic!(
+                "expected a plan/updated notification, got {:?}",
+                mapping.notifications
+            );
+        };
+        assert_eq!(event.session_id, SessionKey("local:demo".into()));
+        assert!(event.turn_id.is_some());
+        assert_eq!(event.plan.title.as_deref(), Some("Building memory panel…"));
+        assert_eq!(event.plan.items.len(), 2);
+        assert_eq!(
+            event.plan.items[1].status,
+            octos_core::ui_protocol::PlanItemStatus::InProgress
+        );
+    }
+
+    #[test]
+    fn ui_protocol_progress_plan_updated_missing_plan_warns() {
+        let mapping = map_progress_json(&context(), &json!({ "type": "plan_updated" }));
+        assert!(mapping.notifications.is_empty());
+        assert!(mapping.warning.is_some());
     }
 
     #[test]


### PR DESCRIPTION
**PR 3 of 4** for the model-authored plan/todo primitive. Builds on #1623.

Turns the agent's `PlanUpdated` progress events into gated, reconnect-safe `plan/updated` notifications:
- `event_to_json` serializes `ProgressEvent::PlanUpdated` onto the progress channel; `map_progress_json` maps it to `UiNotification::PlanUpdated`, scoped to the session + turn.
- `ConnectionUiFeatures` gains `plan_todos`, negotiated from `plan.todos.v1` (header/query, client_hello tokens, auto-on for the stdio all-features slice) and **advertised** back through `negotiated_capabilities()`.
- `live_event_passes_capability_filter` drops `plan/updated` for connections that did not negotiate it — on **both** the live broadcast and reconnect replay (both call this filter).

Reconnect snapshot comes for free: `plan/updated` is appended durably (default drain arm), so the standard `session/open` ledger replay resends the latest plan, gated by the same filter — no extra snapshot store.

Tests: mapper (`plan_updated` → notification, missing-plan warns) + the capability gate (dropped without `plan.todos.v1`, delivered with it).

### Known limitation (follow-up)
`plan/updated` shares the same at-least-once-under-backpressure semantics as every other progress event: if the bounded progress channel overflows, an update can be dropped before reaching the ledger. Durable append + reconnect replay recover every *delivered* plan, and repeated `update_plan` calls self-heal transient drops, but the very last update dropped under sustained backpressure (with no subsequent call before a reconnect) leaves a client stale. A lossless priority lane / latest-plan hydrate projection is a follow-up.

**PR4** renders it in octos-tui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)