### PR TITLE
feat(profile): user-nameable solo profiles via requested_id (protocol)

### DIFF
--- a/crates/octos-cli/src/api/solo_auth.rs
+++ b/crates/octos-cli/src/api/solo_auth.rs
@@ -229,6 +229,7 @@ mod tests {
 
     fn params(name: &str, username: &str, email: &str) -> ProfileLocalCreateParams {
         ProfileLocalCreateParams {
+            requested_id: None,
             name: name.into(),
             username: username.into(),
             email: email.into(),

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -208,6 +208,14 @@ const APPUI_METHOD_ONBOARDING_WORKSPACE_PROBE: &str = "onboarding/workspace_prob
 const APPUI_METHOD_REVIEW_START: &str = octos_core::ui_protocol::methods::REVIEW_START;
 const DASHBOARD_PROVIDERS_JSON: &str = include_str!("../../../../dashboard/src/providers.json");
 const APPUI_FEATURE_PROFILE_LOCAL_CREATE_V1: &str = "profile.local_create.v1";
+/// Additive capability: the server understands the optional `requested_id`
+/// field on `profile/local/create` (and treats `username`/`email` as
+/// optional). Advertised only alongside `profile.local_create.v1` so a client
+/// can negotiate the user-nameable-profile onboarding flow before sending the
+/// new shape. Purely additive — no protocol/capabilities schema-version bump,
+/// matching how `profile.local_create.v1` itself was introduced.
+const APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1: &str =
+    "profile.local_create.requested_id.v1";
 const APPUI_FEATURE_PERMISSION_PROFILE_V1: &str = "permission.profile.v1";
 const APPUI_FEATURE_RUNTIME_POLICY_STAMP_V1: &str = "runtime.policy_stamp.v1";
 const APPUI_FEATURE_CONTEXT_LIFECYCLE_V1: &str = "context.lifecycle.v1";
@@ -1521,6 +1529,14 @@ impl ConnectionUiFeatures {
             push_capability_feature(
                 &mut capabilities.supported_features,
                 APPUI_FEATURE_PROFILE_LOCAL_CREATE_V1,
+            );
+            // Nameable profiles: advertise that this server honors the optional
+            // `requested_id` field (and optional username/email). Additive on
+            // top of the v1 flag, so older clients that negotiate only v1 keep
+            // working with the legacy `{name, username, email}` shape.
+            push_capability_feature(
+                &mut capabilities.supported_features,
+                APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1,
             );
             // #1057: workspace probe ships next to local-solo onboarding so
             // the TUI can advertise the recovery UX only when the backend
@@ -6446,6 +6462,240 @@ fn ensure_existing_local_profile_matches(
     Ok(())
 }
 
+/// Maximum profile-id slug length (mirrors `profiles::validate_slug_shape`).
+const LOCAL_PROFILE_ID_MAX_LEN: usize = 64;
+
+/// Upper bound on the numeric suffix tried when auto-suffixing a requested
+/// profile id (`glm`, `glm-2`, …, `glm-10000`). A store with more collisions
+/// than this falls back to a uuid-based id, so id assignment always
+/// terminates instead of spinning on a pathological store.
+const MAX_LOCAL_PROFILE_ID_SUFFIX: u32 = 10_000;
+
+/// Normalize a user-requested profile id into slug shape: lowercase ASCII
+/// alphanumerics are kept, every other run collapses to a single `-`, edge
+/// `-` are trimmed, and the result is capped at 64 bytes. Returns `None` when
+/// nothing usable remains, or when the result would collide with a reserved
+/// id (a session-key channel name or the synthetic `MAIN_PROFILE_ID`), so the
+/// caller falls back to a generated id. The output always satisfies
+/// `profiles::validate_profile_id`.
+fn normalize_requested_profile_id(requested: &str) -> Option<String> {
+    let mut slug = String::with_capacity(requested.len());
+    let mut last_hyphen = false;
+    for c in requested.chars() {
+        if c.is_ascii_alphanumeric() {
+            slug.push(c.to_ascii_lowercase());
+            last_hyphen = false;
+        } else if !last_hyphen {
+            slug.push('-');
+            last_hyphen = true;
+        }
+    }
+    // All bytes are ASCII, so `truncate` never splits a char; trim any hyphen
+    // the cut (or the edges) left behind.
+    slug.truncate(LOCAL_PROFILE_ID_MAX_LEN);
+    let slug = slug.trim_matches('-').to_owned();
+    if slug.is_empty()
+        || slug == octos_core::MAIN_PROFILE_ID
+        || octos_core::is_reserved_channel_name(&slug)
+    {
+        return None;
+    }
+    Some(slug)
+}
+
+/// Whether `id` is free to claim as a local profile id. Normalized (slug-shaped)
+/// input is assumed. Rejects reserved ids and any id already backed by a
+/// profile file or user record. An unreadable user record is treated as taken
+/// (fail closed) so assignment never overwrites it.
+fn local_profile_id_is_free(
+    id: &str,
+    profile_store: &crate::profiles::ProfileStore,
+    user_store: &crate::user_store::UserStore,
+) -> bool {
+    if id == octos_core::MAIN_PROFILE_ID || octos_core::is_reserved_channel_name(id) {
+        return false;
+    }
+    if profile_store.profile_path(id).exists() {
+        return false;
+    }
+    matches!(user_store.get(id), Ok(None))
+}
+
+/// Assign a unique local profile id from a normalized `base` slug by trying
+/// `base`, then `base-2`, `base-3`, … until a free id is found (bounded by
+/// [`MAX_LOCAL_PROFILE_ID_SUFFIX`]). Returns `None` if the bound is exhausted,
+/// so the caller can fall back to a uuid-based id.
+fn assign_unique_local_profile_id(
+    base: &str,
+    profile_store: &crate::profiles::ProfileStore,
+    user_store: &crate::user_store::UserStore,
+) -> Option<String> {
+    for n in 1..=MAX_LOCAL_PROFILE_ID_SUFFIX {
+        let candidate = if n == 1 {
+            base.to_owned()
+        } else {
+            // Keep `base-N` within the slug budget by trimming the base (not
+            // the numeric tag), then drop any hyphen the trim exposed.
+            let tag = format!("-{n}");
+            let budget = LOCAL_PROFILE_ID_MAX_LEN.saturating_sub(tag.len());
+            let mut trimmed = base.to_owned();
+            trimmed.truncate(budget);
+            let trimmed = trimmed.trim_end_matches('-');
+            if trimmed.is_empty() {
+                continue;
+            }
+            format!("{trimmed}{tag}")
+        };
+        if local_profile_id_is_free(&candidate, profile_store, user_store) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Generate a guaranteed-unique, slug-valid local profile id when no usable
+/// requested id or username is available: derive a slug from `seed` (a display
+/// name) when possible, else a uuid-based id. Always collision-free.
+fn generated_local_profile_id(
+    seed: &str,
+    profile_store: &crate::profiles::ProfileStore,
+    user_store: &crate::user_store::UserStore,
+) -> String {
+    if let Some(id) = normalize_requested_profile_id(seed)
+        .and_then(|base| assign_unique_local_profile_id(&base, profile_store, user_store))
+    {
+        return id;
+    }
+    loop {
+        // A v7 UUID renders as lowercase hex + hyphens with no leading/trailing
+        // hyphen, so `profile-<uuid>` is always slug-valid and well within 64
+        // chars. The loop guards the (practically impossible) collision.
+        let candidate = format!("profile-{}", uuid::Uuid::now_v7());
+        if local_profile_id_is_free(&candidate, profile_store, user_store) {
+            return candidate;
+        }
+    }
+}
+
+/// Resolve the display name for a nameable local profile without erroring: the
+/// provided `name` when it is a valid 1-128 printable string, else the trimmed
+/// original `requested_id` when valid, else the assigned `profile_id`. A
+/// profile therefore always ends up with SOME display name.
+fn resolve_local_display_name(
+    params: &octos_core::ui_protocol::ProfileLocalCreateParams,
+    profile_id: &str,
+) -> String {
+    let is_displayable = |candidate: &str| {
+        let trimmed = candidate.trim();
+        !trimmed.is_empty() && trimmed.len() <= 128 && !trimmed.chars().any(char::is_control)
+    };
+    if is_displayable(&params.name) {
+        return params.name.trim().to_owned();
+    }
+    if let Some(requested) = params.requested_id.as_deref() {
+        if is_displayable(requested) {
+            return requested.trim().to_owned();
+        }
+    }
+    profile_id.to_owned()
+}
+
+/// Resolve the optional owner email: validated when the client provides one,
+/// else `None` (a solo local profile does not require an email).
+fn resolve_optional_local_email(
+    params: &octos_core::ui_protocol::ProfileLocalCreateParams,
+) -> Result<Option<String>, RpcError> {
+    if params.email.trim().is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(validate_local_email(&params.email)?))
+    }
+}
+
+/// A login-ready email for the User record. Solo re-login resolution
+/// (`resolve_solo_user` → `is_login_ready_email`) filters out empty/placeholder
+/// emails, so when the client provides none we synthesize a per-id placeholder
+/// (`<id>@solo.local`) that is unique, login-ready, and never equal to the
+/// admin placeholder (`admin@localhost`).
+fn login_ready_local_email(provided: Option<String>, profile_id: &str) -> String {
+    provided.unwrap_or_else(|| format!("{profile_id}@solo.local"))
+}
+
+/// Create a fresh, uniquely-named local solo profile. Used when the client
+/// sends a `requested_id` (normalized + collision-suffixed) or omits the legacy
+/// `username` entirely (id derived from the display name, else generated).
+/// Unlike the legacy username path this always creates a NEW profile: the
+/// assigned id is guaranteed free, so there is never an existing record to
+/// reconcile.
+fn create_fresh_local_solo_profile(
+    profile_store: &crate::profiles::ProfileStore,
+    user_store: &crate::user_store::UserStore,
+    params: &octos_core::ui_protocol::ProfileLocalCreateParams,
+    requested_slug: Option<String>,
+) -> Result<octos_core::ui_protocol::ProfileLocalCreateResult, RpcError> {
+    let profile_id = match requested_slug {
+        Some(base) => assign_unique_local_profile_id(&base, profile_store, user_store)
+            .unwrap_or_else(|| generated_local_profile_id(&base, profile_store, user_store)),
+        None => generated_local_profile_id(params.name.trim(), profile_store, user_store),
+    };
+
+    let name = resolve_local_display_name(params, &profile_id);
+    let provided_email = resolve_optional_local_email(params)?;
+    // Enforce email uniqueness only for a client-provided email; the
+    // synthesized placeholder is inherently unique per id.
+    if let Some(ref email) = provided_email {
+        if let Some(existing) = user_store
+            .get_by_email(email)
+            .map_err(|error| runtime_unavailable_error(format!("failed to read users: {error}")))?
+        {
+            if existing.id != profile_id {
+                return Err(profile_collision_error(&profile_id, "email"));
+            }
+        }
+    }
+    let email = login_ready_local_email(provided_email, &profile_id);
+    let username = profile_id.clone();
+
+    let now = Utc::now();
+    let user = crate::user_store::User {
+        id: profile_id.clone(),
+        email: email.clone(),
+        name: name.clone(),
+        role: crate::user_store::UserRole::Admin,
+        created_at: now,
+        last_login_at: None,
+    };
+    user_store
+        .save(&user)
+        .map_err(|error| runtime_unavailable_error(format!("failed to save user: {error}")))?;
+
+    let profile = crate::profiles::UserProfile {
+        id: profile_id.clone(),
+        name: name.clone(),
+        public_subdomain: None,
+        enabled: true,
+        data_dir: None,
+        parent_id: None,
+        config: crate::profiles::ProfileConfig::default(),
+        created_at: now,
+        updated_at: now,
+    };
+    profile_store
+        .save(&profile)
+        .map_err(|error| runtime_unavailable_error(format!("failed to save profile: {error}")))?;
+    write_local_profile_metadata(profile_store, &profile, &username, &email)?;
+
+    Ok(octos_core::ui_protocol::ProfileLocalCreateResult {
+        profile_id: profile_id.clone(),
+        user_id: profile_id,
+        name,
+        username,
+        email,
+        created: true,
+        runtime_mode: "solo".to_owned(),
+    })
+}
+
 pub(crate) fn create_or_get_local_solo_profile(
     state: &AppState,
     params: octos_core::ui_protocol::ProfileLocalCreateParams,
@@ -6458,12 +6708,36 @@ pub(crate) fn create_or_get_local_solo_profile(
         ));
     }
 
+    let profile_store = profile_store(state)?;
+    let user_store = user_store(state)?;
+
+    // User-nameable onboarding: an explicit `requested_id` assigns a fresh,
+    // collision-suffixed id; a request that omits the legacy `username` derives
+    // the id from the display name (or generates one). Both create a NEW
+    // profile — the assigned id is guaranteed free — instead of reconciling
+    // against an existing username the way the legacy path below does. A
+    // requested_id that normalizes to nothing usable (empty / reserved) is
+    // treated as absent, deferring to the username path when one was sent.
+    let requested_slug = params
+        .requested_id
+        .as_deref()
+        .and_then(normalize_requested_profile_id);
+    let has_legacy_username = !params.username.trim().is_empty();
+    if requested_slug.is_some() || !has_legacy_username {
+        return create_fresh_local_solo_profile(
+            &profile_store,
+            &user_store,
+            &params,
+            requested_slug,
+        );
+    }
+
+    // ---- Legacy path: id derived from the provided username (idempotent
+    // create-or-get; behavior unchanged). ----
     let name = validate_local_name(&params.name)?;
     let profile_id = normalize_local_username(&params.username)?;
     let email = validate_local_email(&params.email)?;
     let username = profile_id.clone();
-    let profile_store = profile_store(state)?;
-    let user_store = user_store(state)?;
 
     if let Some(existing_email_user) = user_store
         .get_by_email(&email)
@@ -27556,6 +27830,7 @@ mod tests {
         email: &str,
     ) -> octos_core::ui_protocol::ProfileLocalCreateParams {
         octos_core::ui_protocol::ProfileLocalCreateParams {
+            requested_id: None,
             name: name.into(),
             username: username.into(),
             email: email.into(),
@@ -28684,6 +28959,197 @@ mod tests {
         assert_eq!(
             state.profile_store.as_ref().unwrap().list().unwrap().len(),
             1
+        );
+    }
+
+    #[test]
+    fn should_honor_requested_id_when_present_without_username_or_email() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = local_profile_state(dir.path());
+
+        let result = create_or_get_local_solo_profile(
+            &state,
+            octos_core::ui_protocol::ProfileLocalCreateParams {
+                requested_id: Some("glm".into()),
+                ..Default::default()
+            },
+        )
+        .expect("requested_id create should succeed with no username/email");
+
+        assert_eq!(result.profile_id, "glm");
+        assert_eq!(result.user_id, "glm");
+        assert!(result.created);
+        assert_eq!(result.runtime_mode, "solo");
+        // Display name falls back to the requested id when no name is sent.
+        assert_eq!(result.name, "glm");
+        // A login-ready placeholder email is synthesized so solo re-login works.
+        assert_eq!(result.email, "glm@solo.local");
+
+        assert!(
+            state
+                .profile_store
+                .as_ref()
+                .unwrap()
+                .get("glm")
+                .unwrap()
+                .is_some(),
+            "a profile file should exist under the requested id"
+        );
+        assert!(
+            state
+                .user_store
+                .as_ref()
+                .unwrap()
+                .get("glm")
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn should_suffix_requested_id_on_collision() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = local_profile_state(dir.path());
+
+        let mk = |state: &AppState| {
+            create_or_get_local_solo_profile(
+                state,
+                octos_core::ui_protocol::ProfileLocalCreateParams {
+                    requested_id: Some("glm".into()),
+                    ..Default::default()
+                },
+            )
+            .expect("requested_id create")
+        };
+
+        assert_eq!(mk(&state).profile_id, "glm");
+        assert_eq!(mk(&state).profile_id, "glm-2");
+        assert_eq!(mk(&state).profile_id, "glm-3");
+        assert_eq!(
+            state.profile_store.as_ref().unwrap().list().unwrap().len(),
+            3,
+            "each requested_id create makes a distinct suffixed profile"
+        );
+    }
+
+    #[test]
+    fn should_normalize_requested_id_into_slug() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = local_profile_state(dir.path());
+
+        let result = create_or_get_local_solo_profile(
+            &state,
+            octos_core::ui_protocol::ProfileLocalCreateParams {
+                requested_id: Some("My GLM!!".into()),
+                ..Default::default()
+            },
+        )
+        .expect("normalized requested_id create");
+        assert_eq!(result.profile_id, "my-glm");
+    }
+
+    #[test]
+    fn should_generate_id_when_requested_id_and_username_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = local_profile_state(dir.path());
+
+        // A display name but no requested_id/username/email → the id is derived
+        // from the name when that yields a free slug.
+        let named = create_or_get_local_solo_profile(
+            &state,
+            octos_core::ui_protocol::ProfileLocalCreateParams {
+                name: "Robo".into(),
+                ..Default::default()
+            },
+        )
+        .expect("generated create from a display name");
+        assert!(named.created);
+        assert_eq!(named.profile_id, "robo");
+        assert_eq!(named.name, "Robo");
+
+        // Fully empty params still create a valid profile with a non-empty
+        // generated id.
+        let empty = create_or_get_local_solo_profile(
+            &state,
+            octos_core::ui_protocol::ProfileLocalCreateParams::default(),
+        )
+        .expect("generated create from empty params");
+        assert!(empty.created);
+        assert!(!empty.profile_id.is_empty());
+        assert!(
+            state
+                .profile_store
+                .as_ref()
+                .unwrap()
+                .get(&empty.profile_id)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn should_avoid_reserved_id_when_requested_id_is_reserved_channel_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = local_profile_state(dir.path());
+
+        // "slack" is a reserved session-key channel name → it must NOT become a
+        // profile id; the server falls back to a generated id instead.
+        let result = create_or_get_local_solo_profile(
+            &state,
+            octos_core::ui_protocol::ProfileLocalCreateParams {
+                requested_id: Some("slack".into()),
+                ..Default::default()
+            },
+        )
+        .expect("reserved requested_id falls back to a generated id");
+        assert!(result.created);
+        assert_ne!(result.profile_id, "slack");
+        assert!(!octos_core::is_reserved_channel_name(&result.profile_id));
+    }
+
+    #[test]
+    fn should_fall_back_to_generated_when_requested_id_is_pathological() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = local_profile_state(dir.path());
+
+        // Punctuation-only requested_id normalizes to nothing; with no username
+        // to fall back on, the server generates a valid id rather than erroring.
+        let result = create_or_get_local_solo_profile(
+            &state,
+            octos_core::ui_protocol::ProfileLocalCreateParams {
+                requested_id: Some("!!!".into()),
+                ..Default::default()
+            },
+        )
+        .expect("pathological requested_id falls back to a generated id");
+        assert!(result.created);
+        assert!(!result.profile_id.is_empty());
+    }
+
+    #[test]
+    fn should_keep_legacy_username_path_when_no_requested_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = local_profile_state(dir.path());
+
+        // requested_id absent + username present → legacy id == username, and
+        // the path stays idempotent (create-or-get), never suffixed.
+        let first = create_or_get_local_solo_profile(
+            &state,
+            local_profile_params("Ada Lovelace", "ada", "ada@example.com"),
+        )
+        .expect("legacy create");
+        assert_eq!(first.profile_id, "ada");
+        assert!(first.created);
+
+        let second = create_or_get_local_solo_profile(
+            &state,
+            local_profile_params("Ada Lovelace", "ada", "ada@example.com"),
+        )
+        .expect("legacy get");
+        assert_eq!(second.profile_id, "ada");
+        assert!(
+            !second.created,
+            "same owner is a no-op create, never suffixed"
         );
     }
 
@@ -29860,6 +30326,9 @@ ignore = []
                 .any(|method| method == methods::PROFILE_LOCAL_CREATE)
         );
         assert!(local_capabilities.supports_feature(APPUI_FEATURE_PROFILE_LOCAL_CREATE_V1));
+        assert!(
+            local_capabilities.supports_feature(APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1)
+        );
         assert!(local_capabilities.supports_feature(APPUI_FEATURE_PERMISSION_PROFILE_V1));
         assert!(local_capabilities.supports_feature(APPUI_FEATURE_RUNTIME_POLICY_STAMP_V1));
         assert!(local_capabilities.supports_feature(APPUI_FEATURE_CONTEXT_LIFECYCLE_V1));
@@ -29902,6 +30371,10 @@ ignore = []
                 .any(|method| method == methods::PROFILE_LOCAL_CREATE)
         );
         assert!(!tenant_capabilities.supports_feature(APPUI_FEATURE_PROFILE_LOCAL_CREATE_V1));
+        assert!(
+            !tenant_capabilities
+                .supports_feature(APPUI_FEATURE_PROFILE_LOCAL_CREATE_REQUESTED_ID_V1)
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -6514,14 +6514,43 @@ fn normalize_requested_profile_id(requested: &str) -> Option<String> {
     Some(slug)
 }
 
-/// Whether `id` is free to claim as a local profile id. Normalized (slug-shaped)
-/// input is assumed. Rejects reserved ids and any id already backed by a
-/// profile file or user record. An unreadable user record is treated as taken
-/// (fail closed) so assignment never overwrites it.
-fn local_profile_id_is_free(
+/// The synthesized login-ready email for a no-email local profile:
+/// `<id>@solo.local`. The id is already a lowercase slug ≤64 chars, so the
+/// local part (= the id) is ≤64 bytes — within lettre's RFC-5321 limit — with
+/// no separate email suffix that could overflow it.
+fn synthesized_local_email(profile_id: &str) -> String {
+    format!("{profile_id}@solo.local")
+}
+
+/// Snapshot every already-claimed email (lowercased) in ONE `UserStore::list()`
+/// pass so the id-selection loop can require a free `<id>@solo.local` via O(1)
+/// set membership instead of an O(n) `get_by_email` scan per candidate. Taken
+/// under [`LOCAL_PROFILE_CREATE_LOCK`], so no concurrent creator mutates it
+/// mid-selection.
+fn claimed_email_set(
+    user_store: &crate::user_store::UserStore,
+) -> Result<std::collections::HashSet<String>, RpcError> {
+    Ok(user_store
+        .list()
+        .map_err(|error| runtime_unavailable_error(format!("failed to read users: {error}")))?
+        .into_iter()
+        .map(|user| user.email.to_lowercase())
+        .collect())
+}
+
+/// Whether `id` is free to claim, considering BOTH the id itself (reserved /
+/// profile file / user record) AND — when `claimed_emails` is `Some` (the
+/// no-user-email case) — its synthesized `<id>@solo.local`. Folding the email
+/// check in here (against a set snapshotted once) lets the id-selection loop
+/// pick an id whose synthesized email is also free, so the final
+/// `<id>@solo.local` is unique AND length-safe by construction (local part =
+/// id, already ≤64). Normalized slug input assumed; an unreadable user record
+/// is treated as taken (fail closed) so assignment never overwrites it.
+fn local_profile_candidate_is_free(
     id: &str,
     profile_store: &crate::profiles::ProfileStore,
     user_store: &crate::user_store::UserStore,
+    claimed_emails: Option<&std::collections::HashSet<String>>,
 ) -> bool {
     if id == octos_core::MAIN_PROFILE_ID || octos_core::is_reserved_channel_name(id) {
         return false;
@@ -6529,24 +6558,35 @@ fn local_profile_id_is_free(
     if profile_store.profile_path(id).exists() {
         return false;
     }
-    matches!(user_store.get(id), Ok(None))
+    if !matches!(user_store.get(id), Ok(None)) {
+        return false;
+    }
+    match claimed_emails {
+        Some(claimed) => !claimed.contains(&synthesized_local_email(id)),
+        None => true,
+    }
 }
 
 /// Assign a unique local profile id from a normalized `base` slug by trying
 /// `base`, then `base-2`, `base-3`, … until a free id is found (bounded by
-/// [`MAX_LOCAL_PROFILE_ID_SUFFIX`]). Returns `None` if the bound is exhausted,
-/// so the caller can fall back to a uuid-based id.
+/// [`MAX_LOCAL_PROFILE_ID_SUFFIX`]). When `claimed_emails` is `Some`, a
+/// candidate must ALSO have a free `<candidate>@solo.local`, so the id and its
+/// synthesized email are chosen together. Returns `None` if the bound is
+/// exhausted, so the caller can fall back to a uuid-based id.
 fn assign_unique_local_profile_id(
     base: &str,
     profile_store: &crate::profiles::ProfileStore,
     user_store: &crate::user_store::UserStore,
+    claimed_emails: Option<&std::collections::HashSet<String>>,
 ) -> Option<String> {
     for n in 1..=MAX_LOCAL_PROFILE_ID_SUFFIX {
         let candidate = if n == 1 {
             base.to_owned()
         } else {
             // Keep `base-N` within the slug budget by trimming the base (not
-            // the numeric tag), then drop any hyphen the trim exposed.
+            // the numeric tag), then drop any hyphen the trim exposed. Because
+            // the synthesized email's local part IS this id, staying ≤64 here
+            // also keeps `<id>@solo.local` within lettre's local-part limit.
             let tag = format!("-{n}");
             let budget = LOCAL_PROFILE_ID_MAX_LEN.saturating_sub(tag.len());
             let mut trimmed = base.to_owned();
@@ -6557,7 +6597,7 @@ fn assign_unique_local_profile_id(
             }
             format!("{trimmed}{tag}")
         };
-        if local_profile_id_is_free(&candidate, profile_store, user_store) {
+        if local_profile_candidate_is_free(&candidate, profile_store, user_store, claimed_emails) {
             return Some(candidate);
         }
     }
@@ -6571,10 +6611,11 @@ fn generated_local_profile_id(
     seed: &str,
     profile_store: &crate::profiles::ProfileStore,
     user_store: &crate::user_store::UserStore,
+    claimed_emails: Option<&std::collections::HashSet<String>>,
 ) -> String {
-    if let Some(id) = normalize_requested_profile_id(seed)
-        .and_then(|base| assign_unique_local_profile_id(&base, profile_store, user_store))
-    {
+    if let Some(id) = normalize_requested_profile_id(seed).and_then(|base| {
+        assign_unique_local_profile_id(&base, profile_store, user_store, claimed_emails)
+    }) {
         return id;
     }
     loop {
@@ -6582,7 +6623,7 @@ fn generated_local_profile_id(
         // hyphen, so `profile-<uuid>` is always slug-valid and well within 64
         // chars. The loop guards the (practically impossible) collision.
         let candidate = format!("profile-{}", uuid::Uuid::now_v7());
-        if local_profile_id_is_free(&candidate, profile_store, user_store) {
+        if local_profile_candidate_is_free(&candidate, profile_store, user_store, claimed_emails) {
             return candidate;
         }
     }
@@ -6623,65 +6664,50 @@ fn resolve_optional_local_email(
     }
 }
 
-/// Assign a unique, login-ready email for the User record when the client
-/// provides none. Solo re-login resolution (`resolve_solo_user` →
-/// `is_login_ready_email`) filters out empty/placeholder emails and resolves
-/// an owner BY email, so the synthesized address must be login-ready AND
-/// unique among top-level users: an existing user may have EXPLICITLY claimed
-/// `<id>@solo.local`, and duplicate top-level emails make OTP login
-/// ambiguous. We start from the per-id placeholder `<id>@solo.local` (already
-/// unique because the assigned id is unique) and, only if some other user
-/// already holds that exact address, suffix the local-part (`<id>-2@…`, …)
-/// until free. Never equals the admin placeholder (`admin@localhost`). Must be
-/// called while holding [`LOCAL_PROFILE_CREATE_LOCK`] so the check-then-save is
-/// atomic w.r.t. concurrent creators.
-fn assign_synthesized_local_email(
-    profile_id: &str,
-    user_store: &crate::user_store::UserStore,
-) -> Result<String, RpcError> {
-    for n in 1..=MAX_LOCAL_PROFILE_ID_SUFFIX {
-        let local_part = if n == 1 {
-            profile_id.to_owned()
-        } else {
-            format!("{profile_id}-{n}")
-        };
-        let candidate = format!("{local_part}@solo.local");
-        let taken = user_store
-            .get_by_email(&candidate)
-            .map_err(|error| runtime_unavailable_error(format!("failed to read users: {error}")))?
-            .is_some_and(|existing| existing.id != profile_id);
-        if !taken {
-            return Ok(candidate);
-        }
-    }
-    // Practically unreachable (would need 10k explicit `<id>-N@solo.local`
-    // users); fall back to a uuid local-part that cannot collide.
-    Ok(format!("{}@solo.local", uuid::Uuid::now_v7()))
-}
-
 /// Create a fresh, uniquely-named local solo profile. Used when the client
 /// sends a `requested_id` (normalized + collision-suffixed) or omits the legacy
 /// `username` entirely (id derived from the display name, else generated).
 /// Unlike the legacy username path this always creates a NEW profile: the
 /// assigned id is guaranteed free, so there is never an existing record to
 /// reconcile.
+///
+/// When the client sends NO email we synthesize `<id>@solo.local`. Because the
+/// id and its synthesized email must BOTH be unique, the id-selection loop is
+/// given a one-shot snapshot of claimed emails and picks the id and its
+/// `<id>@solo.local` together — so the synthesized address is unique and
+/// length-safe (local part = id, ≤64) by construction, with no per-candidate
+/// email rescan. A client-PROVIDED email keeps its hard-error-on-collision
+/// behavior and does not influence id selection.
 fn create_fresh_local_solo_profile(
     profile_store: &crate::profiles::ProfileStore,
     user_store: &crate::user_store::UserStore,
     params: &octos_core::ui_protocol::ProfileLocalCreateParams,
     requested_slug: Option<String>,
 ) -> Result<octos_core::ui_protocol::ProfileLocalCreateResult, RpcError> {
+    // Resolve the optional client email up front: when absent we must also pick
+    // an id whose synthesized `<id>@solo.local` is free, so snapshot claimed
+    // emails ONCE and thread the set through id selection.
+    let provided_email = resolve_optional_local_email(params)?;
+    let claimed_emails = if provided_email.is_none() {
+        Some(claimed_email_set(user_store)?)
+    } else {
+        None
+    };
+    let claimed_ref = claimed_emails.as_ref();
+
     let profile_id = match requested_slug {
-        Some(base) => assign_unique_local_profile_id(&base, profile_store, user_store)
-            .unwrap_or_else(|| generated_local_profile_id(&base, profile_store, user_store)),
-        None => generated_local_profile_id(params.name.trim(), profile_store, user_store),
+        Some(base) => assign_unique_local_profile_id(&base, profile_store, user_store, claimed_ref)
+            .unwrap_or_else(|| {
+                generated_local_profile_id(&base, profile_store, user_store, claimed_ref)
+            }),
+        None => {
+            generated_local_profile_id(params.name.trim(), profile_store, user_store, claimed_ref)
+        }
     };
 
     let name = resolve_local_display_name(params, &profile_id);
-    // A client-provided email is a hard error on collision (the caller chose
-    // it); a synthesized placeholder is disambiguated by suffixing so top-level
-    // emails stay unique either way.
-    let email = match resolve_optional_local_email(params)? {
+    let email = match provided_email {
+        // Client chose it → a collision with another owner is a hard error.
         Some(provided) => {
             if let Some(existing) = user_store.get_by_email(&provided).map_err(|error| {
                 runtime_unavailable_error(format!("failed to read users: {error}"))
@@ -6692,7 +6718,8 @@ fn create_fresh_local_solo_profile(
             }
             provided
         }
-        None => assign_synthesized_local_email(&profile_id, user_store)?,
+        // Free by construction: the id was chosen so `<id>@solo.local` is unclaimed.
+        None => synthesized_local_email(&profile_id),
     };
     let username = profile_id.clone();
 
@@ -29269,8 +29296,10 @@ mod tests {
     fn should_disambiguate_synthesized_email_on_collision() {
         // P2: a no-email create synthesizes `<id>@solo.local`. If some other
         // user EXPLICITLY claimed that exact address, reusing it would create a
-        // duplicate top-level email (ambiguous OTP login). The synthesized
-        // address must be disambiguated instead, leaving the explicit one intact.
+        // duplicate top-level email (ambiguous OTP login). The id and its
+        // synthesized email are chosen TOGETHER, so the id bumps to `glm-2`
+        // (keeping id == email local-part) rather than issuing a mismatched
+        // email — leaving the explicit address intact.
         let dir = tempfile::tempdir().unwrap();
         let state = local_profile_state(dir.path());
 
@@ -29298,12 +29327,15 @@ mod tests {
         )
         .expect("create with a colliding synthesized email");
 
-        assert_eq!(result.profile_id, "glm");
-        assert_ne!(
-            result.email, "glm@solo.local",
-            "must not reuse an explicitly-claimed email"
+        // Id and email move together: the claimed glm@solo.local pushes the id
+        // to glm-2, whose email glm-2@solo.local is free.
+        assert_eq!(result.profile_id, "glm-2");
+        assert_eq!(result.email, "glm-2@solo.local");
+        assert_eq!(
+            result.email,
+            format!("{}@solo.local", result.profile_id),
+            "synthesized email local-part must equal the assigned id"
         );
-        assert!(result.email.ends_with("@solo.local"));
 
         let users = state.user_store.as_ref().unwrap().list().unwrap();
         assert_eq!(
@@ -29315,6 +29347,63 @@ mod tests {
             users.iter().filter(|u| u.email == "glm@solo.local").count(),
             1,
             "the pre-existing explicit email must be untouched"
+        );
+    }
+
+    #[test]
+    fn should_keep_synthesized_email_local_part_within_64_bytes() {
+        // P2 (length): a max-length (64-char) slug whose `<slug>@solo.local` is
+        // already claimed must NOT produce a 66-byte local part by suffixing the
+        // email separately (`<slug>-2@…` > lettre's 64-byte limit). Choosing the
+        // id and email together instead bumps the ID within the 64-char budget,
+        // so the local part (= the id) stays ≤64.
+        let dir = tempfile::tempdir().unwrap();
+        let state = local_profile_state(dir.path());
+
+        let base = "a".repeat(LOCAL_PROFILE_ID_MAX_LEN); // 64-char slug
+        // Force the synthesized-email collision: a different user explicitly
+        // holds <base>@solo.local.
+        state
+            .user_store
+            .as_ref()
+            .unwrap()
+            .save(&crate::user_store::User {
+                id: "other".into(),
+                email: format!("{base}@solo.local"),
+                name: "Other".into(),
+                role: crate::user_store::UserRole::Admin,
+                created_at: chrono::Utc::now(),
+                last_login_at: None,
+            })
+            .unwrap();
+
+        let result = create_or_get_local_solo_profile(
+            &state,
+            octos_core::ui_protocol::ProfileLocalCreateParams {
+                requested_id: Some(base.clone()),
+                ..Default::default()
+            },
+        )
+        .expect("create with a max-length slug and colliding synthesized email");
+
+        let local_part = result
+            .email
+            .strip_suffix("@solo.local")
+            .expect("synthesized @solo.local email");
+        assert!(
+            local_part.len() <= LOCAL_PROFILE_ID_MAX_LEN,
+            "email local part is {} bytes, exceeds the 64-byte limit",
+            local_part.len()
+        );
+        assert_eq!(
+            local_part, result.profile_id,
+            "email local-part must equal the assigned id"
+        );
+        assert!(result.profile_id.len() <= LOCAL_PROFILE_ID_MAX_LEN);
+        assert_ne!(
+            result.email,
+            format!("{base}@solo.local"),
+            "must not reuse the explicitly-claimed email"
         );
     }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -6677,7 +6677,10 @@ fn resolve_optional_local_email(
 /// `<id>@solo.local` together — so the synthesized address is unique and
 /// length-safe (local part = id, ≤64) by construction, with no per-candidate
 /// email rescan. A client-PROVIDED email keeps its hard-error-on-collision
-/// behavior and does not influence id selection.
+/// behavior and does not influence id selection. A final `get_by_email`
+/// revalidation runs immediately before the write to also catch an email
+/// claimed by a writer OUTSIDE `LOCAL_PROFILE_CREATE_LOCK` after the snapshot
+/// (see the residual-race note at that check).
 fn create_fresh_local_solo_profile(
     profile_store: &crate::profiles::ProfileStore,
     user_store: &crate::user_store::UserStore,
@@ -6706,21 +6709,51 @@ fn create_fresh_local_solo_profile(
     };
 
     let name = resolve_local_display_name(params, &profile_id);
-    let email = match provided_email {
-        // Client chose it → a collision with another owner is a hard error.
-        Some(provided) => {
-            if let Some(existing) = user_store.get_by_email(&provided).map_err(|error| {
-                runtime_unavailable_error(format!("failed to read users: {error}"))
-            })? {
-                if existing.id != profile_id {
-                    return Err(profile_collision_error(&profile_id, "email"));
-                }
-            }
-            provided
+    // The client's email when supplied, else the synthesized `<id>@solo.local`
+    // (chosen free from the snapshot during id selection).
+    let email_provided = provided_email.is_some();
+    let email = provided_email.unwrap_or_else(|| synthesized_local_email(&profile_id));
+
+    // Final email-uniqueness gate, re-read from the live store immediately
+    // before the write. Our earlier snapshot (and the id-selection folding) is
+    // only consistent w.r.t. other creators that hold LOCAL_PROFILE_CREATE_LOCK;
+    // a writer OUTSIDE that lock (e.g. `admin::update_profile`, which sets a
+    // user's email directly) could claim `email` AFTER the snapshot. Re-reading
+    // here shrinks that cross-writer window to the sub-microsecond gap between
+    // this check and `save`.
+    //
+    // RESIDUAL (accepted): an admin/OTP email-write that lands in that tiny gap
+    // can still produce a duplicate top-level email. It is rare and adversarial
+    // (an admin setting some user's email to exactly a concurrently-minted
+    // `<id>@solo.local`) and self-heals — `resolve_solo_user` resolves by newest
+    // `created_at`, and the next create observes the claim. Fully closing it
+    // would require enforcing email uniqueness inside `UserStore::save` itself
+    // (so admin/OTP writers are covered too), a broader change than this
+    // onboarding path warrants; see the codex thread on this file.
+    if let Some(existing) = user_store
+        .get_by_email(&email)
+        .map_err(|error| runtime_unavailable_error(format!("failed to read users: {error}")))?
+    {
+        if existing.id != profile_id {
+            return Err(if email_provided {
+                // Client chose a duplicate address → durable conflict.
+                profile_collision_error(&profile_id, "email")
+            } else {
+                // A synthesized address was raced by an outside writer →
+                // recoverable: a retry mints a fresh id + `<id>@solo.local`.
+                local_profile_error(
+                    "profile_local_collision",
+                    format!("email '{email}' was claimed during creation; retry"),
+                )
+                .with_data(json!({
+                    "kind": "profile_local_collision",
+                    "profile_id": profile_id,
+                    "reason": "email",
+                    "recoverable": true,
+                }))
+            });
         }
-        // Free by construction: the id was chosen so `<id>@solo.local` is unclaimed.
-        None => synthesized_local_email(&profile_id),
-    };
+    }
     let username = profile_id.clone();
 
     let now = Utc::now();
@@ -29404,6 +29437,54 @@ mod tests {
             result.email,
             format!("{base}@solo.local"),
             "must not reuse the explicitly-claimed email"
+        );
+    }
+
+    #[test]
+    fn should_reject_when_provided_email_belongs_to_another_user() {
+        // The pre-save email-uniqueness gate (which also closes the cross-writer
+        // race window) rejects a create whose CLIENT-PROVIDED email is already
+        // held by a different user.
+        let dir = tempfile::tempdir().unwrap();
+        let state = local_profile_state(dir.path());
+
+        state
+            .user_store
+            .as_ref()
+            .unwrap()
+            .save(&crate::user_store::User {
+                id: "zai".into(),
+                email: "taken@example.com".into(),
+                name: "Zai".into(),
+                role: crate::user_store::UserRole::Admin,
+                created_at: chrono::Utc::now(),
+                last_login_at: None,
+            })
+            .unwrap();
+
+        let err = create_or_get_local_solo_profile(
+            &state,
+            octos_core::ui_protocol::ProfileLocalCreateParams {
+                requested_id: Some("glm".into()),
+                email: "taken@example.com".into(),
+                ..Default::default()
+            },
+        )
+        .expect_err("a provided email held by another user must be rejected");
+        assert_eq!(err.code, rpc_error_codes::INVALID_PARAMS);
+        assert_eq!(
+            err.data.as_ref().and_then(|data| data.get("kind")),
+            Some(&json!("profile_local_collision"))
+        );
+        // No half-written profile: the create was rejected before persistence.
+        assert!(
+            state
+                .profile_store
+                .as_ref()
+                .unwrap()
+                .get("glm")
+                .unwrap()
+                .is_none()
         );
     }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -6471,6 +6471,17 @@ const LOCAL_PROFILE_ID_MAX_LEN: usize = 64;
 /// terminates instead of spinning on a pathological store.
 const MAX_LOCAL_PROFILE_ID_SUFFIX: u32 = 10_000;
 
+/// Serializes local-solo profile CREATION (id + email assignment through
+/// persistence). Without it, two concurrent REST/WS creates for the same
+/// `requested_id` can BOTH pass the free-id / free-email checks before either
+/// save runs, then write the same records and clash on the shared
+/// `.json.tmp` paths instead of one getting `glm` and the other `glm-2`. A
+/// single serve process shares one profiles dir, so a process-wide lock is
+/// the reservation boundary that makes find-free + create atomic. Held only
+/// across synchronous store I/O (never across an `.await`); poison is
+/// recovered because one panicking creator must not brick all future ones.
+static LOCAL_PROFILE_CREATE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Normalize a user-requested profile id into slug shape: lowercase ASCII
 /// alphanumerics are kept, every other run collapses to a single `-`, edge
 /// `-` are trimmed, and the result is capped at 64 bytes. Returns `None` when
@@ -6612,13 +6623,40 @@ fn resolve_optional_local_email(
     }
 }
 
-/// A login-ready email for the User record. Solo re-login resolution
-/// (`resolve_solo_user` → `is_login_ready_email`) filters out empty/placeholder
-/// emails, so when the client provides none we synthesize a per-id placeholder
-/// (`<id>@solo.local`) that is unique, login-ready, and never equal to the
-/// admin placeholder (`admin@localhost`).
-fn login_ready_local_email(provided: Option<String>, profile_id: &str) -> String {
-    provided.unwrap_or_else(|| format!("{profile_id}@solo.local"))
+/// Assign a unique, login-ready email for the User record when the client
+/// provides none. Solo re-login resolution (`resolve_solo_user` →
+/// `is_login_ready_email`) filters out empty/placeholder emails and resolves
+/// an owner BY email, so the synthesized address must be login-ready AND
+/// unique among top-level users: an existing user may have EXPLICITLY claimed
+/// `<id>@solo.local`, and duplicate top-level emails make OTP login
+/// ambiguous. We start from the per-id placeholder `<id>@solo.local` (already
+/// unique because the assigned id is unique) and, only if some other user
+/// already holds that exact address, suffix the local-part (`<id>-2@…`, …)
+/// until free. Never equals the admin placeholder (`admin@localhost`). Must be
+/// called while holding [`LOCAL_PROFILE_CREATE_LOCK`] so the check-then-save is
+/// atomic w.r.t. concurrent creators.
+fn assign_synthesized_local_email(
+    profile_id: &str,
+    user_store: &crate::user_store::UserStore,
+) -> Result<String, RpcError> {
+    for n in 1..=MAX_LOCAL_PROFILE_ID_SUFFIX {
+        let local_part = if n == 1 {
+            profile_id.to_owned()
+        } else {
+            format!("{profile_id}-{n}")
+        };
+        let candidate = format!("{local_part}@solo.local");
+        let taken = user_store
+            .get_by_email(&candidate)
+            .map_err(|error| runtime_unavailable_error(format!("failed to read users: {error}")))?
+            .is_some_and(|existing| existing.id != profile_id);
+        if !taken {
+            return Ok(candidate);
+        }
+    }
+    // Practically unreachable (would need 10k explicit `<id>-N@solo.local`
+    // users); fall back to a uuid local-part that cannot collide.
+    Ok(format!("{}@solo.local", uuid::Uuid::now_v7()))
 }
 
 /// Create a fresh, uniquely-named local solo profile. Used when the client
@@ -6640,20 +6678,22 @@ fn create_fresh_local_solo_profile(
     };
 
     let name = resolve_local_display_name(params, &profile_id);
-    let provided_email = resolve_optional_local_email(params)?;
-    // Enforce email uniqueness only for a client-provided email; the
-    // synthesized placeholder is inherently unique per id.
-    if let Some(ref email) = provided_email {
-        if let Some(existing) = user_store
-            .get_by_email(email)
-            .map_err(|error| runtime_unavailable_error(format!("failed to read users: {error}")))?
-        {
-            if existing.id != profile_id {
-                return Err(profile_collision_error(&profile_id, "email"));
+    // A client-provided email is a hard error on collision (the caller chose
+    // it); a synthesized placeholder is disambiguated by suffixing so top-level
+    // emails stay unique either way.
+    let email = match resolve_optional_local_email(params)? {
+        Some(provided) => {
+            if let Some(existing) = user_store.get_by_email(&provided).map_err(|error| {
+                runtime_unavailable_error(format!("failed to read users: {error}"))
+            })? {
+                if existing.id != profile_id {
+                    return Err(profile_collision_error(&profile_id, "email"));
+                }
             }
+            provided
         }
-    }
-    let email = login_ready_local_email(provided_email, &profile_id);
+        None => assign_synthesized_local_email(&profile_id, user_store)?,
+    };
     let username = profile_id.clone();
 
     let now = Utc::now();
@@ -6710,6 +6750,17 @@ pub(crate) fn create_or_get_local_solo_profile(
 
     let profile_store = profile_store(state)?;
     let user_store = user_store(state)?;
+
+    // Reserve the id + email and persist under one process-wide lock so a
+    // concurrent REST/WS double-submit cannot both pass the free-id / free-email
+    // checks before either save runs. Covers BOTH the fresh (requested_id /
+    // generated) path and the legacy username path (whose `.json.tmp`
+    // write-then-rename would otherwise race a same-username peer). Held only
+    // across synchronous store I/O below — the function returns (dropping the
+    // guard) before any caller `.await`s.
+    let _create_guard = LOCAL_PROFILE_CREATE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
 
     // User-nameable onboarding: an explicit `requested_id` assigns a fresh,
     // collision-suffixed id; a request that omits the legacy `username` derives
@@ -29150,6 +29201,120 @@ mod tests {
         assert!(
             !second.created,
             "same owner is a no-op create, never suffixed"
+        );
+    }
+
+    #[test]
+    fn should_reserve_requested_id_atomically_under_concurrency() {
+        // P1: concurrent creates for the same requested_id must each get a
+        // DISTINCT suffixed id (glm, glm-2, …) — never both write "glm" and
+        // overwrite / clash on the shared `.json.tmp`. The reservation lock
+        // makes find-free-id + save atomic, so this is deterministic.
+        let dir = tempfile::tempdir().unwrap();
+        let state = local_profile_state(dir.path());
+
+        let n = 8usize;
+        let barrier = std::sync::Barrier::new(n);
+        let ids: Vec<String> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..n)
+                .map(|_| {
+                    scope.spawn(|| {
+                        // Release all threads together to maximize contention.
+                        barrier.wait();
+                        create_or_get_local_solo_profile(
+                            &state,
+                            octos_core::ui_protocol::ProfileLocalCreateParams {
+                                requested_id: Some("glm".into()),
+                                ..Default::default()
+                            },
+                        )
+                        .expect("concurrent requested_id create")
+                        .profile_id
+                    })
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let unique: std::collections::BTreeSet<&str> = ids.iter().map(String::as_str).collect();
+        assert_eq!(
+            unique.len(),
+            n,
+            "each concurrent create must get a distinct id, got {ids:?}"
+        );
+        let expected: std::collections::BTreeSet<String> = std::iter::once("glm".to_owned())
+            .chain((2..=n).map(|i| format!("glm-{i}")))
+            .collect();
+        assert_eq!(
+            unique
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<std::collections::BTreeSet<_>>(),
+            expected,
+            "ids must be exactly glm, glm-2, … glm-{n}"
+        );
+        assert_eq!(
+            state.profile_store.as_ref().unwrap().list().unwrap().len(),
+            n,
+            "no concurrent create overwrote another profile"
+        );
+        assert_eq!(
+            state.user_store.as_ref().unwrap().list().unwrap().len(),
+            n,
+            "no concurrent create overwrote another user"
+        );
+    }
+
+    #[test]
+    fn should_disambiguate_synthesized_email_on_collision() {
+        // P2: a no-email create synthesizes `<id>@solo.local`. If some other
+        // user EXPLICITLY claimed that exact address, reusing it would create a
+        // duplicate top-level email (ambiguous OTP login). The synthesized
+        // address must be disambiguated instead, leaving the explicit one intact.
+        let dir = tempfile::tempdir().unwrap();
+        let state = local_profile_state(dir.path());
+
+        // A different profile already holds glm@solo.local explicitly.
+        state
+            .user_store
+            .as_ref()
+            .unwrap()
+            .save(&crate::user_store::User {
+                id: "zai".into(),
+                email: "glm@solo.local".into(),
+                name: "Zai".into(),
+                role: crate::user_store::UserRole::Admin,
+                created_at: chrono::Utc::now(),
+                last_login_at: None,
+            })
+            .unwrap();
+
+        let result = create_or_get_local_solo_profile(
+            &state,
+            octos_core::ui_protocol::ProfileLocalCreateParams {
+                requested_id: Some("glm".into()),
+                ..Default::default()
+            },
+        )
+        .expect("create with a colliding synthesized email");
+
+        assert_eq!(result.profile_id, "glm");
+        assert_ne!(
+            result.email, "glm@solo.local",
+            "must not reuse an explicitly-claimed email"
+        );
+        assert!(result.email.ends_with("@solo.local"));
+
+        let users = state.user_store.as_ref().unwrap().list().unwrap();
+        assert_eq!(
+            users.iter().filter(|u| u.email == result.email).count(),
+            1,
+            "the synthesized email must be unique among top-level users"
+        );
+        assert_eq!(
+            users.iter().filter(|u| u.email == "glm@solo.local").count(),
+            1,
+            "the pre-existing explicit email must be untouched"
         );
     }
 

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -2217,10 +2217,40 @@ pub struct PermissionProfileSetResult {
     pub applied: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Parameters for `profile/local/create` (solo local onboarding).
+///
+/// Backward compatible: an older client that sends `{name, username, email}`
+/// with no `requested_id` still deserializes and works — the server derives
+/// the profile id from `username`, exactly as before. A newer client may
+/// instead send a meaningful `requested_id` (e.g. `"glm"`, `"deepseek"`) and
+/// omit `username`/`email`, because a solo local profile does not require an
+/// owner username or email. The server normalizes `requested_id` into a slug
+/// and collision-suffixes it (`glm`, `glm-2`, `glm-3`, …) to derive the
+/// assigned [`ProfileLocalCreateResult::profile_id`].
+///
+/// Servers that understand `requested_id` advertise the additive capability
+/// feature `profile.local_create.requested_id.v1`; a client can negotiate on
+/// that flag before sending the new shape.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProfileLocalCreateParams {
+    /// Meaningful profile id the user typed during onboarding. Normalized
+    /// (lowercased, non-`[a-z0-9-]` collapsed to `-`) and uniqueness-suffixed
+    /// server-side. Absent / empty / pathological → the server derives the id
+    /// from `username` (legacy shape) or generates one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_id: Option<String>,
+    /// Display name. Optional; when empty the server falls back to
+    /// `requested_id` (then the assigned id) so a profile always has some
+    /// display name.
+    #[serde(default)]
     pub name: String,
+    /// Legacy owner username. Optional now that `requested_id` can name a solo
+    /// profile. When present and `requested_id` is absent it still derives the
+    /// profile id, preserving the pre-existing behavior.
+    #[serde(default)]
     pub username: String,
+    /// Legacy owner email. Optional for a solo local profile.
+    #[serde(default)]
     pub email: String,
 }
 
@@ -6845,6 +6875,56 @@ mod tests {
         assert!(decoded_legacy.topic.is_none());
         assert!(decoded_legacy.cwd.is_none());
         assert!(decoded_legacy.sandbox.is_none());
+    }
+
+    #[test]
+    fn profile_local_create_params_new_shape_requested_id_round_trips() {
+        // New shape: a meaningful requested_id, NO username/email/name.
+        let params = ProfileLocalCreateParams {
+            requested_id: Some("glm".into()),
+            name: String::new(),
+            username: String::new(),
+            email: String::new(),
+        };
+        let wire = serde_json::to_value(&params).expect("serialize profile/local/create params");
+        assert_eq!(wire["requested_id"], json!("glm"));
+        let decoded: ProfileLocalCreateParams =
+            serde_json::from_value(wire).expect("round-trip decode");
+        assert_eq!(decoded, params);
+
+        // Raw new-shape JSON that omits username/email/name entirely still
+        // deserializes (the newly-optional fields default to empty).
+        let new_shape = json!({ "requested_id": "deepseek" });
+        let decoded_new: ProfileLocalCreateParams =
+            serde_json::from_value(new_shape).expect("new-shape decode without username/email");
+        assert_eq!(decoded_new.requested_id.as_deref(), Some("deepseek"));
+        assert!(decoded_new.name.is_empty());
+        assert!(decoded_new.username.is_empty());
+        assert!(decoded_new.email.is_empty());
+    }
+
+    #[test]
+    fn profile_local_create_params_legacy_shape_still_deserializes() {
+        // Old client shape: {name, username, email}, NO requested_id.
+        let legacy = json!({
+            "name": "Ada Lovelace",
+            "username": "ada",
+            "email": "ada@example.com"
+        });
+        let decoded: ProfileLocalCreateParams =
+            serde_json::from_value(legacy).expect("legacy profile/local/create params decode");
+        assert!(decoded.requested_id.is_none());
+        assert_eq!(decoded.name, "Ada Lovelace");
+        assert_eq!(decoded.username, "ada");
+        assert_eq!(decoded.email, "ada@example.com");
+
+        // A `None` requested_id serializes to exactly the legacy wire shape
+        // (the key is skipped), so an OLDER server sees the bytes unchanged.
+        let wire = serde_json::to_value(&decoded).expect("serialize legacy-shaped params");
+        assert!(wire.get("requested_id").is_none());
+        assert_eq!(wire["name"], json!("Ada Lovelace"));
+        assert_eq!(wire["username"], json!("ada"));
+        assert_eq!(wire["email"], json!("ada@example.com"));
     }
 
     #[test]


### PR DESCRIPTION
Lets a client request a meaningful profile id (`glm`, `deepseek`) instead of the server forcing name/username/email. Additive + backward compatible:
- `ProfileLocalCreateParams` gains optional `requested_id`; name/username/email become `#[serde(default)]` (wire-identical to old when requested_id absent).
- Additive capability flag `profile.local_create.requested_id.v1` (no schema bump).
- Server normalizes (slug, cap 64) + auto-suffixes collisions (`glm`→`glm-2`); missing email → `<id>@solo.local` placeholder for solo re-login.
- Legacy name/username/email path unchanged. octos-core 309 + octos-cli 2349 tests green.

Enables the octos-tui onboarding slim (name-your-profile, drop email).

🤖 Generated with [Claude Code](https://claude.com/claude-code)