### PR TITLE
chore: release v2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "octos-agent"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -4317,7 +4317,7 @@ dependencies = [
 
 [[package]]
 name = "octos-bus"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aes",
  "async-imap",
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "octos-cli"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "agent-client-protocol",
  "argon2",
@@ -4432,7 +4432,7 @@ dependencies = [
 
 [[package]]
 name = "octos-core"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "chrono",
  "eyre",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "octos-diagnostics"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4459,14 +4459,14 @@ dependencies = [
 
 [[package]]
 name = "octos-dora-mcp"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "octos-agent",
 ]
 
 [[package]]
 name = "octos-llm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "octos-memory"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "bincode",
  "chrono",
@@ -4510,7 +4510,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pipeline"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4534,7 +4534,7 @@ dependencies = [
 
 [[package]]
 name = "octos-plugin"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "eyre",
  "metrics",
@@ -4563,7 +4563,7 @@ dependencies = [
 
 [[package]]
 name = "octos-swarm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7650,7 +7650,7 @@ dependencies = [
 
 [[package]]
 name = "wechat-bridge"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "clap",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 rust-version = "1.85.0"
 authors = ["octos team"]


### PR DESCRIPTION
Version bump for the `octos config` wizard + layered startup config (#1652). Workspace 2.0.0 → 2.0.1; Cargo.lock synced (octos-sandbox stays independent at 0.1.0). Tagging v2.0.1 after merge triggers release.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)