### PR TITLE
test(api): §6 catalog guard covers the FIRST_SERVER registry too

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -24971,7 +24971,10 @@ mod tests {
     /// completeness (`check-ui-protocol-upcr.sh` only checks that a protocol
     /// edit ships with *a* UPCR doc). This test keeps §6 a superset of
     /// `UI_PROTOCOL_COMMAND_METHODS ∪ UI_PROTOCOL_NOTIFICATION_METHODS ∪
-    /// APPUI_EXTRA_METHODS`, so the catalog can no longer silently fall behind.
+    /// UI_PROTOCOL_FIRST_SERVER_METHODS ∪ APPUI_EXTRA_METHODS` — the full set the
+    /// server advertises (`ui_protocol_server_supported_methods` builds from
+    /// `FIRST_SERVER ∪ APPUI_EXTRA`) — so the catalog can no longer silently
+    /// fall behind, even for a future server-only method.
     #[test]
     fn spec_section6_catalog_lists_every_advertised_method() {
         fn is_method_char(c: char) -> bool {
@@ -25073,6 +25076,7 @@ mod tests {
         let missing: Vec<&str> = octos_core::ui_protocol::UI_PROTOCOL_COMMAND_METHODS
             .iter()
             .chain(octos_core::ui_protocol::UI_PROTOCOL_NOTIFICATION_METHODS.iter())
+            .chain(octos_core::ui_protocol::UI_PROTOCOL_FIRST_SERVER_METHODS.iter())
             .chain(APPUI_EXTRA_METHODS.iter())
             .copied()
             .filter(|method| !catalog_lists(section6, method))
@@ -25085,7 +25089,7 @@ mod tests {
              api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md — the catalog is a \
              hand-maintained mirror and must stay a superset of \
              UI_PROTOCOL_COMMAND_METHODS / UI_PROTOCOL_NOTIFICATION_METHODS / \
-             APPUI_EXTRA_METHODS."
+             UI_PROTOCOL_FIRST_SERVER_METHODS / APPUI_EXTRA_METHODS."
         );
     }
 

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_028_CATALOG_GUARD_FIRST_SERVER.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_028_CATALOG_GUARD_FIRST_SERVER.md
@@ -1,0 +1,57 @@
+# Octos UI Protocol Change Request: §6 catalog guard covers the FIRST_SERVER registry
+
+## Header
+
+- Request id: `UPCR-2026-028`
+- Title: Extend the §6 catalog guard to the `UI_PROTOCOL_FIRST_SERVER_METHODS` registry
+- Author: UI Protocol spec-consistency audit (codex follow-up)
+- Date: 2026-07-10
+- Target protocol: `octos-ui/v1alpha1`
+- Status: accepted
+- Sibling UPCRs: `UPCR-2026-027` (introduced the §6 catalog + drift guard)
+
+## Summary
+
+Strictly a test-tooling change. It adds **no** new method, notification, payload,
+enum variant, capability bit, or protocol identifier — the wire surface is
+unchanged. It closes a coverage gap in the drift guard added by `UPCR-2026-027`.
+
+## Motivation
+
+The guard `spec_section6_catalog_lists_every_advertised_method` asserts that §6 is
+a superset of the advertised method constants. `UPCR-2026-027` chained three
+lists: `UI_PROTOCOL_COMMAND_METHODS`, `UI_PROTOCOL_NOTIFICATION_METHODS`, and
+`APPUI_EXTRA_METHODS`.
+
+But the running server advertises its method surface from a different pair:
+`ui_protocol_server_supported_methods` builds
+`UI_PROTOCOL_FIRST_SERVER_METHODS ∪ APPUI_EXTRA_METHODS`. The guard omitted
+`UI_PROTOCOL_FIRST_SERVER_METHODS`.
+
+Today the registries overlap — `FIRST_SERVER ⊆ COMMAND`, so no method is
+currently unguarded (verified: chaining the list in leaves `missing` empty and
+the test green). But a future **server-only** method added to
+`UI_PROTOCOL_FIRST_SERVER_METHODS` (and not to `UI_PROTOCOL_COMMAND_METHODS`)
+could be advertised without a §6 entry and slip past the guard — exactly the
+drift class the guard exists to stop. codex review flagged this on the merge
+commit of `UPCR-2026-027`.
+
+## Changes
+
+- Chain `UI_PROTOCOL_FIRST_SERVER_METHODS` into the guard's `missing` computation
+  so §6 must stay a superset of the full advertised surface
+  (`COMMAND ∪ NOTIFICATION ∪ FIRST_SERVER ∪ APPUI_EXTRA`).
+- Update the test's doc comment and assertion message to name the fourth list.
+
+## Compatibility
+
+- Strictly test-only: no existing method, notification, payload, enum variant,
+  capability bit, or protocol identifier changes; no client or server behavior
+  changes. Zero §6 edits (the catalog was already complete for this set).
+
+## Implementation anchors
+
+- Guard: `octos-cli/src/api/ui_protocol.rs`
+  `spec_section6_catalog_lists_every_advertised_method`
+- Advertised registry: `octos-cli/src/api/ui_protocol.rs`
+  `ui_protocol_server_supported_methods`


### PR DESCRIPTION
## What & why

Follow-up to #1625 (the §6 catalog drift guard). codex review on #1625's merge commit flagged a **coverage gap** in the guard.

The guard `spec_section6_catalog_lists_every_advertised_method` asserts §6 is a superset of the advertised method constants — but it chained only `UI_PROTOCOL_COMMAND_METHODS ∪ UI_PROTOCOL_NOTIFICATION_METHODS ∪ APPUI_EXTRA_METHODS`. The **running server** advertises its method surface from a *different* pair: `ui_protocol_server_supported_methods` builds `UI_PROTOCOL_FIRST_SERVER_METHODS ∪ APPUI_EXTRA_METHODS`. The guard omitted `FIRST_SERVER`.

**Today the registries overlap** — `FIRST_SERVER ⊆ COMMAND`, so nothing is currently unguarded (verified: chaining it in leaves `missing` empty and the test green). But a future **server-only** method added to `FIRST_SERVER` (and not to `COMMAND`) could be advertised without a §6 entry and slip past the guard — exactly the drift class it exists to stop.

## Changes

- Chain `UI_PROTOCOL_FIRST_SERVER_METHODS` into the guard's `missing` computation, so §6 must stay a superset of the **full advertised surface** (`COMMAND ∪ NOTIFICATION ∪ FIRST_SERVER ∪ APPUI_EXTRA`).
- Update the test's doc comment and assertion message to name the fourth list.
- Add `docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_028_CATALOG_GUARD_FIRST_SERVER.md` (per `check-ui-protocol-upcr.sh`).

## Testing

- Guard test **passes** under `cargo test -p octos-cli --features api` with `FIRST_SERVER` chained (empty `missing`, confirming zero live drift — pure hardening).
- `cargo fmt --all -- --check` clean; `scripts/check-ui-protocol-upcr.sh` exit 0 (UPCR-028 as coverage).

Strictly test-only: **no** method, notification, payload, enum variant, capability bit, or protocol-identifier change, and **zero** §6 edits.
