### PR TITLE
fix(agents): spawn robustness — preflight hardening, non-cascading input errors, pre-cap budget reminder

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -63,6 +63,12 @@ type ToolCallResult = (
     Option<TokenUsage>,
     bool,
     Option<(String, serde_json::Value)>,
+    // field 6 — `cascades`: when this call failed (field 4 == `false`), should
+    // it cancel the remaining peers in a serial (M8.8) batch? `true` preserves
+    // the legacy stop-on-error behaviour; `false` marks a no-side-effect
+    // failure — a [`crate::tools::ToolInputError`] from malformed model
+    // arguments — that must NOT nuke well-formed sibling calls (#1690).
+    bool,
 );
 
 fn should_auto_send_tool_files(
@@ -588,6 +594,8 @@ impl Agent {
                             None,
                             false, // hook denial is a failure — cascade in serial mode
                             None,
+                            // hook denial is an intentional stop — cascade to peers
+                            true,
                         );
                     }
                     HookResult::Modified(new_args) => {
@@ -655,6 +663,8 @@ impl Agent {
                             None,
                             false, // policy denial is a failure — cascade in serial mode
                             None,
+                            // policy denial is an intentional stop — cascade to peers
+                            true,
                         );
                     }
                 }
@@ -709,6 +719,8 @@ impl Agent {
                             None,
                             false,
                             None,
+                            // pre-execution denial is an intentional stop — cascade
+                            true,
                         );
                     }
                 }
@@ -801,6 +813,8 @@ impl Agent {
                         None,
                         false,
                         None,
+                        // fanout-cap denial is an intentional stop — cascade
+                        true,
                     );
                 }
                 tools.mark_spawn_only_invoked();
@@ -1933,6 +1947,8 @@ impl Agent {
                     None,
                     true, // spawn_only placeholder is reported as success
                     None,
+                    // spawn_only success — cascade flag is moot when success=true
+                    true,
                 );
             }
 
@@ -2023,6 +2039,7 @@ impl Agent {
                 tool_tokens,
                 tool_success,
                 tool_structured_metadata,
+                tool_cascades,
             ) = match result {
                 Ok(tool_result) => {
                     debug!(
@@ -2104,6 +2121,10 @@ impl Agent {
                         tool_result.tokens_used,
                         success,
                         tool_result.structured_metadata,
+                        // A tool that RAN and reported failure still cascades
+                        // (legacy behaviour); only never-ran input errors below
+                        // opt out.
+                        true,
                     )
                 }
                 Err(e) => {
@@ -2142,6 +2163,14 @@ impl Agent {
                         duration,
                     });
 
+                    // #1690: a malformed-arguments failure (`ToolInputError`)
+                    // has no side effects and must not cancel well-formed
+                    // sibling calls in a serial batch; genuine execution errors
+                    // still cascade. Scan the whole chain so a `wrap_err` in the
+                    // dispatch path cannot hide the marker.
+                    let cascades = !e
+                        .chain()
+                        .any(|src| src.is::<crate::tools::ToolInputError>());
                     (
                         format!("Error: {e}"),
                         Vec::new(),
@@ -2149,6 +2178,7 @@ impl Agent {
                         None,
                         false,
                         None,
+                        cascades,
                     )
                 }
             };
@@ -2193,6 +2223,7 @@ impl Agent {
                 tool_tokens,
                 tool_success,
                 structured_metadata,
+                tool_cascades,
             )
         })
     }
@@ -2367,7 +2398,7 @@ impl Agent {
         // Log completion of the tool batch.
         let result_sizes: Vec<usize> = results
             .iter()
-            .map(|(m, _, _, _, _, _)| m.content.len())
+            .map(|(m, _, _, _, _, _, _)| m.content.len())
             .collect();
         let total_result_bytes: usize = result_sizes.iter().sum();
         tracing::info!(
@@ -2397,6 +2428,7 @@ impl Agent {
             tool_tokens,
             success,
             tool_structured_metadata,
+            _cascades,
         ) in results
         {
             // Pair every executed tool result with its `tool_call_id` so
@@ -2510,13 +2542,17 @@ impl Agent {
                 }
             };
 
-            // The per-call success bit (the 5-th tuple element) drives the
-            // cascade. Every failure path in `spawn_tool_task` — tool error,
-            // hook denial, panic, timeout — sets it to `false`, so we do not
-            // need to peek at the message content.
+            // The per-call success bit (tuple field 4) marks failure; field 6
+            // (`cascades`) decides whether that failure cancels the remaining
+            // peers. Every failure path in `spawn_tool_task` — tool error, hook
+            // denial, panic, timeout — sets success `false`; only a
+            // no-side-effect `ToolInputError` (malformed model arguments) sets
+            // `cascades = false`, so one bad call cannot nuke well-formed
+            // siblings (#1690). No need to peek at message content.
             let failed = !outcome.4;
+            let cascades = outcome.6;
             results.push(outcome);
-            if failed {
+            if failed && cascades {
                 cancelled = true;
             }
         }
@@ -2548,6 +2584,8 @@ fn cancelled_result(tool_call: &octos_core::ToolCall) -> ToolCallResult {
         None,
         false,
         None,
+        // a cancelled peer raised no error of its own — do not further cascade
+        false,
     )
 }
 
@@ -2578,6 +2616,8 @@ fn timed_out_result(tool_call: &octos_core::ToolCall, elapsed_secs: u64) -> Tool
         None,
         false,
         None,
+        // a timeout cascades to peers the same way a regular error does
+        true,
     )
 }
 
@@ -2600,6 +2640,8 @@ fn panic_result(tool_call: &octos_core::ToolCall, reason: &str) -> ToolCallResul
         None,
         false,
         None,
+        // a panic is an unexpected hard failure — cascade to peers
+        true,
     )
 }
 
@@ -3119,6 +3161,171 @@ mod tests {
             arguments: serde_json::json!({}),
             metadata: None,
         }
+    }
+
+    /// Exclusive tool that fails with a `ToolInputError` (malformed model
+    /// arguments). Its failure must NOT cancel well-formed siblings (#1690).
+    struct InputErrorTool;
+
+    #[async_trait]
+    impl Tool for InputErrorTool {
+        fn name(&self) -> &str {
+            "bad_input_tool"
+        }
+        fn description(&self) -> &str {
+            "always fails input validation"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        fn concurrency_class(&self) -> crate::tools::ConcurrencyClass {
+            crate::tools::ConcurrencyClass::Exclusive
+        }
+        async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+            Err(crate::tools::ToolInputError::new(
+                "invalid bad_input_tool input: missing field `target`",
+            )
+            .into())
+        }
+    }
+
+    /// Exclusive tool that HARD-errors (a genuine execution failure, not an
+    /// input error) — this MUST still cascade to peers.
+    struct HardErrorTool;
+
+    #[async_trait]
+    impl Tool for HardErrorTool {
+        fn name(&self) -> &str {
+            "hard_error_tool"
+        }
+        fn description(&self) -> &str {
+            "always errors mid-execution"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        fn concurrency_class(&self) -> crate::tools::ConcurrencyClass {
+            crate::tools::ConcurrencyClass::Exclusive
+        }
+        async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+            Err(eyre::eyre!("boom: unexpected runtime failure"))
+        }
+    }
+
+    /// Exclusive tool that succeeds with a distinctive output — the
+    /// well-formed sibling behind a failing peer.
+    struct GoodExclusiveTool;
+
+    #[async_trait]
+    impl Tool for GoodExclusiveTool {
+        fn name(&self) -> &str {
+            "good_tool"
+        }
+        fn description(&self) -> &str {
+            "succeeds with distinctive output"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        fn concurrency_class(&self) -> crate::tools::ConcurrencyClass {
+            crate::tools::ConcurrencyClass::Exclusive
+        }
+        async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+            Ok(ToolResult {
+                output: "GOOD_REAL_OUTPUT".to_string(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    async fn run_serial_pair(
+        first: &str,
+        second: &str,
+        tools: ToolRegistry,
+    ) -> Vec<octos_core::Message> {
+        let dir = tempfile::tempdir().unwrap();
+        let provider: Arc<dyn LlmProvider> = Arc::new(NoChatProvider);
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let agent =
+            Agent::new(AgentId::new("cascade"), provider, tools, memory).with_config(AgentConfig {
+                save_episodes: false,
+                ..Default::default()
+            });
+        let response = ChatResponse {
+            content: None,
+            reasoning_content: None,
+            tool_calls: vec![
+                tool_call("call_first", first),
+                tool_call("call_second", second),
+            ],
+            stop_reason: StopReason::ToolUse,
+            usage: LlmTokenUsage::default(),
+            provider_index: None,
+        };
+        let (messages, _fm, _fs, _tok, _st, _sid) = agent
+            .execute_tools(&response)
+            .await
+            .expect("execute_tools must not error");
+        messages
+    }
+
+    #[tokio::test]
+    async fn input_error_does_not_cancel_well_formed_sibling() {
+        // #1690: a malformed-arguments failure has no side effects, so the
+        // well-formed sibling behind it in the serial batch must still run.
+        let mut tools = ToolRegistry::new();
+        tools.register(InputErrorTool);
+        tools.register(GoodExclusiveTool);
+        let messages = run_serial_pair("bad_input_tool", "good_tool", tools).await;
+
+        let second = messages
+            .iter()
+            .find(|m| m.tool_call_id.as_deref() == Some("call_second"))
+            .expect("sibling result present");
+        assert!(
+            second.content.contains("GOOD_REAL_OUTPUT"),
+            "well-formed sibling was cancelled by an input-error peer: {:?}",
+            second.content
+        );
+        assert!(
+            !second
+                .content
+                .contains("cancelled due to earlier sibling error")
+        );
+
+        // And the input error's DETAIL reaches the model (#1690 repair hint).
+        let first = messages
+            .iter()
+            .find(|m| m.tool_call_id.as_deref() == Some("call_first"))
+            .expect("failed call result present");
+        assert!(
+            first.content.contains("missing field `target`"),
+            "input-error detail must reach the model: {:?}",
+            first.content
+        );
+    }
+
+    #[tokio::test]
+    async fn hard_error_still_cancels_sibling() {
+        // Contrapositive: a genuine execution error must STILL cascade so a
+        // real mid-batch failure stops dependent work.
+        let mut tools = ToolRegistry::new();
+        tools.register(HardErrorTool);
+        tools.register(GoodExclusiveTool);
+        let messages = run_serial_pair("hard_error_tool", "good_tool", tools).await;
+
+        let second = messages
+            .iter()
+            .find(|m| m.tool_call_id.as_deref() == Some("call_second"))
+            .expect("sibling result present");
+        assert!(
+            second
+                .content
+                .contains("cancelled due to earlier sibling error"),
+            "a genuine execution error must still cancel siblings: {:?}",
+            second.content
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -928,6 +928,9 @@ impl Agent {
                     PersistentRetryStateGuard::new(self.persistent_retry_state.clone());
                 let mut loop_detector = LoopDetector::new(12);
                 let mut turn_ledger = self.new_turn_ledger();
+                // #1691 (codex gap G6): fire the in-band budget reminder once,
+                // when the run first crosses ~80% of its iteration cap.
+                let mut budget_reminder_sent = false;
 
                 // Labeled so the loop-detector recovery arms below can re-enter
                 // the AGENT loop (skip tool execution for this spiraling
@@ -959,9 +962,38 @@ impl Agent {
                                 pending_approval: None,
                             });
                         }
+                        // #1691: grace was granted (we did not return) — this is
+                        // the FINAL iteration. Tell the model to deliver now
+                        // rather than start new work, so a grace call is not
+                        // wasted on more exploration (the mini4 failure mode).
+                        messages.push(Message::user(
+                            "[budget notice] This is your FINAL iteration — the run stops \
+                             immediately after it. Do NOT start new exploration; write your \
+                             deliverable (write_file / edit_file) or give your final answer \
+                             in THIS response.",
+                        ));
                     }
 
                     let iteration = turn.advance_iteration();
+                    // #1691 (codex gap G6): as the run approaches its iteration
+                    // cap, warn the model in-band ONCE (~80%) so a long task
+                    // converges on a written deliverable instead of silently
+                    // hitting the wall with nothing produced (the mini4
+                    // review-worker failure mode). Non-forcing — it only nudges.
+                    let max_iters = self.config.max_iterations;
+                    if !budget_reminder_sent
+                        && max_iters > 0
+                        && iteration.saturating_mul(5) >= max_iters.saturating_mul(4)
+                    {
+                        let remaining = max_iters.saturating_sub(iteration);
+                        messages.push(Message::user(format!(
+                            "[budget notice] ~{remaining} tool iteration(s) left before this \
+                             run is force-stopped at {max_iters}. Stop exploring now and \
+                             deliver: write your result with write_file / edit_file (or state \
+                             your final answer) before you run out."
+                        )));
+                        budget_reminder_sent = true;
+                    }
                     // Realtime heartbeat: beat first, then abort the iteration
                     // with a typed error if the controller reports stalled.
                     // A None controller / disabled config is a no-op so the
@@ -3421,6 +3453,87 @@ mod tests {
                 ..Default::default()
             })
         }
+    }
+
+    /// Planner that keeps requesting a tool call (so the loop runs to its
+    /// iteration cap) and records whether it ever received the in-band budget
+    /// reminder (#1691).
+    struct BudgetProbePlanner {
+        calls: Arc<AtomicUsize>,
+        saw_notice: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl LlmProvider for BudgetProbePlanner {
+        async fn chat(
+            &self,
+            messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &ChatConfig,
+        ) -> Result<ChatResponse> {
+            if messages
+                .iter()
+                .any(|m| m.content.contains("[budget notice]"))
+            {
+                self.saw_notice.store(true, AtomicOrdering::SeqCst);
+            }
+            let n = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+            // Never end the turn — force the loop toward its iteration cap.
+            Ok(tool_use(
+                vec![ToolCall {
+                    id: format!("call_{n}"),
+                    name: "noop_tool".to_string(),
+                    arguments: serde_json::json!({ "n": n }),
+                    metadata: None,
+                }],
+                10,
+                5,
+            ))
+        }
+
+        fn model_id(&self) -> &str {
+            "budget-probe"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    #[tokio::test]
+    async fn budget_reminder_injected_before_iteration_cap() {
+        // #1691: as a run approaches its iteration cap the model must receive an
+        // in-band "wrap up and deliver" reminder, so it converges on a
+        // deliverable instead of silently hitting the wall (the mini4 review
+        // worker burned all 50 iterations and wrote nothing).
+        let dir = tempfile::tempdir().unwrap();
+        let saw_notice = Arc::new(AtomicBool::new(false));
+        let planner = Arc::new(BudgetProbePlanner {
+            calls: Arc::new(AtomicUsize::new(0)),
+            saw_notice: saw_notice.clone(),
+        });
+        let mut tools = ToolRegistry::new();
+        tools.register(StaticResultTool::new(
+            "noop_tool",
+            "ok",
+            true,
+            Arc::new(AtomicUsize::new(0)),
+        ));
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let agent = Agent::new(AgentId::new("budget-probe"), planner, tools, memory).with_config(
+            AgentConfig {
+                max_iterations: 5,
+                save_episodes: false,
+                ..Default::default()
+            },
+        );
+
+        let _ = agent.process_message("do a long task", &[], vec![]).await;
+
+        assert!(
+            saw_notice.load(AtomicOrdering::SeqCst),
+            "the model never received the pre-cap budget reminder (#1691)"
+        );
     }
 
     struct NoCallVerifier {

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -40,6 +40,31 @@ use octos_core::TokenUsage;
 use crate::progress::ProgressReporter;
 use octos_core::{PathClassification, SessionScope};
 
+/// Error a tool returns when the MODEL supplied malformed arguments — a schema
+/// / deserialize failure, as opposed to a genuine execution error. Such
+/// failures have no side effects, so the serial-batch (M8.8) scheduler treats
+/// them as NON-cascading: one malformed call must not cancel its well-formed
+/// siblings (#1690). The `Display` text is delivered verbatim to the model, so
+/// callers should include the underlying detail plus a schema hint the model
+/// can use to self-repair on the next turn.
+#[derive(Debug, Clone)]
+pub struct ToolInputError(String);
+
+impl ToolInputError {
+    /// Build an input-validation error from a model-facing message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl std::fmt::Display for ToolInputError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for ToolInputError {}
+
 /// Registry of [`AgentDefinition`]-style manifests available to tools.
 ///
 /// Re-exported from [`crate::agents`] where the schema and loader live. M8.2

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -1795,16 +1795,15 @@ mod registry_dispatch_tests {
     use super::*;
     use std::path::PathBuf;
 
-    // RFC-0 (#1289): LRU lifecycle was removed. `make_registry` keeps its
-    // two-argument shape purely so the surviving dispatch/spawn_only/policy
-    // tests below compile unchanged; the arguments are ignored.
-    fn make_registry(_max_active: usize, _idle_threshold: u32) -> ToolRegistry {
+    // RFC-0 (#1289): LRU tool-lifecycle deferral was removed, so this helper no
+    // longer carries the old `(max_active, idle_threshold)` tuning knobs.
+    fn make_registry() -> ToolRegistry {
         ToolRegistry::with_builtins(PathBuf::from("/tmp"))
     }
 
     #[test]
     fn spawn_only_message_uses_runtime_output_dir_hint() {
-        let mut reg = make_registry(5, 3);
+        let mut reg = make_registry();
         reg.mark_spawn_only("mofa_slides", None);
         reg.set_output_dir_hint("/tmp/octos-profile/skill-output");
 
@@ -1815,7 +1814,7 @@ mod registry_dispatch_tests {
 
     #[test]
     fn spawn_only_handle_message_returns_task_handle_envelope() {
-        let mut reg = make_registry(5, 3);
+        let mut reg = make_registry();
         reg.mark_spawn_only("search", None);
         reg.set_output_dir_hint("/tmp/octos/skill-output");
 
@@ -1852,7 +1851,7 @@ mod registry_dispatch_tests {
         // Codex round 2 P2: visibility helper must mirror the same filters
         // `specs()` applies, so the spawn_only intercept does not advertise
         // a tool the provider policy hid from the LLM's tool list.
-        let mut reg = make_registry(5, 3);
+        let mut reg = make_registry();
         // After make_registry, "shell" exists.
         assert!(reg.is_tool_visible("shell"));
 
@@ -1870,7 +1869,7 @@ mod registry_dispatch_tests {
 
     #[tokio::test]
     async fn spawn_agent_execution_policy_is_equivalent_to_spawn_alias() {
-        let mut reg = make_registry(5, 3);
+        let mut reg = make_registry();
         reg.set_provider_policy(ToolPolicy {
             deny: vec!["spawn".to_owned()],
             ..Default::default()
@@ -1891,7 +1890,7 @@ mod registry_dispatch_tests {
         };
         assert!(denied.to_string().contains("denied by provider policy"));
 
-        let mut reg = make_registry(5, 3);
+        let mut reg = make_registry();
         reg.set_provider_policy(ToolPolicy {
             allow: vec!["spawn".to_owned()],
             ..Default::default()
@@ -1913,7 +1912,7 @@ mod registry_dispatch_tests {
 
     #[test]
     fn is_tool_visible_returns_false_for_unregistered_tools() {
-        let reg = make_registry(5, 3);
+        let reg = make_registry();
         assert!(!reg.is_tool_visible("nope_does_not_exist"));
     }
 
@@ -1923,7 +1922,7 @@ mod registry_dispatch_tests {
         // the getter the project-root validator path calls must return a no-op
         // sandbox — `ValidatorRunner` then runs command validators' argv
         // directly, keeping host behavior unchanged where no backend exists.
-        let reg = make_registry(5, 3);
+        let reg = make_registry();
         assert!(
             reg.sandbox().is_noop(),
             "registry built without a real sandbox must expose a no-op sandbox"
@@ -1965,7 +1964,7 @@ mod registry_dispatch_tests {
     fn should_permit_all_tools_when_no_provider_policy_is_set() {
         // #1607 (P2): with no provider policy the permit predicate is a no-op,
         // so `MapToolDispatcher::from_registry` snapshots every tool.
-        let reg = make_registry(5, 3);
+        let reg = make_registry();
         assert!(reg.provider_policy_permits("shell"));
         assert!(reg.provider_policy_permits("read_file"));
     }
@@ -1975,7 +1974,7 @@ mod registry_dispatch_tests {
         // #1607 (P2): the permit predicate must mirror the deny-wins semantics
         // (with alias equivalence) that `execute` enforces, so a project-root
         // ToolCall validator can't reach a denied tool via the snapshot.
-        let mut reg = make_registry(5, 3);
+        let mut reg = make_registry();
         reg.set_provider_policy(ToolPolicy {
             deny: vec!["spawn".to_string()],
             ..Default::default()
@@ -1993,7 +1992,7 @@ mod registry_dispatch_tests {
     fn should_permit_only_allowlisted_tools_when_allow_list_is_set() {
         // #1607 (P2): a non-empty allow list means only listed (or
         // alias-equivalent) tools are permitted.
-        let mut reg = make_registry(5, 3);
+        let mut reg = make_registry();
         reg.set_provider_policy(ToolPolicy {
             allow: vec!["read_file".to_string()],
             ..Default::default()
@@ -2009,7 +2008,7 @@ mod registry_dispatch_tests {
     fn spawn_only_handle_message_payload_stays_under_one_kb() {
         // Phase 4 acceptance criterion: spawn_only tool result in agent
         // context is < 1KB (was 50KB+).
-        let mut reg = make_registry(5, 3);
+        let mut reg = make_registry();
         reg.mark_spawn_only("search", None);
 
         let payload = reg.spawn_only_handle_message("search", "task_xyz", &[]);

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -1465,9 +1465,7 @@ struct Input {
     /// worktree gives the child a dedicated git worktree under `.octos/work`.
     #[serde(default)]
     isolation: WorkerIsolation,
-    /// Tool names the subagent is allowed to use. Empty — with no role template
-    /// and no manifest — falls back to a lean coding/review surface (see
-    /// [`DEFAULT_SUBAGENT_TOOLS`]), NOT every builtin. `group:*` tokens allowed.
+    /// Tool names the subagent is allowed to use. Empty = all builtins.
     #[serde(default)]
     allowed_tools: Vec<String>,
     /// Extra context injected as a system-level prefix.
@@ -2010,35 +2008,6 @@ fn effective_allowed_tools(allowed_tools: &[String], disallowed_tools: &[String]
         .collect()
 }
 
-/// Lean default tool surface for a spawned worker that constrained nothing —
-/// no inline `allowed_tools`, no manifest (`apply_agent_definition`), and no
-/// role template (`apply_role_template`). RFC-0 (#1289) removed LRU tool
-/// deferral, so an empty allow-list otherwise exposes every registered tool
-/// (~43 schemas on a bare `octos serve` worker), which reliably degenerates
-/// weaker models into empty / reflexive single-tool responses that never
-/// produce a deliverable (issue #1689). Mirrors the `#1641` lean coding
-/// profile: file ops (read **and write/edit**, so the worker can actually
-/// write its result), shell, file search, and web fetch. `spawn` is denied for
-/// children regardless (see [`build_subagent_tool_policy`]); `group:*` tokens
-/// expand via [`ToolPolicy`]. An explicit allow-list / role / manifest wins.
-const DEFAULT_SUBAGENT_TOOLS: &[&str] = &["group:fs", "group:runtime", "group:search", "group:web"];
-
-/// Resolve the allow-list for a spawned worker: an explicit list (inline,
-/// manifest, or role template — all resolved before this point) is honoured
-/// verbatim; an empty list falls back to [`DEFAULT_SUBAGENT_TOOLS`] instead of
-/// the RFC-0 "every registered tool" behaviour that degenerates weaker models
-/// (issue #1689).
-fn subagent_allowed_tools_or_default(allowed_tools: Vec<String>) -> Vec<String> {
-    if allowed_tools.is_empty() {
-        DEFAULT_SUBAGENT_TOOLS
-            .iter()
-            .map(|tool| (*tool).to_string())
-            .collect()
-    } else {
-        allowed_tools
-    }
-}
-
 fn build_subagent_tool_policy(
     allowed_tools: Vec<String>,
     disallowed_tools: Vec<String>,
@@ -2073,8 +2042,8 @@ fn ensure_subagent_tools_available(
     // EXPRESSIONS — `group:*` named groups and `*` wildcards — which are
     // allow-list patterns that expand against whatever is registered rather
     // than concrete tool names: `tools.get("group:fs")` is always None, so a
-    // caller / role template using group tokens (or the lean default) would
-    // otherwise be falsely rejected as "not available on this host" (#1689).
+    // caller / role template using group tokens would otherwise be falsely
+    // rejected as "not available on this host" (#1689).
     let missing = allowed_tools
         .iter()
         .filter(|entry| !entry.starts_with("group:") && !entry.contains('*'))
@@ -2625,16 +2594,13 @@ impl Tool for SpawnTool {
             None => input.task.clone(),
         };
 
-        // RFC-0 (#1289) removed LRU tool deferral, so an EMPTY allow-list now
-        // means "every registered tool" (~43 schemas), which reliably
-        // degenerates weaker models into empty / reflexive single-tool
-        // responses that never produce a deliverable (issue #1689). By this
-        // point an inline list, a manifest (`apply_agent_definition`), and a
-        // role template (`apply_role_template`) have all had their chance to
-        // fill `allowed_tools`; if it is STILL empty the caller constrained
-        // nothing, so fall back to a lean coding/review surface rather than
-        // everything. An explicit list / role / manifest always wins.
-        let allowed_tools = subagent_allowed_tools_or_default(input.allowed_tools.clone());
+        // An inline list, a manifest (`apply_agent_definition`), and a role
+        // template (`apply_role_template`) have each had their chance to fill
+        // `allowed_tools`. Empty here means the caller deliberately left the
+        // worker unconstrained (every builtin) — honor that; do not synthesize
+        // a default surface (tool count is not what makes a worker fail —
+        // see the benchmark refutation on #1689).
+        let allowed_tools = input.allowed_tools.clone();
         // Effective allow-list = `allowed_tools` minus the manifest's
         // `disallowed_tools`, for the two consumers that cannot apply the local
         // deny-list policy: the `agent_mcp` dispatch payload (codex P1) and the
@@ -5393,74 +5359,11 @@ mod tests {
     }
 
     #[test]
-    fn subagent_defaults_to_lean_toolset_when_unconstrained() {
-        // #1689: an empty allow-list (no inline list, no role, no manifest —
-        // all resolved before this point) must NOT mean "every registered
-        // tool"; it falls back to the lean coding/review surface.
-        let resolved = subagent_allowed_tools_or_default(Vec::new());
-        assert_eq!(
-            resolved,
-            DEFAULT_SUBAGENT_TOOLS
-                .iter()
-                .map(|t| t.to_string())
-                .collect::<Vec<_>>()
-        );
-        assert!(resolved.iter().any(|t| t == "group:fs"));
-
-        // An explicit list is honoured verbatim (the escape hatch).
-        let explicit = vec!["shell".to_string()];
-        assert_eq!(
-            subagent_allowed_tools_or_default(explicit.clone()),
-            explicit
-        );
-    }
-
-    #[test]
-    fn lean_default_policy_keeps_core_tools_and_shrinks_the_surface() {
-        // End-to-end: the lean default, applied as a policy to a full builtin
-        // registry, retains the read/WRITE/shell/search surface (so a worker
-        // can actually produce a deliverable) while shrinking the ~43-tool
-        // surface that degenerates weak models (#1689).
-        let full = ToolRegistry::with_builtins("/tmp").specs().len();
-        let mut tools = ToolRegistry::with_builtins("/tmp");
-        let policy = build_subagent_tool_policy(
-            subagent_allowed_tools_or_default(Vec::new()),
-            Vec::new(),
-            None,
-        );
-        tools.apply_policy(&policy);
-        let names: Vec<String> = tools.specs().into_iter().map(|s| s.name).collect();
-        for kept in [
-            "read_file",
-            "write_file",
-            "edit_file",
-            "shell",
-            "grep",
-            "list_dir",
-        ] {
-            assert!(
-                names.contains(&kept.to_string()),
-                "lean default dropped core tool {kept}: {names:?}"
-            );
-        }
-        assert!(
-            names.len() < full,
-            "lean default must shrink the {full}-tool surface, got {}",
-            names.len()
-        );
-        assert!(
-            names.len() <= 18,
-            "lean default should be ~15 tools, got {}: {names:?}",
-            names.len()
-        );
-    }
-
-    #[test]
     fn preflight_skips_group_and_wildcard_tokens() {
-        // #1689: `group:*` / `*` are policy EXPRESSIONS, not concrete tool
-        // names — `tools.get("group:fs")` is always None — so they must be
-        // skipped, not reported "not available on this host". Otherwise the lean
-        // default (and any role using group tokens) could never spawn.
+        // #1689 (retained sub-fix): `group:*` / `*` are policy EXPRESSIONS,
+        // not concrete tool names — `tools.get("group:fs")` is always None —
+        // so they must be skipped, not reported "not available on this host".
+        // Otherwise any role / caller using group tokens could never spawn.
         let tools = ToolRegistry::with_builtins("/tmp");
         ensure_subagent_tools_available(
             &tools,

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -1465,7 +1465,9 @@ struct Input {
     /// worktree gives the child a dedicated git worktree under `.octos/work`.
     #[serde(default)]
     isolation: WorkerIsolation,
-    /// Tool names the subagent is allowed to use. Empty = all builtins.
+    /// Tool names the subagent is allowed to use. Empty — with no role template
+    /// and no manifest — falls back to a lean coding/review surface (see
+    /// [`DEFAULT_SUBAGENT_TOOLS`]), NOT every builtin. `group:*` tokens allowed.
     #[serde(default)]
     allowed_tools: Vec<String>,
     /// Extra context injected as a system-level prefix.
@@ -2008,6 +2010,35 @@ fn effective_allowed_tools(allowed_tools: &[String], disallowed_tools: &[String]
         .collect()
 }
 
+/// Lean default tool surface for a spawned worker that constrained nothing —
+/// no inline `allowed_tools`, no manifest (`apply_agent_definition`), and no
+/// role template (`apply_role_template`). RFC-0 (#1289) removed LRU tool
+/// deferral, so an empty allow-list otherwise exposes every registered tool
+/// (~43 schemas on a bare `octos serve` worker), which reliably degenerates
+/// weaker models into empty / reflexive single-tool responses that never
+/// produce a deliverable (issue #1689). Mirrors the `#1641` lean coding
+/// profile: file ops (read **and write/edit**, so the worker can actually
+/// write its result), shell, file search, and web fetch. `spawn` is denied for
+/// children regardless (see [`build_subagent_tool_policy`]); `group:*` tokens
+/// expand via [`ToolPolicy`]. An explicit allow-list / role / manifest wins.
+const DEFAULT_SUBAGENT_TOOLS: &[&str] = &["group:fs", "group:runtime", "group:search", "group:web"];
+
+/// Resolve the allow-list for a spawned worker: an explicit list (inline,
+/// manifest, or role template — all resolved before this point) is honoured
+/// verbatim; an empty list falls back to [`DEFAULT_SUBAGENT_TOOLS`] instead of
+/// the RFC-0 "every registered tool" behaviour that degenerates weaker models
+/// (issue #1689).
+fn subagent_allowed_tools_or_default(allowed_tools: Vec<String>) -> Vec<String> {
+    if allowed_tools.is_empty() {
+        DEFAULT_SUBAGENT_TOOLS
+            .iter()
+            .map(|tool| (*tool).to_string())
+            .collect()
+    } else {
+        allowed_tools
+    }
+}
+
 fn build_subagent_tool_policy(
     allowed_tools: Vec<String>,
     disallowed_tools: Vec<String>,
@@ -2038,9 +2069,15 @@ fn ensure_subagent_tools_available(
     allowed_tools: &[String],
 ) -> std::result::Result<(), String> {
     // RFC-0 (#1289): tool deferral was removed — every registered tool is
-    // available. Just verify the allowed tools are actually present.
+    // available. Verify the requested CONCRETE tools are present. Skip policy
+    // EXPRESSIONS — `group:*` named groups and `*` wildcards — which are
+    // allow-list patterns that expand against whatever is registered rather
+    // than concrete tool names: `tools.get("group:fs")` is always None, so a
+    // caller / role template using group tokens (or the lean default) would
+    // otherwise be falsely rejected as "not available on this host" (#1689).
     let missing = allowed_tools
         .iter()
+        .filter(|entry| !entry.starts_with("group:") && !entry.contains('*'))
         .filter(|tool_name| tools.get(tool_name).is_none())
         .cloned()
         .collect::<Vec<_>>();
@@ -2553,8 +2590,18 @@ impl Tool for SpawnTool {
             });
         }
 
-        let mut input: Input =
-            serde_json::from_value(args.clone()).wrap_err("invalid spawn tool input")?;
+        // #1690: surface the serde detail AND the schema so the model can
+        // self-repair next turn, and return a typed `ToolInputError` — a
+        // no-side-effect failure that must NOT cancel well-formed sibling
+        // spawns in a serial batch (see the M8.8 cascade in `execution.rs`).
+        let mut input: Input = serde_json::from_value(args.clone()).map_err(|e| {
+            super::ToolInputError::new(format!(
+                "invalid spawn tool input: {e}. Required: `task` (string — the \
+                 worker's instructions). Optional: `allowed_tools` (string[], \
+                 e.g. [\"group:fs\",\"shell\"]), `role`, `mode` \
+                 (\"background\"|\"sync\"), `context`, `model`, `label`."
+            ))
+        })?;
         // M8.2: if the caller referenced an AgentDefinition manifest by id,
         // layer the manifest's fields onto the inline Input with "inline
         // wins" semantics. Unknown ids are a hard error — silently ignoring
@@ -2578,7 +2625,16 @@ impl Tool for SpawnTool {
             None => input.task.clone(),
         };
 
-        let allowed_tools = input.allowed_tools.clone();
+        // RFC-0 (#1289) removed LRU tool deferral, so an EMPTY allow-list now
+        // means "every registered tool" (~43 schemas), which reliably
+        // degenerates weaker models into empty / reflexive single-tool
+        // responses that never produce a deliverable (issue #1689). By this
+        // point an inline list, a manifest (`apply_agent_definition`), and a
+        // role template (`apply_role_template`) have all had their chance to
+        // fill `allowed_tools`; if it is STILL empty the caller constrained
+        // nothing, so fall back to a lean coding/review surface rather than
+        // everything. An explicit list / role / manifest always wins.
+        let allowed_tools = subagent_allowed_tools_or_default(input.allowed_tools.clone());
         // Effective allow-list = `allowed_tools` minus the manifest's
         // `disallowed_tools`, for the two consumers that cannot apply the local
         // deny-list policy: the `agent_mcp` dispatch payload (codex P1) and the
@@ -5334,6 +5390,93 @@ mod tests {
 
         assert!(error.contains("required tool(s) not available on this host"));
         assert!(error.contains("podcast_generate"));
+    }
+
+    #[test]
+    fn subagent_defaults_to_lean_toolset_when_unconstrained() {
+        // #1689: an empty allow-list (no inline list, no role, no manifest —
+        // all resolved before this point) must NOT mean "every registered
+        // tool"; it falls back to the lean coding/review surface.
+        let resolved = subagent_allowed_tools_or_default(Vec::new());
+        assert_eq!(
+            resolved,
+            DEFAULT_SUBAGENT_TOOLS
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<Vec<_>>()
+        );
+        assert!(resolved.iter().any(|t| t == "group:fs"));
+
+        // An explicit list is honoured verbatim (the escape hatch).
+        let explicit = vec!["shell".to_string()];
+        assert_eq!(
+            subagent_allowed_tools_or_default(explicit.clone()),
+            explicit
+        );
+    }
+
+    #[test]
+    fn lean_default_policy_keeps_core_tools_and_shrinks_the_surface() {
+        // End-to-end: the lean default, applied as a policy to a full builtin
+        // registry, retains the read/WRITE/shell/search surface (so a worker
+        // can actually produce a deliverable) while shrinking the ~43-tool
+        // surface that degenerates weak models (#1689).
+        let full = ToolRegistry::with_builtins("/tmp").specs().len();
+        let mut tools = ToolRegistry::with_builtins("/tmp");
+        let policy = build_subagent_tool_policy(
+            subagent_allowed_tools_or_default(Vec::new()),
+            Vec::new(),
+            None,
+        );
+        tools.apply_policy(&policy);
+        let names: Vec<String> = tools.specs().into_iter().map(|s| s.name).collect();
+        for kept in [
+            "read_file",
+            "write_file",
+            "edit_file",
+            "shell",
+            "grep",
+            "list_dir",
+        ] {
+            assert!(
+                names.contains(&kept.to_string()),
+                "lean default dropped core tool {kept}: {names:?}"
+            );
+        }
+        assert!(
+            names.len() < full,
+            "lean default must shrink the {full}-tool surface, got {}",
+            names.len()
+        );
+        assert!(
+            names.len() <= 18,
+            "lean default should be ~15 tools, got {}: {names:?}",
+            names.len()
+        );
+    }
+
+    #[test]
+    fn preflight_skips_group_and_wildcard_tokens() {
+        // #1689: `group:*` / `*` are policy EXPRESSIONS, not concrete tool
+        // names — `tools.get("group:fs")` is always None — so they must be
+        // skipped, not reported "not available on this host". Otherwise the lean
+        // default (and any role using group tokens) could never spawn.
+        let tools = ToolRegistry::with_builtins("/tmp");
+        ensure_subagent_tools_available(
+            &tools,
+            &["group:fs".into(), "group:web".into(), "exec*".into()],
+        )
+        .expect("group / wildcard tokens must not be treated as missing tools");
+
+        // A concrete missing tool alongside a group token is still reported —
+        // but only the concrete name.
+        let err = ensure_subagent_tools_available(
+            &tools,
+            &["group:fs".into(), "definitely_not_a_tool".into()],
+        )
+        .unwrap_err();
+        assert!(err.contains("definitely_not_a_tool"));
+        assert!(!err.contains("group:fs"));
     }
 
     struct StaticTestTool {

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -2033,9 +2033,21 @@ fn build_subagent_tool_policy(
     }
 }
 
+/// Preflight the child's allow-list against what is actually registered.
+///
+/// `strict` distinguishes who asked for the tools:
+/// - `true`  — the CALLER named them explicitly (inline `allowed_tools`). An
+///   absent one is a hard error (a typo, or the wrong host): return `Err`.
+/// - `false` — a role template or manifest SUGGESTED them (they only fill the
+///   allow-list when the caller left it empty). Some are runtime-gated — e.g.
+///   the `reviewer` role lists `recall_memory` / `synthesize_research`, which
+///   need a memory-store / research provider — so an unwired one must be
+///   dropped-with-a-warning, not fail the whole spawn (the mini4 reviewer-role
+///   failure: the role required tools that aren't wired on that host).
 fn ensure_subagent_tools_available(
     tools: &ToolRegistry,
     allowed_tools: &[String],
+    strict: bool,
 ) -> std::result::Result<(), String> {
     // RFC-0 (#1289): tool deferral was removed — every registered tool is
     // available. Verify the requested CONCRETE tools are present. Skip policy
@@ -2052,11 +2064,19 @@ fn ensure_subagent_tools_available(
         .collect::<Vec<_>>();
     if missing.is_empty() {
         Ok(())
-    } else {
+    } else if strict {
         Err(format!(
             "required tool(s) not available on this host: {}",
             missing.join(", ")
         ))
+    } else {
+        // Role-/manifest-suggested tools that aren't wired here: drop and run
+        // with whatever IS available rather than failing the spawn.
+        warn!(
+            dropped = %missing.join(", "),
+            "subagent role/manifest suggested tools not available on this host; dropping them and proceeding"
+        );
+        Ok(())
     }
 }
 
@@ -2571,6 +2591,12 @@ impl Tool for SpawnTool {
                  (\"background\"|\"sync\"), `context`, `model`, `label`."
             ))
         })?;
+        // Bug A (reviewer-role preflight): capture whether the CALLER named the
+        // tools before a manifest / role template can fill the allow-list (they
+        // only fill it when it is empty). A caller-explicit tool that is absent
+        // hard-fails the spawn; a role-/manifest-suggested one that is unwired
+        // is dropped with a warning (see `ensure_subagent_tools_available`).
+        let allow_list_is_caller_explicit = !input.allowed_tools.is_empty();
         // M8.2: if the caller referenced an AgentDefinition manifest by id,
         // layer the manifest's fields onto the inline Input with "inline
         // wins" semantics. Unknown ids are a hard error — silently ignoring
@@ -3245,8 +3271,12 @@ impl Tool for SpawnTool {
             // Preflight against the EFFECTIVE (post-deny) allow-list: a tool
             // the manifest forbids must not gate the spawn on availability,
             // since the policy below denies it regardless (codex P2).
-            ensure_subagent_tools_available(&tools, &effective_allowed_tools)
-                .map_err(|error| eyre::eyre!(error))?;
+            ensure_subagent_tools_available(
+                &tools,
+                &effective_allowed_tools,
+                allow_list_is_caller_explicit,
+            )
+            .map_err(|error| eyre::eyre!(error))?;
             let policy = build_subagent_tool_policy(
                 allowed_tools,
                 manifest_disallowed_tools,
@@ -3825,9 +3855,12 @@ impl Tool for SpawnTool {
                 // Preflight against the EFFECTIVE (post-deny) allow-list —
                 // mirror the sync path so a manifest-forbidden tool that is
                 // absent from this registry does not fail the spawn (codex P2).
-                let availability_check =
-                    ensure_subagent_tools_available(&tools, &effective_allowed_tools)
-                        .map_err(|error| eyre::eyre!(error));
+                let availability_check = ensure_subagent_tools_available(
+                    &tools,
+                    &effective_allowed_tools,
+                    allow_list_is_caller_explicit,
+                )
+                .map_err(|error| eyre::eyre!(error));
                 let policy = build_subagent_tool_policy(
                     allowed_tools,
                     manifest_disallowed_tools,
@@ -5344,15 +5377,16 @@ mod tests {
         // RFC-0 (#1289): `shell` is always registered and visible — no
         // deferral to un-hide.
         assert!(tools.specs().iter().any(|spec| spec.name == "shell"));
-        ensure_subagent_tools_available(&tools, &[String::from("shell")]).unwrap();
+        ensure_subagent_tools_available(&tools, &[String::from("shell")], true).unwrap();
     }
 
     #[test]
     fn subagent_tool_preflight_reports_missing_allowed_tool() {
         let tools = ToolRegistry::with_builtins("/tmp");
 
-        let error = ensure_subagent_tools_available(&tools, &[String::from("podcast_generate")])
-            .unwrap_err();
+        let error =
+            ensure_subagent_tools_available(&tools, &[String::from("podcast_generate")], true)
+                .unwrap_err();
 
         assert!(error.contains("required tool(s) not available on this host"));
         assert!(error.contains("podcast_generate"));
@@ -5368,6 +5402,7 @@ mod tests {
         ensure_subagent_tools_available(
             &tools,
             &["group:fs".into(), "group:web".into(), "exec*".into()],
+            true,
         )
         .expect("group / wildcard tokens must not be treated as missing tools");
 
@@ -5376,10 +5411,73 @@ mod tests {
         let err = ensure_subagent_tools_available(
             &tools,
             &["group:fs".into(), "definitely_not_a_tool".into()],
+            true,
         )
         .unwrap_err();
         assert!(err.contains("definitely_not_a_tool"));
         assert!(!err.contains("group:fs"));
+    }
+
+    #[test]
+    fn preflight_soft_drops_suggested_missing_tools_but_hard_fails_caller_named() {
+        // Bug A (reviewer-role preflight): when the allow-list came from a role
+        // template / manifest (strict = false), a tool that isn't wired here —
+        // like the reviewer role's runtime-gated recall_memory /
+        // synthesize_research — must be DROPPED with a warning, not fail the
+        // spawn. The SAME missing tool is a hard error when the caller named it.
+        let tools = ToolRegistry::with_builtins("/tmp");
+        let list = [
+            String::from("read_file"),
+            String::from("definitely_not_a_tool"),
+        ];
+
+        ensure_subagent_tools_available(&tools, &list, false)
+            .expect("role/manifest-suggested missing tools must be dropped, not fail the spawn");
+
+        let err = ensure_subagent_tools_available(&tools, &list, true).unwrap_err();
+        assert!(err.contains("definitely_not_a_tool"));
+    }
+
+    #[tokio::test]
+    async fn reviewer_role_spawn_does_not_fail_on_unwired_role_tools() {
+        // Bug A end-to-end (the exact mini4 reviewer failure): a
+        // `role: "reviewer"` spawn with no inline allowed_tools has the role
+        // template fill the allow-list with `recall_memory` / `synthesize_research`
+        // — runtime-gated tools that are NOT registered without a memory /
+        // research provider. Before the fix the availability preflight
+        // hard-failed with "not available on this host: ... recall_memory,
+        // synthesize_research". Now those role-SUGGESTED tools are dropped and
+        // the spawn runs.
+        let (in_tx, _in_rx) = tokio::sync::mpsc::channel(16);
+        let tool = SpawnTool::new(
+            Arc::new(MockProvider),
+            Arc::new(create_test_store().await),
+            PathBuf::from("/tmp"),
+            in_tx,
+        );
+
+        let result = tool
+            .execute(&serde_json::json!({
+                "task": "review the diff",
+                "label": "reviewer",
+                "mode": "sync",
+                "role": "reviewer"
+                // no allowed_tools — the role template fills it with tools that
+                // include unwired recall_memory / synthesize_research
+            }))
+            .await
+            .unwrap();
+
+        assert!(
+            !result.output.contains("not available on this host"),
+            "the preflight must not hard-fail on role-suggested unwired tools: {}",
+            result.output
+        );
+        assert!(
+            result.success,
+            "reviewer-role spawn must run despite unwired role tools: {}",
+            result.output
+        );
     }
 
     struct StaticTestTool {
@@ -6492,13 +6590,13 @@ PY
         // The OLD ordering (preflight on the raw allow-list) rejects the spawn
         // because `podcast_generate` is not available on this host:
         assert!(
-            ensure_subagent_tools_available(&tools, &allowed).is_err(),
+            ensure_subagent_tools_available(&tools, &allowed, true).is_err(),
             "sanity: the unfiltered allow-list still trips the missing-tool guard"
         );
         // The FIX: preflight the EFFECTIVE set — the forbidden-and-missing tool
         // is gone, so the otherwise-valid `shell`-only spawn is admitted.
         let effective = effective_allowed_tools(&allowed, &disallowed);
-        ensure_subagent_tools_available(&tools, &effective)
+        ensure_subagent_tools_available(&tools, &effective, true)
             .expect("a disallowed-and-missing tool must not fail the preflight");
     }
 


### PR DESCRIPTION
## Summary

Three spawn-robustness fixes, surfaced while forensically root-causing "sub-agent code-review workers completed but produced zero deliverables" on mini4 (`octos serve`, 2.0.2-rc.4 `b8ba7fcab`). Each is a real defect **independent of tool count**.

**The full root cause (now proven from the ledgers) is broader than this PR** — see the note at the end. This PR lands the three fixes that are ready; the primary surfacing bug is tracked separately.

## The three fixes

### Availability preflight: group/wildcard-aware **and** role-tool soft-drop
This fired in production: the two `role: "reviewer"` spawns failed at 21:56 with `required tool(s) not available on this host: group:search, recall_memory, synthesize_research`. Two distinct causes, both fixed here:

1. **`group:search` was a false positive.** `ensure_subagent_tools_available` looked up every entry in the registry, but `tools.get("group:fs")` is always `None` — group/wildcard tokens are policy expressions, expanded later, not concrete names. The preflight now skips `group:*` / `*`.
2. **`recall_memory` / `synthesize_research` were genuinely unregistered.** They're real builtins but **runtime-gated** (they need a memory-store / research provider). The reviewer *role template* lists them, but the caller never asked for them. So the preflight now distinguishes who requested a tool:
   - **caller-explicit** (inline `allowed_tools`) → an absent one is a hard error (a typo, or the wrong host);
   - **role-/manifest-suggested** (they fill the allow-list only when the caller left it empty) → an unwired one is **dropped with a warning**, not a failure.

   `ensure_subagent_tools_available` gains a `strict` flag; the spawn captures `allow_list_is_caller_explicit` before the manifest/role fills run and passes it to both preflight sites. End-to-end, a `role: "reviewer"` spawn now runs instead of hard-failing on its own template's unwired tools.

### #1690 — input errors don't cascade; model gets a repair hint
One malformed `spawn` (invalid input — in the mini4 log, `allowed_tools={"item":"glob","grep":""}`) **cancelled its well-formed siblings** in the serial (M8.8) batch, and the model saw a bare `invalid spawn tool input` (eyre's plain `{e}` dropped the serde detail).
- New `ToolInputError`: a no-side-effect failure whose `Display` carries the serde detail **+ a schema hint**, marked **non-cascading**.
- Threaded a `cascades` bit through `ToolCallResult` (6→7-tuple; the compiler enumerated all 8 construction sites). Input-validation failures no longer cancel siblings; genuine errors / timeouts / panics / denials still do.

### #1691 — pre-cap budget reminder
Workers hit the `max_iterations` wall with no warning and no deliverable (the grace call injected no message). Inject an in-band reminder at ~80% of `max_iterations` and a final-call reminder on the grace iteration ("wrap up and WRITE your deliverable"). Codex gap G6.

Also drops the dead `(max_active, idle_threshold)` args from the `make_registry` test helper (RFC-0 leftover).

## Root cause of "zero deliverables" (for context — the primary bug is NOT fixed here)

The re-spawned reviewers (role dropped, `allowed_tools = [shell, web_fetch, web_search, read_file, list_dir, glob, grep]` — **no `write_file`**) did thorough reviews via **73–81 `shell` calls** and wrote their deliverables with a **shell heredoc**: `cat > /tmp/octos-review/octos-one-review.md <<'REPORT_EOF'`. They completed successfully — but `output_files` is built purely from tool-reported `write_file`/`edit_file` `file_modified`, with **no filesystem scan**, so shell-written files never surface → ledger `output_files: []`. The four reviews did exist (later copied into `skill-output/`). Tool count was not involved — `octos-org/llm-benchmark` shows the models used here select correctly at rel=100% up to N=1000 tools. That surfacing gap (and the reviewer-role soft-drop) will be handled in follow-ups.

## Tests
6, all green: group-aware preflight; role-tool soft-drop (suggested-missing dropped, caller-named still hard-fails) + an end-to-end `role: "reviewer"` spawn that runs despite unwired role tools; input-error non-cascade (+ detail reaches the model); hard-error still cascades; pre-cap budget reminder. Full `octos-agent` suite **2116 pass**; clippy + fmt clean.

Fixes #1690, #1691. Partially addresses #1689's preflight symptom (group-token portion). Related: #1508 (batch-failure handling), #1023 (the code-review swarm soak that would have caught the surfacing gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
