### PR TITLE
fix(api): mask email secrets — /api/me leaked SMTP + Feishu credentials

### DIFF
--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -939,11 +939,14 @@ pub async fn my_profile(
         crate::process_manager::ProcessStatus::stopped()
     };
 
-    Ok(Json(ProfileResponse {
-        email: None,
-        profile: mask_secrets(&profile),
-        status,
-    }))
+    // `with_email_lookup` is the only thing that reads the address out of the
+    // user store. Building the literal with `email: None` instead left the
+    // settings page's "Email (for OTP login)" field blank for everyone — on GET,
+    // and again right after a save on PUT.
+    Ok(Json(
+        ProfileResponse::from(mask_secrets(&profile), status)
+            .with_email_lookup(state.user_store.as_deref()),
+    ))
 }
 
 #[derive(Deserialize, Default)]
@@ -1326,11 +1329,14 @@ pub async fn update_my_profile(
         crate::process_manager::ProcessStatus::stopped()
     };
 
-    Ok(Json(ProfileResponse {
-        email: None,
-        profile: mask_secrets(&profile),
-        status,
-    }))
+    // `with_email_lookup` is the only thing that reads the address out of the
+    // user store. Building the literal with `email: None` instead left the
+    // settings page's "Email (for OTP login)" field blank for everyone — on GET,
+    // and again right after a save on PUT.
+    Ok(Json(
+        ProfileResponse::from(mask_secrets(&profile), status)
+            .with_email_lookup(state.user_store.as_deref()),
+    ))
 }
 
 // ── Voice selection endpoints ────────────────────────────────────────

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -1689,7 +1689,10 @@ mod tests {
                         smtp_host: Some("smtp.gmail.com".into()),
                         smtp_port: Some(587),
                         username: Some("dspfac@gmail.com".into()),
-                        password_env: Some("eqepkfbyfymwfhnv".into()),
+                        // Env var NAME, not a password. This field previously
+                        // held a 16-lowercase-char literal — the exact shape of
+                        // a Gmail App Password — next to a real gmail username.
+                        password_env: Some("SMTP_PASSWORD".into()),
                         password: Some("app-password".into()),
                         from_address: Some("dspfac@gmail.com".into()),
                         feishu_app_id: None,

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1329,6 +1329,17 @@ impl ProfileStore {
                     restore_masked_channel_secrets(new_channel, old_channel);
                 }
             }
+            // Same contract as channels: a client that GETs a masked profile and
+            // PUTs it back must not overwrite the stored secret with `ab***xyz`.
+            if let (Some(new_email), Some(old_email)) =
+                (&mut profile.config.email, &existing.config.email)
+            {
+                restore_masked_optional_secret(&mut new_email.password, &old_email.password);
+                restore_masked_optional_secret(
+                    &mut new_email.feishu_app_secret,
+                    &old_email.feishu_app_secret,
+                );
+            }
         }
         self.save(profile)
     }
@@ -1649,8 +1660,29 @@ pub fn mask_secrets(profile: &UserProfile) -> UserProfile {
     for channel in &mut masked.config.channels {
         mask_channel_secrets(channel);
     }
+    if let Some(email) = &mut masked.config.email {
+        mask_email_secrets(email);
+    }
     masked.config.normalize_llm_contract();
     masked
+}
+
+/// Mask the literal secrets in `config.email`.
+///
+/// `password` and `feishu_app_secret` hold real credentials. Their `*_env`
+/// twins hold only env var NAMES, so those stay in the clear — masking them
+/// would hide which variable to set without protecting anything.
+///
+/// Until this existed `mask_secrets` covered `env_vars` and `channels` but not
+/// `config.email`, so `GET /api/me` handed every authenticated caller their own
+/// SMTP password and Feishu app secret in plaintext.
+fn mask_email_secrets(email: &mut EmailSettings) {
+    if let Some(password) = &mut email.password {
+        *password = mask_value(password);
+    }
+    if let Some(secret) = &mut email.feishu_app_secret {
+        *secret = mask_value(secret);
+    }
 }
 
 /// Display string for keychain-backed values in API responses.
@@ -3354,6 +3386,107 @@ mod tests {
         assert_eq!(loaded.config.env_vars["API_KEY"], "sk-real-secret-key");
         assert_eq!(loaded.config.env_vars["OTHER"], "new-value");
         assert_eq!(loaded.config.env_vars["NEW_KEY"], "brand-new");
+    }
+
+    /// Build a profile whose `config.email` carries both literal secrets.
+    fn email_secret_profile(id: &str) -> UserProfile {
+        UserProfile {
+            id: id.into(),
+            name: "Email Secrets".into(),
+            enabled: false,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig {
+                email: Some(EmailSettings {
+                    provider: "smtp".into(),
+                    smtp_host: Some("smtp.example.org".into()),
+                    smtp_port: Some(587),
+                    username: Some("bot@example.org".into()),
+                    password_env: Some("SMTP_PASSWORD".into()),
+                    password: Some("real-smtp-password".into()),
+                    from_address: Some("bot@example.org".into()),
+                    feishu_app_id: Some("cli_realappid".into()),
+                    feishu_app_secret_env: Some("FEISHU_APP_SECRET".into()),
+                    feishu_app_secret: Some("real-feishu-app-secret".into()),
+                    feishu_from_address: None,
+                    feishu_region: None,
+                }),
+                ..Default::default()
+            },
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_mask_secrets_masks_email_password_and_feishu_secret() {
+        let masked = mask_secrets(&email_secret_profile("email-mask"));
+        let email = masked.config.email.expect("email settings survive masking");
+
+        // The literal credentials must never reach the wire.
+        assert!(is_display_secret_value(email.password.as_deref().unwrap()));
+        assert!(is_display_secret_value(
+            email.feishu_app_secret.as_deref().unwrap()
+        ));
+        assert_ne!(email.password.as_deref(), Some("real-smtp-password"));
+        assert_ne!(
+            email.feishu_app_secret.as_deref(),
+            Some("real-feishu-app-secret")
+        );
+
+        // The `*_env` twins name env vars, not secrets — they stay readable, or
+        // the settings page cannot tell you which variable to set.
+        assert_eq!(email.password_env.as_deref(), Some("SMTP_PASSWORD"));
+        assert_eq!(
+            email.feishu_app_secret_env.as_deref(),
+            Some("FEISHU_APP_SECRET")
+        );
+        assert_eq!(email.username.as_deref(), Some("bot@example.org"));
+    }
+
+    #[test]
+    fn test_save_with_merge_preserves_masked_email_secrets() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ProfileStore::open(dir.path()).unwrap();
+        store.save(&email_secret_profile("email-merge")).unwrap();
+
+        // A client GETs the masked profile and PUTs it straight back.
+        let mut round_tripped = mask_secrets(&store.get("email-merge").unwrap().unwrap());
+        store.save_with_merge(&mut round_tripped).unwrap();
+
+        let loaded = store.get("email-merge").unwrap().unwrap();
+        let email = loaded
+            .config
+            .email
+            .expect("email settings survive the merge");
+        assert_eq!(email.password.as_deref(), Some("real-smtp-password"));
+        assert_eq!(
+            email.feishu_app_secret.as_deref(),
+            Some("real-feishu-app-secret")
+        );
+    }
+
+    #[test]
+    fn test_save_with_merge_allows_changing_email_secrets() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ProfileStore::open(dir.path()).unwrap();
+        store.save(&email_secret_profile("email-change")).unwrap();
+
+        // A genuinely new value is NOT a display artifact, so it must land.
+        let mut updated = email_secret_profile("email-change");
+        let email = updated.config.email.as_mut().unwrap();
+        email.password = Some("rotated-smtp-password".into());
+        email.feishu_app_secret = Some("rotated-feishu-secret".into());
+        store.save_with_merge(&mut updated).unwrap();
+
+        let loaded = store.get("email-change").unwrap().unwrap();
+        let email = loaded.config.email.unwrap();
+        assert_eq!(email.password.as_deref(), Some("rotated-smtp-password"));
+        assert_eq!(
+            email.feishu_app_secret.as_deref(),
+            Some("rotated-feishu-secret")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 泄露

`mask_secrets()`(`profiles.rs:1638`)只处理了 `config.env_vars` 和 `config.channels`,**从来没碰过 `config.email`**。

而 `EmailSettings::password` 和 `feishu_app_secret` 是明文 `Option<String>`,没有 `skip_serializing`(`profiles.rs:580-615`)。`mask_secrets` 正是 `GET /api/me` 的返回路径(`auth_handlers.rs:944`),子账号接口(`:3162/:3202/:3284`)同样走它。

**结果:任何已认证用户调 `GET /api/me`,都会拿到自己 profile 的 SMTP 密码和飞书 app secret 明文。**

## 为什么不能只改读的一侧

只加屏蔽会比泄露更糟:客户端 GET 到带 `***` 的 profile、原样 PUT 回来,就会把真密钥覆盖成掩码字符串。

所以 `save_with_merge` 同步补上了回填 —— 这正是 channel 密钥已有的契约(`restore_masked_channel_secrets`),这里复用现成的 `restore_masked_optional_secret` helper。

`*_env` 那一对**保持明文**:它们存的是环境变量**名**不是密钥,屏蔽了只会让人不知道该设哪个变量。

## 顺带修的两处(同一块代码,来自同一次排查)

**1. 设置页 Email 栏永远空白**

`/api/me` 的 GET 和 PUT 都用结构体字面量写死 `email: None`,没走 `with_email_lookup()` —— 而后者是**唯一**从 user store 读邮箱的地方。所以"Email (for OTP login)"对所有人都是空的,而且刚保存完又会被清空。

**2. 测试夹具里疑似真实的 Gmail 应用专用密码**

`serve.rs:1692` 的 `password_env` 字段(按其自身文档注释存的是环境变量**名**)里放着 `eqepkfbyfymwfhnv` —— 16 位全小写,正是 Gmail App Password 的格式,旁边配的是真实形态的 `dspfac@gmail.com` 和 `smtp.gmail.com`。已改成 `SMTP_PASSWORD`。

> ⚠️ **改代码不等于凭据失效。** 该值由 `7ecdff14`(2026-04-20)引入,在公开仓库里已存在约三个月,在轮换之前一直有效。轮换是仓库所有者的手动动作,本 PR 不能代劳。

## 测试

新增 3 个:

| 测试 | 覆盖 |
|---|---|
| `test_mask_secrets_masks_email_password_and_feishu_secret` | 两个密钥被屏蔽,`*_env` 和 username 保持可读 |
| `test_save_with_merge_preserves_masked_email_secrets` | GET→PUT 往返不会覆盖真密钥 |
| `test_save_with_merge_allows_changing_email_secrets` | 真正的新值仍然能写入(不会被误判为掩码) |

- `profiles::tests` **56/56 通过**
- `cargo check -p octos-cli --features api` 干净
- `cargo fmt --all -- --check` 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)