### PR TITLE
feat(hooks): add UserPromptSubmit lifecycle hook (deny + context injection)

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -379,6 +379,9 @@ impl Agent {
                         Err("tool arguments changed since approval request was created".to_string())
                     }
                 }
+                // Context injection is a `user_prompt_submit`-only outcome and
+                // never arises for a before-tool re-validation; allow the call.
+                HookResult::Context(_) => Ok(()),
                 HookResult::Deny(reason) => {
                     if reason.is_empty() {
                         Err("current policy denied the approved tool call".to_string())

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -21,6 +21,7 @@ use super::verifier::{TurnLedger, ledger_entry_from_tool_result};
 use super::{Agent, ConversationResponse, TASK_REPORTER, TokenTracker};
 use crate::harness_errors::HarnessError;
 use crate::harness_events::write_event_to_sink;
+use crate::hooks::{HookEvent, HookPayload, HookResult};
 use crate::loop_detect::LoopDetector;
 use crate::progress::ProgressEvent;
 use crate::prompt_context::PromptContextPhase;
@@ -931,6 +932,99 @@ impl Agent {
                 // #1691 (codex gap G6): fire the in-band budget reminder once,
                 // when the run first crosses ~80% of its iteration cap.
                 let mut budget_reminder_sent = false;
+
+                // UserPromptSubmit lifecycle hook. Fires exactly once here —
+                // when a real user-submitted prompt enters the turn, after the
+                // messages are assembled but BEFORE the first LLM call and
+                // before any loop iteration (per-iteration LLM gating is
+                // BeforeLlmCall's job). A before-hook can:
+                //   * DENY the prompt (exit 1) → block the whole turn with the
+                //     hook's stdout as the surfaced reason (mirrors how a
+                //     denied tool call surfaces its reason), or
+                //   * INJECT context (exit 0 + stdout) → prepend the hook's
+                //     stdout as a per-turn system-context note so it reaches
+                //     the model for THIS turn without being persisted as a
+                //     message.
+                // No-op (byte-identical to before) when no `user_prompt_submit`
+                // hook is configured — the executor returns Allow immediately.
+                if let Some(ref hooks) = self.hooks {
+                    let hook_ctx = self.hook_ctx();
+                    let cwd = self.tools.workspace_root().map(|p| p.display().to_string());
+                    let payload = HookPayload::user_prompt_submit(
+                        user_content,
+                        self.llm.model_id(),
+                        cwd.as_deref(),
+                        hook_ctx.as_ref(),
+                    );
+                    match hooks.run(HookEvent::UserPromptSubmit, &payload).await {
+                        HookResult::Deny(reason) => {
+                            let reason = reason.trim();
+                            let message = if reason.is_empty() {
+                                "[HOOK DENIED] Prompt was blocked by a user_prompt_submit hook."
+                                    .to_string()
+                            } else {
+                                format!(
+                                    "[HOOK DENIED] Prompt was blocked by a user_prompt_submit hook: {reason}"
+                                )
+                            };
+                            tracing::warn!(reason = %reason, "user_prompt_submit hook denied prompt");
+                            self.reporter().report(ProgressEvent::LlmStatus {
+                                message: message.clone(),
+                                iteration: 0,
+                            });
+                            // Mirror the budget-stop early return: persist the
+                            // user's message (turn_output_log) and surface the
+                            // deny reason as the assistant content. The LLM is
+                            // never called.
+                            return Ok(ConversationResponse {
+                                content: message,
+                                reasoning_content: None,
+                                provider_metadata: None,
+                                token_usage: turn.total_usage().clone(),
+                                estimated_spend_usd: turn.priced_spend(),
+                                files_modified,
+                                files_to_send,
+                                streamed: false,
+                                messages: turn_output_log.clone(),
+                                tool_results: tool_structured_metadata.clone(),
+                                synthesized_from_spawn_only: false,
+                                pending_approval: None,
+                            });
+                        }
+                        HookResult::Context(contexts) => {
+                            // Inject each hook's stdout as a per-turn System
+                            // context note, placed right after the primary
+                            // system prompt (index 0). The next
+                            // `normalize_system_messages` pass folds these into
+                            // the system context the model sees. They are NOT
+                            // added to `turn_output_log`, so they are never
+                            // persisted as conversation messages.
+                            for context in contexts.into_iter().rev() {
+                                let trimmed = context.trim();
+                                if trimmed.is_empty() {
+                                    continue;
+                                }
+                                messages.insert(
+                                    1,
+                                    Message {
+                                        role: MessageRole::System,
+                                        content: format!(
+                                            "[UserPromptSubmit hook context]\n{trimmed}"
+                                        ),
+                                        media: vec![],
+                                        tool_calls: None,
+                                        tool_call_id: None,
+                                        reasoning_content: None,
+                                        client_message_id: None,
+                                        thread_id: None,
+                                        timestamp: chrono::Utc::now(),
+                                    },
+                                );
+                            }
+                        }
+                        HookResult::Allow | HookResult::Error(_) | HookResult::Modified(_) => {}
+                    }
+                }
 
                 // Labeled so the loop-detector recovery arms below can re-enter
                 // the AGENT loop (skip tool execution for this spiraling
@@ -8515,6 +8609,156 @@ printf '{"output":"voice saved","success":true}\n'
         assert!(
             rx.try_recv().is_err(),
             "hook-deny must NOT emit a TurnFailure (preserve permission behaviour)"
+        );
+    }
+
+    /// Records the message contents of every LLM call and returns EndTurn
+    /// immediately. Used to assert what the model actually saw and that it was
+    /// (or was not) called at all.
+    struct RecordingEndProvider {
+        chat_calls: Arc<AtomicUsize>,
+        observed: Arc<StdMutex<Vec<Vec<String>>>>,
+    }
+
+    #[async_trait]
+    impl LlmProvider for RecordingEndProvider {
+        async fn chat(
+            &self,
+            messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &ChatConfig,
+        ) -> Result<ChatResponse> {
+            self.chat_calls.fetch_add(1, AtomicOrdering::SeqCst);
+            self.observed
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .push(messages.iter().map(|m| m.content.clone()).collect());
+            Ok(ChatResponse {
+                content: Some("ok".to_string()),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: StopReason::EndTurn,
+                usage: LlmTokenUsage::default(),
+                provider_index: None,
+            })
+        }
+
+        fn model_id(&self) -> &str {
+            "mock"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn user_prompt_submit_hook_injects_stdout_as_turn_context() {
+        use crate::hooks::{HookConfig, HookEvent, HookExecutor};
+
+        let dir = tempfile::tempdir().unwrap();
+        let tools = ToolRegistry::with_builtins(dir.path());
+        let chat_calls = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::new(StdMutex::new(Vec::new()));
+        let provider: Arc<dyn LlmProvider> = Arc::new(RecordingEndProvider {
+            chat_calls: chat_calls.clone(),
+            observed: Arc::clone(&observed),
+        });
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        // Hook prints a context note on stdout (exit 0). It must be injected
+        // into the model's input for this turn.
+        let hooks = Arc::new(HookExecutor::new(vec![HookConfig {
+            event: HookEvent::UserPromptSubmit,
+            command: vec!["sh".into(), "-c".into(), "echo OCTOS_CTX_MARKER_42".into()],
+            timeout_ms: 5000,
+            tool_filter: vec![],
+            path_filter: vec![],
+            requires_bin: None,
+        }]));
+        let agent =
+            Agent::new(AgentId::new("ups-inject"), provider, tools, memory).with_hooks(hooks);
+
+        let result = agent.process_message("do work", &[], vec![]).await.unwrap();
+        assert_eq!(result.content, "ok");
+        assert_eq!(chat_calls.load(AtomicOrdering::SeqCst), 1);
+
+        // The injected context reaches the model input for this turn...
+        let prompts = observed.lock().unwrap_or_else(|error| error.into_inner());
+        assert_eq!(prompts.len(), 1, "exactly one LLM call");
+        assert!(
+            prompts[0]
+                .iter()
+                .any(|content| content.contains("OCTOS_CTX_MARKER_42")),
+            "injected context must reach the model input; got {:?}",
+            prompts[0]
+        );
+        // ...but is NOT persisted as a conversation message.
+        assert!(
+            result
+                .messages
+                .iter()
+                .all(|m| !m.content.contains("OCTOS_CTX_MARKER_42")),
+            "injected context must not be persisted as a message"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn user_prompt_submit_hook_deny_blocks_turn_before_llm() {
+        use crate::hooks::{HookConfig, HookEvent, HookExecutor};
+
+        let dir = tempfile::tempdir().unwrap();
+        let tools = ToolRegistry::with_builtins(dir.path());
+        let chat_calls = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::new(StdMutex::new(Vec::new()));
+        let provider: Arc<dyn LlmProvider> = Arc::new(RecordingEndProvider {
+            chat_calls: chat_calls.clone(),
+            observed: Arc::clone(&observed),
+        });
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        // Hook writes its reason on stdout and exits 1 → prompt denied.
+        let hooks = Arc::new(HookExecutor::new(vec![HookConfig {
+            event: HookEvent::UserPromptSubmit,
+            command: vec![
+                "sh".into(),
+                "-c".into(),
+                "echo 'no coding on fridays'; exit 1".into(),
+            ],
+            timeout_ms: 5000,
+            tool_filter: vec![],
+            path_filter: vec![],
+            requires_bin: None,
+        }]));
+        let agent = Agent::new(AgentId::new("ups-deny"), provider, tools, memory).with_hooks(hooks);
+
+        let result = agent
+            .process_message("write code", &[], vec![])
+            .await
+            .unwrap();
+
+        // The turn is blocked and the hook's reason is surfaced...
+        assert!(
+            result.content.contains("[HOOK DENIED]"),
+            "deny should be clearly surfaced; got {:?}",
+            result.content
+        );
+        assert!(
+            result.content.contains("no coding on fridays"),
+            "deny reason (hook stdout) should be surfaced; got {:?}",
+            result.content
+        );
+        // ...and the LLM is never reached.
+        assert_eq!(
+            chat_calls.load(AtomicOrdering::SeqCst),
+            0,
+            "denied prompt must not reach the model"
+        );
+        assert!(
+            observed
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .is_empty()
         );
     }
 }

--- a/crates/octos-agent/src/hooks.rs
+++ b/crates/octos-agent/src/hooks.rs
@@ -29,6 +29,13 @@ pub struct HookContext {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HookEvent {
+    /// Fires once when a real user-submitted prompt enters a turn, BEFORE the
+    /// agent/LLM processes it (mirrors Claude Code's `UserPromptSubmit`). A
+    /// before-hook can DENY the prompt (exit 1) to block the turn, or inject
+    /// additional per-turn context (exit 0 with stdout) that is prepended to
+    /// the model's input for that turn. Distinct from [`Self::BeforeLlmCall`],
+    /// which fires on every LLM iteration within a turn.
+    UserPromptSubmit,
     BeforeToolCall,
     AfterToolCall,
     BeforeLlmCall,
@@ -39,6 +46,29 @@ pub enum HookEvent {
     OnSpawnVerify,
     OnSpawnComplete,
     OnSpawnFailure,
+}
+
+impl HookEvent {
+    /// The config-string form of this event, matching the `snake_case` serde
+    /// rename used in `config.json`'s `hooks[].event` field. Kept as an
+    /// explicit match (rather than re-deriving from serde) so the enum ⇄
+    /// string mapping is auditable in one place and usable in log/error
+    /// messages without a `serde_json` round-trip.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            HookEvent::UserPromptSubmit => "user_prompt_submit",
+            HookEvent::BeforeToolCall => "before_tool_call",
+            HookEvent::AfterToolCall => "after_tool_call",
+            HookEvent::BeforeLlmCall => "before_llm_call",
+            HookEvent::AfterLlmCall => "after_llm_call",
+            HookEvent::OnResume => "on_resume",
+            HookEvent::OnTurnEnd => "on_turn_end",
+            HookEvent::BeforeSpawnVerify => "before_spawn_verify",
+            HookEvent::OnSpawnVerify => "on_spawn_verify",
+            HookEvent::OnSpawnComplete => "on_spawn_complete",
+            HookEvent::OnSpawnFailure => "on_spawn_failure",
+        }
+    }
 }
 
 /// Configuration for a single hook.
@@ -96,6 +126,14 @@ pub struct HookPayload {
     #[serde(default = "default_hook_payload_schema_version")]
     pub schema_version: u32,
     pub event: HookEvent,
+    /// The user's submitted prompt text (`user_prompt_submit` event only).
+    /// Truncated to [`MAX_PAYLOAD_FIELD_BYTES`] like other free-text fields.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    /// Working directory the turn runs in (`user_prompt_submit` event).
+    /// Lets prompt hooks emit cwd-scoped context (git state, policy, etc).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -257,6 +295,31 @@ impl HookPayload {
         let mut p = Self {
             turn_summary: Some(turn_summary),
             ..Self::empty(HookEvent::OnTurnEnd)
+        };
+        p.apply_context(ctx);
+        p
+    }
+
+    /// Payload for a `user_prompt_submit` hook.
+    ///
+    /// Fires once when a real user prompt enters a turn, before the first LLM
+    /// call. Carries the prompt text plus the turn's `model` and `cwd`, and
+    /// the session/profile context (via `ctx`) — mirroring the request codex's
+    /// UserPromptSubmit handler receives. The prompt is truncated to
+    /// [`MAX_PAYLOAD_FIELD_BYTES`] to keep the hook stdin bounded, matching the
+    /// other free-text payload fields.
+    pub fn user_prompt_submit(
+        prompt: &str,
+        model: &str,
+        cwd: Option<&str>,
+        ctx: Option<&HookContext>,
+    ) -> Self {
+        let mut p = Self {
+            event: HookEvent::UserPromptSubmit,
+            prompt: Some(truncate_string(prompt, MAX_PAYLOAD_FIELD_BYTES)),
+            model: Some(model.to_string()),
+            cwd: cwd.map(str::to_string),
+            ..Self::empty(HookEvent::UserPromptSubmit)
         };
         p.apply_context(ctx);
         p
@@ -522,6 +585,8 @@ impl HookPayload {
         Self {
             schema_version: HOOK_PAYLOAD_SCHEMA_VERSION,
             event,
+            prompt: None,
+            cwd: None,
             tool_name: None,
             arguments: None,
             tool_id: None,
@@ -590,6 +655,11 @@ pub enum HookResult {
     /// A before-hook modified the pending input for the event (exit code 2,
     /// stdout = replacement JSON payload).
     Modified(serde_json::Value),
+    /// One or more `user_prompt_submit` hooks allowed the prompt and emitted
+    /// additional context on stdout (exit code 0) to inject into the turn
+    /// before the first LLM call. Holds one entry per context-emitting hook,
+    /// in configuration order. Only produced for `HookEvent::UserPromptSubmit`.
+    Context(Vec<String>),
     /// A hook encountered an error (does not block).
     Error(String),
 }
@@ -671,6 +741,11 @@ impl HookExecutor {
         };
 
         let mut last_error = None;
+        // Additional context emitted by exit-0 `user_prompt_submit` hooks
+        // (one entry per hook that printed to stdout). Collected across all
+        // matching hooks and returned as `HookResult::Context` at the end so
+        // the caller can inject it into the turn before the first LLM call.
+        let mut injected_contexts: Vec<String> = Vec::new();
 
         for (i, hook) in self.hooks.iter().enumerate() {
             if hook.event != event {
@@ -746,13 +821,20 @@ impl HookExecutor {
             }
 
             match self.execute_hook(hook, &payload_json).await {
-                Ok((0, _stdout)) => {
+                Ok((0, stdout)) => {
                     self.failures[i].store(0, Ordering::Relaxed);
+                    // Context injection (user_prompt_submit): a hook that exits
+                    // 0 and prints to stdout contributes that text as extra
+                    // per-turn context. Other events ignore exit-0 stdout.
+                    if event == HookEvent::UserPromptSubmit && !stdout.is_empty() {
+                        injected_contexts.push(stdout);
+                    }
                 }
                 Ok((1, stdout)) => {
                     if matches!(
                         event,
-                        HookEvent::BeforeToolCall
+                        HookEvent::UserPromptSubmit
+                            | HookEvent::BeforeToolCall
                             | HookEvent::BeforeLlmCall
                             | HookEvent::BeforeSpawnVerify
                     ) {
@@ -828,6 +910,8 @@ impl HookExecutor {
 
         if let Some(err) = last_error {
             HookResult::Error(err)
+        } else if !injected_contexts.is_empty() {
+            HookResult::Context(injected_contexts)
         } else {
             HookResult::Allow
         }
@@ -909,9 +993,15 @@ impl HookExecutor {
             }
             Ok(Err(e)) => Err(e.into()),
             Err(_) => {
-                // Timeout: kill the child process to prevent orphans
+                // Timeout: kill the child process to prevent orphans. The
+                // message names the event and points at the fix so operators
+                // can act on it directly (mirrors Claude Code's guidance).
                 let _ = child.kill().await;
-                Err(eyre::eyre!("hook timed out after {}ms", hook.timeout_ms))
+                Err(eyre::eyre!(
+                    "{} hook timed out after {}ms — raise the hook's timeout_ms to allow more time",
+                    hook.event.as_str(),
+                    hook.timeout_ms
+                ))
             }
         }
     }
@@ -1286,6 +1376,8 @@ mod tests {
         let payload = HookPayload {
             schema_version: HOOK_PAYLOAD_SCHEMA_VERSION,
             event: HookEvent::AfterToolCall,
+            prompt: None,
+            cwd: None,
             tool_name: Some("test".into()),
             arguments: None,
             tool_id: None,
@@ -1845,5 +1937,229 @@ mod tests {
         // Non-object
         let args = serde_json::json!([]);
         assert!(extract_tool_path(&args).is_none());
+    }
+
+    // ----- UserPromptSubmit hook tests -----
+
+    /// Convenience constructor for the UserPromptSubmit tests below.
+    fn user_prompt_hook(command: Vec<&str>, timeout_ms: u64) -> HookConfig {
+        HookConfig {
+            event: HookEvent::UserPromptSubmit,
+            command: command.into_iter().map(String::from).collect(),
+            timeout_ms,
+            tool_filter: vec![],
+            path_filter: vec![],
+            requires_bin: None,
+        }
+    }
+
+    #[test]
+    fn should_map_user_prompt_submit_event_to_snake_case_string() {
+        assert_eq!(HookEvent::UserPromptSubmit.as_str(), "user_prompt_submit");
+        // serde rename matches as_str()
+        let json = serde_json::to_string(&HookEvent::UserPromptSubmit).unwrap();
+        assert_eq!(json, "\"user_prompt_submit\"");
+        // round-trips from the config-string form
+        let parsed: HookEvent = serde_json::from_str("\"user_prompt_submit\"").unwrap();
+        assert_eq!(parsed, HookEvent::UserPromptSubmit);
+        // as_str() agrees with serde for every variant
+        for ev in [
+            HookEvent::UserPromptSubmit,
+            HookEvent::BeforeToolCall,
+            HookEvent::AfterToolCall,
+            HookEvent::BeforeLlmCall,
+            HookEvent::AfterLlmCall,
+            HookEvent::OnResume,
+            HookEvent::OnTurnEnd,
+            HookEvent::BeforeSpawnVerify,
+            HookEvent::OnSpawnVerify,
+            HookEvent::OnSpawnComplete,
+            HookEvent::OnSpawnFailure,
+        ] {
+            let via_serde = serde_json::to_string(&ev).unwrap();
+            assert_eq!(via_serde, format!("\"{}\"", ev.as_str()));
+        }
+    }
+
+    #[test]
+    fn should_deserialize_user_prompt_submit_hook_config() {
+        let cfg: HookConfig =
+            serde_json::from_str(r#"{"event":"user_prompt_submit","command":["true"]}"#).unwrap();
+        assert_eq!(cfg.event, HookEvent::UserPromptSubmit);
+        assert_eq!(cfg.timeout_ms, 5000);
+    }
+
+    #[test]
+    fn should_build_user_prompt_submit_payload_with_prompt_cwd_and_model() {
+        let ctx = HookContext {
+            session_id: Some("sess-9".into()),
+            profile_id: Some("prof-9".into()),
+        };
+        let payload =
+            HookPayload::user_prompt_submit("hello world", "gpt-4", Some("/tmp/wd"), Some(&ctx));
+        assert_eq!(payload.event, HookEvent::UserPromptSubmit);
+        assert_eq!(payload.prompt.as_deref(), Some("hello world"));
+        assert_eq!(payload.model.as_deref(), Some("gpt-4"));
+        assert_eq!(payload.cwd.as_deref(), Some("/tmp/wd"));
+        assert_eq!(payload.session_id.as_deref(), Some("sess-9"));
+        assert_eq!(payload.schema_version, HOOK_PAYLOAD_SCHEMA_VERSION);
+
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("\"event\":\"user_prompt_submit\""));
+        assert!(json.contains("\"prompt\":\"hello world\""));
+        assert!(json.contains("\"cwd\":\"/tmp/wd\""));
+        assert!(json.contains("\"model\":\"gpt-4\""));
+    }
+
+    #[test]
+    fn should_truncate_long_user_prompt_in_payload() {
+        let long = "z".repeat(MAX_PAYLOAD_FIELD_BYTES * 2);
+        let payload = HookPayload::user_prompt_submit(&long, "m", None, None);
+        assert!(
+            payload
+                .prompt
+                .as_deref()
+                .is_some_and(|p| p.ends_with("... (truncated)"))
+        );
+        // cwd omitted when None
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(!json.contains("\"cwd\""));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn should_deny_prompt_when_user_prompt_submit_hook_exits_1() {
+        // A UserPromptSubmit hook is a BEFORE hook: exit 1 denies the prompt.
+        // The hook's stdout is surfaced as the deny reason (same convention as
+        // a denied tool call).
+        let executor = HookExecutor::new(vec![user_prompt_hook(
+            vec!["sh", "-c", "echo 'blocked: policy violation'; exit 1"],
+            5000,
+        )]);
+        let payload = HookPayload::user_prompt_submit("do the risky thing", "m", None, None);
+        let result = executor.run(HookEvent::UserPromptSubmit, &payload).await;
+        match result {
+            HookResult::Deny(reason) => assert_eq!(reason, "blocked: policy violation"),
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn should_inject_context_when_user_prompt_submit_hook_exits_0_with_stdout() {
+        let executor = HookExecutor::new(vec![user_prompt_hook(
+            vec!["sh", "-c", "echo 'git branch: main, 3 files staged'"],
+            5000,
+        )]);
+        let payload = HookPayload::user_prompt_submit("what changed?", "m", None, None);
+        let result = executor.run(HookEvent::UserPromptSubmit, &payload).await;
+        match result {
+            HookResult::Context(contexts) => {
+                assert_eq!(
+                    contexts,
+                    vec!["git branch: main, 3 files staged".to_string()]
+                );
+            }
+            other => panic!("expected Context, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn should_allow_when_user_prompt_submit_hook_exits_0_without_stdout() {
+        let executor = HookExecutor::new(vec![user_prompt_hook(vec!["true"], 5000)]);
+        let payload = HookPayload::user_prompt_submit("hi", "m", None, None);
+        let result = executor.run(HookEvent::UserPromptSubmit, &payload).await;
+        assert_eq!(result, HookResult::Allow);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn should_collect_context_from_multiple_hooks_in_config_order() {
+        let executor = HookExecutor::new(vec![
+            user_prompt_hook(vec!["sh", "-c", "echo first"], 5000),
+            user_prompt_hook(vec!["sh", "-c", "echo second"], 5000),
+        ]);
+        let payload = HookPayload::user_prompt_submit("hi", "m", None, None);
+        let result = executor.run(HookEvent::UserPromptSubmit, &payload).await;
+        match result {
+            HookResult::Context(contexts) => {
+                assert_eq!(contexts, vec!["first".to_string(), "second".to_string()]);
+            }
+            other => panic!("expected Context, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn should_deny_when_any_user_prompt_submit_hook_exits_1_even_after_context() {
+        // First hook injects context, second denies. Deny short-circuits.
+        let executor = HookExecutor::new(vec![
+            user_prompt_hook(vec!["sh", "-c", "echo context-note"], 5000),
+            user_prompt_hook(vec!["sh", "-c", "echo 'denied by second'; exit 1"], 5000),
+        ]);
+        let payload = HookPayload::user_prompt_submit("hi", "m", None, None);
+        let result = executor.run(HookEvent::UserPromptSubmit, &payload).await;
+        match result {
+            HookResult::Deny(reason) => assert_eq!(reason, "denied by second"),
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn should_report_actionable_message_when_user_prompt_submit_hook_times_out() {
+        // Timeout is fail-open (returns Error, not Deny) but the surfaced
+        // message must be actionable and name the event.
+        let executor = HookExecutor::new(vec![user_prompt_hook(vec!["sh", "-c", "sleep 5"], 50)]);
+        let payload = HookPayload::user_prompt_submit("hi", "m", None, None);
+        let result = executor.run(HookEvent::UserPromptSubmit, &payload).await;
+        match result {
+            HookResult::Error(msg) => {
+                assert!(
+                    msg.contains("user_prompt_submit hook timed out after 50ms"),
+                    "message should name the event and timeout: {msg}"
+                );
+                assert!(
+                    msg.contains("raise the hook's timeout_ms"),
+                    "message should be actionable: {msg}"
+                );
+            }
+            other => panic!("expected Error(timeout), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn should_apply_circuit_breaker_to_user_prompt_submit_hook() {
+        // Generic error exit (code 3) counts as a failure; after the threshold
+        // the hook is disabled and the executor returns Allow (fail-open).
+        let executor = HookExecutor::with_threshold(
+            vec![user_prompt_hook(vec!["sh", "-c", "exit 3"], 1000)],
+            3,
+        );
+        let payload = HookPayload::user_prompt_submit("hi", "m", None, None);
+        for _ in 0..3 {
+            executor.run(HookEvent::UserPromptSubmit, &payload).await;
+        }
+        let result = executor.run(HookEvent::UserPromptSubmit, &payload).await;
+        assert_eq!(result, HookResult::Allow);
+    }
+
+    #[tokio::test]
+    async fn should_be_noop_when_no_user_prompt_submit_hook_configured() {
+        // Backwards-compat: an executor with only other events never fires for
+        // UserPromptSubmit.
+        let executor = HookExecutor::new(vec![HookConfig {
+            event: HookEvent::AfterToolCall,
+            command: vec!["false".into()],
+            timeout_ms: 5000,
+            tool_filter: vec![],
+            path_filter: vec![],
+            requires_bin: None,
+        }]);
+        let payload = HookPayload::user_prompt_submit("hi", "m", None, None);
+        let result = executor.run(HookEvent::UserPromptSubmit, &payload).await;
+        assert_eq!(result, HookResult::Allow);
     }
 }

--- a/crates/octos-agent/src/plugins/extras.rs
+++ b/crates/octos-agent/src/plugins/extras.rs
@@ -221,6 +221,7 @@ fn resolve_hook(def: &SkillHookDef, skill_dir: &Path) -> Option<HookConfig> {
     use crate::hooks::HookEvent;
 
     let event = match def.event.as_str() {
+        "user_prompt_submit" => HookEvent::UserPromptSubmit,
         "before_tool_call" => HookEvent::BeforeToolCall,
         "after_tool_call" => HookEvent::AfterToolCall,
         "before_llm_call" => HookEvent::BeforeLlmCall,

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -868,6 +868,9 @@ async fn emit_lifecycle_hook(hooks: Option<&Arc<HookExecutor>>, payload: HookPay
         HookResult::Modified(_) => {
             warn!(event = ?event, "lifecycle hook attempted to modify payload; ignoring");
         }
+        // Context injection is a `user_prompt_submit`-only outcome; a spawn
+        // lifecycle event never produces it, but the match must be exhaustive.
+        HookResult::Context(_) => {}
         HookResult::Deny(reason) => {
             warn!(
                 event = ?event,
@@ -927,6 +930,9 @@ async fn run_before_spawn_verify_hook(
     match hooks.run(event, &payload).await {
         HookResult::Allow => Ok(default_files),
         HookResult::Modified(modified) => parse_modified_spawn_verify_output_files(modified),
+        // `before_spawn_verify` never yields context injection (that is a
+        // `user_prompt_submit`-only outcome); treat it like a plain allow.
+        HookResult::Context(_) => Ok(default_files),
         HookResult::Deny(reason) => Err(reason),
         HookResult::Error(error) => {
             warn!(

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -4518,6 +4518,9 @@ impl SessionActor {
                     "lifecycle hook attempted to modify payload; ignoring"
                 );
             }
+            // Context injection is a `user_prompt_submit`-only outcome; these
+            // emitted lifecycle events never produce it. Exhaustive-match arm.
+            HookResult::Context(_) => {}
             HookResult::Deny(reason) => {
                 warn!(
                     session = %self.session_key,


### PR DESCRIPTION
Adds a `UserPromptSubmit` lifecycle hook — fires once when a user submits a prompt, BEFORE the LLM sees it. Modeled on Claude Code's UserPromptSubmit + codex's richer semantics (studied `codex-rs/hooks/src/events/user_prompt_submit.rs`).

## What it does
- **Deny (exit 1):** blocks the prompt before any LLM call; surfaces the hook's message (`[HOOK DENIED] …`). The user message is still persisted.
- **Context injection (exit-0 stdout):** the hook's stdout is injected as a per-turn `System` context note the model sees for that turn — never persisted as a conversation message. Enables dynamic per-prompt context (git state, reminders, policy).
- **Payload:** prompt (truncated like other fields) + model + cwd + session/profile context — mirrors codex's request shape.
- **Timeout:** actionable, event-named message ("… hook timed out after Nms — raise timeout_ms"). Fail-open (Error, not Deny), consistent with other before-hooks. Circuit breaker applies.

## Firing seam
Fired once per submitted prompt in `agent/loop_runner.rs::process_message_inner`, before the agent loop / first LLM call — the shared point chat/gateway/serve/AppUI all funnel real user prompts through. Distinct from `BeforeLlmCall` (which fires every iteration). Not fired for tool/assistant/system continuations, or for delegated background/spawned worker tasks (`run_task`).

## Compatibility
Backwards-compatible: with no `user_prompt_submit` hook configured, the executor returns `Allow` immediately (verified by test). Config: `"event": "user_prompt_submit"` in the `hooks` array.

## Verified (myself, CI-exact)
`cargo build --workspace` ✓; `cargo test -p octos-agent --lib` 2180/0 (10 new unit + 2 e2e) ✓; `--test domain_hook` 6/0 ✓; `cargo clippy -p octos-agent --all-targets -D warnings` clean ✓; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)