### PR TITLE
feat(skills): per-profile skill layering (config-listed, inheritable)

### DIFF
--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -159,7 +159,7 @@ pub use role_template::{
 pub use sandbox::{Sandbox, SandboxConfig, SandboxMode, create_sandbox};
 pub use session::{SessionLimits, SessionState, SessionStateHandle, SessionUsage};
 pub use session_usage::{SessionUsageHandle, SessionUsageSnapshot, SharedSessionUsage};
-pub use skills::{SkillInfo, SkillsLoader};
+pub use skills::{SkillFilter, SkillInfo, SkillsLoader};
 pub use steering::{SteeringMessage, SteeringReceiver, SteeringSender};
 pub use subagent_output::{
     AppendResult, DEFAULT_GC_AGE, DEFAULT_MAX_BYTES_PER_TASK, DEFAULT_MAX_BYTES_TOTAL,

--- a/crates/octos-agent/src/plugins/loader.rs
+++ b/crates/octos-agent/src/plugins/loader.rs
@@ -193,6 +193,25 @@ impl PluginLoader {
         extra_env: &[(String, String)],
         options: PluginLoadOptions<'_>,
     ) -> Result<PluginLoadResult> {
+        Self::load_into_with_options_and_filter(registry, dirs, extra_env, options, None)
+    }
+
+    /// Like [`load_into_with_options`](Self::load_into_with_options), but applies
+    /// a skill-layering (v1) selection filter: a plugin whose manifest id is
+    /// not permitted by `skill_filter` is skipped entirely (no tools, hooks,
+    /// MCP servers, or prompt fragments registered).
+    ///
+    /// `skill_filter == None` ⇒ no filtering: every discovered plugin loads
+    /// exactly as before this feature existed (backwards-compatible). The
+    /// filter matches on `DiscoveredPlugin.manifest.id`, which equals the
+    /// skill's `SKILL.md` name and directory name.
+    pub fn load_into_with_options_and_filter(
+        registry: &mut ToolRegistry,
+        dirs: &[PathBuf],
+        extra_env: &[(String, String)],
+        options: PluginLoadOptions<'_>,
+        skill_filter: Option<&crate::skills::SkillFilter>,
+    ) -> Result<PluginLoadResult> {
         let mut result = PluginLoadResult::default();
 
         // Delegate dir scanning + dedup to octos_plugin::discovery so the
@@ -228,6 +247,18 @@ impl PluginLoader {
         let discovered = octos_plugin::discover_plugins(&sources, &extra_env_map);
 
         for plugin in discovered {
+            // Skill layering v1: skip plugins whose skill id is disabled (or
+            // not allow-listed) by the profile's inherited selection. Matched
+            // on the manifest id (== SKILL.md name == skill dir name).
+            if let Some(filter) = skill_filter {
+                if !filter.allows(&plugin.manifest.id) {
+                    info!(
+                        skill = %plugin.manifest.id,
+                        "skill layering: skipping plugin disabled by profile config"
+                    );
+                    continue;
+                }
+            }
             let path = plugin.path;
             // Re-parse via the agent-side manifest type below: octos_plugin's
             // PluginManifest is a structural subset and doesn't model
@@ -1207,6 +1238,66 @@ mod tests {
             PluginLoader::load_into(&mut registry, &[dir.path().to_path_buf()], &[]).unwrap();
         assert_eq!(result.tool_count, 1);
         assert_eq!(registry.len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skill_filter_skips_disabled_plugin_tools() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        for name in ["keep-plugin", "drop-plugin"] {
+            let plugin_dir = dir.path().join(name);
+            std::fs::create_dir(&plugin_dir).unwrap();
+            let tool = format!("{}_tool", name.replace('-', "_"));
+            std::fs::write(
+                plugin_dir.join("manifest.json"),
+                format!(
+                    r#"{{"name": "{name}", "version": "1.0", "tools": [{{"name": "{tool}", "description": "d", "input_schema": {{"type": "object", "properties": {{}}}}}}]}}"#
+                ),
+            )
+            .unwrap();
+            let exec_path = plugin_dir.join(name);
+            std::fs::write(
+                &exec_path,
+                "#!/bin/sh\necho '{\"output\": \"hi\", \"success\": true}'",
+            )
+            .unwrap();
+            std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        // AllDiscovered with `drop-plugin` disabled: only keep-plugin loads.
+        let filter = crate::skills::SkillFilter::AllExcept(std::collections::HashSet::from([
+            "drop-plugin".to_string(),
+        ]));
+        let mut registry = ToolRegistry::new();
+        let result = PluginLoader::load_into_with_options_and_filter(
+            &mut registry,
+            &[dir.path().to_path_buf()],
+            &[],
+            PluginLoadOptions::default(),
+            Some(&filter),
+        )
+        .unwrap();
+
+        assert_eq!(result.tool_count, 1, "only the enabled plugin's tool loads");
+        assert!(registry.get("keep_plugin_tool").is_some());
+        assert!(
+            registry.get("drop_plugin_tool").is_none(),
+            "a disabled skill must not register tools"
+        );
+
+        // No filter ⇒ both plugins load (backwards-compatible).
+        let mut registry_all = ToolRegistry::new();
+        let result_all = PluginLoader::load_into_with_options_and_filter(
+            &mut registry_all,
+            &[dir.path().to_path_buf()],
+            &[],
+            PluginLoadOptions::default(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(result_all.tool_count, 2);
     }
 
     #[test]

--- a/crates/octos-agent/src/skills.rs
+++ b/crates/octos-agent/src/skills.rs
@@ -2,11 +2,39 @@
 //!
 //! Loads skills from `.octos/skills/{name}/SKILL.md` with simple frontmatter.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use eyre::{Result, WrapErr};
 
 use crate::builtin_skills::BUILTIN_SKILLS;
+
+/// Crate-agnostic skill selection filter.
+///
+/// This is the lowered form of the CLI's per-profile skill-selection layer
+/// (`octos_cli::profiles::ProfileSkillsConfig`). It is intentionally free of
+/// any CLI dependency so both the [`SkillsLoader`] (prompt / content injection)
+/// and the plugin loader (tool specs) can consult the same selection decision.
+///
+/// A skill's `id` is its package identifier: the `manifest.json` `name`/`id`,
+/// which equals the `SKILL.md` `name` and the skill directory name.
+#[derive(Debug, Clone)]
+pub enum SkillFilter {
+    /// Load every discovered skill except these ids (`AllDiscovered` mode).
+    AllExcept(HashSet<String>),
+    /// Load only these ids (`AllowList` mode).
+    Only(HashSet<String>),
+}
+
+impl SkillFilter {
+    /// Whether a skill with `id` is permitted to load.
+    pub fn allows(&self, id: &str) -> bool {
+        match self {
+            SkillFilter::AllExcept(disabled) => !disabled.contains(id),
+            SkillFilter::Only(enabled) => enabled.contains(id),
+        }
+    }
+}
 
 /// Information about a loaded skill.
 #[derive(Debug, Clone)]
@@ -30,6 +58,10 @@ pub struct SkillInfo {
 /// Earlier directories take priority over later ones for skills with the same name.
 pub struct SkillsLoader {
     skills_dirs: Vec<PathBuf>,
+    /// Optional skill-selection filter (skill layering v1). `None` ⇒ no
+    /// filtering: every discovered skill is listed / loadable exactly as
+    /// before this feature existed (backwards-compatible).
+    filter: Option<SkillFilter>,
 }
 
 impl SkillsLoader {
@@ -37,7 +69,28 @@ impl SkillsLoader {
     pub fn new(data_dir: impl AsRef<Path>) -> Self {
         Self {
             skills_dirs: vec![data_dir.as_ref().join("skills")],
+            filter: None,
         }
+    }
+
+    /// Attach a skill-selection filter (builder form). Disabled skills are
+    /// absent from `list_skills` (hence `build_skills_summary` /
+    /// `get_always_skills`) and cannot be loaded by name.
+    pub fn with_skill_filter(mut self, filter: Option<SkillFilter>) -> Self {
+        self.filter = filter;
+        self
+    }
+
+    /// Attach a skill-selection filter in place.
+    pub fn set_skill_filter(&mut self, filter: Option<SkillFilter>) {
+        self.filter = filter;
+    }
+
+    /// True when `name` is permitted by the active filter (or no filter).
+    fn skill_allowed(&self, name: &str) -> bool {
+        self.filter
+            .as_ref()
+            .is_none_or(|filter| filter.allows(name))
     }
 
     /// Add an additional skills directory (appends `/skills` to the given dir).
@@ -105,6 +158,13 @@ impl SkillsLoader {
             }
         }
 
+        // Skill layering v1: drop skills disabled by the active selection
+        // filter so they are absent from the prompt summary and never treated
+        // as always-on. A `None` filter retains everything (backwards-compatible).
+        if self.filter.is_some() {
+            skills.retain(|s: &SkillInfo| self.skill_allowed(&s.name));
+        }
+
         skills.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(skills)
     }
@@ -114,6 +174,11 @@ impl SkillsLoader {
     /// Checks skills directories in priority order (first added = highest priority),
     /// then falls back to built-in system skills.
     pub async fn load_skill(&self, name: &str) -> Result<Option<String>> {
+        // Skill layering v1: a disabled skill is not loadable by name — its
+        // content must never be injected into the prompt.
+        if !self.skill_allowed(name) {
+            return Ok(None);
+        }
         // Check workspace directories in priority order
         for skills_dir in &self.skills_dirs {
             let skill_file = skills_dir.join(name).join("SKILL.md");
@@ -684,6 +749,125 @@ mod tests {
         let path = PathBuf::from("/data/skills/my-cool-skill/SKILL.md");
         let info = parse_skill(&path, content, false).unwrap();
         assert_eq!(info.name, "my-cool-skill");
+    }
+
+    // --- skill layering v1: SkillFilter ---
+
+    #[test]
+    fn skill_filter_all_except_and_only_semantics() {
+        let deny = SkillFilter::AllExcept(HashSet::from(["weather".to_string()]));
+        assert!(deny.allows("news"));
+        assert!(!deny.allows("weather"));
+
+        let allow = SkillFilter::Only(HashSet::from(["news".to_string()]));
+        assert!(allow.allows("news"));
+        assert!(!allow.allows("weather"));
+    }
+
+    #[tokio::test]
+    async fn disabled_skill_absent_from_list_summary_always_and_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let skills_dir = setup_skills_dir(&dir).await;
+
+        // Two always-on skills; one will be disabled by the filter.
+        for name in &["keep", "drop"] {
+            let sd = skills_dir.join(name);
+            tokio::fs::create_dir_all(&sd).await.unwrap();
+            tokio::fs::write(
+                sd.join("SKILL.md"),
+                format!("---\nname: {name}\ndescription: d\nalways: true\n---\n{name} body\n"),
+            )
+            .await
+            .unwrap();
+        }
+
+        let loader = SkillsLoader::new(dir.path()).with_skill_filter(Some(SkillFilter::AllExcept(
+            HashSet::from(["drop".to_string()]),
+        )));
+
+        // Absent from list_skills (hence the prompt summary + always set).
+        let names: Vec<String> = loader
+            .list_skills()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+        assert!(names.contains(&"keep".to_string()));
+        assert!(!names.contains(&"drop".to_string()));
+
+        let summary = loader.build_skills_summary().await.unwrap();
+        assert!(summary.contains("<name>keep</name>"));
+        assert!(!summary.contains("<name>drop</name>"));
+
+        let always = loader.get_always_skills().await.unwrap();
+        assert!(always.contains(&"keep".to_string()));
+        assert!(!always.contains(&"drop".to_string()));
+
+        // Content of a disabled skill must never be loadable / injectable.
+        assert!(loader.load_skill("keep").await.unwrap().is_some());
+        assert!(loader.load_skill("drop").await.unwrap().is_none());
+        let ctx = loader
+            .load_skills_for_context(&["keep".into(), "drop".into()])
+            .await
+            .unwrap();
+        assert!(ctx.contains("keep body"));
+        assert!(!ctx.contains("drop body"));
+    }
+
+    #[tokio::test]
+    async fn allow_list_only_loads_listed_skills() {
+        let dir = tempfile::tempdir().unwrap();
+        let skills_dir = setup_skills_dir(&dir).await;
+        for name in &["alpha", "beta"] {
+            let sd = skills_dir.join(name);
+            tokio::fs::create_dir_all(&sd).await.unwrap();
+            tokio::fs::write(
+                sd.join("SKILL.md"),
+                format!("---\nname: {name}\ndescription: d\n---\nbody\n"),
+            )
+            .await
+            .unwrap();
+        }
+        let loader = SkillsLoader::new(dir.path()).with_skill_filter(Some(SkillFilter::Only(
+            HashSet::from(["alpha".to_string()]),
+        )));
+        let names: Vec<String> = loader
+            .list_skills()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+        assert!(names.contains(&"alpha".to_string()));
+        assert!(!names.contains(&"beta".to_string()));
+        // AllowList also drops built-in skills that are not listed.
+        assert!(!names.iter().any(|n| n == "cron"));
+    }
+
+    #[tokio::test]
+    async fn no_filter_loads_every_skill_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let skills_dir = setup_skills_dir(&dir).await;
+        let sd = skills_dir.join("solo");
+        tokio::fs::create_dir_all(&sd).await.unwrap();
+        tokio::fs::write(
+            sd.join("SKILL.md"),
+            "---\nname: solo\ndescription: d\n---\nbody\n",
+        )
+        .await
+        .unwrap();
+        // No filter ⇒ identical to today: the installed skill AND builtins load.
+        let loader = SkillsLoader::new(dir.path());
+        let names: Vec<String> = loader
+            .list_skills()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+        assert!(names.contains(&"solo".to_string()));
+        assert!(names.iter().any(|n| n == "cron"));
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -622,7 +622,14 @@ impl GatewayRuntime {
         // is profile-driven by design.
 
         // Customer-installed skills are strictly account-scoped.
-        let skills_loader = crate::skills_scope::build_account_skills_loader(&data_dir);
+        // Skill layering v1: inherit the resolved profile's skill selection.
+        // `None` ⇒ no skills layer ⇒ every discovered skill loads (as before).
+        let skill_filter = resolved_profile
+            .as_ref()
+            .and_then(|p| p.config.skills.as_ref())
+            .map(|s| s.to_agent_filter());
+        let skills_loader = crate::skills_scope::build_account_skills_loader(&data_dir)
+            .with_skill_filter(skill_filter.clone());
 
         // Create message bus (before publisher is consumed by channel manager)
         let (agent_handle, publisher) = create_bus();
@@ -838,7 +845,7 @@ impl GatewayRuntime {
                 plugin_result = octos_agent::PluginLoadResult::default();
                 if !plugin_dirs.is_empty() {
                     let synthesis_config = build_synthesis_config(&config, &provider_name);
-                    match octos_agent::PluginLoader::load_into_with_options(
+                    match octos_agent::PluginLoader::load_into_with_options_and_filter(
                         &mut tools,
                         &plugin_dirs,
                         &plugin_env,
@@ -852,6 +859,7 @@ impl GatewayRuntime {
                             require_signed: config.plugins.require_signed,
                             verified_cache_dir: None,
                         },
+                        skill_filter.as_ref(),
                     ) {
                         Ok(result) => plugin_result = result,
                         Err(e) => warn!("plugin loading failed: {e}"),

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -663,7 +663,15 @@ impl ProfileActorFactoryBuilder {
         let model_id = llm.model_id().to_string();
 
         let profile_data_dir = self.profile_store.resolve_data_dir(&effective_profile);
-        let skills_loader = crate::skills_scope::build_account_skills_loader(&profile_data_dir);
+        // Skill layering v1: the child bot inherits the resolved profile's skill
+        // selection. `None` ⇒ no skills layer ⇒ every discovered skill loads.
+        let skill_filter = effective_profile
+            .config
+            .skills
+            .as_ref()
+            .map(|s| s.to_agent_filter());
+        let skills_loader = crate::skills_scope::build_account_skills_loader(&profile_data_dir)
+            .with_skill_filter(skill_filter.clone());
 
         let mut child_plugin_prompt_fragments = Vec::new();
         let mut child_plugin_hooks: Vec<octos_agent::HookConfig> = Vec::new();
@@ -754,7 +762,7 @@ impl ProfileActorFactoryBuilder {
                 // S2 plumbing: pass profile-scoped synthesis config so per-tenant
                 // routing of synthesis credentials works.
                 let synthesis_config = build_synthesis_config(&profile_config, &provider_name);
-                match octos_agent::PluginLoader::load_into_with_options(
+                match octos_agent::PluginLoader::load_into_with_options_and_filter(
                     &mut tools,
                     &plugin_dirs,
                     &plugin_env,
@@ -769,6 +777,7 @@ impl ProfileActorFactoryBuilder {
                         require_signed: profile_config.plugins.require_signed,
                         verified_cache_dir: None,
                     },
+                    skill_filter.as_ref(),
                 ) {
                     Ok(result) => {
                         child_plugin_prompt_fragments = result.prompt_fragments;

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -172,6 +172,108 @@ pub struct ProfileConfig {
     /// **overrides**.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lane_routing: Option<octos_llm::LaneRoutingConfig>,
+    /// Skill-layering (v1) selection layer. Merged through
+    /// [`ProfileStore::effective_config`] alongside hooks / env / sandbox /
+    /// plugins so a profile inherits the operator's default skill selection
+    /// and may narrow or extend it.
+    ///
+    /// `None` ⇒ "no local skills layer" (inherit the defaults' layer, if
+    /// any). When both the defaults and the profile omit it, the merge yields
+    /// `None` and every discovered skill loads exactly as before this feature
+    /// existed (backwards-compatible). See [`ProfileSkillsConfig`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skills: Option<ProfileSkillsConfig>,
+}
+
+/// How a profile selects which discovered skills to load.
+///
+/// This is ordinary selection, NOT a security policy — a profile may
+/// re-enable a skill that an inherited rule disabled (enforced denies would be
+/// a separate future policy layer, out of scope for v1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillSelectionMode {
+    /// Load every discovered skill except those with an `enabled: false` rule.
+    /// This is the default and matches pre-skill-layering behavior.
+    #[default]
+    AllDiscovered,
+    /// Load only skills that have an explicit `enabled: true` rule.
+    AllowList,
+}
+
+/// A single per-skill selection rule, keyed by the skill's identifier.
+///
+/// `id` is the skill package identifier: the `manifest.json` `name`/`id`
+/// field, which equals the `SKILL.md` `name` and the skill directory name.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SkillRule {
+    /// Skill identifier (manifest `name`/`id` == `SKILL.md` `name`).
+    pub id: String,
+    /// Whether this skill is enabled.
+    pub enabled: bool,
+}
+
+/// Per-profile skill selection layer.
+///
+/// Absent (`ProfileConfig::skills == None`) ⇒ [`SkillSelectionMode::AllDiscovered`]
+/// with no rules ⇒ every discovered skill loads (backwards-compatible).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProfileSkillsConfig {
+    /// Selection mode. `None` preserves "inherit mode" through the merge
+    /// (`profile.mode.or(defaults.mode)`); an absent mode resolves to
+    /// [`SkillSelectionMode::AllDiscovered`] at load time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<SkillSelectionMode>,
+    /// Per-skill rules. Keyed by `id`; the last rule for a given id wins.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<SkillRule>,
+}
+
+impl ProfileSkillsConfig {
+    /// The effective selection mode (absent ⇒ [`SkillSelectionMode::AllDiscovered`]).
+    pub fn effective_mode(&self) -> SkillSelectionMode {
+        self.mode.unwrap_or_default()
+    }
+
+    /// Whether a skill with `id` should load under this selection layer.
+    ///
+    /// Rules are last-wins per id. In [`SkillSelectionMode::AllDiscovered`] a
+    /// skill loads unless a rule disables it; in
+    /// [`SkillSelectionMode::AllowList`] a skill loads only when a rule
+    /// enables it.
+    pub fn allows(&self, id: &str) -> bool {
+        let last = self.rules.iter().rev().find(|rule| rule.id == id);
+        match self.effective_mode() {
+            SkillSelectionMode::AllDiscovered => last.map(|rule| rule.enabled).unwrap_or(true),
+            SkillSelectionMode::AllowList => last.map(|rule| rule.enabled).unwrap_or(false),
+        }
+    }
+
+    /// Lower this selection layer into the crate-agnostic
+    /// [`octos_agent::SkillFilter`] handed to the plugin loader and the
+    /// [`octos_agent::SkillsLoader`]. Rules are collapsed last-wins per id.
+    pub fn to_agent_filter(&self) -> octos_agent::SkillFilter {
+        let mut last: std::collections::HashMap<&str, bool> = std::collections::HashMap::new();
+        for rule in &self.rules {
+            last.insert(rule.id.as_str(), rule.enabled);
+        }
+        match self.effective_mode() {
+            SkillSelectionMode::AllDiscovered => octos_agent::SkillFilter::AllExcept(
+                last.into_iter()
+                    .filter(|(_, enabled)| !*enabled)
+                    .map(|(id, _)| id.to_string())
+                    .collect(),
+            ),
+            SkillSelectionMode::AllowList => octos_agent::SkillFilter::Only(
+                last.into_iter()
+                    .filter(|(_, enabled)| *enabled)
+                    .map(|(id, _)| id.to_string())
+                    .collect(),
+            ),
+        }
+    }
 }
 
 /// Profile-owned review workflow configuration.
@@ -1803,6 +1905,9 @@ pub(crate) fn merge_profile_defaults(
     effective.plugins = merge_plugins_defaults(&base.plugins, &defaults.plugins);
     effective.sandbox = merge_sandbox_defaults(&base.sandbox, &defaults.sandbox);
 
+    // skills: inherited selection layer (union of rules, last-wins per id).
+    effective.skills = merge_skills(&defaults.skills, &base.skills);
+
     // memory / approval_policy / cost_budget: profile wins, else defaults.
     if effective.memory.is_none() {
         effective.memory = defaults.memory.clone();
@@ -1815,6 +1920,43 @@ pub(crate) fn merge_profile_defaults(
     }
 
     effective
+}
+
+/// Merge the inherited skill-selection layer.
+///
+/// This is ordinary selection inheritance (NOT a security floor): a profile
+/// rule for the same id fully REPLACES the defaults' rule (last-wins per id),
+/// so a profile may re-enable a skill the defaults disabled. The result's id
+/// set is the union of both layers' ids.
+///
+/// - `rules`: defaults' rules first (order preserved); each profile rule either
+///   replaces the defaults' rule for the same id in place or is appended.
+/// - `mode`: `profile.mode.or(defaults.mode)` — the profile's explicit mode
+///   wins, else the defaults' mode is inherited, else `None` (⇒ AllDiscovered).
+/// - `None` + `None` ⇒ `None` (byte-identical to pre-skill-layering configs).
+pub(crate) fn merge_skills(
+    defaults: &Option<ProfileSkillsConfig>,
+    profile: &Option<ProfileSkillsConfig>,
+) -> Option<ProfileSkillsConfig> {
+    match (defaults, profile) {
+        (None, None) => None,
+        (Some(defaults), None) => Some(defaults.clone()),
+        (None, Some(profile)) => Some(profile.clone()),
+        (Some(defaults), Some(profile)) => {
+            let mut rules = defaults.rules.clone();
+            for profile_rule in &profile.rules {
+                if let Some(existing) = rules.iter_mut().find(|rule| rule.id == profile_rule.id) {
+                    *existing = profile_rule.clone();
+                } else {
+                    rules.push(profile_rule.clone());
+                }
+            }
+            Some(ProfileSkillsConfig {
+                mode: profile.mode.or(defaults.mode),
+                rules,
+            })
+        }
+    }
 }
 
 /// Presence-aware merge of `plugins` with a security floor on `require_signed`.
@@ -5509,6 +5651,159 @@ mod tests {
             eff.sandbox.allow_network,
             "omitted allow_network must inherit the default"
         );
+    }
+
+    // ---- skill layering v1 ----
+
+    fn skill_rule(id: &str, enabled: bool) -> SkillRule {
+        SkillRule {
+            id: id.to_string(),
+            enabled,
+        }
+    }
+
+    #[test]
+    fn merge_skills_none_and_none_is_none() {
+        // Byte-identical to pre-skill-layering configs: absent on both sides
+        // yields absent, so nothing changes for existing deployments.
+        assert_eq!(merge_skills(&None, &None), None);
+    }
+
+    #[test]
+    fn merge_skills_inherits_defaults_when_profile_absent() {
+        let defaults = Some(ProfileSkillsConfig {
+            mode: Some(SkillSelectionMode::AllowList),
+            rules: vec![skill_rule("news", true)],
+        });
+        let merged = merge_skills(&defaults, &None).unwrap();
+        assert_eq!(merged.mode, Some(SkillSelectionMode::AllowList));
+        assert_eq!(merged.rules, vec![skill_rule("news", true)]);
+    }
+
+    #[test]
+    fn merge_skills_uses_profile_when_defaults_absent() {
+        let profile = Some(ProfileSkillsConfig {
+            mode: None,
+            rules: vec![skill_rule("weather", false)],
+        });
+        let merged = merge_skills(&None, &profile).unwrap();
+        assert_eq!(merged.mode, None);
+        assert_eq!(merged.rules, vec![skill_rule("weather", false)]);
+    }
+
+    #[test]
+    fn merge_skills_replaces_rule_by_id_and_unions() {
+        // defaults disable `news` and `weather`; the profile re-enables `news`
+        // (replace-by-id) and adds `time` (union). `weather` survives untouched.
+        let defaults = Some(ProfileSkillsConfig {
+            mode: Some(SkillSelectionMode::AllDiscovered),
+            rules: vec![skill_rule("news", false), skill_rule("weather", false)],
+        });
+        let profile = Some(ProfileSkillsConfig {
+            mode: None,
+            rules: vec![skill_rule("news", true), skill_rule("time", true)],
+        });
+        let merged = merge_skills(&defaults, &profile).unwrap();
+
+        // Order: defaults first (news replaced in place, weather kept), then the
+        // profile-only `time` appended.
+        assert_eq!(
+            merged.rules,
+            vec![
+                skill_rule("news", true), // profile re-enabled (replace-by-id)
+                skill_rule("weather", false),
+                skill_rule("time", true), // profile-only (union)
+            ]
+        );
+        // A profile may re-enable an inherited disabled rule (ordinary
+        // selection, not a security floor).
+        assert!(merged.allows("news"));
+        assert!(!merged.allows("weather"));
+        assert!(merged.allows("time"));
+    }
+
+    #[test]
+    fn merge_skills_mode_falls_back_to_defaults() {
+        // profile.mode None ⇒ inherit defaults' mode.
+        let defaults = Some(ProfileSkillsConfig {
+            mode: Some(SkillSelectionMode::AllowList),
+            rules: vec![],
+        });
+        let profile = Some(ProfileSkillsConfig {
+            mode: None,
+            rules: vec![skill_rule("news", true)],
+        });
+        let merged = merge_skills(&defaults, &profile).unwrap();
+        assert_eq!(merged.mode, Some(SkillSelectionMode::AllowList));
+
+        // profile.mode Some ⇒ profile wins.
+        let profile_wins = Some(ProfileSkillsConfig {
+            mode: Some(SkillSelectionMode::AllDiscovered),
+            rules: vec![],
+        });
+        let merged = merge_skills(&defaults, &profile_wins).unwrap();
+        assert_eq!(merged.mode, Some(SkillSelectionMode::AllDiscovered));
+    }
+
+    #[test]
+    fn effective_config_merges_skills_layer() {
+        let registry_root = tempfile::tempdir().unwrap();
+        let data_root = tempfile::tempdir().unwrap();
+
+        let defaults = ProfileConfig {
+            skills: Some(ProfileSkillsConfig {
+                mode: Some(SkillSelectionMode::AllDiscovered),
+                rules: vec![skill_rule("news", false)],
+            }),
+            ..Default::default()
+        };
+        write_profile_defaults(registry_root.path(), &defaults);
+        let store = ProfileStore::open(registry_root.path(), data_root.path()).unwrap();
+
+        let mut profile = inheritance_profile("skilluser");
+        profile.config.skills = Some(ProfileSkillsConfig {
+            mode: None,
+            rules: vec![skill_rule("news", true)], // re-enable inherited disable
+        });
+
+        let eff = store.effective_config(&profile);
+        let skills = eff
+            .skills
+            .expect("skills layer must be present after merge");
+        // profile.mode None ⇒ inherit defaults' AllDiscovered.
+        assert_eq!(skills.mode, Some(SkillSelectionMode::AllDiscovered));
+        // profile re-enabled `news`.
+        assert!(skills.allows("news"));
+    }
+
+    #[test]
+    fn effective_config_skills_none_when_neither_sets_it() {
+        // No skills anywhere ⇒ None ⇒ every discovered skill loads as before.
+        let registry_root = tempfile::tempdir().unwrap();
+        let data_root = tempfile::tempdir().unwrap();
+        let defaults = ProfileConfig {
+            hooks: vec![tool_hook("d")],
+            ..Default::default()
+        };
+        write_profile_defaults(registry_root.path(), &defaults);
+        let store = ProfileStore::open(registry_root.path(), data_root.path()).unwrap();
+
+        let profile = inheritance_profile("noskills");
+        assert!(store.effective_config(&profile).skills.is_none());
+    }
+
+    #[test]
+    fn skills_config_roundtrips_and_defaults_to_absent() {
+        // Absent field deserializes to None (backwards-compatible).
+        let cfg: ProfileConfig = serde_json::from_str("{}").unwrap();
+        assert!(cfg.skills.is_none());
+
+        // snake_case mode + rules roundtrip.
+        let json = r#"{ "skills": { "mode": "allow_list", "rules": [ { "id": "news", "enabled": true } ] } }"#;
+        let cfg: ProfileConfig = serde_json::from_str(json).unwrap();
+        let skills = cfg.skills.unwrap();
+        assert_eq!(skills.mode, Some(SkillSelectionMode::AllowList));
+        assert_eq!(skills.rules, vec![skill_rule("news", true)]);
     }
 
     #[test]

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -637,9 +637,34 @@ impl ProfileRuntime {
                 plugin_dirs.push(dir.clone());
             }
         }
+        // --- Skill layering v1 ---
+        // Resolve the profile's inherited skill-selection layer (parent +
+        // global defaults already merged by `resolve_runtime_profile`) into a
+        // crate-agnostic filter handed to BOTH the plugin loader (tool specs)
+        // and the SkillsLoader (prompt / content injection) below. `None` ⇒ no
+        // skills layer ⇒ every discovered skill loads, exactly as before.
+        let skill_filter = profile.config.skills.as_ref().map(|s| s.to_agent_filter());
+        if profile.config.skills.is_some() {
+            let discovered_skill_ids: Vec<String> = build_account_skills_loader(data_dir)
+                .list_skills()
+                .await
+                .map(|skills| skills.into_iter().map(|s| s.name).collect())
+                .unwrap_or_default();
+            let catalog =
+                crate::skills_scope::resolve_profile_skills(profile, &discovered_skill_ids);
+            if catalog.has_disabled() {
+                info!(
+                    profile_id = %profile.id,
+                    mode = ?catalog.mode,
+                    disabled = ?catalog.disabled,
+                    "skill layering: installed skills disabled by profile config"
+                );
+            }
+        }
+
         let mut plugin_result = PluginLoadResult::default();
         if !plugin_dirs.is_empty() {
-            match PluginLoader::load_into_with_options(
+            match PluginLoader::load_into_with_options_and_filter(
                 &mut tools,
                 &plugin_dirs,
                 &plugin_env_template,
@@ -655,6 +680,7 @@ impl ProfileRuntime {
                     require_signed: config.plugins.require_signed,
                     verified_cache_dir: Some(effective_octos_home.join("cache").join("verified")),
                 },
+                skill_filter.as_ref(),
             ) {
                 Ok(result) => plugin_result = result,
                 Err(e) => warn!(profile_id = %profile.id, error = %e, "plugin loading failed"),
@@ -916,7 +942,7 @@ impl ProfileRuntime {
         // can hand to the helper. Operators who want per-profile
         // bootstrap files drop them in `<data_dir>/`, which matches the
         // pre-M11-F serve-mode behavior.
-        let skills_loader = build_account_skills_loader(data_dir);
+        let skills_loader = build_account_skills_loader(data_dir).with_skill_filter(skill_filter);
         let max_inject_tokens =
             crate::config::MemoryConfig::effective_max_inject_tokens(config.memory.as_ref());
         let memory_refresh_enabled =

--- a/crates/octos-cli/src/skills_scope.rs
+++ b/crates/octos-cli/src/skills_scope.rs
@@ -1,9 +1,93 @@
 use std::path::{Path, PathBuf};
 
 use eyre::Result;
-use octos_agent::SkillsLoader;
+use octos_agent::{SkillFilter, SkillsLoader};
 
-use crate::profiles::ProfileStore;
+use crate::profiles::{ProfileStore, SkillSelectionMode, UserProfile};
+
+/// Outcome of resolving a profile's inherited skill selection against a set of
+/// discovered candidate skills (skill layering v1).
+///
+/// Callers pass the output of
+/// [`ProfileStore::resolve_runtime_profile`](crate::profiles::ProfileStore::resolve_runtime_profile)
+/// (an already parent- and defaults-merged profile) plus the discovered
+/// candidate skill ids; the resolver partitions the candidates into the ones
+/// that load and the ones an inherited rule excludes, and produces the
+/// crate-agnostic [`SkillFilter`] handed to both the plugin loader and the
+/// [`SkillsLoader`].
+#[derive(Debug, Clone)]
+pub struct ResolvedSkillCatalog {
+    /// The effective selection mode that was applied.
+    pub mode: SkillSelectionMode,
+    /// Candidate skill ids that will load (deduped, precedence preserved).
+    pub enabled: Vec<String>,
+    /// Candidate skill ids excluded by the active selection (debug logging).
+    pub disabled: Vec<String>,
+    /// Filter to hand to the loaders. `None` ⇒ the profile has no skills layer
+    /// ⇒ load everything (byte-identical to pre-skill-layering behavior).
+    pub filter: Option<SkillFilter>,
+}
+
+impl ResolvedSkillCatalog {
+    /// Whether any candidate was excluded (for a one-line debug log).
+    pub fn has_disabled(&self) -> bool {
+        !self.disabled.is_empty()
+    }
+}
+
+/// Resolve a profile's inherited skill selection over `discovered` candidate
+/// skill ids.
+///
+/// `effective_profile` MUST be the resolved runtime profile (parent + global
+/// `profile-defaults.json` already merged via
+/// [`ProfileStore::resolve_runtime_profile`](crate::profiles::ProfileStore::resolve_runtime_profile))
+/// so its `config.skills` carries the fully-merged selection layer.
+///
+/// Candidates are deduped by id keeping first-occurrence precedence (mirrors
+/// the loader's "first dir wins" discovery). Rule matching is last-wins per id:
+/// in `AllDiscovered` a skill loads unless a rule disables it; in `AllowList`
+/// only skills with an enabling rule load.
+///
+/// When the profile has no skills layer at all the returned `filter` is `None`
+/// and every candidate is reported enabled — callers pass `None` to the loaders
+/// and nothing is filtered.
+pub fn resolve_profile_skills(
+    effective_profile: &UserProfile,
+    discovered: &[String],
+) -> ResolvedSkillCatalog {
+    // Dedupe candidates, preserving first-occurrence precedence.
+    let mut seen = std::collections::HashSet::new();
+    let unique: Vec<String> = discovered
+        .iter()
+        .filter(|id| seen.insert((*id).clone()))
+        .cloned()
+        .collect();
+
+    match effective_profile.config.skills.as_ref() {
+        None => ResolvedSkillCatalog {
+            mode: SkillSelectionMode::AllDiscovered,
+            enabled: unique,
+            disabled: Vec::new(),
+            filter: None,
+        },
+        Some(skills) => {
+            let (mut enabled, mut disabled) = (Vec::new(), Vec::new());
+            for id in unique {
+                if skills.allows(&id) {
+                    enabled.push(id);
+                } else {
+                    disabled.push(id);
+                }
+            }
+            ResolvedSkillCatalog {
+                mode: skills.effective_mode(),
+                enabled,
+                disabled,
+                filter: Some(skills.to_agent_filter()),
+            }
+        }
+    }
+}
 
 /// Resolve the installed skills directory for exactly the requested account.
 ///
@@ -104,7 +188,102 @@ mod tests {
     use chrono::Utc;
 
     use super::*;
-    use crate::profiles::{GatewaySettings, ProfileConfig, UserProfile};
+    use crate::profiles::{
+        GatewaySettings, ProfileConfig, ProfileSkillsConfig, SkillRule, UserProfile,
+    };
+
+    fn ids(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn profile_with_skills(skills: Option<ProfileSkillsConfig>) -> UserProfile {
+        UserProfile {
+            id: "p".into(),
+            name: "p".into(),
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig {
+                skills,
+                ..Default::default()
+            },
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn rule(id: &str, enabled: bool) -> SkillRule {
+        SkillRule {
+            id: id.to_string(),
+            enabled,
+        }
+    }
+
+    #[test]
+    fn resolve_none_layer_loads_everything_and_filters_nothing() {
+        let profile = profile_with_skills(None);
+        let discovered = ids(&["news", "weather", "time"]);
+        let catalog = resolve_profile_skills(&profile, &discovered);
+        assert_eq!(catalog.mode, SkillSelectionMode::AllDiscovered);
+        assert_eq!(catalog.enabled, discovered);
+        assert!(catalog.disabled.is_empty());
+        // No filter ⇒ loaders do zero filtering (backwards-compatible).
+        assert!(catalog.filter.is_none());
+    }
+
+    #[test]
+    fn resolve_all_discovered_excludes_only_disabled_rule() {
+        let profile = profile_with_skills(Some(ProfileSkillsConfig {
+            mode: Some(SkillSelectionMode::AllDiscovered),
+            rules: vec![rule("weather", false)],
+        }));
+        let catalog = resolve_profile_skills(&profile, &ids(&["news", "weather", "time"]));
+        assert_eq!(catalog.enabled, ids(&["news", "time"]));
+        assert_eq!(catalog.disabled, ids(&["weather"]));
+        let filter = catalog.filter.expect("filter present");
+        assert!(filter.allows("news"));
+        assert!(!filter.allows("weather"));
+        // An id with no rule still loads under AllDiscovered.
+        assert!(filter.allows("brand-new-skill"));
+    }
+
+    #[test]
+    fn resolve_allow_list_loads_only_enabled_rules() {
+        let profile = profile_with_skills(Some(ProfileSkillsConfig {
+            mode: Some(SkillSelectionMode::AllowList),
+            rules: vec![rule("news", true), rule("time", false)],
+        }));
+        let catalog = resolve_profile_skills(&profile, &ids(&["news", "weather", "time"]));
+        assert_eq!(catalog.enabled, ids(&["news"]));
+        assert_eq!(catalog.disabled, ids(&["weather", "time"]));
+        let filter = catalog.filter.expect("filter present");
+        assert!(filter.allows("news"));
+        // Not allow-listed ⇒ excluded.
+        assert!(!filter.allows("weather"));
+        // Explicitly disabled ⇒ excluded even though a rule exists.
+        assert!(!filter.allows("time"));
+    }
+
+    #[test]
+    fn resolve_profile_may_reenable_inherited_disabled_rule() {
+        // Simulates the post-merge config where an inherited `enabled: false`
+        // was replaced by the profile's `enabled: true` (last-wins per id).
+        let profile = profile_with_skills(Some(ProfileSkillsConfig {
+            mode: Some(SkillSelectionMode::AllDiscovered),
+            rules: vec![rule("news", false), rule("news", true)],
+        }));
+        let catalog = resolve_profile_skills(&profile, &ids(&["news"]));
+        assert_eq!(catalog.enabled, ids(&["news"]));
+        assert!(catalog.disabled.is_empty());
+    }
+
+    #[test]
+    fn resolve_dedupes_candidates_preserving_precedence() {
+        let profile = profile_with_skills(None);
+        let catalog = resolve_profile_skills(&profile, &ids(&["news", "news", "time"]));
+        assert_eq!(catalog.enabled, ids(&["news", "time"]));
+    }
 
     #[test]
     fn resolve_account_skills_dir_keeps_sub_account_isolated() {


### PR DESCRIPTION
Makes skills config-listed and inheritable per-profile through the same `effective_config` layer as hooks — codex's reviewed "discover candidates, then apply inherited selection rules" design. Backwards-compatible: no `skills` config ⇒ every discovered skill loads exactly as today.

- **Schema:** `skills: Option<ProfileSkillsConfig{ mode: AllDiscovered|AllowList, rules:[{id,enabled}] }>` on `ProfileConfig`.
- **Merge:** `merge_skills` in `effective_config` — rules keyed by manifest id (defaults first, profile replaces same id), mode profile-or-defaults, union of ids. A profile may re-enable an inherited disabled rule.
- **Shared resolver:** `skills_scope::resolve_profile_skills(effective_profile, discovered) -> ResolvedSkillCatalog` → `octos_agent::SkillFilter`, applied at every load site (`PluginLoader` + `SkillsLoader`), wired into serve, gateway, and routed child-bots — one filter, all paths.
- Disabled skills are absent from tool specs, always-on/prompt injection, and content loading. Rule `id` matches the manifest name (= PluginManifest.id = SKILL.md name = dir name), verified.

Verified: octos-agent 2185/0, octos-cli 2397/0; fmt/clippy clean. Comprehensive new tests (merge, resolver, loader-filter, SkillsLoader-filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)