### PR TITLE
refactor(compaction): replace OCTOS_CONTEXT_COMPACT_LLM env var with --llm-compaction serve flag

### DIFF
--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -278,6 +278,12 @@ pub struct AppState {
     /// same keystone that gates selecting the profile from the menu); an
     /// explicit per-session `/permissions` choice always overrides it.
     pub dangerous_default_permissions: bool,
+    /// `--llm-compaction`: AppUI context compaction asks an LLM for a
+    /// higher-quality handoff summary (a real model call — slower, seconds)
+    /// instead of the instant deterministic heuristic. Always falls back to the
+    /// heuristic on any error/timeout/unsupported-runtime, so it can never
+    /// break a turn. Default off.
+    pub llm_compaction: bool,
     /// Resolved HOST-level memory policy (top-level config). Threaded into
     /// lazily-bootstrapped profile runtimes so a host opt-out of memory
     /// refresh (DEFAULT-ON) also binds profiles created after startup.
@@ -402,6 +408,7 @@ impl AppState {
             deployment_mode: crate::config::DeploymentMode::Local,
             solo_login_enabled: false,
             dangerous_default_permissions: false,
+            llm_compaction: false,
             host_memory: None,
             allow_admin_shell: false,
             content_catalog_mgr: None,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2043,43 +2043,26 @@ fn appui_context_compact_keep_items() -> usize {
         .unwrap_or(APPUI_CONTEXT_COMPACT_KEEP_ITEMS)
 }
 
-/// Whether AppUI context compaction uses the LLM-summarization path
-/// (`OCTOS_CONTEXT_COMPACT_LLM=1`) instead of the deterministic heuristic.
-/// Default OFF (heuristic): the LLM path makes a real model call — a
-/// higher-quality handoff summary but slower (seconds) — and always falls
-/// back to the heuristic on any error/timeout, so it can never break a turn.
-fn appui_context_compact_llm_enabled() -> bool {
-    std::env::var("OCTOS_CONTEXT_COMPACT_LLM")
-        .ok()
-        .map(|raw| {
-            matches!(
-                raw.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "on" | "yes"
-            )
-        })
-        .unwrap_or(false)
-}
-
-/// Produce a compaction summary for the AppUI path: LLM-summarization when the
-/// switch is on and a provider is available, otherwise the heuristic — and the
-/// heuristic is also the fallback whenever an LLM summary errors or times out.
-/// Both paths return a plain `String` for the unchanged `compact_context`.
+/// Produce an LLM-summarization compaction summary for the AppUI path, falling
+/// back to the deterministic [`compact_messages`] heuristic whenever the LLM
+/// summary errors, times out, or the runtime is unsupported — so it can never
+/// break a turn. Only invoked when the `--llm-compaction` serve flag is on
+/// (`AppState::llm_compaction`); the flag-off path calls the heuristic directly.
+/// Returns a plain `String` for the unchanged `compact_context`.
 fn appui_compaction_summary(
     llm_provider: &Arc<dyn octos_llm::LlmProvider>,
     messages: &[octos_core::Message],
     budget_tokens: u32,
 ) -> String {
-    if appui_context_compact_llm_enabled() {
-        if let Some(summary) = octos_agent::compaction::llm_compaction_summary(
-            llm_provider,
-            messages,
-            budget_tokens,
-            std::time::Duration::from_secs(
-                octos_agent::compaction::DEFAULT_LLM_COMPACTION_TIMEOUT_SECS,
-            ),
-        ) {
-            return summary;
-        }
+    if let Some(summary) = octos_agent::compaction::llm_compaction_summary(
+        llm_provider,
+        messages,
+        budget_tokens,
+        std::time::Duration::from_secs(
+            octos_agent::compaction::DEFAULT_LLM_COMPACTION_TIMEOUT_SECS,
+        ),
+    ) {
+        return summary;
     }
     octos_agent::compaction::compact_messages(messages, budget_tokens)
 }
@@ -2102,6 +2085,7 @@ fn appui_context_history_for_agent(
     session_id: &SessionKey,
     history: &[Message],
     llm_provider: &Arc<dyn octos_llm::LlmProvider>,
+    llm_compaction_enabled: bool,
     trigger: &str,
 ) -> (
     Vec<Message>,
@@ -2133,7 +2117,11 @@ fn appui_context_history_for_agent(
         ));
         let before = manager.for_prompt(&policy);
         let summary_budget = threshold.clamp(256, 4096) as u32;
-        let summary = appui_compaction_summary(llm_provider, &before.messages, summary_budget);
+        let summary = if llm_compaction_enabled {
+            appui_compaction_summary(llm_provider, &before.messages, summary_budget)
+        } else {
+            octos_agent::compaction::compact_messages(&before.messages, summary_budget)
+        };
         let record = manager.compact_context(
             summary,
             CompactContextPolicy {
@@ -2290,9 +2278,10 @@ struct AppUiPromptContextBridge {
     /// through this hook. `None` in tests and paths without a client.
     context_lifecycle_notify: Option<ContextLifecycleNotify>,
     /// Provider for the OPT-IN LLM-summarization compaction path
-    /// (`OCTOS_CONTEXT_COMPACT_LLM`). `None` = heuristic only (also the
-    /// fallback whenever an LLM summary fails). Set on the per-turn bridge;
-    /// child/spawn bridges leave it `None`.
+    /// (`--llm-compaction` serve flag). `None` = heuristic only (also the
+    /// fallback whenever an LLM summary fails, and the flag-off state). Set on
+    /// the per-turn bridge only when the flag is on; child/spawn bridges leave
+    /// it `None`.
     llm_compaction_provider: Option<Arc<dyn octos_llm::LlmProvider>>,
 }
 
@@ -20018,6 +20007,7 @@ async fn run_standalone_turn(
             &session_id,
             &raw_history,
             &llm_provider,
+            state.llm_compaction,
             "appui_pre_turn",
         );
     for notification in context_lifecycle_notifications {
@@ -20901,16 +20891,21 @@ async fn run_standalone_turn(
             }
         })
     };
-    let prompt_context_bridge: Arc<dyn PromptContextManager> = Arc::new(
-        AppUiPromptContextBridge::new(
-            session_id.clone(),
-            session_runtime.profile.data_dir.clone(),
-            context_manager.clone(),
-            voice_turn_hint,
-        )
-        .with_context_lifecycle_notify(context_lifecycle_notify)
-        .with_llm_compaction_provider(llm_provider.clone()),
-    );
+    let mut prompt_context_bridge_inner = AppUiPromptContextBridge::new(
+        session_id.clone(),
+        session_runtime.profile.data_dir.clone(),
+        context_manager.clone(),
+        voice_turn_hint,
+    )
+    .with_context_lifecycle_notify(context_lifecycle_notify);
+    // Only wire the provider when `--llm-compaction` is on; a present provider
+    // is what flips the in-loop bridge to the LLM-summarization path.
+    if state.llm_compaction {
+        prompt_context_bridge_inner =
+            prompt_context_bridge_inner.with_llm_compaction_provider(llm_provider.clone());
+    }
+    let prompt_context_bridge: Arc<dyn PromptContextManager> =
+        Arc::new(prompt_context_bridge_inner);
     request_agent = request_agent.with_prompt_context_manager(prompt_context_bridge);
     if let Some(hooks) = session_runtime.profile.hook_executor.clone() {
         request_agent = request_agent.with_hooks(hooks);
@@ -26241,8 +26236,14 @@ mod tests {
         }
 
         let provider: Arc<dyn octos_llm::LlmProvider> = Arc::new(TinyContextProvider);
-        let (_messages, _manager, notifications) =
-            appui_context_history_for_agent(dir.path(), &session, &history, &provider, "preflight");
+        let (_messages, _manager, notifications) = appui_context_history_for_agent(
+            dir.path(),
+            &session,
+            &history,
+            &provider,
+            false,
+            "preflight",
+        );
 
         let started_pos = notifications
             .iter()

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -265,6 +265,14 @@ pub struct ServeCommand {
     #[arg(long)]
     pub danger_full_access: bool,
 
+    /// Use LLM-summarization for AppUI context compaction: when a session's
+    /// context fills, ask the model for a high-quality handoff summary (a real
+    /// model call — slower, a few seconds) instead of the instant deterministic
+    /// heuristic. Falls back to the heuristic on any error/timeout, so it never
+    /// breaks a turn. Off by default.
+    #[arg(long)]
+    pub llm_compaction: bool,
+
     /// Disable automatic retry on transient errors.
     #[arg(long)]
     pub no_retry: bool,
@@ -772,6 +780,7 @@ impl ServeCommand {
             host_memory: config.memory.clone(),
             solo_login_enabled: solo_login_enabled_flag,
             dangerous_default_permissions: dangerous_default_permissions_flag,
+            llm_compaction: self.llm_compaction,
             allow_admin_shell: config.allow_admin_shell,
             content_catalog_mgr: Some(Arc::new(
                 crate::content_catalog::ContentCatalogManager::new(profile_store.clone()),


### PR DESCRIPTION
## What

Follow-up to #1644. That PR shipped the opt-in LLM-summarization context-compaction switch as an **environment variable** (`OCTOS_CONTEXT_COMPACT_LLM`). This makes it a first-class, discoverable **CLI option** and removes the env var entirely.

```
octos serve --llm-compaction
```

Shows up in `octos serve --help`; default **off** (the instant deterministic heuristic — unchanged behavior).

## How

- `--llm-compaction` (clap bool on `ServeCommand`) → `AppState.llm_compaction`, mirroring the existing `--danger-full-access` → `AppState.dangerous_default_permissions` threading.
- Both AppUI compaction sites gate on it:
  - **pre-turn** (`appui_context_history_for_agent`) takes an explicit `llm_compaction_enabled` bool and branches LLM-vs-heuristic.
  - **in-loop bridge** (`AppUiPromptContextBridge`) only receives the LLM provider when the flag is on — a present provider is what flips it to the LLM path, so its existing `Some`/`None` switch is reused unchanged.
- `appui_compaction_summary` no longer reads the environment; it's now purely "LLM summary with heuristic fallback", called only when the flag selects the LLM path.
- Deleted `appui_context_compact_llm_enabled()` and every `OCTOS_CONTEXT_COMPACT_LLM` reference (grep-verified none remain).

The LLM-summary core (`llm_compaction_summary`) and its multi-thread runtime gate from #1644 are untouched.

## Tests

Build clean; full `octos-cli --features api` lib suite green (2311 passed). `--llm-compaction` verified present in `serve --help`. fmt + clippy clean.
