### PR TITLE
refactor(server): Stage 1 — scaffold octos-server crate + extraction plan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4565,6 +4565,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "octos-server"
+version = "2.0.2-rc.11"
+dependencies = [
+ "async-trait",
+ "axum",
+ "chrono",
+ "eyre",
+ "futures",
+ "lettre",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "octos-agent",
+ "octos-bus",
+ "octos-core",
+ "octos-llm",
+ "octos-pipeline",
+ "octos-plugin",
+ "octos-services",
+ "octos-store",
+ "octos-workflows",
+ "rand 0.8.5",
+ "rust-embed",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "serde",
+ "serde_json",
+ "subtle",
+ "sysinfo",
+ "tokio",
+ "tokio-tungstenite 0.26.2",
+ "tokio-util",
+ "tower-http",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "octos-services"
 version = "2.0.2-rc.11"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/octos-agent",
     "crates/octos-bus",
     "crates/octos-workflows",
+    "crates/octos-server",
     "crates/octos-store",
     "crates/octos-services",
     "crates/octos-cli",
@@ -52,6 +53,7 @@ octos-llm = { path = "crates/octos-llm" }
 octos-agent = { path = "crates/octos-agent" }
 octos-bus = { path = "crates/octos-bus" }
 octos-workflows = { path = "crates/octos-workflows" }
+octos-server = { path = "crates/octos-server" }
 octos-store = { path = "crates/octos-store" }
 octos-services = { path = "crates/octos-services" }
 octos-pipeline = { path = "crates/octos-pipeline" }

--- a/crates/octos-server/Cargo.toml
+++ b/crates/octos-server/Cargo.toml
@@ -1,0 +1,85 @@
+[package]
+name = "octos-server"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "HTTP/WebSocket API server + session runtime for octos (extracted from octos-cli). Server-core is ungated; the HTTP layer is behind the `api` feature."
+
+[dependencies]
+# --- ungated server-core: the session actor + gateway runtime build WITHOUT the
+# `api` feature (non-API `octos gateway` needs them). ---
+octos-core = { workspace = true }
+octos-agent = { workspace = true }
+octos-llm = { workspace = true }
+octos-bus = { workspace = true }
+octos-store = { workspace = true }
+octos-services = { workspace = true }
+octos-workflows = { workspace = true }
+octos-pipeline = { workspace = true }
+octos-plugin = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+chrono = { workspace = true }
+eyre = { workspace = true }
+uuid = { workspace = true }
+metrics = { workspace = true }
+
+# --- HTTP/WS layer, gated behind `api` (mirrors octos-cli's `api` optional deps) ---
+axum = { workspace = true, optional = true }
+tower-http = { workspace = true, optional = true }
+tokio-util = { version = "0.7", optional = true }
+futures = { workspace = true, optional = true }
+tokio-tungstenite = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
+rustls-native-certs = { workspace = true, optional = true }
+rust-embed = { workspace = true, optional = true }
+metrics-exporter-prometheus = { workspace = true, optional = true }
+lettre = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }
+sysinfo = { version = "0.34", optional = true }
+subtle = { workspace = true, optional = true }
+
+[features]
+default = []
+# HTTP/WS API layer. Mirrors octos-cli's `api` feature; octos-cli's `api` will
+# forward here in Stage 4. `matrix` is required — handlers reference matrix types.
+api = [
+    "dep:axum",
+    "dep:tower-http",
+    "dep:tokio-util",
+    "dep:futures",
+    "dep:tokio-tungstenite",
+    "dep:rustls",
+    "dep:rustls-native-certs",
+    "dep:rust-embed",
+    "dep:metrics-exporter-prometheus",
+    "dep:lettre",
+    "dep:rand",
+    "dep:sysinfo",
+    "dep:subtle",
+    "octos-bus/api",
+    "matrix",
+]
+# Channel features forward to octos-bus (the gateway runtime dispatches them
+# without the HTTP `api` layer).
+matrix = ["octos-bus/matrix"]
+telegram = ["octos-bus/telegram"]
+discord = ["octos-bus/discord"]
+dingtalk = ["octos-bus/dingtalk"]
+slack = ["octos-bus/slack"]
+whatsapp = ["octos-bus/whatsapp"]
+email = ["octos-bus/email"]
+feishu = ["octos-bus/feishu"]
+twilio = ["octos-bus/twilio"]
+wecom = ["octos-bus/wecom"]
+line = ["octos-bus/line"]
+wecom-bot = ["octos-bus/wecom-bot"]
+qq-bot = ["octos-bus/qq-bot"]
+wechat = ["octos-bus/wechat"]
+
+[lints]
+workspace = true

--- a/crates/octos-server/src/lib.rs
+++ b/crates/octos-server/src/lib.rs
@@ -1,0 +1,21 @@
+//! `octos-server` — the HTTP/WebSocket API server and session runtime for octos.
+//!
+//! Extracted from `octos-cli` (see `docs/OCTOS_SERVER_EXTRACTION_PLAN.md`). The
+//! server-core (session actor, gateway runtime) is **ungated**; the HTTP/WS layer
+//! lives behind the **`api`** feature so non-API `octos gateway` still builds
+//! without pulling in axum/tower/rustls/etc.
+//!
+//! ## Stage 1 (this crate, now): scaffold only
+//! Intentionally empty. This establishes the crate, the ungated-core + `api`
+//! feature split, the channel-feature forwarding, and the dependency graph so the
+//! structure is reviewable BEFORE the ~146k-LOC server slice moves.
+//!
+//! ## Stage 2 (next): the server slice moves here
+//! ```ignore
+//! pub mod session_actor;                 // ungated server-core
+//! #[cfg(feature = "api")] pub mod api;   // HTTP/WS transport + handlers
+//! // + context_manager, agent_orchestrator, serve/gateway bootstrap,
+//! //   and the provider/prompt/skills helper impls pulled from commands.
+//! ```
+//! Process-global state (`metrics::METRICS_HANDLE`, the orchestrator, ui-protocol
+//! `OnceLock` stores) and `static/` assets move atomically with it.


### PR DESCRIPTION
**Server-first** extraction of the API/WebSocket server out of octos-cli (which is ~60% server despite its name). This PR is **scaffold + plan only** — no code moved — so the crate boundary, feature split, and dependency graph are reviewable before the ~146k-LOC slice moves.

## What's here
- **`crates/octos-server`**: empty lib with the **ungated server-core** + an **`api` feature** gating the HTTP/WS deps (axum/tower-http/rust-embed/rustls/metrics-exporter/lettre/…), plus channel-feature forwarding to octos-bus. Builds clean in **default** (core), **`--features api`**, and a **channel-feature** config.
  - The `api` gate — *not* putting the whole server behind HTTP — is deliberate: non-API `octos gateway` uses the session actor / gateway runtime **without** `api`.
- **`docs/OCTOS_SERVER_EXTRACTION_PLAN.md`**: the staged plan.

## Why server-first (not foundation-first)
A codex review caught that my first instinct — lift a "clean foundation" (`profiles`/`config`/`runtime`/…) first — is **backwards**. Those modules point **up** (verified):
- `runtime` → `session_actor::PipelineToolFactory`, `commands::gateway::prompt::GatewayPromptParts`, `commands::chat`
- `config` → `memory_refresh::RefreshKnobs` → `commands::chat::create_provider_with_api_type`
- `qos_catalog` → `commands::chat`; `process_manager` → api-gated `monitor`; `api/` → `commands::skills::*` (~25 refs)

Lifting a foundation first would create Cargo cycles. So the server slice moves **down** first; an acyclic `octos-runtime` gets carved out of `octos-server` later.

## Stages
1. **Scaffold (this PR)** — crate + feature split + plan.
2. Move the vertical slice (`api/` + `session_actor` + `context_manager` + orchestrator + serve/gateway/provider/skills helper impls), atomically with `static/` assets + CI paths.
3. Resolve the foundation (into octos-server or a new acyclic `octos-runtime`).
4. Thin CLI; keep the `octos` binary + `api` feature name (facade); validate the full feature matrix + a real `serve`/`gateway` smoke.

## Gotchas the plan records
Process-global state co-location (`METRICS_HANDLE`, orchestrator, ui-protocol `OnceLock`s — never duplicate/`#[path]`); `rust-embed` `static/` + hard-coded CI paths; the `api` feature gating `Config` fields + channels (compat facade); cross-crate `#[cfg(test)]` visibility (`test-util` feature).

No code moved yet; **octos-cli is unchanged**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)