### PR TITLE
fix: isolate session list by tenant profile

### DIFF
--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -669,6 +669,13 @@ pub async fn list_sessions(
     // — Layer-2 authorization still applies, and a parent viewing a
     // sub-account subdomain still lists the routed profile's sessions.
     let routed_profile_id = routed_profile_id_from_headers(&state, &headers);
+    // A localhost / stdio UI Protocol connection has no routed profile
+    // header, but its authenticated profile is frozen onto the connection.
+    // Use that scope for every legacy fallback below; defaulting to `_main`
+    // here leaks solo/admin session metadata into an ordinary user's list.
+    let connection_scoped_profile_id =
+        connection_profile_id.filter(|_| routed_profile_id.is_none());
+    let effective_profile_id = connection_scoped_profile_id.unwrap_or(&profile_id);
     let profile_data_dir = match connection_profile_id {
         Some(pid) if routed_profile_id.is_none() => {
             resolve_profile_data_dir_by_id(&state, pid).ok()
@@ -690,7 +697,7 @@ pub async fn list_sessions(
 
     if let Some(sessions) = &state.sessions {
         let sess = sessions.lock().await;
-        let prefix = format!("{profile_id}:api:");
+        let prefix = format!("{effective_profile_id}:api:");
         // Use `list_top_level_sessions` (skips `child-*` and `*.tasks` at the
         // directory walk) so a user dir with tens of thousands of spawn
         // children does not turn this listing into an O(N) hang. The
@@ -725,9 +732,22 @@ pub async fn list_sessions(
     // #995 follow-up — routed_profile_id used to walk the per-profile
     // gateway is authorized above; the `resolve_api_port_authorized`
     // call re-checks header authorization belt-and-suspenders.
-    let api_port = match resolve_api_port_authorized(&state, &headers, identity_ref).await {
-        Ok(port) => port,
-        Err(response) => return response,
+    let api_port = if let Some(profile_id) = connection_scoped_profile_id {
+        // The frozen connection scope is authoritative on localhost. Never
+        // fall back to the first running gateway, which may belong to a
+        // different profile.
+        match state.process_manager.as_ref() {
+            Some(pm) => pm
+                .api_port(profile_id)
+                .await
+                .map(|port| (profile_id.to_string(), port)),
+            None => None,
+        }
+    } else {
+        match resolve_api_port_authorized(&state, &headers, identity_ref).await {
+            Ok(port) => port,
+            Err(response) => return response,
+        }
     };
     if let Some((_profile_id, port)) = api_port {
         let proxy_resp = super::webhook_proxy::api_get_proxy(&state, port, "/sessions").await;
@@ -4665,6 +4685,102 @@ mod tests {
         assert!(
             list.iter().any(|s| s.id == "web-legacy-1"),
             "admin legacy path must still surface profiled sessions: {ids:?}"
+        );
+    }
+
+    /// A user-authenticated localhost WebSocket has no routed profile header;
+    /// its frozen `connection_profile_id` is the tenant boundary. The legacy
+    /// process-wide store must use that profile prefix instead of `_main`, or
+    /// the launcher exposes the solo/admin session titles while message reads
+    /// correctly remain scoped to the user's own profile.
+    #[tokio::test]
+    async fn list_sessions_user_connection_does_not_merge_main_profile_sessions() {
+        use crate::profiles::{ProfileStore, UserProfile};
+
+        let home = tempfile::tempdir().unwrap();
+        let store = ProfileStore::open(home.path()).unwrap();
+        let tenant_data_dir = home.path().join("tenant-data");
+        store
+            .save(&UserProfile {
+                id: "tenant-user".into(),
+                name: "Tenant User".into(),
+                enabled: true,
+                data_dir: Some(tenant_data_dir.to_string_lossy().into_owned()),
+                parent_id: None,
+                public_subdomain: None,
+                config: Default::default(),
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            })
+            .unwrap();
+
+        {
+            let mut tenant_sessions = octos_bus::SessionManager::open(&tenant_data_dir).unwrap();
+            tenant_sessions
+                .add_message(
+                    &SessionKey("web-own-profile".into()),
+                    Message::user("tenant-owned profile chat"),
+                )
+                .await
+                .unwrap();
+        }
+
+        let legacy_data_dir = tempfile::tempdir().unwrap();
+        let legacy_sessions = Arc::new(tokio::sync::Mutex::new(
+            octos_bus::SessionManager::open(legacy_data_dir.path()).unwrap(),
+        ));
+        {
+            let mut sessions = legacy_sessions.lock().await;
+            sessions
+                .add_message(
+                    &SessionKey::with_profile(MAIN_PROFILE_ID, "api", "web-admin-private"),
+                    Message::user("solo admin chat"),
+                )
+                .await
+                .unwrap();
+            sessions
+                .add_message(
+                    &SessionKey::with_profile("tenant-user", "api", "web-tenant-legacy"),
+                    Message::user("tenant legacy chat"),
+                )
+                .await
+                .unwrap();
+        }
+
+        let state = Arc::new(AppState {
+            profile_store: Some(Arc::new(store)),
+            sessions: Some(legacy_sessions),
+            ..AppState::empty_for_tests()
+        });
+        let response = list_sessions(
+            State(state),
+            HeaderMap::new(),
+            Some(Extension(AuthIdentity::User {
+                id: "tenant-user".into(),
+                role: UserRole::User,
+            })),
+            Some("tenant-user"),
+            None,
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let sessions: Vec<SessionInfo> = serde_json::from_slice(&body).unwrap();
+        let ids: Vec<&str> = sessions.iter().map(|session| session.id.as_str()).collect();
+        assert!(
+            ids.contains(&"web-own-profile"),
+            "own profile missing: {ids:?}"
+        );
+        assert!(
+            ids.contains(&"web-tenant-legacy"),
+            "tenant legacy session missing: {ids:?}"
+        );
+        assert!(
+            !ids.contains(&"web-admin-private"),
+            "main/solo session metadata leaked into tenant list: {ids:?}"
         );
     }
 


### PR DESCRIPTION
## What changed

- Scope legacy process-wide API session listing to the authenticated connection profile.
- Resolve localhost/stdio gateway ports from the authenticated profile instead of falling back to another running profile.
- Preserve explicit routed-profile behavior for authorized administrative requests.
- Add a regression test proving a tenant sees its own legacy sessions but not another profile's sessions.
- Synchronize the branch with the latest `main`.

## Root cause

The session-list handler used the request profile selected later in routing and could fall back to the first running API gateway. In a multi-tenant server this allowed project/session metadata from another profile to appear in a tenant's dashboard, even though subsequent content requests remained unauthorized.

## Impact

Session and project metadata returned to ordinary users is now isolated to their authenticated tenant profile.

## Validation

- `cargo test -p octos-cli --features api --lib --quiet` — 2458 passed, 6 ignored
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- Manual multi-tenant E2E verification
