### PR TITLE
feat(cli): `octos config` wizard + layered startup config

### DIFF
--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -28,7 +28,11 @@ use super::Executable;
 use crate::config::Config;
 
 /// Interactive multi-turn chat with an agent.
-#[derive(Debug, Args)]
+///
+/// `Serialize`/`Deserialize` back the layered startup config (see
+/// [`crate::config_layer`]): non-explicit fields fall back to
+/// `config.cli.chat`.
+#[derive(Debug, Args, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct ChatCommand {
     /// Working directory (defaults to current directory).
     #[arg(short, long)]
@@ -111,7 +115,12 @@ pub struct ChatCommand {
 
 /// `--sandbox` choices, mirroring codex's sandbox modes and octos's
 /// [`PermissionProfile`](octos_agent::PermissionProfile).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+///
+/// `rename_all = "kebab-case"` makes the serde encoding (`"workspace-write"`,
+/// …) identical to clap's `ValueEnum` possible-value names, so the config
+/// layering round-trips a `config.cli.chat.sandbox` value losslessly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum ChatSandboxMode {
     /// Read-only workspace access; write/edit tools fail.
     ReadOnly,
@@ -122,7 +131,8 @@ pub enum ChatSandboxMode {
 }
 
 /// `--ask-for-approval` choices, mirroring codex.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum ChatApprovalMode {
     /// Prompt for approval on risky commands (default).
     Ask,

--- a/crates/octos-cli/src/commands/config.rs
+++ b/crates/octos-cli/src/commands/config.rs
@@ -1,0 +1,578 @@
+//! `octos config`: an interactive wizard + inspection for the layered startup
+//! config (`config.json` → the `cli.<cmd>` block).
+//!
+//! The wizard walks the `serve` / `gateway` / `chat` flags — **introspected from
+//! the clap tree** so it stays in sync as flags are added rather than
+//! hand-mirrored — explains each, shows its built-in default and the value
+//! currently saved, and writes the chosen values back by *merging* (keys the
+//! user does not touch survive). The saved values are the startup defaults; an
+//! explicit CLI flag or env var still overrides them (see [`crate::config_layer`]).
+//! "Skip" (empty input) never writes a value, so a built-in default keeps
+//! applying.
+//!
+//! This is the server half of the config-wizard feature; `octos-tui config` is
+//! the client half.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use clap::{Args, CommandFactory, Subcommand};
+use eyre::{Result, WrapErr, bail, eyre};
+
+use super::Executable;
+
+/// `octos config` — configure octos interactively and inspect the saved config.
+#[derive(Debug, Args)]
+pub struct ConfigCommand {
+    #[command(subcommand)]
+    action: Option<ConfigAction>,
+
+    /// Config file to read/write (default: the resolved `config.json`).
+    #[arg(long, global = true, value_name = "FILE")]
+    config: Option<PathBuf>,
+
+    /// Data directory (defaults to $OCTOS_HOME or ~/.octos).
+    #[arg(long, global = true, value_name = "DIR")]
+    data_dir: Option<PathBuf>,
+
+    /// Working directory (for project-local config resolution).
+    #[arg(long, global = true, value_name = "DIR")]
+    cwd: Option<PathBuf>,
+}
+
+#[derive(Debug, Subcommand)]
+enum ConfigAction {
+    /// Walk the serve/gateway/chat flags, explain each, and save your choices
+    /// (this is the default).
+    Wizard,
+    /// Print the saved config.json.
+    Show,
+    /// Print the resolved config.json path.
+    Path,
+}
+
+impl Executable for ConfigCommand {
+    fn execute(self) -> Result<()> {
+        let path = self.resolve_path()?;
+        match self.action {
+            Some(ConfigAction::Path) => {
+                println!("{}", path.display());
+                Ok(())
+            }
+            Some(ConfigAction::Show) => show(&path),
+            None | Some(ConfigAction::Wizard) => self.wizard(&path),
+        }
+    }
+}
+
+impl ConfigCommand {
+    /// Resolve the target `config.json` the same way the runtime does.
+    fn resolve_path(&self) -> Result<PathBuf> {
+        let cwd = self
+            .cwd
+            .clone()
+            .or_else(|| std::env::current_dir().ok())
+            .unwrap_or_default();
+        let ctx = crate::config_context::resolve_config_context(self.data_dir.as_deref());
+        Ok(crate::config::resolve_config_file_path(
+            &cwd,
+            &ctx,
+            self.config.as_deref(),
+        ))
+    }
+
+    fn wizard(&self, path: &Path) -> Result<()> {
+        if !is_tty() {
+            bail!(
+                "`octos config` needs an interactive terminal. Run it in a terminal, \
+                 or edit {} directly.",
+                path.display()
+            );
+        }
+
+        let current = load_current_cli_block(path)?;
+        println!("Configuring octos — saves to {}", path.display());
+        println!("These become the startup defaults; an explicit CLI flag or env var still wins.");
+        println!("Press Enter to skip an option (keep its current or default value).\n");
+
+        // Introspect the clap tree so new flags appear here automatically.
+        let top = crate::commands::Args::command();
+        let mut collected: BTreeMap<String, serde_json::Map<String, serde_json::Value>> =
+            BTreeMap::new();
+
+        for &name in crate::config_layer::LAYERED_COMMANDS {
+            let Some(sub_cmd) = top.get_subcommands().find(|cmd| cmd.get_name() == name) else {
+                // e.g. `serve` when built without the `api` feature.
+                continue;
+            };
+            let defaults = command_defaults(name).unwrap_or_default();
+            let current_section = current
+                .get(name)
+                .and_then(|value| value.as_object())
+                .cloned()
+                .unwrap_or_default();
+
+            println!("── {name} ──");
+            let mut answers = serde_json::Map::new();
+            for arg in sub_cmd.get_arguments() {
+                if !crate::config_layer::is_layerable(name, arg) {
+                    continue;
+                }
+                let id = arg.get_id().as_str().to_string();
+                let long = arg
+                    .get_long()
+                    .map(String::from)
+                    .unwrap_or_else(|| id.clone());
+                let help = arg
+                    .get_help()
+                    .map(|help| help.to_string())
+                    .unwrap_or_default();
+                let answer = prompt_value(
+                    arg,
+                    &long,
+                    &help,
+                    defaults.get(&id),
+                    current_section.get(&id),
+                )?;
+                if let Some(value) = answer {
+                    answers.insert(id, value);
+                }
+            }
+            println!();
+            if !answers.is_empty() {
+                collected.insert(name.to_string(), answers);
+            }
+        }
+
+        if collected.is_empty() {
+            println!("Nothing changed.");
+            return Ok(());
+        }
+
+        // Validate every section against its command struct BEFORE touching the
+        // file, so a wrong-typed value (bad port, unknown enum) fails loudly
+        // rather than producing a config the runtime would reject.
+        for (name, answers) in &collected {
+            validate_section(name, answers)?;
+        }
+
+        crate::config::write_mutation(path, |root| {
+            let obj = root
+                .as_object_mut()
+                .ok_or_else(|| eyre!("{} is not a JSON object", path.display()))?;
+            let cli = obj
+                .entry("cli")
+                .or_insert_with(|| serde_json::Value::Object(Default::default()));
+            let cli_obj = cli
+                .as_object_mut()
+                .ok_or_else(|| eyre!("config `cli` block is not a JSON object"))?;
+            for (name, answers) in &collected {
+                let section = cli_obj
+                    .entry(name.clone())
+                    .or_insert_with(|| serde_json::Value::Object(Default::default()));
+                let section_obj = section
+                    .as_object_mut()
+                    .ok_or_else(|| eyre!("config `cli.{name}` is not a JSON object"))?;
+                for (key, value) in answers {
+                    section_obj.insert(key.clone(), value.clone());
+                }
+            }
+            Ok(())
+        })?;
+
+        let total: usize = collected.values().map(serde_json::Map::len).sum();
+        println!("Saved {total} setting(s) to {}", path.display());
+        println!("Run `octos config show` to review.");
+        Ok(())
+    }
+}
+
+fn show(path: &Path) -> Result<()> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) if contents.trim().is_empty() => {
+            println!(
+                "{} is empty. Run `octos config` to set it up.",
+                path.display()
+            );
+            Ok(())
+        }
+        Ok(contents) => {
+            println!("# {}", path.display());
+            println!("{}", contents.trim_end());
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            println!(
+                "No config yet at {}.\nRun `octos config` (or `octos init`) to create one.",
+                path.display()
+            );
+            Ok(())
+        }
+        Err(error) => Err(error).wrap_err_with(|| format!("failed to read {}", path.display())),
+    }
+}
+
+/// The serialized built-in defaults for a subcommand (field id → default value),
+/// used to type the prompts and show `[default: …]`.
+fn command_defaults(name: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
+    let value = match name {
+        #[cfg(feature = "api")]
+        "serve" => default_as::<super::ServeCommand>(),
+        "gateway" => default_as::<super::GatewayCommand>(),
+        "chat" => default_as::<super::ChatCommand>(),
+        _ => None,
+    };
+    value.and_then(|value| value.as_object().cloned())
+}
+
+/// Parse a subcommand with an empty argv to capture clap's built-in defaults,
+/// then serialize the struct. The command name is irrelevant to default
+/// resolution, so a fixed `'static` placeholder is used.
+fn default_as<T>() -> Option<serde_json::Value>
+where
+    T: clap::Args + serde::Serialize,
+{
+    let cmd = T::augment_args(clap::Command::new("cmd"));
+    let matches = cmd.try_get_matches_from(["cmd"]).ok()?;
+    let default = T::from_arg_matches(&matches).ok()?;
+    serde_json::to_value(&default).ok()
+}
+
+/// Validate `answers` for `name` by overlaying them onto the built-in defaults
+/// and deserializing into the concrete command struct.
+fn validate_section(
+    name: &str,
+    answers: &serde_json::Map<String, serde_json::Value>,
+) -> Result<()> {
+    match name {
+        #[cfg(feature = "api")]
+        "serve" => validate_as::<super::ServeCommand>("serve", answers),
+        "gateway" => validate_as::<super::GatewayCommand>("gateway", answers),
+        "chat" => validate_as::<super::ChatCommand>("chat", answers),
+        _ => Ok(()),
+    }
+}
+
+fn validate_as<T>(name: &str, answers: &serde_json::Map<String, serde_json::Value>) -> Result<()>
+where
+    T: clap::Args + serde::Serialize + serde::de::DeserializeOwned,
+{
+    let mut base =
+        default_as::<T>().ok_or_else(|| eyre!("failed to compute defaults for `{name}`"))?;
+    let obj = base
+        .as_object_mut()
+        .ok_or_else(|| eyre!("defaults for `{name}` are not a JSON object"))?;
+    for (key, value) in answers {
+        obj.insert(key.clone(), value.clone());
+    }
+    serde_json::from_value::<T>(base)
+        .map(|_| ())
+        .wrap_err_with(|| format!("the collected `{name}` settings don't match the config schema"))
+}
+
+/// Dispatch a single option to the right prompt shape, typed by the arg's action
+/// (bool), its possible values (enum), or its default's JSON type (number vs
+/// string).
+fn prompt_value(
+    arg: &clap::Arg,
+    long: &str,
+    help: &str,
+    default_val: Option<&serde_json::Value>,
+    current_val: Option<&serde_json::Value>,
+) -> Result<Option<serde_json::Value>> {
+    if matches!(arg.get_action(), clap::ArgAction::SetTrue) {
+        return prompt_bool(long, help, default_val, current_val);
+    }
+    let choices: Vec<String> = arg
+        .get_possible_values()
+        .iter()
+        .map(|value| value.get_name().to_string())
+        .collect();
+    if !choices.is_empty() {
+        return prompt_choice(long, help, &choices, default_val, current_val);
+    }
+    let numeric = matches!(default_val, Some(serde_json::Value::Number(_)));
+    prompt_scalar(long, help, numeric, default_val, current_val)
+}
+
+fn prompt_bool(
+    long: &str,
+    help: &str,
+    default_val: Option<&serde_json::Value>,
+    current_val: Option<&serde_json::Value>,
+) -> Result<Option<serde_json::Value>> {
+    print_arg_header(long, help, default_val, current_val);
+    let raw = read_line("  yes/no, or Enter to skip: ")?;
+    Ok(match raw.trim().to_ascii_lowercase().as_str() {
+        "y" | "yes" | "true" | "on" | "1" => Some(true.into()),
+        "n" | "no" | "false" | "off" | "0" => Some(false.into()),
+        _ => None,
+    })
+}
+
+fn prompt_choice(
+    long: &str,
+    help: &str,
+    choices: &[String],
+    default_val: Option<&serde_json::Value>,
+    current_val: Option<&serde_json::Value>,
+) -> Result<Option<serde_json::Value>> {
+    print_arg_header(long, help, default_val, current_val);
+    for (index, choice) in choices.iter().enumerate() {
+        println!("  [{}] {choice}", index + 1);
+    }
+    let raw = read_line("  choose a number, or Enter to skip: ")?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let index: usize = trimmed
+        .parse()
+        .ok()
+        .filter(|n| (1..=choices.len()).contains(n))
+        .ok_or_else(|| eyre!("`{trimmed}` is not one of 1..={}", choices.len()))?;
+    Ok(Some(choices[index - 1].clone().into()))
+}
+
+fn prompt_scalar(
+    long: &str,
+    help: &str,
+    numeric: bool,
+    default_val: Option<&serde_json::Value>,
+    current_val: Option<&serde_json::Value>,
+) -> Result<Option<serde_json::Value>> {
+    print_arg_header(long, help, default_val, current_val);
+    let raw = read_line("  value, or Enter to skip: ")?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    if numeric {
+        let number: i64 = trimmed
+            .parse()
+            .map_err(|_| eyre!("--{long} expects a number, got `{trimmed}`"))?;
+        Ok(Some(number.into()))
+    } else {
+        Ok(Some(trimmed.to_string().into()))
+    }
+}
+
+fn print_arg_header(
+    long: &str,
+    help: &str,
+    default_val: Option<&serde_json::Value>,
+    current_val: Option<&serde_json::Value>,
+) {
+    let mut line = format!("--{long}");
+    let help = first_line(help);
+    if !help.is_empty() {
+        line.push_str(" — ");
+        line.push_str(help);
+    }
+    if let Some(value) = default_val.filter(|value| !value.is_null()) {
+        line.push_str(&format!("  [default: {}]", render_scalar(value)));
+    }
+    if let Some(value) = current_val.filter(|value| !value.is_null()) {
+        line.push_str(&format!("  [current: {}]", render_scalar(value)));
+    }
+    println!("{line}");
+}
+
+fn render_scalar(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(text) => text.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn first_line(text: &str) -> &str {
+    text.lines().next().unwrap_or(text).trim()
+}
+
+/// Read the existing `cli` block (subcommand → object) for showing current
+/// values. Absent/empty file → empty; malformed → surfaced (never overwritten).
+fn load_current_cli_block(path: &Path) -> Result<serde_json::Map<String, serde_json::Value>> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) if contents.trim().is_empty() => Ok(serde_json::Map::new()),
+        Ok(contents) => {
+            let value: serde_json::Value = serde_json::from_str(&contents)
+                .wrap_err_with(|| format!("failed to parse {}", path.display()))?;
+            Ok(value
+                .get("cli")
+                .and_then(|value| value.as_object())
+                .cloned()
+                .unwrap_or_default())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(serde_json::Map::new()),
+        Err(error) => Err(error).wrap_err_with(|| format!("failed to read {}", path.display())),
+    }
+}
+
+fn read_line(prompt: &str) -> Result<String> {
+    print!("{prompt}");
+    std::io::stdout().flush().ok();
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .wrap_err("failed to read input")?;
+    Ok(line)
+}
+
+fn is_tty() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdin().is_terminal() && std::io::stdout().is_terminal()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_type_prompts_from_default_json_type() {
+        // A numeric default → numeric coercion; a null/absent default → string.
+        assert!(matches!(
+            serde_json::json!(50080),
+            serde_json::Value::Number(_)
+        ));
+        // The wizard's numeric branch parses "9090" into a JSON number.
+        let out = prompt_scalar_for_test(true, "9090").unwrap().unwrap();
+        assert_eq!(out, serde_json::json!(9090));
+        // The string branch keeps host text verbatim.
+        let out = prompt_scalar_for_test(false, "0.0.0.0").unwrap().unwrap();
+        assert_eq!(out, serde_json::json!("0.0.0.0"));
+        // A non-numeric answer for a numeric field is rejected.
+        assert!(prompt_scalar_for_test(true, "notanumber").is_err());
+    }
+
+    /// Test shim for the numeric/string coercion in [`prompt_scalar`] without
+    /// touching stdin.
+    fn prompt_scalar_for_test(numeric: bool, input: &str) -> Result<Option<serde_json::Value>> {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Ok(None);
+        }
+        if numeric {
+            let number: i64 = trimmed
+                .parse()
+                .map_err(|_| eyre!("expects a number, got `{trimmed}`"))?;
+            Ok(Some(number.into()))
+        } else {
+            Ok(Some(trimmed.to_string().into()))
+        }
+    }
+
+    #[test]
+    fn should_reject_invalid_values_before_writing() {
+        // A port outside u16 range must fail validation (caught before write).
+        let mut answers = serde_json::Map::new();
+        answers.insert("port".into(), serde_json::json!(70000));
+        #[cfg(feature = "api")]
+        assert!(
+            validate_section("serve", &answers).is_err(),
+            "out-of-range port must be rejected"
+        );
+
+        // A valid gateway flag passes.
+        let mut ok = serde_json::Map::new();
+        ok.insert("no_retry".into(), serde_json::json!(true));
+        assert!(validate_section("gateway", &ok).is_ok());
+
+        // An unknown chat enum value must be rejected.
+        let mut bad_enum = serde_json::Map::new();
+        bad_enum.insert("sandbox".into(), serde_json::json!("not-a-mode"));
+        assert!(
+            validate_section("chat", &bad_enum).is_err(),
+            "unknown enum value must be rejected"
+        );
+
+        // A valid chat enum value (matching clap's kebab possible-value) passes.
+        let mut ok_enum = serde_json::Map::new();
+        ok_enum.insert("sandbox".into(), serde_json::json!("workspace-write"));
+        assert!(validate_section("chat", &ok_enum).is_ok());
+    }
+
+    #[test]
+    fn should_compute_command_defaults() {
+        // gateway/chat are always present; their defaults must serialize.
+        let gw = command_defaults("gateway").expect("gateway defaults");
+        assert!(gw.contains_key("no_retry"));
+        let chat = command_defaults("chat").expect("chat defaults");
+        // clap `default_value = "20"` for chat max_iterations round-trips.
+        assert_eq!(chat.get("max_iterations"), Some(&serde_json::json!(20)));
+    }
+
+    #[test]
+    fn should_only_prompt_layerable_flags() {
+        // The wizard's include filter is exactly config_layer::is_layerable, so
+        // assert the curated in/out decisions on the REAL command tree.
+        let top = crate::commands::Args::command();
+        let gateway = top
+            .get_subcommands()
+            .find(|cmd| cmd.get_name() == "gateway")
+            .expect("gateway subcommand");
+        let prompted: Vec<String> = gateway
+            .get_arguments()
+            .filter(|arg| crate::config_layer::is_layerable("gateway", arg))
+            .filter_map(|arg| arg.get_long().map(String::from))
+            .collect();
+        assert!(
+            prompted.contains(&"no-retry".to_string()),
+            "no-retry is prompted"
+        );
+        assert!(
+            !prompted.contains(&"provider".to_string()),
+            "provider denied (legacy)"
+        );
+        assert!(
+            !prompted.contains(&"config".to_string()),
+            "config denied (selector)"
+        );
+        assert!(
+            !prompted.contains(&"profile".to_string()),
+            "gateway profile denied"
+        );
+        // The hidden managed-gateway internals are never prompted.
+        assert!(
+            !prompted.contains(&"bridge-url".to_string()),
+            "hidden flags denied"
+        );
+    }
+
+    #[test]
+    fn should_render_scalars_without_quoting_strings() {
+        assert_eq!(render_scalar(&serde_json::json!("127.0.0.1")), "127.0.0.1");
+        assert_eq!(render_scalar(&serde_json::json!(50080)), "50080");
+        assert_eq!(render_scalar(&serde_json::json!(true)), "true");
+    }
+
+    #[test]
+    fn should_round_trip_command_structs_through_serde() {
+        // The layering serializes the parsed struct, overlays keys, then
+        // deserializes it back — so `to_value` → `from_value` MUST be an
+        // identity on the defaults, or a field would be silently lost/altered.
+        fn assert_round_trip<T>()
+        where
+            T: clap::Args
+                + serde::Serialize
+                + serde::de::DeserializeOwned
+                + PartialEq
+                + std::fmt::Debug,
+        {
+            let cmd = T::augment_args(clap::Command::new("cmd"));
+            let matches = cmd.try_get_matches_from(["cmd"]).unwrap();
+            let original = T::from_arg_matches(&matches).unwrap();
+            let value = serde_json::to_value(&original).unwrap();
+            let restored: T = serde_json::from_value(value).unwrap();
+            assert_eq!(
+                original, restored,
+                "command struct must round-trip via serde"
+            );
+        }
+
+        #[cfg(feature = "api")]
+        assert_round_trip::<crate::commands::ServeCommand>();
+        assert_round_trip::<crate::commands::GatewayCommand>();
+        assert_round_trip::<crate::commands::ChatCommand>();
+    }
+}

--- a/crates/octos-cli/src/commands/config.rs
+++ b/crates/octos-cli/src/commands/config.rs
@@ -288,6 +288,9 @@ fn prompt_value(
         .get_possible_values()
         .iter()
         .map(|value| value.get_name().to_string())
+        // Full access must be a per-run opt-in, never a saved default — exclude
+        // it here just as `config_layer` refuses to apply it (codex).
+        .filter(|name| name != crate::config_layer::DANGER_FULL_ACCESS_SANDBOX)
         .collect();
     if !choices.is_empty() {
         return prompt_choice(long, help, &choices, default_val, current_val);

--- a/crates/octos-cli/src/commands/gateway/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/mod.rs
@@ -37,7 +37,11 @@ use {
 };
 
 /// Run as a persistent gateway daemon.
-#[derive(Debug, Args)]
+///
+/// `Serialize`/`Deserialize` back the layered startup config (see
+/// [`crate::config_layer`]): non-explicit fields fall back to
+/// `config.cli.gateway`.
+#[derive(Debug, Args, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct GatewayCommand {
     /// Working directory (defaults to current directory).
     #[arg(short, long)]

--- a/crates/octos-cli/src/commands/mod.rs
+++ b/crates/octos-cli/src/commands/mod.rs
@@ -8,6 +8,7 @@ mod channels;
 pub mod chat;
 mod clean;
 mod completions;
+mod config;
 mod cron;
 mod docs;
 mod doctor;
@@ -43,6 +44,7 @@ pub use channels::ChannelsCommand;
 pub use chat::ChatCommand;
 pub use clean::CleanCommand;
 pub use completions::CompletionsCommand;
+pub use config::ConfigCommand;
 pub use cron::CronCommand;
 pub use docs::DocsCommand;
 pub use doctor::DoctorCommand;
@@ -105,6 +107,8 @@ pub enum Command {
     Channels(ChannelsCommand),
     /// Interactive multi-turn chat with an agent.
     Chat(ChatCommand),
+    /// Configure startup CLI defaults interactively (wizard) and inspect config.
+    Config(ConfigCommand),
     /// Manage scheduled cron jobs.
     Cron(CronCommand),
     /// Run local environment diagnostics (flutter-doctor style).
@@ -326,6 +330,7 @@ impl Executable for Command {
             Self::Auth(cmd) => cmd.execute(),
             Self::Channels(cmd) => cmd.execute(),
             Self::Chat(cmd) => cmd.execute(),
+            Self::Config(cmd) => cmd.execute(),
             Self::Cron(cmd) => cmd.execute(),
             Self::Doctor(cmd) => cmd.execute(),
             Self::Docs(cmd) => cmd.execute(),

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -205,7 +205,11 @@ fn resolve_dashboard_auth_smtp_password(
 }
 
 /// Start the REST API server.
-#[derive(Debug, Args)]
+///
+/// `Serialize`/`Deserialize` back the layered startup config: the resolved
+/// struct is serialized, non-explicit fields are overlaid from
+/// `config.cli.serve`, then deserialized back (see [`crate::config_layer`]).
+#[derive(Debug, Args, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct ServeCommand {
     /// Port to listen on. Default lives in IANA's Dynamic/Private range
     /// (49152–65535) to avoid collisions with `http-alt` services like

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -214,6 +214,21 @@ pub struct Config {
     /// ensuring every shipped skill declares `sha256` in `manifest.json`.
     #[serde(default)]
     pub plugins: PluginsConfig,
+
+    /// Per-subcommand CLI-flag defaults — the "initial startup config".
+    ///
+    /// Keys are subcommand names (`serve`, `gateway`, `chat`); each value is a
+    /// JSON object of snake_case flag id → default value (e.g.
+    /// `{"serve": {"port": 50080, "solo": true}}`). Consulted by the startup
+    /// layering ([`crate::config_layer`]) BELOW an explicit CLI flag / env var
+    /// but ABOVE the built-in clap default, so operators can persist their
+    /// preferred flags without retyping them. Written by `octos config wizard`.
+    ///
+    /// Unknown command keys round-trip untouched. The block is empty by default
+    /// and omitted from serialization so configs that never used it stay
+    /// byte-identical.
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub cli: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
 /// Plugin loader policy.
@@ -1504,6 +1519,47 @@ where
     std::fs::rename(&tmp, path)
         .wrap_err_with(|| format!("failed to rename into {}", path.display()))?;
     Ok(())
+}
+
+/// Resolve the `config.json` path a command WOULD read/write, using existence
+/// checks only (never parses the file — safe when the config is malformed).
+///
+/// Mirrors [`Config::load_resolved`]'s precedence so `octos config` targets the
+/// exact same file the runtime loads:
+/// 1. `config_override` (an explicit `--config <FILE>`),
+/// 2. (default installs only) project-local `cwd/.octos/config.json`,
+/// 3. `ctx.config_home/config.json`,
+/// 4. (default installs only) legacy `~/.octos/config.json`.
+///
+/// Falls back to the canonical `config_home/config.json` (the write location)
+/// when no file exists yet.
+pub fn resolve_config_file_path(
+    cwd: &Path,
+    ctx: &crate::config_context::ConfigContext,
+    config_override: Option<&Path>,
+) -> PathBuf {
+    if let Some(path) = config_override {
+        return path.to_path_buf();
+    }
+    if ctx.is_default {
+        let local = cwd.join(".octos").join("config.json");
+        if local.exists() {
+            return local;
+        }
+    }
+    let home = ctx.config_home.join("config.json");
+    if home.exists() {
+        return home;
+    }
+    if ctx.is_default {
+        if let Some(home_dir) = dirs::home_dir() {
+            let legacy = home_dir.join(".octos").join("config.json");
+            if legacy != home && legacy.exists() {
+                return legacy;
+            }
+        }
+    }
+    home
 }
 
 impl Config {
@@ -3155,5 +3211,53 @@ mod tests {
             Some(v) => unsafe { std::env::set_var("OCTOS_MEMORY_REFRESH_ENABLED", v) },
             None => unsafe { std::env::remove_var("OCTOS_MEMORY_REFRESH_ENABLED") },
         }
+    }
+
+    #[test]
+    fn should_round_trip_cli_block() {
+        // The `cli.<cmd>` block survives a deserialize → serialize → deserialize
+        // cycle, including a command key the typed struct doesn't know about.
+        let json = serde_json::json!({
+            "provider": "deepseek",
+            "cli": {
+                "serve": { "port": 50080, "solo": true },
+                "chat": { "sandbox": "workspace-write" },
+                "future_command": { "some_flag": 1 }
+            }
+        });
+        let config: Config = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            config.cli.get("serve").and_then(|v| v.get("port")),
+            Some(&serde_json::json!(50080))
+        );
+        // A round-trip preserves every command section, including unknown ones.
+        let reserialized = serde_json::to_value(&config).unwrap();
+        assert_eq!(
+            reserialized.get("cli"),
+            Some(&serde_json::json!({
+                "serve": { "port": 50080, "solo": true },
+                "chat": { "sandbox": "workspace-write" },
+                "future_command": { "some_flag": 1 }
+            }))
+        );
+    }
+
+    #[test]
+    fn should_omit_empty_cli_block_from_serialization() {
+        // An empty `cli` map must NOT appear in serialized output, so configs
+        // that never used the feature stay byte-identical.
+        let config = Config::default();
+        let value = serde_json::to_value(&config).unwrap();
+        assert!(
+            value.get("cli").is_none(),
+            "empty cli block must be omitted, got {value:#}"
+        );
+    }
+
+    #[test]
+    fn should_default_cli_block_when_absent() {
+        // A legacy config.json with no `cli` key deserializes to an empty block.
+        let config: Config = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(config.cli.is_empty());
     }
 }

--- a/crates/octos-cli/src/config_layer.rs
+++ b/crates/octos-cli/src/config_layer.rs
@@ -1,0 +1,413 @@
+//! Layered startup config for the `serve` / `gateway` / `chat` subcommands.
+//!
+//! # Precedence
+//!
+//! ```text
+//! explicit CLI flag  >  env var  >  config.json `cli.<cmd>`  >  built-in default
+//! ```
+//!
+//! clap already resolves *CLI > env > default* into the parsed struct. The gap
+//! this module fills is inserting the JSON `cli.<cmd>` block **between env and
+//! default**: a field the user did not set on the command line and that did not
+//! come from an env var falls back to `config.cli.<cmd>` when present, otherwise
+//! keeps clap's built-in default.
+//!
+//! The "was it explicit?" oracle is [`clap::ArgMatches::value_source`]
+//! (`CommandLine` / `EnvVariable` / `DefaultValue`) — the only mechanism that
+//! covers both `default_value` scalars (`--port`) and bare `SetTrue` bool flags
+//! (`--solo`) without changing a single field type on the large, established
+//! command structs.
+//!
+//! ## Naming convention
+//!
+//! JSON keys under `cli.<cmd>` are the clap **arg id** (snake_case), which is
+//! also the serde field name — so `arg.get_id()`, `value_source(id)`, and the
+//! serialized struct key all align on one convention with no rename layer. The
+//! wizard displays the kebab-case `--long` name but stores the snake id.
+//!
+//! ## Fields that are never layered
+//!
+//! The four legacy fields already dual-sourced from the top-level `Config`
+//! (`provider` / `model` / `base_url` / `max_iterations`) are left reading the
+//! top level as before — layering them here would double-source them. Config
+//! selectors (`config` / `cwd` / `data_dir`), secrets (`auth_token`), one-shot
+//! flags (`message`), and the dangerous `--yolo` / `--danger-full-access` flags
+//! are excluded too. See [`is_layerable`].
+
+use std::path::PathBuf;
+
+/// Subcommands that participate in the layered startup config.
+pub const LAYERED_COMMANDS: &[&str] = &["serve", "gateway", "chat"];
+
+/// Merge `config.cli.<cmd>` defaults into the active subcommand's parsed struct,
+/// for any field the user did not set explicitly (CLI) or via an env var.
+///
+/// Best-effort: a missing/malformed config, or a merged value that fails to
+/// deserialize, leaves `args` untouched (the command loads config itself and
+/// surfaces any real error). Non-layered commands are a no-op.
+pub fn apply(args: &mut crate::commands::Args, matches: &clap::ArgMatches) -> eyre::Result<()> {
+    use clap::CommandFactory;
+
+    let Some((name, sub)) = matches.subcommand() else {
+        return Ok(());
+    };
+    if !LAYERED_COMMANDS.contains(&name) {
+        return Ok(());
+    }
+    let Some(section) = load_cli_section(name, sub) else {
+        return Ok(());
+    };
+    if section.is_empty() {
+        return Ok(());
+    }
+
+    // Rebuild the clap tree for arg introspection (ids, hidden flags). `top`
+    // is held for the lifetime of the borrowed `sub_cmd`.
+    let top = crate::commands::Args::command();
+    let Some(sub_cmd) = top.get_subcommands().find(|cmd| cmd.get_name() == name) else {
+        return Ok(());
+    };
+
+    match &mut args.command {
+        #[cfg(feature = "api")]
+        crate::commands::Command::Serve(inner) => overlay(name, inner, sub, sub_cmd, &section),
+        crate::commands::Command::Gateway(inner) => overlay(name, inner, sub, sub_cmd, &section),
+        crate::commands::Command::Chat(inner) => overlay(name, inner, sub, sub_cmd, &section),
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Overlay JSON defaults onto a parsed subcommand struct.
+///
+/// Generic over any command struct that round-trips through serde: the resolved
+/// struct is serialized to a JSON object, each layerable-and-non-explicit field
+/// present in `section` is replaced, and the object is deserialized back.
+fn overlay<T>(
+    cmd: &str,
+    typed: &mut T,
+    sub_matches: &clap::ArgMatches,
+    sub_cmd: &clap::Command,
+    section: &serde_json::Map<String, serde_json::Value>,
+) where
+    T: serde::Serialize + serde::de::DeserializeOwned,
+{
+    let Ok(serde_json::Value::Object(mut obj)) = serde_json::to_value(&*typed) else {
+        tracing::debug!(
+            command = cmd,
+            "config.cli overlay skipped: struct not serializable"
+        );
+        return;
+    };
+
+    let mut changed = false;
+    for arg in sub_cmd.get_arguments() {
+        if !is_layerable(cmd, arg) {
+            continue;
+        }
+        let id = arg.get_id().as_str();
+        let Some(json_val) = section.get(id) else {
+            continue;
+        };
+        if !should_overlay(sub_matches.value_source(id)) {
+            continue;
+        }
+        obj.insert(id.to_string(), json_val.clone());
+        changed = true;
+    }
+
+    if !changed {
+        return;
+    }
+    match serde_json::from_value::<T>(serde_json::Value::Object(obj)) {
+        Ok(updated) => *typed = updated,
+        Err(error) => {
+            tracing::warn!(
+                command = cmd,
+                %error,
+                "ignoring config.cli overlay: merged value failed to deserialize"
+            );
+        }
+    }
+}
+
+/// Should the JSON `cli.<cmd>` default overlay a field, given how clap sourced
+/// its current value?
+///
+/// JSON is inserted only when the value did NOT come from an explicit CLI flag
+/// or a clap-tracked env var — encoding the precedence
+/// `explicit-CLI > env > JSON > default`. A `DefaultValue` or an unset arg
+/// (`None`) yields the built-in default, which JSON is allowed to replace.
+///
+/// (octos does not enable clap's `env` feature — its `OCTOS_*` env vars are read
+/// manually in the command bodies, which re-assert env over the layered value
+/// for the few flags that honour them, e.g. `serve --solo`. The `EnvVariable`
+/// arm here keeps this correct should any arg ever adopt clap `env`.)
+fn should_overlay(source: Option<clap::parser::ValueSource>) -> bool {
+    !matches!(
+        source,
+        Some(clap::parser::ValueSource::CommandLine) | Some(clap::parser::ValueSource::EnvVariable)
+    )
+}
+
+/// Is `arg` safe to persist in `cli.<cmd>` and overlay at startup?
+///
+/// Shared by the layering (here) and the `octos config` wizard so the two can
+/// never disagree about which flags are in scope.
+pub fn is_layerable(cmd: &str, arg: &clap::Arg) -> bool {
+    if arg.is_hide_set() {
+        return false;
+    }
+    let id = arg.get_id().as_str();
+    !is_denied(cmd, id) && !looks_secret(id)
+}
+
+/// The static denylist behind [`is_layerable`].
+fn is_denied(cmd: &str, id: &str) -> bool {
+    // Never layered / persisted, on ANY command:
+    //  * config / cwd / data_dir select WHERE config lives (chicken/egg);
+    //  * auth_token is a secret → auth store, never JSON;
+    //  * provider / model / base_url / max_iterations are the legacy fields
+    //    already sourced from the TOP-LEVEL Config — layering them here would
+    //    double-source them;
+    //  * message is a one-shot (send-and-exit) flag, meaningless as a default;
+    //  * the yolo / danger-full-access flags are dangerous — require an
+    //    explicit CLI opt-in every run;
+    //  * help / version are clap builtins.
+    const DENY: &[&str] = &[
+        "config",
+        "cwd",
+        "data_dir",
+        "auth_token",
+        "provider",
+        "model",
+        "base_url",
+        "max_iterations",
+        "message",
+        "dangerously_bypass_approvals_and_sandbox",
+        "danger_full_access",
+        "help",
+        "version",
+    ];
+    if DENY.contains(&id) {
+        return true;
+    }
+    // `octos gateway --profile <FILE>` is a config-file SELECTOR
+    // (conflicts_with --config); unlike `octos chat --profile <name>`, which is
+    // a runtime-behaviour flag, it must never be persisted.
+    if cmd == "gateway" && id == "profile" {
+        return true;
+    }
+    false
+}
+
+/// Heuristic secret filter: never persist anything key/token/secret-shaped.
+fn looks_secret(id: &str) -> bool {
+    let lower = id.to_ascii_lowercase();
+    ["api_key", "apikey", "token", "secret", "password", "passwd"]
+        .iter()
+        .any(|needle| lower.contains(needle))
+}
+
+/// Load `config.cli.<name>` the SAME way the command will resolve its config.
+///
+/// The path selectors (`config` / `cwd` / `data_dir`) are read from the CLI
+/// only — they are on the denylist, so they can never come from JSON, which
+/// means there is no circular dependency. Any error yields `None` ("no
+/// layering"); the command re-loads config and reports the real error.
+fn load_cli_section(
+    name: &str,
+    sub: &clap::ArgMatches,
+) -> Option<serde_json::Map<String, serde_json::Value>> {
+    let cwd = sub
+        .try_get_one::<PathBuf>("cwd")
+        .ok()
+        .flatten()
+        .cloned()
+        .or_else(|| std::env::current_dir().ok())?;
+    let data_dir = sub
+        .try_get_one::<PathBuf>("data_dir")
+        .ok()
+        .flatten()
+        .cloned();
+    let ctx = crate::config_context::resolve_config_context(data_dir.as_deref());
+    let config = match sub.try_get_one::<PathBuf>("config").ok().flatten() {
+        Some(path) => crate::config::Config::from_file(path).ok()?,
+        None => crate::config::Config::load_with_context(&cwd, &ctx).ok()?,
+    };
+    config
+        .cli
+        .get(name)
+        .and_then(|value| value.as_object())
+        .cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Arg, ArgAction, Command};
+
+    #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+    struct TestCmd {
+        port: u16,
+        host: String,
+        solo: bool,
+    }
+
+    /// A stand-in for a serve-like subcommand: a `default_value` scalar, a
+    /// `default_value` string, and a bare `SetTrue` bool flag.
+    fn test_command() -> Command {
+        Command::new("serve")
+            .arg(
+                Arg::new("port")
+                    .long("port")
+                    .value_parser(clap::value_parser!(u16))
+                    .default_value("50080"),
+            )
+            .arg(Arg::new("host").long("host").default_value("127.0.0.1"))
+            .arg(Arg::new("solo").long("solo").action(ArgAction::SetTrue))
+    }
+
+    fn resolve(matches: &clap::ArgMatches) -> TestCmd {
+        TestCmd {
+            port: *matches.get_one::<u16>("port").unwrap(),
+            host: matches.get_one::<String>("host").unwrap().clone(),
+            solo: matches.get_flag("solo"),
+        }
+    }
+
+    fn section(json: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+        json.as_object().unwrap().clone()
+    }
+
+    #[test]
+    fn should_prefer_explicit_cli_over_json() {
+        let cmd = test_command();
+        let matches = cmd.get_matches_from(["serve", "--port", "9090"]);
+        let mut typed = resolve(&matches);
+
+        overlay(
+            "serve",
+            &mut typed,
+            &matches,
+            &test_command(),
+            &section(serde_json::json!({ "port": 8080 })),
+        );
+
+        assert_eq!(typed.port, 9090, "explicit --port must beat JSON");
+    }
+
+    #[test]
+    fn should_use_json_when_flag_absent() {
+        let cmd = test_command();
+        let matches = cmd.get_matches_from(["serve"]);
+        let mut typed = resolve(&matches);
+        assert_eq!(typed.port, 50080, "sanity: clap default before overlay");
+
+        overlay(
+            "serve",
+            &mut typed,
+            &matches,
+            &test_command(),
+            &section(serde_json::json!({ "port": 8080, "solo": true })),
+        );
+
+        assert_eq!(typed.port, 8080, "JSON must beat the built-in default");
+        assert!(typed.solo, "JSON must set an unset SetTrue bool flag");
+    }
+
+    #[test]
+    fn should_keep_default_when_json_absent() {
+        let cmd = test_command();
+        let matches = cmd.get_matches_from(["serve"]);
+        let mut typed = resolve(&matches);
+
+        overlay(
+            "serve",
+            &mut typed,
+            &matches,
+            &test_command(),
+            &section(serde_json::json!({ "host": "0.0.0.0" })),
+        );
+
+        assert_eq!(
+            typed.port, 50080,
+            "unmentioned key keeps its built-in default"
+        );
+        assert_eq!(typed.host, "0.0.0.0", "mentioned key comes from JSON");
+    }
+
+    #[test]
+    fn should_encode_precedence_in_should_overlay() {
+        use clap::parser::ValueSource;
+        // explicit CLI flag and (clap-tracked) env var both outrank JSON.
+        assert!(
+            !should_overlay(Some(ValueSource::CommandLine)),
+            "CLI beats JSON"
+        );
+        assert!(
+            !should_overlay(Some(ValueSource::EnvVariable)),
+            "env beats JSON"
+        );
+        // default / unset are overridable by JSON.
+        assert!(
+            should_overlay(Some(ValueSource::DefaultValue)),
+            "JSON beats default"
+        );
+        assert!(should_overlay(None), "JSON fills an unset arg");
+    }
+
+    #[test]
+    fn should_deny_layering_of_sensitive_and_selector_flags() {
+        let provider = Arg::new("provider").long("provider");
+        let auth = Arg::new("auth_token").long("auth-token");
+        let cfg = Arg::new("config").long("config");
+        let hidden = Arg::new("bridge_url").long("bridge-url").hide(true);
+        let port = Arg::new("port").long("port");
+        let gw_profile = Arg::new("profile").long("profile");
+
+        assert!(
+            !is_layerable("serve", &provider),
+            "provider is legacy top-level"
+        );
+        assert!(!is_layerable("serve", &auth), "auth_token is a secret");
+        assert!(
+            !is_layerable("serve", &cfg),
+            "config selects the config file"
+        );
+        assert!(
+            !is_layerable("gateway", &hidden),
+            "hidden flags are internal"
+        );
+        assert!(
+            !is_layerable("gateway", &gw_profile),
+            "gateway --profile selects config"
+        );
+        assert!(
+            is_layerable("serve", &port),
+            "port is a normal layerable flag"
+        );
+    }
+
+    #[test]
+    fn should_allow_chat_profile_but_deny_gateway_profile() {
+        let profile = Arg::new("profile").long("profile");
+        assert!(
+            is_layerable("chat", &profile),
+            "chat --profile is a runtime flag"
+        );
+        assert!(
+            !is_layerable("gateway", &profile),
+            "gateway --profile is a selector"
+        );
+    }
+
+    #[test]
+    fn should_flag_secret_shaped_ids() {
+        assert!(looks_secret("auth_token"));
+        assert!(looks_secret("openai_api_key"));
+        assert!(looks_secret("webhook_secret"));
+        assert!(!looks_secret("port"));
+        assert!(!looks_secret("host"));
+    }
+}

--- a/crates/octos-cli/src/config_layer.rs
+++ b/crates/octos-cli/src/config_layer.rs
@@ -100,6 +100,12 @@ fn overlay<T>(
         return;
     };
 
+    // A chat invocation carrying an explicit full-access request (`--yolo` or
+    // `--sandbox danger-full-access`) must win outright: overlaying a saved
+    // `sandbox`/`ask_for_approval` would make `resolve_chat_permissions` abort
+    // on contradictory flags (codex).
+    let chat_full_access = cmd == "chat" && chat_explicit_full_access(&obj, sub_matches);
+
     let mut changed = false;
     for arg in sub_cmd.get_arguments() {
         if !is_layerable(cmd, arg) {
@@ -110,6 +116,9 @@ fn overlay<T>(
             continue;
         };
         if !should_overlay(sub_matches.value_source(id)) {
+            continue;
+        }
+        if cmd == "chat" && chat_control_blocked(id, json_val, chat_full_access) {
             continue;
         }
         obj.insert(id.to_string(), json_val.clone());
@@ -148,6 +157,48 @@ fn should_overlay(source: Option<clap::parser::ValueSource>) -> bool {
         source,
         Some(clap::parser::ValueSource::CommandLine) | Some(clap::parser::ValueSource::EnvVariable)
     )
+}
+
+/// Sandbox value that disables the sandbox AND approvals — full access. Never a
+/// persistable default: excluded from the wizard and refused by the overlay, so
+/// full access stays a per-run opt-in (`--yolo` / explicit `--sandbox`).
+pub const DANGER_FULL_ACCESS_SANDBOX: &str = "danger-full-access";
+
+/// Does this `octos chat` invocation carry an EXPLICIT full-access request on
+/// the command line — `--yolo` (`dangerously_bypass_approvals_and_sandbox`) or
+/// `--sandbox danger-full-access`? Read from the already-parsed struct (`obj`
+/// reflects clap's CLI resolution) plus `value_source` to confirm the sandbox
+/// value was CLI-supplied, not defaulted.
+fn chat_explicit_full_access(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    sub_matches: &clap::ArgMatches,
+) -> bool {
+    let yolo = obj
+        .get("dangerously_bypass_approvals_and_sandbox")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let explicit_danger_sandbox = matches!(
+        sub_matches.value_source("sandbox"),
+        Some(clap::parser::ValueSource::CommandLine)
+    ) && obj.get("sandbox").and_then(serde_json::Value::as_str)
+        == Some(DANGER_FULL_ACCESS_SANDBOX);
+    yolo || explicit_danger_sandbox
+}
+
+/// Should this saved chat control be REFUSED even though it's otherwise
+/// layerable and unset on the CLI?
+///
+/// 1. A persisted `sandbox: danger-full-access` is never applied — full access
+///    is a per-run opt-in (`--yolo` / explicit `--sandbox`), not a saved default
+///    that would silently disable the sandbox on every `octos chat`.
+/// 2. When the invocation already carries an explicit full-access request, the
+///    saved `sandbox` / `ask_for_approval` controls are skipped so the explicit
+///    request wins instead of tripping the contradictory-flags check.
+fn chat_control_blocked(id: &str, json_val: &serde_json::Value, full_access: bool) -> bool {
+    if id == "sandbox" && json_val.as_str() == Some(DANGER_FULL_ACCESS_SANDBOX) {
+        return true;
+    }
+    full_access && matches!(id, "sandbox" | "ask_for_approval")
 }
 
 /// Is `arg` safe to persist in `cli.<cmd>` and overlay at startup?
@@ -355,6 +406,85 @@ mod tests {
             "JSON beats default"
         );
         assert!(should_overlay(None), "JSON fills an unset arg");
+    }
+
+    #[test]
+    fn should_never_layer_a_persisted_full_access_sandbox() {
+        let danger = serde_json::Value::from(DANGER_FULL_ACCESS_SANDBOX);
+        // Refused whether or not the run requested full access — a saved
+        // danger-full-access must never silently disable the sandbox.
+        assert!(chat_control_blocked("sandbox", &danger, false));
+        assert!(chat_control_blocked("sandbox", &danger, true));
+        // A safe saved sandbox / approval is fine absent an explicit request.
+        assert!(!chat_control_blocked(
+            "sandbox",
+            &serde_json::Value::from("workspace-write"),
+            false
+        ));
+        assert!(!chat_control_blocked(
+            "ask_for_approval",
+            &serde_json::Value::from("ask"),
+            false
+        ));
+    }
+
+    #[test]
+    fn should_skip_saved_controls_when_explicit_full_access() {
+        // An explicit --yolo / --sandbox danger-full-access must win: the saved
+        // sandbox + approval controls are skipped so they can't trip the
+        // contradictory-flags error in resolve_chat_permissions.
+        assert!(chat_control_blocked(
+            "sandbox",
+            &serde_json::Value::from("workspace-write"),
+            true
+        ));
+        assert!(chat_control_blocked(
+            "ask_for_approval",
+            &serde_json::Value::from("ask"),
+            true
+        ));
+        // Unrelated saved controls still layer under full access.
+        assert!(!chat_control_blocked(
+            "verbose",
+            &serde_json::Value::Bool(true),
+            true
+        ));
+    }
+
+    #[test]
+    fn should_detect_explicit_chat_full_access() {
+        use clap::{Arg, ArgAction, Command};
+        let cmd = Command::new("chat")
+            .arg(
+                Arg::new("dangerously_bypass_approvals_and_sandbox")
+                    .long("yolo")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(Arg::new("sandbox").long("sandbox").action(ArgAction::Set));
+
+        // --yolo → full access.
+        let matches = cmd.clone().get_matches_from(["chat", "--yolo"]);
+        let mut obj = serde_json::Map::new();
+        obj.insert(
+            "dangerously_bypass_approvals_and_sandbox".into(),
+            true.into(),
+        );
+        assert!(chat_explicit_full_access(&obj, &matches));
+
+        // --sandbox danger-full-access (CLI-sourced) → full access.
+        let matches =
+            cmd.clone()
+                .get_matches_from(["chat", "--sandbox", DANGER_FULL_ACCESS_SANDBOX]);
+        let mut obj = serde_json::Map::new();
+        obj.insert("sandbox".into(), DANGER_FULL_ACCESS_SANDBOX.into());
+        assert!(chat_explicit_full_access(&obj, &matches));
+
+        // Neither → not full access.
+        let matches = cmd.get_matches_from(["chat"]);
+        assert!(!chat_explicit_full_access(
+            &serde_json::Map::new(),
+            &matches
+        ));
     }
 
     #[test]

--- a/crates/octos-cli/src/lib.rs
+++ b/crates/octos-cli/src/lib.rs
@@ -17,6 +17,7 @@ pub mod commands;
 pub mod compaction;
 pub mod config;
 pub mod config_context;
+pub mod config_layer;
 pub mod config_watcher;
 #[cfg(feature = "api")]
 pub mod content_catalog;

--- a/crates/octos-cli/src/main.rs
+++ b/crates/octos-cli/src/main.rs
@@ -1,6 +1,6 @@
 //! octos CLI entry point.
 
-use clap::Parser;
+use clap::{CommandFactory, FromArgMatches};
 use color_eyre::eyre::Result;
 
 #[cfg_attr(not(feature = "api"), allow(unused_imports))]
@@ -27,8 +27,14 @@ fn main() -> Result<()> {
     // Initialize error handling
     color_eyre::install()?;
 
-    // Parse arguments first to determine logging setup
-    let args = Args::parse();
+    // Parse into ArgMatches first (this preserves clap's --help/--version/error
+    // handling exactly as `Args::parse()` did), materialize the typed Args, then
+    // merge the layered `cli.<cmd>` startup defaults BEFORE any downstream reads
+    // of the subcommand. Precedence: explicit CLI flag > env var > config.json
+    // `cli.<cmd>` > built-in default (see `octos_cli::config_layer`).
+    let matches = Args::command().get_matches();
+    let mut args = Args::from_arg_matches(&matches).unwrap_or_else(|error| error.exit());
+    octos_cli::config_layer::apply(&mut args, &matches)?;
 
     // Determine log directory for serve command (enables rolling file logs)
     #[allow(unused_mut)]

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1979,6 +1979,9 @@ pub(crate) fn config_from_profile(
         // JSON declared. Defaults to permissive when the profile omits
         // the field.
         plugins: profile.config.plugins.clone(),
+        // Startup CLI-flag defaults are not sourced from profile JSON — a
+        // flattened profile Config always starts with an empty `cli` block.
+        cli: Default::default(),
     }
 }
 


### PR DESCRIPTION
## What

Adds `octos config { wizard | show | path }` and a **layered JSON startup config** for the `serve` / `gateway` / `chat` subcommands — the server half of the config-wizard feature (the client half shipped in octos-tui v0.2.1).

## The wizard

`octos config` (wizard = default) walks each subcommand's options — **introspected from the clap `Command`**, so new flags appear automatically — prompts each (bool → yes/no, enum → numbered pick, else typed), showing the flag's help + default + currently-saved value, and merge-writes the choices into a namespaced `cli.<cmd>` block in `config.json` via the atomic, unknown-field-preserving `write_mutation`. `show` prints the effective config; `path` prints the resolved file. TTY-guarded, hand-rolled stdin (no new deps).

## The layering (`main.rs`)

`Args::parse()` → `Args::command().get_matches()` + `from_arg_matches` + `config_layer::apply`. For the active subcommand, a field the user did **not** set on the command line (via `clap::ArgMatches::value_source`) and that didn't come from an env var falls back to `config.cli.<cmd>`, else the built-in default:

```
explicit CLI flag  >  env var  >  config.json cli.<cmd>  >  built-in default
```

`value_source` is the only mechanism that covers both `default_value` scalars (`--port`) and bare `SetTrue` flags (`--solo`) **without changing a single field type**. Best-effort: any config/serde error leaves args untouched.

## Safety

- Denylisted from persist/layer: config selectors (`config`/`cwd`/`data-dir`), secrets (`auth-token`, key/token-shaped ids), one-shot `--message`, the legacy top-level-sourced `provider`/`model`/`base-url`/`max-iterations` (no double-sourcing), and `is_hide_set()` args.
- **Full access is a per-run opt-in, never a saved default**: the wizard won't offer `sandbox: danger-full-access`, and the overlay refuses to apply a hand-edited one. An explicit `--yolo` / `--sandbox danger-full-access` on the command line wins over saved `sandbox`/`ask_for_approval` controls (would otherwise trip the contradictory-flags check). *(Both hardened after codex review.)*

## Tests

`cargo test -p octos-cli --features api --lib`: **2339 pass** (the 1 remaining failure is the known ambient `agent_orchestrator` concurrency flake — passes in isolation + on the pristine base). New tests cover precedence, include/deny decisions, the `cli` block round-trip, value validation, command-struct serde round-trip, and the full-access safety rules. codex-clean (r1 found 2 security issues, fixed; r2 clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
