### PR TITLE
feat(swarm): CLI agent backend — dispatch to claude -p / codex exec without MCP

### DIFF
--- a/crates/octos-agent/src/tools/mcp_agent.rs
+++ b/crates/octos-agent/src/tools/mcp_agent.rs
@@ -104,6 +104,31 @@ pub enum McpAgentBackendConfig {
         #[serde(default)]
         dispatch_timeout_secs: Option<u64>,
     },
+    /// Invoke a one-shot headless CLI agent per dispatch (for example
+    /// `claude -p` or `codex exec`) instead of speaking MCP. Simpler
+    /// and more robust for fire-and-forget contracts: no handshake, no
+    /// notification stream — but also no approvals, no mid-run events,
+    /// no cancellation short of killing the process.
+    Cli {
+        /// Absolute or PATH-resolved executable to invoke.
+        cmd: String,
+        /// Arguments passed before the prompt (e.g. `["-p"]`).
+        #[serde(default)]
+        args: Vec<String>,
+        /// Extra environment variables the child is allowed to see.
+        /// [`BLOCKED_ENV_VARS`] always win.
+        #[serde(default)]
+        env: HashMap<String, String>,
+        /// Per-dispatch wallclock budget in seconds. Defaults to
+        /// [`DEFAULT_DISPATCH_TIMEOUT_SECS`].
+        #[serde(default)]
+        dispatch_timeout_secs: Option<u64>,
+        /// Deliver the prompt on the child's stdin instead of as the
+        /// final argv entry. Avoids argv size limits and keeps the
+        /// prompt out of process listings.
+        #[serde(default)]
+        prompt_via_stdin: bool,
+    },
 }
 
 impl McpAgentBackendConfig {
@@ -114,6 +139,7 @@ impl McpAgentBackendConfig {
         match self {
             Self::Local { .. } => "local",
             Self::Remote { .. } => "remote",
+            Self::Cli { .. } => "cli",
         }
     }
 
@@ -121,7 +147,7 @@ impl McpAgentBackendConfig {
     /// dispatch events so operators can tell backends apart.
     pub fn endpoint_label(&self) -> String {
         match self {
-            Self::Local { cmd, .. } => cmd.clone(),
+            Self::Local { cmd, .. } | Self::Cli { cmd, .. } => cmd.clone(),
             Self::Remote { url, .. } => url.clone(),
         }
     }
@@ -137,6 +163,10 @@ impl McpAgentBackendConfig {
                 ..
             } => dispatch_timeout_secs,
             Self::Remote {
+                dispatch_timeout_secs,
+                ..
+            } => dispatch_timeout_secs,
+            Self::Cli {
                 dispatch_timeout_secs,
                 ..
             } => dispatch_timeout_secs,
@@ -524,6 +554,231 @@ impl StdioMcpAgent {
 impl McpAgentBackend for StdioMcpAgent {
     fn backend_label(&self) -> &'static str {
         "local"
+    }
+
+    fn endpoint_label(&self) -> String {
+        self.cmd.clone()
+    }
+
+    async fn dispatch(&self, request: DispatchRequest) -> DispatchResponse {
+        self.dispatch_inner(request).await
+    }
+}
+
+// ── CLI backend ───────────────────────────────────────────────────────────
+
+/// One-shot headless CLI agent backend (`claude -p`, `codex exec`, or
+/// any command that takes a prompt and prints the result). No MCP
+/// framing: the prompt goes in as the final argv entry (or on stdin),
+/// stdout comes back as the dispatch output, and the exit code drives
+/// the [`DispatchOutcome`] mapping — `0` → `Success`, non-zero →
+/// `RemoteError` (retryable, mirroring MCP `isError` semantics), spawn
+/// failure → `TransportError`, wallclock overrun → `Timeout` with the
+/// child killed via `kill_on_drop`.
+///
+/// Prompt convention: `task["prompt"]` when present, else the whole
+/// task JSON serialized — so swarm contracts written for MCP backends
+/// degrade gracefully. `tool_name` and the context contract are not
+/// transmitted (a CLI has no `_meta` channel); the context contract
+/// still tags the response for the local evidence ledger.
+pub struct CliAgentBackend {
+    cmd: String,
+    args: Vec<String>,
+    env: HashMap<String, String>,
+    cwd: Option<PathBuf>,
+    dispatch_timeout: Duration,
+    prompt_via_stdin: bool,
+}
+
+/// Cap on captured CLI stdout/stderr, mirroring [`MAX_LINE_BYTES`] so a
+/// runaway transcript cannot OOM the parent.
+const MAX_CLI_CAPTURE_BYTES: usize = MAX_LINE_BYTES;
+
+impl CliAgentBackend {
+    /// Construct a CLI backend from typed config.
+    pub fn from_config(config: &McpAgentBackendConfig) -> Result<Self> {
+        let McpAgentBackendConfig::Cli {
+            cmd,
+            args,
+            env,
+            dispatch_timeout_secs,
+            prompt_via_stdin,
+        } = config
+        else {
+            eyre::bail!("CliAgentBackend requires a Cli backend config");
+        };
+        if cmd.trim().is_empty() {
+            eyre::bail!("CLI agent requires a non-empty command");
+        }
+        Ok(Self {
+            cmd: cmd.clone(),
+            args: args.clone(),
+            env: env.clone(),
+            cwd: None,
+            dispatch_timeout: Duration::from_secs(
+                dispatch_timeout_secs.unwrap_or(DEFAULT_DISPATCH_TIMEOUT_SECS),
+            ),
+            prompt_via_stdin: *prompt_via_stdin,
+        })
+    }
+
+    /// Set the working directory for spawned children.
+    pub fn with_cwd(mut self, cwd: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(cwd.into());
+        self
+    }
+
+    /// Override the dispatch timeout (useful in tests).
+    pub fn with_dispatch_timeout(mut self, timeout: Duration) -> Self {
+        self.dispatch_timeout = timeout;
+        self
+    }
+
+    /// Extract the prompt the CLI receives. `task["prompt"]` when it is
+    /// a string; otherwise the whole task JSON so structured contracts
+    /// still reach the agent verbatim.
+    fn prompt_for(task: &serde_json::Value) -> String {
+        match task.get("prompt").and_then(|value| value.as_str()) {
+            Some(prompt) => prompt.to_string(),
+            None => task.to_string(),
+        }
+    }
+
+    fn build_command(&self, prompt: &str) -> Command {
+        let mut cmd = Command::new(&self.cmd);
+        cmd.args(&self.args);
+        if !self.prompt_via_stdin {
+            cmd.arg(prompt);
+        }
+        cmd.stdin(if self.prompt_via_stdin {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        // Unlike the MCP stdio backend (which inherits stderr for
+        // operator logs), a CLI's stderr is the primary diagnostic on
+        // failure — capture it for the error message.
+        .stderr(Stdio::piped());
+
+        if let Some(cwd) = &self.cwd {
+            cmd.current_dir(cwd);
+        }
+
+        // Same env hygiene as the MCP stdio backend: scrub the parent
+        // env down to the configured allowlist, then strip
+        // [`BLOCKED_ENV_VARS`] last so they win regardless.
+        let allowlist = EnvAllowlist::from_names(self.env.keys().map(|key| key.as_str()));
+        sanitize_command_env(&mut cmd, &allowlist);
+        for (key, value) in &self.env {
+            if BLOCKED_ENV_VARS
+                .iter()
+                .any(|blocked| key.eq_ignore_ascii_case(blocked))
+            {
+                warn!(
+                    key = key.as_str(),
+                    "blocked dangerous CLI agent environment variable"
+                );
+                continue;
+            }
+            if !should_forward_env_name(key, &allowlist) {
+                warn!(
+                    key = key.as_str(),
+                    "blocked non-allowlisted CLI agent environment variable"
+                );
+                continue;
+            }
+            cmd.env(key, value);
+        }
+        for blocked in BLOCKED_ENV_VARS {
+            cmd.env_remove(blocked);
+        }
+
+        cmd.kill_on_drop(true);
+        cmd
+    }
+
+    async fn dispatch_inner(&self, request: DispatchRequest) -> DispatchResponse {
+        let prompt = Self::prompt_for(&request.task);
+        let mut command = self.build_command(&prompt);
+        let mut child = match command.spawn() {
+            Ok(child) => child,
+            Err(error) => {
+                return DispatchResponse::failure(
+                    DispatchOutcome::TransportError,
+                    format!("failed to spawn CLI agent '{}': {error}", self.cmd),
+                );
+            }
+        };
+
+        if self.prompt_via_stdin {
+            if let Some(mut stdin) = child.stdin.take() {
+                let mut payload = prompt.clone();
+                payload.push('\n');
+                if let Err(error) = stdin.write_all(payload.as_bytes()).await {
+                    return DispatchResponse::failure(
+                        DispatchOutcome::TransportError,
+                        format!(
+                            "failed to write prompt to CLI agent '{}': {error}",
+                            self.cmd
+                        ),
+                    );
+                }
+                // Drop closes the pipe so line-readers see EOF.
+            }
+        }
+
+        // `wait_with_output` owns the child; on timeout the dropped
+        // future releases it and `kill_on_drop(true)` reaps the process.
+        match tokio::time::timeout(self.dispatch_timeout, child.wait_with_output()).await {
+            Ok(Ok(output)) => {
+                let mut stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+                octos_core::truncate_utf8(&mut stdout, MAX_CLI_CAPTURE_BYTES, "\n[truncated]");
+                let trimmed = stdout.trim_end().to_string();
+                if output.status.success() {
+                    DispatchResponse::success(trimmed, Vec::new())
+                } else {
+                    let mut stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+                    octos_core::truncate_utf8(&mut stderr, MAX_CLI_CAPTURE_BYTES, "\n[truncated]");
+                    let code = output
+                        .status
+                        .code()
+                        .map(|code| code.to_string())
+                        .unwrap_or_else(|| "signal".to_string());
+                    let mut response = DispatchResponse::failure(
+                        DispatchOutcome::RemoteError,
+                        format!(
+                            "CLI agent '{}' exited with status {code}: {}",
+                            self.cmd,
+                            stderr.trim_end()
+                        ),
+                    );
+                    // Preserve any partial stdout for diagnostics.
+                    if !trimmed.is_empty() {
+                        response.output = trimmed;
+                    }
+                    response
+                }
+            }
+            Ok(Err(error)) => DispatchResponse::failure(
+                DispatchOutcome::TransportError,
+                format!("failed to collect CLI agent '{}' output: {error}", self.cmd),
+            ),
+            Err(_) => DispatchResponse::failure(
+                DispatchOutcome::Timeout,
+                format!(
+                    "CLI agent '{}' did not finish within {:?}",
+                    self.cmd, self.dispatch_timeout
+                ),
+            ),
+        }
+    }
+}
+
+#[async_trait]
+impl McpAgentBackend for CliAgentBackend {
+    fn backend_label(&self) -> &'static str {
+        "cli"
     }
 
     fn endpoint_label(&self) -> String {
@@ -1180,6 +1435,13 @@ pub fn build_backend_from_config(
             Ok(Arc::new(backend))
         }
         McpAgentBackendConfig::Remote { .. } => Ok(Arc::new(HttpMcpAgent::from_config(config)?)),
+        McpAgentBackendConfig::Cli { .. } => {
+            let mut backend = CliAgentBackend::from_config(config)?;
+            if let Some(cwd) = cwd {
+                backend = backend.with_cwd(cwd.to_path_buf());
+            }
+            Ok(Arc::new(backend))
+        }
     }
 }
 

--- a/crates/octos-agent/tests/cli_agent_backend.rs
+++ b/crates/octos-agent/tests/cli_agent_backend.rs
@@ -1,0 +1,213 @@
+//! Integration tests for the CLI agent backend — the non-MCP dispatch
+//! lane that invokes one-shot headless agents (`claude -p`,
+//! `codex exec`) and maps process results onto [`DispatchOutcome`].
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use octos_agent::tools::mcp_agent::{
+    CliAgentBackend, DispatchOutcome, DispatchRequest, McpAgentBackend, McpAgentBackendConfig,
+    build_backend_from_config,
+};
+
+fn write_script(dir: &tempfile::TempDir, name: &str, body: &str) -> PathBuf {
+    let path = dir.path().join(name);
+    std::fs::write(&path, body).expect("write script");
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(&path).expect("perms").permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms).expect("chmod");
+    path
+}
+
+fn cli_config(cmd: &str) -> McpAgentBackendConfig {
+    McpAgentBackendConfig::Cli {
+        cmd: cmd.to_string(),
+        args: Vec::new(),
+        env: HashMap::new(),
+        dispatch_timeout_secs: Some(10),
+        prompt_via_stdin: false,
+    }
+}
+
+fn prompt_request(prompt: &str) -> DispatchRequest {
+    DispatchRequest::new("ignored_for_cli", serde_json::json!({ "prompt": prompt }))
+}
+
+#[tokio::test]
+async fn should_pass_prompt_as_final_arg_and_return_stdout() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_script(
+        &dir,
+        "echo-arg.sh",
+        "#!/bin/sh\nprintf 'cli-out:%s' \"$1\"\n",
+    );
+    let backend = CliAgentBackend::from_config(&cli_config(&script.display().to_string()))
+        .expect("build cli backend");
+
+    let response = backend.dispatch(prompt_request("hello world")).await;
+
+    assert_eq!(response.outcome, DispatchOutcome::Success);
+    assert_eq!(response.output, "cli-out:hello world");
+    assert!(response.error.is_none());
+}
+
+#[tokio::test]
+async fn should_append_prompt_after_configured_args() {
+    let dir = tempfile::tempdir().unwrap();
+    // Mirrors `claude -p <prompt>`: configured args come first, the
+    // prompt is always the final argv entry.
+    let script = write_script(&dir, "argv.sh", "#!/bin/sh\nprintf '%s|%s' \"$1\" \"$2\"\n");
+    let config = McpAgentBackendConfig::Cli {
+        cmd: script.display().to_string(),
+        args: vec!["-p".to_string()],
+        env: HashMap::new(),
+        dispatch_timeout_secs: Some(10),
+        prompt_via_stdin: false,
+    };
+    let backend = CliAgentBackend::from_config(&config).unwrap();
+
+    let response = backend.dispatch(prompt_request("task text")).await;
+
+    assert_eq!(response.outcome, DispatchOutcome::Success);
+    assert_eq!(response.output, "-p|task text");
+}
+
+#[tokio::test]
+async fn should_pipe_prompt_via_stdin_when_configured() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_script(
+        &dir,
+        "stdin.sh",
+        "#!/bin/sh\nread line\nprintf 'stdin:%s' \"$line\"\n",
+    );
+    let config = McpAgentBackendConfig::Cli {
+        cmd: script.display().to_string(),
+        args: Vec::new(),
+        env: HashMap::new(),
+        dispatch_timeout_secs: Some(10),
+        prompt_via_stdin: true,
+    };
+    let backend = CliAgentBackend::from_config(&config).unwrap();
+
+    let response = backend.dispatch(prompt_request("piped prompt")).await;
+
+    assert_eq!(response.outcome, DispatchOutcome::Success);
+    assert_eq!(response.output, "stdin:piped prompt");
+}
+
+#[tokio::test]
+async fn should_serialize_whole_task_when_no_prompt_field() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_script(&dir, "raw.sh", "#!/bin/sh\nprintf '%s' \"$1\"\n");
+    let backend = CliAgentBackend::from_config(&cli_config(&script.display().to_string())).unwrap();
+
+    let request = DispatchRequest::new("ignored", serde_json::json!({ "objective": "x", "n": 1 }));
+    let response = backend.dispatch(request).await;
+
+    assert_eq!(response.outcome, DispatchOutcome::Success);
+    assert!(
+        response.output.contains("\"objective\":\"x\""),
+        "whole task JSON should reach the CLI: {}",
+        response.output
+    );
+}
+
+#[tokio::test]
+async fn should_map_nonzero_exit_to_retryable_remote_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_script(
+        &dir,
+        "fail.sh",
+        "#!/bin/sh\nprintf 'partial' \necho 'boom happened' >&2\nexit 3\n",
+    );
+    let backend = CliAgentBackend::from_config(&cli_config(&script.display().to_string())).unwrap();
+
+    let response = backend.dispatch(prompt_request("x")).await;
+
+    assert_eq!(response.outcome, DispatchOutcome::RemoteError);
+    let error = response.error.expect("error populated");
+    assert!(
+        error.contains('3') && error.contains("boom happened"),
+        "error should carry exit code and stderr: {error}"
+    );
+}
+
+#[tokio::test]
+async fn should_map_missing_binary_to_transport_error() {
+    let backend =
+        CliAgentBackend::from_config(&cli_config("/definitely/not/a/real/binary")).unwrap();
+    let response = backend.dispatch(prompt_request("x")).await;
+    assert_eq!(response.outcome, DispatchOutcome::TransportError);
+}
+
+#[tokio::test]
+async fn should_time_out_and_kill_hung_cli() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_script(&dir, "hang.sh", "#!/bin/sh\nsleep 30\n");
+    let config = McpAgentBackendConfig::Cli {
+        cmd: script.display().to_string(),
+        args: Vec::new(),
+        env: HashMap::new(),
+        dispatch_timeout_secs: Some(1),
+        prompt_via_stdin: false,
+    };
+    let backend = CliAgentBackend::from_config(&config).unwrap();
+
+    let started = Instant::now();
+    let response = backend.dispatch(prompt_request("x")).await;
+
+    assert_eq!(response.outcome, DispatchOutcome::Timeout);
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "timeout must not wait for the hung child: {:?}",
+        started.elapsed()
+    );
+}
+
+#[tokio::test]
+async fn should_scrub_blocked_env_vars_from_cli_child() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("env.txt");
+    let script = write_script(
+        &dir,
+        "env.sh",
+        &format!(
+            "#!/bin/sh\nprintf 'LD=%s NODE=%s OK=%s' \"${{LD_PRELOAD:-}}\" \"${{NODE_OPTIONS:-}}\" \"${{CLI_OK:-}}\" > {}\n",
+            out.display()
+        ),
+    );
+    let mut env = HashMap::new();
+    env.insert("LD_PRELOAD".to_string(), "evil.so".to_string());
+    env.insert("NODE_OPTIONS".to_string(), "--evil".to_string());
+    env.insert("CLI_OK".to_string(), "yes".to_string());
+    let config = McpAgentBackendConfig::Cli {
+        cmd: script.display().to_string(),
+        args: Vec::new(),
+        env,
+        dispatch_timeout_secs: Some(10),
+        prompt_via_stdin: false,
+    };
+    let backend = CliAgentBackend::from_config(&config).unwrap();
+
+    let response = backend.dispatch(prompt_request("x")).await;
+    assert_eq!(response.outcome, DispatchOutcome::Success);
+
+    let seen = std::fs::read_to_string(&out).expect("env capture written");
+    assert_eq!(seen, "LD= NODE= OK=yes", "blocked vars must be scrubbed");
+}
+
+#[tokio::test]
+async fn should_build_cli_backend_via_generic_constructor() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_script(&dir, "ok.sh", "#!/bin/sh\nprintf 'done'\n");
+    let backend =
+        build_backend_from_config(&cli_config(&script.display().to_string()), Some(dir.path()))
+            .expect("generic constructor accepts Cli variant");
+
+    assert_eq!(backend.backend_label(), "cli");
+    let response = backend.dispatch(prompt_request("x")).await;
+    assert_eq!(response.outcome, DispatchOutcome::Success);
+    assert_eq!(response.output, "done");
+}

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -282,18 +282,26 @@ pub struct ServeCommand {
     pub no_retry: bool,
 
     /// ── swarm ── (M7.6 contract-authoring dashboard)
-    /// Backend transport for the swarm MCP agent. When unset the
+    /// Backend transport for the swarm agent. When unset the
     /// `/api/swarm/*` endpoints return 503 (legacy opt-out behaviour).
-    /// `stdio` pairs with `--swarm-backend-cmd`; `http` pairs with
-    /// `--swarm-backend-url`.
-    #[arg(long, value_name = "stdio|http")]
+    /// `stdio` (MCP subprocess) and `cli` (one-shot headless CLI, e.g.
+    /// `claude -p` / `codex exec`) pair with `--swarm-backend-cmd`;
+    /// `http` pairs with `--swarm-backend-url`.
+    #[arg(long, value_name = "stdio|http|cli")]
     pub swarm_backend: Option<String>,
 
-    /// Stdio MCP agent executable (e.g. `claude`). Required when
-    /// `--swarm-backend stdio` is set. Forwarded to
-    /// [`octos_agent::tools::mcp_agent::StdioMcpAgent`].
+    /// Agent executable (e.g. `claude`). Required when
+    /// `--swarm-backend stdio` or `cli` is set. Forwarded to
+    /// [`octos_agent::tools::mcp_agent::StdioMcpAgent`] /
+    /// [`octos_agent::tools::mcp_agent::CliAgentBackend`].
     #[arg(long, value_name = "CMD")]
     pub swarm_backend_cmd: Option<String>,
+
+    /// Arguments passed to the backend executable before the prompt
+    /// (comma-separated, e.g. `-p` or `exec,--json`). Applies to the
+    /// `stdio` and `cli` backends.
+    #[arg(long, value_name = "ARGS", value_delimiter = ',')]
+    pub swarm_backend_args: Vec<String>,
 
     /// HTTPS URL for a remote MCP agent. Required when
     /// `--swarm-backend http` is set. Forwarded to
@@ -777,6 +785,7 @@ impl ServeCommand {
         let swarm_state_init = Self::build_swarm_state_from_flags(
             self.swarm_backend.as_deref(),
             self.swarm_backend_cmd.as_deref(),
+            &self.swarm_backend_args,
             self.swarm_backend_url.as_deref(),
             &data_dir,
             broadcaster.clone(),
@@ -1257,6 +1266,7 @@ impl ServeCommand {
     async fn build_swarm_state_from_flags(
         swarm_backend: Option<&str>,
         swarm_backend_cmd: Option<&str>,
+        swarm_backend_args: &[String],
         swarm_backend_url: Option<&str>,
         data_dir: &std::path::Path,
         broadcaster: Arc<crate::api::EventBroadcaster>,
@@ -1265,7 +1275,7 @@ impl ServeCommand {
     ) -> Result<Option<Arc<crate::api::SwarmState>>> {
         use octos_agent::cost_ledger::PersistentCostLedger;
         use octos_agent::tools::mcp_agent::{
-            HttpMcpAgent, McpAgentBackend, McpAgentBackendConfig, StdioMcpAgent,
+            CliAgentBackend, HttpMcpAgent, McpAgentBackend, McpAgentBackendConfig, StdioMcpAgent,
         };
 
         let Some(kind) = swarm_backend else {
@@ -1280,11 +1290,26 @@ impl ServeCommand {
                     ))?;
                 let config = McpAgentBackendConfig::Local {
                     cmd,
-                    args: Vec::new(),
+                    args: swarm_backend_args.to_vec(),
                     env: Default::default(),
                     dispatch_timeout_secs: None,
                 };
                 Arc::new(StdioMcpAgent::from_config(&config)?)
+            }
+            "cli" => {
+                let cmd = swarm_backend_cmd
+                    .map(str::to_owned)
+                    .ok_or_else(|| eyre::eyre!(
+                        "`--swarm-backend cli` requires `--swarm-backend-cmd <path>` (path to a one-shot agent CLI, e.g. `claude`)"
+                    ))?;
+                let config = McpAgentBackendConfig::Cli {
+                    cmd,
+                    args: swarm_backend_args.to_vec(),
+                    env: Default::default(),
+                    dispatch_timeout_secs: None,
+                    prompt_via_stdin: false,
+                };
+                Arc::new(CliAgentBackend::from_config(&config)?)
             }
             "http" => {
                 let url = swarm_backend_url
@@ -1303,7 +1328,9 @@ impl ServeCommand {
                 Arc::new(HttpMcpAgent::from_config(&config)?)
             }
             other => {
-                eyre::bail!("unknown --swarm-backend value `{other}` (expected `stdio` or `http`)");
+                eyre::bail!(
+                    "unknown --swarm-backend value `{other}` (expected `stdio`, `http`, or `cli`)"
+                );
             }
         };
 
@@ -1708,6 +1735,7 @@ mod tests {
         let state = ServeCommand::build_swarm_state_from_flags(
             None,
             None,
+            &[],
             None,
             dir.path(),
             broadcaster,
@@ -1734,6 +1762,7 @@ mod tests {
         let state = ServeCommand::build_swarm_state_from_flags(
             Some("stdio"),
             Some("/bin/cat"),
+            &[],
             None,
             dir.path(),
             broadcaster,
@@ -1758,6 +1787,60 @@ mod tests {
         let result = ServeCommand::build_swarm_state_from_flags(
             Some("stdio"),
             None,
+            &[],
+            None,
+            dir.path(),
+            broadcaster,
+            None,
+            None,
+        )
+        .await;
+        let err = match result {
+            Ok(_) => panic!("missing cmd must be rejected, got Ok"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--swarm-backend-cmd"),
+            "error must point at the missing flag, got: {msg}"
+        );
+    }
+
+    /// CLI backend: `--swarm-backend cli --swarm-backend-cmd <bin>`
+    /// builds a SwarmState around [`CliAgentBackend`]; args are
+    /// forwarded so `claude` + `-p` compose.
+    #[tokio::test]
+    async fn should_populate_swarm_state_for_cli_backend() {
+        let dir = tempfile::tempdir().unwrap();
+        let broadcaster = Arc::new(EventBroadcaster::new(16));
+        let state = ServeCommand::build_swarm_state_from_flags(
+            Some("cli"),
+            Some("/bin/echo"),
+            &["-n".to_string()],
+            None,
+            dir.path(),
+            broadcaster,
+            None,
+            None,
+        )
+        .await
+        .expect("helper must succeed when cli backend is configured");
+        assert!(
+            state.is_some(),
+            "swarm state must be Some with --swarm-backend cli"
+        );
+    }
+
+    /// CLI backend without `--swarm-backend-cmd` fails at startup like
+    /// the stdio variant.
+    #[tokio::test]
+    async fn should_reject_cli_backend_without_cmd() {
+        let dir = tempfile::tempdir().unwrap();
+        let broadcaster = Arc::new(EventBroadcaster::new(16));
+        let result = ServeCommand::build_swarm_state_from_flags(
+            Some("cli"),
+            None,
+            &[],
             None,
             dir.path(),
             broadcaster,
@@ -1785,6 +1868,7 @@ mod tests {
         let result = ServeCommand::build_swarm_state_from_flags(
             Some("http"),
             None,
+            &[],
             None,
             dir.path(),
             broadcaster,
@@ -1812,6 +1896,7 @@ mod tests {
         let result = ServeCommand::build_swarm_state_from_flags(
             Some("ouija"),
             None,
+            &[],
             None,
             dir.path(),
             broadcaster,
@@ -1825,7 +1910,7 @@ mod tests {
         };
         let msg = err.to_string();
         assert!(
-            msg.contains("stdio") && msg.contains("http"),
+            msg.contains("stdio") && msg.contains("http") && msg.contains("cli"),
             "error must list accepted backends, got: {msg}"
         );
     }
@@ -1851,6 +1936,7 @@ mod tests {
         let state = ServeCommand::build_swarm_state_from_flags(
             Some("stdio"),
             Some("/bin/cat"),
+            &[],
             None,
             dir.path(),
             broadcaster,
@@ -1913,6 +1999,7 @@ mod tests {
         let state = ServeCommand::build_swarm_state_from_flags(
             Some("stdio"),
             Some("/bin/cat"),
+            &[],
             None,
             dir.path(),
             broadcaster,

--- a/crates/octos-swarm/tests/swarm_dispatch.rs
+++ b/crates/octos-swarm/tests/swarm_dispatch.rs
@@ -1458,6 +1458,71 @@ async fn should_not_burn_retry_budget_on_progress_rounds() {
 }
 
 #[tokio::test]
+async fn should_dispatch_through_cli_backend_with_retry_on_nonzero_exit() {
+    // The CLI backend lane end-to-end through the real dispatcher: a
+    // one-shot script that fails on its first invocation (non-zero
+    // exit → RemoteError → retryable) and echoes the prompt on the
+    // retry. Proves exit-code → outcome classification drives the
+    // swarm retry loop exactly like MCP isError does.
+    use octos_agent::tools::mcp_agent::{CliAgentBackend, McpAgentBackendConfig};
+
+    let script_dir = tempfile::tempdir().unwrap();
+    let marker = script_dir.path().join("attempted");
+    let script_path = script_dir.path().join("flaky-cli.sh");
+    std::fs::write(
+        &script_path,
+        format!(
+            "#!/bin/sh\nif [ ! -f {marker} ]; then\n  touch {marker}\n  echo 'transient' >&2\n  exit 1\nfi\nprintf 'cli-answer:%s' \"$1\"\n",
+            marker = marker.display()
+        ),
+    )
+    .unwrap();
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+    }
+
+    let backend = Arc::new(
+        CliAgentBackend::from_config(&McpAgentBackendConfig::Cli {
+            cmd: script_path.display().to_string(),
+            args: Vec::new(),
+            env: HashMap::new(),
+            dispatch_timeout_secs: Some(10),
+            prompt_via_stdin: false,
+        })
+        .unwrap(),
+    );
+
+    let state_dir = tempfile::tempdir().unwrap();
+    let swarm = Swarm::builder(backend, state_dir.path())
+        .build()
+        .await
+        .unwrap();
+    let result = swarm
+        .dispatch(
+            "d-cli",
+            vec![ContractSpec {
+                contract_id: "c1".into(),
+                tool_name: "ignored".into(),
+                task: serde_json::json!({ "prompt": "do the thing" }),
+                label: None,
+            }],
+            SwarmTopology::Sequential,
+            SwarmBudget::default(),
+            context(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.outcome, SwarmOutcomeKind::Success);
+    let subtask = &result.per_task_outcomes[0];
+    assert_eq!(subtask.attempts, 2, "first attempt fails, retry succeeds");
+    assert_eq!(subtask.output, "cli-answer:do the thing");
+}
+
+#[tokio::test]
 async fn should_record_cost_attribution_via_ledger_stub() {
     use octos_swarm::{CostLedger, SwarmCostAttribution};
 


### PR DESCRIPTION
Adds the third backend lane the DispatchPolicy docs always anticipated ("MCP/CLI/native parity"): `CliAgentBackend` invokes a **one-shot headless agent CLI** per dispatch — `claude -p`, `codex exec`, or any command that takes a prompt and prints a result. For fire-and-forget yolo contracts this is simpler and more robust than MCP: no handshake, no notification-stream interop, no schema strictness — the class of bugs #1724 fixed structurally cannot exist here. MCP remains the lane for approvals/streaming/cancellation/resume.

## Shape
- `McpAgentBackendConfig::Cli { cmd, args, env, dispatch_timeout_secs, prompt_via_stdin }`
- Prompt = `task[\"prompt\"]` when present, else the whole task JSON (MCP-shaped contracts degrade gracefully); delivered as the final argv entry (`claude -p <prompt>` style) or via stdin (`prompt_via_stdin` — argv-size and `ps`-visibility safe).
- Outcome mapping mirrors MCP semantics so the swarm retry loop works unchanged: exit 0 → `Success` (stdout trimmed, 1 MiB cap) · non-zero → `RemoteError` (retryable; exit code + stderr in error, partial stdout preserved) · spawn failure → `TransportError` · overrun → `Timeout` (child reaped via `kill_on_drop`).
- Same env hygiene as the stdio MCP backend (allowlist scrub, `BLOCKED_ENV_VARS` win last). stderr is captured (not inherited) since it's the primary CLI diagnostic.
- `octos serve --swarm-backend cli --swarm-backend-cmd claude --swarm-backend-args -p` — new `--swarm-backend-args` (comma-split) also gives the stdio backend an arg surface it previously lacked (wrapper scripts were the only way).
- `DispatchPolicy` gate, redb durability, replay, in-flight guard: all inherited — the backend is just another `McpAgentBackend`.

## Tests
9 backend integration tests (argv + stdin prompt delivery, arg ordering, whole-task fallback, exit-code→outcome mapping, missing-binary, timeout-kill <5s, env scrub, generic constructor) — RED-first against the missing variant; a swarm dispatcher E2E where a fail-once CLI script retries to `Success` (attempts=2); 2 serve flag tests; unknown-backend error lists `cli`.

Live soak on mini4 with real `claude -p` and `codex exec` before merge.