### PR TITLE
feat(api): coalesce child stream deltas (~16ms) + reconnect-sink & surface-wiring analysis (#1799 follow-ups)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -21774,6 +21774,97 @@ fn drain_should_skip_event(event_type: Option<&str>) -> bool {
     )
 }
 
+/// Child-stream coalescing window (#1799 follow-up). A fast child can fire
+/// the spawn `ChildStreamCallback` 100+ times/sec; every fire used to clone
+/// one `agent/output/delta` notification and try-enqueue it onto the bounded
+/// WS writer channel (lossy drop-on-full), so bursts bought
+/// `BackpressureDrop`s. Merging consecutive fragments for up to ~16ms
+/// (≈ one 60fps frame — indistinguishable for a live tail) cuts the enqueue
+/// rate by an order of magnitude.
+const CHILD_STREAM_COALESCE_WINDOW: Duration = Duration::from_millis(16);
+
+/// Flush a merged child-stream frame as soon as it reaches this many bytes,
+/// even inside the coalescing window, so one chatty child can neither grow
+/// an unbounded in-memory buffer nor emit a single oversized WS frame while
+/// the 16ms deadline is still pending.
+const CHILD_STREAM_COALESCE_MAX_BYTES: usize = 4096;
+
+/// One flushable merged `agent/output/delta` frame: CONSECUTIVE stream
+/// fragments of the SAME child, text concatenated, `first_offset` = the
+/// start offset of the FIRST fragment. Fragment offsets are contiguous by
+/// construction (`SpawnChildTranscriptReporter.stream_offset` increments by
+/// exactly the emitted text length), so the merged frame spans
+/// `first_offset..first_offset + text.len()` and the on-the-wire
+/// `OutputCursor` start-offset semantics are byte-identical to the
+/// unmerged frames.
+struct ChildStreamFrame {
+    agent_id: String,
+    first_offset: u64,
+    text: String,
+}
+
+/// Pure merge core of the child-stream coalescer — unit-testable without
+/// the async plumbing. Folds incoming `(agent_id, offset, text)` fragments
+/// into at most one pending frame and yields the frames that must be
+/// flushed NOW: on a task switch (fragments of different children must not
+/// merge) or when the pending buffer crosses
+/// [`CHILD_STREAM_COALESCE_MAX_BYTES`]. Time-based flushing is the pump's
+/// job ([`Self::take_pending`] on the 16ms deadline).
+#[derive(Default)]
+struct ChildStreamCoalescer {
+    pending: Option<ChildStreamFrame>,
+}
+
+impl ChildStreamCoalescer {
+    /// Fold one fragment; returns the frames (0, 1, or 2) that must be
+    /// flushed immediately, in send order.
+    fn push(&mut self, agent_id: &str, offset: u64, text: &str) -> Vec<ChildStreamFrame> {
+        let mut flush = Vec::new();
+        match self.pending.as_mut() {
+            Some(pending) if pending.agent_id == agent_id => {
+                // Consecutive fragment of the same child: concatenate, keep
+                // the FIRST fragment's start offset.
+                pending.text.push_str(text);
+            }
+            Some(_) => {
+                // Task switch: the pending frame must go out BEFORE the
+                // other child's fragment (a frame is a per-child window).
+                flush.extend(self.pending.take());
+                self.pending = Some(ChildStreamFrame {
+                    agent_id: agent_id.to_string(),
+                    first_offset: offset,
+                    text: text.to_string(),
+                });
+            }
+            None => {
+                self.pending = Some(ChildStreamFrame {
+                    agent_id: agent_id.to_string(),
+                    first_offset: offset,
+                    text: text.to_string(),
+                });
+            }
+        }
+        if self
+            .pending
+            .as_ref()
+            .is_some_and(|pending| pending.text.len() >= CHILD_STREAM_COALESCE_MAX_BYTES)
+        {
+            flush.extend(self.pending.take());
+        }
+        flush
+    }
+
+    /// Take the pending frame for a deadline flush (16ms tick, or the final
+    /// flush when the fragment channel closes).
+    fn take_pending(&mut self) -> Option<ChildStreamFrame> {
+        self.pending.take()
+    }
+
+    fn has_pending(&self) -> bool {
+        self.pending.is_some()
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_standalone_turn(
     ws: WsConnection,
@@ -22710,26 +22801,50 @@ async fn run_standalone_turn(
         // lets clients detect gaps / reorder on reconnect. Ephemeral send:
         // deltas are explicitly non-durable (mirrors `message/delta`).
         //
-        // Delivery note (codex review): no per-token coalescing here, and
-        // the ephemeral send is LOSSY — `send_ephemeral`'s `try_enqueue`
-        // DROPS the frame when the bounded WS channel is full
-        // (BackpressureDrop) instead of blocking the producer. Acceptable
-        // for a live tail (the durable record is the reporter's
-        // Response-arm router append); if N parallel children make the
-        // loss user-visible, add a ~16ms coalescing debounce at this site.
+        // #1799 follow-up — coalescing debounce. The raw callback can fire
+        // 100+ times/sec per child; each fire used to clone one
+        // notification and try-enqueue it onto the bounded WS writer
+        // channel (lossy drop-on-full), so bursts bought
+        // `BackpressureDrop`s. The callback now only pushes the fragment
+        // onto an unbounded channel; the per-turn pump below merges
+        // CONSECUTIVE fragments of the same child and flushes a merged
+        // frame on a ~16ms deadline armed at the window's FIRST buffered
+        // fragment (throttle, not trailing-edge debounce: a steady trickle
+        // cannot postpone the flush past one window), or immediately when
+        // the merged buffer reaches `CHILD_STREAM_COALESCE_MAX_BYTES` or
+        // another child's fragment interleaves. Merged-frame cursor
+        // semantics are unchanged: `cursor.offset` = the FIRST fragment's
+        // start offset, and fragments are contiguous by construction
+        // (`SpawnChildTranscriptReporter.stream_offset` increments by
+        // exactly the text length), so a merged frame spans
+        // `offset..offset + text.len()` just like an unmerged one.
+        //
+        // Lifetime: the pump owns the receiver and exits when every sender
+        // is gone. The only senders live inside the callback `Arc`, held by
+        // this turn's registry (dropped at turn end) and by each spawned
+        // child's `SpawnChildTranscriptReporter` (dropped when that child
+        // finishes) — so post-turn background children keep streaming (the
+        // point of #1799) and the pump always terminates after the last
+        // child. The flush still goes through
+        // `send_notification_ephemeral`: the ephemeral/lossy contract
+        // (drop-on-full, never ledgered) is unchanged.
         {
             let ws_for_stream = ws.clone();
             let ledger_for_stream = ledger.clone();
             let session_id_for_stream = session_id.clone();
-            spawn_tool =
-                spawn_tool.with_child_stream_callback(move |agent_id, cursor_offset, text| {
+            let (child_stream_tx, mut child_stream_rx) =
+                mpsc::unbounded_channel::<(String, u64, String)>();
+            tokio::spawn(async move {
+                let mut coalescer = ChildStreamCoalescer::default();
+                let mut flush_deadline: Option<tokio::time::Instant> = None;
+                let flush = |frame: ChildStreamFrame| {
                     let event = AgentOutputDeltaEvent {
                         session_id: session_id_for_stream.clone(),
-                        agent_id: agent_id.to_string(),
+                        agent_id: frame.agent_id,
                         cursor: OutputCursor {
-                            offset: cursor_offset,
+                            offset: frame.first_offset,
                         },
-                        text: text.to_string(),
+                        text: frame.text,
                     };
                     // Ephemeral: deltas must NOT be appended to the ledger
                     // (per-token persistence is the overhead codex flagged).
@@ -22743,6 +22858,59 @@ async fn run_standalone_turn(
                         &ledger_for_stream,
                         UiNotification::AgentOutputDelta(event),
                     );
+                };
+                loop {
+                    let fragment = match flush_deadline {
+                        Some(deadline) => tokio::select! {
+                            fragment = child_stream_rx.recv() => fragment,
+                            _ = tokio::time::sleep_until(deadline) => {
+                                if let Some(frame) = coalescer.take_pending() {
+                                    flush(frame);
+                                }
+                                flush_deadline = None;
+                                continue;
+                            }
+                        },
+                        // Idle (nothing buffered): park on the channel alone
+                        // — no timer wakeups between child bursts.
+                        None => child_stream_rx.recv().await,
+                    };
+                    let Some((agent_id, offset, text)) = fragment else {
+                        // Every sender dropped (turn registry gone AND all
+                        // child reporters finished): final flush, then exit.
+                        if let Some(frame) = coalescer.take_pending() {
+                            flush(frame);
+                        }
+                        break;
+                    };
+                    let flushed = coalescer.push(&agent_id, offset, &text);
+                    let flushed_any = !flushed.is_empty();
+                    for frame in flushed {
+                        flush(frame);
+                    }
+                    if !coalescer.has_pending() {
+                        flush_deadline = None;
+                    } else if flush_deadline.is_none() || flushed_any {
+                        // The pending window's FIRST fragment landed just
+                        // now (either the buffer was empty, or a task
+                        // switch flushed the old window and this fragment
+                        // opened a new one): arm the deadline from now.
+                        flush_deadline =
+                            Some(tokio::time::Instant::now() + CHILD_STREAM_COALESCE_WINDOW);
+                    }
+                }
+            });
+            spawn_tool =
+                spawn_tool.with_child_stream_callback(move |agent_id, cursor_offset, text| {
+                    // Reporter-thread side: a non-blocking push only.
+                    // Unbounded is safe here — the pump drains continuously
+                    // and flushes at 4KB boundaries, so steady-state
+                    // occupancy is one ~16ms window of fragments.
+                    let _ = child_stream_tx.send((
+                        agent_id.to_string(),
+                        cursor_offset,
+                        text.to_string(),
+                    ));
                 });
         }
         let child_context_parent = context_manager.clone();

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -24408,3 +24408,116 @@ async fn peer_prepare_stages_brief_and_worktree() {
     .expect_err("oversized brief refused");
     assert!(too_big.message.contains("bytes"));
 }
+
+// ---------------------------------------------------------------------------
+// Child stream delta coalescing (#1799 follow-up)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn should_merge_consecutive_chunks_into_single_frame_when_same_agent() {
+    let mut coalescer = ChildStreamCoalescer::default();
+    // Contiguous fragments (each offset = previous offset + previous byte
+    // length — the invariant `SpawnChildTranscriptReporter.stream_offset`
+    // guarantees by construction).
+    assert!(coalescer.push("task-a", 0, "hel").is_empty());
+    assert!(coalescer.push("task-a", 3, "lo ").is_empty());
+    assert!(coalescer.push("task-a", 6, "world").is_empty());
+    let frame = coalescer
+        .take_pending()
+        .expect("merged frame must be pending");
+    assert_eq!(frame.agent_id, "task-a");
+    assert_eq!(
+        frame.first_offset, 0,
+        "a merged frame carries the FIRST fragment's start offset"
+    );
+    assert_eq!(frame.text, "hello world");
+    assert!(
+        coalescer.take_pending().is_none(),
+        "take_pending drains the buffer"
+    );
+}
+
+#[test]
+fn should_keep_first_fragment_offset_when_window_opens_mid_stream() {
+    // A window that opens mid-stream (earlier fragments already flushed in
+    // previous windows) must anchor at ITS first fragment's offset, so the
+    // wire cursor still spans `offset..offset + text.len()`.
+    let mut coalescer = ChildStreamCoalescer::default();
+    assert!(coalescer.push("task-a", 120, "foo").is_empty());
+    assert!(coalescer.push("task-a", 123, "bar").is_empty());
+    let frame = coalescer.take_pending().expect("pending frame");
+    assert_eq!(frame.first_offset, 120);
+    assert_eq!(frame.text, "foobar");
+}
+
+#[test]
+fn should_flush_pending_frame_when_agent_id_changes() {
+    let mut coalescer = ChildStreamCoalescer::default();
+    assert!(coalescer.push("task-a", 0, "alpha").is_empty());
+    let flushed = coalescer.push("task-b", 0, "beta");
+    assert_eq!(
+        flushed.len(),
+        1,
+        "a task switch forces the pending frame out immediately"
+    );
+    assert_eq!(flushed[0].agent_id, "task-a");
+    assert_eq!(flushed[0].first_offset, 0);
+    assert_eq!(flushed[0].text, "alpha");
+    // The interleaving child's fragment opens the next pending window.
+    let frame = coalescer
+        .take_pending()
+        .expect("new pending window for task-b");
+    assert_eq!(frame.agent_id, "task-b");
+    assert_eq!(frame.first_offset, 0);
+    assert_eq!(frame.text, "beta");
+}
+
+#[test]
+fn should_flush_immediately_when_merged_buffer_reaches_size_cap() {
+    let mut coalescer = ChildStreamCoalescer::default();
+    assert!(coalescer.push("task-a", 0, "start:").is_empty());
+    let big = "x".repeat(CHILD_STREAM_COALESCE_MAX_BYTES);
+    let flushed = coalescer.push("task-a", 6, &big);
+    assert_eq!(
+        flushed.len(),
+        1,
+        "crossing the byte cap flushes inside the 16ms window"
+    );
+    assert_eq!(flushed[0].first_offset, 0);
+    assert_eq!(flushed[0].text.len(), "start:".len() + big.len());
+    assert!(flushed[0].text.starts_with("start:"));
+    assert!(
+        !coalescer.has_pending(),
+        "a cap-triggered flush drains the buffer"
+    );
+}
+
+#[test]
+fn should_flush_oversized_lone_fragment_immediately_when_buffer_empty() {
+    let mut coalescer = ChildStreamCoalescer::default();
+    let big = "y".repeat(CHILD_STREAM_COALESCE_MAX_BYTES + 7);
+    let flushed = coalescer.push("task-a", 42, &big);
+    assert_eq!(flushed.len(), 1);
+    assert_eq!(flushed[0].agent_id, "task-a");
+    assert_eq!(flushed[0].first_offset, 42);
+    assert_eq!(flushed[0].text, big);
+    assert!(!coalescer.has_pending());
+}
+
+#[test]
+fn should_flush_old_window_and_oversized_new_fragment_in_order_when_task_switches() {
+    // Task switch where the NEW fragment alone already crosses the cap:
+    // both frames flush, old window first (send order preserved).
+    let mut coalescer = ChildStreamCoalescer::default();
+    assert!(coalescer.push("task-a", 10, "tail").is_empty());
+    let big = "z".repeat(CHILD_STREAM_COALESCE_MAX_BYTES);
+    let flushed = coalescer.push("task-b", 0, &big);
+    assert_eq!(flushed.len(), 2, "old pending window, then the new frame");
+    assert_eq!(flushed[0].agent_id, "task-a");
+    assert_eq!(flushed[0].first_offset, 10);
+    assert_eq!(flushed[0].text, "tail");
+    assert_eq!(flushed[1].agent_id, "task-b");
+    assert_eq!(flushed[1].first_offset, 0);
+    assert_eq!(flushed[1].text, big);
+    assert!(!coalescer.has_pending());
+}


### PR DESCRIPTION
Follow-ups to #1799 (child `StreamChunk` deltas streamed as ephemeral `agent/output/delta`). Item 1 is built; items 2 and 3 are investigations whose verdicts are recorded below (no code — the write-ups explain why).

## Built: ~16ms coalescing debounce at the `run_standalone_turn` callback site

A fast child can fire the spawn `ChildStreamCallback` 100+ times/sec; every fire cloned one notification and try-enqueued onto the bounded WS writer channel (lossy drop-on-full), so bursts bought `BackpressureDrop`s. The callback now only pushes `(task_id, offset, text)` onto an unbounded `tokio::mpsc`; a per-turn coalescer task drains it:

- merges CONSECUTIVE fragments of the same `task_id` (concatenate text, keep the FIRST fragment's start offset — offsets are contiguous by construction, `SpawnChildTranscriptReporter.stream_offset` increments by exactly the emitted text length, so a merged frame spans `offset..offset + text.len()` like an unmerged one);
- flushes on a ~16ms deadline armed at the window's FIRST buffered fragment (throttle, not trailing-edge debounce — a steady sub-16ms trickle cannot postpone the flush), or immediately when the merged buffer reaches 4KB (`CHILD_STREAM_COALESCE_MAX_BYTES`) or another child's fragment interleaves;
- parks on the channel alone while idle (no timer wakeups between bursts);
- terminates when every sender drops (turn registry gone + all child `SpawnChildTranscriptReporter`s finished — recv returns `None`), after a final flush. Post-turn background children keep streaming, which is the point of #1799.

The flush still goes through `send_notification_ephemeral` — the ephemeral/lossy contract (drop-on-full, never ledgered) is unchanged, and merged-frame `OutputCursor` start-offset semantics are byte-identical to unmerged frames.

The merge core is a pure `ChildStreamCoalescer` struct (`push` / `take_pending`), unit-tested separately from the async plumbing: merge-consecutive (contiguous offsets in → single frame out with first offset + concatenated text), mid-stream window anchoring, task-switch forced flush, size-cap flush, oversized lone fragment, and task-switch + oversized new fragment ordering (6 tests).

## Item 2 finding — reconnect-safe sink: NOT clean, not built

The only registry resembling a session→forwarder map is `SharedLiveForwarders` (`ui_protocol.rs`, `Arc<Mutex<HashMap<SessionKey, JoinHandle<()>>>>`), but it is created per connection inside `ui_protocol_connection` (and its stdio twin) and maps a session to the pump task feeding that one connection's writer — it dies with the connection. The structure that genuinely outlives connections is `UiProtocolLedger.subscribers: HashMap<SessionKey, broadcast::Sender<LedgeredUiProtocolEvent>>` (`ui_protocol_ledger.rs`), which every reconnect re-taps via `ledger.subscribe(&session_id)` → `spawn_live_forwarder`. That broadcast, however, carries only LEDGERED events — cursor-stamped durable frames. Ephemerals never enter it: `send_notification_ephemeral` contains `let _ = ledger; // unused for ephemeral, kept for symmetry with durable` and goes straight to `ws.send_ephemeral` (the per-connection bounded writer channel). Routing deltas through it would mean either appending them to the ledger (per-frame persistence — exactly what #1799 rejected, and replay would then re-ship every delta) or inventing a parallel non-durable broadcast lane with fake cursors and forwarder-side special-casing — a new delivery class, not a reuse of a clean existing handle. `AppState.broadcaster` (`EventBroadcaster`, `api/events.rs`) is not a candidate either: it is the harness/admin + swarm dashboard surface, and `events.rs` states "No SSE wire path remains in the chat transport — every chat client talks to /api/ui-protocol/ws exclusively".

Connection-scoping is the design of the ephemeral class, and child deltas share it exactly with the parent's own `message/delta`: `run_standalone_turn` captures the same spawning `ws` for the parent's stream deltas, so after a reconnect an in-flight turn's parent tail goes to the same dead connection object too. The failure mode is cheap — the dead `WsConnection`'s writer receiver is gone, `send_ephemeral` fails fast, and the `let _ =` discards it — and catch-up is served by the durable lane: the child transcript is persisted by `SpawnChildTranscriptReporter`'s Response-arm append to the `SubAgentOutputRouter` file and read back via `read_task_output` / the `task/output/read` + `agent/output/read` RPCs, whose `OutputCursor` offsets match the delta stream exactly (why #1799 kept start-offset semantics — a reconnecting client resumes from its last cursor with no gap ambiguity).

Building a session→live-connection registry just for `agent/output/delta` would make child deltas the ONLY ephemeral that follows the session while `message/delta` (and `message/reasoning_delta`) still die with the connection — a surprising split contract. If reconnect-following ephemerals are ever wanted, the right shape is a protocol-level "ephemeral re-attach" that rebinds ALL of a session's ephemeral producers (parent deltas included) to the new connection, which is a UPCR-sized change, not a follow-up. Verdict: write-up only, no registry built.

## Item 3 finding — gateway/chat/ACP wiring: no surface has a live consumer today; nothing wired

**Gateway (`session_actor.rs` spawn site):** this is the one surface where the callback would actually fire — the actor wires `with_task_supervisor` AND `with_parent_subagent_output_router`, which are the two preconditions for `SpawnChildTranscriptReporter` (spawn.rs constructs it only when both are `Some`, background path only). But the gateway's outbound surface is the message bus: `ChannelStreamReporter` (`stream_reporter.rs`) streams the PARENT turn's `StreamChunk`s into ONE per-turn channel message bubble via `edit_message_bound` on channels with `supports_edit()`. Child deltas have no slot in that shape: interleaving a child's tokens into the parent's bubble would corrupt the parent transcript, and a separate per-child bubble needs `send_with_id` + per-child edit throttling + per-child finalize — a new feature, not an existing consumer. There is no agent-dock equivalent on bus channels; child results already reach the chat as discrete messages via the background-result delivery path when the child completes, and mid-flight inspection is served by `read_task_output`. Verdict: no consumer today; not wired.

**Chat (`commands/chat.rs` spawn site):** `octos chat` registers `SpawnTool::new(...)` with NO task supervisor and NO parent output router, so `SpawnChildTranscriptReporter` is never constructed and a wired callback would never fire — and chat's sync spawn path doesn't attach a child reporter at all (`with_reporter` exists only on the detached background arm). The surface is a one-shot/interactive CLI whose only live output is the parent agent's own stream printed to the terminal; there is no dock, no per-child pane, and background mode's delivery channel is explicitly a dummy (`(spawn_tx, _spawn_rx)`). Wiring a callback here would be dead code end to end. Verdict: no producer and no consumer; not wired.

**ACP (`commands/acp.rs` spawn site):** same producer gap as chat — `SpawnTool::new(...)` without supervisor/router ("sync sub-agents; background delivery is a dummy channel"), so the callback would never fire. On the consumer side the ACP protocol COULD carry child deltas in principle: the bridge (`progress_event_to_acp`) already streams `SessionUpdate::AgentMessageChunk` / `AgentThoughtChunk` / `ToolCall` / `ToolCallUpdate`, and `ToolCallUpdate.fields.content` accepts in-progress content chunks keyed by `tool_id` — a child's live text could render as progressive content on the spawn tool call. But that mapping does not exist today, `AgentMessageChunk` is wrong (it would interleave child text into the parent's message and break the reporter's streamed/Response dedup), and the `ChildStreamCallback` carries the spawn `task_id`, not the parent-visible `tool_id`, so a `task_id → tool_id` correlation would have to be built. Editors also have no rendering contract for it wired up. Verdict: protocol-plausible but no consumer today; not wired — if ACP child streaming is ever wanted, the path is supervisor+router wiring plus a `task_id → tool_id` map feeding `ToolCallUpdate` content, as a deliberate feature.

## Gates

- `cargo test -p octos-cli --features api --lib` — green (full lib suite)
- `cargo check -p octos-cli --features api` — clean
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p octos-cli --features api` warnings: 69 = origin/main baseline 69

🤖 Generated with [Claude Code](https://claude.com/claude-code)
