### PR TITLE
feat(api): snapshot/list + snapshot/restore RPCs; serve honors the snapshots opt-in (#1768)

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -442,6 +442,10 @@ Runtime, auth, profile, and onboarding inspection (server-handled
 - `profile/sub_providers/list`, `profile/sub_providers/upsert`,
   `profile/sub_providers/remove` (named provider lanes for per-node pipeline
   routing — e.g. `deep_research`'s isolated `cheap`/`strong` lanes)
+- `snapshot/list`, `snapshot/restore` (#1768 workspace snapshot undo: list
+  the session workspace's pre-mutation undo points; restore rolls the
+  workspace back — refused while a turn is in flight, itself undoable via
+  the automatic pre-restore snapshot)
 - `profile/skills/list`, `profile/skills/registry/search`,
   `profile/skills/install`, `profile/skills/remove` (server-handled skills
   management)

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -211,6 +211,10 @@ const APPUI_METHOD_PROFILE_LLM_FETCH_MODELS: &str = "profile/llm/fetch_models";
 const APPUI_METHOD_PROFILE_SUB_PROVIDERS_LIST: &str = "profile/sub_providers/list";
 const APPUI_METHOD_PROFILE_SUB_PROVIDERS_UPSERT: &str = "profile/sub_providers/upsert";
 const APPUI_METHOD_PROFILE_SUB_PROVIDERS_REMOVE: &str = "profile/sub_providers/remove";
+/// `snapshot/list`: list the session workspace's snapshot undo points (#1768).
+const APPUI_METHOD_SNAPSHOT_LIST: &str = "snapshot/list";
+/// `snapshot/restore`: restore the session workspace to a snapshot (#1768).
+const APPUI_METHOD_SNAPSHOT_RESTORE: &str = "snapshot/restore";
 const APPUI_METHOD_PROFILE_SKILLS_LIST: &str = "profile/skills/list";
 const APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH: &str = "profile/skills/registry/search";
 const APPUI_METHOD_PROFILE_SKILLS_INSTALL: &str = "profile/skills/install";
@@ -281,6 +285,8 @@ const APPUI_EXTRA_METHODS: &[&str] = &[
     APPUI_METHOD_PROFILE_SUB_PROVIDERS_LIST,
     APPUI_METHOD_PROFILE_SUB_PROVIDERS_UPSERT,
     APPUI_METHOD_PROFILE_SUB_PROVIDERS_REMOVE,
+    APPUI_METHOD_SNAPSHOT_LIST,
+    APPUI_METHOD_SNAPSHOT_RESTORE,
     APPUI_METHOD_PROFILE_SKILLS_LIST,
     APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH,
     APPUI_METHOD_PROFILE_SKILLS_INSTALL,
@@ -9393,6 +9399,120 @@ fn raw_profile_sub_providers_list(
     ))
 }
 
+#[derive(Debug, Deserialize)]
+struct RawSnapshotListParams {
+    session_id: SessionKey,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSnapshotRestoreParams {
+    session_id: SessionKey,
+    snapshot_id: String,
+}
+
+/// Resolve the snapshot context for a session: the profile's opt-in +
+/// keep-last policy (from the bootstrapped [`ProfileRuntime`]), the profile
+/// data dir the snapshot git-dirs live under, and the session's workspace
+/// root. Listing works even when the opt-in is currently off (snapshots from
+/// an earlier enabled run remain restorable).
+fn snapshot_context_for_session(
+    state: &Arc<AppState>,
+    connection_profile_id: Option<&str>,
+    session_id: &SessionKey,
+) -> Result<(bool, Option<octos_agent::SnapshotManager>), RpcError> {
+    let profile_id = raw_scoped_llm_profile_id(None, Some(session_id), connection_profile_id)?;
+    let runtime = state.profiles.get(&profile_id);
+    let enabled = runtime
+        .and_then(|rt| rt.snapshots.as_ref())
+        .is_some_and(|cfg| cfg.enabled);
+    let keep_last = runtime
+        .and_then(|rt| rt.snapshots.as_ref())
+        .map(|cfg| cfg.keep_last)
+        .unwrap_or(octos_agent::DEFAULT_SNAPSHOT_KEEP_LAST);
+    let Some(workspace_root) = session_workspace_root_for_state(state, session_id) else {
+        return Ok((enabled, None));
+    };
+    let manager = runtime.and_then(|rt| {
+        octos_agent::SnapshotManager::new(rt.data_dir.join("snapshots"), workspace_root, keep_last)
+    });
+    Ok((enabled, manager))
+}
+
+/// Render one wire row per retained snapshot, newest first.
+fn snapshot_rows(manager: &octos_agent::SnapshotManager) -> Vec<Value> {
+    manager
+        .list_snapshots()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|info| {
+            json!({
+                "id": info.id.as_str(),
+                "label": info.label,
+                "timestamp_unix": info.timestamp_unix,
+            })
+        })
+        .collect()
+}
+
+/// `snapshot/list` (#1768): the session workspace's undo points.
+fn raw_snapshot_list(
+    state: &Arc<AppState>,
+    request: &RpcRequest<Value>,
+    connection_profile_id: Option<&str>,
+) -> Result<Value, RpcError> {
+    let params: RawSnapshotListParams = parse_raw_params(request)?;
+    let (enabled, manager) =
+        snapshot_context_for_session(state, connection_profile_id, &params.session_id)?;
+    let (available, snapshots) = match manager.as_ref() {
+        Some(manager) => (true, snapshot_rows(manager)),
+        None => (false, Vec::new()),
+    };
+    Ok(json!({
+        "session_id": params.session_id,
+        "enabled": enabled,
+        "available": available,
+        "snapshots": snapshots,
+    }))
+}
+
+/// `snapshot/restore` (#1768): roll the session workspace back to a
+/// snapshot. Refused while the session has an in-flight turn — restoring
+/// under a running agent would yank files out from under its tools. The
+/// restore itself takes a pre-restore snapshot first, so it is undoable.
+async fn raw_snapshot_restore(
+    state: &Arc<AppState>,
+    request: &RpcRequest<Value>,
+    connection_profile_id: Option<&str>,
+) -> Result<Value, RpcError> {
+    let params: RawSnapshotRestoreParams = parse_raw_params(request)?;
+    let active = active_turn_sessions(&active_turns_registry()).await;
+    if active.contains(&params.session_id) {
+        return Err(RpcError::invalid_params(
+            "cannot restore while a turn is running in this session — interrupt it first",
+        ));
+    }
+    let (_enabled, manager) =
+        snapshot_context_for_session(state, connection_profile_id, &params.session_id)?;
+    let Some(manager) = manager else {
+        return Err(RpcError::invalid_params(
+            "snapshots are not available for this session (no workspace, or git is not installed)",
+        ));
+    };
+    let snapshot_id = octos_agent::SnapshotId::new(params.snapshot_id.clone());
+    // Git work is blocking; keep it off the reactor.
+    let manager = std::sync::Arc::new(manager);
+    let restore_manager = std::sync::Arc::clone(&manager);
+    tokio::task::spawn_blocking(move || restore_manager.restore(&snapshot_id))
+        .await
+        .map_err(|err| RpcError::internal_error(format!("restore task failed: {err}")))?
+        .map_err(|err| RpcError::invalid_params(format!("restore failed: {err}")))?;
+    Ok(json!({
+        "session_id": params.session_id,
+        "restored": params.snapshot_id,
+        "snapshots": snapshot_rows(&manager),
+    }))
+}
+
 /// Serializes profile `sub_providers` read-modify-write across concurrent
 /// upsert/remove RPCs so two clients adding different lanes don't clobber each
 /// other (a bare get→mutate→save is last-writer-wins because `save_with_merge`
@@ -10004,6 +10124,10 @@ async fn handle_raw_appui_rpc(
         APPUI_METHOD_PROFILE_SUB_PROVIDERS_REMOVE => {
             raw_profile_sub_providers_remove(state, request, connection_profile_id).await
         }
+        APPUI_METHOD_SNAPSHOT_LIST => raw_snapshot_list(state, request, connection_profile_id),
+        APPUI_METHOD_SNAPSHOT_RESTORE => {
+            raw_snapshot_restore(state, request, connection_profile_id).await
+        }
         APPUI_METHOD_PROFILE_SKILLS_LIST => {
             raw_profile_skills_list(state, request, connection_profile_id)
         }
@@ -10380,6 +10504,8 @@ fn raw_method_is_dispatched(method: &str, stdio_transport: bool) -> bool {
             | APPUI_METHOD_PROFILE_SUB_PROVIDERS_LIST
             | APPUI_METHOD_PROFILE_SUB_PROVIDERS_UPSERT
             | APPUI_METHOD_PROFILE_SUB_PROVIDERS_REMOVE
+            | APPUI_METHOD_SNAPSHOT_LIST
+            | APPUI_METHOD_SNAPSHOT_RESTORE
             | APPUI_METHOD_PROFILE_SKILLS_LIST
             | APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH
             | APPUI_METHOD_PROFILE_SKILLS_INSTALL

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -1754,6 +1754,10 @@ fn dispatch_probe_request(method: &str) -> RpcRequest<Value> {
         APPUI_METHOD_PROFILE_SUB_PROVIDERS_REMOVE => {
             json!({ "profile_id": "dev", "key": "cheap" })
         }
+        APPUI_METHOD_SNAPSHOT_LIST => json!({ "session_id": session_id }),
+        APPUI_METHOD_SNAPSHOT_RESTORE => {
+            json!({ "session_id": session_id, "snapshot_id": "deadbeef" })
+        }
         other => panic!("missing AppUI dispatch probe params for {other}"),
     };
 
@@ -21555,6 +21559,7 @@ async fn make_m11e_profile_with_llm_and_sandbox(
         default_sandbox: sandbox,
         max_iterations: None,
         format_after_edit: false,
+        snapshots: None,
         tool_specs: Arc::new(base_tools),
         plugin_tool_names: Vec::new(),
         plugin_dirs: Vec::new(),

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -138,6 +138,10 @@ pub struct ProfileConfig {
     /// after successful edit_file/write_file/diff_edit. Default OFF.
     #[serde(default)]
     pub format_after_edit: bool,
+    /// #1768: opt-in git-backed workspace snapshots before mutating tools
+    /// (`snapshots.enabled` + `keep_last`). Default OFF.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snapshots: Option<octos_agent::SnapshotConfig>,
     /// Sandbox configuration for tool isolation.
     #[serde(default)]
     pub sandbox: octos_agent::SandboxConfig,
@@ -2518,9 +2522,10 @@ pub(crate) fn config_from_profile(
         model_hints: primary.and_then(|selection| selection.model_hints.clone()),
         mcp_servers: vec![],
         sandbox: profile.config.sandbox.clone(),
-        // #1768 workspace snapshots: not configurable through profiles yet
         // (serve-side wiring lands with the UI/RPC follow-up).
-        snapshots: None,
+        // #1768: thread the profile's snapshot opt-in so serve sessions
+        // honor it (parity with format_after_edit).
+        snapshots: profile.config.snapshots.clone(),
         tool_policy: None,
         tool_policy_by_provider: Default::default(),
         embedding: None,

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -768,6 +768,7 @@ mod tests {
             default_sandbox: sandbox,
             max_iterations: None,
             format_after_edit: false,
+            snapshots: None,
             tool_specs: Arc::new(base_tools),
             plugin_tool_names: Vec::new(),
             plugin_dirs: Vec::new(),

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -246,6 +246,10 @@ pub struct ProfileRuntime {
     /// result. Default: false.
     pub format_after_edit: bool,
 
+    /// #1768: opt-in workspace-snapshot config per-session agents use to
+    /// build their `SnapshotManager` (None/disabled = no snapshots).
+    pub snapshots: Option<octos_agent::SnapshotConfig>,
+
     /// The base [`ToolRegistry`] template — builtins + plugins +
     /// MCP agents + the LRU pin set — but **NOT** workspace-bound.
     /// Sessions clone this and call `with_workspace_root` to obtain
@@ -1126,6 +1130,7 @@ impl ProfileRuntime {
             default_sandbox,
             max_iterations: config.max_iterations,
             format_after_edit: config.format_after_edit,
+            snapshots: config.snapshots.clone(),
             tool_specs: Arc::new(tools),
             plugin_tool_names: plugin_result.tool_names.clone(),
             plugin_dirs,

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -593,6 +593,20 @@ impl SessionRuntime {
             agent = agent.with_session_scope(scope);
         }
 
+        // #1768: opt-in git-backed workspace snapshots before mutating tools
+        // (chat.rs parity). Separate git dir under `<data_dir>/snapshots/` —
+        // the session's own repo/index is never touched; silently unavailable
+        // without a git binary (`SnapshotManager::new` returns None, logs once).
+        if let Some(snapshot_cfg) = profile.snapshots.as_ref().filter(|cfg| cfg.enabled) {
+            if let Some(manager) = octos_agent::SnapshotManager::new(
+                profile.data_dir.join("snapshots"),
+                workspace_root.clone(),
+                snapshot_cfg.keep_last,
+            ) {
+                agent = agent.with_snapshot_manager(std::sync::Arc::new(manager));
+            }
+        }
+
         // Memory rides the per-session agent as a NAMED prompt segment
         // (chat.rs pattern) instead of being frozen into the profile's
         // bootstrap prompt String: serve profiles bootstrapped before any
@@ -1131,6 +1145,7 @@ mod tests {
             default_sandbox: sandbox,
             max_iterations: None,
             format_after_edit: false,
+            snapshots: None,
             tool_specs: Arc::new(base_tools),
             plugin_tool_names: Vec::new(),
             plugin_dirs: Vec::new(),
@@ -1804,6 +1819,7 @@ mod tests {
             default_sandbox: sandbox,
             max_iterations: None,
             format_after_edit: false,
+            snapshots: None,
             tool_specs: Arc::new(base_tools),
             plugin_tool_names: Vec::new(),
             plugin_dirs: Vec::new(),


### PR DESCRIPTION
User-facing surface on the #1784 snapshot engine — closes the remaining #1768 scope (the octos-tui `/undo` picker lands as a sibling PR):

- **`snapshot/list`** — session workspace undo points + `enabled`/`available` flags; listing works even when capture is off (old snapshots stay restorable).
- **`snapshot/restore`** — refused while a turn is in flight; itself undoable via the engine's automatic pre-restore snapshot; blocking git work off the reactor; echoes the refreshed list.
- **serve parity** — `ProfileConfig.snapshots` (default OFF) threaded config_from_profile → ProfileRuntime → per-session agents, so `octos serve` sessions actually snapshot when opted in (chat already did).
- All coverage guards satisfied (extra-methods, dispatch probe, spec §6 catalog).

Fixes #1768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)