### PR TITLE
feat(chat): --no-session-persistence lets many agents share one data dir

### DIFF
--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -147,6 +147,14 @@ pub struct ChatCommand {
     /// Do NOT persist this run as an episode (ephemeral). Mirrors
     /// `claude --no-session-persistence`: by default a completed turn is
     /// saved to the episode store for future recall; this skips that write.
+    ///
+    /// This also lets many `octos chat` agents run CONCURRENTLY against one
+    /// `--data-dir` (hence one shared `--profile`): a normal run takes an
+    /// exclusive lock on the data dir's episode DB, but an ephemeral run falls
+    /// back to an in-memory episode handle when the lock is already held,
+    /// instead of failing. Pass this to fan out parallel agents on a single
+    /// profile — e.g. review agents over one repo, or edit agents each in
+    /// their own `--cwd`.
     #[arg(long)]
     pub no_session_persistence: bool,
 
@@ -826,11 +834,32 @@ impl ChatCommand {
             }
         };
 
-        let memory = Arc::new(
+        // Episode store. Normally strict-open (the canonical single writer of
+        // `episodes.redb`, which takes an exclusive process lock). But an
+        // ephemeral run (`--no-session-persistence`) isn't going to save
+        // episodes anyway, so it opens via `open_or_degraded`: if another
+        // `octos chat` already holds the lock on this data dir, this run falls
+        // back to an in-memory episode handle instead of failing. That lets
+        // many ephemeral `octos chat` agents run concurrently against ONE
+        // `--data-dir` (hence one shared `--profile`) — e.g. a fan-out of
+        // review/edit agents — without the redb lock serializing them.
+        let memory = Arc::new(if self.no_session_persistence {
+            let store = EpisodeStore::open_or_degraded(&data_dir)
+                .await
+                .wrap_err("failed to open episode store")?;
+            if store.is_degraded() {
+                tracing::info!(
+                    "episode store on this data dir is held by another process; \
+                     running with an in-memory episode handle (no persistence/recall) \
+                     — expected when running concurrent `octos chat` agents"
+                );
+            }
+            store
+        } else {
             EpisodeStore::open(&data_dir)
                 .await
-                .wrap_err("failed to open episode store")?,
-        );
+                .wrap_err("failed to open episode store")?
+        });
 
         // Resolve the runtime profile (M8.3). Order:
         //   1. --profile CLI arg, if present;


### PR DESCRIPTION
## What

Makes plain `octos chat` support **concurrent agents on ONE `--data-dir` (hence one shared `--profile`)** — no wrapper, no per-agent data-dir juggling.

Today `octos chat` strict-opens the data dir's `episodes.redb`, taking an **exclusive process lock**. So a second `octos chat` on the same `--data-dir` dies with `Database already open. Cannot acquire lock.` Since a profile lives at `<data-dir>/profiles/<id>.json`, that also blocked fanning out several agents on one shared `--profile`.

With `--no-session-persistence` (an ephemeral run that wasn't going to save episodes anyway), the episode store now opens via the existing `EpisodeStore::open_or_degraded` instead of strict `open`: if another process already holds the lock, this run falls back to an in-memory episode handle instead of failing. Many ephemeral `octos chat` agents can then run **concurrently** on one data dir / one profile.

Two patterns this enables (both live-verified below):
1. **One profile + one folder** — N review agents, same `--cwd`, `--sandbox read-only`, each writing its own report.
2. **One profile + N folders** — edit agents, one `--cwd` each, `--sandbox workspace-write`, each changing its own folder.

## Default unchanged

The persisting path still **strict-opens** — preserving the deliberate single-canonical-writer design and still surfacing a real misconfiguration (e.g. a chat racing a `serve` that owns the dir) as an error rather than silently degrading.

## Verification

**A/B, 4 agents launched simultaneously on ONE data-dir, task long enough to force lock overlap (same new binary, only the flag differs):**

| run | flag | success | lock-collisions |
|---|---|--:|--:|
| no flag | — | 1 | **3** (strict lock preserved) |
| ephemeral | `--no-session-persistence` | **4** | **0** |

**Live, both patterns (Kimi K3 via `--profile dev`, key from the profile's `env_vars`):**
- Pattern 1: 3 review agents, one data-dir/repo, read-only → all ran, each produced a distinct review, 0 collisions.
- Pattern 2: 3 edit agents, one data-dir, 3 separate `--cwd`s, workspace-write → all ran, each wrote a distinct file to its own folder, 0 collisions, no cross-talk.

- The concurrent-open mechanism itself is already covered by octos-memory tests (`should_return_degraded_store_when_redb_already_held_by_another_handle`, `should_error_on_strict_open_when_redb_already_held`).
- `cargo test -p octos-cli --lib commands::chat` → 35 passed, 0 failed. `cargo fmt --check` clean; `cargo clippy` → no `chat.rs` warnings.

Pre-existing workspace `check`/`typos` gates are red on `main` independent of this change.