### PR TITLE
fix(swarm): three dispatch P1s — pipeline chain-break, replay fidelity, resume shape/concurrency guard

### DIFF
--- a/crates/octos-swarm/src/dispatcher.rs
+++ b/crates/octos-swarm/src/dispatcher.rs
@@ -25,8 +25,9 @@
 //!    event and increments
 //!    `octos_swarm_dispatch_total{topology,outcome}`.
 
+use std::collections::HashSet;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use eyre::Result;
 use metrics::counter;
@@ -189,6 +190,13 @@ pub struct Swarm {
     /// be `Clone`-cheap. A default policy (`is_noop()`) short-circuits
     /// the gate so existing callers see no behavioural change.
     dispatch_policy: Arc<DispatchPolicy>,
+    /// #1719: per-dispatch-id in-flight registry. Two concurrent
+    /// [`Swarm::dispatch`] calls with the same id would race the
+    /// load/store pair — double-dispatching subtasks and clobbering
+    /// each other's round state — so the second caller is rejected
+    /// while the first holds the id. RAII guard, released on every
+    /// exit path.
+    in_flight: Arc<Mutex<HashSet<String>>>,
 }
 
 impl Swarm {
@@ -223,12 +231,15 @@ impl Swarm {
     /// # Invariants
     /// - Idempotent given same `(contracts, topology, budget)` +
     ///   `dispatch_id`: a second call finds the existing record and
-    ///   returns the finalized result without re-dispatching completed
-    ///   contracts.
+    ///   returns the finalized result verbatim without re-dispatching
+    ///   completed contracts. Reusing a dispatch_id with a different
+    ///   contract list or topology errors, and a concurrent dispatch
+    ///   of an in-flight id errors.
     /// - Fan-out is bounded by [`SwarmTopology::max_concurrency`].
     /// - Sequential aborts on the first terminal failure.
     /// - Pipeline chains `output -> task.pipeline_input` for the next
-    ///   contract.
+    ///   contract; a round ends at the first non-completed stage so a
+    ///   downstream stage never dispatches without its upstream input.
     /// - Retry budget honours [`SwarmBudget::effective_max_retry_rounds`].
     /// - The aggregate validator runs once, after every sub-contract
     ///   reaches terminal state.
@@ -254,14 +265,29 @@ impl Swarm {
             );
         }
 
+        // #1719: serialize dispatches per id. The second concurrent
+        // caller is rejected instead of racing the load/store pair.
+        let _in_flight = InFlightGuard::acquire(&self.in_flight, &dispatch_id)?;
+
         // Load or initialise the durable record. Idempotency invariant:
         // a prior finalized record short-circuits the whole loop.
         let mut record = match self.store.load(&dispatch_id).await? {
             Some(existing) if existing.finalized => {
+                ensure_record_matches_dispatch(&existing, &resolved, &topology)?;
                 debug!(dispatch_id = %dispatch_id, "reusing finalized swarm record");
-                return Ok(self.result_from_record(&existing, Vec::new(), None).await);
+                // #1718: return the exact result computed at
+                // finalization — validator verdicts + cost included.
+                // Legacy records without the snapshot fall back to
+                // recomputing from subtask state.
+                return Ok(match existing.final_result {
+                    Some(result) => result,
+                    None => self.result_from_record(&existing, Vec::new(), None).await,
+                });
             }
-            Some(existing) => existing,
+            Some(existing) => {
+                ensure_record_matches_dispatch(&existing, &resolved, &topology)?;
+                existing
+            }
             None => DispatchRecord::new(
                 dispatch_id.clone(),
                 context.session_id.clone(),
@@ -361,6 +387,9 @@ impl Swarm {
         );
 
         // Mark the record finalized so a future restart short-circuits.
+        // #1718: snapshot the computed result verbatim so the replay
+        // path returns exactly what this call returned.
+        record.final_result = Some(result.clone());
         record.finalized = true;
         self.store.store(&record).await?;
 
@@ -495,9 +524,18 @@ impl Swarm {
             // Forward attribution to the wired ledger adapter.
             self.attribute_cost(record, contracts, *idx, &outcome).await;
             let is_terminal = outcome.status == SubtaskStatus::TerminalFailed;
+            let completed = outcome.status == SubtaskStatus::Completed;
             record.subtasks[*idx] = outcome;
             if is_terminal {
                 return Ok(true);
+            }
+            // #1717: a retryable failure also ends the round — the next
+            // stage's `pipeline_input` requires THIS stage's output.
+            // Continuing would dispatch downstream stages without input
+            // and mark them Completed against a broken chain. They stay
+            // pending and re-enter after the upstream stage retries.
+            if !completed {
+                return Ok(false);
             }
         }
         Ok(false)
@@ -742,8 +780,86 @@ impl SwarmBuilder {
             event_sink: self.event_sink,
             cost_budget: self.cost_budget,
             dispatch_policy: self.dispatch_policy,
+            in_flight: Arc::new(Mutex::new(HashSet::new())),
         })
     }
+}
+
+/// #1719: RAII in-flight marker for one dispatch id. Construction
+/// registers the id — rejecting a concurrent holder — and drop releases
+/// it on every exit path, error paths included.
+struct InFlightGuard {
+    registry: Arc<Mutex<HashSet<String>>>,
+    dispatch_id: String,
+}
+
+impl InFlightGuard {
+    fn acquire(registry: &Arc<Mutex<HashSet<String>>>, dispatch_id: &str) -> Result<Self> {
+        let mut held = registry
+            .lock()
+            .map_err(|_| eyre::eyre!("swarm in-flight registry poisoned"))?;
+        if !held.insert(dispatch_id.to_string()) {
+            eyre::bail!(
+                "swarm dispatch `{dispatch_id}` is already in flight; \
+                 wait for the active dispatch to finish before re-dispatching"
+            );
+        }
+        Ok(Self {
+            registry: Arc::clone(registry),
+            dispatch_id: dispatch_id.to_string(),
+        })
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        if let Ok(mut held) = self.registry.lock() {
+            held.remove(&self.dispatch_id);
+        }
+    }
+}
+
+/// #1719: a reused dispatch_id must present the identical dispatch
+/// shape. Silently resuming against a different one either panicked
+/// (`contracts[idx]` out of bounds when the record had more subtasks
+/// than the caller supplied contracts) or attributed slot outputs to
+/// the wrong contract; a finalized replay with different contracts
+/// silently returned a result for work that never ran.
+fn ensure_record_matches_dispatch(
+    record: &DispatchRecord,
+    resolved: &[ContractSpec],
+    topology: &SwarmTopology,
+) -> Result<()> {
+    if record.topology != *topology {
+        eyre::bail!(
+            "swarm dispatch `{}` topology mismatch: record has `{}`, caller supplied `{}` — \
+             reusing a dispatch_id requires the identical dispatch shape",
+            record.dispatch_id,
+            record.topology.as_str(),
+            topology.as_str()
+        );
+    }
+    if record.subtasks.len() != resolved.len() {
+        eyre::bail!(
+            "swarm dispatch `{}` contract-count mismatch: record has {} subtasks, caller \
+             supplied {} contracts — reusing a dispatch_id requires the identical contract list",
+            record.dispatch_id,
+            record.subtasks.len(),
+            resolved.len()
+        );
+    }
+    for (slot, (subtask, contract)) in record.subtasks.iter().zip(resolved).enumerate() {
+        if subtask.contract_id != contract.contract_id {
+            eyre::bail!(
+                "swarm dispatch `{}` contract mismatch at slot {slot}: record has `{}`, caller \
+                 supplied `{}` — reusing a dispatch_id requires the identical contract list",
+                record.dispatch_id,
+                subtask.contract_id,
+                contract.contract_id
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Review A F-004: wrap [`dispatch_once`] with a

--- a/crates/octos-swarm/src/lib.rs
+++ b/crates/octos-swarm/src/lib.rs
@@ -57,13 +57,18 @@
 //!
 //! 1. [`Swarm::dispatch`] is idempotent given the same
 //!    `(dispatch_id, contracts, topology, budget)`: a finalized record
-//!    in the redb ledger short-circuits re-dispatch.
+//!    in the redb ledger short-circuits re-dispatch and returns the
+//!    stored result verbatim. Reusing a dispatch_id with a different
+//!    contract list or topology is rejected, and a second concurrent
+//!    dispatch of an in-flight id is rejected.
 //! 2. [`SwarmTopology::Parallel`] fans out up to `max_concurrency`
 //!    contracts, aggregation is arrival order.
 //! 3. [`SwarmTopology::Sequential`] runs one-at-a-time and aborts on
 //!    the first terminal (non-retryable) failure.
 //! 4. [`SwarmTopology::Pipeline`] chains output of contract `i` as
-//!    `pipeline_input` into contract `i + 1`.
+//!    `pipeline_input` into contract `i + 1`; a round stops at the
+//!    first non-completed stage so a downstream stage never runs
+//!    without its upstream input.
 //! 5. Retry budget bounded at [`MAX_RETRY_ROUNDS`] (3).
 //! 6. Aggregate M4.3 validator runs AFTER every sub-contract reaches
 //!    terminal state.

--- a/crates/octos-swarm/src/persistence.rs
+++ b/crates/octos-swarm/src/persistence.rs
@@ -18,7 +18,7 @@ use eyre::{Result, WrapErr};
 use redb::{Database, TableDefinition};
 use serde::{Deserialize, Serialize};
 
-use crate::result::SubtaskOutcome;
+use crate::result::{SubtaskOutcome, SwarmResult};
 use crate::topology::SwarmTopology;
 
 /// Current schema for the persisted dispatch record. Bumping this
@@ -46,6 +46,14 @@ pub struct DispatchRecord {
     /// `true` once [`crate::Swarm::dispatch`] returns. Restart logic
     /// treats finalized dispatches as idempotent no-ops.
     pub finalized: bool,
+    /// #1718: snapshot of the exact [`SwarmResult`] returned when the
+    /// dispatch finalized — validator verdicts and cost roll-up
+    /// included. Replays return this verbatim instead of recomputing
+    /// from subtask state (recomputation silently dropped validator
+    /// failures). `None` on records persisted before this field
+    /// existed; those replays fall back to recomputation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub final_result: Option<SwarmResult>,
 }
 
 impl DispatchRecord {
@@ -65,6 +73,7 @@ impl DispatchRecord {
             subtasks,
             retry_rounds_used: 0,
             finalized: false,
+            final_result: None,
         }
     }
 }

--- a/crates/octos-swarm/tests/swarm_dispatch.rs
+++ b/crates/octos-swarm/tests/swarm_dispatch.rs
@@ -740,6 +740,392 @@ async fn should_expand_fanout_pattern_into_variant_contracts() {
 }
 
 #[tokio::test]
+async fn should_stop_pipeline_round_at_retryable_stage_and_resume_with_input() {
+    // #1717: a retryable mid-pipeline failure must end the round. With
+    // the old behaviour stage-3 dispatched in the same round with NO
+    // `pipeline_input` (stage-2 had not completed) and was marked
+    // Completed against a silently-broken chain.
+    let backend = FakeBackend::new();
+    backend.script("stage-1", vec![success("s1-out")]);
+    backend.script(
+        "stage-2",
+        vec![timeout_failure("s2-flaky"), success("s2-out")],
+    );
+    backend.script("stage-3", vec![success("s3-out")]);
+
+    let dir = tempfile::tempdir().unwrap();
+    let swarm = Swarm::builder(backend.clone(), dir.path())
+        .build()
+        .await
+        .unwrap();
+
+    let result = swarm
+        .dispatch(
+            "d11",
+            vec![
+                contract("stage-1"),
+                contract("stage-2"),
+                contract("stage-3"),
+            ],
+            SwarmTopology::Pipeline,
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.outcome, SwarmOutcomeKind::Success);
+    let history = backend.history();
+    // stage-2 was attempted twice, both times chained to stage-1.
+    let stage_2: Vec<_> = history.iter().filter(|(id, _)| id == "stage-2").collect();
+    assert_eq!(stage_2.len(), 2);
+    for (_, task) in &stage_2 {
+        assert_eq!(task["pipeline_input"], "s1-out");
+    }
+    // stage-3 ran exactly once — AFTER stage-2 recovered — and saw its
+    // output. The old behaviour dispatched it early with no input key.
+    let stage_3: Vec<_> = history.iter().filter(|(id, _)| id == "stage-3").collect();
+    assert_eq!(
+        stage_3.len(),
+        1,
+        "stage-3 must not run before stage-2 completes"
+    );
+    assert_eq!(
+        stage_3[0].1.get("pipeline_input").and_then(|v| v.as_str()),
+        Some("s2-out"),
+        "stage-3 must chain the recovered stage-2 output"
+    );
+}
+
+#[tokio::test]
+async fn should_replay_finalized_result_verbatim_including_validator_verdicts() {
+    // #1718: replaying a finalized dispatch must return the ORIGINAL
+    // computed result — validator verdicts and outcome included. The
+    // old short-circuit recomputed from subtask state with empty
+    // validator results, upgrading a validator-failed Partial to
+    // Success on re-POST.
+    use octos_agent::validators::{ValidatorInvocation, ValidatorPhase, ValidatorRunner};
+    use octos_agent::workspace_policy::{Validator, ValidatorPhaseKind, ValidatorSpec};
+    use octos_swarm::AggregateValidator;
+    use std::sync::Arc as StdArc;
+
+    let backend = FakeBackend::new();
+    backend.script("only", vec![success("payload")]);
+
+    let workspace_dir = tempfile::tempdir().unwrap();
+    // Deliberately do NOT create the file the validator requires — the
+    // aggregate validator must fail and demote the outcome.
+    let tools = StdArc::new(octos_agent::tools::ToolRegistry::new());
+    let runner = ValidatorRunner::new(tools, workspace_dir.path().to_path_buf());
+    let invocation = ValidatorInvocation {
+        phase: ValidatorPhase::Completion,
+        workspace_root: workspace_dir.path().to_path_buf(),
+        repo_label: "swarm-replay-test".into(),
+        input_args: None,
+        tool_output: None,
+        spawn_only_files: Vec::new(),
+    };
+    let validator = Validator {
+        id: "missing_artifact".into(),
+        required: true,
+        soft_fail: false,
+        timeout_ms: None,
+        phase: ValidatorPhaseKind::Completion,
+        spec: ValidatorSpec::FileExists {
+            path: "never-written.txt".into(),
+            min_bytes: None,
+        },
+    };
+    let aggregate = AggregateValidator {
+        runner,
+        invocation,
+        validators: vec![validator],
+    };
+
+    let state_dir = tempfile::tempdir().unwrap();
+    let original = {
+        let swarm = Swarm::builder(backend.clone(), state_dir.path())
+            .with_validator(aggregate)
+            .build()
+            .await
+            .unwrap();
+        swarm
+            .dispatch(
+                "d12",
+                vec![contract("only")],
+                SwarmTopology::Sequential,
+                SwarmBudget::default(),
+                context(),
+            )
+            .await
+            .unwrap()
+    };
+    // Required validator failed → the subtask is demoted, so the
+    // original result must NOT be Success and must carry the verdict.
+    assert_ne!(original.outcome, SwarmOutcomeKind::Success);
+    assert!(
+        !original.validator_results.is_empty()
+            || original
+                .per_task_outcomes
+                .iter()
+                .any(|o| o.status != octos_swarm::SubtaskStatus::Completed),
+        "validator failure must be visible in the original result"
+    );
+
+    // Replay on a fresh swarm (no validator configured, counting
+    // backend): must return the stored result verbatim, not recompute.
+    let spy_counter = Arc::new(AtomicUsize::new(0));
+    let second_backend = Arc::new(CountingBackend {
+        counter: spy_counter.clone(),
+    });
+    let swarm_v2 = Swarm::builder(second_backend, state_dir.path())
+        .build()
+        .await
+        .unwrap();
+    let replay = swarm_v2
+        .dispatch(
+            "d12",
+            vec![contract("only")],
+            SwarmTopology::Sequential,
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(spy_counter.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        replay, original,
+        "finalized replay must return the original result verbatim"
+    );
+}
+
+#[tokio::test]
+async fn should_error_not_panic_when_resume_contracts_fewer_than_recorded() {
+    // #1719: a non-finalized record with MORE subtasks than the caller's
+    // contract list used to drive `contracts[idx]` out of bounds — a
+    // panic in production. It must surface as a typed error instead.
+    use octos_swarm::{DispatchRecord, DispatchStore, SubtaskOutcome, SubtaskStatus};
+
+    let state_dir = tempfile::tempdir().unwrap();
+    let pending = |id: &str| SubtaskOutcome {
+        contract_id: id.into(),
+        label: None,
+        status: SubtaskStatus::RetryableFailed,
+        attempts: 0,
+        last_dispatch_outcome: "not_run".into(),
+        output: String::new(),
+        files_to_send: Vec::new(),
+        error: None,
+    };
+    {
+        let store = DispatchStore::open(state_dir.path()).await.unwrap();
+        let record = DispatchRecord::new(
+            "d13",
+            "api:test",
+            "task-1",
+            SwarmTopology::Parallel {
+                max_concurrency: NonZeroUsize::new(2).unwrap(),
+            },
+            vec![pending("a"), pending("b"), pending("c")],
+        );
+        store.store(&record).await.unwrap();
+    }
+
+    let backend = FakeBackend::new();
+    let swarm = Swarm::builder(backend.clone(), state_dir.path())
+        .build()
+        .await
+        .unwrap();
+    let error = swarm
+        .dispatch(
+            "d13",
+            vec![contract("a"), contract("b")],
+            SwarmTopology::Parallel {
+                max_concurrency: NonZeroUsize::new(2).unwrap(),
+            },
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .expect_err("mismatched resume must error, not panic");
+    assert!(
+        error.to_string().contains("d13"),
+        "error should name the dispatch id: {error}"
+    );
+    // The in-flight guard must be released on the error path: a
+    // correctly-shaped dispatch with a fresh id still works.
+    let ok = swarm
+        .dispatch(
+            "d13-fresh",
+            vec![contract("a")],
+            SwarmTopology::Parallel {
+                max_concurrency: NonZeroUsize::new(1).unwrap(),
+            },
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(ok.outcome, SwarmOutcomeKind::Success);
+}
+
+#[tokio::test]
+async fn should_error_when_resume_contract_ids_mismatch_recorded() {
+    // #1719: same count but different contract ids — silently retrying
+    // slot N against a DIFFERENT contract would attribute outputs to
+    // the wrong contract. Must be rejected.
+    use octos_swarm::{DispatchRecord, DispatchStore, SubtaskOutcome, SubtaskStatus};
+
+    let state_dir = tempfile::tempdir().unwrap();
+    {
+        let store = DispatchStore::open(state_dir.path()).await.unwrap();
+        let record = DispatchRecord::new(
+            "d14",
+            "api:test",
+            "task-1",
+            SwarmTopology::Sequential,
+            vec![SubtaskOutcome {
+                contract_id: "original".into(),
+                label: None,
+                status: SubtaskStatus::RetryableFailed,
+                attempts: 0,
+                last_dispatch_outcome: "not_run".into(),
+                output: String::new(),
+                files_to_send: Vec::new(),
+                error: None,
+            }],
+        );
+        store.store(&record).await.unwrap();
+    }
+
+    let backend = FakeBackend::new();
+    let swarm = Swarm::builder(backend.clone(), state_dir.path())
+        .build()
+        .await
+        .unwrap();
+    let error = swarm
+        .dispatch(
+            "d14",
+            vec![contract("different")],
+            SwarmTopology::Sequential,
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .expect_err("contract id mismatch must be rejected");
+    let message = error.to_string();
+    assert!(
+        message.contains("original") && message.contains("different"),
+        "error should name both contract ids: {message}"
+    );
+    assert!(backend.history().is_empty(), "backend must not be touched");
+}
+
+#[tokio::test]
+async fn should_error_when_finalized_replay_contracts_mismatch() {
+    // #1719: a finalized record replayed with a DIFFERENT contract list
+    // used to silently return the old result — the caller believes the
+    // new contracts ran. Must be rejected instead.
+    let backend = FakeBackend::new();
+    backend.script("a", vec![success("a-out")]);
+
+    let state_dir = tempfile::tempdir().unwrap();
+    let swarm = Swarm::builder(backend.clone(), state_dir.path())
+        .build()
+        .await
+        .unwrap();
+    swarm
+        .dispatch(
+            "d15",
+            vec![contract("a")],
+            SwarmTopology::Sequential,
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .unwrap();
+
+    let error = swarm
+        .dispatch(
+            "d15",
+            vec![contract("a"), contract("b")],
+            SwarmTopology::Sequential,
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .expect_err("finalized replay with different contracts must be rejected");
+    assert!(
+        error.to_string().contains("d15"),
+        "error should name the dispatch id: {error}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn should_reject_concurrent_dispatch_with_same_id() {
+    // #1719: two concurrent dispatches with the same id used to race
+    // the load/store pair — double-dispatching subtasks and clobbering
+    // each other's rounds. The second caller must be rejected while the
+    // first is in flight, and the id must be usable again afterwards.
+    let backend = FakeBackend::new();
+    backend.script("slow", vec![success("slow-out")]);
+    backend.set_delay(Duration::from_millis(200));
+
+    let dir = tempfile::tempdir().unwrap();
+    let swarm = Swarm::builder(backend.clone(), dir.path())
+        .build()
+        .await
+        .unwrap();
+
+    let contracts = || vec![contract("slow")];
+    let topology = || SwarmTopology::Parallel {
+        max_concurrency: NonZeroUsize::new(1).unwrap(),
+    };
+    let (first, second) = tokio::join!(
+        swarm.dispatch(
+            "d16",
+            contracts(),
+            topology(),
+            SwarmBudget::default(),
+            context()
+        ),
+        swarm.dispatch(
+            "d16",
+            contracts(),
+            topology(),
+            SwarmBudget::default(),
+            context()
+        ),
+    );
+
+    let error = match (first, second) {
+        (Ok(_), Err(error)) | (Err(error), Ok(_)) => error,
+        (Ok(_), Ok(_)) => panic!("both concurrent dispatches succeeded"),
+        (Err(first), Err(second)) => panic!("both dispatches failed: {first}; {second}"),
+    };
+    assert!(
+        error.to_string().contains("in flight"),
+        "loser should be told the id is in flight: {error}"
+    );
+    // Only one dispatch reached the backend.
+    assert_eq!(backend.history().len(), 1);
+
+    // Guard released: the same id now replays the finalized result.
+    let replay = swarm
+        .dispatch(
+            "d16",
+            contracts(),
+            topology(),
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(replay.outcome, SwarmOutcomeKind::Success);
+}
+
+#[tokio::test]
 async fn should_record_cost_attribution_via_ledger_stub() {
     use octos_swarm::{CostLedger, SwarmCostAttribution};
 


### PR DESCRIPTION
Fixes #1717, fixes #1718, fixes #1719 — the three P1s from the octos-swarm deep review.

## #1717 — pipeline round stops at the first non-completed stage

`run_pipeline_round` only aborted on `TerminalFailed`. A **retryable** mid-stage failure let the next stage dispatch in the same round with `prior_output = None` — no `pipeline_input` injected — and get marked `Completed` against a silently broken chain, poisoning every downstream stage.

Now a retryable failure ends the round: downstream stages stay pending (`not_run`) and re-enter on the next round *after* the upstream stage retries, so every dispatched pipeline stage is guaranteed to see its upstream output. Terminal failures still abort the whole dispatch as before. Sequential topology is untouched (no data dependency between stages).

## #1718 — finalized replays return the original result verbatim

The finalized short-circuit called `result_from_record(&existing, Vec::new(), None)` — recomputing the outcome with **empty validator results and no cost**. A dispatch the aggregate validator had failed re-POSTed as `Success` with no verdicts attached: replay rewrote history.

`DispatchRecord` now snapshots the exact computed `SwarmResult` at finalization (`final_result`, serde-defaulted → old rows parse as `None` and fall back to the legacy recomputation; schema version unchanged, old readers ignore the field).

## #1719 — resume shape check + per-id in-flight guard

Two hardening gaps on dispatch_id reuse:
- A non-finalized record with more subtasks than the caller's contract list drove `contracts[idx]` **index-out-of-bounds — a panic** in production (reachable: REST awaits dispatch inline, a client disconnect cancels mid-round and leaves a non-finalized row). Now both finalized replays and non-finalized resumes verify topology, contract count, and per-slot contract ids against the stored record and return a typed eyre error naming the mismatch.
- No per-id serialization: two concurrent dispatches of the same id raced the load/store pair, double-dispatching subtasks. A per-id in-flight registry (RAII guard, released on every exit path including errors) rejects the second caller with `already in flight`.

## Tests

Six new integration tests in `swarm_dispatch.rs`, each RED against the old code:
- `should_stop_pipeline_round_at_retryable_stage_and_resume_with_input` — stage-3 runs exactly once, after stage-2 recovers, and sees its output (old: dispatched early with no `pipeline_input`)
- `should_replay_finalized_result_verbatim_including_validator_verdicts` — full `SwarmResult` equality incl. `ValidatorOutcome` (old: verdicts dropped)
- `should_error_not_panic_when_resume_contracts_fewer_than_recorded` — was a real index-OOB panic at `dispatcher.rs:574`; also proves the guard releases on the error path
- `should_error_when_resume_contract_ids_mismatch_recorded` — backend untouched on rejection
- `should_error_when_finalized_replay_contracts_mismatch` — old code silently returned the stale result
- `should_reject_concurrent_dispatch_with_same_id` — exactly one winner, one backend dispatch, id reusable afterwards

`cargo test -p octos-swarm` 56/56 · `cargo test -p octos-cli --features api --test swarm_api` 6/6 · fmt + clippy clean.