### PR TITLE
feat(agent): fuzzy edit_file replacer chain + industry param aliases (#1771, #1767)

### DIFF
--- a/crates/octos-agent/src/tools/edit_file.rs
+++ b/crates/octos-agent/src/tools/edit_file.rs
@@ -195,17 +195,33 @@ impl Tool for EditFileTool {
             }
         };
 
+        // When the match came from the escape_normalized replacer, BOTH call
+        // strings carry the same double-escaping pathology — interpret
+        // new_string (and the guard's needle) with the same unescape rules
+        // that made old_string match. Splicing new_string verbatim would
+        // write literal `\n` text into the file as code, and guarding
+        // against the still-escaped old_string (1 physical line) would
+        // falsely reject every legitimate multi-line match (#1771 review).
+        let (guard_needle, splice_new) = if replacer_name == "escape_normalized" {
+            (
+                super::replacer::unescape_find(&input.old_string),
+                super::replacer::unescape_find(&input.new_string),
+            )
+        } else {
+            (input.old_string.clone(), input.new_string.clone())
+        };
+
         // Safety guard: a fuzzy matcher must never silently swallow far more
         // of the file than the old_string described.
         let matched_text = &content[range.clone()];
-        if super::replacer::is_disproportionate_match(matched_text, &input.old_string) {
+        if super::replacer::is_disproportionate_match(matched_text, &guard_needle) {
             return Ok(ToolResult {
                 output: format!(
                     "Fuzzy match rejected as disproportionate: the {replacer_name} replacer matched {} lines / {} bytes for an old_string of {} lines / {} bytes. Provide more context so the match is precise.",
                     matched_text.lines().count(),
                     matched_text.len(),
-                    input.old_string.lines().count(),
-                    input.old_string.len(),
+                    guard_needle.lines().count(),
+                    guard_needle.len(),
                 ),
                 success: false,
                 ..Default::default()
@@ -223,10 +239,9 @@ impl Tool for EditFileTool {
         // Perform replacement by byte range — the fuzzy-matched span may
         // occur elsewhere as a plain substring, so a string replacen could
         // hit the wrong occurrence.
-        let mut new_content =
-            String::with_capacity(content.len() - range.len() + input.new_string.len());
+        let mut new_content = String::with_capacity(content.len() - range.len() + splice_new.len());
         new_content.push_str(&content[..range.start]);
-        new_content.push_str(&input.new_string);
+        new_content.push_str(&splice_new);
         new_content.push_str(&content[range.end..]);
 
         // Write back (O_NOFOLLOW)
@@ -763,6 +778,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn should_unescape_new_string_when_match_is_escape_normalized() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("e2.rs"), "alpha {\n    beta();\n}\n").unwrap();
+
+        let tool = EditFileTool::new(dir.path());
+        // #1771 review: realistic double-escaping afflicts BOTH strings of
+        // the call. The new_string must be unescaped with the same rules
+        // that made old_string match, or literal backslash-n text is
+        // written into the file as code.
+        let result = tool
+            .execute(&serde_json::json!({
+                "path": "e2.rs",
+                "old_string": "alpha {\\n    beta();",
+                "new_string": "alpha {\\n    gamma();"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{}", result.output);
+        assert!(result.output.contains("escape_normalized"));
+        let content = std::fs::read_to_string(dir.path().join("e2.rs")).unwrap();
+        assert_eq!(content, "alpha {\n    gamma();\n}\n");
+    }
+
+    #[tokio::test]
+    async fn should_not_reject_multiline_escape_normalized_match_as_disproportionate() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("m.rs"),
+            "l1();\nl2();\nl3();\nl4();\nl5();\n",
+        )
+        .unwrap();
+
+        let tool = EditFileTool::new(dir.path());
+        // #1771 review: the escaped old_string is ONE physical line but
+        // unescapes to five real lines. The disproportionate guard must
+        // measure against the unescaped needle — with the raw old_string
+        // the line cap is max(1+3, 2) = 4 and every legitimate >= 5-line
+        // escape-normalized match was falsely rejected.
+        let result = tool
+            .execute(&serde_json::json!({
+                "path": "m.rs",
+                "old_string": "l1();\\nl2();\\nl3();\\nl4();\\nl5();",
+                "new_string": "one();\\ntwo();"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{}", result.output);
+        assert!(result.output.contains("escape_normalized"));
+        let content = std::fs::read_to_string(dir.path().join("m.rs")).unwrap();
+        assert_eq!(content, "one();\ntwo();\n");
+    }
+
+    #[tokio::test]
     async fn should_match_via_block_anchor_when_middle_line_drifted() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
@@ -790,14 +860,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_reject_disproportionate_block_anchor_span() {
+    async fn should_refuse_block_anchor_span_far_exceeding_old_string() {
         let dir = tempfile::tempdir().unwrap();
         let original = "fn f() {\n    a();\n    b();\n    c();\n    d();\n    e();\n    g();\n}\n";
         std::fs::write(dir.path().join("g.rs"), original).unwrap();
 
         let tool = EditFileTool::new(dir.path());
-        // Anchors would bracket 8 lines for a 3-line old_string (> the
-        // max(3+3, 3*2) = 6 line cap) — the guard must refuse.
+        // Anchors would bracket 8 lines for a 3-line old_string. The block
+        // similarity score counts the six undescribed middle lines against
+        // the match, so block_anchor refuses outright (NoMatch) before the
+        // disproportionate guard is even consulted.
         let result = tool
             .execute(&serde_json::json!({
                 "path": "g.rs",
@@ -807,15 +879,52 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(!result.success, "guard must reject: {}", result.output);
         assert!(
-            result.output.contains("disproportionate"),
-            "expected guard message, got: {}",
+            !result.success,
+            "runaway span must be refused: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("String not found"),
+            "expected NoMatch refusal, got: {}",
             result.output
         );
         // File untouched.
         assert_eq!(
             std::fs::read_to_string(dir.path().join("g.rs")).unwrap(),
+            original
+        );
+    }
+
+    #[tokio::test]
+    async fn should_reject_disproportionate_byte_growth_on_block_anchor_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let indent = " ".repeat(60);
+        let original = format!("{indent}fn deep() {{\n{indent}    b_call();\n{indent}}}\n");
+        std::fs::write(dir.path().join("d.rs"), &original).unwrap();
+
+        let tool = EditFileTool::new(dir.path());
+        // Line counts line up (3 vs 3) and the drifted middle clears the
+        // similarity bar, but the 60-space indentation makes the span more
+        // than 4x the old_string's bytes — the guard must still refuse
+        // block_anchor matches on byte growth.
+        let result = tool
+            .execute(&serde_json::json!({
+                "path": "d.rs",
+                "old_string": "fn deep() {\n    a_call();\n}",
+                "new_string": "fn deep() {}"
+            }))
+            .await
+            .unwrap();
+
+        assert!(
+            !result.success,
+            "byte blowup must be refused: {}",
+            result.output
+        );
+        assert!(result.output.contains("disproportionate"));
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("d.rs")).unwrap(),
             original
         );
     }

--- a/crates/octos-agent/src/tools/edit_file.rs
+++ b/crates/octos-agent/src/tools/edit_file.rs
@@ -45,8 +45,12 @@ impl EditFileTool {
 
 #[derive(Debug, Deserialize)]
 struct EditFileInput {
+    /// #1767: `filePath` is the industry-convention alias.
+    #[serde(alias = "filePath")]
     path: String,
+    #[serde(alias = "oldString")]
     old_string: String,
+    #[serde(alias = "newString")]
     new_string: String,
 }
 
@@ -57,7 +61,7 @@ impl Tool for EditFileTool {
     }
 
     fn description(&self) -> &str {
-        "Edit a file by replacing an exact string with a new string. The old_string must match exactly (including whitespace and indentation)."
+        "Edit a file by replacing a string with a new string. An exact match of old_string is preferred; when none exists, whitespace-, indentation- and escape-tolerant fuzzy matching is tried as a fallback. The old_string must identify a single location."
     }
 
     fn tags(&self) -> &[&str] {
@@ -76,15 +80,15 @@ impl Tool for EditFileTool {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Path to the file to edit"
+                    "description": "Path to the file to edit (alias: filePath)"
                 },
                 "old_string": {
                     "type": "string",
-                    "description": "The exact string to find and replace"
+                    "description": "The string to find and replace. An exact match is preferred; minor whitespace/indentation/escape differences are tolerated as a fallback. Must identify a unique location. (alias: oldString)"
                 },
                 "new_string": {
                     "type": "string",
-                    "description": "The string to replace it with"
+                    "description": "The string to replace it with (alias: newString)"
                 }
             },
             "required": ["path", "old_string", "new_string"]
@@ -155,33 +159,75 @@ impl Tool for EditFileTool {
             Err(e) => return Ok(super::file_io_error(e, &input.path)),
         };
 
-        // Check if old_string exists
-        let count = content.matches(&input.old_string).count();
+        if input.old_string.is_empty() {
+            return Ok(ToolResult {
+                output: "old_string must not be empty".to_string(),
+                success: false,
+                ..Default::default()
+            });
+        }
 
-        if count == 0 {
+        // #1771: cascading replacer chain — exact match first, then
+        // increasingly whitespace/indentation/escape-tolerant fallbacks.
+        let (range, replacer_name) = match super::replacer::find_replacement(
+            &content,
+            &input.old_string,
+        ) {
+            super::replacer::ChainOutcome::Match { range, replacer } => (range, replacer),
+            super::replacer::ChainOutcome::Ambiguous { count, replacer } => {
+                return Ok(ToolResult {
+                    output: format!(
+                        "Found {count} occurrences of the string (via {replacer} replacer). Please provide more context to make the match unique.",
+                    ),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+            super::replacer::ChainOutcome::NoMatch => {
+                return Ok(ToolResult {
+                    output: format!(
+                        "String not found in file. No exact match, and no fuzzy match via the line-trimmed, whitespace-normalized, indentation-flexible, escape-normalized or block-anchor replacers.\n\nSearched for:\n```\n{}\n```",
+                        input.old_string
+                    ),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+        };
+
+        // Safety guard: a fuzzy matcher must never silently swallow far more
+        // of the file than the old_string described.
+        let matched_text = &content[range.clone()];
+        if super::replacer::is_disproportionate_match(matched_text, &input.old_string) {
             return Ok(ToolResult {
                 output: format!(
-                    "String not found in file. Make sure the old_string matches exactly.\n\nSearched for:\n```\n{}\n```",
-                    input.old_string
+                    "Fuzzy match rejected as disproportionate: the {replacer_name} replacer matched {} lines / {} bytes for an old_string of {} lines / {} bytes. Provide more context so the match is precise.",
+                    matched_text.lines().count(),
+                    matched_text.len(),
+                    input.old_string.lines().count(),
+                    input.old_string.len(),
                 ),
                 success: false,
                 ..Default::default()
             });
         }
 
-        if count > 1 {
-            return Ok(ToolResult {
-                output: format!(
-                    "Found {} occurrences of the string. Please provide more context to make the match unique.",
-                    count
-                ),
-                success: false,
-                ..Default::default()
-            });
+        if replacer_name != "exact" {
+            tracing::info!(
+                replacer = replacer_name,
+                path = %input.path,
+                "edit_file fuzzy match succeeded"
+            );
         }
 
-        // Perform replacement
-        let new_content = content.replacen(&input.old_string, &input.new_string, 1);
+        // Perform replacement by byte range — the fuzzy-matched span may
+        // occur elsewhere as a plain substring, so a string replacen could
+        // hit the wrong occurrence.
+        let mut new_content =
+            String::with_capacity(content.len() - range.len() + input.new_string.len());
+        new_content.push_str(&content[..range.start]);
+        new_content.push_str(&input.new_string);
+        new_content.push_str(&content[range.end..]);
 
         // Write back (O_NOFOLLOW)
         if let Err(e) = super::write_no_follow(&path, new_content.as_bytes()).await {
@@ -204,8 +250,19 @@ impl Tool for EditFileTool {
             );
         }
 
+        // Report which replacer produced the match. The exact-match wording
+        // is kept identical to the historical output for compatibility.
+        let output = if replacer_name == "exact" {
+            format!("Successfully edited {}", input.path)
+        } else {
+            format!(
+                "Successfully edited {} (fuzzy match via {replacer_name} replacer)",
+                input.path
+            )
+        };
+
         Ok(ToolResult {
-            output: format!("Successfully edited {}", input.path),
+            output,
             success: true,
             file_modified: Some(path),
             ..Default::default()
@@ -593,6 +650,342 @@ mod tests {
             .unwrap();
         assert!(!bad.success);
         assert!(bad.output.contains("outside working directory"));
+    }
+
+    // -----------------------------------------------------------------------
+    // #1771: cascading fuzzy replacer chain.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn should_match_via_line_trimmed_when_indentation_differs() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("code.rs"),
+            "fn main() {\n    if ready {\n        launch();\n    }\n}\n",
+        )
+        .unwrap();
+
+        let tool = EditFileTool::new(dir.path());
+        // LLM lost the indentation (flush left) but every line's trimmed
+        // content is right — the line_trimmed replacer must recover it.
+        let result = tool
+            .execute(&serde_json::json!({
+                "path": "code.rs",
+                "old_string": "if ready {\nlaunch();\n}",
+                "new_string": "if ready {\n        abort();\n    }"
+            }))
+            .await
+            .unwrap();
+
+        assert!(
+            result.success,
+            "line-trimmed fuzzy match should succeed: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("line_trimmed"),
+            "success output must report which replacer matched: {}",
+            result.output
+        );
+        let content = std::fs::read_to_string(dir.path().join("code.rs")).unwrap();
+        assert!(content.contains("abort();"));
+        assert!(!content.contains("launch();"));
+    }
+
+    #[tokio::test]
+    async fn should_match_via_whitespace_normalized_when_internal_runs_differ() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("w.rs"), "let x  =  compute( a, b );\n").unwrap();
+
+        let tool = EditFileTool::new(dir.path());
+        let result = tool
+            .execute(&serde_json::json!({
+                "path": "w.rs",
+                "old_string": "let x = compute( a, b );",
+                "new_string": "let x = compute(a, b, c);"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{}", result.output);
+        assert!(result.output.contains("whitespace_normalized"));
+        let content = std::fs::read_to_string(dir.path().join("w.rs")).unwrap();
+        assert_eq!(content, "let x = compute(a, b, c);\n");
+    }
+
+    #[tokio::test]
+    async fn should_match_via_indentation_flexible_when_blank_boundary_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("i.rs"),
+            "fn wrapper() {\n    step_one();\n    step_two();\n}\n",
+        )
+        .unwrap();
+
+        let tool = EditFileTool::new(dir.path());
+        // Needle copied with stray blank lines around the block and a
+        // uniformly deeper indent — only the dedent matcher recovers it.
+        let result = tool
+            .execute(&serde_json::json!({
+                "path": "i.rs",
+                "old_string": "\n        step_one();\n        step_two();\n\n",
+                "new_string": "    merged_steps();"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{}", result.output);
+        assert!(result.output.contains("indentation_flexible"));
+        let content = std::fs::read_to_string(dir.path().join("i.rs")).unwrap();
+        assert_eq!(content, "fn wrapper() {\n    merged_steps();\n}\n");
+    }
+
+    #[tokio::test]
+    async fn should_match_via_escape_normalized_when_newline_double_escaped() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("e.rs"), "alpha {\n    beta();\n}\n").unwrap();
+
+        let tool = EditFileTool::new(dir.path());
+        // old_string carries a literal backslash-n instead of a newline.
+        let result = tool
+            .execute(&serde_json::json!({
+                "path": "e.rs",
+                "old_string": "alpha {\\n    beta();",
+                "new_string": "alpha {\n    gamma();"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{}", result.output);
+        assert!(result.output.contains("escape_normalized"));
+        let content = std::fs::read_to_string(dir.path().join("e.rs")).unwrap();
+        assert_eq!(content, "alpha {\n    gamma();\n}\n");
+    }
+
+    #[tokio::test]
+    async fn should_match_via_block_anchor_when_middle_line_drifted() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("b.rs"),
+            "fn compute() {\n    let total = base + extra;\n    total * 2\n}\n",
+        )
+        .unwrap();
+
+        let tool = EditFileTool::new(dir.path());
+        // Middle line remembered slightly wrong (offset vs extra) — first
+        // and last lines anchor the block, similarity carries the middle.
+        let result = tool
+            .execute(&serde_json::json!({
+                "path": "b.rs",
+                "old_string": "fn compute() {\n    let total = base + offset;\n    total * 2\n}",
+                "new_string": "fn compute() {\n    base * 3\n}"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{}", result.output);
+        assert!(result.output.contains("block_anchor"));
+        let content = std::fs::read_to_string(dir.path().join("b.rs")).unwrap();
+        assert_eq!(content, "fn compute() {\n    base * 3\n}\n");
+    }
+
+    #[tokio::test]
+    async fn should_reject_disproportionate_block_anchor_span() {
+        let dir = tempfile::tempdir().unwrap();
+        let original = "fn f() {\n    a();\n    b();\n    c();\n    d();\n    e();\n    g();\n}\n";
+        std::fs::write(dir.path().join("g.rs"), original).unwrap();
+
+        let tool = EditFileTool::new(dir.path());
+        // Anchors would bracket 8 lines for a 3-line old_string (> the
+        // max(3+3, 3*2) = 6 line cap) — the guard must refuse.
+        let result = tool
+            .execute(&serde_json::json!({
+                "path": "g.rs",
+                "old_string": "fn f() {\n    a();\n}",
+                "new_string": "fn f() {}"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success, "guard must reject: {}", result.output);
+        assert!(
+            result.output.contains("disproportionate"),
+            "expected guard message, got: {}",
+            result.output
+        );
+        // File untouched.
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("g.rs")).unwrap(),
+            original
+        );
+    }
+
+    #[tokio::test]
+    async fn should_reject_disproportionate_char_growth() {
+        let dir = tempfile::tempdir().unwrap();
+        let indent = " ".repeat(60);
+        let original = format!("{indent}x();\n{indent}y();\n{indent}z();\n");
+        std::fs::write(dir.path().join("c.rs"), &original).unwrap();
+
+        let tool = EditFileTool::new(dir.path());
+        // line_trimmed would match, but the span is 194 bytes for a
+        // 14-byte old_string (> 4x) — the guard must refuse.
+        let result = tool
+            .execute(&serde_json::json!({
+                "path": "c.rs",
+                "old_string": "x();\ny();\nz();",
+                "new_string": "w();"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success, "guard must reject: {}", result.output);
+        assert!(result.output.contains("disproportionate"));
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("c.rs")).unwrap(),
+            original
+        );
+    }
+
+    #[tokio::test]
+    async fn should_fail_with_count_when_fuzzy_match_is_ambiguous() {
+        let dir = tempfile::tempdir().unwrap();
+        let original = "fn a() {\n    if ready {\n        launch();\n    }\n}\nfn b() {\n  if ready {\n    launch();\n  }\n}\n";
+        std::fs::write(dir.path().join("amb.rs"), original).unwrap();
+
+        let tool = EditFileTool::new(dir.path());
+        // No exact occurrence, but the trimmed block exists at two
+        // different indentation levels — must fail with the count, not
+        // silently pick one or fall through to a fuzzier stage.
+        let result = tool
+            .execute(&serde_json::json!({
+                "path": "amb.rs",
+                "old_string": "if ready {\nlaunch();\n}",
+                "new_string": "abort();"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success, "{}", result.output);
+        assert!(
+            result.output.contains("2 occurrences"),
+            "expected the ambiguity count, got: {}",
+            result.output
+        );
+        assert!(result.output.contains("line_trimmed"));
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("amb.rs")).unwrap(),
+            original
+        );
+    }
+
+    #[tokio::test]
+    async fn should_reject_empty_old_string() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f.txt"), "content").unwrap();
+
+        let tool = EditFileTool::new(dir.path());
+        let result = tool
+            .execute(&serde_json::json!({
+                "path": "f.txt",
+                "old_string": "",
+                "new_string": "x"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result.output.contains("must not be empty"));
+    }
+
+    #[tokio::test]
+    async fn should_keep_exact_success_output_stable() {
+        // Exact matches keep the historical wording — no replacer chatter.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("s.txt"), "hello world\n").unwrap();
+
+        let tool = EditFileTool::new(dir.path());
+        let result = tool
+            .execute(&serde_json::json!({
+                "path": "s.txt",
+                "old_string": "hello",
+                "new_string": "goodbye"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        assert_eq!(result.output, "Successfully edited s.txt");
+    }
+
+    #[tokio::test]
+    async fn should_splice_fuzzy_match_at_located_span_not_first_substring() {
+        // The fuzzy-matched span's exact text ("    a();\n    b();") ALSO
+        // occurs earlier in the file, but mid-line (inside a string-ish
+        // context), where it is not a valid line window. A string replacen
+        // of the matched text would corrupt the earlier occurrence; the
+        // byte-range splice must edit the located window only.
+        let dir = tempfile::tempdir().unwrap();
+        let original = "code(    a();\n    b();x)\nfn late() {\n    a();\n    b();\n}\n";
+        std::fs::write(dir.path().join("span.rs"), original).unwrap();
+
+        let tool = EditFileTool::new(dir.path());
+        let result = tool
+            .execute(&serde_json::json!({
+                "path": "span.rs",
+                // Flush-left needle: line_trimmed matches only the window
+                // inside fn late().
+                "old_string": "a();\nb();",
+                "new_string": "    c();"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{}", result.output);
+        let content = std::fs::read_to_string(dir.path().join("span.rs")).unwrap();
+        assert_eq!(
+            content,
+            "code(    a();\n    b();x)\nfn late() {\n    c();\n}\n"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #1767: industry-convention parameter aliases.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn should_accept_camel_case_aliases_for_edit_input() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("alias.txt"), "hello world\n").unwrap();
+
+        let tool = EditFileTool::new(dir.path());
+        let result = tool
+            .execute(&serde_json::json!({
+                "filePath": "alias.txt",
+                "oldString": "hello",
+                "newString": "goodbye"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "aliases must work: {}", result.output);
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("alias.txt")).unwrap(),
+            "goodbye world\n"
+        );
+    }
+
+    #[test]
+    fn schema_advertises_canonical_names_only() {
+        let tool = EditFileTool::new("/tmp");
+        let schema = tool.input_schema();
+        let props = schema["properties"].as_object().unwrap();
+        assert!(props.contains_key("path"));
+        assert!(props.contains_key("old_string"));
+        assert!(props.contains_key("new_string"));
+        assert!(!props.contains_key("filePath"));
+        assert!(!props.contains_key("oldString"));
+        assert!(!props.contains_key("newString"));
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -711,6 +711,7 @@ pub mod read_file;
 pub mod read_task_output;
 pub mod recall_memory;
 pub mod record_memory_use;
+pub(crate) mod replacer;
 pub mod research_utils;
 pub mod save_memory;
 pub mod send_app_card;

--- a/crates/octos-agent/src/tools/read_file.rs
+++ b/crates/octos-agent/src/tools/read_file.rs
@@ -36,11 +36,43 @@ impl ReadFileTool {
 
 #[derive(Debug, Deserialize)]
 struct ReadFileInput {
+    /// #1767: `filePath` is the industry-convention alias.
+    #[serde(alias = "filePath")]
     path: String,
-    #[serde(default)]
+    /// `offset` is a 1:1 alias — both mean "first line to read, 1-indexed".
+    #[serde(default, alias = "offset")]
     start_line: Option<usize>,
     #[serde(default)]
     end_line: Option<usize>,
+    /// #1767: distinct field, NOT an alias of `end_line` — `limit` is a
+    /// *count* of lines to read starting at `start_line`, from which the
+    /// effective `end_line` is computed. A bare alias would misread
+    /// `limit: 100` as "stop at line 100".
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+/// Resolve the effective `(start_line, end_line)` pair from the three
+/// accepted range parameters. `limit` computes `end_line = start_line +
+/// limit - 1`; supplying both `end_line` and `limit` is ambiguous and
+/// rejected.
+fn resolve_line_range(
+    start_line: Option<usize>,
+    end_line: Option<usize>,
+    limit: Option<usize>,
+) -> Result<(Option<usize>, Option<usize>), String> {
+    match (end_line, limit) {
+        (Some(_), Some(_)) => Err("Provide either 'end_line' or 'limit', not both.".to_string()),
+        (None, Some(0)) => Err("'limit' must be at least 1.".to_string()),
+        (None, Some(count)) => {
+            let start = start_line.unwrap_or(1);
+            Ok((
+                start_line,
+                Some(start.saturating_add(count).saturating_sub(1)),
+            ))
+        }
+        (end, None) => Ok((start_line, end)),
+    }
 }
 
 #[async_trait]
@@ -63,15 +95,19 @@ impl Tool for ReadFileTool {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Path to the file to read (relative to working directory)"
+                    "description": "Path to the file to read (relative to working directory; alias: filePath)"
                 },
                 "start_line": {
                     "type": "integer",
-                    "description": "Optional starting line number (1-indexed)"
+                    "description": "Optional starting line number (1-indexed; alias: offset)"
                 },
                 "end_line": {
                     "type": "integer",
                     "description": "Optional ending line number (1-indexed, inclusive)"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Optional maximum number of lines to read, starting at start_line (alternative to end_line — do not provide both)"
                 }
             },
             "required": ["path"]
@@ -103,6 +139,21 @@ impl Tool for ReadFileTool {
                 ..Default::default()
             });
         }
+
+        // #1767: fold `limit` into an effective end_line up front so every
+        // consumer below (range slicing AND the file-state cache key) sees
+        // one canonical range.
+        let (start_line, end_line) =
+            match resolve_line_range(input.start_line, input.end_line, input.limit) {
+                Ok(range) => range,
+                Err(message) => {
+                    return Ok(ToolResult {
+                        output: message,
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            };
 
         // Phase 2-C of the SessionScope migration: when the host has
         // threaded a scope through `ToolContext`, use it as the single
@@ -165,7 +216,7 @@ impl Tool for ReadFileTool {
         // file body. This reduces token cost by 30-60 % in long sessions.
         // We store the user-supplied range verbatim so the comparison here is
         // exact (without needing to know the file's total line count).
-        let requested_range = user_range(input.start_line, input.end_line);
+        let requested_range = user_range(start_line, end_line);
         if let (Some(cache), Some(mtime)) = (ctx.file_state_cache.as_ref(), current_mtime) {
             if let Some(entry) = cache.get(&path, mtime) {
                 if cache_matches_request(&entry, requested_range) {
@@ -188,8 +239,8 @@ impl Tool for ReadFileTool {
         let total_lines = lines.len();
 
         // Apply line range
-        let start = input.start_line.unwrap_or(1).saturating_sub(1);
-        let end = input.end_line.unwrap_or(total_lines).min(total_lines);
+        let start = start_line.unwrap_or(1).saturating_sub(1);
+        let end = end_line.unwrap_or(total_lines).min(total_lines);
 
         if start >= total_lines {
             return Ok(ToolResult {
@@ -255,7 +306,7 @@ impl Tool for ReadFileTool {
             let can_cache = !FileStateCache::has_binary_extension(&path)
                 && FileStateCache::is_text_cacheable(content.as_bytes());
             if can_cache {
-                let view_range = user_range(input.start_line, input.end_line);
+                let view_range = user_range(start_line, end_line);
                 cache.put(CacheEntry::new(
                     path.clone(),
                     mtime,
@@ -760,6 +811,199 @@ mod tests {
             .unwrap();
         assert!(!bad.success);
         assert!(bad.output.contains("outside working directory"));
+    }
+
+    // -----------------------------------------------------------------------
+    // #1767: industry-convention parameter aliases.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn should_accept_file_path_alias_for_path() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("hello.txt"), "aliased content\n").unwrap();
+
+        let tool = ReadFileTool::new(dir.path());
+        let result = tool
+            .execute(&serde_json::json!({"filePath": "hello.txt"}))
+            .await
+            .unwrap();
+
+        assert!(
+            result.success,
+            "filePath alias must work: {}",
+            result.output
+        );
+        assert!(result.output.contains("aliased content"));
+    }
+
+    fn ten_lines_file(dir: &tempfile::TempDir) {
+        let content = (1..=10)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(dir.path().join("lines.txt"), &content).unwrap();
+    }
+
+    #[tokio::test]
+    async fn should_accept_offset_alias_for_start_line() {
+        let dir = tempfile::tempdir().unwrap();
+        ten_lines_file(&dir);
+
+        let tool = ReadFileTool::new(dir.path());
+        let result = tool
+            .execute(&serde_json::json!({"path": "lines.txt", "offset": 3, "end_line": 5}))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{}", result.output);
+        assert!(result.output.contains("showing lines 3-5 of 10"));
+    }
+
+    #[tokio::test]
+    async fn should_compute_end_line_from_limit() {
+        // limit is a COUNT of lines, not a line number: offset 3 + limit 3
+        // reads lines 3..=5 (end_line = start + limit - 1).
+        let dir = tempfile::tempdir().unwrap();
+        ten_lines_file(&dir);
+
+        let tool = ReadFileTool::new(dir.path());
+        let result = tool
+            .execute(&serde_json::json!({"path": "lines.txt", "offset": 3, "limit": 3}))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{}", result.output);
+        assert!(
+            result.output.contains("showing lines 3-5 of 10"),
+            "limit must be a line count: {}",
+            result.output
+        );
+        assert!(result.output.contains("line 3"));
+        assert!(result.output.contains("line 5"));
+        assert!(!result.output.contains("line 6"));
+    }
+
+    #[tokio::test]
+    async fn should_default_start_to_one_when_only_limit_given() {
+        let dir = tempfile::tempdir().unwrap();
+        ten_lines_file(&dir);
+
+        let tool = ReadFileTool::new(dir.path());
+        let result = tool
+            .execute(&serde_json::json!({"path": "lines.txt", "limit": 2}))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{}", result.output);
+        assert!(result.output.contains("showing lines 1-2 of 10"));
+    }
+
+    #[tokio::test]
+    async fn should_reject_when_both_end_line_and_limit_supplied() {
+        let dir = tempfile::tempdir().unwrap();
+        ten_lines_file(&dir);
+
+        let tool = ReadFileTool::new(dir.path());
+        let result = tool
+            .execute(
+                &serde_json::json!({"path": "lines.txt", "start_line": 2, "end_line": 5, "limit": 2}),
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.success, "must reject ambiguous range");
+        assert!(
+            result.output.contains("not both"),
+            "expected both-supplied rejection, got: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn should_reject_zero_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        ten_lines_file(&dir);
+
+        let tool = ReadFileTool::new(dir.path());
+        let result = tool
+            .execute(&serde_json::json!({"path": "lines.txt", "limit": 0}))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result.output.contains("at least 1"));
+    }
+
+    #[test]
+    fn resolve_line_range_math() {
+        // Pure math checks, including saturation on absurd inputs.
+        assert_eq!(resolve_line_range(None, None, None), Ok((None, None)));
+        assert_eq!(
+            resolve_line_range(Some(3), None, Some(3)),
+            Ok((Some(3), Some(5)))
+        );
+        assert_eq!(resolve_line_range(None, None, Some(2)), Ok((None, Some(2))));
+        assert_eq!(
+            resolve_line_range(Some(4), Some(9), None),
+            Ok((Some(4), Some(9)))
+        );
+        assert_eq!(
+            resolve_line_range(Some(usize::MAX), None, Some(usize::MAX)),
+            Ok((Some(usize::MAX), Some(usize::MAX - 1))),
+            "absurd inputs saturate instead of overflowing"
+        );
+        assert!(resolve_line_range(Some(1), Some(2), Some(2)).is_err());
+        assert!(resolve_line_range(None, None, Some(0)).is_err());
+    }
+
+    #[test]
+    fn schema_advertises_canonical_names_only() {
+        let tool = ReadFileTool::new("/tmp");
+        let schema = tool.input_schema();
+        let props = schema["properties"].as_object().unwrap();
+        assert!(props.contains_key("path"));
+        assert!(props.contains_key("start_line"));
+        assert!(props.contains_key("end_line"));
+        assert!(props.contains_key("limit"));
+        assert!(!props.contains_key("filePath"));
+        assert!(!props.contains_key("offset"));
+    }
+
+    #[tokio::test]
+    async fn should_hit_cache_when_limit_expresses_same_range_as_end_line() {
+        // limit folds into the canonical (start, end) range BEFORE the
+        // file-state cache is consulted, so an offset+limit request and a
+        // start_line+end_line request for the same lines share one entry.
+        let dir = tempfile::tempdir().unwrap();
+        ten_lines_file(&dir);
+
+        let tool = ReadFileTool::new(dir.path());
+        let cache = Arc::new(FileStateCache::new());
+        let ctx = ctx_with_cache(cache.clone());
+
+        let first = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "lines.txt", "offset": 2, "limit": 3}),
+            )
+            .await
+            .unwrap();
+        assert!(first.success);
+        assert!(!first.output.contains("[FILE_UNCHANGED]"));
+
+        let second = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "lines.txt", "start_line": 2, "end_line": 4}),
+            )
+            .await
+            .unwrap();
+        assert!(second.success);
+        assert!(
+            second.output.contains("[FILE_UNCHANGED]"),
+            "same canonical range must hit the cache: {}",
+            second.output
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/replacer.rs
+++ b/crates/octos-agent/src/tools/replacer.rs
@@ -13,8 +13,9 @@
 //!    minimum indentation from both sides, then compare exactly
 //! 5. `escape_normalized` — unescape literal `\n` / `\t` / `\\` etc. in the
 //!    needle before searching
-//! 6. `block_anchor` — anchor on the first + last trimmed lines, accept when
-//!    the paired middle lines average a Levenshtein similarity >= 0.65
+//! 6. `block_anchor` — anchor on the first + last trimmed lines, score
+//!    candidate spans by average middle-line Levenshtein similarity with
+//!    unpaired lines counting against the score, accept at >= 0.65
 //!
 //! Uniqueness is still enforced: the first stage that matches at all decides
 //! the outcome — exactly one location wins, more than one is an ambiguity
@@ -24,7 +25,7 @@
 
 use std::ops::Range;
 
-/// Minimum average Levenshtein similarity of paired middle lines for the
+/// Minimum block similarity (see [`block_similarity`]) for the
 /// `block_anchor` replacer to accept a candidate block.
 const BLOCK_ANCHOR_SIMILARITY_THRESHOLD: f64 = 0.65;
 
@@ -320,8 +321,10 @@ fn indentation_flexible_matches(
 // ---------------------------------------------------------------------------
 
 /// Unescape literal `\n`, `\t`, `\r`, `\\`, `\"`, `\'` sequences. Unknown
-/// escapes are kept verbatim.
-fn unescape_find(find: &str) -> String {
+/// escapes are kept verbatim. Also used by `edit_file` to interpret the
+/// call's `new_string` (and the guard's needle) consistently when the
+/// `escape_normalized` stage produced the match (#1771 review).
+pub(crate) fn unescape_find(find: &str) -> String {
     let mut out = String::with_capacity(find.len());
     let mut chars = find.chars();
     while let Some(c) = chars.next() {
@@ -391,10 +394,33 @@ fn similarity(a: &str, b: &str) -> f64 {
     1.0 - levenshtein(a, b) as f64 / max_len as f64
 }
 
-/// Anchor on the needle's first and last trimmed lines; between an opening
-/// anchor and the *nearest* closing anchor, pair up the middle lines and
-/// accept when their average trimmed similarity clears the threshold. The
-/// disproportionate-match guard catches spans that ballooned anyway.
+/// Average pairwise similarity of two middle-line sequences, normalized by
+/// the LONGER of the two so unpaired lines on either side drag the score
+/// down instead of being ignored: every line the needle described but the
+/// span lacks — and every span line the needle never described — counts as
+/// a 0-similarity entry (#1771 review).
+fn block_similarity(middle_find: &[&str], middle_content: &[&str]) -> f64 {
+    let total = middle_find.len().max(middle_content.len());
+    if total == 0 {
+        return 1.0;
+    }
+    let paired = middle_find.len().min(middle_content.len());
+    (0..paired)
+        .map(|k| similarity(middle_find[k], middle_content[k]))
+        .sum::<f64>()
+        / total as f64
+}
+
+/// Anchor on the needle's first and last trimmed lines. For each opening
+/// anchor, EVERY closing anchor within reach is considered — a nested block
+/// may close with a line trimmed-equal to the last anchor well before the
+/// real block end, and pairing only the nearest one would splice over a
+/// truncated span (#1771 review). Candidate spans are scored with
+/// [`block_similarity`], so span middle lines the needle never described
+/// count against the score; the best-scoring candidate per opening anchor
+/// that clears the threshold wins. Spans whose middles outnumber the
+/// needle's by more than `1/threshold` are pruned outright: even perfect
+/// pairs cannot lift them over the bar, which also bounds the scan.
 fn block_anchor_matches(content: &str, lines: &[LineSpan], find: &str) -> Vec<Range<usize>> {
     let (find_lines, trailing_newline) = split_find(find);
     if find_lines.len() < 3 {
@@ -409,30 +435,34 @@ fn block_anchor_matches(content: &str, lines: &[LineSpan], find: &str) -> Vec<Ra
         .iter()
         .map(|l| l.trim())
         .collect();
+    // Score is capped by paired/max = middle_find/middle_content once the
+    // span's middles outnumber the needle's — beyond this count it can
+    // never clear the threshold.
+    let max_middle = (middle_find.len() as f64 / BLOCK_ANCHOR_SIMILARITY_THRESHOLD) as usize;
 
     let mut out = Vec::new();
     for (i, line) in lines.iter().enumerate() {
         if line.text(content).trim() != first_anchor {
             continue;
         }
-        // Nearest closing anchor strictly after the opening line.
-        let Some(j) = (i + 1..lines.len()).find(|&j| lines[j].text(content).trim() == last_anchor)
-        else {
-            continue;
-        };
-        let middle_content: Vec<&str> = (i + 1..j).map(|k| lines[k].text(content).trim()).collect();
-        let paired = middle_find.len().min(middle_content.len());
-        let avg = if middle_find.is_empty() && middle_content.is_empty() {
-            1.0
-        } else if paired == 0 {
-            0.0
-        } else {
-            (0..paired)
-                .map(|k| similarity(middle_find[k], middle_content[k]))
-                .sum::<f64>()
-                / paired as f64
-        };
-        if avg >= BLOCK_ANCHOR_SIMILARITY_THRESHOLD {
+        // Best-scoring viable closing anchor for this opening anchor; on a
+        // score tie the nearest one wins (strictly-greater comparison).
+        let mut best: Option<(f64, usize)> = None;
+        for j in i + 1..lines.len() {
+            if j - i - 1 > max_middle {
+                break;
+            }
+            if lines[j].text(content).trim() != last_anchor {
+                continue;
+            }
+            let middle_content: Vec<&str> =
+                (i + 1..j).map(|k| lines[k].text(content).trim()).collect();
+            let score = block_similarity(&middle_find, &middle_content);
+            if score >= BLOCK_ANCHOR_SIMILARITY_THRESHOLD && best.is_none_or(|(s, _)| score > s) {
+                best = Some((score, j));
+            }
+        }
+        if let Some((_, j)) = best {
             let n = j - i + 1;
             out.push(window_range(content, lines, i, n, trailing_newline));
         }
@@ -468,6 +498,21 @@ mod tests {
         assert_eq!(similarity("", ""), 1.0);
         assert_eq!(similarity("same", "same"), 1.0);
         assert!(similarity("abcd", "wxyz") < 0.01);
+    }
+
+    #[test]
+    fn block_similarity_counts_unpaired_lines_in_denominator() {
+        // One extra content line: two perfect pairs over a total of three.
+        let two = ["a();", "b();"];
+        let three = ["a();", "b();", "c();"];
+        assert!((block_similarity(&two, &three) - 2.0 / 3.0).abs() < 1e-9);
+        // Three extra content lines: a single perfect pair over four.
+        let one = ["a();"];
+        let four = ["a();", "x", "y", "z"];
+        assert!((block_similarity(&one, &four) - 0.25).abs() < 1e-9);
+        // Unpaired needle-side lines count identically.
+        assert!((block_similarity(&three, &two) - 2.0 / 3.0).abs() < 1e-9);
+        assert_eq!(block_similarity(&[], &[]), 1.0);
     }
 
     // -- chain precedence + exact ------------------------------------------
@@ -547,6 +592,30 @@ mod tests {
         let (m, name) = matched(content, "let x = compute( a, b );");
         assert_eq!(name, "whitespace_normalized");
         assert_eq!(m, "let x  =  compute( a, b );");
+    }
+
+    #[test]
+    fn should_not_whitespace_normalized_match_when_non_whitespace_differs() {
+        // Collapsing whitespace runs must never paper over a token change.
+        let content = "let x  =  compute( a, b );\n";
+        let lines = index_lines(content);
+        assert!(
+            whitespace_normalized_matches(content, &lines, "let y = compute( a, b );").is_empty()
+        );
+    }
+
+    #[test]
+    fn should_report_ambiguity_when_whitespace_normalized_matches_twice() {
+        // Two lines with different internal spacing both normalize to the
+        // needle — the stage must surface both, not silently pick one.
+        let content = "a  =  f( x );\nother\na =  f( x );\n";
+        assert_eq!(
+            find_replacement(content, "a = f( x );"),
+            ChainOutcome::Ambiguous {
+                count: 2,
+                replacer: "whitespace_normalized"
+            }
+        );
     }
 
     // -- indentation_flexible ----------------------------------------------
@@ -640,6 +709,36 @@ mod tests {
         let (m, name) = matched(content, find);
         assert_eq!(name, "block_anchor");
         assert_eq!(m, "if ok {\n    a();\n    b();\n    c();\n}");
+    }
+
+    #[test]
+    fn should_block_anchor_reach_farther_closing_anchor_past_nested_block() {
+        // #1771 review: the needle spans a whole function whose interior
+        // contains a line trimmed-equal to the last anchor (the nested
+        // match's `}`). Pairing with only the NEAREST closing anchor would
+        // truncate the span to lines 0-3 and corrupt the file on splice —
+        // the farther, better-scoring closing anchor must win.
+        let content = "fn handle() {\n    match x {\n        A => a(),\n    }\n    cleanup();\n}\n";
+        let find = "fn handle() {\n    match x {\n        A => b(),\n    }\n    cleanup();\n}";
+        let (m, name) = matched(content, find);
+        assert_eq!(name, "block_anchor");
+        assert_eq!(
+            m,
+            "fn handle() {\n    match x {\n        A => a(),\n    }\n    cleanup();\n}"
+        );
+    }
+
+    #[test]
+    fn should_block_anchor_refuse_span_with_undescribed_extra_middle_lines() {
+        // #1771 review: unpaired content-side middle lines are part of the
+        // replaced span, so they must count against the similarity score.
+        // Here the anchors bracket four middle lines but the needle only
+        // describes two — most of the span is code the needle never saw
+        // (the old prefix-pair average scored it a perfect 1.0 and deleted
+        // x(); and y(); silently).
+        let content = "if ok {\n    a();\n    b();\n    x();\n    y();\n}\n";
+        let find = "if ok {\n    a();\n    b();\n}";
+        assert_eq!(find_replacement(content, find), ChainOutcome::NoMatch);
     }
 
     // -- disproportionate guard --------------------------------------------

--- a/crates/octos-agent/src/tools/replacer.rs
+++ b/crates/octos-agent/src/tools/replacer.rs
@@ -1,0 +1,682 @@
+//! Cascading fuzzy replacer chain for `edit_file` (#1771).
+//!
+//! LLMs routinely produce `old_string` values with minor whitespace,
+//! indentation, or escape differences. Instead of failing hard on anything
+//! that is not an exact match, `edit_file` runs this chain of increasingly
+//! tolerant matchers **in order** and uses the first one that finds any
+//! match:
+//!
+//! 1. `exact` — plain substring match (today's behaviour, always first)
+//! 2. `line_trimmed` — per-line trim, line-window equality
+//! 3. `whitespace_normalized` — collapse whitespace runs to single spaces
+//! 4. `indentation_flexible` — strip blank boundary lines and the common
+//!    minimum indentation from both sides, then compare exactly
+//! 5. `escape_normalized` — unescape literal `\n` / `\t` / `\\` etc. in the
+//!    needle before searching
+//! 6. `block_anchor` — anchor on the first + last trimmed lines, accept when
+//!    the paired middle lines average a Levenshtein similarity >= 0.65
+//!
+//! Uniqueness is still enforced: the first stage that matches at all decides
+//! the outcome — exactly one location wins, more than one is an ambiguity
+//! error carrying the count. Later (fuzzier) stages never get to overrule an
+//! ambiguous earlier stage. The [`is_disproportionate_match`] guard rejects
+//! runaway fuzzy spans after the fact.
+
+use std::ops::Range;
+
+/// Minimum average Levenshtein similarity of paired middle lines for the
+/// `block_anchor` replacer to accept a candidate block.
+const BLOCK_ANCHOR_SIMILARITY_THRESHOLD: f64 = 0.65;
+
+/// Outcome of running the replacer chain over a file's content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ChainOutcome {
+    /// No stage produced any match.
+    NoMatch,
+    /// The first stage that matched found more than one location.
+    Ambiguous {
+        count: usize,
+        replacer: &'static str,
+    },
+    /// The first stage that matched found exactly one location.
+    Match {
+        range: Range<usize>,
+        replacer: &'static str,
+    },
+}
+
+/// Byte span of one line's content (newline excluded).
+#[derive(Debug, Clone, Copy)]
+struct LineSpan {
+    start: usize,
+    end: usize,
+}
+
+impl LineSpan {
+    fn text<'a>(&self, content: &'a str) -> &'a str {
+        &content[self.start..self.end]
+    }
+}
+
+/// Run the cascading replacer chain. The first stage with any matches
+/// decides the outcome (see module docs).
+pub(crate) fn find_replacement(content: &str, find: &str) -> ChainOutcome {
+    if find.is_empty() {
+        return ChainOutcome::NoMatch;
+    }
+    let lines = index_lines(content);
+    for stage in 0..6u8 {
+        let (name, matches): (&'static str, Vec<Range<usize>>) = match stage {
+            0 => ("exact", exact_matches(content, find)),
+            1 => ("line_trimmed", line_trimmed_matches(content, &lines, find)),
+            2 => (
+                "whitespace_normalized",
+                whitespace_normalized_matches(content, &lines, find),
+            ),
+            3 => (
+                "indentation_flexible",
+                indentation_flexible_matches(content, &lines, find),
+            ),
+            4 => (
+                "escape_normalized",
+                escape_normalized_matches(content, find),
+            ),
+            5 => ("block_anchor", block_anchor_matches(content, &lines, find)),
+            _ => unreachable!(),
+        };
+        match matches.len() {
+            0 => continue,
+            1 => {
+                return ChainOutcome::Match {
+                    range: matches.into_iter().next().expect("len checked"),
+                    replacer: name,
+                };
+            }
+            count => {
+                return ChainOutcome::Ambiguous {
+                    count,
+                    replacer: name,
+                };
+            }
+        }
+    }
+    ChainOutcome::NoMatch
+}
+
+/// Safety guard: reject fuzzy matches whose span is far larger than the
+/// `old_string` that produced them — a runaway match would silently destroy
+/// unrelated code. Rejects when the span exceeds
+/// `max(old_lines + 3, old_lines * 2)` lines or 4x the byte count.
+pub(crate) fn is_disproportionate_match(matched: &str, find: &str) -> bool {
+    let matched_lines = matched.lines().count();
+    let find_lines = find.lines().count().max(1);
+    let line_cap = (find_lines + 3).max(find_lines * 2);
+    matched_lines > line_cap || matched.len() > find.len().saturating_mul(4)
+}
+
+// ---------------------------------------------------------------------------
+// Stage 1: exact
+// ---------------------------------------------------------------------------
+
+fn exact_matches(content: &str, find: &str) -> Vec<Range<usize>> {
+    content
+        .match_indices(find)
+        .map(|(i, m)| i..i + m.len())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Line indexing shared by the window-based stages
+// ---------------------------------------------------------------------------
+
+fn index_lines(content: &str) -> Vec<LineSpan> {
+    let mut spans = Vec::new();
+    let mut start = 0usize;
+    for segment in content.split('\n') {
+        let end = start + segment.len();
+        spans.push(LineSpan { start, end });
+        start = end + 1; // skip the '\n'
+    }
+    spans
+}
+
+/// Split the needle into lines. A single trailing newline is popped off (it
+/// produces a phantom empty line) and remembered so the matched span can
+/// consume the file's newline symmetrically.
+fn split_find(find: &str) -> (Vec<&str>, bool) {
+    let trailing_newline = find.ends_with('\n');
+    let mut lines: Vec<&str> = find.split('\n').collect();
+    if trailing_newline {
+        lines.pop();
+    }
+    (lines, trailing_newline)
+}
+
+/// Byte range of the window `[i, i + n)` of content lines. When the needle
+/// carried a trailing newline, extend over the file's newline too so a
+/// `new_string` that also ends in `\n` doesn't leave a doubled blank line.
+fn window_range(
+    content: &str,
+    lines: &[LineSpan],
+    i: usize,
+    n: usize,
+    consume_trailing_newline: bool,
+) -> Range<usize> {
+    let start = lines[i].start;
+    let mut end = lines[i + n - 1].end;
+    if consume_trailing_newline && content.as_bytes().get(end) == Some(&b'\n') {
+        end += 1;
+    }
+    start..end
+}
+
+/// Generic line-window scan: yield every window of `find_lines.len()`
+/// consecutive content lines for which `eq(window_line, find_line)` holds
+/// pairwise.
+fn window_scan(
+    content: &str,
+    lines: &[LineSpan],
+    find_lines: &[&str],
+    trailing_newline: bool,
+    eq: impl Fn(&str, &str) -> bool,
+) -> Vec<Range<usize>> {
+    let n = find_lines.len();
+    let mut out = Vec::new();
+    if n == 0 || lines.len() < n {
+        return out;
+    }
+    for i in 0..=(lines.len() - n) {
+        let all_equal = find_lines
+            .iter()
+            .enumerate()
+            .all(|(j, fl)| eq(lines[i + j].text(content), fl));
+        if all_equal {
+            out.push(window_range(content, lines, i, n, trailing_newline));
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Stage 2: line_trimmed
+// ---------------------------------------------------------------------------
+
+fn line_trimmed_matches(content: &str, lines: &[LineSpan], find: &str) -> Vec<Range<usize>> {
+    let (find_lines, trailing_newline) = split_find(find);
+    window_scan(content, lines, &find_lines, trailing_newline, |a, b| {
+        a.trim() == b.trim()
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Stage 3: whitespace_normalized
+// ---------------------------------------------------------------------------
+
+/// Collapse every whitespace run to a single space and trim the ends.
+fn normalize_whitespace(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn whitespace_normalized_matches(
+    content: &str,
+    lines: &[LineSpan],
+    find: &str,
+) -> Vec<Range<usize>> {
+    let (find_lines, trailing_newline) = split_find(find);
+    window_scan(content, lines, &find_lines, trailing_newline, |a, b| {
+        normalize_whitespace(a) == normalize_whitespace(b)
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Stage 4: indentation_flexible
+// ---------------------------------------------------------------------------
+
+/// Byte offset of the first non-whitespace character (== line length for
+/// blank lines).
+fn leading_ws_len(s: &str) -> usize {
+    s.char_indices()
+        .find(|(_, c)| !c.is_whitespace())
+        .map(|(i, _)| i)
+        .unwrap_or(s.len())
+}
+
+/// Strip up to `upto` bytes of leading whitespace, never splitting a char.
+fn strip_indent(s: &str, upto: usize) -> &str {
+    let mut cut = 0usize;
+    for (i, c) in s.char_indices() {
+        if !c.is_whitespace() || i + c.len_utf8() > upto {
+            break;
+        }
+        cut = i + c.len_utf8();
+    }
+    &s[cut..]
+}
+
+/// Common minimum indentation (in bytes) over non-blank lines.
+fn common_indent<'a>(lines: impl Iterator<Item = &'a str>) -> usize {
+    lines
+        .filter(|l| !l.trim().is_empty())
+        .map(leading_ws_len)
+        .min()
+        .unwrap_or(0)
+}
+
+/// Strip blank boundary lines from the needle, dedent both sides by their
+/// own common minimum indentation, then require exact per-line equality
+/// (relative indentation and internal spacing are preserved — this stage is
+/// stricter than `line_trimmed` per line, but tolerates a needle that was
+/// copied with stray blank lines around the block).
+fn indentation_flexible_matches(
+    content: &str,
+    lines: &[LineSpan],
+    find: &str,
+) -> Vec<Range<usize>> {
+    let (all_find_lines, trailing_newline) = split_find(find);
+    // Trim blank boundary lines from the needle.
+    let mut start_idx = 0usize;
+    let mut end_idx = all_find_lines.len();
+    while start_idx < end_idx && all_find_lines[start_idx].trim().is_empty() {
+        start_idx += 1;
+    }
+    let mut trimmed_back = 0usize;
+    while end_idx > start_idx && all_find_lines[end_idx - 1].trim().is_empty() {
+        end_idx -= 1;
+        trimmed_back += 1;
+    }
+    let find_lines = &all_find_lines[start_idx..end_idx];
+    if find_lines.is_empty() {
+        return Vec::new();
+    }
+    let find_indent = common_indent(find_lines.iter().copied());
+
+    let n = find_lines.len();
+    let mut out = Vec::new();
+    if lines.len() < n {
+        return out;
+    }
+    for i in 0..=(lines.len() - n) {
+        let window_indent = common_indent((0..n).map(|j| lines[i + j].text(content)));
+        let all_equal = find_lines.iter().enumerate().all(|(j, fl)| {
+            let wl = lines[i + j].text(content);
+            if fl.trim().is_empty() && wl.trim().is_empty() {
+                return true; // blank lines are equal regardless of residue
+            }
+            strip_indent(wl, window_indent) == strip_indent(fl, find_indent)
+        });
+        if all_equal {
+            // Only consume the file's trailing newline when the needle's
+            // boundary was NOT trimmed away — otherwise the span no longer
+            // corresponds to the needle's final newline.
+            let consume = trailing_newline && trimmed_back == 0;
+            out.push(window_range(content, lines, i, n, consume));
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Stage 5: escape_normalized
+// ---------------------------------------------------------------------------
+
+/// Unescape literal `\n`, `\t`, `\r`, `\\`, `\"`, `\'` sequences. Unknown
+/// escapes are kept verbatim.
+fn unescape_find(find: &str) -> String {
+    let mut out = String::with_capacity(find.len());
+    let mut chars = find.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('n') => out.push('\n'),
+            Some('t') => out.push('\t'),
+            Some('r') => out.push('\r'),
+            Some('\\') => out.push('\\'),
+            Some('\'') => out.push('\''),
+            Some('"') => out.push('"'),
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    out
+}
+
+fn escape_normalized_matches(content: &str, find: &str) -> Vec<Range<usize>> {
+    let unescaped = unescape_find(find);
+    if unescaped == find {
+        // Nothing was unescaped — identical to the exact stage, skip.
+        return Vec::new();
+    }
+    exact_matches(content, &unescaped)
+}
+
+// ---------------------------------------------------------------------------
+// Stage 6: block_anchor
+// ---------------------------------------------------------------------------
+
+/// Classic two-row Levenshtein edit distance (chars).
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr = vec![0usize; b.len() + 1];
+    for (i, ca) in a.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
+}
+
+/// Normalized similarity in `[0, 1]` (1.0 = identical).
+fn similarity(a: &str, b: &str) -> f64 {
+    let max_len = a.chars().count().max(b.chars().count());
+    if max_len == 0 {
+        return 1.0;
+    }
+    1.0 - levenshtein(a, b) as f64 / max_len as f64
+}
+
+/// Anchor on the needle's first and last trimmed lines; between an opening
+/// anchor and the *nearest* closing anchor, pair up the middle lines and
+/// accept when their average trimmed similarity clears the threshold. The
+/// disproportionate-match guard catches spans that ballooned anyway.
+fn block_anchor_matches(content: &str, lines: &[LineSpan], find: &str) -> Vec<Range<usize>> {
+    let (find_lines, trailing_newline) = split_find(find);
+    if find_lines.len() < 3 {
+        return Vec::new();
+    }
+    let first_anchor = find_lines[0].trim();
+    let last_anchor = find_lines[find_lines.len() - 1].trim();
+    if first_anchor.is_empty() || last_anchor.is_empty() {
+        return Vec::new();
+    }
+    let middle_find: Vec<&str> = find_lines[1..find_lines.len() - 1]
+        .iter()
+        .map(|l| l.trim())
+        .collect();
+
+    let mut out = Vec::new();
+    for (i, line) in lines.iter().enumerate() {
+        if line.text(content).trim() != first_anchor {
+            continue;
+        }
+        // Nearest closing anchor strictly after the opening line.
+        let Some(j) = (i + 1..lines.len()).find(|&j| lines[j].text(content).trim() == last_anchor)
+        else {
+            continue;
+        };
+        let middle_content: Vec<&str> = (i + 1..j).map(|k| lines[k].text(content).trim()).collect();
+        let paired = middle_find.len().min(middle_content.len());
+        let avg = if middle_find.is_empty() && middle_content.is_empty() {
+            1.0
+        } else if paired == 0 {
+            0.0
+        } else {
+            (0..paired)
+                .map(|k| similarity(middle_find[k], middle_content[k]))
+                .sum::<f64>()
+                / paired as f64
+        };
+        if avg >= BLOCK_ANCHOR_SIMILARITY_THRESHOLD {
+            let n = j - i + 1;
+            out.push(window_range(content, lines, i, n, trailing_newline));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn matched<'a>(content: &'a str, find: &str) -> (&'a str, &'static str) {
+        match find_replacement(content, find) {
+            ChainOutcome::Match { range, replacer } => (&content[range], replacer),
+            other => panic!("expected a unique match, got {other:?}"),
+        }
+    }
+
+    // -- levenshtein / similarity ------------------------------------------
+
+    #[test]
+    fn levenshtein_basics() {
+        assert_eq!(levenshtein("", ""), 0);
+        assert_eq!(levenshtein("abc", "abc"), 0);
+        assert_eq!(levenshtein("abc", ""), 3);
+        assert_eq!(levenshtein("", "abc"), 3);
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+        assert_eq!(levenshtein("flaw", "lawn"), 2);
+    }
+
+    #[test]
+    fn similarity_bounds() {
+        assert_eq!(similarity("", ""), 1.0);
+        assert_eq!(similarity("same", "same"), 1.0);
+        assert!(similarity("abcd", "wxyz") < 0.01);
+    }
+
+    // -- chain precedence + exact ------------------------------------------
+
+    #[test]
+    fn should_report_exact_when_exact_match_exists() {
+        let content = "fn main() {\n    run();\n}\n";
+        let (m, name) = matched(content, "run();");
+        assert_eq!(m, "run();");
+        assert_eq!(name, "exact");
+    }
+
+    #[test]
+    fn should_fail_ambiguous_at_exact_stage_without_falling_through() {
+        // Two exact occurrences: the chain must stop with the count, not
+        // let a fuzzier stage disambiguate.
+        let content = "foo bar foo";
+        assert_eq!(
+            find_replacement(content, "foo"),
+            ChainOutcome::Ambiguous {
+                count: 2,
+                replacer: "exact"
+            }
+        );
+    }
+
+    #[test]
+    fn should_return_no_match_for_empty_find() {
+        assert_eq!(find_replacement("anything", ""), ChainOutcome::NoMatch);
+    }
+
+    #[test]
+    fn should_return_no_match_when_nothing_applies() {
+        assert_eq!(
+            find_replacement("some content", "entirely absent text"),
+            ChainOutcome::NoMatch
+        );
+    }
+
+    // -- line_trimmed -------------------------------------------------------
+
+    #[test]
+    fn should_match_via_line_trimmed_when_only_indentation_differs() {
+        let content = "fn main() {\n    if ready {\n        launch();\n    }\n}\n";
+        let (m, name) = matched(content, "if ready {\nlaunch();\n}");
+        assert_eq!(name, "line_trimmed");
+        assert_eq!(m, "    if ready {\n        launch();\n    }");
+    }
+
+    #[test]
+    fn should_consume_trailing_newline_when_find_has_one() {
+        let content = "a\nfoo();\nb\n";
+        let (m, name) = matched(content, "  foo();\n");
+        assert_eq!(name, "line_trimmed");
+        assert_eq!(m, "foo();\n");
+    }
+
+    #[test]
+    fn should_report_two_locations_when_line_trimmed_is_ambiguous() {
+        let content = "fn a() {\n    go();\n}\nfn b() {\n  go();\n}\n";
+        assert_eq!(
+            find_replacement(content, "go();\u{20}"),
+            ChainOutcome::Ambiguous {
+                count: 2,
+                replacer: "line_trimmed"
+            }
+        );
+    }
+
+    // -- whitespace_normalized ---------------------------------------------
+
+    #[test]
+    fn should_match_via_whitespace_normalized_when_internal_runs_differ() {
+        // Internal double space in the file; needle has single spaces.
+        // trim() does not touch internal runs, so line_trimmed fails.
+        let content = "let x  =  compute( a, b );\n";
+        let (m, name) = matched(content, "let x = compute( a, b );");
+        assert_eq!(name, "whitespace_normalized");
+        assert_eq!(m, "let x  =  compute( a, b );");
+    }
+
+    // -- indentation_flexible ----------------------------------------------
+
+    #[test]
+    fn should_match_via_indentation_flexible_when_needle_has_blank_boundary_lines() {
+        // The needle was copied with stray blank lines around the block and
+        // a uniformly deeper indentation. No blank-line-bounded window
+        // exists in the file, so the earlier line matchers all fail.
+        let content = "fn wrapper() {\n    step_one();\n    step_two();\n}\n";
+        let find = "\n        step_one();\n        step_two();\n\n";
+        let (m, name) = matched(content, find);
+        assert_eq!(name, "indentation_flexible");
+        assert_eq!(m, "    step_one();\n    step_two();");
+    }
+
+    #[test]
+    fn should_preserve_relative_indentation_in_indentation_flexible() {
+        // Same lines but flattened relative indent — must NOT match this
+        // stage (dedent keeps relative structure).
+        let content = "    outer {\n        inner();\n    }\n";
+        let lines = index_lines(content);
+        // "\n" boundary forces the indentation_flexible path directly.
+        let matches =
+            indentation_flexible_matches(content, &lines, "\nouter {\ninner();\n}\n\u{20}\n");
+        assert!(
+            matches.is_empty(),
+            "flattened relative indent must not dedent-match"
+        );
+    }
+
+    // -- escape_normalized --------------------------------------------------
+
+    #[test]
+    fn unescape_find_handles_common_sequences() {
+        assert_eq!(unescape_find(r"a\nb"), "a\nb");
+        assert_eq!(unescape_find(r"a\tb"), "a\tb");
+        assert_eq!(unescape_find(r"a\\b"), r"a\b");
+        assert_eq!(unescape_find(r#"say \"hi\""#), r#"say "hi""#);
+        // Unknown escape preserved, lone trailing backslash preserved.
+        assert_eq!(unescape_find(r"a\qb"), r"a\qb");
+        assert_eq!(unescape_find("tail\\"), "tail\\");
+    }
+
+    #[test]
+    fn should_match_via_escape_normalized_when_newline_is_double_escaped() {
+        let content = "alpha {\n    beta();\n}\n";
+        // The needle contains a literal backslash-n instead of a newline.
+        let (m, name) = matched(content, "alpha {\\n    beta();");
+        assert_eq!(name, "escape_normalized");
+        assert_eq!(m, "alpha {\n    beta();");
+    }
+
+    // -- block_anchor -------------------------------------------------------
+
+    #[test]
+    fn should_match_via_block_anchor_when_middle_line_drifted() {
+        // Middle line content differs materially (not just whitespace), so
+        // every stricter stage fails; anchors + 0.65 similarity recover it.
+        let content = "fn compute() {\n    let total = base + extra;\n    total * 2\n}\n";
+        let find = "fn compute() {\n    let total = base + offset;\n    total * 2\n}";
+        let (m, name) = matched(content, find);
+        assert_eq!(name, "block_anchor");
+        assert_eq!(
+            m,
+            "fn compute() {\n    let total = base + extra;\n    total * 2\n}"
+        );
+    }
+
+    #[test]
+    fn should_not_block_anchor_match_with_fewer_than_three_lines() {
+        let content = "start\nend\n";
+        let lines = index_lines(content);
+        assert!(block_anchor_matches(content, &lines, "start\nend").is_empty());
+    }
+
+    #[test]
+    fn should_not_block_anchor_match_when_middle_similarity_is_low() {
+        let content = "begin\ncompletely different middle here\nfinish\n";
+        let lines = index_lines(content);
+        let matches = block_anchor_matches(content, &lines, "begin\nzzzz\nfinish");
+        assert!(matches.is_empty(), "similarity below 0.65 must not match");
+    }
+
+    #[test]
+    fn should_block_anchor_tolerate_extra_middle_line() {
+        // The file gained one middle line; fixed-window stages all fail,
+        // the anchor pair still brackets the block.
+        let content = "if ok {\n    a();\n    b();\n    c();\n}\n";
+        let find = "if ok {\n    a();\n    b();\n}";
+        let (m, name) = matched(content, find);
+        assert_eq!(name, "block_anchor");
+        assert_eq!(m, "if ok {\n    a();\n    b();\n    c();\n}");
+    }
+
+    // -- disproportionate guard --------------------------------------------
+
+    #[test]
+    fn guard_accepts_proportionate_matches() {
+        assert!(!is_disproportionate_match("a();\nb();", "a();\nb();"));
+        // Same line count, modest char growth.
+        assert!(!is_disproportionate_match(
+            "    a();\n    b();",
+            "a();\nb();"
+        ));
+    }
+
+    #[test]
+    fn guard_rejects_line_blowup() {
+        let find = "x\ny\nz"; // 3 lines → cap = max(6, 6) = 6
+        let matched = "x\n1\n2\n3\n4\n5\nz"; // 7 lines
+        assert!(is_disproportionate_match(matched, find));
+    }
+
+    #[test]
+    fn guard_rejects_char_blowup() {
+        let find = "ab\ncd"; // 5 bytes → cap 20
+        let matched = "ab                        \ncd"; // 29 bytes, still 2 lines
+        assert!(is_disproportionate_match(matched, find));
+    }
+
+    #[test]
+    fn guard_boundary_is_exclusive() {
+        // Exactly at the caps (6 lines for a 3-line find, exactly 4x chars)
+        // is still allowed — the guard fires only when *exceeded*.
+        let find = "x\ny\nz"; // 3 lines, 5 bytes
+        let six_lines = "x\na\nb\nc\nd\nz"; // 6 lines, 11 bytes
+        assert!(!is_disproportionate_match(six_lines, find));
+        let four_x = "x----\ny----\nz-------"; // exactly 20 bytes, 3 lines
+        assert_eq!(four_x.len(), 20);
+        assert!(!is_disproportionate_match(four_x, find));
+    }
+}

--- a/crates/octos-agent/src/tools/write_file.rs
+++ b/crates/octos-agent/src/tools/write_file.rs
@@ -45,6 +45,8 @@ impl WriteFileTool {
 
 #[derive(Debug, Deserialize)]
 struct WriteFileInput {
+    /// #1767: `filePath` is the industry-convention alias.
+    #[serde(alias = "filePath")]
     path: String,
     content: String,
 }
@@ -76,7 +78,7 @@ impl Tool for WriteFileTool {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Path to the file to write"
+                    "description": "Path to the file to write (alias: filePath)"
                 },
                 "content": {
                     "type": "string",
@@ -214,6 +216,36 @@ mod tests {
         assert!(result.output.contains("Successfully wrote"));
         let content = std::fs::read_to_string(dir.path().join("new.txt")).unwrap();
         assert_eq!(content, "hello world\n");
+    }
+
+    #[tokio::test]
+    async fn should_accept_file_path_alias_for_path() {
+        // #1767: `filePath` is the industry-convention alias for `path`.
+        let dir = tempfile::tempdir().unwrap();
+        let tool = WriteFileTool::new(dir.path());
+
+        let result = tool
+            .execute(&serde_json::json!({"filePath": "aliased.txt", "content": "via alias\n"}))
+            .await
+            .unwrap();
+
+        assert!(
+            result.success,
+            "filePath alias must work: {}",
+            result.output
+        );
+        let content = std::fs::read_to_string(dir.path().join("aliased.txt")).unwrap();
+        assert_eq!(content, "via alias\n");
+    }
+
+    #[test]
+    fn schema_advertises_canonical_names_only() {
+        let tool = WriteFileTool::new("/tmp");
+        let schema = tool.input_schema();
+        let props = schema["properties"].as_object().unwrap();
+        assert!(props.contains_key("path"));
+        assert!(props.contains_key("content"));
+        assert!(!props.contains_key("filePath"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
**#1771** (the headline editing fix): `edit_file` exact-match-only → 6-stage cascading replacer chain (exact → line-trimmed → whitespace-normalized → indentation-flexible → escape-normalized → block-anchor with hand-rolled Levenshtein ≥0.65). First matching stage decides; uniqueness enforced per stage; disproportionate-match guard (max(old+3, old×2) lines / 4× bytes); the matching replacer is named in the output.

**#1767**: serde aliases on the file tools — `filePath`, `oldString`/`newString`, `offset` (1:1 with start_line) and a DISTINCT `limit` field computing `end_line = start_line + limit − 1` (a bare alias would misread it; both-supplied rejected). Advertised ToolSpec keeps canonical names.

K3 review fixes: block_anchor scores EVERY closing anchor (nearest-only truncated spans over nested blocks) with unpaired middle lines counting against similarity; escape-normalized matches now unescape `new_string` (and the guard needle) with the same rules that matched `old_string` — literal `\n` text can no longer be spliced into files; test-matrix holes closed per stage.

Built + 3-lens octos/K3 reviewed in the 10-lane opencode-gap run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)