### PR TITLE
feat(server): profile/sub_providers RPCs for the /research menu (Stage 2 server)

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -439,6 +439,9 @@ Runtime, auth, profile, and onboarding inspection (server-handled
 - `profile/llm/catalog`, `profile/llm/list`, `profile/llm/upsert`,
   `profile/llm/select`, `profile/llm/delete`, `profile/llm/test`,
   `profile/llm/fetch_models` (accepted `UPCR-2026-017`)
+- `profile/sub_providers/list`, `profile/sub_providers/upsert`,
+  `profile/sub_providers/remove` (named provider lanes for per-node pipeline
+  routing — e.g. `deep_research`'s isolated `cheap`/`strong` lanes)
 - `profile/skills/list`, `profile/skills/registry/search`,
   `profile/skills/install`, `profile/skills/remove` (server-handled skills
   management)

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -203,6 +203,14 @@ const APPUI_METHOD_PROFILE_LLM_DELETE: &str = "profile/llm/delete";
 const GOAL_SEGMENT_NAME: &str = "session-goal";
 const APPUI_METHOD_PROFILE_LLM_TEST: &str = "profile/llm/test";
 const APPUI_METHOD_PROFILE_LLM_FETCH_MODELS: &str = "profile/llm/fetch_models";
+/// Named provider lanes (`sub_providers`) for per-node pipeline routing (e.g.
+/// `deep_research`'s `cheap`/`strong` lanes). `/research` in the TUI reads +
+/// edits these; they persist to `profile.config.sub_providers` and rebuild the
+/// isolated research router at the next `ProfileRuntime` bootstrap (restart to
+/// apply for a pinned solo profile).
+const APPUI_METHOD_PROFILE_SUB_PROVIDERS_LIST: &str = "profile/sub_providers/list";
+const APPUI_METHOD_PROFILE_SUB_PROVIDERS_UPSERT: &str = "profile/sub_providers/upsert";
+const APPUI_METHOD_PROFILE_SUB_PROVIDERS_REMOVE: &str = "profile/sub_providers/remove";
 const APPUI_METHOD_PROFILE_SKILLS_LIST: &str = "profile/skills/list";
 const APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH: &str = "profile/skills/registry/search";
 const APPUI_METHOD_PROFILE_SKILLS_INSTALL: &str = "profile/skills/install";
@@ -270,6 +278,9 @@ const APPUI_EXTRA_METHODS: &[&str] = &[
     APPUI_METHOD_PROFILE_LLM_DELETE,
     APPUI_METHOD_PROFILE_LLM_TEST,
     APPUI_METHOD_PROFILE_LLM_FETCH_MODELS,
+    APPUI_METHOD_PROFILE_SUB_PROVIDERS_LIST,
+    APPUI_METHOD_PROFILE_SUB_PROVIDERS_UPSERT,
+    APPUI_METHOD_PROFILE_SUB_PROVIDERS_REMOVE,
     APPUI_METHOD_PROFILE_SKILLS_LIST,
     APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH,
     APPUI_METHOD_PROFILE_SKILLS_INSTALL,
@@ -6281,6 +6292,50 @@ struct RawProfileLlmDeleteParams {
     route_id: String,
 }
 
+/// One named provider lane on the wire (mirrors [`crate::config::SubProviderConfig`]).
+/// `key` is required; the rest are optional so the TUI can send whatever the
+/// user filled in.
+#[derive(Debug, Default, Deserialize)]
+struct RawSubProvider {
+    key: String,
+    #[serde(default)]
+    provider: Option<String>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    api_key_env: Option<String>,
+    #[serde(default)]
+    base_url: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    default_context_window: Option<u32>,
+    #[serde(default)]
+    max_output_tokens: Option<u32>,
+    #[serde(default)]
+    api_type: Option<String>,
+}
+
+/// `profile/sub_providers/upsert`: add or replace (by `key`) one named lane.
+#[derive(Debug, Default, Deserialize)]
+struct RawProfileSubProvidersUpsertParams {
+    #[serde(default)]
+    profile_id: Option<String>,
+    sub_provider: RawSubProvider,
+    /// Optional secret to store under the lane's `api_key_env` (never persisted
+    /// to plaintext config — relocated to the OS keychain like the llm path).
+    #[serde(default)]
+    api_key: Option<Value>,
+}
+
+/// `profile/sub_providers/remove`: drop the lane with this `key`.
+#[derive(Debug, Deserialize)]
+struct RawProfileSubProvidersRemoveParams {
+    #[serde(default)]
+    profile_id: Option<String>,
+    key: String,
+}
+
 #[derive(Debug, Default, Deserialize)]
 struct RawAutonomyListParams {
     #[serde(default)]
@@ -9262,6 +9317,204 @@ fn profile_llm_mutation_result(
     result
 }
 
+fn sub_provider_json(sp: &crate::config::SubProviderConfig) -> Value {
+    json!({
+        "key": sp.key,
+        "provider": sp.provider,
+        "model": sp.model,
+        "api_key_env": sp.api_key_env,
+        "base_url": sp.base_url,
+        "description": sp.description,
+        "default_context_window": sp.default_context_window,
+        "max_output_tokens": sp.max_output_tokens,
+        "api_type": sp.api_type,
+    })
+}
+
+fn sub_providers_list_result(
+    state: &AppState,
+    profile_id: &str,
+    profile: Option<&crate::profiles::UserProfile>,
+) -> Value {
+    let sub_providers: Vec<Value> = profile
+        .map(|p| {
+            p.config
+                .sub_providers
+                .iter()
+                .map(sub_provider_json)
+                .collect()
+        })
+        .unwrap_or_default();
+    json!({
+        "profile_id": profile_id,
+        "sub_providers": sub_providers,
+        "runtime_policy_stamp": runtime_policy_stamp_for_profile(state, profile_id, None, profile),
+    })
+}
+
+fn sub_providers_mutation_result(
+    state: &AppState,
+    profile_id: &str,
+    profile: Option<&crate::profiles::UserProfile>,
+    applied: bool,
+) -> Value {
+    let mut result = sub_providers_list_result(state, profile_id, profile);
+    if let Value::Object(ref mut object) = result {
+        object.insert("applied".into(), Value::Bool(applied));
+    }
+    result
+}
+
+/// `profile/sub_providers/list`: read the profile's named provider lanes.
+fn raw_profile_sub_providers_list(
+    state: &Arc<AppState>,
+    request: &RpcRequest<Value>,
+    connection_profile_id: Option<&str>,
+) -> Result<Value, RpcError> {
+    let params: RawProfileParams = parse_raw_params(request)?;
+    let profile_id = raw_scoped_llm_profile_id(
+        params.profile_id.clone(),
+        params.session_id.as_ref(),
+        connection_profile_id,
+    )?;
+    let store = profile_store(state)?;
+    let profile = store
+        .get(&profile_id)
+        .map_err(|err| RpcError::internal_error(format!("failed to read profile: {err}")))?;
+    Ok(sub_providers_list_result(
+        state,
+        &profile_id,
+        profile.as_ref(),
+    ))
+}
+
+/// `profile/sub_providers/upsert`: add or replace one lane by `key`.
+async fn raw_profile_sub_providers_upsert(
+    state: &Arc<AppState>,
+    request: &RpcRequest<Value>,
+    connection_profile_id: Option<&str>,
+) -> Result<Value, RpcError> {
+    let params: RawProfileSubProvidersUpsertParams = parse_raw_params(request)?;
+    let profile_id =
+        raw_scoped_llm_profile_id(params.profile_id.clone(), None, connection_profile_id)?;
+    let store = profile_store(state)?;
+    let mut profile = store
+        .get(&profile_id)
+        .map_err(|err| RpcError::internal_error(format!("failed to read profile: {err}")))?
+        .unwrap_or_else(|| default_profile(&profile_id));
+
+    let key = nonempty(Some(params.sub_provider.key))
+        .ok_or_else(|| RpcError::invalid_params("sub_provider.key is required"))?;
+    let provider = nonempty(params.sub_provider.provider)
+        .ok_or_else(|| RpcError::invalid_params("sub_provider.provider is required"))?;
+    let api_key_env = nonempty(params.sub_provider.api_key_env);
+
+    // Store any pasted secret under the lane's api_key_env, never in plaintext.
+    if let (Some(env), Some(secret)) = (api_key_env.as_ref(), secret_from_value(params.api_key)) {
+        profile.config.env_vars.insert(env.clone(), secret);
+    }
+
+    let entry = crate::config::SubProviderConfig {
+        key: key.clone(),
+        provider,
+        model: nonempty(params.sub_provider.model),
+        api_key_env,
+        base_url: nonempty(params.sub_provider.base_url),
+        description: nonempty(params.sub_provider.description),
+        default_context_window: params.sub_provider.default_context_window,
+        max_output_tokens: params.sub_provider.max_output_tokens,
+        api_type: nonempty(params.sub_provider.api_type),
+    };
+    // Replace the lane with the same key, else append.
+    if let Some(existing) = profile
+        .config
+        .sub_providers
+        .iter_mut()
+        .find(|sp| sp.key == key)
+    {
+        *existing = entry;
+    } else {
+        profile.config.sub_providers.push(entry);
+    }
+
+    crate::api::admin::relocate_keychain_backed_secrets(&mut profile.config.env_vars, &profile_id)
+        .map_err(|(_, msg)| RpcError::invalid_params(msg))?;
+    profile.updated_at = Utc::now();
+    store
+        .save_with_merge(&mut profile)
+        .map_err(|err| RpcError::internal_error(format!("failed to save profile: {err}")))?;
+    // A LIVE runtime is NOT rebuilt here — the isolated research router is built
+    // at ProfileRuntime bootstrap, so a pinned solo profile needs a restart to
+    // pick up the change (the TUI surfaces that). This only bootstraps when no
+    // runtime exists yet.
+    if let Err(error) = ensure_session_profile_runtime(state, Some(&profile_id)).await {
+        tracing::warn!(
+            profile_id = %profile_id,
+            error = %error.message,
+            "profile/sub_providers/upsert saved but runtime bootstrap is not ready yet",
+        );
+    }
+    Ok(sub_providers_mutation_result(
+        state,
+        &profile_id,
+        Some(&profile),
+        true,
+    ))
+}
+
+/// `profile/sub_providers/remove`: drop the lane with this `key`.
+async fn raw_profile_sub_providers_remove(
+    state: &Arc<AppState>,
+    request: &RpcRequest<Value>,
+    connection_profile_id: Option<&str>,
+) -> Result<Value, RpcError> {
+    let params: RawProfileSubProvidersRemoveParams = parse_raw_params(request)?;
+    let profile_id =
+        raw_scoped_llm_profile_id(params.profile_id.clone(), None, connection_profile_id)?;
+    let key =
+        nonempty(Some(params.key)).ok_or_else(|| RpcError::invalid_params("key is required"))?;
+    let store = profile_store(state)?;
+    let Some(mut profile) = store
+        .get(&profile_id)
+        .map_err(|err| RpcError::internal_error(format!("failed to read profile: {err}")))?
+    else {
+        return Ok(sub_providers_mutation_result(
+            state,
+            &profile_id,
+            None,
+            false,
+        ));
+    };
+    let before = profile.config.sub_providers.len();
+    profile.config.sub_providers.retain(|sp| sp.key != key);
+    let applied = profile.config.sub_providers.len() != before;
+    if !applied {
+        return Ok(sub_providers_mutation_result(
+            state,
+            &profile_id,
+            Some(&profile),
+            false,
+        ));
+    }
+    profile.updated_at = Utc::now();
+    store
+        .save_with_merge(&mut profile)
+        .map_err(|err| RpcError::internal_error(format!("failed to save profile: {err}")))?;
+    if let Err(error) = ensure_session_profile_runtime(state, Some(&profile_id)).await {
+        tracing::warn!(
+            profile_id = %profile_id,
+            error = %error.message,
+            "profile/sub_providers/remove saved but runtime bootstrap is not ready yet",
+        );
+    }
+    Ok(sub_providers_mutation_result(
+        state,
+        &profile_id,
+        Some(&profile),
+        true,
+    ))
+}
+
 fn profile_llm_test_result(
     state: &AppState,
     profile_id: &str,
@@ -9710,6 +9963,15 @@ async fn handle_raw_appui_rpc(
         APPUI_METHOD_PROFILE_LLM_FETCH_MODELS => {
             raw_profile_llm_fetch_models(state, request, connection_profile_id).await
         }
+        APPUI_METHOD_PROFILE_SUB_PROVIDERS_LIST => {
+            raw_profile_sub_providers_list(state, request, connection_profile_id)
+        }
+        APPUI_METHOD_PROFILE_SUB_PROVIDERS_UPSERT => {
+            raw_profile_sub_providers_upsert(state, request, connection_profile_id).await
+        }
+        APPUI_METHOD_PROFILE_SUB_PROVIDERS_REMOVE => {
+            raw_profile_sub_providers_remove(state, request, connection_profile_id).await
+        }
         APPUI_METHOD_PROFILE_SKILLS_LIST => {
             raw_profile_skills_list(state, request, connection_profile_id)
         }
@@ -10083,6 +10345,9 @@ fn raw_method_is_dispatched(method: &str, stdio_transport: bool) -> bool {
             | APPUI_METHOD_PROFILE_LLM_SELECT
             | APPUI_METHOD_PROFILE_LLM_DELETE
             | APPUI_METHOD_PROFILE_LLM_FETCH_MODELS
+            | APPUI_METHOD_PROFILE_SUB_PROVIDERS_LIST
+            | APPUI_METHOD_PROFILE_SUB_PROVIDERS_UPSERT
+            | APPUI_METHOD_PROFILE_SUB_PROVIDERS_REMOVE
             | APPUI_METHOD_PROFILE_SKILLS_LIST
             | APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH
             | APPUI_METHOD_PROFILE_SKILLS_INSTALL

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -340,6 +340,97 @@ fn profile_local_create_make_default_persists_pointer() {
     );
 }
 
+/// `profile/sub_providers/{list,upsert,remove}`: add/replace-by-key/remove the
+/// named provider lanes (`cheap`/`strong` etc.) that back the isolated research
+/// pipeline router; upsert with an existing key REPLACES rather than appends,
+/// removing a missing key reports `applied:false`, and everything persists.
+#[tokio::test]
+async fn sub_providers_upsert_list_and_remove_round_trip() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = Arc::new(local_profile_state(dir.path()));
+
+    for (key, provider, model) in [
+        ("cheap", "gemini", "gemini-2.5-flash"),
+        ("strong", "openai", "gpt-5-mini"),
+    ] {
+        let request = RpcRequest::new(
+            format!("u-{key}"),
+            APPUI_METHOD_PROFILE_SUB_PROVIDERS_UPSERT.to_string(),
+            json!({
+                "profile_id": "dev",
+                "sub_provider": { "key": key, "provider": provider, "model": model },
+            }),
+        );
+        let res = raw_profile_sub_providers_upsert(&state, &request, None)
+            .await
+            .expect("upsert");
+        assert_eq!(res["applied"], true);
+    }
+
+    // List reflects both lanes in insertion order.
+    let list_req = RpcRequest::new(
+        "l1".to_string(),
+        APPUI_METHOD_PROFILE_SUB_PROVIDERS_LIST.to_string(),
+        json!({ "profile_id": "dev" }),
+    );
+    let listed = raw_profile_sub_providers_list(&state, &list_req, None).expect("list");
+    let lanes = listed["sub_providers"].as_array().unwrap();
+    assert_eq!(lanes.len(), 2, "both lanes listed: {listed}");
+    assert_eq!(lanes[0]["key"], "cheap");
+    assert_eq!(lanes[0]["model"], "gemini-2.5-flash");
+    assert_eq!(lanes[1]["key"], "strong");
+
+    // Upsert with an existing key REPLACES (not appends).
+    let replace = RpcRequest::new(
+        "u-cheap-2".to_string(),
+        APPUI_METHOD_PROFILE_SUB_PROVIDERS_UPSERT.to_string(),
+        json!({
+            "profile_id": "dev",
+            "sub_provider": { "key": "cheap", "provider": "deepseek", "model": "deepseek-chat" },
+        }),
+    );
+    let res = raw_profile_sub_providers_upsert(&state, &replace, None)
+        .await
+        .expect("replace");
+    let lanes = res["sub_providers"].as_array().unwrap();
+    assert_eq!(lanes.len(), 2, "same-key upsert replaces, not appends");
+    let cheap = lanes.iter().find(|l| l["key"] == "cheap").unwrap();
+    assert_eq!(cheap["provider"], "deepseek");
+
+    // Persisted to disk.
+    let profile = state
+        .profile_store
+        .as_ref()
+        .unwrap()
+        .get("dev")
+        .unwrap()
+        .unwrap();
+    assert_eq!(profile.config.sub_providers.len(), 2);
+
+    // Remove one lane.
+    let rm = RpcRequest::new(
+        "r1".to_string(),
+        APPUI_METHOD_PROFILE_SUB_PROVIDERS_REMOVE.to_string(),
+        json!({ "profile_id": "dev", "key": "cheap" }),
+    );
+    let res = raw_profile_sub_providers_remove(&state, &rm, None)
+        .await
+        .expect("remove");
+    assert_eq!(res["applied"], true);
+    assert_eq!(res["sub_providers"].as_array().unwrap().len(), 1);
+
+    // Removing a missing key is a no-op with applied:false.
+    let rm2 = RpcRequest::new(
+        "r2".to_string(),
+        APPUI_METHOD_PROFILE_SUB_PROVIDERS_REMOVE.to_string(),
+        json!({ "profile_id": "dev", "key": "nonexistent" }),
+    );
+    let res = raw_profile_sub_providers_remove(&state, &rm2, None)
+        .await
+        .expect("remove-miss");
+    assert_eq!(res["applied"], false);
+}
+
 /// Multi-model profiles: `profile/llm/list`-backed model list exposes the
 /// primary AND every fallback; `profile/llm/select` promotes a fallback to
 /// the active primary (demoting the old primary to a fallback), persists,
@@ -1632,6 +1723,14 @@ fn dispatch_probe_request(method: &str) -> RpcRequest<Value> {
         APPUI_METHOD_SESSION_COMPACT => json!({ "session_id": session_id }),
         APPUI_METHOD_SESSION_COMPACT_MODE_SET => {
             json!({ "session_id": session_id, "mode": "heuristic" })
+        }
+        APPUI_METHOD_PROFILE_SUB_PROVIDERS_LIST => json!({ "profile_id": "dev" }),
+        APPUI_METHOD_PROFILE_SUB_PROVIDERS_UPSERT => json!({
+            "profile_id": "dev",
+            "sub_provider": { "key": "cheap", "provider": "gemini", "model": "gemini-2.5-flash" },
+        }),
+        APPUI_METHOD_PROFILE_SUB_PROVIDERS_REMOVE => {
+            json!({ "profile_id": "dev", "key": "cheap" })
         }
         other => panic!("missing AppUI dispatch probe params for {other}"),
     };


### PR DESCRIPTION
Server half of Stage 2 (the `/research` TUI menu). Adds `profile/sub_providers/{list,upsert,remove}` to read/edit the profile's named provider lanes (`sub_providers`) that back the isolated `deep_research` pipeline router (Stage 1, #1761).

Mirrors the `profile/llm/*` path: direct `profile.config.sub_providers` mutation + `save_with_merge`; upsert replaces by `key` else appends; a pasted `api_key` is relocated to the OS keychain (never plaintext). Advertised + dispatched + coverage-guarded (raw_method_is_dispatched, spec §6 catalog, dispatch-probe). **Restart-to-apply** for a pinned solo profile (the router builds at ProfileRuntime bootstrap) — the TUI client surfaces this.

Round-trip test covers upsert/list/replace-by-key/persist/remove/missing-key. octos-cli --features api 2399/0, clippy + fmt clean. TUI client (`/research` menu) is the next PR.