### PR TITLE
feat(serve): multi-instance stdio — per-instance runtime dir, shared profile registry

### DIFF
--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -4162,7 +4162,7 @@ mod tests {
 
     fn temp_profile_store() -> (tempfile::TempDir, ProfileStore) {
         let dir = tempfile::tempdir().unwrap();
-        let ps = ProfileStore::open(dir.path()).unwrap();
+        let ps = ProfileStore::open_unified(dir.path()).unwrap();
         (dir, ps)
     }
 
@@ -4188,7 +4188,7 @@ mod tests {
     ) {
         let dir = tempfile::tempdir().unwrap();
         let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
-        let profile_store = Arc::new(ProfileStore::open(dir.path()).unwrap());
+        let profile_store = Arc::new(ProfileStore::open_unified(dir.path()).unwrap());
         let allowlist_store = Arc::new(LoginAllowlistStore::open(dir.path()).unwrap());
         // Tests that exercise per-email send_code/verify branches expect the
         // SMTP precheck to pass; populate a synthetic config so the common

--- a/crates/octos-cli/src/api/cron_panel.rs
+++ b/crates/octos-cli/src/api/cron_panel.rs
@@ -377,7 +377,7 @@ mod tests {
 
     fn temp_state() -> (tempfile::TempDir, Arc<AppState>, Arc<ProfileStore>) {
         let dir = tempfile::tempdir().unwrap();
-        let profile_store = Arc::new(ProfileStore::open(dir.path()).unwrap());
+        let profile_store = Arc::new(ProfileStore::open_unified(dir.path()).unwrap());
         let state = Arc::new(AppState {
             profile_store: Some(profile_store.clone()),
             ..AppState::empty_for_tests()

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -4698,7 +4698,7 @@ mod tests {
         use crate::profiles::{ProfileStore, UserProfile};
 
         let home = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(home.path()).unwrap();
+        let store = ProfileStore::open_unified(home.path()).unwrap();
         let tenant_data_dir = home.path().join("tenant-data");
         store
             .save(&UserProfile {
@@ -4802,7 +4802,7 @@ mod tests {
         use crate::profiles::{ProfileStore, UserProfile};
 
         let home = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(home.path()).unwrap();
+        let store = ProfileStore::open_unified(home.path()).unwrap();
 
         // A profile whose sessions live at an explicit data dir — the
         // directory the running solo/stdio session persists turns to.
@@ -6159,7 +6159,7 @@ mod tests {
     /// tests with a profile_store containing the listed profiles.
     fn state_with_profiles(profiles: &[(&str, Option<&str>)]) -> (tempfile::TempDir, AppState) {
         let dir = tempfile::tempdir().unwrap();
-        let ps = ProfileStore::open(dir.path()).unwrap();
+        let ps = ProfileStore::open_unified(dir.path()).unwrap();
         for (id, parent) in profiles {
             ps.save(&make_profile(id, *parent)).unwrap();
         }

--- a/crates/octos-cli/src/api/memory_panel.rs
+++ b/crates/octos-cli/src/api/memory_panel.rs
@@ -736,7 +736,7 @@ mod tests {
 
     fn temp_state() -> (tempfile::TempDir, Arc<AppState>, Arc<ProfileStore>) {
         let dir = tempfile::tempdir().unwrap();
-        let profile_store = Arc::new(ProfileStore::open(dir.path()).unwrap());
+        let profile_store = Arc::new(ProfileStore::open_unified(dir.path()).unwrap());
         let state = Arc::new(AppState {
             profile_store: Some(profile_store.clone()),
             ..AppState::empty_for_tests()

--- a/crates/octos-cli/src/api/purge.rs
+++ b/crates/octos-cli/src/api/purge.rs
@@ -232,7 +232,7 @@ mod tests {
     fn build_test_state() -> (TempDir, Arc<AppState>) {
         let temp = TempDir::new().expect("tempdir");
         let data_dir = temp.path();
-        let profile_store = Arc::new(ProfileStore::open(data_dir).expect("profile store"));
+        let profile_store = Arc::new(ProfileStore::open_unified(data_dir).expect("profile store"));
         let user_store = Arc::new(UserStore::open(data_dir).expect("user store"));
         let tenant_store = Arc::new(TenantStore::open(data_dir).expect("tenant store"));
 

--- a/crates/octos-cli/src/api/solo_auth.rs
+++ b/crates/octos-cli/src/api/solo_auth.rs
@@ -191,7 +191,7 @@ mod tests {
         let user_store = Arc::new(UserStore::open(dir).unwrap());
         let auth_manager = Arc::new(AuthManager::new(None, user_store.clone()));
         Arc::new(AppState {
-            profile_store: Some(Arc::new(ProfileStore::open(dir).unwrap())),
+            profile_store: Some(Arc::new(ProfileStore::open_unified(dir).unwrap())),
             user_store: Some(user_store),
             auth_manager: Some(auth_manager),
             deployment_mode: mode,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -28315,7 +28315,9 @@ mod tests {
 
     fn local_profile_state(dir: &Path) -> AppState {
         AppState {
-            profile_store: Some(Arc::new(crate::profiles::ProfileStore::open(dir).unwrap())),
+            profile_store: Some(Arc::new(
+                crate::profiles::ProfileStore::open_unified(dir).unwrap(),
+            )),
             user_store: Some(Arc::new(crate::user_store::UserStore::open(dir).unwrap())),
             deployment_mode: crate::config::DeploymentMode::Local,
             // Solo profile creation is opt-in; the TUI/WS tests exercise the
@@ -32734,7 +32736,7 @@ ignore = []
             .expect("bootstrap profile");
             state.profiles.insert(id.to_string(), runtime);
         }
-        let store = Arc::new(crate::profiles::ProfileStore::open(&home).unwrap());
+        let store = Arc::new(crate::profiles::ProfileStore::open_unified(&home).unwrap());
         // Point the global default at "zeta" — NOT the first-sorted profile.
         store.set_default_profile("zeta").unwrap();
         state.profile_store = Some(store.clone());
@@ -32785,7 +32787,7 @@ ignore = []
         let home = tmp.path().join("home");
         let mut state = AppState::empty_for_tests();
         state.profile_store = Some(Arc::new(
-            crate::profiles::ProfileStore::open(&home).unwrap(),
+            crate::profiles::ProfileStore::open_unified(&home).unwrap(),
         ));
         let state = Arc::new(state);
         let cap = ConnectionUiFeatures::stdio_defaults();
@@ -33614,7 +33616,8 @@ ignore = []
     #[tokio::test]
     async fn memory_and_cron_rpc_methods_forward_rest_panel_bodies() {
         let dir = tempfile::tempdir().unwrap();
-        let profile_store = Arc::new(crate::profiles::ProfileStore::open(dir.path()).unwrap());
+        let profile_store =
+            Arc::new(crate::profiles::ProfileStore::open_unified(dir.path()).unwrap());
         let profile = panel_user_profile("tenant");
         profile_store.save(&profile).unwrap();
         let data_dir = profile_store.resolve_data_dir(&profile);
@@ -33797,7 +33800,8 @@ ignore = []
     #[tokio::test]
     async fn memory_rpc_methods_declare_truncation_when_over_budget() {
         let dir = tempfile::tempdir().unwrap();
-        let profile_store = Arc::new(crate::profiles::ProfileStore::open(dir.path()).unwrap());
+        let profile_store =
+            Arc::new(crate::profiles::ProfileStore::open_unified(dir.path()).unwrap());
         let profile = panel_user_profile("tenant");
         profile_store.save(&profile).unwrap();
         let data_dir = profile_store.resolve_data_dir(&profile);

--- a/crates/octos-cli/src/api/usage.rs
+++ b/crates/octos-cli/src/api/usage.rs
@@ -203,7 +203,7 @@ mod tests {
     #[tokio::test]
     async fn aggregate_profiles_usage_reads_every_profile_ledger() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
         store.save(&profile("alpha")).unwrap();
         store.save(&profile("beta")).unwrap();
 

--- a/crates/octos-cli/src/api/user_admin.rs
+++ b/crates/octos-cli/src/api/user_admin.rs
@@ -522,7 +522,7 @@ mod tests {
     async fn delete_user_cascades_sub_account_profiles_and_data_dirs() {
         let dir = tempfile::tempdir().unwrap();
         let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
-        let profile_store = Arc::new(ProfileStore::open(dir.path()).unwrap());
+        let profile_store = Arc::new(ProfileStore::open_unified(dir.path()).unwrap());
         let parent = test_profile("alice", None);
         let sub_account = test_profile("alice--bot", Some("alice"));
         let parent_data_dir = profile_store.resolve_data_dir(&parent);
@@ -570,7 +570,7 @@ mod tests {
     async fn delete_user_missing_user_does_not_delete_matching_profile() {
         let dir = tempfile::tempdir().unwrap();
         let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
-        let profile_store = Arc::new(ProfileStore::open(dir.path()).unwrap());
+        let profile_store = Arc::new(ProfileStore::open_unified(dir.path()).unwrap());
         let profile = test_profile("alice", None);
         let data_dir = profile_store.resolve_data_dir(&profile);
         profile_store.save(&profile).unwrap();

--- a/crates/octos-cli/src/commands/account.rs
+++ b/crates/octos-cli/src/commands/account.rs
@@ -106,7 +106,7 @@ pub enum AccountAction {
 impl Executable for AccountCommand {
     fn execute(self) -> Result<()> {
         let data_dir = super::resolve_data_dir(None)?;
-        let store = ProfileStore::open(&data_dir)?;
+        let store = ProfileStore::open_unified(&data_dir)?;
 
         match self.action {
             AccountAction::List { profile } => {

--- a/crates/octos-cli/src/commands/auth.rs
+++ b/crates/octos-cli/src/commands/auth.rs
@@ -231,7 +231,7 @@ fn status() -> Result<()> {
 
 fn open_profile_store() -> Result<ProfileStore> {
     let home = dirs::home_dir().ok_or_else(|| eyre::eyre!("cannot determine home directory"))?;
-    ProfileStore::open(&home.join(".octos"))
+    ProfileStore::open_unified(&home.join(".octos"))
 }
 
 /// Whether storing `secret` under `name` must be scoped per profile: a declared

--- a/crates/octos-cli/src/commands/gateway/account_handler.rs
+++ b/crates/octos-cli/src/commands/gateway/account_handler.rs
@@ -404,7 +404,7 @@ mod tests {
 
     fn create_store_with_sub_account() -> (tempfile::TempDir, Arc<ProfileStore>, String) {
         let dir = tempfile::tempdir().expect("tempdir");
-        let store = Arc::new(ProfileStore::open(dir.path()).expect("profile store"));
+        let store = Arc::new(ProfileStore::open_unified(dir.path()).expect("profile store"));
 
         let now = Utc::now();
         let parent = UserProfile {

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -334,7 +334,7 @@ impl GatewayRuntime {
         // resolves --data-dir > $OCTOS_HOME > ~/.octos).
         let effective_octos_home = cmd.octos_home.clone().unwrap_or_else(|| data_dir.clone());
         let profile_store: Option<Arc<crate::profiles::ProfileStore>> =
-            crate::profiles::ProfileStore::open(&effective_octos_home)
+            crate::profiles::ProfileStore::open_unified(&effective_octos_home)
                 .ok()
                 .map(Arc::new);
 

--- a/crates/octos-cli/src/commands/gateway/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/mod.rs
@@ -229,7 +229,7 @@ mod tests {
             std::env::set_var("OPENAI_API_KEY", "test-key");
         }
 
-        let store = Arc::new(crate::profiles::ProfileStore::open(dir.path()).unwrap());
+        let store = Arc::new(crate::profiles::ProfileStore::open_unified(dir.path()).unwrap());
 
         let mut parent = make_profile("botfather", Some("admin parent"));
         parent.config.llm = Some(crate::profiles::LlmProfileConfig {
@@ -572,7 +572,7 @@ mod tests {
     #[test]
     fn test_dispatch_unknown_profile_falls_back() {
         let dir = tempfile::TempDir::new().unwrap();
-        let store = crate::profiles::ProfileStore::open(dir.path()).unwrap();
+        let store = crate::profiles::ProfileStore::open_unified(dir.path()).unwrap();
         store
             .save(&make_profile("weather", Some("weather prompt")))
             .unwrap();
@@ -587,7 +587,7 @@ mod tests {
     #[test]
     fn test_dispatch_known_profile_keeps_target() {
         let dir = tempfile::TempDir::new().unwrap();
-        let store = crate::profiles::ProfileStore::open(dir.path()).unwrap();
+        let store = crate::profiles::ProfileStore::open_unified(dir.path()).unwrap();
         store
             .save(&make_profile("weather", Some("weather prompt")))
             .unwrap();
@@ -625,7 +625,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_bot_keeps_route_when_profile_delete_fails() {
         let dir = tempfile::TempDir::new().unwrap();
-        let store = Arc::new(crate::profiles::ProfileStore::open(dir.path()).unwrap());
+        let store = Arc::new(crate::profiles::ProfileStore::open_unified(dir.path()).unwrap());
         let mut parent = make_profile("botfather", None);
         parent
             .config
@@ -721,7 +721,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_bot_rejects_non_owner() {
         let dir = tempfile::TempDir::new().unwrap();
-        let store = Arc::new(crate::profiles::ProfileStore::open(dir.path()).unwrap());
+        let store = Arc::new(crate::profiles::ProfileStore::open_unified(dir.path()).unwrap());
         let mut parent = make_profile("botfather", None);
         parent
             .config
@@ -804,7 +804,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_bot_allows_operator_override() {
         let dir = tempfile::TempDir::new().unwrap();
-        let store = Arc::new(crate::profiles::ProfileStore::open(dir.path()).unwrap());
+        let store = Arc::new(crate::profiles::ProfileStore::open_unified(dir.path()).unwrap());
         let mut parent = make_profile("botfather", None);
         parent
             .config

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -1426,7 +1426,7 @@ mod tests {
             "test precondition: standalone roots must differ"
         );
 
-        let store = Arc::new(crate::profiles::ProfileStore::open(tmp.path()).unwrap());
+        let store = Arc::new(crate::profiles::ProfileStore::open_unified(tmp.path()).unwrap());
         let tool_config = Arc::new(
             octos_agent::ToolConfigStore::open(&effective_octos_home)
                 .await

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -234,6 +234,19 @@ pub struct ServeCommand {
     #[arg(long)]
     pub data_dir: Option<PathBuf>,
 
+    /// Per-instance runtime data dir (redb stores, sessions, goals, serve lock,
+    /// per-profile data). When set, the profile REGISTRY + model catalog still
+    /// resolve from the shared state home (the normal
+    /// `--data-dir`/`OCTOS_HOME`/`~/.octos`), so many stdio instances share one
+    /// config/profile while each owns private runtime state. Unset ⇒ identical
+    /// to today (runtime == state home).
+    ///
+    /// Also settable via `OCTOS_INSTANCE_DATA_DIR` (the flag wins; an empty env
+    /// value is treated as unset). Env is resolved in `run_async` because the
+    /// workspace `clap` build does not enable the `env` feature.
+    #[arg(long)]
+    pub instance_data_dir: Option<PathBuf>,
+
     /// Path to config file.
     #[arg(long)]
     pub config: Option<PathBuf>,
@@ -403,6 +416,39 @@ impl ServeCommand {
         let ctx = super::resolve_command_context(self.data_dir.clone())?;
         let data_dir = ctx.data_dir.clone();
 
+        // Multi-instance stdio split. `state_home` is the SHARED, config-like
+        // root that holds the profile REGISTRY and the model catalog — always
+        // the normal resolution (`--data-dir`/`OCTOS_HOME`/`~/.octos`), never
+        // the per-instance dir. The `data_dir` used from here on is the
+        // per-instance RUNTIME root (redb stores, sessions, goals, serve lock,
+        // per-profile data): the private per-instance dir when set, else the
+        // state home (byte-identical to today for default installs and for
+        // gateways, which never set a per-instance dir).
+        //
+        // The per-instance dir comes from `--instance-data-dir` (flag wins) or
+        // `OCTOS_INSTANCE_DATA_DIR` (empty ⇒ unset). Env is read here because
+        // the workspace `clap` build omits the `env` feature.
+        let state_home = data_dir.clone();
+        let instance_data_dir = self.instance_data_dir.clone().or_else(|| {
+            std::env::var("OCTOS_INSTANCE_DATA_DIR")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+                .map(PathBuf::from)
+        });
+        let data_dir = instance_data_dir
+            .clone()
+            .unwrap_or_else(|| state_home.clone());
+        if instance_data_dir.is_some() {
+            // A fresh per-instance dir must exist before the serve lock and
+            // redb stores open under it.
+            std::fs::create_dir_all(&data_dir).wrap_err_with(|| {
+                format!(
+                    "failed to create per-instance data dir: {}",
+                    data_dir.display()
+                )
+            })?;
+        }
+
         let (config, resolved_config_path) = if let Some(config_path) = &self.config {
             tracing::info!(path = %config_path.display(), "loading config (--config)");
             (Config::from_file(config_path)?, Some(config_path.clone()))
@@ -535,10 +581,14 @@ impl ServeCommand {
             None
         };
 
-        // Initialize profile store and process manager for admin dashboard
+        // Initialize profile store and process manager for admin dashboard.
+        // Registry (`<id>.json`) resolves from the SHARED `state_home`; the
+        // per-profile `<id>/data` runtime tree roots under the per-instance
+        // `data_dir`. With no `--instance-data-dir`, `state_home == data_dir`,
+        // so this is byte-identical to `open_unified(&data_dir)`.
         tracing::info!("initializing profile store and process manager");
         let profile_store = Arc::new(
-            crate::profiles::ProfileStore::open(&data_dir)
+            crate::profiles::ProfileStore::open(&state_home, &data_dir)
                 .wrap_err("failed to open profile store")?,
         );
 
@@ -1497,7 +1547,7 @@ mod tests {
     #[test]
     fn derives_dashboard_auth_from_admin_profile_email_tool() {
         let dir = tempfile::tempdir().unwrap();
-        let store = crate::profiles::ProfileStore::open(dir.path()).unwrap();
+        let store = crate::profiles::ProfileStore::open_unified(dir.path()).unwrap();
         store
             .save(&crate::profiles::UserProfile {
                 id: crate::api::auth_handlers::ADMIN_PROFILE_ID.into(),
@@ -1550,7 +1600,7 @@ mod tests {
         let _guard = dashboard_smtp_test_env_lock().lock().unwrap();
         let _env = EnvVarGuard::remove("OCTOS_TEST_DASHBOARD_AUTH_ADMIN_SMTP_PASSWORD");
         let dir = tempfile::tempdir().unwrap();
-        let store = crate::profiles::ProfileStore::open(dir.path()).unwrap();
+        let store = crate::profiles::ProfileStore::open_unified(dir.path()).unwrap();
         store
             .save(&crate::profiles::UserProfile {
                 id: crate::api::auth_handlers::ADMIN_PROFILE_ID.into(),
@@ -1601,7 +1651,7 @@ mod tests {
     #[test]
     fn derives_dashboard_auth_from_first_usable_non_admin_profile() {
         let dir = tempfile::tempdir().unwrap();
-        let store = crate::profiles::ProfileStore::open(dir.path()).unwrap();
+        let store = crate::profiles::ProfileStore::open_unified(dir.path()).unwrap();
         store
             .save(&crate::profiles::UserProfile {
                 id: crate::api::auth_handlers::ADMIN_PROFILE_ID.into(),
@@ -1674,7 +1724,7 @@ mod tests {
         let _guard = dashboard_smtp_test_env_lock().lock().unwrap();
         let _env = EnvVarGuard::remove("OCTOS_TEST_DASHBOARD_AUTH_PROFILE_SMTP_PASSWORD");
         let dir = tempfile::tempdir().unwrap();
-        let store = crate::profiles::ProfileStore::open(dir.path()).unwrap();
+        let store = crate::profiles::ProfileStore::open_unified(dir.path()).unwrap();
         store
             .save(&crate::profiles::UserProfile {
                 id: "dspfac".into(),

--- a/crates/octos-cli/src/commands/skills.rs
+++ b/crates/octos-cli/src/commands/skills.rs
@@ -226,7 +226,7 @@ impl Executable for SkillsCommand {
         // Resolve skills directory: per-profile or global
         let skills_dir = if let Some(ref profile_id) = self.profile {
             let data_dir = super::resolve_data_dir(None)?;
-            let store = crate::profiles::ProfileStore::open(&data_dir)?;
+            let store = crate::profiles::ProfileStore::open_unified(&data_dir)?;
             resolve_profile_skills_dir(&store, profile_id)?
         } else {
             cwd.join(".octos").join("skills")

--- a/crates/octos-cli/src/monitor.rs
+++ b/crates/octos-cli/src/monitor.rs
@@ -503,7 +503,7 @@ mod tests {
     #[test]
     fn profile_monitor_overrides_fall_back_to_system_defaults() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
         store
             .save(&profile("alpha", Some(false), Some(true)))
             .unwrap();

--- a/crates/octos-cli/src/process_manager.rs
+++ b/crates/octos-cli/src/process_manager.rs
@@ -1455,7 +1455,7 @@ mod tests {
     /// Create a temporary ProfileStore backed by a real temp directory.
     fn temp_profile_store() -> (tempfile::TempDir, Arc<ProfileStore>) {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
-        let store = ProfileStore::open(dir.path()).expect("failed to open profile store");
+        let store = ProfileStore::open_unified(dir.path()).expect("failed to open profile store");
         (dir, Arc::new(store))
     }
 

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1156,24 +1156,70 @@ pub struct GatewaySettings {
 }
 
 /// Manages profile storage as individual JSON files.
+///
+/// The store has two roots so multi-instance stdio can share one profile
+/// REGISTRY while each instance owns private per-profile runtime state:
+///
+/// * `registry_dir` (`<registry_root>/profiles`) — where the `<id>.json`
+///   registry files are read/written/listed, plus config-like siblings under
+///   the registry parent (the `default-profile` pointer, platform-model
+///   allowlist). Shared across instances.
+/// * `data_profiles_dir` (`<data_root>/profiles`) — where [`resolve_data_dir`]
+///   roots the per-profile `<id>/data` runtime tree when a profile carries no
+///   explicit `data_dir` override. Per-instance.
+///
+/// [`resolve_data_dir`]: ProfileStore::resolve_data_dir
 pub struct ProfileStore {
-    profiles_dir: PathBuf,
+    /// Root for the `<id>.json` registry (shared/config-like).
+    registry_dir: PathBuf,
+    /// Root for the per-profile `<id>/data` runtime tree (per-instance).
+    data_profiles_dir: PathBuf,
 }
 
 impl ProfileStore {
-    /// Open (or create) the profile store at `data_dir/profiles/`.
-    pub fn open(data_dir: &Path) -> Result<Self> {
-        let profiles_dir = data_dir.join("profiles");
-        std::fs::create_dir_all(&profiles_dir).wrap_err_with(|| {
-            format!("failed to create profiles dir: {}", profiles_dir.display())
+    /// Open (or create) the profile store with a split registry / data root.
+    ///
+    /// * `registry_root` — the `<id>.json` registry lives under
+    ///   `registry_root/profiles`.
+    /// * `data_root` — the per-profile `<id>/data` fallback tree roots under
+    ///   `data_root/profiles`.
+    ///
+    /// When `registry_root == data_root` this is byte-identical to the legacy
+    /// single-root behavior; see [`ProfileStore::open_unified`].
+    pub fn open(registry_root: &Path, data_root: &Path) -> Result<Self> {
+        let registry_dir = registry_root.join("profiles");
+        std::fs::create_dir_all(&registry_dir).wrap_err_with(|| {
+            format!(
+                "failed to create profiles registry dir: {}",
+                registry_dir.display()
+            )
         })?;
-        Ok(Self { profiles_dir })
+        let data_profiles_dir = data_root.join("profiles");
+        std::fs::create_dir_all(&data_profiles_dir).wrap_err_with(|| {
+            format!(
+                "failed to create profiles data dir: {}",
+                data_profiles_dir.display()
+            )
+        })?;
+        Ok(Self {
+            registry_dir,
+            data_profiles_dir,
+        })
+    }
+
+    /// Open (or create) the profile store with a single unified root — the
+    /// registry and per-profile data both live under `data_dir/profiles/`.
+    ///
+    /// This preserves the pre-split behavior exactly (registry == data) and is
+    /// the right entry point for every caller that is not multi-instance-aware.
+    pub fn open_unified(data_dir: &Path) -> Result<Self> {
+        Self::open(data_dir, data_dir)
     }
 
     /// List all profiles sorted by name.
     pub fn list(&self) -> Result<Vec<UserProfile>> {
         let mut profiles = Vec::new();
-        let entries = match std::fs::read_dir(&self.profiles_dir) {
+        let entries = match std::fs::read_dir(&self.registry_dir) {
             Ok(entries) => entries,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(profiles),
             Err(e) => return Err(e).wrap_err("failed to read profiles directory"),
@@ -1359,12 +1405,12 @@ impl ProfileStore {
         if let Some(ref dir) = profile.data_dir {
             PathBuf::from(dir)
         } else {
-            self.profiles_dir.join(&profile.id).join("data")
+            self.data_profiles_dir.join(&profile.id).join("data")
         }
     }
 
     pub(crate) fn profile_path(&self, id: &str) -> PathBuf {
-        self.profiles_dir.join(format!("{id}.json"))
+        self.registry_dir.join(format!("{id}.json"))
     }
 
     /// Registration-id reservation policy (codex #1613 r6/r8), wired
@@ -1393,9 +1439,15 @@ impl ProfileStore {
         !matches!(self.get(id), Ok(Some(_)))
     }
 
-    /// Return the parent directory of the profiles dir (i.e. the octos home dir).
+    /// Return the parent directory of the registry profiles dir (i.e. the octos
+    /// home dir). This is the REGISTRY root — the config-like siblings that live
+    /// beside the profiles tree (the `default-profile` pointer, the platform-
+    /// model allowlist, and the `--octos-home` a spawned gateway opens its own
+    /// `ProfileStore` from) all resolve from here, so they stay shared across
+    /// per-instance runtime dirs. With a unified store this is the data dir,
+    /// exactly as before.
     pub fn octos_home_dir(&self) -> &Path {
-        self.profiles_dir.parent().unwrap_or(&self.profiles_dir)
+        self.registry_dir.parent().unwrap_or(&self.registry_dir)
     }
 
     /// Path to the persisted global default-profile pointer
@@ -2552,7 +2604,7 @@ mod tests {
         // the verify path's auto-create (get error → None → save)
         // would overwrite it with a default profile (r8 P2).
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         // Absent: free for anyone.
         assert!(!store.id_reserved_for_registration("ghost", false));
@@ -2584,7 +2636,7 @@ mod tests {
     #[test]
     fn default_profile_pointer_round_trips_and_defaults_to_none() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         // Unset: no pointer file yet.
         assert_eq!(store.default_profile(), None);
@@ -2615,7 +2667,7 @@ mod tests {
         // precedent as unparsable profile JSON) so one legacy record
         // cannot brick a multi-profile deployment.
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         // Plant the legacy record directly on disk, bypassing save().
         let legacy = serde_json::json!({
@@ -2668,7 +2720,7 @@ mod tests {
     #[test]
     fn test_profile_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let profile = UserProfile {
             // Not "test" — a reserved channel name (codex #1613 r4).
@@ -2718,7 +2770,7 @@ mod tests {
     #[test]
     fn test_save_preserves_local_owner_metadata_fields() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
         let mut profile = UserProfile {
             id: "ada".into(),
             name: "Ada Lovelace".into(),
@@ -2826,7 +2878,7 @@ mod tests {
     #[test]
     fn test_save_persists_structured_llm_contract() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let profile = UserProfile {
             id: "legacy-llm".into(),
@@ -3210,7 +3262,7 @@ mod tests {
     #[test]
     fn test_resolve_data_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let mut profile = UserProfile {
             id: "alice".into(),
@@ -3232,6 +3284,78 @@ mod tests {
         profile.data_dir = Some("/custom/path".into());
         let custom_dir = store.resolve_data_dir(&profile);
         assert_eq!(custom_dir, PathBuf::from("/custom/path"));
+    }
+
+    #[test]
+    fn should_read_registry_from_config_root_and_data_from_data_root() {
+        // Multi-instance stdio: a split store reads/writes the `<id>.json`
+        // REGISTRY under the SHARED registry_root while the per-profile
+        // `<id>/data` runtime tree roots under the PER-INSTANCE data_root.
+        let registry_root = tempfile::tempdir().unwrap();
+        let data_root = tempfile::tempdir().unwrap();
+        let store = ProfileStore::open(registry_root.path(), data_root.path()).unwrap();
+
+        let profile = UserProfile {
+            id: "alice".into(),
+            name: "Alice".into(),
+            enabled: false,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig::default(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        store.save(&profile).unwrap();
+
+        // Registry json lands under registry_root/profiles — NOT data_root.
+        let registry_json = registry_root.path().join("profiles").join("alice.json");
+        assert!(
+            registry_json.exists(),
+            "registry <id>.json must live under registry_root/profiles"
+        );
+        assert!(
+            !data_root
+                .path()
+                .join("profiles")
+                .join("alice.json")
+                .exists(),
+            "registry <id>.json must NOT live under data_root/profiles"
+        );
+        // The store must be able to read the profile back through the registry.
+        assert!(store.get("alice").unwrap().is_some());
+        assert_eq!(store.list().unwrap().len(), 1);
+
+        // Per-profile data roots under data_root/profiles — NOT registry_root.
+        let resolved = store.resolve_data_dir(&profile);
+        assert!(
+            resolved.starts_with(data_root.path().join("profiles")),
+            "resolve_data_dir must root under data_root/profiles, got {}",
+            resolved.display()
+        );
+        assert!(resolved.ends_with("alice/data"));
+
+        // octos_home_dir points at the REGISTRY root (shared, config-like).
+        assert_eq!(store.octos_home_dir(), registry_root.path());
+
+        // Regression guard: open_unified(x) collapses both roots under x.
+        let unified_dir = tempfile::tempdir().unwrap();
+        let unified = ProfileStore::open_unified(unified_dir.path()).unwrap();
+        unified.save(&profile).unwrap();
+        assert!(
+            unified_dir
+                .path()
+                .join("profiles")
+                .join("alice.json")
+                .exists(),
+            "open_unified registry must live under x/profiles"
+        );
+        assert!(
+            unified
+                .resolve_data_dir(&profile)
+                .starts_with(unified_dir.path().join("profiles")),
+            "open_unified data must root under x/profiles"
+        );
     }
 
     #[test]
@@ -3312,7 +3436,7 @@ mod tests {
     #[test]
     fn test_file_permissions() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
         let profile = UserProfile {
             id: "perms-test".into(),
             name: "Perms".into(),
@@ -3337,7 +3461,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_preserves_masked_secrets() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         // Save a profile with real secrets
         let original = UserProfile {
@@ -3448,7 +3572,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_preserves_masked_email_secrets() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
         store.save(&email_secret_profile("email-merge")).unwrap();
 
         // A client GETs the masked profile and PUTs it straight back.
@@ -3470,7 +3594,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_allows_changing_email_secrets() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
         store.save(&email_secret_profile("email-change")).unwrap();
 
         // A genuinely new value is NOT a display artifact, so it must land.
@@ -3492,7 +3616,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_preserves_masked_channel_secrets() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let original = UserProfile {
             id: "channel-merge".into(),
@@ -3588,7 +3712,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_allows_clearing_channel_secret() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let original = UserProfile {
             id: "channel-clear".into(),
@@ -3654,7 +3778,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_preserves_channel_secret_after_delete() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let matrix_channel = |user_id: &str, token: &str| ChannelCredentials::Matrix {
             homeserver: "https://matrix.example.org".into(),
@@ -4063,7 +4187,7 @@ mod tests {
     #[test]
     fn test_create_sub_account() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         // Create parent with LLM config
         let parent = UserProfile {
@@ -4133,7 +4257,7 @@ mod tests {
     #[test]
     fn test_public_subdomain_must_be_unique() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let first = UserProfile {
             id: "top-level".into(),
@@ -4165,7 +4289,7 @@ mod tests {
     #[test]
     fn test_resolve_routable_profile_id_prefers_public_subdomain() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let parent = UserProfile {
             id: "tenant".into(),
@@ -4219,7 +4343,7 @@ mod tests {
     #[test]
     fn test_resolve_effective_profile() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         // Create parent
         let parent = UserProfile {
@@ -4324,7 +4448,7 @@ mod tests {
     #[test]
     fn test_resolve_effective_profile_inherits_structured_sections() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let parent = UserProfile {
             id: "parent".into(),
@@ -4568,7 +4692,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_preserves_keychain_marker() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         // Save profile with keychain marker
         let original = UserProfile {
@@ -4617,7 +4741,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_allows_setting_keychain_marker() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         // Profile with plaintext secret
         let original = UserProfile {
@@ -4654,7 +4778,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_empty_does_not_overwrite_keychain() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let original = UserProfile {
             id: "kc-empty".into(),

--- a/crates/octos-cli/src/skills_scope.rs
+++ b/crates/octos-cli/src/skills_scope.rs
@@ -109,7 +109,7 @@ mod tests {
     #[test]
     fn resolve_account_skills_dir_keeps_sub_account_isolated() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let parent = UserProfile {
             id: "dspfac".into(),

--- a/crates/octos-cli/tests/preview_auth.rs
+++ b/crates/octos-cli/tests/preview_auth.rs
@@ -85,7 +85,7 @@ async fn build_fixture() -> Fixture {
     //    back up to recover the profile id, so we MUST leave
     //    `data_dir = None` (an override breaks that lookup and the
     //    session-workspace search misses the pre-seeded files).
-    let profile_store = Arc::new(ProfileStore::open(&octos_home).expect("profile store"));
+    let profile_store = Arc::new(ProfileStore::open_unified(&octos_home).expect("profile store"));
 
     let profile_a = UserProfile {
         id: "tenant-a".into(),

--- a/crates/octos-cli/tests/preview_signed.rs
+++ b/crates/octos-cli/tests/preview_signed.rs
@@ -76,7 +76,7 @@ async fn build_fixture_with_ttl(ttl: std::time::Duration) -> Fixture {
     let tempdir = TempDir::new().expect("tempdir");
     let octos_home = tempdir.path().to_path_buf();
 
-    let profile_store = Arc::new(ProfileStore::open(&octos_home).expect("profile store"));
+    let profile_store = Arc::new(ProfileStore::open_unified(&octos_home).expect("profile store"));
 
     let profile_a = UserProfile {
         id: "tenant-a".into(),

--- a/crates/octos-cli/tests/ws_token_url_decode.rs
+++ b/crates/octos-cli/tests/ws_token_url_decode.rs
@@ -50,7 +50,7 @@ use tower::util::ServiceExt;
 /// pass in `Authorization: Bearer …`. The WS path must arrive at this
 /// same byte sequence after percent-decoding the `?token=` value.
 fn build_state_with_admin_token(_dir: &TempDir, token: &str) -> Arc<AppState> {
-    let store = Arc::new(octos_cli::profiles::ProfileStore::open(_dir.path()).unwrap());
+    let store = Arc::new(octos_cli::profiles::ProfileStore::open_unified(_dir.path()).unwrap());
     Arc::new(AppState {
         profile_store: Some(store),
         auth_token: Some(token.into()),

--- a/crates/octos-cli/tests/x_profile_id_strip.rs
+++ b/crates/octos-cli/tests/x_profile_id_strip.rs
@@ -71,7 +71,7 @@ fn with_connect_info(mut req: Request<Body>, addr: SocketAddr) -> Request<Body> 
 /// can grant sessions for these ids) and the X-Profile-Id branch in
 /// `is_authorized_for_profile` can resolve sub-account parentage.
 fn build_state(_dir: &TempDir, profiles: &[(&str, Option<&str>)]) -> Arc<AppState> {
-    let store = Arc::new(octos_cli::profiles::ProfileStore::open(_dir.path()).unwrap());
+    let store = Arc::new(octos_cli::profiles::ProfileStore::open_unified(_dir.path()).unwrap());
     for (id, parent) in profiles {
         let profile = octos_cli::profiles::UserProfile {
             id: (*id).into(),
@@ -104,7 +104,8 @@ fn build_state_with_users(
     users: &[(&str, &str, octos_cli::user_store::UserRole)],
     profiles: &[(&str, Option<&str>)],
 ) -> (Arc<AppState>, Arc<octos_cli::otp::AuthManager>) {
-    let profile_store = Arc::new(octos_cli::profiles::ProfileStore::open(dir.path()).unwrap());
+    let profile_store =
+        Arc::new(octos_cli::profiles::ProfileStore::open_unified(dir.path()).unwrap());
     for (id, parent) in profiles {
         let profile = octos_cli::profiles::UserProfile {
             id: (*id).into(),
@@ -649,7 +650,8 @@ async fn build_state_with_sessions_for_tenant_b(
     tenant_b_id: &str,
     session_id: &str,
 ) -> Arc<AppState> {
-    let profile_store = Arc::new(octos_cli::profiles::ProfileStore::open(dir.path()).unwrap());
+    let profile_store =
+        Arc::new(octos_cli::profiles::ProfileStore::open_unified(dir.path()).unwrap());
     for (id, parent) in profiles {
         let profile = octos_cli::profiles::UserProfile {
             id: (*id).into(),


### PR DESCRIPTION
## What

Lets many `octos serve` processes — and therefore many stdio `octos-tui` windows — run **concurrently** against ONE shared profile/config while each owns private runtime state.

## Why

redb is single-writer-single-**process**. octos has many redb stores (top-level *and* per-profile: `admin_audit`, `credential_pool`, `episodes`, `cost_ledger`, `usage_ledger`, …), so the serve flock (`acquire_serve_data_dir_lock`) refuses a 2nd serve on the same data dir. Users hit this trying to open more than one stdio octos-tui.

## How

Almost every store already keys off `data_dir`, so making the **runtime** dir per-instance isolates the redb stores + sessions + goals + the flock automatically. The only config-like store that must stay **shared** is the profile registry — split out here.

- **`ProfileStore` registry/data split:** `open(registry_root, data_root)` reads the `<id>.json` registry from `registry_root/profiles` (shared) and roots per-profile data (`resolve_data_dir`) under `data_root/profiles` (per-instance). `open_unified(x) = open(x, x)` keeps legacy behavior byte-identical; all non-serve callers use it. `octos_home_dir` tracks the registry root (default-profile pointer / gateway `--octos-home` stay shared).
- **serve:** new `--instance-data-dir` (+ `OCTOS_INSTANCE_DATA_DIR`, flag wins, empty env = unset). `state_home` = normal resolution (profiles registry + per-profile catalog); effective runtime `data_dir` rebinds to the instance dir when set. **Unset ⇒ `state_home == data_dir` ⇒ identical to today** for default installs AND gateways (which never set it).
- **model_catalog.json** needs no routing: in serve's flow it is per-profile (rides `resolve_data_dir` → already per-instance); the shared fallback + compiled-in catalog are data_dir-independent.

## Validation

- **Two serves boot concurrently** on distinct instance dirs sharing one `state_home` — both `/health` OK, zero `OCTOS_DATA_DIR_LOCKED`, each with its own `admin_audit.redb`/`sessions`/lock; `state_home` clean of runtime.
- **Negative control:** same instance dir ⇒ 2nd still refused (lock intact — safety preserved).
- Full `octos-cli` lib suite green **serialized** (2366 passed, 0 failed); profiles **57/57** incl. the new registry/data split test.

## Client side (follow-up, separate PR in octos-tui)

octos-tui sets `OCTOS_INSTANCE_DATA_DIR=~/.octos/instances/<cwd-hash>` on the serve it spawns (per-cwd ⇒ session persistence across relaunch, concurrency across folders). Profiles/catalog/config auto-share from `state_home`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)