### PR TITLE
perf(agent): mixed tool batches run Safe calls in parallel, Exclusive serially (#1766)

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -1,27 +1,59 @@
 //! Tool execution: dispatching tool calls with hooks and timeout handling.
 //!
-//! # Batch admission (M8.8)
+//! # Batch admission (M8.8, #1766)
 //!
 //! Each turn of the agent loop receives a batch of tool calls from the LLM.
 //! Before M8.8 every call in a batch fired in parallel, which races when a
 //! mutating tool (shell, write_file, edit_file, diff_edit, save_memory) sits
 //! next to a reader in the same batch. The executor now consults
 //! [`crate::tools::Tool::concurrency_class`] for every call and picks one of
-//! two admission strategies:
+//! three admission strategies:
 //!
 //! - **All-Safe batch** — the classic path. Every call is [`ConcurrencyClass::Safe`]
 //!   (read-only, side-effect-free). The executor spawns each call as a detached
 //!   task and aggregates via `futures::join_all`, preserving call order.
-//! - **Any-Exclusive batch** — new M8.8 path. At least one call reports
+//! - **All-Exclusive batch** — the M8.8 path. Every call reports
 //!   [`ConcurrencyClass::Exclusive`]. The executor runs calls serially in LLM
 //!   call order. On the first error (including hook denials and panics), the
 //!   remaining peers are skipped and each receives a synthetic
 //!   "cancelled due to sibling error" [`Message`] so the LLM still sees a
 //!   result for every `tool_call_id`.
+//! - **Mixed batch** — the #1766 path (previously such batches fell back to
+//!   fully-serial). Phase 1 runs every Safe call in parallel, with the same
+//!   spawn/aggregate shape as the all-Safe path; phase 2 then runs the
+//!   Exclusive calls serially in LLM call order. Aggregated results are
+//!   reassembled in the ORIGINAL LLM call order, so downstream consumers see
+//!   the same 1:1 `tool_call_id` mapping as the other two strategies.
 //!
-//! The split is pessimistic — a batch containing one Exclusive + four Safe
-//! tools still serializes the whole batch. An optimised "run Safe in parallel,
-//! then Exclusive in order" pipeline is explicitly deferred (see the M8.8 spec).
+//! ## Mixed-batch semantics (#1766, pinned by the `mixed_batch_*` tests)
+//!
+//! - **Visibility** — Safe calls observe the PRE-batch state. A Safe read the
+//!   LLM listed AFTER an Exclusive mutation still runs in phase 1, i.e.
+//!   BEFORE that mutation, and does NOT see the sibling's write. (Before
+//!   M8.8 the two raced nondeterministically; under the M8.8 serial fallback
+//!   the read saw the write. The phased pipeline pins a deterministic
+//!   reads-before-writes snapshot, regardless of list position.)
+//! - **Cascade, phase 1 → phase 2** — any Safe-call failure that carries the
+//!   cascade bit (real execution errors, hook denials, panics, timeouts —
+//!   everything except a no-side-effect [`crate::tools::ToolInputError`],
+//!   #1690) cancels the ENTIRE Exclusive phase, position-independently: no
+//!   mutation runs after a failed read. Cancelled Exclusive calls receive
+//!   the same synthetic "cancelled due to sibling error" [`Message`] as the
+//!   serial path.
+//! - **Cascade, inside phase 2** — identical to the all-Exclusive path: the
+//!   first cascading failure cancels the REMAINING Exclusive peers (in LLM
+//!   order). Phase-1 Safe results are never retroactively cancelled by a
+//!   phase-2 failure: they already completed, are side-effect-free by
+//!   definition, and their real outputs are strictly more information for
+//!   the LLM than a synthetic cancellation.
+//! - **Approvals / human-input determinism** — approval-gated tools (shell,
+//!   edit_file, write_file, …) are all Exclusive, so their in-tool approval
+//!   prompts fire one at a time, in LLM call order, during phase 2. Phase 1
+//!   fully joins before phase 2 starts, so a human-wait Safe tool
+//!   (`ask_user_question`) can never overlap an approval prompt. The
+//!   per-turn requester bridges (`TOOL_APPROVAL_CTX`, `USER_QUESTION_CTX`)
+//!   are captured per call in `spawn_tool_task`, exactly as before — the
+//!   phase split does not change how they propagate.
 
 use std::time::{Duration, Instant};
 
@@ -449,10 +481,12 @@ impl Agent {
     ///
     /// The returned [`JoinHandle`] yields the per-call [`ToolCallResult`]:
     /// tool-output [`Message`], modified file paths, files-to-send paths, and
-    /// optional sub-agent [`TokenUsage`]. This is the worker used by both
-    /// dispatch strategies in [`Agent::execute_tools`] — parallel (Safe) runs
-    /// many in flight via `join_all`; serial (any-Exclusive) spawns one,
-    /// awaits it, then spawns the next.
+    /// optional sub-agent [`TokenUsage`]. This is the worker used by every
+    /// dispatch strategy in [`Agent::execute_tools`] — parallel dispatch
+    /// (all-Safe batches and the mixed-batch Safe phase, #1766) runs many in
+    /// flight via `join_all`; serial dispatch (all-Exclusive batches and the
+    /// mixed-batch Exclusive phase) spawns one, awaits it, then spawns the
+    /// next.
     ///
     /// `explicit_send_file_requested` is a per-batch fact (true when the same
     /// LLM turn already issued a `send_file`), so the caller computes it once
@@ -2236,16 +2270,26 @@ impl Agent {
         let explicit_send_file_requested =
             response.tool_calls.iter().any(|tc| tc.name == "send_file");
 
-        // M8.8 — classify the batch and pick an admission strategy.
-        let any_exclusive = response
+        // M8.8 + #1766 — classify the batch and pick an admission strategy.
+        let exclusive_count = response
             .tool_calls
             .iter()
-            .any(|tc| self.tools.concurrency_class(&tc.name) == ConcurrencyClass::Exclusive);
+            .filter(|tc| self.tools.concurrency_class(&tc.name) == ConcurrencyClass::Exclusive)
+            .count();
+        let any_exclusive = exclusive_count > 0;
+        let all_exclusive = exclusive_count == response.tool_calls.len();
+        let dispatch_mode = if !any_exclusive {
+            "parallel"
+        } else if all_exclusive {
+            "serial"
+        } else {
+            "mixed"
+        };
 
         tracing::info!(
             parallel_tools = response.tool_calls.len(),
             tool_names = %tool_names.join(", "),
-            dispatch = if any_exclusive { "serial" } else { "parallel" },
+            dispatch = dispatch_mode,
             "executing tool batch"
         );
 
@@ -2290,21 +2334,11 @@ impl Agent {
         );
         let tool_timeout = tool_timeout_secs.map(Duration::from_secs);
 
-        let results: Vec<ToolCallResult> = if any_exclusive {
-            // Serial admission: run each tool in LLM call order, bail out of
-            // the remaining calls if any one errors and emit synthetic
-            // "cancelled" results so the LLM still sees every tool_call_id.
-            self.execute_serial_batch(
-                response,
-                explicit_send_file_requested,
-                &turn_attachment_ctx,
-                tool_timeout,
-                tool_timeout_secs,
-            )
-            .await
-        } else {
-            // Parallel admission — today's behaviour. Spawn every tool call
-            // as a detached task and join them.
+        let results: Vec<ToolCallResult> = if !any_exclusive {
+            // Parallel admission — the classic all-Safe path. Spawn every
+            // tool call as a detached task and join them against one shared
+            // deadline (see `join_parallel_handles` for the aggregation and
+            // UPCR-2026-023 human-wait semantics).
             let handles: Vec<_> = response
                 .tool_calls
                 .iter()
@@ -2316,58 +2350,34 @@ impl Agent {
                     )
                 })
                 .collect();
-
-            // UPCR-2026-023: a human-wait batch (`tool_timeout == None`) awaits
-            // `join_all` DIRECTLY, with no timeout wrap, so the human-wait
-            // tool task is never detached by a fired ceiling. It is unblocked
-            // by the user answering or by a turn interrupt/abort (which drains
-            // the pending question).
-            //
-            // All other batches share ONE absolute deadline, but each handle
-            // is raced against it INDIVIDUALLY (`tokio::time::timeout_at`): a
-            // call that already resolved keeps its REAL result even when a
-            // sibling overruns the ceiling — only the still-pending calls get
-            // the synthetic "timed out" message (success=false, so the
-            // spawn_only synth-ack gate in loop_runner still suppresses the
-            // fabricated "Background work started" bubble for them). The
-            // previous shape — one `timeout()` wrapped around the whole
-            // `join_all` — dropped the joined future on expiry and fabricated
-            // a timeout message for EVERY call, discarding the real output of
-            // calls (including spawn_only acks) that had already completed.
-            // `timeout_at` polls the inner handle before the timer, so a
-            // handle that completed by the time we reach it yields its result
-            // even at/past the deadline. Timed-out tasks are NOT aborted —
-            // they keep running detached for cleanup, exactly as before.
-            match tool_timeout {
-                Some(dur) => {
-                    let deadline = tokio::time::Instant::now() + dur;
-                    let elapsed_secs = dur.as_secs();
-                    let mut results: Vec<ToolCallResult> =
-                        Vec::with_capacity(response.tool_calls.len());
-                    for (handle, tc) in handles.into_iter().zip(response.tool_calls.iter()) {
-                        match tokio::time::timeout_at(deadline, handle).await {
-                            Ok(Ok(result)) => results.push(result),
-                            Ok(Err(e)) => results.push(panic_result(tc, &e.to_string())),
-                            Err(_elapsed) => {
-                                tracing::error!(
-                                    timeout_secs = elapsed_secs,
-                                    tool = %tc.name,
-                                    tool_id = %tc.id,
-                                    "tool execution timed out -- spawned task continues running for cleanup"
-                                );
-                                results.push(timed_out_result(tc, elapsed_secs));
-                            }
-                        }
-                    }
-                    results
-                }
-                None => futures::future::join_all(handles)
-                    .await
-                    .into_iter()
-                    .zip(response.tool_calls.iter())
-                    .map(|(r, tc)| r.unwrap_or_else(|e| panic_result(tc, &e.to_string())))
-                    .collect(),
-            }
+            let calls: Vec<&octos_core::ToolCall> = response.tool_calls.iter().collect();
+            join_parallel_handles(handles, &calls, tool_timeout).await
+        } else if all_exclusive {
+            // Serial admission: run each tool in LLM call order, bail out of
+            // the remaining calls if any one errors and emit synthetic
+            // "cancelled" results so the LLM still sees every tool_call_id.
+            let calls: Vec<&octos_core::ToolCall> = response.tool_calls.iter().collect();
+            self.run_serial_calls(
+                &calls,
+                /* start_cancelled */ false,
+                explicit_send_file_requested,
+                &turn_attachment_ctx,
+                tool_timeout,
+                tool_timeout_secs,
+            )
+            .await
+        } else {
+            // Mixed admission (#1766): Safe calls in parallel first, then
+            // Exclusive calls serially, reassembled in LLM call order. See
+            // the module doc for the pinned semantics.
+            self.execute_mixed_batch(
+                response,
+                explicit_send_file_requested,
+                &turn_attachment_ctx,
+                tool_timeout,
+                tool_timeout_secs,
+            )
+            .await
         };
 
         // Log completion of the tool batch.
@@ -2378,7 +2388,7 @@ impl Agent {
         let total_result_bytes: usize = result_sizes.iter().sum();
         tracing::info!(
             parallel_tools = results.len(),
-            dispatch = if any_exclusive { "serial" } else { "parallel" },
+            dispatch = dispatch_mode,
             result_sizes = %result_sizes.iter().map(|s| s.to_string()).collect::<Vec<_>>().join(", "),
             total_result_bytes,
             "all tools in batch completed"
@@ -2436,7 +2446,17 @@ impl Agent {
         ))
     }
 
-    /// Serial dispatch for batches that contain at least one Exclusive tool (M8.8).
+    /// Serial dispatch core (M8.8): run `calls` one at a time, in order.
+    ///
+    /// Used by two admission strategies in [`Agent::execute_tools`]:
+    /// - **All-Exclusive batch** — `calls` is the full batch in LLM call
+    ///   order and `start_cancelled` is `false` (the original M8.8 path,
+    ///   behaviour unchanged).
+    /// - **Mixed batch (#1766), phase 2** — `calls` is the Exclusive subset
+    ///   in LLM call order and `start_cancelled` carries the phase-1
+    ///   verdict: `true` when a parallel Safe sibling already failed with
+    ///   the cascade bit set, in which case every call here is skipped and
+    ///   receives the synthetic "cancelled due to sibling error" [`Message`].
     ///
     /// Each tool call runs to completion before the next one is spawned. If
     /// any call's result message reports a failure (success=false), every
@@ -2457,20 +2477,21 @@ impl Agent {
     /// inside `spawn_tool_task` → `ToolRegistry::execute_with_context`. Cleanup
     /// of the human-wait call comes from the user answering or a turn
     /// interrupt/abort draining the pending question — never from this wrap.
-    async fn execute_serial_batch(
+    async fn run_serial_calls(
         &self,
-        response: &ChatResponse,
+        calls: &[&octos_core::ToolCall],
+        start_cancelled: bool,
         explicit_send_file_requested: bool,
         turn_attachment_ctx: &crate::tools::TurnAttachmentContext,
         tool_timeout: Option<Duration>,
         tool_timeout_secs: Option<u64>,
     ) -> Vec<ToolCallResult> {
-        let mut results: Vec<ToolCallResult> = Vec::with_capacity(response.tool_calls.len());
-        let mut cancelled = false;
+        let mut results: Vec<ToolCallResult> = Vec::with_capacity(calls.len());
+        let mut cancelled = start_cancelled;
 
-        for (idx, tool_call) in response.tool_calls.iter().enumerate() {
+        for (idx, tool_call) in calls.iter().enumerate() {
             if cancelled {
-                let skipped = response.tool_calls.len() - idx;
+                let skipped = calls.len() - idx;
                 tracing::info!(
                     tool = %tool_call.name,
                     tool_id = %tool_call.id,
@@ -2533,6 +2554,161 @@ impl Agent {
         }
 
         results
+    }
+
+    /// Two-phase dispatch for mixed batches (#1766): at least one Safe AND
+    /// at least one Exclusive call in the same batch.
+    ///
+    /// Phase 1 spawns every [`ConcurrencyClass::Safe`] call in parallel and
+    /// joins them exactly like the all-Safe path (shared absolute deadline,
+    /// per-handle race — see [`join_parallel_handles`]). Phase 2 then runs
+    /// the Exclusive calls serially in LLM call order via
+    /// [`Agent::run_serial_calls`], starting cancelled when any phase-1
+    /// failure carried the cascade bit — so no mutation runs after a failed
+    /// read, while a no-side-effect `ToolInputError` does NOT cancel (#1690).
+    ///
+    /// Results are reassembled into the ORIGINAL LLM call order before
+    /// returning, so callers observe the same 1:1 `tool_call_id` mapping as
+    /// the other dispatch strategies. See the module doc for the pinned
+    /// visibility / cascade / approval-ordering semantics.
+    async fn execute_mixed_batch(
+        &self,
+        response: &ChatResponse,
+        explicit_send_file_requested: bool,
+        turn_attachment_ctx: &crate::tools::TurnAttachmentContext,
+        tool_timeout: Option<Duration>,
+        tool_timeout_secs: Option<u64>,
+    ) -> Vec<ToolCallResult> {
+        // Partition into the two phases, remembering each call's original
+        // batch position for reassembly. Order within each partition is LLM
+        // call order (`enumerate` over the original list).
+        let mut safe_calls: Vec<(usize, &octos_core::ToolCall)> = Vec::new();
+        let mut exclusive_calls: Vec<(usize, &octos_core::ToolCall)> = Vec::new();
+        for (idx, tool_call) in response.tool_calls.iter().enumerate() {
+            if self.tools.concurrency_class(&tool_call.name) == ConcurrencyClass::Exclusive {
+                exclusive_calls.push((idx, tool_call));
+            } else {
+                safe_calls.push((idx, tool_call));
+            }
+        }
+
+        // Phase 1 — every Safe call in parallel, aggregated with the same
+        // shared-deadline semantics as the all-Safe path.
+        let handles: Vec<_> = safe_calls
+            .iter()
+            .map(|(_, tool_call)| {
+                self.spawn_tool_task(tool_call, explicit_send_file_requested, turn_attachment_ctx)
+            })
+            .collect();
+        let safe_refs: Vec<&octos_core::ToolCall> =
+            safe_calls.iter().map(|(_, tool_call)| *tool_call).collect();
+        let safe_results = join_parallel_handles(handles, &safe_refs, tool_timeout).await;
+
+        // Phase-1 verdict: a Safe failure with the cascade bit set (real
+        // error / hook denial / panic / timeout — NOT a `ToolInputError`,
+        // #1690) cancels the entire Exclusive phase, position-independently.
+        let safe_failure_cancels_exclusive =
+            safe_results.iter().any(|result| !result.4 && result.6);
+        if safe_failure_cancels_exclusive {
+            tracing::info!(
+                cancelled_exclusive_calls = exclusive_calls.len(),
+                "mixed batch: Safe phase failed; cancelling entire Exclusive phase"
+            );
+        }
+
+        // Phase 2 — Exclusive calls serially in LLM call order.
+        let exclusive_refs: Vec<&octos_core::ToolCall> = exclusive_calls
+            .iter()
+            .map(|(_, tool_call)| *tool_call)
+            .collect();
+        let exclusive_results = self
+            .run_serial_calls(
+                &exclusive_refs,
+                safe_failure_cancels_exclusive,
+                explicit_send_file_requested,
+                turn_attachment_ctx,
+                tool_timeout,
+                tool_timeout_secs,
+            )
+            .await;
+
+        // Reassemble in the ORIGINAL LLM call order. Every original index
+        // appears in exactly one partition, and each phase returns exactly
+        // one result per call, so every slot fills.
+        let mut slots: Vec<Option<ToolCallResult>> = Vec::with_capacity(response.tool_calls.len());
+        slots.resize_with(response.tool_calls.len(), || None);
+        for ((idx, _), result) in safe_calls.iter().zip(safe_results) {
+            slots[*idx] = Some(result);
+        }
+        for ((idx, _), result) in exclusive_calls.iter().zip(exclusive_results) {
+            slots[*idx] = Some(result);
+        }
+        slots
+            .into_iter()
+            .map(|slot| slot.expect("mixed-batch dispatch fills every original call slot"))
+            .collect()
+    }
+}
+
+/// Join already-spawned parallel tool tasks against ONE shared absolute
+/// deadline (or no deadline at all for a human-wait batch). `calls` must be
+/// index-aligned with `handles`.
+///
+/// Extracted from the all-Safe dispatch arm of [`Agent::execute_tools`] so
+/// the mixed-batch phase 1 (#1766) shares the exact same aggregation
+/// semantics.
+///
+/// UPCR-2026-023: a human-wait batch (`tool_timeout == None`) awaits
+/// `join_all` DIRECTLY, with no timeout wrap, so the human-wait tool task is
+/// never detached by a fired ceiling. It is unblocked by the user answering
+/// or by a turn interrupt/abort (which drains the pending question).
+///
+/// All other batches share ONE absolute deadline, but each handle is raced
+/// against it INDIVIDUALLY (`tokio::time::timeout_at`): a call that already
+/// resolved keeps its REAL result even when a sibling overruns the ceiling —
+/// only the still-pending calls get the synthetic "timed out" message
+/// (success=false, so the spawn_only synth-ack gate in loop_runner still
+/// suppresses the fabricated "Background work started" bubble for them). The
+/// previous shape — one `timeout()` wrapped around the whole `join_all` —
+/// dropped the joined future on expiry and fabricated a timeout message for
+/// EVERY call, discarding the real output of calls (including spawn_only
+/// acks) that had already completed. `timeout_at` polls the inner handle
+/// before the timer, so a handle that completed by the time we reach it
+/// yields its result even at/past the deadline. Timed-out tasks are NOT
+/// aborted — they keep running detached for cleanup, exactly as before.
+async fn join_parallel_handles(
+    handles: Vec<JoinHandle<ToolCallResult>>,
+    calls: &[&octos_core::ToolCall],
+    tool_timeout: Option<Duration>,
+) -> Vec<ToolCallResult> {
+    match tool_timeout {
+        Some(dur) => {
+            let deadline = tokio::time::Instant::now() + dur;
+            let elapsed_secs = dur.as_secs();
+            let mut results: Vec<ToolCallResult> = Vec::with_capacity(calls.len());
+            for (handle, tc) in handles.into_iter().zip(calls.iter()) {
+                match tokio::time::timeout_at(deadline, handle).await {
+                    Ok(Ok(result)) => results.push(result),
+                    Ok(Err(e)) => results.push(panic_result(tc, &e.to_string())),
+                    Err(_elapsed) => {
+                        tracing::error!(
+                            timeout_secs = elapsed_secs,
+                            tool = %tc.name,
+                            tool_id = %tc.id,
+                            "tool execution timed out -- spawned task continues running for cleanup"
+                        );
+                        results.push(timed_out_result(tc, elapsed_secs));
+                    }
+                }
+            }
+            results
+        }
+        None => futures::future::join_all(handles)
+            .await
+            .into_iter()
+            .zip(calls.iter())
+            .map(|(r, tc)| r.unwrap_or_else(|e| panic_result(tc, &e.to_string())))
+            .collect(),
     }
 }
 
@@ -3214,34 +3390,60 @@ mod tests {
         }
     }
 
+    /// Run one `execute_tools` batch against a fresh throwaway agent and
+    /// return the result messages plus the per-call success bits.
+    async fn run_batch_with_config(
+        tool_calls: Vec<ToolCall>,
+        tools: ToolRegistry,
+        config: AgentConfig,
+    ) -> (Vec<octos_core::Message>, Vec<(String, bool)>) {
+        let dir = tempfile::tempdir().unwrap();
+        let provider: Arc<dyn LlmProvider> = Arc::new(NoChatProvider);
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let agent = Agent::new(AgentId::new("batch"), provider, tools, memory).with_config(config);
+        let response = ChatResponse {
+            content: None,
+            reasoning_content: None,
+            tool_calls,
+            stop_reason: StopReason::ToolUse,
+            usage: LlmTokenUsage::default(),
+            provider_index: None,
+        };
+        let (messages, _fm, _fs, _tok, _st, success_by_id) = agent
+            .execute_tools(&response)
+            .await
+            .expect("execute_tools must not error");
+        (messages, success_by_id)
+    }
+
+    async fn run_batch(
+        tool_calls: Vec<ToolCall>,
+        tools: ToolRegistry,
+    ) -> (Vec<octos_core::Message>, Vec<(String, bool)>) {
+        run_batch_with_config(
+            tool_calls,
+            tools,
+            AgentConfig {
+                save_episodes: false,
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
     async fn run_serial_pair(
         first: &str,
         second: &str,
         tools: ToolRegistry,
     ) -> Vec<octos_core::Message> {
-        let dir = tempfile::tempdir().unwrap();
-        let provider: Arc<dyn LlmProvider> = Arc::new(NoChatProvider);
-        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
-        let agent =
-            Agent::new(AgentId::new("cascade"), provider, tools, memory).with_config(AgentConfig {
-                save_episodes: false,
-                ..Default::default()
-            });
-        let response = ChatResponse {
-            content: None,
-            reasoning_content: None,
-            tool_calls: vec![
+        let (messages, _success_by_id) = run_batch(
+            vec![
                 tool_call("call_first", first),
                 tool_call("call_second", second),
             ],
-            stop_reason: StopReason::ToolUse,
-            usage: LlmTokenUsage::default(),
-            provider_index: None,
-        };
-        let (messages, _fm, _fs, _tok, _st, _sid) = agent
-            .execute_tools(&response)
-            .await
-            .expect("execute_tools must not error");
+            tools,
+        )
+        .await;
         messages
     }
 
@@ -3378,6 +3580,400 @@ mod tests {
         assert!(
             success_by_id.contains(&("call_slow".to_string(), false)),
             "timed-out call must report success=false: {success_by_id:?}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // #1766 — mixed-batch two-phase dispatch: Safe calls run in parallel
+    // first (phase 1), Exclusive calls run serially in LLM order (phase 2),
+    // and results are reassembled in the ORIGINAL LLM call order.
+    // ------------------------------------------------------------------
+
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Safe (default class) reader that reports whether the shared flag was
+    /// already flipped by the Exclusive `MutatingTool` when it ran — the
+    /// probe for the pinned #1766 visibility semantics.
+    struct SnapshotReadTool {
+        mutated: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl Tool for SnapshotReadTool {
+        fn name(&self) -> &str {
+            "snapshot_read_tool"
+        }
+        fn description(&self) -> &str {
+            "reports whether the sibling mutation already happened"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+            let saw = if self.mutated.load(Ordering::SeqCst) {
+                "SAW_POST_MUTATION"
+            } else {
+                "SAW_PRE_MUTATION"
+            };
+            Ok(ToolResult {
+                output: saw.to_string(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    /// Exclusive tool that flips the shared flag `SnapshotReadTool` observes.
+    struct MutatingTool {
+        mutated: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl Tool for MutatingTool {
+        fn name(&self) -> &str {
+            "mutating_tool"
+        }
+        fn description(&self) -> &str {
+            "flips the shared mutation flag"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        fn concurrency_class(&self) -> crate::tools::ConcurrencyClass {
+            crate::tools::ConcurrencyClass::Exclusive
+        }
+        async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+            self.mutated.store(true, Ordering::SeqCst);
+            Ok(ToolResult {
+                output: "MUTATION_DONE".to_string(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    /// Safe (default class) tool that hard-errors — a genuine execution
+    /// failure whose cascade bit must cancel the whole Exclusive phase.
+    struct SafeHardErrorTool;
+
+    #[async_trait]
+    impl Tool for SafeHardErrorTool {
+        fn name(&self) -> &str {
+            "safe_hard_error_tool"
+        }
+        fn description(&self) -> &str {
+            "safe reader that always errors mid-execution"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+            Err(eyre::eyre!("safe boom: reader exploded"))
+        }
+    }
+
+    /// Safe (default class) tool that fails with a `ToolInputError` — a
+    /// no-side-effect malformed-arguments failure that must NOT cancel the
+    /// Exclusive phase (#1690 semantics carried into the mixed path).
+    struct SafeInputErrorTool;
+
+    #[async_trait]
+    impl Tool for SafeInputErrorTool {
+        fn name(&self) -> &str {
+            "safe_bad_input_tool"
+        }
+        fn description(&self) -> &str {
+            "safe reader that always fails input validation"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+            Err(
+                crate::tools::ToolInputError::new("invalid safe_bad_input_tool input: missing `q`")
+                    .into(),
+            )
+        }
+    }
+
+    /// Safe pair-gate: each call waits on a shared 2-party barrier, so BOTH
+    /// calls must be in flight simultaneously to complete. Proves the
+    /// mixed-batch Safe phase actually runs in parallel — under serial
+    /// dispatch the first call would block alone until the per-call timeout
+    /// fired.
+    struct RendezvousTool {
+        barrier: Arc<tokio::sync::Barrier>,
+    }
+
+    #[async_trait]
+    impl Tool for RendezvousTool {
+        fn name(&self) -> &str {
+            "rendezvous_tool"
+        }
+        fn description(&self) -> &str {
+            "completes only when both sibling calls are in flight"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+            self.barrier.wait().await;
+            Ok(ToolResult {
+                output: "RENDEZVOUS_OK".to_string(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    fn result_for<'a>(messages: &'a [octos_core::Message], id: &str) -> &'a octos_core::Message {
+        messages
+            .iter()
+            .find(|m| m.tool_call_id.as_deref() == Some(id))
+            .unwrap_or_else(|| panic!("no result message for tool_call_id {id}"))
+    }
+
+    #[tokio::test]
+    async fn mixed_batch_reassembles_results_in_original_llm_call_order() {
+        // #1766: interleaved Safe/Exclusive calls execute in two phases but
+        // the aggregated results MUST come back in the original LLM call
+        // order with every call's REAL output (no synthetic messages).
+        let mutated = Arc::new(AtomicBool::new(false));
+        let mut tools = ToolRegistry::new();
+        tools.register(MutatingTool {
+            mutated: mutated.clone(),
+        });
+        tools.register(SnapshotReadTool {
+            mutated: mutated.clone(),
+        });
+        tools.register(GoodExclusiveTool);
+        let calls = vec![
+            tool_call("call_0_excl", "mutating_tool"),
+            tool_call("call_1_safe", "snapshot_read_tool"),
+            tool_call("call_2_excl", "good_tool"),
+            tool_call("call_3_safe", "snapshot_read_tool"),
+        ];
+        let (messages, success_by_id) = run_batch(calls, tools).await;
+
+        assert_eq!(messages.len(), 4, "one result message per tool call");
+        assert_eq!(messages[0].tool_call_id.as_deref(), Some("call_0_excl"));
+        assert_eq!(messages[1].tool_call_id.as_deref(), Some("call_1_safe"));
+        assert_eq!(messages[2].tool_call_id.as_deref(), Some("call_2_excl"));
+        assert_eq!(messages[3].tool_call_id.as_deref(), Some("call_3_safe"));
+
+        assert!(messages[0].content.contains("MUTATION_DONE"));
+        assert!(messages[2].content.contains("GOOD_REAL_OUTPUT"));
+        // Pinned visibility: BOTH Safe reads ran in phase 1, before any
+        // Exclusive mutation — even the read listed after the mutator.
+        assert!(
+            messages[1].content.contains("SAW_PRE_MUTATION"),
+            "Safe read listed after the mutator must still see pre-mutation state: {:?}",
+            messages[1].content
+        );
+        assert!(messages[3].content.contains("SAW_PRE_MUTATION"));
+        assert!(
+            success_by_id.iter().all(|(_, ok)| *ok),
+            "every call succeeded: {success_by_id:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_batch_safe_reads_see_pre_mutation_state() {
+        // Pinned #1766 visibility semantics: Safe calls observe the
+        // PRE-batch state. A Safe read the LLM listed AFTER an Exclusive
+        // mutation runs in phase 1 — BEFORE the mutation — and must not see
+        // the sibling's write. (Before M8.8 the two raced; under the M8.8
+        // serial fallback the read saw the write. The phased pipeline makes
+        // the pre-mutation snapshot deterministic.)
+        let mutated = Arc::new(AtomicBool::new(false));
+        let mut tools = ToolRegistry::new();
+        tools.register(MutatingTool {
+            mutated: mutated.clone(),
+        });
+        tools.register(SnapshotReadTool {
+            mutated: mutated.clone(),
+        });
+        let calls = vec![
+            tool_call("call_mutate", "mutating_tool"),
+            tool_call("call_read", "snapshot_read_tool"),
+        ];
+        let (messages, _success_by_id) = run_batch(calls, tools).await;
+
+        assert!(
+            result_for(&messages, "call_read")
+                .content
+                .contains("SAW_PRE_MUTATION"),
+            "Safe read must run in phase 1 and see pre-mutation state: {:?}",
+            result_for(&messages, "call_read").content
+        );
+        assert!(
+            result_for(&messages, "call_mutate")
+                .content
+                .contains("MUTATION_DONE")
+        );
+        assert!(
+            mutated.load(Ordering::SeqCst),
+            "the Exclusive mutation still ran (phase 2)"
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_batch_runs_safe_calls_in_parallel() {
+        // Two Safe calls gated on a 2-party rendezvous barrier: they can
+        // only complete if BOTH are in flight at once. Under the old serial
+        // fallback the first call would block alone until the per-call
+        // timeout fired and cascaded; under #1766 phase 1 they release each
+        // other immediately.
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let mut tools = ToolRegistry::new();
+        tools.register(RendezvousTool { barrier });
+        tools.register(GoodExclusiveTool);
+        let calls = vec![
+            tool_call("call_r1", "rendezvous_tool"),
+            tool_call("call_r2", "rendezvous_tool"),
+            tool_call("call_excl", "good_tool"),
+        ];
+        let (messages, _success_by_id) = run_batch_with_config(
+            calls,
+            tools,
+            AgentConfig {
+                // Keep the failure mode (serial dispatch deadlocking on the
+                // barrier) a fast per-call timeout instead of a hung test.
+                default_interactive_tool_timeout_secs: 2,
+                tool_timeout_secs: 2,
+                save_episodes: false,
+                ..Default::default()
+            },
+        )
+        .await;
+
+        assert!(
+            result_for(&messages, "call_r1")
+                .content
+                .contains("RENDEZVOUS_OK"),
+            "first Safe call must run concurrently with its sibling: {:?}",
+            result_for(&messages, "call_r1").content
+        );
+        assert!(
+            result_for(&messages, "call_r2")
+                .content
+                .contains("RENDEZVOUS_OK")
+        );
+        assert!(
+            result_for(&messages, "call_excl")
+                .content
+                .contains("GOOD_REAL_OUTPUT"),
+            "Exclusive phase must still run after a parallel Safe phase: {:?}",
+            result_for(&messages, "call_excl").content
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_batch_safe_error_cancels_every_exclusive_call() {
+        // #1766 acceptance criterion: an error in any Safe call still
+        // triggers the "cancelled due to sibling error" synthetic result for
+        // the Exclusive calls — position-independently. The failing reader
+        // here sits AFTER the Exclusive call in LLM order, and the Exclusive
+        // call is still cancelled: no mutation runs once a sibling read
+        // failed in phase 1.
+        let mut tools = ToolRegistry::new();
+        tools.register(GoodExclusiveTool);
+        tools.register(SafeHardErrorTool);
+        let calls = vec![
+            tool_call("call_excl", "good_tool"),
+            tool_call("call_bad_read", "safe_hard_error_tool"),
+        ];
+        let (messages, success_by_id) = run_batch(calls, tools).await;
+
+        assert!(
+            result_for(&messages, "call_excl")
+                .content
+                .contains("cancelled due to earlier sibling error"),
+            "a failed Safe call must cancel the whole Exclusive phase: {:?}",
+            result_for(&messages, "call_excl").content
+        );
+        assert!(
+            result_for(&messages, "call_bad_read")
+                .content
+                .contains("safe boom"),
+            "the Safe failure detail must reach the model: {:?}",
+            result_for(&messages, "call_bad_read").content
+        );
+        assert!(success_by_id.contains(&("call_excl".to_string(), false)));
+        assert!(success_by_id.contains(&("call_bad_read".to_string(), false)));
+    }
+
+    #[tokio::test]
+    async fn mixed_batch_safe_input_error_does_not_cancel_exclusive() {
+        // #1690 carried into the mixed path: a malformed-arguments failure
+        // (`ToolInputError`) has no side effects and must NOT cancel the
+        // Exclusive phase.
+        let mut tools = ToolRegistry::new();
+        tools.register(SafeInputErrorTool);
+        tools.register(GoodExclusiveTool);
+        let calls = vec![
+            tool_call("call_bad_input", "safe_bad_input_tool"),
+            tool_call("call_excl", "good_tool"),
+        ];
+        let (messages, _success_by_id) = run_batch(calls, tools).await;
+
+        assert!(
+            result_for(&messages, "call_excl")
+                .content
+                .contains("GOOD_REAL_OUTPUT"),
+            "an input-error Safe call must not cancel the Exclusive phase: {:?}",
+            result_for(&messages, "call_excl").content
+        );
+        assert!(
+            result_for(&messages, "call_bad_input")
+                .content
+                .contains("missing `q`"),
+            "input-error detail must reach the model"
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_batch_exclusive_error_keeps_completed_safe_results() {
+        // Phase-2 cascade stays inside phase 2: when an Exclusive call
+        // fails, LATER Exclusive peers are cancelled, but phase-1 Safe
+        // results — already complete and side-effect-free — keep their real
+        // outputs even when the LLM listed them after the failing mutator
+        // (the old serial fallback would have cancelled them).
+        let mutated = Arc::new(AtomicBool::new(false));
+        let mut tools = ToolRegistry::new();
+        tools.register(HardErrorTool);
+        tools.register(SnapshotReadTool {
+            mutated: mutated.clone(),
+        });
+        tools.register(GoodExclusiveTool);
+        let calls = vec![
+            tool_call("call_bad_excl", "hard_error_tool"),
+            tool_call("call_safe", "snapshot_read_tool"),
+            tool_call("call_good_excl", "good_tool"),
+        ];
+        let (messages, success_by_id) = run_batch(calls, tools).await;
+
+        // Original LLM call order preserved.
+        assert_eq!(messages[0].tool_call_id.as_deref(), Some("call_bad_excl"));
+        assert_eq!(messages[1].tool_call_id.as_deref(), Some("call_safe"));
+        assert_eq!(messages[2].tool_call_id.as_deref(), Some("call_good_excl"));
+
+        // The Safe read completed in phase 1 — its real output survives the
+        // later Exclusive failure.
+        assert!(
+            messages[1].content.contains("SAW_PRE_MUTATION"),
+            "phase-1 Safe result must never be converted to cancelled: {:?}",
+            messages[1].content
+        );
+        assert!(success_by_id.contains(&("call_safe".to_string(), true)));
+
+        // The Exclusive peer AFTER the failing Exclusive call is cancelled.
+        assert!(
+            messages[2]
+                .content
+                .contains("cancelled due to earlier sibling error"),
+            "later Exclusive peer must be cancelled by the phase-2 cascade: {:?}",
+            messages[2].content
         );
     }
 }

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -468,11 +468,15 @@ pub enum ToolProgress {
 ///
 /// Admission policy (implemented in `agent::execution`):
 /// - If every call in the batch is [`ConcurrencyClass::Safe`], the batch
-///   dispatches in parallel (today's behaviour).
-/// - If *any* call is [`ConcurrencyClass::Exclusive`], the entire batch runs
+///   dispatches in parallel.
+/// - If every call is [`ConcurrencyClass::Exclusive`], the batch runs
 ///   serially in call order. A single error from an exclusive call cancels
 ///   the remaining peers so the LLM sees the cascade instead of continuing
 ///   to mutate state on a doomed path.
+/// - Mixed batches (#1766) run the Safe calls in parallel first, then the
+///   Exclusive calls serially in call order; results are reassembled in the
+///   original call order. See the `agent::execution` module doc for the
+///   pinned visibility and cascade semantics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ConcurrencyClass {

--- a/crates/octos-agent/src/tools/shell.rs
+++ b/crates/octos-agent/src/tools/shell.rs
@@ -588,7 +588,8 @@ impl Tool for ShellTool {
         // Shell commands can mutate the filesystem or spawn long-lived
         // processes. Running them in parallel with other tool calls races
         // observable state (e.g. `shell: rm foo` vs `read_file foo/x`), so
-        // shell serializes the whole batch. See M8.8.
+        // shell runs in the serialized Exclusive phase — after every Safe
+        // sibling in the batch has completed. See M8.8 and #1766.
         ConcurrencyClass::Exclusive
     }
 

--- a/crates/octos-agent/tests/concurrent_scheduler.rs
+++ b/crates/octos-agent/tests/concurrent_scheduler.rs
@@ -1,20 +1,24 @@
-//! M8.8 concurrent-safe vs exclusive scheduler integration tests.
+//! M8.8 / #1766 concurrent-safe vs exclusive scheduler integration tests.
 //!
 //! Drives the `Agent` loop through a mock LLM with scripted tool-call batches
 //! and observes the executor's admission decisions via probe tools that
-//! record start/end timestamps on a shared log. The tests assert on two
+//! record start/end timestamps on a shared log. The tests assert on these
 //! invariants:
 //!
 //! 1. A batch composed entirely of [`ConcurrencyClass::Safe`] tools runs in
 //!    parallel (the last start precedes the first end — i.e. windows
 //!    overlap).
-//! 2. A batch that contains *any* [`ConcurrencyClass::Exclusive`] tool runs
-//!    each call serially in LLM call order (every start strictly follows the
-//!    previous end).
+//! 2. A batch composed entirely of [`ConcurrencyClass::Exclusive`] tools
+//!    runs each call serially in LLM call order (every start strictly
+//!    follows the previous end).
+//! 3. A mixed batch (#1766) runs its Safe calls in parallel FIRST (phase 1),
+//!    then its Exclusive calls serially in LLM call order (phase 2) — even
+//!    when the LLM listed an Exclusive call before the Safe ones.
 //!
-//! A third test triggers an error cascade: the first Exclusive call fails
-//! and the remaining peers receive a synthetic "cancelled" tool-result
-//! message without being dispatched.
+//! The cascade tests pin the error semantics: an Exclusive failure cancels
+//! the REMAINING Exclusive peers (synthetic "cancelled" results, never
+//! dispatched) while completed phase-1 Safe results are kept, and every
+//! LLM-issued tool_call_id round-trips regardless of what was cancelled.
 
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -364,9 +368,12 @@ async fn executor_dispatches_exclusive_serially_in_call_order() {
 }
 
 #[tokio::test]
-async fn executor_serializes_mixed_batch_when_any_exclusive() {
-    // One Exclusive + two Safe must serialize the WHOLE batch per the M8.8
-    // admission rule ("if any Exclusive, run the whole batch serially").
+async fn executor_runs_mixed_batch_safe_parallel_then_exclusive_serial() {
+    // #1766: one Exclusive + two Safe. The Safe calls run in parallel FIRST
+    // (phase 1, overlapping windows) and the Exclusive call runs AFTER both
+    // Safe calls completed (phase 2) — even though the LLM listed the
+    // Exclusive call first. Before #1766 the whole batch serialized in LLM
+    // call order.
     let dir = TempDir::new().unwrap();
     let log = CallLog::new();
     let probes = vec![
@@ -379,13 +386,13 @@ async fn executor_serializes_mixed_batch_when_any_exclusive() {
         ProbeTool::new(
             "safe_y",
             ConcurrencyClass::Safe,
-            Duration::from_millis(50),
+            Duration::from_millis(100),
             log.clone(),
         ),
         ProbeTool::new(
             "safe_z",
             ConcurrencyClass::Safe,
-            Duration::from_millis(50),
+            Duration::from_millis(100),
             log.clone(),
         ),
     ];
@@ -407,23 +414,34 @@ async fn executor_serializes_mixed_batch_when_any_exclusive() {
 
     let spans = log.lock().unwrap().snapshot();
     assert_eq!(spans.len(), 3);
+    let span = |name: &str| {
+        spans
+            .iter()
+            .find(|s| s.name == name)
+            .unwrap_or_else(|| panic!("no span for {name}: {spans:?}"))
+    };
+    let (x, y, z) = (span("excl_x"), span("safe_y"), span("safe_z"));
 
-    // No two spans may overlap; each start >= previous end.
-    for pair in spans.windows(2) {
-        assert!(
-            pair[1].started_us >= pair[0].ended_us,
-            "mixed batch was not serialized: {:?}",
-            spans
-        );
-    }
+    // Phase 1: the two Safe windows overlap (parallel dispatch).
+    assert!(
+        y.started_us.max(z.started_us) < y.ended_us.min(z.ended_us),
+        "mixed-batch Safe phase did not overlap: {spans:?}"
+    );
+    // Phase 2: the Exclusive call starts only after BOTH Safe calls ended,
+    // despite being listed first by the LLM.
+    assert!(
+        x.started_us >= y.ended_us && x.started_us >= z.ended_us,
+        "Exclusive call must not start before the Safe phase joined: {spans:?}"
+    );
 }
 
 #[tokio::test]
-async fn executor_cancels_siblings_after_exclusive_tool_error() {
-    // First Exclusive tool fails; the remaining two must not execute. Each
-    // cancelled peer gets a synthetic "cancelled" tool-result message so the
-    // LLM sees every tool_call_id. The spans log records exactly ONE probe
-    // invocation (the failing first call).
+async fn executor_cancels_later_exclusive_but_keeps_safe_phase_after_error() {
+    // #1766 cascade pin: the failing Exclusive call cancels the REMAINING
+    // Exclusive peer (never dispatched), but the Safe call already completed
+    // in phase 1 and keeps its real result — it is NOT retroactively
+    // cancelled. The spans log records exactly TWO probe invocations: the
+    // phase-1 Safe call, then the failing Exclusive call.
     let dir = TempDir::new().unwrap();
     let log = CallLog::new();
     let probes = vec![
@@ -441,8 +459,8 @@ async fn executor_cancels_siblings_after_exclusive_tool_error() {
             log.clone(),
         ),
         ProbeTool::new(
-            "safe_peer2",
-            ConcurrencyClass::Safe,
+            "excl_peer2",
+            ConcurrencyClass::Exclusive,
             Duration::from_millis(20),
             log.clone(),
         ),
@@ -451,7 +469,7 @@ async fn executor_cancels_siblings_after_exclusive_tool_error() {
         tool_use_response(vec![
             tc("call_1", "excl_bad"),
             tc("call_2", "safe_peer1"),
-            tc("call_3", "safe_peer2"),
+            tc("call_3", "excl_peer2"),
         ]),
         end_turn("post-cascade"),
     ];
@@ -463,10 +481,21 @@ async fn executor_cancels_siblings_after_exclusive_tool_error() {
         .expect("agent loop must succeed (cancellation is not an error)");
     assert_eq!(resp.content, "post-cascade");
 
-    // Only the failing probe actually ran.
+    // The Safe call ran (phase 1), then the failing Exclusive call ran
+    // (phase 2); the second Exclusive peer was cancelled and never
+    // dispatched.
     let spans = log.lock().unwrap().snapshot();
-    assert_eq!(spans.len(), 1, "only the failing probe should execute");
-    assert_eq!(spans[0].name, "excl_bad");
+    assert_eq!(
+        spans.iter().map(|s| s.name.as_str()).collect::<Vec<_>>(),
+        vec!["safe_peer1", "excl_bad"],
+        "phase-1 Safe runs first, failing Exclusive second, victim never"
+    );
+    // Phase separation: the Exclusive call started only after the Safe
+    // phase joined.
+    assert!(
+        spans[1].started_us >= spans[0].ended_us,
+        "Exclusive phase must start after the Safe phase joined: {spans:?}"
+    );
 }
 
 #[tokio::test]
@@ -506,13 +535,13 @@ async fn executor_preserves_tool_call_ids_across_cascade() {
         )
         .with_failure(true),
         ProbeTool::new(
-            "safe_late_a",
-            ConcurrencyClass::Safe,
+            "excl_victim",
+            ConcurrencyClass::Exclusive,
             Duration::from_millis(10),
             log.clone(),
         ),
         ProbeTool::new(
-            "safe_late_b",
+            "safe_survivor",
             ConcurrencyClass::Safe,
             Duration::from_millis(10),
             log.clone(),
@@ -521,8 +550,8 @@ async fn executor_preserves_tool_call_ids_across_cascade() {
     let responses = vec![
         tool_use_response(vec![
             tc("call_alpha", "excl_fail"),
-            tc("call_beta", "safe_late_a"),
-            tc("call_gamma", "safe_late_b"),
+            tc("call_beta", "excl_victim"),
+            tc("call_gamma", "safe_survivor"),
         ]),
         end_turn("ok"),
     ];
@@ -573,12 +602,15 @@ async fn executor_preserves_tool_call_ids_across_cascade() {
     );
     assert!(
         ids.contains(&"call_gamma"),
-        "missing cancelled call_gamma in {:?}",
+        "missing completed call_gamma in {:?}",
         ids
     );
 
-    // 3) The two cancelled peers must carry a "cancelled" marker in their
-    //    content so the LLM can distinguish them from an ordinary failure.
+    // 3) The cancelled Exclusive peer carries a "cancelled" marker so the
+    //    LLM can distinguish it from an ordinary failure, while the Safe
+    //    call — which completed in phase 1 before the Exclusive failure —
+    //    keeps its REAL output (#1766: phase-1 results are never
+    //    retroactively cancelled).
     let find = |id: &str| -> &str {
         tool_msgs
             .iter()
@@ -593,8 +625,13 @@ async fn executor_preserves_tool_call_ids_across_cascade() {
         find("call_beta")
     );
     assert!(
-        find("call_gamma").contains("cancelled"),
-        "call_gamma result should mark cancellation; got {}",
+        find("call_gamma").contains("safe_survivor ok"),
+        "call_gamma (phase-1 Safe) must keep its real output; got {}",
+        find("call_gamma")
+    );
+    assert!(
+        !find("call_gamma").contains("cancelled"),
+        "call_gamma (phase-1 Safe) must not be retroactively cancelled; got {}",
         find("call_gamma")
     );
 }


### PR DESCRIPTION
Implements the M8.8-deferred optimization: a mixed batch no longer serializes wholesale — phase 1 runs all `ConcurrencyClass::Safe` calls in parallel (join_all), phase 2 runs `Exclusive` calls serially in LLM call order; results reassemble in the original call order. All-Safe and All-Exclusive behavior unchanged. Approvals/hooks/spawn_only flow verified through the phased path; the Safe-before-Exclusive visibility semantics are pinned in tests and the module doc. ~50% latency cut for the common 3-reads+1-edit batch.

Built + 3-lens octos/K3 reviewed (verdict clean) in the 10-lane opencode-gap run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)