### PR TITLE
style: clippy write_literal in doctor.rs (unbreak main clippy gate under rust 1.97.0)

### DIFF
--- a/crates/octos-cli/src/commands/doctor.rs
+++ b/crates/octos-cli/src/commands/doctor.rs
@@ -2081,7 +2081,7 @@ mod tests {
             use std::io::{Seek, SeekFrom, Write};
             let mut file = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
             file.seek(SeekFrom::End(0)).unwrap();
-            writeln!(file, "{}", r#"{"role":"user"}"#).unwrap();
+            file.write_all(b"{\"role\":\"user\"}\n").unwrap();
         }
 
         let checks = session_checks(&data_dir, &[]);


### PR DESCRIPTION
## What

`cargo clippy --workspace --all-targets -- -D warnings` (the `check` CI gate) fails on `main` under the current stable toolchain (**rust 1.97.0**, released 2026-07-07):

```
error: literal with an empty format string
  --> crates/octos-cli/src/commands/doctor.rs:2084
   |
   |  writeln!(file, "{}", r#"{"role":"user"}"#).unwrap();
   = note: `-D clippy::write-literal` implied by `-D warnings`
```

`clippy::write_literal` got stricter in 1.97.0 and now flags passing a string literal through an empty `{}`. This is the clippy sibling of the rustfmt casualty #1676 fixed — same toolchain bump. Local clippy 1.95.0 doesn't flag it, which is how it slipped in via #1675.

## Fix

Drop the format string and write the bytes directly — byte-identical output (`{"role":"user"}\n`), and `Write` is already in scope in that block:

```diff
-            writeln!(file, "{}", r#"{"role":"user"}"#).unwrap();
+            file.write_all(b"{\"role\":\"user\"}\n").unwrap();
```

## Testing

Verified under the **actual CI toolchain** (pinned rust 1.97.0): `cargo fmt --all -- --check` clean **and** `cargo clippy --workspace --all-targets -- -D warnings` clean. This was the only remaining `check`-gate casualty on `main` (the fmt half was #1676), so it turns `main`'s `check` green again and unblocks all open PRs.
