### PR TITLE
feat(serve): network-on by default for Local sessions; --no-network opt-out

### DIFF
--- a/crates/octos-agent/src/sandbox/macos.rs
+++ b/crates/octos-agent/src/sandbox/macos.rs
@@ -504,6 +504,14 @@ mod tests {
             profile.contains(r#"(allow file-read* (subpath "/custom/path"))"#),
             "should allow reading custom path"
         );
+        // `/private/etc` must reach the restricted profile by its CANONICAL path
+        // (macOS `/etc` symlink) so system curl/LibreSSL can read
+        // `/private/etc/ssl/openssl.cnf` + `cert.pem` under the network-on
+        // default — otherwise TLS clients fast-fail "Operation not permitted".
+        assert!(
+            profile.contains(r#"(allow file-read* (subpath "/private/etc"))"#),
+            "should allow reading /private/etc (canonical of /etc) for TLS config, profile:\n{profile}"
+        );
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/octos-agent/src/sandbox/mod.rs
+++ b/crates/octos-agent/src/sandbox/mod.rs
@@ -112,6 +112,13 @@ pub(crate) const DEFAULT_READ_ALLOW_PATHS: &[&str] = &[
     "/tmp",
     "/var/tmp",
     "/etc", // system config (needed for DNS resolution, etc.)
+    // macOS `/etc` is a symlink to `/private/etc`, and SBPL subpath rules match
+    // the CANONICAL path — so the `/etc` entry above never covers a real read of
+    // `/private/etc/...`. Without this, TLS clients that resolve via the symlink
+    // (system `curl`/LibreSSL reading `/etc/ssl/openssl.cnf` + `cert.pem`) fail at
+    // init with a confusing "Operation not permitted" — very visible now that
+    // network is allowed by default. Mirrors the `/tmp` + `/private/tmp` pairing.
+    "/private/etc",
     "/dev/null",
     "/dev/urandom",
     "/dev/random",

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -276,6 +276,15 @@ pub struct AppState {
     /// same keystone that gates selecting the profile from the menu); an
     /// explicit per-session `/permissions` choice always overrides it.
     pub dangerous_default_permissions: bool,
+    /// `--no-network` opt-OUT of the network-on default. By default a fresh
+    /// solo/Local session with NO explicit `/permissions` selection resolves to
+    /// Workspace-Write **with network ALLOWED** (filesystem still sandboxed) so
+    /// the common dev workflow — `npm install`, git, fetch — works out of the
+    /// box. Setting this (via `--no-network` / `OCTOS_NO_NETWORK=1`) reverts the
+    /// default to Workspace-Write with network DENIED. Cloud/tenant deployments
+    /// are unaffected (they always default to network-denied). An explicit
+    /// per-session `/permissions` choice always overrides either default.
+    pub default_network_denied: bool,
     /// `--llm-compaction`: AppUI context compaction asks an LLM for a
     /// higher-quality handoff summary (a real model call — slower, seconds)
     /// instead of the instant deterministic heuristic. Always falls back to the
@@ -406,6 +415,7 @@ impl AppState {
             deployment_mode: crate::config::DeploymentMode::Local,
             solo_login_enabled: false,
             dangerous_default_permissions: false,
+            default_network_denied: false,
             llm_compaction: false,
             host_memory: None,
             allow_admin_shell: false,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -927,6 +927,26 @@ fn effective_session_permission_state(
             approval_policy: Some(octos_agent::ApprovalPolicy::Never),
         };
     }
+    // Network-on default: a fresh Local session with no explicit selection gets
+    // Workspace-Write with network ALLOWED (filesystem still sandboxed, approvals
+    // unchanged) so `npm install` / git / fetch work out of the box — the macOS
+    // SBPL otherwise emits `(deny network*)` and silently breaks the most common
+    // dev workflow. Scoped exactly like the dangerous default (Local deployment +
+    // a session key that doesn't encode a tenant/cloud scope) so cloud/tenant
+    // stays network-denied. Opt OUT with `--no-network` (`OCTOS_NO_NETWORK=1`).
+    // An explicit `/permissions` choice still overrides this.
+    if !state.default_network_denied
+        && state.deployment_mode == crate::config::DeploymentMode::Local
+        && !session_id_encodes_non_solo_scope(session_id)
+    {
+        return StoredSessionPermissionProfile {
+            selection: octos_core::ui_protocol::PermissionProfileSelection {
+                mode: octos_core::ui_protocol::PermissionProfileMode::WorkspaceWrite,
+                network: octos_core::ui_protocol::PermissionNetworkPolicy::Allow,
+            },
+            approval_policy: None,
+        };
+    }
     StoredSessionPermissionProfile::default()
 }
 
@@ -34381,28 +34401,40 @@ ignore = []
             Some(octos_agent::ApprovalPolicy::Never)
         );
 
-        // Flag off -> the gated workspace-write default, approvals unset.
+        // Danger flag off, Local, solo -> the NETWORK-ON default: Workspace-Write
+        // (filesystem still sandboxed) with network ALLOWED and approvals unset,
+        // so npm/git/fetch work out of the box.
         let plain = AppState::empty_for_tests();
         let resolved = effective_session_permission_state(&plain, &session_id);
         assert_eq!(resolved.selection.mode, Mode::WorkspaceWrite);
-        assert_eq!(resolved.selection.network, Network::Deny);
+        assert_eq!(resolved.selection.network, Network::Allow);
         assert_eq!(resolved.approval_policy, None);
 
-        // Flag on but NON-Local deployment -> gated default (codex P2): the
-        // full-access profile is not grantable outside Local mode.
+        // `--no-network` opt-out -> Workspace-Write with network DENIED.
+        let mut no_net = AppState::empty_for_tests();
+        no_net.default_network_denied = true;
+        let resolved = effective_session_permission_state(&no_net, &session_id);
+        assert_eq!(resolved.selection.mode, Mode::WorkspaceWrite);
+        assert_eq!(resolved.selection.network, Network::Deny);
+
+        // NON-Local deployment -> network stays DENIED (the network-on default is
+        // Local-only; cloud/tenant is never widened). Danger flag also ignored
+        // outside Local (codex P2).
         let mut tenant = AppState::empty_for_tests();
         tenant.dangerous_default_permissions = true;
         tenant.deployment_mode = crate::config::DeploymentMode::Tenant;
         let resolved = effective_session_permission_state(&tenant, &session_id);
         assert_eq!(resolved.selection.mode, Mode::WorkspaceWrite);
+        assert_eq!(resolved.selection.network, Network::Deny);
 
-        // Flag on, Local, but a NON-SOLO-scoped session key -> gated default
-        // (codex P1): the fallback must not hand a tenant-scoped session the
-        // host access the explicit path would reject.
+        // Local, but a NON-SOLO-scoped session key -> gated default with network
+        // DENIED (codex P1): neither the danger fallback NOR the network-on
+        // default may widen a tenant/cloud-scoped session.
         let scoped = SessionKey("coding:tenant:m12-danger-default".into());
         assert!(session_id_encodes_non_solo_scope(&scoped));
         let resolved = effective_session_permission_state(&state, &scoped);
         assert_eq!(resolved.selection.mode, Mode::WorkspaceWrite);
+        assert_eq!(resolved.selection.network, Network::Deny);
     }
 
     #[test]

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -269,6 +269,15 @@ pub struct ServeCommand {
     #[arg(long)]
     pub danger_full_access: bool,
 
+    /// Opt OUT of the network-on default. By default a fresh Local session with
+    /// no explicit `/permissions` choice runs Workspace-Write with network
+    /// ALLOWED (filesystem still sandboxed) so `npm install` / git / fetch work
+    /// out of the box. Pass `--no-network` (or `OCTOS_NO_NETWORK=1`) to revert
+    /// the default to network DENIED. Cloud/tenant deployments always default to
+    /// network-denied regardless. An explicit `/permissions` choice still wins.
+    #[arg(long)]
+    pub no_network: bool,
+
     /// Use LLM-summarization for AppUI context compaction: when a session's
     /// context fills, ask the model for a high-quality handoff summary (a real
     /// model call — slower, a few seconds) instead of the instant deterministic
@@ -816,6 +825,10 @@ impl ServeCommand {
             || std::env::var("OCTOS_DANGER_FULL_ACCESS")
                 .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
                 .unwrap_or(false);
+        let default_network_denied_flag = self.no_network
+            || std::env::var("OCTOS_NO_NETWORK")
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false);
         // SECURITY KEYSTONE: the dangerous default rides the SAME solo
         // opt-in that gates selecting Full Access from the menu — a fleet
         // config that never sets --solo can reach neither surface.
@@ -891,6 +904,7 @@ impl ServeCommand {
             host_memory: config.memory.clone(),
             solo_login_enabled: solo_login_enabled_flag,
             dangerous_default_permissions: dangerous_default_permissions_flag,
+            default_network_denied: default_network_denied_flag,
             llm_compaction: self.llm_compaction,
             allow_admin_shell: config.allow_admin_shell,
             content_catalog_mgr: Some(Arc::new(


### PR DESCRIPTION
## Why
A fresh Local session with no explicit `/permissions` choice defaulted to Workspace-Write with **network DENIED** → macOS SBPL `(deny network*)` → `npm install` / git / fetch / Playwright silently fail. The only escape was Full Access, which *also* drops the filesystem sandbox. (This is exactly what blocked the World Cup goal on mini5.)

## What
Reuse the existing permission machinery — `effective_session_permission_state` now returns **Workspace-Write + network ALLOWED** (filesystem still sandboxed, approvals unchanged) for a fresh **Local, solo-scoped** session, i.e. the same `network: Allow` the `/permissions` menu's network option sets. Launching octos-tui with no options gets working network out of the box, keeping FS confinement (unlike Full Access).

- **Scope:** identical to the dangerous default — `deployment_mode == Local` AND a session key that doesn't encode a tenant/cloud scope. **Cloud/tenant is unchanged** (always network-denied; no widening).
- **Opt out:** `--no-network` (or `OCTOS_NO_NETWORK=1`) restores the network-denied default.
- An explicit `/permissions` choice always overrides either default.

## Security posture
- Filesystem stays sandboxed (Workspace-Write) — this is NOT Full Access.
- Network-on is Local-solo only, gated by the same two checks as `--danger-full-access`.
- In-process web tools keep SSRF protection; shell-spawned network is now reachable on Local (expected for a local dev agent, the operator IS the user).

## Tests
`dangerous_default_permissions_resolves_without_an_explicit_choice` extended: Local default → Allow; `--no-network` → Deny; tenant + non-solo-scoped keys stay Deny. Full octos-cli lib suite green (2365).

🤖 Generated with [Claude Code](https://claude.com/claude-code)