### PR TITLE
fix(llm): retry transport send-failures + prompt-cache kill-switch

### DIFF
--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -1226,7 +1226,10 @@ mod tests {
 
     #[test]
     fn test_build_request_filters_system() {
-        let provider = AnthropicProvider::new("test-key", "claude-test");
+        // Pin caching ON: the extraction assertion below reads block-form
+        // `system[0].text`, which only exists when caching is enabled — keep
+        // it hermetic w.r.t. an ambient `OCTOS_PROMPT_CACHING=0`.
+        let provider = AnthropicProvider::new("test-key", "claude-test").with_prompt_caching(true);
         let messages = vec![
             msg(MessageRole::System, "system prompt"),
             msg(MessageRole::User, "hello"),
@@ -1605,7 +1608,11 @@ mod tests {
 
     #[test]
     fn should_mark_system_last_tool_and_last_user_block_with_cache_control() {
-        let provider = AnthropicProvider::new("test-key", "claude-test");
+        // Pin caching ON so this wire-shape assertion is hermetic w.r.t. an
+        // ambient `OCTOS_PROMPT_CACHING=0` (the builder override wins over the
+        // env default). The default-resolution truth table is covered
+        // separately by `prompt_caching_env_*` unit tests.
+        let provider = AnthropicProvider::new("test-key", "claude-test").with_prompt_caching(true);
         let tools = vec![
             tool_spec("alpha", "first tool"),
             tool_spec("omega", "last tool"),
@@ -1672,7 +1679,9 @@ mod tests {
         // batch — the breakpoint must land on its LAST block only, so the
         // whole history including the current results is cached for the
         // next iteration.
-        let provider = AnthropicProvider::new("test-key", "claude-test");
+        // Pin caching ON so the assertion is independent of the ambient
+        // `OCTOS_PROMPT_CACHING` kill-switch (builder override wins).
+        let provider = AnthropicProvider::new("test-key", "claude-test").with_prompt_caching(true);
         let mut assistant = msg(MessageRole::Assistant, "");
         assistant.tool_calls = Some(vec![
             tool_call("toolu_a", "shell", serde_json::json!({"command": "ls"})),
@@ -1704,7 +1713,9 @@ mod tests {
     fn should_keep_blank_system_as_string_even_when_caching_enabled() {
         // An empty text BLOCK is rejected by Anthropic while `"system": ""`
         // is not — an all-blank system prompt must stay in string form.
-        let provider = AnthropicProvider::new("test-key", "claude-test");
+        // Pin caching ON (the test name asserts "even_when_caching_enabled")
+        // so it does not silently pass under an ambient `OCTOS_PROMPT_CACHING=0`.
+        let provider = AnthropicProvider::new("test-key", "claude-test").with_prompt_caching(true);
         let messages = vec![msg(MessageRole::System, ""), msg(MessageRole::User, "hi")];
         let config = ChatConfig::default();
         let body = serde_json::to_value(provider.build_request(&messages, &[], &config)).unwrap();
@@ -1836,8 +1847,11 @@ mod tests {
             .mount(&server)
             .await;
 
-        let provider =
-            AnthropicProvider::new("test-key", "claude-test").with_base_url(server.uri());
+        // Pin caching ON — this test asserts cache breakpoints are sent on the
+        // wire, so it must not depend on the ambient `OCTOS_PROMPT_CACHING`.
+        let provider = AnthropicProvider::new("test-key", "claude-test")
+            .with_base_url(server.uri())
+            .with_prompt_caching(true);
         let tools = vec![tool_spec("shell", "run a command")];
         let messages = vec![
             msg(MessageRole::System, "sys"),

--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -32,8 +32,33 @@ pub struct AnthropicProvider {
     /// Emit `cache_control: {"type": "ephemeral"}` breakpoints so Anthropic
     /// serves the replayed prefix from its prompt cache (~0.1x input rate on
     /// reads) instead of billing the whole conversation at full rate every
-    /// round. Default ON — see [`Self::with_prompt_caching`].
+    /// round. Default ON, but the `OCTOS_PROMPT_CACHING` env kill-switch can
+    /// force it off at startup without a rebuild — see
+    /// [`Self::with_prompt_caching`] and [`prompt_caching_default`].
     prompt_caching: bool,
+}
+
+/// Resolve the default prompt-caching state from a raw env value.
+///
+/// Caching stays ON unless the value is explicitly falsy (`0`, `false`,
+/// `off`, `no`, case- and whitespace-insensitive). Unset, empty, or any
+/// other value keeps the default ON. Pure over its input so the kill-switch
+/// is unit-testable without mutating process env (the workspace is
+/// `deny(unsafe_code)`, and `std::env::set_var` is `unsafe` on edition 2024).
+fn prompt_caching_default_from(env_value: Option<&str>) -> bool {
+    match env_value {
+        Some(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "no"
+        ),
+        None => true,
+    }
+}
+
+/// Default prompt-caching state, honoring the `OCTOS_PROMPT_CACHING`
+/// kill-switch. See [`prompt_caching_default_from`].
+fn prompt_caching_default() -> bool {
+    prompt_caching_default_from(std::env::var("OCTOS_PROMPT_CACHING").ok().as_deref())
 }
 
 impl AnthropicProvider {
@@ -48,7 +73,7 @@ impl AnthropicProvider {
             model: model.into(),
             base_url: "https://api.anthropic.com".to_string(),
             provider_label: "anthropic".to_string(),
-            prompt_caching: true,
+            prompt_caching: prompt_caching_default(),
         }
     }
 
@@ -90,6 +115,10 @@ impl AnthropicProvider {
     /// unconditionally). Disable for odd proxies that reject the field or
     /// the block-array `system` form; disabling restores the exact
     /// pre-caching wire shape (plain-string `system`, verbatim tools).
+    ///
+    /// Operators can flip the default OFF at startup without a rebuild via
+    /// `OCTOS_PROMPT_CACHING=0` (see [`prompt_caching_default`]); this
+    /// explicit builder still wins over the env default when called.
     pub fn with_prompt_caching(mut self, enabled: bool) -> Self {
         self.prompt_caching = enabled;
         self
@@ -1715,6 +1744,32 @@ mod tests {
             !body.to_string().contains("cache_control"),
             "no cache_control key may appear anywhere when caching is off: {body}"
         );
+    }
+
+    #[test]
+    fn prompt_caching_env_default_stays_on_when_unset_or_truthy() {
+        // Default ON is preserved: unset, empty, or any non-falsy value keeps
+        // caching enabled (Claude Code sends cache_control unconditionally).
+        assert!(prompt_caching_default_from(None));
+        assert!(prompt_caching_default_from(Some("")));
+        assert!(prompt_caching_default_from(Some("1")));
+        assert!(prompt_caching_default_from(Some("true")));
+        assert!(prompt_caching_default_from(Some("on")));
+        assert!(prompt_caching_default_from(Some("yes")));
+        assert!(prompt_caching_default_from(Some("anything-else")));
+    }
+
+    #[test]
+    fn prompt_caching_env_kill_switch_disables_on_falsy_values() {
+        // OCTOS_PROMPT_CACHING kill-switch: disable without a rebuild for any
+        // Anthropic-compatible proxy that rejects cache_control / block-form
+        // system. Case- and whitespace-insensitive.
+        for v in ["0", "false", "FALSE", "off", "Off", "no", "  no ", " 0 "] {
+            assert!(
+                !prompt_caching_default_from(Some(v)),
+                "OCTOS_PROMPT_CACHING={v:?} must disable prompt caching"
+            );
+        }
     }
 
     #[test]

--- a/crates/octos-llm/src/retry.rs
+++ b/crates/octos-llm/src/retry.rs
@@ -201,6 +201,26 @@ impl RetryProvider {
                 // above missed them and a mid-turn drop hard-failed the whole
                 // turn with no retry and no failover. Retry on the same
                 // provider — a fresh connection is dialed on the next attempt.
+                //
+                // DELIBERATE at-least-once tradeoff: a statusless send failure
+                // is ambiguous — the request may have been fully received and
+                // billed by the server before the connection dropped ("no
+                // response" != "not accepted"). Replaying can therefore
+                // double-bill a non-idempotent chat POST in the rare
+                // mid-generation-drop sub-case. We accept this because (a) the
+                // dominant cause here is a reused idle-keepalive socket the LB
+                // closed BEFORE servicing the request (never billed → safe to
+                // replay), and for a streaming POST a server that had begun
+                // generating would have already flushed response headers, so
+                // `.send()` would have resolved and the drop would surface as a
+                // stream/body error OUTSIDE this retry scope; (b) the agent
+                // loop consumes exactly one ChatResponse, so a replay never
+                // duplicates tool side-effects — the only residual harm is
+                // provider-side double-billing; (c) the alternative is hard-
+                // failing the entire turn on any transient drop, which is
+                // strictly worse UX. Future hardening (not done here): a short
+                // pool idle-timeout to stop reusing about-to-close sockets, or
+                // a client idempotency key where the endpoint supports one.
                 if reqwest_err.is_request() || reqwest_err.is_body() {
                     return true;
                 }

--- a/crates/octos-llm/src/retry.rs
+++ b/crates/octos-llm/src/retry.rs
@@ -172,15 +172,37 @@ impl RetryProvider {
                 if let Some(status) = reqwest_err.status() {
                     return matches!(status.as_u16(), 429 | 500 | 502 | 503 | 504 | 529);
                 }
-                // Connection errors are retryable (may be transient network issue)
+                // Timeout errors should NOT be retried on the same provider —
+                // if a provider is unresponsive, retrying wastes the
+                // per-request budget × retries. Timeouts trigger failover to a
+                // different provider instead. Checked BEFORE `is_connect`: a
+                // connect *timeout* is BOTH `is_timeout()` and `is_connect()`,
+                // and must fail over rather than hammer the same unreachable
+                // lane (empirically confirmed against a black-holed address).
+                if reqwest_err.is_timeout() {
+                    return false;
+                }
+                // Connection *establishment* errors with no timeout (refused,
+                // DNS, TLS handshake) are transient — retry on the same
+                // provider (may be a transient network blip).
                 if reqwest_err.is_connect() {
                     return true;
                 }
-                // Timeout errors should NOT be retried on the same provider —
-                // if a provider is unresponsive, retrying wastes 120s × retries.
-                // Timeouts trigger failover to a different provider instead.
-                if reqwest_err.is_timeout() {
-                    return false;
+                // Transport-level send/body failures WITHOUT an HTTP status —
+                // the status-bearing branch above already returned, so any
+                // reqwest error reaching here carried no response. These are
+                // transient network faults while sending the request or
+                // reading the response head: connection reset, broken pipe,
+                // early EOF, and most importantly "connection closed before
+                // message completed" — reqwest reusing a pooled keepalive
+                // socket that the peer's load balancer already closed. reqwest
+                // classifies these as `is_request()`/`is_body()` (NOT
+                // `is_connect`, NOT `is_timeout`), so the connect-only branch
+                // above missed them and a mid-turn drop hard-failed the whole
+                // turn with no retry and no failover. Retry on the same
+                // provider — a fresh connection is dialed on the next attempt.
+                if reqwest_err.is_request() || reqwest_err.is_body() {
+                    return true;
                 }
             }
         }
@@ -194,10 +216,17 @@ impl RetryProvider {
             }
         }
 
-        // Network-level errors without reqwest context
+        // Network-level errors without reqwest context (flattened error
+        // strings, provider `bail!`s, or a cause chain that lost the typed
+        // reqwest error). "connection closed before message completed" is the
+        // reused-keepalive drop; "error sending request" / "broken pipe" cover
+        // the same transport family surfaced as plain text.
         let lower = error_str.to_lowercase();
         if lower.contains("connection refused")
             || lower.contains("connection reset")
+            || lower.contains("connection closed")
+            || lower.contains("broken pipe")
+            || lower.contains("error sending request")
             || lower.contains("timed out")
             || lower.contains("overloaded")
         {
@@ -886,5 +915,202 @@ mod tests {
             Err(e) => assert!(e.to_string().contains("503"), "unexpected error: {e}"),
             Ok(_) => panic!("should fail after exhausting retries"),
         }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Transport-level send-failure classification (issue: glm-5.2
+    // `failed to send streaming request` hard-failed a 20-action turn).
+    //
+    // These drive a real `reqwest` client at a local TCP server that fails
+    // the request in the same way z.ai's endpoint does under load, then wrap
+    // the error EXACTLY like `anthropic.rs`
+    // (`.send().await.wrap_err("failed to send streaming request to Anthropic")`)
+    // and assert the retry/failover verdict.
+    // ──────────────────────────────────────────────────────────────────────
+    use eyre::WrapErr;
+
+    /// Produce a real `reqwest` send failure of the requested `kind`, wrapped
+    /// like the Anthropic provider does:
+    ///   - `"refused"`         → nothing listening (reqwest `is_connect`)
+    ///   - `"immediate_close"` → server accepts then drops the socket
+    ///   - `"read_then_close"` → server reads the request then closes without
+    ///     replying ("connection closed before message completed" — the
+    ///     reused-keepalive / half-open-socket case)
+    async fn transport_send_error(kind: &str) -> eyre::Report {
+        use tokio::io::AsyncReadExt;
+        use tokio::net::TcpListener;
+
+        let client = crate::provider::build_http_client(5, 5);
+
+        if kind == "refused" {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            drop(listener);
+            let url = format!("http://127.0.0.1:{port}/v1/messages");
+            let res = client
+                .post(&url)
+                .json(&serde_json::json!({"x": 1}))
+                .send()
+                .await;
+            return res
+                .map(|_| ())
+                .wrap_err("failed to send streaming request to Anthropic")
+                .unwrap_err();
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let read_then_close = kind == "read_then_close";
+        let accept = tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                if read_then_close {
+                    let mut buf = [0u8; 1024];
+                    let _ = sock.read(&mut buf).await;
+                }
+                drop(sock);
+            }
+        });
+
+        let url = format!("http://127.0.0.1:{port}/v1/messages");
+        let res = client
+            .post(&url)
+            .json(&serde_json::json!({"x": 1}))
+            .send()
+            .await;
+        let _ = accept.await;
+        res.map(|_| ())
+            .wrap_err("failed to send streaming request to Anthropic")
+            .unwrap_err()
+    }
+
+    #[tokio::test]
+    async fn should_retry_and_failover_on_connection_closed_before_completed() {
+        // The exact failure z.ai returns when reqwest reuses a keepalive
+        // socket the load balancer already closed: reqwest reports it as
+        // `is_request()` (NOT `is_connect`, NOT `is_timeout`, no status).
+        // Before the fix this was classified non-retryable AND
+        // non-failover-worthy, hard-failing the whole turn.
+        let err = transport_send_error("read_then_close").await;
+        assert!(
+            RetryProvider::is_retryable_error(&err),
+            "statusless transport send failure must retry on the same provider: {err:#}"
+        );
+        assert!(
+            RetryProvider::should_failover(&err),
+            "statusless transport send failure must also be failover-worthy: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_retry_and_failover_on_immediate_connection_close() {
+        let err = transport_send_error("immediate_close").await;
+        assert!(
+            RetryProvider::is_retryable_error(&err),
+            "reset-after-accept must retry: {err:#}"
+        );
+        assert!(
+            RetryProvider::should_failover(&err),
+            "reset-after-accept must failover: {err:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_failover_not_retry_on_connect_timeout() {
+        // A connect timeout is BOTH is_connect() and is_timeout(); it must be
+        // treated as a timeout (failover, don't retry the same unreachable
+        // lane), so is_timeout() is checked before is_connect(). TEST-NET-1
+        // (192.0.2.0/24, RFC 5737) is routed nowhere → the connect hangs until
+        // connect_timeout fires.
+        let client = reqwest::Client::builder()
+            // Bypass any ambient HTTP_PROXY/ALL_PROXY — a proxy could answer
+            // the request and turn the expected connect-timeout error into a
+            // response, panicking `unwrap_err()`.
+            .no_proxy()
+            .connect_timeout(Duration::from_millis(400))
+            .timeout(Duration::from_secs(30))
+            .build()
+            .unwrap();
+        let err = client
+            .post("http://192.0.2.1:81/v1/messages")
+            .json(&serde_json::json!({"x": 1}))
+            .send()
+            .await
+            .map(|_| ())
+            .wrap_err("failed to send streaming request to Anthropic")
+            .unwrap_err();
+
+        let is_timeout = err
+            .chain()
+            .find_map(|c| c.downcast_ref::<reqwest::Error>())
+            .map(|re| re.is_timeout())
+            .unwrap_or(false);
+
+        if is_timeout {
+            assert!(
+                !RetryProvider::is_retryable_error(&err),
+                "connect timeout must NOT retry the same provider: {err:#}"
+            );
+            assert!(
+                RetryProvider::should_failover(&err),
+                "connect timeout must fail over to another provider: {err:#}"
+            );
+        } else {
+            // Environment produced an immediate non-timeout connect error
+            // (e.g. network unreachable) instead of a timeout — still a
+            // transient connect failure, which stays retryable.
+            assert!(
+                RetryProvider::is_retryable_error(&err),
+                "connect error must remain retryable: {err:#}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn should_retry_and_failover_on_connection_refused() {
+        // Regression guard: connect-refused was already retryable
+        // (`is_connect`); it must stay that way.
+        let err = transport_send_error("refused").await;
+        assert!(RetryProvider::is_retryable_error(&err), "{err:#}");
+        assert!(RetryProvider::should_failover(&err), "{err:#}");
+    }
+
+    #[tokio::test]
+    async fn should_not_retry_request_timeout_on_same_provider_but_should_failover() {
+        // A per-request timeout keeps its existing semantics: NOT retried on
+        // the same (unresponsive) provider, but failover-worthy. Guards that
+        // the new transport branch sits AFTER the `is_timeout` check.
+        use tokio::net::TcpListener;
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accept = tokio::spawn(async move {
+            // Accept and hold the socket open without ever responding.
+            if let Ok((sock, _)) = listener.accept().await {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                drop(sock);
+            }
+        });
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(300))
+            .build()
+            .unwrap();
+        let url = format!("http://127.0.0.1:{port}/v1/messages");
+        let err = client
+            .post(&url)
+            .json(&serde_json::json!({"x": 1}))
+            .send()
+            .await
+            .map(|_| ())
+            .wrap_err("failed to send streaming request to Anthropic")
+            .unwrap_err();
+        accept.abort();
+
+        assert!(
+            !RetryProvider::is_retryable_error(&err),
+            "request timeout must not retry the same provider: {err:#}"
+        );
+        assert!(
+            RetryProvider::should_failover(&err),
+            "request timeout must failover to another provider: {err:#}"
+        );
     }
 }

--- a/crates/octos-llm/tests/glm_send_failure_ab.rs
+++ b/crates/octos-llm/tests/glm_send_failure_ab.rs
@@ -1,0 +1,204 @@
+//! LIVE A/B: does Anthropic prompt-caching (#1640) change the transport
+//! send-failure rate on z.ai's Anthropic endpoint for glm-5.2?
+//!
+//! Ignored by default (needs a real key + network). Run with:
+//!   ZAI_API_KEY=... ZAI_MODEL=glm-5.2 AB_ROUNDS=12 \
+//!     cargo test -p octos-llm --test glm_send_failure_ab -- --ignored --nocapture
+//!
+//! Emits a failure-rate table per config plus a cache-acceptance probe.
+
+use chrono::Utc;
+use futures::StreamExt;
+use octos_core::{Message, MessageRole};
+use octos_llm::anthropic::AnthropicProvider;
+use octos_llm::{ChatConfig, LlmProvider, StreamEvent, ToolSpec};
+
+fn msg(role: MessageRole, content: impl Into<String>) -> Message {
+    Message {
+        role,
+        content: content.into(),
+        media: vec![],
+        tool_calls: None,
+        tool_call_id: None,
+        reasoning_content: None,
+        client_message_id: None,
+        thread_id: None,
+        timestamp: Utc::now(),
+    }
+}
+
+fn tools() -> Vec<ToolSpec> {
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {"path": {"type": "string"}},
+        "required": ["path"]
+    });
+    vec![
+        ToolSpec {
+            name: "read_file".into(),
+            description: "Read a file".into(),
+            input_schema: schema.clone(),
+        },
+        ToolSpec {
+            name: "write_file".into(),
+            description: "Write a file".into(),
+            input_schema: schema.clone(),
+        },
+        ToolSpec {
+            name: "shell".into(),
+            description: "Run a shell command".into(),
+            input_schema: schema,
+        },
+    ]
+}
+
+fn big_history() -> Vec<Message> {
+    // Pad system past the cacheable minimum so caching actually engages.
+    let filler = "Reference material describing an Android AVD emulator install. ".repeat(700);
+    let system = format!("You are a terse coding assistant. Background: {filler}");
+    vec![
+        msg(MessageRole::System, system),
+        msg(
+            MessageRole::User,
+            "List three shell commands to create an Android AVD. One line each, no prose.",
+        ),
+    ]
+}
+
+#[derive(Default, Debug)]
+struct Tally {
+    ok: u32,
+    send_failure: u32,
+    http_error: u32,
+    stream_error: u32,
+    other: u32,
+}
+
+/// Fire N sequential streaming requests through ONE provider (shared reqwest
+/// connection pool — the condition under which stale keepalive sockets
+/// surface as "connection closed before message completed").
+async fn run_config(label: &str, provider: &AnthropicProvider, rounds: u32) -> Tally {
+    let history = big_history();
+    let tools = tools();
+    let config = ChatConfig {
+        max_tokens: Some(128),
+        ..Default::default()
+    };
+    let mut t = Tally::default();
+
+    for i in 0..rounds {
+        match provider.chat_stream(&history, &tools, &config).await {
+            Ok(mut stream) => {
+                let mut saw_error = None;
+                while let Some(ev) = stream.next().await {
+                    if let StreamEvent::Error(e) = ev {
+                        saw_error = Some(e);
+                    }
+                }
+                match saw_error {
+                    None => t.ok += 1,
+                    Some(e) => {
+                        t.stream_error += 1;
+                        println!("[{label}] round {i}: STREAM error: {e}");
+                    }
+                }
+            }
+            Err(e) => {
+                let s = format!("{e:#}");
+                if s.contains("failed to send") {
+                    t.send_failure += 1;
+                    println!("[{label}] round {i}: SEND FAILURE: {s}");
+                } else if s.contains("HTTP") || s.contains("API error") {
+                    t.http_error += 1;
+                    println!("[{label}] round {i}: HTTP error: {s}");
+                } else {
+                    t.other += 1;
+                    println!("[{label}] round {i}: OTHER error: {s}");
+                }
+            }
+        }
+        // Space requests to avoid colliding with a co-running soak agent's
+        // rate budget.
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+    }
+    t
+}
+
+#[tokio::test]
+#[ignore = "live: needs ZAI_API_KEY + network"]
+async fn glm_cache_on_vs_off_send_failure_rate() {
+    let key = std::env::var("ZAI_API_KEY").expect("ZAI_API_KEY not set");
+    let model = std::env::var("ZAI_MODEL").unwrap_or_else(|_| "glm-5.2".to_string());
+    let base = std::env::var("ZAI_BASE_URL")
+        .unwrap_or_else(|_| "https://api.z.ai/api/anthropic".to_string());
+    let rounds: u32 = std::env::var("AB_ROUNDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(12);
+
+    println!("== model={model} base={base} rounds={rounds} ==");
+
+    // ── Cache-acceptance probe: prove z.ai returns 200 + reports cache usage
+    // when cache_control breakpoints are present (i.e. caching per se does not
+    // make z.ai drop the connection).
+    let cache_on = AnthropicProvider::new(&key, &model)
+        .with_base_url(&base)
+        .with_provider_label("zai")
+        .with_prompt_caching(true);
+    let history = big_history();
+    let cfg = ChatConfig {
+        max_tokens: Some(64),
+        ..Default::default()
+    };
+    match cache_on.chat(&history, &tools(), &cfg).await {
+        Ok(r1) => {
+            println!(
+                "cache-probe round 1: input={} output={} cache_read={} cache_write={}",
+                r1.usage.input_tokens,
+                r1.usage.output_tokens,
+                r1.usage.cache_read_tokens,
+                r1.usage.cache_write_tokens
+            );
+            let mut h2 = history.clone();
+            h2.push(msg(
+                MessageRole::Assistant,
+                r1.content.clone().unwrap_or_default(),
+            ));
+            h2.push(msg(
+                MessageRole::User,
+                "Now the same but for iOS simulators.",
+            ));
+            if let Ok(r2) = cache_on.chat(&h2, &tools(), &cfg).await {
+                println!(
+                    "cache-probe round 2: input={} output={} cache_read={} cache_write={}  <- 200 OK w/ cache_control",
+                    r2.usage.input_tokens,
+                    r2.usage.output_tokens,
+                    r2.usage.cache_read_tokens,
+                    r2.usage.cache_write_tokens
+                );
+            }
+        }
+        Err(e) => println!("cache-probe FAILED: {e:#}"),
+    }
+
+    // ── A/B send-failure rate.
+    let cache_off = AnthropicProvider::new(&key, &model)
+        .with_base_url(&base)
+        .with_provider_label("zai")
+        .with_prompt_caching(false);
+
+    let on = run_config("cache=ON ", &cache_on, rounds).await;
+    let off = run_config("cache=OFF", &cache_off, rounds).await;
+
+    println!("\n================ SEND-FAILURE A/B ({rounds} rounds each) ================");
+    println!("config     ok  send_fail  http_err  stream_err  other");
+    println!(
+        "cache=ON  {:4}  {:9}  {:8}  {:10}  {:5}",
+        on.ok, on.send_failure, on.http_error, on.stream_error, on.other
+    );
+    println!(
+        "cache=OFF {:4}  {:9}  {:8}  {:10}  {:5}",
+        off.ok, off.send_failure, off.http_error, off.stream_error, off.other
+    );
+    println!("=========================================================================");
+}


### PR DESCRIPTION
## Diagnosis: did prompt caching (#1640) break glm-5.2? **No.**

A user's `glm-5.2` turn hard-failed with `runtime_error: failed to send streaming request to Anthropic` after 20 successful tool actions (installing an Android AVD), with a partial response. glm-5.2 **is** routed through `AnthropicProvider` at `https://api.z.ai/api/anthropic` with prompt-caching ON, so caching was a fair suspect. It is exonerated by evidence:

| Evidence | Finding |
|---|---|
| **Error signature** | The string comes from `wrap_err("failed to send streaming request to Anthropic")` on the reqwest `.send()` — a **transport** failure. A `cache_control` payload rejection would instead **succeed the send** and return a non-2xx *response* (a different, HTTP-status-carrying error). |
| **Live cache-acceptance probe** | z.ai glm-5.2 returns **200 with `cache_read=7232`** when `cache_control` is present — caching works, z.ai does not reject it or drop the connection. |
| **Live A/B (10 rounds each)** | caching **ON**: 10 ok / 0 send-failures. caching **OFF**: 10 ok / 0 send-failures. No differential. |
| **Timing** | Failed at action 20 (not action 1) and only once. A systematic caching incompat would fail immediately and every turn. |

The failure is a **transient transport drop** — reqwest reusing a pooled keepalive socket that z.ai's load balancer had already closed ("connection closed before message completed"). `build_http_client` keeps idle sockets for 90s, so a later request in a long turn grabs a stale one.

## The real bug: that transport error was neither retried nor failed over

`RetryProvider::is_retryable_error` / `should_failover` are the single classification chokepoint for **both** same-provider retry (`RetryProvider`) and failover (`ProviderChain`/`FallbackProvider`). Proven empirically with a local TCP server:

| Failure mode | reqwest | old is_retryable | old should_failover |
|---|---|---|---|
| connection refused | `is_connect=true` | true | true |
| **connection closed before message completed** | `is_connect=false, is_request=true`, no status | **false** | **false** |

So the user's turn hard-failed with **no retry and no failover** to the configured deepseek lanes.

## Changes (octos-llm only)

- **`retry.rs`** — statusless transport send/body failures (`is_request()` / `is_body()`) are now retryable. Status-bearing errors already return above, so only true transport faults reach the new branch. Also **reorder `is_timeout` before `is_connect`** so a connect *timeout* (which is both) fails over instead of hammering the same unreachable lane. String fallback also matches `connection closed` / `broken pipe` / `error sending request`.
- **`anthropic.rs`** — **`OCTOS_PROMPT_CACHING` kill-switch**: disable prompt caching at startup without a rebuild for any Anthropic-compatible proxy that rejects `cache_control`. Default stays **ON**; only falsy values (`0`/`false`/`off`/`no`) disable. Pure, unit-tested seam (no `unsafe` env mutation; workspace is `deny(unsafe_code)`).

No per-endpoint cache gating was added — caching is exonerated for glm-5.2, so it would be unwarranted.

## Tests / gates

- Real-socket transport-failure classification: connection-closed, immediate-close, refused, request-timeout, connect-timeout.
- Env kill-switch parsing.
- Ignored live z.ai A/B (`glm_send_failure_ab.rs`).
- `cargo test -p octos-llm` green (455 lib); `cargo fmt --all --check` + `cargo clippy -p octos-llm --all-targets -D warnings` clean.
- **codex review**: 2 rounds. R1 → P2 (connect-timeout ordering) fixed. R2 → "Reorder is correct" + P3 (test proxy-robustness) fixed with `.no_proxy()`.

Note: the `test-octos-agent-integration` CI job is pre-existing-broken on main (unrelated).