### PR TITLE
ci: stabilize octos-agent integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,8 +300,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # `lib` runs `--lib` only. `integration` runs `--tests` (every
-        # integration test binary).
+        # `lib` runs `--lib` only. `integration` selects every integration
+        # test target with `--test '*'` without rebuilding the lib unit-test
+        # harness, which `--tests` includes by default.
         # Splitting these onto separate runners means each gets a fresh
         # 16GB allocation and neither inherits residual RAM from the
         # other's compile phase.
@@ -329,6 +330,14 @@ jobs:
 
       - name: Test octos-agent (integration)
         if: matrix.test-mode == 'integration'
+        env:
+          # Keep a cache miss viable on the standard runner. This shard links
+          # many test binaries, so omit debug info to reduce disk and peak RSS.
+          CARGO_PROFILE_TEST_DEBUG: "0"
+          CARGO_PROFILE_DEV_DEBUG: "0"
+        # `--tests` also builds and runs the lib unit-test harness, duplicating
+        # the lib matrix job. The quoted target glob selects integration tests
+        # only and prevents the shell from expanding it before Cargo sees it.
         # --test-threads=1: validator_runner.rs::should_kill_child_process_on_validator_timeout
         # spawns a `sh -c "... sleep 30"` child to test the kill path. Under the
         # default thread-per-core parallelism, multiple validator-timeout tests
@@ -337,7 +346,7 @@ jobs:
         # after the preceding test passes). Serialising the integration tests
         # eliminates the pileup. The full integration suite still finishes
         # comfortably within the runner's 6h budget.
-        run: cargo test -p octos-agent --tests -- --test-threads=1
+        run: cargo test -p octos-agent --test '*' -- --test-threads=1
 
 
   test-octos-cli:


### PR DESCRIPTION
## Summary

- Select all `octos-agent` integration test targets with `--test '*'` instead of `--tests`.
- Disable test-profile debug info only for the integration shard to reduce cold-build disk usage and linker peak RSS.
- Preserve the existing `lib` shard, serial test execution, matrix shape, and check names.

## Root cause

Several otherwise unrelated pull requests are failing the same `test-octos-agent (integration)` check after approximately 52 minutes:

- #1663
- #1661
- #1651
- #1637

Each failed job has the same GitHub annotation: the hosted runner lost communication with the server. The step never reported a Rust test assertion failure, and the post-job cache and checkout steps did not run. A `main` push showed the same failure, so this is a shared workflow problem rather than a defect in each feature branch.

The current integration command uses `cargo test -p octos-agent --tests`. Cargo's plural `--tests` selector does not mean "integration tests only". By default, it includes library and binary unit-test targets as well as integration tests, and may build the library twice: once as a unit-test harness and once as an integration-test dependency.

The most recent successful job log confirms the duplication in this repository: the integration shard first ran the `octos-agent` library harness with 2,044 tests, then ran the package's integration test binaries. The matrix already has a separate `cargo test -p octos-agent --lib` shard, so that work and its large link artifact are redundant.

## Behavior difference

| Command | Selected targets |
| --- | --- |
| `cargo test -p octos-agent --tests` | Library unit tests, eligible binary unit tests, and all integration tests |
| `cargo test -p octos-agent --test '*'` | All named integration test targets only |

The glob is quoted so the shell passes it to Cargo unchanged. Cargo expands it across all 47 integration test targets currently declared by `octos-agent`.

## Why this change

The integration shard succeeds quickly when its approximately 828 MB Rust cache is available, but the current cold build repeatedly exhausts the standard hosted runner. Removing the duplicate library test harness lowers compile and link work without reducing coverage. Disabling debug info for this one heavy shard further reduces disk consumption and peak linker memory while leaving line-table debug information enabled for the separate library shard.

This belongs in one centralized CI pull request because the failure is present on `main` and affects multiple unrelated feature branches. Fixing every feature branch independently would duplicate the same workflow change.

## Coverage and compatibility

- Library unit-test coverage remains in the existing `lib` matrix job.
- All 47 integration test targets remain selected by the quoted Cargo glob.
- `--test-threads=1` remains in place for validator timeout tests.
- Existing matrix values and GitHub check names are unchanged.

## Validation

- Parsed `.github/workflows/ci.yml` successfully as YAML (18 jobs).
- Confirmed through `cargo metadata` that `octos-agent` exposes 47 integration test targets.
- Confirmed that Cargo accepts quoted glob patterns for `--test` target selection.
- Ran `git diff --check`.

The remaining validation is the GitHub-hosted Linux cold-cache run started by this draft pull request.
