### PR TITLE
fix(goal): cwd-scope the goal store so goals don't leak across folders

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -358,6 +358,32 @@ pub(crate) fn method_not_supported_error(
 #[derive(Debug, Default)]
 pub(crate) struct InProcessAgentOrchestrator {
     state: StdMutex<AutonomyRuntimeState>,
+    /// #1666 residue — per-project (cwd) scope for the goal/autonomy store,
+    /// mirroring the ledger's `scopes` map (`ui_protocol_ledger.rs`).
+    /// Registered on `session/open` alongside `ledger.set_session_scope` so a
+    /// goal set in one folder does NOT leak into a fresh session that reuses
+    /// the same WIRE session key in another folder (same profile). Keyed by
+    /// the plain wire session id; held under a SEPARATE lock from `state` so
+    /// [`Self::scoped_goal_key`] can be resolved without re-entering the state
+    /// mutex the goal handlers already hold. Empty (no scope) → the goal store
+    /// keys by the plain wire id, byte-identical to the legacy behavior and to
+    /// the gateway/session-actor path (which never registers a scope).
+    goal_scopes: StdMutex<HashMap<String, String>>,
+}
+
+/// The plain WIRE session id underlying a (possibly cwd-scoped) goal-store
+/// key: strips a `\u{0}~cwd-<scope>` suffix if present, else returns the key
+/// unchanged. Used at the continuation-dispatch boundary so a goal enqueued
+/// under a scoped key is still delivered to the session runtime / actor keyed
+/// by the plain wire id (which is how `session_workspaces()`, `active_turns`,
+/// and the ledger's live-subscriber map are all keyed). The NUL separator is
+/// the same injective marker `storage_session_id` uses, so a legitimate wire
+/// id can never be mistaken for a scoped key.
+pub(crate) fn wire_key_from_goal_key(key: &SessionKey) -> SessionKey {
+    match key.0.split_once("\u{0}~cwd-") {
+        Some((wire, _)) => SessionKey(wire.to_owned()),
+        None => key.clone(),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -637,6 +663,65 @@ impl InProcessAgentOrchestrator {
     #[cfg(test)]
     pub(crate) fn clear_for_test(&self) {
         *self.state() = AutonomyRuntimeState::default();
+        self.goal_scopes
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
+    }
+
+    /// #1666 residue — register (or clear) the per-project goal-store scope
+    /// for a wire session id. The goal/autonomy half of `appui.sessions_in_cwd`
+    /// isolation, called from `register_session_ledger_scope` right beside
+    /// `ledger.set_session_scope` so the goal store and the ledger agree on
+    /// each session's cwd scope. Mirrors
+    /// [`UiProtocolLedger::set_session_scope`].
+    pub(crate) fn set_goal_scope(&self, session_id: &SessionKey, scope: Option<String>) {
+        let mut scopes = self
+            .goal_scopes
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match scope {
+            Some(scope) => {
+                scopes.insert(session_id.0.clone(), scope);
+            }
+            None => {
+                scopes.remove(session_id.0.as_str());
+            }
+        }
+    }
+
+    /// #1666 residue — the STORAGE identity for a wire session id in the goal
+    /// store: the id itself, or `<id>\u{0}~cwd-<scope>` when a per-project
+    /// scope is registered. Mirrors [`UiProtocolLedger::storage_session_id`]
+    /// byte-for-byte (same NUL-separated, injective encoding) so the goal store
+    /// isolates cwds exactly as the ledger already isolates transcripts.
+    pub(crate) fn scoped_goal_key(&self, session_id: &SessionKey) -> SessionKey {
+        let scopes = self
+            .goal_scopes
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match scopes.get(session_id.0.as_str()) {
+            Some(scope) => SessionKey(format!("{}\u{0}~cwd-{scope}", session_id.0)),
+            None => session_id.clone(),
+        }
+    }
+
+    /// #1666 residue — whether a (possibly cwd-scoped) goal-continuation
+    /// target is safe to dispatch on the AppUI tick path. A SCOPED goal target
+    /// fires ONLY when its cwd scope is the one CURRENTLY registered for its
+    /// wire id (the most-recently-opened folder — the same last-write-wins
+    /// scope the ledger and `session_workspaces()` resolve by). This stops a
+    /// backgrounded folder's goal from firing a continuation that
+    /// `run_standalone_turn` would then execute against the currently-active
+    /// folder's workspace (which resolves by the plain wire id), i.e. the
+    /// continuation-side twin of the get/set leak. Unscoped targets (loops,
+    /// gateway sessions) are always dispatchable.
+    pub(crate) fn goal_target_is_dispatchable(&self, target: &SessionKey) -> bool {
+        if !target.0.contains("\u{0}~cwd-") {
+            return true;
+        }
+        let wire = wire_key_from_goal_key(target);
+        self.scoped_goal_key(&wire) == *target
     }
 
     pub(crate) fn configure_supervisor_store(
@@ -2262,8 +2347,14 @@ impl InProcessAgentOrchestrator {
             .goals
             .get(session_id)
             .filter(|goal| goal.profile_id == profile_id)?;
+        // #1666 residue — `session_id` here is the goal STORE identity (the
+        // cwd-scoped key for an AppUI folder), but the client keys the goal
+        // chip by the plain WIRE id and would drop an event carrying a scoped
+        // key. Emit the wire id in the event while looking up under the scoped
+        // key. Unscoped/gateway keys strip to themselves (no-op).
+        let wire_id = wire_key_from_goal_key(session_id);
         Some(json!({
-            "session_id": session_id,
+            "session_id": wire_id,
             "profile_id": profile_id,
             "goal": autonomy_goal_json(goal),
             "transition_actor": "backend",
@@ -2274,10 +2365,14 @@ impl InProcessAgentOrchestrator {
     /// Never errors: no goal (or a goal outside the profile scope) renders
     /// as `status: "none"` so the model gets a stable shape either way.
     pub(crate) fn model_goal_snapshot(&self, session_id: &SessionKey, profile_id: &str) -> Value {
+        // #1666 residue — the `goal_get` tool runs inside a turn keyed by the
+        // plain wire session id; resolve it to the cwd-scoped store identity so
+        // the model reads THIS folder's goal, not another folder's.
+        let key = self.scoped_goal_key(session_id);
         let state = self.state();
         match state
             .goals
-            .get(session_id)
+            .get(&key)
             .filter(|goal| goal.profile_id == profile_id)
         {
             Some(goal) => json!({
@@ -2311,8 +2406,10 @@ impl InProcessAgentOrchestrator {
                 "status `{status}` is not a model-allowed transition (only complete|blocked)"
             ));
         }
+        // #1666 residue — the `goal_update` tool addresses THIS folder's goal.
+        let key = self.scoped_goal_key(session_id);
         let mut state = self.state();
-        let Some(goal) = state.goals.get_mut(session_id) else {
+        let Some(goal) = state.goals.get_mut(&key) else {
             return Err("no goal is set for this session".to_owned());
         };
         if goal.profile_id != profile_id {
@@ -2324,7 +2421,7 @@ impl InProcessAgentOrchestrator {
         goal.status = status.to_owned();
         goal.updated_at_ms = now_ms();
         let snapshot = goal.clone();
-        persist_goal_state(&state, session_id, &snapshot, false);
+        persist_goal_state(&state, &key, &snapshot, false);
         tracing::info!(
             session = %session_id,
             goal_id = %snapshot.goal_id,
@@ -2359,9 +2456,13 @@ impl InProcessAgentOrchestrator {
         // Reject when an unfinished goal already exists (codex: "Fails if an
         // unfinished goal exists"). Scope the state guard so `set_goal` can
         // re-lock below without deadlocking.
+        // #1666 residue — inspect/replace THIS folder's goal under the
+        // cwd-scoped store identity. `set_goal` below is handed the plain wire
+        // `session_id` and re-resolves the same scope, so the two agree.
+        let key = self.scoped_goal_key(session_id);
         {
             let mut state = self.state();
-            if let Some(existing) = state.goals.get(session_id) {
+            if let Some(existing) = state.goals.get(&key) {
                 if existing.profile_id != profile_id {
                     return Err(
                         "a goal outside this profile's scope already exists for this session"
@@ -2388,7 +2489,7 @@ impl InProcessAgentOrchestrator {
             // fail the goal-id identity check in
             // `pending_continuation_is_schedulable`. (`remove` is a no-op when
             // no goal exists, so the fresh-goal path is unaffected.)
-            state.goals.remove(session_id);
+            state.goals.remove(&key);
         }
         self.set_goal(GoalSetRequest {
             session_id: session_id.clone(),
@@ -2520,7 +2621,15 @@ impl InProcessAgentOrchestrator {
             if !pending_continuation_is_schedulable(state, item) {
                 continue;
             }
-            sessions.insert(SessionKey(item.session_id.as_str().to_owned()));
+            // #1666 residue — a goal continuation is enqueued under the
+            // cwd-scoped store identity, but the client's orchestration
+            // indicator (and the `subscribed`/`live_forwarders` set it is
+            // reconciled against) is keyed by the plain wire id. Strip the cwd
+            // scope so a scoped goal still lights the "orchestrating" chip on
+            // its wire session instead of being dropped as an unknown key.
+            sessions.insert(wire_key_from_goal_key(&SessionKey(
+                item.session_id.as_str().to_owned(),
+            )));
         }
         sessions
     }
@@ -2966,10 +3075,15 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
     }
 
     fn get_goal(&self, request: GoalSessionRequest) -> Result<Value, RpcError> {
+        // #1666 residue — resolve the wire session id to its cwd-scoped store
+        // identity so a `goal_get` in folder B never returns folder A's goal
+        // (both reuse the same wire key `<profile>:local:tui#coding`). The
+        // response still echoes the plain wire `request.session_id`.
+        let key = self.scoped_goal_key(&request.session_id);
         let state = self.state();
         let goal = state
             .goals
-            .get(&request.session_id)
+            .get(&key)
             .filter(|goal| goal.profile_id == request.profile_id)
             .map(autonomy_goal_json);
         Ok(json!({
@@ -3050,13 +3164,21 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
             ));
         }
         let now = now_ms();
+        // #1666 residue — resolve the wire session id to its cwd-scoped store
+        // identity BEFORE touching `state.goals`, so a goal set in folder A is
+        // stored under a key distinct from folder B's even though both reuse
+        // the same wire key. Every store op below (get/insert, continuation
+        // enqueue, wrap-up enqueue, persistence) uses `key`; the wire
+        // `request.session_id` is kept only for the wire-facing response /
+        // error payloads. Resolved before the state lock (separate scope lock).
+        let key = self.scoped_goal_key(&request.session_id);
         let mut state = self.state();
         // Fix A: an over-budget mutation that would leave the goal `active`
         // must instead flip it to `budget_limited` and emit the wrap-up. We
         // stage the wrap-up prompt here and enqueue it AFTER the mutable
         // `goal` borrow ends (the wrap-up enqueue needs `&mut state`).
         let mut pending_wrap_up: Option<String> = None;
-        let goal = if let Some(goal) = state.goals.get_mut(&request.session_id) {
+        let goal = if let Some(goal) = state.goals.get_mut(&key) {
             if goal.profile_id != request.profile_id {
                 return Err(autonomy_error(
                     kinds::GOAL_UNAVAILABLE,
@@ -3161,11 +3283,11 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
                 wrap_up_emitted: false,
                 consecutive_failed_turns: 0,
             };
-            state.goals.insert(request.session_id.clone(), goal.clone());
+            state.goals.insert(key.clone(), goal.clone());
             goal
         };
         if goal.status == "active" {
-            enqueue_goal_continuation(&mut state, &request.session_id, &request.profile_id, &goal);
+            enqueue_goal_continuation(&mut state, &key, &request.profile_id, &goal);
         }
         // Fix A: if the mutation crossed the goal over its budget, enqueue the
         // one-shot wrap-up now that the mutable `goal` borrow is released. The
@@ -3174,7 +3296,7 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
         if let Some(prompt) = pending_wrap_up {
             enqueue_goal_wrap_up(
                 &mut state,
-                &request.session_id,
+                &key,
                 &request.profile_id,
                 &goal.goal_id,
                 &goal.objective,
@@ -3182,7 +3304,7 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
                 SystemTime::now(),
             );
         }
-        persist_goal_state(&state, &request.session_id, &goal, false);
+        persist_goal_state(&state, &key, &goal, false);
         Ok(json!({
             "session_id": request.session_id,
             "profile_id": request.profile_id,
@@ -3192,10 +3314,13 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
     }
 
     fn clear_goal(&self, request: GoalSessionRequest) -> Result<Value, RpcError> {
+        // #1666 residue — clear the cwd-scoped goal for this wire session id so
+        // `goal_clear` in folder B never removes folder A's goal.
+        let key = self.scoped_goal_key(&request.session_id);
         let mut state = self.state();
-        let cleared = match state.goals.get(&request.session_id) {
+        let cleared = match state.goals.get(&key) {
             Some(goal) if goal.profile_id == request.profile_id => {
-                state.goals.remove(&request.session_id).is_some()
+                state.goals.remove(&key).is_some()
             }
             Some(_) => {
                 return Err(autonomy_error(
@@ -3210,7 +3335,7 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
             None => false,
         };
         if cleared {
-            persist_goal_cleared(&state, &request.session_id, &request.profile_id);
+            persist_goal_cleared(&state, &key, &request.profile_id);
         }
         Ok(json!({
             "session_id": request.session_id,
@@ -12861,6 +12986,223 @@ mod tests {
         assert_eq!(
             window_after, 1,
             "AppUI option (b) must produce exactly ONE rate_window_count increment per turn"
+        );
+    }
+
+    /// #1666 residue — the goal STORE must isolate two folders (cwds) that
+    /// share the same WIRE session key, exactly as the ledger already isolates
+    /// their transcripts (mirror of
+    /// `ui_protocol_ledger::should_isolate_ledger_storage_between_cwd_scopes_sharing_a_wire_key`).
+    /// Before this fix the goal store keyed on the bare wire key, so a goal set
+    /// in folder A leaked into a fresh session reusing the key in folder B (the
+    /// leaked "orchestrating" chip in the live mini2 repro).
+    #[test]
+    fn should_isolate_goal_store_between_cwd_scopes_sharing_a_wire_key() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        // Both folders open the SAME wire key (the TUI hardcodes `#coding`).
+        let key = SessionKey("octos:local:tui#coding".into());
+
+        // Folder A registers its cwd scope and sets a goal.
+        orchestrator.set_goal_scope(&key, Some("aaaa111122223333".into()));
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: key.clone(),
+                profile_id: "octos".into(),
+                objective: "objective-a".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set goal A");
+
+        // Folder B re-registers the SAME wire key under its own scope. A fresh
+        // `goal_get` must NOT surface folder A's goal — this is the leak.
+        orchestrator.set_goal_scope(&key, Some("bbbb444455556666".into()));
+        let got_b = orchestrator
+            .get_goal(GoalSessionRequest {
+                session_id: key.clone(),
+                profile_id: "octos".into(),
+            })
+            .expect("get goal B");
+        assert!(
+            got_b["goal"].is_null(),
+            "folder B must not read folder A's goal (got {got_b:?})"
+        );
+
+        // Folder B sets its own goal; the two coexist under distinct keys.
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: key.clone(),
+                profile_id: "octos".into(),
+                objective: "objective-b".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set goal B");
+        let got_b2 = orchestrator
+            .get_goal(GoalSessionRequest {
+                session_id: key.clone(),
+                profile_id: "octos".into(),
+            })
+            .expect("get goal B2");
+        assert_eq!(
+            got_b2["goal"]["objective"],
+            json!("objective-b"),
+            "folder B reads its own goal"
+        );
+
+        // Back to folder A: its goal is intact under its own scope, wholly
+        // unaffected by folder B's goal.
+        orchestrator.set_goal_scope(&key, Some("aaaa111122223333".into()));
+        let got_a = orchestrator
+            .get_goal(GoalSessionRequest {
+                session_id: key.clone(),
+                profile_id: "octos".into(),
+            })
+            .expect("get goal A");
+        assert_eq!(
+            got_a["goal"]["objective"],
+            json!("objective-a"),
+            "folder A still reads objective-a, never folder B's objective-b"
+        );
+        // The response echoes the PLAIN wire id, never the scoped store id.
+        assert_eq!(got_a["session_id"], json!(key.0));
+
+        // Under the hood the two goals occupy two distinct, NUL-separated store
+        // keys (the same injective encoding the ledger uses), and the bare wire
+        // key holds nothing — the leak vector is closed.
+        let scoped_a = SessionKey(format!("{}\u{0}~cwd-aaaa111122223333", key.0));
+        let scoped_b = SessionKey(format!("{}\u{0}~cwd-bbbb444455556666", key.0));
+        {
+            let state = orchestrator.state();
+            assert_eq!(
+                state.goals.get(&scoped_a).map(|g| g.objective.as_str()),
+                Some("objective-a"),
+            );
+            assert_eq!(
+                state.goals.get(&scoped_b).map(|g| g.objective.as_str()),
+                Some("objective-b"),
+            );
+            assert!(
+                state.goals.get(&key).is_none(),
+                "the bare wire key must hold no goal — nothing to leak",
+            );
+        }
+
+        // Clearing the scope falls back to the (empty) plain wire identity.
+        orchestrator.set_goal_scope(&key, None);
+        let got_none = orchestrator
+            .get_goal(GoalSessionRequest {
+                session_id: key.clone(),
+                profile_id: "octos".into(),
+            })
+            .expect("get unscoped");
+        assert!(
+            got_none["goal"].is_null(),
+            "no scope registered → plain wire identity, which holds no goal",
+        );
+    }
+
+    /// #1666 residue — the CONSTRAINT: store-scoping the goal must NOT break
+    /// autonomous continuations. A goal set in a cwd-scoped session is (1)
+    /// surfaced by the continuation sweep under its SCOPED store key, (2)
+    /// dispatchable only while its folder is the active one, (3) stripped back
+    /// to the plain WIRE key the session actor / runtime is keyed by, and (4)
+    /// drained + charged under the SCOPED key. Adapts
+    /// `appui_goal_dispatch_path_does_not_double_count_continuations` for the
+    /// scoped path.
+    #[test]
+    fn scoped_goal_continuation_is_swept_and_strips_to_wire_key_for_dispatch() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let wire = SessionKey::with_profile("tenant-a", "api", "goal-scoped-dispatch");
+        orchestrator.set_goal_scope(&wire, Some("aaaa111122223333".into()));
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: wire.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "keep firing per folder".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active scoped goal");
+
+        // The goal record lives under the SCOPED store key, not the wire key.
+        let scoped = SessionKey(format!("{}\u{0}~cwd-aaaa111122223333", wire.0));
+        assert!(
+            orchestrator.state().goals.contains_key(&scoped),
+            "goal stored under the scoped key",
+        );
+        assert!(
+            !orchestrator.state().goals.contains_key(&wire),
+            "the bare wire key must be empty",
+        );
+
+        // (1) The sweep surfaces the SCOPED key as the continuation target.
+        let targets = orchestrator.due_loop_targets(Some("tenant-a"), 8);
+        let target = targets
+            .iter()
+            .find(|(session_id, _)| session_id == &scoped)
+            .map(|(session_id, _)| session_id.clone())
+            .unwrap_or_else(|| {
+                panic!("sweep must surface the scoped goal target (got {targets:?})")
+            });
+
+        // (2) + (3): while folder A's scope is current, the target is
+        // dispatchable and strips back to the plain wire key for the actor.
+        assert!(
+            orchestrator.goal_target_is_dispatchable(&target),
+            "the currently-scoped folder's goal must be dispatchable",
+        );
+        assert_eq!(
+            wire_key_from_goal_key(&target),
+            wire,
+            "dispatch strips the cwd scope back to the wire key the actor is keyed by",
+        );
+
+        // (4) The continuation drains under the SCOPED key and carries it.
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &scoped,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        assert!(
+            drained
+                .iter()
+                .any(|c| matches!(c.reason, MasterContinuationReason::GoalContinue)),
+            "the scoped goal's continuation drains under the scoped key",
+        );
+        assert!(
+            drained.iter().all(|c| c.session_id.as_str() == scoped.0),
+            "every drained continuation carries the scoped session id",
+        );
+
+        // A DIFFERENT folder becoming current makes folder A's goal
+        // NON-dispatchable — the continuation-side leak is closed — but the
+        // record still exists, so re-opening folder A resumes it.
+        orchestrator.set_goal_scope(&wire, Some("bbbb444455556666".into()));
+        assert!(
+            !orchestrator.goal_target_is_dispatchable(&scoped),
+            "a backgrounded folder's goal must not fire into the now-active folder",
+        );
+        orchestrator.set_goal_scope(&wire, Some("aaaa111122223333".into()));
+        assert!(
+            orchestrator.goal_target_is_dispatchable(&scoped),
+            "re-activating folder A's scope makes its goal dispatchable again",
+        );
+
+        // Post-turn accounting addresses the scoped key (what the AppUI
+        // dispatch passes via `goal_context.goal_session_key`) and charges the
+        // scoped goal exactly once — the fire path stays intact end-to-end.
+        orchestrator.record_goal_turn(&scoped, "tenant-a", 500, 3);
+        let (_, continuations_after, _) = orchestrator
+            .goal_counters_for_test(&scoped)
+            .expect("scoped goal exists");
+        assert_eq!(
+            continuations_after, 1,
+            "one recorded turn charges the scoped goal exactly once",
         );
     }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -87,7 +87,7 @@ use super::agent_orchestrator::{
     AgentRequest, AgentUpsert, GoalSessionRequest, GoalSetRequest, LoopControlKind,
     LoopControlRequest, LoopCreateRequest, LoopListRequest, NativeSpecialistAppUiEvent,
     NativeSpecialistLaunchRequest, default_agent_orchestrator, master_continuation_prompt,
-    master_continuation_reason_name, upsert_background_task_agent,
+    master_continuation_reason_name, upsert_background_task_agent, wire_key_from_goal_key,
 };
 #[cfg(test)]
 use super::agent_orchestrator::{
@@ -2987,6 +2987,16 @@ fn register_session_ledger_scope(
             .collect::<String>()
     });
     ledger.set_session_scope(&runtime.session_key, scope.clone());
+    // #1666 residue — mirror the SAME cwd scope into the goal/autonomy store so
+    // a goal set in one folder does not leak into a fresh session that reuses
+    // this wire key in another folder. The goal store was keyed by the bare
+    // wire key while #1666 only cwd-scoped the ledger, so the goal chip leaked
+    // across folders (same profile). Keeping the two scope maps in lock-step
+    // (registered at the same site, cleared together when the flag is off) is
+    // what makes the goal store isolate cwds exactly as the transcript already
+    // does. The goal continuation dispatch strips this scope back to the wire
+    // key when it reaches the session runtime / actor.
+    default_agent_orchestrator().set_goal_scope(&runtime.session_key, scope.clone());
     // Topic-suffixed sessions also emit ledger events under their BASE key:
     // the alpha-9 file/visual bridges deliberately strip the `#topic` before
     // appending so base-bucket subscribers see them (see
@@ -2996,7 +3006,8 @@ fn register_session_ledger_scope(
     // never mis-route a different project's base-key session.
     let base = runtime.session_key.base_key();
     if base != runtime.session_key.0 {
-        ledger.set_session_scope(&SessionKey(base.to_owned()), scope);
+        ledger.set_session_scope(&SessionKey(base.to_owned()), scope.clone());
+        default_agent_orchestrator().set_goal_scope(&SessionKey(base.to_owned()), scope);
     }
 }
 
@@ -9856,6 +9867,9 @@ async fn handle_raw_appui_rpc(
             }
             let _ = send_rpc_result(ws, id, result);
             if let Some((session_id, profile_id)) = continuation_target {
+                // This immediate-drain path is `loop/fire_now` only (see
+                // `appui_continuation_target_from_raw_result`); loops are not
+                // cwd-scoped, so the goal store key equals the wire id.
                 let _ = maybe_spawn_appui_master_continuation_runner(
                     ws,
                     state,
@@ -9863,6 +9877,7 @@ async fn handle_raw_appui_rpc(
                     contracts,
                     active_turns,
                     connection_turns,
+                    session_id.clone(),
                     session_id,
                     profile_id,
                     features,
@@ -12974,7 +12989,16 @@ async fn maybe_spawn_appui_master_continuation_runner(
     contracts: &Arc<UiProtocolContractStores>,
     active_turns: &SharedActiveTurns,
     connection_turns: &SharedConnectionTurns,
+    // The PLAIN WIRE session id: the turn runs, the ledger/runtime resolve, and
+    // the active-turn/connection bookkeeping key on this.
     session_id: SessionKey,
+    // #1666 residue — the goal STORE identity (cwd-scoped for AppUI folders,
+    // == `session_id` for loops / gateway sessions). The continuation queue,
+    // the goal in-flight set, and the post-turn goal accountant all key on
+    // THIS; a scoped goal enqueued its continuation under this key and must be
+    // drained + charged under it. For unscoped targets it equals `session_id`,
+    // so the loop/gateway path is byte-identical to before.
+    goal_storage_key: SessionKey,
     profile_id: String,
     features: ConnectionUiFeatures,
 ) -> bool {
@@ -12995,7 +13019,7 @@ async fn maybe_spawn_appui_master_continuation_runner(
     // tick would drain + spawn a SECOND concurrent turn on the same session
     // while the actor's turn runs. The actor clears the marker (RAII guard)
     // when its turn ends, so the next tick re-dispatches normally.
-    if default_agent_orchestrator().is_goal_dispatch_in_flight(&session_id) {
+    if default_agent_orchestrator().is_goal_dispatch_in_flight(&goal_storage_key) {
         return false;
     }
 
@@ -13006,7 +13030,7 @@ async fn maybe_spawn_appui_master_continuation_runner(
             .is_empty(),
     );
     let Some(continuation) = default_agent_orchestrator()
-        .drain_ready_continuations_for_session(&session_id, &profile_id, runtime_state, 1)
+        .drain_ready_continuations_for_session(&goal_storage_key, &profile_id, runtime_state, 1)
         .into_iter()
         .next()
     else {
@@ -13082,6 +13106,10 @@ async fn maybe_spawn_appui_master_continuation_runner(
         MasterContinuationReason::GoalContinue | MasterContinuationReason::GoalWrapUp => {
             Some(GoalContinuationContext {
                 profile_id: continuation.profile_id.as_str().to_owned(),
+                // The continuation carries the cwd-scoped goal store key it was
+                // enqueued under; the post-turn accountant must charge THAT
+                // record, not the plain wire id.
+                goal_session_key: SessionKey(continuation.session_id.as_str().to_owned()),
             })
         }
         _ => None,
@@ -13186,8 +13214,18 @@ async fn drain_appui_due_master_continuations(
     profile_filter: Option<&str>,
     features: ConnectionUiFeatures,
 ) {
-    for (session_id, profile_id) in default_agent_orchestrator().due_loop_targets(profile_filter, 8)
-    {
+    let orchestrator = default_agent_orchestrator();
+    for (storage_key, profile_id) in orchestrator.due_loop_targets(profile_filter, 8) {
+        // #1666 residue — a scoped goal target fires only for the currently
+        // active folder of its wire id (a backgrounded folder's goal is
+        // skipped until it is re-opened), so a stale-cwd continuation can never
+        // run against the wrong workspace. Unscoped targets (loops, gateway)
+        // always pass. The turn dispatches on the plain WIRE id while the goal
+        // record/queue/accountant stay on the scoped `storage_key`.
+        if !orchestrator.goal_target_is_dispatchable(&storage_key) {
+            continue;
+        }
+        let wire_key = wire_key_from_goal_key(&storage_key);
         let _ = maybe_spawn_appui_master_continuation_runner(
             ws,
             state,
@@ -13195,7 +13233,8 @@ async fn drain_appui_due_master_continuations(
             contracts,
             active_turns,
             connection_turns,
-            session_id,
+            wire_key,
+            storage_key,
             profile_id,
             features,
         )
@@ -13437,17 +13476,32 @@ pub(crate) fn spawn_global_master_continuation_drain(state: Arc<AppState>) {
             // sessions is not operationally reachable on a single serve.
             const DRAIN_SPAWN_CAP: usize = 8;
             const DRAIN_CANDIDATE_WINDOW: usize = 64;
-            let runnable = |session: &SessionKey| session_workspaces().get(session).is_some();
-            let due = default_agent_orchestrator().due_loop_targets_with_filter(
+            // #1666 residue — a goal target is cwd-scoped (`<wire>\u{0}~cwd-…`)
+            // while `session_workspaces()` is keyed by the plain wire id, so
+            // the workspace-known gate must strip the scope before probing.
+            let runnable = |session: &SessionKey| {
+                session_workspaces()
+                    .get(&wire_key_from_goal_key(session))
+                    .is_some()
+            };
+            let orchestrator = default_agent_orchestrator();
+            let due = orchestrator.due_loop_targets_with_filter(
                 None,
                 DRAIN_CANDIDATE_WINDOW,
                 Some(&runnable),
             );
             let mut advanced = 0usize;
-            for (session_id, profile_id) in due {
+            for (storage_key, profile_id) in due {
                 if advanced >= DRAIN_SPAWN_CAP {
                     break;
                 }
+                // Only fire a scoped goal for the currently-active folder of
+                // its wire id (see `goal_target_is_dispatchable`); dispatch on
+                // the plain WIRE id, account on the scoped `storage_key`.
+                if !orchestrator.goal_target_is_dispatchable(&storage_key) {
+                    continue;
+                }
+                let wire_key = wire_key_from_goal_key(&storage_key);
                 if maybe_spawn_appui_master_continuation_runner(
                     &ws,
                     &state,
@@ -13455,7 +13509,8 @@ pub(crate) fn spawn_global_master_continuation_drain(state: Arc<AppState>) {
                     &contracts,
                     &active_turns,
                     &connection_turns,
-                    session_id,
+                    wire_key,
+                    storage_key,
                     profile_id,
                     features,
                 )
@@ -21000,6 +21055,16 @@ async fn seed_m9_task_output_fixture(
 #[derive(Debug, Clone)]
 struct GoalContinuationContext {
     profile_id: String,
+    /// #1666 residue — the cwd-scoped goal STORE identity this continuation was
+    /// enqueued under (`<wire>\u{0}~cwd-<scope>`, or the plain wire id for an
+    /// unscoped/gateway session). The turn itself runs keyed by the plain wire
+    /// id (`params.session_id`) so the ledger/runtime/workspace all resolve
+    /// correctly, but the post-turn accountant (`record_goal_turn`,
+    /// `record_goal_dispatch_timestamp_only`, `maybe_complete_goal_from_model`)
+    /// must address the goal record under THIS scoped key — otherwise a folder
+    /// A goal turn would charge nothing (the wire key finds no scoped goal) and
+    /// recur forever without ever hitting its budget.
+    goal_session_key: SessionKey,
 }
 
 /// #1134 — pick the LAST non-empty assistant row after `pre` from a
@@ -24773,8 +24838,16 @@ async fn run_standalone_turn(
         // `record_goal_turn` below also stamps `last_continued_at_ms
         // = now`, but the await on `sessions_for_reschedule.lock()`
         // is the exact yield point we need to guard.
+        // #1666 residue — the goal record lives under the cwd-scoped store key
+        // (`goal_ctx.goal_session_key`), NOT the plain wire `session_id` the
+        // turn runs under. Charge/complete the goal via the scoped key so a
+        // folder-A goal turn actually accrues its spend (a wire-keyed lookup
+        // would find nothing and the goal would recur past its budget forever).
+        // The session-history read below stays on the wire `session_id` (that
+        // is how the runtime/transcript is keyed).
+        let goal_key = &goal_ctx.goal_session_key;
         default_agent_orchestrator()
-            .record_goal_dispatch_timestamp_only(&session_id, &goal_ctx.profile_id);
+            .record_goal_dispatch_timestamp_only(goal_key, &goal_ctx.profile_id);
         let pre = pre_assistant_count_for_post_turn.unwrap_or(0);
         let assistant_reply: Option<String> = {
             let mut guard = sessions_for_reschedule.lock().await;
@@ -24794,7 +24867,7 @@ async fn run_standalone_turn(
             .unwrap_or(0);
         let orchestrator = default_agent_orchestrator();
         orchestrator.record_goal_turn(
-            &session_id,
+            goal_key,
             &goal_ctx.profile_id,
             final_tokens_consumed,
             elapsed_seconds,
@@ -24805,11 +24878,8 @@ async fn run_standalone_turn(
             // tail of the reply. The return value is intentionally
             // unused — the goal is either complete now or stays active
             // and the next scheduler tick decides whether to re-queue.
-            let _ = orchestrator.maybe_complete_goal_from_model(
-                &session_id,
-                &goal_ctx.profile_id,
-                &reply,
-            );
+            let _ =
+                orchestrator.maybe_complete_goal_from_model(goal_key, &goal_ctx.profile_id, &reply);
         }
         // #1696/#1698 — push the post-turn goal snapshot to the OWNING
         // connection so autonomous transitions repaint the chip live:
@@ -24819,7 +24889,7 @@ async fn run_standalone_turn(
         // above — a durable append would fan the goal to every subscriber
         // of an unprofiled shared session id regardless of profile.
         if let Some(goal_event_json) =
-            orchestrator.session_goal_updated_event_json(&session_id, &goal_ctx.profile_id)
+            orchestrator.session_goal_updated_event_json(goal_key, &goal_ctx.profile_id)
         {
             match serde_json::from_value::<octos_core::ui_protocol::SessionGoalUpdatedEvent>(
                 goal_event_json,


### PR DESCRIPTION
## Root cause

The TUI opens the **same** wire session key `<profile>:local:tui#coding` for **every folder (cwd)** under a profile — the `coding` topic is hardcoded and the cwd never enters the wire key. #1666 cwd-scoped the **ledger/transcript** store (`storage_session_id` → `<key>\u{0}~cwd-<sha16>`, registered on `session/open`) so a fresh folder shows an empty transcript — but the **goal/autonomy** store was still keyed by the **bare wire key** (`state.goals: HashMap<SessionKey, _>`; persisted `autonomy-goal:<session_key>`). So a goal set in folder A leaked into a fresh session in folder B (same profile) — same key → same goal → same "orchestrating" chip. A **different profile** did not leak (different key). This is the exact residue of the #1666 fix (which cwd-scoped the ledger but not the goal store).

Live repro (mini2): a session in cwd `work` and a fresh session in cwd `work2` (same profile `octos`) both got byte-identical key `octos:local:tui#coding`; `work2` showed 0 messages (ledger scoped) but the leaked goal chip (goal store un-scoped).

## Approach — (A) store-scoping, mirroring #1666

The orchestrator gets its own per-project scope map (`goal_scopes`) + `set_goal_scope` + `scoped_goal_key` — a byte-for-byte mirror of the ledger's `scopes` map / `storage_session_id` (same NUL-separated, injective `\u{0}~cwd-<scope>` encoding). It is registered on `session/open` right beside `ledger.set_session_scope`, in lock-step, so the goal store and the ledger agree on each session's cwd scope. The scope is `Some` **only** when the session is cwd-relocated (`sessions_root != profile.data_dir`, i.e. `appui.sessions_in_cwd` ON) — with the flag off (default) the goal store keys by the plain wire id, **byte-identical to before** and to the gateway/session-actor path (which never registers a scope).

**Every goal-keying site that receives a WIRE key resolves it to the scoped store identity:** `set_goal` / `get_goal` / `clear_goal` (RPC), and the model tools `model_goal_snapshot` / `model_transition_goal` / `model_create_goal`. The store, the master-continuation queue, the in-flight set, and persistence (`persist_goal_state` → `autonomy_goal_group_id`) all key on the scoped identity; the wire-facing responses/events echo the plain wire id (`session_goal_updated_event_json` and `sessions_with_active_orchestration` strip back to it so the chip still lights).

## How continuations stay intact (the hard constraint)

Goal continuations are autonomous: the orchestrator sweeps `state.goals` (`due_loop_targets`) and enqueues continuations that the AppUI tick drains into `run_standalone_turn` (the serve/TUI path; the gateway path uses `SessionActorManager`, keyed by distinct channel keys, never cwd-scoped). If the goal were stored under a scoped key but dispatch still used the bare wire key, continuations would never fire.

- The sweep surfaces the **scoped** store key as the target (goals/queue/in-flight are all scoped-consistent, so `pending_continuation_is_schedulable` and the drain match).
- At the AppUI dispatch boundary (`maybe_spawn_appui_master_continuation_runner`, both drain sites) the target is **stripped back to the plain wire key** (`wire_key_from_goal_key`) for everything keyed by the wire id — the session runtime, ledger, `active_turns`, `session_workspaces()` — while the goal **record / queue / in-flight / post-turn accountant** stay on the scoped key. The scoped key rides through `GoalContinuationContext.goal_session_key`, so the post-turn `record_goal_dispatch_timestamp_only` / `record_goal_turn` / `maybe_complete_goal_from_model` charge the **scoped** goal instead of a wire-keyed miss (a miss would let the goal recur past its budget forever).
- A scoped goal is dispatchable **only for the currently-active folder** of its wire id (`goal_target_is_dispatchable`, last-write-wins like the ledger/`session_workspaces()`), closing the continuation-side twin of the leak: a backgrounded folder's goal can't fire a continuation into the active folder's workspace.

**Goal-keying sites scoped:** `set_goal`, `get_goal`, `clear_goal`, `model_goal_snapshot`, `model_transition_goal`, `model_create_goal`, the continuation sweep + `enqueue_goal_continuation`/`enqueue_goal_wrap_up`, `record_goal_turn` / `record_goal_dispatch_timestamp_only` / `maybe_complete_goal_from_model` (via `goal_session_key`), `persist_goal_state` / `autonomy_goal_group_id`, and the dispatch gate + wire-key strip in both AppUI drain sites. `session_goal_updated_event_json` and `sessions_with_active_orchestration` look up by the scoped key but emit the wire id.

## Tests (agent_orchestrator)

1. `should_isolate_goal_store_between_cwd_scopes_sharing_a_wire_key` — mirrors `ui_protocol_ledger::should_isolate_ledger_storage_between_cwd_scopes_sharing_a_wire_key`: two goals under the same wire key + different cwd scopes store/retrieve independently; folder B never reads folder A's goal; the two occupy distinct NUL-separated keys; the **bare wire key holds nothing** (leak vector closed); the response echoes the plain wire id.
2. `scoped_goal_continuation_is_swept_and_strips_to_wire_key_for_dispatch` — the scoped goal is (1) surfaced by the sweep under its scoped key, (2) dispatchable only while its folder is active, (3) stripped back to the wire key the actor is keyed by, (4) drained + charged under the scoped key exactly once. Proves the scoping did NOT break the fire path.

`cargo test -p octos-cli --features api --lib goal` → **61 passed** (was 59). Full `octos-cli` lib suite green (2367). `cargo fmt`/`clippy` clean.

## Risk / edges

- **Gated:** scope is `Some` only for cwd-relocated sessions (`sessions_in_cwd` ON). Flag-off installs are byte-identical; the gateway/session-actor path is unchanged (scope always `None`).
- **Simultaneous same-wire-key folders:** the scope map is last-write-wins per wire id (inherent to #1666 — the wire key is client-minted and stable). Two folders open at once resolve to the most-recently-opened cwd for reads and continuation firing; each folder's goal still **persists** isolated under its own scoped key. Matches the ledger's existing behavior.
- **Migration:** a goal persisted under a bare wire key *before* this change, in a cwd-relocated session, becomes invisible to the now-scoped `goal_get` (its continuation could still fire once under the wire key). Narrow — only affects users who ran `sessions_in_cwd` ON with an active goal across the upgrade; goals are ephemeral.
- **Loops** (`loop/create`) remain wire-keyed — out of scope for this goal-store fix; a possible follow-up if loops show the same cross-folder leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)