### PR TITLE
chore(web): bump octos-web submodule; retire memory + cron REST for the WS methods

### DIFF
--- a/crates/octos-cli/src/api/cron_panel.rs
+++ b/crates/octos-cli/src/api/cron_panel.rs
@@ -1,7 +1,12 @@
-//! `/api/my/cron*` — user-scoped cron viewer + enable toggle (web
-//! parity audit P3 item 7: the book documents scheduled tasks, but the
-//! dashboard had no cron surface at all — only the admin-token
-//! `GET /api/admin/profiles/{id}/cron` list).
+//! User-scoped cron viewer + enable toggle (web parity audit P3 item 7: the
+//! book documents scheduled tasks, but the dashboard had no cron surface at
+//! all — only the admin-token `GET /api/admin/profiles/{id}/cron` list).
+//!
+//! Reached over the UI Protocol via the `cron/list` / `cron/toggle` methods
+//! (gated by `auxiliary.rest_to_ws.v1`), which wrap these handlers on the WS
+//! transport. `cron/list` is byte-budget-bounded (row + serialized-size caps
+//! with a `truncated` signal) so it fits one WS frame; the former
+//! `/api/my/cron*` REST routes were retired (see `router.rs`).
 //!
 //! Runtime-ownership constraint that shapes this API: `cron.json` has
 //! up to three writers, and a bare file edit races all of them (each
@@ -148,13 +153,60 @@ pub async fn my_cron(
     };
 
     let now_ms = Utc::now().timestamp_millis();
-    let jobs: Vec<serde_json::Value> = jobs.iter().map(|j| job_json(j, now_ms)).collect();
+    // Bound the serialized list so `cron/list` (the sole transport once the WS
+    // methods replace REST) always fits one WS frame: cap each row's string
+    // fields, stop before the byte budget, and signal via `truncated` with
+    // `count` = true total. Without this the generic outbound-frame guard would
+    // silently drop jobs with a stale count.
+    let total = jobs.len();
+    let mut rendered: Vec<serde_json::Value> = Vec::new();
+    let mut bytes = 0usize;
+    for j in jobs.iter() {
+        if rendered.len() >= MAX_CRON_PANEL_JOBS {
+            break;
+        }
+        let row = cap_cron_row(job_json(j, now_ms));
+        let sz = serde_json::to_string(&row).map(|s| s.len()).unwrap_or(0);
+        // Always include at least one row (even an oversized single row, now
+        // field-capped) so an empty list never masks a present job.
+        if !rendered.is_empty() && bytes + sz > CRON_LIST_BYTE_BUDGET {
+            break;
+        }
+        bytes += sz;
+        rendered.push(row);
+    }
+    let truncated = rendered.len() < total;
     Ok(Json(serde_json::json!({
         "ok": true,
-        "count": jobs.len(),
-        "jobs": jobs,
+        // `count` is the TRUE total; `truncated` marks that `jobs` is capped.
+        "count": total,
+        "truncated": truncated,
+        "jobs": rendered,
         "gateway_running": running,
     })))
+}
+
+/// Row cap for a single `cron/list` response, and the serialized-byte budget
+/// that stops the list well under the 1 MiB WS frame. Per-field cap bounds any
+/// one tenant-controlled string (name / channel / timezone / schedule) so no
+/// single row can blow the frame on its own.
+const MAX_CRON_PANEL_JOBS: usize = 1000;
+const CRON_LIST_BYTE_BUDGET: usize = 900 * 1024;
+const MAX_CRON_FIELD_CHARS: usize = 256;
+
+/// Cap every string field of a rendered cron row to [`MAX_CRON_FIELD_CHARS`],
+/// so an oversized tenant-controlled field can't push the frame over budget.
+fn cap_cron_row(mut row: serde_json::Value) -> serde_json::Value {
+    if let serde_json::Value::Object(map) = &mut row {
+        for value in map.values_mut() {
+            if let serde_json::Value::String(s) = value {
+                if s.chars().count() > MAX_CRON_FIELD_CHARS {
+                    *s = crate::api::admin::truncate_str(s, MAX_CRON_FIELD_CHARS);
+                }
+            }
+        }
+    }
+    row
 }
 
 #[derive(Debug, Deserialize)]
@@ -281,7 +333,9 @@ pub async fn set_my_cron_enabled(
             let now_ms = Utc::now().timestamp_millis();
             Ok(Json(serde_json::json!({
                 "ok": true,
-                "job": job_json(&job, now_ms),
+                // Field-cap the single row too, so `cron/toggle` (WS) can't blow
+                // the frame on an oversized tenant-controlled field.
+                "job": cap_cron_row(job_json(&job, now_ms)),
             })))
         }
         Err(ToggleError::NotFound) => Err(err(StatusCode::NOT_FOUND, "job_not_found")),
@@ -384,6 +438,41 @@ mod tests {
         assert_eq!(resp["ok"], true);
         assert_eq!(resp["count"], 0);
         assert_eq!(resp["gateway_running"], false);
+    }
+
+    #[test]
+    fn cap_cron_row_bounds_oversized_string_fields() {
+        let row = serde_json::json!({
+            "id": "x",
+            "name": "a".repeat(1000),
+            "enabled": true,
+        });
+        let capped = cap_cron_row(row);
+        // `truncate_str` keeps `MAX_CRON_FIELD_CHARS` chars + a `...` marker.
+        assert!(capped["name"].as_str().unwrap().chars().count() <= MAX_CRON_FIELD_CHARS + 3);
+        // Short fields + non-strings are left untouched.
+        assert_eq!(capped["id"], "x");
+        assert_eq!(capped["enabled"], true);
+    }
+
+    #[tokio::test]
+    async fn my_cron_caps_large_lists_and_signals_truncation() {
+        let (_dir, state, ps) = temp_state();
+        let profile = make_user_profile("tenant-big");
+        ps.save(&profile).unwrap();
+        let jobs: Vec<_> = (0..MAX_CRON_PANEL_JOBS + 5)
+            .map(|i| make_job(&format!("job{i:04}"), i % 2 == 0))
+            .collect();
+        seed_cron(&ps, &profile, jobs).await;
+
+        let Json(resp) = my_cron(State(state), HeaderMap::new(), user_identity("tenant-big"))
+            .await
+            .unwrap();
+        // `count` is the TRUE total; `jobs` is capped and `truncated` set, so the
+        // WS frame can't silently drop entries behind a stale count.
+        assert_eq!(resp["count"], MAX_CRON_PANEL_JOBS + 5);
+        assert_eq!(resp["truncated"], true);
+        assert_eq!(resp["jobs"].as_array().unwrap().len(), MAX_CRON_PANEL_JOBS);
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/memory_panel.rs
+++ b/crates/octos-cli/src/api/memory_panel.rs
@@ -1,7 +1,12 @@
-//! `/api/my/memory*` — read-only memory panel endpoints (web parity
-//! audit P3 item 6: the book gives the memory system top-3 prominence,
-//! but the web dashboard had ZERO memory UX — MEMORY.md, daily notes
-//! and the entity bank were invisible outside the CLI).
+//! Read-only memory panel handlers (web parity audit P3 item 6: the book
+//! gives the memory system top-3 prominence, but the web dashboard had ZERO
+//! memory UX — MEMORY.md, daily notes and the entity bank were invisible
+//! outside the CLI).
+//!
+//! Reached over the UI Protocol via the `memory/overview` / `memory/entity`
+//! methods (gated by `auxiliary.rest_to_ws.v1`), which wrap these handlers on
+//! the WS transport. The former `/api/my/memory*` REST routes were retired to
+//! keep a single transport (see `router.rs`).
 //!
 //! Deliberately VIEWER-ONLY: writes stay with the agent tools
 //! (`save_memory`, `memory_note`) and the refresh pipeline, so the

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -16,11 +16,9 @@ use super::admin_audit;
 use super::admin_setup;
 use super::auth_handlers;
 use super::bilibili;
-use super::cron_panel;
 use super::events_harness;
 use super::frps_plugin;
 use super::handlers;
-use super::memory_panel;
 use super::metrics;
 use super::purge;
 use super::session_ingress;
@@ -219,20 +217,15 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/my/voice", put(auth_handlers::set_my_voice))
         // Per-tenant voice-assistant pre-flight: ASR + LLM + (route-aware) TTS.
         .route("/api/voice/readiness", get(auth_handlers::voice_readiness))
-        // Memory panel (web parity P3): read-only per-profile memory
-        // surface — MEMORY.md, daily notes, entity bank, staging count.
-        .route("/api/my/memory", get(memory_panel::my_memory))
-        .route(
-            "/api/my/memory/entities/{name}",
-            get(memory_panel::my_memory_entity),
-        )
-        // Cron panel (web parity P3): user-scoped schedule list + the
-        // enable toggle (409 while the profile gateway owns cron.json).
-        .route("/api/my/cron", get(cron_panel::my_cron))
-        .route(
-            "/api/my/cron/{job_id}/enabled",
-            put(cron_panel::set_my_cron_enabled),
-        )
+        // Memory + Cron panel REST routes retired in favor of the UI Protocol
+        // methods (`memory/overview`, `memory/entity`, `cron/list`,
+        // `cron/toggle`, gated by `auxiliary.rest_to_ws.v1`), which wrap the
+        // SAME `memory_panel::*` / `cron_panel::*` handlers over the WS
+        // transport. `cron/list` is now byte-budget-bounded (row + serialized
+        // caps with a `truncated` signal), matching `memory/overview`, so it is
+        // safe as the sole transport. Mirrors the earlier `/api/my/content` →
+        // `content/*` retirement (M12 Phase D-5): one implementation, one
+        // transport.
         .route("/api/my/soul", get(auth_handlers::my_soul))
         .route("/api/my/soul", put(auth_handlers::update_my_soul))
         .route("/api/my/soul", delete(auth_handlers::delete_my_soul))

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -15517,6 +15517,13 @@ async fn handle_cron_list(
                 .get("gateway_running")
                 .and_then(Value::as_bool)
                 .unwrap_or(false);
+            // Forward the truncation signal so a client can show "N of `count`"
+            // instead of silently seeing a short list (`cron/list` bounds the
+            // row set to keep the frame under budget).
+            let truncated = body
+                .get("truncated")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
             send_aux_rpc_result(
                 ws,
                 id,
@@ -15525,6 +15532,7 @@ async fn handle_cron_list(
                     "jobs": jobs,
                     "count": count,
                     "gateway_running": gateway_running,
+                    "truncated": truncated,
                 }),
             );
         }

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -3251,6 +3251,12 @@ pub struct CronListResult {
     pub jobs: Value,
     pub count: usize,
     pub gateway_running: bool,
+    /// True when `jobs` was capped (row count or serialized byte budget) so the
+    /// result fits a single WS frame. `count` still reports the true total, so a
+    /// client can surface "showing N of `count`". Defaults to `false` for
+    /// backward compatibility with pre-truncation payloads.
+    #[serde(default)]
+    pub truncated: bool,
 }
 
 /// Params for `cron/toggle`.
@@ -11131,6 +11137,7 @@ mod tests {
             jobs: serde_json::json!([{ "id": "job-1" }]),
             count: 1,
             gateway_running: false,
+            truncated: false,
         };
         let value = serde_json::to_value(&cron).expect("serialize");
         let decoded: CronListResult = serde_json::from_value(value).expect("deserialize");
@@ -11571,18 +11578,20 @@ mod tests {
             }),
         );
 
-        // cron/list — `{ jobs, count, gateway_running }`
+        // cron/list — `{ jobs, count, gateway_running, truncated }`
         assert_eq!(
             serde_json::to_value(CronListResult {
                 jobs: serde_json::json!([{ "id": "job-1" }]),
                 count: 1,
                 gateway_running: true,
+                truncated: false,
             })
             .expect("serialize"),
             serde_json::json!({
                 "jobs": [{ "id": "job-1" }],
                 "count": 1,
                 "gateway_running": true,
+                "truncated": false,
             }),
         );
 


### PR DESCRIPTION
Unifies the memory + cron panels onto the UI Protocol and drops the redundant REST transport, in the "shrink REST" direction.

### 1. Bump the octos-web submodule `86d2117` → `1e98538` (main)
The web-parity wave (#259–#268), including **#268** which rides the Memory + Schedule Settings tabs on the UI-protocol bridge (`memory/overview`, `memory/entity`, `cron/list`, `cron/toggle` over WS). Until this bump the embedded `/app` bundle had **no** memory/cron client at all. Build-verified: `npm ci && npm run build` at `1e98538` is green.

### 2. Harden `cron/list` for the WS transport
The bump moves the web Schedule tab onto `cron/list` **exclusively**, and it had no size bound (unlike `memory/overview`). Now: cap the row set by **count + serialized byte budget**, **field-cap** each row so one oversized tenant-controlled field can't blow the 1 MiB frame, and add a **`truncated`** signal (with `count` = true total) forwarded through `CronListResult` + `handle_cron_list`; `cron/toggle`'s single row is field-capped too. `CronListResult.truncated` is `#[serde(default)]` for back-compat.

### 3. Retire `/api/my/memory*` + `/api/my/cron*` REST
With the embedded web on the WS methods and `cron/list` bounded, drop the four REST route registrations (handlers stay — the WS dispatch calls them; only the HTTP entry points + now-unused router imports go). The UI Protocol V1 spec already declares these as the replacement. Mirrors the earlier `/api/my/content` → `content/*` retirement (M12 Phase D-5).

Memory + cron handler/WS-dispatch tests, the cron cap/truncation tests, and the core serde-shape tests stay green. Reviewed across 5 codex rounds (the submodule-consumer coupling and the cron truncation gaps were caught and fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)