### PR TITLE
feat(agent): doom-loop guard (#1765) + structured tool-arg errors (#1770)

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -1322,9 +1322,43 @@ impl Agent {
                         StopReason::ToolUse => {
                             // Check for loop detection before executing
                             for tc in &response.tool_calls {
-                                if let Some(warning) = loop_detector.record(&tc.name, &tc.arguments)
+                                // #1765 doom-loop guard: 3+ CONSECUTIVE
+                                // identical tool calls (same name + identical
+                                // arguments JSON) abort the turn before the
+                                // next LLM call. Checked ahead of the cycle
+                                // detector so the tighter threshold owns pure
+                                // identical streaks; the cycle detector keeps
+                                // owning alternating (cycle 2/3) patterns,
+                                // which never build a doom streak. When the
+                                // guard fires, the shell-spiral recovery is
+                                // still consulted first — extracting real
+                                // shell output from a retry spiral is a
+                                // strictly better outcome than a doom abort.
+                                //
+                                // Verifier-configured agents are exempt: the
+                                // verifier lane classifies each repeated
+                                // failure into the turn ledger and injects a
+                                // `verdict: Repeating` note the planner acts
+                                // on at exactly this streak length — a
+                                // strictly richer recovery than an abort
+                                // (see `verifier_repeating_note_changes_
+                                // next_planner_action`). The cycle detector
+                                // below still terminates true thrash there.
+                                let doom_streak = if self.verifier_config.is_some() {
+                                    None
+                                } else {
+                                    loop_detector.record_doom(&tc.name, &tc.arguments)
+                                };
+                                let cycle_warning = if doom_streak.is_some() {
+                                    None
+                                } else {
+                                    loop_detector.record(&tc.name, &tc.arguments)
+                                };
+                                if doom_streak.is_none() && cycle_warning.is_none() {
+                                    continue;
+                                }
+                                warn!("loop detected — breaking agent loop");
                                 {
-                                    warn!("loop detected — breaking agent loop");
                                     let spiral_iteration = turn.iteration();
                                     if let Some(outcome) = self
                                         .dispatch_shell_retry_recovery(
@@ -1414,6 +1448,45 @@ impl Agent {
                                 pending_approval: None,
                                         });
                                     }
+                                    self.emit_cost_update(&turn, &response, attributed_cost);
+                                    // #1765 v1 escalation: the doom guard
+                                    // aborts the turn with a clear model-and-
+                                    // user-facing message — no further LLM
+                                    // call, no execution of the tripping
+                                    // call. (Interactive continue/edit
+                                    // options are follow-up work; v1
+                                    // deliberately avoids a new AppUI
+                                    // approval kind.)
+                                    if let Some(streak) = doom_streak {
+                                        self.mark_loop_detected_recently();
+                                        warn!(
+                                            tool = %tc.name,
+                                            streak,
+                                            "doom loop detected — aborting turn before the next LLM call (#1765)"
+                                        );
+                                        return Ok(ConversationResponse {
+                                            content: doom_loop_terminal_message(
+                                                &tc.name, streak,
+                                            ),
+                                            reasoning_content: None,
+                                            provider_metadata: None,
+                                            token_usage: turn.total_usage().clone(),
+                                            estimated_spend_usd: turn.priced_spend(),
+                                            files_modified,
+                                            files_to_send,
+                                            streamed,
+                                            messages: turn_output_log.clone(),
+                                            tool_results: tool_structured_metadata.clone(),
+                                            synthesized_from_spawn_only: false,
+                                            pending_approval: None,
+                                        });
+                                    }
+                                    let Some(warning) = cycle_warning else {
+                                        // Unreachable: doom returned above and
+                                        // the earlier gate skipped no-signal
+                                        // calls. Kept defensive.
+                                        continue;
+                                    };
                                     // Two-stage loop-detector recovery:
                                     //
                                     // 1. First fire in this turn — inject the
@@ -1443,7 +1516,6 @@ impl Agent {
                                     // returns on second fire is caught and
                                     // converted to a terminal Ok response
                                     // here so callers don't see an error.
-                                    self.emit_cost_update(&turn, &response, attributed_cost);
                                     match self.dedup_loop_warning(warning) {
                                         Ok(warning_content) => {
                                             inject_loop_detected_synthetic_results_with_log(
@@ -3263,6 +3335,22 @@ fn inject_loop_detected_synthetic_results_with_log(
     if let Some(log) = turn_output_log {
         log.extend(rows_for_log);
     }
+}
+
+/// #1765: terminal message returned when the doom-loop guard fires —
+/// the model issued the same tool call (same name + identical arguments
+/// JSON) [`crate::loop_detect::DOOM_LOOP_THRESHOLD`]+ times in a row.
+/// The text is both model-facing (it lands in session history, so the
+/// model can change course next turn) and user-facing (it is the
+/// assistant reply for the aborted turn).
+fn doom_loop_terminal_message(tool_name: &str, streak: usize) -> String {
+    format!(
+        "[DOOM LOOP DETECTED] The `{tool_name}` tool was called {streak} times in a row \
+         with identical arguments, so this turn was stopped before issuing another model \
+         call. Repeating the exact same call cannot produce a different result. Try a \
+         different approach — vary the arguments, use a different tool, or rephrase the \
+         request."
+    )
 }
 
 /// Terminal message returned when the LLM ignores the loop-detector

--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -3490,23 +3490,20 @@ impl LlmProvider for CountingAlwaysSameToolProvider {
 }
 
 #[tokio::test]
-async fn loop_detected_first_fire_continues_then_second_fire_terminates() {
-    // Exercises the full PR `fix/news-fetch-loop-and-detect-recovery`
-    // recovery contract end-to-end:
-    //   1. The looping LLM trips the detector on the 4th call (cycle-1).
-    //   2. First detection MUST NOT terminate — it injects a synthetic
-    //      tool result with the warning and calls the LLM again.
-    //   3. If the LLM repeats the same call, the SECOND detection
-    //      terminates with `loop_detected_terminal_message()`.
+async fn doom_loop_aborts_turn_when_third_identical_call_arrives() {
+    // #1765 doom-loop guard: when the LLM issues the SAME tool call
+    // (same name + identical arguments JSON) 3 times in a row, the
+    // conversation loop must abort the turn with a clear message
+    // instead of issuing the next LLM call.
     //
     // We assert via:
+    //   - The terminal `content` matches `doom_loop_terminal_message`
+    //     (proves the doom guard fired, not the older two-stage
+    //     warn-then-terminate cycle path).
+    //   - The mock LLM was called EXACTLY 3 times: calls 1 and 2
+    //     execute the tool; the 3rd identical call trips the guard and
+    //     no further LLM call is issued.
     //   - The flag (`is_loop_detected_recently`) is set after the run.
-    //   - The terminal `content` matches `loop_detected_terminal_message`
-    //     (proves the second-fire path ran, not the original first-fire
-    //     return-immediately path).
-    //   - The mock LLM was called AT LEAST 5 times (>=4 to trigger first
-    //     fire, +1 for the recovery iteration), confirming the loop
-    //     continued after the first fire.
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(dir.path().join("loopy.txt"), b"x").unwrap();
     let provider = Arc::new(CountingAlwaysSameToolProvider {
@@ -3526,25 +3523,107 @@ async fn loop_detected_first_fire_continues_then_second_fire_terminates() {
     let result = agent
         .process_message("please loop", &[], vec![])
         .await
-        .expect("process_message should return Ok even when the loop terminates");
+        .expect("process_message should return Ok even when the doom guard aborts");
 
-    // The terminal message proves the second-fire branch ran. The
-    // pre-fix behaviour would have returned the FIRST-fire warning
-    // text and stopped before issuing another LLM call.
     assert_eq!(
         result.content,
-        loop_detected_terminal_message(),
-        "expected the terminal hard-stop message after the second \
-             loop detection; pre-fix code would have returned the warning \
-             text on the first fire"
+        doom_loop_terminal_message("read_file", 3),
+        "expected the doom-loop abort message when the 3rd identical \
+             call arrives"
     );
     assert!(agent.is_loop_detected_recently());
 
     let total_calls = provider.calls.load(AtomicOrdering::SeqCst);
+    assert_eq!(
+        total_calls, 3,
+        "expected exactly 3 LLM calls — the doom guard must stop the \
+             loop instead of issuing a 4th; got {total_calls}"
+    );
+}
+
+/// LLM mock that alternates between two different argument sets for the
+/// same tool. The doom guard (consecutive identical) must never fire;
+/// the cycle detector (`LoopDetector::record`) owns alternating
+/// patterns and still runs its two-stage warn-then-terminate recovery.
+struct CountingAlternatingArgsProvider {
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl LlmProvider for CountingAlternatingArgsProvider {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &octos_llm::ChatConfig,
+    ) -> Result<ChatResponse> {
+        let n = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+        let path = if n % 2 == 0 { "a.txt" } else { "b.txt" };
+        Ok(ChatResponse {
+            content: None,
+            reasoning_content: None,
+            tool_calls: vec![ToolCall {
+                id: format!("call_alt_{n}"),
+                name: "read_file".to_string(),
+                arguments: serde_json::json!({ "path": path }),
+                metadata: None,
+            }],
+            stop_reason: StopReason::ToolUse,
+            usage: LlmTokenUsage::default(),
+            provider_index: None,
+        })
+    }
+
+    fn model_id(&self) -> &str {
+        "mock"
+    }
+
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+#[tokio::test]
+async fn alternating_cycle_still_uses_two_stage_warning_not_doom_abort() {
+    // #1765: the doom guard counts CONSECUTIVE identical calls only —
+    // an A,B,A,B,… alternation resets the streak every call, so the
+    // existing cycle detector must keep owning that pattern with its
+    // two-stage recovery (first fire injects a warning + one more LLM
+    // iteration; second fire terminates with
+    // `loop_detected_terminal_message`).
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.txt"), b"a").unwrap();
+    std::fs::write(dir.path().join("b.txt"), b"b").unwrap();
+    let provider = Arc::new(CountingAlternatingArgsProvider {
+        calls: AtomicUsize::new(0),
+    });
+    let provider_arc: Arc<dyn LlmProvider> = provider.clone();
+    let tools = ToolRegistry::with_builtins(dir.path());
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let agent = Agent::new(AgentId::new("recover"), provider_arc, tools, memory).with_config(
+        crate::AgentConfig {
+            max_iterations: 30,
+            save_episodes: false,
+            ..Default::default()
+        },
+    );
+
+    let result = agent
+        .process_message("please alternate", &[], vec![])
+        .await
+        .expect("process_message should return Ok when the cycle detector terminates");
+
+    assert_eq!(
+        result.content,
+        loop_detected_terminal_message(),
+        "alternating A,B cycles belong to the two-stage cycle detector, \
+             not the doom guard"
+    );
+    let total_calls = provider.calls.load(AtomicOrdering::SeqCst);
     assert!(
-        total_calls >= 5,
-        "expected at least 5 LLM calls (4 to trigger first detection + \
-             1 recovery iteration); got {total_calls}"
+        total_calls >= 7,
+        "expected >= 7 LLM calls (6 to reach a cycle-2 first fire + 1 \
+             recovery iteration before the terminating fire); got {total_calls}"
     );
 }
 
@@ -3589,22 +3668,16 @@ impl LlmProvider for CountingAlwaysNamedToolProvider {
 }
 
 #[tokio::test]
-async fn loop_detected_first_fire_does_not_execute_the_spiraling_tool() {
-    // Regression: the loop-detector `continue` after injecting synthetic
-    // results must re-enter the AGENT loop, not merely the inner
-    // `for tc in &response.tool_calls` loop. When it bound to the `for`,
-    // control fell through to `handle_tool_use` and the spiraling tool
-    // EXECUTED anyway (extra side effects + a duplicate tool_call_id row),
-    // defeating the detector's "inject a warning, do NOT call the tools"
-    // contract.
+async fn doom_loop_does_not_execute_the_tripping_call() {
+    // #1765: the doom guard runs BEFORE tool execution. When the 3rd
+    // identical call arrives it must abort the turn without executing
+    // the call again — re-running an identical call is pure waste (and
+    // possibly a duplicated side effect).
     //
-    // With the same-tool provider the detector trips on the 4th call, so:
-    //   - iterations 1..=3 execute the tool  (3 executions)
-    //   - iteration 4 (FIRST fire) injects synthetic results and re-enters
-    //     the loop WITHOUT executing
-    //   - iteration 5 (SECOND fire) terminates before executing
-    // ⇒ executions == total_llm_calls - 2. The buggy fall-through executed
-    // on the first-fire iteration too (executions == total_llm_calls - 1).
+    // With the same-call provider:
+    //   - iterations 1..=2 execute the tool  (2 executions)
+    //   - iteration 3 trips the doom guard pre-execution and terminates
+    // ⇒ executions == total_llm_calls - 1 == 2.
     let dir = tempfile::tempdir().unwrap();
     let exec_count = Arc::new(AtomicUsize::new(0));
     let provider = Arc::new(CountingAlwaysNamedToolProvider {
@@ -3630,18 +3703,32 @@ async fn loop_detected_first_fire_does_not_execute_the_spiraling_tool() {
     let result = agent
         .process_message("please loop", &[], vec![])
         .await
-        .expect("process_message should return Ok even when the loop terminates");
-    assert_eq!(result.content, loop_detected_terminal_message());
+        .expect("process_message should return Ok even when the doom guard aborts");
+    assert_eq!(result.content, doom_loop_terminal_message("loopy_tool", 3));
 
     let total_calls = provider.calls.load(AtomicOrdering::SeqCst);
     let executions = exec_count.load(AtomicOrdering::SeqCst);
+    assert_eq!(total_calls, 3, "doom aborts before a 4th LLM call");
     assert_eq!(
         executions,
-        total_calls - 2,
-        "the spiraling tool must NOT execute on the first-fire (synthetic-\
-             injection) iteration; got {executions} executions across \
-             {total_calls} LLM calls (buggy fall-through would be {})",
-        total_calls - 1
+        total_calls - 1,
+        "the tripping call must NOT execute; got {executions} executions \
+             across {total_calls} LLM calls"
+    );
+}
+
+#[test]
+fn doom_loop_terminal_message_is_model_and_user_facing() {
+    let msg = doom_loop_terminal_message("read_file", 3);
+    assert!(msg.contains("read_file"), "names the looping tool: {msg}");
+    assert!(msg.contains('3'), "states the streak length: {msg}");
+    assert!(
+        msg.contains("identical arguments"),
+        "explains WHY the turn stopped: {msg}"
+    );
+    assert!(
+        msg.contains("different approach") || msg.contains("rephrase"),
+        "guides the model/user toward a way forward: {msg}"
     );
 }
 

--- a/crates/octos-agent/src/loop_detect.rs
+++ b/crates/octos-agent/src/loop_detect.rs
@@ -24,6 +24,24 @@ use std::hash::{Hash, Hasher};
 /// background job runs) are unaffected.
 pub const NO_PROGRESS_HINT: &str = "\n\n[NO PROGRESS] You have now called this tool 3 times in a row with identical arguments AND received identical results. Calling it again will produce the same result. To make progress, either switch to a different tool (read_file / list_dir / view_image for file content) or finish the turn with the information you already have.";
 
+/// #1765: number of consecutive identical tool calls (same name +
+/// identical arguments JSON) that trips the doom-loop guard. When the
+/// LLM issues the SAME call this many times in a row, the conversation
+/// loop aborts the turn with a clear model-and-user-facing message
+/// instead of issuing the next LLM call — each further retry would only
+/// burn tokens. Mirrors opencode's `DOOM_LOOP_THRESHOLD = 3`
+/// (`packages/opencode/src/session/processor.ts:29`).
+///
+/// Scope: the guard is wired into the CONVERSATION loop
+/// (`process_message_inner`) only. The background task loop
+/// deliberately keeps its softer treatment (the `record_result`
+/// no-progress hint) because unattended tasks legitimately poll
+/// status tools with identical arguments while a background job runs.
+/// Verifier-configured agents are likewise exempt — the verifier lane
+/// injects a `verdict: Repeating` note at this exact streak length and
+/// the planner self-corrects, which is a richer recovery than an abort.
+pub const DOOM_LOOP_THRESHOLD: usize = 3;
+
 /// Tracks tool call patterns and detects loops.
 pub struct LoopDetector {
     /// Ring buffer of recent tool call signatures (name + args).
@@ -36,6 +54,11 @@ pub struct LoopDetector {
     result_signatures: Vec<u64>,
     /// Maximum window size to check for patterns.
     window: usize,
+    /// #1765: signature of the most recent call recorded by
+    /// [`Self::record_doom`], used to detect consecutive identical calls.
+    doom_last_signature: Option<u64>,
+    /// #1765: length of the current consecutive-identical-call streak.
+    doom_streak: usize,
 }
 
 impl LoopDetector {
@@ -45,7 +68,29 @@ impl LoopDetector {
             signatures: Vec::with_capacity(window * 2),
             result_signatures: Vec::with_capacity(window * 2),
             window,
+            doom_last_signature: None,
+            doom_streak: 0,
         }
+    }
+
+    /// #1765: record a tool call for the doom-loop guard and return the
+    /// streak length when it reaches [`DOOM_LOOP_THRESHOLD`].
+    ///
+    /// A call is "identical" when both the tool name and the exact
+    /// arguments JSON match the previous call; any non-identical call
+    /// resets the streak to 1. Returns `Some(streak)` for every call at
+    /// or past the threshold (not just the first) so a caller that
+    /// defers the abort once — e.g. because the shell-spiral recovery
+    /// path owns the streak — still gets a signal on the next repeat.
+    pub fn record_doom(&mut self, tool_name: &str, args: &serde_json::Value) -> Option<usize> {
+        let sig = Self::signature(tool_name, args);
+        if self.doom_last_signature == Some(sig) {
+            self.doom_streak += 1;
+        } else {
+            self.doom_last_signature = Some(sig);
+            self.doom_streak = 1;
+        }
+        (self.doom_streak >= DOOM_LOOP_THRESHOLD).then_some(self.doom_streak)
     }
 
     /// Record a tool call and check for repeating patterns.
@@ -297,5 +342,70 @@ mod tests {
         // The hard cycle detector picks up anything that survives.
         let second = d.record_result("t", &args, result);
         assert!(second.is_none());
+    }
+
+    // ----- record_doom tests (#1765 doom-loop guard) -----
+
+    #[test]
+    fn should_fire_doom_when_third_identical_call_arrives() {
+        let mut d = LoopDetector::new(10);
+        let args = json!({"path": "a.txt"});
+        assert!(d.record_doom("read_file", &args).is_none());
+        assert!(d.record_doom("read_file", &args).is_none());
+        assert_eq!(d.record_doom("read_file", &args), Some(3));
+    }
+
+    #[test]
+    fn should_stay_quiet_when_only_two_identical_calls() {
+        let mut d = LoopDetector::new(10);
+        let args = json!({"cmd": "ls"});
+        assert!(d.record_doom("shell", &args).is_none());
+        assert!(d.record_doom("shell", &args).is_none());
+    }
+
+    #[test]
+    fn should_reset_doom_streak_when_arguments_differ() {
+        let mut d = LoopDetector::new(10);
+        assert!(d.record_doom("read_file", &json!({"path": "a"})).is_none());
+        assert!(d.record_doom("read_file", &json!({"path": "a"})).is_none());
+        // Different args → streak resets; the 3rd call is NOT doom.
+        assert!(d.record_doom("read_file", &json!({"path": "b"})).is_none());
+        // Two more identical "b" calls: streak is 3 only now.
+        assert!(d.record_doom("read_file", &json!({"path": "b"})).is_none());
+        assert_eq!(d.record_doom("read_file", &json!({"path": "b"})), Some(3));
+    }
+
+    #[test]
+    fn should_reset_doom_streak_when_tool_name_differs() {
+        let mut d = LoopDetector::new(10);
+        let args = json!({"path": "a"});
+        assert!(d.record_doom("read_file", &args).is_none());
+        assert!(d.record_doom("read_file", &args).is_none());
+        // Same args, different tool → reset.
+        assert!(d.record_doom("list_dir", &args).is_none());
+        assert!(d.record_doom("list_dir", &args).is_none());
+        assert_eq!(d.record_doom("list_dir", &args), Some(3));
+    }
+
+    #[test]
+    fn should_keep_firing_doom_past_threshold() {
+        // ">= threshold" semantics: if the caller chooses to continue
+        // (e.g. the shell-spiral recovery path defers the abort), a 4th
+        // identical call must fire again rather than go quiet.
+        let mut d = LoopDetector::new(10);
+        let args = json!({});
+        d.record_doom("t", &args);
+        d.record_doom("t", &args);
+        assert_eq!(d.record_doom("t", &args), Some(3));
+        assert_eq!(d.record_doom("t", &args), Some(4));
+    }
+
+    #[test]
+    fn should_not_fire_doom_for_alternating_calls() {
+        let mut d = LoopDetector::new(10);
+        for _ in 0..10 {
+            assert!(d.record_doom("read_file", &json!({"path": "a"})).is_none());
+            assert!(d.record_doom("read_file", &json!({"path": "b"})).is_none());
+        }
     }
 }

--- a/crates/octos-agent/src/tools/args.rs
+++ b/crates/octos-agent/src/tools/args.rs
@@ -1,0 +1,479 @@
+//! Structured, model-facing tool-argument validation (#1770).
+//!
+//! When a tool call fails to deserialize, the model used to see a terse
+//! serde message ("missing field `path`") that stops at the FIRST
+//! problem and never explains unknown/misspelled parameters (serde
+//! ignores them unless the input struct opts into
+//! `#[serde(deny_unknown_fields)]`). The model then either retries the
+//! identical call (doom loop, #1765) or hallucinates a fix.
+//!
+//! [`parse_tool_args`] keeps serde as the source of truth for parsing
+//! but, on failure, walks the raw JSON against the tool's own
+//! `input_schema()` and reports EVERY problem in one model-facing
+//! message:
+//!
+//! ```text
+//! Invalid arguments for tool 'read_file':
+//! - path: missing required parameter
+//! - file_path: unknown parameter (did you mean 'path'?)
+//! - start_line: expected integer, got string
+//! Fix the arguments and call the tool again.
+//! ```
+//!
+//! The error is a [`super::ToolInputError`] wrapped in `eyre`, so the
+//! existing plumbing applies unchanged: the text reaches the model
+//! verbatim via the `Error: {e}` tool result, and the #1690 marker
+//! keeps a malformed call from cascade-cancelling well-formed siblings
+//! in a serial batch.
+
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use super::ToolInputError;
+
+/// One problem found while validating tool arguments. Mirrors the
+/// opencode `InvalidArgumentsError.issues` shape
+/// (`packages/opencode/src/tool/tool.ts:24-37`): a parameter path, a
+/// human-readable message, and an optional "did you mean" suggestion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationIssue {
+    /// Parameter the issue is about (e.g. `path`, `start_line`), or
+    /// `(input)` for issues with the argument object itself.
+    pub path: String,
+    /// What is wrong (e.g. "missing required parameter").
+    pub message: String,
+    /// Optional correction hint (e.g. "did you mean 'path'?").
+    pub suggestion: Option<String>,
+}
+
+impl ValidationIssue {
+    fn new(path: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            message: message.into(),
+            suggestion: None,
+        }
+    }
+
+    fn with_suggestion(mut self, suggestion: Option<String>) -> Self {
+        self.suggestion = suggestion;
+        self
+    }
+}
+
+/// Parse tool arguments via serde, producing a structured, model-facing
+/// error on failure.
+///
+/// On success this is exactly `serde_json::from_value`. On failure it
+/// collects ALL issues (missing required parameters, unknown parameters
+/// with did-you-mean suggestions, shallow type mismatches) by
+/// validating `args` against the tool's JSON `schema` — the same object
+/// the LLM was shown — and returns a [`ToolInputError`] whose `Display`
+/// lists each one. When the schema walk finds nothing (e.g. a
+/// constraint the shallow walk cannot see), the serde error text is
+/// surfaced instead so the model still learns something actionable.
+pub fn parse_tool_args<T: DeserializeOwned>(
+    tool_name: &str,
+    schema: &Value,
+    args: &Value,
+) -> eyre::Result<T> {
+    match serde_json::from_value::<T>(args.clone()) {
+        Ok(input) => Ok(input),
+        Err(serde_err) => {
+            let mut issues = validate_args_against_schema(schema, args);
+            if issues.is_empty() {
+                issues.push(ValidationIssue::new("(input)", serde_err.to_string()));
+            }
+            // Structured log for debugging/analytics (#1770 acceptance):
+            // the typed issue list, not just the flattened prose.
+            tracing::warn!(
+                tool = tool_name,
+                issues = ?issues,
+                "tool argument validation failed; returning model-facing issue list"
+            );
+            Err(eyre::Report::new(ToolInputError::new(
+                invalid_args_message(tool_name, &issues),
+            )))
+        }
+    }
+}
+
+/// Format the collected issues as the model-facing message.
+pub fn invalid_args_message(tool_name: &str, issues: &[ValidationIssue]) -> String {
+    let mut msg = format!("Invalid arguments for tool '{tool_name}':\n");
+    for issue in issues {
+        msg.push_str(&format!("- {}: {}", issue.path, issue.message));
+        if let Some(suggestion) = &issue.suggestion {
+            msg.push_str(&format!(" ({suggestion})"));
+        }
+        msg.push('\n');
+    }
+    msg.push_str("Fix the arguments and call the tool again.");
+    msg
+}
+
+/// Validate `args` against a tool's JSON schema, collecting every issue
+/// instead of failing on the first (opencode-style, #1770).
+///
+/// Checks performed (shallow, top-level object only — the depth our
+/// tool schemas use):
+/// - the argument value is a JSON object;
+/// - every `required` property is present (with a did-you-mean pointing
+///   at a stray near-miss key when one exists);
+/// - every supplied key is a known property (with a did-you-mean
+///   against the schema's property names);
+/// - each supplied non-null value matches the property's declared
+///   `type` (null is skipped: optional fields deserialize from null).
+pub fn validate_args_against_schema(schema: &Value, args: &Value) -> Vec<ValidationIssue> {
+    let mut issues = Vec::new();
+    let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+        return issues;
+    };
+    let known: Vec<&str> = properties.keys().map(String::as_str).collect();
+
+    let Some(args_obj) = args.as_object() else {
+        issues.push(ValidationIssue::new(
+            "(input)",
+            format!(
+                "expected a JSON object with the tool's parameters, got {}",
+                json_type_name(args)
+            ),
+        ));
+        return issues;
+    };
+
+    let required: Vec<&str> = schema
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|entries| entries.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+
+    // Missing required parameters. If the model supplied a near-miss
+    // key instead (`file_path` for `path`), point at it.
+    for name in &required {
+        if !args_obj.contains_key(*name) {
+            let stray_near_miss = args_obj
+                .keys()
+                .filter(|key| !known.contains(&key.as_str()))
+                .find(|key| is_near_miss(name, key))
+                .map(|key| format!("did you supply it as '{key}'?"));
+            issues.push(
+                ValidationIssue::new(*name, "missing required parameter")
+                    .with_suggestion(stray_near_miss),
+            );
+        }
+    }
+
+    // Unknown parameters, with did-you-mean against the known names.
+    for key in args_obj.keys() {
+        if !known.contains(&key.as_str()) {
+            let suggestion = did_you_mean(key, &known);
+            issues.push(
+                ValidationIssue::new(key.clone(), "unknown parameter").with_suggestion(suggestion),
+            );
+        }
+    }
+
+    // Shallow type check for known, non-null values.
+    for (key, value) in args_obj {
+        if value.is_null() {
+            continue;
+        }
+        let Some(expected) = properties.get(key).and_then(|prop| prop.get("type")) else {
+            continue;
+        };
+        if !value_matches_schema_type(value, expected) {
+            issues.push(ValidationIssue::new(
+                key.clone(),
+                format!(
+                    "expected {}, got {}",
+                    schema_type_label(expected),
+                    json_type_name(value)
+                ),
+            ));
+        }
+    }
+
+    issues
+}
+
+/// Best did-you-mean candidate among `known` parameter names.
+pub fn did_you_mean(unknown: &str, known: &[&str]) -> Option<String> {
+    known
+        .iter()
+        .filter(|candidate| is_near_miss(candidate, unknown))
+        .min_by_key(|candidate| levenshtein(&candidate.to_lowercase(), &unknown.to_lowercase()))
+        .map(|candidate| format!("did you mean '{candidate}'?"))
+}
+
+/// Whether `candidate` is close enough to `name` to suggest. Accepts
+/// case/underscore variants (`startLine` → `start_line`), affixed
+/// variants (`file_path` → `path`), and small typos (edit distance
+/// scaled by length, minimum 2).
+fn is_near_miss(name: &str, candidate: &str) -> bool {
+    let a = name.to_lowercase().replace(['_', '-'], "");
+    let b = candidate.to_lowercase().replace(['_', '-'], "");
+    if a == b {
+        return true;
+    }
+    // Affixed variant of the same word (`filepath` vs `path`): a common
+    // LLM confusion between tools with different parameter spellings.
+    if a.len() >= 3
+        && b.len() >= 3
+        && (a.starts_with(&b) || a.ends_with(&b) || b.starts_with(&a) || b.ends_with(&a))
+    {
+        return true;
+    }
+    let max_distance = (name.len().max(candidate.len()) / 3).max(2);
+    levenshtein(&name.to_lowercase(), &candidate.to_lowercase()) <= max_distance
+}
+
+/// Classic dynamic-programming edit distance (single row). Inputs are
+/// parameter names — short ASCII-ish identifiers — so O(a*b) is fine.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut row: Vec<usize> = (0..=b.len()).collect();
+    for (i, ca) in a.iter().enumerate() {
+        let mut previous_diagonal = row[0];
+        row[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let substitution = previous_diagonal + usize::from(ca != cb);
+            previous_diagonal = row[j + 1];
+            row[j + 1] = substitution.min(row[j] + 1).min(previous_diagonal + 1);
+        }
+    }
+    row[b.len()]
+}
+
+/// Human-readable JSON type of a value.
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(n) if n.is_i64() || n.is_u64() => "integer",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+/// Whether a value satisfies a JSON-schema `type` declaration (a single
+/// type string, or an array of alternatives like `["string", "null"]`).
+fn value_matches_schema_type(value: &Value, expected: &Value) -> bool {
+    match expected {
+        Value::String(type_name) => match type_name.as_str() {
+            "string" => value.is_string(),
+            "integer" => value.as_number().is_some_and(|n| n.is_i64() || n.is_u64()),
+            "number" => value.is_number(),
+            "boolean" => value.is_boolean(),
+            "array" => value.is_array(),
+            "object" => value.is_object(),
+            "null" => value.is_null(),
+            // Unknown type keyword: don't second-guess serde.
+            _ => true,
+        },
+        Value::Array(alternatives) => alternatives
+            .iter()
+            .any(|alternative| value_matches_schema_type(value, alternative)),
+        // Malformed schema: skip the check rather than false-positive.
+        _ => true,
+    }
+}
+
+/// Label for the expected type in the issue message.
+fn schema_type_label(expected: &Value) -> String {
+    match expected {
+        Value::String(type_name) => type_name.clone(),
+        Value::Array(alternatives) => alternatives
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>()
+            .join(" or "),
+        _ => "the declared type".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use serde_json::json;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct DemoInput {
+        path: String,
+        #[serde(default)]
+        start_line: Option<usize>,
+    }
+
+    fn demo_schema() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "start_line": { "type": "integer" }
+            },
+            "required": ["path"]
+        })
+    }
+
+    #[test]
+    fn should_parse_valid_args_unchanged() {
+        let input: DemoInput = parse_tool_args(
+            "demo",
+            &demo_schema(),
+            &json!({"path": "a.txt", "start_line": 3}),
+        )
+        .expect("valid args parse");
+        assert_eq!(input.path, "a.txt");
+        assert_eq!(input.start_line, Some(3));
+    }
+
+    #[test]
+    fn should_collect_all_issues_not_just_first() {
+        // Missing required + unknown key + type mismatch in ONE report.
+        let issues = validate_args_against_schema(
+            &demo_schema(),
+            &json!({"file_path": "a.txt", "start_line": "abc"}),
+        );
+        let paths: Vec<&str> = issues.iter().map(|issue| issue.path.as_str()).collect();
+        assert!(paths.contains(&"path"), "missing required: {issues:?}");
+        assert!(paths.contains(&"file_path"), "unknown key: {issues:?}");
+        assert!(
+            issues.iter().any(|issue| issue.path == "start_line"
+                && issue.message.contains("expected integer, got string")),
+            "type mismatch: {issues:?}"
+        );
+        assert_eq!(issues.len(), 3, "exactly the three issues: {issues:?}");
+    }
+
+    #[test]
+    fn should_suggest_near_miss_for_unknown_parameter() {
+        let issues =
+            validate_args_against_schema(&demo_schema(), &json!({"path": "a.txt", "startline": 2}));
+        let unknown = issues
+            .iter()
+            .find(|issue| issue.path == "startline")
+            .expect("unknown param issue");
+        assert_eq!(
+            unknown.suggestion.as_deref(),
+            Some("did you mean 'start_line'?")
+        );
+    }
+
+    #[test]
+    fn should_suggest_camel_case_variant() {
+        // `filePath` → `path`? No: near-miss must map camelCase to the
+        // snake_case KNOWN name when the letters match.
+        let issues =
+            validate_args_against_schema(&demo_schema(), &json!({"path": "x", "startLine": 2}));
+        let unknown = issues
+            .iter()
+            .find(|issue| issue.path == "startLine")
+            .expect("unknown param issue");
+        assert_eq!(
+            unknown.suggestion.as_deref(),
+            Some("did you mean 'start_line'?")
+        );
+    }
+
+    #[test]
+    fn should_report_non_object_input() {
+        let issues = validate_args_against_schema(&demo_schema(), &json!("just a string"));
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].message.contains("expected a JSON object"));
+        assert!(issues[0].message.contains("got string"));
+    }
+
+    #[test]
+    fn should_skip_type_check_for_null_optionals() {
+        // Optional fields deserialize from null; the walk must not
+        // report a mismatch serde would accept.
+        let issues = validate_args_against_schema(
+            &demo_schema(),
+            &json!({"path": "a.txt", "start_line": null}),
+        );
+        assert!(issues.is_empty(), "null optional is fine: {issues:?}");
+    }
+
+    #[test]
+    fn should_accept_type_alternatives() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "limit": { "type": ["integer", "null"] } },
+            "required": []
+        });
+        assert!(validate_args_against_schema(&schema, &json!({"limit": 5})).is_empty());
+        assert!(!validate_args_against_schema(&schema, &json!({"limit": "5"})).is_empty());
+    }
+
+    #[test]
+    fn should_wrap_error_as_tool_input_error_with_full_message() {
+        let err = parse_tool_args::<DemoInput>("demo", &demo_schema(), &json!({"pth": "a.txt"}))
+            .expect_err("must fail");
+        assert!(
+            err.chain().any(|src| src.is::<ToolInputError>()),
+            "carries the #1690 non-cascading marker"
+        );
+        let msg = format!("{err}");
+        assert!(msg.contains("Invalid arguments for tool 'demo'"), "{msg}");
+        assert!(msg.contains("- path: missing required parameter"), "{msg}");
+        assert!(msg.contains("did you supply it as 'pth'?"), "{msg}");
+        assert!(
+            msg.contains("- pth: unknown parameter (did you mean 'path'?)"),
+            "{msg}"
+        );
+        assert!(
+            msg.contains("Fix the arguments and call the tool again."),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn should_fall_back_to_serde_error_when_schema_walk_finds_nothing() {
+        // A constraint the shallow walk cannot see: negative value for
+        // usize. Schema type is integer (matches), serde still fails.
+        let err = parse_tool_args::<DemoInput>(
+            "demo",
+            &demo_schema(),
+            &json!({"path": "a.txt", "start_line": -4}),
+        )
+        .expect_err("must fail");
+        let msg = format!("{err}");
+        assert!(msg.contains("Invalid arguments for tool 'demo'"), "{msg}");
+        assert!(msg.contains("(input)"), "falls back to serde text: {msg}");
+        assert!(
+            msg.contains("invalid value"),
+            "serde detail retained: {msg}"
+        );
+    }
+
+    #[test]
+    fn should_not_suggest_for_totally_unrelated_name() {
+        let issues =
+            validate_args_against_schema(&demo_schema(), &json!({"path": "a.txt", "zzzzqqqq": 1}));
+        let unknown = issues
+            .iter()
+            .find(|issue| issue.path == "zzzzqqqq")
+            .expect("unknown param issue");
+        assert_eq!(unknown.suggestion, None, "no bogus suggestion");
+    }
+
+    #[test]
+    fn levenshtein_basics() {
+        assert_eq!(levenshtein("", "abc"), 3);
+        assert_eq!(levenshtein("abc", ""), 3);
+        assert_eq!(levenshtein("abc", "abc"), 0);
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+        assert_eq!(levenshtein("path", "pth"), 1);
+    }
+}

--- a/crates/octos-agent/src/tools/edit_file.rs
+++ b/crates/octos-agent/src/tools/edit_file.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 
 use async_trait::async_trait;
-use eyre::{Result, WrapErr};
+use eyre::Result;
 use serde::Deserialize;
 use tracing::warn;
 
@@ -44,6 +44,10 @@ impl EditFileTool {
 }
 
 #[derive(Debug, Deserialize)]
+// #1770: unknown keys are usually a typo of a real parameter; rejecting
+// them (with a did-you-mean via `args::parse_tool_args`) lets the model
+// self-correct instead of silently dropping its intent.
+#[serde(deny_unknown_fields)]
 struct EditFileInput {
     /// #1767: `filePath` is the industry-convention alias.
     #[serde(alias = "filePath")]
@@ -108,7 +112,7 @@ impl Tool for EditFileTool {
         args: &serde_json::Value,
     ) -> Result<ToolResult> {
         let input: EditFileInput =
-            serde_json::from_value(args.clone()).wrap_err("invalid edit_file tool input")?;
+            super::args::parse_tool_args(self.name(), &self.input_schema(), args)?;
 
         if !self.file_access.allows_write() {
             return Ok(ToolResult {

--- a/crates/octos-agent/src/tools/glob_tool.rs
+++ b/crates/octos-agent/src/tools/glob_tool.rs
@@ -37,6 +37,10 @@ impl GlobTool {
 }
 
 #[derive(Debug, Deserialize)]
+// #1770: unknown keys are usually a typo of a real parameter; rejecting
+// them (with a did-you-mean via `args::parse_tool_args`) lets the model
+// self-correct instead of silently dropping its intent.
+#[serde(deny_unknown_fields)]
 struct GlobInput {
     /// Glob pattern to match (e.g., "**/*.rs", "src/*.py").
     pattern: String,
@@ -140,7 +144,7 @@ impl Tool for GlobTool {
         args: &serde_json::Value,
     ) -> Result<ToolResult> {
         let input: GlobInput =
-            serde_json::from_value(args.clone()).wrap_err("invalid glob tool input")?;
+            super::args::parse_tool_args(self.name(), &self.input_schema(), args)?;
 
         let pattern = input.pattern.clone();
         let limit = input.limit;

--- a/crates/octos-agent/src/tools/grep_tool.rs
+++ b/crates/octos-agent/src/tools/grep_tool.rs
@@ -28,6 +28,10 @@ impl GrepTool {
 }
 
 #[derive(Debug, Deserialize)]
+// #1770: unknown keys are usually a typo of a real parameter; rejecting
+// them (with a did-you-mean via `args::parse_tool_args`) lets the model
+// self-correct instead of silently dropping its intent.
+#[serde(deny_unknown_fields)]
 struct GrepInput {
     /// Regex pattern to search for.
     pattern: String,
@@ -114,7 +118,7 @@ impl Tool for GrepTool {
         args: &serde_json::Value,
     ) -> Result<ToolResult> {
         let input: GrepInput =
-            serde_json::from_value(args.clone()).wrap_err("invalid grep tool input")?;
+            super::args::parse_tool_args(self.name(), &self.input_schema(), args)?;
 
         // Reject file_pattern with absolute paths or traversal.
         if let Some(ref fp) = input.file_pattern {

--- a/crates/octos-agent/src/tools/list_dir.rs
+++ b/crates/octos-agent/src/tools/list_dir.rs
@@ -31,6 +31,10 @@ impl ListDirTool {
 }
 
 #[derive(Deserialize)]
+// #1770: unknown keys are usually a typo of a real parameter; rejecting
+// them (with a did-you-mean via `args::parse_tool_args`) lets the model
+// self-correct instead of silently dropping its intent.
+#[serde(deny_unknown_fields)]
 struct Input {
     path: String,
 }
@@ -74,7 +78,7 @@ impl Tool for ListDirTool {
         ctx: &ToolContext,
         args: &serde_json::Value,
     ) -> Result<ToolResult> {
-        let input: Input = serde_json::from_value(args.clone())?;
+        let input: Input = super::args::parse_tool_args(self.name(), &self.input_schema(), args)?;
 
         // Interim mitigation (#1378, superseded by #1377): `up/<base64>/<name>`
         // is an opaque upload handle, not a browsable directory. When the input

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -690,6 +690,9 @@ pub use robot_groups::{RobotToolRegistry, install_registry as install_robot_regi
 // Shared SSRF protection
 pub mod ssrf;
 
+// #1770: structured, model-facing tool-argument validation.
+pub mod args;
+
 // Built-in tools
 pub mod apply_patch;
 pub mod ask_user_question;

--- a/crates/octos-agent/src/tools/read_file.rs
+++ b/crates/octos-agent/src/tools/read_file.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 
 use async_trait::async_trait;
-use eyre::{Result, WrapErr};
+use eyre::Result;
 use serde::Deserialize;
 
 use super::{Tool, ToolContext, ToolResult};
@@ -35,6 +35,10 @@ impl ReadFileTool {
 }
 
 #[derive(Debug, Deserialize)]
+// #1770: unknown keys are usually a typo of a real parameter; rejecting
+// them (with a did-you-mean via `args::parse_tool_args`) lets the model
+// self-correct instead of silently dropping its intent.
+#[serde(deny_unknown_fields)]
 struct ReadFileInput {
     /// #1767: `filePath` is the industry-convention alias.
     #[serde(alias = "filePath")]
@@ -127,7 +131,7 @@ impl Tool for ReadFileTool {
         args: &serde_json::Value,
     ) -> Result<ToolResult> {
         let input: ReadFileInput =
-            serde_json::from_value(args.clone()).wrap_err("invalid read_file tool input")?;
+            super::args::parse_tool_args(self.name(), &self.input_schema(), args)?;
 
         // M8.1 permission gate (stub): consult the typed permissions record
         // so the hook is in place before M8.3 wires real allow lists. Today
@@ -371,6 +375,94 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tool = ReadFileTool::new(dir.path());
         assert_eq!(tool.concurrency_class(), ConcurrencyClass::Safe);
+    }
+
+    #[tokio::test]
+    async fn invalid_args_error_names_each_problem_with_did_you_mean() {
+        // #1770: a misspelled parameter must produce a model-facing
+        // message that (a) names the missing required parameter, (b)
+        // names the unknown parameter, and (c) suggests the correction —
+        // so the LLM can self-correct on the next iteration instead of
+        // retrying blind.
+        let dir = tempfile::tempdir().unwrap();
+        let tool = ReadFileTool::new(dir.path());
+        let err = match tool
+            .execute(&serde_json::json!({"file_path": "a.txt"}))
+            .await
+        {
+            Err(e) => e,
+            Ok(_) => panic!("misspelled parameter must fail"),
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("Invalid arguments for tool 'read_file'"),
+            "names the tool: {msg}"
+        );
+        assert!(
+            msg.contains("path") && msg.contains("missing required parameter"),
+            "names the missing parameter: {msg}"
+        );
+        assert!(
+            msg.contains("file_path") && msg.contains("unknown parameter"),
+            "names the unknown parameter: {msg}"
+        );
+        assert!(
+            msg.contains("did you mean 'path'?"),
+            "suggests the correction: {msg}"
+        );
+        // #1690 contract: argument errors are ToolInputError so a
+        // malformed call never cascade-cancels well-formed siblings.
+        assert!(
+            err.chain()
+                .any(|src| src.is::<crate::tools::ToolInputError>()),
+            "argument errors must carry the ToolInputError marker"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_args_error_reports_type_mismatch() {
+        // #1770: wrong-typed values are reported per-parameter with the
+        // expected and actual JSON types.
+        let dir = tempfile::tempdir().unwrap();
+        let tool = ReadFileTool::new(dir.path());
+        let err = match tool
+            .execute(&serde_json::json!({"path": "a.txt", "start_line": "abc"}))
+            .await
+        {
+            Err(e) => e,
+            Ok(_) => panic!("wrong-typed parameter must fail"),
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("start_line") && msg.contains("expected integer, got string"),
+            "reports the type mismatch: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_extra_parameter_is_rejected_with_suggestion() {
+        // #1770: `deny_unknown_fields` — a stray parameter alongside an
+        // otherwise valid call is rejected (it is usually a typo of a
+        // real parameter, and silently ignoring it hides model bugs).
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("ok.txt"), b"ok").unwrap();
+        let tool = ReadFileTool::new(dir.path());
+        let err = match tool
+            .execute(&serde_json::json!({"path": "ok.txt", "startline": 1}))
+            .await
+        {
+            Err(e) => e,
+            Ok(_) => panic!("unknown parameter must fail"),
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("startline") && msg.contains("unknown parameter"),
+            "names the unknown parameter: {msg}"
+        );
+        assert!(
+            msg.contains("did you mean 'start_line'?"),
+            "suggests the near-miss known parameter: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/shell.rs
+++ b/crates/octos-agent/src/tools/shell.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use eyre::{Result, WrapErr};
+use eyre::Result;
 use serde::Deserialize;
 use tokio::time::timeout;
 
@@ -510,6 +510,10 @@ fn apply_harness_event_sink_env(cmd: &mut tokio::process::Command, ctx: &ToolCon
 }
 
 #[derive(Debug, Deserialize)]
+// #1770: unknown keys are usually a typo of a real parameter; rejecting
+// them (with a did-you-mean via `args::parse_tool_args`) lets the model
+// self-correct instead of silently dropping its intent.
+#[serde(deny_unknown_fields)]
 struct ShellInput {
     command: String,
     #[serde(default)]
@@ -627,7 +631,7 @@ impl Tool for ShellTool {
         args: &serde_json::Value,
     ) -> Result<ToolResult> {
         let input: ShellInput =
-            serde_json::from_value(args.clone()).wrap_err("invalid shell tool input")?;
+            super::args::parse_tool_args(self.name(), &self.input_schema(), args)?;
 
         // Phase 2-D of the SessionScope migration: when the host has
         // threaded a scope through `ToolContext`, prefer the scope's

--- a/crates/octos-agent/src/tools/write_file.rs
+++ b/crates/octos-agent/src/tools/write_file.rs
@@ -44,6 +44,10 @@ impl WriteFileTool {
 }
 
 #[derive(Debug, Deserialize)]
+// #1770: unknown keys are usually a typo of a real parameter; rejecting
+// them (with a did-you-mean via `args::parse_tool_args`) lets the model
+// self-correct instead of silently dropping its intent.
+#[serde(deny_unknown_fields)]
 struct WriteFileInput {
     /// #1767: `filePath` is the industry-convention alias.
     #[serde(alias = "filePath")]
@@ -102,7 +106,7 @@ impl Tool for WriteFileTool {
         args: &serde_json::Value,
     ) -> Result<ToolResult> {
         let input: WriteFileInput =
-            serde_json::from_value(args.clone()).wrap_err("invalid write_file tool input")?;
+            super::args::parse_tool_args(self.name(), &self.input_schema(), args)?;
 
         if !self.file_access.allows_write() {
             return Ok(ToolResult {

--- a/crates/octos-agent/tests/integration.rs
+++ b/crates/octos-agent/tests/integration.rs
@@ -150,14 +150,16 @@ async fn test_agent_tool_call_loop() {
 async fn test_agent_max_iterations() {
     let dir = TempDir::new().unwrap();
 
-    // Mock always returns tool use — will hit max iterations
+    // Mock always returns tool use — will hit max iterations. The path
+    // varies per call so the #1765 doom-loop guard (3+ consecutive
+    // IDENTICAL calls) stays quiet and the budget stop is what fires.
     let responses: Vec<ChatResponse> = (0..5)
         .map(|i| {
             tool_use(
                 vec![ToolCall {
                     id: format!("call_{i}"),
                     name: "read_file".into(),
-                    arguments: serde_json::json!({"path": "nonexistent.txt"}),
+                    arguments: serde_json::json!({"path": format!("nonexistent_{i}.txt")}),
 
                     metadata: None,
                 }],

--- a/crates/octos-agent/tests/realtime_loop.rs
+++ b/crates/octos-agent/tests/realtime_loop.rs
@@ -86,7 +86,10 @@ impl LlmProvider for ToolLoopProvider {
                 tool_calls: vec![octos_core::ToolCall {
                     id: format!("call_noop_{call}"),
                     name: "noop".into(),
-                    arguments: serde_json::json!({}),
+                    // Vary the args per call so the #1765 doom-loop guard
+                    // (3+ consecutive IDENTICAL calls) stays quiet — this
+                    // suite exercises heartbeat semantics, not loop stops.
+                    arguments: serde_json::json!({ "i": call }),
                     metadata: None,
                 }],
                 stop_reason: StopReason::ToolUse,


### PR DESCRIPTION
**#1765**: 3+ consecutive identical tool calls (same name + identical args JSON) abort the turn with a clear model/user-facing message — the tripping call is never executed, no further LLM call issued; streak resets on any variation. Design notes: shell-spiral recovery is consulted first (recovered real output beats an abort); verifier lanes exempt (their `Repeating` note self-corrects at exactly streak 3); background task loop deliberately unwired (legitimate identical polling); alternating cycles stay with the existing two-stage detector. v1 escalation = abort (continue/edit AppUI options = follow-up).

**#1770**: `parse_tool_args` keeps serde as the parser but on failure validates the raw JSON against the tool's own schema and reports EVERY issue model-facing: missing required params, unknown params with did-you-mean (case/underscore/affix + Levenshtein), shallow type mismatches. Wired into read_file/edit_file/write_file/glob/grep/list_dir/shell with `deny_unknown_fields`.

3-lens octos/K3 review verdict: clean (advisory notes only). Built in the 10-lane opencode-gap run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)