### PR TITLE
feat(pipeline): isolated per-node provider lane for deep_research on serve

### DIFF
--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -54,6 +54,16 @@ pub struct ProfileConfig {
     /// First-class structured LLM selection contract.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub llm: Option<LlmProfileConfig>,
+    /// Named provider lanes for per-node pipeline routing (e.g. the
+    /// `deep_research` pipeline's `cheap`/`strong` nodes) and sub-agent model
+    /// selection. These are ISOLATED from the primary coding provider: the serve
+    /// path builds a `ProviderRouter` from these entries ONLY (never the coding
+    /// primary/fallbacks), so a research-lane failover trips its own circuit
+    /// breakers and can never disturb the coding conversation's provider or its
+    /// KV/prompt cache. Empty by default (pipeline nodes then use the shared
+    /// coding provider, unchanged behavior).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sub_providers: Vec<crate::config::SubProviderConfig>,
     /// Per-tenant reply-voice (TTS timbre) choice. Voice route/ASR settings stay
     /// platform-level on the serve config; only the chosen timbre is per-user.
     /// Applied at profile bootstrap over the shared `VoiceConfig.default_voice`
@@ -2511,7 +2521,7 @@ pub(crate) fn config_from_profile(
         hooks: profile.config.hooks.clone(),
         approval_policy: profile.config.approval_policy.clone(),
         context_filter: vec![],
-        sub_providers: vec![],
+        sub_providers: profile.config.sub_providers.clone(),
         email: profile
             .config
             .email
@@ -3261,6 +3271,55 @@ mod tests {
         assert_eq!(saved["username"], serde_json::json!("ada"));
         assert_eq!(saved["email"], serde_json::json!("ada@example.com"));
         assert_eq!(saved["name"], serde_json::json!("Ada Byron"));
+    }
+
+    #[test]
+    fn config_from_profile_maps_sub_providers_for_isolated_pipeline_lanes() {
+        // The `deep_research` pipeline's `cheap`/`strong` nodes resolve through
+        // the profile's `sub_providers`; `config_from_profile` must carry them
+        // into the runtime `Config`. It used to hard-zero them (`vec![]`), so
+        // serve-mode pipelines could never reach an isolated research lane.
+        let sp = |key: &str, provider: &str, model: &str| crate::config::SubProviderConfig {
+            key: key.into(),
+            provider: provider.into(),
+            model: Some(model.into()),
+            api_key_env: None,
+            base_url: None,
+            description: None,
+            default_context_window: None,
+            max_output_tokens: None,
+            api_type: None,
+        };
+        let profile = UserProfile {
+            id: "research-lane".into(),
+            name: "Research Lane".into(),
+            enabled: false,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig {
+                sub_providers: vec![
+                    sp("cheap", "gemini", "gemini-2.5-flash"),
+                    sp("strong", "openai", "gpt-5-mini"),
+                ],
+                ..Default::default()
+            },
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        let config = config_from_profile(&profile, None, None);
+        assert_eq!(
+            config.sub_providers.len(),
+            2,
+            "profile sub_providers must reach the runtime config (was hard-zeroed)"
+        );
+        assert_eq!(config.sub_providers[0].key, "cheap");
+        assert_eq!(
+            config.sub_providers[0].model.as_deref(),
+            Some("gemini-2.5-flash")
+        );
+        assert_eq!(config.sub_providers[1].key, "strong");
     }
 
     #[test]

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -32,6 +32,64 @@ use crate::skills_scope::{
     build_account_skills_loader, discover_ominix_url, push_runtime_plugin_env,
 };
 
+/// Build an ISOLATED per-node pipeline provider router from the profile's
+/// `sub_providers` (e.g. the `deep_research` pipeline's `cheap`/`strong`
+/// nodes, resolved via `RunPipelineTool`'s provider router).
+///
+/// Registers ONLY the declared sub-providers — never the coding primary or its
+/// fallbacks — so a research-lane failover (`FallbackProvider` +
+/// `compatible_fallbacks`) trips its OWN circuit breakers and can never disturb
+/// the coding conversation's provider or its KV/prompt cache. Returns `None`
+/// when no sub-providers are configured, in which case pipeline nodes fall back
+/// to the shared coding provider (`self.llm` in `resolve_provider`) exactly as
+/// before. Mirrors the gateway's sub-provider registration
+/// (`gateway_runtime.rs`) but deliberately omits the primary/fallback
+/// auto-registration to keep the research lane isolated.
+fn build_sub_provider_router(config: &Config) -> Option<Arc<octos_llm::ProviderRouter>> {
+    if config.sub_providers.is_empty() {
+        return None;
+    }
+    let router = Arc::new(octos_llm::ProviderRouter::new());
+    let mut registered = 0usize;
+    for sp in &config.sub_providers {
+        // Per-sub-provider key override, matching the gateway path: an explicit
+        // `api_key_env` selects a distinct credential; otherwise inherit the
+        // profile's default for the provider.
+        let sp_config = if sp.api_key_env.is_some() {
+            let mut c = config.clone();
+            c.api_key_env = sp.api_key_env.clone();
+            c
+        } else {
+            config.clone()
+        };
+        match chat::create_provider_with_api_type(
+            &sp.provider,
+            &sp_config,
+            sp.model.clone(),
+            sp.base_url.clone(),
+            sp.api_type.as_deref(),
+        ) {
+            Ok(p) => {
+                router.register_with_full_meta(
+                    &sp.key,
+                    Arc::new(octos_llm::RetryProvider::new(p)),
+                    sp.description.clone(),
+                    sp.default_context_window,
+                    sp.max_output_tokens,
+                );
+                registered += 1;
+            }
+            Err(e) => warn!(
+                key = %sp.key,
+                provider = %sp.provider,
+                error = %e,
+                "skipping isolated pipeline sub-provider (research lane)"
+            ),
+        }
+    }
+    if registered > 0 { Some(router) } else { None }
+}
+
 /// All long-lived state that belongs to a single profile within the
 /// current host process.
 ///
@@ -807,6 +865,12 @@ impl ProfileRuntime {
                 /// agents inherit the contamination-safe hybrid scored
                 /// + filtered memory recall path.
                 embedder: Option<Arc<dyn octos_llm::EmbeddingProvider>>,
+                /// Isolated per-node model router built from the profile's
+                /// `sub_providers` (e.g. `deep_research`'s `cheap`/`strong`
+                /// nodes). Registers ONLY sub-providers, so per-node failover
+                /// trips its own breakers and never disturbs the coding
+                /// provider/cache. `None` ⇒ nodes use the shared coding `llm`.
+                provider_router: Option<Arc<octos_llm::ProviderRouter>>,
             }
 
             impl crate::session_actor::PipelineToolFactory for AppUiPipelineToolFactory {
@@ -831,6 +895,9 @@ impl ProfileRuntime {
                     if let Some(ref embedder) = self.embedder {
                         pt = pt.with_embedder(embedder.clone());
                     }
+                    if let Some(ref router) = self.provider_router {
+                        pt = pt.with_provider_router(router.clone());
+                    }
                     Arc::new(pt)
                 }
             }
@@ -845,6 +912,7 @@ impl ProfileRuntime {
                     octos_home: effective_octos_home.clone(),
                     plugin_require_signed: config.plugins.require_signed,
                     embedder: embedder.clone(),
+                    provider_router: build_sub_provider_router(&config),
                 });
 
             // Register the parent `run_pipeline` via the same factory so the

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -597,22 +597,34 @@ impl CodergenHandler {
     /// automatically falls back to another provider with sufficient max_output_tokens.
     fn resolve_provider(&self, model: Option<&str>) -> Result<Arc<dyn LlmProvider>> {
         match (model, &self.provider_router) {
-            (Some(model_key), Some(router)) => {
-                let primary = router.resolve(model_key)?;
-                let fallbacks = router.compatible_fallbacks(model_key);
-                if !fallbacks.is_empty() {
-                    info!(
-                        model = model_key,
-                        fallback_count = fallbacks.len(),
-                        "pipeline node provider resolved with fallbacks"
-                    );
+            (Some(model_key), Some(router)) => match router.resolve(model_key) {
+                Ok(primary) => {
+                    let fallbacks = router.compatible_fallbacks(model_key);
+                    if !fallbacks.is_empty() {
+                        info!(
+                            model = model_key,
+                            fallback_count = fallbacks.len(),
+                            "pipeline node provider resolved with fallbacks"
+                        );
+                    }
+                    Ok(octos_llm::FallbackProvider::wrap_with_router(
+                        primary,
+                        fallbacks,
+                        router.clone(),
+                    ))
                 }
-                Ok(octos_llm::FallbackProvider::wrap_with_router(
-                    primary,
-                    fallbacks,
-                    router.clone(),
-                ))
-            }
+                // The pipeline references a model key (e.g. `cheap`/`strong`)
+                // that this profile's router doesn't define — degrade to the
+                // shared coding provider instead of failing the node, so a
+                // partially-configured (or absent) research lane still runs.
+                Err(_) => {
+                    warn!(
+                        model = model_key,
+                        "pipeline node model not in provider router; using default provider"
+                    );
+                    Ok(self.llm.clone())
+                }
+            },
             (Some(model_key), None) => {
                 warn!(
                     model = model_key,
@@ -1317,6 +1329,70 @@ mod tests {
             forwarded.contains("320") && forwarded.contains("110"),
             "forwarded message should carry the per-node token totals; got {forwarded:?}"
         );
+    }
+
+    /// A minimal provider whose only observable trait is its `model_id`, used to
+    /// assert WHICH provider `resolve_provider` returns. `chat` is never reached
+    /// (resolve_provider only touches the router + `self.llm`).
+    struct NamedMock(&'static str);
+
+    #[async_trait::async_trait]
+    impl LlmProvider for NamedMock {
+        async fn chat(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            unreachable!("resolve_provider must not call chat()")
+        }
+        fn model_id(&self) -> &str {
+            self.0
+        }
+        fn provider_name(&self) -> &str {
+            self.0
+        }
+    }
+
+    /// A pipeline node whose model key is NOT in the profile's sub-provider
+    /// router (a `cheap`/`strong` deep_research node on a profile with no — or a
+    /// partial — research lane) must gracefully fall back to the shared coding
+    /// provider instead of erroring the node. A key that IS present must resolve
+    /// to the research lane, never the coding default.
+    #[tokio::test]
+    async fn resolve_provider_falls_back_to_coding_llm_when_key_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let memory = Arc::new(EpisodeStore::open(dir.path()).await.unwrap());
+        let router = Arc::new(ProviderRouter::new());
+        router.register("strong", Arc::new(NamedMock("research-strong")));
+
+        let handler = CodergenHandler::new(
+            Arc::new(NamedMock("coding-default")),
+            memory,
+            dir.path().to_path_buf(),
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        )
+        .with_provider_router(router);
+
+        // Absent key ("cheap" not registered) → coding default, node still runs.
+        let fallback = handler.resolve_provider(Some("cheap")).unwrap();
+        assert_eq!(
+            fallback.model_id(),
+            "coding-default",
+            "an unresolved node model key must degrade to the coding provider, not error"
+        );
+
+        // Present key ("strong") → the research lane, NOT the coding default.
+        let resolved = handler.resolve_provider(Some("strong")).unwrap();
+        assert_ne!(
+            resolved.model_id(),
+            "coding-default",
+            "a resolvable node model key must use the research lane, not the coding default"
+        );
+
+        // No model key → the shared coding provider (unchanged behavior).
+        let default = handler.resolve_provider(None).unwrap();
+        assert_eq!(default.model_id(), "coding-default");
     }
 
     /// Codex round-5 P2: GateHandler must evaluate its predicate against


### PR DESCRIPTION
Gives `run_pipeline deep_research` its own model + failover in coding sessions (serve/AppUi path) WITHOUT touching the coding conversation's provider or KV cache.

- **profiles.rs**: add `sub_providers` to ProfileConfig + thread through `config_from_profile` (was hard-zeroed on the profile path, so serve-mode pipelines could never reach a research lane).
- **runtime/profile.rs**: build an ISOLATED `ProviderRouter` from `sub_providers` ONLY (never the coding primary/fallbacks) and wire it into the serve-path `RunPipelineTool` factory. deep_research's `cheap`/`strong` nodes resolve to the research lane with `FallbackProvider` failover; separate circuit breakers, so a research rate-limit can't cold-start the coding cache.
- **handler.rs**: `resolve_provider` degrades to the coding provider when a node's model key isn't in the router (partial/absent research lane runs, never errors).

No IR change — deep_research nodes are already keyed `cheap`/`strong` via `contract_for(kind)`. Opt-in: no `sub_providers` ⇒ unchanged behavior.

Tests: `config_from_profile_maps_sub_providers` + `resolve_provider_falls_back_to_coding_llm_when_key_absent`. octos-pipeline 340/0, octos-cli 969/0, clippy clean, fmt clean.