### PR TITLE
feat(appui): per-project sessions at <cwd>/.octos/sessions (default-OFF flag)

### DIFF
--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -593,6 +593,15 @@ pub async fn list_sessions(
     headers: HeaderMap,
     identity: Option<Extension<AuthIdentity>>,
     connection_profile_id: Option<&str>,
+    // Per-project (`appui.sessions_in_cwd`) session-store root, already
+    // resolved to `<cwd>/.octos` and gated by the WS handler (flag on +
+    // `session.workspace_cwd.v1` negotiated + canonicalized cwd). When
+    // `Some`, the listing is scoped to that project's store ONLY — the
+    // per-profile / global / gateway merge below is skipped, because the
+    // client asked for "this project's conversations", not every scope.
+    // `None` (the default, and always when the flag is off) → byte-identical
+    // legacy behavior.
+    cwd_sessions_root: Option<std::path::PathBuf>,
 ) -> Response {
     // Collect sessions from both the standalone store and gateway profiles.
     let mut all: Vec<SessionInfo> = Vec::new();
@@ -606,6 +615,16 @@ pub async fn list_sessions(
         Ok(pid) => pid,
         Err(response) => return response,
     };
+
+    // Per-project listing short-circuit (`appui.sessions_in_cwd`). The
+    // authorization gate above still runs (the connection must be allowed to
+    // list at all); we then scope the listing to the cwd's `<cwd>/.octos`
+    // store instead of the profile/global stores. Runs BEFORE the legacy
+    // merge so a project session list never bleeds in another scope's rows.
+    if let Some(cwd_root) = cwd_sessions_root {
+        let cwd_sessions = list_profile_sessions(&cwd_root);
+        return Json(cwd_sessions).into_response();
+    }
 
     // M11-F per-profile SessionManager listing. Mirrors the
     // `session_messages` fix in commit 10cc9378d (`fix(api): route
@@ -4634,6 +4653,7 @@ mod tests {
             HeaderMap::new(),
             Some(Extension(AuthIdentity::Admin)),
             None,
+            None,
         )
         .await;
         assert_eq!(response.status(), StatusCode::OK);
@@ -4710,7 +4730,7 @@ mod tests {
 
         // connection_profile_id = "dev", empty headers, no identity — the
         // frozen scope a solo stdio connection carries.
-        let response = list_sessions(State(state), HeaderMap::new(), None, Some("dev")).await;
+        let response = list_sessions(State(state), HeaderMap::new(), None, Some("dev"), None).await;
         assert_eq!(response.status(), StatusCode::OK);
         let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
             .await
@@ -5500,7 +5520,7 @@ mod tests {
             ..AppState::empty_for_tests()
         });
 
-        let response = list_sessions(State(state), HeaderMap::new(), None, None).await;
+        let response = list_sessions(State(state), HeaderMap::new(), None, None, None).await;
         assert_eq!(response.status(), StatusCode::OK);
         let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
             .await
@@ -5558,7 +5578,7 @@ mod tests {
         });
 
         let start = std::time::Instant::now();
-        let response = list_sessions(State(state), HeaderMap::new(), None, None).await;
+        let response = list_sessions(State(state), HeaderMap::new(), None, None, None).await;
         let elapsed = start.elapsed();
 
         assert_eq!(response.status(), StatusCode::OK);

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -4681,6 +4681,7 @@ async fn ui_protocol_connection(
                     &connection_headers,
                     connection_identity.as_ref(),
                     connection_profile_id,
+                    features,
                     id,
                     params,
                 )
@@ -5395,6 +5396,7 @@ where
                     &connection_headers,
                     None,
                     connection_profile_id_owned.as_deref(),
+                    features,
                     id,
                     params,
                 )
@@ -15529,15 +15531,28 @@ async fn handle_session_list(
     headers: &HeaderMap,
     identity: Option<&AuthIdentity>,
     connection_profile_id: Option<&str>,
+    features: ConnectionUiFeatures,
     id: String,
-    _params: SessionListParams,
+    params: SessionListParams,
 ) {
+    // Per-project (`appui.sessions_in_cwd`) scoping. When the client sends a
+    // `cwd` AND the server flag is on AND the connection negotiated
+    // `session.workspace_cwd.v1`, the listing is scoped to `<cwd>/.octos`.
+    // Absent cwd / flag off → `None` → byte-identical legacy listing.
+    let cwd_sessions_root = match resolve_session_list_cwd_root(state, features, &params) {
+        Ok(root) => root,
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+            return;
+        }
+    };
     let identity_ext = identity.cloned().map(Extension);
     let response = super::handlers::list_sessions(
         State(state.clone()),
         headers.clone(),
         identity_ext,
         connection_profile_id,
+        cwd_sessions_root,
     )
     .await;
     let method = octos_core::ui_protocol::methods::SESSION_LIST;
@@ -15553,6 +15568,55 @@ async fn handle_session_list(
             let _ = send_rpc_error(ws, Some(id), error);
         }
     }
+}
+
+/// Resolve an optional `session/list` `cwd` into the per-project session-store
+/// root (`<cwd>/.octos`), applying the same three gates the write path uses so
+/// list and open agree on where a project's sessions live:
+///
+/// 1. **Flag** — when `appui.sessions_in_cwd` is off, the `cwd` is ignored
+///    entirely (`Ok(None)` → legacy per-profile/global listing). This keeps a
+///    flag-off server byte-identical: nothing was ever written under
+///    `<cwd>/.octos`, so scoping to it would only ever return an empty list.
+/// 2. **Capability** — a `cwd` under the flag requires the connection to have
+///    negotiated `session.workspace_cwd.v1` (mirrors `session/open`'s cwd
+///    gate). A client that sends `cwd` without it gets a typed error rather
+///    than a silently-global list.
+/// 3. **Canonicalization** — the cwd must canonicalize to an existing
+///    directory; the store root is `canonical(cwd).join(".octos")`, matching
+///    `resolve_sessions_root` (which roots at the canonicalized
+///    `workspace_root`), so the listing reads exactly where the runtime
+///    persisted.
+///
+/// A trimmed-empty or absent `cwd` is always `Ok(None)` (legacy listing).
+fn resolve_session_list_cwd_root(
+    state: &AppState,
+    features: ConnectionUiFeatures,
+    params: &SessionListParams,
+) -> Result<Option<PathBuf>, RpcError> {
+    let Some(cwd) = params
+        .cwd
+        .as_deref()
+        .map(str::trim)
+        .filter(|cwd| !cwd.is_empty())
+    else {
+        return Ok(None);
+    };
+    // Flag off → the store was never relocated; ignore the cwd (legacy).
+    if !state.session_cache.sessions_in_cwd() {
+        return Ok(None);
+    }
+    if !features.session_workspace_cwd {
+        return Err(RpcError::invalid_params(
+            "session/list cwd requires feature session.workspace_cwd.v1",
+        )
+        .with_data(json!({
+            "kind": "feature_required",
+            "feature": UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
+        })));
+    }
+    let workspace_root = canonical_existing_dir(cwd)?;
+    Ok(Some(workspace_root.join(".octos")))
 }
 
 async fn handle_session_status_get(
@@ -30915,6 +30979,65 @@ ignore = []
         .await;
     }
 
+    #[tokio::test]
+    async fn session_list_cwd_root_honors_flag_and_capability() {
+        // The `session/list` cwd gate: flag OFF ignores cwd (legacy listing);
+        // flag ON honors it only with the `session.workspace_cwd.v1`
+        // capability, resolving to the canonical `<cwd>/.octos` — the same
+        // root the write path (`resolve_sessions_root`) persists to.
+        use octos_core::ui_protocol::SessionListParams;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = tmp.path().join("proj");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let cwd_canon = std::fs::canonicalize(&cwd).unwrap();
+
+        let has_cap = ConnectionUiFeatures::stdio_defaults(); // workspace_cwd = true
+        let no_cap = ConnectionUiFeatures {
+            session_workspace_cwd: false,
+            ..ConnectionUiFeatures::stdio_defaults()
+        };
+        let with_cwd = SessionListParams {
+            cwd: Some(cwd.to_string_lossy().into_owned()),
+        };
+        let no_cwd = SessionListParams { cwd: None };
+
+        let state_off = {
+            let mut s = AppState::empty_for_tests();
+            s.session_cache = Arc::new(
+                crate::runtime::SessionRuntimeCache::new(4, std::time::Duration::from_secs(60))
+                    .with_sessions_in_cwd(false),
+            );
+            s
+        };
+        // Flag OFF → cwd ignored even with the capability (byte-identical legacy).
+        assert_eq!(
+            resolve_session_list_cwd_root(&state_off, has_cap, &with_cwd).unwrap(),
+            None,
+        );
+
+        let state_on = {
+            let mut s = AppState::empty_for_tests();
+            s.session_cache = Arc::new(
+                crate::runtime::SessionRuntimeCache::new(4, std::time::Duration::from_secs(60))
+                    .with_sessions_in_cwd(true),
+            );
+            s
+        };
+        // Flag ON + capability + valid cwd → the canonical <cwd>/.octos root.
+        assert_eq!(
+            resolve_session_list_cwd_root(&state_on, has_cap, &with_cwd).unwrap(),
+            Some(cwd_canon.join(".octos")),
+        );
+        // Flag ON + no cwd → None (legacy listing).
+        assert_eq!(
+            resolve_session_list_cwd_root(&state_on, has_cap, &no_cwd).unwrap(),
+            None,
+        );
+        // Flag ON + cwd but NO capability → typed error (mirrors session/open).
+        assert!(resolve_session_list_cwd_root(&state_on, no_cap, &with_cwd).is_err());
+    }
+
     async fn assert_advertised_stdio_methods_have_dispatch_path(state: Arc<AppState>) {
         let features = ConnectionUiFeatures::stdio_defaults();
         let capabilities = features.advertised_capabilities(&state);
@@ -44088,8 +44211,17 @@ ignore = []
         let observed: Arc<std::sync::Mutex<Vec<(SessionKey, Message, usize)>>> =
             Arc::new(std::sync::Mutex::new(Vec::new()));
         let observed_clone = observed.clone();
+        // Filter to THIS test's session id: the commit observer is
+        // process-global, so a concurrently-running suite test that commits a
+        // message to a DIFFERENT session would otherwise pollute this sink and
+        // make `observed.len()` exceed 3 (the `message_commit_observer_test_lock`
+        // only serialises observer-MUTATING tests, not every committer).
+        let filter_key = "local:persisted-order";
         let prev =
             octos_bus::set_message_commit_observer(Some(Arc::new(move |key, message, seq| {
+                if key.0 != filter_key {
+                    return;
+                }
                 observed_clone
                     .lock()
                     .unwrap_or_else(|e| e.into_inner())
@@ -44099,7 +44231,7 @@ ignore = []
         let tmp = tempfile::tempdir().expect("tempdir");
         let mut manager =
             octos_bus::SessionManager::open(tmp.path()).expect("session manager open");
-        let session_id = SessionKey("local:persisted-order".into());
+        let session_id = SessionKey(filter_key.into());
         for content in ["one", "two", "three"] {
             let msg = Message {
                 role: MessageRole::User,
@@ -44178,8 +44310,13 @@ ignore = []
         assert!(observed.lock().unwrap().is_empty());
 
         // Install the sink and run a second commit. Sink must contain
-        // exactly one event (the second), not two.
-        octos_bus::set_message_commit_observer(Some(Arc::new(move |_key, _message, _seq| {
+        // exactly one event (the second), not two. Filter to this test's
+        // session id so a concurrent suite committer (the observer is
+        // process-global) cannot inflate the count past 1.
+        octos_bus::set_message_commit_observer(Some(Arc::new(move |key, _message, _seq| {
+            if key.0 != "local:persisted-failure" {
+                return;
+            }
             observed_clone.lock().unwrap().push(());
         })));
         let msg2 = Message {

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -15539,13 +15539,14 @@ async fn handle_session_list(
     // `cwd` AND the server flag is on AND the connection negotiated
     // `session.workspace_cwd.v1`, the listing is scoped to `<cwd>/.octos`.
     // Absent cwd / flag off → `None` → byte-identical legacy listing.
-    let cwd_sessions_root = match resolve_session_list_cwd_root(state, features, &params) {
-        Ok(root) => root,
-        Err(error) => {
-            let _ = send_rpc_error(ws, Some(id), error);
-            return;
-        }
-    };
+    let cwd_sessions_root =
+        match resolve_session_list_cwd_root(state, features, connection_profile_id, &params) {
+            Ok(root) => root,
+            Err(error) => {
+                let _ = send_rpc_error(ws, Some(id), error);
+                return;
+            }
+        };
     let identity_ext = identity.cloned().map(Extension);
     let response = super::handlers::list_sessions(
         State(state.clone()),
@@ -15570,9 +15571,10 @@ async fn handle_session_list(
     }
 }
 
-/// Resolve an optional `session/list` `cwd` into the per-project session-store
-/// root (`<cwd>/.octos`), applying the same three gates the write path uses so
-/// list and open agree on where a project's sessions live:
+/// Resolve an optional `session/list` `cwd` into the per-project, per-profile
+/// session-store root (`<cwd>/.octos/<profile_id>`), applying the same gates
+/// the write path uses so list and open agree on where a project's sessions
+/// live:
 ///
 /// 1. **Flag** — when `appui.sessions_in_cwd` is off, the `cwd` is ignored
 ///    entirely (`Ok(None)` → legacy per-profile/global listing). This keeps a
@@ -15582,16 +15584,23 @@ async fn handle_session_list(
 ///    negotiated `session.workspace_cwd.v1` (mirrors `session/open`'s cwd
 ///    gate). A client that sends `cwd` without it gets a typed error rather
 ///    than a silently-global list.
-/// 3. **Canonicalization** — the cwd must canonicalize to an existing
-///    directory; the store root is `canonical(cwd).join(".octos")`, matching
-///    `resolve_sessions_root` (which roots at the canonicalized
-///    `workspace_root`), so the listing reads exactly where the runtime
-///    persisted.
+/// 3. **Workspace safety** — the SAME [`validate_session_workspace_allowed`]
+///    gate `session/open` runs: the cwd must canonicalize to a directory AND
+///    must not be rooted under a banned system path. Without this a client
+///    could point the listing at `/etc` (or any service-writable path) and
+///    `SessionManager::open` would CREATE `<cwd>/.octos/…` there and enumerate
+///    it. On rejection we surface the typed error (consistent with
+///    `session/open`) rather than silently degrading.
+/// 4. **Profile namespace** — the store root is
+///    `<cwd>/.octos/<profile_id>` (via [`project_sessions_root`]), matching
+///    the write path so two profiles that share a project cwd never read each
+///    other's transcripts.
 ///
 /// A trimmed-empty or absent `cwd` is always `Ok(None)` (legacy listing).
 fn resolve_session_list_cwd_root(
     state: &AppState,
     features: ConnectionUiFeatures,
+    connection_profile_id: Option<&str>,
     params: &SessionListParams,
 ) -> Result<Option<PathBuf>, RpcError> {
     let Some(cwd) = params
@@ -15616,7 +15625,19 @@ fn resolve_session_list_cwd_root(
         })));
     }
     let workspace_root = canonical_existing_dir(cwd)?;
-    Ok(Some(workspace_root.join(".octos")))
+    // SAME safety gate as session/open — reject banned system roots (and the
+    // missing-profile-runtime case) BEFORE opening a SessionManager that would
+    // otherwise materialize `<cwd>/.octos` at an arbitrary path.
+    validate_session_workspace_allowed(state, connection_profile_id, &workspace_root)?;
+    // Namespace by the SAME profile the write path uses so the listing reads
+    // exactly the connection's own project store.
+    let profile_id = resolve_session_profile_runtime(state, connection_profile_id)
+        .map(|runtime| runtime.profile_id.clone())
+        .unwrap_or_else(|| connection_profile_id.unwrap_or(MAIN_PROFILE_ID).to_string());
+    Ok(Some(crate::runtime::session::project_sessions_root(
+        &workspace_root,
+        &profile_id,
+    )))
 }
 
 async fn handle_session_status_get(
@@ -30983,14 +31004,15 @@ ignore = []
     async fn session_list_cwd_root_honors_flag_and_capability() {
         // The `session/list` cwd gate: flag OFF ignores cwd (legacy listing);
         // flag ON honors it only with the `session.workspace_cwd.v1`
-        // capability, resolving to the canonical `<cwd>/.octos` — the same
-        // root the write path (`resolve_sessions_root`) persists to.
+        // capability; and it runs the SAME workspace-safety gate as
+        // session/open before resolving a root (proven here by the no-runtime
+        // rejection — see `session_list_cwd_root_gates_path_and_namespaces_by_profile`
+        // for the safe-path happy case + banned-path rejection).
         use octos_core::ui_protocol::SessionListParams;
 
         let tmp = tempfile::tempdir().unwrap();
         let cwd = tmp.path().join("proj");
         std::fs::create_dir_all(&cwd).unwrap();
-        let cwd_canon = std::fs::canonicalize(&cwd).unwrap();
 
         let has_cap = ConnectionUiFeatures::stdio_defaults(); // workspace_cwd = true
         let no_cap = ConnectionUiFeatures {
@@ -31012,7 +31034,7 @@ ignore = []
         };
         // Flag OFF → cwd ignored even with the capability (byte-identical legacy).
         assert_eq!(
-            resolve_session_list_cwd_root(&state_off, has_cap, &with_cwd).unwrap(),
+            resolve_session_list_cwd_root(&state_off, has_cap, None, &with_cwd).unwrap(),
             None,
         );
 
@@ -31024,18 +31046,104 @@ ignore = []
             );
             s
         };
-        // Flag ON + capability + valid cwd → the canonical <cwd>/.octos root.
-        assert_eq!(
-            resolve_session_list_cwd_root(&state_on, has_cap, &with_cwd).unwrap(),
-            Some(cwd_canon.join(".octos")),
-        );
         // Flag ON + no cwd → None (legacy listing).
         assert_eq!(
-            resolve_session_list_cwd_root(&state_on, has_cap, &no_cwd).unwrap(),
+            resolve_session_list_cwd_root(&state_on, has_cap, None, &no_cwd).unwrap(),
             None,
         );
         // Flag ON + cwd but NO capability → typed error (mirrors session/open).
-        assert!(resolve_session_list_cwd_root(&state_on, no_cap, &with_cwd).is_err());
+        assert!(resolve_session_list_cwd_root(&state_on, no_cap, None, &with_cwd).is_err());
+        // Flag ON + capability + a valid cwd but NO registered profile runtime
+        // → the workspace-safety gate (`validate_session_workspace_allowed`)
+        // rejects. This proves the gate is wired BEFORE any SessionManager is
+        // opened at the cwd (the P1 the codex review flagged).
+        assert!(resolve_session_list_cwd_root(&state_on, has_cap, None, &with_cwd).is_err());
+    }
+
+    #[tokio::test]
+    async fn session_list_cwd_root_gates_path_and_namespaces_by_profile() {
+        // With a registered profile runtime: a SAFE cwd resolves to the
+        // per-project, per-PROFILE store `<cwd>/.octos/<profile_id>` (so two
+        // profiles sharing a cwd can't read each other's transcripts), and a
+        // banned system path is rejected by the shared safety gate.
+        use octos_core::ui_protocol::SessionListParams;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let profile = crate::profiles::UserProfile {
+            id: "dev".to_string(),
+            name: "Dev".to_string(),
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: crate::profiles::ProfileConfig {
+                llm: Some(crate::profiles::LlmProfileConfig {
+                    primary: Some(crate::profiles::LlmModelSelectionConfig {
+                        family_id: Some("openai".to_string()),
+                        model_id: Some("gpt-4o-mini".to_string()),
+                        route: Some(crate::profiles::LlmRouteConfig {
+                            route_id: None,
+                            label: None,
+                            base_url: None,
+                            api_key_env: Some("SESS_CWD_TEST_KEY".to_string()),
+                            api_type: None,
+                        }),
+                        ..Default::default()
+                    }),
+                    fallbacks: Vec::new(),
+                }),
+                env_vars: [("SESS_CWD_TEST_KEY".to_string(), "test-key".to_string())]
+                    .into_iter()
+                    .collect(),
+                ..Default::default()
+            },
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let runtime = crate::runtime::ProfileRuntime::bootstrap(
+            &profile,
+            &data_dir,
+            None,
+            crate::runtime::BootstrapRole::Serve,
+        )
+        .await
+        .expect("bootstrap dev runtime");
+
+        let mut state = AppState::empty_for_tests();
+        state.profiles.insert("dev".to_string(), runtime);
+        state.session_cache = Arc::new(
+            crate::runtime::SessionRuntimeCache::new(4, std::time::Duration::from_secs(60))
+                .with_sessions_in_cwd(true),
+        );
+
+        let cap = ConnectionUiFeatures::stdio_defaults();
+
+        // Safe cwd → `<cwd>/.octos/dev` (profile-namespaced).
+        let good = tmp.path().join("project");
+        std::fs::create_dir_all(&good).unwrap();
+        let good_canon = std::fs::canonicalize(&good).unwrap();
+        let good_params = SessionListParams {
+            cwd: Some(good.to_string_lossy().into_owned()),
+        };
+        let resolved =
+            resolve_session_list_cwd_root(&state, cap, Some("dev"), &good_params).unwrap();
+        assert_eq!(
+            resolved,
+            Some(crate::runtime::session::project_sessions_root(
+                &good_canon,
+                "dev"
+            )),
+        );
+        assert_eq!(resolved, Some(good_canon.join(".octos").join("dev")));
+
+        // Banned system root (`/usr` is a real dir on Linux and macOS that
+        // canonicalizes to `/usr`) → rejected by the safety gate.
+        let banned = SessionListParams {
+            cwd: Some("/usr".to_string()),
+        };
+        assert!(resolve_session_list_cwd_root(&state, cap, Some("dev"), &banned).is_err());
     }
 
     async fn assert_advertised_stdio_methods_have_dispatch_path(state: Arc<AppState>) {

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -535,10 +535,13 @@ impl ServeCommand {
                 }
             }
         }
-        let session_cache = Arc::new(crate::runtime::SessionRuntimeCache::new(
-            64,
-            std::time::Duration::from_secs(1800),
-        ));
+        let session_cache = Arc::new(
+            crate::runtime::SessionRuntimeCache::new(64, std::time::Duration::from_secs(1800))
+                // Per-project session storage (opt-in, default off). When set,
+                // a cwd-hinted AppUi session's transcript store relocates to
+                // `<cwd>/.octos`; no-hint/gateway sessions are unaffected.
+                .with_sessions_in_cwd(config.appui.sessions_in_cwd),
+        );
 
         let bridge_js_path = data_dir.join("whatsapp-bridge").join("bridge.js");
         let process_manager = Arc::new(

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -283,6 +283,24 @@ pub struct AppUiConfig {
     /// `config.json`.
     #[serde(default)]
     pub default_session_cwd: Option<PathBuf>,
+
+    /// Relocate AppUi/stdio "coding-agent" session storage from the global
+    /// per-profile store (`<data_dir>/sessions/`) to a **per-project** store
+    /// at `<cwd>/.octos/sessions/`, so `resume` / `session/list` show the
+    /// conversations that belong to the folder the client launched in.
+    ///
+    /// Scope: only sessions opened with a `cwd`/`workspace_hint` (the
+    /// AppUi/coding-agent path). No-hint web-chat and every gateway session
+    /// stay on the per-profile store regardless of this flag — the
+    /// sessions-root resolver returns `profile.data_dir` when there is no
+    /// hint, so per-cwd storage is inert for those paths by construction.
+    ///
+    /// Default `false` for a conservative first cut: nothing changes for
+    /// existing deployments until an operator opts in. Legacy global sessions
+    /// are left in place (their cwd was never persisted, so retro-migration is
+    /// infeasible) and remain reachable via a no-`cwd` `session/list`.
+    #[serde(default)]
+    pub sessions_in_cwd: bool,
 }
 
 /// Top-level credential-pool configuration for `chat` / `serve`. Mirrors

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -112,6 +112,14 @@ pub struct SessionRuntimeCache {
     session_generations: Arc<std::sync::Mutex<HashMap<SessionKey, u64>>>,
     max_size: usize,
     idle_ttl: Duration,
+    /// Process-global `appui.sessions_in_cwd` flag, threaded verbatim into
+    /// every [`SessionRuntime::bootstrap_with_permissions_and_sandbox`] this
+    /// cache performs. Held on the cache (constructed once per `octos serve`)
+    /// so the flag has a single source of truth and `get_or_init*` needs no
+    /// per-call parameter. When set, a cwd-hinted session's transcript store
+    /// relocates to `<cwd>/.octos`; no-hint sessions are unaffected. Default
+    /// `false` (legacy per-profile storage).
+    sessions_in_cwd: bool,
     /// Cancellation signal for the background sweep task. Notified
     /// when the cache is dropped so the task can shut down cleanly
     /// instead of leaking onto the runtime.
@@ -232,9 +240,29 @@ impl SessionRuntimeCache {
             session_generations: Arc::new(std::sync::Mutex::new(HashMap::new())),
             max_size,
             idle_ttl,
+            // Default OFF: legacy per-profile storage. `octos serve` opts in
+            // via `with_sessions_in_cwd(config.appui.sessions_in_cwd)`.
+            sessions_in_cwd: false,
             shutdown,
             sweep_task: std::sync::Mutex::new(sweep_task),
         }
+    }
+
+    /// Enable per-project (`appui.sessions_in_cwd`) session storage for every
+    /// runtime this cache bootstraps. Wired by `octos serve` from
+    /// `config.appui.sessions_in_cwd`; off by default so all existing call
+    /// sites (and tests) keep legacy per-profile storage.
+    pub fn with_sessions_in_cwd(mut self, sessions_in_cwd: bool) -> Self {
+        self.sessions_in_cwd = sessions_in_cwd;
+        self
+    }
+
+    /// Whether this cache relocates cwd-hinted sessions to `<cwd>/.octos`.
+    /// Read by the `session/list` handler to decide whether an incoming
+    /// `cwd` param scopes the listing (single source of truth with the
+    /// bootstrap path).
+    pub fn sessions_in_cwd(&self) -> bool {
+        self.sessions_in_cwd
     }
 
     /// The LRU capacity this cache was constructed with. Exposed
@@ -428,6 +456,10 @@ impl SessionRuntimeCache {
                         workspace_hint,
                         permissions,
                         sandbox_override,
+                        // Process-global flag (default false). A cwd-hinted
+                        // session relocates its store to `<cwd>/.octos` only
+                        // when this is on; no-hint sessions ignore it.
+                        self.sessions_in_cwd,
                     )
                     .await;
                     match result {
@@ -1226,5 +1258,56 @@ mod tests {
                 .is_empty(),
         );
         drop(rt);
+    }
+
+    #[test]
+    fn with_sessions_in_cwd_builder_toggles_flag() {
+        // Default OFF; the builder flips it. Single source of truth for the
+        // bootstrap path and the `session/list` cwd gate.
+        let cache = SessionRuntimeCache::new(4, Duration::from_secs(60));
+        assert!(!cache.sessions_in_cwd());
+        assert!(
+            SessionRuntimeCache::new(4, Duration::from_secs(60))
+                .with_sessions_in_cwd(true)
+                .sessions_in_cwd()
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_flag_on_relocates_cwd_hinted_session() {
+        // The flag on the cache must reach `SessionRuntime::bootstrap` via
+        // `get_or_init` so a cwd-hinted session's store lands under
+        // `<cwd>/.octos`.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir.clone()).await;
+        let cwd = tmp.path().join("proj");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let cwd_canon = std::fs::canonicalize(&cwd).unwrap();
+
+        let cache = SessionRuntimeCache::new(4, Duration::from_secs(60)).with_sessions_in_cwd(true);
+        let rt = cache
+            .get_or_init(&profile, SessionKey::new("api", "coding"), Some(cwd))
+            .await
+            .expect("bootstrap via cache");
+        assert_eq!(rt.sessions_root, cwd_canon.join(".octos"));
+    }
+
+    #[tokio::test]
+    async fn cache_default_keeps_cwd_hinted_session_in_profile() {
+        // Regression: a default (flag-off) cache keeps a cwd-hinted session on
+        // profile.data_dir — byte-identical to today.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir.clone()).await;
+        let cwd = tmp.path().join("proj");
+        std::fs::create_dir_all(&cwd).unwrap();
+
+        let cache = SessionRuntimeCache::new(4, Duration::from_secs(60));
+        let rt = cache
+            .get_or_init(&profile, SessionKey::new("api", "coding"), Some(cwd))
+            .await
+            .expect("bootstrap via cache");
+        assert_eq!(rt.sessions_root, data_dir);
     }
 }

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -32,11 +32,22 @@ use super::{ProfileRuntime, SessionRuntime};
 /// sweep cadence is fixed.
 const BACKGROUND_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
 
-/// Cache key shared by every storage map in this module. Pairs the
-/// profile id (from [`ProfileRuntime::profile_id`]) with the session
-/// key half so a profile reload only invalidates entries belonging
-/// to that profile.
-type CacheKey = (String, SessionKey);
+/// Cache key shared by every storage map in this module. Triples the
+/// profile id (from [`ProfileRuntime::profile_id`]), the session key,
+/// and the resolved **sessions root** so a profile reload only
+/// invalidates entries belonging to that profile.
+///
+/// The `PathBuf` third element is the on-disk store root a runtime is
+/// bootstrapped against ([`resolve_sessions_root_from_hint`]). It is
+/// **constant** (`profile.data_dir`) while `appui.sessions_in_cwd` is off, so
+/// keying by it is byte-identical to the historical `(profile, session_key)`
+/// pair in that mode. With the flag on it makes the cache identity distinguish
+/// the SAME `SessionKey` opened against DIFFERENT project cwds: same key + same
+/// cwd stays single-flight (one runtime), but same key + different cwd
+/// resolves to SEPARATE runtimes/roots — closing the corruption where a
+/// re-open in project B was handed project A's cached runtime (and then ran
+/// tools / wrote history under A's root).
+type CacheKey = (String, SessionKey, PathBuf);
 
 /// Storage shape for the main cache: `(profile_id, session_key) ->
 /// CacheEntry`. Factored into a `type` alias because clippy flags
@@ -361,7 +372,16 @@ impl SessionRuntimeCache {
         // round 3 on #1639).
         permissions_epoch: u64,
     ) -> Result<Arc<SessionRuntime>> {
-        let key = (profile.profile_id.clone(), session_key.clone());
+        // Resolve the sessions root the same way bootstrap will, so the cache
+        // identity separates the same key opened against different project
+        // cwds (flag on) while staying constant — `profile.data_dir` — for
+        // every session when the flag is off (byte-identical legacy keying).
+        let key_root = super::session::resolve_sessions_root_from_hint(
+            profile,
+            workspace_hint.as_deref(),
+            self.sessions_in_cwd,
+        );
+        let key = (profile.profile_id.clone(), session_key.clone(), key_root);
 
         loop {
             // Fast path: read lock + last_used bump on hit.
@@ -568,15 +588,22 @@ impl SessionRuntimeCache {
         canonical
     }
 
-    /// Drop the entry for `key` if present. Used by M11-D's
-    /// `/api/sessions/:id/delete` handler and by the config
-    /// watcher when a profile reload invalidates every cached
-    /// session for the profile.
+    /// Drop every cached entry for `(profile_id, session_key)` regardless of
+    /// the resolved sessions root. Used by M11-D's
+    /// `/api/sessions/:id/delete` handler and by the config watcher when a
+    /// profile reload invalidates every cached session for the profile.
+    ///
+    /// Root-agnostic on purpose: a session key can now be cached under more
+    /// than one root (the same key opened against two project cwds with
+    /// `appui.sessions_in_cwd` on), and an invalidation of that logical
+    /// session must clear all of them.
     ///
     /// Idempotent: removing an absent key is a no-op.
-    pub async fn invalidate(&self, key: &(String, SessionKey)) {
+    pub async fn invalidate(&self, profile_id: &str, session_key: &SessionKey) {
         let mut guard = self.inner.write().await;
-        guard.remove(key);
+        guard.retain(|(key_profile, key_session, _), _| {
+            key_profile != profile_id || key_session != session_key
+        });
     }
 
     /// Drop every cached session runtime belonging to `profile_id`. Used when
@@ -595,7 +622,7 @@ impl SessionRuntimeCache {
             *generations.entry(profile_id.to_owned()).or_insert(0) += 1;
         }
         let mut guard = self.inner.write().await;
-        guard.retain(|(key_profile, _), _| key_profile != profile_id);
+        guard.retain(|(key_profile, _, _), _| key_profile != profile_id);
     }
 
     fn profile_generation(&self, profile_id: &str) -> u64 {
@@ -622,7 +649,7 @@ impl SessionRuntimeCache {
             *generations.entry(session_key.clone()).or_insert(0) += 1;
         }
         let mut guard = self.inner.write().await;
-        guard.retain(|(_, key_session), _| key_session != session_key);
+        guard.retain(|(_, key_session, _), _| key_session != session_key);
     }
 
     pub(crate) fn session_generation(&self, session_key: &SessionKey) -> u64 {
@@ -1021,13 +1048,11 @@ mod tests {
             .expect("init");
         assert_eq!(cache.len().await, 1);
 
-        cache
-            .invalidate(&(profile.profile_id.clone(), key.clone()))
-            .await;
+        cache.invalidate(&profile.profile_id, &key).await;
         assert!(cache.is_empty().await);
 
         // Idempotent.
-        cache.invalidate(&(profile.profile_id.clone(), key)).await;
+        cache.invalidate(&profile.profile_id, &key).await;
     }
 
     #[tokio::test]
@@ -1142,7 +1167,12 @@ mod tests {
 
         let canonical = cache
             .insert_with_eviction(
-                (profile.profile_id.clone(), key.clone()),
+                // Flag off ⇒ the seed above was cached under `profile.data_dir`.
+                (
+                    profile.profile_id.clone(),
+                    key.clone(),
+                    profile.data_dir.clone(),
+                ),
                 redundant,
                 cache.profile_generation(&profile.profile_id),
                 cache.session_generation(&key),
@@ -1182,7 +1212,12 @@ mod tests {
 
         let cache = Arc::new(SessionRuntimeCache::new(8, Duration::from_secs(60)));
         let key = SessionKey::new("api", "owner-cancelled");
-        let cache_key = (profile.profile_id.clone(), key.clone());
+        // Flag off ⇒ get_or_init keys this session under `profile.data_dir`.
+        let cache_key = (
+            profile.profile_id.clone(),
+            key.clone(),
+            profile.data_dir.clone(),
+        );
 
         // Step 1+2: hand-construct a guard the way `get_or_init`
         // would, then drop it. This is the same `InflightGuard`
@@ -1290,7 +1325,10 @@ mod tests {
             .get_or_init(&profile, SessionKey::new("api", "coding"), Some(cwd))
             .await
             .expect("bootstrap via cache");
-        assert_eq!(rt.sessions_root, cwd_canon.join(".octos"));
+        assert_eq!(
+            rt.sessions_root,
+            cwd_canon.join(".octos").join(&profile.profile_id)
+        );
     }
 
     #[tokio::test]
@@ -1309,5 +1347,119 @@ mod tests {
             .await
             .expect("bootstrap via cache");
         assert_eq!(rt.sessions_root, data_dir);
+    }
+
+    #[tokio::test]
+    async fn cache_separates_same_key_across_cwds_flag_on() {
+        // Codex P1: with the flag ON, opening the SAME SessionKey in project A
+        // then project B THROUGH THE CACHE must return DISTINCT runtimes rooted
+        // at each project — NOT hand B project A's cached runtime (which would
+        // make B run tools / write history under A's root). Exercises the cache
+        // path (the corruption site), not a direct bootstrap.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir).await;
+        let proj_a = tmp.path().join("project-a");
+        let proj_b = tmp.path().join("project-b");
+        std::fs::create_dir_all(&proj_a).unwrap();
+        std::fs::create_dir_all(&proj_b).unwrap();
+
+        let cache = SessionRuntimeCache::new(8, Duration::from_secs(60)).with_sessions_in_cwd(true);
+        let key = SessionKey::new("api", "default");
+
+        let rt_a = cache
+            .get_or_init(&profile, key.clone(), Some(proj_a.clone()))
+            .await
+            .expect("open K in A");
+        let rt_b = cache
+            .get_or_init(&profile, key.clone(), Some(proj_b.clone()))
+            .await
+            .expect("open K in B");
+
+        // Distinct cached runtimes rooted at their own project — no cross-wire.
+        assert!(
+            !Arc::ptr_eq(&rt_a, &rt_b),
+            "same key + different cwd must yield distinct runtimes"
+        );
+        assert_ne!(rt_a.sessions_root, rt_b.sessions_root);
+        assert!(
+            rt_a.sessions_root
+                .starts_with(std::fs::canonicalize(&proj_a).unwrap())
+        );
+        assert!(
+            rt_b.sessions_root
+                .starts_with(std::fs::canonicalize(&proj_b).unwrap())
+        );
+        // Both entries coexist in the cache (not one clobbering the other).
+        assert_eq!(cache.len().await, 2);
+
+        // Single-flight preserved for same key + SAME cwd: re-opening K in A
+        // returns the SAME cached runtime, not a third entry.
+        let rt_a2 = cache
+            .get_or_init(&profile, key.clone(), Some(proj_a.clone()))
+            .await
+            .expect("re-open K in A");
+        assert!(
+            Arc::ptr_eq(&rt_a, &rt_a2),
+            "same key + same cwd must stay single-flight"
+        );
+        assert_eq!(cache.len().await, 2);
+
+        // No cross-write: each runtime's manager persists under its own root.
+        {
+            let mut mgr = rt_a.sessions.lock().await;
+            mgr.add_message(&key, octos_core::Message::user("for-A"))
+                .await
+                .unwrap();
+        }
+        {
+            let mut mgr = rt_b.sessions.lock().await;
+            mgr.add_message(&key, octos_core::Message::user("for-B"))
+                .await
+                .unwrap();
+        }
+        let mut reload_a = octos_bus::SessionManager::open(&rt_a.sessions_root).unwrap();
+        assert_eq!(reload_a.get_or_create(&key).await.messages.len(), 1);
+        assert_eq!(
+            reload_a.get_or_create(&key).await.messages[0].content,
+            "for-A"
+        );
+        let mut reload_b = octos_bus::SessionManager::open(&rt_b.sessions_root).unwrap();
+        assert_eq!(reload_b.get_or_create(&key).await.messages.len(), 1);
+        assert_eq!(
+            reload_b.get_or_create(&key).await.messages[0].content,
+            "for-B"
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_shares_same_key_across_cwds_flag_off() {
+        // Regression: with the flag OFF the cache key's root element is constant
+        // (`profile.data_dir`), so the same key opened against two different
+        // cwds collapses to ONE runtime — byte-identical to the historical
+        // `(profile, session_key)` keying / first-cwd-wins.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir).await;
+        let proj_a = tmp.path().join("project-a");
+        let proj_b = tmp.path().join("project-b");
+        std::fs::create_dir_all(&proj_a).unwrap();
+        std::fs::create_dir_all(&proj_b).unwrap();
+
+        let cache = SessionRuntimeCache::new(8, Duration::from_secs(60)); // flag OFF
+        let key = SessionKey::new("api", "default");
+        let rt_a = cache
+            .get_or_init(&profile, key.clone(), Some(proj_a))
+            .await
+            .expect("A");
+        let rt_b = cache
+            .get_or_init(&profile, key.clone(), Some(proj_b))
+            .await
+            .expect("B");
+        assert!(
+            Arc::ptr_eq(&rt_a, &rt_b),
+            "flag off: same key must reuse one runtime regardless of cwd"
+        );
+        assert_eq!(cache.len().await, 1);
     }
 }

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -692,10 +692,15 @@ impl SessionRuntime {
 /// (`SessionManager::open(root)`), so relocating it is "pass a different
 /// root", not "re-architect the store".
 ///
-/// - `sessions_in_cwd && had_hint` → `<cwd>/.octos`, where `<cwd>` is the
-///   canonical hinted workspace (`workspace_root` already canonicalizes a
-///   coding-agent hint, so `workspace_root.join(".octos")` is the project
-///   store and matches what `session/list`'s `cwd` branch derives).
+/// - `sessions_in_cwd && had_hint` → `<cwd>/.octos/<profile_id>` (see
+///   [`project_sessions_root`]), where `<cwd>` is the canonical hinted
+///   workspace (`workspace_root` already canonicalizes a coding-agent hint).
+///   The `<profile_id>` segment is load-bearing: two authenticated profiles
+///   that point at the SAME project cwd must NOT share on-disk files — without
+///   it, raw `web-*` session ids (whose key carries no profile) would collide
+///   in `users/<base>/` and one profile could list/open/mutate another's
+///   transcripts. It mirrors how the global store isolates profiles by giving
+///   each its own `data_dir` root.
 /// - otherwise → [`ProfileRuntime::data_dir`] — the historical per-profile
 ///   store. This includes **every** no-hint session (web-chat, gateway) and
 ///   **every** session while the flag is off, so per-cwd storage is inert for
@@ -713,9 +718,49 @@ pub(crate) fn resolve_sessions_root(
     sessions_in_cwd: bool,
 ) -> PathBuf {
     if sessions_in_cwd && had_hint {
-        workspace_root.join(".octos")
+        project_sessions_root(workspace_root, &profile.profile_id)
     } else {
         profile.data_dir.clone()
+    }
+}
+
+/// The per-project, per-profile session-store root: `<cwd>/.octos/<profile_id>`.
+///
+/// The single source of truth for the on-disk location of a cwd-scoped store,
+/// shared by the write path ([`resolve_sessions_root`] /
+/// [`resolve_sessions_root_from_hint`]) and the `session/list` cwd branch so
+/// listing reads exactly where the runtime persisted. `profile_id` is
+/// percent-encoded so an exotic profile id (`:`, `/`, …) can't escape the
+/// project's `.octos` directory.
+pub(crate) fn project_sessions_root(canonical_cwd: &Path, profile_id: &str) -> PathBuf {
+    canonical_cwd
+        .join(".octos")
+        .join(octos_bus::session::encode_path_component(profile_id))
+}
+
+/// Resolve the sessions root from a **raw** (possibly non-canonical) workspace
+/// hint, as the [`super::SessionRuntimeCache`] sees it before bootstrap
+/// canonicalizes it.
+///
+/// This is the cache-key form of [`resolve_sessions_root`]: it best-effort
+/// canonicalizes the hint (idempotent when it is already canonical, which it is
+/// on the `session/open` and turn/read paths — both pass a canonicalized cwd or
+/// the stored canonical `workspace_root`) so the cache identity a session is
+/// stored under matches the `sessions_root` bootstrap computes from the
+/// canonical `workspace_root`. A canonicalization failure (e.g. a hint that
+/// bootstrap will itself reject as banned/nonexistent) falls back to the raw
+/// path; nothing is cached under a rejected hint, so the fallback is inert.
+pub(crate) fn resolve_sessions_root_from_hint(
+    profile: &ProfileRuntime,
+    workspace_hint: Option<&Path>,
+    sessions_in_cwd: bool,
+) -> PathBuf {
+    match (sessions_in_cwd, workspace_hint) {
+        (true, Some(hint)) => {
+            let canonical = std::fs::canonicalize(hint).unwrap_or_else(|_| hint.to_path_buf());
+            project_sessions_root(&canonical, &profile.profile_id)
+        }
+        _ => profile.data_dir.clone(),
     }
 }
 
@@ -1935,10 +1980,15 @@ mod tests {
         let profile = make_profile(data_dir.clone()).await;
         let cwd = tmp.path().join("proj");
 
-        // flag ON + hint -> per-project store.
+        // flag ON + hint -> per-project, per-PROFILE store (the profile
+        // segment isolates two profiles that share a project cwd).
         assert_eq!(
             resolve_sessions_root(&profile, &cwd, true, true),
-            cwd.join(".octos"),
+            cwd.join(".octos").join(&profile.profile_id),
+        );
+        assert_eq!(
+            resolve_sessions_root(&profile, &cwd, true, true),
+            project_sessions_root(&cwd, &profile.profile_id),
         );
         // flag OFF + hint -> legacy (regression guard: flipping off is a no-op).
         assert_eq!(resolve_sessions_root(&profile, &cwd, true, false), data_dir,);
@@ -1969,11 +2019,13 @@ mod tests {
             .await
             .expect("bootstrap in cwd");
 
-        // sessions_root and the manager's data_dir both point at <cwd>/.octos.
-        assert_eq!(rt.sessions_root, cwd_canon.join(".octos"));
+        // sessions_root and the manager's data_dir both point at
+        // <cwd>/.octos/<profile_id>.
+        let expected_root = cwd_canon.join(".octos").join(&profile.profile_id);
+        assert_eq!(rt.sessions_root, expected_root);
         {
             let mgr = rt.sessions.lock().await;
-            assert_eq!(mgr.data_dir(), cwd_canon.join(".octos"));
+            assert_eq!(mgr.data_dir(), expected_root);
         }
 
         // Persist a message and confirm the JSONL lives under <cwd>/.octos and
@@ -2091,10 +2143,19 @@ mod tests {
                 .await
                 .expect("bootstrap B");
 
-        // Distinct roots — the isolation boundary.
+        // Distinct roots — the isolation boundary — each the project's own
+        // profile-namespaced `<cwd>/.octos/<profile_id>`.
         assert_ne!(rt_a.sessions_root, rt_b.sessions_root);
-        assert!(rt_a.sessions_root.ends_with(".octos"));
-        assert!(rt_b.sessions_root.ends_with(".octos"));
+        let proj_a_canon = std::fs::canonicalize(&proj_a).unwrap();
+        let proj_b_canon = std::fs::canonicalize(&proj_b).unwrap();
+        assert_eq!(
+            rt_a.sessions_root,
+            project_sessions_root(&proj_a_canon, &profile.profile_id)
+        );
+        assert_eq!(
+            rt_b.sessions_root,
+            project_sessions_root(&proj_b_canon, &profile.profile_id)
+        );
 
         // Write a distinct message through each runtime's own manager.
         {
@@ -2153,7 +2214,10 @@ mod tests {
         .expect("bootstrap");
 
         let gitignore = rt.sessions_root.join(".gitignore");
-        assert_eq!(rt.sessions_root, cwd_canon.join(".octos"));
+        assert_eq!(
+            rt.sessions_root,
+            cwd_canon.join(".octos").join(&profile.profile_id)
+        );
         assert!(
             gitignore.exists(),
             "per-project store must have a .gitignore"

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -118,9 +118,29 @@ pub struct SessionRuntime {
     /// `/api/chat` and UI Protocol v1 dispatchers invoke.
     pub agent: Arc<Agent>,
 
+    /// The on-disk **root** the session transcript store is opened at
+    /// (`SessionManager::open(sessions_root)` yields
+    /// `sessions_root/sessions/` + `sessions_root/users/<base>/sessions/`).
+    ///
+    /// Equals [`ProfileRuntime::data_dir`] for the historical behavior
+    /// (web-chat, gateway, or any session with no cwd hint). For an
+    /// AppUi/coding-agent session opened with a cwd hint **and** the
+    /// `appui.sessions_in_cwd` flag on, this is `<cwd>/.octos` — the
+    /// per-project store. Sidecars that derive their path from
+    /// `sessions.data_dir()` (reasoning-effort, task ledger) therefore
+    /// follow the transcript to the same root automatically.
+    ///
+    /// Held explicitly (rather than re-derived) so callers that need the
+    /// root without locking the manager — and tests asserting the per-cwd
+    /// relocation — can read it directly.
+    pub sessions_root: PathBuf,
+
     /// The per-session chat history manager. Wrapped in a
     /// [`tokio::sync::Mutex`] because multiple subscribers
     /// (SSE + WS) may observe and persist messages concurrently.
+    ///
+    /// Opened at [`Self::sessions_root`] (which is
+    /// [`ProfileRuntime::data_dir`] unless the session is cwd-scoped).
     pub sessions: Arc<tokio::sync::Mutex<SessionManager>>,
 }
 
@@ -154,11 +174,15 @@ impl SessionRuntime {
     ///    AppState-derived plumbing (broadcaster/MetricsReporter/
     ///    HookExecutor/system prompt fragments) layers on at the
     ///    dispatcher (UI Protocol / `/api/chat`).
-    /// 7. Open the [`SessionManager`] via
-    ///    `SessionManager::open(&profile.data_dir)` — the canonical
-    ///    JSONL session store namespaces on-disk files by
-    ///    [`SessionKey`] under `data_dir/sessions/`, so the
-    ///    profile data dir is the correct root.
+    /// 7. Open the [`SessionManager`] at the resolved **sessions root**
+    ///    (`resolve_sessions_root`). The canonical JSONL store namespaces
+    ///    on-disk files by [`SessionKey`] under `<root>/sessions/` +
+    ///    `<root>/users/<base>/sessions/`, so the store is fully
+    ///    root-parameterized. The root is `profile.data_dir` for every
+    ///    no-hint/gateway/web-chat session and while `appui.sessions_in_cwd`
+    ///    is off (byte-identical to the historic behavior); a cwd-hinted AppUi
+    ///    session with the flag on relocates to `<cwd>/.octos` (per-project
+    ///    storage). Stored on [`Self::sessions_root`].
     /// 8. Return `Arc<Self>`.
     ///
     /// # Parameters
@@ -195,6 +219,27 @@ impl SessionRuntime {
         .await
     }
 
+    /// [`Self::bootstrap`] with an explicit `sessions_in_cwd` flag. The
+    /// convenience [`Self::bootstrap`] hard-codes `false` (legacy per-profile
+    /// storage); this variant lets the AppUi path (and tests) request the
+    /// per-project relocation when a cwd hint is present.
+    pub async fn bootstrap_in_cwd(
+        profile: &Arc<ProfileRuntime>,
+        session_key: SessionKey,
+        workspace_hint: Option<PathBuf>,
+        sessions_in_cwd: bool,
+    ) -> Result<Arc<Self>> {
+        Self::bootstrap_with_permissions_and_sandbox(
+            profile,
+            session_key,
+            workspace_hint,
+            EffectivePermissions::workspace_write(),
+            None,
+            sessions_in_cwd,
+        )
+        .await
+    }
+
     /// Construct a [`SessionRuntime`] with an explicit effective permission
     /// profile. AppUI integration should resolve and gate requested permission
     /// profiles before calling this hook.
@@ -210,6 +255,11 @@ impl SessionRuntime {
             workspace_hint,
             permissions,
             None,
+            // Legacy per-profile storage. The AppUi path opts into per-cwd
+            // storage via the `sessions_in_cwd` param on
+            // `bootstrap_with_permissions_and_sandbox`, threaded by the
+            // session-runtime cache from `appui.sessions_in_cwd`.
+            false,
         )
         .await
     }
@@ -223,8 +273,18 @@ impl SessionRuntime {
         workspace_hint: Option<PathBuf>,
         permissions: EffectivePermissions,
         sandbox_override: Option<SandboxConfig>,
+        // When `true` AND a `workspace_hint` (cwd) is present, the session
+        // transcript store is relocated from `profile.data_dir` to
+        // `<cwd>/.octos` (per-project storage, `appui.sessions_in_cwd`). No
+        // hint → `profile.data_dir` regardless, so gateway/web-chat are inert.
+        // Threaded from the `SessionRuntimeCache`'s process-global flag.
+        sessions_in_cwd: bool,
     ) -> Result<Arc<Self>> {
-        // Step 1: resolve workspace_root.
+        // Step 1: resolve workspace_root. Capture whether a hint was supplied
+        // BEFORE it is consumed — the sessions-root resolution below keys off
+        // "was this a cwd/coding-agent session" (a hint), not off the derived
+        // workspace path.
+        let had_workspace_hint = workspace_hint.is_some();
         let workspace_root = resolve_workspace_root(profile, &session_key, workspace_hint)?;
         std::fs::create_dir_all(&workspace_root).wrap_err_with(|| {
             format!("create workspace root failed: {}", workspace_root.display())
@@ -578,14 +638,36 @@ impl SessionRuntime {
 
         let agent = Arc::new(agent);
 
-        // Step 6: open the per-profile SessionManager. The on-disk
-        // layout (`<data_dir>/sessions/`) already namespaces by
-        // SessionKey via `encode_path_component`, so the profile
-        // data_dir is the correct root. Sharing one SessionManager
-        // per profile (vs per session) matches today's serve +
-        // gateway call sites.
+        // Step 6: open the SessionManager at the resolved sessions root.
+        //
+        // The on-disk layout (`<root>/sessions/` +
+        // `<root>/users/<base>/sessions/<topic>.jsonl`) already namespaces by
+        // SessionKey via `encode_path_component`, so re-rooting it at
+        // `<cwd>/.octos` (per-project storage) instead of `profile.data_dir`
+        // relocates the whole store with zero storage-code change — the store
+        // is fully root-parameterized.
+        //
+        // `resolve_sessions_root` returns `profile.data_dir` for every
+        // no-hint session (web-chat, gateway) and for every session while
+        // `sessions_in_cwd` is off, so this is byte-identical to the historic
+        // `SessionManager::open(&profile.data_dir)` unless a cwd-scoped AppUi
+        // session has explicitly opted in. Sidecars that build their path
+        // from `sessions.data_dir()` (reasoning-effort, task ledger) follow to
+        // the same root by construction.
+        let sessions_root = resolve_sessions_root(
+            profile,
+            &workspace_root,
+            had_workspace_hint,
+            sessions_in_cwd,
+        );
+        // Keep a project-local `.gitignore` under a freshly-created
+        // `<cwd>/.octos` so transcripts never leak into the user's repo. No-op
+        // for the profile-data-dir root (not a project working tree).
+        if sessions_root != profile.data_dir {
+            ensure_session_store_gitignore(&sessions_root);
+        }
         let sessions = Arc::new(tokio::sync::Mutex::new(
-            SessionManager::open(&profile.data_dir).wrap_err("failed to open session manager")?,
+            SessionManager::open(&sessions_root).wrap_err("failed to open session manager")?,
         ));
 
         Ok(Arc::new(Self {
@@ -597,8 +679,106 @@ impl SessionRuntime {
             permissions,
             tools,
             agent,
+            sessions_root,
             sessions,
         }))
+    }
+}
+
+/// Resolve the on-disk **root** for a session's transcript store.
+///
+/// This is the one seam that makes per-project (`appui.sessions_in_cwd`)
+/// storage possible: the session store is fully root-parameterized
+/// (`SessionManager::open(root)`), so relocating it is "pass a different
+/// root", not "re-architect the store".
+///
+/// - `sessions_in_cwd && had_hint` → `<cwd>/.octos`, where `<cwd>` is the
+///   canonical hinted workspace (`workspace_root` already canonicalizes a
+///   coding-agent hint, so `workspace_root.join(".octos")` is the project
+///   store and matches what `session/list`'s `cwd` branch derives).
+/// - otherwise → [`ProfileRuntime::data_dir`] — the historical per-profile
+///   store. This includes **every** no-hint session (web-chat, gateway) and
+///   **every** session while the flag is off, so per-cwd storage is inert for
+///   the gateway/web-chat paths by construction and flipping the flag off is a
+///   guaranteed no-op.
+///
+/// Only a hinted (coding-agent) session can relocate: a no-hint session's
+/// `workspace_root` is the conventional `<data_dir>/users/<base>/workspace`
+/// path, which is NOT a project the user launched in — rooting a store at
+/// `<that>/.octos` would be meaningless, so `had_hint` gates it.
+pub(crate) fn resolve_sessions_root(
+    profile: &ProfileRuntime,
+    workspace_root: &Path,
+    had_hint: bool,
+    sessions_in_cwd: bool,
+) -> PathBuf {
+    if sessions_in_cwd && had_hint {
+        workspace_root.join(".octos")
+    } else {
+        profile.data_dir.clone()
+    }
+}
+
+/// Idempotently write a `.gitignore` into a per-project session-store root
+/// (`<cwd>/.octos`) so chat transcripts and runtime state never get committed
+/// into the user's repository.
+///
+/// Uses `OpenOptions::create_new` (single `open(O_CREAT|O_EXCL)`), so a
+/// pre-existing `.gitignore` (e.g. one an operator hand-wrote alongside a
+/// project-local `.octos/config.json`) is left untouched — `AlreadyExists` is
+/// treated as success. Best-effort: a failure to write the ignore file must
+/// not fail session bootstrap (the transcript store still works), it only
+/// risks leaking runtime state into git, which we log.
+///
+/// Selective (not `*`) to match the `octos init` convention
+/// (`init.rs`: `sessions/`, `tasks/`, `*.redb`) and to leave a
+/// deliberately-committed `<cwd>/.octos/config.json` untouched; `users/` is
+/// added because per-project transcripts + their sidecars land under
+/// `<cwd>/.octos/users/<base>/sessions/`.
+fn ensure_session_store_gitignore(sessions_root: &Path) {
+    use std::io::Write;
+
+    const GITIGNORE_BODY: &str = "\
+# Managed by octos (appui.sessions_in_cwd): per-project session store.
+# Chat transcripts and runtime state must not be committed to the repo.
+sessions/
+users/
+tasks/
+*.redb
+";
+    if let Err(error) = std::fs::create_dir_all(sessions_root) {
+        tracing::warn!(
+            root = %sessions_root.display(),
+            error = %error,
+            "failed to create per-project session store root for .gitignore",
+        );
+        return;
+    }
+    let path = sessions_root.join(".gitignore");
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+    {
+        Ok(mut file) => {
+            if let Err(error) = file.write_all(GITIGNORE_BODY.as_bytes()) {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %error,
+                    "failed to write per-project session-store .gitignore",
+                );
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            // Operator/earlier bootstrap already placed one — never clobber.
+        }
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %error,
+                "failed to create per-project session-store .gitignore",
+            );
+        }
     }
 }
 
@@ -1064,6 +1244,7 @@ mod tests {
             Some(tmp.path().join("gamma")),
             EffectivePermissions::workspace_write(),
             Some(gamma_sandbox),
+            false,
         )
         .await
         .expect("gamma bootstrap");
@@ -1073,6 +1254,7 @@ mod tests {
             Some(tmp.path().join("delta")),
             EffectivePermissions::workspace_write(),
             None,
+            false,
         )
         .await
         .expect("delta bootstrap");
@@ -1739,5 +1921,310 @@ mod tests {
             .expect("write_file result");
         assert!(write.success, "write_file failed: {}", write.output);
         assert_eq!(std::fs::read_to_string(outside).unwrap(), "host\n");
+    }
+
+    // ---- Per-project session storage (appui.sessions_in_cwd) --------------
+
+    #[tokio::test]
+    async fn resolve_sessions_root_relocates_only_with_flag_and_hint() {
+        // The one seam that gates per-cwd storage. Only (flag ON + a hint)
+        // relocates; every other combination stays on `profile.data_dir` so
+        // gateway/web-chat and a flag-off server are inert by construction.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir.clone()).await;
+        let cwd = tmp.path().join("proj");
+
+        // flag ON + hint -> per-project store.
+        assert_eq!(
+            resolve_sessions_root(&profile, &cwd, true, true),
+            cwd.join(".octos"),
+        );
+        // flag OFF + hint -> legacy (regression guard: flipping off is a no-op).
+        assert_eq!(resolve_sessions_root(&profile, &cwd, true, false), data_dir,);
+        // flag ON + NO hint (web-chat / gateway) -> legacy.
+        assert_eq!(resolve_sessions_root(&profile, &cwd, false, true), data_dir,);
+        // flag OFF + NO hint -> legacy.
+        assert_eq!(
+            resolve_sessions_root(&profile, &cwd, false, false),
+            data_dir,
+        );
+    }
+
+    #[tokio::test]
+    async fn bootstrap_relocates_store_to_cwd_when_flag_on() {
+        // A cwd-hinted AppUi session with the flag on persists its transcript
+        // under `<cwd>/.octos`, NOT under `profile.data_dir`. Sidecars that
+        // derive their path from `sessions.data_dir()` follow to the same
+        // root by construction (asserted via data_dir()).
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir.clone()).await;
+        let cwd = tmp.path().join("project");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let cwd_canon = std::fs::canonicalize(&cwd).unwrap();
+
+        let key = SessionKey::new("api", "coding");
+        let rt = SessionRuntime::bootstrap_in_cwd(&profile, key.clone(), Some(cwd.clone()), true)
+            .await
+            .expect("bootstrap in cwd");
+
+        // sessions_root and the manager's data_dir both point at <cwd>/.octos.
+        assert_eq!(rt.sessions_root, cwd_canon.join(".octos"));
+        {
+            let mgr = rt.sessions.lock().await;
+            assert_eq!(mgr.data_dir(), cwd_canon.join(".octos"));
+        }
+
+        // Persist a message and confirm the JSONL lives under <cwd>/.octos and
+        // NOT under the profile data dir.
+        let session_path = {
+            let mut mgr = rt.sessions.lock().await;
+            mgr.add_message(&key, Message::user("hello from the project"))
+                .await
+                .unwrap();
+            mgr.session_path(&key)
+        };
+        assert!(
+            session_path.starts_with(cwd_canon.join(".octos")),
+            "transcript must live under <cwd>/.octos: {}",
+            session_path.display()
+        );
+        assert!(
+            !session_path.starts_with(&data_dir),
+            "transcript must NOT live under profile.data_dir: {}",
+            session_path.display()
+        );
+        assert!(
+            session_path.exists(),
+            "transcript file should exist on disk"
+        );
+        // The profile data dir has no `users/` session tree for this key.
+        assert!(
+            !data_dir.join("users").exists()
+                || std::fs::read_dir(data_dir.join("users"))
+                    .map(|mut d| d.next().is_none())
+                    .unwrap_or(true),
+            "profile data dir must not accrue this session's transcript"
+        );
+    }
+
+    #[tokio::test]
+    async fn bootstrap_keeps_store_in_profile_when_flag_off() {
+        // Regression: with the flag OFF a cwd-hinted session is byte-identical
+        // to today — the store stays under profile.data_dir.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir.clone()).await;
+        let cwd = tmp.path().join("project");
+        std::fs::create_dir_all(&cwd).unwrap();
+
+        let key = SessionKey::new("api", "coding");
+        let rt = SessionRuntime::bootstrap_in_cwd(&profile, key.clone(), Some(cwd.clone()), false)
+            .await
+            .expect("bootstrap flag off");
+
+        assert_eq!(rt.sessions_root, data_dir);
+        let session_path = {
+            let mut mgr = rt.sessions.lock().await;
+            mgr.add_message(&key, Message::user("legacy"))
+                .await
+                .unwrap();
+            mgr.session_path(&key)
+        };
+        assert!(
+            session_path.starts_with(&data_dir),
+            "flag OFF must keep the store under profile.data_dir: {}",
+            session_path.display()
+        );
+        // Nothing was created under <cwd>/.octos.
+        assert!(
+            !cwd.join(".octos").exists(),
+            "flag OFF must not create a per-project store"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_hint_session_stays_in_profile_even_with_flag_on() {
+        // The gateway/web-chat guarantee: a NO-hint session ignores the flag
+        // (its "workspace" is the conventional data-dir path, not a project),
+        // so its store stays on profile.data_dir. This is what keeps per-cwd
+        // storage inert for the gateway path by construction.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir.clone()).await;
+
+        let key = SessionKey::new("api", "web-chat");
+        let rt = SessionRuntime::bootstrap_in_cwd(&profile, key, None, true)
+            .await
+            .expect("bootstrap no hint, flag on");
+
+        assert_eq!(
+            rt.sessions_root, data_dir,
+            "a no-hint session must stay on profile.data_dir even with the flag on"
+        );
+    }
+
+    #[tokio::test]
+    async fn two_cwds_same_key_do_not_collide() {
+        // The sharpest risk: the SAME logical session key opened against two
+        // different projects must not conflate transcripts. Per-cwd roots are
+        // separate file trees, so two runtimes with the same key + distinct
+        // hints persist to distinct files with no cross-contamination.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir.clone()).await;
+
+        let proj_a = tmp.path().join("project-a");
+        let proj_b = tmp.path().join("project-b");
+        std::fs::create_dir_all(&proj_a).unwrap();
+        std::fs::create_dir_all(&proj_b).unwrap();
+
+        // Same key, two projects.
+        let key = SessionKey::new("api", "default");
+        let rt_a =
+            SessionRuntime::bootstrap_in_cwd(&profile, key.clone(), Some(proj_a.clone()), true)
+                .await
+                .expect("bootstrap A");
+        let rt_b =
+            SessionRuntime::bootstrap_in_cwd(&profile, key.clone(), Some(proj_b.clone()), true)
+                .await
+                .expect("bootstrap B");
+
+        // Distinct roots — the isolation boundary.
+        assert_ne!(rt_a.sessions_root, rt_b.sessions_root);
+        assert!(rt_a.sessions_root.ends_with(".octos"));
+        assert!(rt_b.sessions_root.ends_with(".octos"));
+
+        // Write a distinct message through each runtime's own manager.
+        {
+            let mut mgr = rt_a.sessions.lock().await;
+            mgr.add_message(&key, Message::user("message-for-A"))
+                .await
+                .unwrap();
+        }
+        {
+            let mut mgr = rt_b.sessions.lock().await;
+            mgr.add_message(&key, Message::user("message-for-B"))
+                .await
+                .unwrap();
+        }
+
+        // Reload each project's store from scratch (fresh manager, no shared
+        // in-memory cache) and confirm each holds ONLY its own message.
+        let mut reload_a = SessionManager::open(&rt_a.sessions_root).unwrap();
+        let a = reload_a.get_or_create(&key).await;
+        assert_eq!(
+            a.messages.len(),
+            1,
+            "project A must have exactly its message"
+        );
+        assert_eq!(a.messages[0].content, "message-for-A");
+
+        let mut reload_b = SessionManager::open(&rt_b.sessions_root).unwrap();
+        let b = reload_b.get_or_create(&key).await;
+        assert_eq!(
+            b.messages.len(),
+            1,
+            "project B must have exactly its message"
+        );
+        assert_eq!(b.messages[0].content, "message-for-B");
+    }
+
+    #[tokio::test]
+    async fn cwd_store_writes_gitignore_idempotently() {
+        // A freshly-created per-project store gets a `.gitignore` so chat logs
+        // never leak into the user's repo; a pre-existing one is never
+        // clobbered.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir).await;
+        let cwd = tmp.path().join("project");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let cwd_canon = std::fs::canonicalize(&cwd).unwrap();
+
+        let rt = SessionRuntime::bootstrap_in_cwd(
+            &profile,
+            SessionKey::new("api", "gi"),
+            Some(cwd.clone()),
+            true,
+        )
+        .await
+        .expect("bootstrap");
+
+        let gitignore = rt.sessions_root.join(".gitignore");
+        assert_eq!(rt.sessions_root, cwd_canon.join(".octos"));
+        assert!(
+            gitignore.exists(),
+            "per-project store must have a .gitignore"
+        );
+        let body = std::fs::read_to_string(&gitignore).unwrap();
+        assert!(body.contains("sessions/"));
+        assert!(body.contains("users/"));
+
+        // Idempotent + non-clobbering: hand-edit it, re-run the helper, and
+        // confirm the operator's content survives.
+        std::fs::write(&gitignore, "custom operator content\n").unwrap();
+        ensure_session_store_gitignore(&rt.sessions_root);
+        assert_eq!(
+            std::fs::read_to_string(&gitignore).unwrap(),
+            "custom operator content\n",
+            "existing .gitignore must never be clobbered"
+        );
+    }
+
+    #[tokio::test]
+    async fn fork_and_rollback_resolve_through_cwd_root() {
+        // hydrate/rollback/fork all operate on the session runtime's own
+        // `SessionManager` (resolved via `resolve_sessions_for_lookup` in the
+        // dispatcher), so once the manager is rooted at `<cwd>/.octos` they
+        // follow automatically. Prove it for fork + rollback: a child forked
+        // from a cwd-scoped session lands under the SAME `<cwd>/.octos` root,
+        // and a rollback rewrites there too.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir.clone()).await;
+        let cwd = tmp.path().join("project");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let cwd_canon = std::fs::canonicalize(&cwd).unwrap();
+
+        let key = SessionKey::new("api", "parent");
+        let rt = SessionRuntime::bootstrap_in_cwd(&profile, key.clone(), Some(cwd), true)
+            .await
+            .expect("bootstrap");
+
+        let child_path = {
+            let mut mgr = rt.sessions.lock().await;
+            // User rows only: the new write path requires a caller-supplied
+            // thread_id for Assistant/Tool rows, and this test only cares
+            // about the on-disk ROOT, not the transcript shape.
+            mgr.add_message(&key, Message::user("q1")).await.unwrap();
+            mgr.add_message(&key, Message::user("q2")).await.unwrap();
+            let child = mgr.fork(&key, "child-1", 2).await.expect("fork");
+            mgr.session_path(&child)
+        };
+        assert!(
+            child_path.starts_with(cwd_canon.join(".octos")),
+            "forked child must live under <cwd>/.octos: {}",
+            child_path.display()
+        );
+        assert!(
+            !child_path.starts_with(&data_dir),
+            "forked child must NOT live under profile.data_dir"
+        );
+
+        // Rollback rewrites in-place under the same root.
+        {
+            let mut mgr = rt.sessions.lock().await;
+            mgr.rollback_last_n_user_turns(&key, 1)
+                .await
+                .expect("rollback");
+            let parent_path = mgr.session_path(&key);
+            assert!(
+                parent_path.starts_with(cwd_canon.join(".octos")),
+                "rollback must rewrite under <cwd>/.octos: {}",
+                parent_path.display()
+            );
+        }
     }
 }

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -2986,9 +2986,26 @@ pub struct TurnStateGetResult {
 // `StatusResponse`, `ContentEntry`) into the protocol crate. The shapes
 // are unchanged from the REST contract — only the transport flips.
 
-/// Params for `session/list` — empty request.
+/// Params for `session/list`.
+///
+/// Historically an empty request (`{}`). The optional `cwd` field is an
+/// **additive** extension for per-project session storage
+/// (`appui.sessions_in_cwd`): when a client supplies it (and has negotiated
+/// [`UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1`]), a server with the flag
+/// enabled lists the sessions stored under `<cwd>/.octos` instead of the
+/// per-profile global store. It is `#[serde(default, skip_serializing_if =
+/// "Option::is_none")]` so old clients that send `{}` still deserialize
+/// (→ `cwd: None` → legacy global listing) and the wire shape of a
+/// no-cwd request is byte-identical to the historical empty object.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SessionListParams {}
+pub struct SessionListParams {
+    /// Optional project working directory. When present, honored by a
+    /// server with `appui.sessions_in_cwd` enabled to scope the listing to
+    /// that project's `<cwd>/.octos` session store. Absent → legacy
+    /// per-profile/global listing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+}
 
 /// Result for `session/list`. `sessions` is the JSON array the existing
 /// `GET /api/sessions` handler emits (one `SessionInfo` per entry, per
@@ -11327,14 +11344,32 @@ mod tests {
     /// REST DTO to fail this test before it lands.
     #[test]
     fn aux_rest_to_ws_v1_request_dtos_match_json_goldens() {
-        // session/list — empty params
+        // session/list — default (no cwd) params still serialize to the
+        // historical empty object. The `cwd` field is
+        // `skip_serializing_if = "Option::is_none"`, so an additive optional
+        // field does NOT break the pinned wire shape: a no-cwd request is
+        // byte-identical to the legacy `{}`.
         assert_eq!(
             serde_json::to_value(SessionListParams::default()).expect("serialize"),
             serde_json::json!({}),
         );
+        // Old clients that send a bare `{}` still deserialize (→ cwd: None).
         let parsed: SessionListParams =
             serde_json::from_value(serde_json::json!({})).expect("decode");
         assert_eq!(parsed, SessionListParams::default());
+        assert_eq!(parsed.cwd, None);
+        // session/list — WITH the additive cwd (per-project storage). Pin the
+        // new wire shape so a rename/type-flip of the field fails here.
+        let with_cwd = SessionListParams {
+            cwd: Some("/home/me/proj".into()),
+        };
+        assert_eq!(
+            serde_json::to_value(&with_cwd).expect("serialize"),
+            serde_json::json!({ "cwd": "/home/me/proj" }),
+        );
+        let parsed_cwd: SessionListParams =
+            serde_json::from_value(serde_json::json!({ "cwd": "/home/me/proj" })).expect("decode");
+        assert_eq!(parsed_cwd, with_cwd);
 
         // session/snapshot
         let p = SessionSnapshotParams {


### PR DESCRIPTION
Phase 4 of the config redesign. Relocates AppUi/stdio cwd-hinted session storage from the global per-profile store to **`<cwd>/.octos/sessions/`**, so resume/`/sessions` shows the current project's conversations. Behind a **default-OFF** `appui.sessions_in_cwd` flag — flag off is byte-identical; gateway + no-cwd web-chat unaffected by construction.

- Store is root-parameterized, so it's 'pass a different root', not a rewrite.
- Cross-cwd isolation via separate file trees (keeps first-cwd-wins security semantics).
- `session/list` gains optional `cwd` (additive, `{}` when absent — golden test green); gated on flag + `session.workspace_cwd.v1`.
- Selective `.octos/.gitignore` written on first creation.
- Migration: existing global sessions left in place (SessionMeta has no cwd). 3 residual risks documented.
- octos-core 309 + octos-bus + octos-cli 2360 tests green.

**Client follow-up (separate):** octos-tui sends `cwd` on `session/list` + pins octos-core ≥ this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)