### PR TITLE
fix(ci): unbreak main — duplicate #[test], const assert, typo, provider parity

### DIFF
--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -3410,7 +3410,6 @@ impl Drop for TaskTerminalGuard {
 mod tests {
     use super::*;
 
-    #[test]
     /// #1723: `record_final_output` fires `on_change` so the roster mirror
     /// (`upsert_background_task_agent` → `set_agent_output_if_empty`) re-runs
     /// with `final_output` present. It is called AFTER `mark_completed`, so the

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -1628,6 +1628,13 @@ const MAX_SPAWN_MAX_ITERATIONS: u32 = 300;
 /// raise it up to [`MAX_SPAWN_MAX_ITERATIONS`] or lower it explicitly.
 const DEFAULT_SPAWN_MAX_ITERATIONS: u32 = 150;
 
+/// The whole point of the constant above is that it exceeds the interactive
+/// default of 50 (`AgentConfig::max_iterations`). Asserted at compile time:
+/// both sides are consts, so a runtime `assert!` in a test is really a
+/// `clippy::assertions_on_constants` — and this way an edit that breaks the
+/// invariant fails the build instead of a test run.
+const _: () = assert!(DEFAULT_SPAWN_MAX_ITERATIONS > 50);
+
 /// Resolve the effective iteration budget for a spawn: a caller-supplied value
 /// clamped into `[1, MAX]`, or [`DEFAULT_SPAWN_MAX_ITERATIONS`] when unset.
 fn resolve_spawn_max_iterations(requested: Option<u32>) -> u32 {
@@ -7442,10 +7449,8 @@ PY
             resolve_spawn_max_iterations(None),
             DEFAULT_SPAWN_MAX_ITERATIONS
         );
-        assert!(
-            DEFAULT_SPAWN_MAX_ITERATIONS > 50,
-            "must exceed the interactive default"
-        );
+        // (That it exceeds the interactive 50 is asserted at compile time
+        // beside the constant itself.)
         // Normal value passes through.
         assert_eq!(resolve_spawn_max_iterations(Some(120)), 120);
         // 0 is nonsensical → clamped up to 1.

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -7844,9 +7844,9 @@ mod tests {
         let session_id = SessionKey::with_profile("tenant-a", "api", "bg-final-output");
         let now = Utc::now();
         let task = octos_agent::BackgroundTask {
-            id: "bg-fo-1".into(),
+            id: "bg-final-1".into(),
             tool_name: "review-child".into(),
-            tool_call_id: "call-fo-1".into(),
+            tool_call_id: "call-final-1".into(),
             parent_session_key: Some(session_id.to_string()),
             child_session_key: None,
             child_terminal_state: None,

--- a/dashboard/src/providers.json
+++ b/dashboard/src/providers.json
@@ -135,6 +135,17 @@
       { "id": "qwen/qwen3-32b", "input": 0.29, "output": 0.39, "max_output": 8192 }
     ]
   },
+  "moonshot-coding": {
+    "env": "KIMI_CODING_API_KEY",
+    "models": [
+      { "id": "k3", "input": 0.0, "output": 0.0, "max_output": 131072, "endpoints": [
+        { "id": "moonshot-coding", "label": "Kimi Coding Plan", "base_url": "https://api.kimi.com/coding/v1", "api_key_env": "KIMI_API_KEY" }
+      ] },
+      { "id": "kimi-for-coding-highspeed", "input": 0.0, "output": 0.0, "max_output": 131072, "endpoints": [
+        { "id": "moonshot-coding", "label": "Kimi Coding Plan", "base_url": "https://api.kimi.com/coding/v1", "api_key_env": "KIMI_API_KEY" }
+      ] }
+    ]
+  },
   "moonshot": {
     "env": "MOONSHOT_API_KEY",
     "models": [
@@ -173,6 +184,14 @@
       { "id": "MiniMax-M2.1", "input": 0.5, "output": 2.0, "max_output": 16384 },
       { "id": "MiniMax-M2.1-highspeed", "input": 0.5, "output": 2.0, "max_output": 16384 },
       { "id": "MiniMax-M2", "input": 0.2, "output": 1.1, "max_output": 16384 }
+    ]
+  },
+  "zai-coding": {
+    "env": "ZAI_CODING_API_KEY",
+    "models": [
+      { "id": "glm-5.2", "input": 0.0, "output": 0.0, "max_output": 131072, "endpoints": [
+        { "id": "zai-coding", "label": "GLM Coding Plan", "base_url": "https://api.z.ai/api/anthropic", "api_key_env": "ZAI_API_KEY" }
+      ] }
     ]
   },
   "zhipu": {


### PR DESCRIPTION
## 为什么

`main` 目前有 **4 个独立的检查项是红的**,而且都不是某个 PR 引入的 —— 是 main 自己的问题。后果是:任何开放 PR 一旦重跑 CI 就会变红,于是没人能区分"这个 PR 真有问题"和"main 本来就坏了"。

这也是为什么现在 8 个开放 PR 里有 6 个都挂着看起来吓人的失败。

## 修了什么

### `check`(clippy `-D warnings`),两处

**1. `task_supervisor.rs` 同一个函数上叠了两个 `#[test]`**

给测试写的文档注释被插到了两个 `#[test]` 之间:

```rust
#[test]
/// #1723: `record_final_output` fires `on_change` …
#[test]
fn record_final_output_fires_on_change_with_the_output() {
```

删掉多余的那个。

**2. `spawn.rs` 在运行时断言两个常量的关系**

```rust
assert!(DEFAULT_SPAWN_MAX_ITERATIONS > 50, "must exceed the interactive default");
```

两边都是 const,所以这是 `clippy::assertions_on_constants`。改成常量定义旁边的编译期断言:

```rust
const _: () = assert!(DEFAULT_SPAWN_MAX_ITERATIONS > 50);
```

顺带把这个不变量从"测试期才发现"提前到"构建期就失败"——破坏它的人在编译时就会被拦住,而不是等测试跑到。

### `typos`

后台任务的测试夹具用 `fo` 作为 "final output" 的缩写(`bg-fo-1` / `call-fo-1`),被拼写检查判为错词。改成 `bg-final-1` / `call-final-1`,和相邻的 `call-legacy` / `call-acked` / `call-preack` 命名风格一致。

### `dashboard`(providers.json parity)

`model_catalog.json` 里有 `moonshot-coding` 和 `zai-coding` 两个 family 的模型,但 `dashboard/src/providers.json` 里没有这两个 family,parity 检查因此失败。

`scripts/sync-dashboard-providers.py` 不会自动补——因为 family 的 `env`(API key 环境变量)不在 catalog 里,按脚本自己的文档说明必须镜像 `octos_llm::registry`。据此从 registry 取权威值:

| family | env | 来源 |
|---|---|---|
| `moonshot-coding` | `KIMI_CODING_API_KEY` | `registry/moonshot_coding.rs:20` |
| `zai-coding` | `ZAI_CODING_API_KEY` | `registry/zai_coding.rs:21` |

插入位置也按 registry 的顺序(coding family 排在对应基础 family 之前),然后重跑同步脚本,自动补齐 3 个 catalog 模型,现在**零警告**。

## 验证

- `cargo clippy -p octos-agent -p octos-cli --all-targets` —— 干净,无 error 无告警
- `record_final_output_fires_on_change_with_the_output` —— 通过
- `resolve_spawn_max_iterations_defaults_and_bounds` —— 通过
- `scripts/sync-dashboard-providers.py` 二次运行是 no-op(幂等)

## 建议合并顺序

这个 PR 和 **#1667**(`ci: stabilize octos-agent integration tests`)是解锁其余 PR 的两把钥匙:

- 本 PR 修 main 上的 4 处真实断裂
- #1667 修 `test-octos-agent (integration)` 那个 52 分钟超时(runner 失联,已确认在 main 上同样复现,属基础设施问题)

两个都合了之后,其余 PR rebase 重跑 CI 才能得到有意义的信号。

🤖 Generated with [Claude Code](https://claude.com/claude-code)