### PR TITLE
feat(chat): add `octos chat --json` for machine-readable one-shot output

### DIFF
--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -12,8 +12,9 @@ use eyre::{Result, WrapErr, eyre};
 use octos_agent::compaction::CompactionRunner;
 use octos_agent::{
     Agent, AgentConfig, CompactionSummarizerKind, ConsoleReporter, ConversationResponse,
-    HookExecutor, ToolApprovalDecision, ToolApprovalRequest, ToolApprovalRequester, ToolRegistry,
-    UserQuestionOutcome, UserQuestionRequest, UserQuestionRequester, read_workspace_policy,
+    HookExecutor, ProgressReporter, SilentReporter, ToolApprovalDecision, ToolApprovalRequest,
+    ToolApprovalRequester, ToolRegistry, UserQuestionOutcome, UserQuestionRequest,
+    UserQuestionRequester, read_workspace_policy,
 };
 use octos_core::ui_protocol::UserQuestionAnswer;
 use octos_core::{AgentId, Message, MessageRole, SessionScope};
@@ -80,6 +81,17 @@ pub struct ChatCommand {
     /// Send a single message and exit (non-interactive mode).
     #[arg(short, long)]
     pub message: Option<String>,
+
+    /// Emit the result as a single JSON object on stdout (logs + UI go to
+    /// stderr); intended for scripting / one-shot `--message` use. Requires
+    /// `--message`: interactive `--json` is rejected (a REPL cannot keep
+    /// stdout pure). On any runtime error a `{"error": "..."}` object is
+    /// printed to stdout and the process exits non-zero, so stdout is always
+    /// parseable — for a valid invocation. (Argument errors and `--help` are
+    /// handled by the arg parser and follow normal CLI conventions: usage/help
+    /// text and a non-zero exit, not a JSON object.)
+    #[arg(long)]
+    pub json: bool,
 
     /// Runtime profile to apply at startup (M8.3). Accepts a built-in name
     /// (`coding`, `coding-full`, `swarm`), a user-dir id under
@@ -526,19 +538,123 @@ async fn process_chat_turn(
     .await
 }
 
+/// Machine-readable result envelope for `octos chat --json --message`.
+///
+/// Serialized as a single JSON object — the ONLY thing `--json` writes to
+/// stdout on success. Deliberately limited to the fields the completed
+/// [`ConversationResponse`] reports as ground truth (final text, answering
+/// model, token usage). Turn telemetry — a real terminal stop reason, the loop
+/// iteration count, the executed tool-call count — is intentionally omitted:
+/// `ConversationResponse` does not carry those, and deriving them from the
+/// message list is wrong in edge cases (budget / max-token cutoffs mislabel the
+/// stop reason; the loop detector inserts synthetic tool-result rows that
+/// overstate tool calls). Surfacing them correctly needs an octos-agent change
+/// to populate them at every turn return site — deferred to a follow-up.
+#[derive(Debug, serde::Serialize)]
+struct ChatJsonResult {
+    /// Final assistant text for this turn.
+    text: String,
+    /// Model that actually produced the answer (e.g. `glm-5.2`). Taken from the
+    /// final reply's provider provenance, so adaptive failover to a fallback
+    /// lane is reported honestly.
+    model: String,
+    /// Prompt tokens consumed across the turn.
+    input_tokens: u32,
+    /// Completion tokens produced across the turn.
+    output_tokens: u32,
+    // NOTE: intentionally limited to fields `ConversationResponse` reports as
+    // ground truth. Turn telemetry (a real terminal `stop_reason`, the loop
+    // iteration count, executed tool-call count) is deferred to a follow-up:
+    // `ConversationResponse` does not carry those, and deriving them from
+    // `messages` is wrong in edge cases (budget/max-token cutoffs mislabel the
+    // stop reason; the loop detector inserts synthetic tool-result rows that
+    // overstate tool calls). Surfacing them correctly needs an octos-agent
+    // change to populate them at every turn return site.
+}
+
+impl ChatJsonResult {
+    /// Build the envelope from a completed turn. `fallback_model` is the
+    /// configured model id, used only when the reply carries no provider
+    /// provenance.
+    fn from_response(response: &ConversationResponse, fallback_model: &str) -> Self {
+        // Prefer the provenance of the FINAL reply: adaptive failover can answer
+        // from a different lane than the primary provider, and the caller should
+        // see the model that actually produced the text.
+        let model = response
+            .provider_metadata
+            .as_ref()
+            .map(|m| m.model.clone())
+            .unwrap_or_else(|| fallback_model.to_string());
+        Self {
+            text: response.content.clone(),
+            model,
+            input_tokens: response.token_usage.input_tokens,
+            output_tokens: response.token_usage.output_tokens,
+        }
+    }
+
+    /// Serialize to a single-line JSON string (nice for piping). This fixed
+    /// string/number-only struct cannot realistically fail to serialize; if it
+    /// ever did, fall back to a valid JSON error object so stdout stays
+    /// parseable.
+    fn to_json_line(&self) -> String {
+        serde_json::to_string(self)
+            .unwrap_or_else(|_| "{\"error\":\"failed to serialize chat result\"}".to_string())
+    }
+}
+
+/// Emit `{"error": "<message>"}` on stdout (so a `--json` caller can always
+/// parse stdout) and flush. Used on the `--json` error paths before a
+/// non-zero exit; `serde_json` handles all string escaping.
+fn print_json_error(message: &str) {
+    let obj = serde_json::json!({ "error": message });
+    println!("{obj}");
+    let _ = io::stdout().flush();
+}
+
 impl Executable for ChatCommand {
     fn execute(self) -> Result<()> {
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .thread_stack_size(8 * 1024 * 1024) // 8MB stack for deep agent futures
-            .build()
-            .wrap_err("failed to create tokio runtime")?
-            .block_on(self.run_async())
+        // Capture before `self` is moved: in `--json` mode ANY failure —
+        // provider/config bootstrap or the turn itself — must surface as a
+        // `{"error": ...}` object on stdout with a non-zero exit, so a caller
+        // can always parse stdout instead of hitting an empty stream + an eyre
+        // report on stderr.
+        let json = self.json;
+        // Build the runtime and run the turn inside one fallible block so that
+        // EVERY failure — including a runtime-build failure — is caught by the
+        // `--json` arm below rather than escaping as a bare `?` before it.
+        let outcome = (|| -> Result<()> {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .thread_stack_size(8 * 1024 * 1024) // 8MB stack for deep agent futures
+                .build()
+                .wrap_err("failed to create tokio runtime")?;
+            runtime.block_on(self.run_async())
+        })();
+        match outcome {
+            Ok(()) => Ok(()),
+            Err(error) if json => {
+                print_json_error(&error.to_string());
+                std::process::exit(1);
+            }
+            Err(error) => Err(error),
+        }
     }
 }
 
 impl ChatCommand {
     async fn run_async(self) -> Result<()> {
+        // `--json` is a one-shot, machine-readable mode: exactly one JSON
+        // object on stdout, and it requires `--message`. An interactive REPL
+        // cannot keep stdout pure (the readline prompt and per-turn framing
+        // would interleave with the JSON), so reject `--json` without
+        // `--message` up front — emitted as a JSON error so even this failure
+        // is parseable on stdout — before doing any provider/agent bootstrap.
+        if self.json && self.message.is_none() {
+            print_json_error("--json requires --message (interactive --json is not supported)");
+            std::process::exit(2);
+        }
+
         let cwd = match self.cwd {
             Some(p) => p,
             None => std::env::current_dir().wrap_err("failed to get current directory")?,
@@ -580,7 +696,11 @@ impl ChatCommand {
         let api_type = self.api_type.as_deref().or(config.api_type.as_deref());
         let base_provider: Arc<dyn LlmProvider> =
             create_provider_with_api_type(&provider_name, &config, model, base_url, api_type)?;
-        eprintln!("{}: {}", "Model".green(), base_provider.model_id());
+        // Status line goes to stderr; suppress it entirely in `--json` mode to
+        // keep even stderr quiet for scripting.
+        if !self.json {
+            eprintln!("{}: {}", "Model".green(), base_provider.model_id());
+        }
         let model_id = base_provider.model_id().to_string();
 
         let llm: Arc<dyn LlmProvider> = if self.no_retry {
@@ -916,8 +1036,15 @@ impl ChatCommand {
             .filter(|cfg| cfg.enabled)
             .map(|cfg| Arc::new(octos_llm::ContentClassifier::new(cfg.clone())));
 
-        // Create agent
-        let reporter = Arc::new(ConsoleReporter::new().with_verbose(self.verbose));
+        // Create agent. In `--json` mode nothing may reach stdout except the
+        // final result object, so silence the console reporter — its spinner,
+        // `◆` answer preview, streamed chunks, and tool-progress lines all
+        // print to stdout.
+        let reporter: Arc<dyn ProgressReporter> = if self.json {
+            Arc::new(SilentReporter)
+        } else {
+            Arc::new(ConsoleReporter::new().with_verbose(self.verbose))
+        };
         let agent_config = AgentConfig {
             max_iterations: self.max_iterations,
             save_episodes: true,
@@ -1158,10 +1285,22 @@ impl ChatCommand {
         let approval_requester: Arc<dyn ToolApprovalRequester> =
             Arc::new(CliApprovalRequester::default());
 
-        // Single-message mode: send one message and exit
+        // Single-message mode: send one message and exit.
         if let Some(msg) = self.message {
             let response =
                 process_chat_turn(&agent, &msg, &[], Arc::clone(&approval_requester)).await?;
+            if self.json {
+                // JSON mode: emit exactly one machine-readable result object on
+                // stdout (the reporter is silent and every status line goes to
+                // stderr). A turn failure propagates via `?` and is rendered as
+                // a JSON error at the `execute` boundary.
+                println!(
+                    "{}",
+                    ChatJsonResult::from_response(&response, &model_id).to_json_line()
+                );
+                let _ = io::stdout().flush();
+                return Ok(());
+            }
             if !response.streamed {
                 println!("{}", response.content);
             }
@@ -1652,6 +1791,74 @@ mod tests {
 
         // Absent by default (falls back to config's api_type at runtime).
         assert_eq!(Wrap::parse_from(["prog"]).chat.api_type, None);
+    }
+
+    // ---- `--json` result envelope ----
+
+    #[test]
+    fn should_serialize_chat_json_result_with_expected_shape() {
+        // The `--json` envelope is a single-line object with every documented
+        // key, in declaration order, so an agent/script can parse it directly.
+        let result = ChatJsonResult {
+            text: "hello world".to_string(),
+            model: "glm-5.2".to_string(),
+            input_tokens: 4582,
+            output_tokens: 7,
+        };
+        let json = serde_json::to_string(&result).expect("envelope must serialize");
+        assert_eq!(
+            json,
+            r#"{"text":"hello world","model":"glm-5.2","input_tokens":4582,"output_tokens":7}"#
+        );
+
+        // And it parses back to the exact fields/values a caller reads.
+        let value: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        assert_eq!(value["text"], "hello world");
+        assert_eq!(value["model"], "glm-5.2");
+        assert_eq!(value["input_tokens"], 4582);
+        assert_eq!(value["output_tokens"], 7);
+    }
+
+    #[test]
+    fn should_build_envelope_from_conversation_response() {
+        // The envelope carries ground-truth fields only: text + token usage pass
+        // through, and `model` comes from the final reply's provider provenance
+        // so adaptive failover is reported honestly — falling back to the
+        // configured id only when the reply carries no provenance.
+        let build = |provider_metadata: Option<octos_llm::ProviderMetadata>| ConversationResponse {
+            content: "final answer".to_string(),
+            reasoning_content: None,
+            provider_metadata,
+            token_usage: octos_core::TokenUsage {
+                input_tokens: 100,
+                output_tokens: 5,
+                ..Default::default()
+            },
+            estimated_spend_usd: None,
+            files_modified: vec![],
+            files_to_send: vec![],
+            streamed: false,
+            messages: vec![],
+            tool_results: vec![],
+            synthesized_from_spawn_only: false,
+            pending_approval: None,
+        };
+
+        // No provenance → fall back to the configured model id.
+        let fallback = build(None);
+        let envelope = ChatJsonResult::from_response(&fallback, "glm-5.2");
+        assert_eq!(envelope.text, "final answer");
+        assert_eq!(envelope.model, "glm-5.2");
+        assert_eq!(envelope.input_tokens, 100);
+        assert_eq!(envelope.output_tokens, 5);
+
+        // Failover: the reply came from a different lane than the configured id
+        // → report the model that actually answered, not the fallback.
+        let routed = build(Some(octos_llm::ProviderMetadata::new(
+            "zai", "glm-4.7", None,
+        )));
+        let envelope = ChatJsonResult::from_response(&routed, "glm-5.2");
+        assert_eq!(envelope.model, "glm-4.7");
     }
 
     // ---- #1570: [y/s/N] approval prompt + numbered user-question prompt ----

--- a/crates/octos-cli/src/commands/mod.rs
+++ b/crates/octos-cli/src/commands/mod.rs
@@ -144,6 +144,26 @@ pub enum Command {
     Office(OfficeCommand),
 }
 
+/// Whether `command` emits machine-readable output on stdout and therefore
+/// needs the tracing console layer routed to stderr so logs never corrupt that
+/// stream.
+///
+/// * `acp` speaks ACP JSON-RPC on stdout (one stray log line → a `-32700`
+///   parse error at strict clients like Zed);
+/// * `mcp-serve --transport stdio` speaks MCP JSON-RPC on stdout;
+/// * `profile` emits payloads meant for `$(...)` capture / piping;
+/// * `chat --json` emits a single JSON result object on stdout (scripting /
+///   agent-to-agent).
+///
+/// Every other command keeps its historical stdout console routing untouched.
+pub fn reserve_stdout(command: &Command) -> bool {
+    match command {
+        Command::Acp(_) | Command::Profile(_) | Command::McpServe(_) => true,
+        Command::Chat(cmd) => cmd.json,
+        _ => false,
+    }
+}
+
 /// Trait for executable commands (following dora-rs pattern).
 pub trait Executable {
     fn execute(self) -> Result<()>;
@@ -349,5 +369,46 @@ impl Executable for Command {
             Self::Completions(cmd) => cmd.execute(),
             Self::Office(cmd) => cmd.execute(),
         }
+    }
+}
+
+#[cfg(test)]
+mod reserve_stdout_tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn should_reserve_stdout_when_chat_json_set() {
+        // `octos chat --json` opts into a pure-stdout JSON result stream, so
+        // its tracing logs must route to stderr.
+        let args = Args::try_parse_from(["octos", "chat", "--json", "--message", "hi"])
+            .expect("`chat --json` must parse");
+        assert!(reserve_stdout(&args.command));
+    }
+
+    #[test]
+    fn should_not_reserve_stdout_when_chat_lacks_json() {
+        // Plain `octos chat` keeps its historical stdout console routing.
+        let args =
+            Args::try_parse_from(["octos", "chat", "--message", "hi"]).expect("`chat` must parse");
+        assert!(!reserve_stdout(&args.command));
+    }
+
+    #[test]
+    fn should_not_reserve_stdout_for_ordinary_command() {
+        // A non-protocol command (e.g. `status`) is unchanged by the chat-json
+        // extension — Serve, Status, etc. never reserve stdout.
+        let args = Args::try_parse_from(["octos", "status"]).expect("`status` must parse");
+        assert!(!reserve_stdout(&args.command));
+    }
+
+    #[test]
+    fn should_reserve_stdout_for_stdio_protocol_commands() {
+        // Pre-existing reservations must remain: acp / mcp-serve speak a
+        // machine protocol on stdout.
+        let acp = Args::try_parse_from(["octos", "acp"]).expect("`acp` must parse");
+        assert!(reserve_stdout(&acp.command));
+        let mcp = Args::try_parse_from(["octos", "mcp-serve"]).expect("`mcp-serve` must parse");
+        assert!(reserve_stdout(&mcp.command));
     }
 }

--- a/crates/octos-cli/src/main.rs
+++ b/crates/octos-cli/src/main.rs
@@ -47,18 +47,12 @@ fn main() -> Result<()> {
         log_dir = Some(dir);
     }
 
-    // Initialize tracing (with optional rolling file output for serve).
-    // `octos acp` speaks ACP JSON-RPC on STDOUT, so its logs MUST NOT touch
-    // stdout — one stray log line corrupts the protocol stream and strict
-    // clients (Zed) reject it all with a -32700 parse error. Route to stderr.
-    // `octos mcp-serve --transport stdio` speaks MCP JSON-RPC on STDOUT for
-    // the same reason (and stderr logging is harmless for its http transport).
-    // `octos profile` emits payloads meant for `$(...)` capture and piping
-    // (`qr --payload-only`, `decode`), so it reserves stdout the same way.
-    let reserve_stdout = matches!(
-        args.command,
-        commands::Command::Acp(_) | commands::Command::Profile(_) | commands::Command::McpServe(_)
-    );
+    // Initialize tracing (with optional rolling file output for serve). Some
+    // commands emit a machine-readable stream on STDOUT (ACP/MCP JSON-RPC,
+    // `profile` payloads, `chat --json`) and must keep it pure — one stray log
+    // line corrupts it — so their console logs are routed to stderr. See
+    // [`commands::reserve_stdout`] for the exact set.
+    let reserve_stdout = commands::reserve_stdout(&args.command);
     let _log_guard = init_tracing(log_dir.as_deref(), reserve_stdout)?;
 
     args.command.execute()


### PR DESCRIPTION
## `octos chat --json` — machine-readable one-shot output

The octos equivalent of `codex --json`: a pure-stdout mode so **another agent** can call `octos chat` and parse the result, instead of scraping logs interleaved with the answer.

```console
$ octos chat --json --message "Reply with one word: pong" --provider zai --model glm-5.2 …
{"text":"pong","model":"glm-5.2","input_tokens":4220,"output_tokens":2}
```

### Contract
- **stdout is exactly one JSON object** — the envelope on success, or `{"error":"…"}` on any runtime failure (non-zero exit). All logs, the `Model:` line, spinner/preview chrome, and approval/question prompts go to **stderr** (`reserve_stdout` gains `Chat(cmd) if cmd.json`; a `SilentReporter` replaces the console reporter).
- Requires `--message` (interactive `--json` is rejected as a JSON error, exit 2). Arg-parse errors and `--help` stay clap's domain (usage/help text, non-zero exit) — documented on the flag.
- **Non-`--json` behavior is byte-identical** — every stdout/reporter change is gated behind `self.json`.
- Composes with `--model` / `--provider` / `--base-url` / `--api-type` / `--yolo` / `--sandbox` (output-only flag).

### Envelope fields — deliberately ground-truth only
`{text, model, input_tokens, output_tokens}`. `model` is taken from the final reply's `provider_metadata` (so adaptive **failover** to a fallback lane is reported honestly), falling back to the configured id only when absent.

Turn telemetry (`stop_reason`, `iterations`, `tool_calls`) was **intentionally left out**: `ConversationResponse` carries no ground truth for them, and deriving them from the message list is wrong in edge cases — budget/max-token cutoffs mislabel the stop reason, and the loop detector inserts synthetic tool-result rows that overstate tool calls (both caught in review). Surfacing them correctly needs an octos-agent change to populate them at every turn return site — **deferred to a follow-up** rather than shipping fields that lie.

### Verification
- **Live** against z.ai / glm-5.2: successful turn → exactly one JSON line on stdout (exit 0, logs on stderr); missing-key → `{"error":"ZAI_API_KEY not set…"}` on stdout (exit 1).
- `octos-cli --features api --lib`: **2356 passed, 0 failed**; `cargo fmt --check` clean; no new clippy warnings.
- **Codex-reviewed (2 rounds)**: round 1 flagged the telemetry fields + a `model`-before-failover bug + a runtime-build `?` that escaped the JSON error handler; all addressed (trim + provenance model + fallible-closure wrap). Round 2: CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
