### PR TITLE
feat(serve): --danger-full-access defaults sessions to the full-access profile

### DIFF
--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -270,6 +270,14 @@ pub struct AppState {
     /// configs never set) is the primary defence; the handlers additionally
     /// reject any request carrying proxy-forwarding headers.
     pub solo_login_enabled: bool,
+    /// `--danger-full-access`: sessions with NO explicit `/permissions`
+    /// selection default to the dangerous full-access profile (sandbox off,
+    /// network allowed, approvals never) instead of the gated
+    /// workspace-write default — octos' analogue of Claude Code's
+    /// `--dangerously-skip-permissions`. Solo-gated at serve startup (the
+    /// same keystone that gates selecting the profile from the menu); an
+    /// explicit per-session `/permissions` choice always overrides it.
+    pub dangerous_default_permissions: bool,
     /// Resolved HOST-level memory policy (top-level config). Threaded into
     /// lazily-bootstrapped profile runtimes so a host opt-out of memory
     /// refresh (DEFAULT-ON) also binds profiles created after startup.
@@ -393,6 +401,7 @@ impl AppState {
             frps_port: None,
             deployment_mode: crate::config::DeploymentMode::Local,
             solo_login_enabled: false,
+            dangerous_default_permissions: false,
             host_memory: None,
             allow_admin_shell: false,
             content_catalog_mgr: None,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -10027,6 +10027,12 @@ async fn open_session_result(
         resolve_session_profile_runtime(state, active_profile_id.as_deref())
     {
         let hint = effective_workspace_hint.clone();
+        // Capture the session epoch BEFORE resolving permissions so any
+        // concurrent `permission/profile/set` (which bumps the epoch AFTER
+        // writing the store) that could have made these permissions stale
+        // also invalidates this epoch — the cache insert then rejects the
+        // stale bootstrap (codex P1 round 3 on #1639).
+        let permissions_epoch = state.session_cache.session_generation(&params.session_id);
         let permissions = effective_permissions_for_session(state, &params.session_id)?;
         let sandbox_override = validate_requested_session_sandbox(
             features,
@@ -10041,6 +10047,7 @@ async fn open_session_result(
                 hint,
                 permissions,
                 sandbox_override,
+                permissions_epoch,
             )
             .await
         {

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -871,7 +871,19 @@ fn effective_session_permission_state(
     if let Some(stored) = session_permission_profiles().get_state_explicit(session_id) {
         return stored;
     }
-    if state.dangerous_default_permissions {
+    // The dangerous default is granted ONLY where an EXPLICIT Full Access
+    // selection would also be allowed (codex P1/P2 on #1639): Local
+    // deployment mode (`effective_permissions_for_session` rejects
+    // DangerFullAccess for Tenant/Cloud — an unscoped default there would
+    // fail every unselected session/open) AND a session key that does not
+    // encode a non-solo tenant/cloud scope (the same defence-in-depth gate
+    // `permission_selection_allowed` applies, so a tenant-scoped session
+    // can't be handed host access via the fallback). A session that fails
+    // either check falls through to the gated workspace-write default.
+    if state.dangerous_default_permissions
+        && state.deployment_mode == crate::config::DeploymentMode::Local
+        && !session_id_encodes_non_solo_scope(session_id)
+    {
         return StoredSessionPermissionProfile {
             selection: octos_core::ui_protocol::PermissionProfileSelection {
                 mode: octos_core::ui_protocol::PermissionProfileMode::DangerFullAccess,
@@ -4574,18 +4586,22 @@ async fn ui_protocol_connection(
             }
             UiCommand::PermissionProfileSet(params) => {
                 let session_id = params.session_id.clone();
+                // Fall back to MAIN_PROFILE_ID so the cache is ALWAYS evicted
+                // (codex P1 on #1639): a bare AppUI session on an unscoped
+                // connection resolves to `_main` at session/open, so without
+                // this fallback an explicit downgrade would report success
+                // while the danger-seeded runtime stayed cached and in use.
                 let profile_id = session_id
                     .profile_id()
                     .or(connection_profile_id)
-                    .map(ToOwned::to_owned);
+                    .map(ToOwned::to_owned)
+                    .unwrap_or_else(|| MAIN_PROFILE_ID.to_owned());
                 match permission_profile_set_result(&state, params) {
                     Ok(result) => {
-                        if let Some(profile_id) = profile_id {
-                            state
-                                .session_cache
-                                .invalidate(&(profile_id, session_id))
-                                .await;
-                        }
+                        state
+                            .session_cache
+                            .invalidate(&(profile_id, session_id))
+                            .await;
                         let _ =
                             send_ui_rpc_result(&ws, id, UiRpcResult::PermissionProfileSet(result));
                     }
@@ -5303,18 +5319,20 @@ where
             }
             UiCommand::PermissionProfileSet(params) => {
                 let session_id = params.session_id.clone();
+                // MAIN_PROFILE_ID fallback so the cache is ALWAYS evicted on a
+                // permission change (codex P1 on #1639) — see the sibling
+                // dispatcher above.
                 let profile_id = session_id
                     .profile_id()
                     .or(connection_profile_id_owned.as_deref())
-                    .map(ToOwned::to_owned);
+                    .map(ToOwned::to_owned)
+                    .unwrap_or_else(|| MAIN_PROFILE_ID.to_owned());
                 match permission_profile_set_result(&state, params) {
                     Ok(result) => {
-                        if let Some(profile_id) = profile_id {
-                            state
-                                .session_cache
-                                .invalidate(&(profile_id, session_id))
-                                .await;
-                        }
+                        state
+                            .session_cache
+                            .invalidate(&(profile_id, session_id))
+                            .await;
                         let _ =
                             send_ui_rpc_result(&ws, id, UiRpcResult::PermissionProfileSet(result));
                     }
@@ -31088,12 +31106,14 @@ ignore = []
             PermissionNetworkPolicy as Network, PermissionProfileMode as Mode,
         };
 
-        // Fresh unique session — never stored, so the resolver takes the
-        // no-explicit-selection path in both cases.
+        // Fresh unique solo-scoped session — never stored, so the resolver
+        // takes the no-explicit-selection path in every case below.
         let session_id = SessionKey("local:danger-default-pure-probe".into());
 
+        // Flag on, Local mode, solo-scoped session -> full access.
         let mut state = AppState::empty_for_tests();
         state.dangerous_default_permissions = true;
+        assert_eq!(state.deployment_mode, crate::config::DeploymentMode::Local);
         let resolved = effective_session_permission_state(&state, &session_id);
         assert_eq!(resolved.selection.mode, Mode::DangerFullAccess);
         assert_eq!(resolved.selection.network, Network::Allow);
@@ -31108,6 +31128,22 @@ ignore = []
         assert_eq!(resolved.selection.mode, Mode::WorkspaceWrite);
         assert_eq!(resolved.selection.network, Network::Deny);
         assert_eq!(resolved.approval_policy, None);
+
+        // Flag on but NON-Local deployment -> gated default (codex P2): the
+        // full-access profile is not grantable outside Local mode.
+        let mut tenant = AppState::empty_for_tests();
+        tenant.dangerous_default_permissions = true;
+        tenant.deployment_mode = crate::config::DeploymentMode::Tenant;
+        let resolved = effective_session_permission_state(&tenant, &session_id);
+        assert_eq!(resolved.selection.mode, Mode::WorkspaceWrite);
+
+        // Flag on, Local, but a NON-SOLO-scoped session key -> gated default
+        // (codex P1): the fallback must not hand a tenant-scoped session the
+        // host access the explicit path would reject.
+        let scoped = SessionKey("coding:tenant:m12-danger-default".into());
+        assert!(session_id_encodes_non_solo_scope(&scoped));
+        let resolved = effective_session_permission_state(&state, &scoped);
+        assert_eq!(resolved.selection.mode, Mode::WorkspaceWrite);
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -4586,22 +4586,16 @@ async fn ui_protocol_connection(
             }
             UiCommand::PermissionProfileSet(params) => {
                 let session_id = params.session_id.clone();
-                // Fall back to MAIN_PROFILE_ID so the cache is ALWAYS evicted
-                // (codex P1 on #1639): a bare AppUI session on an unscoped
-                // connection resolves to `_main` at session/open, so without
-                // this fallback an explicit downgrade would report success
-                // while the danger-seeded runtime stayed cached and in use.
-                let profile_id = session_id
-                    .profile_id()
-                    .or(connection_profile_id)
-                    .map(ToOwned::to_owned)
-                    .unwrap_or_else(|| MAIN_PROFILE_ID.to_owned());
                 match permission_profile_set_result(&state, params) {
                     Ok(result) => {
-                        state
-                            .session_cache
-                            .invalidate(&(profile_id, session_id))
-                            .await;
+                        // Evict by SESSION across every profile (codex P1 ×2
+                        // on #1639): the runtime may be cached under a
+                        // session/open `params.profile_id` this connection no
+                        // longer knows, and `invalidate_session` also bumps
+                        // the session generation so a concurrent in-flight
+                        // bootstrap can't re-cache the pre-change (possibly
+                        // dangerous) permissions after the downgrade.
+                        state.session_cache.invalidate_session(&session_id).await;
                         let _ =
                             send_ui_rpc_result(&ws, id, UiRpcResult::PermissionProfileSet(result));
                     }
@@ -5319,20 +5313,12 @@ where
             }
             UiCommand::PermissionProfileSet(params) => {
                 let session_id = params.session_id.clone();
-                // MAIN_PROFILE_ID fallback so the cache is ALWAYS evicted on a
-                // permission change (codex P1 on #1639) — see the sibling
-                // dispatcher above.
-                let profile_id = session_id
-                    .profile_id()
-                    .or(connection_profile_id_owned.as_deref())
-                    .map(ToOwned::to_owned)
-                    .unwrap_or_else(|| MAIN_PROFILE_ID.to_owned());
                 match permission_profile_set_result(&state, params) {
                     Ok(result) => {
-                        state
-                            .session_cache
-                            .invalidate(&(profile_id, session_id))
-                            .await;
+                        // Session-scoped eviction across all profiles + the
+                        // in-flight generation guard — see the sibling
+                        // dispatcher above (codex P1 ×2 on #1639).
+                        state.session_cache.invalidate_session(&session_id).await;
                         let _ =
                             send_ui_rpc_result(&ws, id, UiRpcResult::PermissionProfileSet(result));
                     }

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -7027,6 +7027,10 @@ async fn tool_status_list_result(
 ) -> Result<Value, RpcError> {
     let profile_runtime = ensure_session_profile_runtime(state, active_profile_id).await?;
     let session_runtime = if let Some(profile_runtime) = profile_runtime.as_ref() {
+        // Epoch BEFORE permission resolution so a concurrent downgrade
+        // can't pair a post-bump epoch with pre-bump permissions on a
+        // preempted caller (codex P1 round 4 on #1639).
+        let permissions_epoch = state.session_cache.session_generation(session_id);
         let permissions = effective_permissions_for_session(state, session_id)?;
         let workspace_hint = session_workspaces().get(session_id);
         Some(
@@ -7037,6 +7041,7 @@ async fn tool_status_list_result(
                     session_id.clone(),
                     workspace_hint,
                     permissions,
+                    permissions_epoch,
                 )
                 .await
                 .map_err(|error| {
@@ -10846,10 +10851,17 @@ pub(crate) async fn resolve_sessions_for_lookup(
         .or(routed_profile_id);
     if let Some(profile_runtime) = resolve_session_profile_runtime(state, active_profile_id) {
         let hint = session_workspaces().get(session_id);
+        let permissions_epoch = state.session_cache.session_generation(session_id);
         let permissions = effective_permissions_for_session(state, session_id).ok()?;
         if let Ok(runtime) = state
             .session_cache
-            .get_or_init_with_permissions(&profile_runtime, session_id.clone(), hint, permissions)
+            .get_or_init_with_permissions(
+                &profile_runtime,
+                session_id.clone(),
+                hint,
+                permissions,
+                permissions_epoch,
+            )
             .await
         {
             return Some(runtime.sessions.clone());
@@ -18047,6 +18059,7 @@ async fn run_native_code_review_turn(
         }
     };
     let hint = session_workspaces().get(&session_id);
+    let permissions_epoch = state.session_cache.session_generation(&session_id);
     let permissions = match effective_permissions_for_session(&state, &session_id) {
         Ok(permissions) => permissions,
         Err(error) => {
@@ -18068,7 +18081,13 @@ async fn run_native_code_review_turn(
     };
     let session_runtime = match state
         .session_cache
-        .get_or_init_with_permissions(&profile_runtime, session_id.clone(), hint, permissions)
+        .get_or_init_with_permissions(
+            &profile_runtime,
+            session_id.clone(),
+            hint,
+            permissions,
+            permissions_epoch,
+        )
         .await
     {
         Ok(runtime) => runtime,
@@ -19588,6 +19607,7 @@ async fn run_standalone_turn(
     // use that as the `workspace_hint`. Otherwise the bootstrap default
     // Tier-3 (`<profile_data_dir>/users/.../workspace`) wins.
     let hint = session_workspaces().get(&session_id);
+    let permissions_epoch = state.session_cache.session_generation(&session_id);
     let permissions = match effective_permissions_for_session(&state, &session_id) {
         Ok(permissions) => permissions,
         Err(error) => {
@@ -19609,7 +19629,13 @@ async fn run_standalone_turn(
     };
     let session_runtime = match state
         .session_cache
-        .get_or_init_with_permissions(&profile_runtime, session_id.clone(), hint, permissions)
+        .get_or_init_with_permissions(
+            &profile_runtime,
+            session_id.clone(),
+            hint,
+            permissions,
+            permissions_epoch,
+        )
         .await
     {
         Ok(rt) => rt,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -820,12 +820,21 @@ impl SessionPermissionProfileStore {
     }
 
     fn get_state(&self, session_id: &SessionKey) -> StoredSessionPermissionProfile {
+        self.get_state_explicit(session_id).unwrap_or_default()
+    }
+
+    /// The stored selection ONLY if the session made an explicit
+    /// `/permissions` choice — `None` lets the caller apply a configurable
+    /// default (see `effective_session_permission_state`).
+    fn get_state_explicit(
+        &self,
+        session_id: &SessionKey,
+    ) -> Option<StoredSessionPermissionProfile> {
         self.selections
             .lock()
             .unwrap_or_else(|error| error.into_inner())
             .get(session_id)
             .copied()
-            .unwrap_or_default()
     }
 
     fn set(
@@ -845,6 +854,33 @@ impl SessionPermissionProfileStore {
                 },
             );
     }
+}
+
+/// Session permission state honoring the serve-level dangerous default
+/// (`--danger-full-access`, octos' analogue of Claude Code's
+/// `--dangerously-skip-permissions`): a session with NO explicit
+/// `/permissions` selection falls back to the full-access profile —
+/// sandbox off, network allowed, approvals never — instead of the gated
+/// workspace-write default. The flag is solo-gated at serve startup (the
+/// same keystone that gates selecting the profile from the menu), and an
+/// explicit per-session choice always wins.
+fn effective_session_permission_state(
+    state: &AppState,
+    session_id: &SessionKey,
+) -> StoredSessionPermissionProfile {
+    if let Some(stored) = session_permission_profiles().get_state_explicit(session_id) {
+        return stored;
+    }
+    if state.dangerous_default_permissions {
+        return StoredSessionPermissionProfile {
+            selection: octos_core::ui_protocol::PermissionProfileSelection {
+                mode: octos_core::ui_protocol::PermissionProfileMode::DangerFullAccess,
+                network: octos_core::ui_protocol::PermissionNetworkPolicy::Allow,
+            },
+            approval_policy: Some(octos_agent::ApprovalPolicy::Never),
+        };
+    }
+    StoredSessionPermissionProfile::default()
 }
 
 #[derive(Default)]
@@ -6854,7 +6890,7 @@ fn effective_permissions_for_session(
         PermissionNetworkPolicy as Network, PermissionProfileMode as Mode,
     };
 
-    let permission_state = session_permission_profiles().get_state(session_id);
+    let permission_state = effective_session_permission_state(state, session_id);
     let requested = match permission_state.selection.mode {
         Mode::ReadOnly => octos_agent::PermissionProfile::ReadOnly,
         Mode::WorkspaceWrite => octos_agent::PermissionProfile::WorkspaceWrite,
@@ -6895,8 +6931,7 @@ fn permission_profile_list_result(
     state: &AppState,
     params: octos_core::ui_protocol::PermissionProfileListParams,
 ) -> octos_core::ui_protocol::PermissionProfileListResult {
-    let store = session_permission_profiles();
-    let current = store.get(&params.session_id);
+    let current = effective_session_permission_state(state, &params.session_id).selection;
     let profiles = permission_profile_supported_selections(state, &params.session_id);
     octos_core::ui_protocol::PermissionProfileListResult {
         session_id: params.session_id,
@@ -6910,7 +6945,7 @@ fn permission_profile_set_result(
     params: octos_core::ui_protocol::PermissionProfileSetParams,
 ) -> Result<octos_core::ui_protocol::PermissionProfileSetResult, RpcError> {
     let store = session_permission_profiles();
-    let previous_state = store.get_state(&params.session_id);
+    let previous_state = effective_session_permission_state(state, &params.session_id);
     let previous = previous_state.selection;
     let approval_policy =
         parse_permission_approval_policy(params.update.approval_policy.as_deref())?
@@ -7056,7 +7091,7 @@ async fn tool_status_list_result(
     let tool_name_refs: Vec<&str> = tool_names.iter().map(String::as_str).collect();
     let disabled_tool_refs: Vec<&str> = disabled_tool_names.iter().map(String::as_str).collect();
     let deferred_name_refs: Vec<&str> = recoverable_deferred.iter().map(String::as_str).collect();
-    let permission_state = session_permission_profiles().get_state(session_id);
+    let permission_state = effective_session_permission_state(state, session_id);
     let session_id_wire = session_id.to_string();
     let profile_id = active_profile_id.unwrap_or(MAIN_PROFILE_ID).to_owned();
 
@@ -7118,7 +7153,7 @@ fn runtime_policy_stamp_for_profile(
         )
     };
     let permission_state = session_id
-        .map(|session_id| session_permission_profiles().get_state(session_id))
+        .map(|session_id| effective_session_permission_state(state, session_id))
         .unwrap_or_default();
     let (approval_policy, sandbox_mode, permission_profile, filesystem_scope, network) =
         permission_selection_policy_fields(
@@ -31036,6 +31071,43 @@ ignore = []
             requested_workspace.as_deref(),
             Some(workspace.path().canonicalize().unwrap().as_path())
         );
+    }
+
+    /// `--danger-full-access` (solo-gated at serve startup): a session with
+    /// NO explicit `/permissions` selection resolves to the dangerous
+    /// full-access profile — sandbox off, network allowed, approvals never —
+    /// when the flag is set, and to the gated default when it is not. Tests
+    /// the pure resolver directly so it writes NOTHING to the process-global
+    /// permission store (a leaked entry there flakes concurrent tests); the
+    /// explicit-choice-wins branch is a structural early-return exercised by
+    /// the store round-trip in
+    /// `runtime_policy_stamp_exposes_effective_permission_fields`.
+    #[test]
+    fn dangerous_default_permissions_resolves_without_an_explicit_choice() {
+        use octos_core::ui_protocol::{
+            PermissionNetworkPolicy as Network, PermissionProfileMode as Mode,
+        };
+
+        // Fresh unique session — never stored, so the resolver takes the
+        // no-explicit-selection path in both cases.
+        let session_id = SessionKey("local:danger-default-pure-probe".into());
+
+        let mut state = AppState::empty_for_tests();
+        state.dangerous_default_permissions = true;
+        let resolved = effective_session_permission_state(&state, &session_id);
+        assert_eq!(resolved.selection.mode, Mode::DangerFullAccess);
+        assert_eq!(resolved.selection.network, Network::Allow);
+        assert_eq!(
+            resolved.approval_policy,
+            Some(octos_agent::ApprovalPolicy::Never)
+        );
+
+        // Flag off -> the gated workspace-write default, approvals unset.
+        let plain = AppState::empty_for_tests();
+        let resolved = effective_session_permission_state(&plain, &session_id);
+        assert_eq!(resolved.selection.mode, Mode::WorkspaceWrite);
+        assert_eq!(resolved.selection.network, Network::Deny);
+        assert_eq!(resolved.approval_policy, None);
     }
 
     #[test]

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -255,6 +255,16 @@ pub struct ServeCommand {
     #[arg(long)]
     pub solo: bool,
 
+    /// Default every session to the dangerous FULL-ACCESS permission
+    /// profile: sandbox disabled, network allowed, approvals never —
+    /// octos' analogue of Claude Code's `--dangerously-skip-permissions`.
+    /// Requires `--solo` (the same local-single-user keystone that gates
+    /// selecting Full Access from the `/permissions` menu). A session's
+    /// explicit `/permissions` choice still overrides the default. Also
+    /// settable via `OCTOS_DANGER_FULL_ACCESS=1`.
+    #[arg(long)]
+    pub danger_full_access: bool,
+
     /// Disable automatic retry on transient errors.
     #[arg(long)]
     pub no_retry: bool,
@@ -679,6 +689,24 @@ impl ServeCommand {
             crate::api::DEFAULT_PREVIEW_SWEEP_INTERVAL,
         );
 
+        let solo_login_enabled_flag = self.solo
+            || std::env::var("OCTOS_SOLO_LOGIN")
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false);
+        let dangerous_default_permissions_flag = self.danger_full_access
+            || std::env::var("OCTOS_DANGER_FULL_ACCESS")
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false);
+        // SECURITY KEYSTONE: the dangerous default rides the SAME solo
+        // opt-in that gates selecting Full Access from the menu — a fleet
+        // config that never sets --solo can reach neither surface.
+        if dangerous_default_permissions_flag && !solo_login_enabled_flag {
+            eyre::bail!(
+                "--danger-full-access requires --solo (local single-user opt-in); \
+                 refusing to default sessions to the dangerous profile on a \
+                 potentially shared host"
+            );
+        }
         let state = Arc::new(AppState {
             profiles: profile_runtimes,
             session_cache,
@@ -728,10 +756,8 @@ impl ServeCommand {
             frps_port: std::env::var("FRPS_PORT").ok().and_then(|p| p.parse().ok()),
             deployment_mode: config.mode.clone(),
             host_memory: config.memory.clone(),
-            solo_login_enabled: self.solo
-                || std::env::var("OCTOS_SOLO_LOGIN")
-                    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                    .unwrap_or(false),
+            solo_login_enabled: solo_login_enabled_flag,
+            dangerous_default_permissions: dangerous_default_permissions_flag,
             allow_admin_shell: config.allow_admin_shell,
             content_catalog_mgr: Some(Arc::new(
                 crate::content_catalog::ContentCatalogManager::new(profile_store.clone()),

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -707,6 +707,20 @@ impl ServeCommand {
                  potentially shared host"
             );
         }
+        // `effective_permissions_for_session` only grants DangerFullAccess in
+        // Local deployment mode; enabling the default under Tenant/Cloud would
+        // fail every unselected `session/open` at permission resolution and
+        // let `profile/list` advertise a current profile the runtime rejects
+        // (codex P2 on #1639). Refuse the misconfiguration at startup.
+        if dangerous_default_permissions_flag && config.mode != crate::config::DeploymentMode::Local
+        {
+            eyre::bail!(
+                "--danger-full-access requires Local deployment mode (mode is {:?}); \
+                 the full-access profile is not grantable under Tenant/Cloud, so an \
+                 unselected session would fail permission resolution",
+                config.mode
+            );
+        }
         let state = Arc::new(AppState {
             profiles: profile_runtimes,
             session_cache,

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -271,11 +271,15 @@ impl SessionRuntimeCache {
         session_key: SessionKey,
         workspace_hint: Option<PathBuf>,
     ) -> Result<Arc<SessionRuntime>> {
+        // Fixed workspace-write default (no mutable-store resolution to race
+        // against): sampling the epoch here is correct.
+        let permissions_epoch = self.session_generation(&session_key);
         self.get_or_init_with_permissions(
             profile,
             session_key,
             workspace_hint,
             EffectivePermissions::workspace_write(),
+            permissions_epoch,
         )
         .await
     }
@@ -290,10 +294,14 @@ impl SessionRuntimeCache {
         session_key: SessionKey,
         workspace_hint: Option<PathBuf>,
         permissions: EffectivePermissions,
+        // Epoch captured by the caller BEFORE it resolved `permissions` — see
+        // `get_or_init_with_permissions_and_sandbox`. REQUIRED (not
+        // self-sampled) so every permission-bearing call site is forced to
+        // pair its snapshot with the pre-resolution epoch; a self-sample here
+        // could pair a post-downgrade epoch with pre-downgrade permissions on
+        // a preempted multi-threaded caller (codex P1 round 4 on #1639).
+        permissions_epoch: u64,
     ) -> Result<Arc<SessionRuntime>> {
-        // Non-race callers (no separate permission-change dance): sample the
-        // current epoch at call time — equivalent to the prior behaviour.
-        let permissions_epoch = self.session_generation(&session_key);
         self.get_or_init_with_permissions_and_sandbox(
             profile,
             session_key,

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -103,6 +103,13 @@ pub struct SessionRuntimeCache {
     /// (holding the old `ProfileRuntime`) must not insert its stale runtime
     /// after the sweep — it serves its own caller uncached instead.
     generations: Arc<std::sync::Mutex<HashMap<String, u64>>>,
+    /// Per-SESSION invalidation generation. Bumped by
+    /// [`Self::invalidate_session`] on a permission change; a bootstrap that
+    /// STARTED before the bump (holding the pre-change permissions) must not
+    /// insert its now-stale runtime after the sweep. Session-scoped rather
+    /// than profile-scoped because a permission change targets one session
+    /// but its runtime may be cached under any of several profile ids.
+    session_generations: Arc<std::sync::Mutex<HashMap<SessionKey, u64>>>,
     max_size: usize,
     idle_ttl: Duration,
     /// Cancellation signal for the background sweep task. Notified
@@ -222,6 +229,7 @@ impl SessionRuntimeCache {
             inner,
             inflight: Arc::new(std::sync::Mutex::new(HashMap::new())),
             generations: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            session_generations: Arc::new(std::sync::Mutex::new(HashMap::new())),
             max_size,
             idle_ttl,
             shutdown,
@@ -391,6 +399,7 @@ impl SessionRuntimeCache {
                 }
                 InflightOutcome::OwnGuard(guard) => {
                     let generation_at_start = self.profile_generation(&key.0);
+                    let session_generation_at_start = self.session_generation(&session_key);
                     let result = SessionRuntime::bootstrap_with_permissions_and_sandbox(
                         profile,
                         session_key.clone(),
@@ -416,7 +425,12 @@ impl SessionRuntimeCache {
                             // than a "one bootstrap per inflight
                             // era" invariant.
                             let canonical = self
-                                .insert_with_eviction(key.clone(), runtime, generation_at_start)
+                                .insert_with_eviction(
+                                    key.clone(),
+                                    runtime,
+                                    generation_at_start,
+                                    session_generation_at_start,
+                                )
                                 .await;
                             drop(guard);
                             return Ok(canonical);
@@ -451,14 +465,18 @@ impl SessionRuntimeCache {
         key: CacheKey,
         runtime: Arc<SessionRuntime>,
         generation_at_start: u64,
+        session_generation_at_start: u64,
     ) -> Arc<SessionRuntime> {
         let mut guard = self.inner.write().await;
-        // Re-check the profile generation UNDER the map lock: the sweep in
-        // `invalidate_profile` serializes on this same lock and its bump
-        // happens-before its sweep, so either we observe the bump here (and
-        // skip caching the stale runtime) or our insert lands first and the
-        // sweep removes it — a stale runtime can never survive a switch.
-        if self.profile_generation(&key.0) != generation_at_start {
+        // Re-check BOTH generations UNDER the map lock: each sweep
+        // (`invalidate_profile` / `invalidate_session`) serializes on this
+        // same lock and its bump happens-before its sweep, so either we
+        // observe the bump here (and skip caching the stale runtime) or our
+        // insert lands first and the sweep removes it — a stale runtime can
+        // never survive a profile switch OR a permission change.
+        if self.profile_generation(&key.0) != generation_at_start
+            || self.session_generation(&key.1) != session_generation_at_start
+        {
             return runtime;
         }
 
@@ -531,6 +549,33 @@ impl SessionRuntimeCache {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .get(profile_id)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Drop every cached runtime for `session_key` REGARDLESS of profile, and
+    /// bump its session generation so an in-flight bootstrap (started before
+    /// this call, holding pre-change permissions) skips caching at insert.
+    /// Used on a permission change (`permission/profile/set`): the runtime
+    /// embeds the old sandbox/network policy, and the connection may not know
+    /// which profile id the session was opened under (codex P1 ×2 on #1639).
+    pub async fn invalidate_session(&self, session_key: &SessionKey) {
+        {
+            let mut generations = self
+                .session_generations
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            *generations.entry(session_key.clone()).or_insert(0) += 1;
+        }
+        let mut guard = self.inner.write().await;
+        guard.retain(|(_, key_session), _| key_session != session_key);
+    }
+
+    fn session_generation(&self, session_key: &SessionKey) -> u64 {
+        self.session_generations
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(session_key)
             .copied()
             .unwrap_or(0)
     }
@@ -734,6 +779,77 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn invalidate_session_sweeps_the_session_across_profiles() {
+        // A permission change targets ONE session but its runtime may be
+        // cached under any profile id — `invalidate_session` drops every
+        // profile's entry for that session and spares other sessions
+        // (codex P1 ×2 on #1639).
+        let tmp = TempDir::new().unwrap();
+        let profile_a = make_profile(tmp.path().join("profile-a")).await;
+        let mut profile_b = make_profile(tmp.path().join("profile-b")).await;
+        if let Some(profile) = std::sync::Arc::get_mut(&mut profile_b) {
+            profile.profile_id = "other".to_owned();
+        }
+        let shared = SessionKey::new("api", "shared");
+        let spared = SessionKey::new("api", "spared");
+
+        let cache = SessionRuntimeCache::new(8, Duration::from_secs(60));
+        cache
+            .get_or_init(&profile_a, shared.clone(), None)
+            .await
+            .expect("a");
+        cache
+            .get_or_init(&profile_b, shared.clone(), None)
+            .await
+            .expect("b");
+        cache
+            .get_or_init(&profile_a, spared.clone(), None)
+            .await
+            .expect("s");
+        assert_eq!(cache.len().await, 3);
+
+        cache.invalidate_session(&shared).await;
+        assert_eq!(
+            cache.len().await,
+            1,
+            "both profiles' entries for the target session are gone; the other session survives"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalidate_session_mid_bootstrap_skips_the_stale_insert() {
+        // A bootstrap that STARTED before an `invalidate_session` (holding the
+        // pre-change permissions) must not cache its stale runtime after the
+        // bump — the session generation re-check rejects it at insert (codex
+        // P1 in-flight race on #1639).
+        let tmp = TempDir::new().unwrap();
+        let profile = make_profile(tmp.path().join("profile-data")).await;
+        let session = SessionKey::new("api", "inflight-perm");
+
+        let cache = SessionRuntimeCache::new(8, Duration::from_secs(60));
+        // Simulate the race: the invalidate bumps the generation while a
+        // bootstrap is notionally in flight, then that bootstrap tries to
+        // land its runtime with a stale generation snapshot.
+        cache.invalidate_session(&session).await;
+        assert_eq!(
+            cache.session_generation(&session),
+            1,
+            "the invalidate bumped the session generation"
+        );
+
+        // A fresh init AFTER the bump caches normally (its snapshot matches).
+        cache
+            .get_or_init(&profile, session.clone(), None)
+            .await
+            .expect("post-bump init");
+        assert_eq!(
+            cache.len().await,
+            1,
+            "a post-invalidate bootstrap caches normally"
+        );
+    }
+
+    #[tokio::test]
     async fn get_or_init_returns_same_arc_on_second_call() {
         let tmp = TempDir::new().unwrap();
         let data_dir = tmp.path().join("profile-data");
@@ -924,6 +1040,7 @@ mod tests {
                 (profile.profile_id.clone(), key.clone()),
                 redundant,
                 cache.profile_generation(&profile.profile_id),
+                cache.session_generation(&key),
             )
             .await;
         assert!(

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -291,12 +291,16 @@ impl SessionRuntimeCache {
         workspace_hint: Option<PathBuf>,
         permissions: EffectivePermissions,
     ) -> Result<Arc<SessionRuntime>> {
+        // Non-race callers (no separate permission-change dance): sample the
+        // current epoch at call time — equivalent to the prior behaviour.
+        let permissions_epoch = self.session_generation(&session_key);
         self.get_or_init_with_permissions_and_sandbox(
             profile,
             session_key,
             workspace_hint,
             permissions,
             None,
+            permissions_epoch,
         )
         .await
     }
@@ -312,6 +316,14 @@ impl SessionRuntimeCache {
         workspace_hint: Option<PathBuf>,
         permissions: EffectivePermissions,
         sandbox_override: Option<SandboxConfig>,
+        // Session-generation epoch captured by the CALLER at (or before) the
+        // moment it resolved `permissions` — NOT re-sampled here. A bootstrap
+        // that waits on an in-flight slot and then claims its own must reject
+        // its insert if an `invalidate_session` bumped the generation any time
+        // after the permissions were resolved, or it would re-cache the
+        // pre-change (possibly dangerous) policy after a downgrade (codex P1
+        // round 3 on #1639).
+        permissions_epoch: u64,
     ) -> Result<Arc<SessionRuntime>> {
         let key = (profile.profile_id.clone(), session_key.clone());
 
@@ -399,7 +411,9 @@ impl SessionRuntimeCache {
                 }
                 InflightOutcome::OwnGuard(guard) => {
                     let generation_at_start = self.profile_generation(&key.0);
-                    let session_generation_at_start = self.session_generation(&session_key);
+                    // Caller-supplied epoch (tied to the permission snapshot),
+                    // not a post-wait re-sample — see the param doc.
+                    let session_generation_at_start = permissions_epoch;
                     let result = SessionRuntime::bootstrap_with_permissions_and_sandbox(
                         profile,
                         session_key.clone(),
@@ -571,7 +585,7 @@ impl SessionRuntimeCache {
         guard.retain(|(_, key_session), _| key_session != session_key);
     }
 
-    fn session_generation(&self, session_key: &SessionKey) -> u64 {
+    pub(crate) fn session_generation(&self, session_key: &SessionKey) -> u64 {
         self.session_generations
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -847,6 +861,57 @@ mod tests {
             1,
             "a post-invalidate bootstrap caches normally"
         );
+    }
+
+    #[tokio::test]
+    async fn stale_permission_epoch_is_rejected_at_insert() {
+        // codex P1 round 3: an epoch captured BEFORE a concurrent
+        // `invalidate_session` must reject the bootstrap's insert even though
+        // the OwnGuard arm no longer re-samples the (now-bumped) generation.
+        // This is the wait-race made deterministic: capture the epoch, bump
+        // it, then run get_or_init with the STALE epoch — nothing caches.
+        let tmp = TempDir::new().unwrap();
+        let profile = make_profile(tmp.path().join("profile-data")).await;
+        let session = SessionKey::new("api", "stale-epoch");
+
+        let cache = SessionRuntimeCache::new(8, Duration::from_secs(60));
+        let stale_epoch = cache.session_generation(&session); // 0
+        cache.invalidate_session(&session).await; // bump -> 1
+
+        let runtime = cache
+            .get_or_init_with_permissions_and_sandbox(
+                &profile,
+                session.clone(),
+                None,
+                EffectivePermissions::workspace_write(),
+                None,
+                stale_epoch,
+            )
+            .await
+            .expect("bootstrap succeeds but must not cache");
+        // The caller still gets a working runtime…
+        assert_eq!(runtime.session_key, session);
+        // …but it was NOT cached (stale epoch rejected at insert).
+        assert_eq!(
+            cache.len().await,
+            0,
+            "a bootstrap carrying a pre-invalidate epoch must not cache"
+        );
+
+        // A fresh call with the CURRENT epoch caches normally.
+        let current_epoch = cache.session_generation(&session);
+        cache
+            .get_or_init_with_permissions_and_sandbox(
+                &profile,
+                session.clone(),
+                None,
+                EffectivePermissions::workspace_write(),
+                None,
+                current_epoch,
+            )
+            .await
+            .expect("current-epoch bootstrap");
+        assert_eq!(cache.len().await, 1, "current epoch caches");
     }
 
     #[tokio::test]


### PR DESCRIPTION
octos' analogue of Claude Code's `--dangerously-skip-permissions`. User ask: run octos-dev with full permissions / no sandbox once granted, without re-picking Full Access from the `/permissions` menu after every backend restart.

## What
`octos serve --danger-full-access` (also `OCTOS_DANGER_FULL_ACCESS=1`) defaults every session with **no explicit** `/permissions` selection to the dangerous full-access profile — **sandbox off, network allowed, approvals never** — instead of the gated workspace-write default.

## Security keystone preserved
`--danger-full-access` **requires `--solo`** (the same local-single-user opt-in that already gates *selecting* Full Access from the menu), enforced at serve startup with a hard `bail!`. A fleet daemon that never sets `--solo` can reach neither surface. An explicit per-session `/permissions` choice **always overrides** the launch default.

## Implementation
- `AppState.dangerous_default_permissions` (defaulted false everywhere, incl. `empty_for_tests`).
- `effective_session_permission_state(state, session_id)`: returns the explicit stored selection if any, else the full-access profile when the flag is set, else the gated default. **With the flag off it returns byte-identically to the prior `get_state` path** — a pure no-op for every existing caller.
- Four read sites routed through it (permissions resolve, tool-status, runtime-policy stamp, permission list/set).

## Testing
- Hermetic unit test on the pure resolver (flag-on default, flag-off default) — deliberately writes nothing to the process-global permission store.
- Live-proven earlier this session: selecting Full Access made `curl https://example.com` succeed through the shell tool despite the profile's `allow_network: false` sandbox config; this flag makes that the boot default.
- Caveat unchanged: even Full Access keeps the unconditional hardening (18 `BLOCKED_ENV_VARS` scrub, ShellTool SafePolicy, SSRF guards).

**Note on flaky tests:** the octos-cli lib suite has pre-existing ambient flakies under heavy local load — global message-commit-observer tests (serialized only against each other, not against unrelated committers), `should_report_free_port_as_available` (port binding), and actor-tick timing tests. They pass cleanly in isolation and the suite passes green on unloaded runs; this change is behavior-preserving with the flag off, so it doesn't introduce them, though adding a test perturbs thread-bucketing enough to surface them occasionally. Not addressed here (separate test-infra concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)