### PR TITLE
feat(appui): real multi-model switching — list fallbacks, implement profile/llm/select, fresh onboarding catalog

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -7116,11 +7116,14 @@ fn raw_catalog_result(state: &AppState, profile_id: Option<&str>) -> Result<Valu
     // the home seed (`load_seed_qos_catalog` also falls back to `~/.octos`).
     let mut sources = Vec::new();
     if let Some(store) = state.profile_store.as_ref() {
-        let home = store.octos_home_dir().to_path_buf();
-        if let Some(profile_id) = profile_id {
-            sources.push(home.join("profiles").join(profile_id).join("data"));
+        if let Some(profile) =
+            profile_id.and_then(|profile_id| store.get(profile_id).ok().flatten())
+        {
+            // Honors `UserProfile.data_dir` overrides — the same resolution
+            // `ProfileRuntime::bootstrap` uses when it exports the catalog.
+            sources.push(store.resolve_data_dir(&profile));
         }
-        sources.push(home);
+        sources.push(store.octos_home_dir().to_path_buf());
     }
     for qos in sources
         .iter()

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -5684,6 +5684,20 @@ struct RawLlmSelection {
 }
 
 #[derive(Debug, Default, Deserialize)]
+struct RawProfileLlmSelectParams {
+    #[serde(default)]
+    profile_id: Option<String>,
+    #[serde(default)]
+    session_id: Option<SessionKey>,
+    #[serde(default)]
+    family_id: Option<String>,
+    #[serde(default)]
+    model_id: Option<String>,
+    #[serde(default)]
+    route_id: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
 struct RawProfileLlmUpsertParams {
     #[serde(default)]
     profile_id: Option<String>,
@@ -7038,43 +7052,96 @@ fn profile_llm_list_result(
     })
 }
 
+fn configured_model_status_json(provider: &Value, selected: bool) -> Value {
+    json!({
+        "model": provider.get("model_id").and_then(Value::as_str).unwrap_or("unknown"),
+        "provider": provider.get("family_id").and_then(Value::as_str).unwrap_or("unknown"),
+        "title": format!(
+            "{} / {}",
+            provider.get("family_id").and_then(Value::as_str).unwrap_or("unknown"),
+            provider.get("model_id").and_then(Value::as_str).unwrap_or("unknown")
+        ),
+        "family": provider.get("family_id").cloned(),
+        "route": provider.get("route_id").cloned(),
+        "selected": selected,
+        "available": true,
+        "queue_mode": "adaptive",
+        "qoe_policy": "profile",
+    })
+}
+
 fn model_list_result(
     state: &AppState,
     session_id: SessionKey,
     profile_id: &str,
     profile: Option<&crate::profiles::UserProfile>,
 ) -> Value {
-    let primary = profile_llm_list_result(state, profile_id, profile)
+    // EVERY configured model rides the list — the primary as `selected`,
+    // fallbacks as switchable alternatives (`profile/llm/select` promotes
+    // one to primary). A single-primary profile keeps its one-entry shape.
+    let listed = profile_llm_list_result(state, profile_id, profile);
+    let primary = listed
         .get("primary")
         .cloned()
         .filter(|value| !value.is_null());
-    let models = primary
+    let fallbacks = listed
+        .get("fallbacks")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let mut models = primary
         .into_iter()
-        .map(|provider| {
-            json!({
-                "model": provider.get("model_id").and_then(Value::as_str).unwrap_or("unknown"),
-                "provider": provider.get("family_id").and_then(Value::as_str).unwrap_or("unknown"),
-                "title": format!(
-                    "{} / {}",
-                    provider.get("family_id").and_then(Value::as_str).unwrap_or("unknown"),
-                    provider.get("model_id").and_then(Value::as_str).unwrap_or("unknown")
-                ),
-                "family": provider.get("family_id").cloned(),
-                "route": provider.get("route_id").cloned(),
-                "selected": true,
-                "available": true,
-                "queue_mode": "adaptive",
-                "qoe_policy": "profile",
-            })
-        })
+        .map(|provider| configured_model_status_json(&provider, true))
         .collect::<Vec<_>>();
+    models.extend(
+        fallbacks
+            .iter()
+            .map(|provider| configured_model_status_json(provider, false)),
+    );
     json!({ "session_id": session_id, "models": models })
 }
 
-fn raw_catalog_result() -> Result<Value, RpcError> {
-    let families = serde_json::from_str::<Value>(DASHBOARD_PROVIDERS_JSON).map_err(|err| {
+fn raw_catalog_result(state: &AppState) -> Result<Value, RpcError> {
+    let mut families = serde_json::from_str::<Value>(DASHBOARD_PROVIDERS_JSON).map_err(|err| {
         RpcError::internal_error(format!("dashboard provider catalog was not JSON: {err}"))
     })?;
+    // Union in the QoS model catalog (model_catalog.json): it tracks the LIVE
+    // model lineup per provider (e.g. new zai GLM releases) while the bundled
+    // dashboard catalog is hand-maintained and lags. Only models are merged —
+    // a family absent from the bundled catalog has no key-env/route metadata,
+    // so it cannot be onboarded and is skipped.
+    let data_dir = state
+        .profile_store
+        .as_ref()
+        .map(|store| store.octos_home_dir().to_path_buf())
+        .unwrap_or_default();
+    if let Some(qos) = crate::qos_catalog::load_seed_qos_catalog(&data_dir) {
+        if let Some(families_map) = families.as_object_mut() {
+            for entry in &qos.models {
+                let Some((family_id, model_id)) = entry.provider.split_once('/') else {
+                    continue;
+                };
+                let Some(models) = families_map
+                    .get_mut(family_id)
+                    .and_then(|family| family.get_mut("models"))
+                    .and_then(Value::as_array_mut)
+                else {
+                    continue;
+                };
+                let known = models
+                    .iter()
+                    .any(|model| model.get("id").and_then(Value::as_str) == Some(model_id));
+                if !known {
+                    models.push(json!({
+                        "id": model_id,
+                        "input": entry.cost_in,
+                        "output": entry.cost_out,
+                        "max_output": entry.max_output,
+                    }));
+                }
+            }
+        }
+    }
     Ok(json!({ "families": families }))
 }
 
@@ -7357,6 +7424,135 @@ async fn raw_profile_skills_remove(
         "ok": true,
         "removed": removed,
         "message": format!("Removed skill: {removed}"),
+    }))
+}
+
+/// `profile/llm/select` — promote one CONFIGURED model (the primary or any
+/// fallback) to be the ACTIVE primary. The demoted primary becomes a fallback,
+/// so switching back and forth never loses a configuration. Persisted to the
+/// profile store, and the profile's cached runtimes are evicted so the very
+/// next turn runs on the newly selected model — no restart.
+async fn raw_profile_llm_select(
+    state: &Arc<AppState>,
+    request: &RpcRequest<Value>,
+    connection_profile_id: Option<&str>,
+) -> Result<Value, RpcError> {
+    let params: RawProfileLlmSelectParams = parse_raw_params(request)?;
+    let profile_id = raw_profile_id(
+        &RawProfileParams {
+            profile_id: params.profile_id.clone(),
+            session_id: params.session_id.clone(),
+        },
+        connection_profile_id,
+    );
+    let model_id = nonempty(params.model_id)
+        .ok_or_else(|| RpcError::invalid_params("model_id is required"))?;
+    let family_id = nonempty(params.family_id);
+    let route_id = nonempty(params.route_id).filter(|route| route != "official");
+
+    let store = profile_store(state)?;
+    let mut profile = store
+        .get(&profile_id)
+        .map_err(|err| RpcError::internal_error(format!("failed to read profile: {err}")))?
+        .ok_or_else(|| RpcError::not_found("profile", profile_id.clone()))?;
+
+    let mut llm = profile.config.llm.take().unwrap_or_default();
+    let matches_selection = |selection: &crate::profiles::LlmModelSelectionConfig| {
+        selection.model_id.as_deref() == Some(model_id.as_str())
+            && family_id
+                .as_deref()
+                .is_none_or(|family| selection.family_id.as_deref() == Some(family))
+            && route_id.as_deref().is_none_or(|route| {
+                selection
+                    .route
+                    .as_ref()
+                    .and_then(|selection_route| selection_route.route_id.as_deref())
+                    == Some(route)
+            })
+    };
+
+    let already_primary = llm.primary.as_ref().is_some_and(&matches_selection);
+    let mut applied = already_primary;
+    if !already_primary {
+        let Some(index) = llm.fallbacks.iter().position(&matches_selection) else {
+            profile.config.llm = Some(llm);
+            return Err(RpcError::not_found(
+                "configured model",
+                format!(
+                    "{model_id} (not configured on profile '{profile_id}' — save it first \
+                     via profile/llm/upsert / the onboarding provider step)"
+                ),
+            ));
+        };
+        let promoted = llm.fallbacks.remove(index);
+        if let Some(demoted) = llm.primary.take() {
+            upsert_llm_fallback(&mut llm.fallbacks, demoted);
+        }
+        llm.primary = Some(promoted);
+        applied = true;
+    }
+    profile.config.llm = Some(llm);
+
+    if !already_primary {
+        profile.updated_at = Utc::now();
+        store
+            .save_with_merge(&mut profile)
+            .map_err(|err| RpcError::internal_error(format!("failed to save profile: {err}")))?;
+
+        // The switch must take effect on the NEXT turn, not the next restart:
+        // cached SessionRuntimes embed the old provider chain and the dynamic
+        // ProfileRuntime caches forever, so evict both and re-bootstrap.
+        state.session_cache.invalidate_profile(&profile_id).await;
+        if let Some(key) = dynamic_profile_runtime_key(state, &profile_id) {
+            dynamic_profile_runtimes().write().await.remove(&key);
+        }
+        if state.profiles.contains_key(&profile_id) {
+            // Startup-config profiles live in an immutable map — the saved
+            // selection persists but cannot rebuild without a restart.
+            tracing::warn!(
+                profile_id = %profile_id,
+                "profile/llm/select saved, but this startup-config profile's runtime \
+                 rebuilds on restart only"
+            );
+        } else if let Err(error) = ensure_session_profile_runtime(state, Some(&profile_id)).await {
+            tracing::warn!(
+                profile_id = %profile_id,
+                error = %error.message,
+                "profile/llm/select saved; runtime bootstrap deferred to the next turn",
+            );
+        }
+    }
+
+    let session_id = params
+        .session_id
+        .unwrap_or_else(|| SessionKey::with_profile_topic(&profile_id, "local", "tui", "coding"));
+    let refreshed = store
+        .get(&profile_id)
+        .ok()
+        .flatten()
+        .or(Some(profile))
+        .unwrap();
+    let models = model_list_result(state, session_id.clone(), &profile_id, Some(&refreshed));
+    let selected = models
+        .get("models")
+        .and_then(Value::as_array)
+        .and_then(|models| {
+            models
+                .iter()
+                .find(|model| model.get("selected") == Some(&Value::Bool(true)))
+                .cloned()
+        })
+        .unwrap_or_else(|| json!({ "model": model_id, "selected": true }));
+    Ok(json!({
+        "session_id": session_id,
+        "selected": selected,
+        "applied": applied,
+        "runtime_policy_stamp": runtime_policy_stamp_for_profile(
+            state,
+            &profile_id,
+            Some(&session_id),
+            Some(&refreshed),
+        ),
     }))
 }
 
@@ -8125,7 +8321,7 @@ async fn handle_raw_appui_rpc(
         APPUI_METHOD_SESSION_STATUS_READ => {
             raw_session_status_result(state, request, features, connection_profile_id).await
         }
-        APPUI_METHOD_PROFILE_LLM_CATALOG => raw_catalog_result(),
+        APPUI_METHOD_PROFILE_LLM_CATALOG => raw_catalog_result(state),
         APPUI_METHOD_PROFILE_LLM_LIST => {
             let params: RawProfileParams = match parse_raw_params(request) {
                 Ok(params) => params,
@@ -8161,41 +8357,7 @@ async fn handle_raw_appui_rpc(
             raw_profile_llm_test(state, request, connection_profile_id).await
         }
         APPUI_METHOD_PROFILE_LLM_SELECT => {
-            let params: RawProfileParams = match parse_raw_params(request) {
-                Ok(params) => params,
-                Err(error) => {
-                    let _ = send_rpc_error(ws, Some(id), error);
-                    return true;
-                }
-            };
-            let profile_id = raw_profile_id(&params, connection_profile_id);
-            let profile = state
-                .profile_store
-                .as_ref()
-                .and_then(|store| store.get(&profile_id).ok().flatten());
-            let session_id = params.session_id.unwrap_or_else(|| {
-                SessionKey::with_profile_topic(&profile_id, "local", "tui", "coding")
-            });
-            let models =
-                model_list_result(state, session_id.clone(), &profile_id, profile.as_ref());
-            let selected = models
-                .get("models")
-                .and_then(Value::as_array)
-                .and_then(|models| models.first())
-                .cloned()
-                .unwrap_or_else(|| {
-                    json!({
-                        "model": "unknown",
-                        "provider": "unknown",
-                        "selected": true
-                    })
-                });
-            Ok(json!({
-                "session_id": session_id,
-                "selected": selected,
-                "applied": true,
-                "runtime_policy_stamp": runtime_policy_stamp_for_profile(state, &profile_id, Some(&session_id), profile.as_ref()),
-            }))
+            raw_profile_llm_select(state, request, connection_profile_id).await
         }
         APPUI_METHOD_PROFILE_LLM_DELETE => {
             let params: RawProfileParams = match parse_raw_params(request) {
@@ -25203,6 +25365,169 @@ mod tests {
             solo_login_enabled: true,
             ..AppState::empty_for_tests()
         }
+    }
+
+    /// Multi-model profiles: `profile/llm/list`-backed model list exposes the
+    /// primary AND every fallback; `profile/llm/select` promotes a fallback to
+    /// the active primary (demoting the old primary to a fallback), persists,
+    /// and is idempotent for the current primary; unconfigured models reject.
+    #[tokio::test]
+    async fn llm_select_promotes_fallback_and_lists_all_models() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = Arc::new(local_profile_state(dir.path()));
+        for (family, model, set_primary) in [
+            ("deepseek", "deepseek-v4-pro", true),
+            ("zai", "glm-5.2", false),
+        ] {
+            let request = RpcRequest::new(
+                format!("u-{model}"),
+                APPUI_METHOD_PROFILE_LLM_UPSERT.to_string(),
+                json!({
+                    "profile_id": "dev",
+                    "selection": {
+                        "family_id": family,
+                        "model_id": model,
+                        "route": { "route_id": "official" },
+                    },
+                    "set_primary": set_primary,
+                }),
+            );
+            raw_profile_llm_upsert(&state, &request, None)
+                .await
+                .expect("upsert");
+        }
+
+        let profile = state.profile_store.as_ref().unwrap().get("dev").unwrap();
+        let models = model_list_result(
+            &state,
+            SessionKey("dev:local:t".into()),
+            "dev",
+            profile.as_ref(),
+        );
+        let list = models["models"].as_array().unwrap();
+        assert_eq!(list.len(), 2, "primary + fallback both listed: {models}");
+        assert_eq!(list[0]["model"], "deepseek-v4-pro");
+        assert_eq!(list[0]["selected"], true);
+        assert_eq!(list[1]["model"], "glm-5.2");
+        assert_eq!(list[1]["selected"], false);
+
+        let request = RpcRequest::new(
+            "s1".to_string(),
+            APPUI_METHOD_PROFILE_LLM_SELECT.to_string(),
+            json!({
+                "profile_id": "dev",
+                "family_id": "zai",
+                "model_id": "glm-5.2",
+                "route_id": "official",
+            }),
+        );
+        let result = raw_profile_llm_select(&state, &request, None)
+            .await
+            .expect("select");
+        assert_eq!(result["applied"], true);
+        assert_eq!(result["selected"]["model"], "glm-5.2");
+        assert_eq!(result["selected"]["selected"], true);
+
+        let profile = state
+            .profile_store
+            .as_ref()
+            .unwrap()
+            .get("dev")
+            .unwrap()
+            .unwrap();
+        let llm = profile.config.llm.as_ref().unwrap();
+        assert_eq!(
+            llm.primary.as_ref().unwrap().model_id.as_deref(),
+            Some("glm-5.2"),
+            "fallback promoted to primary"
+        );
+        assert_eq!(llm.fallbacks.len(), 1, "demoted primary kept as fallback");
+        assert_eq!(
+            llm.fallbacks[0].model_id.as_deref(),
+            Some("deepseek-v4-pro")
+        );
+
+        let request = RpcRequest::new(
+            "s2".to_string(),
+            APPUI_METHOD_PROFILE_LLM_SELECT.to_string(),
+            json!({ "profile_id": "dev", "model_id": "glm-5.2" }),
+        );
+        let result = raw_profile_llm_select(&state, &request, None)
+            .await
+            .expect("selecting the current primary is idempotent");
+        assert_eq!(result["applied"], true);
+
+        let request = RpcRequest::new(
+            "s3".to_string(),
+            APPUI_METHOD_PROFILE_LLM_SELECT.to_string(),
+            json!({ "profile_id": "dev", "model_id": "kimi-k2.5" }),
+        );
+        let error = raw_profile_llm_select(&state, &request, None)
+            .await
+            .expect_err("unconfigured model must reject");
+        assert_eq!(error.code, rpc_error_codes::RESOURCE_NOT_FOUND);
+    }
+
+    /// The onboarding catalog unions the QoS model catalog into the bundled
+    /// families — new provider releases (e.g. zai GLM updates) appear without
+    /// waiting for the hand-maintained dashboard list; families with no
+    /// onboarding metadata (key env/route) are skipped.
+    #[test]
+    fn catalog_result_unions_qos_models_into_families() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("model_catalog.json"),
+            serde_json::to_string(&json!({
+                "updated_at": "2026-07-10T00:00:00Z",
+                "models": [
+                    {
+                        "provider": "zai/glm-9.9-test",
+                        "type": "strong",
+                        "stability": 0.7,
+                        "tool_avg_ms": 1,
+                        "p95_ms": 1,
+                        "score": 0.1,
+                        "cost_in": 1.0,
+                        "cost_out": 4.0,
+                        "ds_output": 1,
+                        "context_window": 1000,
+                        "max_output": 99
+                    },
+                    {
+                        "provider": "unknownfam/mystery-1",
+                        "type": "fast",
+                        "stability": 0.5,
+                        "tool_avg_ms": 1,
+                        "p95_ms": 1,
+                        "score": 0.2,
+                        "cost_in": 0.1,
+                        "cost_out": 0.2,
+                        "ds_output": 1,
+                        "context_window": 1000,
+                        "max_output": 9
+                    }
+                ]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let state = local_profile_state(dir.path());
+
+        let catalog = raw_catalog_result(&state).expect("catalog");
+        let families = &catalog["families"];
+        let zai_models = families["zai"]["models"].as_array().unwrap();
+        assert!(
+            zai_models.iter().any(|model| model["id"] == "glm-9.9-test"),
+            "QoS-only zai model unioned in: {zai_models:?}"
+        );
+        assert!(
+            zai_models.iter().any(|model| model["id"] == "glm-5.2"),
+            "bundled zai lineup still present"
+        );
+        assert!(
+            families.get("unknownfam").is_none(),
+            "families without onboarding metadata are skipped"
+        );
     }
 
     fn local_profile_state_with_sessions(dir: &Path) -> Arc<AppState> {

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -7877,20 +7877,18 @@ fn upsert_llm_fallback(
     }
 }
 
+/// Full selection *identity*: the [`same_llm_selection_address`] (which
+/// normalizes a missing route_id to the synthetic `"official"`) plus the
+/// endpoint. Two entries that agree on both resolve to the same provider —
+/// defined in terms of the address comparison so the two predicates cannot
+/// drift on route_id normalization (codex P2 round 3: a raw `Option`
+/// comparison here kept a route_id-less fallback alongside an identical
+/// `"official"` primary as a redundant retry-chain duplicate).
 fn same_llm_selection_identity(
     left: &crate::profiles::LlmModelSelectionConfig,
     right: &crate::profiles::LlmModelSelectionConfig,
 ) -> bool {
-    left.family_id == right.family_id
-        && left.model_id == right.model_id
-        && left
-            .route
-            .as_ref()
-            .and_then(|route| route.route_id.as_ref())
-            == right
-                .route
-                .as_ref()
-                .and_then(|route| route.route_id.as_ref())
+    same_llm_selection_address(left, right)
         && left
             .route
             .as_ref()
@@ -26348,6 +26346,115 @@ mod tests {
         assert!(
             llm.fallbacks.is_empty(),
             "promoting the exact identity must de-dup it out of the fallbacks: {llm:?}"
+        );
+    }
+
+    /// Identity comparison normalizes a missing route_id to the synthetic
+    /// `"official"` exactly like the address comparison (codex P2 round 3):
+    /// a route_id-less fallback with the same endpoint is the SAME provider
+    /// as an `"official"` upsert — it updates in place rather than
+    /// duplicating, and de-dups out of the list when promoted to primary.
+    #[tokio::test]
+    async fn llm_upsert_normalizes_default_route_ids_when_deduping() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = Arc::new(local_profile_state(dir.path()));
+        let upsert = |route: Value, set_primary: bool, tag: &str| {
+            RpcRequest::new(
+                format!("u-{tag}"),
+                APPUI_METHOD_PROFILE_LLM_UPSERT.to_string(),
+                json!({
+                    "profile_id": "dev",
+                    "selection": {
+                        "family_id": "deepseek",
+                        "model_id": "deepseek-chat",
+                        "route": route,
+                    },
+                    "set_primary": set_primary,
+                }),
+            )
+        };
+        let llm_of = |state: &Arc<AppState>| {
+            state
+                .profile_store
+                .as_ref()
+                .unwrap()
+                .get("dev")
+                .unwrap()
+                .unwrap()
+                .config
+                .llm
+                .clone()
+                .unwrap()
+        };
+
+        let mirror = "https://mirror.example";
+        raw_profile_llm_upsert(
+            &state,
+            &upsert(
+                json!({ "route_id": "official", "base_url": "https://one.example" }),
+                true,
+                "seed-primary",
+            ),
+            None,
+        )
+        .await
+        .expect("seed primary");
+        // Fallback saved WITHOUT a route_id (legacy/default-route shape).
+        raw_profile_llm_upsert(
+            &state,
+            &upsert(json!({ "base_url": mirror }), false, "seed-fallback"),
+            None,
+        )
+        .await
+        .expect("seed route_id-less fallback");
+
+        // Re-adding the same endpoint under the synthetic "official" id must
+        // update the existing fallback in place, not append a duplicate.
+        raw_profile_llm_upsert(
+            &state,
+            &upsert(
+                json!({ "route_id": "official", "base_url": mirror }),
+                false,
+                "readd",
+            ),
+            None,
+        )
+        .await
+        .expect("re-add under official");
+        assert_eq!(
+            llm_of(&state).fallbacks.len(),
+            1,
+            "official ≡ missing route_id: same provider must update in place"
+        );
+
+        // Promoting that provider under "official" de-dups the route_id-less
+        // row out of the retry chain.
+        raw_profile_llm_upsert(
+            &state,
+            &upsert(
+                json!({ "route_id": "official", "base_url": mirror }),
+                true,
+                "promote",
+            ),
+            None,
+        )
+        .await
+        .expect("promote");
+        let llm = llm_of(&state);
+        assert_eq!(
+            llm.primary
+                .as_ref()
+                .unwrap()
+                .route
+                .as_ref()
+                .unwrap()
+                .base_url
+                .as_deref(),
+            Some(mirror)
+        );
+        assert!(
+            llm.fallbacks.is_empty(),
+            "the normalized-identity duplicate must leave the retry chain: {llm:?}"
         );
     }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -7101,7 +7101,7 @@ fn model_list_result(
     json!({ "session_id": session_id, "models": models })
 }
 
-fn raw_catalog_result(state: &AppState) -> Result<Value, RpcError> {
+fn raw_catalog_result(state: &AppState, profile_id: Option<&str>) -> Result<Value, RpcError> {
     let mut families = serde_json::from_str::<Value>(DASHBOARD_PROVIDERS_JSON).map_err(|err| {
         RpcError::internal_error(format!("dashboard provider catalog was not JSON: {err}"))
     })?;
@@ -7110,12 +7110,22 @@ fn raw_catalog_result(state: &AppState) -> Result<Value, RpcError> {
     // dashboard catalog is hand-maintained and lags. Only models are merged —
     // a family absent from the bundled catalog has no key-env/route metadata,
     // so it cannot be onboarded and is skipped.
-    let data_dir = state
-        .profile_store
-        .as_ref()
-        .map(|store| store.octos_home_dir().to_path_buf())
-        .unwrap_or_default();
-    if let Some(qos) = crate::qos_catalog::load_seed_qos_catalog(&data_dir) {
+    // Per-profile QoS catalogs live under `profiles/<id>/data`
+    // (`ProfileRuntime::bootstrap` exports them there); the octos-home file
+    // is the shared seed. Merge the requesting profile's catalog first, then
+    // the home seed (`load_seed_qos_catalog` also falls back to `~/.octos`).
+    let mut sources = Vec::new();
+    if let Some(store) = state.profile_store.as_ref() {
+        let home = store.octos_home_dir().to_path_buf();
+        if let Some(profile_id) = profile_id {
+            sources.push(home.join("profiles").join(profile_id).join("data"));
+        }
+        sources.push(home);
+    }
+    for qos in sources
+        .iter()
+        .filter_map(|dir| crate::qos_catalog::load_seed_qos_catalog(dir))
+    {
         if let Some(families_map) = families.as_object_mut() {
             for entry in &qos.models {
                 let Some((family_id, model_id)) = entry.provider.split_once('/') else {
@@ -7438,17 +7448,15 @@ async fn raw_profile_llm_select(
     connection_profile_id: Option<&str>,
 ) -> Result<Value, RpcError> {
     let params: RawProfileLlmSelectParams = parse_raw_params(request)?;
-    let profile_id = raw_profile_id(
-        &RawProfileParams {
-            profile_id: params.profile_id.clone(),
-            session_id: params.session_id.clone(),
-        },
+    let profile_id = raw_scoped_llm_profile_id(
+        params.profile_id.clone(),
+        params.session_id.as_ref(),
         connection_profile_id,
-    );
+    )?;
     let model_id = nonempty(params.model_id)
         .ok_or_else(|| RpcError::invalid_params("model_id is required"))?;
     let family_id = nonempty(params.family_id);
-    let route_id = nonempty(params.route_id).filter(|route| route != "official");
+    let route_id = nonempty(params.route_id);
 
     let store = profile_store(state)?;
     let mut profile = store
@@ -7457,32 +7465,81 @@ async fn raw_profile_llm_select(
         .ok_or_else(|| RpcError::not_found("profile", profile_id.clone()))?;
 
     let mut llm = profile.config.llm.take().unwrap_or_default();
-    let matches_selection = |selection: &crate::profiles::LlmModelSelectionConfig| {
+    let matches_family_model = |selection: &crate::profiles::LlmModelSelectionConfig| {
         selection.model_id.as_deref() == Some(model_id.as_str())
             && family_id
                 .as_deref()
                 .is_none_or(|family| selection.family_id.as_deref() == Some(family))
-            && route_id.as_deref().is_none_or(|route| {
-                selection
-                    .route
-                    .as_ref()
-                    .and_then(|selection_route| selection_route.route_id.as_deref())
-                    == Some(route)
-            })
     };
-
-    let already_primary = llm.primary.as_ref().is_some_and(&matches_selection);
+    let matches_route = |selection: &crate::profiles::LlmModelSelectionConfig| {
+        route_id.as_deref().is_none_or(|route| {
+            selection
+                .route
+                .as_ref()
+                .and_then(|selection_route| selection_route.route_id.as_deref())
+                == Some(route)
+        })
+    };
+    let matches_exact = |selection: &crate::profiles::LlmModelSelectionConfig| {
+        matches_family_model(selection) && matches_route(selection)
+    };
+    // The route is a REAL discriminator: the same family/model can be
+    // configured on two routes with different endpoints and credentials.
+    // An exact route match always wins; the TUI's synthetic default
+    // ("official" when a configured entry carries no route) may fall back
+    // to a family/model match ONLY when that match is unambiguous.
+    let route_is_synthetic_default = route_id.as_deref() == Some("official");
+    let exact_primary = llm.primary.as_ref().is_some_and(matches_exact);
+    let exact_fallback = llm.fallbacks.iter().position(matches_exact);
+    let target = if exact_primary {
+        None
+    } else if let Some(index) = exact_fallback {
+        Some(index)
+    } else if route_is_synthetic_default {
+        let primary_matches = llm.primary.as_ref().is_some_and(matches_family_model);
+        let fallback_matches = llm
+            .fallbacks
+            .iter()
+            .enumerate()
+            .filter(|(_, selection)| matches_family_model(selection))
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        match (primary_matches, fallback_matches.as_slice()) {
+            (true, []) => None,
+            (false, [index]) => Some(*index),
+            (false, []) => {
+                profile.config.llm = Some(llm);
+                return Err(RpcError::not_found(
+                    "configured model",
+                    format!(
+                        "{model_id} (not configured on profile '{profile_id}' — save it \
+                         first via profile/llm/upsert / the onboarding provider step)"
+                    ),
+                ));
+            }
+            _ => {
+                profile.config.llm = Some(llm);
+                return Err(RpcError::invalid_params(format!(
+                    "model '{model_id}' is configured on multiple routes — pass the \
+                     route_id to disambiguate"
+                )));
+            }
+        }
+    } else {
+        profile.config.llm = Some(llm);
+        return Err(RpcError::not_found(
+            "configured model",
+            format!(
+                "{model_id} (not configured on profile '{profile_id}' — save it first \
+                 via profile/llm/upsert / the onboarding provider step)"
+            ),
+        ));
+    };
+    let already_primary = target.is_none();
     let mut applied = already_primary;
     if !already_primary {
-        let Some(index) = llm.fallbacks.iter().position(&matches_selection) else {
-            profile.config.llm = Some(llm);
-            return Err(RpcError::not_found(
-                "configured model",
-                format!(
-                    "{model_id} (not configured on profile '{profile_id}' — save it first \
-                     via profile/llm/upsert / the onboarding provider step)"
-                ),
-            ));
+        let Some(index) = target else {
+            unreachable!("already_primary guarantees a fallback target index");
         };
         let promoted = llm.fallbacks.remove(index);
         if let Some(demoted) = llm.primary.take() {
@@ -7556,19 +7613,45 @@ async fn raw_profile_llm_select(
     }))
 }
 
+/// Resolve the target profile for the profile-LLM raw methods, rejecting
+/// cross-profile targets on authenticated (profile-scoped) connections —
+/// profile A's credential must never rewire, probe, or spend against
+/// profile B's configured providers.
+fn raw_scoped_llm_profile_id(
+    requested_profile_id: Option<String>,
+    requested_session_id: Option<&SessionKey>,
+    connection_profile_id: Option<&str>,
+) -> Result<String, RpcError> {
+    let requested = nonempty(requested_profile_id).or_else(|| {
+        requested_session_id.and_then(|session_id| session_id.profile_id().map(ToOwned::to_owned))
+    });
+    if let Some(connection_profile_id) = connection_profile_id {
+        if requested
+            .as_deref()
+            .is_some_and(|requested| requested != connection_profile_id)
+        {
+            return Err(RpcError::permission_denied(
+                "profile_id is outside the authenticated profile",
+            )
+            .with_data(json!({
+                "kind": "auth_scope_violation",
+                "connection_profile_id": connection_profile_id,
+                "requested_profile_id": requested,
+            })));
+        }
+        return Ok(connection_profile_id.to_owned());
+    }
+    Ok(requested.unwrap_or_else(|| MAIN_PROFILE_ID.to_string()))
+}
+
 async fn raw_profile_llm_upsert(
     state: &Arc<AppState>,
     request: &RpcRequest<Value>,
     connection_profile_id: Option<&str>,
 ) -> Result<Value, RpcError> {
     let params: RawProfileLlmUpsertParams = parse_raw_params(request)?;
-    let profile_id = raw_profile_id(
-        &RawProfileParams {
-            profile_id: params.profile_id.clone(),
-            session_id: None,
-        },
-        connection_profile_id,
-    );
+    let profile_id =
+        raw_scoped_llm_profile_id(params.profile_id.clone(), None, connection_profile_id)?;
     let store = profile_store(state)?;
     let mut profile = store
         .get(&profile_id)
@@ -7676,13 +7759,8 @@ async fn raw_profile_llm_test(
     connection_profile_id: Option<&str>,
 ) -> Result<Value, RpcError> {
     let params: RawProfileLlmUpsertParams = parse_raw_params(request)?;
-    let profile_id = raw_profile_id(
-        &RawProfileParams {
-            profile_id: params.profile_id.clone(),
-            session_id: None,
-        },
-        connection_profile_id,
-    );
+    let profile_id =
+        raw_scoped_llm_profile_id(params.profile_id.clone(), None, connection_profile_id)?;
     let profile = state
         .profile_store
         .as_ref()
@@ -7813,13 +7891,8 @@ async fn raw_profile_llm_fetch_models(
     connection_profile_id: Option<&str>,
 ) -> Result<Value, RpcError> {
     let params: RawProfileLlmUpsertParams = parse_raw_params(request)?;
-    let profile_id = raw_profile_id(
-        &RawProfileParams {
-            profile_id: params.profile_id.clone(),
-            session_id: None,
-        },
-        connection_profile_id,
-    );
+    let profile_id =
+        raw_scoped_llm_profile_id(params.profile_id.clone(), None, connection_profile_id)?;
     let profile = state
         .profile_store
         .as_ref()
@@ -8321,7 +8394,7 @@ async fn handle_raw_appui_rpc(
         APPUI_METHOD_SESSION_STATUS_READ => {
             raw_session_status_result(state, request, features, connection_profile_id).await
         }
-        APPUI_METHOD_PROFILE_LLM_CATALOG => raw_catalog_result(state),
+        APPUI_METHOD_PROFILE_LLM_CATALOG => raw_catalog_result(state, connection_profile_id),
         APPUI_METHOD_PROFILE_LLM_LIST => {
             let params: RawProfileParams = match parse_raw_params(request) {
                 Ok(params) => params,
@@ -25468,6 +25541,94 @@ mod tests {
         assert_eq!(error.code, rpc_error_codes::RESOURCE_NOT_FOUND);
     }
 
+    /// A profile-scoped connection must not rewire another profile's models
+    /// (codex P1) — and an ambiguous route wildcard must reject rather than
+    /// promote an arbitrary route (codex P2).
+    #[tokio::test]
+    async fn llm_select_enforces_scope_and_route_discrimination() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = Arc::new(local_profile_state(dir.path()));
+
+        // Cross-profile mutation from a profile-scoped connection: denied.
+        let request = RpcRequest::new(
+            "sx".to_string(),
+            APPUI_METHOD_PROFILE_LLM_SELECT.to_string(),
+            json!({ "profile_id": "victim", "model_id": "deepseek-chat" }),
+        );
+        let error = raw_profile_llm_select(&state, &request, Some("attacker"))
+            .await
+            .expect_err("cross-profile select must be denied");
+        assert_eq!(
+            error.data.as_ref().and_then(|data| data.get("kind")),
+            Some(&json!("auth_scope_violation")),
+            "got {error:?}"
+        );
+
+        // Same family/model on two routes: the synthetic "official" wildcard
+        // must reject as ambiguous; an exact route selects that route.
+        for (route, set_primary) in [("autodl", true), ("proxy", false)] {
+            let request = RpcRequest::new(
+                format!("u-{route}"),
+                APPUI_METHOD_PROFILE_LLM_UPSERT.to_string(),
+                json!({
+                    "profile_id": "dev",
+                    "selection": {
+                        "family_id": "zai",
+                        "model_id": "glm-5.2",
+                        "route": { "route_id": route },
+                    },
+                    "set_primary": set_primary,
+                }),
+            );
+            raw_profile_llm_upsert(&state, &request, None)
+                .await
+                .expect("upsert");
+        }
+        let request = RpcRequest::new(
+            "amb".to_string(),
+            APPUI_METHOD_PROFILE_LLM_SELECT.to_string(),
+            json!({
+                "profile_id": "dev",
+                "model_id": "glm-5.2",
+                "route_id": "official",
+            }),
+        );
+        let error = raw_profile_llm_select(&state, &request, None)
+            .await
+            .expect_err("ambiguous route wildcard must reject");
+        assert!(error.message.contains("multiple routes"), "got {error:?}");
+
+        let request = RpcRequest::new(
+            "exact".to_string(),
+            APPUI_METHOD_PROFILE_LLM_SELECT.to_string(),
+            json!({
+                "profile_id": "dev",
+                "model_id": "glm-5.2",
+                "route_id": "proxy",
+            }),
+        );
+        let result = raw_profile_llm_select(&state, &request, None)
+            .await
+            .expect("exact route selects");
+        assert_eq!(result["applied"], true);
+        let profile = state
+            .profile_store
+            .as_ref()
+            .unwrap()
+            .get("dev")
+            .unwrap()
+            .unwrap();
+        let llm = profile.config.llm.as_ref().unwrap();
+        assert_eq!(
+            llm.primary
+                .as_ref()
+                .and_then(|primary| primary.route.as_ref())
+                .and_then(|route| route.route_id.as_deref()),
+            Some("proxy"),
+            "the EXACT route was promoted"
+        );
+    }
+
     /// The onboarding catalog unions the QoS model catalog into the bundled
     /// families — new provider releases (e.g. zai GLM updates) appear without
     /// waiting for the hand-maintained dashboard list; families with no
@@ -25513,7 +25674,7 @@ mod tests {
         .unwrap();
         let state = local_profile_state(dir.path());
 
-        let catalog = raw_catalog_result(&state).expect("catalog");
+        let catalog = raw_catalog_result(&state, None).expect("catalog");
         let families = &catalog["families"];
         let zai_models = families["zai"]["models"].as_array().unwrap();
         assert!(

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -7817,18 +7817,23 @@ async fn raw_profile_llm_upsert(
     if params.set_primary || llm.primary.is_none() {
         // set_primary is lossless (mirrors `profile/llm/select`): a replaced
         // primary is demoted into the fallback list, and the promoted
-        // selection is de-duplicated out of it. Comparison is by selection
-        // *address* (family/model/route_id — all `profile/llm/select` can
-        // discriminate): a same-address upsert is an endpoint edit and
-        // replaces outright, or the old endpoint would linger as a fallback
-        // row the selector can never promote (codex P2).
+        // selection is de-duplicated out of it. The two decisions use
+        // different comparisons (codex P2 ×2):
+        // - demote by *address* (family/model/route_id — all the selector can
+        //   discriminate): a same-address upsert is an endpoint edit and
+        //   replaces outright, or the old endpoint would linger as a fallback
+        //   row `profile/llm/select` can never promote;
+        // - de-dup by full *identity* (address + base_url): endpoint-distinct
+        //   fallbacks are real failover chain entries (`config_from_profile`
+        //   threads every fallback's endpoint into the runtime), so only an
+        //   exact duplicate of the new primary leaves the list.
         if let Some(old_primary) = llm.primary.take() {
             if !same_llm_selection_address(&old_primary, &selection) {
                 upsert_llm_fallback(&mut llm.fallbacks, old_primary);
             }
         }
         llm.fallbacks
-            .retain(|fallback| !same_llm_selection_address(fallback, &selection));
+            .retain(|fallback| !same_llm_selection_identity(fallback, &selection));
         llm.primary = Some(selection);
     } else {
         upsert_llm_fallback(&mut llm.fallbacks, selection);
@@ -26246,6 +26251,103 @@ mod tests {
         assert!(
             llm.fallbacks.is_empty(),
             "endpoint edits must not accrete unselectable fallback rows: {llm:?}"
+        );
+    }
+
+    /// Endpoint-distinct fallbacks (same family/model/route_id, different
+    /// base_url) are real failover-chain entries, not selector duplicates —
+    /// `config_from_profile` threads every fallback's endpoint into the
+    /// runtime. A set_primary upsert must not sweep them away (codex P2 on
+    /// the address-comparison fix); only an exact-identity duplicate of the
+    /// new primary leaves the list.
+    #[tokio::test]
+    async fn llm_upsert_preserves_endpoint_distinct_failover_fallbacks() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = Arc::new(local_profile_state(dir.path()));
+        let upsert = |base_url: &str, set_primary: bool| {
+            RpcRequest::new(
+                format!("u-{base_url}-{set_primary}"),
+                APPUI_METHOD_PROFILE_LLM_UPSERT.to_string(),
+                json!({
+                    "profile_id": "dev",
+                    "selection": {
+                        "family_id": "deepseek",
+                        "model_id": "deepseek-chat",
+                        "route": { "route_id": "official", "base_url": base_url },
+                    },
+                    "set_primary": set_primary,
+                }),
+            )
+        };
+        let llm_of = |state: &Arc<AppState>| {
+            state
+                .profile_store
+                .as_ref()
+                .unwrap()
+                .get("dev")
+                .unwrap()
+                .unwrap()
+                .config
+                .llm
+                .clone()
+                .unwrap()
+        };
+
+        // Primary at ONE, plus a same-address failover mirror at MIRROR.
+        for (url, primary) in [
+            ("https://one.example", true),
+            ("https://mirror.example", false),
+        ] {
+            raw_profile_llm_upsert(&state, &upsert(url, primary), None)
+                .await
+                .expect("seed");
+        }
+
+        // Endpoint edit of the primary: the mirror fallback must survive.
+        raw_profile_llm_upsert(&state, &upsert("https://two.example", true), None)
+            .await
+            .expect("endpoint edit");
+        let llm = llm_of(&state);
+        assert_eq!(
+            llm.primary
+                .as_ref()
+                .unwrap()
+                .route
+                .as_ref()
+                .unwrap()
+                .base_url
+                .as_deref(),
+            Some("https://two.example")
+        );
+        assert_eq!(
+            llm.fallbacks
+                .iter()
+                .map(|fb| fb.route.as_ref().unwrap().base_url.as_deref().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["https://mirror.example"],
+            "endpoint-distinct failover fallback must survive a set_primary upsert"
+        );
+
+        // Promoting the exact mirror identity removes it from the fallback
+        // list (true duplicate) rather than leaving two copies.
+        raw_profile_llm_upsert(&state, &upsert("https://mirror.example", true), None)
+            .await
+            .expect("promote mirror");
+        let llm = llm_of(&state);
+        assert_eq!(
+            llm.primary
+                .as_ref()
+                .unwrap()
+                .route
+                .as_ref()
+                .unwrap()
+                .base_url
+                .as_deref(),
+            Some("https://mirror.example")
+        );
+        assert!(
+            llm.fallbacks.is_empty(),
+            "promoting the exact identity must de-dup it out of the fallbacks: {llm:?}"
         );
     }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -7815,6 +7815,16 @@ async fn raw_profile_llm_upsert(
 
     let mut llm = profile.config.llm.take().unwrap_or_default();
     if params.set_primary || llm.primary.is_none() {
+        // set_primary is lossless (mirrors `profile/llm/select`): a replaced
+        // primary is demoted into the fallback list, and the promoted
+        // selection is de-duplicated out of it.
+        if let Some(old_primary) = llm.primary.take() {
+            if !same_llm_selection_identity(&old_primary, &selection) {
+                upsert_llm_fallback(&mut llm.fallbacks, old_primary);
+            }
+        }
+        llm.fallbacks
+            .retain(|fallback| !same_llm_selection_identity(fallback, &selection));
         llm.primary = Some(selection);
     } else {
         upsert_llm_fallback(&mut llm.fallbacks, selection);
@@ -26054,6 +26064,98 @@ mod tests {
             .await
             .expect_err("unconfigured model must reject");
         assert_eq!(error.code, rpc_error_codes::RESOURCE_NOT_FOUND);
+    }
+
+    /// `profile/llm/upsert` with `set_primary` must be lossless: replacing
+    /// the primary demotes the old one to a fallback instead of dropping it
+    /// (the onboarding wizard's "Save" path — a user onboarding glm-5.2 lost
+    /// their deepseek primary and was left with a single unusable model), and
+    /// re-promoting a model that already sits in the fallback list must not
+    /// duplicate it there.
+    #[tokio::test]
+    async fn llm_upsert_set_primary_demotes_old_primary_instead_of_dropping_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = Arc::new(local_profile_state(dir.path()));
+        for (family, model) in [("deepseek", "deepseek-v4-pro"), ("zai", "glm-5.2")] {
+            let request = RpcRequest::new(
+                format!("u-{model}"),
+                APPUI_METHOD_PROFILE_LLM_UPSERT.to_string(),
+                json!({
+                    "profile_id": "dev",
+                    "selection": {
+                        "family_id": family,
+                        "model_id": model,
+                        "route": { "route_id": "official" },
+                    },
+                    "set_primary": true,
+                }),
+            );
+            raw_profile_llm_upsert(&state, &request, None)
+                .await
+                .expect("upsert");
+        }
+
+        let profile = state
+            .profile_store
+            .as_ref()
+            .unwrap()
+            .get("dev")
+            .unwrap()
+            .unwrap();
+        let llm = profile.config.llm.as_ref().unwrap();
+        assert_eq!(
+            llm.primary.as_ref().unwrap().model_id.as_deref(),
+            Some("glm-5.2")
+        );
+        assert_eq!(
+            llm.fallbacks.len(),
+            1,
+            "replaced primary must survive as a fallback: {llm:?}"
+        );
+        assert_eq!(
+            llm.fallbacks[0].model_id.as_deref(),
+            Some("deepseek-v4-pro")
+        );
+
+        // Promote the demoted model back through the same wizard path: it
+        // must leave the fallback list (no duplicate) and demote glm-5.2.
+        let request = RpcRequest::new(
+            "u-back".to_string(),
+            APPUI_METHOD_PROFILE_LLM_UPSERT.to_string(),
+            json!({
+                "profile_id": "dev",
+                "selection": {
+                    "family_id": "deepseek",
+                    "model_id": "deepseek-v4-pro",
+                    "route": { "route_id": "official" },
+                },
+                "set_primary": true,
+            }),
+        );
+        raw_profile_llm_upsert(&state, &request, None)
+            .await
+            .expect("re-promote");
+
+        let profile = state
+            .profile_store
+            .as_ref()
+            .unwrap()
+            .get("dev")
+            .unwrap()
+            .unwrap();
+        let llm = profile.config.llm.as_ref().unwrap();
+        assert_eq!(
+            llm.primary.as_ref().unwrap().model_id.as_deref(),
+            Some("deepseek-v4-pro")
+        );
+        assert_eq!(
+            llm.fallbacks
+                .iter()
+                .map(|fb| fb.model_id.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("glm-5.2")],
+            "round-trip must neither duplicate the promoted model nor drop the demoted one"
+        );
     }
 
     /// A profile-scoped connection must not rewire another profile's models

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -7817,14 +7817,18 @@ async fn raw_profile_llm_upsert(
     if params.set_primary || llm.primary.is_none() {
         // set_primary is lossless (mirrors `profile/llm/select`): a replaced
         // primary is demoted into the fallback list, and the promoted
-        // selection is de-duplicated out of it.
+        // selection is de-duplicated out of it. Comparison is by selection
+        // *address* (family/model/route_id — all `profile/llm/select` can
+        // discriminate): a same-address upsert is an endpoint edit and
+        // replaces outright, or the old endpoint would linger as a fallback
+        // row the selector can never promote (codex P2).
         if let Some(old_primary) = llm.primary.take() {
-            if !same_llm_selection_identity(&old_primary, &selection) {
+            if !same_llm_selection_address(&old_primary, &selection) {
                 upsert_llm_fallback(&mut llm.fallbacks, old_primary);
             }
         }
         llm.fallbacks
-            .retain(|fallback| !same_llm_selection_identity(fallback, &selection));
+            .retain(|fallback| !same_llm_selection_address(fallback, &selection));
         llm.primary = Some(selection);
     } else {
         upsert_llm_fallback(&mut llm.fallbacks, selection);
@@ -7890,6 +7894,27 @@ fn same_llm_selection_identity(
                 .route
                 .as_ref()
                 .and_then(|route| route.base_url.as_ref())
+}
+
+/// Selection *address* as `profile/llm/select` can discriminate it: family +
+/// model + route_id, with a missing route_id normalized to the synthetic
+/// `"official"` the TUI sends for default routes. `base_url` is deliberately
+/// excluded — the selector cannot address it, so two selections differing
+/// only by endpoint are the same switchable row.
+fn same_llm_selection_address(
+    left: &crate::profiles::LlmModelSelectionConfig,
+    right: &crate::profiles::LlmModelSelectionConfig,
+) -> bool {
+    fn route_address(selection: &crate::profiles::LlmModelSelectionConfig) -> &str {
+        selection
+            .route
+            .as_ref()
+            .and_then(|route| route.route_id.as_deref())
+            .unwrap_or("official")
+    }
+    left.family_id == right.family_id
+        && left.model_id == right.model_id
+        && route_address(left) == route_address(right)
 }
 
 async fn raw_profile_llm_test(
@@ -26155,6 +26180,72 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![Some("glm-5.2")],
             "round-trip must neither duplicate the promoted model nor drop the demoted one"
+        );
+    }
+
+    /// A same-address upsert (same family/model/route_id — including a
+    /// missing route_id, which normalizes to the synthetic "official") is an
+    /// endpoint edit: it replaces the primary outright instead of demoting
+    /// the old endpoint into a fallback row that `profile/llm/select` can
+    /// never address (codex P2 on the lossless-save fix).
+    #[tokio::test]
+    async fn llm_upsert_endpoint_edit_replaces_instead_of_demoting() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = Arc::new(local_profile_state(dir.path()));
+        for (route, tag) in [
+            (
+                json!({ "route_id": "official", "base_url": "https://one.example" }),
+                "one",
+            ),
+            // Same address, new endpoint: must replace, not demote.
+            (
+                json!({ "route_id": "official", "base_url": "https://two.example" }),
+                "two",
+            ),
+            // Missing route_id normalizes to "official": still the same address.
+            (json!({ "base_url": "https://three.example" }), "three"),
+        ] {
+            let request = RpcRequest::new(
+                format!("u-{tag}"),
+                APPUI_METHOD_PROFILE_LLM_UPSERT.to_string(),
+                json!({
+                    "profile_id": "dev",
+                    "selection": {
+                        "family_id": "deepseek",
+                        "model_id": "deepseek-chat",
+                        "route": route,
+                    },
+                    "set_primary": true,
+                }),
+            );
+            raw_profile_llm_upsert(&state, &request, None)
+                .await
+                .expect("upsert");
+        }
+
+        let profile = state
+            .profile_store
+            .as_ref()
+            .unwrap()
+            .get("dev")
+            .unwrap()
+            .unwrap();
+        let llm = profile.config.llm.as_ref().unwrap();
+        assert_eq!(
+            llm.primary
+                .as_ref()
+                .unwrap()
+                .route
+                .as_ref()
+                .unwrap()
+                .base_url
+                .as_deref(),
+            Some("https://three.example"),
+            "the endpoint edit lands on the primary"
+        );
+        assert!(
+            llm.fallbacks.is_empty(),
+            "endpoint edits must not accrete unselectable fallback rows: {llm:?}"
         );
     }
 

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -98,6 +98,11 @@ pub struct SessionRuntimeCache {
     /// [`InflightStorage`] type alias for the lost-wake-race
     /// reasoning behind picking `Semaphore` over `Notify`.
     inflight: InflightStorage,
+    /// Per-profile invalidation generation. Bumped by
+    /// [`Self::invalidate_profile`]; a bootstrap that STARTED before the bump
+    /// (holding the old `ProfileRuntime`) must not insert its stale runtime
+    /// after the sweep — it serves its own caller uncached instead.
+    generations: Arc<std::sync::Mutex<HashMap<String, u64>>>,
     max_size: usize,
     idle_ttl: Duration,
     /// Cancellation signal for the background sweep task. Notified
@@ -216,6 +221,7 @@ impl SessionRuntimeCache {
         Self {
             inner,
             inflight: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            generations: Arc::new(std::sync::Mutex::new(HashMap::new())),
             max_size,
             idle_ttl,
             shutdown,
@@ -384,6 +390,7 @@ impl SessionRuntimeCache {
                     continue;
                 }
                 InflightOutcome::OwnGuard(guard) => {
+                    let generation_at_start = self.profile_generation(&key.0);
                     let result = SessionRuntime::bootstrap_with_permissions_and_sandbox(
                         profile,
                         session_key.clone(),
@@ -394,6 +401,15 @@ impl SessionRuntimeCache {
                     .await;
                     match result {
                         Ok(runtime) => {
+                            if self.profile_generation(&key.0) != generation_at_start {
+                                // The profile was invalidated (e.g. a model
+                                // switch) while we bootstrapped against its
+                                // OLD runtime: serve this caller, but do NOT
+                                // cache — the next turn re-materializes on
+                                // the rebuilt ProfileRuntime.
+                                drop(guard);
+                                return Ok(runtime);
+                            }
                             // `insert_with_eviction` returns the
                             // canonical `Arc<SessionRuntime>` for
                             // this key — either the one we just
@@ -494,8 +510,27 @@ impl SessionRuntimeCache {
     /// upsert): cached `SessionRuntime`s embed the OLD provider chain, so the
     /// next turn must re-materialize against the rebuilt `ProfileRuntime`.
     pub async fn invalidate_profile(&self, profile_id: &str) {
+        // Bump the generation FIRST: any in-flight bootstrap that started
+        // against the old ProfileRuntime observes the change at insert time
+        // and skips caching its stale runtime.
+        {
+            let mut generations = self
+                .generations
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            *generations.entry(profile_id.to_owned()).or_insert(0) += 1;
+        }
         let mut guard = self.inner.write().await;
         guard.retain(|(key_profile, _), _| key_profile != profile_id);
+    }
+
+    fn profile_generation(&self, profile_id: &str) -> u64 {
+        self.generations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(profile_id)
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Drop every entry whose `last_used` is older than
@@ -629,6 +664,37 @@ mod tests {
             lane_routing: None,
             voice: crate::config::VoiceConfig::default(),
         })
+    }
+
+    /// A bootstrap that started BEFORE an invalidation (still holding the old
+    /// ProfileRuntime) must not cache its stale runtime after the sweep.
+    #[tokio::test]
+    async fn invalidation_mid_bootstrap_skips_the_stale_insert() {
+        let tmp = TempDir::new().unwrap();
+        let profile = make_profile(tmp.path().join("profile-data")).await;
+        let cache = SessionRuntimeCache::new(8, Duration::from_secs(60));
+        let key = SessionKey::new("api", "stale-guard");
+
+        // Simulate "invalidation raced the bootstrap": bump the generation
+        // between the snapshot a bootstrap would take and its insert. The
+        // public surface can't pause mid-bootstrap, so drive the same
+        // sequence the OwnGuard arm runs: snapshot → (invalidate) → insert
+        // gate.
+        let generation_at_start = cache.profile_generation(&profile.profile_id);
+        cache.invalidate_profile(&profile.profile_id).await;
+        assert_ne!(
+            cache.profile_generation(&profile.profile_id),
+            generation_at_start,
+            "invalidation must advance the profile generation"
+        );
+
+        // A fresh get_or_init AFTER the invalidation snapshots the NEW
+        // generation and caches normally.
+        cache
+            .get_or_init(&profile, key.clone(), None)
+            .await
+            .expect("bootstrap");
+        assert_eq!(cache.len().await, 1);
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -489,6 +489,15 @@ impl SessionRuntimeCache {
         guard.remove(key);
     }
 
+    /// Drop every cached session runtime belonging to `profile_id`. Used when
+    /// a profile's LLM selection changes at runtime (`profile/llm/select` /
+    /// upsert): cached `SessionRuntime`s embed the OLD provider chain, so the
+    /// next turn must re-materialize against the rebuilt `ProfileRuntime`.
+    pub async fn invalidate_profile(&self, profile_id: &str) {
+        let mut guard = self.inner.write().await;
+        guard.retain(|(key_profile, _), _| key_profile != profile_id);
+    }
+
     /// Drop every entry whose `last_used` is older than
     /// [`Self::idle_ttl`]. Exposed so tests can verify the eviction
     /// invariant without waiting for the 60 s background sweep.
@@ -620,6 +629,39 @@ mod tests {
             lane_routing: None,
             voice: crate::config::VoiceConfig::default(),
         })
+    }
+
+    #[tokio::test]
+    async fn invalidate_profile_sweeps_only_that_profile() {
+        let tmp = TempDir::new().unwrap();
+        let profile_a = make_profile(tmp.path().join("profile-a")).await;
+        let mut profile_b = make_profile(tmp.path().join("profile-b")).await;
+        // `make_profile` fixes the id; give the second a distinct identity so
+        // the sweep has something to spare.
+        std::sync::Arc::get_mut(&mut profile_b)
+            .map(|profile| profile.profile_id = "other".to_owned());
+
+        let cache = SessionRuntimeCache::new(8, Duration::from_secs(60));
+        cache
+            .get_or_init(&profile_a, SessionKey::new("api", "a1"), None)
+            .await
+            .expect("a1");
+        cache
+            .get_or_init(&profile_a, SessionKey::new("api", "a2"), None)
+            .await
+            .expect("a2");
+        cache
+            .get_or_init(&profile_b, SessionKey::new("api", "b1"), None)
+            .await
+            .expect("b1");
+        assert_eq!(cache.len().await, 3);
+
+        cache.invalidate_profile(&profile_a.profile_id).await;
+        assert_eq!(
+            cache.len().await,
+            1,
+            "only the other profile's entry survives"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -401,15 +401,6 @@ impl SessionRuntimeCache {
                     .await;
                     match result {
                         Ok(runtime) => {
-                            if self.profile_generation(&key.0) != generation_at_start {
-                                // The profile was invalidated (e.g. a model
-                                // switch) while we bootstrapped against its
-                                // OLD runtime: serve this caller, but do NOT
-                                // cache — the next turn re-materializes on
-                                // the rebuilt ProfileRuntime.
-                                drop(guard);
-                                return Ok(runtime);
-                            }
                             // `insert_with_eviction` returns the
                             // canonical `Arc<SessionRuntime>` for
                             // this key — either the one we just
@@ -424,7 +415,9 @@ impl SessionRuntimeCache {
                             // runtime per key" invariant rather
                             // than a "one bootstrap per inflight
                             // era" invariant.
-                            let canonical = self.insert_with_eviction(key.clone(), runtime).await;
+                            let canonical = self
+                                .insert_with_eviction(key.clone(), runtime, generation_at_start)
+                                .await;
                             drop(guard);
                             return Ok(canonical);
                         }
@@ -457,8 +450,17 @@ impl SessionRuntimeCache {
         &self,
         key: CacheKey,
         runtime: Arc<SessionRuntime>,
+        generation_at_start: u64,
     ) -> Arc<SessionRuntime> {
         let mut guard = self.inner.write().await;
+        // Re-check the profile generation UNDER the map lock: the sweep in
+        // `invalidate_profile` serializes on this same lock and its bump
+        // happens-before its sweep, so either we observe the bump here (and
+        // skip caching the stale runtime) or our insert lands first and the
+        // sweep removes it — a stale runtime can never survive a switch.
+        if self.profile_generation(&key.0) != generation_at_start {
+            return runtime;
+        }
 
         // If a runtime is already present (e.g. another task
         // bootstrapped in a prior single-flight era and inserted
@@ -917,7 +919,11 @@ mod tests {
         );
 
         let canonical = cache
-            .insert_with_eviction((profile.profile_id.clone(), key.clone()), redundant)
+            .insert_with_eviction(
+                (profile.profile_id.clone(), key.clone()),
+                redundant,
+                cache.profile_generation(&profile.profile_id),
+            )
             .await;
         assert!(
             Arc::ptr_eq(&canonical, &original),

--- a/dashboard/src/providers.json
+++ b/dashboard/src/providers.json
@@ -188,6 +188,8 @@
   "zai": {
     "env": "ZAI_API_KEY",
     "models": [
+      { "id": "glm-5.2", "input": 1.0, "output": 4.0, "max_output": 131072 },
+      { "id": "glm-5-turbo", "input": 1.0, "output": 0.4, "max_output": 131072 },
       { "id": "glm-5.1", "input": 0.5, "output": 2.0, "max_output": 131072 },
       { "id": "glm-4.7", "input": 0.3, "output": 1.2, "max_output": 8192 },
       { "id": "glm-4.5-air", "input": 0.07, "output": 0.07, "max_output": 4096 }


### PR DESCRIPTION
## What

Three gaps kept a profile pinned to its primary model (user report: "/model and /onboard only ever offer deepseek"):

1. **`profile/llm/list`-backed model lists exposed only the primary** → the TUI `/model` menu had one row. Now every configured model rides the list — primary as `selected`, fallbacks as switchable alternatives.
2. **`profile/llm/select` was a stub** — it echoed the primary back and ignored the request. Now it promotes the requested *configured* model to primary, demotes the old primary to a fallback (lossless, reversible), persists to the profile store, honors the caller's `session_id` in the result, and rejects unconfigured models with a save-it-first error. **The switch takes effect on the next turn, no restart**: the profile's cached `SessionRuntime`s are evicted (new `SessionRuntimeCache::invalidate_profile`) and the dynamic `ProfileRuntime` is dropped + re-bootstrapped. Startup-config profiles persist the change with a restart-only note.
3. **The onboarding catalog lagged provider releases** (zai stopped at glm-5.1). `profile/llm/catalog` now unions the QoS model catalog (`model_catalog.json`) into the bundled families — new provider models appear without a code change; families lacking onboarding metadata (key env/route) are skipped. `providers.json` also gains the current zai lineup (`glm-5.2`, `glm-5-turbo`) as a 2-line refresh.

Multi-model *configuration* already existed (`profile/llm/upsert` `set_primary:false` → fallbacks; the onboarding wizard's "Add as fallback" row) — this PR makes those configurations listable and switchable.

## Testing

- 3 new tests: select promote/idempotent/reject + full list shape; catalog union (QoS-only model appears, unknown families skipped, bundled lineup intact); cache profile sweep spares other profiles.
- `cargo test -p octos-cli --features api --lib`: 2284 green.
- **Live-verified** (tmux, TUI ↔ `serve --stdio`, real deepseek key): `/model` lists both configured models, selecting flips the composer footer instantly, the next turn answers on the switched model, the swap survives a restart and is reversible, and the onboarding zai list shows `glm-5.2`.

Companion TUI PR (sends `session_id` in select params + auto-loads the onboarding catalog) follows; both directions are wire-compatible with the other side's current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)