### PR TITLE
style: rustfmt memory_store.rs (unbreak main fmt gate)

### DIFF
--- a/crates/octos-memory/src/memory_store.rs
+++ b/crates/octos-memory/src/memory_store.rs
@@ -1388,7 +1388,9 @@ mod tests {
         assert!(ctx.contains("===== framework.md ====="));
         assert!(ctx.contains("===== widgets/sys.md ====="));
         assert!(ctx.contains("===== apps/stock/app.md ====="));
-        assert!(ctx.contains("===== apps/stock/exemplars/card.splash (known-good reference) ====="));
+        assert!(
+            ctx.contains("===== apps/stock/exemplars/card.splash (known-good reference) =====")
+        );
         assert!(ctx.contains("===== apps/news/app.md ====="));
         // Stable order: framework < widgets < app.md < exemplar; apps sorted (news < stock).
         let f = ctx.find("framework.md").unwrap();


### PR DESCRIPTION
ef3d004e1 (direct push) left one over-width assert; `cargo fmt --all -- --check` fails for main + every PR since. Pure rustfmt output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)