### PR TITLE
docs(api): resync UI Protocol §6 method catalog + guard it against drift

### DIFF
--- a/.github/workflows/ci-self-hosted.yml
+++ b/.github/workflows/ci-self-hosted.yml
@@ -50,6 +50,11 @@ jobs:
       - name: API feature tests
         run: cargo test -p octos-cli --features api api::auth_handlers
 
+      # Feature-gated §6 catalog guard — `cargo test --workspace` above never
+      # compiles the `api` module, so run it explicitly to catch spec drift.
+      - name: UI Protocol §6 catalog guard (octos-cli)
+        run: cargo test -p octos-cli --features api spec_section6_catalog_lists_every_advertised_method -- --nocapture
+
       - name: QoS adaptive/runtime catalog regressions
         run: |
           cargo test -p octos-llm test_qos_ranking_changes_lane_selection -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,12 @@ jobs:
       - name: API feature tests
         run: cargo test -p octos-cli --features api api::auth_handlers
 
+      # The §6 catalog guard lives in the feature-gated `api` module, so the
+      # unfeatured lib/integration runs above never compile it. Run it
+      # explicitly so UI Protocol spec/impl drift actually fails CI.
+      - name: UI Protocol §6 catalog guard (octos-cli)
+        run: cargo test -p octos-cli --features api spec_section6_catalog_lists_every_advertised_method -- --nocapture
+
       - name: gateway_runtime regression (octos-cli)
         run: cargo test -p octos-cli gateway_runtime::tests --features api -- --nocapture
 

--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -373,6 +373,10 @@ Session, turn, and approval core:
 
 - `session/open`
 - `session/hydrate` (gate `state.session_hydrate.v1`, accepted `UPCR-2026-009`)
+- `session/rollback` (conversation-only rewind; drops the last N user turns and
+  re-projects the trimmed thread exactly like `session/hydrate`; #1516)
+- `session/fork` (branch a session into a new one with copied history; #1613)
+- `session/btw` (quick aside question answered while the current turn runs; #1609)
 - `turn/start`
 - `turn/interrupt`
 - `turn/state/get` (gate `state.turn_state_get.v1`, accepted `UPCR-2026-011`)
@@ -446,6 +450,8 @@ Turn, message, and tool lifecycle:
 
 - `turn/started`, `turn/completed`, `turn/error`
 - `message/delta`
+- `message/reasoning_delta` (live LLM reasoning/thinking stream, sibling of
+  `message/delta`; #1502)
 - `message/persisted` (accepted `UPCR-2026-012`)
 - `turn/spawn_complete` (gate `event.spawn_complete.v1`; M10 background-tool completion envelope)
 - `tool/started`, `tool/progress`, `tool/completed`
@@ -463,6 +469,8 @@ Structured user-question lifecycle (gate `user_question.v1`, proposed
 Task and progress:
 
 - `task/updated`
+- `plan/updated` (gate `plan.todos.v1`; model-authored plan/todo checklist
+  snapshot that replaces any prior plan wholesale; #1622)
 - `task/output/delta`
 - `progress/updated`
 - `warning`
@@ -487,6 +495,15 @@ Voice rich-output visual lifecycle (#1477, ungated; accepted
   `file/attached` stays a pure artifact-delivery signal while these carry
   the placeholder lifecycle, so the split survives a future
   `projection.envelope.v1` cutover. See § 8.
+
+Voice reply-audio streaming (gate `event.voice_audio.v1`; #1504):
+
+- `voice/audio_chunk` — streamed reply-audio frames (base64) for a voice turn.
+  Delivery is gated by the `event.voice_audio.v1` capability: a client that did
+  not negotiate it is filtered off the chunk stream and instead receives the
+  whole-file audio as a `file/attached` envelope, which is itself gated by
+  `event.file_attached.v1` (the reply audio has no other carrier — a client
+  that negotiated neither capability receives no playable reply audio).
 
 Voice exit intent (ungated; accepted `UPCR-2026-025`):
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -24963,6 +24963,132 @@ mod tests {
         rpc_error_codes,
     };
 
+    /// The §6 "Envelope Model" catalog in
+    /// `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` is a hand-maintained
+    /// mirror of the advertised method constants and has historically drifted
+    /// — methods shipped without a catalog update (e.g. `session/rollback`
+    /// #1516, `message/reasoning_delta` #1502). Nothing else gates catalog
+    /// completeness (`check-ui-protocol-upcr.sh` only checks that a protocol
+    /// edit ships with *a* UPCR doc). This test keeps §6 a superset of
+    /// `UI_PROTOCOL_COMMAND_METHODS ∪ UI_PROTOCOL_NOTIFICATION_METHODS ∪
+    /// APPUI_EXTRA_METHODS`, so the catalog can no longer silently fall behind.
+    #[test]
+    fn spec_section6_catalog_lists_every_advertised_method() {
+        fn is_method_char(c: char) -> bool {
+            // `.` is part of a method token (dotted M12 names like
+            // `session/status.get`), NOT a boundary — otherwise a drifted
+            // `session/status.get.v2` catalog entry would still satisfy the
+            // advertised `session/status.get`.
+            c.is_ascii_alphanumeric() || c == '_' || c == '/' || c == '.'
+        }
+        // Bounded substring match within an entry's method-token head, so
+        // `artifact/list` is not satisfied by `agent/artifact/list`; backticks,
+        // commas, and spaces are all boundaries.
+        fn head_has_method(head: &str, method: &str) -> bool {
+            let bytes = head.as_bytes();
+            let mut from = 0;
+            while let Some(rel) = head[from..].find(method) {
+                let i = from + rel;
+                let before_ok = i == 0 || !is_method_char(bytes[i - 1] as char);
+                let after = i + method.len();
+                let after_ok = after >= bytes.len() || !is_method_char(bytes[after] as char);
+                if before_ok && after_ok {
+                    return true;
+                }
+                from = i + 1;
+            }
+            false
+        }
+
+        // A method counts as cataloged only when it appears in the method-token
+        // HEAD of a `- ` list entry — the entry's first line PLUS any indented
+        // continuation lines, truncated at the first description delimiter (`(`
+        // annotation or `—` prose). Grouped entries wrap their comma-separated
+        // method list across continuation lines, so those must be folded in;
+        // but a method named only inside another entry's parenthetical/prose
+        // (e.g. `session/hydrate` inside the `session/rollback` bullet) must NOT
+        // count, or genuine drift for that method would hide.
+        fn catalog_lists(section: &str, method: &str) -> bool {
+            fn head(entry: &str) -> &str {
+                let cut = [entry.find('('), entry.find('—')]
+                    .into_iter()
+                    .flatten()
+                    .min()
+                    .unwrap_or(entry.len());
+                &entry[..cut]
+            }
+            let mut entries: Vec<String> = Vec::new();
+            let mut current: Option<String> = None;
+            for line in section.lines() {
+                let trimmed = line.trim_start();
+                if let Some(rest) = trimmed.strip_prefix("- ") {
+                    if let Some(entry) = current.take() {
+                        entries.push(entry);
+                    }
+                    current = Some(rest.to_string());
+                } else if !trimmed.is_empty() && line.starts_with(char::is_whitespace) {
+                    // Continuation of the active grouped entry, if any.
+                    if let Some(entry) = current.as_mut() {
+                        entry.push(' ');
+                        entry.push_str(trimmed);
+                    }
+                } else {
+                    // Blank / non-indented line ends the active entry.
+                    if let Some(entry) = current.take() {
+                        entries.push(entry);
+                    }
+                }
+            }
+            if let Some(entry) = current.take() {
+                entries.push(entry);
+            }
+            entries
+                .iter()
+                .any(|entry| head_has_method(head(entry), method))
+        }
+
+        let spec_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md"
+        );
+        let spec = std::fs::read_to_string(spec_path)
+            .unwrap_or_else(|e| panic!("cannot read UI Protocol spec at {spec_path}: {e}"));
+
+        // Slice the §6 catalog: its header up to the next top-level section.
+        let start = spec
+            .find("## 6. Envelope Model")
+            .expect("UI Protocol spec is missing `## 6. Envelope Model`");
+        let rest = &spec[start..];
+        // Bound §6 at the NEXT top-level (`## `) heading, whatever its number
+        // or title. Hardcoding `## 7.` would fail OPEN if §7 is ever renamed or
+        // renumbered — the slice would run to end-of-spec, and later semantic
+        // sections repeat these method names in list entries, so a deleted §6
+        // entry could still be satisfied. Fail closed: §6 must be followed by
+        // another top-level section.
+        let end = rest
+            .find("\n## ")
+            .expect("UI Protocol spec §6 must be followed by a `## ` section heading");
+        let section6 = &rest[..end];
+
+        let missing: Vec<&str> = octos_core::ui_protocol::UI_PROTOCOL_COMMAND_METHODS
+            .iter()
+            .chain(octos_core::ui_protocol::UI_PROTOCOL_NOTIFICATION_METHODS.iter())
+            .chain(APPUI_EXTRA_METHODS.iter())
+            .copied()
+            .filter(|method| !catalog_lists(section6, method))
+            .collect();
+
+        assert!(
+            missing.is_empty(),
+            "UI Protocol spec §6 catalog is missing advertised method(s): {missing:?}\n\
+             Add them under `## 6. Envelope Model` in \
+             api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md — the catalog is a \
+             hand-maintained mirror and must stay a superset of \
+             UI_PROTOCOL_COMMAND_METHODS / UI_PROTOCOL_NOTIFICATION_METHODS / \
+             APPUI_EXTRA_METHODS."
+        );
+    }
+
     #[tokio::test]
     async fn compaction_started_precedes_completed_in_lifecycle_batch() {
         // UPCR-2026-026: when the threshold trips, the lifecycle batch must

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_027_SECTION6_CATALOG_GUARD.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_027_SECTION6_CATALOG_GUARD.md
@@ -1,0 +1,87 @@
+# Octos UI Protocol Change Request: §6 Envelope-Model catalog resync + drift guard
+
+## Header
+
+- Request id: `UPCR-2026-027`
+- Title: Resync the §6 "Envelope Model" method catalog and guard it against drift
+- Author: UI Protocol spec-consistency audit
+- Date: 2026-07-10
+- Target protocol: `octos-ui/v1alpha1`
+- Status: accepted
+- Sibling UPCRs: none (documentation-reconciliation record; the methods below
+  each shipped under their own feature work)
+
+## Summary
+
+Strictly a documentation + test-tooling change. It adds **no** new method,
+notification, payload, enum variant, capability bit, or protocol identifier —
+the wire surface is unchanged. Two things happen:
+
+1. The §6 "Envelope Model" catalog is resynced to list six already-shipped,
+   already-advertised methods that had drifted out of the hand-maintained
+   catalog.
+2. A guard test is added so the catalog can no longer silently fall behind the
+   advertised method constants.
+
+This UPCR exists because the completeness gate (`scripts/check-ui-protocol-upcr.sh`)
+treats any edit to a Rust protocol file (`crates/octos-cli/src/api/ui_protocol.rs`,
+which is where the guard and the `APPUI_EXTRA_METHODS` list live) as a
+protocol-visible change requiring a paired UPCR. The change is documented here
+so that governance stays honest even for a docs/test reconciliation.
+
+## Motivation
+
+§6 is a **hand-maintained mirror** of
+`UI_PROTOCOL_COMMAND_METHODS ∪ UI_PROTOCOL_NOTIFICATION_METHODS` (octos-core) ∪
+`APPUI_EXTRA_METHODS` (octos-cli). Nothing enforced its completeness — the
+existing `check-ui-protocol-upcr.sh` only checks that a protocol edit ships with
+*a* UPCR doc, not that §6 lists every advertised method — so it drifted. Six
+methods were advertised and implemented but absent from the catalog:
+
+| Method | Kind | Shipped in |
+|---|---|---|
+| `session/rollback` | command | #1516 |
+| `session/fork` | command | #1613 |
+| `session/btw` | command | #1609 |
+| `message/reasoning_delta` | notification | #1502 |
+| `voice/audio_chunk` | notification (gate `event.voice_audio.v1`) | #1504 |
+| `plan/updated` | notification (gate `plan.todos.v1`) | #1622 |
+
+§6 referenced no phantom methods, so this was pure under-documentation — not a
+wire-breaking contradiction.
+
+## Changes
+
+- §6 gains the six methods in their natural groups. `voice/audio_chunk` is
+  documented as gated by `event.voice_audio.v1`; the whole-file `file/attached`
+  fallback is itself gated by `event.file_attached.v1`, and since the reply
+  audio has no other carrier, a client with neither capability receives none
+  (matching the server's two independent delivery filters). `plan/updated` is
+  documented as gated by `plan.todos.v1`.
+- New test `spec_section6_catalog_lists_every_advertised_method`
+  (`octos-cli`, `api` module) reads the spec at runtime, bounds §6 at the next
+  `## ` heading (fail-closed rather than a hardcoded `## 7.`), and asserts §6 is
+  a superset of the three constant lists. Matching folds each entry's wrapped
+  continuation lines into one logical bullet, restricts to the method-token head
+  (before the first `(`/`—`) so prose can't mask an absence, and treats `.` as
+  part of a dotted token so `session/status.get.v2` can't satisfy
+  `session/status.get`.
+- The guard is wired into CI explicitly (`ci.yml`, `ci-self-hosted.yml`,
+  `scripts/milestone-ci.sh`) via
+  `cargo test -p octos-cli --features api spec_section6_catalog_lists_every_advertised_method`,
+  because the `api` module is feature-gated and the unfeatured lib/integration
+  jobs never compile it.
+
+## Compatibility
+
+- Strictly additive/documentation-only: no existing method, notification,
+  payload, enum variant, capability bit, or protocol identifier changes.
+- No client or server behavior changes.
+
+## Implementation anchors
+
+- Spec: `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` §6 "Envelope Model"
+- Guard: `octos-cli/src/api/ui_protocol.rs`
+  `spec_section6_catalog_lists_every_advertised_method`
+- CI: `.github/workflows/ci.yml`, `.github/workflows/ci-self-hosted.yml`,
+  `scripts/milestone-ci.sh`

--- a/scripts/milestone-ci.sh
+++ b/scripts/milestone-ci.sh
@@ -69,6 +69,9 @@ run_hosted_fast() {
   # helpers) is feature-gated, so `cargo test --workspace` above never compiles
   # it. Run the api-gated unit tests explicitly so this coverage is real.
   cargo test -p octos-cli --features api voice_turn -- --nocapture
+  # §6 catalog guard is in the same feature-gated `api` module; run it
+  # explicitly so UI Protocol spec/impl drift is caught here too.
+  cargo test -p octos-cli --features api spec_section6_catalog_lists_every_advertised_method -- --nocapture
   cargo test -p octos-agent --test activate_tools_regression -- --nocapture
   cargo test -p octos-bus --test file_handle_resolve_tool_path -- --nocapture
 }


### PR DESCRIPTION
## What & why

The §6 "Envelope Model" catalog in `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` is a **hand-maintained mirror** of the advertised UI-Protocol method constants, and nothing gated its completeness — `scripts/check-ui-protocol-upcr.sh` only checks that a protocol edit ships with *a* UPCR doc, not that §6 lists every method. So it drifted.

I audited the implementation's advertised surface — `UI_PROTOCOL_COMMAND_METHODS ∪ UI_PROTOCOL_NOTIFICATION_METHODS` (octos-core) ∪ `APPUI_EXTRA_METHODS` (octos-cli) — against §6. **Six** advertised-and-implemented methods were missing:

| Method | Kind | Added in |
|---|---|---|
| `session/rollback` | command | #1516 |
| `session/fork` | command | #1613 |
| `session/btw` | command | #1609 |
| `message/reasoning_delta` | notification | #1502 |
| `voice/audio_chunk` | notification (gate `event.voice_audio.v1`) | #1504 |
| `plan/updated` | notification (gate `plan.todos.v1`) | #1622 |

§6 referenced **no** phantom methods, so this is under-documentation, not a wire-breaking contradiction.

> The guard immediately earned its keep: `plan/updated` (#1622) landed on `main` **during** this review, already drifted from §6, and the new test caught it on rebase — which is exactly the failure mode this PR closes.

## Changes

1. **Resync §6** — added the six methods in their natural groups. `voice/audio_chunk` is documented as gated by `event.voice_audio.v1`; a client without it gets the whole-file audio as a `file/attached` envelope (**itself** gated by `event.file_attached.v1`), and since the reply audio has no other carrier, a client with neither capability receives none — matching the server's two independent delivery filters. `plan/updated` is gated by `plan.todos.v1`.
2. **Guard it** — new test `spec_section6_catalog_lists_every_advertised_method` (octos-cli `api` module) reads the spec at runtime and asserts §6 ⊇ the three constant lists. The matcher:
   - folds each catalog entry's wrapped continuation lines into one logical bullet, then restricts to the entry's **method-token head** (before the first `(`/`—`), so a method named only inside another entry's prose can't mask its own absence;
   - treats `.` as part of a dotted token, so a drifted `session/status.get.v2` can't satisfy `session/status.get`;
   - bounds §6 at the **next `## ` heading (fail-closed)** rather than a hardcoded `## 7.` that would scan the whole spec if §7 were renamed.
3. **Run it in CI** — the `api` module is feature-gated, so the unfeatured `--lib`/`--tests` jobs never compile the guard and the existing `--features api` runs are name-filtered. Added an explicit `cargo test -p octos-cli --features api spec_section6_catalog_lists_every_advertised_method` step to `ci.yml`, `ci-self-hosted.yml`, and `scripts/milestone-ci.sh`.
4. **UPCR record** — added `docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_027_SECTION6_CATALOG_GUARD.md` so the protocol-file edit satisfies `check-ui-protocol-upcr.sh`.

## Testing

- Guard test **passes** under `cargo test -p octos-cli --features api`.
- **Non-vacuous** (each temporarily reverted, then restored):
  - Removing the `session/hydrate` bullet fails with `missing: ["session/hydrate"]` even though it's still named in `session/rollback`'s parenthetical — proving prose no longer counts.
  - Renaming a catalog entry to `session/status.get.v2` fails with `missing: ["session/status.get"]` — proving dotted-token drift is caught.
  - `plan/updated` (landed on main during review) failed the guard on rebase until added — a real, unplanned drift catch.
- `scripts/check-ui-protocol-upcr.sh` passes (exit 0) with the new UPCR doc as coverage.
- `cargo fmt --all -- --check` clean; the added test code is clippy-clean under `--features api --all-targets`.

Iterated through `codex review` to convergence (findings 4 → 3 → 1, all resolved) before rebasing onto current `main`.
