### PR TITLE
fix(swarm): close the interruption/resume holes behind the P1 fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4573,6 +4573,7 @@ dependencies = [
  "redb",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tokio-test",

--- a/crates/octos-swarm/Cargo.toml
+++ b/crates/octos-swarm/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
+sha2.workspace = true
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/octos-swarm/src/dispatcher.rs
+++ b/crates/octos-swarm/src/dispatcher.rs
@@ -284,25 +284,34 @@ impl Swarm {
                     None => self.result_from_record(&existing, Vec::new(), None).await,
                 });
             }
-            Some(existing) => {
+            Some(mut existing) => {
                 ensure_record_matches_dispatch(&existing, &resolved, &topology)?;
+                // Legacy rows predate the payload fingerprint —
+                // unverifiable, so trust-on-first-resume and backfill.
+                if existing.contracts_fingerprint.is_none() {
+                    existing.contracts_fingerprint = Some(contracts_fingerprint(&resolved));
+                }
                 existing
             }
-            None => DispatchRecord::new(
-                dispatch_id.clone(),
-                context.session_id.clone(),
-                context.task_id.clone(),
-                topology.clone(),
-                resolved
-                    .iter()
-                    .map(|contract| {
-                        SubtaskOutcome::pending(
-                            contract.contract_id.clone(),
-                            contract.label.clone(),
-                        )
-                    })
-                    .collect(),
-            ),
+            None => {
+                let mut record = DispatchRecord::new(
+                    dispatch_id.clone(),
+                    context.session_id.clone(),
+                    context.task_id.clone(),
+                    topology.clone(),
+                    resolved
+                        .iter()
+                        .map(|contract| {
+                            SubtaskOutcome::pending(
+                                contract.contract_id.clone(),
+                                contract.label.clone(),
+                            )
+                        })
+                        .collect(),
+                );
+                record.contracts_fingerprint = Some(contracts_fingerprint(&resolved));
+                record
+            }
         };
 
         // Persist the freshly-initialised record before doing any work
@@ -327,12 +336,22 @@ impl Swarm {
                 break;
             }
 
+            // Review finding 2 on #1717: enforce the cap BEFORE
+            // dispatching. Checking only after a round ran handed a
+            // record checkpointed at the cap one extra round per
+            // crash/cancel resume — unbounded across repeated cycles.
+            if round >= max_rounds {
+                break;
+            }
+
             debug!(
                 dispatch_id = %dispatch_id,
                 round,
                 pending = pending_indices.len(),
                 "dispatching swarm round"
             );
+
+            let completed_before = completed_count(&record);
 
             match topology {
                 SwarmTopology::Parallel { .. } | SwarmTopology::Fanout { .. } => {
@@ -359,13 +378,19 @@ impl Swarm {
                 }
             }
 
-            record.retry_rounds_used = round + 1;
-            self.store.store(&record).await?;
-
-            round += 1;
-            if round >= max_rounds {
-                break;
+            // Review finding 5 on #1717: only rounds that made NO
+            // progress consume the retry budget. The early pipeline
+            // stop means a round can complete upstream stages and end
+            // at a fresh downstream failure — charging that round would
+            // starve later stages of retries they never used. Progress
+            // rounds are bounded by the subtask count, so the loop
+            // still terminates.
+            let progressed = completed_count(&record) > completed_before;
+            if !progressed {
+                round += 1;
             }
+            record.retry_rounds_used = round;
+            self.store.store(&record).await?;
         }
 
         // Aggregate validator (M4.3) runs AFTER every sub-contract
@@ -457,6 +482,16 @@ impl Swarm {
         pending: &[usize],
     ) -> Result<bool> {
         for idx in pending {
+            // Review finding 1 sibling: invariant 3 says the dispatch
+            // aborted at the first terminal failure. A record resumed
+            // after a crash/cancel still carries that terminal marker —
+            // the contracts behind it must stay `not_run`.
+            if record.subtasks[..*idx]
+                .iter()
+                .any(|subtask| subtask.status == SubtaskStatus::TerminalFailed)
+            {
+                return Ok(true);
+            }
             let contract = &contracts[*idx];
             let attempts = record.subtasks[*idx].attempts;
             let mut outcome = dispatch_with_budget(
@@ -487,14 +522,28 @@ impl Swarm {
         pending: &[usize],
     ) -> Result<bool> {
         for idx in pending {
+            // #1717 + review finding 1: never dispatch a stage whose
+            // predecessor is not Completed. This covers a fresh failure
+            // earlier in THIS round and — critically — a resumed record
+            // whose upstream stage already failed before a crash or
+            // cancellation: the tail must not run input-less. A terminal
+            // predecessor aborts the dispatch (invariant 3 semantics);
+            // a retryable one just ends the round so the upstream stage
+            // retries first.
+            if *idx > 0 {
+                match record.subtasks[*idx - 1].status {
+                    SubtaskStatus::Completed => {}
+                    SubtaskStatus::TerminalFailed => return Ok(true),
+                    SubtaskStatus::RetryableFailed => return Ok(false),
+                }
+            }
             let mut contract = contracts[*idx].clone();
             // Pipeline invariant 4: fold the previous completed
             // subtask's output into this task's `pipeline_input` key.
+            // The precondition above guarantees the predecessor is
+            // Completed, so every stage after the first sees its input.
             let prior_output = if *idx > 0 {
-                match record.subtasks[*idx - 1].status {
-                    SubtaskStatus::Completed => Some(record.subtasks[*idx - 1].output.clone()),
-                    _ => None,
-                }
+                Some(record.subtasks[*idx - 1].output.clone())
             } else {
                 None
             };
@@ -524,19 +573,12 @@ impl Swarm {
             // Forward attribution to the wired ledger adapter.
             self.attribute_cost(record, contracts, *idx, &outcome).await;
             let is_terminal = outcome.status == SubtaskStatus::TerminalFailed;
-            let completed = outcome.status == SubtaskStatus::Completed;
             record.subtasks[*idx] = outcome;
             if is_terminal {
                 return Ok(true);
             }
-            // #1717: a retryable failure also ends the round — the next
-            // stage's `pipeline_input` requires THIS stage's output.
-            // Continuing would dispatch downstream stages without input
-            // and mark them Completed against a broken chain. They stay
-            // pending and re-enter after the upstream stage retries.
-            if !completed {
-                return Ok(false);
-            }
+            // A retryable failure ends the round via the predecessor
+            // precondition on the next iteration (or the loop end).
         }
         Ok(false)
     }
@@ -859,7 +901,53 @@ fn ensure_record_matches_dispatch(
             );
         }
     }
+    // Review finding 4: matching ids are not enough — the same
+    // contract_id with a changed tool_name/task would replay stale
+    // results (finalized) or graft old outcomes onto new work (resume).
+    // Legacy rows carry no fingerprint and are accepted as-is. The
+    // error exposes hashes only, never payload content, matching the
+    // REST layer's scrubbing posture.
+    if let Some(ref recorded) = record.contracts_fingerprint {
+        let supplied = contracts_fingerprint(resolved);
+        if *recorded != supplied {
+            eyre::bail!(
+                "swarm dispatch `{}` contract payload mismatch (recorded fingerprint {}, caller \
+                 supplied {}) — reusing a dispatch_id requires identical tool_name/task payloads",
+                record.dispatch_id,
+                recorded,
+                supplied
+            );
+        }
+    }
     Ok(())
+}
+
+/// Review finding 4: order-sensitive sha-256 over each resolved
+/// contract's `(contract_id, tool_name, task)`. `label` is display-only
+/// and deliberately excluded. `serde_json::Value` renders object keys
+/// in sorted (BTreeMap) order, so semantically-identical payloads hash
+/// identically regardless of the caller's key order.
+fn contracts_fingerprint(resolved: &[ContractSpec]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    for contract in resolved {
+        hasher.update(contract.contract_id.as_bytes());
+        hasher.update([0u8]);
+        hasher.update(contract.tool_name.as_bytes());
+        hasher.update([0u8]);
+        hasher.update(contract.task.to_string().as_bytes());
+        hasher.update([0u8]);
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+/// Completed-subtask count for the round loop's progress accounting.
+fn completed_count(record: &DispatchRecord) -> usize {
+    record
+        .subtasks
+        .iter()
+        .filter(|subtask| subtask.status == SubtaskStatus::Completed)
+        .count()
 }
 
 /// Review A F-004: wrap [`dispatch_once`] with a

--- a/crates/octos-swarm/src/lib.rs
+++ b/crates/octos-swarm/src/lib.rs
@@ -59,17 +59,23 @@
 //!    `(dispatch_id, contracts, topology, budget)`: a finalized record
 //!    in the redb ledger short-circuits re-dispatch and returns the
 //!    stored result verbatim. Reusing a dispatch_id with a different
-//!    contract list or topology is rejected, and a second concurrent
-//!    dispatch of an in-flight id is rejected.
+//!    contract list, task payload, or topology is rejected, and a
+//!    second concurrent dispatch of an in-flight id is rejected.
 //! 2. [`SwarmTopology::Parallel`] fans out up to `max_concurrency`
 //!    contracts, aggregation is arrival order.
 //! 3. [`SwarmTopology::Sequential`] runs one-at-a-time and aborts on
-//!    the first terminal (non-retryable) failure.
+//!    the first terminal (non-retryable) failure — including across a
+//!    crash/resume: contracts behind a persisted terminal failure stay
+//!    `not_run`.
 //! 4. [`SwarmTopology::Pipeline`] chains output of contract `i` as
-//!    `pipeline_input` into contract `i + 1`; a round stops at the
-//!    first non-completed stage so a downstream stage never runs
-//!    without its upstream input.
-//! 5. Retry budget bounded at [`MAX_RETRY_ROUNDS`] (3).
+//!    `pipeline_input` into contract `i + 1`; a stage never dispatches
+//!    unless its predecessor is Completed (fresh round or resume), so a
+//!    downstream stage never runs without its upstream input.
+//! 5. Retry budget bounded at [`MAX_RETRY_ROUNDS`] (3) no-progress
+//!    rounds, enforced before each round (a record resumed at the cap
+//!    dispatches nothing). Rounds that complete at least one new
+//!    sub-contract do not consume the budget — they are bounded by the
+//!    contract count.
 //! 6. Aggregate M4.3 validator runs AFTER every sub-contract reaches
 //!    terminal state.
 //! 7. Session-durable: redb-backed, supervisor can reload state and

--- a/crates/octos-swarm/src/persistence.rs
+++ b/crates/octos-swarm/src/persistence.rs
@@ -54,6 +54,14 @@ pub struct DispatchRecord {
     /// existed; those replays fall back to recomputation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub final_result: Option<SwarmResult>,
+    /// #1719 follow-up: sha-256 over the resolved contracts'
+    /// `(contract_id, tool_name, task)` triples, in slot order. A
+    /// reused dispatch_id must present byte-identical payloads —
+    /// contract-id equality alone let a re-POST with the same ids but
+    /// different task payloads replay stale results. `None` on legacy
+    /// rows (unverifiable — accepted and backfilled on next store).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contracts_fingerprint: Option<String>,
 }
 
 impl DispatchRecord {
@@ -74,6 +82,7 @@ impl DispatchRecord {
             retry_rounds_used: 0,
             finalized: false,
             final_result: None,
+            contracts_fingerprint: None,
         }
     }
 }
@@ -84,6 +93,14 @@ impl DispatchRecord {
 pub struct DispatchStore {
     db: Arc<Database>,
     path: Arc<PathBuf>,
+    /// #1719 follow-up: orders every load/store on this ledger. The
+    /// owned guard MOVES INTO the `spawn_blocking` closure, so a caller
+    /// future cancelled mid-await (REST client disconnect) cannot leave
+    /// its blocking write unordered against the next caller's read —
+    /// `spawn_blocking` work is not abortable, and without this gate a
+    /// re-dispatch could load pre-write state and then be clobbered by
+    /// the cancelled write landing late.
+    io_gate: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl DispatchStore {
@@ -115,6 +132,7 @@ impl DispatchStore {
         Ok(Self {
             db: Arc::new(db),
             path: Arc::new(db_path),
+            io_gate: Arc::new(tokio::sync::Mutex::new(())),
         })
     }
 
@@ -129,7 +147,11 @@ impl DispatchStore {
     pub async fn load(&self, dispatch_id: &str) -> Result<Option<DispatchRecord>> {
         let db = self.db.clone();
         let dispatch_id = dispatch_id.to_string();
+        // Waits for any in-flight (possibly cancellation-orphaned)
+        // write to land before reading — see `io_gate`.
+        let held = self.io_gate.clone().lock_owned().await;
         tokio::task::spawn_blocking(move || {
+            let _held = held;
             let read_txn = db.begin_read().wrap_err("begin swarm state read")?;
             let table = read_txn
                 .open_table(DISPATCH_TABLE)
@@ -157,7 +179,12 @@ impl DispatchStore {
         let db = self.db.clone();
         let key = record.dispatch_id.clone();
         let json = serde_json::to_string(record).wrap_err("serialize swarm dispatch row")?;
+        // The guard moves into the closure: if this future is cancelled
+        // while awaiting the join handle, the write still completes
+        // under the gate, and the next load/store waits for it.
+        let held = self.io_gate.clone().lock_owned().await;
         tokio::task::spawn_blocking(move || {
+            let _held = held;
             let write_txn = db.begin_write().wrap_err("begin swarm state write")?;
             {
                 let mut table = write_txn

--- a/crates/octos-swarm/tests/swarm_dispatch.rs
+++ b/crates/octos-swarm/tests/swarm_dispatch.rs
@@ -220,6 +220,26 @@ fn context() -> SwarmContext {
     }
 }
 
+/// Hand-built subtask row for tests that seed the redb ledger with a
+/// mid-dispatch (non-finalized) record.
+fn seeded_subtask(
+    id: &str,
+    status: octos_swarm::SubtaskStatus,
+    last_outcome: &str,
+    output: &str,
+) -> octos_swarm::SubtaskOutcome {
+    octos_swarm::SubtaskOutcome {
+        contract_id: id.into(),
+        label: None,
+        status,
+        attempts: if last_outcome == "not_run" { 0 } else { 1 },
+        last_dispatch_outcome: last_outcome.into(),
+        output: output.into(),
+        files_to_send: Vec::new(),
+        error: None,
+    }
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -953,8 +973,22 @@ async fn should_error_not_panic_when_resume_contracts_fewer_than_recorded() {
         error.to_string().contains("d13"),
         "error should name the dispatch id: {error}"
     );
-    // The in-flight guard must be released on the error path: a
-    // correctly-shaped dispatch with a fresh id still works.
+    // The in-flight guard must be released on the error path — for the
+    // SAME id, not just fresh ones: d13 with the correct recorded shape
+    // must now resume cleanly (review finding 6 on the original test).
+    let resumed = swarm
+        .dispatch(
+            "d13",
+            vec![contract("a"), contract("b"), contract("c")],
+            SwarmTopology::Parallel {
+                max_concurrency: NonZeroUsize::new(2).unwrap(),
+            },
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .expect("guard must be released for the failed id itself");
+    assert_eq!(resumed.outcome, SwarmOutcomeKind::Success);
     let ok = swarm
         .dispatch(
             "d13-fresh",
@@ -1123,6 +1157,304 @@ async fn should_reject_concurrent_dispatch_with_same_id() {
         .await
         .unwrap();
     assert_eq!(replay.outcome, SwarmOutcomeKind::Success);
+}
+
+#[tokio::test]
+async fn should_not_resume_pipeline_tail_after_persisted_terminal_failure() {
+    // Review finding 1 on #1717: a crash/cancel can persist a
+    // non-finalized record whose mid-pipeline stage failed TERMINALLY.
+    // On resume the terminal stage is no longer pending, so the old
+    // code dispatched the tail with no `pipeline_input` and rolled the
+    // outcome up as Partial instead of Aborted.
+    use octos_swarm::{DispatchRecord, DispatchStore, SubtaskStatus};
+
+    let state_dir = tempfile::tempdir().unwrap();
+    {
+        let store = DispatchStore::open(state_dir.path()).await.unwrap();
+        let record = DispatchRecord::new(
+            "d20",
+            "api:test",
+            "task-1",
+            SwarmTopology::Pipeline,
+            vec![
+                seeded_subtask("a", SubtaskStatus::Completed, "success", "a-out"),
+                seeded_subtask("b", SubtaskStatus::TerminalFailed, "transport_error", ""),
+                seeded_subtask("c", SubtaskStatus::RetryableFailed, "not_run", ""),
+            ],
+        );
+        store.store(&record).await.unwrap();
+    }
+
+    let backend = FakeBackend::new();
+    let swarm = Swarm::builder(backend.clone(), state_dir.path())
+        .build()
+        .await
+        .unwrap();
+    let result = swarm
+        .dispatch(
+            "d20",
+            vec![contract("a"), contract("b"), contract("c")],
+            SwarmTopology::Pipeline,
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        backend.history().is_empty(),
+        "tail stage must not dispatch behind a terminal failure: {:?}",
+        backend.history()
+    );
+    assert_eq!(result.outcome, SwarmOutcomeKind::Aborted);
+}
+
+#[tokio::test]
+async fn should_not_resume_sequential_tail_after_persisted_terminal_failure() {
+    // Same resume hole for Sequential: invariant 3 says the dispatch
+    // aborted at the first terminal failure — a resumed record must not
+    // dispatch the contracts behind it.
+    use octos_swarm::{DispatchRecord, DispatchStore, SubtaskStatus};
+
+    let state_dir = tempfile::tempdir().unwrap();
+    {
+        let store = DispatchStore::open(state_dir.path()).await.unwrap();
+        let record = DispatchRecord::new(
+            "d21",
+            "api:test",
+            "task-1",
+            SwarmTopology::Sequential,
+            vec![
+                seeded_subtask("a", SubtaskStatus::TerminalFailed, "transport_error", ""),
+                seeded_subtask("b", SubtaskStatus::RetryableFailed, "not_run", ""),
+            ],
+        );
+        store.store(&record).await.unwrap();
+    }
+
+    let backend = FakeBackend::new();
+    let swarm = Swarm::builder(backend.clone(), state_dir.path())
+        .build()
+        .await
+        .unwrap();
+    let result = swarm
+        .dispatch(
+            "d21",
+            vec![contract("a"), contract("b")],
+            SwarmTopology::Sequential,
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        backend.history().is_empty(),
+        "aborted tail must stay not_run"
+    );
+    assert_eq!(result.outcome, SwarmOutcomeKind::Aborted);
+}
+
+#[tokio::test]
+async fn should_not_run_extra_round_when_resumed_at_retry_cap() {
+    // Review finding 2: the cap was checked only AFTER a round ran, so
+    // a record checkpointed at the cap got one extra round per resume —
+    // repeated crash/resume cycles made the bounded-cost invariant
+    // unbounded.
+    use octos_swarm::{DispatchRecord, DispatchStore, SubtaskStatus};
+
+    let state_dir = tempfile::tempdir().unwrap();
+    {
+        let store = DispatchStore::open(state_dir.path()).await.unwrap();
+        let mut record = DispatchRecord::new(
+            "d22",
+            "api:test",
+            "task-1",
+            SwarmTopology::Parallel {
+                max_concurrency: NonZeroUsize::new(1).unwrap(),
+            },
+            vec![seeded_subtask(
+                "a",
+                SubtaskStatus::RetryableFailed,
+                "timeout",
+                "",
+            )],
+        );
+        record.retry_rounds_used = octos_swarm::MAX_RETRY_ROUNDS;
+        store.store(&record).await.unwrap();
+    }
+
+    let backend = FakeBackend::new();
+    let swarm = Swarm::builder(backend.clone(), state_dir.path())
+        .build()
+        .await
+        .unwrap();
+    let result = swarm
+        .dispatch(
+            "d22",
+            vec![contract("a")],
+            SwarmTopology::Parallel {
+                max_concurrency: NonZeroUsize::new(1).unwrap(),
+            },
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        backend.history().is_empty(),
+        "a record resumed at the retry cap must not dispatch again"
+    );
+    assert_eq!(result.retry_rounds_used, octos_swarm::MAX_RETRY_ROUNDS);
+    assert_eq!(result.outcome, SwarmOutcomeKind::Failed);
+}
+
+#[tokio::test]
+async fn should_recompute_replay_for_legacy_finalized_record_without_snapshot() {
+    // #1718 back-compat: rows persisted before `final_result` existed
+    // must still replay via the legacy recomputation fallback.
+    use octos_swarm::{DispatchRecord, DispatchStore, SubtaskStatus};
+
+    let state_dir = tempfile::tempdir().unwrap();
+    {
+        let store = DispatchStore::open(state_dir.path()).await.unwrap();
+        let mut record = DispatchRecord::new(
+            "d23",
+            "api:test",
+            "task-1",
+            SwarmTopology::Sequential,
+            vec![seeded_subtask(
+                "a",
+                SubtaskStatus::Completed,
+                "success",
+                "legacy-out",
+            )],
+        );
+        record.finalized = true;
+        assert!(
+            record.final_result.is_none(),
+            "legacy row must lack snapshot"
+        );
+        store.store(&record).await.unwrap();
+    }
+
+    let backend = FakeBackend::new();
+    let swarm = Swarm::builder(backend.clone(), state_dir.path())
+        .build()
+        .await
+        .unwrap();
+    let replay = swarm
+        .dispatch(
+            "d23",
+            vec![contract("a")],
+            SwarmTopology::Sequential,
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .unwrap();
+
+    assert!(backend.history().is_empty());
+    assert_eq!(replay.outcome, SwarmOutcomeKind::Success);
+    assert_eq!(replay.aggregate_artifact.combined_output, "legacy-out");
+}
+
+#[tokio::test]
+async fn should_reject_same_id_with_changed_task_payload() {
+    // Review finding 4: id-equality alone let a re-POST with the same
+    // contract_id but a DIFFERENT task payload silently replay stale
+    // results. The recorded payload fingerprint must reject it.
+    let backend = FakeBackend::new();
+    backend.script("a", vec![success("a-out")]);
+
+    let state_dir = tempfile::tempdir().unwrap();
+    let swarm = Swarm::builder(backend.clone(), state_dir.path())
+        .build()
+        .await
+        .unwrap();
+    swarm
+        .dispatch(
+            "d24",
+            vec![contract("a")],
+            SwarmTopology::Sequential,
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .unwrap();
+
+    let mut changed = contract("a");
+    changed.task = serde_json::json!({ "contract_id": "a", "extra": "changed" });
+    let error = swarm
+        .dispatch(
+            "d24",
+            vec![changed],
+            SwarmTopology::Sequential,
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .expect_err("changed payload under a reused dispatch_id must be rejected");
+    assert!(
+        error.to_string().contains("payload"),
+        "error should name the payload mismatch: {error}"
+    );
+}
+
+#[tokio::test]
+async fn should_not_burn_retry_budget_on_progress_rounds() {
+    // Review finding 5: with #1717's early stop, a first-time failure
+    // at each successive pipeline stage consumed a whole global round —
+    // a 4-stage pipeline where every stage recovers on its second try
+    // exhausted the cap before stage 4 got its retry. Rounds that
+    // complete at least one new subtask must not consume the budget.
+    let backend = FakeBackend::new();
+    backend.script("s1", vec![success("s1-out")]);
+    backend.script("s2", vec![timeout_failure("s2-flaky"), success("s2-out")]);
+    backend.script("s3", vec![timeout_failure("s3-flaky"), success("s3-out")]);
+    backend.script("s4", vec![timeout_failure("s4-flaky"), success("s4-out")]);
+
+    let dir = tempfile::tempdir().unwrap();
+    let swarm = Swarm::builder(backend.clone(), dir.path())
+        .build()
+        .await
+        .unwrap();
+    let result = swarm
+        .dispatch(
+            "d25",
+            vec![
+                contract("s1"),
+                contract("s2"),
+                contract("s3"),
+                contract("s4"),
+            ],
+            SwarmTopology::Pipeline,
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.outcome,
+        SwarmOutcomeKind::Success,
+        "every stage recovers within one retry — progress rounds must not starve stage 4"
+    );
+    assert_eq!(result.completed_subtasks, 4);
+    // Chaining stayed intact throughout the retries.
+    let history = backend.history();
+    let s4_inputs: Vec<_> = history
+        .iter()
+        .filter(|(id, _)| id == "s4")
+        .map(|(_, task)| task.get("pipeline_input").cloned())
+        .collect();
+    assert!(
+        s4_inputs
+            .iter()
+            .all(|input| input.as_ref().and_then(|v| v.as_str()) == Some("s3-out")),
+        "every s4 attempt must chain s3's output: {s4_inputs:?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Follow-up to #1720. An adversarial review of `f8a16bec8` confirmed the three P1 fixes hold on fresh rounds and clean error paths, but found five residual holes in the **interruption corridor** — records persisted mid-dispatch by a crash or a cancelled REST request (the handler awaits `dispatch()` inline, so a client disconnect drops the future between round checkpoints):

1. **Terminal-pipeline resume ran the tail input-less.** The #1717 round-stop only fired when the failure happened in the current round. A resumed record whose mid-pipeline stage had failed terminally excluded that stage from `pending`, so the tail dispatched with no `pipeline_input` and the outcome rolled up Partial instead of Aborted. Now a stage never dispatches unless its predecessor is Completed (precondition, not post-check) — fresh rounds and resumes take the same path. Sequential gets the matching guard: contracts behind a persisted terminal failure stay `not_run` per invariant 3.
2. **Retry cap bypassable on resume.** The cap was checked after a round ran; a record checkpointed at the cap got one extra round per resume — unbounded across repeated crash/resume cycles. The cap is now enforced before each round.
3. **In-flight guard wasn't cancellation-safe.** Dropping the dispatch future releases the guard immediately, but `spawn_blocking` writes are not abortable — a re-dispatch could load pre-write state and then be clobbered by the cancelled write landing late. `DispatchStore` now orders every load/store through an owned async mutex **moved into the blocking closure**: the next caller's read waits for any orphaned write to land.
4. **Shape check was id-equality only.** Same `contract_id`, changed `tool_name`/`task` → silently replayed stale results. `DispatchRecord` gains a serde-defaulted `contracts_fingerprint` (sha-256 per slot over id/tool_name/task; `label` excluded; `serde_json` BTreeMap key order makes it canonical). Mismatch → typed error exposing hashes only (REST scrubbing posture preserved). Legacy rows: accepted, backfilled on next store.
5. **Progress rounds burned the retry budget.** With the #1717 early stop, a first-time failure at each successive stage consumed a global round — a 4-stage pipeline recovering each stage on its second try exhausted the cap before stage 4 got a retry. Rounds that complete ≥1 new subtask no longer consume budget (they're bounded by the contract count, so termination holds); as a side effect the classic flaky-contract case now gets the documented initial + 3 retries.

## Tests
Six new integration tests (RED against `f8a16bec8` where applicable): `should_not_resume_pipeline_tail_after_persisted_terminal_failure`, `should_not_resume_sequential_tail_after_persisted_terminal_failure`, `should_not_run_extra_round_when_resumed_at_retry_cap`, `should_recompute_replay_for_legacy_finalized_record_without_snapshot`, `should_reject_same_id_with_changed_task_payload`, `should_not_burn_retry_budget_on_progress_rounds`; the guard-release test now re-dispatches the failed id itself instead of a fresh one.

`cargo test -p octos-swarm` 56/56 · `swarm_api` 6/6 · fmt + clippy clean. Live re-soak on mini4 before merge.