### PR TITLE
fix(cli): satisfy clippy 1.95 option_map_unit_fn in cache test

### DIFF
--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -706,8 +706,9 @@ mod tests {
         let mut profile_b = make_profile(tmp.path().join("profile-b")).await;
         // `make_profile` fixes the id; give the second a distinct identity so
         // the sweep has something to spare.
-        std::sync::Arc::get_mut(&mut profile_b)
-            .map(|profile| profile.profile_id = "other".to_owned());
+        if let Some(profile) = std::sync::Arc::get_mut(&mut profile_b) {
+            profile.profile_id = "other".to_owned();
+        }
 
         let cache = SessionRuntimeCache::new(8, Duration::from_secs(60));
         cache


### PR DESCRIPTION
Main's `check` job (`cargo clippy --workspace --all-targets -- -D warnings`) fails since #1627 merged: CI's stable toolchain now resolves to clippy 1.95, whose **default** `option_map_unit_fn` lint fires on the `Arc::get_mut(..).map(|p| p.profile_id = ...)` unit-closure in the eviction test (`runtime/cache.rs:709`). #1627's own CI predated the toolchain bump — same post-merge-combination class as octos-tui#277.

Every open PR currently fails `check` on this. One-line `if let` rewrite; `cargo clippy --workspace --all-targets -- -D warnings` and the cache tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)