### PR TITLE
fix(release): exclude octos-sandbox from cargo release (shared-version collision)

### DIFF
--- a/crates/octos-sandbox/Cargo.toml
+++ b/crates/octos-sandbox/Cargo.toml
@@ -5,6 +5,15 @@ edition = "2024"
 rust-version = "1.85.0"
 description = "Platform sandbox helper for octos"
 
+# Excluded from `cargo release`. Unlike every other crate (which inherits the
+# shared workspace version via `version.workspace = true`), this helper keeps an
+# independent `0.1.0`. With the workspace's `shared-version = true`, a workspace
+# bump would otherwise try to bump + tag this crate on its OWN track — e.g. a
+# `major` release computes `1.0.0` for it and fails on `tag v1.0.0 already
+# exists`. `release = false` makes `cargo release` skip it entirely.
+[package.metadata.release]
+release = false
+
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 eyre = "0.6"


### PR DESCRIPTION
The 'Release (Manual)' workflow (`cargo release major`) fails with `tag v1.0.0 already exists (for octos-sandbox)`.

**Root cause:** `octos-sandbox` keeps an independent `version = "0.1.0"` while every other crate inherits the shared workspace version (`version.workspace = true`). With `[workspace.metadata.release] shared-version = true`, `cargo release major` bumps the sandbox on its own track to `1.0.0` and aborts on the pre-existing `v1.0.0` tag — blocking every workspace release via the button.

**Fix:** mark the sandbox `[package.metadata.release] release = false` so cargo release skips it entirely; the shared workspace version then bumps + tags cleanly (e.g. `1.1.0 → 2.0.0 → v2.0.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)