### PR TITLE
fix(serve): single-writer data-dir lock + clearer workspace-not-writable error

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -10881,6 +10881,13 @@ async fn open_session_result(
                     session = %params.session_id,
                     "session/open: SessionRuntime::bootstrap failed",
                 );
+                // The most common bootstrap failure is a non-writable workspace
+                // folder — the session can't create its `.octos-workspace.toml`
+                // there. Surface a clear, actionable message naming the folder
+                // instead of the opaque "failed to bootstrap session runtime".
+                if is_permission_denied_error(&error) {
+                    return Err(workspace_not_writable_error(params.cwd.as_deref()));
+                }
                 return Err(runtime_unavailable_error(format!(
                     "failed to bootstrap session runtime: {error}"
                 )));
@@ -25084,6 +25091,41 @@ fn string_field(value: &Value, keys: &[&str]) -> Option<String> {
 fn runtime_unavailable_error(message: impl Into<String>) -> RpcError {
     RpcError::internal_error(message).with_data(json!({
         "kind": "runtime_unavailable",
+    }))
+}
+
+/// True when `error` (anywhere in its eyre chain) is an OS permission-denied
+/// failure. The common trigger is session bootstrap failing to create
+/// `<workspace>/.octos-workspace.toml` in a folder the user can't write to.
+/// Structural — downcasts to `std::io::Error` — not string matching.
+fn is_permission_denied_error(error: &eyre::Report) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|io| io.kind() == std::io::ErrorKind::PermissionDenied)
+    })
+}
+
+/// Clear, actionable RPC error for the "session workspace folder isn't writable"
+/// case (a session/open bootstrap denied writing its `.octos-workspace.toml`).
+/// Names the folder so the user can act; the client renders `data.message`
+/// verbatim (preferred over the numeric code), so it reads as a plain sentence
+/// instead of an opaque "failed to bootstrap session runtime".
+fn workspace_not_writable_error(workspace: Option<&str>) -> RpcError {
+    let sentence = match workspace {
+        Some(path) => format!(
+            "Can't start a session in {path} — the folder isn't writable (permission denied). \
+             octos needs to create a .octos-workspace.toml there. Start octos in a folder you \
+             own, or make this one writable."
+        ),
+        None => "Can't start a session — the workspace folder isn't writable (permission denied). \
+                 Start octos in a folder you own, or make it writable."
+            .to_string(),
+    };
+    RpcError::internal_error(sentence.clone()).with_data(json!({
+        "kind": "workspace_not_writable",
+        "workspace": workspace,
+        "message": sentence,
     }))
 }
 
@@ -40452,6 +40494,48 @@ ignore = []
             error.data.as_ref().and_then(|data| data.get("kind")),
             Some(&json!("runtime_unavailable"))
         );
+    }
+
+    #[test]
+    fn permission_denied_workspace_yields_a_clear_actionable_error() {
+        // A session/open bootstrap failure caused by a non-writable workspace
+        // folder must be recognized structurally (through the eyre wrap chain)
+        // and rendered as a clear, folder-named message the client shows
+        // verbatim — not the opaque "failed to bootstrap session runtime".
+        let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "Permission denied");
+        let report = eyre::Report::new(io_err)
+            .wrap_err("write workspace policy failed: /Users/dev/.octos-workspace.toml")
+            .wrap_err("failed to bootstrap session workspace policy");
+        assert!(
+            is_permission_denied_error(&report),
+            "permission denial must be detected through the eyre wrap chain"
+        );
+
+        let error = workspace_not_writable_error(Some("/Users/dev"));
+        assert_eq!(
+            error.data.as_ref().and_then(|d| d.get("kind")),
+            Some(&json!("workspace_not_writable"))
+        );
+        let message = error
+            .data
+            .as_ref()
+            .and_then(|d| d.get("message"))
+            .and_then(|m| m.as_str())
+            .unwrap_or_default();
+        assert!(
+            message.contains("/Users/dev"),
+            "message must name the folder: {message}"
+        );
+        assert!(
+            message.contains("writable"),
+            "message must explain the cause: {message}"
+        );
+    }
+
+    #[test]
+    fn non_permission_bootstrap_error_is_not_misclassified_as_writability() {
+        let report = eyre::eyre!("some other failure: database corrupt");
+        assert!(!is_permission_denied_error(&report));
     }
 
     #[test]

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -318,6 +318,61 @@ fn stdio_task_query_store(stdio: bool) -> Option<crate::session_actor::SessionTa
     stdio.then(crate::session_actor::SessionTaskQueryStore::default)
 }
 
+/// Stable, machine-greppable marker embedded in the "data directory is already
+/// owned by another serve" error. octos-tui (a separate repo) spawns
+/// `octos serve --stdio` as a child and greps its stderr for this exact token
+/// on child-exit to recognize the single-writer conflict and STOP relaunching —
+/// instead of the silent ~5s crash-loop it used to hit when the second serve
+/// died mid-startup opening `admin_audit.redb`. MUST stay byte-stable: the
+/// client matches it verbatim (octos-tui `transport.rs` DATA_DIR_LOCKED_MARKER).
+pub(crate) const DATA_DIR_LOCKED_MARKER: &str = "OCTOS_DATA_DIR_LOCKED";
+
+/// Held for the serve process's whole lifetime: an exclusive OS advisory lock
+/// (flock / LockFileEx via `fs2`) on `<data_dir>/.octos-serve.lock`. redb is
+/// single-writer-single-process, so two `octos serve` against one data dir can
+/// never coexist — the second used to crash mid-startup opening the first
+/// data-dir-level redb store (`admin_audit.redb`) with `DatabaseAlreadyOpen`,
+/// which a stdio client silently respawned in a loop. Taking this lock BEFORE
+/// any store open turns that into one clean, greppable refusal. The lock is
+/// released on process exit (fd close), so a legitimate relaunch AFTER the
+/// previous serve has exited acquires it cleanly (no stale-lock hazard).
+struct ServeDataDirLock {
+    _file: std::fs::File,
+}
+
+/// Acquire the serve single-writer lock for `data_dir`, or return a clear error
+/// carrying [`DATA_DIR_LOCKED_MARKER`] when another serve already holds it.
+/// Contention is detected structurally via the platform's canonical
+/// lock-contended errno (`fs2::lock_contended_error`), never string matching.
+/// Fully-qualified `fs2::FileExt` calls: std 1.89 grew inherent methods of the
+/// same names and the workspace MSRV is 1.85.
+fn acquire_serve_data_dir_lock(data_dir: &std::path::Path) -> Result<ServeDataDirLock> {
+    std::fs::create_dir_all(data_dir)
+        .wrap_err_with(|| format!("failed to create data dir: {}", data_dir.display()))?;
+    let lock_path = data_dir.join(".octos-serve.lock");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .wrap_err_with(|| format!("failed to open serve lockfile: {}", lock_path.display()))?;
+    match fs2::FileExt::try_lock_exclusive(&file) {
+        Ok(()) => Ok(ServeDataDirLock { _file: file }),
+        Err(error) if error.raw_os_error() == fs2::lock_contended_error().raw_os_error() => {
+            Err(eyre::eyre!(
+                "{DATA_DIR_LOCKED_MARKER}: another octos server is already running for this data \
+                 directory ({}). Close the other octos-tui (or `octos serve`), or start this one \
+                 against a different --data-dir.",
+                data_dir.display()
+            ))
+        }
+        Err(error) => Err(eyre::Report::new(error).wrap_err(format!(
+            "failed to acquire serve single-writer lock: {}",
+            lock_path.display()
+        ))),
+    }
+}
+
 impl Executable for ServeCommand {
     fn execute(self) -> Result<()> {
         tokio::runtime::Builder::new_multi_thread()
@@ -347,6 +402,30 @@ impl ServeCommand {
             Config::load_with_context_path(&cwd, &ctx)?
         };
         tracing::info!(data_dir = %data_dir.display(), "data directory resolved");
+
+        // Single-writer guard: redb is single-process, so a second `octos serve`
+        // on this data dir can't coexist. Fail FAST here with one clean,
+        // client-greppable refusal instead of crashing mid-startup opening
+        // `admin_audit.redb` (which a stdio client silently respawned in a
+        // ~5s loop). Held for the whole process via `_data_dir_lock`; released
+        // on exit so a relaunch after the prior serve quits still starts.
+        let _data_dir_lock = match acquire_serve_data_dir_lock(&data_dir) {
+            Ok(guard) => guard,
+            Err(error) => {
+                if error.to_string().contains(DATA_DIR_LOCKED_MARKER) {
+                    // A guaranteed clean, un-colored stderr line the octos-tui
+                    // client greps on child-exit (color-eyre's rendering of the
+                    // returned error may interleave ANSI, so don't rely on it).
+                    eprintln!(
+                        "{DATA_DIR_LOCKED_MARKER}: another octos server already owns data \
+                         directory {}",
+                        data_dir.display()
+                    );
+                }
+                return Err(error);
+            }
+        };
+
         if let Err(error) = crate::api::agent_orchestrator::default_agent_orchestrator()
             .configure_supervisor_store(data_dir.join("supervisor"))
         {
@@ -1283,6 +1362,36 @@ mod tests {
             stdio_task_query_store(false).is_none(),
             "gateway/http serve must leave task_query_store None"
         );
+    }
+
+    /// Two `octos serve` against one data dir can't coexist (redb is
+    /// single-process). The second must be refused FAST with a stable,
+    /// client-greppable marker — not crash mid-startup opening `admin_audit.redb`
+    /// (which a stdio client respawned in a silent ~5s loop). Releasing the first
+    /// (process exit) must free the lock so a legitimate relaunch still starts.
+    #[test]
+    fn second_serve_on_same_data_dir_is_refused_with_a_greppable_marker() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let first = acquire_serve_data_dir_lock(dir.path()).expect("first serve acquires the lock");
+
+        let err = acquire_serve_data_dir_lock(dir.path())
+            .err()
+            .expect("a second serve must be refused while the first holds the lock");
+        assert!(
+            err.to_string().contains(DATA_DIR_LOCKED_MARKER),
+            "refusal must carry the stable client-greppable marker; got: {err}"
+        );
+        assert!(
+            err.to_string().contains(&dir.path().display().to_string()),
+            "refusal must name the contended data dir; got: {err}"
+        );
+
+        // Prior serve exits → lock released → a fresh relaunch acquires it. This
+        // pins that the guard never false-positives a normal client relaunch.
+        drop(first);
+        let _relaunch = acquire_serve_data_dir_lock(dir.path())
+            .expect("after the holder exits, a fresh serve acquires the lock");
     }
 
     fn dashboard_smtp_test_env_lock() -> &'static std::sync::Mutex<()> {


### PR DESCRIPTION
Two server-side robustness fixes for `octos serve`, one commit each. This is the
server half of the two-instance data-dir work whose octos-tui client half already
landed on main.

## 1. Refuse a second serve on the same data dir (fixes a silent crash-loop)

redb is single-writer-single-process, so two `octos serve` against one data dir
can never coexist. The second process used to crash mid-startup opening the
data-dir-level `admin_audit.redb` with `DatabaseAlreadyOpen` — and a stdio client
(octos-tui) silently respawned it in a ~5s crash-loop.

- Take an exclusive advisory lock (`fs2` flock / LockFileEx) on
  `<data_dir>/.octos-serve.lock` **before any store opens**.
- On contention, fail fast with a stable, machine-greppable marker
  `OCTOS_DATA_DIR_LOCKED` on stderr — the octos-tui client matches it verbatim on
  child-exit to stop relaunching and show a clean message instead of looping.
- Contention is detected **structurally** via the platform's lock-contended errno
  (`fs2::lock_contended_error`), never string matching.
- The lock releases on process exit (fd close), so a legitimate relaunch after the
  prior serve quits still starts cleanly — no stale-lock hazard.

## 2. Clearer error when a session workspace folder isn't writable

A `session/open` bootstrap failure caused by a non-writable workspace folder
(can't create `.octos-workspace.toml`) surfaced as the opaque "failed to bootstrap
session runtime".

- Detect the permission-denied case **structurally** through the eyre chain
  (downcast to `std::io::Error`, `ErrorKind::PermissionDenied`).
- Return a clear, folder-named message the client renders verbatim, telling the
  user to start octos in a folder they own or make this one writable.

## Tests

- `second_serve_on_same_data_dir_is_refused_with_a_greppable_marker` — the second
  acquire is refused with the marker + the data-dir name; after the holder drops,
  a fresh acquire succeeds (no false-positive on a normal client relaunch).
- `permission_denied_workspace_yields_a_clear_actionable_error` and
  `non_permission_bootstrap_error_is_not_misclassified_as_writability`.
