### PR TITLE
fix(appui): per-project isolation for ledger + context stores (sessions_in_cwd flag-ON leak)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2668,6 +2668,50 @@ fn combine_typed_prompt_with_transcript(typed_prompt: &str, transcript: &str) ->
     }
 }
 
+/// Register the per-project ledger storage scope for a just-materialized
+/// [`SessionRuntime`] — the UI-protocol half of `appui.sessions_in_cwd`
+/// isolation (#1666).
+///
+/// The ledger is a process-global singleton rooted at the serve data dir, and
+/// it keys each session's ring/dir by the session id alone. With
+/// `sessions_in_cwd` the SAME wire id can belong to different projects, so a
+/// relocated session (`sessions_root != profile.data_dir`) registers a
+/// 16-hex digest of its canonical `sessions_root`; the ledger then keeps that
+/// project's events under a distinct storage identity. Flag-OFF (or no cwd
+/// hint) resolves `sessions_root == profile.data_dir` → scope `None` →
+/// byte-identical legacy behavior (and clears a stale registration if the
+/// flag was toggled off).
+///
+/// MUST be called before the flow replays the session (`session/open` calls
+/// it right after the runtime cache materializes, before
+/// `replay_after_with_head`) so replay and subsequent appends agree.
+fn register_session_ledger_scope(
+    ledger: &UiProtocolLedger,
+    runtime: &crate::runtime::SessionRuntime,
+) {
+    let scope = (runtime.sessions_root != runtime.profile.data_dir).then(|| {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(runtime.sessions_root.as_os_str().as_encoded_bytes());
+        hasher.finalize()[..8]
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>()
+    });
+    ledger.set_session_scope(&runtime.session_key, scope.clone());
+    // Topic-suffixed sessions also emit ledger events under their BASE key:
+    // the alpha-9 file/visual bridges deliberately strip the `#topic` before
+    // appending so base-bucket subscribers see them (see
+    // `ui_protocol_alpha9_bridge.rs`). Register the base alias with the same
+    // scope so those appends land in the same per-project dir instead of the
+    // unscoped legacy one (codex v2 P2). Same cwd → same scope, so this can
+    // never mis-route a different project's base-key session.
+    let base = runtime.session_key.base_key();
+    if base != runtime.session_key.0 {
+        ledger.set_session_scope(&SessionKey(base.to_owned()), scope);
+    }
+}
+
 /// Process-global event ledger.
 ///
 /// First call decides the durability path:
@@ -10498,6 +10542,11 @@ async fn open_session_result(
             .await
         {
             Ok(runtime) => {
+                // Per-project ledger isolation (#1666): registered BEFORE the
+                // `replay_after_with_head` below, so this open replays (and
+                // this session's turns later append) under the per-cwd
+                // storage identity. No-op when the store wasn't relocated.
+                register_session_ledger_scope(ledger, &runtime);
                 effective_workspace_root = Some(runtime.workspace_root.clone());
             }
             Err(error) => {
@@ -18671,6 +18720,11 @@ async fn run_native_code_review_turn(
             return;
         }
     };
+    // Per-project ledger isolation (#1666): the review turn appends durable
+    // task/turn events for this session — same idempotent registration as
+    // `run_standalone_turn`, covering runtimes that re-materialized without
+    // a fresh `session/open`.
+    register_session_ledger_scope(&ledger, &session_runtime);
 
     let profile_id = session_id
         .profile_id()
@@ -20260,6 +20314,12 @@ async fn run_standalone_turn(
             return;
         }
     };
+    // Per-project ledger isolation (#1666): every event this turn appends
+    // must land under the session's per-cwd storage identity. `session/open`
+    // registered it already for the normal flow; re-registering here is an
+    // idempotent no-op that also covers turns whose runtime re-materialized
+    // (e.g. after cache eviction) without a fresh open.
+    register_session_ledger_scope(&ledger, &session_runtime);
     let usage_profile_id = active_profile_id
         .clone()
         .or_else(|| session_id.profile_id().map(ToOwned::to_owned))
@@ -20568,7 +20628,15 @@ async fn run_standalone_turn(
     };
     let (history, context_manager, context_lifecycle_notifications) =
         appui_context_history_for_agent(
-            &session_runtime.profile.data_dir,
+            // Root the context ledger at the session's TRANSCRIPT root, not the
+            // profile-global data dir: with `appui.sessions_in_cwd` the
+            // transcript relocates to `<cwd>/.octos/<profile>` and a
+            // profile-rooted context ledger is SHARED across projects that
+            // reuse the same session key — project B's snapshot would beat
+            // project A's raw history on rebuild and leak B's conversation
+            // into A's LLM context (#1666). Flag-OFF: `sessions_root ==
+            // profile.data_dir`, byte-identical.
+            &session_runtime.sessions_root,
             &session_id,
             &raw_history,
             &llm_provider,
@@ -21162,7 +21230,11 @@ async fn run_standalone_turn(
             spawn_tool = spawn_tool.with_parent_subagent_summary_generator(generator);
         }
         let child_context_parent = context_manager.clone();
-        let child_context_data_dir = session_runtime.profile.data_dir.clone();
+        // Child (forked sub-agent) context ledgers belong to the parent's
+        // project store: with `appui.sessions_in_cwd` on, `sessions_root` is
+        // the per-cwd root; profile-rooting them would leak child context
+        // across projects sharing a child key (#1666). Flag-OFF: identical.
+        let child_context_data_dir = session_runtime.sessions_root.clone();
         let child_context_parent_session = session_id.clone();
         spawn_tool = spawn_tool.with_child_prompt_context_manager_factory(Arc::new(
             move |request: octos_agent::tools::spawn::ChildPromptContextRequest| {
@@ -21458,7 +21530,10 @@ async fn run_standalone_turn(
     };
     let mut prompt_context_bridge_inner = AppUiPromptContextBridge::new(
         session_id.clone(),
-        session_runtime.profile.data_dir.clone(),
+        // Mid-turn (compaction-bridge) context persists share the transcript
+        // root — per-cwd under `appui.sessions_in_cwd` — for the same
+        // cross-project isolation as the pre/post-turn sites above (#1666).
+        session_runtime.sessions_root.clone(),
         context_manager.clone(),
         voice_turn_hint,
     )
@@ -21593,7 +21668,10 @@ async fn run_standalone_turn(
     let turn_thread_id_for_persist = turn_id.0.to_string();
     let turn_thread_id_for_done = turn_thread_id_for_persist.clone();
     let context_manager_for_result = context_manager.clone();
-    let context_data_dir_for_result = session_runtime.profile.data_dir.clone();
+    // Post-turn context persists go to the session's transcript root (per-cwd
+    // when `appui.sessions_in_cwd` is on) so the snapshot the NEXT turn's
+    // `appui_context_history_for_agent` loads is the same project's (#1666).
+    let context_data_dir_for_result = session_runtime.sessions_root.clone();
     let usage_ledger_for_result = usage_ledger.clone();
     let usage_profile_id_for_result = usage_profile_id.clone();
     let usage_session_id_for_result = session_id.to_string();

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -417,6 +417,35 @@ impl SessionLedger {
 pub(crate) struct UiProtocolLedger {
     config: LedgerConfig,
     inner: Mutex<LedgerInner>,
+    /// Per-project (`appui.sessions_in_cwd`) storage scopes, keyed by the
+    /// WIRE session id (`SessionKey.0`). When a session's transcript store is
+    /// relocated to `<cwd>/.octos/<profile>` the API layer registers a scope
+    /// here (`set_session_scope`, a 16-hex digest of the relocated
+    /// `sessions_root`), and every ring/disk/cursor identity for that session
+    /// becomes `<key>\u{0}~cwd-<scope>` via [`Self::storage_session_id`].
+    /// Two projects reusing the same wire key then get DISTINCT ledger rings
+    /// and on-disk dirs instead of replaying each other's conversation
+    /// (#1666).
+    ///
+    /// The registry is authoritative: unregistered keys pass through
+    /// verbatim (never parsed for the marker), so a wire key that happens to
+    /// contain the marker text is never reinterpreted, and flag-OFF behavior
+    /// is byte-identical. Wire EVENT payloads and the live-subscriber map
+    /// keep the plain key — the scope exists only in storage identities.
+    ///
+    /// KNOWN RESIDUAL (documented on #1666, same class as the Phase-4
+    /// `session_workspaces()` last-wins map): the registry holds ONE scope
+    /// per wire key, so two connections using the SAME key for DIFFERENT
+    /// cwds **concurrently in one process** flip-flop the mapping
+    /// (last-writer-wins) — appends/replays can land in whichever project
+    /// registered last, and live fan-out (plain-keyed by design) crosses
+    /// projects. Pre-fix, that scenario shared ONE dir outright, so this is
+    /// no new confidentiality exposure, but full isolation needs
+    /// per-connection identity threading. Sequential use — one project at a
+    /// time per key, the shipping AppUi/stdio flow — is fully isolated.
+    ///
+    /// Guarded by its own tiny mutex (never held across `inner`).
+    scopes: Mutex<HashMap<String, String>>,
 }
 
 struct LedgerInner {
@@ -529,6 +558,49 @@ impl UiProtocolLedger {
         Self {
             config,
             inner: Mutex::new(LedgerInner::new()),
+            scopes: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Register (or clear, with `None`) the per-project storage scope for a
+    /// session — see the `scopes` field doc. Called by the API layer whenever
+    /// a `SessionRuntime` materializes with a RELOCATED transcript store
+    /// (`sessions_root != profile.data_dir`, i.e. `appui.sessions_in_cwd`),
+    /// and always BEFORE that flow replays the session so replay and
+    /// subsequent appends agree on the storage identity. Idempotent;
+    /// re-registering the same scope is a no-op, and `None` removes a stale
+    /// entry (e.g. the flag was toggled off between restarts).
+    pub(crate) fn set_session_scope(&self, session_id: &SessionKey, scope: Option<String>) {
+        let mut scopes = self.scopes.lock().unwrap_or_else(|p| p.into_inner());
+        match scope {
+            Some(scope) => {
+                scopes.insert(session_id.0.clone(), scope);
+            }
+            None => {
+                scopes.remove(session_id.0.as_str());
+            }
+        }
+    }
+
+    /// The STORAGE identity for a wire session id: the id itself, or
+    /// `<id>\u{0}~cwd-<scope>` when a per-project scope is registered.
+    /// Storage identities key the in-memory ring, the LRU, the on-disk
+    /// `ui-protocol/<hex>` dir, thread watermarks/seq state, and replay
+    /// cursors' `stream` — everything EXCEPT wire event payloads and the
+    /// live-subscriber map, which stay on the plain wire id.
+    ///
+    /// The NUL separator makes the encoding injective against realistic wire
+    /// ids: `SessionKey` is an unconstrained string, so a plain-ASCII marker
+    /// could be *equalled* by a hostile client naming its session
+    /// `<victim>~cwd-<hash>` and thereby sharing the victim project's dir
+    /// (codex v2 P2). A NUL pushes that collision outside anything a
+    /// legitimate client id contains; the byte is opaque to the hex dir
+    /// encoding, the HashMap keys, and JSON cursor `stream` strings.
+    fn storage_session_id(&self, session_id: &SessionKey) -> SessionKey {
+        let scopes = self.scopes.lock().unwrap_or_else(|p| p.into_inner());
+        match scopes.get(session_id.0.as_str()) {
+            Some(scope) => SessionKey(format!("{}\u{0}~cwd-{scope}", session_id.0)),
+            None => session_id.clone(),
         }
     }
 
@@ -641,7 +713,7 @@ impl UiProtocolLedger {
         > = std::collections::HashMap::new();
         let mut started_turns: std::collections::HashMap<
             String,
-            (octos_core::TurnId, Option<String>),
+            (SessionKey, octos_core::TurnId, Option<String>),
         > = std::collections::HashMap::new();
         let mut terminal_turns: std::collections::HashSet<String> =
             std::collections::HashSet::new();
@@ -660,7 +732,16 @@ impl UiProtocolLedger {
                 UiNotification::TurnStarted(turn) => {
                     started_turns.insert(
                         turn.turn_id.0.to_string(),
-                        (turn.turn_id.clone(), turn.topic.clone()),
+                        // Carry the turn's own WIRE session id for the
+                        // synthesized terminal below: the `session_id` param
+                        // here is a STORAGE identity at recovery time (dir
+                        // decode may include a `~cwd-` scope), which must
+                        // never appear in an event payload.
+                        (
+                            turn.session_id.clone(),
+                            turn.turn_id.clone(),
+                            turn.topic.clone(),
+                        ),
                     );
                 }
                 UiNotification::TurnCompleted(turn) => {
@@ -683,23 +764,33 @@ impl UiProtocolLedger {
             ) {
                 task.state = TaskRuntimeState::Cancelled;
                 task.runtime_detail = Some("orphaned_by_restart".to_owned());
-                self.append_notification(UiNotification::TaskUpdated(task));
+                // Storage-id append: land in the same (possibly scoped) dir
+                // as the orphaned row — see `append_with_storage_id`.
+                self.append_with_storage_id(
+                    session_id.clone(),
+                    UiProtocolLedgerEvent::Notification(UiNotification::TaskUpdated(task)),
+                    None,
+                );
                 swept += 1;
             }
         }
-        for (key, (turn_id, topic)) in started_turns {
+        for (key, (turn_session_id, turn_id, topic)) in started_turns {
             if terminal_turns.contains(&key) {
                 continue;
             }
             // Preserve the topic so topic-scoped replay filters still see the
             // synthesized terminal for a topic-suffixed turn.
-            self.append_notification(UiNotification::TurnError(TurnErrorEvent {
-                session_id: session_id.clone(),
-                topic,
-                turn_id,
-                code: "orphaned_by_restart".to_owned(),
-                message: "server restarted before this turn finished".to_owned(),
-            }));
+            self.append_with_storage_id(
+                session_id.clone(),
+                UiProtocolLedgerEvent::Notification(UiNotification::TurnError(TurnErrorEvent {
+                    session_id: turn_session_id,
+                    topic,
+                    turn_id,
+                    code: "orphaned_by_restart".to_owned(),
+                    message: "server restarted before this turn finished".to_owned(),
+                })),
+                None,
+            );
             swept += 1;
         }
         for (_, mut agent) in agents {
@@ -711,7 +802,11 @@ impl UiProtocolLedger {
             }
             agent.agent.status = "failed".to_owned();
             agent.agent.summary = Some("orphaned by server restart".to_owned());
-            self.append_notification(UiNotification::AgentUpdated(agent));
+            self.append_with_storage_id(
+                session_id.clone(),
+                UiProtocolLedgerEvent::Notification(UiNotification::AgentUpdated(agent)),
+                None,
+            );
             swept += 1;
         }
         swept
@@ -1024,7 +1119,11 @@ impl UiProtocolLedger {
         // order. `broadcast::Sender::send` is non-blocking (try_send on
         // a bounded queue) so the lock-hold is microseconds.
         let session_id_clone = session_id.clone();
-        let preload_snapshot = self.snapshot_if_session_absent(&session_id_clone);
+        // Storage identity for ring/seq/disk/LRU; `session_id_clone` (the
+        // plain wire id) still stamps the envelope payload and keys the live
+        // subscriber lookup below.
+        let storage_id = self.storage_session_id(session_id);
+        let preload_snapshot = self.snapshot_if_session_absent(&storage_id);
         let cursor;
         let stamped;
         let on_disk_delta;
@@ -1034,12 +1133,11 @@ impl UiProtocolLedger {
             let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
 
             // --- step 1: envelope seq allocation + hard barrier ---
-            let alloc = self.allocate_envelope_seq_locked(
-                &session_id_clone,
-                &thread_id,
-                &payload,
-                &mut inner,
-            );
+            // Seq/thread state follows the STORAGE identity so two projects
+            // sharing a wire key allocate independent, per-project seq
+            // streams consistent with their separate rings/dirs.
+            let alloc =
+                self.allocate_envelope_seq_locked(&storage_id, &thread_id, &payload, &mut inner);
             let seq = match alloc {
                 Ok(seq) => seq,
                 Err(kind) => {
@@ -1071,7 +1169,7 @@ impl UiProtocolLedger {
 
             // --- step 3: append to the ledger (LRU, ring, disk) ---
             let append_outcome =
-                self.append_locked(&session_id_clone, event, None, preload_snapshot, &mut inner);
+                self.append_locked(&storage_id, event, None, preload_snapshot, &mut inner);
             cursor = append_outcome.cursor;
             stamped = append_outcome.stamped;
             on_disk_delta = append_outcome.on_disk_delta;
@@ -1089,7 +1187,7 @@ impl UiProtocolLedger {
             } else {
                 inner.on_disk_bytes = inner.on_disk_bytes.saturating_sub((-on_disk_delta) as u64);
             }
-            inner.touch_lru(&session_id_clone);
+            inner.touch_lru(&storage_id);
 
             // --- step 4: publish to live subscribers WHILE STILL
             // HOLDING THE LOCK so the broadcast send order strictly
@@ -1369,19 +1467,38 @@ impl UiProtocolLedger {
 
     fn append(
         &self,
+        event: UiProtocolLedgerEvent,
+        from_connection: Option<ConnectionId>,
+    ) -> LedgeredUiProtocolEvent {
+        // Ring/LRU/disk are keyed by the per-project STORAGE identity; the
+        // live fan-out stays on the plain wire id (`publish_live`).
+        let storage_id = self.storage_session_id(event.session_id());
+        self.append_with_storage_id(storage_id, event, from_connection)
+    }
+
+    /// [`Self::append`] with the storage identity supplied by the caller
+    /// instead of resolved from the scope registry. Recovery-time reconcile
+    /// uses this: it walks dir-decoded storage identities while the registry
+    /// is still empty, and its synthesized terminal events must land in the
+    /// SAME (possibly `~cwd-`-scoped) ring/dir as the orphaned rows they
+    /// close — resolving through the registry would divert them to the
+    /// unscoped dir and leave phantom running turns behind.
+    fn append_with_storage_id(
+        &self,
+        storage_id: SessionKey,
         mut event: UiProtocolLedgerEvent,
         from_connection: Option<ConnectionId>,
     ) -> LedgeredUiProtocolEvent {
         event.stamp_topic_from_session();
         let session_id = event.session_id().clone();
-        let preload_snapshot = self.snapshot_if_session_absent(&session_id);
+        let preload_snapshot = self.snapshot_if_session_absent(&storage_id);
         let cursor;
         let stamped;
         let on_disk_delta;
         {
             let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
             let outcome =
-                self.append_locked(&session_id, event, None, preload_snapshot, &mut inner);
+                self.append_locked(&storage_id, event, None, preload_snapshot, &mut inner);
             cursor = outcome.cursor;
             stamped = outcome.stamped;
             on_disk_delta = outcome.on_disk_delta;
@@ -1390,7 +1507,7 @@ impl UiProtocolLedger {
             } else {
                 inner.on_disk_bytes = inner.on_disk_bytes.saturating_sub((-on_disk_delta) as u64);
             }
-            inner.touch_lru(&session_id);
+            inner.touch_lru(&storage_id);
         }
 
         let ledgered = LedgeredUiProtocolEvent {
@@ -1802,8 +1919,9 @@ impl UiProtocolLedger {
 
     #[cfg(test)]
     pub(crate) fn has_session_in_memory_for_test(&self, session_id: &SessionKey) -> bool {
+        let session_id = self.storage_session_id(session_id);
         let inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
-        inner.sessions.contains_key(session_id)
+        inner.sessions.contains_key(&session_id)
     }
 
     /// Snapshot of the observability counters. Useful for tests and the
@@ -1839,6 +1957,11 @@ impl UiProtocolLedger {
         session_id: &SessionKey,
         after: Option<&UiCursor>,
     ) -> Result<(Vec<LedgeredUiProtocolEvent>, UiCursor), RpcError> {
+        // Shadow with the per-project STORAGE identity (no-op when no scope
+        // is registered): ring lookups, disk fallbacks, minted cursor
+        // `stream`s, and the `after.stream` check below all follow it, so
+        // cursors round-trip against the same identity appends mint.
+        let session_id = &self.storage_session_id(session_id);
         // Atomicity contract (codex review #1): events and the returned
         // cursor are observed under a single lock acquisition. Concurrent
         // appenders see the same `inner` mutex, so no event can land
@@ -2037,6 +2160,9 @@ impl UiProtocolLedger {
         session_id: &SessionKey,
         after: Option<&UiCursor>,
     ) -> Result<(Vec<LedgeredUiProtocolEvent>, u64), RpcError> {
+        // Per-project STORAGE identity (no-op without a registered scope) —
+        // see `snapshot_with_cursor`. Callers pass the plain wire id.
+        let session_id = &self.storage_session_id(session_id);
         let Some(after) = after else {
             // No `after` — caller asked for "live only", no replay history.
             // Pair the empty replay with the current head_seq so the
@@ -3045,6 +3171,161 @@ mod tests {
             count_after_first,
             "second recovery must sweep nothing (rows already terminal)"
         );
+    }
+
+    /// #1666 per-project isolation: two projects (`appui.sessions_in_cwd`)
+    /// can share the same WIRE session id. Registering distinct storage
+    /// scopes must give them distinct in-memory rings AND on-disk dirs —
+    /// including the warm-ring case where project A's events are still
+    /// resident when project B opens — while replayed events keep the plain
+    /// wire id in their payloads.
+    #[test]
+    fn should_isolate_ledger_storage_between_cwd_scopes_sharing_a_wire_key() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let ledger = UiProtocolLedger::with_config(LedgerConfig::durable(temp.path().into()));
+        let key = SessionKey("glm:local:tui#coding".into());
+
+        ledger.set_session_scope(&key, Some("aaaa111122223333".into()));
+        ledger.append_notification(delta(&key, "from-project-a"));
+
+        // Project B re-registers the SAME wire key under its own scope while
+        // A's ring entry is still warm.
+        ledger.set_session_scope(&key, Some("bbbb444455556666".into()));
+        ledger.append_notification(delta(&key, "from-project-b"));
+        let (events, _) = ledger
+            .snapshot_with_cursor(&key, None)
+            .expect("scoped snapshot");
+        assert_eq!(
+            replay_texts(&events),
+            vec!["from-project-b"],
+            "project B must not replay project A's warm-ring events"
+        );
+        assert!(
+            events.iter().all(|event| event.event.session_id() == &key),
+            "replayed payloads keep the PLAIN wire id, never the storage id"
+        );
+
+        // Back to A: its events are intact under its own storage identity.
+        ledger.set_session_scope(&key, Some("aaaa111122223333".into()));
+        let (events, _) = ledger
+            .snapshot_with_cursor(&key, None)
+            .expect("re-scoped snapshot");
+        assert_eq!(replay_texts(&events), vec!["from-project-a"]);
+
+        // Clearing the scope falls back to the (empty) legacy identity.
+        ledger.set_session_scope(&key, None);
+        let (events, _) = ledger
+            .snapshot_with_cursor(&key, None)
+            .expect("unscoped snapshot");
+        assert!(
+            replay_texts(&events).is_empty(),
+            "no scope registered → plain storage identity, which holds nothing"
+        );
+
+        // And the two projects own two distinct on-disk dirs (NUL-separated
+        // storage identities — see `storage_session_id`).
+        let scoped_a = SessionKey(format!("{}\u{0}~cwd-aaaa111122223333", key.0));
+        let scoped_b = SessionKey(format!("{}\u{0}~cwd-bbbb444455556666", key.0));
+        for scoped in [&scoped_a, &scoped_b] {
+            let dir = temp
+                .path()
+                .join("ui-protocol")
+                .join(encode_session_dir_name(scoped));
+            assert!(dir.is_dir(), "expected scoped dir {}", dir.display());
+        }
+
+        // Injectivity: a WIRE key that literally spells the old plain-ASCII
+        // marker shape must NOT alias into a scoped dir — its storage
+        // identity is itself (no NUL), so it stays a separate, empty bucket.
+        let impostor = SessionKey(format!("{}~cwd-aaaa111122223333", key.0));
+        let (events, _) = ledger
+            .snapshot_with_cursor(&impostor, None)
+            .expect("impostor snapshot");
+        assert!(
+            replay_texts(&events).is_empty(),
+            "a literal `~cwd-` wire key must not read a scoped project's events"
+        );
+    }
+
+    /// #1666: scoped dirs survive a restart under the SAME storage identity —
+    /// recovery decodes the scoped dir name verbatim, and a re-registered
+    /// scope replays it while an unregistered (plain) read stays empty.
+    #[test]
+    fn should_recover_scoped_sessions_under_their_storage_identity() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let key = SessionKey("glm:local:tui#coding".into());
+        {
+            let ledger = UiProtocolLedger::with_config(LedgerConfig::durable(temp.path().into()));
+            ledger.set_session_scope(&key, Some("aaaa111122223333".into()));
+            ledger.append_notification(delta(&key, "scoped-before-restart"));
+        } // process "dies"
+
+        let recovered = UiProtocolLedger::recover(LedgerConfig::durable(temp.path().into()));
+        let (unregistered, _) = recovered
+            .ledger
+            .snapshot_with_cursor(&key, None)
+            .expect("plain snapshot");
+        assert!(
+            replay_texts(&unregistered).is_empty(),
+            "without a registered scope the plain identity must not see scoped events"
+        );
+
+        recovered
+            .ledger
+            .set_session_scope(&key, Some("aaaa111122223333".into()));
+        let (events, _) = recovered
+            .ledger
+            .snapshot_with_cursor(&key, None)
+            .expect("scoped snapshot after recovery");
+        assert_eq!(replay_texts(&events), vec!["scoped-before-restart"]);
+    }
+
+    /// #1666: recovery's orphan sweep must close rows INSIDE a scoped dir
+    /// (the synthesized terminal lands in the same scoped ring, not the
+    /// plain one) and its synthesized payloads must carry the plain WIRE
+    /// session id — never the `~cwd-` storage identity.
+    #[test]
+    fn recovery_sweeps_orphans_in_scoped_dirs_with_wire_session_ids() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let key = SessionKey("glm:local:tui#coding".into());
+        let turn_id = octos_core::TurnId::new();
+        {
+            let ledger = UiProtocolLedger::with_config(LedgerConfig::durable(temp.path().into()));
+            ledger.set_session_scope(&key, Some("aaaa111122223333".into()));
+            let started: octos_core::ui_protocol::TurnStartedEvent =
+                serde_json::from_value(json!({
+                    "session_id": key.0,
+                    "turn_id": turn_id.0,
+                    "timestamp": chrono::Utc::now(),
+                }))
+                .expect("turn started");
+            ledger.append_notification(UiNotification::TurnStarted(started));
+        } // dies mid-turn, no terminal event
+
+        let recovered = UiProtocolLedger::recover(LedgerConfig::durable(temp.path().into()));
+        recovered
+            .ledger
+            .set_session_scope(&key, Some("aaaa111122223333".into()));
+        let (events, _) = recovered
+            .ledger
+            .snapshot_with_cursor(&key, None)
+            .expect("scoped snapshot");
+        let synthesized = events
+            .iter()
+            .find_map(|event| match &event.event {
+                UiProtocolLedgerEvent::Notification(UiNotification::TurnError(error))
+                    if error.code == "orphaned_by_restart" =>
+                {
+                    Some(error.clone())
+                }
+                _ => None,
+            })
+            .expect("orphan sweep must synthesize the terminal INSIDE the scoped ring");
+        assert_eq!(
+            synthesized.session_id, key,
+            "synthesized terminal must carry the plain wire id, not the storage id"
+        );
+        assert_eq!(synthesized.turn_id, turn_id);
     }
 
     #[test]

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -779,7 +779,9 @@ pub(crate) fn resolve_sessions_root_from_hint(
 /// (`init.rs`: `sessions/`, `tasks/`, `*.redb`) and to leave a
 /// deliberately-committed `<cwd>/.octos/config.json` untouched; `users/` is
 /// added because per-project transcripts + their sidecars land under
-/// `<cwd>/.octos/users/<base>/sessions/`.
+/// `<cwd>/.octos/users/<base>/sessions/`; `context_ledgers/` because the
+/// per-turn context-manager snapshots (verbatim conversation content) are
+/// rooted at this store alongside the transcript (#1666).
 fn ensure_session_store_gitignore(sessions_root: &Path) {
     use std::io::Write;
 
@@ -789,6 +791,7 @@ fn ensure_session_store_gitignore(sessions_root: &Path) {
 sessions/
 users/
 tasks/
+context_ledgers/
 *.redb
 ";
     if let Err(error) = std::fs::create_dir_all(sessions_root) {
@@ -2225,6 +2228,9 @@ mod tests {
         let body = std::fs::read_to_string(&gitignore).unwrap();
         assert!(body.contains("sessions/"));
         assert!(body.contains("users/"));
+        // Context-manager snapshots hold verbatim conversation content and
+        // are rooted at this store alongside the transcript (#1666).
+        assert!(body.contains("context_ledgers/"));
 
         // Idempotent + non-clobbering: hand-edit it, re-run the helper, and
         // confirm the operator's content survives.


### PR DESCRIPTION
Closes the flag-ON cross-project context leak in `appui.sessions_in_cwd` (#1666, live-reproduced: store *watermelon* in projX / *harmonica* in projY with the same profile, resume projX, ask for the codeword → the model answered **harmonica**).

## Root cause

Phase 4 relocated the **transcript** to `<cwd>/.octos/<profile>`, but two session-keyed stores stayed rooted globally, and the wire session key (`profile:transport:client#topic`) has no cwd component — so two projects reusing the same key shared them:

| store | pre-fix root | consequence |
|---|---|---|
| context-manager snapshots | `profile.data_dir/context_ledgers/` | snapshot **beats raw history** on context rebuild → project B's conversation fed project A's LLM turns |
| UI-protocol event ledger | `<data_dir>/ui-protocol/<hex(key)>/` + a warm in-memory ring (1 h TTL), process-global singleton | replay/hydrate crossed projects |

## Why not scope the key? (the discarded v1)

A first attempt folded a cwd hash into the key's **topic**. Adversarial review found 7 P1s: the topic is *semantic* — `read_session_prompt` slugifies it into a template filename, lane routing consumes it, ingress scope gates compare it, gateway proxies re-derive it — and the fold was bypassable. **v2 leaves the wire key completely untouched** (verified live: client status line still shows `glm:local:tui#coding`) and scopes the *stores*:

1. **Context manager** — the 4 turn-path bindings (pre-turn load, post-turn persist, compaction bridge, forked child) now use `session_runtime.sessions_root` instead of `profile.data_dir`. Rollback + open-inspection already derived from the resolved manager. Flag-OFF: `sessions_root == profile.data_dir` → identity.
2. **Event ledger** — gains an authoritative scope registry (`set_session_scope`). When a `SessionRuntime` materializes with a relocated store, the API layer registers `sha256hex16(sessions_root)` (three sites: `session/open` *before* replay, `run_standalone_turn`, `run_native_code_review_turn`; topic keys also register their **base-key alias** since the alpha-9 file/visual bridges append under the base). Ring/LRU/disk-dir/thread-seq/cursor-stream identities become `<key>\u{0}~cwd-<hash>`; **wire event payloads and the live-subscriber map keep the plain key**. Unregistered keys pass through verbatim — never string-parsed (NUL separator makes the encoding injective against hostile literal keys).
3. **Recovery orphan sweep** — synthesized terminals now land in the *same* (possibly scoped) dir as the rows they close (`append_with_storage_id`) and carry the turn's own wire session id.
4. **Per-project `.gitignore`** now covers `context_ledgers/` (conversation-content JSON was committable to the user's repo).

## Verification

- **Live 2-project soak** (octos-tui → `serve --stdio` → glm-5.2/z.ai, tmux): resume projX now recalls **watermelon**; ledger dirs distinct per project (each holds only its own codeword); context ledgers per-cwd; the old global leak file is no longer written at all; **0 files contain both codewords**. Flag-OFF run: cwd stays clean, transcript stays profile-global, plain ledger dir, real turn works.
- **Unit**: warm-ring isolation across scope flips (the in-memory leak case), scoped-dir restart recovery, scoped orphan-sweep with wire-id payloads, literal-marker impostor key isolation, gitignore coverage. `octos-cli --features api --lib`: **2373 passed / 0 failed**; fmt + clippy clean.
- **Codex-reviewed ×2**: round 1 flagged the registration gaps (code-review turn, base-key alias), the marker injectivity, and the concurrent residual; the first three are fixed in this PR.

## Documented residuals (flag stays OFF; tracked on #1666)

- **Concurrent same-key-different-cwd in one process**: the registry is last-writer-wins (same class as the Phase-4 `session_workspaces()` map — full fix needs per-connection identity threading). Pre-fix that scenario shared one dir outright, so no new confidentiality exposure; sequential per-key use (the AppUi/stdio flow) is fully isolated.
- Cold read paths after a restart without a `session/open` (hydrate/rollback on a never-opened key) read the legacy unscoped dir — pre-existing Phase-4 residual class.
- `SessionContextStatusStore` (context *metadata*, not content) remains plain-keyed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
