### PR TITLE
fix(agents): ghost sub-agents — terminal status on restart-orphaned children + durable specialist terminals

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -4790,7 +4790,15 @@ fn restored_agent_status(child: &ChildAgentRecord) -> String {
         .to_owned();
     }
     match &child.status {
-        ChildStatus::Starting | ChildStatus::Running => "running",
+        // Ghost-agent fix: this replay runs at process boot, before this
+        // server has spawned anything. A child persisted as Starting/Running
+        // was live in the PREVIOUS server process and died with it (children
+        // are in-process tasks / child processes of the server) — nothing will
+        // ever move its status again. Restoring it as "running" resurrected
+        // permanently-active ghosts: `list_agents` kept returning them and the
+        // TUI showed the chips as active forever. Restore as terminal
+        // "interrupted" so rehydration tells clients the truth.
+        ChildStatus::Starting | ChildStatus::Running => "interrupted",
         ChildStatus::Completed => "completed",
         ChildStatus::Failed => "failed",
         ChildStatus::Cancelled => "interrupted",
@@ -10297,12 +10305,32 @@ mod tests {
                 }],
             )
             .expect("persist artifact");
+        // A sibling that finished BEFORE the restart must keep its real
+        // terminal status through the replay.
+        orchestrator.upsert_agent(AgentUpsert {
+            agent_id: "child-done".into(),
+            parent_agent_id: Some("master".into()),
+            session_id: session_id.clone(),
+            task_id: None,
+            path: "master/child-done".into(),
+            role: "reviewer".into(),
+            nickname: "Noether".into(),
+            backend_kind: "native".into(),
+            status: "completed".into(),
+            last_task: Some("review persistence module".into()),
+            cwd: Some("/tmp/project".into()),
+            profile_id: "tenant-a".into(),
+        });
 
         let restarted = InProcessAgentOrchestrator::default();
         restarted
             .configure_supervisor_store(&store_dir)
             .expect("replay store");
 
+        // Ghost-agent fix: the child persisted as "running" was live in the
+        // OLD process and died with it — the replay must restore it as
+        // terminal "interrupted", not resurrect a permanently-"running"
+        // ghost the TUI would show as active forever.
         let status = restarted
             .read_agent_status(AgentRequest {
                 agent_id: "child-restore".into(),
@@ -10310,8 +10338,17 @@ mod tests {
                 profile_id: "tenant-a".into(),
             })
             .expect("restored status");
-        assert_eq!(status["agent"]["status"], json!("running"));
+        assert_eq!(status["agent"]["status"], json!("interrupted"));
         assert_eq!(status["agent"]["nickname"], json!("Curie"));
+
+        let done = restarted
+            .read_agent_status(AgentRequest {
+                agent_id: "child-done".into(),
+                session_id: Some(session_id.clone()),
+                profile_id: "tenant-a".into(),
+            })
+            .expect("restored terminal status");
+        assert_eq!(done["agent"]["status"], json!("completed"));
 
         let artifacts = restarted
             .list_agent_artifacts(AgentRequest {

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -18888,12 +18888,45 @@ struct M15LiveSubagentResult {
 
 struct WsSupervisorEventSink {
     ws: WsConnection,
+    ledger: Arc<UiProtocolLedger>,
 }
 
 impl AppUiSupervisorEventSink for WsSupervisorEventSink {
     fn emit_supervisor_event(&self, method: &'static str, params: Value) {
+        // Stuck-chip fix (specialist lane): a TERMINAL `agent/updated` must
+        // survive the emitting connection — ephemeral delivery is dropped if
+        // the client blips or the frame races a reconnect, leaving the chip
+        // on the last non-terminal status forever. Mirror the background-task
+        // lane (`forward_terminal_agent_update_durable`): append terminal
+        // flips to the durable per-session ledger so cursor replay and the
+        // live broadcast forwarder both observe them. Non-terminal updates
+        // (spawned/running/heartbeats) stay ephemeral — appending each would
+        // bloat replay history with redundant in-flight states.
+        if method == octos_core::ui_protocol::methods::AGENT_UPDATED {
+            if let Some(event) = terminal_agent_updated_event(&params) {
+                let _ = send_notification_durable(
+                    &self.ws,
+                    self.ledger.as_ref(),
+                    UiNotification::AgentUpdated(event),
+                );
+                return;
+            }
+        }
         let _ = send_raw_notification_ephemeral(&self.ws, method, params);
     }
+}
+
+/// Parse a supervisor `agent/updated` payload and return it ONLY when the
+/// carried agent status is terminal (`completed` / `failed` / `interrupted` /
+/// `cancelled` / `closed`). Non-terminal or unparseable payloads return `None`
+/// and stay on the ephemeral path.
+fn terminal_agent_updated_event(params: &Value) -> Option<AgentUpdatedEvent> {
+    let event: AgentUpdatedEvent = serde_json::from_value(params.clone()).ok()?;
+    matches!(
+        event.agent.status.as_str(),
+        "completed" | "failed" | "interrupted" | "cancelled" | "closed"
+    )
+    .then_some(event)
 }
 
 const REVIEW_NATIVE_SPECIALISTS_ENV: &str = "OCTOS_REVIEW_NATIVE_SPECIALISTS_JSON";
@@ -19355,6 +19388,7 @@ async fn run_native_code_review_turn(
     maybe_spawn_cli_review_specialist(
         &mut joins,
         &ws,
+        &ledger,
         &session_id,
         &profile_id,
         &workspace_root,
@@ -19367,6 +19401,7 @@ async fn run_native_code_review_turn(
         &mut joins,
         &state,
         &ws,
+        &ledger,
         &session_id,
         &profile_id,
         &workspace_root,
@@ -19617,6 +19652,7 @@ fn native_review_task(objective: &str, target: &str, spec: &NativeCodeReviewSpec
 fn maybe_spawn_cli_review_specialist(
     joins: &mut tokio::task::JoinSet<NativeCodeReviewResult>,
     ws: &WsConnection,
+    ledger: &Arc<UiProtocolLedger>,
     session_id: &SessionKey,
     profile_id: &str,
     workspace_root: &Path,
@@ -19664,7 +19700,10 @@ fn maybe_spawn_cli_review_specialist(
         )
         .timeout(std::time::Duration::from_secs(90))
         .declared_artifact(&artifact_path);
-    let sink = WsSupervisorEventSink { ws: ws.clone() };
+    let sink = WsSupervisorEventSink {
+        ws: ws.clone(),
+        ledger: ledger.clone(),
+    };
     joins.spawn(async move {
         match run_supervised_cli_specialist(
             default_agent_orchestrator(),
@@ -19698,6 +19737,7 @@ fn maybe_spawn_mcp_review_specialist(
     joins: &mut tokio::task::JoinSet<NativeCodeReviewResult>,
     state: &AppState,
     ws: &WsConnection,
+    ledger: &Arc<UiProtocolLedger>,
     session_id: &SessionKey,
     profile_id: &str,
     workspace_root: &Path,
@@ -19738,7 +19778,10 @@ fn maybe_spawn_mcp_review_specialist(
         "artifact_path": artifact_path.to_string_lossy().into_owned(),
         "instructions": "Run a focused code review specialist task and return concise findings first.",
     });
-    let sink = WsSupervisorEventSink { ws: ws.clone() };
+    let sink = WsSupervisorEventSink {
+        ws: ws.clone(),
+        ledger: ledger.clone(),
+    };
     let backend = swarm_state.swarm.backend();
     let dispatch_policy = swarm_state.swarm.dispatch_policy();
     let timeout = review_mcp_timeout();
@@ -20362,7 +20405,10 @@ print(f"{agent_id}: {finding}")
             path: artifact_path.clone(),
         }],
     };
-    let sink = WsSupervisorEventSink { ws: ws.clone() };
+    let sink = WsSupervisorEventSink {
+        ws: ws.clone(),
+        ledger: ledger.clone(),
+    };
     let summary = run_supervised_cli_specialist(
         default_agent_orchestrator(),
         &sink,
@@ -48302,6 +48348,81 @@ ignore = []
 
         abort_live_forwarders(&forwarders, &ledger).await;
         abort_live_forwarders(&forwarders_other, &ledger).await;
+    }
+
+    /// Stuck-chip fix (specialist lane): a TERMINAL `agent/updated` emitted
+    /// through the supervisor sink must be appended to the durable per-session
+    /// ledger (so reconnect replay observes the flip), while non-terminal
+    /// updates stay ephemeral (never ledgered — they'd bloat replay history).
+    #[tokio::test]
+    async fn supervisor_sink_ledgers_terminal_agent_updates_only() {
+        let (ws, mut rx) = ws_connection_for_test(16);
+        let ledger = Arc::new(UiProtocolLedger::new(16));
+        let session_id = SessionKey("local:sink-durable".into());
+        let sink = WsSupervisorEventSink {
+            ws: ws.clone(),
+            ledger: ledger.clone(),
+        };
+
+        let agent_json = |status: &str| {
+            json!({
+                "session_id": session_id.0,
+                "agent": {
+                    "agent_id": "edison",
+                    "session_id": session_id.0,
+                    "path": "master/edison",
+                    "role": "worker",
+                    "nickname": "Edison",
+                    "backend_kind": "cli_process",
+                    "status": status,
+                    "profile_id": "dev",
+                    "created_at_ms": 1,
+                    "updated_at_ms": 1,
+                }
+            })
+        };
+
+        // Non-terminal: delivered live, but must NOT be appended durably.
+        sink.emit_supervisor_event(
+            octos_core::ui_protocol::methods::AGENT_UPDATED,
+            agent_json("running"),
+        );
+        // Terminal: must be appended to the durable ledger.
+        sink.emit_supervisor_event(
+            octos_core::ui_protocol::methods::AGENT_UPDATED,
+            agent_json("failed"),
+        );
+
+        // Both frames still reach the live connection exactly once each.
+        for expected_status in ["running", "failed"] {
+            let frame = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+                .await
+                .expect("live frame")
+                .expect("ws open");
+            assert_eq!(
+                frame_method(&frame).as_deref(),
+                Some(octos_core::ui_protocol::methods::AGENT_UPDATED),
+                "live delivery must be preserved for {expected_status}"
+            );
+        }
+
+        let (events, _) = ledger
+            .snapshot_with_cursor(&session_id, None)
+            .expect("ledger snapshot");
+        let ledgered_statuses: Vec<&str> = events
+            .iter()
+            .filter_map(|event| match &event.event {
+                UiProtocolLedgerEvent::Notification(UiNotification::AgentUpdated(update)) => {
+                    Some(update.agent.status.as_str())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            ledgered_statuses,
+            vec!["failed"],
+            "exactly the terminal update must be ledgered — non-terminal stays ephemeral"
+        );
     }
 
     /// MUST-FIX-3: a `subscribe()` call followed by dropping the


### PR DESCRIPTION
Two fixes for spawned sub-agents that die without the UI ever learning about it
— the "ghost agent" bugs: chips stuck on an active ⏵ status forever, surviving
even a client relaunch.

## 1. Restart-orphaned children restore as `interrupted`, not `running`

The supervisor-store replay at boot (`restore_agents_from_supervisor_state`)
restored a child persisted as `Starting`/`Running` **as `"running"`**. But that
replay runs at process boot, before this server has spawned anything — a child
that was still running belonged to the PREVIOUS server process and died with it
(children are in-process tasks / child processes of the server). Nothing will
ever move its status again, so `agent/list` kept returning a permanently-
"running" ghost and the TUI showed its chip as active forever. In the stdio
setup this bites on every TUI relaunch (the relaunch restarts the `serve
--stdio` child, and re-hydration then resurrects the ghosts).

The ledger layer already sweeps orphans on recover (marking them failed) — but
the orchestrator's `agent/list` snapshot clobbered that with the restored
"running" records. This makes the two layers agree: a non-terminal child
restores as terminal `interrupted`; children with real terminal state keep it.

## 2. Terminal specialist `agent/updated` events are ledgered durably

`WsSupervisorEventSink` delivered every specialist lifecycle event via
`send_raw_notification_ephemeral` — including the TERMINAL flip. An ephemeral
frame is dropped if the client blips or the frame races a reconnect, leaving
the chip on the last non-terminal status with nothing to correct it (the
roster is upsert-only on the client). The background-task lane already solved
exactly this with `forward_terminal_agent_update_durable`; this gives the
specialist lane the same contract: terminal `agent/updated` goes through
`send_notification_durable` (per-session ledger append + live broadcast), so
cursor replay after a reconnect still observes the flip. Non-terminal updates
(spawned/running/heartbeats) stay ephemeral — ledgering each would bloat
replay history with redundant in-flight states.

## Tests

- `supervisor_store_restarts_restore_agents_and_artifacts` — extended: a child
  persisted as `running` restores as `interrupted`; a sibling persisted as
  `completed` keeps its terminal status. (The old assertion codified the ghost
  behavior.)
- `supervisor_sink_ledgers_terminal_agent_updates_only` — a terminal
  `agent/updated` through the sink lands in the durable ledger exactly once
  while live delivery is preserved; a non-terminal one is never ledgered.
