### PR TITLE
feat(catalog): add Kimi K3 with thinking-level mapping

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -28713,7 +28713,7 @@ mod tests {
 
         // Key-env comes from the registry, not a hand-maintained env map.
         assert_eq!(families["zai"]["env"], "ZAI_API_KEY");
-        // Curation: glm-5.2 + kimi-k2.6 present; deepseek-chat removed.
+        // Curation: glm-5.2 + kimi-k2.6 + kimi-k3 present; deepseek-chat removed.
         assert!(
             ids("zai").contains(&"glm-5.2".to_owned()),
             "{:?}",
@@ -28724,6 +28724,22 @@ mod tests {
             "{:?}",
             ids("moonshot")
         );
+        assert!(
+            ids("moonshot").contains(&"kimi-k3".to_owned()),
+            "{:?}",
+            ids("moonshot")
+        );
+        // kimi-k3 onboards under the moonshot family key-env with its
+        // researched 1M context window.
+        assert_eq!(families["moonshot"]["env"], "MOONSHOT_API_KEY");
+        let k3 = families["moonshot"]["models"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["id"] == "kimi-k3")
+            .unwrap();
+        assert_eq!(k3["context_window"], 1_048_576);
+        assert_eq!(k3["max_output"], 131_072);
         assert!(
             !ids("deepseek").contains(&"deepseek-chat".to_owned()),
             "deepseek-chat curated out: {:?}",

--- a/crates/octos-cli/src/qos_catalog.rs
+++ b/crates/octos-cli/src/qos_catalog.rs
@@ -680,14 +680,15 @@ mod tests {
     }
 
     /// The compiled-in canonical catalog (the seed floor for fresh installs) is
-    /// well-formed and reflects curation: glm-5.2 + kimi-k2.6 present,
-    /// deepseek-chat removed.
+    /// well-formed and reflects curation: glm-5.2 + kimi-k2.6 + kimi-k3
+    /// present, deepseek-chat removed.
     #[test]
     fn embedded_qos_catalog_is_curated_ssot() {
         let catalog = embedded_qos_catalog().expect("embedded canonical catalog must parse");
         let has = |p: &str| catalog.models.iter().any(|m| m.provider == p);
         assert!(has("zai/glm-5.2"), "glm-5.2 present");
         assert!(has("moonshot/kimi-k2.6"), "kimi-k2.6 present");
+        assert!(has("moonshot/kimi-k3"), "kimi-k3 present");
         assert!(
             !has("deepseek/deepseek-chat"),
             "deepseek-chat curated out of the embedded catalog"
@@ -699,6 +700,17 @@ mod tests {
             .find(|m| m.provider == "zai/glm-5.2")
             .unwrap();
         assert_eq!(glm52.context_window, 1_000_000);
+        // kimi-k3 researched values: 1M window, 131072 (default max
+        // completion), official pricing $3.00/M in (cache miss) / $15.00/M out.
+        let k3 = catalog
+            .models
+            .iter()
+            .find(|m| m.provider == "moonshot/kimi-k3")
+            .unwrap();
+        assert_eq!(k3.context_window, 1_048_576);
+        assert_eq!(k3.max_output, 131_072);
+        assert!((k3.cost_in - 3.0).abs() < f64::EPSILON);
+        assert!((k3.cost_out - 15.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/octos-llm/src/context.rs
+++ b/crates/octos-llm/src/context.rs
@@ -120,9 +120,10 @@ pub fn context_window_tokens(model_id: &str) -> u32 {
     }
     // Model-specific defaults for known long-context models when the catalog
     // is unavailable or lacks the exact variant (e.g. deepseek-v4-flash, which
-    // has no dedicated catalog lane). DeepSeek V4 and MiniMax M3 are 1M-context.
+    // has no dedicated catalog lane). DeepSeek V4, MiniMax M3 and Kimi K3 are
+    // 1M-context.
     let m = model_id.to_lowercase();
-    if m.contains("deepseek-v4") || m.contains("minimax-m3") {
+    if m.contains("deepseek-v4") || m.contains("minimax-m3") || m.contains("kimi-k3") {
         return 1_048_576;
     }
     // Conservative default for unknown models
@@ -143,7 +144,9 @@ pub fn max_output_tokens(model_id: &str) -> u32 {
     // substring branches below (e.g. minimax-m3 before the generic minimax).
     if m.contains("deepseek-v4") {
         384_000
-    } else if m.contains("minimax-m3") {
+    } else if m.contains("minimax-m3") || m.contains("kimi-k3") {
+        // kimi-k3 default max completion is 131072 (settable up to 1M);
+        // must win over the broader "kimi" branch below.
         131_072
     } else if m.contains("kimi") || m.contains("qwen") || m.contains("gemini") {
         65_535
@@ -216,6 +219,18 @@ mod tests {
         assert_eq!(max_output_tokens("deepseek-v4-pro"), 384_000);
         assert_eq!(max_output_tokens("deepseek-v4-flash"), 384_000);
         assert_eq!(max_output_tokens("minimax-m3"), 131_072);
+    }
+
+    #[test]
+    fn should_use_1m_context_for_kimi_k3_when_not_in_catalog() {
+        // kimi-k3 is never seeded by the unit-test catalog fixtures, so this
+        // exercises the hardcoded fallbacks regardless of CATALOG state:
+        // 1M window and 131072 default max completion, checked before the
+        // broader "kimi" substring branch (65_535).
+        assert_eq!(context_window_tokens("kimi-k3"), 1_048_576);
+        assert_eq!(context_window_tokens("moonshot/kimi-k3"), 1_048_576);
+        assert_eq!(max_output_tokens("kimi-k3"), 131_072);
+        assert_eq!(max_output_tokens("moonshot/kimi-k3"), 131_072);
     }
 
     #[test]

--- a/crates/octos-llm/src/openai.rs
+++ b/crates/octos-llm/src/openai.rs
@@ -78,8 +78,13 @@ impl ModelHints {
         let uses_completion_tokens =
             is_o_series || m.starts_with("gpt-5") || m.starts_with("gpt-4.1");
 
-        let fixed_temperature =
-            is_o_series || m.starts_with("gpt-5") || m.contains("kimi-k2") || m == "gpt-4.1-nano";
+        // kimi-k3 pins its sampling params server-side (temperature=1.0,
+        // top_p=0.95, …) and rejects overrides, so never send temperature.
+        let fixed_temperature = is_o_series
+            || m.starts_with("gpt-5")
+            || m.contains("kimi-k2")
+            || m.contains("kimi-k3")
+            || m == "gpt-4.1-nano";
 
         // Vision capability is NO LONGER inferred from the model name. The old
         // allow/deny list wrongly stripped images from vision-capable models —
@@ -102,7 +107,10 @@ impl ModelHints {
         // Reasoning-control style on the chat/completions path. DeepSeek V4
         // (incl. `deepseek-reasoner`, a V4-Flash thinking alias) wants
         // `reasoning_effort` + a `thinking` toggle; OpenAI reasoning models and
-        // grok-4.x take a plain `reasoning_effort`. Everything else emits nothing.
+        // grok-4.x take a plain `reasoning_effort`; Kimi K3 takes a top-level
+        // `reasoning_effort` whose only accepted value is `"max"` (thinking is
+        // always on and K3 rejects the K2.x `thinking` object). Everything else
+        // emits nothing.
         // Effort/thinking is only EMITTED when an operator sets `reasoning_effort`
         // (opt-in), and the style is config-overridable per route — important
         // because the same `deepseek-v4` name fronts endpoints that differ
@@ -111,6 +119,8 @@ impl ModelHints {
         // families can reject `reasoning_effort`.
         let reasoning_style = if m.contains("deepseek-v4") || m.contains("deepseek-reasoner") {
             ReasoningStyle::EffortAndThinkingToggle
+        } else if m.contains("kimi-k3") {
+            ReasoningStyle::EffortMaxOnly
         } else if m.starts_with("grok-4") || is_o_series || m.starts_with("gpt-5") {
             ReasoningStyle::Effort
         } else {
@@ -143,6 +153,12 @@ pub enum ReasoningStyle {
     Effort,
     /// `reasoning_effort` plus `thinking: {"type": "enabled"}` — DeepSeek V4.
     EffortAndThinkingToggle,
+    /// Top-level `reasoning_effort` whose only accepted value is `"max"` —
+    /// Kimi K3, where thinking is always on and per K3's docs the K2.x
+    /// `thinking` object must NOT be sent. Every configured effort level maps
+    /// to `"max"`; when no effort is configured nothing is emitted (the model
+    /// still thinks — that is its server-side default).
+    EffortMaxOnly,
 }
 
 /// OpenAI GPT provider.
@@ -336,19 +352,24 @@ impl OpenAIProvider {
                 // pure context bloat (and grows unboundedly across a tool loop) —
                 // OpenAI's own API and codex both drop it.
                 //
-                // kimi-k2 is the exception. With thinking enabled it (a) returns 400
-                // "reasoning_content is missing in assistant tool call message" if the
-                // field is absent, AND (b) per kimi's docs preserves historical
-                // assistant reasoning for multi-step tool-use continuity. So for
-                // kimi-k2 we keep the REAL reasoning when present, and fall back to a
-                // minimal "." stub only to satisfy the presence check when it's absent.
+                // kimi-k2/k3 are the exception. With thinking enabled kimi-k2 (a)
+                // returns 400 "reasoning_content is missing in assistant tool call
+                // message" if the field is absent, AND (b) per kimi's docs preserves
+                // historical assistant reasoning for multi-step tool-use continuity
+                // (K3's quickstart likewise mandates "add the complete assistant
+                // message returned by the API to the next request. Do not keep only
+                // `content`"). So for kimi-k2/k3 we keep the REAL reasoning when
+                // present, and fall back to a minimal "." stub only to satisfy the
+                // presence check when it's absent.
                 //
-                // kimi-k2 is detected via fixed_temperature + model name containing
-                // "kimi-k2". Other models (e.g. deepseek-v4, verified live to return
-                // 200 without the field, and non-official nvidia/vllm endpoints that
-                // don't expect it) get no reasoning_content at all.
-                let needs_reasoning_stub =
-                    self.hints.fixed_temperature && self.model.to_lowercase().contains("kimi-k2");
+                // kimi-k2/k3 are detected via fixed_temperature + model name
+                // containing "kimi-k2"/"kimi-k3". Other models (e.g. deepseek-v4,
+                // verified live to return 200 without the field, and non-official
+                // nvidia/vllm endpoints that don't expect it) get no
+                // reasoning_content at all.
+                let model_lower = self.model.to_lowercase();
+                let needs_reasoning_stub = self.hints.fixed_temperature
+                    && (model_lower.contains("kimi-k2") || model_lower.contains("kimi-k3"));
                 let reasoning = if role == "assistant" && needs_reasoning_stub {
                     match m.reasoning_content.as_deref() {
                         Some(r) if !r.is_empty() => Some(r),
@@ -430,6 +451,9 @@ impl OpenAIProvider {
                 (Some(effort), style) if style != ReasoningStyle::None => {
                     use crate::config::ReasoningEffort as RE;
                     let effort_str = match (effort, style) {
+                        // Kimi K3 accepts exactly one value ("max"): thinking
+                        // is always on, so every configured level clamps to it.
+                        (_, ReasoningStyle::EffortMaxOnly) => "max",
                         (RE::Low, _) => "low",
                         (RE::Medium, _) => "medium",
                         (RE::High, _) => "high",
@@ -1291,6 +1315,15 @@ mod tests {
             ModelHints::detect("gpt-5.3-codex").reasoning_style,
             ReasoningStyle::Effort
         );
+        // Kimi K3 (incl. provider-prefixed) -> max-only reasoning_effort.
+        assert_eq!(
+            ModelHints::detect("kimi-k3").reasoning_style,
+            ReasoningStyle::EffortMaxOnly
+        );
+        assert_eq!(
+            ModelHints::detect("moonshotai/kimi-k3").reasoning_style,
+            ReasoningStyle::EffortMaxOnly
+        );
         // Non-thinking / unknown-control models emit nothing. grok-3 is
         // excluded (only grok-4.x is known to accept reasoning_effort).
         for m in [
@@ -1498,6 +1531,103 @@ mod tests {
             a2.get("reasoning_content").and_then(|r| r.as_str()),
             Some("."),
             "kimi-k2 must get the \".\" stub when reasoning_content is absent"
+        );
+    }
+
+    #[test]
+    fn kimi_k3_hints_survive_official_endpoint_and_pin_temperature() {
+        // K3 pins sampling params server-side -> never send temperature.
+        assert!(ModelHints::detect("kimi-k3").fixed_temperature);
+        // Unlike the DeepSeek-specific thinking toggle, K3's max-only
+        // reasoning_effort is a plain top-level field, so with_base_url must
+        // not downgrade it on the official moonshot endpoint.
+        let p = OpenAIProvider::new("k", "kimi-k3")
+            .with_provider_label("moonshot")
+            .with_base_url("https://api.moonshot.ai/v1");
+        assert_eq!(p.hints.reasoning_style, ReasoningStyle::EffortMaxOnly);
+        // Explicit config override still wins (with_hints runs after
+        // with_base_url), e.g. for a proxy that rejects reasoning_effort.
+        let overridden = OpenAIProvider::new("k", "kimi-k3")
+            .with_base_url("https://api.moonshot.ai/v1")
+            .with_hints(ModelHints {
+                reasoning_style: ReasoningStyle::None,
+                fixed_temperature: true,
+                ..Default::default()
+            });
+        assert_eq!(overridden.hints.reasoning_style, ReasoningStyle::None);
+    }
+
+    #[test]
+    fn build_request_maps_every_effort_to_max_for_kimi_k3() {
+        // K3's only accepted reasoning_effort value is "max" (thinking is
+        // always on), and the K2.x thinking object must NOT be sent.
+        let p = OpenAIProvider::new("key", "kimi-k3");
+        let msgs = [msg("hi")];
+        use crate::config::ReasoningEffort as RE;
+        for effort in [RE::Low, RE::Medium, RE::High, RE::Max] {
+            let cfg = ChatConfig {
+                reasoning_effort: Some(effort),
+                ..Default::default()
+            };
+            let v = serde_json::to_value(p.build_request(&msgs, &[], &cfg, false)).unwrap();
+            assert_eq!(v["reasoning_effort"], "max", "{effort:?} must clamp to max");
+            assert!(
+                v.get("thinking").is_none(),
+                "kimi-k3 must not emit the K2.x thinking object"
+            );
+            assert!(
+                v.get("temperature").is_none(),
+                "kimi-k3 pins temperature server-side"
+            );
+        }
+        // No configured effort -> nothing emitted (K3 thinks by default).
+        let v = serde_json::to_value(p.build_request(&msgs, &[], &ChatConfig::default(), false))
+            .unwrap();
+        assert!(v.get("reasoning_effort").is_none());
+        assert!(v.get("thinking").is_none());
+    }
+
+    #[test]
+    fn build_request_preserves_reasoning_for_kimi_k3() {
+        // K3's quickstart mandates the same round-trip contract as kimi-k2:
+        // "add the complete assistant message returned by the API to the next
+        // request. Do not keep only `content`". Auto-detected hints (no
+        // with_hints) must be enough to get it.
+        let p = OpenAIProvider::new("key", "kimi-k3");
+        let mut assistant = msg("the answer");
+        assistant.role = MessageRole::Assistant;
+        assistant.reasoning_content = Some("prior k3 reasoning".to_string());
+        let msgs = [assistant];
+        let v = serde_json::to_value(p.build_request(&msgs, &[], &ChatConfig::default(), false))
+            .unwrap();
+        let a = v["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["role"] == "assistant")
+            .expect("assistant message present");
+        assert_eq!(
+            a.get("reasoning_content").and_then(|r| r.as_str()),
+            Some("prior k3 reasoning"),
+            "kimi-k3 must round-trip prior assistant reasoning_content"
+        );
+        // Absent reasoning -> "." stub (same presence contract as kimi-k2).
+        let mut assistant2 = msg("the answer");
+        assistant2.role = MessageRole::Assistant;
+        assistant2.reasoning_content = None;
+        let msgs2 = [assistant2];
+        let v2 = serde_json::to_value(p.build_request(&msgs2, &[], &ChatConfig::default(), false))
+            .unwrap();
+        let a2 = v2["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["role"] == "assistant")
+            .expect("assistant message present");
+        assert_eq!(
+            a2.get("reasoning_content").and_then(|r| r.as_str()),
+            Some("."),
+            "kimi-k3 must get the \".\" stub when reasoning_content is absent"
         );
     }
 

--- a/crates/octos-llm/src/pricing.rs
+++ b/crates/octos-llm/src/pricing.rs
@@ -285,7 +285,16 @@ pub fn model_pricing(model_id: &str) -> Option<ModelPricing> {
         });
     }
 
-    // Kimi / Moonshot
+    // Kimi / Moonshot — NOTE: kimi-k3 MUST be checked before the generic
+    // kimi-k2/moonshot branch: the full provider key ("moonshot/kimi-k3")
+    // contains both substrings. K3 official rates: $3.00/M input (cache
+    // miss) / $15.00/M output.
+    if m.contains("kimi-k3") {
+        return Some(ModelPricing {
+            input_per_million: 3.00,
+            output_per_million: 15.0,
+        });
+    }
     if m.contains("kimi-k2") || m.contains("moonshot") {
         return Some(ModelPricing {
             input_per_million: 0.60,
@@ -395,6 +404,22 @@ mod tests {
     fn test_unknown_model_returns_none() {
         assert!(model_pricing("my-local-model").is_none());
         assert!(model_pricing("ollama/phi-custom").is_none());
+    }
+
+    #[test]
+    fn should_price_kimi_k3_before_generic_moonshot_branch() {
+        // kimi-k3 ($3.00/M in, $15.00/M out) must match before the generic
+        // kimi-k2/moonshot branch — the full provider key contains BOTH
+        // "kimi-k3" and "moonshot", and last-writer semantics would misprice
+        // it at the k2 rates ($0.60/$2.40).
+        for id in ["kimi-k3", "moonshot/kimi-k3"] {
+            let p = model_pricing(id).unwrap();
+            assert!((p.input_per_million - 3.0).abs() < f64::EPSILON, "{id}");
+            assert!((p.output_per_million - 15.0).abs() < f64::EPSILON, "{id}");
+        }
+        // The k2 family keeps its own rates.
+        let k2 = model_pricing("kimi-k2.6").unwrap();
+        assert!((k2.input_per_million - 0.60).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/dashboard/src/providers.json
+++ b/dashboard/src/providers.json
@@ -142,7 +142,8 @@
         { "id": "moonshot", "label": "Official API" },
         { "id": "autodl", "label": "AutoDL", "base_url": "https://www.autodl.art/api/v1", "api_key_env": "AUTODL_API_KEY" }
       ] },
-      { "id": "kimi-k2.6", "input": 0.6, "output": 2.4, "max_output": 65535 }
+      { "id": "kimi-k2.6", "input": 0.6, "output": 2.4, "max_output": 65535 },
+      { "id": "kimi-k3", "input": 3.0, "output": 15.0, "max_output": 131072 }
     ]
   },
   "dashscope": {

--- a/model_catalog.json
+++ b/model_catalog.json
@@ -596,6 +596,19 @@
       "max_output": 98304
     },
     {
+      "provider": "moonshot/kimi-k3",
+      "type": "strong",
+      "stability": 1.0,
+      "tool_avg_ms": 0,
+      "p95_ms": 0,
+      "score": 0.0,
+      "ds_output": 0,
+      "cost_in": 3.0,
+      "cost_out": 15.0,
+      "context_window": 1048576,
+      "max_output": 131072
+    },
+    {
       "provider": "nvidia/deepseek-ai/deepseek-v3.2",
       "type": "fast",
       "cost_in": 0.0,


### PR DESCRIPTION
## What

Adds **Kimi K3** (`moonshot/kimi-k3`) to the canonical model catalog with a correct thinking-level mapping, per the official docs ([K3 quickstart](https://platform.kimi.ai/docs/guide/kimi-k3-quickstart), [K2 thinking guide](https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model)).

## Catalog entry (`model_catalog.json`)

- `moonshot/kimi-k3`, type `strong`, context window **1048576** (1M), max_output **131072** (documented default max completion; settable up to 1M — catalog carries the default), cost **$3.00/M in (cache miss) / $15.00/M out** (from the official K3 pricing page).
- Official route only, via the existing moonshot registry entry (`MOONSHOT_API_KEY`, `https://api.moonshot.ai/v1`) — same shape as `kimi-k2.6`. No `endpoints` array: every endpoint-carrying entry in the catalog pairs Official with a real alternative (AutoDL/WiseModel), and no alternative host serves K3 today.
- Docs list exactly one K3 model id (`kimi-k3`, no variants).

## Thinking mapping

K3 differs from K2.x on the wire:

| | K2.x thinking (k2.5/k2.6) | **K3** |
|---|---|---|
| control | `thinking: {"type": "enabled"\|"disabled"}` | top-level `reasoning_effort` |
| allowed values | enabled/disabled (+`keep`) | **only `"max"`** |
| default | enabled | always on (cannot be disabled) |

The K3 quickstart explicitly says **do not use the K2.x `thinking` parameter**.

New `ReasoningStyle::EffortMaxOnly` (`octos-llm/src/openai.rs`), auto-detected for `kimi-k3` names and config-overridable via `model_hints` like the existing styles:

- octos `reasoning_effort` low / medium / high / max → all emit `reasoning_effort: "max"` (the single accepted value; thinking is always on so there is no lower tier to map to).
- No configured effort → nothing emitted (K3 thinks by default server-side).
- Never emits the DeepSeek/K2-style `thinking` object.

## Related K3 request-shape fixes (same docs)

- `fixed_temperature` now covers `kimi-k3`: K3 pins `temperature=1.0, top_p=0.95, …` server-side and rejects overrides, so we never send temperature.
- The kimi-k2 `reasoning_content` preserve/`"."`-stub path now covers `kimi-k3`: the K3 quickstart mandates "add the complete assistant message returned by the API to the next request. Do not keep only `content`".
- Pricing (`pricing.rs`) and context/max-output fallback tables (`context.rs`) get `kimi-k3` branches ordered **before** the broader `kimi`/`moonshot` substring matches (the full key `moonshot/kimi-k3` contains both).

## Tests

- `cargo test -p octos-llm --lib`: **465 passed, 0 failed** (new: style detection incl. provider-prefixed names, every-effort-clamps-to-max + no `thinking` object + no temperature, official-endpoint hint survival + override, reasoning_content round-trip/stub, pricing order, 1M-context fallback)
- `cargo test -p octos-cli --features api --lib`: **2449 passed, 0 failed** (embedded-catalog curation + onboarding catalog now assert kimi-k3 under moonshot with `MOONSHOT_API_KEY` and 1M window)
- `cargo test -p octos-cli --lib` (default features): **1023 passed, 0 failed**
- `cargo fmt --all -- --check` clean; `cargo clippy -p octos-llm -p octos-cli` (default features): 0 warnings

**No live probe**: no `MOONSHOT`/`KIMI` API key is available in this environment, so the `reasoning_effort: "max"` wire shape was not exercised against the live API — it is asserted by unit tests against the documented request format.
