### PR TITLE
refactor(cli): extract config_context into octos-services (coupled-module case)

### DIFF
--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -172,6 +172,7 @@ octos-llm = { workspace = true, features = ["test-utils"] }
 # the `api::ui_protocol_audit` alias) to octos-cli's tests. Production builds
 # don't see it; only `cargo test -p octos-cli`.
 octos-store = { workspace = true, features = ["test-util"] }
+octos-services = { workspace = true, features = ["test-util"] }
 tokio-tungstenite.workspace = true
 
 [[test]]

--- a/crates/octos-cli/src/lib.rs
+++ b/crates/octos-cli/src/lib.rs
@@ -18,7 +18,7 @@ pub use octos_services::cli_agent_adapter;
 pub mod commands;
 pub use octos_services::compaction;
 pub mod config;
-pub mod config_context;
+pub use octos_services::config_context;
 pub mod config_layer;
 pub mod config_watcher;
 #[cfg(feature = "api")]

--- a/crates/octos-services/Cargo.toml
+++ b/crates/octos-services/Cargo.toml
@@ -23,6 +23,12 @@ tar = { workspace = true }
 dirs = { workspace = true }
 futures = { workspace = true }
 
+[features]
+# Exposes the crate-wide env-test lock (config_context::TEST_ENV_LOCK) to
+# downstream crates' test builds, so octos-cli's env-pivoting tests serialize
+# on one mutex per test binary. Never enable in production.
+test-util = []
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/crates/octos-services/src/config_context.rs
+++ b/crates/octos-services/src/config_context.rs
@@ -375,8 +375,8 @@ pub fn run_migrations(ctx: &ConfigContext) {
 /// EVERY env-pivoting test in the crate (here and in `config.rs`) must
 /// serialize against this single mutex — separate per-module locks would let
 /// tests in different modules race each other and flake.
-#[cfg(test)]
-pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+#[cfg(any(test, feature = "test-util"))]
+pub static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(test)]
 mod tests {

--- a/crates/octos-services/src/lib.rs
+++ b/crates/octos-services/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod cli_agent_adapter;
 pub mod compaction;
+pub mod config_context;
 pub mod persona_service;
 pub mod soul_service;
 pub mod tenant;


### PR DESCRIPTION
First of the **coupled** modules (leaf extraction #4). config_context's production code is a clean leaf, but its `#[cfg(test)] pub(crate) static TEST_ENV_LOCK` — the crate-wide mutex every env-pivoting test serializes on — was reached across modules by `config.rs`. That one intra-crate tie kept it in octos-cli.

## The insight
Env vars are process-global, so the lock only needs to serialize tests **within one test binary**. Across a crate split, the two crates' env tests run in **separate processes with isolated env** — so they no longer need a *shared* lock, only a single instance per test binary.

## The fix (established `test-util` pattern)
- Expose the lock as `#[cfg(any(test, feature = "test-util"))] pub` (was `#[cfg(test)] pub(crate)`).
- Add a `test-util` feature to octos-services; enable it in octos-cli's **dev-deps** (mirrors octos-store's `read_audit_lines` + octos-llm's `test-utils`).
- **`config.rs` is unchanged** — `crate::config_context::TEST_ENV_LOCK` resolves through the crate-root re-export to the feature-exposed static (one instance per test binary — exactly the invariant the doc comment describes).

## Validation
- octos-services: builds (+ `test-util`), **52 tests pass** (incl. the 14 config_context env tests), clippy clean.
- octos-cli: builds **with** api (lib + test code) and **without**; the `config.rs` env test that consumes the moved lock (`write_mutation_creates_file_with_pretty_json`) **passes at runtime**.
- octos-cli/src: 221,174 → 220,476.

`workflow_runtime` remains deferred — it pulls in `workflow_families/` which itself depends on `crate::workflows` (a separate directory), so it's a subsystem, not a 2-piece move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)