### PR TITLE
fix(agents): workspace-scope the scatter/gather sibling join (#1707)

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -4433,12 +4433,27 @@ fn enqueue_agent_terminal_continuations(
     .with_metadata("status", agent.status.clone())
     .with_metadata("nickname", agent.nickname.clone())
     .with_metadata("role", agent.role.clone());
+    // #1707: stamp the child's workspace so a future drain-site guard can drop
+    // a continuation replayed under a wire session key that has since been
+    // rebound to a DIFFERENT project (sessions_in_cwd reuse). Self-describing;
+    // no behavior change on its own.
+    if let Some(cwd) = agent.cwd.as_deref().filter(|value| !value.is_empty()) {
+        child = child.with_metadata("workspace", cwd.to_owned());
+    }
     if let Some(last_task) = agent.last_task.as_deref().filter(|value| !value.is_empty()) {
         child = child.with_metadata("summary", last_task.chars().take(1200).collect::<String>());
     }
     enqueue_and_persist_continuation(state, child);
     persist_agent_terminal(state, agent);
 
+    // #1707: siblings for the scatter/gather join MUST share a workspace. Two
+    // agents that merely reuse the same wire `session_id` across different
+    // project cwds (sessions_in_cwd) are NOT siblings — counting a prior
+    // project's terminal children here fired a false `ScatterJoinComplete`
+    // (and an inflated `terminal_children` count) into the reused session.
+    // `cwd == cwd` keeps the legacy behavior byte-identical when the workspace
+    // is unknown (both `None`), and same-workspace restart recovery still joins
+    // (the restored siblings carry the same cwd).
     let siblings = state
         .agents
         .values()
@@ -4446,6 +4461,7 @@ fn enqueue_agent_terminal_continuations(
             candidate.session_id == agent.session_id
                 && candidate.profile_id == agent.profile_id
                 && candidate.parent_agent_id == agent.parent_agent_id
+                && candidate.cwd == agent.cwd
         })
         .collect::<Vec<_>>();
     if siblings.is_empty()
@@ -4477,6 +4493,11 @@ fn enqueue_agent_terminal_continuations(
             .unwrap_or_else(|| "master".to_owned()),
     )
     .with_metadata("terminal_children", siblings.len().to_string());
+    // #1707: same workspace stamp as the per-child ChildCompleted above.
+    let scatter = match agent.cwd.as_deref().filter(|value| !value.is_empty()) {
+        Some(cwd) => scatter.with_metadata("workspace", cwd.to_owned()),
+        None => scatter,
+    };
     enqueue_and_persist_continuation(state, scatter);
 }
 
@@ -7681,6 +7702,86 @@ mod tests {
                 MasterContinuationReason::ChildCompleted,
                 MasterContinuationReason::ScatterJoinComplete
             ]
+        );
+    }
+
+    /// #1707: the scatter/gather join is workspace-scoped. A stale terminal
+    /// child left in the roster under the SAME wire `session_id` but a
+    /// DIFFERENT project cwd (sessions_in_cwd reuse) must NOT be counted as a
+    /// sibling of a freshly-completing child — otherwise it fires a false
+    /// `ScatterJoinComplete` and inflates `terminal_children` into the reused
+    /// session.
+    #[test]
+    fn scatter_join_excludes_cross_workspace_siblings() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        // Live child in project A.
+        let mut child_a = sample_agent("child-a", "tenant-a");
+        child_a.parent_agent_id = Some("master".into());
+        child_a.cwd = Some("/projects/a".into());
+        let session_id = child_a.session_id.clone();
+        // Stale terminal child from project B, already in the roster under the
+        // SAME session key (a prior lifetime's workspace binding of the reused
+        // wire id). Inserted pre-terminal so it enqueues nothing on its own.
+        let mut stale_b = sample_agent("stale-b", "tenant-a");
+        stale_b.parent_agent_id = Some("master".into());
+        stale_b.cwd = Some("/projects/b".into());
+        stale_b.status = "completed".into();
+        assert_eq!(stale_b.session_id, session_id, "same wire session key");
+        orchestrator
+            .state()
+            .agents
+            .insert(child_a.agent_id.clone(), child_a);
+        orchestrator
+            .state()
+            .agents
+            .insert(stale_b.agent_id.clone(), stale_b);
+
+        orchestrator
+            .set_agent_status(
+                "child-a",
+                &session_id,
+                "tenant-a",
+                "completed",
+                Some("project A review done".into()),
+            )
+            .expect("complete project-A child");
+
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        let reasons = drained
+            .iter()
+            .map(|item| item.reason.clone())
+            .collect::<Vec<_>>();
+        // The join fires (child-a's own workspace group is all-terminal)...
+        assert_eq!(
+            reasons,
+            vec![
+                MasterContinuationReason::ChildCompleted,
+                MasterContinuationReason::ScatterJoinComplete
+            ]
+        );
+        // ...but scoped to project A ONLY: terminal_children == 1, NOT 2. The
+        // cross-workspace `stale-b` is excluded from the sibling set.
+        let scatter = drained
+            .iter()
+            .find(|item| item.reason == MasterContinuationReason::ScatterJoinComplete)
+            .expect("scatter join present");
+        assert_eq!(
+            scatter
+                .metadata
+                .get("terminal_children")
+                .map(String::as_str),
+            Some("1"),
+            "cross-workspace stale sibling must not inflate the join count"
+        );
+        assert_eq!(
+            scatter.metadata.get("workspace").map(String::as_str),
+            Some("/projects/a"),
+            "the join is stamped with the completing child's workspace"
         );
     }
 


### PR DESCRIPTION
## Problem (#1707, live-path half)

With `sessions_in_cwd`, the SAME wire `session_id` (e.g. `octos:local:tui#coding`) can bind to different project cwds across server lifetimes. The scatter/gather join in `enqueue_agent_terminal_continuations` grouped siblings by `(session_id, profile_id, parent_agent_id)` with **no workspace component**. So a prior project's terminal children — restored into the roster under a reused session key — were counted as siblings of a freshly-completing child in a *different* project, firing a false `ScatterJoinComplete` and inflating `terminal_children`.

(#1669 already scoped the ledger + context stores per-cwd; the agent roster + continuation identity were the remaining un-scoped session-keyed state.)

## Fix

- **Sibling filter is workspace-scoped:** add `candidate.cwd == agent.cwd` to the join's sibling predicate. Siblings genuinely share a workspace. Legacy behavior is byte-identical when the workspace is unknown (both `None`), and same-workspace restart recovery still joins (restored siblings carry the same cwd).
- **Continuations are workspace-stamped:** both `ChildCompleted` and `ScatterJoinComplete` now carry a `workspace` metadata key (the child's cwd). Self-describing; no behavior change on its own.

## Test
`scatter_join_excludes_cross_workspace_siblings` — a stale `/projects/b` terminal child in the roster under the same session key must not inflate the `/projects/a` child's join (`terminal_children == 1`, not `2`). **RED-verified**: removing the cwd guard makes it fail with `terminal_children == 2`. 113 orchestrator tests pass.

## Remaining follow-up (boot-replay half — documented, not in this PR)

`configure_supervisor_store` re-enqueues every non-completed persisted continuation at boot (keyed by `(session_id, profile_id)`), so a stale `ScatterJoinComplete` from a prior cwd binding still drains for a reused key. The correct guard is **fire-time**: at the drain site (`maybe_spawn_appui_master_continuation_runner`, which holds `AppState` + `session_id`), resolve the session's current `sessions_root`, and drop a drained continuation whose stamped `workspace` no longer matches (tombstone so it doesn't recur). This PR adds the `workspace` stamp that guard needs. It is deliberately separated because it threads the session's live cwd through the drain path and must not weaken the durable same-cwd crash-recovery replay — worth doing deliberately with its own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)