### PR TITLE
fix(agent): session-cumulative cost priced per answering model

### DIFF
--- a/crates/octos-agent/src/agent/budget.rs
+++ b/crates/octos-agent/src/agent/budget.rs
@@ -408,6 +408,7 @@ mod tests {
                 output_tokens: 20,
                 ..Default::default()
             },
+            estimated_spend_usd: None,
             files_modified: vec![],
             files_to_send: vec![],
             streamed: false,

--- a/crates/octos-agent/src/agent/llm_call.rs
+++ b/crates/octos-agent/src/agent/llm_call.rs
@@ -27,7 +27,14 @@ impl Agent {
         iteration: u32,
         total_usage: &TokenUsage,
         turn: &mut LoopTurnState,
-    ) -> Result<(ChatResponse, bool)> {
+        // Returns `(response, streamed, attributed_cost_usd)`. The response's
+        // `usage` MERGES discarded retry attempts into the final attempt, and
+        // those attempts can come from DIFFERENT provider slots (an empty
+        // stream falling through to a fallback). `attributed_cost_usd` prices
+        // each attempt's tokens at the provider that actually consumed them,
+        // so callers must record it instead of re-pricing the merged total at
+        // the winner's rate (codex #1632 P2). `None` = no attempt was priced.
+    ) -> Result<(ChatResponse, bool, Option<f64>)> {
         let ctx = self.hook_ctx();
         if let Some(ref hooks) = self.hooks {
             let payload = HookPayload::before_llm(
@@ -45,6 +52,9 @@ impl Agent {
         // Track token usage from retried (discarded) attempts so cost reporting
         // reflects actual consumption, not just the final successful call.
         let mut retry_usage = TokenUsage::default();
+        // Spend already attributed to DISCARDED attempts, each priced at the
+        // provider slot that produced it (see the return-value doc above).
+        let mut retry_spend: Option<f64> = None;
 
         let fail_fast = octos_llm::current_llm_call_policy() == LlmCallPolicy::FailFast;
         let retry_max = if fail_fast { 0 } else { Self::LLM_RETRY_MAX };
@@ -85,7 +95,18 @@ impl Agent {
             match call_result {
                 Ok((response, streamed)) => {
                     if !Self::is_retriable_response(&response) {
-                        // Genuine success -- merge retry usage into response
+                        // Genuine success -- merge retry usage into response.
+                        // Price the FINAL attempt at its own slot BEFORE the
+                        // merge, then add the pre-priced retry spend.
+                        let final_cost = self.response_usage_cost(
+                            response.usage.input_tokens,
+                            response.usage.output_tokens,
+                            response.provider_index,
+                        );
+                        let attributed_cost = match (retry_spend, final_cost) {
+                            (None, None) => None,
+                            (a, b) => Some(a.unwrap_or(0.0) + b.unwrap_or(0.0)),
+                        };
                         let mut response = response;
                         response.usage.input_tokens += retry_usage.input_tokens;
                         response.usage.output_tokens += retry_usage.output_tokens;
@@ -116,7 +137,7 @@ impl Agent {
                             );
                             let _ = hooks.run(HookEvent::AfterLlmCall, &payload).await;
                         }
-                        return Ok((response, streamed));
+                        return Ok((response, streamed, attributed_cost));
                     }
 
                     if attempt == retry_max {
@@ -152,10 +173,19 @@ impl Agent {
                         match self.llm.chat(messages, tools_spec, config).await {
                             Ok(fallback_resp) if !Self::is_retriable_response(&fallback_resp) => {
                                 info!("non-streaming fallback succeeded");
+                                let final_cost = self.response_usage_cost(
+                                    fallback_resp.usage.input_tokens,
+                                    fallback_resp.usage.output_tokens,
+                                    fallback_resp.provider_index,
+                                );
+                                let attributed_cost = match (retry_spend, final_cost) {
+                                    (None, None) => None,
+                                    (a, b) => Some(a.unwrap_or(0.0) + b.unwrap_or(0.0)),
+                                };
                                 let mut fallback_resp = fallback_resp;
                                 fallback_resp.usage.input_tokens += retry_usage.input_tokens;
                                 fallback_resp.usage.output_tokens += retry_usage.output_tokens;
-                                return Ok((fallback_resp, false));
+                                return Ok((fallback_resp, false, attributed_cost));
                             }
                             Ok(_) => {
                                 warn!("non-streaming fallback also returned empty response");
@@ -172,7 +202,17 @@ impl Agent {
                         ));
                     }
 
-                    // Empty or abnormal response -- accumulate usage and retry
+                    // Empty or abnormal response -- accumulate usage and retry.
+                    // Price THIS attempt at the slot that produced it now;
+                    // by the time a later attempt wins, the winning slot's
+                    // rate would misprice these tokens.
+                    if let Some(cost) = self.response_usage_cost(
+                        response.usage.input_tokens,
+                        response.usage.output_tokens,
+                        response.provider_index,
+                    ) {
+                        retry_spend = Some(retry_spend.unwrap_or(0.0) + cost);
+                    }
                     retry_usage.input_tokens += response.usage.input_tokens;
                     retry_usage.output_tokens += response.usage.output_tokens;
 
@@ -259,7 +299,20 @@ impl Agent {
                         match self.llm.chat(messages, tools_spec, config).await {
                             Ok(resp) if !Self::is_retriable_response(&resp) => {
                                 info!("non-streaming fallback succeeded after stream failures");
-                                return Ok((resp, false));
+                                // Stream-error path: discarded attempts never
+                                // yielded usage, so the fallback's own cost
+                                // (plus any retry_spend from earlier empty
+                                // responses) is the whole attribution.
+                                let final_cost = self.response_usage_cost(
+                                    resp.usage.input_tokens,
+                                    resp.usage.output_tokens,
+                                    resp.provider_index,
+                                );
+                                let attributed_cost = match (retry_spend, final_cost) {
+                                    (None, None) => None,
+                                    (a, b) => Some(a.unwrap_or(0.0) + b.unwrap_or(0.0)),
+                                };
+                                return Ok((resp, false, attributed_cost));
                             }
                             Ok(_) => {
                                 warn!("non-streaming fallback also returned empty");

--- a/crates/octos-agent/src/agent/llm_call.rs
+++ b/crates/octos-agent/src/agent/llm_call.rs
@@ -299,10 +299,14 @@ impl Agent {
                         match self.llm.chat(messages, tools_spec, config).await {
                             Ok(resp) if !Self::is_retriable_response(&resp) => {
                                 info!("non-streaming fallback succeeded after stream failures");
-                                // Stream-error path: discarded attempts never
-                                // yielded usage, so the fallback's own cost
-                                // (plus any retry_spend from earlier empty
-                                // responses) is the whole attribution.
+                                // Codex #1632 r2 P2: merge the accumulated
+                                // retry usage here like the empty-response
+                                // fallback does — earlier EMPTY attempts (not
+                                // just stream errors) can be behind us on
+                                // this path, and `retry_spend` already prices
+                                // them; returning fallback-only tokens next
+                                // to a spend that includes both would skew
+                                // the persisted token/cost pairing.
                                 let final_cost = self.response_usage_cost(
                                     resp.usage.input_tokens,
                                     resp.usage.output_tokens,
@@ -312,6 +316,9 @@ impl Agent {
                                     (None, None) => None,
                                     (a, b) => Some(a.unwrap_or(0.0) + b.unwrap_or(0.0)),
                                 };
+                                let mut resp = resp;
+                                resp.usage.input_tokens += retry_usage.input_tokens;
+                                resp.usage.output_tokens += retry_usage.output_tokens;
                                 return Ok((resp, false, attributed_cost));
                             }
                             Ok(_) => {

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -949,6 +949,7 @@ impl Agent {
                                 reasoning_content: None,
                                 provider_metadata: None,
                                 token_usage: turn.total_usage().clone(),
+                                estimated_spend_usd: turn.priced_spend(),
                                 files_modified,
                                 files_to_send,
                                 streamed: false,
@@ -1038,7 +1039,7 @@ impl Agent {
                     // providers ignore `context_management` via
                     // `skip_serializing_if`.
                     let call_config = with_tier2_context_management(&config, self);
-                    let (mut response, streamed) = match self
+                    let (mut response, streamed, attributed_cost) = match self
                         .call_llm_with_hooks(
                             &messages,
                             &tools_spec,
@@ -1148,14 +1149,12 @@ impl Agent {
                         response.usage.input_tokens,
                         response.usage.output_tokens,
                         tracker,
-                        // Priced at the slot that ACTUALLY answered, so a
-                        // mid-turn failover doesn't re-price earlier
-                        // responses at the new model's rate.
-                        self.response_usage_cost(
-                            response.usage.input_tokens,
-                            response.usage.output_tokens,
-                            response.provider_index,
-                        ),
+                        // Attributed inside `call_llm_with_hooks`: each
+                        // attempt (discarded retries included) priced at the
+                        // slot that actually consumed it — re-pricing the
+                        // merged usage at the winner's rate here would
+                        // misprice cross-provider retries.
+                        attributed_cost,
                     );
 
                     match response.stop_reason {
@@ -1182,6 +1181,7 @@ impl Agent {
                                     self.llm.provider_metadata_for_index(response.provider_index),
                                 ),
                                 token_usage: turn.total_usage().clone(),
+                                estimated_spend_usd: turn.priced_spend(),
                                 files_modified,
                                 files_to_send,
                                 streamed,
@@ -1276,6 +1276,7 @@ impl Agent {
                                             reasoning_content: None,
                                             provider_metadata: None,
                                             token_usage: turn.total_usage().clone(),
+                                estimated_spend_usd: turn.priced_spend(),
                                             files_modified,
                                             files_to_send,
                                             streamed,
@@ -1338,6 +1339,7 @@ impl Agent {
                                                 reasoning_content: None,
                                                 provider_metadata: None,
                                                 token_usage: turn.total_usage().clone(),
+                                estimated_spend_usd: turn.priced_spend(),
                                                 files_modified,
                                                 files_to_send,
                                                 streamed,
@@ -1421,6 +1423,7 @@ impl Agent {
                                         ),
                                     ),
                                     token_usage: turn.total_usage().clone(),
+                                estimated_spend_usd: turn.priced_spend(),
                                     files_modified,
                                     files_to_send,
                                     streamed,
@@ -1511,6 +1514,7 @@ impl Agent {
                                         ),
                                     ),
                                     token_usage: turn.total_usage().clone(),
+                                estimated_spend_usd: turn.priced_spend(),
                                     files_modified,
                                     files_to_send,
                                     streamed,
@@ -1684,6 +1688,7 @@ impl Agent {
                                             self.llm.provider_metadata_for_index(response.provider_index),
                                         ),
                                         token_usage: turn.total_usage().clone(),
+                                estimated_spend_usd: turn.priced_spend(),
                                         files_modified,
                                         files_to_send,
                                         streamed,
@@ -1716,6 +1721,7 @@ impl Agent {
                                     self.llm.provider_metadata_for_index(response.provider_index),
                                 ),
                                 token_usage: turn.total_usage().clone(),
+                                estimated_spend_usd: turn.priced_spend(),
                                 files_modified,
                                 files_to_send,
                                 streamed,
@@ -1741,6 +1747,7 @@ impl Agent {
                                     self.llm.provider_metadata_for_index(response.provider_index),
                                 ),
                                 token_usage: turn.total_usage().clone(),
+                                estimated_spend_usd: turn.priced_spend(),
                                 files_modified,
                                 files_to_send,
                                 streamed,
@@ -1851,7 +1858,7 @@ impl Agent {
 
                 // M8.5 tier 2: decorate the config with the Anthropic header.
                 let call_config = with_tier2_context_management(&config, self);
-                let (mut response, _streamed) = match self
+                let (mut response, _streamed, attributed_cost) = match self
                     .call_llm_with_hooks(
                         &messages,
                         &tools_spec,
@@ -1883,11 +1890,9 @@ impl Agent {
                     response.usage.input_tokens,
                     response.usage.output_tokens,
                     None,
-                    self.response_usage_cost(
-                        response.usage.input_tokens,
-                        response.usage.output_tokens,
-                        response.provider_index,
-                    ),
+                    // Attributed per attempt inside `call_llm_with_hooks`
+                    // (cross-provider retries priced at their own slot).
+                    attributed_cost,
                 );
 
                 let tool_names: Vec<&str> = response

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -1173,7 +1173,7 @@ impl Agent {
                             {
                                 continue;
                             }
-                            self.emit_cost_update(&turn, &response);
+                            self.emit_cost_update(&turn, &response, attributed_cost);
                             return Ok(ConversationResponse {
                                 content,
                                 reasoning_content: response.reasoning_content.clone(),
@@ -1270,7 +1270,7 @@ impl Agent {
                                             decision = %outcome.decision,
                                             "shell spiral terminal: returning recovered content as final assistant reply"
                                         );
-                                        self.emit_cost_update(&turn, &response);
+                                        self.emit_cost_update(&turn, &response, attributed_cost);
                                         return Ok(ConversationResponse {
                                             content: terminal_content,
                                             reasoning_content: None,
@@ -1315,7 +1315,7 @@ impl Agent {
                                     // returns on second fire is caught and
                                     // converted to a terminal Ok response
                                     // here so callers don't see an error.
-                                    self.emit_cost_update(&turn, &response);
+                                    self.emit_cost_update(&turn, &response, attributed_cost);
                                     match self.dedup_loop_warning(warning) {
                                         Ok(warning_content) => {
                                             inject_loop_detected_synthetic_results_with_log(
@@ -1413,7 +1413,7 @@ impl Agent {
                             // `Agent::execute_approved_tool` when an
                             // authorized human answers.
                             if let Some(draft) = iter_pending_approval {
-                                self.emit_cost_update(&turn, &sanitized_response);
+                                self.emit_cost_update(&turn, &sanitized_response, attributed_cost);
                                 return Ok(ConversationResponse {
                                     content: String::new(),
                                     reasoning_content: None,
@@ -1504,7 +1504,7 @@ impl Agent {
                                     decision = %outcome.decision,
                                     "shell spiral terminal: returning recovered content as final assistant reply"
                                 );
-                                self.emit_cost_update(&turn, &response);
+                                self.emit_cost_update(&turn, &response, attributed_cost);
                                 return Ok(ConversationResponse {
                                     content: terminal_content,
                                     reasoning_content: None,
@@ -1611,7 +1611,7 @@ impl Agent {
                                     {
                                         continue;
                                     }
-                                    self.emit_cost_update(&turn, &response);
+                                    self.emit_cost_update(&turn, &response, attributed_cost);
                                     // Post-spawn failure feedback loop
                                     // (feat/spawn-only-failure-feedback-loop):
                                     // record that the synth-ack went out for
@@ -1713,7 +1713,7 @@ impl Agent {
                             }
                         }
                         StopReason::MaxTokens => {
-                            self.emit_cost_update(&turn, &response);
+                            self.emit_cost_update(&turn, &response, attributed_cost);
                             return Ok(ConversationResponse {
                                 content: response.content.unwrap_or_default(),
                                 reasoning_content: response.reasoning_content.clone(),
@@ -1734,7 +1734,7 @@ impl Agent {
                         StopReason::ContentFiltered => {
                             // After retries in call_llm_with_hooks, content is still filtered.
                             // Return a user-visible message instead of empty content.
-                            self.emit_cost_update(&turn, &response);
+                            self.emit_cost_update(&turn, &response, attributed_cost);
                             warn!("content filtered by provider safety/moderation after retries");
                             return Ok(ConversationResponse {
                                 content: response.content.unwrap_or_else(|| {
@@ -1978,7 +1978,7 @@ impl Agent {
                             }
                         }
 
-                        self.emit_cost_update(&turn, &final_response);
+                        self.emit_cost_update(&turn, &final_response, attributed_cost);
 
                         // Audit Gap-8: auto-fire `check_workspace_contract`
                         // on Completion. The LLM-callable wrapper stays for
@@ -2135,7 +2135,7 @@ impl Agent {
 
                         let final_response =
                             response_with_max_token_fragments(&response, &max_token_fragments);
-                        self.emit_cost_update(&turn, &final_response);
+                        self.emit_cost_update(&turn, &final_response, attributed_cost);
                         self.reporter().report(ProgressEvent::TaskCompleted {
                             success: false,
                             iterations: iteration,
@@ -2150,7 +2150,7 @@ impl Agent {
                     }
                     StopReason::ContentFiltered => {
                         warn!("content filtered by provider safety/moderation in task");
-                        self.emit_cost_update(&turn, &response);
+                        self.emit_cost_update(&turn, &response, attributed_cost);
                         self.reporter().report(ProgressEvent::TaskCompleted {
                             success: false,
                             iterations: iteration,

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -1148,6 +1148,14 @@ impl Agent {
                         response.usage.input_tokens,
                         response.usage.output_tokens,
                         tracker,
+                        // Priced at the slot that ACTUALLY answered, so a
+                        // mid-turn failover doesn't re-price earlier
+                        // responses at the new model's rate.
+                        self.response_usage_cost(
+                            response.usage.input_tokens,
+                            response.usage.output_tokens,
+                            response.provider_index,
+                        ),
                     );
 
                     match response.stop_reason {
@@ -1166,7 +1174,7 @@ impl Agent {
                             {
                                 continue;
                             }
-                            self.emit_cost_update(turn.total_usage(), &response);
+                            self.emit_cost_update(&turn, &response);
                             return Ok(ConversationResponse {
                                 content,
                                 reasoning_content: response.reasoning_content.clone(),
@@ -1262,7 +1270,7 @@ impl Agent {
                                             decision = %outcome.decision,
                                             "shell spiral terminal: returning recovered content as final assistant reply"
                                         );
-                                        self.emit_cost_update(turn.total_usage(), &response);
+                                        self.emit_cost_update(&turn, &response);
                                         return Ok(ConversationResponse {
                                             content: terminal_content,
                                             reasoning_content: None,
@@ -1306,7 +1314,7 @@ impl Agent {
                                     // returns on second fire is caught and
                                     // converted to a terminal Ok response
                                     // here so callers don't see an error.
-                                    self.emit_cost_update(turn.total_usage(), &response);
+                                    self.emit_cost_update(&turn, &response);
                                     match self.dedup_loop_warning(warning) {
                                         Ok(warning_content) => {
                                             inject_loop_detected_synthetic_results_with_log(
@@ -1403,7 +1411,7 @@ impl Agent {
                             // `Agent::execute_approved_tool` when an
                             // authorized human answers.
                             if let Some(draft) = iter_pending_approval {
-                                self.emit_cost_update(turn.total_usage(), &sanitized_response);
+                                self.emit_cost_update(&turn, &sanitized_response);
                                 return Ok(ConversationResponse {
                                     content: String::new(),
                                     reasoning_content: None,
@@ -1493,7 +1501,7 @@ impl Agent {
                                     decision = %outcome.decision,
                                     "shell spiral terminal: returning recovered content as final assistant reply"
                                 );
-                                self.emit_cost_update(turn.total_usage(), &response);
+                                self.emit_cost_update(&turn, &response);
                                 return Ok(ConversationResponse {
                                     content: terminal_content,
                                     reasoning_content: None,
@@ -1599,7 +1607,7 @@ impl Agent {
                                     {
                                         continue;
                                     }
-                                    self.emit_cost_update(turn.total_usage(), &response);
+                                    self.emit_cost_update(&turn, &response);
                                     // Post-spawn failure feedback loop
                                     // (feat/spawn-only-failure-feedback-loop):
                                     // record that the synth-ack went out for
@@ -1700,7 +1708,7 @@ impl Agent {
                             }
                         }
                         StopReason::MaxTokens => {
-                            self.emit_cost_update(turn.total_usage(), &response);
+                            self.emit_cost_update(&turn, &response);
                             return Ok(ConversationResponse {
                                 content: response.content.unwrap_or_default(),
                                 reasoning_content: response.reasoning_content.clone(),
@@ -1720,7 +1728,7 @@ impl Agent {
                         StopReason::ContentFiltered => {
                             // After retries in call_llm_with_hooks, content is still filtered.
                             // Return a user-visible message instead of empty content.
-                            self.emit_cost_update(turn.total_usage(), &response);
+                            self.emit_cost_update(&turn, &response);
                             warn!("content filtered by provider safety/moderation after retries");
                             return Ok(ConversationResponse {
                                 content: response.content.unwrap_or_else(|| {
@@ -1871,7 +1879,16 @@ impl Agent {
                     }
                 };
                 Self::normalize_inline_invokes(&mut response);
-                turn.record_usage(response.usage.input_tokens, response.usage.output_tokens, None);
+                turn.record_usage(
+                    response.usage.input_tokens,
+                    response.usage.output_tokens,
+                    None,
+                    self.response_usage_cost(
+                        response.usage.input_tokens,
+                        response.usage.output_tokens,
+                        response.provider_index,
+                    ),
+                );
 
                 let tool_names: Vec<&str> = response
                     .tool_calls
@@ -1956,7 +1973,7 @@ impl Agent {
                             }
                         }
 
-                        self.emit_cost_update(turn.total_usage(), &final_response);
+                        self.emit_cost_update(&turn, &final_response);
 
                         // Audit Gap-8: auto-fire `check_workspace_contract`
                         // on Completion. The LLM-callable wrapper stays for
@@ -2113,7 +2130,7 @@ impl Agent {
 
                         let final_response =
                             response_with_max_token_fragments(&response, &max_token_fragments);
-                        self.emit_cost_update(turn.total_usage(), &final_response);
+                        self.emit_cost_update(&turn, &final_response);
                         self.reporter().report(ProgressEvent::TaskCompleted {
                             success: false,
                             iterations: iteration,
@@ -2128,7 +2145,7 @@ impl Agent {
                     }
                     StopReason::ContentFiltered => {
                         warn!("content filtered by provider safety/moderation in task");
-                        self.emit_cost_update(turn.total_usage(), &response);
+                        self.emit_cost_update(&turn, &response);
                         self.reporter().report(ProgressEvent::TaskCompleted {
                             success: false,
                             iterations: iteration,
@@ -2546,7 +2563,14 @@ impl Agent {
         if let Some(files_to_send) = files_to_send {
             files_to_send.extend(tool_send_files);
         }
-        turn.record_usage(tool_tokens.input_tokens, tool_tokens.output_tokens, tracker);
+        turn.record_usage(
+            tool_tokens.input_tokens,
+            tool_tokens.output_tokens,
+            tracker,
+            // Tool-reported usage has no per-response provider attribution;
+            // price it at the active slot as the closest estimate.
+            self.response_usage_cost(tool_tokens.input_tokens, tool_tokens.output_tokens, None),
+        );
         // Codex round-3: return the sanitized response so the caller's
         // synth-ack gate sees the SAME tool_call_ids that the success-bit
         // sink was keyed by. See doc-comment on this fn.

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -377,6 +377,15 @@ pub struct Agent {
     /// sub-agents (pipeline workers, spawn children) reserve and commit
     /// against the same ledger as the parent session.
     pub(super) cost_accountant: Option<Arc<crate::cost_ledger::CostAccountant>>,
+    /// Session-cumulative usage base shared with the owning session
+    /// actor. The actor seeds it from the persistent usage ledger and
+    /// folds each completed run back in (priced at the model that ran
+    /// it); `emit_cost_update` READS it so the `session_*` figures on
+    /// `ProgressEvent::CostUpdate` cover the whole session — surviving
+    /// per-turn resets, provider failover, and the runtime-cache
+    /// eviction a `profile/llm/select` model switch triggers. `None`
+    /// (chat mode, sub-agents) keeps emissions turn-scoped.
+    pub(super) session_usage_base: Option<crate::session_usage::SharedSessionUsage>,
     /// M8 parity: optional parent session key. When the agent is owned
     /// by a session actor, this carries the session key down through
     /// `ToolContext.parent_session_key` so spawn children / pipeline
@@ -495,6 +504,7 @@ impl Agent {
             subagent_output_router: None,
             subagent_summary_generator: None,
             cost_accountant: None,
+            session_usage_base: None,
             parent_session_key: None,
             spawn_depth: 0,
             sandbox_config: None,
@@ -569,6 +579,7 @@ impl Agent {
             subagent_output_router: None,
             subagent_summary_generator: None,
             cost_accountant: None,
+            session_usage_base: None,
             parent_session_key: None,
             spawn_depth: 0,
             sandbox_config: None,
@@ -816,6 +827,19 @@ impl Agent {
     /// Access the configured cost accountant, if any.
     pub fn cost_accountant(&self) -> Option<&Arc<crate::cost_ledger::CostAccountant>> {
         self.cost_accountant.as_ref()
+    }
+
+    /// Share a session-cumulative usage base with this agent. The owner
+    /// (session actor) seeds it from the usage ledger and folds completed
+    /// runs; the agent only reads it when emitting cost updates, so the
+    /// wire's `session_*` figures cover the whole session instead of
+    /// resetting every turn. See [`crate::session_usage`].
+    pub fn with_session_usage_base(
+        mut self,
+        usage: crate::session_usage::SharedSessionUsage,
+    ) -> Self {
+        self.session_usage_base = Some(usage);
+        self
     }
 
     /// Record the owning session key so pipeline workers / spawn

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -218,6 +218,14 @@ pub struct ConversationResponse {
     /// Exact provider instance provenance for the final assistant reply.
     pub provider_metadata: Option<ProviderMetadata>,
     pub token_usage: TokenUsage,
+    /// Estimated spend for `token_usage`, summed per response with each
+    /// response priced at the model that actually produced it (failover /
+    /// routed slots at their own rate). `None` when no response in the
+    /// turn had catalog pricing. Embedders must persist THIS instead of
+    /// re-pricing `token_usage` at the final `provider_metadata` model —
+    /// a turn that crossed models would re-price earlier responses at
+    /// the final model's rate (codex #1632 P1).
+    pub estimated_spend_usd: Option<f64>,
     pub files_modified: Vec<PathBuf>,
     pub files_to_send: Vec<PathBuf>,
     pub streamed: bool,

--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -491,7 +491,18 @@ impl Agent {
             .map(|p| p.cost(input_tokens, output_tokens))
     }
 
-    pub(super) fn emit_cost_update(&self, turn: &LoopTurnState, response: &ChatResponse) {
+    /// `attributed_cost` is the caller's per-attempt-priced cost for
+    /// exactly `response.usage` (see `call_llm_with_hooks`' return value).
+    /// `response.usage` MERGES discarded retry attempts, which can span
+    /// provider slots — re-pricing the aggregate at the final slot's rate
+    /// (the `None` fallback) misprices cross-provider retries, so callers
+    /// that hold the attribution must pass it (codex #1632 r3 P2).
+    pub(super) fn emit_cost_update(
+        &self,
+        turn: &LoopTurnState,
+        response: &ChatResponse,
+        attributed_cost: Option<f64>,
+    ) {
         let response_usage = &response.usage;
         // Codex round-1 P2: for failover / routed responses the slot that
         // produced this response may not match `self.llm.model_id()`
@@ -504,8 +515,9 @@ impl Agent {
             .llm
             .provider_metadata_for_index(response.provider_index);
         let pricing = octos_llm::pricing::model_pricing(&metadata.model);
-        let response_cost =
-            pricing.map(|p| p.cost(response_usage.input_tokens, response_usage.output_tokens));
+        let response_cost = attributed_cost.or_else(|| {
+            pricing.map(|p| p.cost(response_usage.input_tokens, response_usage.output_tokens))
+        });
         // Session figures = completed-runs base + this turn so far.
         //
         // The base comes from the shared session-usage handle (seeded from

--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -4,11 +4,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use eyre::Result;
 use futures::StreamExt;
-use octos_core::{Message, MessageRole, TokenUsage};
+use octos_core::{Message, MessageRole};
 use octos_llm::{ChatResponse, ChatStream, StopReason, StreamError, StreamEvent};
 use tracing::warn;
 
 use super::Agent;
+use super::turn_state::LoopTurnState;
 use crate::progress::ProgressEvent;
 
 /// Process-global monotonic counter for synthesizing tool-call ids when a
@@ -473,7 +474,24 @@ impl Agent {
         ))
     }
 
-    pub(super) fn emit_cost_update(&self, total_usage: &TokenUsage, response: &ChatResponse) {
+    /// Estimate the cost of one response's usage at the model that
+    /// actually produced it (resolved via `provider_index`, so failover /
+    /// routed slots price at their own model, not the active slot's).
+    /// `None` when that model has no catalog pricing. Pass
+    /// `provider_index: None` to price at the active slot — used for
+    /// tool-reported usage that has no per-response attribution.
+    pub(super) fn response_usage_cost(
+        &self,
+        input_tokens: u32,
+        output_tokens: u32,
+        provider_index: Option<usize>,
+    ) -> Option<f64> {
+        let metadata = self.llm.provider_metadata_for_index(provider_index);
+        octos_llm::pricing::model_pricing(&metadata.model)
+            .map(|p| p.cost(input_tokens, output_tokens))
+    }
+
+    pub(super) fn emit_cost_update(&self, turn: &LoopTurnState, response: &ChatResponse) {
         let response_usage = &response.usage;
         // Codex round-1 P2: for failover / routed responses the slot that
         // produced this response may not match `self.llm.model_id()`
@@ -488,8 +506,32 @@ impl Agent {
         let pricing = octos_llm::pricing::model_pricing(&metadata.model);
         let response_cost =
             pricing.map(|p| p.cost(response_usage.input_tokens, response_usage.output_tokens));
-        let session_cost =
-            pricing.map(|p| p.cost(total_usage.input_tokens, total_usage.output_tokens));
+        // Session figures = completed-runs base + this turn so far.
+        //
+        // The base comes from the shared session-usage handle (seeded from
+        // the usage ledger and folded per completed run by the session
+        // actor — each run priced at the model that ran it), so the wire's
+        // `session_*` fields survive per-turn resets and the runtime
+        // rebuild a `profile/llm/select` switch triggers. The turn part
+        // uses `LoopTurnState`'s per-response spend, NOT
+        // `pricing.cost(turn totals)` — the old form re-priced the whole
+        // turn at the latest answering model whenever failover switched
+        // models mid-turn. Without an injected handle (chat mode,
+        // sub-agents) the base is zero and the figures stay turn-scoped.
+        let total_usage = turn.total_usage();
+        let base = self
+            .session_usage_base
+            .as_ref()
+            .map(|handle| handle.snapshot())
+            .unwrap_or_default();
+        let session_input_tokens = base
+            .input_tokens
+            .saturating_add(u64::from(total_usage.input_tokens));
+        let session_output_tokens = base
+            .output_tokens
+            .saturating_add(u64::from(total_usage.output_tokens));
+        let session_cost = (turn.has_priced_usage() || base.priced_runs > 0)
+            .then(|| base.spend_usd + turn.spend_usd());
         // Carry the model id so chat clients can render
         // `model · tokens_in / tokens_out · duration` footers. Skip the
         // synthesis if the provider returns an empty identifier — empty
@@ -512,8 +554,8 @@ impl Agent {
             _ => self.llm.context_window(),
         };
         self.reporter().report(ProgressEvent::CostUpdate {
-            session_input_tokens: total_usage.input_tokens,
-            session_output_tokens: total_usage.output_tokens,
+            session_input_tokens,
+            session_output_tokens,
             response_cost,
             session_cost,
             model,

--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -556,6 +556,8 @@ impl Agent {
         self.reporter().report(ProgressEvent::CostUpdate {
             session_input_tokens,
             session_output_tokens,
+            response_input_tokens: response_usage.input_tokens,
+            response_output_tokens: response_usage.output_tokens,
             response_cost,
             session_cost,
             model,

--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -556,8 +556,8 @@ impl Agent {
         self.reporter().report(ProgressEvent::CostUpdate {
             session_input_tokens,
             session_output_tokens,
-            response_input_tokens: response_usage.input_tokens,
-            response_output_tokens: response_usage.output_tokens,
+            turn_input_tokens: total_usage.input_tokens,
+            turn_output_tokens: total_usage.output_tokens,
             response_cost,
             session_cost,
             model,

--- a/crates/octos-agent/src/agent/turn_state.rs
+++ b/crates/octos-agent/src/agent/turn_state.rs
@@ -114,6 +114,12 @@ impl LoopTurnState {
         self.priced_usage
     }
 
+    /// `spend_usd` gated on any usage having been priced — the shape
+    /// `ConversationResponse::estimated_spend_usd` carries.
+    pub(crate) fn priced_spend(&self) -> Option<f64> {
+        self.priced_usage.then_some(self.turn_spend_usd)
+    }
+
     #[cfg(test)]
     pub(crate) fn retry_reasons(&self) -> &[LoopRetryReason] {
         &self.retry_reasons

--- a/crates/octos-agent/src/agent/turn_state.rs
+++ b/crates/octos-agent/src/agent/turn_state.rs
@@ -60,6 +60,17 @@ pub(crate) struct LoopTurnState {
     started_at: Instant,
     iteration: u32,
     total_usage: TokenUsage,
+    /// Estimated spend for THIS turn: the sum of per-response costs,
+    /// each priced at the model that actually produced the response.
+    /// The old emission path instead re-priced the whole turn's token
+    /// totals at whichever model answered LAST, silently re-pricing
+    /// earlier iterations whenever failover/routing switched models
+    /// mid-turn.
+    turn_spend_usd: f64,
+    /// Whether any recorded usage carried a price. Distinguishes "spend
+    /// is genuinely $0 so far" from "no model in this turn had catalog
+    /// pricing" — emission hides the cost line in the latter case.
+    priced_usage: bool,
     retry_reasons: Vec<LoopRetryReason>,
     repair_reasons: Vec<LoopRepairReason>,
     terminal_reason: Option<LoopTerminalReason>,
@@ -71,6 +82,8 @@ impl LoopTurnState {
             started_at,
             iteration: 0,
             total_usage: TokenUsage::default(),
+            turn_spend_usd: 0.0,
+            priced_usage: false,
             retry_reasons: Vec::new(),
             repair_reasons: Vec::new(),
             terminal_reason: None,
@@ -90,6 +103,17 @@ impl LoopTurnState {
         &self.total_usage
     }
 
+    /// Sum of per-response estimated costs recorded this turn, each
+    /// priced at the model that produced it.
+    pub(crate) fn spend_usd(&self) -> f64 {
+        self.turn_spend_usd
+    }
+
+    /// True once at least one recorded response carried a price.
+    pub(crate) fn has_priced_usage(&self) -> bool {
+        self.priced_usage
+    }
+
     #[cfg(test)]
     pub(crate) fn retry_reasons(&self) -> &[LoopRetryReason] {
         &self.retry_reasons
@@ -100,14 +124,24 @@ impl LoopTurnState {
         &self.repair_reasons
     }
 
+    /// Record one response's usage. `estimated_cost_usd` is that usage
+    /// priced at the model which produced it (`None` when the model has
+    /// no catalog pricing) — the explicit parameter forces every call
+    /// site to decide the attribution instead of a later pass re-pricing
+    /// the turn total at the wrong model.
     pub(crate) fn record_usage(
         &mut self,
         input_tokens: u32,
         output_tokens: u32,
         tracker: Option<&TokenTracker>,
+        estimated_cost_usd: Option<f64>,
     ) {
         self.total_usage.input_tokens += input_tokens;
         self.total_usage.output_tokens += output_tokens;
+        if let Some(cost) = estimated_cost_usd {
+            self.turn_spend_usd += cost;
+            self.priced_usage = true;
+        }
         if let Some(tracker) = tracker {
             tracker.input_tokens.store(
                 self.total_usage.input_tokens,
@@ -183,6 +217,25 @@ mod tests {
                 message: "Token budget exceeded (120 of 100).".to_string(),
             })
         );
+    }
+
+    #[test]
+    fn should_sum_per_response_costs_when_usage_recorded_across_models() {
+        let mut state = LoopTurnState::new(Instant::now());
+        assert!(!state.has_priced_usage());
+        assert!((state.spend_usd() - 0.0).abs() < f64::EPSILON);
+
+        // Two responses priced at DIFFERENT models' rates plus one from
+        // an unpriced model: tokens all count, spend sums only the known
+        // costs — no re-pricing of earlier responses at the last model.
+        state.record_usage(1_000, 200, None, Some(0.015));
+        state.record_usage(2_000, 400, None, Some(0.002));
+        state.record_usage(500, 100, None, None);
+
+        assert_eq!(state.total_usage().input_tokens, 3_500);
+        assert_eq!(state.total_usage().output_tokens, 700);
+        assert!(state.has_priced_usage());
+        assert!((state.spend_usd() - 0.017).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/octos-agent/src/agent/verifier.rs
+++ b/crates/octos-agent/src/agent/verifier.rs
@@ -549,13 +549,20 @@ impl Agent {
             config.provider.chat(&messages, &[], &verifier_config),
         )
         .await?;
+        // The verifier runs on its own provider — price its usage at the
+        // model that actually answered, resolved from the provider (which
+        // also handles verifier-side failover). `config.model_label` is a
+        // DISPLAY label ("session-cheap-verifier" when no explicit
+        // OCTOS_AGENT_VERIFIER_MODEL is set) and misses the catalog.
+        let verifier_model = config
+            .provider
+            .provider_metadata_for_index(response.provider_index)
+            .model;
         turn.record_usage(
             response.usage.input_tokens,
             response.usage.output_tokens,
             tracker,
-            // The verifier runs on its own provider — price its usage at
-            // the verifier's model, not the conversation's active slot.
-            octos_llm::pricing::model_pricing(&config.model_label)
+            octos_llm::pricing::model_pricing(&verifier_model)
                 .map(|p| p.cost(response.usage.input_tokens, response.usage.output_tokens)),
         );
         let content = response.content.unwrap_or_default();

--- a/crates/octos-agent/src/agent/verifier.rs
+++ b/crates/octos-agent/src/agent/verifier.rs
@@ -553,6 +553,10 @@ impl Agent {
             response.usage.input_tokens,
             response.usage.output_tokens,
             tracker,
+            // The verifier runs on its own provider — price its usage at
+            // the verifier's model, not the conversation's active slot.
+            octos_llm::pricing::model_pricing(&config.model_label)
+                .map(|p| p.cost(response.usage.input_tokens, response.usage.output_tokens)),
         );
         let content = response.content.unwrap_or_default();
         let verdict = parse_verifier_verdict(&content).unwrap_or_else(|| {

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -46,6 +46,7 @@ pub mod role_template;
 pub mod sandbox;
 mod sanitize;
 pub mod session;
+pub mod session_usage;
 pub mod skills;
 pub mod steering;
 pub mod subagent_output;
@@ -157,6 +158,7 @@ pub use role_template::{
 };
 pub use sandbox::{Sandbox, SandboxConfig, SandboxMode, create_sandbox};
 pub use session::{SessionLimits, SessionState, SessionStateHandle, SessionUsage};
+pub use session_usage::{SessionUsageHandle, SessionUsageSnapshot, SharedSessionUsage};
 pub use skills::{SkillInfo, SkillsLoader};
 pub use steering::{SteeringMessage, SteeringReceiver, SteeringSender};
 pub use subagent_output::{

--- a/crates/octos-agent/src/progress.rs
+++ b/crates/octos-agent/src/progress.rs
@@ -149,6 +149,12 @@ pub enum ProgressEvent {
         /// the live turn. u64 because sessions outlive single turns.
         session_input_tokens: u64,
         session_output_tokens: u64,
+        /// THIS response's token counts. Metrics counters must increment
+        /// by these — adding the cumulative fields per event over-counts
+        /// (and overflows the u32 metrics boundary now that the
+        /// cumulative fields are session-wide u64).
+        response_input_tokens: u32,
+        response_output_tokens: u32,
         /// Cost of this response (None if pricing unknown).
         response_cost: Option<f64>,
         /// Cumulative session cost: each completed run and each response

--- a/crates/octos-agent/src/progress.rs
+++ b/crates/octos-agent/src/progress.rs
@@ -144,11 +144,16 @@ pub enum ProgressEvent {
 
     /// Cost update after a response.
     CostUpdate {
-        session_input_tokens: u32,
-        session_output_tokens: u32,
+        /// Session-cumulative token counts: completed runs folded into the
+        /// shared session-usage base (when the embedder injected one) plus
+        /// the live turn. u64 because sessions outlive single turns.
+        session_input_tokens: u64,
+        session_output_tokens: u64,
         /// Cost of this response (None if pricing unknown).
         response_cost: Option<f64>,
-        /// Cumulative session cost.
+        /// Cumulative session cost: each completed run and each response
+        /// of the live turn priced at the model that produced it. `None`
+        /// until any priced usage exists.
         session_cost: Option<f64>,
         /// Model identifier that produced this response. Forwarded by the
         /// API bridge into `metadata.token_cost.model` so chat clients can

--- a/crates/octos-agent/src/progress.rs
+++ b/crates/octos-agent/src/progress.rs
@@ -149,12 +149,15 @@ pub enum ProgressEvent {
         /// the live turn. u64 because sessions outlive single turns.
         session_input_tokens: u64,
         session_output_tokens: u64,
-        /// THIS response's token counts. Metrics counters must increment
-        /// by these — adding the cumulative fields per event over-counts
-        /// (and overflows the u32 metrics boundary now that the
-        /// cumulative fields are session-wide u64).
-        response_input_tokens: u32,
-        response_output_tokens: u32,
+        /// TURN-cumulative token counts (every response recorded this
+        /// turn so far, including ones that emit no cost update of their
+        /// own — mid-turn tool iterations, the verifier). Metrics
+        /// counters meter the DELTA between successive events, so
+        /// nothing is dropped when only the terminal response emits;
+        /// the session_* fields are unsuitable for that (their base
+        /// includes pre-turn history the per-turn reporter never saw).
+        turn_input_tokens: u32,
+        turn_output_tokens: u32,
         /// Cost of this response (None if pricing unknown).
         response_cost: Option<f64>,
         /// Cumulative session cost: each completed run and each response

--- a/crates/octos-agent/src/session_usage.rs
+++ b/crates/octos-agent/src/session_usage.rs
@@ -1,0 +1,123 @@
+//! Session-cumulative usage shared between an embedder and the agent.
+//!
+//! The agent's per-turn accounting (`LoopTurnState`) resets on every
+//! `run_conversation` call, so the `session_*` figures it emits on
+//! `ProgressEvent::CostUpdate` used to cover only the CURRENT turn — and
+//! were re-priced wholesale at whichever model produced the latest
+//! response. A multi-model session (provider failover today, and
+//! `profile/llm/select` switching once the runtime cache evicts and
+//! rebuilds the agent) therefore never saw a truthful cumulative figure:
+//! each turn's spend vanished from the display when the next turn began.
+//!
+//! `SessionUsageHandle` is the cross-turn base. The embedder that owns the
+//! session (the gateway/serve session actor) creates one per session, seeds
+//! it from the persistent usage ledger so it survives agent rebuilds and
+//! process restarts, injects it via [`Agent::with_session_usage`], and folds
+//! each completed run back in — priced at the model that ran it. The agent
+//! only ever READS it (`snapshot`) when emitting cost updates: emission =
+//! base (completed runs, per-model priced) + live turn (per-response
+//! priced). Without an injected handle the agent behaves as before, minus
+//! the re-pricing: emission covers just the live turn.
+//!
+//! [`Agent::with_session_usage`]: crate::Agent::with_session_usage
+
+use std::sync::{Arc, RwLock};
+
+/// Point-in-time view of a session's cumulative usage across completed runs.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct SessionUsageSnapshot {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    /// Sum of per-run estimated costs, each priced at the model that
+    /// produced the run. Runs whose model had no catalog pricing
+    /// contribute tokens but no spend.
+    pub spend_usd: f64,
+    /// How many folded runs carried a price. Zero means `spend_usd` is
+    /// vacuous — emission uses this to keep the cost line hidden instead
+    /// of showing a misleading `$0.0000` for never-priced sessions.
+    pub priced_runs: u64,
+}
+
+/// Shared, thread-safe session usage accumulator. See the module docs for
+/// the ownership contract (embedder writes, agent reads).
+#[derive(Debug, Default)]
+pub struct SessionUsageHandle {
+    inner: RwLock<SessionUsageSnapshot>,
+}
+
+impl SessionUsageHandle {
+    pub fn snapshot(&self) -> SessionUsageSnapshot {
+        *self.inner.read().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Replace the accumulated state wholesale — used once at session
+    /// start to hydrate from the persistent usage ledger.
+    pub fn seed(&self, snapshot: SessionUsageSnapshot) {
+        *self.inner.write().unwrap_or_else(|e| e.into_inner()) = snapshot;
+    }
+
+    /// Fold one completed run into the base. `estimated_cost_usd` is the
+    /// run's spend priced at the model that ran it; `None` means pricing
+    /// was unavailable for that model.
+    pub fn fold_run(&self, input_tokens: u64, output_tokens: u64, estimated_cost_usd: Option<f64>) {
+        let mut inner = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        inner.input_tokens = inner.input_tokens.saturating_add(input_tokens);
+        inner.output_tokens = inner.output_tokens.saturating_add(output_tokens);
+        if let Some(cost) = estimated_cost_usd {
+            inner.spend_usd += cost;
+            inner.priced_runs = inner.priced_runs.saturating_add(1);
+        }
+    }
+}
+
+/// The sharing unit: one per session, cloned into the agent at build time.
+pub type SharedSessionUsage = Arc<SessionUsageHandle>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_accumulate_tokens_and_spend_when_runs_fold() {
+        let handle = SessionUsageHandle::default();
+        handle.fold_run(100, 40, Some(0.5));
+        handle.fold_run(200, 60, Some(0.25));
+        let snap = handle.snapshot();
+        assert_eq!(snap.input_tokens, 300);
+        assert_eq!(snap.output_tokens, 100);
+        assert!((snap.spend_usd - 0.75).abs() < f64::EPSILON);
+        assert_eq!(snap.priced_runs, 2);
+    }
+
+    #[test]
+    fn should_count_tokens_but_not_priced_runs_when_cost_unknown() {
+        let handle = SessionUsageHandle::default();
+        handle.fold_run(100, 40, None);
+        let snap = handle.snapshot();
+        assert_eq!(snap.input_tokens, 100);
+        assert_eq!(snap.priced_runs, 0);
+        assert!((snap.spend_usd - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn should_replace_state_when_seeded_from_ledger() {
+        let handle = SessionUsageHandle::default();
+        handle.fold_run(1, 1, Some(0.1));
+        handle.seed(SessionUsageSnapshot {
+            input_tokens: 5000,
+            output_tokens: 700,
+            spend_usd: 1.25,
+            priced_runs: 3,
+        });
+        let snap = handle.snapshot();
+        assert_eq!(snap.input_tokens, 5000);
+        assert_eq!(snap.priced_runs, 3);
+        // Folds after a seed keep accumulating on top of it.
+        handle.fold_run(1000, 300, Some(0.75));
+        let snap = handle.snapshot();
+        assert_eq!(snap.input_tokens, 6000);
+        assert_eq!(snap.output_tokens, 1000);
+        assert!((snap.spend_usd - 2.0).abs() < f64::EPSILON);
+        assert_eq!(snap.priced_runs, 4);
+    }
+}

--- a/crates/octos-cli/src/api/events.rs
+++ b/crates/octos-cli/src/api/events.rs
@@ -402,6 +402,8 @@ mod tests {
         let event = ProgressEvent::CostUpdate {
             session_input_tokens: 100,
             session_output_tokens: 50,
+            turn_input_tokens: 100,
+            turn_output_tokens: 50,
             response_cost: Some(0.001),
             session_cost: Some(0.005),
             model: None,
@@ -423,6 +425,8 @@ mod tests {
         let event = ProgressEvent::CostUpdate {
             session_input_tokens: 200,
             session_output_tokens: 100,
+            turn_input_tokens: 200,
+            turn_output_tokens: 100,
             response_cost: None,
             session_cost: None,
             model: None,
@@ -442,6 +446,8 @@ mod tests {
         let event = ProgressEvent::CostUpdate {
             session_input_tokens: 12,
             session_output_tokens: 7,
+            turn_input_tokens: 12,
+            turn_output_tokens: 7,
             response_cost: None,
             session_cost: None,
             model: Some("deepseek-v4-pro".into()),
@@ -457,6 +463,8 @@ mod tests {
         let event = ProgressEvent::CostUpdate {
             session_input_tokens: 1,
             session_output_tokens: 1,
+            turn_input_tokens: 1,
+            turn_output_tokens: 1,
             response_cost: None,
             session_cost: None,
             model: None,
@@ -545,6 +553,8 @@ mod tests {
                 ProgressEvent::CostUpdate {
                     session_input_tokens: 0,
                     session_output_tokens: 0,
+                    turn_input_tokens: 0,
+                    turn_output_tokens: 0,
                     response_cost: None,
                     session_cost: None,
                     model: None,

--- a/crates/octos-cli/src/api/metrics.rs
+++ b/crates/octos-cli/src/api/metrics.rs
@@ -978,12 +978,16 @@ impl octos_agent::ProgressReporter for MetricsReporter {
                 record_tool_call(name, *success, duration.as_secs_f64());
             }
             octos_agent::ProgressEvent::CostUpdate {
-                session_input_tokens,
-                session_output_tokens,
+                response_input_tokens,
+                response_output_tokens,
                 ..
             } => {
-                record_llm_tokens("input", *session_input_tokens);
-                record_llm_tokens("output", *session_output_tokens);
+                // Count THIS response's tokens. The session_* fields are
+                // cumulative (now session-wide, not just turn-wide) —
+                // incrementing a counter by a cumulative value per event
+                // multiply-counted earlier responses.
+                record_llm_tokens("input", *response_input_tokens);
+                record_llm_tokens("output", *response_output_tokens);
             }
             _ => {}
         }

--- a/crates/octos-cli/src/api/metrics.rs
+++ b/crates/octos-cli/src/api/metrics.rs
@@ -958,11 +958,31 @@ pub fn record_routing_decision(tier: &str, lane: Option<&str>) {
 /// then delegates to an inner reporter.
 pub struct MetricsReporter {
     inner: Arc<dyn octos_agent::ProgressReporter>,
+    /// Turn-cumulative counters at the last `CostUpdate` this reporter
+    /// metered. `octos_llm_tokens_total` increments by the DELTA between
+    /// successive events so responses that emit no cost update of their
+    /// own (mid-turn tool iterations, the verifier) are still counted by
+    /// the next event that does fire. The reporter is built per turn, so
+    /// the counters start at zero with the turn; a smaller-than-last
+    /// value (a reporter reused across turns) is treated as a reset.
+    last_turn_input_tokens: std::sync::atomic::AtomicU32,
+    last_turn_output_tokens: std::sync::atomic::AtomicU32,
 }
 
 impl MetricsReporter {
     pub fn new(inner: Arc<dyn octos_agent::ProgressReporter>) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            last_turn_input_tokens: std::sync::atomic::AtomicU32::new(0),
+            last_turn_output_tokens: std::sync::atomic::AtomicU32::new(0),
+        }
+    }
+
+    /// Delta since the last metered value, treating a decrease as a
+    /// turn reset (the new value counts in full).
+    fn meter_delta(last: &std::sync::atomic::AtomicU32, now: u32) -> u32 {
+        let prev = last.swap(now, std::sync::atomic::Ordering::AcqRel);
+        if now >= prev { now - prev } else { now }
     }
 }
 
@@ -978,16 +998,23 @@ impl octos_agent::ProgressReporter for MetricsReporter {
                 record_tool_call(name, *success, duration.as_secs_f64());
             }
             octos_agent::ProgressEvent::CostUpdate {
-                response_input_tokens,
-                response_output_tokens,
+                turn_input_tokens,
+                turn_output_tokens,
                 ..
             } => {
-                // Count THIS response's tokens. The session_* fields are
-                // cumulative (now session-wide, not just turn-wide) —
-                // incrementing a counter by a cumulative value per event
-                // multiply-counted earlier responses.
-                record_llm_tokens("input", *response_input_tokens);
-                record_llm_tokens("output", *response_output_tokens);
+                // Meter the delta of the TURN-cumulative counters (see
+                // the field docs on `MetricsReporter`). The old form
+                // added the cumulative session values on every event —
+                // multiply-counting earlier responses and overflowing
+                // the u32 boundary once those went session-wide u64.
+                record_llm_tokens(
+                    "input",
+                    Self::meter_delta(&self.last_turn_input_tokens, *turn_input_tokens),
+                );
+                record_llm_tokens(
+                    "output",
+                    Self::meter_delta(&self.last_turn_output_tokens, *turn_output_tokens),
+                );
             }
             _ => {}
         }

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -19474,6 +19474,39 @@ async fn run_standalone_turn(
             None
         }
     };
+    // Session-cumulative usage base for cost emissions (codex #1632 P1):
+    // this path builds a FRESH agent per turn, so without a seeded base
+    // every `cost_update` reported turn-only "session" figures. Hydrate
+    // from the ledger this same path writes each completed run to —
+    // making the emitted `session_*` figures cover the whole session
+    // across turns, reconnects, and the per-turn agent rebuild. The
+    // completed-run write below lands before the client can start the
+    // next turn on this session, so the next hydration includes it.
+    let session_usage_base = octos_agent::SharedSessionUsage::default();
+    if let Some(ledger) = usage_ledger.as_ref() {
+        match ledger.session_totals(&session_id.to_string()).await {
+            Ok(totals) if totals.run_count > 0 => {
+                session_usage_base.seed(octos_agent::SessionUsageSnapshot {
+                    input_tokens: totals.input_tokens,
+                    output_tokens: totals.output_tokens,
+                    spend_usd: totals.estimated_cost_usd,
+                    priced_runs: if totals.estimated_cost_usd > 0.0 {
+                        totals.run_count
+                    } else {
+                        0
+                    },
+                });
+            }
+            Ok(_) => {}
+            Err(error) => {
+                warn!(
+                    session = %session_id.0,
+                    error = %error,
+                    "failed to hydrate session usage base from ledger"
+                );
+            }
+        }
+    }
 
     // Source the per-session primitives from the SessionRuntime.
     //
@@ -20595,6 +20628,7 @@ async fn run_standalone_turn(
         system_prompt_base.clone(),
         workspace_root.as_deref(),
     ))
+    .with_session_usage_base(session_usage_base.clone())
     .with_reporter(reporter);
     // In-loop compaction delivery (UPCR-2026-026 follow-up): mirror the
     // pre-turn lifecycle delivery — durable direct send for clients that
@@ -21581,13 +21615,18 @@ async fn run_standalone_turn(
                             let model = request_agent.model_id();
                             (!model.is_empty()).then(|| model.to_string())
                         });
-                    let estimated_cost_usd =
+                    // Attributed by the agent loop: each response priced at
+                    // the model that produced it. Re-pricing the turn total
+                    // at the final model mispriced cross-model turns (codex
+                    // #1632 P1); the reprice fallback covers legacy paths.
+                    let estimated_cost_usd = response.estimated_spend_usd.or_else(|| {
                         model.as_deref().and_then(model_pricing).map(|pricing| {
                             pricing.cost(
                                 response.token_usage.input_tokens,
                                 response.token_usage.output_tokens,
                             )
-                        });
+                        })
+                    });
                     let cost_source = if estimated_cost_usd.is_some() {
                         UsageCostSource::CatalogEstimate
                     } else {

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -706,8 +706,9 @@ mod tests {
         let mut profile_b = make_profile(tmp.path().join("profile-b")).await;
         // `make_profile` fixes the id; give the second a distinct identity so
         // the sweep has something to spare.
-        std::sync::Arc::get_mut(&mut profile_b)
-            .map(|profile| profile.profile_id = "other".to_owned());
+        if let Some(profile) = std::sync::Arc::get_mut(&mut profile_b) {
+            profile.profile_id = "other".to_owned();
+        }
 
         let cache = SessionRuntimeCache::new(8, Duration::from_secs(60));
         cache

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -8665,6 +8665,67 @@ impl SessionActor {
                 handle.stop().await;
             }
 
+            // Codex #1632 r2 P2: account BEFORE any response-suppression
+            // exit (slash-command cancellation, pending-approval refusal)
+            // — the tokens were consumed regardless of whether the reply
+            // is shown. Same numbers, same attribution rules as
+            // `record_usage_event` on foreground turns.
+            if let Ok(Ok(conv_response)) = &result {
+                let overflow_model = conv_response
+                    .provider_metadata
+                    .as_ref()
+                    .map(|meta| meta.model.clone());
+                let overflow_cost = conv_response.estimated_spend_usd.or_else(|| {
+                    overflow_model
+                        .as_deref()
+                        .and_then(model_pricing)
+                        .map(|pricing| {
+                            pricing.cost(
+                                conv_response.token_usage.input_tokens,
+                                conv_response.token_usage.output_tokens,
+                            )
+                        })
+                });
+                overflow_session_usage.fold_run(
+                    u64::from(conv_response.token_usage.input_tokens),
+                    u64::from(conv_response.token_usage.output_tokens),
+                    overflow_cost,
+                );
+                if let Some(ledger) = overflow_usage_ledger.as_ref() {
+                    let event = UsageEvent::completed_run(
+                        overflow_usage_profile_id.clone(),
+                        session_key.to_string(),
+                        uuid::Uuid::now_v7().to_string(),
+                        conv_response
+                            .provider_metadata
+                            .as_ref()
+                            .map(|meta| meta.provider.clone()),
+                        overflow_model,
+                        conv_response
+                            .provider_metadata
+                            .as_ref()
+                            .and_then(|meta| meta.endpoint.clone()),
+                        u64::from(conv_response.token_usage.input_tokens),
+                        u64::from(conv_response.token_usage.output_tokens),
+                        overflow_cost,
+                        if overflow_cost.is_some() {
+                            UsageCostSource::CatalogEstimate
+                        } else {
+                            UsageCostSource::Unavailable
+                        },
+                        channel.clone(),
+                        Some("speculative_overflow".to_string()),
+                    );
+                    if let Err(error) = ledger.record(event).await {
+                        warn!(
+                            session = %session_key,
+                            error = %error,
+                            "failed to record overflow usage event"
+                        );
+                    }
+                }
+            }
+
             // If a slash command was handled while this overflow task was
             // running, suppress the response so it doesn't preempt the
             // command reply (GitHub issue #21).
@@ -8720,62 +8781,6 @@ impl SessionActor {
                         // blocking master continuations / new overflow turns.
                         overflow_counter.fetch_sub(1, Ordering::Release);
                         return;
-                    }
-                    // Fold this overflow run into the session usage base and
-                    // the durable ledger — same numbers, same attribution
-                    // rules as `record_usage_event` on foreground turns.
-                    let overflow_model = conv_response
-                        .provider_metadata
-                        .as_ref()
-                        .map(|meta| meta.model.clone());
-                    let overflow_cost = conv_response.estimated_spend_usd.or_else(|| {
-                        overflow_model
-                            .as_deref()
-                            .and_then(model_pricing)
-                            .map(|pricing| {
-                                pricing.cost(
-                                    conv_response.token_usage.input_tokens,
-                                    conv_response.token_usage.output_tokens,
-                                )
-                            })
-                    });
-                    overflow_session_usage.fold_run(
-                        u64::from(conv_response.token_usage.input_tokens),
-                        u64::from(conv_response.token_usage.output_tokens),
-                        overflow_cost,
-                    );
-                    if let Some(ledger) = overflow_usage_ledger.as_ref() {
-                        let event = UsageEvent::completed_run(
-                            overflow_usage_profile_id.clone(),
-                            session_key.to_string(),
-                            uuid::Uuid::now_v7().to_string(),
-                            conv_response
-                                .provider_metadata
-                                .as_ref()
-                                .map(|meta| meta.provider.clone()),
-                            overflow_model.clone(),
-                            conv_response
-                                .provider_metadata
-                                .as_ref()
-                                .and_then(|meta| meta.endpoint.clone()),
-                            u64::from(conv_response.token_usage.input_tokens),
-                            u64::from(conv_response.token_usage.output_tokens),
-                            overflow_cost,
-                            if overflow_cost.is_some() {
-                                UsageCostSource::CatalogEstimate
-                            } else {
-                                UsageCostSource::Unavailable
-                            },
-                            channel.clone(),
-                            Some("speculative_overflow".to_string()),
-                        );
-                        if let Err(error) = ledger.record(event).await {
-                            warn!(
-                                session = %session_key,
-                                error = %error,
-                                "failed to record overflow usage event"
-                            );
-                        }
                     }
                     let final_content = finalize_assistant_content(
                         &session_key,

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -4511,11 +4511,19 @@ impl SessionActor {
                 let model = self.agent.model_id();
                 (!model.is_empty()).then(|| model.to_string())
             });
-        let estimated_cost_usd = model.as_deref().and_then(model_pricing).map(|pricing| {
-            pricing.cost(
-                response.token_usage.input_tokens,
-                response.token_usage.output_tokens,
-            )
+        // The turn's spend as attributed by the agent loop: each response
+        // priced at the model that produced it. Re-pricing token_usage at
+        // the FINAL provider_metadata model here (the old form) mispriced
+        // any turn that crossed models (failover, verifier) — and then
+        // persisted the wrong number in the ledger (codex #1632 P1). The
+        // fallback reprice covers legacy paths that predate the field.
+        let estimated_cost_usd = response.estimated_spend_usd.or_else(|| {
+            model.as_deref().and_then(model_pricing).map(|pricing| {
+                pricing.cost(
+                    response.token_usage.input_tokens,
+                    response.token_usage.output_tokens,
+                )
+            })
         });
         // Fold this run into the shared session base FIRST — the live
         // display must accumulate across turns even when no ledger is
@@ -8387,6 +8395,14 @@ impl SessionActor {
         let user_workspace = self.user_workspace.clone();
         let data_dir = self.data_dir.clone();
         let overflow_client_message_id = inbound_client_message_id(msg);
+        // codex #1632 P2: overflow runs consume real tokens but never
+        // reached `record_usage_event` (they run detached from the actor),
+        // so both the live session-usage base and the durable ledger
+        // omitted them. Clone the plumbing so the completion arm below can
+        // fold + record with the same numbers a foreground turn would.
+        let overflow_session_usage = self.session_usage.clone();
+        let overflow_usage_ledger = self.usage_ledger.clone();
+        let overflow_usage_profile_id = self.usage_profile_id.clone();
 
         tokio::spawn(async move {
             // Save user message to history first so it survives even if the
@@ -8704,6 +8720,62 @@ impl SessionActor {
                         // blocking master continuations / new overflow turns.
                         overflow_counter.fetch_sub(1, Ordering::Release);
                         return;
+                    }
+                    // Fold this overflow run into the session usage base and
+                    // the durable ledger — same numbers, same attribution
+                    // rules as `record_usage_event` on foreground turns.
+                    let overflow_model = conv_response
+                        .provider_metadata
+                        .as_ref()
+                        .map(|meta| meta.model.clone());
+                    let overflow_cost = conv_response.estimated_spend_usd.or_else(|| {
+                        overflow_model
+                            .as_deref()
+                            .and_then(model_pricing)
+                            .map(|pricing| {
+                                pricing.cost(
+                                    conv_response.token_usage.input_tokens,
+                                    conv_response.token_usage.output_tokens,
+                                )
+                            })
+                    });
+                    overflow_session_usage.fold_run(
+                        u64::from(conv_response.token_usage.input_tokens),
+                        u64::from(conv_response.token_usage.output_tokens),
+                        overflow_cost,
+                    );
+                    if let Some(ledger) = overflow_usage_ledger.as_ref() {
+                        let event = UsageEvent::completed_run(
+                            overflow_usage_profile_id.clone(),
+                            session_key.to_string(),
+                            uuid::Uuid::now_v7().to_string(),
+                            conv_response
+                                .provider_metadata
+                                .as_ref()
+                                .map(|meta| meta.provider.clone()),
+                            overflow_model.clone(),
+                            conv_response
+                                .provider_metadata
+                                .as_ref()
+                                .and_then(|meta| meta.endpoint.clone()),
+                            u64::from(conv_response.token_usage.input_tokens),
+                            u64::from(conv_response.token_usage.output_tokens),
+                            overflow_cost,
+                            if overflow_cost.is_some() {
+                                UsageCostSource::CatalogEstimate
+                            } else {
+                                UsageCostSource::Unavailable
+                            },
+                            channel.clone(),
+                            Some("speculative_overflow".to_string()),
+                        );
+                        if let Err(error) = ledger.record(event).await {
+                            warn!(
+                                session = %session_key,
+                                error = %error,
+                                "failed to record overflow usage event"
+                            );
+                        }
                     }
                     let final_content = finalize_assistant_content(
                         &session_key,
@@ -11994,6 +12066,10 @@ mod tests {
                 output_tokens,
                 ..Default::default()
             },
+            // What the agent loop would carry: the turn's usage priced at
+            // the model that produced it.
+            estimated_spend_usd: model_pricing(model)
+                .map(|pricing| pricing.cost(input_tokens, output_tokens)),
             files_modified: vec![],
             files_to_send: vec![],
             streamed: false,

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -3865,6 +3865,14 @@ impl ActorFactory {
         // back-reference now that tools are in Arc.
         agent.wire_mofa_make_dispatcher();
 
+        // Session-cumulative usage base: the agent READS it when emitting
+        // `cost_update` progress (base + live turn); this actor seeds it
+        // from the usage ledger at run() start and folds every completed
+        // run back in. Without it the wire's `session_*` figures reset to
+        // zero each turn and past turns were re-priced at the latest model.
+        let session_usage = octos_agent::SharedSessionUsage::default();
+        let agent = agent.with_session_usage_base(session_usage.clone());
+
         // Load per-user status configuration
         let user_status_config = UserStatusConfig::load(&self.data_dir, session_key.base_key());
 
@@ -3884,6 +3892,7 @@ impl ActorFactory {
             user_status_config,
             data_dir: self.data_dir.clone(),
             usage_ledger: self.usage_ledger.clone(),
+            session_usage,
             max_history: self.max_history.clone(),
             idle_timeout: self.idle_timeout,
             session_timeout: self.session_timeout,
@@ -4374,6 +4383,13 @@ struct SessionActor {
     /// Durable per-profile usage ledger. `None` only in tests or if startup
     /// deliberately omitted usage accounting.
     usage_ledger: Option<Arc<PersistentUsageLedger>>,
+    /// Session-cumulative usage base shared with the agent (see the
+    /// `octos_agent::session_usage` module docs). Seeded from
+    /// `usage_ledger` at run() start so it survives the runtime-cache
+    /// eviction a `profile/llm/select` model switch triggers; folded
+    /// after every completed run, each run priced at the model that
+    /// ran it.
+    session_usage: octos_agent::SharedSessionUsage,
     /// Profile/account id used for usage analytics rollups.
     usage_profile_id: String,
     max_history: Arc<std::sync::atomic::AtomicUsize>,
@@ -4480,9 +4496,6 @@ impl SessionActor {
         run_id: Option<&str>,
         attribution: Option<&str>,
     ) {
-        let Some(usage_ledger) = self.usage_ledger.as_ref() else {
-            return;
-        };
         let provider_metadata = response.provider_metadata.clone();
         let provider = provider_metadata
             .as_ref()
@@ -4504,6 +4517,20 @@ impl SessionActor {
                 response.token_usage.output_tokens,
             )
         });
+        // Fold this run into the shared session base FIRST — the live
+        // display must accumulate across turns even when no ledger is
+        // configured. Uses the SAME numbers the ledger event records
+        // (turn totals priced at the run's model), so re-seeding from the
+        // ledger after a runtime rebuild reproduces exactly the sum of
+        // these folds — no drift between the live figure and the seed.
+        self.session_usage.fold_run(
+            u64::from(response.token_usage.input_tokens),
+            u64::from(response.token_usage.output_tokens),
+            estimated_cost_usd,
+        );
+        let Some(usage_ledger) = self.usage_ledger.as_ref() else {
+            return;
+        };
         let cost_source = if estimated_cost_usd.is_some() {
             UsageCostSource::CatalogEstimate
         } else {
@@ -5410,7 +5437,44 @@ impl SessionActor {
         true
     }
 
+    /// Hydrate the session-cumulative usage base from the durable ledger.
+    /// Runs BEFORE the first turn so cost emissions include prior runs:
+    /// the runtime cache evicts and rebuilds this actor on a
+    /// `profile/llm/select` model switch — without the re-seed every
+    /// switch would zero the displayed session spend.
+    async fn hydrate_session_usage_from_ledger(&self) {
+        let Some(ledger) = self.usage_ledger.as_ref() else {
+            return;
+        };
+        match ledger.session_totals(&self.session_key.to_string()).await {
+            Ok(totals) if totals.run_count > 0 => {
+                self.session_usage.seed(octos_agent::SessionUsageSnapshot {
+                    input_tokens: totals.input_tokens,
+                    output_tokens: totals.output_tokens,
+                    spend_usd: totals.estimated_cost_usd,
+                    // The ledger doesn't track per-run priced-ness; this
+                    // only drives the Some/None gate on the cost line,
+                    // never the amount.
+                    priced_runs: if totals.estimated_cost_usd > 0.0 {
+                        totals.run_count
+                    } else {
+                        0
+                    },
+                });
+            }
+            Ok(_) => {}
+            Err(error) => {
+                warn!(
+                    session = %self.session_key,
+                    error = %error,
+                    "failed to hydrate session usage base from ledger"
+                );
+            }
+        }
+    }
+
     async fn run(mut self) {
+        self.hydrate_session_usage_from_ledger().await;
         self.emit_resume_hook().await;
         // Wave-4 B3.4 — surface adaptive-router failovers on the bus so
         // operators on a chat channel SEE when the router escalated
@@ -7801,11 +7865,18 @@ impl SessionActor {
                             Some(model.to_string())
                         }
                     });
-                let session_cost = model_id.as_deref().and_then(model_pricing).map(|pricing| {
-                    pricing.cost(cr.token_usage.input_tokens, cr.token_usage.output_tokens)
-                });
                 self.record_usage_event(cr, client_message_id.as_deref(), None)
                     .await;
+                // Session-cumulative, read AFTER the fold above so it
+                // includes the run that just completed. Despite living in
+                // per-message metadata this field is named `session_cost`,
+                // and clients merge it into session stats — it used to
+                // carry only THIS turn priced at the final model, silently
+                // shrinking the displayed spend after every model switch.
+                let session_cost = {
+                    let snapshot = self.session_usage.snapshot();
+                    (snapshot.priced_runs > 0).then_some(snapshot.spend_usd)
+                };
                 // Bug 3 / W1.G4 cost panel — collect per-node cost rows that
                 // tools (today: `run_pipeline`) surfaced through their
                 // `ToolResult.structured_metadata` side-channel. Without this
@@ -11799,6 +11870,7 @@ mod tests {
             user_status_config: UserStatusConfig::default(),
             data_dir: dir.path().to_path_buf(),
             usage_ledger: None,
+            session_usage: Default::default(),
             usage_profile_id: "test-profile".to_string(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
@@ -11827,6 +11899,205 @@ mod tests {
 
         let handle = tokio::spawn(actor.run());
         (inbox_tx, out_rx, handle, session_mgr)
+    }
+
+    /// Minimal non-spawned actor for unit-testing methods directly
+    /// (`record_usage_event`, `hydrate_session_usage_from_ledger`).
+    /// Unlike `setup_actor_with_mode` the actor loop never runs, so the
+    /// test observes exactly the state a single method call produced.
+    async fn build_unspawned_actor(
+        dir: &tempfile::TempDir,
+        usage_ledger: Option<Arc<PersistentUsageLedger>>,
+    ) -> SessionActor {
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let tools = octos_agent::ToolRegistry::with_builtins(dir.path());
+        let provider: Arc<dyn LlmProvider> =
+            Arc::new(ErrorMockProvider::new("unused-mock", "never called"));
+        let agent = Agent::new(AgentId::new("test-usage"), provider, tools, memory).with_config(
+            AgentConfig {
+                save_episodes: false,
+                max_iterations: 1,
+                ..Default::default()
+            },
+        );
+        let (inbox_tx, inbox_rx) = mpsc::channel(4);
+        // The outbound receiver is dropped; these tests never send.
+        let (out_tx, _out_rx) = mpsc::channel(4);
+        SessionActor {
+            session_key: test_session_key(dir.path()),
+            channel: "cli".to_string(),
+            chat_id: "test".to_string(),
+            tenant_id: None,
+            inbox: inbox_rx,
+            self_tx: inbox_tx,
+            pending_approvals: HumanPendingApprovalStore::default(),
+            approvals_audit: Arc::new(crate::approvals_audit::ApprovalsAuditLog::new(
+                dir.path(),
+                crate::approvals_audit::ApprovalsAuditConfig::from_env(),
+            )),
+            agent: Arc::new(agent),
+            hooks: None,
+            hook_context: None,
+            session_handle: Arc::new(Mutex::new(SessionHandle::open(
+                dir.path(),
+                &test_session_key(dir.path()),
+            ))),
+            out_tx,
+            status_indicator: None,
+            sender_user_id: None,
+            user_status_config: UserStatusConfig::default(),
+            data_dir: dir.path().to_path_buf(),
+            usage_ledger,
+            session_usage: Default::default(),
+            usage_profile_id: "test-profile".to_string(),
+            max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
+            idle_timeout: Duration::from_secs(60),
+            session_timeout: Duration::from_secs(120),
+            semaphore: Arc::new(Semaphore::new(10)),
+            global_shutdown: Arc::new(AtomicBool::new(false)),
+            cancelled: Arc::new(AtomicBool::new(false)),
+            queue_mode: QueueMode::Followup,
+            responsiveness: ResponsivenessObserver::new(),
+            adaptive_router: None,
+            lane_routing: None,
+            memory_store: None,
+            active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            overflow_cancelled: Arc::new(AtomicBool::new(false)),
+            active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
+            user_workspace: dir.path().join("workspace"),
+            cron_tool: None,
+            persistent_retry_state: Arc::new(StdMutex::new(LoopRetryState::default())),
+            context_manager: test_context_manager(&test_session_key(dir.path())),
+            retry_state_path: None,
+            recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
+            current_command_cmid: None,
+            last_turn_total_tokens: 0,
+        }
+    }
+
+    fn conversation_response_with_usage(
+        model: &str,
+        input_tokens: u32,
+        output_tokens: u32,
+    ) -> ConversationResponse {
+        ConversationResponse {
+            content: "done".to_string(),
+            reasoning_content: None,
+            provider_metadata: Some(octos_llm::ProviderMetadata::new(
+                "test-provider",
+                model,
+                None,
+            )),
+            token_usage: octos_core::TokenUsage {
+                input_tokens,
+                output_tokens,
+                ..Default::default()
+            },
+            files_modified: vec![],
+            files_to_send: vec![],
+            streamed: false,
+            messages: vec![],
+            tool_results: vec![],
+            synthesized_from_spawn_only: false,
+            pending_approval: None,
+        }
+    }
+
+    /// Each completed run must fold into the shared session base priced
+    /// at ITS OWN model — the old path priced the whole session at the
+    /// latest model, so switching models re-priced (or vanished) prior
+    /// spend.
+    #[tokio::test]
+    async fn record_usage_event_folds_each_run_at_its_own_model_pricing() {
+        let dir = tempfile::tempdir().unwrap();
+        let actor = build_unspawned_actor(&dir, None).await;
+
+        // claude-opus-4 ladder rate: $15/M in, $75/M out.
+        actor
+            .record_usage_event(
+                &conversation_response_with_usage("claude-opus-4", 1_000, 500),
+                Some("run-1"),
+                None,
+            )
+            .await;
+        // gpt-4o-mini ladder rate: $0.15/M in, $0.60/M out.
+        actor
+            .record_usage_event(
+                &conversation_response_with_usage("gpt-4o-mini", 2_000, 1_000),
+                Some("run-2"),
+                None,
+            )
+            .await;
+
+        let snapshot = actor.session_usage.snapshot();
+        assert_eq!(snapshot.input_tokens, 3_000);
+        assert_eq!(snapshot.output_tokens, 1_500);
+        assert_eq!(snapshot.priced_runs, 2);
+        let expected = (0.015 + 0.0375) + (0.0003 + 0.0006);
+        assert!(
+            (snapshot.spend_usd - expected).abs() < 1e-9,
+            "spend {} != expected {} (runs must keep their own model's pricing)",
+            snapshot.spend_usd,
+            expected
+        );
+    }
+
+    /// A rebuilt actor (the runtime cache evicts on `profile/llm/select`)
+    /// must hydrate the base from the durable ledger so the displayed
+    /// session spend survives model switches and restarts.
+    #[tokio::test]
+    async fn hydrate_session_usage_seeds_base_from_ledger_totals() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Arc::new(
+            PersistentUsageLedger::open(dir.path())
+                .await
+                .expect("open test ledger"),
+        );
+        let session_id = test_session_key(dir.path()).to_string();
+        ledger
+            .record(UsageEvent::completed_run(
+                "test-profile",
+                session_id.clone(),
+                "run-1",
+                Some("test-provider".to_string()),
+                Some("claude-opus-4".to_string()),
+                None,
+                1_000,
+                500,
+                Some(0.0525),
+                UsageCostSource::CatalogEstimate,
+                "cli",
+                None,
+            ))
+            .await
+            .unwrap();
+        ledger
+            .record(UsageEvent::completed_run(
+                "test-profile",
+                session_id,
+                "run-2",
+                Some("test-provider".to_string()),
+                Some("gpt-4o-mini".to_string()),
+                None,
+                2_000,
+                1_000,
+                Some(0.0009),
+                UsageCostSource::CatalogEstimate,
+                "cli",
+                None,
+            ))
+            .await
+            .unwrap();
+
+        let actor = build_unspawned_actor(&dir, Some(ledger)).await;
+        actor.hydrate_session_usage_from_ledger().await;
+
+        let snapshot = actor.session_usage.snapshot();
+        assert_eq!(snapshot.input_tokens, 3_000);
+        assert_eq!(snapshot.output_tokens, 1_500);
+        assert!(snapshot.priced_runs > 0);
+        assert!((snapshot.spend_usd - 0.0534).abs() < 1e-9);
     }
 
     async fn setup_actor_with_timeout(
@@ -11880,6 +12151,7 @@ mod tests {
             user_status_config: UserStatusConfig::default(),
             data_dir: dir.path().to_path_buf(),
             usage_ledger: None,
+            session_usage: Default::default(),
             usage_profile_id: "test-profile".to_string(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
@@ -12146,6 +12418,7 @@ mod tests {
             user_status_config: UserStatusConfig::default(),
             data_dir: dir.path().to_path_buf(),
             usage_ledger: None,
+            session_usage: Default::default(),
             usage_profile_id: "test-profile".to_string(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
@@ -12280,6 +12553,7 @@ mod tests {
             user_status_config: UserStatusConfig::default(),
             data_dir: dir.path().to_path_buf(),
             usage_ledger: None,
+            session_usage: Default::default(),
             usage_profile_id: "test-profile".to_string(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
@@ -12410,6 +12684,7 @@ mod tests {
             user_status_config: UserStatusConfig::default(),
             data_dir: dir.path().to_path_buf(),
             usage_ledger: None,
+            session_usage: Default::default(),
             usage_profile_id: "test-profile".to_string(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
@@ -12512,6 +12787,7 @@ mod tests {
             user_status_config: UserStatusConfig::default(),
             data_dir: dir.path().to_path_buf(),
             usage_ledger: None,
+            session_usage: Default::default(),
             usage_profile_id: "test-profile".to_string(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
@@ -12613,6 +12889,7 @@ mod tests {
             user_status_config: UserStatusConfig::default(),
             data_dir: std::path::PathBuf::from("/tmp"),
             usage_ledger: None,
+            session_usage: Default::default(),
             usage_profile_id: "test-profile".to_string(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
@@ -18070,6 +18347,7 @@ mod tests {
             current_command_cmid: None,
             last_turn_total_tokens: 0,
             usage_ledger: None,
+            session_usage: Default::default(),
             usage_profile_id: "test-profile".to_string(),
         };
 

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -1040,8 +1040,8 @@ mod tests {
         reporter.report(ProgressEvent::CostUpdate {
             session_input_tokens: 12,
             session_output_tokens: 7,
-            response_input_tokens: 12 as u32,
-            response_output_tokens: 7 as u32,
+            response_input_tokens: 12,
+            response_output_tokens: 7,
             response_cost: None,
             session_cost: None,
             model: Some("deepseek-v4-pro".into()),
@@ -1069,8 +1069,8 @@ mod tests {
         reporter.report(ProgressEvent::CostUpdate {
             session_input_tokens: 12,
             session_output_tokens: 7,
-            response_input_tokens: 12 as u32,
-            response_output_tokens: 7 as u32,
+            response_input_tokens: 12,
+            response_output_tokens: 7,
             response_cost: None,
             session_cost: None,
             model: None,
@@ -1099,8 +1099,8 @@ mod tests {
         reporter.report(ProgressEvent::CostUpdate {
             session_input_tokens: 12,
             session_output_tokens: 7,
-            response_input_tokens: 12 as u32,
-            response_output_tokens: 7 as u32,
+            response_input_tokens: 12,
+            response_output_tokens: 7,
             response_cost: None,
             session_cost: None,
             model: None,

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -989,6 +989,8 @@ mod tests {
         reporter.report(ProgressEvent::CostUpdate {
             session_input_tokens: 10,
             session_output_tokens: 20,
+            response_input_tokens: 10,
+            response_output_tokens: 20,
             response_cost: None,
             session_cost: None,
             model: None,
@@ -1038,6 +1040,8 @@ mod tests {
         reporter.report(ProgressEvent::CostUpdate {
             session_input_tokens: 12,
             session_output_tokens: 7,
+            response_input_tokens: 12 as u32,
+            response_output_tokens: 7 as u32,
             response_cost: None,
             session_cost: None,
             model: Some("deepseek-v4-pro".into()),
@@ -1065,6 +1069,8 @@ mod tests {
         reporter.report(ProgressEvent::CostUpdate {
             session_input_tokens: 12,
             session_output_tokens: 7,
+            response_input_tokens: 12 as u32,
+            response_output_tokens: 7 as u32,
             response_cost: None,
             session_cost: None,
             model: None,
@@ -1093,6 +1099,8 @@ mod tests {
         reporter.report(ProgressEvent::CostUpdate {
             session_input_tokens: 12,
             session_output_tokens: 7,
+            response_input_tokens: 12 as u32,
+            response_output_tokens: 7 as u32,
             response_cost: None,
             session_cost: None,
             model: None,

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -989,8 +989,8 @@ mod tests {
         reporter.report(ProgressEvent::CostUpdate {
             session_input_tokens: 10,
             session_output_tokens: 20,
-            response_input_tokens: 10,
-            response_output_tokens: 20,
+            turn_input_tokens: 10,
+            turn_output_tokens: 20,
             response_cost: None,
             session_cost: None,
             model: None,
@@ -1040,8 +1040,8 @@ mod tests {
         reporter.report(ProgressEvent::CostUpdate {
             session_input_tokens: 12,
             session_output_tokens: 7,
-            response_input_tokens: 12,
-            response_output_tokens: 7,
+            turn_input_tokens: 12,
+            turn_output_tokens: 7,
             response_cost: None,
             session_cost: None,
             model: Some("deepseek-v4-pro".into()),
@@ -1069,8 +1069,8 @@ mod tests {
         reporter.report(ProgressEvent::CostUpdate {
             session_input_tokens: 12,
             session_output_tokens: 7,
-            response_input_tokens: 12,
-            response_output_tokens: 7,
+            turn_input_tokens: 12,
+            turn_output_tokens: 7,
             response_cost: None,
             session_cost: None,
             model: None,
@@ -1099,8 +1099,8 @@ mod tests {
         reporter.report(ProgressEvent::CostUpdate {
             session_input_tokens: 12,
             session_output_tokens: 7,
-            response_input_tokens: 12,
-            response_output_tokens: 7,
+            turn_input_tokens: 12,
+            turn_output_tokens: 7,
             response_cost: None,
             session_cost: None,
             model: None,

--- a/crates/octos-llm/src/pricing.rs
+++ b/crates/octos-llm/src/pricing.rs
@@ -42,12 +42,26 @@ fn catalog_pricing(model_id: &str) -> Option<ModelPricing> {
     if let Some(p) = map.get(&m) {
         return Some(*p);
     }
-    for (key, p) in map {
-        if m.contains(key) || key.contains(&m) {
-            return Some(*p);
-        }
+    // The substring fallback used to return the FIRST HashMap hit, which
+    // made pricing nondeterministic whenever a model id matched several
+    // keys ("gpt-5.2-codex" matches both "gpt-5.2" and "gpt-5" — which
+    // one won differed per process). Deterministic rule instead:
+    //   1. Keys the model id CONTAINS name a family the id extends; the
+    //      LONGEST such key is the most specific family, so it wins.
+    //   2. Otherwise, among keys that contain the model id, the SHORTEST
+    //      is the closest match.
+    // Ties break lexicographically so equal-length keys are stable too.
+    let family = map
+        .iter()
+        .filter(|(key, _)| m.contains(key.as_str()))
+        .max_by(|(a, _), (b, _)| a.len().cmp(&b.len()).then_with(|| b.cmp(a)));
+    if let Some((_, p)) = family {
+        return Some(*p);
     }
-    None
+    map.iter()
+        .filter(|(key, _)| key.contains(&m))
+        .min_by(|(a, _), (b, _)| a.len().cmp(&b.len()).then_with(|| a.cmp(b)))
+        .map(|(_, p)| *p)
 }
 
 impl ModelPricing {
@@ -306,5 +320,44 @@ mod tests {
         let r1 = model_pricing("deepseek-ai/deepseek-r1").unwrap();
         let base = model_pricing("deepseek-chat").unwrap();
         assert!(r1.input_per_million > base.input_per_million);
+    }
+
+    /// Catalog substring fallback must be deterministic. The old scan
+    /// returned the FIRST HashMap hit, so a model id matching several
+    /// catalog keys ("octestfam-5.2-codex" matches both "octestfam-5"
+    /// and "octestfam-5.2") got a random sibling's pricing per process.
+    ///
+    /// One #[test] on purpose: these sections share the process-global
+    /// PRICING_CATALOG, so splitting them into parallel tests would race.
+    /// Key names are deliberately weird so no other test's probe can
+    /// substring-match them while the seed is live.
+    #[test]
+    fn should_match_catalog_keys_deterministically_when_no_exact_hit() {
+        // Section 1: model id EXTENDS several family keys — the longest
+        // (most specific) family must win, not HashMap iteration order.
+        seed_pricing_catalog(&[
+            ("octestprov/octestfam-5".to_string(), 1.0, 2.0),
+            ("octestprov/octestfam-5.2".to_string(), 3.0, 4.0),
+        ]);
+        let p = model_pricing("octestfam-5.2-codex").unwrap();
+        assert!((p.input_per_million - 3.0).abs() < f64::EPSILON);
+        assert!((p.output_per_million - 4.0).abs() < f64::EPSILON);
+
+        // Section 2: exact key still wins over any substring candidate.
+        let exact = model_pricing("octestfam-5").unwrap();
+        assert!((exact.input_per_million - 1.0).abs() < f64::EPSILON);
+
+        // Section 3: model id is a PREFIX of several keys — the shortest
+        // (closest) super-key must win deterministically.
+        seed_pricing_catalog(&[
+            ("octestprov/octestfam-7.2".to_string(), 5.0, 6.0),
+            ("octestprov/octestfam-7-mini-preview".to_string(), 7.0, 8.0),
+        ]);
+        let sup = model_pricing("octestfam-7").unwrap();
+        assert!((sup.input_per_million - 5.0).abs() < f64::EPSILON);
+
+        // Restore an empty catalog so parallel tests keep hitting the
+        // hardcoded ladder exactly as before this test ran.
+        seed_pricing_catalog(&[]);
     }
 }

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -1289,8 +1289,8 @@ mod tests {
                 node_reporter.report(ProgressEvent::CostUpdate {
                     session_input_tokens: 320,
                     session_output_tokens: 110,
-                    response_input_tokens: 320,
-                    response_output_tokens: 110,
+                    turn_input_tokens: 320,
+                    turn_output_tokens: 110,
                     response_cost: Some(0.0008),
                     session_cost: Some(0.0008),
                     model: Some("claude-sonnet".into()),

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -1289,6 +1289,8 @@ mod tests {
                 node_reporter.report(ProgressEvent::CostUpdate {
                     session_input_tokens: 320,
                     session_output_tokens: 110,
+                    response_input_tokens: 320,
+                    response_output_tokens: 110,
                     response_cost: Some(0.0008),
                     session_cost: Some(0.0008),
                     model: Some("claude-sonnet".into()),


### PR DESCRIPTION
## Problem

The TUI/web status figures (`↑in ↓out · $cost`) come from the wire's `cost_update` events — whose `session_*` fields were **turn-scoped and re-priced at the latest model**:

1. `LoopTurnState` resets per user message, so the "session" spend displayed reset to $0 every turn — prior turns' spend vanished from the display.
2. `emit_cost_update` priced the WHOLE turn's token totals at whichever model produced the latest response — a mid-turn provider failover retroactively re-priced earlier iterations at the new model's rate.
3. `catalog_pricing`'s substring fallback scanned a `HashMap` in iteration order — a model id matching several catalog keys (`gpt-5.2-codex` → `gpt-5.2` **and** `gpt-5`) got a random sibling's pricing per process.
4. Once #1627 (`profile/llm/select`) lands, every model switch evicts and rebuilds the session runtime — wiping any in-memory spend state. Exactly the flow where a truthful cumulative figure matters most.

## Fix

**octos-llm** — deterministic pricing fallback: longest family key wins (`m.contains(key)`), then shortest super-key (`key.contains(m)`), lexicographic tie-breaks.

**octos-agent** — `LoopTurnState::record_usage` now takes the response's estimated cost **priced at the model that actually produced it** (failover slot via `provider_index`; verifier at its own model; tool-reported usage at the active slot — no per-response attribution exists there). The compiler enumerates every call site. New `session_usage` module: a `SharedSessionUsage` handle the embedder seeds + folds, the agent only reads; `emit_cost_update` emits **base (completed runs, each priced at its own model) + live turn (per-response priced)**. `CostUpdate` session token fields widen to u64.

**octos-cli** — the session actor owns the handle (`with_session_usage_base`), hydrates it from `PersistentUsageLedger::session_totals` at `run()` start — **surviving the runtime-cache eviction a model switch triggers and process restarts** — and folds each completed run in `record_usage_event` with the same numbers the ledger records, so a re-seed reproduces exactly the sum of prior folds (no drift). The `_completion` footer's `session_cost` reads the folded handle instead of re-pricing the turn at its final model.

No wire shape changes — the fields finally mean what their names (and the TUI/web comments consuming them) already claimed.

## Tests

- `should_match_catalog_keys_deterministically_when_no_exact_hit` (family-specificity + super-key + exact precedence, single test to avoid global-catalog races)
- `should_sum_per_response_costs_when_usage_recorded_across_models` (turn spend keeps per-model attribution)
- `session_usage` module unit tests (fold/seed/priced-run gating)
- `record_usage_event_folds_each_run_at_its_own_model_pricing` (opus + mini runs keep their own rates; the old behavior would have priced both at the last model)
- `hydrate_session_usage_seeds_base_from_ledger_totals` (rebuilt actor reproduces ledger totals)

Suites: octos-llm 437 ✓, octos-agent 2090 ✓, octos-cli 917 ✓; clippy + fmt clean.

Follow-up (separate octos-web PR): `handleMeta` merges per-turn `tokens_in/tokens_out` into the same session-stats store that `cost_update` feeds — after this change that's the one remaining source of turn/session conflation in the web display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)