### PR TITLE
fix(agent): spiral dedup flag, repetitive-output message, approved-tool context (#1656, #1507, #1532)

### DIFF
--- a/crates/octos-agent/src/agent/detection.rs
+++ b/crates/octos-agent/src/agent/detection.rs
@@ -52,6 +52,11 @@ impl Agent {
     /// Catches:
     /// - Empty content with no tool calls and no reasoning (including output_tokens > 0 bug)
     /// - Content filtered by safety/moderation
+    /// - Repetitive output suppressed by the stream consumer (#1507): the
+    ///   placeholder message stands in for degenerate output, so the retry /
+    ///   non-streaming-fallback ladder still gets its chance to recover the
+    ///   real content — only when that ladder is disabled or exhausted does
+    ///   the placeholder reach the user (instead of the old blank bubble).
     pub(super) fn is_retriable_response(response: &ChatResponse) -> bool {
         let has_reasoning = response
             .reasoning_content
@@ -63,7 +68,12 @@ impl Agent {
         let is_abnormal_tool_use =
             response.stop_reason == StopReason::ToolUse && response.tool_calls.is_empty();
         let is_filtered = response.stop_reason == StopReason::ContentFiltered;
-        is_empty || is_filtered || is_abnormal_tool_use
+        let is_suppressed_repetition = response
+            .content
+            .as_deref()
+            .is_some_and(|c| c == super::streaming::REPETITIVE_OUTPUT_MESSAGE)
+            && response.tool_calls.is_empty();
+        is_empty || is_filtered || is_abnormal_tool_use || is_suppressed_repetition
     }
 
     /// Normalize inline XML-style invocations into structured tool calls.

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -449,8 +449,31 @@ impl Agent {
         // own pre-mutation snapshot point.
         self.snapshot_before_mutating_tools(&[pending.request.tool_name.as_str()])
             .await;
+        // #1532: an approved call must run with the SAME agent-level
+        // infrastructure the foreground path (`spawn_tool_task`) provides —
+        // this used to spread `zero()`, silently dropping the file-state
+        // cache, the profile permission envelope, cost tracking, the
+        // sub-agent plumbing, and the session scope for exactly the calls a
+        // human just vetted. Attachment paths stay empty: they are per-turn
+        // batch state, and an approved call resumes outside a turn batch.
         let ctx = ToolContext {
             tool_id: pending.tool_id.clone(),
+            reporter: self.reporter(),
+            harness_event_sink: self.harness_event_sink.clone(),
+            agent_definitions: self.agent_definitions.clone(),
+            file_state_cache: self.file_state_cache.clone(),
+            permissions: self
+                .profile
+                .as_deref()
+                .map(crate::tools::ToolPermissions::from_profile)
+                .unwrap_or_default(),
+            subagent_output_router: self.subagent_output_router.clone(),
+            subagent_summary_generator: self.subagent_summary_generator.clone(),
+            task_supervisor: Some(self.tools.supervisor()),
+            cost_accountant: self.cost_accountant.clone(),
+            parent_session_key: self.parent_session_key.clone(),
+            spawn_depth: self.spawn_depth,
+            session_scope: self.session_scope.clone(),
             // #1774: approval-gated edits still honor the post-edit
             // formatting opt-in.
             format_after_edit: self.config.format_after_edit,
@@ -464,13 +487,22 @@ impl Agent {
         // already-approved call is not re-denied by that inner gate.
         let approver: std::sync::Arc<dyn ToolApprovalRequester> =
             std::sync::Arc::new(ApprovedToolAutoApprover);
+        // #1532 (part 2): dispatch through `execute_with_context` like the
+        // foreground path — the legacy `execute` entry point never hands the
+        // TYPED context to native tools (they receive `zero()` via the
+        // default delegation), so every field above was reaching only
+        // task-local (`TOOL_CTX`) readers. TOOL_CTX stays scoped for plugin
+        // tools that read the task-local.
         let result = TOOL_APPROVAL_CTX
             .scope(
                 approver,
                 TOOL_CTX.scope(
-                    ctx,
-                    self.tools
-                        .execute(&pending.request.tool_name, &pending.tool_args),
+                    ctx.clone(),
+                    self.tools.execute_with_context(
+                        &ctx,
+                        &pending.request.tool_name,
+                        &pending.tool_args,
+                    ),
                 ),
             )
             .await?;
@@ -3587,6 +3619,114 @@ mod tests {
         assert!(
             seen.load(std::sync::atomic::Ordering::SeqCst),
             "AgentConfig.format_after_edit=true must reach the ToolContext"
+        );
+    }
+
+    /// #1532: probe recording whether the approved-call ToolContext carries
+    /// the agent-level infrastructure (it used to be a bare `zero()` spread).
+    struct CtxInfraProbe {
+        supervisor_seen: Arc<std::sync::atomic::AtomicBool>,
+        cache_seen: Arc<std::sync::atomic::AtomicBool>,
+        format_seen: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    #[async_trait]
+    impl Tool for CtxInfraProbe {
+        fn name(&self) -> &str {
+            "ctx_infra_probe"
+        }
+        fn description(&self) -> &str {
+            "records which ToolContext infra fields are populated"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+            self.execute_with_context(&crate::tools::ToolContext::zero(), _args)
+                .await
+        }
+        async fn execute_with_context(
+            &self,
+            ctx: &crate::tools::ToolContext,
+            _args: &serde_json::Value,
+        ) -> eyre::Result<ToolResult> {
+            use std::sync::atomic::Ordering;
+            self.supervisor_seen
+                .store(ctx.task_supervisor.is_some(), Ordering::SeqCst);
+            self.cache_seen
+                .store(ctx.file_state_cache.is_some(), Ordering::SeqCst);
+            self.format_seen
+                .store(ctx.format_after_edit, Ordering::SeqCst);
+            Ok(ToolResult {
+                output: "probe".to_string(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn approved_tool_context_carries_agent_infrastructure() {
+        // #1532: `execute_approved_tool` must hand the tool the SAME
+        // agent-level infrastructure as the foreground path — a human
+        // approving a call must not silently strip the cache, supervisor,
+        // or config-driven behavior from it.
+        let supervisor_seen = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let cache_seen = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let format_seen = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let mut tools = ToolRegistry::new();
+        tools.register(CtxInfraProbe {
+            supervisor_seen: supervisor_seen.clone(),
+            cache_seen: cache_seen.clone(),
+            format_seen: format_seen.clone(),
+        });
+
+        let dir = tempfile::tempdir().unwrap();
+        let provider: Arc<dyn LlmProvider> = Arc::new(NoChatProvider);
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let agent = Agent::new(AgentId::new("approved-ctx"), provider, tools, memory)
+            .with_file_state_cache(Arc::new(crate::file_state_cache::FileStateCache::new()))
+            .with_config(AgentConfig {
+                save_episodes: false,
+                format_after_edit: true,
+                ..Default::default()
+            });
+
+        let pending = crate::approval::PendingApproval {
+            request: crate::approval::ApprovalRequestEnvelope {
+                request_id: "req-1".into(),
+                tool_name: "ctx_infra_probe".into(),
+                tool_args_digest: "digest".into(),
+                title: "probe".into(),
+                summary: "probe".into(),
+                risk_level: crate::approval::ApprovalRiskLevel::Normal,
+                authorized_approvers: vec![],
+                expires_at: chrono::Utc::now() + chrono::Duration::minutes(5),
+                on_timeout: crate::approval::ApprovalTimeoutBehavior::Notify,
+            },
+            room_id: "room".into(),
+            requester: "user".into(),
+            tool_id: "call_probe".into(),
+            tool_args: serde_json::json!({}),
+        };
+
+        let result = agent
+            .execute_approved_tool(&pending)
+            .await
+            .expect("approved probe must execute");
+        assert!(result.success);
+        use std::sync::atomic::Ordering;
+        assert!(
+            supervisor_seen.load(Ordering::SeqCst),
+            "approved ctx must carry the task supervisor"
+        );
+        assert!(
+            cache_seen.load(Ordering::SeqCst),
+            "approved ctx must carry the file-state cache"
+        );
+        assert!(
+            format_seen.load(Ordering::SeqCst),
+            "approved ctx must carry config-driven flags (format_after_edit)"
         );
     }
 

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -383,6 +383,11 @@ impl Agent {
             return None;
         }
         let recovery = recover_shell_retry(window, SHELL_RETRY_RECOVERY_THRESHOLD)?;
+        // #1656: a firing spiral IS a loop detection — mark the two-stage
+        // dedup flag so a generic loop detection later in the SAME turn is
+        // treated as the second fire (terminal) instead of restarting the
+        // warn-then-terminate ladder with no memory of this one.
+        self.mark_loop_detected_recently();
         let decision = retry_state.observe_shell_spiral();
         tracing::warn!(
             recovery_kind = ?recovery.kind,

--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -3024,6 +3024,69 @@ async fn dedup_loop_warning_resets_after_reset() {
 }
 
 #[tokio::test]
+async fn shell_spiral_dispatch_marks_loop_detected_recently() {
+    // #1656: a firing shell spiral must mark the two-stage dedup flag, so a
+    // generic loop detection later in the SAME turn is treated as the second
+    // fire (terminal) instead of restarting the warn-then-terminate ladder.
+    let dir = tempfile::tempdir().unwrap();
+    let agent = build_agent_with_mock(dir.path()).await;
+
+    // Four consecutive failing shell exchanges inside the current user turn —
+    // the spiral detector's threshold.
+    let mut messages = vec![Message::user("fix the build")];
+    for i in 0..4 {
+        let call_id = format!("call_shell_{i}");
+        messages.push(Message {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            media: vec![],
+            tool_calls: Some(vec![ToolCall {
+                id: call_id.clone(),
+                name: "shell".into(),
+                arguments: serde_json::json!({"command": "cargo build"}),
+                metadata: None,
+            }]),
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: None,
+            timestamp: chrono::Utc::now(),
+        });
+        messages.push(Message {
+            role: MessageRole::Tool,
+            content: "error[E0999]: broken\n\nExit code: 101".into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: Some(call_id),
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: None,
+            timestamp: chrono::Utc::now(),
+        });
+    }
+
+    assert!(!agent.is_loop_detected_recently());
+    let mut retry_state = LoopRetryState::new();
+    let outcome = agent.dispatch_shell_retry_recovery(&messages, &mut retry_state, 1);
+    assert!(
+        outcome.is_some(),
+        "the spiral must fire on 4 failing shells"
+    );
+    assert!(
+        agent.is_loop_detected_recently(),
+        "a firing spiral must mark the loop-detected flag (#1656)"
+    );
+
+    // The NEXT generic loop detection in this turn is the SECOND fire —
+    // terminal, not a fresh warning.
+    let second = agent.dedup_loop_warning("[LOOP DETECTED] generic".to_string());
+    assert!(
+        second.is_err(),
+        "generic detection after a spiral must be terminal, got {second:?}"
+    );
+}
+
+#[tokio::test]
 async fn process_message_resets_loop_detected_flag_at_start() {
     // Pre-set the flag, then run a process_message that does NOT trigger
     // the loop detector. The reset at the start of process_message_inner

--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -41,6 +41,12 @@ pub(super) struct StreamTimeouts {
     pub overall_max_secs: u64,
 }
 
+/// #1507: shown in place of suppressed repetitive output. The content must
+/// never become `None` here — the `EndTurn` consumer renders
+/// `content.unwrap_or_default()`, so `None` surfaced as a completely blank
+/// assistant bubble with no hint that anything was suppressed.
+pub(super) const REPETITIVE_OUTPUT_MESSAGE: &str = "The model got stuck repeating itself, so the repetitive output was suppressed. Please try again or rephrase the request.";
+
 impl Agent {
     /// Wait until the shutdown flag is set. Used with `tokio::select!`
     /// to cancel long-running operations on Ctrl+C.
@@ -501,14 +507,16 @@ impl Agent {
         }
 
         // Detect repetitive/looping output -- model got stuck repeating itself.
-        // Replace with a short message so the user sees something useful.
+        // Replace with a short message so the user sees something useful
+        // (#1507: this used to set `None`, which the EndTurn consumer rendered
+        // as a completely blank assistant reply).
         let content = if let Some(ref text) = content {
             if Self::is_repetitive_output(text) {
                 tracing::warn!(
                     content_len = text.len(),
                     "detected repetitive LLM output, replacing with error message"
                 );
-                None
+                Some(REPETITIVE_OUTPUT_MESSAGE.to_string())
             } else {
                 content
             }
@@ -945,6 +953,34 @@ mod tests {
         assert!(streamed);
         assert_eq!(response.content.as_deref(), Some("Hello, fast world!"));
         assert_eq!(response.stop_reason, StopReason::EndTurn);
+    }
+
+    #[tokio::test]
+    async fn repetitive_output_is_replaced_with_message_not_none() {
+        // #1507: suppressed repetitive output used to become `content: None`,
+        // which the EndTurn consumer rendered as a completely blank assistant
+        // bubble. The user must see a short explanatory message instead.
+        let (agent, _dir) = build_test_agent().await;
+
+        // A >=20-char phrase repeated enough that the last 500 chars are pure
+        // repeats — trips `is_repetitive_output` (pattern seen 4+ times).
+        let phrase = "I will now check the file once more. ";
+        let repetitive: String = phrase.repeat(20);
+        let stream = into_chat_stream(vec![
+            StreamEvent::TextDelta(repetitive),
+            StreamEvent::Done(StopReason::EndTurn),
+        ]);
+
+        let (response, _streamed) = agent
+            .consume_stream_for_test(stream, 1, 0, test_thresholds(1))
+            .await
+            .expect("repetitive stream still completes");
+        assert_eq!(response.stop_reason, StopReason::EndTurn);
+        assert_eq!(
+            response.content.as_deref(),
+            Some(super::REPETITIVE_OUTPUT_MESSAGE),
+            "suppression must yield the explanatory message, never None/blank"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Three bugs verified still-open against main, fixed with regression tests:

**Fixes #1656** — `dispatch_shell_retry_recovery` now marks `loop_detected_recently` when a spiral fires, so a generic loop detection later in the same turn is the terminal second fire instead of a fresh warning (the two-stage dedup had no memory of the spiral).

**Fixes #1507** — repetitive-output suppression substitutes a short explanatory message instead of `None` (which rendered a completely blank assistant bubble). `is_retriable_response` treats the placeholder as abnormal, preserving the existing retry → non-streaming-fallback recovery ladder; the message reaches the user only when that ladder is off or exhausted — exactly the case that used to be blank. (Found via the spawn deliverable-salvage test: the old `None` was accidentally load-bearing as a retry trigger.)

**Fixes #1532** — `execute_approved_tool` now builds the same ToolContext as the foreground path (cache, permissions, supervisor, cost accountant, sub-agent plumbing, session scope, spawn depth) AND dispatches through `execute_with_context` — the legacy `execute` entry meant even previously-threaded fields never reached native tools' typed context on the approved path.

2721 octos-agent tests pass; fmt clean; clippy 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)