### PR TITLE
feat(chat): --effort, --no-session-persistence, positional PROMPT (claude -p parity)

### DIFF
--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -130,6 +130,25 @@ pub struct ChatCommand {
     /// boundary instead of prompting.
     #[arg(long, value_enum)]
     pub ask_for_approval: Option<ChatApprovalMode>,
+
+    /// Reasoning effort for thinking models: `low`, `medium`, `high`, or
+    /// `max` (claude/codex parity). Overrides the config
+    /// `gateway.reasoning_effort`; non-thinking models ignore it, and
+    /// providers without a distinct `max` tier clamp it to `high`.
+    #[arg(long, value_enum)]
+    pub effort: Option<ChatEffort>,
+
+    /// Do NOT persist this run as an episode (ephemeral). Mirrors
+    /// `claude --no-session-persistence`: by default a completed turn is
+    /// saved to the episode store for future recall; this skips that write.
+    #[arg(long)]
+    pub no_session_persistence: bool,
+
+    /// One-shot PROMPT (positional): `octos chat "…"` runs a single turn and
+    /// exits, matching `claude -p "…"`. Sugar for `--message`; supplying the
+    /// prompt both positionally and via `--message` is an error.
+    #[arg(value_name = "PROMPT")]
+    pub prompt: Option<String>,
 }
 
 /// `--sandbox` choices, mirroring codex's sandbox modes and octos's
@@ -157,6 +176,48 @@ pub enum ChatApprovalMode {
     Ask,
     /// Never prompt; risky commands fail closed at the tool boundary.
     Never,
+}
+
+/// `--effort` choices, mirroring claude/codex reasoning-effort tiers. Maps
+/// 1:1 to [`octos_llm::ReasoningEffort`]. For these single-word variants
+/// clap's default `ValueEnum` naming and serde's `kebab-case` agree
+/// (`low`/`medium`/`high`/`max`), so a `config.cli.chat.effort` round-trips
+/// losslessly — matching [`ChatSandboxMode`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ChatEffort {
+    Low,
+    Medium,
+    High,
+    Max,
+}
+
+impl From<ChatEffort> for octos_llm::ReasoningEffort {
+    fn from(effort: ChatEffort) -> Self {
+        match effort {
+            ChatEffort::Low => octos_llm::ReasoningEffort::Low,
+            ChatEffort::Medium => octos_llm::ReasoningEffort::Medium,
+            ChatEffort::High => octos_llm::ReasoningEffort::High,
+            ChatEffort::Max => octos_llm::ReasoningEffort::Max,
+        }
+    }
+}
+
+/// `claude -p "…"` parity: fold a positional PROMPT into `--message`. The two
+/// are two spellings of the same one-shot prompt, so supplying both is
+/// contradictory — fail closed. Returns the single effective one-shot message,
+/// or `None` for interactive mode (neither given).
+fn reconcile_one_shot_prompt(
+    message: Option<String>,
+    prompt: Option<String>,
+) -> Result<Option<String>> {
+    match (message, prompt) {
+        (Some(_), Some(_)) => Err(eyre!(
+            "provide the prompt positionally OR via --message/-m, not both"
+        )),
+        (Some(message), None) => Ok(Some(message)),
+        (None, prompt) => Ok(prompt),
+    }
 }
 
 /// Resolve the chat session's [`EffectivePermissions`] from the CLI flags.
@@ -643,7 +704,12 @@ impl Executable for ChatCommand {
 }
 
 impl ChatCommand {
-    async fn run_async(self) -> Result<()> {
+    async fn run_async(mut self) -> Result<()> {
+        // `claude -p "…"` parity: fold a positional PROMPT into `--message` up
+        // front so every downstream `self.message` check (the `--json` guard
+        // just below and the one-shot dispatch) sees a single source of truth.
+        self.message = reconcile_one_shot_prompt(self.message.take(), self.prompt.take())?;
+
         // `--json` is a one-shot, machine-readable mode: exactly one JSON
         // object on stdout, and it requires `--message`. An interactive REPL
         // cannot keep stdout pure (the readline prompt and per-turn framing
@@ -1047,9 +1113,14 @@ impl ChatCommand {
         };
         let agent_config = AgentConfig {
             max_iterations: self.max_iterations,
-            save_episodes: true,
+            // `--no-session-persistence` (claude parity): skip the episode write.
+            save_episodes: !self.no_session_persistence,
             chat_max_tokens: config.gateway.as_ref().and_then(|g| g.max_output_tokens),
-            reasoning_effort: config.gateway.as_ref().and_then(|g| g.reasoning_effort),
+            // `--effort` (claude/codex parity) overrides `gateway.reasoning_effort`.
+            reasoning_effort: self
+                .effort
+                .map(octos_llm::ReasoningEffort::from)
+                .or_else(|| config.gateway.as_ref().and_then(|g| g.reasoning_effort)),
             ..Default::default()
         };
         // M8.2: load sub-agent manifests from `<cwd>/agents/` layered on
@@ -1763,6 +1834,86 @@ mod tests {
         assert!(!bare.dangerously_bypass_approvals_and_sandbox);
         assert_eq!(bare.sandbox, None);
         assert_eq!(bare.ask_for_approval, None);
+    }
+
+    #[test]
+    fn should_map_chat_effort_to_reasoning_effort() {
+        use octos_llm::ReasoningEffort;
+        assert_eq!(ReasoningEffort::from(ChatEffort::Low), ReasoningEffort::Low);
+        assert_eq!(
+            ReasoningEffort::from(ChatEffort::Medium),
+            ReasoningEffort::Medium
+        );
+        assert_eq!(
+            ReasoningEffort::from(ChatEffort::High),
+            ReasoningEffort::High
+        );
+        assert_eq!(ReasoningEffort::from(ChatEffort::Max), ReasoningEffort::Max);
+    }
+
+    #[test]
+    fn should_reconcile_positional_prompt_with_message() {
+        // Positional-only → used as the one-shot message.
+        assert_eq!(
+            reconcile_one_shot_prompt(None, Some("hi".into())).unwrap(),
+            Some("hi".to_string())
+        );
+        // --message-only → passthrough.
+        assert_eq!(
+            reconcile_one_shot_prompt(Some("hi".into()), None).unwrap(),
+            Some("hi".to_string())
+        );
+        // Neither → interactive (None).
+        assert_eq!(reconcile_one_shot_prompt(None, None).unwrap(), None);
+        // Both → contradictory, fail closed.
+        let err = reconcile_one_shot_prompt(Some("a".into()), Some("b".into()))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not both"), "{err}");
+    }
+
+    #[test]
+    fn should_parse_effort_no_persistence_and_positional_prompt_via_clap() {
+        // `claude -p` parity: --effort, --no-session-persistence, and a bare
+        // positional PROMPT all parse into the expected fields.
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Wrap {
+            #[command(flatten)]
+            chat: ChatCommand,
+        }
+
+        let full = Wrap::parse_from([
+            "prog",
+            "--effort",
+            "max",
+            "--no-session-persistence",
+            "Review the diff",
+        ])
+        .chat;
+        assert_eq!(full.effort, Some(ChatEffort::Max));
+        assert!(full.no_session_persistence);
+        // The positional prompt lands in `prompt`, distinct from `--message`.
+        assert_eq!(full.prompt.as_deref(), Some("Review the diff"));
+        assert_eq!(full.message, None);
+
+        // Every effort tier parses (clap's default kebab/lower naming).
+        for (arg, want) in [
+            ("low", ChatEffort::Low),
+            ("medium", ChatEffort::Medium),
+            ("high", ChatEffort::High),
+            ("max", ChatEffort::Max),
+        ] {
+            let c = Wrap::parse_from(["prog", "--effort", arg]).chat;
+            assert_eq!(c.effort, Some(want));
+        }
+
+        // Defaults: no effort, persistence ON, no positional prompt.
+        let bare = Wrap::parse_from(["prog"]).chat;
+        assert_eq!(bare.effort, None);
+        assert!(!bare.no_session_persistence);
+        assert_eq!(bare.prompt, None);
     }
 
     #[test]


### PR DESCRIPTION
## What

Finishes making `octos chat` a drop-in headless runner in the `claude -p` / `codex exec` style. The permission surface already shipped (`--yolo` / `--sandbox {read-only|workspace-write|danger-full-access}` / `--ask-for-approval` / `--json`, the "yolo GAP #3" work). This adds the three remaining knobs:

| `claude -p` flag | now on `octos chat` |
|---|---|
| `--effort max` | **`--effort {low\|medium\|high\|max}`** → overrides `gateway.reasoning_effort` |
| `--no-session-persistence` | **`--no-session-persistence`** → `save_episodes = false` |
| positional prompt (`claude -p "…"`) | **`octos chat "…"`** (positional `[PROMPT]`, sugar for `--message`) |

So the example invocation now works end-to-end:

```bash
octos chat --model fable --effort max --no-session-persistence \
  --sandbox read-only "Review the diff"
```

(`--sandbox read-only` is octos's `--permission-mode plan` — the `ReadOnly` profile; `--yolo` is full-access.)

## How

- **`ChatEffort`** value-enum (mirrors `ChatSandboxMode`: `ValueEnum` + serde `kebab-case` so a `config.cli.chat.effort` round-trips) with a 1:1 `From<ChatEffort> for octos_llm::ReasoningEffort`. Wired into `AgentConfig.reasoning_effort` as a CLI override of the config gateway value.
- **`--no-session-persistence`** flips the previously-hardcoded `save_episodes: true`.
- **positional `[PROMPT]`** reconciled into `--message` at the top of `run_async` via a small pure helper `reconcile_one_shot_prompt` — both-set is contradictory and fails closed, so downstream `--json`/one-shot logic keeps a single source of truth.

No change to the permission/sandbox/approval path.

## Tests

- `should_map_chat_effort_to_reasoning_effort` — the enum mapping.
- `should_reconcile_positional_prompt_with_message` — positional-only, `--message`-only, neither, and the both-set conflict.
- `should_parse_effort_no_persistence_and_positional_prompt_via_clap` — clap accepts all three (every effort tier; positional lands in `prompt`, distinct from `--message`; defaults).

Full `octos-cli` lib suite green (1023 passed, 0 failed) · `cargo fmt --all -- --check` clean · `cargo clippy -p octos-cli --all-targets` 0 warnings. Verified on the built binary: `--help` shows the surface, the positional+`--message` conflict exits non-zero with the right message, and `--effort max --no-session-persistence --sandbox read-only "…"` threads past clap into provider resolution (no "unexpected argument").

🤖 Generated with [Claude Code](https://claude.com/claude-code)