### PR TITLE
feat(llm): Anthropic prompt-cache breakpoints + cache-usage accounting (+ deterministic tool-spec order)

### DIFF
--- a/crates/octos-agent/src/agent/budget.rs
+++ b/crates/octos-agent/src/agent/budget.rs
@@ -77,17 +77,12 @@ impl BudgetStop {
 }
 
 /// Tokens counted against the turn token budget: everything the provider
-/// processed. Anthropic reports cached prefix tokens OUTSIDE `input_tokens`
-/// (disjoint accounting: total prompt = input + cache_read + cache_write),
-/// so counting only input+output would let a cache-served loop run ~10x
-/// past the cap that bounded it before prompt caching landed.
-///
-/// Providers with INCLUSIVE accounting (OpenAI/Gemini report cached tokens
-/// inside `input_tokens`) get their cached portion counted twice here —
-/// deliberately conservative: the opt-in budget fires somewhat EARLY on
-/// their cache hits rather than 10x late on Anthropic's. Exact per-provider
-/// budgets need usage-semantics normalization (tracked as the pricing
-/// follow-up on the caching PR).
+/// processed. Per the [`octos_llm::TokenUsage`] contract, cache counts are
+/// DISJOINT from `input_tokens` on every provider (total prompt = input +
+/// cache_read + cache_write; inclusive wire formats are normalized at their
+/// parse boundary), so this sum is exact. Counting only input+output would
+/// let a cache-served Anthropic loop run ~10x past the cap that bounded it
+/// before prompt caching landed.
 fn budget_tokens_used(total_usage: &TokenUsage) -> u32 {
     total_usage
         .input_tokens

--- a/crates/octos-agent/src/agent/budget.rs
+++ b/crates/octos-agent/src/agent/budget.rs
@@ -76,6 +76,26 @@ impl BudgetStop {
     }
 }
 
+/// Tokens counted against the turn token budget: everything the provider
+/// processed. Anthropic reports cached prefix tokens OUTSIDE `input_tokens`
+/// (disjoint accounting: total prompt = input + cache_read + cache_write),
+/// so counting only input+output would let a cache-served loop run ~10x
+/// past the cap that bounded it before prompt caching landed.
+///
+/// Providers with INCLUSIVE accounting (OpenAI/Gemini report cached tokens
+/// inside `input_tokens`) get their cached portion counted twice here —
+/// deliberately conservative: the opt-in budget fires somewhat EARLY on
+/// their cache hits rather than 10x late on Anthropic's. Exact per-provider
+/// budgets need usage-semantics normalization (tracked as the pricing
+/// follow-up on the caching PR).
+fn budget_tokens_used(total_usage: &TokenUsage) -> u32 {
+    total_usage
+        .input_tokens
+        .saturating_add(total_usage.output_tokens)
+        .saturating_add(total_usage.cache_read_tokens)
+        .saturating_add(total_usage.cache_write_tokens)
+}
+
 impl Agent {
     /// Check whether the agent loop should stop due to budget constraints.
     pub(super) fn check_budget(
@@ -107,7 +127,7 @@ impl Agent {
             }
         }
         if let Some(max_tokens) = self.config.max_tokens {
-            let used = total_usage.input_tokens + total_usage.output_tokens;
+            let used = budget_tokens_used(total_usage);
             if used >= max_tokens {
                 return Some(BudgetStop::MaxTokens {
                     used,
@@ -166,6 +186,29 @@ mod tests {
     use super::super::{AgentConfig, TokenTracker};
 
     // ---------- AgentConfig::default ----------
+
+    #[test]
+    fn budget_counts_cache_tokens_as_used() {
+        // With prompt caching, Anthropic moves most of the prompt out of
+        // input_tokens into cache_read/cache_write — the budget must still
+        // see the full processed volume or the max_tokens gate fires ~10x
+        // late on cache-served loops.
+        let usage = TokenUsage {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_read_tokens: 4_000,
+            cache_write_tokens: 850,
+            ..Default::default()
+        };
+        assert_eq!(budget_tokens_used(&usage), 5_000);
+
+        let uncached = TokenUsage {
+            input_tokens: 100,
+            output_tokens: 50,
+            ..Default::default()
+        };
+        assert_eq!(budget_tokens_used(&uncached), 150);
+    }
 
     #[test]
     fn agent_config_default_values() {

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -2411,6 +2411,8 @@ impl Agent {
             if let Some(tokens) = tool_tokens {
                 tokens_used.input_tokens += tokens.input_tokens;
                 tokens_used.output_tokens += tokens.output_tokens;
+                tokens_used.cache_read_tokens += tokens.cache_read_tokens;
+                tokens_used.cache_write_tokens += tokens.cache_write_tokens;
             }
             if let Some(meta) = tool_structured_metadata {
                 structured_metadata.push(meta);

--- a/crates/octos-agent/src/agent/llm_call.rs
+++ b/crates/octos-agent/src/agent/llm_call.rs
@@ -110,6 +110,8 @@ impl Agent {
                         let mut response = response;
                         response.usage.input_tokens += retry_usage.input_tokens;
                         response.usage.output_tokens += retry_usage.output_tokens;
+                        response.usage.cache_read_tokens += retry_usage.cache_read_tokens;
+                        response.usage.cache_write_tokens += retry_usage.cache_write_tokens;
 
                         if let Some(ref hooks) = self.hooks {
                             let latency_ms = call_start.elapsed().as_millis() as u64;
@@ -185,6 +187,10 @@ impl Agent {
                                 let mut fallback_resp = fallback_resp;
                                 fallback_resp.usage.input_tokens += retry_usage.input_tokens;
                                 fallback_resp.usage.output_tokens += retry_usage.output_tokens;
+                                fallback_resp.usage.cache_read_tokens +=
+                                    retry_usage.cache_read_tokens;
+                                fallback_resp.usage.cache_write_tokens +=
+                                    retry_usage.cache_write_tokens;
                                 return Ok((fallback_resp, false, attributed_cost));
                             }
                             Ok(_) => {
@@ -215,6 +221,8 @@ impl Agent {
                     }
                     retry_usage.input_tokens += response.usage.input_tokens;
                     retry_usage.output_tokens += response.usage.output_tokens;
+                    retry_usage.cache_read_tokens += response.usage.cache_read_tokens;
+                    retry_usage.cache_write_tokens += response.usage.cache_write_tokens;
 
                     let delay = Duration::from_secs(1 << attempt);
                     let reason = if response.stop_reason == StopReason::ContentFiltered {
@@ -319,6 +327,8 @@ impl Agent {
                                 let mut resp = resp;
                                 resp.usage.input_tokens += retry_usage.input_tokens;
                                 resp.usage.output_tokens += retry_usage.output_tokens;
+                                resp.usage.cache_read_tokens += retry_usage.cache_read_tokens;
+                                resp.usage.cache_write_tokens += retry_usage.cache_write_tokens;
                                 return Ok((resp, false, attributed_cost));
                             }
                             Ok(_) => {

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -1148,6 +1148,8 @@ impl Agent {
                     turn.record_usage(
                         response.usage.input_tokens,
                         response.usage.output_tokens,
+                        response.usage.cache_read_tokens,
+                        response.usage.cache_write_tokens,
                         tracker,
                         // Attributed inside `call_llm_with_hooks`: each
                         // attempt (discarded retries included) priced at the
@@ -1889,6 +1891,8 @@ impl Agent {
                 turn.record_usage(
                     response.usage.input_tokens,
                     response.usage.output_tokens,
+                    response.usage.cache_read_tokens,
+                    response.usage.cache_write_tokens,
                     None,
                     // Attributed per attempt inside `call_llm_with_hooks`
                     // (cross-provider retries priced at their own slot).
@@ -2203,6 +2207,8 @@ impl Agent {
             token_usage: octos_core::TokenUsage {
                 input_tokens: usage.input_tokens,
                 output_tokens: usage.output_tokens,
+                cache_read_tokens: usage.cache_read_tokens,
+                cache_write_tokens: usage.cache_write_tokens,
                 ..Default::default()
             },
         }
@@ -2469,6 +2475,8 @@ impl Agent {
             tool_send_files.extend(batch_send_files);
             tool_tokens.input_tokens += batch_tokens.input_tokens;
             tool_tokens.output_tokens += batch_tokens.output_tokens;
+            tool_tokens.cache_read_tokens += batch_tokens.cache_read_tokens;
+            tool_tokens.cache_write_tokens += batch_tokens.cache_write_tokens;
             tool_metadata.extend(batch_metadata);
             tool_success.extend(batch_success);
         }
@@ -2571,6 +2579,8 @@ impl Agent {
         turn.record_usage(
             tool_tokens.input_tokens,
             tool_tokens.output_tokens,
+            tool_tokens.cache_read_tokens,
+            tool_tokens.cache_write_tokens,
             tracker,
             // Tool-reported usage has no per-response provider attribution;
             // price it at the active slot as the closest estimate.

--- a/crates/octos-agent/src/agent/turn_state.rs
+++ b/crates/octos-agent/src/agent/turn_state.rs
@@ -139,11 +139,19 @@ impl LoopTurnState {
         &mut self,
         input_tokens: u32,
         output_tokens: u32,
+        cache_read_tokens: u32,
+        cache_write_tokens: u32,
         tracker: Option<&TokenTracker>,
         estimated_cost_usd: Option<f64>,
     ) {
         self.total_usage.input_tokens += input_tokens;
         self.total_usage.output_tokens += output_tokens;
+        // Cache traffic is real processed prompt volume — Anthropic reports
+        // it OUTSIDE input_tokens (disjoint accounting) — so accumulate it
+        // too, keeping the turn totals and the token-budget gate at their
+        // pre-caching meaning (everything the provider processed).
+        self.total_usage.cache_read_tokens += cache_read_tokens;
+        self.total_usage.cache_write_tokens += cache_write_tokens;
         if let Some(cost) = estimated_cost_usd {
             self.turn_spend_usd += cost;
             self.priced_usage = true;
@@ -234,14 +242,27 @@ mod tests {
         // Two responses priced at DIFFERENT models' rates plus one from
         // an unpriced model: tokens all count, spend sums only the known
         // costs — no re-pricing of earlier responses at the last model.
-        state.record_usage(1_000, 200, None, Some(0.015));
-        state.record_usage(2_000, 400, None, Some(0.002));
-        state.record_usage(500, 100, None, None);
+        state.record_usage(1_000, 200, 0, 0, None, Some(0.015));
+        state.record_usage(2_000, 400, 0, 0, None, Some(0.002));
+        state.record_usage(500, 100, 0, 0, None, None);
 
         assert_eq!(state.total_usage().input_tokens, 3_500);
         assert_eq!(state.total_usage().output_tokens, 700);
         assert!(state.has_priced_usage());
         assert!((state.spend_usd() - 0.017).abs() < 1e-9);
+    }
+
+    #[test]
+    fn should_accumulate_cache_tokens_when_usage_recorded() {
+        // Anthropic reports cached prefix tokens OUTSIDE input_tokens; the
+        // turn total must carry them so the token budget and downstream
+        // ledgers see the full processed volume.
+        let mut state = LoopTurnState::new(Instant::now());
+        state.record_usage(100, 50, 4_000, 850, None, None);
+        assert_eq!(state.total_usage().input_tokens, 100);
+        assert_eq!(state.total_usage().output_tokens, 50);
+        assert_eq!(state.total_usage().cache_read_tokens, 4_000);
+        assert_eq!(state.total_usage().cache_write_tokens, 850);
     }
 
     #[test]

--- a/crates/octos-agent/src/agent/verifier.rs
+++ b/crates/octos-agent/src/agent/verifier.rs
@@ -561,6 +561,8 @@ impl Agent {
         turn.record_usage(
             response.usage.input_tokens,
             response.usage.output_tokens,
+            response.usage.cache_read_tokens,
+            response.usage.cache_write_tokens,
             tracker,
             octos_llm::pricing::model_pricing(&verifier_model)
                 .map(|p| p.cost(response.usage.input_tokens, response.usage.output_tokens)),

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -663,7 +663,7 @@ impl ToolRegistry {
         // dispatcher targets), provider-policy denials, and context-filter
         // misses. There is no longer any recency-based (LRU) deferral nor an
         // `activate_tools` meta-tool description to inject.
-        let specs: Vec<ToolSpec> = self
+        let mut specs: Vec<ToolSpec> = self
             .tools
             .values()
             // RFC-1 fixup (codex P1): exclude internal-hidden tools from
@@ -689,6 +689,15 @@ impl ToolRegistry {
                 input_schema: t.input_schema(),
             })
             .collect();
+
+        // Deterministic order: `self.tools` is a HashMap, so `.values()`
+        // iteration order varies per process and per registry rebuild.
+        // Providers replay this array verbatim into the LLM prompt prefix, so
+        // a shuffled order made requests nondeterministic AND busted
+        // provider-side prompt caches (the tool array is the first segment of
+        // the cached prefix — e.g. Anthropic `cache_control`) on every
+        // rebuild. Sort by name so identical tool sets serialize identically.
+        specs.sort_by(|a, b| a.name.cmp(&b.name));
 
         *cache = Some(specs.clone());
         specs
@@ -3130,6 +3139,81 @@ mod profile_filter_tests {
                 .iter()
                 .map(|e| &e.content_type)
                 .collect::<Vec<_>>()
+        );
+    }
+}
+
+#[cfg(test)]
+mod spec_order_tests {
+    //! `specs()` order determinism: providers replay the tool array verbatim
+    //! into the LLM prompt prefix, so a shuffled order both busts
+    //! provider-side prompt caches (Anthropic `cache_control` breakpoints
+    //! cache the tools+system prefix) and makes requests nondeterministic
+    //! across registry rebuilds. `specs()` must emit tools sorted by name.
+
+    use super::super::{Tool, ToolResult};
+    use super::*;
+    use async_trait::async_trait;
+    use eyre::Result;
+    use serde_json::Value;
+
+    struct NamedTool {
+        name: String,
+    }
+
+    #[async_trait]
+    impl Tool for NamedTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn description(&self) -> &str {
+            "test-only"
+        }
+        fn input_schema(&self) -> Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn execute(&self, _args: &Value) -> Result<ToolResult> {
+            Ok(ToolResult {
+                output: String::new(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    fn registry_with(names: &[&str]) -> ToolRegistry {
+        let mut registry = ToolRegistry::new();
+        for name in names {
+            registry.register(NamedTool {
+                name: (*name).to_string(),
+            });
+        }
+        registry
+    }
+
+    #[test]
+    fn specs_are_sorted_by_name_and_deterministic_across_rebuilds() {
+        let names = [
+            "zeta", "alpha", "mid", "beta", "omega", "kappa", "gamma", "delta",
+        ];
+        let mut reversed = names;
+        reversed.reverse();
+
+        let a = registry_with(&names);
+        let b = registry_with(&reversed);
+
+        let a_names: Vec<String> = a.specs().iter().map(|s| s.name.clone()).collect();
+        let b_names: Vec<String> = b.specs().iter().map(|s| s.name.clone()).collect();
+
+        let mut sorted = a_names.clone();
+        sorted.sort();
+        assert_eq!(
+            a_names, sorted,
+            "specs() must emit tools sorted by name (HashMap order is nondeterministic)"
+        );
+        assert_eq!(
+            a_names, b_names,
+            "two registries with the same tools must serialize identically"
         );
     }
 }

--- a/crates/octos-agent/src/tools/research_utils.rs
+++ b/crates/octos-agent/src/tools/research_utils.rs
@@ -167,6 +167,8 @@ pub async fn extract_findings(
     let usage = TokenUsage {
         input_tokens: response.usage.input_tokens,
         output_tokens: response.usage.output_tokens,
+        cache_read_tokens: response.usage.cache_read_tokens,
+        cache_write_tokens: response.usage.cache_write_tokens,
         ..Default::default()
     };
     Ok((response.content.unwrap_or_default(), usage))
@@ -233,6 +235,8 @@ pub async fn merge_findings(
     let usage = TokenUsage {
         input_tokens: response.usage.input_tokens,
         output_tokens: response.usage.output_tokens,
+        cache_read_tokens: response.usage.cache_read_tokens,
+        cache_write_tokens: response.usage.cache_write_tokens,
         ..Default::default()
     };
     Ok((response.content.unwrap_or_default(), usage))

--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -29,6 +29,11 @@ pub struct AnthropicProvider {
     /// registry entries (e.g. `"zai"`, `"r9s"`) so providers are
     /// distinguishable in failover chains.
     provider_label: String,
+    /// Emit `cache_control: {"type": "ephemeral"}` breakpoints so Anthropic
+    /// serves the replayed prefix from its prompt cache (~0.1x input rate on
+    /// reads) instead of billing the whole conversation at full rate every
+    /// round. Default ON — see [`Self::with_prompt_caching`].
+    prompt_caching: bool,
 }
 
 impl AnthropicProvider {
@@ -43,6 +48,7 @@ impl AnthropicProvider {
             model: model.into(),
             base_url: "https://api.anthropic.com".to_string(),
             provider_label: "anthropic".to_string(),
+            prompt_caching: true,
         }
     }
 
@@ -71,6 +77,24 @@ impl AnthropicProvider {
         self
     }
 
+    /// Toggle Anthropic prompt-cache breakpoints (default: enabled).
+    ///
+    /// When enabled the request carries three ephemeral `cache_control`
+    /// breakpoints (Anthropic allows up to 4): the system-prompt block, the
+    /// LAST tool definition, and the last content block of the LAST
+    /// user-role message — caching the stable prefix (tools + system) plus
+    /// the rolling conversation history across loop iterations.
+    ///
+    /// Default ON: any endpoint claiming Anthropic Messages API
+    /// compatibility must tolerate `cache_control` (Claude Code sends it
+    /// unconditionally). Disable for odd proxies that reject the field or
+    /// the block-array `system` form; disabling restores the exact
+    /// pre-caching wire shape (plain-string `system`, verbatim tools).
+    pub fn with_prompt_caching(mut self, enabled: bool) -> Self {
+        self.prompt_caching = enabled;
+        self
+    }
+
     /// Build the shared request struct used by both chat() and chat_stream().
     fn build_request<'a>(
         &'a self,
@@ -79,10 +103,15 @@ impl AnthropicProvider {
         config: &'a ChatConfig,
     ) -> AnthropicRequest<'a> {
         let max_tokens = config.max_tokens.unwrap_or(4096);
+        let cache = self.prompt_caching.then_some(EPHEMERAL_CACHE_CONTROL);
+        let mut api_messages = build_anthropic_messages(messages);
+        if cache.is_some() {
+            apply_message_cache_breakpoint(&mut api_messages);
+        }
         AnthropicRequest {
             model: &self.model,
             max_tokens,
-            messages: build_anthropic_messages(messages),
+            messages: api_messages,
             system: {
                 let system_parts: Vec<&str> = messages
                     .iter()
@@ -92,10 +121,42 @@ impl AnthropicProvider {
                 if system_parts.is_empty() {
                     None
                 } else {
-                    Some(system_parts.join("\n\n"))
+                    let text = system_parts.join("\n\n");
+                    Some(match cache {
+                        // Block-array form: the only shape that can carry
+                        // cache_control (Anthropic accepts both forms). An
+                        // all-blank system stays in string form — an empty
+                        // text BLOCK is rejected while `"system": ""` is not.
+                        Some(cc) if !text.is_empty() => {
+                            AnthropicSystem::Blocks(vec![AnthropicSystemBlock {
+                                r#type: "text",
+                                text,
+                                cache_control: Some(cc),
+                            }])
+                        }
+                        _ => AnthropicSystem::Text(text),
+                    })
                 }
             },
-            tools: if tools.is_empty() { None } else { Some(tools) },
+            tools: if tools.is_empty() {
+                None
+            } else {
+                let last = tools.len() - 1;
+                Some(
+                    tools
+                        .iter()
+                        .enumerate()
+                        .map(|(i, t)| AnthropicTool {
+                            name: &t.name,
+                            description: &t.description,
+                            input_schema: &t.input_schema,
+                            // One breakpoint on the LAST tool caches the
+                            // whole (deterministically ordered) tool array.
+                            cache_control: if i == last { cache } else { None },
+                        })
+                        .collect(),
+                )
+            },
             thinking: config
                 .reasoning_effort
                 .and_then(|effort| build_anthropic_thinking(effort, max_tokens)),
@@ -215,15 +276,58 @@ impl LlmProvider for AnthropicProvider {
     }
 }
 
+/// The `cache_control: {"type": "ephemeral"}` marker Anthropic uses to place
+/// prompt-cache breakpoints (max 4 per request; this provider emits 3).
+#[derive(Serialize, Clone, Copy)]
+struct AnthropicCacheControl {
+    r#type: &'static str,
+}
+
+const EPHEMERAL_CACHE_CONTROL: AnthropicCacheControl = AnthropicCacheControl {
+    r#type: "ephemeral",
+};
+
+/// Top-level `system` field. Anthropic accepts both a plain string and an
+/// array of text blocks; only the block form can carry `cache_control`.
+#[derive(Serialize)]
+#[serde(untagged)]
+enum AnthropicSystem {
+    /// Legacy plain-string form — emitted when prompt caching is disabled so
+    /// odd Anthropic-compatible proxies see the exact pre-caching shape.
+    Text(String),
+    /// Block-array form carrying the cache breakpoint.
+    Blocks(Vec<AnthropicSystemBlock>),
+}
+
+#[derive(Serialize)]
+struct AnthropicSystemBlock {
+    r#type: &'static str,
+    text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<AnthropicCacheControl>,
+}
+
+/// [`ToolSpec`] plus the optional cache breakpoint. Field-for-field the same
+/// wire shape as serializing `ToolSpec` verbatim, with `cache_control`
+/// appended on the LAST tool only.
+#[derive(Serialize)]
+struct AnthropicTool<'a> {
+    name: &'a str,
+    description: &'a str,
+    input_schema: &'a serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<AnthropicCacheControl>,
+}
+
 #[derive(Serialize)]
 struct AnthropicRequest<'a> {
     model: &'a str,
     max_tokens: u32,
     messages: Vec<AnthropicMessage<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    system: Option<String>,
+    system: Option<AnthropicSystem>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tools: Option<&'a [ToolSpec]>,
+    tools: Option<Vec<AnthropicTool<'a>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     thinking: Option<AnthropicThinking>,
     /// M8.5 tier 2: forwarded from `ChatConfig.context_management`. Opaque
@@ -287,13 +391,23 @@ enum AnthropicContent {
 #[serde(tag = "type")]
 enum AnthropicContentBlock {
     #[serde(rename = "text")]
-    Text { text: String },
+    Text {
+        text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<AnthropicCacheControl>,
+    },
     #[serde(rename = "image")]
-    Image { source: AnthropicImageSource },
+    Image {
+        source: AnthropicImageSource,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<AnthropicCacheControl>,
+    },
     /// Prior assistant tool invocation, round-tripped from
     /// [`octos_core::Message::tool_calls`]. Anthropic requires the original
     /// `tool_use` block in the assistant turn for the following
     /// `tool_result` to pair with — without it the request 400s.
+    /// (No `cache_control` field: message breakpoints only ever land on
+    /// USER-role messages, and `tool_use` blocks are assistant-only.)
     #[serde(rename = "tool_use")]
     ToolUse {
         id: String,
@@ -306,7 +420,48 @@ enum AnthropicContentBlock {
     ToolResult {
         tool_use_id: String,
         content: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<AnthropicCacheControl>,
     },
+}
+
+/// Place the rolling-history breakpoint: `cache_control` on the last content
+/// block of the LAST user-role message (a plain user turn or the merged
+/// tool_result batch — both serialize as role "user"). Combined with the
+/// system/tools breakpoints this caches the whole replayed prefix; the next
+/// round only pays full input rate for what was appended since.
+///
+/// The marker intentionally moves forward each round — Anthropic reuses the
+/// longest previously-cached prefix (earlier breakpoints stay valid read
+/// points within the TTL), so advancing the marker EXTENDS the cache rather
+/// than invalidating it.
+fn apply_message_cache_breakpoint(messages: &mut [AnthropicMessage<'_>]) {
+    let Some(last_user) = messages.iter_mut().rev().find(|m| m.role == "user") else {
+        return;
+    };
+    match &mut last_user.content {
+        AnthropicContent::Parts(parts) => match parts.last_mut() {
+            Some(
+                AnthropicContentBlock::Text { cache_control, .. }
+                | AnthropicContentBlock::Image { cache_control, .. }
+                | AnthropicContentBlock::ToolResult { cache_control, .. },
+            ) => *cache_control = Some(EPHEMERAL_CACHE_CONTROL),
+            // `tool_use` never appears in user messages; nothing to mark.
+            Some(AnthropicContentBlock::ToolUse { .. }) | None => {}
+        },
+        AnthropicContent::Text(text) => {
+            // An empty text BLOCK is rejected by Anthropic, so leave a
+            // (degenerate) empty string message untouched.
+            if text.is_empty() {
+                return;
+            }
+            let text = std::mem::take(text);
+            last_user.content = AnthropicContent::Parts(vec![AnthropicContentBlock::Text {
+                text,
+                cache_control: Some(EPHEMERAL_CACHE_CONTROL),
+            }]);
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -454,6 +609,7 @@ fn build_assistant_anthropic_content(msg: &Message) -> Option<AnthropicContent> 
     if has_text {
         parts.push(AnthropicContentBlock::Text {
             text: msg.content.clone(),
+            cache_control: None,
         });
     }
     for tc in tool_calls {
@@ -474,6 +630,7 @@ fn anthropic_tool_result_block(msg: &Message) -> Option<AnthropicContentBlock> {
     Some(AnthropicContentBlock::ToolResult {
         tool_use_id: tool_use_id.to_string(),
         content: msg.content.clone(),
+        cache_control: None,
     })
 }
 
@@ -527,12 +684,14 @@ fn build_anthropic_content(msg: &Message) -> AnthropicContent {
                     media_type: mime,
                     data,
                 },
+                cache_control: None,
             });
         }
     }
     if !msg.content.is_empty() {
         parts.push(AnthropicContentBlock::Text {
             text: msg.content.clone(),
+            cache_control: None,
         });
     }
     AnthropicContent::Parts(parts)
@@ -571,6 +730,15 @@ enum ContentBlock {
 struct ApiUsage {
     input_tokens: u32,
     output_tokens: u32,
+    /// Tokens written to the prompt cache this request (billed ~1.25x the
+    /// input rate). Absent from providers without caching — defaults to 0.
+    #[serde(default)]
+    cache_creation_input_tokens: u32,
+    /// Tokens served from the prompt cache (billed ~0.1x the input rate).
+    /// NOTE: Anthropic's `input_tokens` EXCLUDES cached tokens — the total
+    /// prompt is `input + cache_read + cache_creation`.
+    #[serde(default)]
+    cache_read_input_tokens: u32,
 }
 
 fn append_nonempty(target: &mut Option<String>, text: String) {
@@ -621,6 +789,8 @@ fn anthropic_response_to_chat_response(api_response: AnthropicResponse) -> ChatR
         usage: TokenUsage {
             input_tokens: api_response.usage.input_tokens,
             output_tokens: api_response.usage.output_tokens,
+            cache_read_tokens: api_response.usage.cache_read_input_tokens,
+            cache_write_tokens: api_response.usage.cache_creation_input_tokens,
             ..Default::default()
         },
         provider_index: None,
@@ -634,6 +804,8 @@ struct AnthropicStreamState {
     block_to_tool: std::collections::HashMap<usize, usize>,
     tool_count: usize,
     input_tokens: u32,
+    cache_read_tokens: u32,
+    cache_write_tokens: u32,
 }
 
 // Visible for testing
@@ -669,8 +841,17 @@ fn map_anthropic_sse(
 
     match data["type"].as_str().unwrap_or("") {
         "message_start" => {
-            if let Some(t) = data["message"]["usage"]["input_tokens"].as_u64() {
+            let usage = &data["message"]["usage"];
+            if let Some(t) = usage["input_tokens"].as_u64() {
                 state.input_tokens = t as u32;
+            }
+            // Cache usage arrives on message_start (Anthropic reports it once
+            // the prompt is processed, before any output tokens stream).
+            if let Some(t) = usage["cache_read_input_tokens"].as_u64() {
+                state.cache_read_tokens = t as u32;
+            }
+            if let Some(t) = usage["cache_creation_input_tokens"].as_u64() {
+                state.cache_write_tokens = t as u32;
             }
             vec![]
         }
@@ -739,10 +920,23 @@ fn map_anthropic_sse(
                     state.input_tokens = t as u32;
                 }
             }
+            // Mirror the input_tokens fallback for cache counters.
+            if let Some(t) = data["usage"]["cache_read_input_tokens"].as_u64() {
+                if t > 0 {
+                    state.cache_read_tokens = t as u32;
+                }
+            }
+            if let Some(t) = data["usage"]["cache_creation_input_tokens"].as_u64() {
+                if t > 0 {
+                    state.cache_write_tokens = t as u32;
+                }
+            }
             vec![
                 StreamEvent::Usage(TokenUsage {
                     input_tokens: state.input_tokens,
                     output_tokens,
+                    cache_read_tokens: state.cache_read_tokens,
+                    cache_write_tokens: state.cache_write_tokens,
                     ..Default::default()
                 }),
                 StreamEvent::Done(stop_reason),
@@ -868,7 +1062,9 @@ mod tests {
         // a tool_result in the IMMEDIATELY following message. Two consecutive
         // Tool-role rows (parallel calls) must therefore merge into one user
         // message with two tool_result blocks — separate user messages 400.
-        let provider = AnthropicProvider::new("test-key", "claude-test");
+        // (Caching off: this test pins the legacy plain-string content shape;
+        // breakpoint placement has its own tests below.)
+        let provider = AnthropicProvider::new("test-key", "claude-test").with_prompt_caching(false);
         let mut assistant = msg(MessageRole::Assistant, "Running both.");
         assistant.tool_calls = Some(vec![
             tool_call("toolu_a", "shell", serde_json::json!({"command": "ls"})),
@@ -915,8 +1111,9 @@ mod tests {
     fn empty_assistant_message_is_dropped_from_request() {
         // Mirrors the openai.rs empty-assistant filter: a fully-empty
         // assistant row (no text, no tool calls) must be dropped, not sent as
-        // `content: ""` which Anthropic rejects.
-        let provider = AnthropicProvider::new("test-key", "claude-test");
+        // `content: ""` which Anthropic rejects. (Caching off: pins the
+        // legacy plain-string content shape.)
+        let provider = AnthropicProvider::new("test-key", "claude-test").with_prompt_caching(false);
         let messages = vec![
             msg(MessageRole::User, "hi"),
             msg(MessageRole::Assistant, ""),
@@ -937,7 +1134,8 @@ mod tests {
         // assistant row, or the window starts mid-loop) must NOT serialize as
         // a tool_result — Anthropic rejects orphan tool_result blocks. Fall
         // back to plain user text, the pre-fix behaviour for these rows.
-        let provider = AnthropicProvider::new("test-key", "claude-test");
+        // (Caching off: pins the legacy plain-string content shape.)
+        let provider = AnthropicProvider::new("test-key", "claude-test").with_prompt_caching(false);
 
         // Case 1: transcript starts with a Tool row (assistant trimmed away).
         let mut orphan = msg(MessageRole::Tool, "stale output");
@@ -982,8 +1180,9 @@ mod tests {
     fn tool_result_without_id_falls_back_to_plain_text() {
         // ID-less providers can leave tool_call_id empty; a tool_result block
         // with an empty tool_use_id would 400, so fall back to plain user
-        // text (pre-fix behaviour) for that row only.
-        let provider = AnthropicProvider::new("test-key", "claude-test");
+        // text (pre-fix behaviour) for that row only. (Caching off: pins the
+        // legacy plain-string content shape.)
+        let provider = AnthropicProvider::new("test-key", "claude-test").with_prompt_caching(false);
         let mut orphan = msg(MessageRole::Tool, "orphan output");
         orphan.tool_call_id = None;
         let messages = vec![msg(MessageRole::User, "go"), orphan];
@@ -1008,7 +1207,11 @@ mod tests {
         let request = provider.build_request(&messages, &[], &config);
 
         // System message should be extracted, not in messages array
-        assert_eq!(request.system, Some("system prompt".to_string()));
+        let body = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            body["system"][0]["text"], "system prompt",
+            "system row extracted into the top-level field: {body}"
+        );
         assert_eq!(request.messages.len(), 2); // user + assistant only
         assert_eq!(request.messages[0].role, "user");
         assert_eq!(request.messages[1].role, "assistant");
@@ -1352,5 +1555,257 @@ mod tests {
         let provider = AnthropicProvider::new("test-key", "claude-3-5-sonnet");
         let error_label = format!("{}/{}", provider.provider_label, provider.model);
         assert_eq!(error_label, "anthropic/claude-3-5-sonnet");
+    }
+
+    // --- prompt caching tests ---
+    //
+    // Anthropic bills the full replayed conversation at the full input rate
+    // unless the request marks cache breakpoints. The provider emits three
+    // `cache_control: {"type": "ephemeral"}` breakpoints (Anthropic allows
+    // up to 4): the system prompt block, the LAST tool definition, and the
+    // last content block of the LAST user-role message — stable prefix
+    // (tools + system) plus rolling conversation history.
+
+    fn tool_spec(name: &str, description: &str) -> ToolSpec {
+        ToolSpec {
+            name: name.to_string(),
+            description: description.to_string(),
+            input_schema: serde_json::json!({"type": "object"}),
+        }
+    }
+
+    #[test]
+    fn should_mark_system_last_tool_and_last_user_block_with_cache_control() {
+        let provider = AnthropicProvider::new("test-key", "claude-test");
+        let tools = vec![
+            tool_spec("alpha", "first tool"),
+            tool_spec("omega", "last tool"),
+        ];
+        let messages = vec![
+            msg(MessageRole::System, "system prompt"),
+            msg(MessageRole::User, "first question"),
+            msg(MessageRole::Assistant, "first answer"),
+            msg(MessageRole::User, "second question"),
+        ];
+        let config = ChatConfig::default();
+        let body =
+            serde_json::to_value(provider.build_request(&messages, &tools, &config)).unwrap();
+
+        // (a) System prompt: block form with the ephemeral marker. Anthropic
+        // accepts both string and block-array `system`; only the block form
+        // can carry cache_control.
+        let system = body["system"]
+            .as_array()
+            .unwrap_or_else(|| panic!("system must be a block array: {body}"));
+        assert_eq!(system.len(), 1);
+        assert_eq!(system[0]["type"], "text");
+        assert_eq!(system[0]["text"], "system prompt");
+        assert_eq!(system[0]["cache_control"]["type"], "ephemeral");
+
+        // (b) ONLY the last tool carries cache_control (a breakpoint caches
+        // everything before it, so one marker on the last tool covers the
+        // whole tool array).
+        let tools_out = body["tools"].as_array().unwrap();
+        assert_eq!(tools_out.len(), 2);
+        assert!(
+            tools_out[0].get("cache_control").is_none(),
+            "only the LAST tool may carry cache_control: {body}"
+        );
+        assert_eq!(tools_out[1]["name"], "omega");
+        assert_eq!(tools_out[1]["description"], "last tool");
+        assert_eq!(tools_out[1]["input_schema"]["type"], "object");
+        assert_eq!(tools_out[1]["cache_control"]["type"], "ephemeral");
+
+        // (c) ONLY the last user message's last content block carries
+        // cache_control; earlier messages keep the plain-string shape.
+        let msgs = body["messages"].as_array().unwrap();
+        assert_eq!(msgs.len(), 3);
+        assert!(
+            msgs[0]["content"].is_string(),
+            "earlier user message must stay plain text: {body}"
+        );
+        assert!(
+            msgs[1]["content"].is_string(),
+            "assistant message must stay plain text: {body}"
+        );
+        let blocks = msgs[2]["content"]
+            .as_array()
+            .unwrap_or_else(|| panic!("last user content must be blocks: {body}"));
+        let last_block = blocks.last().unwrap();
+        assert_eq!(last_block["type"], "text");
+        assert_eq!(last_block["text"], "second question");
+        assert_eq!(last_block["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn should_place_message_breakpoint_on_last_tool_result_block() {
+        // Mid tool-loop the last user-role message is the merged tool_result
+        // batch — the breakpoint must land on its LAST block only, so the
+        // whole history including the current results is cached for the
+        // next iteration.
+        let provider = AnthropicProvider::new("test-key", "claude-test");
+        let mut assistant = msg(MessageRole::Assistant, "");
+        assistant.tool_calls = Some(vec![
+            tool_call("toolu_a", "shell", serde_json::json!({"command": "ls"})),
+            tool_call("toolu_b", "read_file", serde_json::json!({"path": "x"})),
+        ]);
+        let mut result_a = msg(MessageRole::Tool, "out-a");
+        result_a.tool_call_id = Some("toolu_a".into());
+        let mut result_b = msg(MessageRole::Tool, "out-b");
+        result_b.tool_call_id = Some("toolu_b".into());
+        let messages = vec![msg(MessageRole::User, "go"), assistant, result_a, result_b];
+
+        let config = ChatConfig::default();
+        let body = serde_json::to_value(provider.build_request(&messages, &[], &config)).unwrap();
+        let msgs = body["messages"].as_array().unwrap();
+        let results = msgs[2]["content"].as_array().unwrap();
+        assert_eq!(results.len(), 2);
+        assert!(
+            results[0].get("cache_control").is_none(),
+            "only the LAST tool_result block may carry cache_control: {body}"
+        );
+        assert_eq!(results[1]["type"], "tool_result");
+        assert_eq!(results[1]["tool_use_id"], "toolu_b");
+        assert_eq!(results[1]["cache_control"]["type"], "ephemeral");
+        // The plain user message BEFORE the tool loop must stay untouched.
+        assert!(msgs[0]["content"].is_string(), "{body}");
+    }
+
+    #[test]
+    fn should_keep_blank_system_as_string_even_when_caching_enabled() {
+        // An empty text BLOCK is rejected by Anthropic while `"system": ""`
+        // is not — an all-blank system prompt must stay in string form.
+        let provider = AnthropicProvider::new("test-key", "claude-test");
+        let messages = vec![msg(MessageRole::System, ""), msg(MessageRole::User, "hi")];
+        let config = ChatConfig::default();
+        let body = serde_json::to_value(provider.build_request(&messages, &[], &config)).unwrap();
+        assert_eq!(
+            body["system"], "",
+            "blank system must not become an empty block: {body}"
+        );
+    }
+
+    #[test]
+    fn should_not_emit_cache_control_anywhere_when_prompt_caching_disabled() {
+        // `with_prompt_caching(false)` must restore the exact pre-caching
+        // wire shape for odd Anthropic-compatible proxies: plain-string
+        // system, verbatim tools, no cache_control key anywhere.
+        let provider = AnthropicProvider::new("test-key", "claude-test").with_prompt_caching(false);
+        let tools = vec![
+            tool_spec("alpha", "first tool"),
+            tool_spec("omega", "last tool"),
+        ];
+        let messages = vec![
+            msg(MessageRole::System, "system prompt"),
+            msg(MessageRole::User, "hello"),
+        ];
+        let config = ChatConfig::default();
+        let body =
+            serde_json::to_value(provider.build_request(&messages, &tools, &config)).unwrap();
+
+        assert_eq!(
+            body["system"], "system prompt",
+            "system must stay a plain string when caching is off: {body}"
+        );
+        assert!(
+            body["messages"][0]["content"].is_string(),
+            "user content must stay a plain string when caching is off: {body}"
+        );
+        assert!(
+            !body.to_string().contains("cache_control"),
+            "no cache_control key may appear anywhere when caching is off: {body}"
+        );
+    }
+
+    #[test]
+    fn should_parse_cache_usage_fields_from_response() {
+        let api_response: AnthropicResponse = serde_json::from_value(serde_json::json!({
+            "content": [{ "type": "text", "text": "hi" }],
+            "stop_reason": "end_turn",
+            "usage": {
+                "input_tokens": 3,
+                "output_tokens": 7,
+                "cache_creation_input_tokens": 4096,
+                "cache_read_input_tokens": 10240
+            }
+        }))
+        .unwrap();
+
+        let response = anthropic_response_to_chat_response(api_response);
+        assert_eq!(response.usage.input_tokens, 3);
+        assert_eq!(response.usage.output_tokens, 7);
+        assert_eq!(response.usage.cache_write_tokens, 4096);
+        assert_eq!(response.usage.cache_read_tokens, 10240);
+    }
+
+    #[test]
+    fn should_emit_cache_usage_in_stream_events() {
+        let mut state = AnthropicStreamState::default();
+        let start = crate::sse::SseEvent {
+            event: None,
+            data: r#"{"type":"message_start","message":{"usage":{"input_tokens":3,"cache_creation_input_tokens":4096,"cache_read_input_tokens":10240}}}"#.into(),
+        };
+        assert!(map_anthropic_sse(&mut state, &start).is_empty());
+
+        let end = crate::sse::SseEvent {
+            event: None,
+            data: r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":9}}"#.into(),
+        };
+        let events = map_anthropic_sse(&mut state, &end);
+        match &events[0] {
+            StreamEvent::Usage(u) => {
+                assert_eq!(u.input_tokens, 3);
+                assert_eq!(u.output_tokens, 9);
+                assert_eq!(u.cache_write_tokens, 4096);
+                assert_eq!(u.cache_read_tokens, 10240);
+            }
+            other => panic!("expected Usage event, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn should_send_cache_breakpoints_and_parse_cache_usage_end_to_end() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(
+                        r#"{"content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":5,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":2048}}"#,
+                    )
+                    .append_header("Content-Type", "application/json"),
+            )
+            .mount(&server)
+            .await;
+
+        let provider =
+            AnthropicProvider::new("test-key", "claude-test").with_base_url(server.uri());
+        let tools = vec![tool_spec("shell", "run a command")];
+        let messages = vec![
+            msg(MessageRole::System, "sys"),
+            msg(MessageRole::User, "hi"),
+        ];
+        let response = provider
+            .chat(&messages, &tools, &ChatConfig::default())
+            .await
+            .unwrap();
+        assert_eq!(response.usage.cache_read_tokens, 2048);
+        assert_eq!(response.usage.cache_write_tokens, 0);
+
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 1);
+        let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+        assert_eq!(body["system"][0]["cache_control"]["type"], "ephemeral");
+        let tools_out = body["tools"].as_array().unwrap();
+        assert_eq!(
+            tools_out.last().unwrap()["cache_control"]["type"],
+            "ephemeral"
+        );
+        let msgs = body["messages"].as_array().unwrap();
+        let blocks = msgs.last().unwrap()["content"].as_array().unwrap();
+        assert_eq!(blocks.last().unwrap()["cache_control"]["type"], "ephemeral");
     }
 }

--- a/crates/octos-llm/src/gemini.rs
+++ b/crates/octos-llm/src/gemini.rs
@@ -841,7 +841,12 @@ fn gemini_response_to_chat_response(api_response: GeminiResponse) -> Result<Chat
         tool_calls,
         stop_reason,
         usage: TokenUsage {
-            input_tokens: usage.prompt_token_count,
+            // Gemini reports cached tokens INSIDE promptTokenCount; the
+            // TokenUsage contract is disjoint (Anthropic-style: total prompt
+            // = input + cache_read), so subtract at the boundary.
+            input_tokens: usage
+                .prompt_token_count
+                .saturating_sub(usage.cached_content_token_count),
             output_tokens: usage.candidates_token_count,
             reasoning_tokens: usage.thoughts_token_count,
             cache_read_tokens: usage.cached_content_token_count,
@@ -939,7 +944,9 @@ fn map_gemini_sse(state: &mut GeminiStreamState, event: &crate::sse::SseEvent) -
         let cached = usage["cachedContentTokenCount"].as_u64().unwrap_or(0) as u32;
         if input > 0 || output > 0 {
             events.push(StreamEvent::Usage(TokenUsage {
-                input_tokens: input,
+                // promptTokenCount INCLUDES cached tokens; the TokenUsage
+                // contract is disjoint (total prompt = input + cache_read).
+                input_tokens: input.saturating_sub(cached),
                 output_tokens: output,
                 reasoning_tokens: thinking,
                 cache_read_tokens: cached,
@@ -1512,8 +1519,10 @@ mod tests {
             data: r#"{"usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 50, "thoughtsTokenCount": 20, "cachedContentTokenCount": 30}}"#.into(),
         };
         let events = map_gemini_sse(&mut state, &event);
+        // input is normalized to disjoint accounting: promptTokenCount (100)
+        // minus cachedContentTokenCount (30).
         assert!(events.iter().any(
-            |e| matches!(e, StreamEvent::Usage(u) if u.reasoning_tokens == 20 && u.cache_read_tokens == 30)
+            |e| matches!(e, StreamEvent::Usage(u) if u.reasoning_tokens == 20 && u.cache_read_tokens == 30 && u.input_tokens == 70)
         ));
     }
 }

--- a/crates/octos-llm/src/openai.rs
+++ b/crates/octos-llm/src/openai.rs
@@ -593,6 +593,12 @@ impl LlmProvider for OpenAIProvider {
             usage: TokenUsage {
                 input_tokens: api_response.usage.prompt_tokens,
                 output_tokens: api_response.usage.completion_tokens,
+                cache_read_tokens: api_response
+                    .usage
+                    .prompt_tokens_details
+                    .as_ref()
+                    .map(|d| d.cached_tokens)
+                    .unwrap_or(0),
                 ..Default::default()
             },
             provider_index: None,
@@ -943,6 +949,18 @@ struct FunctionCall {
 struct Usage {
     prompt_tokens: u32,
     completion_tokens: u32,
+    /// Automatic prompt-cache breakdown. `cached_tokens` counts the portion
+    /// of `prompt_tokens` served from OpenAI's cache (INCLUDED in
+    /// `prompt_tokens`, unlike Anthropic's disjoint accounting). Compat
+    /// providers that omit the object parse as `None`.
+    #[serde(default)]
+    prompt_tokens_details: Option<PromptTokensDetails>,
+}
+
+#[derive(Deserialize, Default)]
+struct PromptTokensDetails {
+    #[serde(default)]
+    cached_tokens: u32,
 }
 
 // --- Streaming SSE helpers (shared with OpenRouter) ---
@@ -1032,6 +1050,9 @@ pub(crate) fn parse_openai_sse_events(event: &SseEvent) -> Vec<StreamEvent> {
         events.push(StreamEvent::Usage(TokenUsage {
             input_tokens: usage["prompt_tokens"].as_u64().unwrap_or(0) as u32,
             output_tokens: usage["completion_tokens"].as_u64().unwrap_or(0) as u32,
+            cache_read_tokens: usage["prompt_tokens_details"]["cached_tokens"]
+                .as_u64()
+                .unwrap_or(0) as u32,
             ..Default::default()
         }));
     }
@@ -1704,5 +1725,91 @@ mod tests {
         assert!(!full_text.is_empty(), "Stream should produce text");
         assert!(full_text.contains('1'), "Should contain '1': {full_text}");
         assert!(full_text.contains('5'), "Should contain '5': {full_text}");
+    }
+}
+
+#[cfg(test)]
+mod cache_usage_tests {
+    //! OpenAI chat-completions caches long prompts automatically and reports
+    //! the cached portion in `usage.prompt_tokens_details.cached_tokens`.
+    //! Both the non-streaming and SSE paths must surface it as
+    //! `TokenUsage::cache_read_tokens` so cache hits flow into the
+    //! usage/cost pipeline. Compat providers that omit the field parse as 0.
+
+    use super::*;
+    use crate::config::ChatConfig;
+    use octos_core::{Message, MessageRole};
+
+    #[test]
+    fn should_parse_cached_tokens_from_sse_usage() {
+        let event = SseEvent {
+            event: None,
+            data: r#"{"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":75}}}"#.into(),
+        };
+        let events = parse_openai_sse_events(&event);
+        let usage = events
+            .iter()
+            .find_map(|e| match e {
+                StreamEvent::Usage(u) => Some(u.clone()),
+                _ => None,
+            })
+            .expect("usage event");
+        assert_eq!(usage.input_tokens, 100);
+        assert_eq!(usage.cache_read_tokens, 75);
+    }
+
+    #[test]
+    fn should_default_cached_tokens_to_zero_when_details_missing() {
+        let event = SseEvent {
+            event: None,
+            data: r#"{"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":2}}"#.into(),
+        };
+        let events = parse_openai_sse_events(&event);
+        let usage = events
+            .iter()
+            .find_map(|e| match e {
+                StreamEvent::Usage(u) => Some(u.clone()),
+                _ => None,
+            })
+            .expect("usage event");
+        assert_eq!(usage.cache_read_tokens, 0);
+    }
+
+    #[tokio::test]
+    async fn should_parse_cached_tokens_from_chat_response() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(
+                        r#"{"choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":100,"completion_tokens":3,"prompt_tokens_details":{"cached_tokens":75}}}"#,
+                    )
+                    .append_header("Content-Type", "application/json"),
+            )
+            .mount(&server)
+            .await;
+
+        let provider = OpenAIProvider::new("test-key", "gpt-4o").with_base_url(server.uri());
+        let messages = vec![Message {
+            role: MessageRole::User,
+            content: "hi".into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: None,
+            timestamp: chrono::Utc::now(),
+        }];
+        let response = provider
+            .chat(&messages, &[], &ChatConfig::default())
+            .await
+            .unwrap();
+        assert_eq!(response.usage.input_tokens, 100);
+        assert_eq!(response.usage.cache_read_tokens, 75);
     }
 }

--- a/crates/octos-llm/src/openai.rs
+++ b/crates/octos-llm/src/openai.rs
@@ -590,16 +590,22 @@ impl LlmProvider for OpenAIProvider {
             reasoning_content,
             tool_calls,
             stop_reason,
-            usage: TokenUsage {
-                input_tokens: api_response.usage.prompt_tokens,
-                output_tokens: api_response.usage.completion_tokens,
-                cache_read_tokens: api_response
+            usage: {
+                // OpenAI reports cached tokens INSIDE prompt_tokens; the
+                // TokenUsage contract is disjoint (Anthropic-style: total
+                // prompt = input + cache_read), so subtract at the boundary.
+                let cached = api_response
                     .usage
                     .prompt_tokens_details
                     .as_ref()
                     .map(|d| d.cached_tokens)
-                    .unwrap_or(0),
-                ..Default::default()
+                    .unwrap_or(0);
+                TokenUsage {
+                    input_tokens: api_response.usage.prompt_tokens.saturating_sub(cached),
+                    output_tokens: api_response.usage.completion_tokens,
+                    cache_read_tokens: cached,
+                    ..Default::default()
+                }
             },
             provider_index: None,
         })
@@ -1047,12 +1053,16 @@ pub(crate) fn parse_openai_sse_events(event: &SseEvent) -> Vec<StreamEvent> {
     }
 
     if let Some(usage) = data.get("usage").filter(|u| !u.is_null()) {
+        // OpenAI reports cached tokens INSIDE prompt_tokens; the TokenUsage
+        // contract is disjoint (total prompt = input + cache_read).
+        let prompt = usage["prompt_tokens"].as_u64().unwrap_or(0) as u32;
+        let cached = usage["prompt_tokens_details"]["cached_tokens"]
+            .as_u64()
+            .unwrap_or(0) as u32;
         events.push(StreamEvent::Usage(TokenUsage {
-            input_tokens: usage["prompt_tokens"].as_u64().unwrap_or(0) as u32,
+            input_tokens: prompt.saturating_sub(cached),
             output_tokens: usage["completion_tokens"].as_u64().unwrap_or(0) as u32,
-            cache_read_tokens: usage["prompt_tokens_details"]["cached_tokens"]
-                .as_u64()
-                .unwrap_or(0) as u32,
+            cache_read_tokens: cached,
             ..Default::default()
         }));
     }
@@ -1754,7 +1764,9 @@ mod cache_usage_tests {
                 _ => None,
             })
             .expect("usage event");
-        assert_eq!(usage.input_tokens, 100);
+        // Normalized to disjoint accounting: OpenAI's prompt_tokens INCLUDES
+        // cached_tokens, TokenUsage does not — total = input + cache_read.
+        assert_eq!(usage.input_tokens, 25);
         assert_eq!(usage.cache_read_tokens, 75);
     }
 
@@ -1809,7 +1821,9 @@ mod cache_usage_tests {
             .chat(&messages, &[], &ChatConfig::default())
             .await
             .unwrap();
-        assert_eq!(response.usage.input_tokens, 100);
+        // Normalized to disjoint accounting: OpenAI's prompt_tokens INCLUDES
+        // cached_tokens, TokenUsage does not — total = input + cache_read.
+        assert_eq!(response.usage.input_tokens, 25);
         assert_eq!(response.usage.cache_read_tokens, 75);
     }
 }

--- a/crates/octos-llm/src/pricing.rs
+++ b/crates/octos-llm/src/pricing.rs
@@ -64,11 +64,44 @@ fn catalog_pricing(model_id: &str) -> Option<ModelPricing> {
         .map(|(_, p)| *p)
 }
 
+/// Prompt-cache read multiplier on the input rate (Anthropic bills cache
+/// hits at ~10% of the base input price).
+const CACHE_READ_INPUT_MULTIPLIER: f64 = 0.1;
+/// Prompt-cache write multiplier on the input rate (Anthropic bills 5-minute
+/// ephemeral cache writes at 1.25x the base input price).
+const CACHE_WRITE_INPUT_MULTIPLIER: f64 = 1.25;
+
 impl ModelPricing {
     /// Calculate cost for given token counts.
     pub fn cost(&self, input_tokens: u32, output_tokens: u32) -> f64 {
         (input_tokens as f64 / 1_000_000.0) * self.input_per_million
             + (output_tokens as f64 / 1_000_000.0) * self.output_per_million
+    }
+
+    /// Cache-aware cost using Anthropic's DISJOINT accounting: `input_tokens`
+    /// excludes cached tokens, `cache_read_tokens` bills at 0.1x the input
+    /// rate and `cache_write_tokens` at 1.25x. Degenerates to [`Self::cost`]
+    /// when both cache counts are zero.
+    ///
+    /// Do NOT feed this OpenAI/Gemini usage as-is: those providers report
+    /// cached tokens INSIDE `input_tokens` (overlapping accounting), so the
+    /// cached portion would be double-billed. Call sites that price mixed
+    /// providers need per-provider normalization first — until then they
+    /// keep using [`Self::cost`].
+    pub fn cost_with_cache(
+        &self,
+        input_tokens: u32,
+        output_tokens: u32,
+        cache_read_tokens: u32,
+        cache_write_tokens: u32,
+    ) -> f64 {
+        self.cost(input_tokens, output_tokens)
+            + (cache_read_tokens as f64 / 1_000_000.0)
+                * self.input_per_million
+                * CACHE_READ_INPUT_MULTIPLIER
+            + (cache_write_tokens as f64 / 1_000_000.0)
+                * self.input_per_million
+                * CACHE_WRITE_INPUT_MULTIPLIER
     }
 }
 
@@ -285,6 +318,22 @@ mod tests {
         let cost = p.cost(1_000_000, 100_000);
         // $3.00 input + $1.50 output = $4.50
         assert!((cost - 4.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_cost_with_cache_applies_read_and_write_multipliers() {
+        let p = ModelPricing {
+            input_per_million: 3.0,
+            output_per_million: 15.0,
+        };
+        // 100k uncached in ($0.30) + 10k out ($0.15)
+        // + 900k cache-read at 0.1x ($0.27) + 50k cache-write at 1.25x ($0.1875)
+        let cost = p.cost_with_cache(100_000, 10_000, 900_000, 50_000);
+        assert!((cost - 0.9075).abs() < 1e-9, "got {cost}");
+
+        // Zero cache counts degenerate to the plain cost().
+        let plain = p.cost_with_cache(100_000, 10_000, 0, 0);
+        assert!((plain - p.cost(100_000, 10_000)).abs() < 1e-12);
     }
 
     #[test]

--- a/crates/octos-llm/src/types.rs
+++ b/crates/octos-llm/src/types.rs
@@ -71,8 +71,19 @@ pub enum StopReason {
 }
 
 /// Token usage statistics.
+///
+/// Cache accounting contract: `cache_read_tokens` / `cache_write_tokens`
+/// are DISJOINT from `input_tokens` (Anthropic-style) — the total prompt is
+/// `input + cache_read + cache_write`. Anthropic reports this natively;
+/// providers whose wire format counts cached tokens INSIDE the prompt total
+/// (OpenAI `prompt_tokens_details.cached_tokens`, Gemini
+/// `cachedContentTokenCount`) are normalized at their parse boundary by
+/// subtracting the cached share from `input_tokens`. Consumers summing
+/// "everything processed" must add all three; never re-add cache counts to
+/// an inclusive total.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TokenUsage {
+    /// Non-cached prompt tokens billed at the full input rate.
     pub input_tokens: u32,
     pub output_tokens: u32,
     /// Tokens used for internal chain-of-thought (o1/o3, Claude thinking, Gemini thinking).

--- a/crates/octos-llm/tests/prompt_cache_live.rs
+++ b/crates/octos-llm/tests/prompt_cache_live.rs
@@ -1,0 +1,93 @@
+//! Live prompt-cache validation against a real Anthropic-protocol endpoint.
+//!
+//! Sends the same large system prompt twice in a 2-round chat and prints the
+//! usage fields; on round 2 the prefix (system + round-1 history) should be
+//! served from the provider's prompt cache (`cache_read_tokens > 0`).
+//!
+//! Ignored by default (needs a real key + network). Run with:
+//!   ZAI_API_KEY=... cargo test -p octos-llm --test prompt_cache_live -- --ignored --nocapture
+
+use chrono::Utc;
+use octos_core::{Message, MessageRole};
+use octos_llm::anthropic::AnthropicProvider;
+use octos_llm::{ChatConfig, LlmProvider};
+
+fn msg(role: MessageRole, content: impl Into<String>) -> Message {
+    Message {
+        role,
+        content: content.into(),
+        media: vec![],
+        tool_calls: None,
+        tool_call_id: None,
+        reasoning_content: None,
+        client_message_id: None,
+        thread_id: None,
+        timestamp: Utc::now(),
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn zai_two_round_chat_reports_cache_read_tokens_on_round_two() {
+    let key = std::env::var("ZAI_API_KEY").expect("ZAI_API_KEY not set");
+    let model = std::env::var("ZAI_MODEL").unwrap_or_else(|_| "glm-4.7".to_string());
+    let provider = AnthropicProvider::new(key, &model)
+        .with_base_url("https://api.z.ai/api/anthropic")
+        .with_provider_label("zai");
+
+    // Anthropic-protocol caches have a minimum cacheable prefix (1024-4096
+    // tokens depending on model) — pad the system prompt well past it.
+    let filler =
+        "The quick brown fox jumps over the lazy dog near the riverbank at dawn. ".repeat(700);
+    let system = format!(
+        "You are a terse assistant; answer with a single word. \
+         Reference corpus (background only, do not quote): {filler}"
+    );
+
+    let mut history = vec![
+        msg(MessageRole::System, system),
+        msg(MessageRole::User, "Reply with the single word: ping"),
+    ];
+    let config = ChatConfig {
+        max_tokens: Some(512),
+        ..Default::default()
+    };
+
+    let r1 = provider
+        .chat(&history, &[], &config)
+        .await
+        .expect("round 1 chat failed");
+    println!(
+        "round 1 usage: input={} output={} cache_read={} cache_write={}",
+        r1.usage.input_tokens,
+        r1.usage.output_tokens,
+        r1.usage.cache_read_tokens,
+        r1.usage.cache_write_tokens,
+    );
+
+    history.push(msg(
+        MessageRole::Assistant,
+        r1.content.clone().unwrap_or_else(|| "pong".to_string()),
+    ));
+    history.push(msg(MessageRole::User, "Reply with the single word: pong"));
+
+    let r2 = provider
+        .chat(&history, &[], &config)
+        .await
+        .expect("round 2 chat failed");
+    println!(
+        "round 2 usage: input={} output={} cache_read={} cache_write={}",
+        r2.usage.input_tokens,
+        r2.usage.output_tokens,
+        r2.usage.cache_read_tokens,
+        r2.usage.cache_write_tokens,
+    );
+
+    assert!(
+        r2.usage.cache_read_tokens > 0,
+        "expected round 2 to be served from the provider prompt cache \
+         (cache_read_tokens > 0); the endpoint either ignored the \
+         cache_control breakpoints or does not report cache usage: {:?}",
+        r2.usage
+    );
+}


### PR DESCRIPTION
## Motivation

A harness review against reference agent implementations (pi / Claude Code) found that `octos-llm` **never sets `cache_control`** — `types.rs` only declared the `cache_read_tokens` / `cache_write_tokens` fields ("Tokens served from provider cache") but no provider populated them and no request ever placed a breakpoint. On Anthropic-protocol providers octos therefore pays the **full input rate for the entire replayed conversation every round** of the agent loop. The reference implementation (pi, TypeScript) places `cache_control: {type:"ephemeral"}` on (a) the system prompt block, (b) the LAST tool definition, and (c) the LAST user/tool_result content block — stable-prefix + rolling-history caching.

## What changed

### `crates/octos-llm/src/anthropic.rs` — the three breakpoints (request) + cache usage (response)
- Request now carries 3 ephemeral breakpoints (Anthropic max is 4):
  - **system**: emitted in block-array form `[{type:"text", text, cache_control:{type:"ephemeral"}}]` (Anthropic accepts both string and block-array `system`; only blocks can carry the marker);
  - **tools**: `ToolSpec`s are wrapped in a field-identical `AnthropicTool` that appends `cache_control` to the **last tool only** (one marker caches the whole array);
  - **messages**: `cache_control` on the last content block of the **last user-role message** (plain user turn or the merged `tool_result` batch — both serialize as role `user`). A plain-string user turn is converted to a single text block; empty-string turns are left untouched (an empty text *block* 400s).
- **Provider-level toggle, default ON**: `with_prompt_caching(bool)`. Disabling restores the exact pre-caching wire shape (plain-string `system`, verbatim tools, no `cache_control` anywhere) for odd Anthropic-compatible proxies. Default-ON rationale: any endpoint claiming Anthropic Messages API compatibility must tolerate `cache_control` — Claude Code sends it unconditionally (verified live against z.ai, below).
- Response side: `cache_creation_input_tokens` / `cache_read_input_tokens` are parsed (non-streaming `usage` + SSE `message_start`, with the same `message_delta` non-zero fallback the code already used for Z.AI's `input_tokens`) into the existing `TokenUsage::cache_write_tokens` / `cache_read_tokens`. The stream accumulator already clones the whole `TokenUsage`, so streamed responses carry them too.

### `crates/octos-llm/src/openai.rs` — cache-usage accounting only
- Parses `usage.prompt_tokens_details.cached_tokens` (OpenAI automatic caching) into `cache_read_tokens` on both the non-streaming and SSE paths (the SSE helper is shared with OpenRouter), **subtracting it from `input_tokens`** per the disjoint `TokenUsage` contract. Safe for the 8 `with_base_url` compat providers — a missing field parses as 0 and leaves `input_tokens` untouched. Gemini's pre-existing `cachedContentTokenCount` population gets the same normalization.
- **`prompt_cache_key` was NOT added — skipped deliberately**: no conversation/session id reaches `LlmProvider::chat()` (`ChatConfig` carries none), and inventing that plumbing was out of scope. Follow-up if a stable per-conversation id ever lands in `ChatConfig`.

### `crates/octos-agent/src/tools/registry.rs` — deterministic tool order
`ToolRegistry::specs()` iterated a `HashMap` — the RED test run showed genuinely scrambled output (`["delta","zeta","gamma","kappa",...]`). Providers replay this array verbatim as the **first segment of the prompt prefix**, so a shuffled order busted any prefix cache on every registry rebuild *and* made requests nondeterministic. `specs()` now sorts by tool name before memoizing; the new determinism test builds two registries with opposite insertion orders and asserts identical, sorted serialization.

### `crates/octos-agent` + provider normalization — cache tokens count against the turn budget (codex R1+R2 findings, fixed)
Codex R1 flagged that with disjoint accounting the `max_tokens` budget gate (`budget.rs`: `input + output`) would fire ~10x late on cache-served Anthropic loops; R2 flagged the converse (inclusive-provider double-count) and that tool-originated cache usage was dropped before reaching parent budgets. Both fixed:
- **`TokenUsage` contract documented and enforced**: `cache_read`/`cache_write` are DISJOINT from `input_tokens` on every provider (total prompt = `input + cache_read + cache_write`). Anthropic reports this natively; **openai.rs and gemini.rs now subtract the cached share from `input_tokens` at their parse boundaries** (chat + SSE), so `budget_tokens_used() = input + output + cache_read + cache_write` is exact for all providers — no double-count, no late fire.
- `record_usage` takes and accumulates `cache_read`/`cache_write` (signature change so the compiler enumerates every call site); `llm_call` retry/fallback merges carry cache fields so discarded attempts keep counting.
- The child-to-parent accounting chain is complete: `execute_tools` aggregates cache fields, `research_utils` map/reduce carries them, `TaskResult.token_usage` propagates them — subagent/research cache traffic reaches parent budgets.

### `crates/octos-llm/src/pricing.rs` — cache-aware pricing primitive
`ModelPricing::cost_with_cache()` bills cache reads at **0.1x** and writes at **1.25x** the input rate (Anthropic's disjoint accounting: `input_tokens` EXCLUDES cached tokens). **Call-site wiring is deferred as a follow-up**: with the disjoint normalization (below) the shared cost sites (`llm_call.rs`, `streaming.rs`, `verifier.rs`, `session_actor.rs`) can now adopt it safely, but the multipliers are Anthropic's (OpenAI bills cache reads at 0.25-0.5x, Gemini at ~0.25x), so per-provider rates belong in the catalog before the swap. Until then `cost()` underestimates cached traffic (cached tokens billed at 0) — closer to the truth than the pre-PR full-rate overestimate.

## Prefix-stability audit (findings)

1. **`ToolRegistry::specs()`** — nondeterministic HashMap order confirmed and fixed (above).
2. **`truncate_old_tool_results`** (`message_repair.rs`, invoked from `loop_compaction.rs` every iteration) — verified it only rewrites messages **before** the last user message, and that boundary is **fixed within a turn** (the loop appends assistant/tool rows after it). Re-truncation is byte-idempotent: the 800-char cut of an already-truncated message reproduces the identical string. History edits therefore land only at turn boundaries (when a new user message moves the boundary past the previous turn's tool results) — exactly where a cache miss is unavoidable anyway. **No fix needed.**
3. **`compose_system_prompt`** (`execution.rs`, called from `loop_runner.rs`) — composed **once per `run_conversation`**, before the loop, not per iteration, so the system block is byte-identical across iterations within a turn. The memory segment is fingerprint-gated (`memory_segment.rs::refresh()` returns `None` when MEMORY.md is unchanged), keeping it byte-stable across turns too. The optional realtime **sensor summary can change the system prompt between turns** — a known, bounded invalidation (first call of the new turn re-writes the cache; all subsequent iterations hit it).
4. **OpenRouter** (`openrouter.rs`) — audited: its wire format is OpenAI-style chat-completions (`prompt_tokens`, `ApiTool{type,function}`), **not** Anthropic Messages API, so no breakpoints were added there. It benefits from the shared SSE `cached_tokens` parsing only.

## Empirical validation

- **Mock (exact outgoing JSON)**: wiremock end-to-end test (`should_send_cache_breakpoints_and_parse_cache_usage_end_to_end`) captures the request received by a mock `/v1/messages` and asserts all three breakpoints, plus cache-usage parsing of the mocked response.
- **Real 2-round chat** against an Anthropic-protocol endpoint (`api.z.ai/api/anthropic`, glm-4.7, isolated env, key never printed), via the new `#[ignore]`d `tests/prompt_cache_live.rs`:
  ```
  round 1 usage: input=11235 output=2 cache_read=0     cache_write=0
  round 2 usage: input=46    output=2 cache_read=11200 cache_write=0
  ```
  Round 2 paid full rate for **46** tokens instead of 11,235 — the replayed prefix was served from the provider cache and surfaced through the new usage fields. (Z.AI reports reads but not writes; against `api.anthropic.com` caching is strictly opt-in via `cache_control`, which the mock test pins.)

## Expected savings (math)

A typical octos session re-sends ~10K tokens of system prompt + tool specs every round, plus the growing history. For a 10-iteration tool turn, the stable prefix alone goes from `10 x 10K = 100K` full-rate input tokens to `10K x 1.25 + 9 x 10K x 0.1 = 21.5K` full-rate-equivalent — **~78% off the prefix input cost** — and the rolling-history breakpoint compounds this on long conversations (history quickly dwarfs 10K; the live run above billed an 11.2K-token prefix at 46 tokens on round 2).

## Tests (RED -> GREEN)

RED first (all failed against base, incl. visibly scrambled specs order), then GREEN:
- `anthropic::tests::should_mark_system_last_tool_and_last_user_block_with_cache_control`
- `anthropic::tests::should_place_message_breakpoint_on_last_tool_result_block`
- `anthropic::tests::should_not_emit_cache_control_anywhere_when_prompt_caching_disabled` (toggle OFF -> pre-caching wire shape, zero `cache_control` keys)
- `anthropic::tests::should_parse_cache_usage_fields_from_response`
- `anthropic::tests::should_emit_cache_usage_in_stream_events`
- `anthropic::tests::should_send_cache_breakpoints_and_parse_cache_usage_end_to_end` (wiremock)
- `openai::cache_usage_tests::{should_parse_cached_tokens_from_sse_usage, should_default_cached_tokens_to_zero_when_details_missing, should_parse_cached_tokens_from_chat_response}` (wiremock)
- `tools::registry::spec_order_tests::specs_are_sorted_by_name_and_deterministic_across_rebuilds`
- `pricing::tests::test_cost_with_cache_applies_read_and_write_multipliers`
- `agent::budget::tests::budget_counts_cache_tokens_as_used` + `agent::turn_state::tests::should_accumulate_cache_tokens_when_usage_recorded` (codex R1 budget fix)
- OpenAI/Gemini disjoint-normalization assertions (chat + SSE: `input=25/cache_read=75` from `prompt_tokens=100/cached=75`; gemini `input=70` from `100/30`)
- 4 legacy anthropic tests that pin the plain-string content shape now construct with `with_prompt_caching(false)` (their concern — merging/orphan fallback — is orthogonal to caching).

## Gates

- `cargo fmt --all -- --check` clean
- `cargo clippy -p octos-llm -p octos-agent --all-targets` — zero warnings
- `cargo test -p octos-llm` — 447 lib tests + all integration suites pass
- `cargo test -p octos-agent` — 2093 lib tests + all integration suites pass
- `cargo check -p octos-cli --features api` — compiles (no shared type shapes changed)

> Note: if `test-octos-agent-integration` shows red, it is pre-existing broken on `main` (52-minute macos-14 timeout) and unrelated to this change.

## Follow-ups

- Wire `cost_with_cache` into the shared cost sites once per-provider cached-token semantics are normalized (Anthropic disjoint vs OpenAI/Gemini inclusive).
- `prompt_cache_key` for native OpenAI once a stable per-conversation id is threadable through `ChatConfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
