### PR TITLE
feat(compaction): opt-in LLM-summarization context compaction (AppUI)

### DIFF
--- a/crates/octos-agent/src/compaction.rs
+++ b/crates/octos-agent/src/compaction.rs
@@ -20,13 +20,15 @@
 
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
 use chrono::Utc;
 use octos_core::{Message, MessageRole};
+use octos_llm::ChatConfig;
 use octos_llm::LlmProvider;
 use octos_llm::context::{estimate_message_tokens, estimate_tokens};
 use serde::{Deserialize, Serialize};
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::abi_schema::COMPACTION_POLICY_SCHEMA_VERSION;
 use crate::harness_events::{HarnessEvent, write_event_to_sink};
@@ -944,10 +946,191 @@ pub fn repo_label_from_path(path: &Path) -> String {
         .unwrap_or_else(|| path.display().to_string())
 }
 
+/// System prompt for LLM context compaction (codex-style handoff summary).
+const LLM_COMPACTION_SYSTEM_PROMPT: &str = "You are compacting a long conversation so it fits the model's \
+context window. Produce a CONTEXT CHECKPOINT: a concise handoff summary another LLM can use to seamlessly \
+continue the task. Include the current goal, key decisions made, progress completed and what remains, and \
+any critical constraints, data, file paths, or references. Be structured and factual — no preamble, no \
+questions, no commentary.";
+
+/// Default timeout for a single LLM compaction call. The provider's own
+/// default (~300s) is far too coarse for a per-turn operation — a slow or hung
+/// summary must fall back to the heuristic quickly rather than stall the turn.
+pub const DEFAULT_LLM_COMPACTION_TIMEOUT_SECS: u64 = 60;
+
+/// Render a message slice as a plain `ROLE: content` transcript for the
+/// summarization prompt.
+fn render_transcript(messages: &[Message]) -> String {
+    let mut out = String::new();
+    for msg in messages {
+        out.push_str(msg.role.as_str());
+        out.push_str(": ");
+        out.push_str(msg.content.trim());
+        out.push('\n');
+    }
+    out
+}
+
+/// One-shot LLM context-compaction summary: prompts the model for a handoff
+/// summary of `messages`, bounded by `budget_tokens` and `timeout`. Returns
+/// `None` on ANY error, timeout, empty content, or unsupported runtime so the
+/// caller falls back to the deterministic [`compact_messages`] heuristic —
+/// compaction must never block or fail a turn.
+///
+/// Requires a **multi-threaded** Tokio runtime. The async→sync bridge relies on
+/// `block_in_place`, which keeps the runtime's I/O + timer drivers alive on
+/// other workers while this thread parks; on a single-worker `current_thread`
+/// runtime that same worker would be parked while the summary future needs the
+/// very same runtime to drive its network call and 60s timeout — which can hang
+/// indefinitely. AppUI (`octos serve`), `chat`, and `acp` all run multi-threaded
+/// (`new_multi_thread`), so the LLM path always applies there; anywhere else
+/// (tests, exotic embeddings, no runtime at all) we degrade to the heuristic.
+pub fn llm_compaction_summary(
+    provider: &Arc<dyn LlmProvider>,
+    messages: &[Message],
+    budget_tokens: u32,
+    timeout: Duration,
+) -> Option<String> {
+    if messages.is_empty() {
+        return None;
+    }
+    // Bail to the heuristic unless we're on a multi-threaded runtime (see the
+    // doc comment): `block_in_place` is only hang-safe there.
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {}
+        _ => {
+            debug!("llm compaction unavailable off a multi-threaded runtime; using heuristic");
+            return None;
+        }
+    }
+    let provider = Arc::clone(provider);
+    let transcript = render_transcript(messages);
+    crate::summarizer::run_llm_call_blocking(async move {
+        let config = ChatConfig {
+            max_tokens: Some(budget_tokens),
+            // Low but non-zero: a factual handoff summary, lightly deterministic.
+            temperature: Some(0.2),
+            ..Default::default()
+        };
+        let request = vec![
+            Message::system(LLM_COMPACTION_SYSTEM_PROMPT),
+            Message::user(transcript),
+        ];
+        match tokio::time::timeout(timeout, provider.chat(&request, &[], &config)).await {
+            Ok(Ok(response)) => response
+                .content
+                .map(|content| content.trim().to_string())
+                .filter(|content| !content.is_empty()),
+            Ok(Err(error)) => {
+                warn!(%error, "llm compaction summary failed; falling back to heuristic");
+                None
+            }
+            Err(_) => {
+                warn!(
+                    timeout_secs = timeout.as_secs(),
+                    "llm compaction summary timed out; falling back to heuristic"
+                );
+                None
+            }
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use octos_core::ToolCall;
+    use std::time::Duration;
+
+    struct CompactionMockProvider {
+        result: std::result::Result<String, String>,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmProvider for CompactionMockProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            match &self.result {
+                Ok(content) => Ok(octos_llm::ChatResponse {
+                    content: Some(content.clone()),
+                    reasoning_content: None,
+                    tool_calls: Vec::new(),
+                    stop_reason: octos_llm::StopReason::EndTurn,
+                    usage: octos_llm::TokenUsage::default(),
+                    provider_index: None,
+                }),
+                Err(message) => Err(eyre::eyre!("{message}")),
+            }
+        }
+
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatStream> {
+            unimplemented!("mock does not stream")
+        }
+
+        fn model_id(&self) -> &str {
+            "mock-compaction"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn llm_compaction_summary_returns_model_output() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(CompactionMockProvider {
+            result: Ok("Goal: X. Done: Y. Next: Z.".into()),
+        });
+        let messages = vec![Message::user("do X"), Message::assistant("did Y")];
+        let out = llm_compaction_summary(&provider, &messages, 512, Duration::from_secs(5));
+        assert_eq!(out.as_deref(), Some("Goal: X. Done: Y. Next: Z."));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn llm_compaction_summary_returns_none_on_provider_error() {
+        // The caller falls back to the heuristic on None — a failing provider
+        // must NEVER break or block the turn.
+        let provider: Arc<dyn LlmProvider> = Arc::new(CompactionMockProvider {
+            result: Err("provider down".into()),
+        });
+        let messages = vec![Message::user("do X")];
+        let out = llm_compaction_summary(&provider, &messages, 512, Duration::from_secs(5));
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn llm_compaction_summary_none_for_empty_messages() {
+        // Short-circuits before any blocking call, so needs no runtime.
+        let provider: Arc<dyn LlmProvider> = Arc::new(CompactionMockProvider {
+            result: Ok("unused".into()),
+        });
+        assert!(llm_compaction_summary(&provider, &[], 512, Duration::from_secs(5)).is_none());
+    }
+
+    #[tokio::test] // current_thread runtime (the default, no `flavor`)
+    async fn llm_compaction_summary_degrades_to_heuristic_on_current_thread() {
+        // The async→sync bridge is only hang-safe on a multi-threaded runtime,
+        // so on a current_thread runtime the LLM path must be skipped entirely
+        // (caller falls back to the heuristic) rather than risk a hang.
+        let provider: Arc<dyn LlmProvider> = Arc::new(CompactionMockProvider {
+            result: Ok("should not be used on current_thread".into()),
+        });
+        let messages = vec![Message::user("do X")];
+        let out = llm_compaction_summary(&provider, &messages, 512, Duration::from_secs(5));
+        assert!(
+            out.is_none(),
+            "current_thread runtime must degrade to the heuristic, not run the LLM path"
+        );
+    }
 
     fn user_msg(content: &str) -> Message {
         Message {

--- a/crates/octos-agent/src/summarizer.rs
+++ b/crates/octos-agent/src/summarizer.rs
@@ -438,7 +438,7 @@ rather than appending duplicates.\n\n",
 ///   thread is not itself inside the runtime. This keeps the trait
 ///   signature synchronous without forcing callers into multi-threaded
 ///   scheduling.
-fn run_llm_call_blocking<F, T>(future: F) -> T
+pub(crate) fn run_llm_call_blocking<F, T>(future: F) -> T
 where
     F: std::future::Future<Output = T> + Send + 'static,
     T: Send + 'static,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2043,6 +2043,47 @@ fn appui_context_compact_keep_items() -> usize {
         .unwrap_or(APPUI_CONTEXT_COMPACT_KEEP_ITEMS)
 }
 
+/// Whether AppUI context compaction uses the LLM-summarization path
+/// (`OCTOS_CONTEXT_COMPACT_LLM=1`) instead of the deterministic heuristic.
+/// Default OFF (heuristic): the LLM path makes a real model call — a
+/// higher-quality handoff summary but slower (seconds) — and always falls
+/// back to the heuristic on any error/timeout, so it can never break a turn.
+fn appui_context_compact_llm_enabled() -> bool {
+    std::env::var("OCTOS_CONTEXT_COMPACT_LLM")
+        .ok()
+        .map(|raw| {
+            matches!(
+                raw.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "on" | "yes"
+            )
+        })
+        .unwrap_or(false)
+}
+
+/// Produce a compaction summary for the AppUI path: LLM-summarization when the
+/// switch is on and a provider is available, otherwise the heuristic — and the
+/// heuristic is also the fallback whenever an LLM summary errors or times out.
+/// Both paths return a plain `String` for the unchanged `compact_context`.
+fn appui_compaction_summary(
+    llm_provider: &Arc<dyn octos_llm::LlmProvider>,
+    messages: &[octos_core::Message],
+    budget_tokens: u32,
+) -> String {
+    if appui_context_compact_llm_enabled() {
+        if let Some(summary) = octos_agent::compaction::llm_compaction_summary(
+            llm_provider,
+            messages,
+            budget_tokens,
+            std::time::Duration::from_secs(
+                octos_agent::compaction::DEFAULT_LLM_COMPACTION_TIMEOUT_SECS,
+            ),
+        ) {
+            return summary;
+        }
+    }
+    octos_agent::compaction::compact_messages(messages, budget_tokens)
+}
+
 fn appui_context_prompt_policy(llm_provider: &dyn octos_llm::LlmProvider) -> PromptBuildPolicy {
     PromptBuildPolicy {
         include_reasoning: false,
@@ -2060,7 +2101,7 @@ fn appui_context_history_for_agent(
     data_dir: &Path,
     session_id: &SessionKey,
     history: &[Message],
-    llm_provider: &dyn octos_llm::LlmProvider,
+    llm_provider: &Arc<dyn octos_llm::LlmProvider>,
     trigger: &str,
 ) -> (
     Vec<Message>,
@@ -2075,8 +2116,8 @@ fn appui_context_history_for_agent(
         ledger_status = ?ledger_status,
         "appui context manager loaded for turn"
     );
-    let threshold = appui_context_compact_threshold_tokens(llm_provider);
-    let policy = appui_context_prompt_policy(llm_provider);
+    let threshold = appui_context_compact_threshold_tokens(llm_provider.as_ref());
+    let policy = appui_context_prompt_policy(llm_provider.as_ref());
     let state = manager.state();
     if state.token_estimate > threshold {
         // UPCR-2026-026: the started event precedes the (synchronous) pass;
@@ -2092,7 +2133,7 @@ fn appui_context_history_for_agent(
         ));
         let before = manager.for_prompt(&policy);
         let summary_budget = threshold.clamp(256, 4096) as u32;
-        let summary = octos_agent::compaction::compact_messages(&before.messages, summary_budget);
+        let summary = appui_compaction_summary(llm_provider, &before.messages, summary_budget);
         let record = manager.compact_context(
             summary,
             CompactContextPolicy {
@@ -2248,6 +2289,11 @@ struct AppUiPromptContextBridge {
     /// [`Self::prepare_prompt`] emits `ContextCompactionStarted`/`Completed`
     /// through this hook. `None` in tests and paths without a client.
     context_lifecycle_notify: Option<ContextLifecycleNotify>,
+    /// Provider for the OPT-IN LLM-summarization compaction path
+    /// (`OCTOS_CONTEXT_COMPACT_LLM`). `None` = heuristic only (also the
+    /// fallback whenever an LLM summary fails). Set on the per-turn bridge;
+    /// child/spawn bridges leave it `None`.
+    llm_compaction_provider: Option<Arc<dyn octos_llm::LlmProvider>>,
 }
 
 impl AppUiPromptContextBridge {
@@ -2264,11 +2310,17 @@ impl AppUiPromptContextBridge {
             scratch: StdMutex::new(None),
             voice_turn,
             context_lifecycle_notify: None,
+            llm_compaction_provider: None,
         }
     }
 
     fn with_context_lifecycle_notify(mut self, notify: ContextLifecycleNotify) -> Self {
         self.context_lifecycle_notify = Some(notify);
+        self
+    }
+
+    fn with_llm_compaction_provider(mut self, provider: Arc<dyn octos_llm::LlmProvider>) -> Self {
+        self.llm_compaction_provider = Some(provider);
         self
     }
 
@@ -2387,8 +2439,12 @@ impl PromptContextManager for AppUiPromptContextBridge {
             }
             let before = scratch.manager.for_prompt(&policy);
             let summary_budget = threshold.clamp(256, 4096) as u32;
-            let summary =
-                octos_agent::compaction::compact_messages(&before.messages, summary_budget);
+            let summary = match &self.llm_compaction_provider {
+                Some(provider) => {
+                    appui_compaction_summary(provider, &before.messages, summary_budget)
+                }
+                None => octos_agent::compaction::compact_messages(&before.messages, summary_budget),
+            };
             let record = scratch.manager.compact_context(
                 summary,
                 CompactContextPolicy {
@@ -19961,7 +20017,7 @@ async fn run_standalone_turn(
             &session_runtime.profile.data_dir,
             &session_id,
             &raw_history,
-            llm_provider.as_ref(),
+            &llm_provider,
             "appui_pre_turn",
         );
     for notification in context_lifecycle_notifications {
@@ -20852,7 +20908,8 @@ async fn run_standalone_turn(
             context_manager.clone(),
             voice_turn_hint,
         )
-        .with_context_lifecycle_notify(context_lifecycle_notify),
+        .with_context_lifecycle_notify(context_lifecycle_notify)
+        .with_llm_compaction_provider(llm_provider.clone()),
     );
     request_agent = request_agent.with_prompt_context_manager(prompt_context_bridge);
     if let Some(hooks) = session_runtime.profile.hook_executor.clone() {
@@ -26183,7 +26240,7 @@ mod tests {
             });
         }
 
-        let provider = TinyContextProvider;
+        let provider: Arc<dyn octos_llm::LlmProvider> = Arc::new(TinyContextProvider);
         let (_messages, _manager, notifications) =
             appui_context_history_for_agent(dir.path(), &session, &history, &provider, "preflight");
 


### PR DESCRIPTION
## What

Adds an **opt-in LLM-summarization context-compaction path** for the AppUI (`octos serve`) flow, with an on/off switch. Default behavior is unchanged — the deterministic heuristic still runs unless the switch is set.

octos's AppUI compaction always used `compact_messages` (the fast heuristic — strip tool args, truncate to first lines). That's instant but lossy. codex-style compaction instead asks the model for a handoff summary: a few seconds slower, but a far higher-quality checkpoint that another turn can seamlessly continue from.

## The switch

`OCTOS_CONTEXT_COMPACT_LLM` — `1`/`true`/`on`/`yes` enables the LLM path. **Default OFF** (heuristic).

When on, the LLM path is tried first; on **any** error, timeout (60s default), empty content, or unsupported runtime it transparently falls back to `compact_messages`, so compaction can never block indefinitely or fail a turn.

**Runtime requirement:** the LLM path is gated to **multi-threaded** Tokio runtimes. The shared `run_llm_call_blocking` bridge uses `block_in_place`, which keeps the runtime's I/O + timer drivers alive on other workers while this thread parks. On a single-worker `current_thread` runtime that worker would be parked while the summary future needs the same runtime to drive its network call and timeout — which can hang. `octos serve`, `chat`, and `acp` all run `new_multi_thread`, so the LLM path always applies there in practice; anywhere else (tests, exotic embeddings, no runtime) it degrades to the heuristic.

## How

- **`octos_agent::compaction::llm_compaction_summary(provider, messages, budget, timeout)`** — one-shot handoff-summary call via the shared `run_llm_call_blocking` async→sync bridge (already used by `LlmIterativeSummarizer`; flavor-aware: multi-thread `block_in_place`, current-thread off-host). Returns `Option<String>` — `None` on error/timeout/empty so the caller falls back.
- **`appui_compaction_summary`** in `ui_protocol.rs` selects LLM-vs-heuristic and folds in the fallback. Both AppUI compaction sites route through it:
  - pre-turn history (`appui_context_history_for_agent`) — operates on a locally-owned `ContextManager`, no lock held across the call.
  - in-loop bridge (`AppUiPromptContextBridge::prepare_prompt`) — gains a `with_llm_compaction_provider` builder, set only on the per-turn bridge (child/spawn bridges stay `None` = heuristic).

## Scope / follow-ups

- Gateway compaction sites (`session_actor.rs`) and durable per-profile config (`ProfileConfig.compaction`) are follow-ups; the env switch covers `octos serve` for v1.
- A dwelling "Compacting…" indicator during the (now slower) LLM call is a UX follow-up — v1 delivers the codex-like blocking behavior + the existing compaction notice.

## Tests

- `llm_compaction_summary_returns_model_output` (multi-thread runtime — exercises the `block_in_place` branch)
- `llm_compaction_summary_returns_none_on_provider_error` (fallback guarantee)
- `llm_compaction_summary_degrades_to_heuristic_on_current_thread` (runtime gate — no hang)
- `llm_compaction_summary_none_for_empty_messages` (short-circuit, no runtime)

Full suite green: `octos-agent` lib + `octos-cli --features api` lib (2311 tests). fmt + clippy clean.

## Review

Reviewed by codex (gpt-5.6-terra, max effort). One P2 found — the shared bridge's `current_thread` branch can hang because the spawned worker's `block_on` can't drive that runtime's I/O/timer drivers while the owner thread is parked. Addressed by gating the LLM path to multi-thread runtimes (above); the pre-existing `current_thread` behavior of the shared bridge (used by `LlmIterativeSummarizer`) is left untouched — hardening the bridge itself is a separate follow-up. No P1s.
