### PR TITLE
fix(compaction): LLM summary call uses the model's full output budget (not the 4096 summary-size cap)

### DIFF
--- a/crates/octos-agent/src/compaction.rs
+++ b/crates/octos-agent/src/compaction.rs
@@ -972,7 +972,7 @@ fn render_transcript(messages: &[Message]) -> String {
 }
 
 /// One-shot LLM context-compaction summary: prompts the model for a handoff
-/// summary of `messages`, bounded by `budget_tokens` and `timeout`. Returns
+/// summary of `messages`, bounded by the model's max output and `timeout`. Returns
 /// `None` on ANY error, timeout, empty content, or unsupported runtime so the
 /// caller falls back to the deterministic [`compact_messages`] heuristic —
 /// compaction must never block or fail a turn.
@@ -988,7 +988,6 @@ fn render_transcript(messages: &[Message]) -> String {
 pub fn llm_compaction_summary(
     provider: &Arc<dyn LlmProvider>,
     messages: &[Message],
-    budget_tokens: u32,
     timeout: Duration,
 ) -> Option<String> {
     if messages.is_empty() {
@@ -1006,8 +1005,14 @@ pub fn llm_compaction_summary(
     let provider = Arc::clone(provider);
     let transcript = render_transcript(messages);
     crate::summarizer::run_llm_call_blocking(async move {
+        // Give the call the model's FULL output budget, not a small
+        // summary-size heuristic. Reasoning models spend tokens on
+        // `reasoning_content` before emitting the summary `content`; capping at
+        // a small budget starves the summary and returns empty content (a
+        // silent heuristic fallback). Mirrors codex, which sets no output cap on
+        // its compaction turn — the system prompt keeps the summary concise.
         let config = ChatConfig {
-            max_tokens: Some(budget_tokens),
+            max_tokens: Some(provider.max_output_tokens()),
             // Low but non-zero: a factual handoff summary, lightly deterministic.
             temperature: Some(0.2),
             ..Default::default()
@@ -1091,7 +1096,7 @@ mod tests {
             result: Ok("Goal: X. Done: Y. Next: Z.".into()),
         });
         let messages = vec![Message::user("do X"), Message::assistant("did Y")];
-        let out = llm_compaction_summary(&provider, &messages, 512, Duration::from_secs(5));
+        let out = llm_compaction_summary(&provider, &messages, Duration::from_secs(5));
         assert_eq!(out.as_deref(), Some("Goal: X. Done: Y. Next: Z."));
     }
 
@@ -1103,7 +1108,7 @@ mod tests {
             result: Err("provider down".into()),
         });
         let messages = vec![Message::user("do X")];
-        let out = llm_compaction_summary(&provider, &messages, 512, Duration::from_secs(5));
+        let out = llm_compaction_summary(&provider, &messages, Duration::from_secs(5));
         assert!(out.is_none());
     }
 
@@ -1113,7 +1118,7 @@ mod tests {
         let provider: Arc<dyn LlmProvider> = Arc::new(CompactionMockProvider {
             result: Ok("unused".into()),
         });
-        assert!(llm_compaction_summary(&provider, &[], 512, Duration::from_secs(5)).is_none());
+        assert!(llm_compaction_summary(&provider, &[], Duration::from_secs(5)).is_none());
     }
 
     #[tokio::test] // current_thread runtime (the default, no `flavor`)
@@ -1125,7 +1130,7 @@ mod tests {
             result: Ok("should not be used on current_thread".into()),
         });
         let messages = vec![Message::user("do X")];
-        let out = llm_compaction_summary(&provider, &messages, 512, Duration::from_secs(5));
+        let out = llm_compaction_summary(&provider, &messages, Duration::from_secs(5));
         assert!(
             out.is_none(),
             "current_thread runtime must degrade to the heuristic, not run the LLM path"

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2073,13 +2073,13 @@ fn appui_compaction_summary(
     if let Some(summary) = octos_agent::compaction::llm_compaction_summary(
         llm_provider,
         messages,
-        budget_tokens,
         std::time::Duration::from_secs(
             octos_agent::compaction::DEFAULT_LLM_COMPACTION_TIMEOUT_SECS,
         ),
     ) {
         return summary;
     }
+    // Heuristic fallback still uses the summary-size budget (correct there).
     octos_agent::compaction::compact_messages(messages, budget_tokens)
 }
 


### PR DESCRIPTION
## What

Follow-up to #1644. The opt-in LLM-summarization compaction (`octos serve --llm-compaction`) was **silently degrading to the heuristic** with reasoning models. This fixes it.

## The bug

The LLM summary call set `max_tokens` to the **summary-size budget** (`threshold.clamp(256, 4096)`) — the same number the heuristic uses to bound its extracted output:

```rust
// #1644 (before)
max_tokens: Some(budget_tokens),   // budget_tokens = threshold.clamp(256, 4096)
```

That conflates two different quantities:
- For the **heuristic** (`compact_messages`), `budget_tokens` *is* the output size — correct.
- For the **LLM**, `max_tokens` caps the **whole response, reasoning included**.

A reasoning model (deepseek-v4-pro) spends `max_tokens` on `reasoning_content` **before** emitting the summary `content`. With the budget that small, reasoning exhausts it → the call returns **empty `content`** → `llm_compaction_summary` returns `None` → silent fallback to the heuristic. Two faults in one:
1. **Reasoning starvation** — even a real summarization returns nothing.
2. **The `4096` clamp is far too small anyway** for large-context models — a 1M-window model compacts ~700K tokens into a ≤4096-token summary (~170:1), which can't be a usable handoff.

## The fix (codex-aligned)

codex sets **no output cap** on its compaction turn (its `Prompt` struct has no `max_output_tokens` field) — it trusts the summarization prompt to keep the summary concise and lets the model size it. Mirror that:

```rust
// after
max_tokens: Some(provider.max_output_tokens()),   // the model's full per-call output budget
```

- The `256..4096` clamp **stays for the heuristic** (correct there).
- Reasoning models now get room to reason *and* write the summary.
- Scales with the model — no magic per-window formula.

## How it was found & verified

Caught by a **live soak** driving the real `serve --stdio` turn path with deepseek-v4-pro (headless UI-protocol driver) until compaction fired. Unit tests couldn't catch it — their mock provider always returns content.

| | before fix | after fix |
|---|---|---|
| installed summary | heuristic (`## Conversation Summary (compacted from N…)`) | real LLM **`CONTEXT CHECKPOINT`** prose |
| LLM call result | empty content → `None` → fallback | content returned |

deepseek accepted the larger `max_tokens`. `cargo fmt`/`clippy` clean; `octos-agent` + `octos-cli --features api` lib suites green (one unrelated `session_actor` flake, passes in isolation).
