### PR TITLE
feat(goal): structured goal_get/goal_update tools replace the completion sentinel

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -2185,6 +2185,71 @@ impl InProcessAgentOrchestrator {
         true
     }
 
+    /// #1696 — read-only goal snapshot for the model's `goal_get` tool.
+    /// Never errors: no goal (or a goal outside the profile scope) renders
+    /// as `status: "none"` so the model gets a stable shape either way.
+    pub(crate) fn model_goal_snapshot(&self, session_id: &SessionKey, profile_id: &str) -> Value {
+        let state = self.state();
+        match state
+            .goals
+            .get(session_id)
+            .filter(|goal| goal.profile_id == profile_id)
+        {
+            Some(goal) => json!({
+                "status": goal.status,
+                "goal_id": goal.goal_id,
+                "objective": goal.objective,
+                "tokens_used": goal.tokens_used,
+                "token_budget": goal.token_budget,
+                "tokens_remaining": goal.token_budget.saturating_sub(goal.tokens_used),
+                "time_used_seconds": goal.time_used_seconds,
+                "continuations_used": goal.continuations_used,
+            }),
+            None => json!({ "status": "none" }),
+        }
+    }
+
+    /// #1696 — model-owned goal transition for the `goal_update` tool.
+    /// Enforces the ownership matrix server-side (defense in depth beyond
+    /// the tool executor): the model may set ONLY `complete` or `blocked`.
+    /// Structured successor to the `<goal:complete>` text sentinel
+    /// ([`Self::maybe_complete_goal_from_model`], kept for back-compat).
+    pub(crate) fn model_transition_goal(
+        &self,
+        session_id: &SessionKey,
+        profile_id: &str,
+        status: &str,
+        reason: &str,
+    ) -> Result<Value, String> {
+        if !matches!(status, "complete" | "blocked") {
+            return Err(format!(
+                "status `{status}` is not model-transitionable (only complete|blocked)"
+            ));
+        }
+        let mut state = self.state();
+        let Some(goal) = state.goals.get_mut(session_id) else {
+            return Err("no goal is set for this session".to_owned());
+        };
+        if goal.profile_id != profile_id {
+            return Err("goal is outside this profile's scope".to_owned());
+        }
+        if goal.status == "complete" {
+            return Err("goal is already complete".to_owned());
+        }
+        goal.status = status.to_owned();
+        goal.updated_at_ms = now_ms();
+        let snapshot = goal.clone();
+        persist_goal_state(&state, session_id, &snapshot, false);
+        tracing::info!(
+            session = %session_id,
+            goal_id = %snapshot.goal_id,
+            status = %status,
+            reason = %reason,
+            "model transitioned goal via goal_update tool"
+        );
+        Ok(autonomy_goal_json(&snapshot))
+    }
+
     #[cfg(test)]
     pub(crate) fn force_goal_tokens_used_for_test(
         &self,
@@ -4220,8 +4285,14 @@ fn record_goal_turn_internal(
     } else {
         goal.rate_window_count = goal.rate_window_count.saturating_add(1);
     }
-    let budget_exhausted =
-        goal.token_budget > 0 && goal.tokens_used >= goal.token_budget && !goal.wrap_up_emitted;
+    // Active-only (#1696): the model can transition the goal to
+    // complete/blocked MID-TURN via `goal_update`; the post-turn accountant
+    // must not overwrite that terminal state with `budget_limited` when the
+    // same turn's spend crosses the budget.
+    let budget_exhausted = goal.status == "active"
+        && goal.token_budget > 0
+        && goal.tokens_used >= goal.token_budget
+        && !goal.wrap_up_emitted;
     if budget_exhausted {
         goal.status = "budget_limited".to_owned();
         goal.wrap_up_emitted = true;
@@ -5271,7 +5342,7 @@ pub(crate) fn master_continuation_prompt(continuation: &QueuedMasterContinuation
                 );
             }
             format!(
-                "[system-internal]\nAn active goal continuation is ready.\n\nGoal: {goal_id}\nMetadata:\n{metadata}\n\nAdvance the goal by one bounded step. If the goal needs user input, ask a numbered choice question and recommend one option.",
+                "[system-internal]\nAn active goal continuation is ready.\n\nGoal: {goal_id}\nMetadata:\n{metadata}\n\nAdvance the goal by one bounded step. If the goal needs user input, ask a numbered choice question and recommend one option.\n\nGoal protocol: use the `goal_get` tool to check the objective and remaining token budget. When the goal's success criteria are DEMONSTRABLY met (verify against evidence, not intent), call `goal_update` with status=\"complete\" and a one-line reason. If the same blocker has persisted across turns and you cannot advance, call `goal_update` with status=\"blocked\". Do not redefine the goal around a smaller or easier task.",
             )
         }
         // #1131 — wrap-up turns must instruct the model to summarize
@@ -8569,6 +8640,131 @@ mod tests {
     /// transition the goal to `budget_limited`. Subsequent calls must
     /// be idempotent (no duplicate wrap-up).
     #[test]
+    /// #1696 — the model-owned transition matrix: complete|blocked only,
+    /// profile-scoped, refuses double-complete; the post-turn budget flip
+    /// must not overwrite a mid-turn model transition.
+    #[test]
+    fn model_transition_goal_enforces_ownership_matrix() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-tool");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "write the haiku".into(),
+                status: Some("active".into()),
+                token_budget: Some(1_000),
+                transition_actor: None,
+            })
+            .expect("set active goal");
+
+        // User/system-owned statuses are rejected server-side.
+        for status in ["paused", "active", "budget_limited", "cleared"] {
+            assert!(
+                orchestrator
+                    .model_transition_goal(&session_id, "tenant-a", status, "nope")
+                    .is_err(),
+                "{status} must not be model-transitionable"
+            );
+        }
+        // Wrong profile is rejected.
+        assert!(
+            orchestrator
+                .model_transition_goal(&session_id, "tenant-b", "complete", "scope")
+                .is_err()
+        );
+
+        // complete works and returns the goal snapshot.
+        let goal = orchestrator
+            .model_transition_goal(&session_id, "tenant-a", "complete", "haiku written")
+            .expect("model completes");
+        assert_eq!(goal["status"], json!("complete"));
+        assert_eq!(
+            orchestrator.goal_status_for_test(&session_id).as_deref(),
+            Some("complete")
+        );
+        // Double-complete refused.
+        assert!(
+            orchestrator
+                .model_transition_goal(&session_id, "tenant-a", "complete", "again")
+                .is_err()
+        );
+
+        // The post-turn accountant for the SAME turn (which crosses the
+        // budget) must not overwrite the model's terminal state with
+        // budget_limited.
+        orchestrator.force_goal_tokens_used_for_test(&session_id, 900);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", 500, 5);
+        assert_eq!(
+            orchestrator.goal_status_for_test(&session_id).as_deref(),
+            Some("complete"),
+            "budget flip must not clobber a model-set terminal status"
+        );
+    }
+
+    /// #1696 — `goal_get` snapshot: stable shape with remaining budget;
+    /// `status: none` when no goal exists or the profile mismatches.
+    #[test]
+    fn model_goal_snapshot_reports_remaining_budget() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-snap");
+        assert_eq!(
+            orchestrator.model_goal_snapshot(&session_id, "tenant-a")["status"],
+            json!("none")
+        );
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "snapshot me".into(),
+                status: Some("active".into()),
+                token_budget: Some(2_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        orchestrator.force_goal_tokens_used_for_test(&session_id, 500);
+        let snap = orchestrator.model_goal_snapshot(&session_id, "tenant-a");
+        assert_eq!(snap["objective"], json!("snapshot me"));
+        assert_eq!(snap["tokens_remaining"], json!(1_500));
+        assert_eq!(
+            orchestrator.model_goal_snapshot(&session_id, "tenant-b")["status"],
+            json!("none"),
+            "profile mismatch renders as none, never leaks the goal"
+        );
+    }
+
+    /// #1696 — the GoalContinue prompt must teach the goal protocol (the
+    /// sentinel era never told the model how to declare success).
+    #[test]
+    fn goal_continuation_prompt_teaches_goal_tools() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-prompt");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "write the haiku".into(),
+                status: Some("active".into()),
+                token_budget: Some(2_000_000),
+                transition_actor: None,
+            })
+            .expect("set active goal enqueues the initial continuation");
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        assert_eq!(drained.len(), 1, "initial GoalContinue drains");
+        let prompt = master_continuation_prompt(&drained[0]);
+        assert!(prompt.contains("goal_update"), "teach the transition tool");
+        assert!(prompt.contains("goal_get"), "teach the read tool");
+        assert!(
+            prompt.contains("Do not redefine the goal"),
+            "anti-scope-shrink language present"
+        );
+    }
+
     /// #1693 — three consecutive zero-token continuation turns (a
     /// permanently failing goal charges nothing, so the budget never
     /// stops it) flip the goal to `blocked`; one token-consuming turn

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -2185,6 +2185,30 @@ impl InProcessAgentOrchestrator {
         true
     }
 
+    /// #1696/#1698 — `SessionGoalUpdated`-shaped snapshot of the session's
+    /// CURRENT goal, for the autonomous post-turn accountant to push to the
+    /// owning connection after `record_goal_turn` / a model `goal_update`.
+    /// Without this push, autonomous transitions (complete via the goal
+    /// tool, blocked via the circuit breaker, budget_limited) repainted
+    /// nothing until an explicit `goal/get`.
+    pub(crate) fn session_goal_updated_event_json(
+        &self,
+        session_id: &SessionKey,
+        profile_id: &str,
+    ) -> Option<Value> {
+        let state = self.state();
+        let goal = state
+            .goals
+            .get(session_id)
+            .filter(|goal| goal.profile_id == profile_id)?;
+        Some(json!({
+            "session_id": session_id,
+            "profile_id": profile_id,
+            "goal": autonomy_goal_json(goal),
+            "transition_actor": "backend",
+        }))
+    }
+
     /// #1696 — read-only goal snapshot for the model's `goal_get` tool.
     /// Never errors: no goal (or a goal outside the profile scope) renders
     /// as `status: "none"` so the model gets a stable shape either way.

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -2247,7 +2247,7 @@ impl InProcessAgentOrchestrator {
     ) -> Result<Value, String> {
         if !matches!(status, "complete" | "blocked") {
             return Err(format!(
-                "status `{status}` is not model-transitionable (only complete|blocked)"
+                "status `{status}` is not a model-allowed transition (only complete|blocked)"
             ));
         }
         let mut state = self.state();
@@ -8688,7 +8688,7 @@ mod tests {
                 orchestrator
                     .model_transition_goal(&session_id, "tenant-a", status, "nope")
                     .is_err(),
-                "{status} must not be model-transitionable"
+                "{status} must not be a model-allowed transition"
             );
         }
         // Wrong profile is rejected.

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -22131,6 +22131,12 @@ async fn run_standalone_turn(
         workspace_root.as_deref(),
     ))
     .with_session_usage_base(session_usage_base.clone())
+    // #1696 soak fix: thread the session key into every ToolContext this
+    // turn builds. Without it the goal tools (and anything else reading
+    // `ToolContext::parent_session_key`) see no session on AppUI turns —
+    // the live goal continuation failed with "no session context" while
+    // the gateway actor path carried it fine.
+    .with_parent_session_key(session_id.to_string())
     .with_reporter(reporter);
     // In-loop compaction delivery (UPCR-2026-026 follow-up): mirror the
     // pre-turn lifecycle delivery — durable direct send for clients that
@@ -24389,6 +24395,35 @@ async fn run_standalone_turn(
                 &goal_ctx.profile_id,
                 &reply,
             );
+        }
+        // #1696/#1698 — push the post-turn goal snapshot to the OWNING
+        // connection so autonomous transitions repaint the chip live:
+        // complete (goal_update tool or sentinel), blocked (circuit
+        // breaker), budget_limited, and plain token-count growth. Same
+        // ephemeral owning-connection delivery as the interactive charge
+        // above — a durable append would fan the goal to every subscriber
+        // of an unprofiled shared session id regardless of profile.
+        if let Some(goal_event_json) =
+            orchestrator.session_goal_updated_event_json(&session_id, &goal_ctx.profile_id)
+        {
+            match serde_json::from_value::<octos_core::ui_protocol::SessionGoalUpdatedEvent>(
+                goal_event_json,
+            ) {
+                Ok(event) => {
+                    let _ = send_notification_ephemeral(
+                        &ws,
+                        &ledger,
+                        UiNotification::SessionGoalUpdated(event),
+                    );
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        error = %err,
+                        session_id = %session_id,
+                        "autonomous goal accountant produced an unparseable update event",
+                    );
+                }
+            }
         }
         // #1140 codex P2 re-review #5: do NOT call
         // `clear_goal_dispatch_in_flight` explicitly here. The RAII

--- a/crates/octos-cli/src/goal_tool.rs
+++ b/crates/octos-cli/src/goal_tool.rs
@@ -157,7 +157,7 @@ impl Tool for GoalUpdateTool {
         if !MODEL_ALLOWED_TRANSITIONS.contains(&status) {
             return Ok(ToolResult {
                 output: format!(
-                    "goal_update: status `{status}` is not model-transitionable — only \
+                    "goal_update: status `{status}` is not a model-allowed transition — only \
                      `complete` and `blocked` are. Pause/resume/budget changes belong to the user."
                 ),
                 success: false,

--- a/crates/octos-cli/src/goal_tool.rs
+++ b/crates/octos-cli/src/goal_tool.rs
@@ -1,0 +1,192 @@
+//! Structured goal tools for the model (#1696) — replaces the fragile
+//! `<goal:complete>` text sentinel with first-class, executor-enforced tool
+//! calls, mirroring codex's `get_goal`/`update_goal` ownership matrix.
+//!
+//! - `goal_get` — read the CURRENT session's goal: objective, status, token
+//!   spend vs budget (so the model can see remaining budget), continuation
+//!   count. Read-only.
+//! - `goal_update` — transition the goal. The executor accepts ONLY
+//!   `complete` (success criteria demonstrably met) and `blocked` (the same
+//!   blocker persists and the model cannot advance). `pause`, `resume`,
+//!   `active`, and budget changes are user/system-owned and are REJECTED here
+//!   regardless of what the model asks for.
+//!
+//! Both tools resolve the session from [`ToolContext::parent_session_key`],
+//! which every session-actor and AppUI turn threads into tool execution. The
+//! goal record itself lives in the process-wide
+//! [`default_agent_orchestrator`], so the tools carry no state of their own
+//! beyond the owning profile id (enforced against `goal.profile_id` exactly
+//! like the accountants).
+
+use async_trait::async_trait;
+use eyre::Result;
+use octos_agent::tools::{Tool, ToolContext, ToolResult};
+use octos_core::SessionKey;
+use serde_json::{Value, json};
+
+use crate::api::agent_orchestrator::default_agent_orchestrator;
+
+/// Statuses the MODEL may set via `goal_update`. Everything else is
+/// user/system-owned (see the module docs). Keep in sync with the
+/// `input_schema` enum below.
+const MODEL_ALLOWED_TRANSITIONS: [&str; 2] = ["complete", "blocked"];
+
+fn session_from_ctx(ctx: &ToolContext) -> Option<SessionKey> {
+    ctx.parent_session_key
+        .as_deref()
+        .filter(|key| !key.is_empty())
+        .map(|key| SessionKey(key.to_owned()))
+}
+
+/// `goal_get` — read-only goal snapshot for the current session.
+pub struct GoalGetTool {
+    profile_id: String,
+}
+
+impl GoalGetTool {
+    pub fn new(profile_id: impl Into<String>) -> Self {
+        Self {
+            profile_id: profile_id.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for GoalGetTool {
+    fn name(&self) -> &str {
+        "goal_get"
+    }
+
+    fn description(&self) -> &str {
+        "Read this session's persistent goal: objective, status, token spend vs budget \
+         (remaining budget), and continuation count. Returns status=none when no goal is set."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, args: &Value) -> Result<ToolResult> {
+        self.execute_with_context(&ToolContext::zero(), args).await
+    }
+
+    async fn execute_with_context(&self, ctx: &ToolContext, _args: &Value) -> Result<ToolResult> {
+        let Some(session_id) = session_from_ctx(ctx) else {
+            return Ok(ToolResult {
+                output: "goal_get: no session context for this turn".into(),
+                success: false,
+                ..Default::default()
+            });
+        };
+        let snapshot =
+            default_agent_orchestrator().model_goal_snapshot(&session_id, &self.profile_id);
+        Ok(ToolResult {
+            output: serde_json::to_string_pretty(&snapshot)
+                .unwrap_or_else(|_| snapshot.to_string()),
+            success: true,
+            ..Default::default()
+        })
+    }
+}
+
+/// `goal_update` — model-owned terminal transitions ONLY.
+pub struct GoalUpdateTool {
+    profile_id: String,
+}
+
+impl GoalUpdateTool {
+    pub fn new(profile_id: impl Into<String>) -> Self {
+        Self {
+            profile_id: profile_id.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for GoalUpdateTool {
+    fn name(&self) -> &str {
+        "goal_update"
+    }
+
+    fn description(&self) -> &str {
+        "Transition this session's goal. Allowed ONLY when justified: status=\"complete\" once \
+         the goal's success criteria are demonstrably met (verify against evidence first), or \
+         status=\"blocked\" when the same blocker has persisted across turns and you cannot \
+         advance. Include a short evidence-based reason. Pause/resume/budget changes are \
+         user-owned and will be rejected."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": MODEL_ALLOWED_TRANSITIONS,
+                    "description": "complete = success criteria met; blocked = cannot advance"
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "One-line evidence-based justification for the transition"
+                }
+            },
+            "required": ["status"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, args: &Value) -> Result<ToolResult> {
+        self.execute_with_context(&ToolContext::zero(), args).await
+    }
+
+    async fn execute_with_context(&self, ctx: &ToolContext, args: &Value) -> Result<ToolResult> {
+        let Some(session_id) = session_from_ctx(ctx) else {
+            return Ok(ToolResult {
+                output: "goal_update: no session context for this turn".into(),
+                success: false,
+                ..Default::default()
+            });
+        };
+        let status = args.get("status").and_then(Value::as_str).unwrap_or("");
+        // Executor-enforced ownership: reject anything outside the model's
+        // allowed matrix EVEN IF the schema was bypassed.
+        if !MODEL_ALLOWED_TRANSITIONS.contains(&status) {
+            return Ok(ToolResult {
+                output: format!(
+                    "goal_update: status `{status}` is not model-transitionable — only \
+                     `complete` and `blocked` are. Pause/resume/budget changes belong to the user."
+                ),
+                success: false,
+                ..Default::default()
+            });
+        }
+        let reason = args
+            .get("reason")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        match default_agent_orchestrator().model_transition_goal(
+            &session_id,
+            &self.profile_id,
+            status,
+            reason,
+        ) {
+            Ok(goal) => Ok(ToolResult {
+                output: format!(
+                    "goal transitioned to `{status}`:\n{}",
+                    serde_json::to_string_pretty(&goal).unwrap_or_else(|_| goal.to_string())
+                ),
+                success: true,
+                ..Default::default()
+            }),
+            Err(message) => Ok(ToolResult {
+                output: format!("goal_update: {message}"),
+                success: false,
+                ..Default::default()
+            }),
+        }
+    }
+}

--- a/crates/octos-cli/src/lib.rs
+++ b/crates/octos-cli/src/lib.rs
@@ -25,6 +25,7 @@ pub mod content_catalog;
 pub(crate) mod context_manager;
 pub mod cron_tool;
 pub mod gateway_dispatcher;
+#[cfg(feature = "api")]
 pub mod goal_tool;
 #[cfg(feature = "api")]
 pub mod login_allowlist;

--- a/crates/octos-cli/src/lib.rs
+++ b/crates/octos-cli/src/lib.rs
@@ -25,6 +25,7 @@ pub mod content_catalog;
 pub(crate) mod context_manager;
 pub mod cron_tool;
 pub mod gateway_dispatcher;
+pub mod goal_tool;
 #[cfg(feature = "api")]
 pub mod login_allowlist;
 pub mod memory_consolidate;

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -870,8 +870,13 @@ impl ProfileRuntime {
         // budget) and goal_update (model-owned complete|blocked ONLY,
         // executor-enforced). Session resolved per-call from
         // ToolContext::parent_session_key; profile scope pinned here.
-        tools.register(crate::goal_tool::GoalGetTool::new(profile.id.clone()));
-        tools.register(crate::goal_tool::GoalUpdateTool::new(profile.id.clone()));
+        // Goals live in the AppUI orchestrator, so the tools exist only
+        // with the `api` feature (like the orchestrator itself).
+        #[cfg(feature = "api")]
+        {
+            tools.register(crate::goal_tool::GoalGetTool::new(profile.id.clone()));
+            tools.register(crate::goal_tool::GoalUpdateTool::new(profile.id.clone()));
+        }
 
         // Step 17: re-apply tool policy AFTER plugin / memory-bank
         // registration so deny entries can target plugin-declared

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -866,6 +866,12 @@ impl ProfileRuntime {
         let cron_service = Arc::new(CronService::new(data_dir.join("cron.json"), cron_tx));
         cron_service.start();
         tools.register(CronTool::with_context(cron_service.clone(), "api", ""));
+        // #1696 — structured goal tools: goal_get (objective + remaining
+        // budget) and goal_update (model-owned complete|blocked ONLY,
+        // executor-enforced). Session resolved per-call from
+        // ToolContext::parent_session_key; profile scope pinned here.
+        tools.register(crate::goal_tool::GoalGetTool::new(profile.id.clone()));
+        tools.register(crate::goal_tool::GoalUpdateTool::new(profile.id.clone()));
 
         // Step 17: re-apply tool policy AFTER plugin / memory-bank
         // registration so deny entries can target plugin-declared

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -578,6 +578,10 @@ impl SessionRuntime {
         .with_subagent_output_router(subagent_output_router)
         .with_subagent_summary_generator(subagent_summary_generator)
         .with_sandbox_config(sandbox.clone())
+        // #1696: session-scoped tools (goal_get/goal_update) resolve their
+        // session from ToolContext::parent_session_key — thread it on the
+        // runtime-held agent exactly like the per-turn AppUI rebuild does.
+        .with_parent_session_key(session_key.to_string())
         .with_workspace_root(workspace_root.clone());
 
         // Phase 1 of the SessionScope migration: attach the constructed


### PR DESCRIPTION
Closes #1696 (top adoptable from the codex goal review; also addresses the #1697 comment finding that the continuation prompt never taught the sentinel — model-owned completion effectively could not fire).

- **goal_get** — objective, status, tokens used/budget/**remaining**, continuation count (`status: none` when unset; profile mismatch never leaks).
- **goal_update(status, reason)** — executor-enforced to `complete|blocked` ONLY, with server-side defense in depth (`model_transition_goal`: matrix + profile scope + no double-complete). Pause/resume/budget remain user-owned.
- **GoalContinue prompt teaches the protocol**: evidence-based completion, blocked on persistent blockers, anti-scope-shrink.
- **Budget flip is active-only** so the same turn's post-accounting can't clobber a mid-turn model transition.
- Sentinel kept for back-compat. TUI unchanged (tui#330 already renders/toasts complete/blocked).

Tests: ownership matrix (rejects paused/active/budget_limited/cleared + wrong profile + double-complete), budget-flip guard, snapshot shape + remaining budget + profile isolation, prompt teaches goal_get/goal_update/anti-scope-shrink. Suite 2456/0. Live real-server soak on an isolated data dir follows before release.