### PR TITLE
fix(pipeline): deep_research review — read-only perms, findings collisions, worker prompt gate

### DIFF
--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -56,7 +56,10 @@ fn sanitize_label_for_filename(label: &str) -> String {
     if trimmed.is_empty() {
         "task".to_string()
     } else {
-        trimmed.to_string()
+        // Cap the length (by chars, UTF-8-safe) so a pathological label can't
+        // produce a filename-too-long error. Per-worker uniqueness is added by
+        // the caller (the fan-out index), so truncation can't collide two lanes.
+        trimmed.chars().take(48).collect()
     }
 }
 
@@ -3257,7 +3260,16 @@ impl PipelineExecutor {
                     // file-pointer contract was unreliable).
                     let prompt = worker_prompt_template
                         .replace("{task}", &task.task)
-                        .replace("{label}", &sanitize_label_for_filename(&label));
+                        // Append the fan-out index so two labels that sanitize to
+                        // the same token (e.g. "Official Docs" / "official docs",
+                        // or duplicate CJK labels) don't both write the SAME
+                        // findings file and silently overwrite each other. The
+                        // analyze node reads `findings-*.md`, so uniqueness here
+                        // doesn't break its glob.
+                        .replace(
+                            "{label}",
+                            &format!("{}-{i}", sanitize_label_for_filename(&label)),
+                        );
 
                     // Round-robin model from pool
                     let worker_model = Some(model_pool[i % model_pool.len()].to_string());

--- a/crates/octos-pipeline/src/executor_tests.rs
+++ b/crates/octos-pipeline/src/executor_tests.rs
@@ -26,6 +26,13 @@ fn sanitize_label_for_filename_yields_a_deterministic_fs_safe_token() {
     assert_eq!(sanitize_label_for_filename("///"), "task");
     // CJK (and other alphanumeric scripts) are preserved.
     assert_eq!(sanitize_label_for_filename("技术架构"), "技术架构");
+    // Length is capped (by chars, UTF-8-safe) so a pathological label can't
+    // overflow the filename; per-worker uniqueness comes from the index suffix
+    // the caller appends, not from the full label.
+    let long = "a".repeat(200);
+    assert_eq!(sanitize_label_for_filename(&long).chars().count(), 48);
+    let long_cjk = "中".repeat(100);
+    assert_eq!(sanitize_label_for_filename(&long_cjk).chars().count(), 48);
 }
 
 #[test]

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -666,9 +666,23 @@ impl Handler for CodergenHandler {
         // reads `self.tools.sandbox()`). `with_builtins` would store `NoSandbox`,
         // letting such a command validator escape to the host from a sandboxed
         // pipeline. A no-op backend runs the argv directly (unchanged).
-        let mut tools = octos_agent::ToolRegistry::with_builtins_and_sandbox(
+        // Research review (BLOCKER): the worker registry MUST inherit the
+        // session's write permission, not hardcode workspace_write.
+        // `with_builtins_and_sandbox` pins `EffectivePermissions::workspace_write()`,
+        // so once the Fanout palette grants `write_file`, a worker in a READ-ONLY
+        // session could write files (a permission escalation — worse because
+        // search workers run web_search/web_fetch on untrusted pages that can
+        // prompt-inject a write). Derive permissions from the session sandbox so a
+        // read-only session's workers get read-only file access.
+        let permissions = if self.sandbox.workspace_write {
+            octos_agent::EffectivePermissions::workspace_write()
+        } else {
+            octos_agent::EffectivePermissions::read_only()
+        };
+        let mut tools = octos_agent::ToolRegistry::with_builtins_and_permissions(
             &self.working_dir,
             octos_agent::create_sandbox(&self.sandbox),
+            permissions,
         );
 
         // Backend bug #1: load plugin tools from a process-shared cache.
@@ -753,7 +767,14 @@ impl Handler for CodergenHandler {
         // to a file in ONE call and return a concise executive summary as text.
         // Without explicit "single call" instruction, some models (e.g. kimi-k2.5)
         // chunk output into ~4K token pieces across many iterations, causing timeouts.
-        if node.tools.iter().any(|t| t == "write_file") {
+        //
+        // Only genuine final-report nodes get this. Fan-out workers (synthetic id
+        // `<parent>_task_<i>`) now also carry write_file, but they follow their own
+        // deliverable prompt (write `findings-<label>.md`, return a short summary);
+        // the generic report injection (descriptive filename, ~1000-word body,
+        // "delivered to the user") would contradict it and let a worker write an
+        // arbitrarily-named file the analyze node can't find.
+        if node.tools.iter().any(|t| t == "write_file") && !node.id.contains("_task_") {
             system_prompt.push_str(
                 "\n\nIMPORTANT: You MUST do two things:\n\
                  1. Save your COMPLETE report in ONE SINGLE write_file call (choose a descriptive \


### PR DESCRIPTION
Post-merge review (codex + octos/K3) on #1763:
- **BLOCKER**: fan-out workers used `with_builtins_and_sandbox` which hardcodes `workspace_write()` — a read-only-session worker (now granted `write_file` by the Fanout palette) could write files (escalation, worse via prompt-injected web content). Now derives `EffectivePermissions` from the session sandbox and uses `with_builtins_and_permissions`.
- **Findings collisions**: append the fan-out index to `{label}` so same-sanitized labels don't overwrite one file; cap sanitized-label length.
- **Injection gate**: the 'final-report writer' `write_file` injection now fires only for genuine report nodes, not fan-out workers (which have their own deliverable prompt it would contradict).

octos-pipeline all tests pass, clippy + fmt clean; octos-cli --features api builds.