### PR TITLE
fix(ci): clear main's red checks (new-clippy borrows, typos, kill-test race)

### DIFF
--- a/crates/octos-agent/src/task_supervisor_tests.rs
+++ b/crates/octos-agent/src/task_supervisor_tests.rs
@@ -11,7 +11,7 @@ fn record_final_output_fires_on_change_with_the_output() {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     let supervisor = TaskSupervisor::new();
-    let id = supervisor.register("spawn", "call-fo", None);
+    let id = supervisor.register("spawn", "call-final-output", None);
     supervisor.mark_completed(&id, vec![]);
 
     // Only observe changes AFTER completion, so we isolate the
@@ -22,8 +22,8 @@ fn record_final_output_fires_on_change_with_the_output() {
     let calls_c = calls.clone();
     supervisor.set_on_change(move |task| {
         calls_c.fetch_add(1, Ordering::SeqCst);
-        if let Some(fo) = task.final_output.clone() {
-            *seen_c.lock().unwrap() = Some(fo);
+        if let Some(output) = task.final_output.clone() {
+            *seen_c.lock().unwrap() = Some(output);
         }
     });
 

--- a/crates/octos-agent/src/tools/check.rs
+++ b/crates/octos-agent/src/tools/check.rs
@@ -1250,7 +1250,7 @@ vet: helper.go:4:6: undefined: missingFn
         std::fs::write(
             &script,
             format!(
-                "#!/bin/sh\n(sleep 3; touch {}) & wait\n",
+                "#!/bin/sh\n(sleep 6; touch {}) & wait\n",
                 sentinel.display()
             ),
         )
@@ -1277,13 +1277,13 @@ vet: helper.go:4:6: undefined: missingFn
             result.output
         );
         assert!(
-            started.elapsed() < Duration::from_secs(3),
+            started.elapsed() < Duration::from_secs(5),
             "check must return promptly on timeout (got {:?})",
             started.elapsed()
         );
 
         // Wait past when the orphaned grandchild's `touch` would fire.
-        tokio::time::sleep(Duration::from_millis(4_000)).await;
+        tokio::time::sleep(Duration::from_millis(7_000)).await;
         assert!(
             !sentinel.exists(),
             "grandchild must be killed via the checker's process group on \

--- a/crates/octos-cli/src/memory_consolidate/mod.rs
+++ b/crates/octos-cli/src/memory_consolidate/mod.rs
@@ -924,7 +924,7 @@ pub async fn run_consolidation(
         }
     }
 
-    // Confirmed pendings: restore every unconfirmed interim candidate
+    // Confirmed pending entries: restore every unconfirmed interim candidate
     // byte-identically and schedule the note files for deletion.
     for (entry_id, block) in &restores {
         if working.iter().any(|e| e.id == *entry_id) {

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -3340,8 +3340,8 @@ mod tests {
         // left serve permanently OFF while chat/gateway/acp honored the
         // opt-in. The profile's flag must reach the runtime Config.
         let profile = UserProfile {
-            id: "fmt-optin".into(),
-            name: "Fmt Optin".into(),
+            id: "fmt-opt-in".into(),
+            name: "Fmt Opt-In".into(),
             enabled: false,
             data_dir: None,
             parent_id: None,

--- a/crates/octos-sandbox/src/main.rs
+++ b/crates/octos-sandbox/src/main.rs
@@ -734,7 +734,7 @@ fn run_sandboxed(args: &Args) -> eyre::Result<u8> {
     // 1. Create or reuse the AppContainer profile
     let profile = AppContainerProfile::ensure(
         &args.profile,
-        &format!("octos-sandbox-{}", &args.profile),
+        &format!("octos-sandbox-{}", args.profile),
         Some("octos agent sandbox"),
     )
     .wrap_err("failed to create AppContainer profile")?;

--- a/crates/octos-services/src/updater.rs
+++ b/crates/octos-services/src/updater.rs
@@ -145,7 +145,7 @@ impl Updater {
     /// Download and install a release. Returns the update result on success.
     pub async fn update(&self, release: &ReleaseInfo) -> Result<UpdateResult> {
         let old_version = env!("CARGO_PKG_VERSION").to_string();
-        let tmp_dir = std::env::temp_dir().join(format!("octos-update-{}", &release.tag));
+        let tmp_dir = std::env::temp_dir().join(format!("octos-update-{}", release.tag));
 
         // Clean up any previous attempt
         if tmp_dir.exists() {

--- a/typos.toml
+++ b/typos.toml
@@ -34,6 +34,11 @@ pn = "pn"
 unparseable = "unparseable"
 # Base64 placeholder token
 iz = "iz"
+# Deliberate mid-token chunk split of "</think>" in the stream-splitter test
+# (octos-llm types.rs) — the split point IS the test.
+thi = "thi"
+# "borderline" label abbreviation in the deepseek routing probe test
+bord = "bord"
 # One-Time Passwords (OTPs)
 ot = "ot"
 # Rust TUI library name


### PR DESCRIPTION
Main's CI fails on its own latest run, blocking every PR (including #1781). Three independent causes, all main-side:

1. **clippy** (toolchain bump): `useless_borrows_in_formatting` at `octos-services/src/updater.rs` and `octos-sandbox/src/main.rs` — needless `&` on `format!` args.
2. **typos**: real fixes for the `fo` fixture/variable in task_supervisor_tests, `fmt-optin` test ids, a `pendings` comment; allowlist for two deliberate fixtures (`thi` = the mid-token `</think>` chunk split whose split point IS the test; `bord` = the routing probe's "borderline" label).
3. **flaky test**: `should_kill_checker_grandchildren_when_timeout_fires` (from #1785) raced its SIGTERM→grace→SIGKILL ladder against the grandchild's 3s timer under CI load. Margins widened (6s grandchild / 5s return bound / 7s check).

`typos` binary clean locally; targeted tests + builds pass; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)