### PR TITLE
fix(spawn): warn orchestrator that narrowed allowed_tools needs write_file/deliverable

### DIFF
--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -1654,7 +1654,10 @@ struct Input {
     /// worktree gives the child a dedicated git worktree under `.octos/work`.
     #[serde(default)]
     isolation: WorkerIsolation,
-    /// Tool names the subagent is allowed to use. Empty = all builtins.
+    /// Tool names the subagent is allowed to use. Empty = all builtins. A
+    /// narrowed list that omits `write_file` leaves the child unable to write a
+    /// deliverable except via a shell redirect (which is only captured when a
+    /// `deliverable` glob is set) — see the JSON-schema `description`.
     #[serde(default)]
     allowed_tools: Vec<String>,
     /// Extra context injected as a system-level prefix.
@@ -2808,7 +2811,7 @@ impl Tool for SpawnTool {
                 "allowed_tools": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Tool names the subagent may use. Empty = all builtins."
+                    "description": "Tool names the subagent may use. Empty = all builtins (the recommended default). CAUTION: if you narrow this list AND the subagent must PRODUCE A FILE (a report, review, generated code, any deliverable), you MUST include `write_file` (and usually `edit_file`) here — OR set the top-level `deliverable` glob. A subagent given `shell` but not `write_file` and no `deliverable` can only write via a shell redirect, and any file it writes outside the working tree (e.g. under /tmp) is LOST (never collected as output_files). When in doubt, leave this empty."
                 },
                 "role": {
                     "type": "string",

--- a/crates/octos-agent/src/tools/spawn_tests.rs
+++ b/crates/octos-agent/src/tools/spawn_tests.rs
@@ -2429,6 +2429,32 @@ async fn spawn_spec_exposes_max_iterations() {
     assert_eq!(props["max_iterations"]["type"], "integer");
 }
 
+#[tokio::test]
+async fn spawn_schema_warns_narrowed_allowed_tools_needs_write_file_or_deliverable() {
+    // Guards the guidance that stops the "worker shell-wrote to /tmp, deliverable
+    // lost" failure: if the orchestrator narrows allowed_tools, it must include
+    // write_file OR set a deliverable glob. Keyed loosely so rewording is fine.
+    let (in_tx, _in_rx) = tokio::sync::mpsc::channel(16);
+    let tool = SpawnTool::new(
+        Arc::new(MockProvider),
+        Arc::new(create_test_store().await),
+        PathBuf::from("/tmp"),
+        in_tx,
+    );
+    let desc = tool.input_schema()["properties"]["allowed_tools"]["description"]
+        .as_str()
+        .expect("allowed_tools description present")
+        .to_string();
+    assert!(
+        desc.contains("write_file"),
+        "allowed_tools guidance must mention write_file: {desc}"
+    );
+    assert!(
+        desc.contains("deliverable"),
+        "allowed_tools guidance must point at the deliverable glob: {desc}"
+    );
+}
+
 #[test]
 fn apply_agent_definition_preserves_inline_max_iterations() {
     // An inline max_iterations must survive manifest layering (inline wins /


### PR DESCRIPTION
A sub-agent given an explicit allowed_tools with shell but not write_file (and no deliverable glob) can only shell-write, and files it writes outside the tree (/tmp) are lost. Hardens the LLM-facing allowed_tools schema to require write_file OR a deliverable glob for file-producing workers. Prompt/schema only; no policy change. Root-cause: the default already has write_file; #1721 fixed roles; this is the explicit-allowlist path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)