### PR TITLE
Land full bundle: multi-instance stdio + goal-leak fix + network default + curl fix

### DIFF
--- a/crates/octos-agent/src/sandbox/macos.rs
+++ b/crates/octos-agent/src/sandbox/macos.rs
@@ -504,6 +504,14 @@ mod tests {
             profile.contains(r#"(allow file-read* (subpath "/custom/path"))"#),
             "should allow reading custom path"
         );
+        // `/private/etc` must reach the restricted profile by its CANONICAL path
+        // (macOS `/etc` symlink) so system curl/LibreSSL can read
+        // `/private/etc/ssl/openssl.cnf` + `cert.pem` under the network-on
+        // default — otherwise TLS clients fast-fail "Operation not permitted".
+        assert!(
+            profile.contains(r#"(allow file-read* (subpath "/private/etc"))"#),
+            "should allow reading /private/etc (canonical of /etc) for TLS config, profile:\n{profile}"
+        );
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/octos-agent/src/sandbox/mod.rs
+++ b/crates/octos-agent/src/sandbox/mod.rs
@@ -112,6 +112,13 @@ pub(crate) const DEFAULT_READ_ALLOW_PATHS: &[&str] = &[
     "/tmp",
     "/var/tmp",
     "/etc", // system config (needed for DNS resolution, etc.)
+    // macOS `/etc` is a symlink to `/private/etc`, and SBPL subpath rules match
+    // the CANONICAL path — so the `/etc` entry above never covers a real read of
+    // `/private/etc/...`. Without this, TLS clients that resolve via the symlink
+    // (system `curl`/LibreSSL reading `/etc/ssl/openssl.cnf` + `cert.pem`) fail at
+    // init with a confusing "Operation not permitted" — very visible now that
+    // network is allowed by default. Mirrors the `/tmp` + `/private/tmp` pairing.
+    "/private/etc",
     "/dev/null",
     "/dev/urandom",
     "/dev/random",

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -358,6 +358,32 @@ pub(crate) fn method_not_supported_error(
 #[derive(Debug, Default)]
 pub(crate) struct InProcessAgentOrchestrator {
     state: StdMutex<AutonomyRuntimeState>,
+    /// #1666 residue — per-project (cwd) scope for the goal/autonomy store,
+    /// mirroring the ledger's `scopes` map (`ui_protocol_ledger.rs`).
+    /// Registered on `session/open` alongside `ledger.set_session_scope` so a
+    /// goal set in one folder does NOT leak into a fresh session that reuses
+    /// the same WIRE session key in another folder (same profile). Keyed by
+    /// the plain wire session id; held under a SEPARATE lock from `state` so
+    /// [`Self::scoped_goal_key`] can be resolved without re-entering the state
+    /// mutex the goal handlers already hold. Empty (no scope) → the goal store
+    /// keys by the plain wire id, byte-identical to the legacy behavior and to
+    /// the gateway/session-actor path (which never registers a scope).
+    goal_scopes: StdMutex<HashMap<String, String>>,
+}
+
+/// The plain WIRE session id underlying a (possibly cwd-scoped) goal-store
+/// key: strips a `\u{0}~cwd-<scope>` suffix if present, else returns the key
+/// unchanged. Used at the continuation-dispatch boundary so a goal enqueued
+/// under a scoped key is still delivered to the session runtime / actor keyed
+/// by the plain wire id (which is how `session_workspaces()`, `active_turns`,
+/// and the ledger's live-subscriber map are all keyed). The NUL separator is
+/// the same injective marker `storage_session_id` uses, so a legitimate wire
+/// id can never be mistaken for a scoped key.
+pub(crate) fn wire_key_from_goal_key(key: &SessionKey) -> SessionKey {
+    match key.0.split_once("\u{0}~cwd-") {
+        Some((wire, _)) => SessionKey(wire.to_owned()),
+        None => key.clone(),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -637,6 +663,65 @@ impl InProcessAgentOrchestrator {
     #[cfg(test)]
     pub(crate) fn clear_for_test(&self) {
         *self.state() = AutonomyRuntimeState::default();
+        self.goal_scopes
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
+    }
+
+    /// #1666 residue — register (or clear) the per-project goal-store scope
+    /// for a wire session id. The goal/autonomy half of `appui.sessions_in_cwd`
+    /// isolation, called from `register_session_ledger_scope` right beside
+    /// `ledger.set_session_scope` so the goal store and the ledger agree on
+    /// each session's cwd scope. Mirrors
+    /// [`UiProtocolLedger::set_session_scope`].
+    pub(crate) fn set_goal_scope(&self, session_id: &SessionKey, scope: Option<String>) {
+        let mut scopes = self
+            .goal_scopes
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match scope {
+            Some(scope) => {
+                scopes.insert(session_id.0.clone(), scope);
+            }
+            None => {
+                scopes.remove(session_id.0.as_str());
+            }
+        }
+    }
+
+    /// #1666 residue — the STORAGE identity for a wire session id in the goal
+    /// store: the id itself, or `<id>\u{0}~cwd-<scope>` when a per-project
+    /// scope is registered. Mirrors [`UiProtocolLedger::storage_session_id`]
+    /// byte-for-byte (same NUL-separated, injective encoding) so the goal store
+    /// isolates cwds exactly as the ledger already isolates transcripts.
+    pub(crate) fn scoped_goal_key(&self, session_id: &SessionKey) -> SessionKey {
+        let scopes = self
+            .goal_scopes
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match scopes.get(session_id.0.as_str()) {
+            Some(scope) => SessionKey(format!("{}\u{0}~cwd-{scope}", session_id.0)),
+            None => session_id.clone(),
+        }
+    }
+
+    /// #1666 residue — whether a (possibly cwd-scoped) goal-continuation
+    /// target is safe to dispatch on the AppUI tick path. A SCOPED goal target
+    /// fires ONLY when its cwd scope is the one CURRENTLY registered for its
+    /// wire id (the most-recently-opened folder — the same last-write-wins
+    /// scope the ledger and `session_workspaces()` resolve by). This stops a
+    /// backgrounded folder's goal from firing a continuation that
+    /// `run_standalone_turn` would then execute against the currently-active
+    /// folder's workspace (which resolves by the plain wire id), i.e. the
+    /// continuation-side twin of the get/set leak. Unscoped targets (loops,
+    /// gateway sessions) are always dispatchable.
+    pub(crate) fn goal_target_is_dispatchable(&self, target: &SessionKey) -> bool {
+        if !target.0.contains("\u{0}~cwd-") {
+            return true;
+        }
+        let wire = wire_key_from_goal_key(target);
+        self.scoped_goal_key(&wire) == *target
     }
 
     pub(crate) fn configure_supervisor_store(
@@ -2262,8 +2347,14 @@ impl InProcessAgentOrchestrator {
             .goals
             .get(session_id)
             .filter(|goal| goal.profile_id == profile_id)?;
+        // #1666 residue — `session_id` here is the goal STORE identity (the
+        // cwd-scoped key for an AppUI folder), but the client keys the goal
+        // chip by the plain WIRE id and would drop an event carrying a scoped
+        // key. Emit the wire id in the event while looking up under the scoped
+        // key. Unscoped/gateway keys strip to themselves (no-op).
+        let wire_id = wire_key_from_goal_key(session_id);
         Some(json!({
-            "session_id": session_id,
+            "session_id": wire_id,
             "profile_id": profile_id,
             "goal": autonomy_goal_json(goal),
             "transition_actor": "backend",
@@ -2274,10 +2365,14 @@ impl InProcessAgentOrchestrator {
     /// Never errors: no goal (or a goal outside the profile scope) renders
     /// as `status: "none"` so the model gets a stable shape either way.
     pub(crate) fn model_goal_snapshot(&self, session_id: &SessionKey, profile_id: &str) -> Value {
+        // #1666 residue — the `goal_get` tool runs inside a turn keyed by the
+        // plain wire session id; resolve it to the cwd-scoped store identity so
+        // the model reads THIS folder's goal, not another folder's.
+        let key = self.scoped_goal_key(session_id);
         let state = self.state();
         match state
             .goals
-            .get(session_id)
+            .get(&key)
             .filter(|goal| goal.profile_id == profile_id)
         {
             Some(goal) => json!({
@@ -2311,8 +2406,10 @@ impl InProcessAgentOrchestrator {
                 "status `{status}` is not a model-allowed transition (only complete|blocked)"
             ));
         }
+        // #1666 residue — the `goal_update` tool addresses THIS folder's goal.
+        let key = self.scoped_goal_key(session_id);
         let mut state = self.state();
-        let Some(goal) = state.goals.get_mut(session_id) else {
+        let Some(goal) = state.goals.get_mut(&key) else {
             return Err("no goal is set for this session".to_owned());
         };
         if goal.profile_id != profile_id {
@@ -2324,7 +2421,7 @@ impl InProcessAgentOrchestrator {
         goal.status = status.to_owned();
         goal.updated_at_ms = now_ms();
         let snapshot = goal.clone();
-        persist_goal_state(&state, session_id, &snapshot, false);
+        persist_goal_state(&state, &key, &snapshot, false);
         tracing::info!(
             session = %session_id,
             goal_id = %snapshot.goal_id,
@@ -2359,9 +2456,13 @@ impl InProcessAgentOrchestrator {
         // Reject when an unfinished goal already exists (codex: "Fails if an
         // unfinished goal exists"). Scope the state guard so `set_goal` can
         // re-lock below without deadlocking.
+        // #1666 residue — inspect/replace THIS folder's goal under the
+        // cwd-scoped store identity. `set_goal` below is handed the plain wire
+        // `session_id` and re-resolves the same scope, so the two agree.
+        let key = self.scoped_goal_key(session_id);
         {
             let mut state = self.state();
-            if let Some(existing) = state.goals.get(session_id) {
+            if let Some(existing) = state.goals.get(&key) {
                 if existing.profile_id != profile_id {
                     return Err(
                         "a goal outside this profile's scope already exists for this session"
@@ -2388,7 +2489,7 @@ impl InProcessAgentOrchestrator {
             // fail the goal-id identity check in
             // `pending_continuation_is_schedulable`. (`remove` is a no-op when
             // no goal exists, so the fresh-goal path is unaffected.)
-            state.goals.remove(session_id);
+            state.goals.remove(&key);
         }
         self.set_goal(GoalSetRequest {
             session_id: session_id.clone(),
@@ -2520,7 +2621,15 @@ impl InProcessAgentOrchestrator {
             if !pending_continuation_is_schedulable(state, item) {
                 continue;
             }
-            sessions.insert(SessionKey(item.session_id.as_str().to_owned()));
+            // #1666 residue — a goal continuation is enqueued under the
+            // cwd-scoped store identity, but the client's orchestration
+            // indicator (and the `subscribed`/`live_forwarders` set it is
+            // reconciled against) is keyed by the plain wire id. Strip the cwd
+            // scope so a scoped goal still lights the "orchestrating" chip on
+            // its wire session instead of being dropped as an unknown key.
+            sessions.insert(wire_key_from_goal_key(&SessionKey(
+                item.session_id.as_str().to_owned(),
+            )));
         }
         sessions
     }
@@ -2966,10 +3075,15 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
     }
 
     fn get_goal(&self, request: GoalSessionRequest) -> Result<Value, RpcError> {
+        // #1666 residue — resolve the wire session id to its cwd-scoped store
+        // identity so a `goal_get` in folder B never returns folder A's goal
+        // (both reuse the same wire key `<profile>:local:tui#coding`). The
+        // response still echoes the plain wire `request.session_id`.
+        let key = self.scoped_goal_key(&request.session_id);
         let state = self.state();
         let goal = state
             .goals
-            .get(&request.session_id)
+            .get(&key)
             .filter(|goal| goal.profile_id == request.profile_id)
             .map(autonomy_goal_json);
         Ok(json!({
@@ -3050,13 +3164,21 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
             ));
         }
         let now = now_ms();
+        // #1666 residue — resolve the wire session id to its cwd-scoped store
+        // identity BEFORE touching `state.goals`, so a goal set in folder A is
+        // stored under a key distinct from folder B's even though both reuse
+        // the same wire key. Every store op below (get/insert, continuation
+        // enqueue, wrap-up enqueue, persistence) uses `key`; the wire
+        // `request.session_id` is kept only for the wire-facing response /
+        // error payloads. Resolved before the state lock (separate scope lock).
+        let key = self.scoped_goal_key(&request.session_id);
         let mut state = self.state();
         // Fix A: an over-budget mutation that would leave the goal `active`
         // must instead flip it to `budget_limited` and emit the wrap-up. We
         // stage the wrap-up prompt here and enqueue it AFTER the mutable
         // `goal` borrow ends (the wrap-up enqueue needs `&mut state`).
         let mut pending_wrap_up: Option<String> = None;
-        let goal = if let Some(goal) = state.goals.get_mut(&request.session_id) {
+        let goal = if let Some(goal) = state.goals.get_mut(&key) {
             if goal.profile_id != request.profile_id {
                 return Err(autonomy_error(
                     kinds::GOAL_UNAVAILABLE,
@@ -3161,11 +3283,11 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
                 wrap_up_emitted: false,
                 consecutive_failed_turns: 0,
             };
-            state.goals.insert(request.session_id.clone(), goal.clone());
+            state.goals.insert(key.clone(), goal.clone());
             goal
         };
         if goal.status == "active" {
-            enqueue_goal_continuation(&mut state, &request.session_id, &request.profile_id, &goal);
+            enqueue_goal_continuation(&mut state, &key, &request.profile_id, &goal);
         }
         // Fix A: if the mutation crossed the goal over its budget, enqueue the
         // one-shot wrap-up now that the mutable `goal` borrow is released. The
@@ -3174,7 +3296,7 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
         if let Some(prompt) = pending_wrap_up {
             enqueue_goal_wrap_up(
                 &mut state,
-                &request.session_id,
+                &key,
                 &request.profile_id,
                 &goal.goal_id,
                 &goal.objective,
@@ -3182,7 +3304,7 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
                 SystemTime::now(),
             );
         }
-        persist_goal_state(&state, &request.session_id, &goal, false);
+        persist_goal_state(&state, &key, &goal, false);
         Ok(json!({
             "session_id": request.session_id,
             "profile_id": request.profile_id,
@@ -3192,10 +3314,13 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
     }
 
     fn clear_goal(&self, request: GoalSessionRequest) -> Result<Value, RpcError> {
+        // #1666 residue — clear the cwd-scoped goal for this wire session id so
+        // `goal_clear` in folder B never removes folder A's goal.
+        let key = self.scoped_goal_key(&request.session_id);
         let mut state = self.state();
-        let cleared = match state.goals.get(&request.session_id) {
+        let cleared = match state.goals.get(&key) {
             Some(goal) if goal.profile_id == request.profile_id => {
-                state.goals.remove(&request.session_id).is_some()
+                state.goals.remove(&key).is_some()
             }
             Some(_) => {
                 return Err(autonomy_error(
@@ -3210,7 +3335,7 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
             None => false,
         };
         if cleared {
-            persist_goal_cleared(&state, &request.session_id, &request.profile_id);
+            persist_goal_cleared(&state, &key, &request.profile_id);
         }
         Ok(json!({
             "session_id": request.session_id,
@@ -12861,6 +12986,223 @@ mod tests {
         assert_eq!(
             window_after, 1,
             "AppUI option (b) must produce exactly ONE rate_window_count increment per turn"
+        );
+    }
+
+    /// #1666 residue — the goal STORE must isolate two folders (cwds) that
+    /// share the same WIRE session key, exactly as the ledger already isolates
+    /// their transcripts (mirror of
+    /// `ui_protocol_ledger::should_isolate_ledger_storage_between_cwd_scopes_sharing_a_wire_key`).
+    /// Before this fix the goal store keyed on the bare wire key, so a goal set
+    /// in folder A leaked into a fresh session reusing the key in folder B (the
+    /// leaked "orchestrating" chip in the live mini2 repro).
+    #[test]
+    fn should_isolate_goal_store_between_cwd_scopes_sharing_a_wire_key() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        // Both folders open the SAME wire key (the TUI hardcodes `#coding`).
+        let key = SessionKey("octos:local:tui#coding".into());
+
+        // Folder A registers its cwd scope and sets a goal.
+        orchestrator.set_goal_scope(&key, Some("aaaa111122223333".into()));
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: key.clone(),
+                profile_id: "octos".into(),
+                objective: "objective-a".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set goal A");
+
+        // Folder B re-registers the SAME wire key under its own scope. A fresh
+        // `goal_get` must NOT surface folder A's goal — this is the leak.
+        orchestrator.set_goal_scope(&key, Some("bbbb444455556666".into()));
+        let got_b = orchestrator
+            .get_goal(GoalSessionRequest {
+                session_id: key.clone(),
+                profile_id: "octos".into(),
+            })
+            .expect("get goal B");
+        assert!(
+            got_b["goal"].is_null(),
+            "folder B must not read folder A's goal (got {got_b:?})"
+        );
+
+        // Folder B sets its own goal; the two coexist under distinct keys.
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: key.clone(),
+                profile_id: "octos".into(),
+                objective: "objective-b".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set goal B");
+        let got_b2 = orchestrator
+            .get_goal(GoalSessionRequest {
+                session_id: key.clone(),
+                profile_id: "octos".into(),
+            })
+            .expect("get goal B2");
+        assert_eq!(
+            got_b2["goal"]["objective"],
+            json!("objective-b"),
+            "folder B reads its own goal"
+        );
+
+        // Back to folder A: its goal is intact under its own scope, wholly
+        // unaffected by folder B's goal.
+        orchestrator.set_goal_scope(&key, Some("aaaa111122223333".into()));
+        let got_a = orchestrator
+            .get_goal(GoalSessionRequest {
+                session_id: key.clone(),
+                profile_id: "octos".into(),
+            })
+            .expect("get goal A");
+        assert_eq!(
+            got_a["goal"]["objective"],
+            json!("objective-a"),
+            "folder A still reads objective-a, never folder B's objective-b"
+        );
+        // The response echoes the PLAIN wire id, never the scoped store id.
+        assert_eq!(got_a["session_id"], json!(key.0));
+
+        // Under the hood the two goals occupy two distinct, NUL-separated store
+        // keys (the same injective encoding the ledger uses), and the bare wire
+        // key holds nothing — the leak vector is closed.
+        let scoped_a = SessionKey(format!("{}\u{0}~cwd-aaaa111122223333", key.0));
+        let scoped_b = SessionKey(format!("{}\u{0}~cwd-bbbb444455556666", key.0));
+        {
+            let state = orchestrator.state();
+            assert_eq!(
+                state.goals.get(&scoped_a).map(|g| g.objective.as_str()),
+                Some("objective-a"),
+            );
+            assert_eq!(
+                state.goals.get(&scoped_b).map(|g| g.objective.as_str()),
+                Some("objective-b"),
+            );
+            assert!(
+                state.goals.get(&key).is_none(),
+                "the bare wire key must hold no goal — nothing to leak",
+            );
+        }
+
+        // Clearing the scope falls back to the (empty) plain wire identity.
+        orchestrator.set_goal_scope(&key, None);
+        let got_none = orchestrator
+            .get_goal(GoalSessionRequest {
+                session_id: key.clone(),
+                profile_id: "octos".into(),
+            })
+            .expect("get unscoped");
+        assert!(
+            got_none["goal"].is_null(),
+            "no scope registered → plain wire identity, which holds no goal",
+        );
+    }
+
+    /// #1666 residue — the CONSTRAINT: store-scoping the goal must NOT break
+    /// autonomous continuations. A goal set in a cwd-scoped session is (1)
+    /// surfaced by the continuation sweep under its SCOPED store key, (2)
+    /// dispatchable only while its folder is the active one, (3) stripped back
+    /// to the plain WIRE key the session actor / runtime is keyed by, and (4)
+    /// drained + charged under the SCOPED key. Adapts
+    /// `appui_goal_dispatch_path_does_not_double_count_continuations` for the
+    /// scoped path.
+    #[test]
+    fn scoped_goal_continuation_is_swept_and_strips_to_wire_key_for_dispatch() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let wire = SessionKey::with_profile("tenant-a", "api", "goal-scoped-dispatch");
+        orchestrator.set_goal_scope(&wire, Some("aaaa111122223333".into()));
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: wire.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "keep firing per folder".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active scoped goal");
+
+        // The goal record lives under the SCOPED store key, not the wire key.
+        let scoped = SessionKey(format!("{}\u{0}~cwd-aaaa111122223333", wire.0));
+        assert!(
+            orchestrator.state().goals.contains_key(&scoped),
+            "goal stored under the scoped key",
+        );
+        assert!(
+            !orchestrator.state().goals.contains_key(&wire),
+            "the bare wire key must be empty",
+        );
+
+        // (1) The sweep surfaces the SCOPED key as the continuation target.
+        let targets = orchestrator.due_loop_targets(Some("tenant-a"), 8);
+        let target = targets
+            .iter()
+            .find(|(session_id, _)| session_id == &scoped)
+            .map(|(session_id, _)| session_id.clone())
+            .unwrap_or_else(|| {
+                panic!("sweep must surface the scoped goal target (got {targets:?})")
+            });
+
+        // (2) + (3): while folder A's scope is current, the target is
+        // dispatchable and strips back to the plain wire key for the actor.
+        assert!(
+            orchestrator.goal_target_is_dispatchable(&target),
+            "the currently-scoped folder's goal must be dispatchable",
+        );
+        assert_eq!(
+            wire_key_from_goal_key(&target),
+            wire,
+            "dispatch strips the cwd scope back to the wire key the actor is keyed by",
+        );
+
+        // (4) The continuation drains under the SCOPED key and carries it.
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &scoped,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        assert!(
+            drained
+                .iter()
+                .any(|c| matches!(c.reason, MasterContinuationReason::GoalContinue)),
+            "the scoped goal's continuation drains under the scoped key",
+        );
+        assert!(
+            drained.iter().all(|c| c.session_id.as_str() == scoped.0),
+            "every drained continuation carries the scoped session id",
+        );
+
+        // A DIFFERENT folder becoming current makes folder A's goal
+        // NON-dispatchable — the continuation-side leak is closed — but the
+        // record still exists, so re-opening folder A resumes it.
+        orchestrator.set_goal_scope(&wire, Some("bbbb444455556666".into()));
+        assert!(
+            !orchestrator.goal_target_is_dispatchable(&scoped),
+            "a backgrounded folder's goal must not fire into the now-active folder",
+        );
+        orchestrator.set_goal_scope(&wire, Some("aaaa111122223333".into()));
+        assert!(
+            orchestrator.goal_target_is_dispatchable(&scoped),
+            "re-activating folder A's scope makes its goal dispatchable again",
+        );
+
+        // Post-turn accounting addresses the scoped key (what the AppUI
+        // dispatch passes via `goal_context.goal_session_key`) and charges the
+        // scoped goal exactly once — the fire path stays intact end-to-end.
+        orchestrator.record_goal_turn(&scoped, "tenant-a", 500, 3);
+        let (_, continuations_after, _) = orchestrator
+            .goal_counters_for_test(&scoped)
+            .expect("scoped goal exists");
+        assert_eq!(
+            continuations_after, 1,
+            "one recorded turn charges the scoped goal exactly once",
         );
     }
 

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -4162,7 +4162,7 @@ mod tests {
 
     fn temp_profile_store() -> (tempfile::TempDir, ProfileStore) {
         let dir = tempfile::tempdir().unwrap();
-        let ps = ProfileStore::open(dir.path()).unwrap();
+        let ps = ProfileStore::open_unified(dir.path()).unwrap();
         (dir, ps)
     }
 
@@ -4188,7 +4188,7 @@ mod tests {
     ) {
         let dir = tempfile::tempdir().unwrap();
         let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
-        let profile_store = Arc::new(ProfileStore::open(dir.path()).unwrap());
+        let profile_store = Arc::new(ProfileStore::open_unified(dir.path()).unwrap());
         let allowlist_store = Arc::new(LoginAllowlistStore::open(dir.path()).unwrap());
         // Tests that exercise per-email send_code/verify branches expect the
         // SMTP precheck to pass; populate a synthetic config so the common

--- a/crates/octos-cli/src/api/cron_panel.rs
+++ b/crates/octos-cli/src/api/cron_panel.rs
@@ -377,7 +377,7 @@ mod tests {
 
     fn temp_state() -> (tempfile::TempDir, Arc<AppState>, Arc<ProfileStore>) {
         let dir = tempfile::tempdir().unwrap();
-        let profile_store = Arc::new(ProfileStore::open(dir.path()).unwrap());
+        let profile_store = Arc::new(ProfileStore::open_unified(dir.path()).unwrap());
         let state = Arc::new(AppState {
             profile_store: Some(profile_store.clone()),
             ..AppState::empty_for_tests()

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -4698,7 +4698,7 @@ mod tests {
         use crate::profiles::{ProfileStore, UserProfile};
 
         let home = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(home.path()).unwrap();
+        let store = ProfileStore::open_unified(home.path()).unwrap();
         let tenant_data_dir = home.path().join("tenant-data");
         store
             .save(&UserProfile {
@@ -4802,7 +4802,7 @@ mod tests {
         use crate::profiles::{ProfileStore, UserProfile};
 
         let home = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(home.path()).unwrap();
+        let store = ProfileStore::open_unified(home.path()).unwrap();
 
         // A profile whose sessions live at an explicit data dir — the
         // directory the running solo/stdio session persists turns to.
@@ -6159,7 +6159,7 @@ mod tests {
     /// tests with a profile_store containing the listed profiles.
     fn state_with_profiles(profiles: &[(&str, Option<&str>)]) -> (tempfile::TempDir, AppState) {
         let dir = tempfile::tempdir().unwrap();
-        let ps = ProfileStore::open(dir.path()).unwrap();
+        let ps = ProfileStore::open_unified(dir.path()).unwrap();
         for (id, parent) in profiles {
             ps.save(&make_profile(id, *parent)).unwrap();
         }

--- a/crates/octos-cli/src/api/memory_panel.rs
+++ b/crates/octos-cli/src/api/memory_panel.rs
@@ -736,7 +736,7 @@ mod tests {
 
     fn temp_state() -> (tempfile::TempDir, Arc<AppState>, Arc<ProfileStore>) {
         let dir = tempfile::tempdir().unwrap();
-        let profile_store = Arc::new(ProfileStore::open(dir.path()).unwrap());
+        let profile_store = Arc::new(ProfileStore::open_unified(dir.path()).unwrap());
         let state = Arc::new(AppState {
             profile_store: Some(profile_store.clone()),
             ..AppState::empty_for_tests()

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -276,6 +276,15 @@ pub struct AppState {
     /// same keystone that gates selecting the profile from the menu); an
     /// explicit per-session `/permissions` choice always overrides it.
     pub dangerous_default_permissions: bool,
+    /// `--no-network` opt-OUT of the network-on default. By default a fresh
+    /// solo/Local session with NO explicit `/permissions` selection resolves to
+    /// Workspace-Write **with network ALLOWED** (filesystem still sandboxed) so
+    /// the common dev workflow — `npm install`, git, fetch — works out of the
+    /// box. Setting this (via `--no-network` / `OCTOS_NO_NETWORK=1`) reverts the
+    /// default to Workspace-Write with network DENIED. Cloud/tenant deployments
+    /// are unaffected (they always default to network-denied). An explicit
+    /// per-session `/permissions` choice always overrides either default.
+    pub default_network_denied: bool,
     /// `--llm-compaction`: AppUI context compaction asks an LLM for a
     /// higher-quality handoff summary (a real model call — slower, seconds)
     /// instead of the instant deterministic heuristic. Always falls back to the
@@ -406,6 +415,7 @@ impl AppState {
             deployment_mode: crate::config::DeploymentMode::Local,
             solo_login_enabled: false,
             dangerous_default_permissions: false,
+            default_network_denied: false,
             llm_compaction: false,
             host_memory: None,
             allow_admin_shell: false,

--- a/crates/octos-cli/src/api/purge.rs
+++ b/crates/octos-cli/src/api/purge.rs
@@ -232,7 +232,7 @@ mod tests {
     fn build_test_state() -> (TempDir, Arc<AppState>) {
         let temp = TempDir::new().expect("tempdir");
         let data_dir = temp.path();
-        let profile_store = Arc::new(ProfileStore::open(data_dir).expect("profile store"));
+        let profile_store = Arc::new(ProfileStore::open_unified(data_dir).expect("profile store"));
         let user_store = Arc::new(UserStore::open(data_dir).expect("user store"));
         let tenant_store = Arc::new(TenantStore::open(data_dir).expect("tenant store"));
 

--- a/crates/octos-cli/src/api/solo_auth.rs
+++ b/crates/octos-cli/src/api/solo_auth.rs
@@ -191,7 +191,7 @@ mod tests {
         let user_store = Arc::new(UserStore::open(dir).unwrap());
         let auth_manager = Arc::new(AuthManager::new(None, user_store.clone()));
         Arc::new(AppState {
-            profile_store: Some(Arc::new(ProfileStore::open(dir).unwrap())),
+            profile_store: Some(Arc::new(ProfileStore::open_unified(dir).unwrap())),
             user_store: Some(user_store),
             auth_manager: Some(auth_manager),
             deployment_mode: mode,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -927,6 +927,26 @@ fn effective_session_permission_state(
             approval_policy: Some(octos_agent::ApprovalPolicy::Never),
         };
     }
+    // Network-on default: a fresh Local session with no explicit selection gets
+    // Workspace-Write with network ALLOWED (filesystem still sandboxed, approvals
+    // unchanged) so `npm install` / git / fetch work out of the box — the macOS
+    // SBPL otherwise emits `(deny network*)` and silently breaks the most common
+    // dev workflow. Scoped exactly like the dangerous default (Local deployment +
+    // a session key that doesn't encode a tenant/cloud scope) so cloud/tenant
+    // stays network-denied. Opt OUT with `--no-network` (`OCTOS_NO_NETWORK=1`).
+    // An explicit `/permissions` choice still overrides this.
+    if !state.default_network_denied
+        && state.deployment_mode == crate::config::DeploymentMode::Local
+        && !session_id_encodes_non_solo_scope(session_id)
+    {
+        return StoredSessionPermissionProfile {
+            selection: octos_core::ui_protocol::PermissionProfileSelection {
+                mode: octos_core::ui_protocol::PermissionProfileMode::WorkspaceWrite,
+                network: octos_core::ui_protocol::PermissionNetworkPolicy::Allow,
+            },
+            approval_policy: None,
+        };
+    }
     StoredSessionPermissionProfile::default()
 }
 
@@ -34381,28 +34401,40 @@ ignore = []
             Some(octos_agent::ApprovalPolicy::Never)
         );
 
-        // Flag off -> the gated workspace-write default, approvals unset.
+        // Danger flag off, Local, solo -> the NETWORK-ON default: Workspace-Write
+        // (filesystem still sandboxed) with network ALLOWED and approvals unset,
+        // so npm/git/fetch work out of the box.
         let plain = AppState::empty_for_tests();
         let resolved = effective_session_permission_state(&plain, &session_id);
         assert_eq!(resolved.selection.mode, Mode::WorkspaceWrite);
-        assert_eq!(resolved.selection.network, Network::Deny);
+        assert_eq!(resolved.selection.network, Network::Allow);
         assert_eq!(resolved.approval_policy, None);
 
-        // Flag on but NON-Local deployment -> gated default (codex P2): the
-        // full-access profile is not grantable outside Local mode.
+        // `--no-network` opt-out -> Workspace-Write with network DENIED.
+        let mut no_net = AppState::empty_for_tests();
+        no_net.default_network_denied = true;
+        let resolved = effective_session_permission_state(&no_net, &session_id);
+        assert_eq!(resolved.selection.mode, Mode::WorkspaceWrite);
+        assert_eq!(resolved.selection.network, Network::Deny);
+
+        // NON-Local deployment -> network stays DENIED (the network-on default is
+        // Local-only; cloud/tenant is never widened). Danger flag also ignored
+        // outside Local (codex P2).
         let mut tenant = AppState::empty_for_tests();
         tenant.dangerous_default_permissions = true;
         tenant.deployment_mode = crate::config::DeploymentMode::Tenant;
         let resolved = effective_session_permission_state(&tenant, &session_id);
         assert_eq!(resolved.selection.mode, Mode::WorkspaceWrite);
+        assert_eq!(resolved.selection.network, Network::Deny);
 
-        // Flag on, Local, but a NON-SOLO-scoped session key -> gated default
-        // (codex P1): the fallback must not hand a tenant-scoped session the
-        // host access the explicit path would reject.
+        // Local, but a NON-SOLO-scoped session key -> gated default with network
+        // DENIED (codex P1): neither the danger fallback NOR the network-on
+        // default may widen a tenant/cloud-scoped session.
         let scoped = SessionKey("coding:tenant:m12-danger-default".into());
         assert!(session_id_encodes_non_solo_scope(&scoped));
         let resolved = effective_session_permission_state(&state, &scoped);
         assert_eq!(resolved.selection.mode, Mode::WorkspaceWrite);
+        assert_eq!(resolved.selection.network, Network::Deny);
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -87,7 +87,7 @@ use super::agent_orchestrator::{
     AgentRequest, AgentUpsert, GoalSessionRequest, GoalSetRequest, LoopControlKind,
     LoopControlRequest, LoopCreateRequest, LoopListRequest, NativeSpecialistAppUiEvent,
     NativeSpecialistLaunchRequest, default_agent_orchestrator, master_continuation_prompt,
-    master_continuation_reason_name, upsert_background_task_agent,
+    master_continuation_reason_name, upsert_background_task_agent, wire_key_from_goal_key,
 };
 #[cfg(test)]
 use super::agent_orchestrator::{
@@ -2987,6 +2987,16 @@ fn register_session_ledger_scope(
             .collect::<String>()
     });
     ledger.set_session_scope(&runtime.session_key, scope.clone());
+    // #1666 residue — mirror the SAME cwd scope into the goal/autonomy store so
+    // a goal set in one folder does not leak into a fresh session that reuses
+    // this wire key in another folder. The goal store was keyed by the bare
+    // wire key while #1666 only cwd-scoped the ledger, so the goal chip leaked
+    // across folders (same profile). Keeping the two scope maps in lock-step
+    // (registered at the same site, cleared together when the flag is off) is
+    // what makes the goal store isolate cwds exactly as the transcript already
+    // does. The goal continuation dispatch strips this scope back to the wire
+    // key when it reaches the session runtime / actor.
+    default_agent_orchestrator().set_goal_scope(&runtime.session_key, scope.clone());
     // Topic-suffixed sessions also emit ledger events under their BASE key:
     // the alpha-9 file/visual bridges deliberately strip the `#topic` before
     // appending so base-bucket subscribers see them (see
@@ -2996,7 +3006,8 @@ fn register_session_ledger_scope(
     // never mis-route a different project's base-key session.
     let base = runtime.session_key.base_key();
     if base != runtime.session_key.0 {
-        ledger.set_session_scope(&SessionKey(base.to_owned()), scope);
+        ledger.set_session_scope(&SessionKey(base.to_owned()), scope.clone());
+        default_agent_orchestrator().set_goal_scope(&SessionKey(base.to_owned()), scope);
     }
 }
 
@@ -9856,6 +9867,9 @@ async fn handle_raw_appui_rpc(
             }
             let _ = send_rpc_result(ws, id, result);
             if let Some((session_id, profile_id)) = continuation_target {
+                // This immediate-drain path is `loop/fire_now` only (see
+                // `appui_continuation_target_from_raw_result`); loops are not
+                // cwd-scoped, so the goal store key equals the wire id.
                 let _ = maybe_spawn_appui_master_continuation_runner(
                     ws,
                     state,
@@ -9863,6 +9877,7 @@ async fn handle_raw_appui_rpc(
                     contracts,
                     active_turns,
                     connection_turns,
+                    session_id.clone(),
                     session_id,
                     profile_id,
                     features,
@@ -12974,7 +12989,16 @@ async fn maybe_spawn_appui_master_continuation_runner(
     contracts: &Arc<UiProtocolContractStores>,
     active_turns: &SharedActiveTurns,
     connection_turns: &SharedConnectionTurns,
+    // The PLAIN WIRE session id: the turn runs, the ledger/runtime resolve, and
+    // the active-turn/connection bookkeeping key on this.
     session_id: SessionKey,
+    // #1666 residue — the goal STORE identity (cwd-scoped for AppUI folders,
+    // == `session_id` for loops / gateway sessions). The continuation queue,
+    // the goal in-flight set, and the post-turn goal accountant all key on
+    // THIS; a scoped goal enqueued its continuation under this key and must be
+    // drained + charged under it. For unscoped targets it equals `session_id`,
+    // so the loop/gateway path is byte-identical to before.
+    goal_storage_key: SessionKey,
     profile_id: String,
     features: ConnectionUiFeatures,
 ) -> bool {
@@ -12995,7 +13019,7 @@ async fn maybe_spawn_appui_master_continuation_runner(
     // tick would drain + spawn a SECOND concurrent turn on the same session
     // while the actor's turn runs. The actor clears the marker (RAII guard)
     // when its turn ends, so the next tick re-dispatches normally.
-    if default_agent_orchestrator().is_goal_dispatch_in_flight(&session_id) {
+    if default_agent_orchestrator().is_goal_dispatch_in_flight(&goal_storage_key) {
         return false;
     }
 
@@ -13006,7 +13030,7 @@ async fn maybe_spawn_appui_master_continuation_runner(
             .is_empty(),
     );
     let Some(continuation) = default_agent_orchestrator()
-        .drain_ready_continuations_for_session(&session_id, &profile_id, runtime_state, 1)
+        .drain_ready_continuations_for_session(&goal_storage_key, &profile_id, runtime_state, 1)
         .into_iter()
         .next()
     else {
@@ -13082,6 +13106,10 @@ async fn maybe_spawn_appui_master_continuation_runner(
         MasterContinuationReason::GoalContinue | MasterContinuationReason::GoalWrapUp => {
             Some(GoalContinuationContext {
                 profile_id: continuation.profile_id.as_str().to_owned(),
+                // The continuation carries the cwd-scoped goal store key it was
+                // enqueued under; the post-turn accountant must charge THAT
+                // record, not the plain wire id.
+                goal_session_key: SessionKey(continuation.session_id.as_str().to_owned()),
             })
         }
         _ => None,
@@ -13186,8 +13214,18 @@ async fn drain_appui_due_master_continuations(
     profile_filter: Option<&str>,
     features: ConnectionUiFeatures,
 ) {
-    for (session_id, profile_id) in default_agent_orchestrator().due_loop_targets(profile_filter, 8)
-    {
+    let orchestrator = default_agent_orchestrator();
+    for (storage_key, profile_id) in orchestrator.due_loop_targets(profile_filter, 8) {
+        // #1666 residue — a scoped goal target fires only for the currently
+        // active folder of its wire id (a backgrounded folder's goal is
+        // skipped until it is re-opened), so a stale-cwd continuation can never
+        // run against the wrong workspace. Unscoped targets (loops, gateway)
+        // always pass. The turn dispatches on the plain WIRE id while the goal
+        // record/queue/accountant stay on the scoped `storage_key`.
+        if !orchestrator.goal_target_is_dispatchable(&storage_key) {
+            continue;
+        }
+        let wire_key = wire_key_from_goal_key(&storage_key);
         let _ = maybe_spawn_appui_master_continuation_runner(
             ws,
             state,
@@ -13195,7 +13233,8 @@ async fn drain_appui_due_master_continuations(
             contracts,
             active_turns,
             connection_turns,
-            session_id,
+            wire_key,
+            storage_key,
             profile_id,
             features,
         )
@@ -13437,17 +13476,32 @@ pub(crate) fn spawn_global_master_continuation_drain(state: Arc<AppState>) {
             // sessions is not operationally reachable on a single serve.
             const DRAIN_SPAWN_CAP: usize = 8;
             const DRAIN_CANDIDATE_WINDOW: usize = 64;
-            let runnable = |session: &SessionKey| session_workspaces().get(session).is_some();
-            let due = default_agent_orchestrator().due_loop_targets_with_filter(
+            // #1666 residue — a goal target is cwd-scoped (`<wire>\u{0}~cwd-…`)
+            // while `session_workspaces()` is keyed by the plain wire id, so
+            // the workspace-known gate must strip the scope before probing.
+            let runnable = |session: &SessionKey| {
+                session_workspaces()
+                    .get(&wire_key_from_goal_key(session))
+                    .is_some()
+            };
+            let orchestrator = default_agent_orchestrator();
+            let due = orchestrator.due_loop_targets_with_filter(
                 None,
                 DRAIN_CANDIDATE_WINDOW,
                 Some(&runnable),
             );
             let mut advanced = 0usize;
-            for (session_id, profile_id) in due {
+            for (storage_key, profile_id) in due {
                 if advanced >= DRAIN_SPAWN_CAP {
                     break;
                 }
+                // Only fire a scoped goal for the currently-active folder of
+                // its wire id (see `goal_target_is_dispatchable`); dispatch on
+                // the plain WIRE id, account on the scoped `storage_key`.
+                if !orchestrator.goal_target_is_dispatchable(&storage_key) {
+                    continue;
+                }
+                let wire_key = wire_key_from_goal_key(&storage_key);
                 if maybe_spawn_appui_master_continuation_runner(
                     &ws,
                     &state,
@@ -13455,7 +13509,8 @@ pub(crate) fn spawn_global_master_continuation_drain(state: Arc<AppState>) {
                     &contracts,
                     &active_turns,
                     &connection_turns,
-                    session_id,
+                    wire_key,
+                    storage_key,
                     profile_id,
                     features,
                 )
@@ -21000,6 +21055,16 @@ async fn seed_m9_task_output_fixture(
 #[derive(Debug, Clone)]
 struct GoalContinuationContext {
     profile_id: String,
+    /// #1666 residue — the cwd-scoped goal STORE identity this continuation was
+    /// enqueued under (`<wire>\u{0}~cwd-<scope>`, or the plain wire id for an
+    /// unscoped/gateway session). The turn itself runs keyed by the plain wire
+    /// id (`params.session_id`) so the ledger/runtime/workspace all resolve
+    /// correctly, but the post-turn accountant (`record_goal_turn`,
+    /// `record_goal_dispatch_timestamp_only`, `maybe_complete_goal_from_model`)
+    /// must address the goal record under THIS scoped key — otherwise a folder
+    /// A goal turn would charge nothing (the wire key finds no scoped goal) and
+    /// recur forever without ever hitting its budget.
+    goal_session_key: SessionKey,
 }
 
 /// #1134 — pick the LAST non-empty assistant row after `pre` from a
@@ -24773,8 +24838,16 @@ async fn run_standalone_turn(
         // `record_goal_turn` below also stamps `last_continued_at_ms
         // = now`, but the await on `sessions_for_reschedule.lock()`
         // is the exact yield point we need to guard.
+        // #1666 residue — the goal record lives under the cwd-scoped store key
+        // (`goal_ctx.goal_session_key`), NOT the plain wire `session_id` the
+        // turn runs under. Charge/complete the goal via the scoped key so a
+        // folder-A goal turn actually accrues its spend (a wire-keyed lookup
+        // would find nothing and the goal would recur past its budget forever).
+        // The session-history read below stays on the wire `session_id` (that
+        // is how the runtime/transcript is keyed).
+        let goal_key = &goal_ctx.goal_session_key;
         default_agent_orchestrator()
-            .record_goal_dispatch_timestamp_only(&session_id, &goal_ctx.profile_id);
+            .record_goal_dispatch_timestamp_only(goal_key, &goal_ctx.profile_id);
         let pre = pre_assistant_count_for_post_turn.unwrap_or(0);
         let assistant_reply: Option<String> = {
             let mut guard = sessions_for_reschedule.lock().await;
@@ -24794,7 +24867,7 @@ async fn run_standalone_turn(
             .unwrap_or(0);
         let orchestrator = default_agent_orchestrator();
         orchestrator.record_goal_turn(
-            &session_id,
+            goal_key,
             &goal_ctx.profile_id,
             final_tokens_consumed,
             elapsed_seconds,
@@ -24805,11 +24878,8 @@ async fn run_standalone_turn(
             // tail of the reply. The return value is intentionally
             // unused — the goal is either complete now or stays active
             // and the next scheduler tick decides whether to re-queue.
-            let _ = orchestrator.maybe_complete_goal_from_model(
-                &session_id,
-                &goal_ctx.profile_id,
-                &reply,
-            );
+            let _ =
+                orchestrator.maybe_complete_goal_from_model(goal_key, &goal_ctx.profile_id, &reply);
         }
         // #1696/#1698 — push the post-turn goal snapshot to the OWNING
         // connection so autonomous transitions repaint the chip live:
@@ -24819,7 +24889,7 @@ async fn run_standalone_turn(
         // above — a durable append would fan the goal to every subscriber
         // of an unprofiled shared session id regardless of profile.
         if let Some(goal_event_json) =
-            orchestrator.session_goal_updated_event_json(&session_id, &goal_ctx.profile_id)
+            orchestrator.session_goal_updated_event_json(goal_key, &goal_ctx.profile_id)
         {
             match serde_json::from_value::<octos_core::ui_protocol::SessionGoalUpdatedEvent>(
                 goal_event_json,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -28315,7 +28315,9 @@ mod tests {
 
     fn local_profile_state(dir: &Path) -> AppState {
         AppState {
-            profile_store: Some(Arc::new(crate::profiles::ProfileStore::open(dir).unwrap())),
+            profile_store: Some(Arc::new(
+                crate::profiles::ProfileStore::open_unified(dir).unwrap(),
+            )),
             user_store: Some(Arc::new(crate::user_store::UserStore::open(dir).unwrap())),
             deployment_mode: crate::config::DeploymentMode::Local,
             // Solo profile creation is opt-in; the TUI/WS tests exercise the
@@ -32734,7 +32736,7 @@ ignore = []
             .expect("bootstrap profile");
             state.profiles.insert(id.to_string(), runtime);
         }
-        let store = Arc::new(crate::profiles::ProfileStore::open(&home).unwrap());
+        let store = Arc::new(crate::profiles::ProfileStore::open_unified(&home).unwrap());
         // Point the global default at "zeta" — NOT the first-sorted profile.
         store.set_default_profile("zeta").unwrap();
         state.profile_store = Some(store.clone());
@@ -32785,7 +32787,7 @@ ignore = []
         let home = tmp.path().join("home");
         let mut state = AppState::empty_for_tests();
         state.profile_store = Some(Arc::new(
-            crate::profiles::ProfileStore::open(&home).unwrap(),
+            crate::profiles::ProfileStore::open_unified(&home).unwrap(),
         ));
         let state = Arc::new(state);
         let cap = ConnectionUiFeatures::stdio_defaults();
@@ -33614,7 +33616,8 @@ ignore = []
     #[tokio::test]
     async fn memory_and_cron_rpc_methods_forward_rest_panel_bodies() {
         let dir = tempfile::tempdir().unwrap();
-        let profile_store = Arc::new(crate::profiles::ProfileStore::open(dir.path()).unwrap());
+        let profile_store =
+            Arc::new(crate::profiles::ProfileStore::open_unified(dir.path()).unwrap());
         let profile = panel_user_profile("tenant");
         profile_store.save(&profile).unwrap();
         let data_dir = profile_store.resolve_data_dir(&profile);
@@ -33797,7 +33800,8 @@ ignore = []
     #[tokio::test]
     async fn memory_rpc_methods_declare_truncation_when_over_budget() {
         let dir = tempfile::tempdir().unwrap();
-        let profile_store = Arc::new(crate::profiles::ProfileStore::open(dir.path()).unwrap());
+        let profile_store =
+            Arc::new(crate::profiles::ProfileStore::open_unified(dir.path()).unwrap());
         let profile = panel_user_profile("tenant");
         profile_store.save(&profile).unwrap();
         let data_dir = profile_store.resolve_data_dir(&profile);

--- a/crates/octos-cli/src/api/usage.rs
+++ b/crates/octos-cli/src/api/usage.rs
@@ -203,7 +203,7 @@ mod tests {
     #[tokio::test]
     async fn aggregate_profiles_usage_reads_every_profile_ledger() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
         store.save(&profile("alpha")).unwrap();
         store.save(&profile("beta")).unwrap();
 

--- a/crates/octos-cli/src/api/user_admin.rs
+++ b/crates/octos-cli/src/api/user_admin.rs
@@ -522,7 +522,7 @@ mod tests {
     async fn delete_user_cascades_sub_account_profiles_and_data_dirs() {
         let dir = tempfile::tempdir().unwrap();
         let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
-        let profile_store = Arc::new(ProfileStore::open(dir.path()).unwrap());
+        let profile_store = Arc::new(ProfileStore::open_unified(dir.path()).unwrap());
         let parent = test_profile("alice", None);
         let sub_account = test_profile("alice--bot", Some("alice"));
         let parent_data_dir = profile_store.resolve_data_dir(&parent);
@@ -570,7 +570,7 @@ mod tests {
     async fn delete_user_missing_user_does_not_delete_matching_profile() {
         let dir = tempfile::tempdir().unwrap();
         let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
-        let profile_store = Arc::new(ProfileStore::open(dir.path()).unwrap());
+        let profile_store = Arc::new(ProfileStore::open_unified(dir.path()).unwrap());
         let profile = test_profile("alice", None);
         let data_dir = profile_store.resolve_data_dir(&profile);
         profile_store.save(&profile).unwrap();

--- a/crates/octos-cli/src/commands/account.rs
+++ b/crates/octos-cli/src/commands/account.rs
@@ -106,7 +106,7 @@ pub enum AccountAction {
 impl Executable for AccountCommand {
     fn execute(self) -> Result<()> {
         let data_dir = super::resolve_data_dir(None)?;
-        let store = ProfileStore::open(&data_dir)?;
+        let store = ProfileStore::open_unified(&data_dir)?;
 
         match self.action {
             AccountAction::List { profile } => {

--- a/crates/octos-cli/src/commands/auth.rs
+++ b/crates/octos-cli/src/commands/auth.rs
@@ -231,7 +231,7 @@ fn status() -> Result<()> {
 
 fn open_profile_store() -> Result<ProfileStore> {
     let home = dirs::home_dir().ok_or_else(|| eyre::eyre!("cannot determine home directory"))?;
-    ProfileStore::open(&home.join(".octos"))
+    ProfileStore::open_unified(&home.join(".octos"))
 }
 
 /// Whether storing `secret` under `name` must be scoped per profile: a declared

--- a/crates/octos-cli/src/commands/gateway/account_handler.rs
+++ b/crates/octos-cli/src/commands/gateway/account_handler.rs
@@ -404,7 +404,7 @@ mod tests {
 
     fn create_store_with_sub_account() -> (tempfile::TempDir, Arc<ProfileStore>, String) {
         let dir = tempfile::tempdir().expect("tempdir");
-        let store = Arc::new(ProfileStore::open(dir.path()).expect("profile store"));
+        let store = Arc::new(ProfileStore::open_unified(dir.path()).expect("profile store"));
 
         let now = Utc::now();
         let parent = UserProfile {

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -334,7 +334,7 @@ impl GatewayRuntime {
         // resolves --data-dir > $OCTOS_HOME > ~/.octos).
         let effective_octos_home = cmd.octos_home.clone().unwrap_or_else(|| data_dir.clone());
         let profile_store: Option<Arc<crate::profiles::ProfileStore>> =
-            crate::profiles::ProfileStore::open(&effective_octos_home)
+            crate::profiles::ProfileStore::open_unified(&effective_octos_home)
                 .ok()
                 .map(Arc::new);
 

--- a/crates/octos-cli/src/commands/gateway/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/mod.rs
@@ -229,7 +229,7 @@ mod tests {
             std::env::set_var("OPENAI_API_KEY", "test-key");
         }
 
-        let store = Arc::new(crate::profiles::ProfileStore::open(dir.path()).unwrap());
+        let store = Arc::new(crate::profiles::ProfileStore::open_unified(dir.path()).unwrap());
 
         let mut parent = make_profile("botfather", Some("admin parent"));
         parent.config.llm = Some(crate::profiles::LlmProfileConfig {
@@ -572,7 +572,7 @@ mod tests {
     #[test]
     fn test_dispatch_unknown_profile_falls_back() {
         let dir = tempfile::TempDir::new().unwrap();
-        let store = crate::profiles::ProfileStore::open(dir.path()).unwrap();
+        let store = crate::profiles::ProfileStore::open_unified(dir.path()).unwrap();
         store
             .save(&make_profile("weather", Some("weather prompt")))
             .unwrap();
@@ -587,7 +587,7 @@ mod tests {
     #[test]
     fn test_dispatch_known_profile_keeps_target() {
         let dir = tempfile::TempDir::new().unwrap();
-        let store = crate::profiles::ProfileStore::open(dir.path()).unwrap();
+        let store = crate::profiles::ProfileStore::open_unified(dir.path()).unwrap();
         store
             .save(&make_profile("weather", Some("weather prompt")))
             .unwrap();
@@ -625,7 +625,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_bot_keeps_route_when_profile_delete_fails() {
         let dir = tempfile::TempDir::new().unwrap();
-        let store = Arc::new(crate::profiles::ProfileStore::open(dir.path()).unwrap());
+        let store = Arc::new(crate::profiles::ProfileStore::open_unified(dir.path()).unwrap());
         let mut parent = make_profile("botfather", None);
         parent
             .config
@@ -721,7 +721,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_bot_rejects_non_owner() {
         let dir = tempfile::TempDir::new().unwrap();
-        let store = Arc::new(crate::profiles::ProfileStore::open(dir.path()).unwrap());
+        let store = Arc::new(crate::profiles::ProfileStore::open_unified(dir.path()).unwrap());
         let mut parent = make_profile("botfather", None);
         parent
             .config
@@ -804,7 +804,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_bot_allows_operator_override() {
         let dir = tempfile::TempDir::new().unwrap();
-        let store = Arc::new(crate::profiles::ProfileStore::open(dir.path()).unwrap());
+        let store = Arc::new(crate::profiles::ProfileStore::open_unified(dir.path()).unwrap());
         let mut parent = make_profile("botfather", None);
         parent
             .config

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -1426,7 +1426,7 @@ mod tests {
             "test precondition: standalone roots must differ"
         );
 
-        let store = Arc::new(crate::profiles::ProfileStore::open(tmp.path()).unwrap());
+        let store = Arc::new(crate::profiles::ProfileStore::open_unified(tmp.path()).unwrap());
         let tool_config = Arc::new(
             octos_agent::ToolConfigStore::open(&effective_octos_home)
                 .await

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -234,6 +234,19 @@ pub struct ServeCommand {
     #[arg(long)]
     pub data_dir: Option<PathBuf>,
 
+    /// Per-instance runtime data dir (redb stores, sessions, goals, serve lock,
+    /// per-profile data). When set, the profile REGISTRY + model catalog still
+    /// resolve from the shared state home (the normal
+    /// `--data-dir`/`OCTOS_HOME`/`~/.octos`), so many stdio instances share one
+    /// config/profile while each owns private runtime state. Unset ⇒ identical
+    /// to today (runtime == state home).
+    ///
+    /// Also settable via `OCTOS_INSTANCE_DATA_DIR` (the flag wins; an empty env
+    /// value is treated as unset). Env is resolved in `run_async` because the
+    /// workspace `clap` build does not enable the `env` feature.
+    #[arg(long)]
+    pub instance_data_dir: Option<PathBuf>,
+
     /// Path to config file.
     #[arg(long)]
     pub config: Option<PathBuf>,
@@ -403,6 +416,39 @@ impl ServeCommand {
         let ctx = super::resolve_command_context(self.data_dir.clone())?;
         let data_dir = ctx.data_dir.clone();
 
+        // Multi-instance stdio split. `state_home` is the SHARED, config-like
+        // root that holds the profile REGISTRY and the model catalog — always
+        // the normal resolution (`--data-dir`/`OCTOS_HOME`/`~/.octos`), never
+        // the per-instance dir. The `data_dir` used from here on is the
+        // per-instance RUNTIME root (redb stores, sessions, goals, serve lock,
+        // per-profile data): the private per-instance dir when set, else the
+        // state home (byte-identical to today for default installs and for
+        // gateways, which never set a per-instance dir).
+        //
+        // The per-instance dir comes from `--instance-data-dir` (flag wins) or
+        // `OCTOS_INSTANCE_DATA_DIR` (empty ⇒ unset). Env is read here because
+        // the workspace `clap` build omits the `env` feature.
+        let state_home = data_dir.clone();
+        let instance_data_dir = self.instance_data_dir.clone().or_else(|| {
+            std::env::var("OCTOS_INSTANCE_DATA_DIR")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+                .map(PathBuf::from)
+        });
+        let data_dir = instance_data_dir
+            .clone()
+            .unwrap_or_else(|| state_home.clone());
+        if instance_data_dir.is_some() {
+            // A fresh per-instance dir must exist before the serve lock and
+            // redb stores open under it.
+            std::fs::create_dir_all(&data_dir).wrap_err_with(|| {
+                format!(
+                    "failed to create per-instance data dir: {}",
+                    data_dir.display()
+                )
+            })?;
+        }
+
         let (config, resolved_config_path) = if let Some(config_path) = &self.config {
             tracing::info!(path = %config_path.display(), "loading config (--config)");
             (Config::from_file(config_path)?, Some(config_path.clone()))
@@ -535,10 +581,14 @@ impl ServeCommand {
             None
         };
 
-        // Initialize profile store and process manager for admin dashboard
+        // Initialize profile store and process manager for admin dashboard.
+        // Registry (`<id>.json`) resolves from the SHARED `state_home`; the
+        // per-profile `<id>/data` runtime tree roots under the per-instance
+        // `data_dir`. With no `--instance-data-dir`, `state_home == data_dir`,
+        // so this is byte-identical to `open_unified(&data_dir)`.
         tracing::info!("initializing profile store and process manager");
         let profile_store = Arc::new(
-            crate::profiles::ProfileStore::open(&data_dir)
+            crate::profiles::ProfileStore::open(&state_home, &data_dir)
                 .wrap_err("failed to open profile store")?,
         );
 
@@ -1497,7 +1547,7 @@ mod tests {
     #[test]
     fn derives_dashboard_auth_from_admin_profile_email_tool() {
         let dir = tempfile::tempdir().unwrap();
-        let store = crate::profiles::ProfileStore::open(dir.path()).unwrap();
+        let store = crate::profiles::ProfileStore::open_unified(dir.path()).unwrap();
         store
             .save(&crate::profiles::UserProfile {
                 id: crate::api::auth_handlers::ADMIN_PROFILE_ID.into(),
@@ -1550,7 +1600,7 @@ mod tests {
         let _guard = dashboard_smtp_test_env_lock().lock().unwrap();
         let _env = EnvVarGuard::remove("OCTOS_TEST_DASHBOARD_AUTH_ADMIN_SMTP_PASSWORD");
         let dir = tempfile::tempdir().unwrap();
-        let store = crate::profiles::ProfileStore::open(dir.path()).unwrap();
+        let store = crate::profiles::ProfileStore::open_unified(dir.path()).unwrap();
         store
             .save(&crate::profiles::UserProfile {
                 id: crate::api::auth_handlers::ADMIN_PROFILE_ID.into(),
@@ -1601,7 +1651,7 @@ mod tests {
     #[test]
     fn derives_dashboard_auth_from_first_usable_non_admin_profile() {
         let dir = tempfile::tempdir().unwrap();
-        let store = crate::profiles::ProfileStore::open(dir.path()).unwrap();
+        let store = crate::profiles::ProfileStore::open_unified(dir.path()).unwrap();
         store
             .save(&crate::profiles::UserProfile {
                 id: crate::api::auth_handlers::ADMIN_PROFILE_ID.into(),
@@ -1674,7 +1724,7 @@ mod tests {
         let _guard = dashboard_smtp_test_env_lock().lock().unwrap();
         let _env = EnvVarGuard::remove("OCTOS_TEST_DASHBOARD_AUTH_PROFILE_SMTP_PASSWORD");
         let dir = tempfile::tempdir().unwrap();
-        let store = crate::profiles::ProfileStore::open(dir.path()).unwrap();
+        let store = crate::profiles::ProfileStore::open_unified(dir.path()).unwrap();
         store
             .save(&crate::profiles::UserProfile {
                 id: "dspfac".into(),

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -269,6 +269,15 @@ pub struct ServeCommand {
     #[arg(long)]
     pub danger_full_access: bool,
 
+    /// Opt OUT of the network-on default. By default a fresh Local session with
+    /// no explicit `/permissions` choice runs Workspace-Write with network
+    /// ALLOWED (filesystem still sandboxed) so `npm install` / git / fetch work
+    /// out of the box. Pass `--no-network` (or `OCTOS_NO_NETWORK=1`) to revert
+    /// the default to network DENIED. Cloud/tenant deployments always default to
+    /// network-denied regardless. An explicit `/permissions` choice still wins.
+    #[arg(long)]
+    pub no_network: bool,
+
     /// Use LLM-summarization for AppUI context compaction: when a session's
     /// context fills, ask the model for a high-quality handoff summary (a real
     /// model call — slower, a few seconds) instead of the instant deterministic
@@ -816,6 +825,10 @@ impl ServeCommand {
             || std::env::var("OCTOS_DANGER_FULL_ACCESS")
                 .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
                 .unwrap_or(false);
+        let default_network_denied_flag = self.no_network
+            || std::env::var("OCTOS_NO_NETWORK")
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false);
         // SECURITY KEYSTONE: the dangerous default rides the SAME solo
         // opt-in that gates selecting Full Access from the menu — a fleet
         // config that never sets --solo can reach neither surface.
@@ -891,6 +904,7 @@ impl ServeCommand {
             host_memory: config.memory.clone(),
             solo_login_enabled: solo_login_enabled_flag,
             dangerous_default_permissions: dangerous_default_permissions_flag,
+            default_network_denied: default_network_denied_flag,
             llm_compaction: self.llm_compaction,
             allow_admin_shell: config.allow_admin_shell,
             content_catalog_mgr: Some(Arc::new(

--- a/crates/octos-cli/src/commands/skills.rs
+++ b/crates/octos-cli/src/commands/skills.rs
@@ -226,7 +226,7 @@ impl Executable for SkillsCommand {
         // Resolve skills directory: per-profile or global
         let skills_dir = if let Some(ref profile_id) = self.profile {
             let data_dir = super::resolve_data_dir(None)?;
-            let store = crate::profiles::ProfileStore::open(&data_dir)?;
+            let store = crate::profiles::ProfileStore::open_unified(&data_dir)?;
             resolve_profile_skills_dir(&store, profile_id)?
         } else {
             cwd.join(".octos").join("skills")

--- a/crates/octos-cli/src/monitor.rs
+++ b/crates/octos-cli/src/monitor.rs
@@ -503,7 +503,7 @@ mod tests {
     #[test]
     fn profile_monitor_overrides_fall_back_to_system_defaults() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
         store
             .save(&profile("alpha", Some(false), Some(true)))
             .unwrap();

--- a/crates/octos-cli/src/process_manager.rs
+++ b/crates/octos-cli/src/process_manager.rs
@@ -1455,7 +1455,7 @@ mod tests {
     /// Create a temporary ProfileStore backed by a real temp directory.
     fn temp_profile_store() -> (tempfile::TempDir, Arc<ProfileStore>) {
         let dir = tempfile::tempdir().expect("failed to create temp dir");
-        let store = ProfileStore::open(dir.path()).expect("failed to open profile store");
+        let store = ProfileStore::open_unified(dir.path()).expect("failed to open profile store");
         (dir, Arc::new(store))
     }
 

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1156,24 +1156,70 @@ pub struct GatewaySettings {
 }
 
 /// Manages profile storage as individual JSON files.
+///
+/// The store has two roots so multi-instance stdio can share one profile
+/// REGISTRY while each instance owns private per-profile runtime state:
+///
+/// * `registry_dir` (`<registry_root>/profiles`) — where the `<id>.json`
+///   registry files are read/written/listed, plus config-like siblings under
+///   the registry parent (the `default-profile` pointer, platform-model
+///   allowlist). Shared across instances.
+/// * `data_profiles_dir` (`<data_root>/profiles`) — where [`resolve_data_dir`]
+///   roots the per-profile `<id>/data` runtime tree when a profile carries no
+///   explicit `data_dir` override. Per-instance.
+///
+/// [`resolve_data_dir`]: ProfileStore::resolve_data_dir
 pub struct ProfileStore {
-    profiles_dir: PathBuf,
+    /// Root for the `<id>.json` registry (shared/config-like).
+    registry_dir: PathBuf,
+    /// Root for the per-profile `<id>/data` runtime tree (per-instance).
+    data_profiles_dir: PathBuf,
 }
 
 impl ProfileStore {
-    /// Open (or create) the profile store at `data_dir/profiles/`.
-    pub fn open(data_dir: &Path) -> Result<Self> {
-        let profiles_dir = data_dir.join("profiles");
-        std::fs::create_dir_all(&profiles_dir).wrap_err_with(|| {
-            format!("failed to create profiles dir: {}", profiles_dir.display())
+    /// Open (or create) the profile store with a split registry / data root.
+    ///
+    /// * `registry_root` — the `<id>.json` registry lives under
+    ///   `registry_root/profiles`.
+    /// * `data_root` — the per-profile `<id>/data` fallback tree roots under
+    ///   `data_root/profiles`.
+    ///
+    /// When `registry_root == data_root` this is byte-identical to the legacy
+    /// single-root behavior; see [`ProfileStore::open_unified`].
+    pub fn open(registry_root: &Path, data_root: &Path) -> Result<Self> {
+        let registry_dir = registry_root.join("profiles");
+        std::fs::create_dir_all(&registry_dir).wrap_err_with(|| {
+            format!(
+                "failed to create profiles registry dir: {}",
+                registry_dir.display()
+            )
         })?;
-        Ok(Self { profiles_dir })
+        let data_profiles_dir = data_root.join("profiles");
+        std::fs::create_dir_all(&data_profiles_dir).wrap_err_with(|| {
+            format!(
+                "failed to create profiles data dir: {}",
+                data_profiles_dir.display()
+            )
+        })?;
+        Ok(Self {
+            registry_dir,
+            data_profiles_dir,
+        })
+    }
+
+    /// Open (or create) the profile store with a single unified root — the
+    /// registry and per-profile data both live under `data_dir/profiles/`.
+    ///
+    /// This preserves the pre-split behavior exactly (registry == data) and is
+    /// the right entry point for every caller that is not multi-instance-aware.
+    pub fn open_unified(data_dir: &Path) -> Result<Self> {
+        Self::open(data_dir, data_dir)
     }
 
     /// List all profiles sorted by name.
     pub fn list(&self) -> Result<Vec<UserProfile>> {
         let mut profiles = Vec::new();
-        let entries = match std::fs::read_dir(&self.profiles_dir) {
+        let entries = match std::fs::read_dir(&self.registry_dir) {
             Ok(entries) => entries,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(profiles),
             Err(e) => return Err(e).wrap_err("failed to read profiles directory"),
@@ -1359,12 +1405,12 @@ impl ProfileStore {
         if let Some(ref dir) = profile.data_dir {
             PathBuf::from(dir)
         } else {
-            self.profiles_dir.join(&profile.id).join("data")
+            self.data_profiles_dir.join(&profile.id).join("data")
         }
     }
 
     pub(crate) fn profile_path(&self, id: &str) -> PathBuf {
-        self.profiles_dir.join(format!("{id}.json"))
+        self.registry_dir.join(format!("{id}.json"))
     }
 
     /// Registration-id reservation policy (codex #1613 r6/r8), wired
@@ -1393,9 +1439,15 @@ impl ProfileStore {
         !matches!(self.get(id), Ok(Some(_)))
     }
 
-    /// Return the parent directory of the profiles dir (i.e. the octos home dir).
+    /// Return the parent directory of the registry profiles dir (i.e. the octos
+    /// home dir). This is the REGISTRY root — the config-like siblings that live
+    /// beside the profiles tree (the `default-profile` pointer, the platform-
+    /// model allowlist, and the `--octos-home` a spawned gateway opens its own
+    /// `ProfileStore` from) all resolve from here, so they stay shared across
+    /// per-instance runtime dirs. With a unified store this is the data dir,
+    /// exactly as before.
     pub fn octos_home_dir(&self) -> &Path {
-        self.profiles_dir.parent().unwrap_or(&self.profiles_dir)
+        self.registry_dir.parent().unwrap_or(&self.registry_dir)
     }
 
     /// Path to the persisted global default-profile pointer
@@ -2552,7 +2604,7 @@ mod tests {
         // the verify path's auto-create (get error → None → save)
         // would overwrite it with a default profile (r8 P2).
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         // Absent: free for anyone.
         assert!(!store.id_reserved_for_registration("ghost", false));
@@ -2584,7 +2636,7 @@ mod tests {
     #[test]
     fn default_profile_pointer_round_trips_and_defaults_to_none() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         // Unset: no pointer file yet.
         assert_eq!(store.default_profile(), None);
@@ -2615,7 +2667,7 @@ mod tests {
         // precedent as unparsable profile JSON) so one legacy record
         // cannot brick a multi-profile deployment.
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         // Plant the legacy record directly on disk, bypassing save().
         let legacy = serde_json::json!({
@@ -2668,7 +2720,7 @@ mod tests {
     #[test]
     fn test_profile_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let profile = UserProfile {
             // Not "test" — a reserved channel name (codex #1613 r4).
@@ -2718,7 +2770,7 @@ mod tests {
     #[test]
     fn test_save_preserves_local_owner_metadata_fields() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
         let mut profile = UserProfile {
             id: "ada".into(),
             name: "Ada Lovelace".into(),
@@ -2826,7 +2878,7 @@ mod tests {
     #[test]
     fn test_save_persists_structured_llm_contract() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let profile = UserProfile {
             id: "legacy-llm".into(),
@@ -3210,7 +3262,7 @@ mod tests {
     #[test]
     fn test_resolve_data_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let mut profile = UserProfile {
             id: "alice".into(),
@@ -3232,6 +3284,78 @@ mod tests {
         profile.data_dir = Some("/custom/path".into());
         let custom_dir = store.resolve_data_dir(&profile);
         assert_eq!(custom_dir, PathBuf::from("/custom/path"));
+    }
+
+    #[test]
+    fn should_read_registry_from_config_root_and_data_from_data_root() {
+        // Multi-instance stdio: a split store reads/writes the `<id>.json`
+        // REGISTRY under the SHARED registry_root while the per-profile
+        // `<id>/data` runtime tree roots under the PER-INSTANCE data_root.
+        let registry_root = tempfile::tempdir().unwrap();
+        let data_root = tempfile::tempdir().unwrap();
+        let store = ProfileStore::open(registry_root.path(), data_root.path()).unwrap();
+
+        let profile = UserProfile {
+            id: "alice".into(),
+            name: "Alice".into(),
+            enabled: false,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig::default(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        store.save(&profile).unwrap();
+
+        // Registry json lands under registry_root/profiles — NOT data_root.
+        let registry_json = registry_root.path().join("profiles").join("alice.json");
+        assert!(
+            registry_json.exists(),
+            "registry <id>.json must live under registry_root/profiles"
+        );
+        assert!(
+            !data_root
+                .path()
+                .join("profiles")
+                .join("alice.json")
+                .exists(),
+            "registry <id>.json must NOT live under data_root/profiles"
+        );
+        // The store must be able to read the profile back through the registry.
+        assert!(store.get("alice").unwrap().is_some());
+        assert_eq!(store.list().unwrap().len(), 1);
+
+        // Per-profile data roots under data_root/profiles — NOT registry_root.
+        let resolved = store.resolve_data_dir(&profile);
+        assert!(
+            resolved.starts_with(data_root.path().join("profiles")),
+            "resolve_data_dir must root under data_root/profiles, got {}",
+            resolved.display()
+        );
+        assert!(resolved.ends_with("alice/data"));
+
+        // octos_home_dir points at the REGISTRY root (shared, config-like).
+        assert_eq!(store.octos_home_dir(), registry_root.path());
+
+        // Regression guard: open_unified(x) collapses both roots under x.
+        let unified_dir = tempfile::tempdir().unwrap();
+        let unified = ProfileStore::open_unified(unified_dir.path()).unwrap();
+        unified.save(&profile).unwrap();
+        assert!(
+            unified_dir
+                .path()
+                .join("profiles")
+                .join("alice.json")
+                .exists(),
+            "open_unified registry must live under x/profiles"
+        );
+        assert!(
+            unified
+                .resolve_data_dir(&profile)
+                .starts_with(unified_dir.path().join("profiles")),
+            "open_unified data must root under x/profiles"
+        );
     }
 
     #[test]
@@ -3312,7 +3436,7 @@ mod tests {
     #[test]
     fn test_file_permissions() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
         let profile = UserProfile {
             id: "perms-test".into(),
             name: "Perms".into(),
@@ -3337,7 +3461,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_preserves_masked_secrets() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         // Save a profile with real secrets
         let original = UserProfile {
@@ -3448,7 +3572,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_preserves_masked_email_secrets() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
         store.save(&email_secret_profile("email-merge")).unwrap();
 
         // A client GETs the masked profile and PUTs it straight back.
@@ -3470,7 +3594,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_allows_changing_email_secrets() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
         store.save(&email_secret_profile("email-change")).unwrap();
 
         // A genuinely new value is NOT a display artifact, so it must land.
@@ -3492,7 +3616,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_preserves_masked_channel_secrets() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let original = UserProfile {
             id: "channel-merge".into(),
@@ -3588,7 +3712,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_allows_clearing_channel_secret() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let original = UserProfile {
             id: "channel-clear".into(),
@@ -3654,7 +3778,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_preserves_channel_secret_after_delete() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let matrix_channel = |user_id: &str, token: &str| ChannelCredentials::Matrix {
             homeserver: "https://matrix.example.org".into(),
@@ -4063,7 +4187,7 @@ mod tests {
     #[test]
     fn test_create_sub_account() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         // Create parent with LLM config
         let parent = UserProfile {
@@ -4133,7 +4257,7 @@ mod tests {
     #[test]
     fn test_public_subdomain_must_be_unique() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let first = UserProfile {
             id: "top-level".into(),
@@ -4165,7 +4289,7 @@ mod tests {
     #[test]
     fn test_resolve_routable_profile_id_prefers_public_subdomain() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let parent = UserProfile {
             id: "tenant".into(),
@@ -4219,7 +4343,7 @@ mod tests {
     #[test]
     fn test_resolve_effective_profile() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         // Create parent
         let parent = UserProfile {
@@ -4324,7 +4448,7 @@ mod tests {
     #[test]
     fn test_resolve_effective_profile_inherits_structured_sections() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let parent = UserProfile {
             id: "parent".into(),
@@ -4568,7 +4692,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_preserves_keychain_marker() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         // Save profile with keychain marker
         let original = UserProfile {
@@ -4617,7 +4741,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_allows_setting_keychain_marker() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         // Profile with plaintext secret
         let original = UserProfile {
@@ -4654,7 +4778,7 @@ mod tests {
     #[test]
     fn test_save_with_merge_empty_does_not_overwrite_keychain() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let original = UserProfile {
             id: "kc-empty".into(),

--- a/crates/octos-cli/src/skills_scope.rs
+++ b/crates/octos-cli/src/skills_scope.rs
@@ -109,7 +109,7 @@ mod tests {
     #[test]
     fn resolve_account_skills_dir_keeps_sub_account_isolated() {
         let dir = tempfile::tempdir().unwrap();
-        let store = ProfileStore::open(dir.path()).unwrap();
+        let store = ProfileStore::open_unified(dir.path()).unwrap();
 
         let parent = UserProfile {
             id: "dspfac".into(),

--- a/crates/octos-cli/tests/preview_auth.rs
+++ b/crates/octos-cli/tests/preview_auth.rs
@@ -85,7 +85,7 @@ async fn build_fixture() -> Fixture {
     //    back up to recover the profile id, so we MUST leave
     //    `data_dir = None` (an override breaks that lookup and the
     //    session-workspace search misses the pre-seeded files).
-    let profile_store = Arc::new(ProfileStore::open(&octos_home).expect("profile store"));
+    let profile_store = Arc::new(ProfileStore::open_unified(&octos_home).expect("profile store"));
 
     let profile_a = UserProfile {
         id: "tenant-a".into(),

--- a/crates/octos-cli/tests/preview_signed.rs
+++ b/crates/octos-cli/tests/preview_signed.rs
@@ -76,7 +76,7 @@ async fn build_fixture_with_ttl(ttl: std::time::Duration) -> Fixture {
     let tempdir = TempDir::new().expect("tempdir");
     let octos_home = tempdir.path().to_path_buf();
 
-    let profile_store = Arc::new(ProfileStore::open(&octos_home).expect("profile store"));
+    let profile_store = Arc::new(ProfileStore::open_unified(&octos_home).expect("profile store"));
 
     let profile_a = UserProfile {
         id: "tenant-a".into(),

--- a/crates/octos-cli/tests/ws_token_url_decode.rs
+++ b/crates/octos-cli/tests/ws_token_url_decode.rs
@@ -50,7 +50,7 @@ use tower::util::ServiceExt;
 /// pass in `Authorization: Bearer …`. The WS path must arrive at this
 /// same byte sequence after percent-decoding the `?token=` value.
 fn build_state_with_admin_token(_dir: &TempDir, token: &str) -> Arc<AppState> {
-    let store = Arc::new(octos_cli::profiles::ProfileStore::open(_dir.path()).unwrap());
+    let store = Arc::new(octos_cli::profiles::ProfileStore::open_unified(_dir.path()).unwrap());
     Arc::new(AppState {
         profile_store: Some(store),
         auth_token: Some(token.into()),

--- a/crates/octos-cli/tests/x_profile_id_strip.rs
+++ b/crates/octos-cli/tests/x_profile_id_strip.rs
@@ -71,7 +71,7 @@ fn with_connect_info(mut req: Request<Body>, addr: SocketAddr) -> Request<Body> 
 /// can grant sessions for these ids) and the X-Profile-Id branch in
 /// `is_authorized_for_profile` can resolve sub-account parentage.
 fn build_state(_dir: &TempDir, profiles: &[(&str, Option<&str>)]) -> Arc<AppState> {
-    let store = Arc::new(octos_cli::profiles::ProfileStore::open(_dir.path()).unwrap());
+    let store = Arc::new(octos_cli::profiles::ProfileStore::open_unified(_dir.path()).unwrap());
     for (id, parent) in profiles {
         let profile = octos_cli::profiles::UserProfile {
             id: (*id).into(),
@@ -104,7 +104,8 @@ fn build_state_with_users(
     users: &[(&str, &str, octos_cli::user_store::UserRole)],
     profiles: &[(&str, Option<&str>)],
 ) -> (Arc<AppState>, Arc<octos_cli::otp::AuthManager>) {
-    let profile_store = Arc::new(octos_cli::profiles::ProfileStore::open(dir.path()).unwrap());
+    let profile_store =
+        Arc::new(octos_cli::profiles::ProfileStore::open_unified(dir.path()).unwrap());
     for (id, parent) in profiles {
         let profile = octos_cli::profiles::UserProfile {
             id: (*id).into(),
@@ -649,7 +650,8 @@ async fn build_state_with_sessions_for_tenant_b(
     tenant_b_id: &str,
     session_id: &str,
 ) -> Arc<AppState> {
-    let profile_store = Arc::new(octos_cli::profiles::ProfileStore::open(dir.path()).unwrap());
+    let profile_store =
+        Arc::new(octos_cli::profiles::ProfileStore::open_unified(dir.path()).unwrap());
     for (id, parent) in profiles {
         let profile = octos_cli::profiles::UserProfile {
             id: (*id).into(),


### PR DESCRIPTION
Integrates the tested `deploy/full-bundle` (already deployed to local + mini5) into main. Current `main` merged in cleanly (auto-merge with the ui-protocol delete-legacy work; verified: `cargo build -p octos-cli --features api` clean, 760 merged-area tests pass — goal/profiles/permission/network/ui_protocol).

Contents (each already has its own PR — #1743, #1741, #1740 — which this supersedes by landing them together against current main):
- **Multi-instance stdio** (#1743): `--instance-data-dir`/`OCTOS_INSTANCE_DATA_DIR` per-instance runtime dir; `ProfileStore` registry/data split; shared profile registry.
- **Goal cwd-leak fix** (#1741): goals no longer bleed across folders.
- **Network-on default + `--no-network`** (#1740) and the `/private/etc` sandbox read fix (TLS/curl under network-on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)