### PR TITLE
fix(release): embed the swarm dashboard in release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
           cd ..
           git submodule update --init octos-web
           bash scripts/build-web-app.sh
+          bash scripts/build-swarm-app.sh
 
       - name: Build
         run: |
@@ -92,6 +93,7 @@ jobs:
           cd ..
           git submodule update --init octos-web
           bash scripts/build-web-app.sh
+          bash scripts/build-swarm-app.sh
 
       - name: Build
         run: |
@@ -138,6 +140,7 @@ jobs:
           cd ..
           git submodule update --init octos-web
           bash scripts/build-web-app.sh
+          bash scripts/build-swarm-app.sh
 
       - name: Build
         run: |
@@ -186,6 +189,7 @@ jobs:
           cd ..
           git submodule update --init octos-web
           bash scripts/build-web-app.sh
+          bash scripts/build-swarm-app.sh
 
       - name: Build
         run: |


### PR DESCRIPTION
Found by smoking the v2.0.2-rc.10 macos-arm release artifact: `GET /swarm/` returns `{"error":"swarm_bundle_missing"}` — the release jobs build `dashboard/` and `octos-web` before `cargo build` but never run `scripts/build-swarm-app.sh`, so the M7.6 swarm dashboard has never shipped in any release binary. (The PR-CI `swarm-app` job builds it for its own checks, but that output never reaches the release build.)

One-line-per-job fix: append `bash scripts/build-swarm-app.sh` to the existing fail-fast "Build dashboard" step in all four platform jobs (macos-arm, linux-x86, linux-arm, windows — the step already runs under `shell: bash` on windows).

Verified locally: running the script then rebuilding octos-cli serves the real SPA at /swarm/ instead of the placeholder.