### PR TITLE
feat(profiles): lean coding profile — core tools only (~3.5K tok/round), coding-full escape hatch

### DIFF
--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -15,6 +15,8 @@ Options:
       --base-url <URL>     Custom API endpoint
   -m, --message <MSG>      Single message (non-interactive)
       --max-iterations <N> Max tool iterations per message (default: 50)
+      --profile <NAME>     Runtime tool profile (default: coding — lean
+                           core-coding tools; coding-full = everything)
   -v, --verbose            Show tool outputs
       --no-retry           Disable retry
 ```
@@ -24,7 +26,9 @@ Options:
 - Arrow keys and line editing (rustyline)
 - Persistent history at `.octos/history/chat_history`
 - Exit: `/exit`, `/quit`, `exit`, `quit`, `:q`, Ctrl+C, Ctrl+D
-- Full tool access (shell, files, search, web)
+- Lean default tool surface (files, shell, search, memory, spawn); web,
+  research, pipelines, and bundled skills via `--profile coding-full`
+  (see [Configuration → Runtime Tool Profiles](./configuration.md#runtime-tool-profiles))
 
 **Examples:**
 
@@ -33,6 +37,7 @@ octos chat                              # Interactive (default)
 octos chat --provider deepseek          # Use DeepSeek
 octos chat --model glm-4-plus           # Auto-detects Zhipu
 octos chat --message "Fix auth bug"     # Single message, exit
+octos chat --profile coding-full        # Unfiltered tool set (web, skills, pipelines)
 ```
 
 ---

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -175,6 +175,60 @@ The complete configuration structure with all available fields:
 
 > The `memory.refresh` pipeline is **on by default**. See [Memory & Skills → Automatic Memory Refresh](./memory-skills.md) for the full field list and the `octos memory` command. Opt out with `"enabled": false` or `OCTOS_MEMORY_REFRESH_ENABLED=0`.
 
+## Runtime Tool Profiles
+
+`octos chat` and `octos acp` resolve a **runtime profile** at startup that
+decides which tools are exposed to the LLM. Every tool schema in the registry
+is serialized into *every* LLM round, so the default profile is deliberately
+lean.
+
+Built-in profiles:
+
+| Profile | Tool surface |
+|---------|--------------|
+| `coding` (default) | **Lean core-coding loop only**: files (`group:fs`), shell (`group:runtime`), search (`group:search`), long-term memory (`group:memory`), `spawn`, `ask_user_question` — ≈15–18 tools, ≈3.3K tokens of schemas per round. Web/research/media/messaging tools, `run_pipeline`, and bundled skills (weather, news, send_email, …) are **excluded**. |
+| `coding-full` | The unfiltered pre-lean surface — every native, bundled-skill, plugin, and MCP tool (≈48 tools, ≈9K tokens per round). Byte-for-byte the old `coding` behaviour. |
+| `swarm` | Coding set plus swarm-coordination tools (`send_to_agent`, `cancel_task`, `relaunch_task`, …). |
+
+Switching profiles:
+
+```bash
+octos chat --profile coding-full        # one-off: everything back
+ln -s coding-full ~/.octos/profile      # persistent default (name or path)
+```
+
+Per-project customization — drop a profile file in
+`~/.octos/profiles/<name>/profile.json` (or pass a path via `--profile`) and
+add tools back with allow-list entries (`group:<id>`, exact names, or
+`prefix*` wildcards):
+
+```json
+{
+  "name": "coding-plus-web",
+  "version": 1,
+  "tools": {
+    "mode": "allow_list",
+    "tools": ["group:fs", "group:runtime", "group:search", "group:memory",
+              "spawn", "ask_user_question", "group:web"]
+  },
+  "agents": ["research-worker", "repo-editor"]
+}
+```
+
+Notes:
+
+- The profile filter runs **after** plugins/skills/MCP register, so it
+  applies to bundled-skill and plugin tools exactly as to builtins. Tools
+  marked `spawn_only` are never evicted by the filter; `run_pipeline` is
+  instead gated at registration time by the profile allow list.
+- Sub-agents are unaffected: `spawn` workers build their own registries, so
+  the built-in `research-worker` keeps `web_search`/`web_fetch` under the
+  lean default.
+- `config.json`'s `tool_policy` (below) still applies and can further narrow
+  (deny-wins) any profile.
+- `octos gateway` / `octos serve` do not use runtime profiles; their tool
+  surface is unchanged.
+
 ## Human Approval Rules
 
 Tool calls matching a configured rule suspend the turn until an authorized

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -1336,21 +1336,21 @@ mod profile_integration_tests {
         Agent::new(AgentId::new("default"), provider, tools, memory)
     }
 
-    async fn agent_with_coding_profile(cwd: &std::path::Path) -> Agent {
+    async fn agent_with_builtin_profile(cwd: &std::path::Path, name: &str) -> Agent {
         use crate::profile::ProfileDefinition;
 
         let memory = Arc::new(
-            EpisodeStore::open(cwd.join("memory-profile"))
+            EpisodeStore::open(cwd.join(format!("memory-profile-{name}")))
                 .await
                 .expect("episode store"),
         );
         let provider: Arc<dyn LlmProvider> = Arc::new(NoopProvider);
 
-        let coding = ProfileDefinition::builtin("coding").expect("coding builtin");
+        let profile = ProfileDefinition::builtin(name).expect("builtin profile");
         let mut tools = ToolRegistry::with_builtins(cwd);
-        coding.apply_to_registry(&mut tools);
+        profile.apply_to_registry(&mut tools);
 
-        Agent::new(AgentId::new("coding"), provider, tools, memory).with_profile(Arc::new(coding))
+        Agent::new(AgentId::new(name), provider, tools, memory).with_profile(Arc::new(profile))
     }
 
     fn tool_names(agent: &Agent) -> Vec<String> {
@@ -1365,20 +1365,61 @@ mod profile_integration_tests {
     }
 
     #[tokio::test]
-    async fn coding_profile_matches_default_tool_set() {
+    async fn coding_profile_narrows_default_tool_set() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let base = agent_default(tmp.path()).await;
-        let profiled = agent_with_coding_profile(tmp.path()).await;
+        let profiled = agent_with_builtin_profile(tmp.path(), "coding").await;
 
-        assert_eq!(
-            tool_names(&base),
-            tool_names(&profiled),
-            "coding profile must preserve the default tool set byte-for-byte",
+        let base_names = tool_names(&base);
+        let lean_names = tool_names(&profiled);
+        // Lean default: `coding` narrows the surface to the core coding
+        // loop instead of passing the registry through untouched.
+        assert!(
+            lean_names.len() < base_names.len(),
+            "lean coding profile must narrow the default set \
+             ({} -> {})",
+            base_names.len(),
+            lean_names.len(),
         );
+        assert!(
+            lean_names.iter().all(|n| base_names.contains(n)),
+            "lean set must be a subset of the default set",
+        );
+        for kept in ["read_file", "shell", "edit_file", "grep"] {
+            assert!(
+                lean_names.contains(&kept.to_string()),
+                "core-loop tool {kept} missing from lean set: {lean_names:?}",
+            );
+        }
+        for dropped in ["web_search", "browser", "image_generation"] {
+            assert!(
+                !lean_names.contains(&dropped.to_string()),
+                "non-core tool {dropped} must be filtered by the lean coding profile",
+            );
+        }
 
         // The profiled agent also exposes the recorded profile handle.
         let prof = profiled.profile().expect("profile handle present");
         assert_eq!(prof.name, "coding");
+        assert_eq!(prof.version, 1);
+    }
+
+    #[tokio::test]
+    async fn coding_full_profile_matches_default_tool_set() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let base = agent_default(tmp.path()).await;
+        let profiled = agent_with_builtin_profile(tmp.path(), "coding-full").await;
+
+        // The byte-for-byte parity contract moved from `coding` to the
+        // `coding-full` escape hatch when the lean default landed.
+        assert_eq!(
+            tool_names(&base),
+            tool_names(&profiled),
+            "coding-full profile must preserve the default tool set byte-for-byte",
+        );
+
+        let prof = profiled.profile().expect("profile handle present");
+        assert_eq!(prof.name, "coding-full");
         assert_eq!(prof.version, 1);
     }
 

--- a/crates/octos-agent/src/assets/profiles/coding-full.json
+++ b/crates/octos-agent/src/assets/profiles/coding-full.json
@@ -1,0 +1,9 @@
+{
+  "name": "coding-full",
+  "version": 1,
+  "description": "Unfiltered escape hatch — preserves the pre-lean `coding` behaviour byte-for-byte. Tools are not filtered (every native, bundled-skill, plugin, and MCP tool schema is sent to the LLM each round); the M8.2 built-in sub-agents are preloaded.",
+  "tools": {"mode": "default"},
+  "mcp_servers": [],
+  "permissions": "default",
+  "agents": ["research-worker", "repo-editor"]
+}

--- a/crates/octos-agent/src/assets/profiles/coding.json
+++ b/crates/octos-agent/src/assets/profiles/coding.json
@@ -1,8 +1,18 @@
 {
   "name": "coding",
   "version": 1,
-  "description": "Default profile — preserves today's no-flag octos chat behaviour byte-for-byte. Tools are not filtered; the M8.2 built-in sub-agents are preloaded.",
-  "tools": {"mode": "default"},
+  "description": "Default profile — lean core-coding tool surface: files (group:fs), shell (group:runtime), search (group:search), long-term memory (group:memory), sub-agent spawn, and structured user questions. Web/research/media/messaging/pipeline tools and bundled skills are excluded to keep per-round tool-schema overhead low; run with `--profile coding-full` to restore the unfiltered set. The M8.2 built-in sub-agents are preloaded.",
+  "tools": {
+    "mode": "allow_list",
+    "tools": [
+      "group:fs",
+      "group:runtime",
+      "group:search",
+      "group:memory",
+      "spawn",
+      "ask_user_question"
+    ]
+  },
   "mcp_servers": [],
   "permissions": "default",
   "agents": ["research-worker", "repo-editor"]

--- a/crates/octos-agent/src/assets/profiles/swarm.json
+++ b/crates/octos-agent/src/assets/profiles/swarm.json
@@ -33,7 +33,8 @@
       "message",
       "activate_tools",
       "configure_tool",
-      "manage_skills"
+      "manage_skills",
+      "run_pipeline"
     ]
   },
   "mcp_servers": [],

--- a/crates/octos-agent/src/profile/mod.rs
+++ b/crates/octos-agent/src/profile/mod.rs
@@ -901,6 +901,12 @@ mod tests {
             }
             other => panic!("swarm must declare an allow list, got {other:?}"),
         }
+        // Swarm coordinators keep the pipeline engine. Pre-lean this fell
+        // out of the spawn_only carve-out (run_pipeline survived the
+        // filter without being named); now that the chat/acp bootstrap
+        // gates registration on `allows`, the swarm allow list must name
+        // it explicitly or coordinators would silently lose it.
+        assert!(swarm.tools.allows("run_pipeline"));
         assert!(!swarm.agents.is_empty());
     }
 

--- a/crates/octos-agent/src/profile/mod.rs
+++ b/crates/octos-agent/src/profile/mod.rs
@@ -10,10 +10,13 @@
 //! across a dozen startup sites; afterwards, a single profile declaration
 //! consolidates the envelope.
 //!
-//! The built-in `coding` profile captures today's no-flag default verbatim
-//! so `octos chat` keeps producing byte-for-byte the same runtime behaviour
-//! as before. Alternate profiles (e.g. `swarm`) layer on top of `coding`
-//! through explicit allow-list changes and expanded agent sets.
+//! The built-in `coding` profile is the no-flag default and carries a lean
+//! core-coding allow list (files, shell, search, memory, spawn, user
+//! questions) so `octos chat` does not ship every tool schema to the LLM on
+//! every round. The `coding-full` built-in preserves the pre-lean
+//! unfiltered surface byte-for-byte for sessions that want everything.
+//! Alternate profiles (e.g. `swarm`) declare their own allow lists and
+//! expanded agent sets.
 //!
 //! # Forward compatibility
 //!
@@ -36,8 +39,9 @@
 //! 3. Finally the loader falls back to the crate-shipped built-in registry
 //!    (JSON files under `crates/octos-agent/src/assets/profiles/`).
 //!
-//! Today's built-in profiles are `coding` (the default) and `swarm` (an
-//! allow-list extension that enables multi-worker swarm coordination tools).
+//! Today's built-in profiles are `coding` (the lean default), `coding-full`
+//! (the unfiltered pre-lean surface), and `swarm` (an allow-list extension
+//! that enables multi-worker swarm coordination tools).
 //!
 //! # Applied vs recorded settings
 //!
@@ -75,6 +79,10 @@ pub const PROFILE_SCHEMA_VERSION: u32 = 1;
 /// user-config search. Ordered (name, raw JSON text).
 const BUILTIN_PROFILES: &[(&str, &str)] = &[
     ("coding", include_str!("../assets/profiles/coding.json")),
+    (
+        "coding-full",
+        include_str!("../assets/profiles/coding-full.json"),
+    ),
     ("swarm", include_str!("../assets/profiles/swarm.json")),
 ];
 
@@ -94,8 +102,8 @@ pub enum ProfileSource {
 /// called out in the issue scope:
 ///
 /// - `default` — no filter; the registry passes through untouched. This is
-///   what the built-in `coding` profile uses so behaviour parity with the
-///   pre-M8.3 default path is guaranteed.
+///   what the built-in `coding-full` profile uses so behaviour parity with
+///   the pre-M8.3 default path stays reachable.
 /// - `allow_list` — only the named tools survive. Names may reference
 ///   [`crate::tools::policy::ToolGroupInfo`] groups via `group:*` strings.
 /// - `deny_list` — every tool survives except the named ones. Useful for
@@ -123,6 +131,32 @@ pub enum ProfileTools {
         #[serde(default)]
         tools: Vec<String>,
     },
+}
+
+impl ProfileTools {
+    /// Whether a tool named `tool_name` would survive this filter.
+    ///
+    /// Mirrors [`crate::tools::ToolRegistry::filter_by_profile`]'s
+    /// name-matching exactly — `group:<id>` expansion, `<prefix>*`
+    /// wildcards, exact names, and the empty-allow-list pass-through —
+    /// but deliberately WITHOUT the spawn_only carve-out. Once a
+    /// spawn_only tool is registered it can never be evicted by the
+    /// filter, so bootstrap sites (chat/acp `run_pipeline`) consult this
+    /// predicate FIRST and skip registration when the profile excludes
+    /// the tool.
+    pub fn allows(&self, tool_name: &str) -> bool {
+        use crate::tools::policy::entry_matches;
+        match self {
+            Self::Default => true,
+            Self::AllowList { tools } => {
+                // Empty allow lists are treated as pass-through by
+                // `filter_by_profile` (with a warning); agree with it so
+                // the bootstrap gate never drops a tool the filter keeps.
+                tools.is_empty() || tools.iter().any(|entry| entry_matches(entry, tool_name))
+            }
+            Self::DenyList { tools } => !tools.iter().any(|entry| entry_matches(entry, tool_name)),
+        }
+    }
 }
 
 /// Reference to an MCP server that the profile wants attached. For M8.3 we
@@ -554,9 +588,15 @@ mod tests {
         let coding = ProfileDefinition::builtin("coding").expect("coding builtin");
         assert_eq!(coding.name, "coding");
         assert_eq!(coding.version, 1);
-        // `coding` must declare the default tool filter so behaviour
-        // parity with the pre-M8.3 no-flag path is preserved.
-        assert!(matches!(coding.tools, ProfileTools::Default));
+        // Lean default: `coding` declares a core-loop allow list so the
+        // no-flag `octos chat` stops shipping every tool schema each round.
+        assert!(matches!(coding.tools, ProfileTools::AllowList { .. }));
+
+        // `coding-full` is the escape hatch that preserves the pre-lean
+        // unfiltered surface (one `--profile coding-full` away).
+        let full = ProfileDefinition::builtin("coding-full").expect("coding-full builtin");
+        assert_eq!(full.name, "coding-full");
+        assert!(matches!(full.tools, ProfileTools::Default));
 
         let swarm = ProfileDefinition::builtin("swarm").expect("swarm builtin");
         assert_eq!(swarm.name, "swarm");
@@ -626,10 +666,44 @@ mod tests {
     fn should_load_builtin_coding_profile_without_error() {
         let coding = ProfileDefinition::builtin("coding").expect("coding");
         coding.validate().expect("valid");
-        // The default profile must not declare a tool allow/deny list —
-        // otherwise the registry would be filtered and behaviour parity
-        // with the pre-M8.3 no-flag path would regress.
-        assert!(matches!(coding.tools, ProfileTools::Default));
+        // Lean default: the allow list covers the core coding loop ONLY.
+        // The exact envelope is pinned here so accidental JSON edits fail
+        // loudly instead of silently re-inflating (or hollowing out) the
+        // per-round tool-schema overhead.
+        match &coding.tools {
+            ProfileTools::AllowList { tools } => {
+                for required in [
+                    "group:fs",
+                    "group:runtime",
+                    "group:search",
+                    "group:memory",
+                    "spawn",
+                    "ask_user_question",
+                ] {
+                    assert!(
+                        tools.contains(&required.to_string()),
+                        "coding allow list must keep {required}, got {tools:?}",
+                    );
+                }
+                // The heavy non-core surfaces must stay out of the lean
+                // default (available via `coding-full` or a custom profile).
+                for excluded in [
+                    "group:web",
+                    "group:research",
+                    "group:media",
+                    "run_pipeline",
+                    "synthesize_research",
+                    "message",
+                    "cron",
+                ] {
+                    assert!(
+                        !tools.contains(&excluded.to_string()),
+                        "coding allow list must not name {excluded}",
+                    );
+                }
+            }
+            other => panic!("coding must declare a lean allow list, got {other:?}"),
+        }
         // Today's coding default carries no compaction or permission
         // override — those live at the workspace / app-state level.
         assert!(coding.compaction_policy.is_none());
@@ -638,6 +712,179 @@ mod tests {
         // resolve them by id.
         assert!(coding.agents.contains(&"research-worker".to_string()));
         assert!(coding.agents.contains(&"repo-editor".to_string()));
+    }
+
+    #[test]
+    fn should_load_builtin_coding_full_profile_as_unfiltered_escape_hatch() {
+        let full = ProfileDefinition::builtin("coding-full").expect("coding-full");
+        full.validate().expect("valid");
+        // `coding-full` preserves the pre-lean unfiltered registry
+        // byte-for-byte: no allow/deny list, no compaction or permission
+        // override.
+        assert!(
+            matches!(full.tools, ProfileTools::Default),
+            "coding-full must not filter tools",
+        );
+        assert!(full.compaction_policy.is_none());
+        assert_eq!(full.permissions, PermissionMode::Default);
+        // Same preloaded sub-agents as `coding` so switching profiles
+        // never changes spawn() manifest resolution.
+        let coding = ProfileDefinition::builtin("coding").expect("coding");
+        assert_eq!(full.agents, coding.agents);
+        assert!(ProfileDefinition::builtin_ids().contains(&"coding-full"));
+    }
+
+    /// Minimal schema-bearing tool used to stand in for bundled-skill /
+    /// plugin tools (and for chat-registered natives like `spawn`) in
+    /// registry-narrowing tests.
+    struct StubTool {
+        name: &'static str,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::tools::Tool for StubTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn description(&self) -> &str {
+            "stub"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}})
+        }
+        async fn execute(&self, _args: &serde_json::Value) -> Result<crate::tools::ToolResult> {
+            Ok(crate::tools::ToolResult {
+                output: "ok".into(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    #[test]
+    fn coding_profile_narrows_registry_to_core_coding_loop() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut tools = ToolRegistry::with_builtins(tmp.path());
+        // Bundled-skill / plugin tools are plain registry entries that
+        // register BEFORE the profile narrowing runs in the chat/acp
+        // bootstrap — the allow list must apply to them exactly as it
+        // does to builtins.
+        tools.register(StubTool {
+            name: "get_weather",
+        });
+        // `spawn` is registered by the chat/acp bootstrap (SpawnTool),
+        // not by `with_builtins`; a stub stands in for the inclusion
+        // assertion.
+        tools.register(StubTool { name: "spawn" });
+
+        let coding = ProfileDefinition::builtin("coding").expect("coding");
+        coding.apply_to_registry(&mut tools);
+
+        let names: std::collections::BTreeSet<String> =
+            tools.specs().into_iter().map(|s| s.name).collect();
+
+        for included in [
+            "read_file",
+            "write_file",
+            "edit_file",
+            "shell",
+            "glob",
+            "grep",
+            "list_dir",
+            "spawn",
+            "ask_user_question",
+        ] {
+            assert!(
+                names.contains(included),
+                "lean coding profile must keep {included}, got {names:?}",
+            );
+        }
+        for excluded in [
+            "web_search",
+            "web_fetch",
+            "browser",
+            "get_weather",
+            "synthesize_research",
+            "image_generation",
+            "workspace_diff",
+            "spawn_agent",
+            "delegate",
+            "update_plan",
+        ] {
+            assert!(
+                !names.contains(excluded),
+                "lean coding profile must drop {excluded}, got {names:?}",
+            );
+        }
+        // Budget pin (#1578 harness review: 48 tools ≈ 9.3K tokens per
+        // round in the unfiltered default). The lean surface must stay a
+        // small fraction of that; 20 leaves headroom for core-loop growth
+        // while failing loudly on accidental bloat.
+        assert!(
+            names.len() <= 20,
+            "lean coding profile grew to {} tools: {names:?}",
+            names.len(),
+        );
+    }
+
+    #[test]
+    fn spawn_only_tools_survive_filter_so_bootstrap_gates_on_allows() {
+        let mut tools = ToolRegistry::new();
+        tools.register(StubTool {
+            name: "run_pipeline",
+        });
+        tools.mark_spawn_only("run_pipeline", None);
+        tools.register(StubTool { name: "read_file" });
+
+        let coding = ProfileDefinition::builtin("coding").expect("coding");
+        coding.apply_to_registry(&mut tools);
+
+        let names: Vec<String> = tools.specs().into_iter().map(|s| s.name).collect();
+        // Registry-level carve-out (M8.3): spawn_only tools are never
+        // evicted by `filter_by_profile` — they carry background-execution
+        // wiring the runtime depends on once registered...
+        assert!(
+            names.contains(&"run_pipeline".to_string()),
+            "spawn_only carve-out regressed: {names:?}",
+        );
+        // ...which is exactly why the chat/acp bootstrap must consult
+        // `ProfileTools::allows` BEFORE registering + marking a spawn_only
+        // tool. The lean coding profile says no; coding-full says yes.
+        assert!(!coding.tools.allows("run_pipeline"));
+        let full = ProfileDefinition::builtin("coding-full").expect("coding-full");
+        assert!(full.tools.allows("run_pipeline"));
+    }
+
+    #[test]
+    fn profile_tools_allows_mirrors_filter_matching() {
+        // Default mode: everything passes.
+        assert!(ProfileTools::Default.allows("anything"));
+
+        let allow = ProfileTools::AllowList {
+            tools: vec!["group:fs".into(), "exec*".into(), "spawn".into()],
+        };
+        assert!(allow.allows("read_file"), "group member must match");
+        assert!(allow.allows("exec_command"), "wildcard must match");
+        assert!(allow.allows("spawn"), "exact name must match");
+        assert!(!allow.allows("web_search"));
+
+        // Empty allow list is treated as pass-through by
+        // `ToolRegistry::filter_by_profile` (with a warning); `allows`
+        // must agree or the bootstrap gate would drop tools the filter
+        // keeps.
+        let empty = ProfileTools::AllowList { tools: vec![] };
+        assert!(empty.allows("web_search"));
+
+        let deny = ProfileTools::DenyList {
+            tools: vec!["group:web".into()],
+        };
+        assert!(!deny.allows("web_fetch"), "denied group member");
+        assert!(deny.allows("read_file"));
+
+        // Empty deny list denies nothing (mirrors the filter's early
+        // return).
+        let empty_deny = ProfileTools::DenyList { tools: vec![] };
+        assert!(empty_deny.allows("web_fetch"));
     }
 
     #[test]

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -2554,25 +2554,28 @@ mod profile_filter_tests {
     }
 
     #[test]
-    fn coding_profile_produces_same_registry_as_default_builtins() {
-        // Behaviour parity gate: applying the built-in `coding` profile
-        // to a builtin registry must leave the registry IDENTICAL to
-        // what today's no-flag default path produces. This is the
-        // critical regression guard called out in the M8.3 issue.
+    fn coding_full_profile_produces_same_registry_as_default_builtins() {
+        // Behaviour parity gate: applying the built-in `coding-full`
+        // profile to a builtin registry must leave the registry IDENTICAL
+        // to what the no-flag default path produced before the lean
+        // `coding` default landed. This is the critical regression guard
+        // called out in the M8.3 issue, retargeted at the unfiltered
+        // escape hatch now that `coding` itself carries an allow list
+        // (see `crate::profile::tests` for the lean-narrowing pins).
         use crate::profile::ProfileDefinition;
 
         let dir = tempfile::tempdir().expect("tempdir");
         let reference = ToolRegistry::with_builtins(dir.path());
         let reference_names = builtin_names(&reference);
 
-        let coding = ProfileDefinition::builtin("coding").expect("coding builtin");
+        let full = ProfileDefinition::builtin("coding-full").expect("coding-full builtin");
         let mut profiled = ToolRegistry::with_builtins(dir.path());
-        coding.apply_to_registry(&mut profiled);
+        full.apply_to_registry(&mut profiled);
 
         let profiled_names = builtin_names(&profiled);
         assert_eq!(
             reference_names, profiled_names,
-            "coding profile must preserve behaviour parity with the default path",
+            "coding-full profile must preserve behaviour parity with the default path",
         );
     }
 

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -120,8 +120,11 @@ pub struct AcpCommand {
     #[arg(long, default_value = "20")]
     pub max_iterations: u32,
 
-    /// Runtime profile hint (accepted for parity with `octos chat`; the ACP
-    /// bridge builds a minimal agent and does not apply profile tool filters).
+    /// Runtime profile to apply at startup (parity with `octos chat`).
+    /// Accepts a built-in name (`coding`, `coding-full`, `swarm`), a
+    /// user-dir id under `~/.octos/profiles/<id>/`, or a path. Defaults to
+    /// `coding`, the lean core-coding tool surface; use `coding-full` for
+    /// the unfiltered pre-lean tool set.
     #[arg(long)]
     pub profile: Option<String>,
 }
@@ -451,30 +454,36 @@ impl AcpBootstrap {
         }
 
         // Pipeline tool (DOT workflows), embedder-aware, marked spawn_only.
-        let pipeline_tool = super::chat::build_run_pipeline_tool(
-            llm.clone(),
-            memory.clone(),
-            cwd.clone(),
-            data_dir.clone(),
-            // P3 (codex): resolve provider policy NOW (finalize runs later) so
-            // pipeline workers inherit tool_policy_by_provider denials.
-            super::chat::resolve_provider_policy(&config, &provider_name, &model_id),
-            plugin_dirs.clone(),
-            config.plugins.require_signed,
-            shared.embedder.clone(),
-            // #1607: same sandbox the ACP agent registry uses (built at
-            // `build_acp_tool_registry` / the `create_sandbox(&sandbox)` above),
-            // so pipeline command validators run under the identical backend.
-            sandbox.clone(),
-        );
-        tools.register(pipeline_tool);
-        tools.mark_spawn_only(
-            "run_pipeline",
-            Some(
-                "Pipeline started in background. The final result and any artifacts will be sent here when complete."
-                    .to_string(),
-            ),
-        );
+        // Lean-profile gate (mirrors `octos chat`): spawn_only tools survive
+        // `filter_by_profile` unconditionally, so a profile can only exclude
+        // `run_pipeline` by never registering it. The lean `coding` default
+        // excludes it; `coding-full` keeps it.
+        if profile.tools.allows("run_pipeline") {
+            let pipeline_tool = super::chat::build_run_pipeline_tool(
+                llm.clone(),
+                memory.clone(),
+                cwd.clone(),
+                data_dir.clone(),
+                // P3 (codex): resolve provider policy NOW (finalize runs later) so
+                // pipeline workers inherit tool_policy_by_provider denials.
+                super::chat::resolve_provider_policy(&config, &provider_name, &model_id),
+                plugin_dirs.clone(),
+                config.plugins.require_signed,
+                shared.embedder.clone(),
+                // #1607: same sandbox the ACP agent registry uses (built at
+                // `build_acp_tool_registry` / the `create_sandbox(&sandbox)` above),
+                // so pipeline command validators run under the identical backend.
+                sandbox.clone(),
+            );
+            tools.register(pipeline_tool);
+            tools.mark_spawn_only(
+                "run_pipeline",
+                Some(
+                    "Pipeline started in background. The final result and any artifacts will be sent here when complete."
+                        .to_string(),
+                ),
+            );
+        }
 
         // Policy + context filter + provider policy + profile narrowing (LAST).
         finalize_tool_registry(&mut tools, &config, &provider_name, &model_id, &profile);

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -214,6 +214,32 @@ fn finalize_tool_registry(
     profile.apply_to_registry(tools);
 }
 
+/// Rebind the per-cwd base registry to one session's cwd and re-apply the
+/// finalize narrowing envelope.
+///
+/// codex P1 (lean default): `rebind_cwd_with_permissions` re-registers
+/// every cwd-bound builtin (workspace_*, view_image, tool_search/suggest,
+/// optionally git/code_structure) so they run against the session's repo —
+/// which resurrects tools the profile / config tool-policy narrowing
+/// evicted from the base registry. Re-running [`finalize_tool_registry`]
+/// keeps per-session registries on exactly the same envelope as the
+/// per-cwd base (the filters are idempotent).
+#[allow(clippy::too_many_arguments)]
+fn rebind_session_registry(
+    base: &ToolRegistry,
+    cwd: &std::path::Path,
+    sandbox: Box<dyn octos_agent::Sandbox>,
+    permissions: octos_agent::EffectivePermissions,
+    config: &Config,
+    provider_name: &str,
+    model_id: &str,
+    profile: &octos_agent::profile::ProfileDefinition,
+) -> ToolRegistry {
+    let mut tools = base.rebind_cwd_with_permissions(cwd, sandbox, permissions);
+    finalize_tool_registry(&mut tools, config, provider_name, model_id, profile);
+    tools
+}
+
 /// Process-global, **cwd-independent** state, assembled ONCE per `octos acp`
 /// process (lazily, on the first `session/new`). The redb episode store is a
 /// single-writer resource, so it must live here — never rebuilt per cwd. Also
@@ -646,11 +672,18 @@ impl SessionAgentFactory for ConfigAgentFactory {
 
         // Per-session: rebind this cwd's base registry so the cwd-bound tools
         // (shell/read_file/…) run against the client's repo, and give this session
-        // its own Arc-able registry.
-        let tools = b.tool_specs.rebind_cwd_with_permissions(
+        // its own Arc-able registry. The helper re-applies the finalize
+        // narrowing because the rebind re-registers cwd-bound builtins the
+        // profile/policy filters had evicted (codex P1 on the lean default).
+        let tools = rebind_session_registry(
+            &b.tool_specs,
             &cwd,
             create_sandbox(&b.sandbox),
             octos_agent::EffectivePermissions::workspace_write(),
+            &shared.config,
+            &shared.provider_name,
+            &shared.model_id,
+            &b.profile,
         );
 
         // Per-session filesystem scope (codex P1): contain file tools + plugins to
@@ -1430,6 +1463,68 @@ mod tests {
             );
         }
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// codex P1 (lean default): `rebind_cwd_with_permissions` re-registers
+    /// every cwd-bound builtin (workspace_*, view_image, tool_search, …),
+    /// resurrecting tools that the per-cwd finalize narrowing evicted from
+    /// the base registry. Session assembly must therefore re-run the
+    /// finalize envelope on the rebound registry — pinned here against the
+    /// `rebind_session_registry` helper the production path uses.
+    #[test]
+    fn rebind_session_registry_reapplies_profile_narrowing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = Config::default();
+        let profile =
+            octos_agent::profile::ProfileDefinition::builtin("coding").expect("coding builtin");
+
+        // Base registry the per-cwd bootstrap ends up with: builtins +
+        // finalize narrowing (lean coding profile applied LAST).
+        let mut base = ToolRegistry::with_builtins_and_sandbox(
+            dir.path(),
+            create_sandbox(&octos_agent::SandboxConfig::default()),
+        );
+        finalize_tool_registry(&mut base, &config, "openai", "gpt-test", &profile);
+        assert!(
+            !base.is_tool_visible("workspace_diff"),
+            "lean coding base registry must have dropped workspace_diff"
+        );
+
+        // Pin the resurrection behaviour a raw rebind exhibits — if this
+        // ever stops holding, the helper below can be simplified away.
+        let raw = base.rebind_cwd_with_permissions(
+            dir.path(),
+            create_sandbox(&octos_agent::SandboxConfig::default()),
+            octos_agent::EffectivePermissions::workspace_write(),
+        );
+        assert!(
+            raw.is_tool_visible("workspace_diff"),
+            "rebind_cwd_with_permissions re-registers cwd-bound builtins"
+        );
+
+        // The session helper must re-narrow to the profile envelope.
+        let session = rebind_session_registry(
+            &base,
+            dir.path(),
+            create_sandbox(&octos_agent::SandboxConfig::default()),
+            octos_agent::EffectivePermissions::workspace_write(),
+            &config,
+            "openai",
+            "gpt-test",
+            &profile,
+        );
+        for resurrected in ["workspace_diff", "view_image", "tool_search", "web_search"] {
+            assert!(
+                !session.is_tool_visible(resurrected),
+                "{resurrected} must stay excluded in the rebound session registry"
+            );
+        }
+        for kept in ["read_file", "shell", "grep", "edit_file"] {
+            assert!(
+                session.is_tool_visible(kept),
+                "{kept} must survive the rebound session registry"
+            );
+        }
     }
 
     /// RFC-0 (#1289): LRU tool deferral was removed, so `shell` /

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -71,11 +71,14 @@ pub struct ChatCommand {
     pub message: Option<String>,
 
     /// Runtime profile to apply at startup (M8.3). Accepts a built-in name
-    /// (`coding`, `swarm`), a user-dir id under `~/.octos/profiles/<id>/`,
-    /// or an explicit path to a profile JSON/TOML file.
+    /// (`coding`, `coding-full`, `swarm`), a user-dir id under
+    /// `~/.octos/profiles/<id>/`, or an explicit path to a profile
+    /// JSON/TOML file.
     ///
-    /// Defaults to `coding` which preserves today's no-flag behaviour
-    /// byte-for-byte.
+    /// Defaults to `coding`, the lean core-coding tool surface (files,
+    /// shell, search, memory, spawn, user questions). Use `coding-full`
+    /// for the unfiltered pre-lean tool set (web, research, pipelines,
+    /// bundled skills).
     #[arg(long)]
     pub profile: Option<String>,
 
@@ -816,28 +819,38 @@ impl ChatCommand {
         // [`build_run_pipeline_tool`] so the regression test in
         // `octos-pipeline/tests/embedder_propagation.rs` can pin the
         // wiring without instantiating the full chat command.
-        let pipeline_tool = build_run_pipeline_tool(
-            llm.clone(),
-            memory.clone(),
-            cwd.clone(),
-            data_dir.clone(),
-            tools.provider_policy().cloned(),
-            plugin_dirs.clone(),
-            config.plugins.require_signed,
-            embedder.clone(),
-            // #1607: same sandbox `octos chat` builds for its shell/exec tools
-            // (see `effective_sandbox_config` above), so pipeline command
-            // validators run under the identical backend.
-            effective_sandbox_config.clone(),
-        );
-        tools.register(pipeline_tool);
-        tools.mark_spawn_only(
-            "run_pipeline",
-            Some(
-                "Pipeline started in background. The final result and any artifacts will be sent here when complete. You can keep chatting in the meantime."
-                    .to_string(),
-            ),
-        );
+        // Lean-profile gate: `run_pipeline` is marked spawn_only, and
+        // spawn_only tools survive `filter_by_profile` unconditionally —
+        // so a profile can only exclude the pipeline engine by never
+        // registering it. `ProfileTools::allows` mirrors the filter's
+        // name-matching (groups / wildcards / exact names), which keeps
+        // this gate and the registry narrowing below in agreement. The
+        // lean `coding` default excludes it; `coding-full` (and any
+        // profile without an explicit filter) keeps it.
+        if profile.tools.allows("run_pipeline") {
+            let pipeline_tool = build_run_pipeline_tool(
+                llm.clone(),
+                memory.clone(),
+                cwd.clone(),
+                data_dir.clone(),
+                tools.provider_policy().cloned(),
+                plugin_dirs.clone(),
+                config.plugins.require_signed,
+                embedder.clone(),
+                // #1607: same sandbox `octos chat` builds for its shell/exec tools
+                // (see `effective_sandbox_config` above), so pipeline command
+                // validators run under the identical backend.
+                effective_sandbox_config.clone(),
+            );
+            tools.register(pipeline_tool);
+            tools.mark_spawn_only(
+                "run_pipeline",
+                Some(
+                    "Pipeline started in background. The final result and any artifacts will be sent here when complete. You can keep chatting in the meantime."
+                        .to_string(),
+                ),
+            );
+        }
 
         // Apply tool policy from config
         if let Some(ref policy) = config.tool_policy {


### PR DESCRIPTION
## Motivation

A harness review vs pi found the default `octos chat` ships **every tool schema to the LLM on every round**: RFC-0 (#1289) removed LRU deferral so `specs()` emits everything, the default `coding` profile declared no filter (`tools: {"mode": "default"}`), and `chat.rs` auto-bootstraps 9 bundled-skill tools (weather/news/email/search/…) into every chat. Ground-truth capture on `59da36916` (fake OpenAI endpoint, isolated `$HOME`, skills bootstrapped): **49 tools, 44,622 bytes ≈ 11.2K tokens per round** — `run_pipeline` alone is 4,055 B, `spawn` 3,292 B. pi ships 4 tools ≈ 678 tokens. The `ToolPolicy`/group machinery (`group:fs`, `group:runtime`, wildcards) already existed — this is mostly configuration.

## What changed

1. **`coding` (the no-flag default for `octos chat` / `octos acp`) is now lean** — allow list: `group:fs`, `group:runtime`, `group:search`, `group:memory`, `spawn`, `ask_user_question`. The memory quartet stays because the memory system-prompt riders (`memory_segment.rs`) tell the model to call `recall_memory` / `save_memory` / `record_memory_use` / `memory_note` — filtering them would make the prompt lie (`memory_note` registers only when `memory.refresh` is enabled, as before).
2. **New `coding-full` built-in** — unfiltered pass-through, byte-for-byte the old default. One `--profile coding-full` (or `ln -s coding-full ~/.octos/profile`) away.
3. **`run_pipeline` registration gate** — it's marked `spawn_only`, and `filter_by_profile` never evicts spawn_only tools, so profiles alone can't exclude it. The chat/acp bootstraps now consult the new `ProfileTools::allows()` predicate (mirrors the filter's group/wildcard/exact matching incl. the empty-allow-list pass-through) before registering it.
4. **`swarm` names `run_pipeline` explicitly** — pre-lean it kept the tool only via the spawn_only carve-out; without this it would silently lose it under the new gate.
5. **ACP per-session rebind re-applies the narrowing** (codex-review P1) — `rebind_cwd_with_permissions` re-registers every cwd-bound builtin (workspace_*, view_image, tool_search/suggest, git/ast), resurrecting tools the profile/`tool_policy` filters evicted from the per-cwd base registry. New `rebind_session_registry` helper reruns `finalize_tool_registry` on the rebound registry (idempotent). This bypass was pre-existing for restrictive custom ACP profiles; the lean default made it load-bearing.
6. **Docs** — new “Runtime Tool Profiles” section in `book/src/configuration.md` (built-in table, switching, per-project add-back via custom profiles or `tool_policy`), `book/src/cli-reference.md` chat flags, `--profile` help text in chat/acp.

## Before / after (empirical, release build, isolated `$HOME`, tools array captured off the wire)

| default `octos chat`, per LLM round | tools | serialized bytes | ≈tokens (4 B/tok) |
|---|---|---|---|
| BEFORE — `main` default (59da36916) | 49 | 44,622 | ~11.2K |
| AFTER — lean `coding` default | **18** | **14,520** | **~3.6K** (−67%) |
| AFTER — `--profile coding-full` | 49 | 44,622 | ~11.2K |

- Lean set (18): read_file, write_file, edit_file, apply_patch, diff_edit · shell, exec_command, write_stdin, bash · glob, grep, list_dir · recall_memory, save_memory, record_memory_use, memory_note · spawn · ask_user_question.
- `coding-full` vs pristine-main default: **identical 49-tool sets, per-tool serialized JSON byte-identical** (array order differs across runs — HashMap iteration order, nondeterministic even on the same binary).
- The motivation review counted 48 ≈ 9.3K tok; the wire capture shows 49/11.2K because real chat also registers `configure_tool` and OpenAI-format serialization adds the `{"type":"function",…}` wrapper.

## Does the profile filter reach skill/plugin tools?

**Yes — verified.** `filter_by_profile` retains by name over the whole registry, and both bootstraps apply it **after** plugins/skills/MCP register (`chat.rs` “profile narrowing runs AFTER every other filter”, `acp.rs finalize_tool_registry`). Proven on the wire (all 9 bundled-skill tools present under `coding-full`, absent under lean `coding`, skills bootstrapped in both runs) and pinned by `coding_profile_narrows_registry_to_core_coding_loop`.

The one structural bypass is `spawn_only` tools, which survive `filter_by_profile` by design. `run_pipeline` is handled via the registration gate above. Residual edge: a `spawn_only` **skill** tool (today only `voice_synthesize` from the platform `voice` skill, which installs only when its backend is reachable — not part of default chat) would still bypass an allow list once registered. A registry-level fix (e.g. profile-narrowing that consults `allows()` for spawn_only entries not yet invoked) is left as a **follow-up for the registry/tools workstream** to avoid colliding with the concurrent registry PR.

## ⚠️ Compat / migration (please read before release)

**This changes default behavior for existing `coding`-profile users** (`octos chat`, `octos acp`):

- Web (`web_search`/`web_fetch`/`browser`), research (`search`/`synthesize_research`/`deep_crawl`), `run_pipeline`, `image_generation`, workspace-report tools, agent-session tools (`spawn_agent`/`delegate`/…), and all bundled-skill tools (weather/news/send_email/…) **are no longer exposed** until the user switches to `--profile coding-full`, symlinks `~/.octos/profile → coding-full`, or writes a custom profile.
- Built-in sub-agents are unaffected (spawn workers build their own registries — `research-worker` keeps `web_search`/`web_fetch`).
- **`octos gateway` / `octos serve` are unaffected** — they do not resolve runtime profiles (relevant for octos.mofa.ai production).
- Custom **allow-list** profiles no longer implicitly receive `run_pipeline` via the spawn_only leak; add `"run_pipeline"` to the allow list to keep it (the built-in `swarm` was updated accordingly).

Suggested release-notes wording:

> **Breaking (CLI default):** `octos chat`/`octos acp` now default to a lean coding tool set (files, shell, search, memory, spawn, user questions — ~3.6K tokens of tool schemas per round instead of ~11K). Web, research, pipelines, and bundled skills are one switch away: `octos chat --profile coding-full`, or persist it with `ln -s coding-full ~/.octos/profile`. Gateways and the web dashboard are unchanged.

## Tests (RED → GREEN)

- `profile::tests`: lean-envelope pins (`should_load_builtin_coding_profile_without_error`, `should_resolve_profile_name_to_builtin`), `coding-full` escape-hatch pin, registry narrowing incl. a stub skill tool (`coding_profile_narrows_registry_to_core_coding_loop`), spawn_only carve-out + gate rationale (`spawn_only_tools_survive_filter_so_bootstrap_gates_on_allows`), `allows()` semantics vs the filter (`profile_tools_allows_mirrors_filter_matching`), swarm `run_pipeline` pin.
- `agent::tests`: `coding_profile_narrows_default_tool_set` (subset + inclusions/exclusions), `coding_full_profile_matches_default_tool_set` (byte-for-byte parity contract moved to `coding-full`).
- `acp::tests`: `rebind_session_registry_reapplies_profile_narrowing` — pins both the raw-rebind resurrection behaviour and the re-narrowed session registry.
- `tools/registry.rs`: **test-only** retarget of the M8.3 parity gate at `coding-full` (`coding_full_profile_produces_same_registry_as_default_builtins`) — no registry implementation code touched (kept clear of the concurrent registry workstream).
- Suites: `cargo test -p octos-agent` green (2095 lib + integration); `cargo test -p octos-cli --features api` green (2306 lib; the `acp_integration` spawn test fails on pristine `main` in this environment too — pre-existing local-only). `cargo fmt --check` clean; clippy: no warnings in changed files.

## Review

codex round 1 (full diff): one P1 — the ACP rebind resurrection above — fixed + regression-pinned. codex round 2 (fix commits, incl. double-application/idempotency + spawn_only interactions): **CLEAN**. Gates: `cargo fmt --check` clean; clippy — zero warnings in changed files.

## CI note

`test-octos-agent-integration` is pre-existing broken on `main` (macos-14 ~52-min timeout) — if it's red here, it's not from this PR.
