### PR TITLE
feat(gateway): Matrix app-card emitter — project agent events as org.octos.app cards

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -746,14 +746,18 @@ impl Agent {
         media: Vec<String>,
         tracker: &TokenTracker,
     ) -> Result<ConversationResponse> {
-        self.process_message_inner(
-            user_content,
-            history,
-            media,
-            TurnAttachmentContext::default(),
-            Some(tracker),
-        )
-        .await
+        let turn_start = Instant::now();
+        let result = self
+            .process_message_inner(
+                user_content,
+                history,
+                media,
+                TurnAttachmentContext::default(),
+                Some(tracker),
+            )
+            .await;
+        self.report_gateway_turn_completed(result.is_ok(), turn_start);
+        result
     }
 
     pub async fn process_message_tracked_with_attachments(
@@ -764,8 +768,33 @@ impl Agent {
         attachments: TurnAttachmentContext,
         tracker: &TokenTracker,
     ) -> Result<ConversationResponse> {
-        self.process_message_inner(user_content, history, media, attachments, Some(tracker))
-            .await
+        let turn_start = Instant::now();
+        let result = self
+            .process_message_inner(user_content, history, media, attachments, Some(tracker))
+            .await;
+        self.report_gateway_turn_completed(result.is_ok(), turn_start);
+        result
+    }
+
+    /// Emit `TaskCompleted` at the end of a gateway turn.
+    ///
+    /// Gateway turns (e.g. Matrix) drive the agent through the `_tracked`
+    /// wrappers, which — unlike [`run_task`] — otherwise never report
+    /// `TaskCompleted`. Emitting it at turn end lets per-turn reporters (the
+    /// Matrix `ChannelStreamReporter`) drain and flush their coalesced app
+    /// cards (`tool_activity` / `run_summary` / `artifact`); without it those
+    /// accumulators are silently discarded when the reporter drops. Only the
+    /// `_tracked` variants are used by the gateway, so this stays scoped to the
+    /// gateway path and does not alter the API / ACP / CLI event streams (which
+    /// use the untracked variants). `iterations` is not surfaced by
+    /// `ConversationResponse` and is unused by that reporter, so 0 is a safe
+    /// placeholder.
+    fn report_gateway_turn_completed(&self, success: bool, turn_start: Instant) {
+        self.reporter().report(ProgressEvent::TaskCompleted {
+            success,
+            iterations: 0,
+            duration: turn_start.elapsed(),
+        });
     }
 
     async fn process_message_inner(

--- a/crates/octos-agent/src/tools/coding_tools.rs
+++ b/crates/octos-agent/src/tools/coding_tools.rs
@@ -918,7 +918,7 @@ fn normalize_plan(args: &Value, now_ms: i64) -> octos_core::ui_protocol::UiPlanR
             arr.iter()
                 .enumerate()
                 .map(|(i, item)| {
-                    let title = ["step", "title", "content", "text"]
+                    let title = ["step", "title", "content", "text", "description"]
                         .iter()
                         .find_map(|k| item.get(*k).and_then(|v| v.as_str()))
                         .unwrap_or_default()

--- a/crates/octos-bus/src/channel.rs
+++ b/crates/octos-bus/src/channel.rs
@@ -145,6 +145,20 @@ pub trait Channel: Send + Sync {
             .await
     }
 
+    /// Finalize a streamed message, carrying platform metadata (e.g. `org.octos.*`
+    /// keys the Matrix channel projects into the replace event's content and
+    /// `m.new_content`). Default: ignores metadata and delegates to
+    /// [`finish_stream`], so channels that can't carry it are unaffected.
+    async fn finish_stream_with_metadata(
+        &self,
+        chat_id: &str,
+        message_id: &str,
+        final_content: &str,
+        _metadata: &serde_json::Value,
+    ) -> Result<()> {
+        self.finish_stream(chat_id, message_id, final_content).await
+    }
+
     /// Delete a message by platform message ID.
     async fn delete_message(&self, _chat_id: &str, _message_id: &str) -> Result<()> {
         Ok(())

--- a/crates/octos-bus/src/matrix_channel.rs
+++ b/crates/octos-bus/src/matrix_channel.rs
@@ -45,6 +45,9 @@ const HTML_FORMAT: &str = "org.matrix.custom.html";
 const METADATA_TARGET_PROFILE_ID: &str = "target_profile_id";
 const METADATA_TARGET_MATRIX_USER_ID: &str = "target_matrix_user_id";
 const CONTENT_APP: &str = "org.octos.app";
+/// Per-turn run detail (tools + token/cost) embedded on the answer message so a
+/// client can render it as an expandable section, instead of a separate card.
+const CONTENT_RUN: &str = "org.octos.run";
 const CONTENT_ACTIONS: &str = "org.octos.actions";
 const CONTENT_ACTION_RESPONSE: &str = "org.octos.action_response";
 const CONTENT_APPROVAL_REQUEST: &str = "org.octos.approval_request";
@@ -2090,7 +2093,7 @@ impl Channel for MatrixChannel {
     }
 
     async fn edit_message(&self, chat_id: &str, message_id: &str, new_content: &str) -> Result<()> {
-        self.send_replace_event(chat_id, message_id, new_content, true)
+        self.send_replace_event(chat_id, message_id, new_content, true, None)
             .await
     }
 
@@ -2100,7 +2103,42 @@ impl Channel for MatrixChannel {
         message_id: &str,
         final_content: &str,
     ) -> Result<()> {
-        self.send_replace_event(chat_id, message_id, final_content, false)
+        self.send_replace_event(chat_id, message_id, final_content, false, None)
+            .await
+    }
+
+    /// Finalize a streamed message (thread-bound variant).
+    ///
+    /// The stream forwarder ends every stream via `finish_stream_bound`. Without
+    /// this Matrix override it falls through to the default → `edit_message` →
+    /// `send_replace_event(live=TRUE)`, which RE-ARMS the MSC4357 live marker at
+    /// stream end — leaving the client's "generating" spinner spinning until a
+    /// later live=false edit lands (after the turn's disk persistence). Clear the
+    /// marker here so the spinner stops promptly. `thread_id` is unused on Matrix
+    /// (the sender is resolved from `event_senders`).
+    async fn finish_stream_bound(
+        &self,
+        chat_id: &str,
+        message_id: &str,
+        final_content: &str,
+        _thread_id: Option<&str>,
+    ) -> Result<()> {
+        self.send_replace_event(chat_id, message_id, final_content, false, None)
+            .await
+    }
+
+    /// Finalize the streamed answer, projecting the turn's `org.octos.run` detail
+    /// (if present in `metadata`) onto the replace event so the answer carries an
+    /// embedded, expandable tool section instead of a separate card message.
+    async fn finish_stream_with_metadata(
+        &self,
+        chat_id: &str,
+        message_id: &str,
+        final_content: &str,
+        metadata: &serde_json::Value,
+    ) -> Result<()> {
+        let run = metadata.get(CONTENT_RUN);
+        self.send_replace_event(chat_id, message_id, final_content, false, run)
             .await
     }
 
@@ -2222,6 +2260,9 @@ impl MatrixChannel {
         }
         if let Some(app) = metadata.get(CONTENT_APP) {
             body[CONTENT_APP] = app.clone();
+        }
+        if let Some(run) = metadata.get(CONTENT_RUN) {
+            body[CONTENT_RUN] = run.clone();
         }
         if let Some(actions) = metadata.get(CONTENT_ACTIONS) {
             body[CONTENT_ACTIONS] = actions.clone();
@@ -2436,6 +2477,7 @@ impl MatrixChannel {
         message_id: &str,
         new_content: &str,
         live: bool,
+        run_details: Option<&serde_json::Value>,
     ) -> Result<()> {
         let sender = self
             .event_senders
@@ -2476,6 +2518,14 @@ impl MatrixChannel {
         if live {
             body[LIVE_MARKER] = json!({});
             body["m.new_content"][LIVE_MARKER] = json!({});
+        }
+
+        // Embed the turn's run detail on BOTH the top-level content and
+        // `m.new_content` (the latter is what clients treat as the edited event's
+        // effective content), so the answer carries its expandable tool section.
+        if let Some(run) = run_details {
+            body[CONTENT_RUN] = run.clone();
+            body["m.new_content"][CONTENT_RUN] = run.clone();
         }
 
         let resp = self

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -68,6 +68,38 @@ pub use preview_tokens::{
 };
 pub use router::{DEFAULT_BASE_DOMAIN, build_router, cors_allowlist_for_base_domain};
 
+/// Build a `diff_view` card's `initial_state` from the files edited during a
+/// turn, reconstructing each file's unified diff via `git diff` (BLOCKING — the
+/// caller must run this off the async executor). Each path with no obtainable
+/// diff (not a git repo, staged-only, …) degrades to a path-only entry, the
+/// same fallback the web diff-preview path ships. Returns `None` when nothing
+/// could be produced. Shared by the Matrix `diff_view` emitter (stream_reporter).
+pub(crate) fn diff_view_for_paths(
+    paths: &[String],
+    workspace_root: &std::path::Path,
+) -> Option<serde_json::Value> {
+    use octos_core::ui_protocol::{UiFileMutationNotice, file_mutation_operations};
+    let mut files = Vec::new();
+    for path in paths {
+        let notice = UiFileMutationNotice::new(path.as_str(), file_mutation_operations::MODIFY);
+        match ui_protocol::materialize_file_mutation_diff(&notice, Some(workspace_root))
+            .and_then(|diff| ui_protocol_diff::parse_unified_diff_preview_files(&diff))
+            .filter(|f| !f.is_empty())
+        {
+            Some(mut f) => files.append(&mut f),
+            None => files.push(ui_protocol_diff::file_from_mutation_notice(&notice)),
+        }
+    }
+    if files.is_empty() {
+        return None;
+    }
+    let n = files.len();
+    Some(serde_json::json!({
+        "title": format!("Edited {n} file(s)"),
+        "files": files,
+    }))
+}
+
 /// Test-only re-exports for the build_output_dir validation suite.
 /// Not part of the public API — used by
 /// `crates/octos-cli/tests/build_output_dir_validation.rs` to assert

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -24814,7 +24814,7 @@ fn harden_progress_emitted_approval(event: &mut ApprovalRequestedEvent) {
     }
 }
 
-fn materialize_file_mutation_diff(
+pub(crate) fn materialize_file_mutation_diff(
     notice: &UiFileMutationNotice,
     workspace_root: Option<&Path>,
 ) -> Option<String> {

--- a/crates/octos-cli/src/api/ui_protocol_diff.rs
+++ b/crates/octos-cli/src/api/ui_protocol_diff.rs
@@ -988,7 +988,7 @@ fn preview_from_file_mutation(
     }
 }
 
-fn file_from_mutation_notice(notice: &UiFileMutationNotice) -> DiffPreviewFile {
+pub(crate) fn file_from_mutation_notice(notice: &UiFileMutationNotice) -> DiffPreviewFile {
     DiffPreviewFile {
         path: super::ui_protocol_sanitize::sanitize_display_path(&notice.path),
         old_path: None,
@@ -1015,7 +1015,7 @@ fn status_from_operation(operation: &str) -> DiffPreviewFileStatus {
     }
 }
 
-fn parse_unified_diff_preview_files(diff: &str) -> Option<Vec<DiffPreviewFile>> {
+pub(crate) fn parse_unified_diff_preview_files(diff: &str) -> Option<Vec<DiffPreviewFile>> {
     let mut files = Vec::new();
     let mut current: Option<DiffPreviewFile> = None;
     let mut current_hunk: Option<DiffPreviewHunk> = None;

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -7441,7 +7441,12 @@ impl SessionActor {
             crate::stream_reporter::ChannelStreamReporter::new(stream_tx.clone())
                 .with_thread_id(client_message_id.clone()),
         );
-        self.agent.set_reporter(reporter);
+        // Keep our own handle so we can drain the turn's `run_details` (tools +
+        // cost) AFTER the agent finishes and attach it to the final answer
+        // message (as `org.octos.run` metadata) rather than posting a separate
+        // card. The clone handed to the agent is reset to Silent at turn end, but
+        // this Arc keeps the stashed detail alive for us to take.
+        self.agent.set_reporter(reporter.clone());
 
         // Wire adaptive router status callback to forward through the stream channel.
         // This lets failover events inside chat_stream() surface as LlmStatus messages.
@@ -7803,6 +7808,14 @@ impl SessionActor {
             self.responsiveness.set_active(false);
             self.queue_mode = QueueMode::Followup;
         }
+
+        // Drain this turn's run detail (stashed on TaskCompleted) and DROP our
+        // reporter handle NOW: it holds a `stream_tx` clone, so keeping it alive
+        // past here would stop the forwarder's channel from ever closing and
+        // deadlock the `handle.await` below — which would hang the whole session
+        // actor and silence every subsequent turn.
+        let run_detail = reporter.take_run_details();
+        drop(reporter);
 
         // Reset reporter to silent (drops stream_tx → forwarder finishes)
         self.agent
@@ -8192,6 +8205,9 @@ impl SessionActor {
                         display_content
                     };
 
+                    // `run_detail` (tools + cost) was drained above, before the
+                    // reporter handle was dropped; attach it to the answer below.
+
                     // Skip streaming edit when session is inactive — let the
                     // reply go through proxy → pending buffer for later flush.
                     let session_active = self.is_active().await;
@@ -8208,9 +8224,21 @@ impl SessionActor {
                         if let Some(ref sr) = stream_result {
                             if let Some(ref mid) = sr.message_id {
                                 if let Some(ref si) = self.status_indicator {
+                                    // Attach the turn's run detail (tools + cost)
+                                    // to the streamed answer's final edit so the
+                                    // client shows it embedded + expandable.
+                                    let finish_metadata = run_detail
+                                        .as_ref()
+                                        .map(|rd| serde_json::json!({ "org.octos.run": rd }))
+                                        .unwrap_or_else(|| serde_json::json!({}));
                                     let _ = si
                                         .channel()
-                                        .finish_stream(&self.chat_id, mid, &display_content)
+                                        .finish_stream_with_metadata(
+                                            &self.chat_id,
+                                            mid,
+                                            &display_content,
+                                            &finish_metadata,
+                                        )
                                         .await;
                                 }
                                 true
@@ -8235,6 +8263,13 @@ impl SessionActor {
                                     "thread_id".to_string(),
                                     serde_json::Value::String(tid.clone()),
                                 );
+                            }
+                        }
+                        // Embed the turn's run detail on the fresh answer send so
+                        // the client can render its expandable tool section.
+                        if let Some(ref rd) = run_detail {
+                            if let Some(map) = reply_metadata.as_object_mut() {
+                                map.insert("org.octos.run".to_string(), rd.clone());
                             }
                         }
                         let _ = self
@@ -8592,7 +8627,10 @@ impl SessionActor {
             // critical bit that makes overflow stop being a special case —
             // same code path, same events, just a different thread_id.
             let (stream_tx, stream_rx) = tokio::sync::mpsc::unbounded_channel();
-            let overflow_reporter: Arc<dyn octos_agent::ProgressReporter> = Arc::new(
+            // Concrete handle (not `Arc<dyn ProgressReporter>`) so we can drain
+            // the turn's `run_details` after the agent runs and attach it to the
+            // overflow answer, like the primary finalize paths do.
+            let overflow_reporter = Arc::new(
                 crate::stream_reporter::ChannelStreamReporter::new(stream_tx)
                     .with_thread_id(overflow_client_message_id.clone()),
             );
@@ -8633,7 +8671,8 @@ impl SessionActor {
             // Wave-4 B3.4 — stamp `RouterContext` so the overflow agent's
             // failovers are attributed to this session. The forwarder
             // task filters strictly on `originating_session_id`.
-            let reporter_for_scope = overflow_reporter.clone();
+            let reporter_for_scope: Arc<dyn octos_agent::ProgressReporter> =
+                overflow_reporter.clone();
             let router_ctx_session = session_key.to_string();
             let router_ctx_turn = overflow_client_message_id.clone();
             let result = octos_agent::TASK_REPORTER
@@ -8651,6 +8690,10 @@ impl SessionActor {
                     .await
                 })
                 .await;
+
+            // Drain this overflow turn's run detail (tools + cost) before the
+            // reporter is dropped, to attach it to the answer below.
+            let overflow_run_detail = overflow_reporter.take_run_details();
 
             // Drop the reporter so the stream forwarder sees channel close
             drop(overflow_reporter);
@@ -8963,6 +9006,17 @@ impl SessionActor {
                                 serde_json::Value::String(tid.clone()),
                             );
                         }
+                        // Attach this turn's run detail to the fresh overflow
+                        // answer (embedded + expandable, like the primary paths).
+                        // Skipped when the answer was already streamed: that
+                        // bubble is finalized without a metadata channel and this
+                        // send is empty, so the strip can't ride it — a known
+                        // overflow-streamed limitation, not a silent drop.
+                        if !already_streamed {
+                            if let Some(ref rd) = overflow_run_detail {
+                                metadata.insert("org.octos.run".to_string(), rd.clone());
+                            }
+                        }
                         let _ = out_tx
                             .send(OutboundMessage {
                                 channel: channel.clone(),
@@ -9213,7 +9267,12 @@ impl SessionActor {
             crate::stream_reporter::ChannelStreamReporter::new(stream_tx.clone())
                 .with_thread_id(client_message_id.clone()),
         );
-        self.agent.set_reporter(reporter);
+        // Keep our own handle so we can drain the turn's `run_details` (tools +
+        // cost) AFTER the agent finishes and attach it to the final answer
+        // message (as `org.octos.run` metadata) rather than posting a separate
+        // card. The clone handed to the agent is reset to Silent at turn end, but
+        // this Arc keeps the stashed detail alive for us to take.
+        self.agent.set_reporter(reporter.clone());
 
         // Wire adaptive router status callback for failover notifications
         if let Some(ref router) = self.adaptive_router {
@@ -9344,6 +9403,14 @@ impl SessionActor {
             self.responsiveness.set_active(false);
             self.queue_mode = QueueMode::Followup;
         }
+
+        // Drain this turn's run detail (stashed on TaskCompleted) and DROP our
+        // reporter handle NOW: it holds a `stream_tx` clone, so keeping it alive
+        // past here would stop the forwarder's channel from ever closing and
+        // deadlock the forwarder await below — hanging the session actor and
+        // silencing every subsequent turn.
+        let run_detail = reporter.take_run_details();
+        drop(reporter);
 
         // Reset reporter to silent (drop the stream sender → forwarder will finish)
         self.agent
@@ -9631,6 +9698,9 @@ impl SessionActor {
                         display_content
                     };
 
+                    // `run_detail` (tools + cost) was drained above, before the
+                    // reporter handle was dropped; attach it to the answer below.
+
                     // If stream forwarder already sent a message AND this session
                     // is active, do a final edit. When inactive, skip the edit so
                     // the reply goes through the proxy → pending buffer path.
@@ -9639,9 +9709,21 @@ impl SessionActor {
                         if let Some(ref sr) = stream_result {
                             if let Some(ref mid) = sr.message_id {
                                 if let Some(ref si) = self.status_indicator {
+                                    // Attach the turn's run detail (tools + cost)
+                                    // to the streamed answer's final edit so the
+                                    // client shows it embedded + expandable.
+                                    let finish_metadata = run_detail
+                                        .as_ref()
+                                        .map(|rd| serde_json::json!({ "org.octos.run": rd }))
+                                        .unwrap_or_else(|| serde_json::json!({}));
                                     let _ = si
                                         .channel()
-                                        .finish_stream(&self.chat_id, mid, &display_content)
+                                        .finish_stream_with_metadata(
+                                            &self.chat_id,
+                                            mid,
+                                            &display_content,
+                                            &finish_metadata,
+                                        )
                                         .await;
                                 }
                                 true
@@ -9666,6 +9748,13 @@ impl SessionActor {
                                     "thread_id".to_string(),
                                     serde_json::Value::String(tid.clone()),
                                 );
+                            }
+                        }
+                        // Embed the turn's run detail on the fresh answer send so
+                        // the client can render its expandable tool section.
+                        if let Some(ref rd) = run_detail {
+                            if let Some(map) = reply_metadata.as_object_mut() {
+                                map.insert("org.octos.run".to_string(), rd.clone());
                             }
                         }
                         let _ = self

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -7489,6 +7489,7 @@ impl SessionActor {
                     // bubble.
                     client_message_id.clone(),
                     Arc::clone(&app_reply_tools),
+                    Some(self.user_workspace.clone()),
                 )))
             } else {
                 drop(stream_rx);
@@ -8620,6 +8621,7 @@ impl SessionActor {
                     // the bubble of whichever turn arrived last.
                     overflow_client_message_id.clone(),
                     Arc::clone(&app_reply_tools),
+                    Some(user_workspace.clone()),
                 )))
             } else {
                 drop(stream_rx);
@@ -9255,6 +9257,7 @@ impl SessionActor {
                     // cmid so streaming chunks stamp it on the wire.
                     client_message_id.clone(),
                     Arc::clone(&app_reply_tools),
+                    Some(self.user_workspace.clone()),
                 )))
             } else {
                 drop(stream_rx);

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -4,8 +4,8 @@
 //! enabling real-time LLM text streaming to Telegram, WhatsApp, etc.
 //! Text is accumulated and the channel message is edited at a throttled rate.
 
-use std::collections::HashSet;
-use std::sync::Arc;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use octos_agent::progress::{ProgressEvent, ProgressReporter};
@@ -38,6 +38,18 @@ pub enum StreamProgressEvent {
     /// Used for discrete progress events (thinking, cost_update) that
     /// the web UI needs as separate SSE events, not baked into message text.
     RawSse { json: String },
+    /// An `org.octos.app` agent-output card projected from a runtime event
+    /// (a completed tool call, a plan update, …). The forwarder emits it as a
+    /// structured Matrix card on capable clients (Robrix); other clients fall
+    /// back to the `body` text. See `run_stream_forwarder`.
+    AppCard {
+        /// The `org.octos.app.type` key (e.g. `"tool_call"`, `"plan"`).
+        card_type: String,
+        /// Human-readable fallback text for clients without the type registry.
+        body: String,
+        /// The card's `initial_state` object.
+        initial_state: serde_json::Value,
+    },
 }
 
 /// A `ProgressReporter` that forwards stream events through an unbounded channel.
@@ -53,6 +65,11 @@ pub enum StreamProgressEvent {
 pub struct ChannelStreamReporter {
     tx: mpsc::UnboundedSender<StreamProgressEvent>,
     thread_id: Option<String>,
+    /// In-flight tool-call arguments keyed by `tool_id`, recorded on
+    /// `ToolStarted` and consumed on `ToolCompleted` so the projected
+    /// `tool_call` card can echo what the tool was asked to do (the
+    /// completion event itself does not carry the arguments).
+    tool_args: Mutex<HashMap<String, serde_json::Value>>,
 }
 
 impl ChannelStreamReporter {
@@ -60,6 +77,7 @@ impl ChannelStreamReporter {
         Self {
             tx,
             thread_id: None,
+            tool_args: Mutex::new(HashMap::new()),
         }
     }
 
@@ -80,6 +98,19 @@ fn inject_thread_id(value: &mut serde_json::Value, thread_id: Option<&str>) {
             "thread_id".to_string(),
             serde_json::Value::String(tid.to_string()),
         );
+    }
+}
+
+/// Truncate a preview string to at most `max` characters (char-safe), trimming
+/// surrounding whitespace and appending an ellipsis when cut. Bounds the tool
+/// output echoed into a projected `tool_call` card.
+fn truncate_card_preview(s: &str, max: usize) -> String {
+    let t = s.trim();
+    if t.chars().count() <= max {
+        t.to_string()
+    } else {
+        let cut: String = t.chars().take(max).collect();
+        format!("{cut}…")
     }
 }
 
@@ -111,8 +142,15 @@ impl ProgressReporter for ChannelStreamReporter {
             ProgressEvent::ToolStarted {
                 ref name,
                 ref tool_id,
-                ..
+                ref arguments,
             } => {
+                // Record the call arguments so the `tool_call` card projected on
+                // ToolCompleted can echo them (the completion event omits them).
+                if let Some(args) = arguments {
+                    if let Ok(mut m) = self.tool_args.lock() {
+                        m.insert(tool_id.clone(), args.clone());
+                    }
+                }
                 // Also send raw SSE for web client status indicators
                 let mut payload = serde_json::json!({
                     "type": "tool_start",
@@ -129,7 +167,8 @@ impl ProgressReporter for ChannelStreamReporter {
                 ref name,
                 ref tool_id,
                 success,
-                ..
+                ref output_preview,
+                duration,
             } => {
                 let mut payload = serde_json::json!({
                     "type": "tool_end",
@@ -140,6 +179,33 @@ impl ProgressReporter for ChannelStreamReporter {
                 inject_thread_id(&mut payload, thread_id);
                 let _ = self.tx.send(StreamProgressEvent::RawSse {
                     json: payload.to_string(),
+                });
+                // Project a `tool_call` card (org.octos.app) so capable clients
+                // render the invocation as a structured card (name · status ·
+                // args · result · duration).
+                let arguments = self
+                    .tool_args
+                    .lock()
+                    .ok()
+                    .and_then(|mut m| m.remove(tool_id));
+                let status = if success { "completed" } else { "error" };
+                let mut initial_state = serde_json::json!({
+                    "tool_name": name,
+                    "status": status,
+                    "duration_ms": duration.as_millis() as u64,
+                });
+                if let Some(args) = arguments {
+                    initial_state["arguments"] = args;
+                }
+                let preview = truncate_card_preview(output_preview, 600);
+                if !preview.is_empty() {
+                    let key = if success { "output_preview" } else { "error" };
+                    initial_state[key] = serde_json::Value::String(preview);
+                }
+                let _ = self.tx.send(StreamProgressEvent::AppCard {
+                    card_type: "tool_call".to_string(),
+                    body: format!("{name} {status}"),
+                    initial_state,
                 });
                 StreamProgressEvent::ToolCompleted {
                     name: name.clone(),
@@ -218,6 +284,16 @@ impl ProgressReporter for ChannelStreamReporter {
                 StreamProgressEvent::RawSse {
                     json: payload.to_string(),
                 }
+            }
+            ProgressEvent::PlanUpdated { plan } => {
+                // `plan` is a serialized UiPlanRecord ({items, title?, …}), which
+                // is exactly the `plan` card's initial_state contract.
+                let _ = self.tx.send(StreamProgressEvent::AppCard {
+                    card_type: "plan".to_string(),
+                    body: "Plan updated".to_string(),
+                    initial_state: plan,
+                });
+                return;
             }
             _ => return,
         };
@@ -534,6 +610,44 @@ pub async fn run_stream_forwarder(
                         }
                         last_edit = Instant::now();
                     }
+                }
+            }
+            StreamProgressEvent::AppCard {
+                card_type,
+                body,
+                initial_state,
+            } => {
+                // Automatic agent-output card. Only meaningful on clients that
+                // understand `org.octos.app` (Robrix); other clients render the
+                // `body` fallback. Gated on the same condition as transient tool
+                // status suppression: matrix + an app-reply-capable tool set.
+                if !suppress_matrix_transient_status {
+                    continue;
+                }
+                if !is_session_active(&session_key, &active_sessions).await {
+                    continue;
+                }
+                let mut metadata = serde_json::json!({
+                    "org.octos.app": {
+                        "type": card_type.clone(),
+                        "version": 1,
+                        "initial_state": initial_state,
+                    }
+                });
+                if let Some(uid) = sender_user_id.as_deref() {
+                    metadata[METADATA_SENDER_USER_ID] =
+                        serde_json::Value::String(uid.to_string());
+                }
+                let msg = OutboundMessage {
+                    channel: channel.name().to_string(),
+                    chat_id: chat_id.clone(),
+                    content: body,
+                    reply_to: None,
+                    media: Vec::new(),
+                    metadata,
+                };
+                if let Err(e) = channel.send(&msg).await {
+                    warn!(card = %card_type, "failed to emit agent-output card: {e}");
                 }
             }
             StreamProgressEvent::ToolProgress { name, message } => {
@@ -1022,6 +1136,72 @@ mod tests {
                 "payload `{json}` missing `thread_id` field",
             );
         }
+    }
+
+    /// The reporter projects an `org.octos.app` `tool_call` card on
+    /// `ToolCompleted` (echoing the arguments recorded at `ToolStarted`) and a
+    /// `plan` card on `PlanUpdated`. Capable Matrix clients (Robrix) render
+    /// these as structured cards; `run_stream_forwarder` gates emission on
+    /// matrix + an app-reply-capable tool set.
+    #[test]
+    fn projects_tool_call_and_plan_app_cards() {
+        use octos_agent::progress::ProgressEvent;
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let reporter = ChannelStreamReporter::new(tx);
+
+        reporter.report(ProgressEvent::ToolStarted {
+            name: "shell".into(),
+            tool_id: "t1".into(),
+            arguments: Some(serde_json::json!({ "command": "ls -la" })),
+        });
+        reporter.report(ProgressEvent::ToolCompleted {
+            name: "shell".into(),
+            tool_id: "t1".into(),
+            success: true,
+            output_preview: "total 0\ndrwxr-xr-x".into(),
+            duration: Duration::from_millis(1200),
+        });
+        reporter.report(ProgressEvent::PlanUpdated {
+            plan: serde_json::json!({
+                "title": "Do the thing",
+                "items": [{ "id": "1", "title": "step", "status": "in_progress" }],
+            }),
+        });
+
+        let mut cards: Vec<(String, serde_json::Value)> = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            if let StreamProgressEvent::AppCard {
+                card_type,
+                initial_state,
+                ..
+            } = event
+            {
+                cards.push((card_type, initial_state));
+            }
+        }
+
+        assert_eq!(cards.len(), 2, "expected a tool_call + a plan card, got {cards:?}");
+
+        let (tc_type, tc_state) = &cards[0];
+        assert_eq!(tc_type.as_str(), "tool_call");
+        assert_eq!(tc_state["tool_name"].as_str(), Some("shell"));
+        assert_eq!(tc_state["status"].as_str(), Some("completed"));
+        assert_eq!(tc_state["arguments"]["command"].as_str(), Some("ls -la"));
+        assert_eq!(tc_state["duration_ms"].as_u64(), Some(1200));
+        assert!(
+            tc_state["output_preview"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("total 0")
+        );
+
+        let (plan_type, plan_state) = &cards[1];
+        assert_eq!(plan_type.as_str(), "plan");
+        assert_eq!(
+            plan_state["items"][0]["status"].as_str(),
+            Some("in_progress")
+        );
     }
 
     /// The channel stream reporter feeds API/channel clients that read

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -4,7 +4,7 @@
 //! enabling real-time LLM text streaming to Telegram, WhatsApp, etc.
 //! Text is accumulated and the channel message is edited at a throttled rate.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -18,9 +18,19 @@ use tracing::{debug, warn};
 /// card), so the generic `tool_call` projection would duplicate their output.
 const SELF_CARDING_TOOLS: &[&str] = &["update_plan", "send_app_card"];
 
+/// Max length of a failed tool's error summary embedded in the `run_details`
+/// card (surfaced only when the user expands the card).
+///
+/// Truncated because it enters the room event unencrypted and can carry noise
+/// or secrets. Successful tools carry NO arguments/output at all — only a failed
+/// tool contributes a (truncated) error, so a problem can be diagnosed on expand
+/// without leaking a whole command line or `.env` on every successful call.
+const TOOL_ERROR_PREVIEW_MAX: usize = 200;
+
 /// Accumulates a turn's token/cost figures across the per-response `CostUpdate`
-/// events so a single `run_summary` card can be emitted on `TaskCompleted`
-/// (turn end) rather than one per response.
+/// events so, on `TaskCompleted` (turn end), a single token/cost block can be
+/// folded into the merged `run_details` (attached to the answer message) rather
+/// than emitted per response.
 #[derive(Default)]
 struct RunSummaryAccum {
     model: Option<String>,
@@ -85,21 +95,21 @@ pub enum StreamProgressEvent {
 pub struct ChannelStreamReporter {
     tx: mpsc::UnboundedSender<StreamProgressEvent>,
     thread_id: Option<String>,
-    /// In-flight tool-call arguments keyed by `tool_id`, recorded on
-    /// `ToolStarted` and consumed on `ToolCompleted` so the projected
-    /// `tool_call` card can echo what the tool was asked to do (the
-    /// completion event itself does not carry the arguments).
-    tool_args: Mutex<HashMap<String, serde_json::Value>>,
-    /// Per-turn token/cost accumulator, drained on `TaskCompleted` into a
-    /// single `run_summary` card.
+    /// Per-turn token/cost accumulator, drained on `TaskCompleted` into the
+    /// merged `run_details` card.
     run_accum: Mutex<Option<RunSummaryAccum>>,
     /// Files modified this turn (deduped), drained on `TaskCompleted` into a
     /// single `artifact` card — so N edits never post N cards.
     modified_files: Mutex<Vec<String>>,
-    /// Tool invocations this turn, drained on `TaskCompleted` into a single
-    /// `tool_activity` card — so a research turn with N searches posts ONE
-    /// card, not N `tool_call` cards.
+    /// Tool invocations this turn, drained on `TaskCompleted` into the merged
+    /// `run_details` object — so a research turn with N searches contributes ONE
+    /// embedded detail, not N `tool_call` cards.
     tool_activity: Mutex<Vec<serde_json::Value>>,
+    /// The merged `run_details` (`{tools, tokens, cost, …}`) built on
+    /// `TaskCompleted`, held here for the session actor to drain via
+    /// [`take_run_details`](Self::take_run_details) and attach as
+    /// `org.octos.run` metadata onto the final answer message.
+    run_details: Mutex<Option<serde_json::Value>>,
 }
 
 impl ChannelStreamReporter {
@@ -107,10 +117,10 @@ impl ChannelStreamReporter {
         Self {
             tx,
             thread_id: None,
-            tool_args: Mutex::new(HashMap::new()),
             run_accum: Mutex::new(None),
             modified_files: Mutex::new(Vec::new()),
             tool_activity: Mutex::new(Vec::new()),
+            run_details: Mutex::new(None),
         }
     }
 
@@ -119,6 +129,17 @@ impl ChannelStreamReporter {
     pub fn with_thread_id(mut self, thread_id: Option<String>) -> Self {
         self.thread_id = thread_id.filter(|s| !s.is_empty());
         self
+    }
+
+    /// Take the merged `run_details` (`{tools, tokens, cost, …}`) built on the
+    /// turn's `TaskCompleted`, if any. Returns `None` when the turn ran no tools.
+    /// Callable through a shared handle after the agent task completes; the value
+    /// is cleared so a subsequent turn starts fresh.
+    pub fn take_run_details(&self) -> Option<serde_json::Value> {
+        self.run_details
+            .lock()
+            .ok()
+            .and_then(|mut slot| slot.take())
     }
 }
 
@@ -193,16 +214,11 @@ impl ProgressReporter for ChannelStreamReporter {
             ProgressEvent::ToolStarted {
                 ref name,
                 ref tool_id,
-                ref arguments,
+                arguments: _,
             } => {
-                // Record the call arguments so the `tool_call` card projected on
-                // ToolCompleted can echo them (the completion event omits them).
-                if let Some(args) = arguments {
-                    if let Ok(mut m) = self.tool_args.lock() {
-                        m.insert(tool_id.clone(), args.clone());
-                    }
-                }
-                // Also send raw SSE for web client status indicators
+                // Send raw SSE for web client status indicators. Call arguments
+                // are intentionally not recorded — the `run_details` card never
+                // echoes them (only a failed tool's truncated error is surfaced).
                 let mut payload = serde_json::json!({
                     "type": "tool_start",
                     "tool": name,
@@ -231,34 +247,27 @@ impl ProgressReporter for ChannelStreamReporter {
                 let _ = self.tx.send(StreamProgressEvent::RawSse {
                     json: payload.to_string(),
                 });
-                // Consume any recorded args regardless, so the entry never leaks.
-                let arguments = self
-                    .tool_args
-                    .lock()
-                    .ok()
-                    .and_then(|mut m| m.remove(tool_id));
-                // Accumulate into a per-turn `tool_activity` card (one card at
-                // turn end) instead of one `tool_call` card per tool — except
-                // self-carding tools, which already emit their own card.
+                // Accumulate this tool into the per-turn `run_details` card (one
+                // merged card at turn end) — except self-carding tools, which
+                // emit their own card. A FAILED tool contributes a truncated
+                // error so the failure can be diagnosed when the card is
+                // expanded; a successful tool carries only name/status/duration
+                // (no args/output on the wire — see `TOOL_ERROR_PREVIEW_MAX`).
                 if !SELF_CARDING_TOOLS.contains(&name.as_str()) {
                     let status = if success { "completed" } else { "error" };
-                    // Short "what it did" line: the call args on success, the
-                    // error on failure.
-                    let summary = if success {
-                        arguments
-                            .as_ref()
-                            .map(|a| truncate_card_preview(&a.to_string(), 120))
-                            .unwrap_or_default()
-                    } else {
-                        truncate_card_preview(output_preview, 120)
-                    };
+                    let mut entry = serde_json::json!({
+                        "tool_name": name,
+                        "status": status,
+                        "duration_ms": duration.as_millis() as u64,
+                    });
+                    if !success {
+                        entry["error"] = serde_json::Value::String(truncate_card_preview(
+                            output_preview,
+                            TOOL_ERROR_PREVIEW_MAX,
+                        ));
+                    }
                     if let Ok(mut v) = self.tool_activity.lock() {
-                        v.push(serde_json::json!({
-                            "tool_name": name,
-                            "status": status,
-                            "duration_ms": duration.as_millis() as u64,
-                            "summary": summary,
-                        }));
+                        v.push(entry);
                     }
                 }
                 StreamProgressEvent::ToolCompleted {
@@ -322,8 +331,8 @@ impl ProgressReporter for ChannelStreamReporter {
                 model,
                 context_window,
             } => {
-                // Accumulate the turn's token/cost figures for a single
-                // `run_summary` card emitted on TaskCompleted (turn end).
+                // Accumulate the turn's token/cost figures; folded into the
+                // merged `run_details` on TaskCompleted (turn end).
                 if let Ok(mut acc) = self.run_accum.lock() {
                     let a = acc.get_or_insert_with(RunSummaryAccum::default);
                     a.input_tokens = turn_input_tokens as u64;
@@ -378,57 +387,47 @@ impl ProgressReporter for ChannelStreamReporter {
                 return;
             }
             ProgressEvent::TaskCompleted { duration, .. } => {
-                // Drain this turn's tool invocations into ONE `tool_activity`
-                // card, rather than one `tool_call` card per tool.
-                if let Some(tools) = self
+                // Drain BOTH per-turn accumulators (always, so a turn never
+                // bleeds into the next), then merge tool activity + token/cost
+                // into ONE `run_details` object. Rather than posting a separate
+                // card message, we STASH it so the session actor can attach it as
+                // `org.octos.run` metadata onto the FINAL answer message — the
+                // client renders it embedded + expandable under the answer, not
+                // as its own row. Built only when the turn ran tools (a pure-text
+                // answer stashes nothing). Matrix canonical JSON forbids floats,
+                // so costs are decimal strings.
+                let tools = self
                     .tool_activity
                     .lock()
                     .ok()
                     .map(|mut v| std::mem::take(&mut *v))
-                    .filter(|v| !v.is_empty())
-                {
-                    let n = tools.len();
-                    let failed = tools
-                        .iter()
-                        .filter(|t| t.get("status").and_then(|s| s.as_str()) == Some("error"))
-                        .count();
-                    let body = if failed > 0 {
-                        format!("{n} tools · {failed} failed")
-                    } else {
-                        format!("{n} tools")
-                    };
-                    let _ = self.tx.send(StreamProgressEvent::AppCard {
-                        card_type: "tool_activity".to_string(),
-                        body,
-                        initial_state: serde_json::json!({ "tools": tools }),
-                    });
-                }
-                // Drain the accumulated cost into one per-turn `run_summary`
-                // card. Matrix canonical JSON forbids floats, so costs are sent
-                // as decimal strings.
-                if let Some(acc) = self.run_accum.lock().ok().and_then(|mut a| a.take()) {
+                    .unwrap_or_default();
+                let run = self.run_accum.lock().ok().and_then(|mut a| a.take());
+                if !tools.is_empty() {
                     let mut initial_state = serde_json::json!({
-                        "input_tokens": acc.input_tokens,
-                        "output_tokens": acc.output_tokens,
-                        "total_tokens": acc.input_tokens + acc.output_tokens,
+                        "tools": tools,
                         "duration_ms": duration.as_millis() as u64,
                     });
-                    if let Some(m) = acc.model {
-                        initial_state["model"] = serde_json::Value::String(m);
-                    }
-                    if acc.has_cost {
-                        initial_state["response_cost"] =
-                            serde_json::Value::String(format!("{:.4}", acc.turn_cost));
-                        if let Some(sc) = acc.session_cost {
-                            initial_state["session_cost"] =
-                                serde_json::Value::String(format!("{:.4}", sc));
+                    if let Some(acc) = run {
+                        initial_state["input_tokens"] = acc.input_tokens.into();
+                        initial_state["output_tokens"] = acc.output_tokens.into();
+                        initial_state["total_tokens"] =
+                            acc.input_tokens.saturating_add(acc.output_tokens).into();
+                        if let Some(m) = acc.model {
+                            initial_state["model"] = serde_json::Value::String(m);
+                        }
+                        if acc.has_cost {
+                            initial_state["response_cost"] =
+                                serde_json::Value::String(format!("{:.4}", acc.turn_cost));
+                            if let Some(sc) = acc.session_cost {
+                                initial_state["session_cost"] =
+                                    serde_json::Value::String(format!("{:.4}", sc));
+                            }
                         }
                     }
-                    let _ = self.tx.send(StreamProgressEvent::AppCard {
-                        card_type: "run_summary".to_string(),
-                        body: "Turn complete".to_string(),
-                        initial_state,
-                    });
+                    if let Ok(mut slot) = self.run_details.lock() {
+                        *slot = Some(initial_state);
+                    }
                 }
                 // Emit one `artifact` card listing the files produced this turn.
                 if let Some(files) = self
@@ -991,11 +990,20 @@ pub async fn run_stream_forwarder(
         && let Some(root) = workspace_root.clone()
     {
         let paths = std::mem::take(&mut diff_paths);
-        let initial_state =
-            tokio::task::spawn_blocking(move || crate::api::diff_view_for_paths(&paths, &root))
-                .await
-                .ok()
-                .flatten();
+        // Match the JoinResult explicitly: a panic inside the blocking closure
+        // must be logged, not silently collapsed into `None` (which is also the
+        // legitimate "no diff" result), or a panic here is undiagnosable.
+        let initial_state = match tokio::task::spawn_blocking(move || {
+            crate::api::diff_view_for_paths(&paths, &root)
+        })
+        .await
+        {
+            Ok(state) => state,
+            Err(join_err) => {
+                warn!("diff_view reconstruction task panicked: {join_err}");
+                None
+            }
+        };
         if let Some(initial_state) = initial_state {
             let mut metadata = serde_json::json!({
                 "org.octos.app": {
@@ -1358,13 +1366,15 @@ mod tests {
         }
     }
 
-    /// The reporter projects an `org.octos.app` `tool_call` card on
-    /// `ToolCompleted` (echoing the arguments recorded at `ToolStarted`) and a
-    /// `plan` card on `PlanUpdated`. Capable Matrix clients (Robrix) render
-    /// these as structured cards; `run_stream_forwarder` gates emission on
-    /// matrix + an app-reply-capable tool set.
+    /// A turn's tools (one ok, one failed) coalesce with the turn's token/cost
+    /// into ONE merged `run_details` object — STASHED (via `take_run_details`)
+    /// for attachment to the answer message, NOT posted as a card, and NOT split
+    /// into `tool_call` / `tool_activity` / `run_summary` cards. A failed tool
+    /// carries a truncated `error`; a successful tool carries no args/output. The
+    /// `plan` card still fires immediately on `PlanUpdated`. Costs are decimal
+    /// strings (Matrix canonical JSON forbids floats).
     #[test]
-    fn projects_tool_activity_and_plan_app_cards() {
+    fn projects_run_details_and_plan_app_cards() {
         use octos_agent::progress::ProgressEvent;
         use std::collections::HashMap;
 
@@ -1396,6 +1406,16 @@ mod tests {
             output_preview: "private IP not allowed".into(),
             duration: Duration::from_millis(30),
         });
+        reporter.report(ProgressEvent::CostUpdate {
+            session_input_tokens: 130,
+            session_output_tokens: 70,
+            turn_input_tokens: 70,
+            turn_output_tokens: 40,
+            response_cost: Some(0.003),
+            session_cost: Some(0.013),
+            model: Some("deepseek-chat".into()),
+            context_window: Some(64000),
+        });
         reporter.report(ProgressEvent::PlanUpdated {
             plan: serde_json::json!({
                 "title": "Do the thing",
@@ -1424,35 +1444,129 @@ mod tests {
         let plan = cards.get("plan").expect("plan card");
         assert_eq!(plan["items"][0]["status"].as_str(), Some("in_progress"));
 
-        // The two tools coalesce into ONE tool_activity card at turn end — NOT
-        // two per-tool tool_call cards.
+        // The run detail is NOT a standalone card (it's stashed for the answer
+        // message), and there are no per-tool / tool_activity / run_summary cards.
         assert!(
             !cards.contains_key("tool_call"),
             "must not emit per-tool tool_call cards"
         );
-        let tools = cards.get("tool_activity").expect("tool_activity card")["tools"]
-            .as_array()
-            .expect("tools array")
-            .clone();
+        assert!(
+            !cards.contains_key("tool_activity"),
+            "no tool_activity card"
+        );
+        assert!(!cards.contains_key("run_summary"), "no run_summary card");
+        assert!(
+            !cards.contains_key("run_details"),
+            "run_details is stashed, not posted as a standalone card"
+        );
+
+        // The merged run detail is available for the answer message to carry.
+        let state = reporter
+            .take_run_details()
+            .expect("run_details stashed on TaskCompleted");
+        let tools = state["tools"].as_array().expect("tools array");
         assert_eq!(tools.len(), 2);
+        // Successful tool: name/status/duration, and NO error / NO args leak.
         assert_eq!(tools[0]["tool_name"].as_str(), Some("web_search"));
         assert_eq!(tools[0]["status"].as_str(), Some("completed"));
         assert_eq!(tools[0]["duration_ms"].as_u64(), Some(3800));
-        assert!(tools[0]["summary"].as_str().unwrap().contains("SK Hynix"));
+        assert!(
+            tools[0].get("error").is_none(),
+            "successful tool carries no error/output on the wire"
+        );
+        // Failed tool: a truncated error so the failure can be diagnosed on expand.
         assert_eq!(tools[1]["tool_name"].as_str(), Some("web_fetch"));
         assert_eq!(tools[1]["status"].as_str(), Some("error"));
-        assert!(tools[1]["summary"].as_str().unwrap().contains("private IP"));
+        assert!(
+            tools[1]["error"].as_str().unwrap().contains("private IP"),
+            "failed tool surfaces its (truncated) error"
+        );
+
+        // Token/cost folded into the SAME detail (shown on expand).
+        assert_eq!(state["model"].as_str(), Some("deepseek-chat"));
+        assert_eq!(state["input_tokens"].as_u64(), Some(70));
+        assert_eq!(state["output_tokens"].as_u64(), Some(40));
+        assert_eq!(state["total_tokens"].as_u64(), Some(110));
+        assert_eq!(state["duration_ms"].as_u64(), Some(5000));
+        assert_eq!(state["response_cost"].as_str(), Some("0.0030"));
+        assert_eq!(state["session_cost"].as_str(), Some("0.0130"));
+
+        // Draining clears it so the next turn starts fresh.
+        assert!(
+            reporter.take_run_details().is_none(),
+            "run_details is cleared after being taken"
+        );
     }
 
-    /// The reporter coalesces per-response `CostUpdate`s and emits ONE
-    /// `run_summary` card on `TaskCompleted` (turn end): turn-cumulative tokens,
-    /// summed turn cost, and duration. Costs are decimal strings (Matrix
-    /// canonical JSON forbids floats).
+    /// A `run_details` object is stashed for every turn that ran tools, and the
+    /// per-turn accumulator never bleeds: turn 1 (a successful tool) and turn 2
+    /// (a failing tool) each yield their OWN detail carrying only that turn's
+    /// tool.
     #[test]
-    fn projects_run_summary_on_turn_end() {
+    fn run_details_emits_per_turn_without_bleed() {
         use octos_agent::progress::ProgressEvent;
 
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let reporter = ChannelStreamReporter::new(tx);
+
+        // Turn 1: one successful tool, then turn end.
+        reporter.report(ProgressEvent::ToolStarted {
+            name: "web_search".into(),
+            tool_id: "t1".into(),
+            arguments: None,
+        });
+        reporter.report(ProgressEvent::ToolCompleted {
+            name: "web_search".into(),
+            tool_id: "t1".into(),
+            success: true,
+            output_preview: "ok".into(),
+            duration: Duration::from_millis(1200),
+        });
+        reporter.report(ProgressEvent::TaskCompleted {
+            success: true,
+            iterations: 1,
+            duration: Duration::from_millis(1500),
+        });
+        let t1_state = reporter.take_run_details().expect("turn 1 run_details");
+        let t1 = t1_state["tools"].as_array().expect("turn 1 tools");
+        assert_eq!(t1.len(), 1);
+        assert_eq!(t1[0]["tool_name"].as_str(), Some("web_search"));
+        assert_eq!(t1[0]["status"].as_str(), Some("completed"));
+
+        // Turn 2: one FAILING tool, then turn end.
+        reporter.report(ProgressEvent::ToolStarted {
+            name: "web_fetch".into(),
+            tool_id: "t2".into(),
+            arguments: None,
+        });
+        reporter.report(ProgressEvent::ToolCompleted {
+            name: "web_fetch".into(),
+            tool_id: "t2".into(),
+            success: false,
+            output_preview: "boom".into(),
+            duration: Duration::from_millis(30),
+        });
+        reporter.report(ProgressEvent::TaskCompleted {
+            success: true,
+            iterations: 1,
+            duration: Duration::from_millis(50),
+        });
+        let t2_state = reporter.take_run_details().expect("turn 2 run_details");
+        let t2 = t2_state["tools"].as_array().expect("turn 2 tools");
+        // ONLY turn 2's failing tool — turn 1 did not bleed in.
+        assert_eq!(t2.len(), 1, "turn 1's tool must not bleed into turn 2");
+        assert_eq!(t2[0]["tool_name"].as_str(), Some("web_fetch"));
+        assert_eq!(t2[0]["status"].as_str(), Some("error"));
+    }
+
+    /// A turn with cost updates but NO tools stashes NO run detail: token/cost is
+    /// telemetry that only rides along when the turn actually did tool work. The
+    /// cost accumulator is still drained so it never bleeds into the next turn.
+    #[test]
+    fn run_details_suppressed_on_cost_only_turn() {
+        use octos_agent::progress::ProgressEvent;
+
+        let (tx, _rx) = mpsc::unbounded_channel();
         let reporter = ChannelStreamReporter::new(tx);
 
         reporter.report(ProgressEvent::CostUpdate {
@@ -1465,44 +1579,16 @@ mod tests {
             model: Some("deepseek-chat".into()),
             context_window: Some(64000),
         });
-        reporter.report(ProgressEvent::CostUpdate {
-            session_input_tokens: 130,
-            session_output_tokens: 70,
-            turn_input_tokens: 70, // turn-cumulative -> latest wins
-            turn_output_tokens: 40,
-            response_cost: Some(0.002), // summed with the first -> 0.0030
-            session_cost: Some(0.013),
-            model: Some("deepseek-chat".into()),
-            context_window: Some(64000),
-        });
         reporter.report(ProgressEvent::TaskCompleted {
             success: true,
-            iterations: 2,
+            iterations: 1,
             duration: Duration::from_millis(3400),
         });
 
-        let mut card = None;
-        while let Ok(event) = rx.try_recv() {
-            if let StreamProgressEvent::AppCard {
-                card_type,
-                initial_state,
-                ..
-            } = event
-            {
-                if card_type == "run_summary" {
-                    card = Some(initial_state);
-                }
-            }
-        }
-        let card = card.expect("expected a run_summary card on TaskCompleted");
-
-        assert_eq!(card["model"].as_str(), Some("deepseek-chat"));
-        assert_eq!(card["input_tokens"].as_u64(), Some(70));
-        assert_eq!(card["output_tokens"].as_u64(), Some(40));
-        assert_eq!(card["total_tokens"].as_u64(), Some(110));
-        assert_eq!(card["duration_ms"].as_u64(), Some(3400));
-        assert_eq!(card["response_cost"].as_str(), Some("0.0030"));
-        assert_eq!(card["session_cost"].as_str(), Some("0.0130"));
+        assert!(
+            reporter.take_run_details().is_none(),
+            "a cost-only turn (no tools) stashes no run_details"
+        );
     }
 
     /// Files modified during a turn are deduped and coalesced into ONE

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -808,8 +808,7 @@ pub async fn run_stream_forwarder(
                     }
                 });
                 if let Some(uid) = sender_user_id.as_deref() {
-                    metadata[METADATA_SENDER_USER_ID] =
-                        serde_json::Value::String(uid.to_string());
+                    metadata[METADATA_SENDER_USER_ID] = serde_json::Value::String(uid.to_string());
                 }
                 let msg = OutboundMessage {
                     channel: channel.name().to_string(),
@@ -1431,9 +1430,7 @@ mod tests {
             !cards.contains_key("tool_call"),
             "must not emit per-tool tool_call cards"
         );
-        let tools = cards
-            .get("tool_activity")
-            .expect("tool_activity card")["tools"]
+        let tools = cards.get("tool_activity").expect("tool_activity card")["tools"]
             .as_array()
             .expect("tools array")
             .clone();

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -14,6 +14,26 @@ use octos_core::{METADATA_SENDER_USER_ID, OutboundMessage, SessionKey};
 use tokio::sync::{RwLock, mpsc};
 use tracing::{debug, warn};
 
+/// Tools that already emit their own `org.octos.app` card (a plan card, an app
+/// card), so the generic `tool_call` projection would duplicate their output.
+const SELF_CARDING_TOOLS: &[&str] = &["update_plan", "send_app_card"];
+
+/// Accumulates a turn's token/cost figures across the per-response `CostUpdate`
+/// events so a single `run_summary` card can be emitted on `TaskCompleted`
+/// (turn end) rather than one per response.
+#[derive(Default)]
+struct RunSummaryAccum {
+    model: Option<String>,
+    /// Turn-cumulative token counts — the latest `CostUpdate` carries the total.
+    input_tokens: u64,
+    output_tokens: u64,
+    /// Cumulative session cost from the latest `CostUpdate`.
+    session_cost: Option<f64>,
+    /// Turn cost = sum of the per-response costs seen this turn.
+    turn_cost: f64,
+    has_cost: bool,
+}
+
 /// Events forwarded from the synchronous reporter to the async forwarder.
 #[derive(Debug)]
 pub enum StreamProgressEvent {
@@ -70,6 +90,9 @@ pub struct ChannelStreamReporter {
     /// `tool_call` card can echo what the tool was asked to do (the
     /// completion event itself does not carry the arguments).
     tool_args: Mutex<HashMap<String, serde_json::Value>>,
+    /// Per-turn token/cost accumulator, drained on `TaskCompleted` into a
+    /// single `run_summary` card.
+    run_accum: Mutex<Option<RunSummaryAccum>>,
 }
 
 impl ChannelStreamReporter {
@@ -78,6 +101,7 @@ impl ChannelStreamReporter {
             tx,
             thread_id: None,
             tool_args: Mutex::new(HashMap::new()),
+            run_accum: Mutex::new(None),
         }
     }
 
@@ -180,33 +204,37 @@ impl ProgressReporter for ChannelStreamReporter {
                 let _ = self.tx.send(StreamProgressEvent::RawSse {
                     json: payload.to_string(),
                 });
-                // Project a `tool_call` card (org.octos.app) so capable clients
-                // render the invocation as a structured card (name · status ·
-                // args · result · duration).
+                // Consume any recorded args regardless, so the entry never leaks.
                 let arguments = self
                     .tool_args
                     .lock()
                     .ok()
                     .and_then(|mut m| m.remove(tool_id));
-                let status = if success { "completed" } else { "error" };
-                let mut initial_state = serde_json::json!({
-                    "tool_name": name,
-                    "status": status,
-                    "duration_ms": duration.as_millis() as u64,
-                });
-                if let Some(args) = arguments {
-                    initial_state["arguments"] = args;
+                // Project a `tool_call` card (org.octos.app) so capable clients
+                // render the invocation as a structured card (name · status ·
+                // args · result · duration) — except for tools that already emit
+                // their own card, which would otherwise be duplicated.
+                if !SELF_CARDING_TOOLS.contains(&name.as_str()) {
+                    let status = if success { "completed" } else { "error" };
+                    let mut initial_state = serde_json::json!({
+                        "tool_name": name,
+                        "status": status,
+                        "duration_ms": duration.as_millis() as u64,
+                    });
+                    if let Some(args) = arguments {
+                        initial_state["arguments"] = args;
+                    }
+                    let preview = truncate_card_preview(output_preview, 600);
+                    if !preview.is_empty() {
+                        let key = if success { "output_preview" } else { "error" };
+                        initial_state[key] = serde_json::Value::String(preview);
+                    }
+                    let _ = self.tx.send(StreamProgressEvent::AppCard {
+                        card_type: "tool_call".to_string(),
+                        body: format!("{name} {status}"),
+                        initial_state,
+                    });
                 }
-                let preview = truncate_card_preview(output_preview, 600);
-                if !preview.is_empty() {
-                    let key = if success { "output_preview" } else { "error" };
-                    initial_state[key] = serde_json::Value::String(preview);
-                }
-                let _ = self.tx.send(StreamProgressEvent::AppCard {
-                    card_type: "tool_call".to_string(),
-                    body: format!("{name} {status}"),
-                    initial_state,
-                });
                 StreamProgressEvent::ToolCompleted {
                     name: name.clone(),
                     success,
@@ -253,11 +281,31 @@ impl ProgressReporter for ChannelStreamReporter {
             ProgressEvent::CostUpdate {
                 session_input_tokens,
                 session_output_tokens,
+                turn_input_tokens,
+                turn_output_tokens,
+                response_cost,
                 session_cost,
                 model,
                 context_window,
-                ..
             } => {
+                // Accumulate the turn's token/cost figures for a single
+                // `run_summary` card emitted on TaskCompleted (turn end).
+                if let Ok(mut acc) = self.run_accum.lock() {
+                    let a = acc.get_or_insert_with(RunSummaryAccum::default);
+                    a.input_tokens = turn_input_tokens as u64;
+                    a.output_tokens = turn_output_tokens as u64;
+                    if model.is_some() {
+                        a.model = model.clone();
+                    }
+                    if let Some(c) = session_cost {
+                        a.session_cost = Some(c);
+                        a.has_cost = true;
+                    }
+                    if let Some(c) = response_cost {
+                        a.turn_cost += c;
+                        a.has_cost = true;
+                    }
+                }
                 // Codex round-1 P2: every wire-shape mapper for
                 // `cost_update` must carry `model` so the chat bubble
                 // footer (`model · tokens_in / tokens_out · duration`)
@@ -293,6 +341,36 @@ impl ProgressReporter for ChannelStreamReporter {
                     body: "Plan updated".to_string(),
                     initial_state: plan,
                 });
+                return;
+            }
+            ProgressEvent::TaskCompleted { duration, .. } => {
+                // Drain the accumulated cost into one per-turn `run_summary`
+                // card. Matrix canonical JSON forbids floats, so costs are sent
+                // as decimal strings.
+                if let Some(acc) = self.run_accum.lock().ok().and_then(|mut a| a.take()) {
+                    let mut initial_state = serde_json::json!({
+                        "input_tokens": acc.input_tokens,
+                        "output_tokens": acc.output_tokens,
+                        "total_tokens": acc.input_tokens + acc.output_tokens,
+                        "duration_ms": duration.as_millis() as u64,
+                    });
+                    if let Some(m) = acc.model {
+                        initial_state["model"] = serde_json::Value::String(m);
+                    }
+                    if acc.has_cost {
+                        initial_state["response_cost"] =
+                            serde_json::Value::String(format!("{:.4}", acc.turn_cost));
+                        if let Some(sc) = acc.session_cost {
+                            initial_state["session_cost"] =
+                                serde_json::Value::String(format!("{:.4}", sc));
+                        }
+                    }
+                    let _ = self.tx.send(StreamProgressEvent::AppCard {
+                        card_type: "run_summary".to_string(),
+                        body: "Turn complete".to_string(),
+                        initial_state,
+                    });
+                }
                 return;
             }
             _ => return,
@@ -1202,6 +1280,67 @@ mod tests {
             plan_state["items"][0]["status"].as_str(),
             Some("in_progress")
         );
+    }
+
+    /// The reporter coalesces per-response `CostUpdate`s and emits ONE
+    /// `run_summary` card on `TaskCompleted` (turn end): turn-cumulative tokens,
+    /// summed turn cost, and duration. Costs are decimal strings (Matrix
+    /// canonical JSON forbids floats).
+    #[test]
+    fn projects_run_summary_on_turn_end() {
+        use octos_agent::progress::ProgressEvent;
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let reporter = ChannelStreamReporter::new(tx);
+
+        reporter.report(ProgressEvent::CostUpdate {
+            session_input_tokens: 100,
+            session_output_tokens: 50,
+            turn_input_tokens: 40,
+            turn_output_tokens: 20,
+            response_cost: Some(0.001),
+            session_cost: Some(0.010),
+            model: Some("deepseek-chat".into()),
+            context_window: Some(64000),
+        });
+        reporter.report(ProgressEvent::CostUpdate {
+            session_input_tokens: 130,
+            session_output_tokens: 70,
+            turn_input_tokens: 70, // turn-cumulative -> latest wins
+            turn_output_tokens: 40,
+            response_cost: Some(0.002), // summed with the first -> 0.0030
+            session_cost: Some(0.013),
+            model: Some("deepseek-chat".into()),
+            context_window: Some(64000),
+        });
+        reporter.report(ProgressEvent::TaskCompleted {
+            success: true,
+            iterations: 2,
+            duration: Duration::from_millis(3400),
+        });
+
+        let mut card = None;
+        while let Ok(event) = rx.try_recv() {
+            if let StreamProgressEvent::AppCard {
+                card_type,
+                initial_state,
+                ..
+            } = event
+            {
+                if card_type == "run_summary" {
+                    card = Some(initial_state);
+                }
+            }
+        }
+        let card = card.expect("expected a run_summary card on TaskCompleted");
+
+        assert_eq!(card["model"].as_str(), Some("deepseek-chat"));
+        assert_eq!(card["input_tokens"].as_u64(), Some(70));
+        assert_eq!(card["output_tokens"].as_u64(), Some(40));
+        assert_eq!(card["total_tokens"].as_u64(), Some(110));
+        assert_eq!(card["duration_ms"].as_u64(), Some(3400));
+        assert_eq!(card["response_cost"].as_str(), Some("0.0030"));
+        assert_eq!(card["session_cost"].as_str(), Some("0.0130"));
     }
 
     /// The channel stream reporter feeds API/channel clients that read

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -598,6 +598,9 @@ pub async fn run_stream_forwarder(
     operation_updater: Option<Arc<dyn Fn(&str) + Send + Sync>>,
     thread_id: Option<String>,
     matrix_app_reply_tools: Arc<HashSet<String>>,
+    // Session workspace root — used to reconstruct `git diff` for the
+    // `diff_view` card at turn end (`api` feature only).
+    workspace_root: Option<std::path::PathBuf>,
 ) -> StreamResult {
     let mut buffer = String::new();
     let mut message_id: Option<String> = None;
@@ -615,6 +618,10 @@ pub async fn run_stream_forwarder(
     // When true, the channel doesn't support send_with_id (returned None),
     // so we stop streaming edits and let the final reply go through out_tx.
     let mut no_edit_support = false;
+    // Files written this turn (deduped), used to emit ONE `diff_view` card after
+    // the loop (turn end), reconstructed via `git diff`. `api` feature only.
+    #[cfg(feature = "api")]
+    let mut diff_paths: Vec<String> = Vec::new();
 
     while let Some(event) = rx.recv().await {
         match event {
@@ -893,6 +900,11 @@ pub async fn run_stream_forwarder(
                 }
             }
             StreamProgressEvent::FileWritten { path } => {
+                // Record (deduped) for a coalesced `diff_view` card at turn end.
+                #[cfg(feature = "api")]
+                if !diff_paths.contains(&path) {
+                    diff_paths.push(path.clone());
+                }
                 if suppress_follow_up_text_after_app_reply || suppress_matrix_transient_status {
                     continue;
                 }
@@ -968,6 +980,49 @@ pub async fn run_stream_forwarder(
             .await;
         }
     }
+
+    // Turn end: emit ONE `diff_view` card for the files edited this turn, with
+    // each diff reconstructed via `git diff` off the async executor. Coalesced
+    // (one card, net diff), gated on the same matrix + app-reply condition, and
+    // on the `api` feature (which owns the diff-reconstruction helpers).
+    #[cfg(feature = "api")]
+    if suppress_matrix_transient_status
+        && !diff_paths.is_empty()
+        && is_session_active(&session_key, &active_sessions).await
+        && let Some(root) = workspace_root.clone()
+    {
+        let paths = std::mem::take(&mut diff_paths);
+        let initial_state =
+            tokio::task::spawn_blocking(move || crate::api::diff_view_for_paths(&paths, &root))
+                .await
+                .ok()
+                .flatten();
+        if let Some(initial_state) = initial_state {
+            let mut metadata = serde_json::json!({
+                "org.octos.app": {
+                    "type": "diff_view",
+                    "version": 1,
+                    "initial_state": initial_state,
+                }
+            });
+            if let Some(uid) = sender_user_id.as_deref() {
+                metadata[METADATA_SENDER_USER_ID] = serde_json::Value::String(uid.to_string());
+            }
+            let msg = OutboundMessage {
+                channel: channel.name().to_string(),
+                chat_id: chat_id.clone(),
+                content: "Diff preview".to_string(),
+                reply_to: None,
+                media: Vec::new(),
+                metadata,
+            };
+            if let Err(e) = channel.send(&msg).await {
+                warn!("failed to emit diff_view card: {e}");
+            }
+        }
+    }
+    #[cfg(not(feature = "api"))]
+    let _ = &workspace_root;
 
     StreamResult {
         message_id,
@@ -1743,6 +1798,7 @@ mod tests {
             None,
             None,
             Arc::new(HashSet::from(["send_app_card".to_string()])),
+            None,
         )
         .await;
 

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -93,6 +93,9 @@ pub struct ChannelStreamReporter {
     /// Per-turn token/cost accumulator, drained on `TaskCompleted` into a
     /// single `run_summary` card.
     run_accum: Mutex<Option<RunSummaryAccum>>,
+    /// Files modified this turn (deduped), drained on `TaskCompleted` into a
+    /// single `artifact` card — so N edits never post N cards.
+    modified_files: Mutex<Vec<String>>,
 }
 
 impl ChannelStreamReporter {
@@ -102,6 +105,7 @@ impl ChannelStreamReporter {
             thread_id: None,
             tool_args: Mutex::new(HashMap::new()),
             run_accum: Mutex::new(None),
+            modified_files: Mutex::new(Vec::new()),
         }
     }
 
@@ -122,6 +126,24 @@ fn inject_thread_id(value: &mut serde_json::Value, thread_id: Option<&str>) {
             "thread_id".to_string(),
             serde_json::Value::String(tid.to_string()),
         );
+    }
+}
+
+/// Coarse artifact kind from a file extension, feeding the `artifact` card's
+/// per-item glyph on the client.
+fn artifact_kind_for(path: &str) -> &'static str {
+    let ext = std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match ext.as_str() {
+        "rs" | "py" | "js" | "ts" | "go" | "c" | "cpp" | "h" | "java" | "rb" | "sh" => "code",
+        "md" | "txt" | "rst" | "adoc" => "doc",
+        "png" | "jpg" | "jpeg" | "gif" | "svg" | "webp" => "image",
+        "json" | "csv" | "tsv" | "yaml" | "yml" | "toml" => "data",
+        "log" => "log",
+        _ => "file",
     }
 }
 
@@ -261,7 +283,15 @@ impl ProgressReporter for ChannelStreamReporter {
                 }
             }
             ProgressEvent::LlmStatus { message, .. } => StreamProgressEvent::LlmStatus { message },
-            ProgressEvent::FileModified { path } => StreamProgressEvent::FileWritten { path },
+            ProgressEvent::FileModified { path } => {
+                // Record for a coalesced `artifact` card at turn end (deduped).
+                if let Ok(mut v) = self.modified_files.lock() {
+                    if !v.iter().any(|p| p == &path) {
+                        v.push(path.clone());
+                    }
+                }
+                StreamProgressEvent::FileWritten { path }
+            }
             ProgressEvent::StreamRetry { .. } => StreamProgressEvent::BufferReset,
             // Forward discrete progress events as raw SSE JSON for the web client.
             ProgressEvent::Thinking { iteration } => {
@@ -369,6 +399,35 @@ impl ProgressReporter for ChannelStreamReporter {
                         card_type: "run_summary".to_string(),
                         body: "Turn complete".to_string(),
                         initial_state,
+                    });
+                }
+                // Emit one `artifact` card listing the files produced this turn.
+                if let Some(files) = self
+                    .modified_files
+                    .lock()
+                    .ok()
+                    .map(|mut v| std::mem::take(&mut *v))
+                    .filter(|v| !v.is_empty())
+                {
+                    let artifacts: Vec<serde_json::Value> = files
+                        .iter()
+                        .map(|path| {
+                            let filename = std::path::Path::new(path)
+                                .file_name()
+                                .and_then(|n| n.to_str())
+                                .unwrap_or(path.as_str());
+                            serde_json::json!({
+                                "title": filename,
+                                "kind": artifact_kind_for(path),
+                                "status": "ready",
+                                "path": path,
+                            })
+                        })
+                        .collect();
+                    let _ = self.tx.send(StreamProgressEvent::AppCard {
+                        card_type: "artifact".to_string(),
+                        body: format!("{} file(s) written", files.len()),
+                        initial_state: serde_json::json!({ "artifacts": artifacts }),
                     });
                 }
                 return;
@@ -1341,6 +1400,53 @@ mod tests {
         assert_eq!(card["duration_ms"].as_u64(), Some(3400));
         assert_eq!(card["response_cost"].as_str(), Some("0.0030"));
         assert_eq!(card["session_cost"].as_str(), Some("0.0130"));
+    }
+
+    /// Files modified during a turn are deduped and coalesced into ONE
+    /// `artifact` card on `TaskCompleted`, with a kind inferred per extension.
+    #[test]
+    fn projects_artifact_card_coalesced_on_turn_end() {
+        use octos_agent::progress::ProgressEvent;
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let reporter = ChannelStreamReporter::new(tx);
+
+        reporter.report(ProgressEvent::FileModified {
+            path: "src/auth/mod.rs".into(),
+        });
+        reporter.report(ProgressEvent::FileModified {
+            path: "src/auth/mod.rs".into(), // duplicate -> one entry
+        });
+        reporter.report(ProgressEvent::FileModified {
+            path: "README.md".into(),
+        });
+        reporter.report(ProgressEvent::TaskCompleted {
+            success: true,
+            iterations: 1,
+            duration: Duration::from_millis(10),
+        });
+
+        let mut art = None;
+        while let Ok(event) = rx.try_recv() {
+            if let StreamProgressEvent::AppCard {
+                card_type,
+                initial_state,
+                ..
+            } = event
+            {
+                if card_type == "artifact" {
+                    art = Some(initial_state);
+                }
+            }
+        }
+        let art = art.expect("expected an artifact card on TaskCompleted");
+        let items = art["artifacts"].as_array().expect("artifacts array");
+        assert_eq!(items.len(), 2, "src/auth/mod.rs deduped -> 2 files");
+        assert_eq!(items[0]["title"].as_str(), Some("mod.rs"));
+        assert_eq!(items[0]["kind"].as_str(), Some("code"));
+        assert_eq!(items[0]["path"].as_str(), Some("src/auth/mod.rs"));
+        assert_eq!(items[1]["title"].as_str(), Some("README.md"));
+        assert_eq!(items[1]["kind"].as_str(), Some("doc"));
     }
 
     /// The channel stream reporter feeds API/channel clients that read

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -96,6 +96,10 @@ pub struct ChannelStreamReporter {
     /// Files modified this turn (deduped), drained on `TaskCompleted` into a
     /// single `artifact` card — so N edits never post N cards.
     modified_files: Mutex<Vec<String>>,
+    /// Tool invocations this turn, drained on `TaskCompleted` into a single
+    /// `tool_activity` card — so a research turn with N searches posts ONE
+    /// card, not N `tool_call` cards.
+    tool_activity: Mutex<Vec<serde_json::Value>>,
 }
 
 impl ChannelStreamReporter {
@@ -106,6 +110,7 @@ impl ChannelStreamReporter {
             tool_args: Mutex::new(HashMap::new()),
             run_accum: Mutex::new(None),
             modified_files: Mutex::new(Vec::new()),
+            tool_activity: Mutex::new(Vec::new()),
         }
     }
 
@@ -232,30 +237,29 @@ impl ProgressReporter for ChannelStreamReporter {
                     .lock()
                     .ok()
                     .and_then(|mut m| m.remove(tool_id));
-                // Project a `tool_call` card (org.octos.app) so capable clients
-                // render the invocation as a structured card (name · status ·
-                // args · result · duration) — except for tools that already emit
-                // their own card, which would otherwise be duplicated.
+                // Accumulate into a per-turn `tool_activity` card (one card at
+                // turn end) instead of one `tool_call` card per tool — except
+                // self-carding tools, which already emit their own card.
                 if !SELF_CARDING_TOOLS.contains(&name.as_str()) {
                     let status = if success { "completed" } else { "error" };
-                    let mut initial_state = serde_json::json!({
-                        "tool_name": name,
-                        "status": status,
-                        "duration_ms": duration.as_millis() as u64,
-                    });
-                    if let Some(args) = arguments {
-                        initial_state["arguments"] = args;
+                    // Short "what it did" line: the call args on success, the
+                    // error on failure.
+                    let summary = if success {
+                        arguments
+                            .as_ref()
+                            .map(|a| truncate_card_preview(&a.to_string(), 120))
+                            .unwrap_or_default()
+                    } else {
+                        truncate_card_preview(output_preview, 120)
+                    };
+                    if let Ok(mut v) = self.tool_activity.lock() {
+                        v.push(serde_json::json!({
+                            "tool_name": name,
+                            "status": status,
+                            "duration_ms": duration.as_millis() as u64,
+                            "summary": summary,
+                        }));
                     }
-                    let preview = truncate_card_preview(output_preview, 600);
-                    if !preview.is_empty() {
-                        let key = if success { "output_preview" } else { "error" };
-                        initial_state[key] = serde_json::Value::String(preview);
-                    }
-                    let _ = self.tx.send(StreamProgressEvent::AppCard {
-                        card_type: "tool_call".to_string(),
-                        body: format!("{name} {status}"),
-                        initial_state,
-                    });
                 }
                 StreamProgressEvent::ToolCompleted {
                     name: name.clone(),
@@ -374,6 +378,31 @@ impl ProgressReporter for ChannelStreamReporter {
                 return;
             }
             ProgressEvent::TaskCompleted { duration, .. } => {
+                // Drain this turn's tool invocations into ONE `tool_activity`
+                // card, rather than one `tool_call` card per tool.
+                if let Some(tools) = self
+                    .tool_activity
+                    .lock()
+                    .ok()
+                    .map(|mut v| std::mem::take(&mut *v))
+                    .filter(|v| !v.is_empty())
+                {
+                    let n = tools.len();
+                    let failed = tools
+                        .iter()
+                        .filter(|t| t.get("status").and_then(|s| s.as_str()) == Some("error"))
+                        .count();
+                    let body = if failed > 0 {
+                        format!("{n} tools · {failed} failed")
+                    } else {
+                        format!("{n} tools")
+                    };
+                    let _ = self.tx.send(StreamProgressEvent::AppCard {
+                        card_type: "tool_activity".to_string(),
+                        body,
+                        initial_state: serde_json::json!({ "tools": tools }),
+                    });
+                }
                 // Drain the accumulated cost into one per-turn `run_summary`
                 // card. Matrix canonical JSON forbids floats, so costs are sent
                 // as decimal strings.
@@ -1281,23 +1310,37 @@ mod tests {
     /// these as structured cards; `run_stream_forwarder` gates emission on
     /// matrix + an app-reply-capable tool set.
     #[test]
-    fn projects_tool_call_and_plan_app_cards() {
+    fn projects_tool_activity_and_plan_app_cards() {
         use octos_agent::progress::ProgressEvent;
+        use std::collections::HashMap;
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         let reporter = ChannelStreamReporter::new(tx);
 
+        // Two tool calls in one turn (one ok, one error).
         reporter.report(ProgressEvent::ToolStarted {
-            name: "shell".into(),
+            name: "web_search".into(),
             tool_id: "t1".into(),
-            arguments: Some(serde_json::json!({ "command": "ls -la" })),
+            arguments: Some(serde_json::json!({ "query": "SK Hynix 2025" })),
         });
         reporter.report(ProgressEvent::ToolCompleted {
-            name: "shell".into(),
+            name: "web_search".into(),
             tool_id: "t1".into(),
             success: true,
-            output_preview: "total 0\ndrwxr-xr-x".into(),
-            duration: Duration::from_millis(1200),
+            output_preview: "Results for: SK Hynix".into(),
+            duration: Duration::from_millis(3800),
+        });
+        reporter.report(ProgressEvent::ToolStarted {
+            name: "web_fetch".into(),
+            tool_id: "t2".into(),
+            arguments: Some(serde_json::json!({ "url": "https://x" })),
+        });
+        reporter.report(ProgressEvent::ToolCompleted {
+            name: "web_fetch".into(),
+            tool_id: "t2".into(),
+            success: false,
+            output_preview: "private IP not allowed".into(),
+            duration: Duration::from_millis(30),
         });
         reporter.report(ProgressEvent::PlanUpdated {
             plan: serde_json::json!({
@@ -1305,8 +1348,13 @@ mod tests {
                 "items": [{ "id": "1", "title": "step", "status": "in_progress" }],
             }),
         });
+        reporter.report(ProgressEvent::TaskCompleted {
+            success: true,
+            iterations: 2,
+            duration: Duration::from_millis(5000),
+        });
 
-        let mut cards: Vec<(String, serde_json::Value)> = Vec::new();
+        let mut cards: HashMap<String, serde_json::Value> = HashMap::new();
         while let Ok(event) = rx.try_recv() {
             if let StreamProgressEvent::AppCard {
                 card_type,
@@ -1314,31 +1362,34 @@ mod tests {
                 ..
             } = event
             {
-                cards.push((card_type, initial_state));
+                cards.insert(card_type, initial_state);
             }
         }
 
-        assert_eq!(cards.len(), 2, "expected a tool_call + a plan card, got {cards:?}");
+        // Plan card fires immediately on PlanUpdated.
+        let plan = cards.get("plan").expect("plan card");
+        assert_eq!(plan["items"][0]["status"].as_str(), Some("in_progress"));
 
-        let (tc_type, tc_state) = &cards[0];
-        assert_eq!(tc_type.as_str(), "tool_call");
-        assert_eq!(tc_state["tool_name"].as_str(), Some("shell"));
-        assert_eq!(tc_state["status"].as_str(), Some("completed"));
-        assert_eq!(tc_state["arguments"]["command"].as_str(), Some("ls -la"));
-        assert_eq!(tc_state["duration_ms"].as_u64(), Some(1200));
+        // The two tools coalesce into ONE tool_activity card at turn end — NOT
+        // two per-tool tool_call cards.
         assert!(
-            tc_state["output_preview"]
-                .as_str()
-                .unwrap_or_default()
-                .contains("total 0")
+            !cards.contains_key("tool_call"),
+            "must not emit per-tool tool_call cards"
         );
-
-        let (plan_type, plan_state) = &cards[1];
-        assert_eq!(plan_type.as_str(), "plan");
-        assert_eq!(
-            plan_state["items"][0]["status"].as_str(),
-            Some("in_progress")
-        );
+        let tools = cards
+            .get("tool_activity")
+            .expect("tool_activity card")["tools"]
+            .as_array()
+            .expect("tools array")
+            .clone();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0]["tool_name"].as_str(), Some("web_search"));
+        assert_eq!(tools[0]["status"].as_str(), Some("completed"));
+        assert_eq!(tools[0]["duration_ms"].as_u64(), Some(3800));
+        assert!(tools[0]["summary"].as_str().unwrap().contains("SK Hynix"));
+        assert_eq!(tools[1]["tool_name"].as_str(), Some("web_fetch"));
+        assert_eq!(tools[1]["status"].as_str(), Some("error"));
+        assert!(tools[1]["summary"].as_str().unwrap().contains("private IP"));
     }
 
     /// The reporter coalesces per-response `CostUpdate`s and emits ONE


### PR DESCRIPTION
## Summary

Adds a **Matrix app-card emitter** to the gateway: agent runtime events are auto-projected into structured `org.octos.app` cards over the Matrix channel, so a Matrix client (e.g. Robrix) can render native tool/plan/summary/artifact/diff cards instead of plain text.

All of this rides existing infra — no new config. The emitter only fires when the `send_app_card` tool is registered **and** we're on the `matrix` channel (`suppress_matrix_transient_status`), so nothing changes for non-Matrix channels.

## How it works

`ChannelStreamReporter` (`crates/octos-cli/src/stream_reporter.rs`) implements `ProgressReporter::report(ProgressEvent)`. It maps runtime events → a new `StreamProgressEvent::AppCard { card_type, body, initial_state }` on the existing unbounded channel; `run_stream_forwarder` consumes them and does the actual `Channel::send(&OutboundMessage)` with the card in `metadata["org.octos.app"]`.

## Cards emitted

| Card | Trigger | Notes |
|---|---|---|
| `plan` | `PlanUpdated` | checklist; reads `step/title/content/text/description` for the item label |
| `tool_activity` | `ToolCompleted` (accumulated) | **one coalesced card per turn** — a list of all tool calls with status/duration, instead of one card per tool call |
| `run_summary` | `CostUpdate` (accumulated) → `TaskCompleted` | per-turn token/cost footer; costs sent as decimal **strings** (Matrix canonical JSON forbids floats) |
| `artifact` | `FileModified` (accumulated) → `TaskCompleted` | coalesced per-turn file list |
| `diff_view` | `FileWritten` paths → end of turn | green/red unified diff, reconstructed via `git diff` (`api::diff_view_for_paths`) |

`update_plan` / `send_app_card` are treated as **self-carding** and excluded from `tool_activity` so they don't double-report.

## Design notes

- **Coalescing**: the AppCard path always sends a *new* message (no edit), so tool/summary/artifact/diff cards are accumulated during the turn and flushed once on `TaskCompleted` — one card each per turn, not a flood.
- **No floats on the wire**: all costs are `format!("{:.4}", …)` strings.
- **diff_view** is gated behind the `api` feature (the diff reconstruction helpers live there); `run_stream_forwarder` gained a `workspace_root: Option<PathBuf>` param, threaded from `session_actor.rs` call sites.

## Tests

- `projects_tool_activity_and_plan_app_cards`
- `projects_run_summary_on_turn_end`
- `projects_artifact_card_coalesced_on_turn_end`