### PR TITLE
fix(api): session/status/read omits the model object when no model is resolved

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -7236,17 +7236,30 @@ async fn raw_session_status_result(
     } else {
         (None, None)
     };
-    Ok(json!({
+    // Emit the `model` object only when the policy actually resolved a
+    // model AND provider. Clients (octos-tui) decode it into a struct whose
+    // `model`/`provider` are non-optional strings, so
+    // `{"model": null, "provider": null, "selected": true}` fails the whole
+    // session/status/read decode and the composer footer degrades to a
+    // placeholder. A missing key is handled fine by their
+    // `Option<ModelStatus>` + `#[serde(default)]` — including in shipped
+    // octos-tui 0.1.5 binaries.
+    let resolved_model = policy.get("model").filter(|value| !value.is_null());
+    let resolved_provider = policy.get("provider").filter(|value| !value.is_null());
+    let model = match (resolved_model, resolved_provider) {
+        (Some(model), Some(provider)) => Some(json!({
+            "model": model,
+            "provider": provider,
+            "selected": true
+        })),
+        _ => None,
+    };
+    let mut result = json!({
         "session_id": session_id,
         "profile_id": profile_id,
         "runtime_policy_stamp": policy,
         "context": context,
         "context_state": context_state,
-        "model": {
-            "model": policy.get("model").cloned().unwrap_or(Value::Null),
-            "provider": policy.get("provider").cloned().unwrap_or(Value::Null),
-            "selected": true
-        },
         "permission_profile": policy.get("permission_profile").cloned().unwrap_or(Value::Null),
         "sandbox": policy.get("sandbox_mode").cloned().unwrap_or(Value::Null),
         "health": { "status": "ok" },
@@ -7255,7 +7268,11 @@ async fn raw_session_status_result(
         "usage": {},
         "cursor": { "healthy": true, "replay_supported": true },
         "capabilities": features.advertised_capabilities(state),
-    }))
+    });
+    if let Some(model) = model {
+        result["model"] = model;
+    }
+    Ok(result)
 }
 
 fn add_autonomy_policy_stamp(policy: &mut Value, features: ConnectionUiFeatures) {
@@ -28582,6 +28599,75 @@ ignore = []
         assert_eq!(
             error.data.as_ref().and_then(|data| data.get("profile_id")),
             Some(&json!("missing"))
+        );
+    }
+
+    #[tokio::test]
+    async fn raw_session_status_read_omits_model_object_when_no_model_resolved() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = Arc::new(local_profile_state(dir.path()));
+        create_or_get_local_solo_profile(
+            &state,
+            local_profile_params("Ada Lovelace", "ada", "ada@example.com"),
+        )
+        .expect("create ada profile");
+
+        let status = raw_session_status_result(
+            &state,
+            &RpcRequest::<Value>::new(
+                "status-no-model",
+                APPUI_METHOD_SESSION_STATUS_READ,
+                json!({ "session_id": "local:tui#coding" }),
+            ),
+            ConnectionUiFeatures::stdio_defaults(),
+            Some("ada"),
+        )
+        .await
+        .expect("status for a profile without a configured model");
+
+        // Guard the setup assumption: this profile really has no resolved
+        // model/provider in its runtime policy stamp.
+        assert_eq!(status["runtime_policy_stamp"]["model"], Value::Null);
+        assert_eq!(status["runtime_policy_stamp"]["provider"], Value::Null);
+        // The contract under test: no resolved model => NO `model` key at
+        // all. Emitting `{"model": null, "provider": null, "selected": true}`
+        // breaks shipped octos-tui decoders whose ModelStatus requires
+        // non-null `model`/`provider` strings — the whole
+        // session/status/read result fails to decode and the composer
+        // footer degrades to the `<server authenticated profile>`
+        // placeholder.
+        assert!(
+            status.get("model").is_none(),
+            "session/status/read must omit the model object when no model is resolved, got: {status}"
+        );
+    }
+
+    #[tokio::test]
+    async fn raw_session_status_read_includes_model_object_when_model_resolved() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, _runtime) = state_with_profile(dir.path(), "coding").await;
+
+        let status = raw_session_status_result(
+            &state,
+            &RpcRequest::<Value>::new(
+                "status-with-model",
+                APPUI_METHOD_SESSION_STATUS_READ,
+                json!({ "session_id": "local:tui#coding" }),
+            ),
+            ConnectionUiFeatures::stdio_defaults(),
+            Some("coding"),
+        )
+        .await
+        .expect("status for a profile with a configured model");
+
+        assert_eq!(
+            status["model"],
+            json!({
+                "model": "m11e-stub",
+                "provider": "stub",
+                "selected": true
+            }),
+            "a resolved model must keep emitting the full model object"
         );
     }
 


### PR DESCRIPTION
## Problem

`octos serve --stdio` answers AppUI `session/status/read` from `raw_session_status_result` with an unconditional

```json
"model": { "model": null, "provider": null, "selected": true }
```

whenever the runtime policy has no resolved model/provider (fresh data dir, onboarding before a provider is saved).

Shipped **octos-tui 0.1.5** decodes that member into `ModelStatus` whose `model`/`provider` are non-optional `String`s, so the explicit nulls fail the **entire** `SessionStatusReadResult` decode → the transport surfaces `app_error("invalid_result", …)` → the status never lands → the composer footer degrades to the `<server authenticated profile>` placeholder.

## Fix

Emit the `model` object only when the policy resolved **both** model and provider; otherwise omit the key entirely. A missing key is handled fine by the client's `Option<ModelStatus>` + `#[serde(default)]` — **including already-shipped octos-tui 0.1.5 binaries, so this PR alone un-breaks them** (proven live below). Everything else in the response is unchanged; `permission_profile`/`sandbox` keep their null-when-absent behavior (clients type them `Option<String>`, where explicit null is tolerated).

No other consumer depends on the key: `octos-web`, `dashboard/`, and the e2e scripts never read `status.model` (they only use `context_state`).

## Tests (TDD, RED → GREEN)

- `raw_session_status_read_omits_model_object_when_no_model_resolved` — **failed before the fix** with the exact null-member object in the response; guards the setup assumption via `runtime_policy_stamp.model/provider == null`.
- `raw_session_status_read_includes_model_object_when_model_resolved` — a configured runtime (`m11e-stub`/`stub`) still emits the full object.

## Gates

- `cargo test -p octos-cli --features api`: lib **2290 passed / 0 failed** (one unrelated flake, `session_actor::…::master_continuation_tick_reenters_actor_loop`, failed once under full-suite parallel load and passes 3/3 in isolation and on rerun).
- Pre-existing on pristine `origin/main` (verified via `git stash`): `tests/acp_integration.rs::should_emit_only_valid_json_on_stdout_when_running_acp` fails in this environment — unrelated to this change.
- `cargo fmt --all -- --check` clean; clippy has no warnings on the changed lines (remaining crate warnings are pre-existing).
- **Known-broken CI**: the `test-octos-agent-integration` job is pre-existing broken on main (52-min macos-14 timeout) — if it shows red here, it is not from this PR.

## Live skew-matrix validation (tmux, isolated data dirs, release binaries)

Protocol-level probe (fresh data dir, profile with no provider):

- old installed server 1.1.0 (`c9ffc735b`): `"model": {"model": null, "provider": null, "selected": true}`
- this branch (`38e69f87d`): **no `model` key**; `runtime_policy_stamp.model/provider: null`; rest of response intact.

TUI-level (tmux capture, `skew` profile, no provider configured):

- old server + old TUI 0.1.5 (bug repro): `Error [invalid_result]: failed to decode UI protocol result … invalid type: n…`
- **this server + old TUI 0.1.5**: `… | skew | 1 msgs/0 tasks | Runtime status refreshed | interactive idle` — no `invalid_result`, no placeholder.
- this server + fixed TUI (octos-org/octos-tui PR: `fix/status-read-null-tolerance`): same clean state.

codex review: **APPROVE** — "correct wire-shape fix with appropriate regression coverage and no serialization/borrow issue" (non-blocking suggestion: a one-sided model/provider state test; the all-or-nothing `match` makes that path explicit).

Companion client-side PR (defense in depth): octos-org/octos-tui `fix/status-read-null-tolerance`.
