### PR TITLE
fix(pre-release): read_allow_paths ..-escape + GLM/K3 reasoning-style precision

### DIFF
--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -2043,15 +2043,50 @@ fn merge_sandbox_defaults(
     eff
 }
 
+/// Lexically normalize an absolute `/`-rooted path, collapsing `.`/`..`
+/// segments WITHOUT touching the filesystem (the read roots may not exist yet).
+/// Returns `None` for a non-absolute path or one whose `..` segments climb above
+/// the root — such a path can never be a valid subset of an operator root, so
+/// the clamp drops it. This is what closes the `..` traversal that a bare
+/// `strip_prefix` check would wave through (e.g. `/srv/data/../../etc` → `/etc`).
+fn normalize_abs_lexical(path: &str) -> Option<String> {
+    if !path.starts_with('/') {
+        return None;
+    }
+    let mut out: Vec<&str> = Vec::new();
+    for seg in path.split('/') {
+        match seg {
+            "" | "." => {}
+            ".." => {
+                // Escapes above the root — reject the whole path.
+                out.pop()?;
+            }
+            seg => out.push(seg),
+        }
+    }
+    Some(format!("/{}", out.join("/")))
+}
+
 /// True when `path` is exactly one of `roots` or nested beneath one of them.
 /// Enforces the `read_allow_paths` floor: a profile may only keep read roots
-/// that fall within an operator-approved root.
+/// that fall within an operator-approved root. Both sides are lexically
+/// normalized first so a profile CANNOT use `..` (or a non-absolute path) to
+/// escape an operator root and still pass the subset check.
 fn sandbox_path_within_any(path: &str, roots: &[String]) -> bool {
+    let Some(path) = normalize_abs_lexical(path) else {
+        return false;
+    };
     roots.iter().any(|root| {
-        let root = root.trim_end_matches('/');
-        path == root
+        let Some(root) = normalize_abs_lexical(root) else {
+            return false;
+        };
+        // A `/` root allows all absolute paths; otherwise require an exact
+        // match or a `<root>/…` descendant (not a mere string prefix, so
+        // `/srv/database` is NOT within `/srv/data`).
+        root == "/"
+            || path == root
             || path
-                .strip_prefix(root)
+                .strip_prefix(&root)
                 .is_some_and(|rest| rest.starts_with('/'))
     })
 }
@@ -5879,6 +5914,35 @@ mod tests {
             eff.sandbox.read_allow_paths,
             vec!["/srv/data".to_string()],
             "an entirely out-of-floor profile list is clamped to the operator's roots"
+        );
+
+        // A profile using `..` to climb out of the operator root must NOT slip
+        // through the subset check: `/srv/data/../../etc` resolves to `/etc`,
+        // outside the floor, so it is dropped and the list clamps to defaults.
+        let mut traverse = inheritance_profile("mallory");
+        traverse.config.sandbox = octos_agent::SandboxConfig {
+            read_allow_paths: vec!["/srv/data/../../etc".into()],
+            ..Default::default()
+        };
+        let eff = store.effective_config(&traverse);
+        assert_eq!(
+            eff.sandbox.read_allow_paths,
+            vec!["/srv/data".to_string()],
+            "a `..` traversal escaping the operator root must be clamped, not honored"
+        );
+
+        // Sibling-prefix guard: `/srv/database` must not count as within
+        // `/srv/data` (string prefix ≠ path containment).
+        let mut sibling = inheritance_profile("neil");
+        sibling.config.sandbox = octos_agent::SandboxConfig {
+            read_allow_paths: vec!["/srv/database".into()],
+            ..Default::default()
+        };
+        let eff = store.effective_config(&sibling);
+        assert_eq!(
+            eff.sandbox.read_allow_paths,
+            vec!["/srv/data".to_string()],
+            "a sibling dir sharing a string prefix must not pass the containment check"
         );
     }
 

--- a/crates/octos-llm/src/openai.rs
+++ b/crates/octos-llm/src/openai.rs
@@ -125,17 +125,29 @@ impl ModelHints {
         // families can reject `reasoning_effort`.
         let reasoning_style = if m.contains("deepseek-v4") || m.contains("deepseek-reasoner") {
             ReasoningStyle::EffortAndThinkingToggle
-        } else if m.contains("kimi-k3") || m == "k3" {
-            // K3 (incl. the coding plan's bare `k3` id): per its quickstart docs
-            // `reasoning_effort` accepts low|high|max (default max); thinking is
-            // always on and the K2.x `thinking` object is rejected. Graded effort
-            // IS honored — do NOT collapse everything to "max".
+        } else if m.contains("kimi-k3") || m == "k3" || m.starts_with("kimi-for-coding") {
+            // K3, incl. the coding plan's bare `k3` and `kimi-for-coding*` ids
+            // (same K3 model, different ids that don't contain `kimi-k3`): per
+            // its quickstart docs `reasoning_effort` accepts low|high|max
+            // (default max); thinking is always on and the K2.x `thinking`
+            // object is rejected. Graded effort IS honored — do NOT collapse
+            // everything to "max". (These ids already pin temperature above;
+            // they must get the graded style too or `/thinking` is a no-op.)
             ReasoningStyle::EffortLowHighMax
-        } else if m.contains("glm") {
-            // GLM-4.5+/5.x (Zhipu / Z.ai, e.g. `glm-5.2`): thinking is a binary
-            // `thinking:{"type":"enabled"}` toggle, no graded effort. Any set
-            // effort level enables thinking (previously fell to None → /thinking
-            // was a no-op for GLM).
+        } else if m.contains("glm-4.5")
+            || m.contains("glm-4.6")
+            || m.contains("glm-5")
+            || m.contains("glm-z")
+        {
+            // GLM-4.5+/4.6/5.x + the z-reasoning line (Zhipu / Z.ai, e.g.
+            // `glm-5.2`): thinking is a binary `thinking:{"type":"enabled"}`
+            // toggle, no graded effort. Any set effort level enables thinking.
+            // Narrowed from a bare `contains("glm")`: legacy `glm-4`/`glm-4-plus`/
+            // `glm-3` REJECT the thinking object (400), so they must not match.
+            // NOTE: the SHIPPED `glm-5.2` route runs through AnthropicProvider
+            // (Z.ai's Anthropic-compatible endpoint), which maps `/thinking` via
+            // `build_anthropic_thinking`; this arm only governs a GLM added
+            // through an OpenAI-compatible endpoint.
             ReasoningStyle::ThinkingToggle
         } else if m.starts_with("grok-4") || is_o_series || m.starts_with("gpt-5") {
             ReasoningStyle::Effort
@@ -1439,6 +1451,16 @@ mod tests {
             ModelHints::detect("zai-org/glm-4.6").reasoning_style,
             ReasoningStyle::ThinkingToggle
         );
+        // Legacy GLM (pre-4.5) REJECTS the `thinking` object — it must NOT get
+        // the toggle style (a bare `contains("glm")` used to misfire here and
+        // send an unsupported field → 400).
+        for legacy in ["glm-4", "glm-4-plus", "zhipu/glm-4-air", "glm-3-turbo"] {
+            assert_eq!(
+                ModelHints::detect(legacy).reasoning_style,
+                ReasoningStyle::None,
+                "{legacy} predates the thinking toggle and must emit no reasoning control"
+            );
+        }
         // Non-thinking / unknown-control models emit nothing. grok-3 is
         // excluded (only grok-4.x is known to accept reasoning_effort).
         for m in [
@@ -1684,12 +1706,15 @@ mod tests {
                 h.fixed_temperature,
                 "{id} must pin temperature (K3 rejects any temperature != 1)"
             );
+            // These ids ARE the K3 model, so they must also get K3's graded
+            // low|high|max reasoning — otherwise `/thinking` is silently a
+            // no-op for the coding-plan aliases even though temperature is pinned.
+            assert_eq!(
+                h.reasoning_style,
+                ReasoningStyle::EffortLowHighMax,
+                "{id} is the K3 model and must get K3's graded low|high|max reasoning"
+            );
         }
-        // Bare `k3` also gets K3's low|high|max reasoning.
-        assert_eq!(
-            ModelHints::detect("k3").reasoning_style,
-            ReasoningStyle::EffortLowHighMax
-        );
         // Guard: an unrelated model containing "k3" as a substring is NOT the
         // coding plan (exact match only), so it is unaffected.
         assert!(!ModelHints::detect("mock-k3000").fixed_temperature);


### PR DESCRIPTION
Pre-release codex/windows review findings (all verified + tested):

- **BLOCKER** `read_allow_paths` subset-clamp used lexical `strip_prefix` — a profile read root `/srv/data/../../etc` passed the operator-floor subset check but resolves to `/etc`, escaping the #1754 security floor. Now normalizes `.`/`..` on both sides before containment (`normalize_abs_lexical`); adds `..`-escape + sibling-prefix tests.
- **should-fix** openai.rs GLM thinking-toggle narrowed from `contains("glm")` to glm-4.5/4.6/5.x/z so legacy glm-4/glm-3 via an OpenAI-compatible endpoint don't get an unsupported `thinking` object (400). Shipped glm-5.2 route is AnthropicProvider (unaffected).
- **should-fix** `kimi-for-coding*` ids now get K3's graded low|high|max reasoning (already pinned temp) so /thinking isn't a no-op.

octos-llm 482/0, octos-cli 968/0, clippy clean, fmt clean.