### PR TITLE
fix(agent): Linux group-kill silently broken — `--` before negative PIDs + group-liveness probe

### DIFF
--- a/crates/octos-agent/src/tools/check.rs
+++ b/crates/octos-agent/src/tools/check.rs
@@ -689,32 +689,41 @@ fn tail_chars(text: &str, max_chars: usize) -> &str {
 ///
 /// The child was spawned in its own process group (`process_group(0)`), so
 /// the negative-PID signals reach the WHOLE tree (cargo's rustc/linker
-/// grandchildren, tsc workers). Mirrors `tools/shell.rs`: SIGTERM to the
-/// group + direct PID first (graceful — lets cargo release the build
-/// lock), 500ms grace, then SIGKILL only if the direct PID is still alive
-/// (`kill -0` liveness probe avoids signalling a recycled PID).
+/// grandchildren, tsc workers). SIGTERM to the group + direct PID first
+/// (graceful — lets cargo release the build lock), 500ms grace, then
+/// SIGKILL gated on a liveness probe of the GROUP (not just the leader:
+/// on Linux `dash` exits to SIGTERM immediately, and a leader-only probe
+/// skipped the escalation while orphaned grandchildren lived on — #1781
+/// CI). Negative PIDs are passed after `--`: GNU/procps `kill` otherwise
+/// parses `-<pid>` as an option and the group signal is silently never
+/// delivered (macOS accepted it, Linux did not).
 async fn kill_by_pid(pid: Option<u32>) {
     let Some(pid) = pid else { return };
     #[cfg(unix)]
     {
         use std::process::Command as StdCommand;
-        let _ = StdCommand::new("kill")
-            .args(["-15", &format!("-{pid}")])
-            .status();
+        let group = format!("-{pid}");
+        let _ = StdCommand::new("kill").args(["-15", "--", &group]).status();
         let _ = StdCommand::new("kill")
             .args(["-15", &pid.to_string()])
             .status();
 
         tokio::time::sleep(Duration::from_millis(500)).await;
 
-        let still_alive = StdCommand::new("kill")
+        // `kill -0 -- -pgid` succeeds while ANY member of the group is
+        // alive, and cannot hit a recycled group while a member remains.
+        let group_alive = StdCommand::new("kill")
+            .args(["-0", "--", &group])
+            .status()
+            .is_ok_and(|s| s.success());
+        if group_alive {
+            let _ = StdCommand::new("kill").args(["-9", "--", &group]).status();
+        }
+        let leader_alive = StdCommand::new("kill")
             .args(["-0", &pid.to_string()])
             .status()
             .is_ok_and(|s| s.success());
-        if still_alive {
-            let _ = StdCommand::new("kill")
-                .args(["-9", &format!("-{pid}")])
-                .status();
+        if leader_alive {
             let _ = StdCommand::new("kill")
                 .args(["-9", &pid.to_string()])
                 .status();

--- a/crates/octos-agent/src/tools/shell.rs
+++ b/crates/octos-agent/src/tools/shell.rs
@@ -828,28 +828,37 @@ impl Tool for ShellTool {
                 if let Some(pid) = child_pid {
                     use std::process::Command as StdCommand;
 
-                    // 1. Send SIGTERM to process group for graceful shutdown
-                    let _ = StdCommand::new("kill")
-                        .args(["-15", &format!("-{pid}")])
-                        .status();
+                    // 1. Send SIGTERM to process group for graceful shutdown.
+                    // `--` is required before the negative PID: GNU/procps
+                    // `kill` otherwise parses `-<pid>` as an option and the
+                    // group signal is silently never delivered (macOS
+                    // accepted the bare form, Linux did not).
+                    let group = format!("-{pid}");
+                    let _ = StdCommand::new("kill").args(["-15", "--", &group]).status();
                     let _ = StdCommand::new("kill")
                         .args(["-15", &pid.to_string()])
                         .status();
 
-                    // 2. Brief grace period, then SIGKILL only if still alive.
-                    // Check /proc/{pid} (Linux) or kill -0 (portable) to avoid
-                    // killing a recycled PID.
+                    // 2. Brief grace period, then SIGKILL gated on a probe of
+                    // the GROUP — a leader-only probe skipped the escalation
+                    // when the shell died to SIGTERM while backgrounded
+                    // grandchildren lived on (#1781 CI). `kill -0 -- -pgid`
+                    // succeeds while ANY member is alive and cannot hit a
+                    // recycled group while a member remains.
                     tokio::time::sleep(Duration::from_millis(500)).await;
 
-                    let still_alive = StdCommand::new("kill")
+                    let group_alive = StdCommand::new("kill")
+                        .args(["-0", "--", &group])
+                        .status()
+                        .is_ok_and(|s| s.success());
+                    if group_alive {
+                        let _ = StdCommand::new("kill").args(["-9", "--", &group]).status();
+                    }
+                    let leader_alive = StdCommand::new("kill")
                         .args(["-0", &pid.to_string()])
                         .status()
                         .is_ok_and(|s| s.success());
-
-                    if still_alive {
-                        let _ = StdCommand::new("kill")
-                            .args(["-9", &format!("-{pid}")])
-                            .status();
+                    if leader_alive {
                         let _ = StdCommand::new("kill")
                             .args(["-9", &pid.to_string()])
                             .status();


### PR DESCRIPTION
The persistent `test-octos-agent (lib)` CI failure (blocking #1781) is a REAL Linux bug, not flake: both timeout kill ladders (`tools/check.rs`, `tools/shell.rs`) invoked `kill -15 -<pid>` — GNU/procps `kill` parses `-<pid>` as an option, so **the process-group signal was never delivered on Linux** (macOS accepts the bare form, which is why it always passed locally). Additionally the SIGKILL escalation probed only the LEADER pid: `dash` dies to SIGTERM instantly, the probe reported dead, and the escalation was skipped while orphaned grandchildren (cargo's rustc/linker, backgrounded shell children) lived on.

Fix in both ladders: negative PIDs passed after `--`, and the group SIGKILL gated on a **group** liveness probe (`kill -0 -- -pgid` — true while any member is alive, and cannot address a recycled group while a member remains). Direct-pid resignal keeps its leader probe.

This also means the K3 review's "low" on the check tool ("SIGKILL escalation gated on a direct-PID liveness probe") was in fact the production bug — and shell.rs has carried the same Linux breakage for its whole life.

🤖 Generated with [Claude Code](https://claude.com/claude-code)