### PR TITLE
feat(api): turn/steer — mid-turn prompt injection into the active turn (codex-parity)

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -381,6 +381,22 @@ Session, turn, and approval core:
 - `session/compact/mode/set` (per-session LLM-vs-heuristic compaction mode; the `/context` menu)
 - `turn/start`
 - `turn/interrupt`
+- `turn/steer` (mid-turn prompt injection into the ACTIVE turn, codex
+  app-server parity. Params `{session_id, expected_turn_id?, input}`,
+  result `{turn_id, steered}`. With a live turn the text input items are
+  pushed into that turn's pending-input buffer under the active-turns
+  registry lock; the agent loop drains them FIFO at its next iteration
+  boundary — before the next LLM call — as plain `role: user` messages
+  with no wrapper text, persisting each through the canonical session
+  path so the standard v2 `UserMessage` envelope announces the fold-in;
+  a steer landing after the model's final answer forces one more round
+  in the SAME turn. Returns `steered: true` + the ACTIVE turn id. An
+  `expected_turn_id` naming a different turn → `invalid_params`; a live
+  non-steerable turn (review/fixture) → `invalid_request`. With no live
+  turn the call falls back to the ordinary `turn/start` admission and
+  returns `steered: false` + the NEW turn id. Raw server-handled method
+  — session-ingress credentials cannot call it, and steering is NOT an
+  interrupt: `turn/interrupt` stays the separate cancel op)
 - `turn/state/get` (gate `state.turn_state_get.v1`, accepted `UPCR-2026-011`)
 - `thread/graph/get` (gate `state.thread_graph.v1`, accepted `UPCR-2026-010`)
 - `approval/respond`

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -714,6 +714,63 @@ impl Agent {
         Ok(warning)
     }
 
+    /// Drain the per-turn steer buffer (mid-turn injected user inputs) into
+    /// the live conversation.
+    ///
+    /// Codex parity: `run_turn` drains `TurnState.pending_input` at the TOP
+    /// of each loop iteration, before building the next model request
+    /// (codex-rs `core/src/session/turn.rs:225-233`), and records each item
+    /// as a plain `role: user` message with NO wrapper text
+    /// (`record_user_prompt_and_emit_turn_item`). FIFO order is the
+    /// buffer's append order (`split_off(0)` semantics).
+    ///
+    /// Persistence ownership: when a drained-callback is registered the
+    /// HOST persists each steer row (and emits its standard persisted
+    /// user-message event) at drain time, so the rows stay OUT of
+    /// `turn_output_log` — otherwise the end-of-turn persist pass would
+    /// write them a second time. Without a callback (chat/gateway paths)
+    /// the rows ride the normal end-of-turn persistence via the log.
+    ///
+    /// No-op without a configured buffer — pre-steer loops are
+    /// byte-identical.
+    async fn drain_pending_steer_input(
+        &self,
+        messages: &mut Vec<Message>,
+        turn_output_log: &mut Vec<Message>,
+    ) {
+        let Some(buffer) = self.steer_buffer.as_ref() else {
+            return;
+        };
+        let drained = buffer.drain();
+        if drained.is_empty() {
+            return;
+        }
+        tracing::info!(
+            count = drained.len(),
+            "draining mid-turn steer input into the conversation before the next LLM call"
+        );
+        for text in &drained {
+            let message = Message::user(text.clone());
+            messages.push(message.clone());
+            if self.steer_drained_callback.is_none() {
+                turn_output_log.push(message);
+            }
+        }
+        if let Some(callback) = self.steer_drained_callback.as_ref() {
+            callback(drained).await;
+        }
+    }
+
+    /// Whether a mid-turn steer input is pending (codex `has_pending_input`,
+    /// `turn.rs:304-318`). Read in the EndTurn arm so
+    /// `needs_follow_up = model_wants_more || buffer_nonempty` — a steer
+    /// landing after the model's final answer forces one more round.
+    fn steer_input_pending(&self) -> bool {
+        self.steer_buffer
+            .as_ref()
+            .is_some_and(|buffer| !buffer.is_empty())
+    }
+
     /// Process a single message in conversation mode (chat/gateway).
     /// Takes the user's message, conversation history, and optional media paths.
     pub async fn process_message(
@@ -1037,6 +1094,15 @@ impl Agent {
                 // loop — an unlabeled `continue` there fell through to
                 // `handle_tool_use` and executed the spiraling tools anyway.
                 'agent_loop: loop {
+                    // Codex-parity steer drain (turn.rs:225-233): fold any
+                    // mid-turn injected user inputs into the conversation at
+                    // the TOP of each iteration, BEFORE the next LLM call,
+                    // in FIFO order. Steering never interrupts an in-flight
+                    // round — inputs buffered while the model streams are
+                    // picked up here, after the previous round's tool
+                    // results are recorded.
+                    self.drain_pending_steer_input(&mut messages, &mut turn_output_log)
+                        .await;
                     if let Some(stop) = turn.check_budget(self, activity.as_ref()) {
                         let stop_iteration = turn.iteration();
                         if !self.try_budget_grace_call(
@@ -1305,6 +1371,30 @@ impl Agent {
                                 .await?
                             {
                                 continue;
+                            }
+                            // Codex-parity follow-up gate (turn.rs:304-318):
+                            // `needs_follow_up = model_needs_follow_up ||
+                            // has_pending_input`. The model produced its
+                            // final answer, but a steer landed during this
+                            // round — record that answer as a normal
+                            // assistant row (so the model sees its own
+                            // reply next round and the row persists), then
+                            // loop again; the top-of-loop drain folds the
+                            // steer in as a plain user message and the
+                            // steer gets a response inside the SAME turn.
+                            if self.steer_input_pending() {
+                                if !content.trim().is_empty() {
+                                    let mut assistant_row = Message::assistant(content.clone());
+                                    assistant_row.reasoning_content =
+                                        response.reasoning_content.clone();
+                                    messages.push(assistant_row.clone());
+                                    turn_output_log.push(assistant_row);
+                                }
+                                tracing::info!(
+                                    "steer input pending at EndTurn — running another round \
+                                     instead of terminating the turn"
+                                );
+                                continue 'agent_loop;
                             }
                             self.emit_cost_update(&turn, &response, attributed_cost);
                             return Ok(ConversationResponse {

--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -5520,3 +5520,332 @@ async fn user_prompt_submit_hook_deny_blocks_turn_before_llm() {
             .is_empty()
     );
 }
+
+// --- Mid-turn steer injection (codex `TurnState.pending_input` parity) ---
+
+/// Per-request prompt capture: `(role, content)` per message, one vec per
+/// LLM call.
+type ObservedRolePrompts = Arc<StdMutex<Vec<Vec<(MessageRole, String)>>>>;
+
+/// Records every prompt as `(role, content)` pairs. Call 0 pushes the given
+/// steer inputs into the shared buffer MID-CALL (simulating a `turn/steer`
+/// racing in while the model streams), then returns a tool call; call 1
+/// returns EndTurn.
+struct SteerDuringToolRoundProvider {
+    calls: AtomicUsize,
+    observed: ObservedRolePrompts,
+    buffer: crate::steering::SharedSteerBuffer,
+    steers: Vec<String>,
+}
+
+#[async_trait]
+impl LlmProvider for SteerDuringToolRoundProvider {
+    async fn chat(
+        &self,
+        messages: &[Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &octos_llm::ChatConfig,
+    ) -> Result<ChatResponse> {
+        self.observed
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .push(
+                messages
+                    .iter()
+                    .map(|message| (message.role, message.content.clone()))
+                    .collect(),
+            );
+        let call = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+        Ok(if call == 0 {
+            for steer in &self.steers {
+                self.buffer.push(steer.clone());
+            }
+            tool_use(
+                vec![ToolCall {
+                    id: "call_alpha".to_string(),
+                    name: "alpha".to_string(),
+                    arguments: serde_json::json!({}),
+                    metadata: None,
+                }],
+                1,
+                1,
+            )
+        } else {
+            end_turn("done", 1, 1)
+        })
+    }
+
+    fn model_id(&self) -> &str {
+        "mock"
+    }
+
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+/// Call 0 pushes steer inputs mid-call and returns a FINAL answer
+/// (EndTurn). The pending steer must force one more round; call 1 returns
+/// the follow-up answer.
+struct SteerAfterFinalAnswerProvider {
+    calls: AtomicUsize,
+    observed: ObservedRolePrompts,
+    buffer: crate::steering::SharedSteerBuffer,
+    steers: Vec<String>,
+}
+
+#[async_trait]
+impl LlmProvider for SteerAfterFinalAnswerProvider {
+    async fn chat(
+        &self,
+        messages: &[Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &octos_llm::ChatConfig,
+    ) -> Result<ChatResponse> {
+        self.observed
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .push(
+                messages
+                    .iter()
+                    .map(|message| (message.role, message.content.clone()))
+                    .collect(),
+            );
+        let call = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+        Ok(if call == 0 {
+            for steer in &self.steers {
+                self.buffer.push(steer.clone());
+            }
+            end_turn("first answer", 1, 1)
+        } else {
+            end_turn("second answer", 1, 1)
+        })
+    }
+
+    fn model_id(&self) -> &str {
+        "mock"
+    }
+
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+/// Steer landing between tool rounds is drained at the top of the next
+/// iteration, BEFORE the next LLM call, as a plain `role: user` message
+/// appended after the previous round's tool output — no wrapper text.
+#[tokio::test]
+async fn should_fold_steer_into_next_llm_call_when_injected_between_rounds() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut tools = ToolRegistry::with_builtins(dir.path());
+    tools.register(NamedEchoTool {
+        name: "alpha",
+        output: "alpha ok",
+    });
+    let buffer: crate::steering::SharedSteerBuffer =
+        Arc::new(crate::steering::SteerBuffer::default());
+    let observed = Arc::new(StdMutex::new(Vec::new()));
+    let provider: Arc<dyn LlmProvider> = Arc::new(SteerDuringToolRoundProvider {
+        calls: AtomicUsize::new(0),
+        observed: Arc::clone(&observed),
+        buffer: Arc::clone(&buffer),
+        steers: vec!["also check the tests".to_string()],
+    });
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let agent = Agent::new(AgentId::new("steer-agent"), provider, tools, memory)
+        .with_steer_buffer(Arc::clone(&buffer));
+
+    let result = agent.process_message("do work", &[], vec![]).await.unwrap();
+    assert_eq!(result.content, "done");
+
+    let observed = observed.lock().unwrap_or_else(|error| error.into_inner());
+    assert_eq!(observed.len(), 2, "tool round + follow-up round");
+    // First call: no steer yet (it lands mid-call).
+    assert!(
+        !observed[0]
+            .iter()
+            .any(|(_, content)| content.contains("also check the tests")),
+        "steer must not time-travel into the request that was already built"
+    );
+    // Second call: the steer is a plain user message with NO wrapper text,
+    // appended AFTER the previous round's tool output.
+    let steer_idx = observed[1]
+        .iter()
+        .position(|(role, content)| *role == MessageRole::User && content == "also check the tests")
+        .expect("second request must carry the steer as a plain role:user message");
+    let tool_idx = observed[1]
+        .iter()
+        .position(|(role, _)| *role == MessageRole::Tool)
+        .expect("second request must carry the tool result");
+    assert!(
+        steer_idx > tool_idx,
+        "steer must append after the prior round's tool output (append-only history)"
+    );
+    // Buffer fully drained.
+    assert!(buffer.is_empty());
+    // No callback registered → the steer row rides the turn output log so
+    // the host's end-of-turn persistence writes it exactly once.
+    assert!(
+        result
+            .messages
+            .iter()
+            .any(|m| m.role == MessageRole::User && m.content == "also check the tests"),
+        "without a drained-callback the steer row must land in the turn output log"
+    );
+}
+
+/// A steer that lands while the model produces its FINAL answer forces one
+/// more round (`needs_follow_up = model_wants_more || buffer_nonempty`),
+/// and the prior answer is recorded as a normal assistant row the model
+/// sees in the follow-up request.
+#[tokio::test]
+async fn should_run_extra_round_when_steer_lands_after_final_answer() {
+    let dir = tempfile::tempdir().unwrap();
+    let tools = ToolRegistry::with_builtins(dir.path());
+    let buffer: crate::steering::SharedSteerBuffer =
+        Arc::new(crate::steering::SteerBuffer::default());
+    let observed = Arc::new(StdMutex::new(Vec::new()));
+    let provider: Arc<dyn LlmProvider> = Arc::new(SteerAfterFinalAnswerProvider {
+        calls: AtomicUsize::new(0),
+        observed: Arc::clone(&observed),
+        buffer: Arc::clone(&buffer),
+        steers: vec!["one more thing".to_string()],
+    });
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let agent = Agent::new(AgentId::new("steer-agent"), provider, tools, memory)
+        .with_steer_buffer(Arc::clone(&buffer));
+
+    let result = agent.process_message("do work", &[], vec![]).await.unwrap();
+
+    // The steer forced a second round and the turn ends on ITS answer.
+    assert_eq!(result.content, "second answer");
+    let observed = observed.lock().unwrap_or_else(|error| error.into_inner());
+    assert_eq!(
+        observed.len(),
+        2,
+        "steer after EndTurn must force another round"
+    );
+    let assistant_idx = observed[1]
+        .iter()
+        .position(|(role, content)| *role == MessageRole::Assistant && content == "first answer")
+        .expect("follow-up request must carry the recorded first answer");
+    let steer_idx = observed[1]
+        .iter()
+        .position(|(role, content)| *role == MessageRole::User && content == "one more thing")
+        .expect("follow-up request must carry the steer as a plain role:user message");
+    assert!(
+        steer_idx > assistant_idx,
+        "steer must follow the recorded final answer in history order"
+    );
+    // Both the intermediate answer and the steer row persist via the log.
+    assert!(
+        result
+            .messages
+            .iter()
+            .any(|m| m.role == MessageRole::Assistant && m.content == "first answer"),
+        "the pre-steer final answer must persist as a normal assistant row"
+    );
+    assert!(
+        result
+            .messages
+            .iter()
+            .any(|m| m.role == MessageRole::User && m.content == "one more thing")
+    );
+}
+
+/// Rapid steers drain together, in FIFO order, at the next boundary.
+#[tokio::test]
+async fn should_preserve_fifo_order_when_multiple_steers_accumulate() {
+    let dir = tempfile::tempdir().unwrap();
+    let tools = ToolRegistry::with_builtins(dir.path());
+    let buffer: crate::steering::SharedSteerBuffer =
+        Arc::new(crate::steering::SteerBuffer::default());
+    let observed = Arc::new(StdMutex::new(Vec::new()));
+    let provider: Arc<dyn LlmProvider> = Arc::new(SteerAfterFinalAnswerProvider {
+        calls: AtomicUsize::new(0),
+        observed: Arc::clone(&observed),
+        buffer: Arc::clone(&buffer),
+        steers: vec!["steer one".to_string(), "steer two".to_string()],
+    });
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let agent = Agent::new(AgentId::new("steer-agent"), provider, tools, memory)
+        .with_steer_buffer(Arc::clone(&buffer));
+
+    let result = agent.process_message("do work", &[], vec![]).await.unwrap();
+    assert_eq!(result.content, "second answer");
+
+    let observed = observed.lock().unwrap_or_else(|error| error.into_inner());
+    assert_eq!(observed.len(), 2);
+    let first_idx = observed[1]
+        .iter()
+        .position(|(role, content)| *role == MessageRole::User && content == "steer one")
+        .expect("first steer present");
+    let second_idx = observed[1]
+        .iter()
+        .position(|(role, content)| *role == MessageRole::User && content == "steer two")
+        .expect("second steer present");
+    assert!(
+        first_idx < second_idx,
+        "steers must drain in FIFO (arrival) order"
+    );
+}
+
+/// With a drained-callback registered, the HOST owns steer-row persistence:
+/// the callback sees the drained batch (before the next LLM call) and the
+/// rows stay OUT of the turn output log so end-of-turn persistence cannot
+/// double-write them. The prompt still carries them.
+#[tokio::test]
+async fn should_hand_drained_steers_to_callback_and_skip_output_log() {
+    let dir = tempfile::tempdir().unwrap();
+    let tools = ToolRegistry::with_builtins(dir.path());
+    let buffer: crate::steering::SharedSteerBuffer =
+        Arc::new(crate::steering::SteerBuffer::default());
+    let observed = Arc::new(StdMutex::new(Vec::new()));
+    let provider: Arc<dyn LlmProvider> = Arc::new(SteerAfterFinalAnswerProvider {
+        calls: AtomicUsize::new(0),
+        observed: Arc::clone(&observed),
+        buffer: Arc::clone(&buffer),
+        steers: vec!["persist me host-side".to_string()],
+    });
+    let drained_batches: Arc<StdMutex<Vec<Vec<String>>>> = Arc::new(StdMutex::new(Vec::new()));
+    let drained_for_callback = Arc::clone(&drained_batches);
+    let callback: crate::steering::SteerDrainedCallback = Arc::new(move |batch: Vec<String>| {
+        let drained = Arc::clone(&drained_for_callback);
+        Box::pin(async move {
+            drained
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .push(batch);
+        })
+    });
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let agent = Agent::new(AgentId::new("steer-agent"), provider, tools, memory)
+        .with_steer_buffer(Arc::clone(&buffer))
+        .with_steer_drained_callback(callback);
+
+    let result = agent.process_message("do work", &[], vec![]).await.unwrap();
+    assert_eq!(result.content, "second answer");
+
+    let batches = drained_batches
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    assert_eq!(
+        batches.as_slice(),
+        [vec!["persist me host-side".to_string()]]
+    );
+    // Host owns persistence → the row must NOT ride the output log.
+    assert!(
+        !result
+            .messages
+            .iter()
+            .any(|m| m.role == MessageRole::User && m.content == "persist me host-side"),
+        "steer rows must stay out of the turn output log when the host persists them"
+    );
+    // ...but the model did see it.
+    let observed = observed.lock().unwrap_or_else(|error| error.into_inner());
+    assert!(
+        observed[1]
+            .iter()
+            .any(|(role, content)| *role == MessageRole::User && content == "persist me host-side")
+    );
+}

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -459,6 +459,22 @@ pub struct Agent {
     /// pre-mutation state later. `None` (the default) disables the
     /// feature entirely — no git subprocess is ever spawned.
     pub(super) snapshot_manager: Option<Arc<crate::snapshot::SnapshotManager>>,
+    /// Per-turn pending-input buffer for mid-turn prompt injection
+    /// ("steer") — codex `TurnState.pending_input` parity. The host pushes
+    /// while the turn runs; the conversation loop drains FIFO at the top of
+    /// each iteration (before the next LLM call) and appends each entry as
+    /// a plain `role: user` message with no wrapper text. A steer that
+    /// lands after the model's final answer forces one more round
+    /// (`needs_follow_up = model_wants_more || buffer_nonempty`). `None`
+    /// (the default) keeps the loop byte-identical to pre-steer behaviour.
+    pub(super) steer_buffer: Option<crate::steering::SharedSteerBuffer>,
+    /// Host callback observing each drained steer batch (codex
+    /// `record_user_prompt_and_emit_turn_item` parity): the host persists
+    /// the injected user message + emits its standard persisted
+    /// user-message event. Called inline at the drain point, before the
+    /// next LLM call. When set, drained steer rows stay OUT of the turn
+    /// output log so end-of-turn persistence cannot double-write them.
+    pub(super) steer_drained_callback: Option<crate::steering::SteerDrainedCallback>,
 }
 
 impl Agent {
@@ -534,6 +550,8 @@ impl Agent {
             verifier_config: None,
             voice_failure_sink: None,
             snapshot_manager: None,
+            steer_buffer: None,
+            steer_drained_callback: None,
         }
     }
 
@@ -610,6 +628,8 @@ impl Agent {
             verifier_config: None,
             voice_failure_sink: None,
             snapshot_manager: None,
+            steer_buffer: None,
+            steer_drained_callback: None,
         }
     }
 
@@ -779,6 +799,33 @@ impl Agent {
         tx: tokio::sync::mpsc::UnboundedSender<crate::TurnFailure>,
     ) {
         self.voice_failure_sink = Some(tx);
+    }
+
+    /// Attach the per-turn pending-input buffer for mid-turn prompt
+    /// injection ("steer"). The host keeps a clone and pushes inputs while
+    /// the turn runs; the conversation loop drains FIFO at the top of each
+    /// iteration, before the next LLM call, appending each entry as a plain
+    /// `role: user` message (codex `TurnState.pending_input` parity —
+    /// codex-rs `core/src/session/turn.rs:225-233`). Absent = pre-steer
+    /// behaviour, byte-identical.
+    pub fn with_steer_buffer(mut self, buffer: crate::steering::SharedSteerBuffer) -> Self {
+        self.steer_buffer = Some(buffer);
+        self
+    }
+
+    /// Register the host callback observing each drained steer batch.
+    /// Called inline from the drain point (after the drained texts joined
+    /// the prompt, before the next LLM call) so the host can persist the
+    /// injected user message and emit its standard persisted user-message
+    /// event. When set, the loop keeps drained steer rows OUT of
+    /// `ConversationResponse.messages` — the host owns their persistence,
+    /// and the end-of-turn persist pass must not write them again.
+    pub fn with_steer_drained_callback(
+        mut self,
+        callback: crate::steering::SteerDrainedCallback,
+    ) -> Self {
+        self.steer_drained_callback = Some(callback);
+        self
     }
 
     /// Enable M8.4's [`FileStateCache`] for file tools.

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -166,7 +166,10 @@ pub use skills::{SkillFilter, SkillInfo, SkillsLoader};
 pub use snapshot::{
     DEFAULT_SNAPSHOT_KEEP_LAST, SnapshotConfig, SnapshotId, SnapshotInfo, SnapshotManager,
 };
-pub use steering::{SteeringMessage, SteeringReceiver, SteeringSender};
+pub use steering::{
+    SharedSteerBuffer, SteerBuffer, SteerDrainedCallback, SteeringMessage, SteeringReceiver,
+    SteeringSender,
+};
 pub use subagent_output::{
     AppendResult, DEFAULT_GC_AGE, DEFAULT_MAX_BYTES_PER_TASK, DEFAULT_MAX_BYTES_TOTAL,
     DEFAULT_PREVIEW_BYTES, SubAgentOutputRouter,

--- a/crates/octos-agent/src/steering.rs
+++ b/crates/octos-agent/src/steering.rs
@@ -9,6 +9,66 @@
 use octos_core::Message;
 use tokio::sync::mpsc;
 
+/// Per-turn pending-input buffer for mid-turn prompt injection ("steer").
+///
+/// Codex parity: mirrors `TurnState.pending_input` (`codex-rs
+/// core/src/state/turn.rs` + `input_queue.rs`) — an append-order `Vec`
+/// guarded by a mutex, drained FIFO via `split_off(0)` at the TOP of each
+/// agent-loop iteration, before the next LLM call. Steer inputs land as
+/// plain `role: user` messages with NO wrapper text.
+///
+/// The host (e.g. `octos serve`'s `turn/steer` RPC) holds one end via
+/// [`SharedSteerBuffer`] and pushes under its own active-turn registry
+/// lock; the agent loop holds the other via
+/// [`crate::Agent::with_steer_buffer`]. Steering is NOT an interrupt:
+/// the interrupt channel stays separate (codex `Op::Interrupt` vs
+/// `Op::UserInput`).
+#[derive(Debug, Default)]
+pub struct SteerBuffer {
+    items: std::sync::Mutex<Vec<String>>,
+}
+
+impl SteerBuffer {
+    /// Append one steer input (FIFO position preserved).
+    pub fn push(&self, text: String) {
+        self.items
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .push(text);
+    }
+
+    /// Drain every pending input in arrival order (codex `split_off(0)`).
+    pub fn drain(&self) -> Vec<String> {
+        let mut items = self.items.lock().unwrap_or_else(|error| error.into_inner());
+        items.split_off(0)
+    }
+
+    /// Whether the buffer currently holds no pending input.
+    pub fn is_empty(&self) -> bool {
+        self.items
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .is_empty()
+    }
+}
+
+/// Shared handle to a per-turn [`SteerBuffer`].
+pub type SharedSteerBuffer = std::sync::Arc<SteerBuffer>;
+
+/// Host callback observing each drained steer batch, called INLINE from the
+/// agent loop right after the drained texts are appended to the prompt and
+/// BEFORE the next LLM call. Hosts use it to persist the injected user
+/// message and emit their standard persisted-user-message event (codex
+/// `record_user_prompt_and_emit_turn_item` parity). When a callback is
+/// registered the host owns persistence of steer rows; the loop then keeps
+/// them OUT of the turn output log so end-of-turn persistence cannot write
+/// them a second time.
+pub type SteerDrainedCallback = std::sync::Arc<
+    dyn Fn(Vec<String>) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
+        + Send
+        + Sync,
+>;
+
 /// Sender half — held by callers who want to inject messages.
 pub type SteeringSender = mpsc::Sender<SteeringMessage>;
 
@@ -99,5 +159,26 @@ mod tests {
         tx.send(SteeringMessage::RequestPause).await.unwrap();
         let msg = rx.recv().await.unwrap();
         assert!(matches!(msg, SteeringMessage::RequestPause));
+    }
+
+    #[test]
+    fn should_drain_steer_buffer_fifo_when_pushed_in_order() {
+        let buffer = SteerBuffer::default();
+        assert!(buffer.is_empty());
+        buffer.push("first".to_string());
+        buffer.push("second".to_string());
+        assert!(!buffer.is_empty());
+        assert_eq!(buffer.drain(), vec!["first", "second"]);
+        assert!(buffer.is_empty());
+        assert!(buffer.drain().is_empty());
+    }
+
+    #[test]
+    fn should_keep_later_pushes_when_drained_between() {
+        let buffer = SteerBuffer::default();
+        buffer.push("a".to_string());
+        assert_eq!(buffer.drain(), vec!["a"]);
+        buffer.push("b".to_string());
+        assert_eq!(buffer.drain(), vec!["b"]);
     }
 }

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -228,6 +228,19 @@ const APPUI_METHOD_PEER_PREPARE: &str = "peer/prepare";
 /// session. Read-only; results survive client crashes/reconnects because
 /// they are files, not connection state.
 const APPUI_METHOD_PEER_GATHER: &str = "peer/gather";
+/// `turn/steer` — mid-turn prompt injection into the ACTIVE turn (codex
+/// parity: app-server `turn/steer` → `Session::steer_input`). Params
+/// `{session_id, expected_turn_id?, input}`; result `{turn_id, steered}`.
+/// With a live turn, the input is pushed into that turn's pending-input
+/// buffer under the active-turns registry lock and drained by the agent
+/// loop at the next iteration boundary as a plain `role: user` message
+/// (`steered: true` + the ACTIVE turn id). `expected_turn_id` mismatch →
+/// `invalid_params` (codex `ExpectedTurnMismatch`). With NO live turn, the
+/// call falls back to the ordinary `turn/start` admission path and returns
+/// `steered: false` + the NEW turn id (codex `user_input_or_turn_inner`'s
+/// `NoActiveTurn` fallback). Steering is NOT an interrupt — the in-flight
+/// round always completes; `turn/interrupt` stays a separate op.
+const APPUI_METHOD_TURN_STEER: &str = "turn/steer";
 const APPUI_METHOD_PROFILE_SKILLS_LIST: &str = "profile/skills/list";
 const APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH: &str = "profile/skills/registry/search";
 const APPUI_METHOD_PROFILE_SKILLS_INSTALL: &str = "profile/skills/install";
@@ -302,6 +315,7 @@ const APPUI_EXTRA_METHODS: &[&str] = &[
     APPUI_METHOD_SNAPSHOT_RESTORE,
     APPUI_METHOD_PEER_PREPARE,
     APPUI_METHOD_PEER_GATHER,
+    APPUI_METHOD_TURN_STEER,
     APPUI_METHOD_PROFILE_SKILLS_LIST,
     APPUI_METHOD_PROFILE_SKILLS_REGISTRY_SEARCH,
     APPUI_METHOD_PROFILE_SKILLS_INSTALL,
@@ -1132,6 +1146,13 @@ struct ActiveTurn {
     /// Single-shot wake-up so the turn loop can return from `progress_rx.recv`
     /// promptly when an interrupt arrives. `None` once consumed.
     interrupt_tx: Arc<TokioMutex<Option<mpsc::Sender<()>>>>,
+    /// Per-turn pending-input buffer for `turn/steer` (codex
+    /// `TurnState.pending_input` parity). `Some` for regular standalone
+    /// turns — `turn/steer` pushes into it under the registry lock and the
+    /// agent loop drains at the next iteration boundary. `None` for
+    /// non-steerable turns (code review, M9 protocol fixtures), mirroring
+    /// codex's `ActiveTurnNotSteerable` for review/compact turn kinds.
+    steer: Option<octos_agent::SharedSteerBuffer>,
     abort: AbortHandle,
 }
 
@@ -6548,6 +6569,20 @@ struct RawReviewStartParams {
     delivery: Option<String>,
 }
 
+/// `turn/steer` params: `{session_id, expected_turn_id?, input}` —
+/// mirrors codex `TurnSteerParams { thread_id, expected_turn_id, input }`
+/// with octos's optional-precondition twist: an ABSENT `expected_turn_id`
+/// steers whatever turn is live (a mismatch when present is rejected, codex
+/// `ExpectedTurnMismatch`).
+#[derive(Debug, Clone, Deserialize)]
+struct RawTurnSteerParams {
+    session_id: SessionKey,
+    #[serde(default)]
+    expected_turn_id: Option<TurnId>,
+    #[serde(default)]
+    input: Vec<InputItem>,
+}
+
 fn parse_raw_params<T>(request: &RpcRequest<Value>) -> Result<T, RpcError>
 where
     T: serde::de::DeserializeOwned,
@@ -10646,6 +10681,23 @@ async fn handle_raw_appui_rpc(
         return true;
     }
 
+    if request.method == APPUI_METHOD_TURN_STEER {
+        handle_turn_steer(
+            ws,
+            state,
+            ledger,
+            contracts,
+            active_turns,
+            connection_turns,
+            connection_profile_id,
+            features,
+            id,
+            request,
+        )
+        .await;
+        return true;
+    }
+
     let result = match request.method.as_str() {
         method if is_autonomy_method(method) => {
             raw_autonomy_rpc(request, features, connection_profile_id)
@@ -11079,7 +11131,10 @@ fn string_session_with_optional_topic(session_id: &str, topic: Option<&str>) -> 
 /// adding it here without a matching arm panics the `unreachable!`. Both point
 /// back to this one function.
 fn raw_method_is_dispatched(method: &str, stdio_transport: bool) -> bool {
-    if method == APPUI_METHOD_REVIEW_START || is_autonomy_method(method) {
+    if method == APPUI_METHOD_REVIEW_START
+        || method == APPUI_METHOD_TURN_STEER
+        || is_autonomy_method(method)
+    {
         return true;
     }
     if matches!(
@@ -13631,6 +13686,9 @@ async fn handle_review_start(
                     profile_id: profile_for_stamp.clone(),
                     state: turn_state,
                     interrupt_tx,
+                    // Review turns are non-steerable (codex
+                    // `ActiveTurnNotSteerable` for the Review turn kind).
+                    steer: None,
                     abort: handle.abort_handle(),
                 },
             );
@@ -13682,7 +13740,48 @@ async fn handle_turn_start(
     routed_profile_id: Option<&str>,
     features: ConnectionUiFeatures,
     id: String,
+    params: TurnStartParams,
+) {
+    handle_turn_start_with_accept(
+        ws,
+        state,
+        ledger,
+        contracts,
+        active_turns,
+        connection_turns,
+        connection_profile_id,
+        routed_profile_id,
+        features,
+        id,
+        params,
+        json!({ "accepted": true }),
+    )
+    .await;
+}
+
+/// `handle_turn_start` body with a caller-chosen accept payload.
+///
+/// The lifecycle (admission → registry insert → accept reply → `start_tx`)
+/// is shared verbatim between `turn/start` (accept = `{"accepted": true}`)
+/// and the `turn/steer` no-active-turn fallback (accept =
+/// `{"turn_id": ..., "steered": false}`) — codex parity: `Op::UserInput`
+/// falls back from `steer_input` to `spawn_task(RegularTask)` through the
+/// SAME submission path (`handlers.rs:220-266`); only the RPC result shape
+/// differs on the app-server surface.
+#[allow(clippy::too_many_arguments)]
+async fn handle_turn_start_with_accept(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    ledger: &Arc<UiProtocolLedger>,
+    contracts: &Arc<UiProtocolContractStores>,
+    active_turns: &SharedActiveTurns,
+    connection_turns: &SharedConnectionTurns,
+    connection_profile_id: Option<&str>,
+    routed_profile_id: Option<&str>,
+    features: ConnectionUiFeatures,
+    id: String,
     mut params: TurnStartParams,
+    accept_result: Value,
 ) {
     // UPCR-2026-015 (M9-β-1): if the client carried a `topic` field
     // alongside the session_id, fold it into the resolved SessionKey
@@ -13791,6 +13890,14 @@ async fn handle_turn_start(
     let interrupt_tx = Arc::new(TokioMutex::new(Some(interrupt_tx)));
     let turn_state_for_task = turn_state.clone();
     let (start_tx, start_rx) = tokio::sync::oneshot::channel();
+    // `turn/steer` pending-input buffer (codex `TurnState.pending_input`).
+    // Regular standalone turns are steerable; M9 protocol fixture turns are
+    // not (they never run the agent loop, so a pushed input would silently
+    // vanish — advertise that by registering no buffer).
+    let steer_buffer: Option<octos_agent::SharedSteerBuffer> = fixture
+        .is_none()
+        .then(|| Arc::new(octos_agent::SteerBuffer::default()));
+    let steer_buffer_for_turn = steer_buffer.clone();
     let resolved_profile_id = connection_profile_id
         .or(routed_profile_id)
         .map(ToOwned::to_owned);
@@ -13864,6 +13971,7 @@ async fn handle_turn_start(
                 resolved_profile_id,
                 turn_state_for_task,
                 interrupt_rx,
+                steer_buffer_for_turn,
                 false,
                 None,
                 // #1133 — regular `turn/start` path is user-initiated;
@@ -13904,6 +14012,7 @@ async fn handle_turn_start(
                     profile_id: profile_for_stamp.clone(),
                     state: turn_state.clone(),
                     interrupt_tx,
+                    steer: steer_buffer,
                     abort: handle.abort_handle(),
                 },
             );
@@ -13926,11 +14035,176 @@ async fn handle_turn_start(
         .insert(session_id, turn_id.clone());
     // Lifecycle reply: if the client cannot receive the accept, abort the
     // freshly-inserted turn — running an unaccepted turn would be a leak.
-    if send_rpc_result(ws, id, json!({ "accepted": true })).is_err() {
+    if send_rpc_result(ws, id, accept_result).is_err() {
         handle.abort();
         return;
     }
     let _ = start_tx.send(());
+}
+
+/// Outcome of the `turn/steer` registry decision (computed under the
+/// active-turns registry lock — see [`handle_turn_steer`]).
+enum TurnSteerDecision {
+    /// Input pushed into the ACTIVE turn's pending buffer.
+    Steered(TurnId),
+    /// `expected_turn_id` was present and does not name the active turn
+    /// (codex `ExpectedTurnMismatch`). Carries the actual active id for the
+    /// error message.
+    Mismatch(TurnId),
+    /// A live turn exists but registered no steer buffer (code review / M9
+    /// fixture turns) — codex `ActiveTurnNotSteerable`.
+    NotSteerable,
+    /// No live turn — fall back to the ordinary `turn/start` path (codex
+    /// `NoActiveTurn` → `spawn_task(RegularTask)`).
+    NoActiveTurn,
+}
+
+/// `turn/steer` — mid-turn prompt injection into the active turn (see the
+/// [`APPUI_METHOD_TURN_STEER`] doc for the full contract).
+///
+/// The steer-vs-fallback decision and the buffer push happen atomically
+/// under the active-turns registry lock, closing the turn-end race the
+/// codex report calls out (§5): natural completion flips the per-turn
+/// state to `Terminal` before the registry entry is considered dead, and a
+/// non-terminal entry's buffer is still drained by the live loop (an
+/// EndTurn with a pending steer runs another round instead of returning).
+/// Steering never touches the interrupt channel.
+#[allow(clippy::too_many_arguments)]
+async fn handle_turn_steer(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    ledger: &Arc<UiProtocolLedger>,
+    contracts: &Arc<UiProtocolContractStores>,
+    active_turns: &SharedActiveTurns,
+    connection_turns: &SharedConnectionTurns,
+    connection_profile_id: Option<&str>,
+    features: ConnectionUiFeatures,
+    id: String,
+    request: &RpcRequest<Value>,
+) {
+    let params: RawTurnSteerParams = match parse_raw_params(request) {
+        Ok(params) => params,
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+            return;
+        }
+    };
+    if let Err(error) = validate_session_scope(&params.session_id, None, connection_profile_id) {
+        send_scope_error(ws, id, error);
+        return;
+    }
+    let Some(prompt) = prompt_text(&params.input) else {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            RpcError::invalid_params("turn/steer requires at least one text input item"),
+        );
+        return;
+    };
+
+    let decision = {
+        let active = active_turns.lock().await;
+        match active.get(&params.session_id) {
+            Some(existing) => {
+                // A `Terminal` entry is a finished turn kept only so late
+                // `turn/interrupt`s see `terminal_state` — for steering it
+                // counts as "no active turn" (same predicate `turn/start`'s
+                // admission uses for `occupied`). `Interrupting` still
+                // counts as live: the client asked to stop, and a raced
+                // steer behaves like the codex loop-exit race (buffered,
+                // possibly dropped at turn end — logged, never mis-routed).
+                let terminal = matches!(*existing.state.lock().await, TurnState::Terminal(_));
+                if terminal {
+                    TurnSteerDecision::NoActiveTurn
+                } else if params
+                    .expected_turn_id
+                    .as_ref()
+                    .is_some_and(|expected| *expected != existing.turn_id)
+                {
+                    TurnSteerDecision::Mismatch(existing.turn_id.clone())
+                } else {
+                    match existing.steer.as_ref() {
+                        Some(buffer) => {
+                            // Push while still holding the registry lock so
+                            // the accept below can never name a turn that a
+                            // concurrent admission already replaced.
+                            buffer.push(prompt.clone());
+                            TurnSteerDecision::Steered(existing.turn_id.clone())
+                        }
+                        None => TurnSteerDecision::NotSteerable,
+                    }
+                }
+            }
+            None => TurnSteerDecision::NoActiveTurn,
+        }
+    };
+
+    match decision {
+        TurnSteerDecision::Steered(turn_id) => {
+            info!(
+                session = %params.session_id.0,
+                turn = %turn_id.0,
+                "turn/steer accepted into the active turn's pending-input buffer"
+            );
+            let _ = send_rpc_result(ws, id, json!({ "turn_id": turn_id, "steered": true }));
+        }
+        TurnSteerDecision::Mismatch(active_turn_id) => {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::invalid_params(format!(
+                    "expected_turn_id does not match the active turn ({})",
+                    active_turn_id.0
+                )),
+            );
+        }
+        TurnSteerDecision::NotSteerable => {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::invalid_request("the active turn does not accept steering"),
+            );
+        }
+        TurnSteerDecision::NoActiveTurn => {
+            // Codex fallback (`handlers.rs:233-265`): no active turn — the
+            // input is NOT dropped; it starts an ordinary turn through the
+            // full `turn/start` admission path (scope re-validation,
+            // runtime gate, occupied-race rejection, registry insert). The
+            // accept payload is the steer shape: the NEW server-minted id
+            // plus `steered: false`. A concurrent admission winning the
+            // race surfaces the standard "a turn is already running"
+            // rejection — the caller retries as a steer.
+            let new_turn_id = TurnId::new();
+            let start_params = TurnStartParams {
+                session_id: params.session_id,
+                turn_id: new_turn_id.clone(),
+                input: params.input,
+                media: Vec::new(),
+                topic: None,
+                rewrite_for: None,
+                reasoning_effort: None,
+                live_video: false,
+            };
+            handle_turn_start_with_accept(
+                ws,
+                state,
+                ledger,
+                contracts,
+                active_turns,
+                connection_turns,
+                connection_profile_id,
+                // Raw surface carries no routed profile; the session key /
+                // connection scope dominate resolution (same stance as
+                // `review/start` on this surface).
+                None,
+                features,
+                id,
+                start_params,
+                json!({ "turn_id": new_turn_id, "steered": false }),
+            )
+            .await;
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -14010,6 +14284,11 @@ async fn maybe_spawn_appui_master_continuation_runner(
     let interrupt_tx = Arc::new(TokioMutex::new(Some(interrupt_tx)));
     let turn_state_for_task = turn_state.clone();
     let (start_tx, start_rx) = tokio::sync::oneshot::channel();
+    // Continuation turns run the ordinary agent loop, so they are steerable
+    // like any regular turn (codex steers every RegularTask).
+    let steer_buffer: octos_agent::SharedSteerBuffer =
+        Arc::new(octos_agent::SteerBuffer::default());
+    let steer_buffer_for_turn = steer_buffer.clone();
 
     let ws_for_turn = ws.clone();
     let state_for_turn = state.clone();
@@ -14120,6 +14399,7 @@ async fn maybe_spawn_appui_master_continuation_runner(
             routed_profile_id,
             turn_state_for_task,
             interrupt_rx,
+            Some(steer_buffer_for_turn),
             true,
             loop_id_for_self_paced,
             goal_context_for_appui,
@@ -14143,6 +14423,7 @@ async fn maybe_spawn_appui_master_continuation_runner(
             profile_id: profile_id.clone(),
             state: turn_state,
             interrupt_tx,
+            steer: Some(steer_buffer),
             abort: handle.abort_handle(),
         },
     );
@@ -22238,6 +22519,15 @@ async fn run_standalone_turn(
     routed_profile_id: Option<String>,
     turn_state: Arc<TokioMutex<TurnState>>,
     mut interrupt_rx: mpsc::Receiver<()>,
+    // `turn/steer` pending-input buffer for THIS turn (codex
+    // `TurnState.pending_input`). The RPC pushes into it under the
+    // active-turns registry lock; here it is threaded onto the per-turn
+    // agent, whose loop drains it at each iteration boundary. The drained
+    // callback registered below persists each steer row through the
+    // canonical session path (same commit-observer emit the `turn/start`
+    // prompt row gets) the moment it is folded into the conversation.
+    // `None` for non-steerable turns.
+    steer_buffer: Option<octos_agent::SharedSteerBuffer>,
     internal_master_continuation: bool,
     // #1128 codex P1 re-review #2 — when this turn is draining a
     // self-paced or maintenance LoopFire continuation, pass the loop
@@ -23776,6 +24066,69 @@ async fn run_standalone_turn(
     // when `appui.sessions_in_cwd` is on) so the snapshot the NEXT turn's
     // `appui_context_history_for_agent` loads is the same project's (#1666).
     let context_data_dir_for_result = session_runtime.sessions_root.clone();
+    // `turn/steer` wiring: hand the per-turn pending-input buffer to the
+    // agent loop and register the drained-callback that makes an injected
+    // steer land EXACTLY like the `turn/start` prompt row does — persisted
+    // through the canonical session path (whose `MessageCommitObserver`
+    // emits the standard v2 `UserMessage` envelope, so clients see the
+    // steer fold in the moment it is drained), the SessionManager cache
+    // invalidated, and the row recorded into the context ledger so the
+    // NEXT turn's rebuilt LLM context keeps it. Because the host persists
+    // at drain time, the agent loop keeps steer rows OUT of
+    // `response.messages` — the end-of-turn persist loop below therefore
+    // never double-writes them.
+    if let Some(buffer) = steer_buffer.clone() {
+        let steer_sessions = sessions.clone();
+        let steer_data_dir = sessions.lock().await.data_dir();
+        let steer_session_id = session_id.clone();
+        let steer_thread_id = turn_thread_id_for_persist.clone();
+        let steer_context_dir = context_data_dir_for_result.clone();
+        let steer_context_manager = context_manager.clone();
+        let drained_callback: octos_agent::SteerDrainedCallback = Arc::new(move |texts| {
+            let sessions = steer_sessions.clone();
+            let data_dir = steer_data_dir.clone();
+            let session_id = steer_session_id.clone();
+            let thread_id = steer_thread_id.clone();
+            let context_dir = steer_context_dir.clone();
+            let context_manager = steer_context_manager.clone();
+            Box::pin(async move {
+                for text in texts {
+                    let message = pre_stamp_turn_thread_id(Message::user(text), &thread_id);
+                    match octos_bus::session::persist_message_through_canonical_path(
+                        &data_dir,
+                        &session_id,
+                        message.clone(),
+                    )
+                    .await
+                    {
+                        Ok(seq) => {
+                            sessions.lock().await.invalidate_cache(&session_id);
+                            record_appui_context_manager_message(
+                                &context_dir,
+                                &context_manager,
+                                &session_id,
+                                &message,
+                                seq,
+                            );
+                        }
+                        Err(error) => {
+                            warn!(
+                                session = %session_id.0,
+                                turn = %thread_id,
+                                error = %error,
+                                "failed to persist drained turn/steer input; the model \
+                                 still sees it this turn but it will be missing from \
+                                 durable history"
+                            );
+                        }
+                    }
+                }
+            })
+        });
+        request_agent = request_agent
+            .with_steer_buffer(buffer)
+            .with_steer_drained_callback(drained_callback);
+    }
     let usage_ledger_for_result = usage_ledger.clone();
     let usage_profile_id_for_result = usage_profile_id.clone();
     let usage_session_id_for_result = session_id.to_string();
@@ -25315,6 +25668,25 @@ async fn run_standalone_turn(
     }
 
     let _ = agent_task.await;
+
+    // `turn/steer` turn-end race residual (codex §5 parity): the loop keeps
+    // the turn alive for steers that land BEFORE its final EndTurn check,
+    // but a steer accepted in the narrow window between that check and this
+    // point never drains. Make the drop observable rather than silent — the
+    // registry entry is still keyed to this turn, so no later turn can
+    // consume the leftovers.
+    if let Some(buffer) = steer_buffer.as_ref() {
+        let leftovers = buffer.drain();
+        if !leftovers.is_empty() {
+            warn!(
+                session = %session_id.0,
+                turn = %turn_id.0,
+                dropped = leftovers.len(),
+                "turn/steer input(s) arrived as the turn ended and were dropped; \
+                 the client should re-send (a fresh call now falls back to a new turn)"
+            );
+        }
+    }
 
     // NEW-16 codex round-3 P1+P2: GC moved from here to the
     // TTL-based opportunistic pruner inside the persist block.

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -1763,6 +1763,10 @@ fn dispatch_probe_request(method: &str) -> RpcRequest<Value> {
             "session_id": session_id,
         }),
         APPUI_METHOD_PEER_GATHER => json!({ "session_id": session_id }),
+        APPUI_METHOD_TURN_STEER => json!({
+            "session_id": session_id,
+            "input": [{ "kind": "text", "text": "steer probe" }],
+        }),
         other => panic!("missing AppUI dispatch probe params for {other}"),
     };
 
@@ -2033,6 +2037,7 @@ async fn stdio_shutdown_drain_waits_for_turn_finalization() {
             turn_id: turn_id.clone(),
             state: Arc::new(TokioMutex::new(TurnState::Active)),
             interrupt_tx: Arc::new(TokioMutex::new(None)),
+            steer: None,
             abort,
         },
     );
@@ -2074,6 +2079,7 @@ async fn stdio_shutdown_drain_gives_up_at_deadline_and_ignores_foreign_turns() {
             turn_id: TurnId::new(),
             state: Arc::new(TokioMutex::new(TurnState::Active)),
             interrupt_tx: Arc::new(TokioMutex::new(None)),
+            steer: None,
             abort: foreign_abort,
         },
     );
@@ -2097,6 +2103,7 @@ async fn stdio_shutdown_drain_gives_up_at_deadline_and_ignores_foreign_turns() {
             turn_id: turn_id.clone(),
             state: Arc::new(TokioMutex::new(TurnState::Active)),
             interrupt_tx: Arc::new(TokioMutex::new(None)),
+            steer: None,
             abort,
         },
     );
@@ -9777,6 +9784,7 @@ fn test_active_turn(turn_id: TurnId, abort: AbortHandle) -> ActiveTurn {
         profile_id: MAIN_PROFILE_ID.to_owned(),
         state: Arc::new(TokioMutex::new(TurnState::Active)),
         interrupt_tx: Arc::new(TokioMutex::new(Some(tx))),
+        steer: None,
         abort,
     }
 }
@@ -12716,6 +12724,7 @@ async fn session_btw_reads_draft_only_for_a_non_terminal_turn() {
                 TerminalReason::Completed,
             ))),
             interrupt_tx: Arc::new(TokioMutex::new(None)),
+            steer: None,
             abort,
         },
     );
@@ -12748,6 +12757,7 @@ async fn session_btw_reads_draft_only_for_a_non_terminal_turn() {
             turn_id: turn_id.clone(),
             state: Arc::new(TokioMutex::new(TurnState::Active)),
             interrupt_tx: Arc::new(TokioMutex::new(None)),
+            steer: None,
             abort,
         },
     );
@@ -12782,6 +12792,7 @@ async fn session_btw_reads_draft_only_for_a_non_terminal_turn() {
             turn_id: turn_id.clone(),
             state: Arc::new(TokioMutex::new(TurnState::Active)),
             interrupt_tx: Arc::new(TokioMutex::new(None)),
+            steer: None,
             abort,
         },
     );
@@ -16918,6 +16929,7 @@ async fn session_rollback_rejects_when_turn_in_progress() {
                 profile_id: MAIN_PROFILE_ID.to_owned(),
                 state: Arc::new(TokioMutex::new(TurnState::Active)),
                 interrupt_tx: Arc::new(TokioMutex::new(Some(interrupt_tx))),
+                steer: None,
                 abort: dummy_handle.abort_handle(),
             },
         );
@@ -17700,6 +17712,7 @@ async fn turn_state_get_returns_active_for_in_flight() {
                 profile_id: MAIN_PROFILE_ID.to_owned(),
                 state: Arc::new(TokioMutex::new(TurnState::Active)),
                 interrupt_tx: Arc::new(TokioMutex::new(Some(interrupt_tx))),
+                steer: None,
                 abort: dummy_handle.abort_handle(),
             },
         );
@@ -24898,4 +24911,643 @@ async fn peer_fleet_result_writer_and_gather_roundtrip() {
     let rows = filtered["peers"].as_array().unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0]["slug"], "lens-review-3");
+}
+
+// --- turn/steer: mid-turn prompt injection (codex parity) ---
+
+fn steer_request(id: &str, params: Value) -> RpcRequest<Value> {
+    RpcRequest::new(id.to_string(), APPUI_METHOD_TURN_STEER, params)
+}
+
+/// Await the RPC response frame carrying `id`, skipping interleaved
+/// notification frames (turn/started, projection envelopes, ...).
+async fn recv_rpc_response_with_id(
+    rx: &mut mpsc::Receiver<axum::extract::ws::Message>,
+    id: &str,
+) -> Value {
+    for _ in 0..256 {
+        let frame = recv_rpc_json(rx).await;
+        if frame.get("id").and_then(Value::as_str) == Some(id) {
+            return frame;
+        }
+    }
+    panic!("no rpc response with id {id} within 256 frames");
+}
+
+/// Synthetic non-terminal registry entry, exactly as `handle_turn_start`
+/// inserts it — with a live steer buffer unless `steerable` is false.
+fn synthetic_active_turn(
+    turn_id: &TurnId,
+    steerable: bool,
+) -> (ActiveTurn, Option<octos_agent::SharedSteerBuffer>) {
+    // The receiver drops here — nothing interrupts these synthetic turns.
+    let (interrupt_tx, _interrupt_rx) = mpsc::channel::<()>(1);
+    let buffer: Option<octos_agent::SharedSteerBuffer> =
+        steerable.then(|| Arc::new(octos_agent::SteerBuffer::default()));
+    let dummy_handle = tokio::spawn(async {});
+    (
+        ActiveTurn {
+            turn_id: turn_id.clone(),
+            profile_id: MAIN_PROFILE_ID.to_owned(),
+            state: Arc::new(TokioMutex::new(TurnState::Active)),
+            interrupt_tx: Arc::new(TokioMutex::new(Some(interrupt_tx))),
+            steer: buffer.clone(),
+            abort: dummy_handle.abort_handle(),
+        },
+        buffer,
+    )
+}
+
+/// Active turn present → the input lands in ITS pending buffer and the
+/// result names the ACTIVE turn id with `steered: true`.
+#[tokio::test(flavor = "current_thread")]
+async fn turn_steer_pushes_into_active_turn_buffer_and_returns_active_id() {
+    let session_id = SessionKey("local:steer-active".into());
+    let active_turn_id = TurnId::new();
+    let active_turns: SharedActiveTurns = Arc::new(TokioMutex::new(HashMap::new()));
+    let (entry, buffer) = synthetic_active_turn(&active_turn_id, true);
+    active_turns.lock().await.insert(session_id.clone(), entry);
+    let buffer = buffer.expect("steerable entry");
+
+    let state = Arc::new(AppState::empty_for_tests());
+    let ledger = Arc::new(UiProtocolLedger::new(32));
+    let contracts = Arc::new(UiProtocolContractStores::default());
+    let connection_turns: SharedConnectionTurns = Arc::new(TokioMutex::new(HashMap::new()));
+    let (ws, mut rx) = ws_connection_for_test(32);
+
+    handle_turn_steer(
+        &ws,
+        &state,
+        &ledger,
+        &contracts,
+        &active_turns,
+        &connection_turns,
+        None,
+        ConnectionUiFeatures::stdio_defaults(),
+        "steer-1".into(),
+        &steer_request(
+            "steer-1",
+            json!({
+                "session_id": session_id,
+                "expected_turn_id": active_turn_id,
+                "input": [{ "kind": "text", "text": "also update the docs" }],
+            }),
+        ),
+    )
+    .await;
+
+    let frame = recv_rpc_json(&mut rx).await;
+    assert_eq!(frame["result"]["steered"], true, "frame: {frame}");
+    assert_eq!(
+        frame["result"]["turn_id"],
+        serde_json::to_value(&active_turn_id).unwrap(),
+        "steer must return the ACTIVE turn id"
+    );
+    assert_eq!(buffer.drain(), vec!["also update the docs".to_string()]);
+}
+
+/// Rapid steers into the same live turn accumulate FIFO in the buffer.
+#[tokio::test(flavor = "current_thread")]
+async fn turn_steer_rapid_calls_accumulate_fifo() {
+    let session_id = SessionKey("local:steer-fifo".into());
+    let active_turn_id = TurnId::new();
+    let active_turns: SharedActiveTurns = Arc::new(TokioMutex::new(HashMap::new()));
+    let (entry, buffer) = synthetic_active_turn(&active_turn_id, true);
+    active_turns.lock().await.insert(session_id.clone(), entry);
+    let buffer = buffer.expect("steerable entry");
+
+    let state = Arc::new(AppState::empty_for_tests());
+    let ledger = Arc::new(UiProtocolLedger::new(32));
+    let contracts = Arc::new(UiProtocolContractStores::default());
+    let connection_turns: SharedConnectionTurns = Arc::new(TokioMutex::new(HashMap::new()));
+    let (ws, mut rx) = ws_connection_for_test(32);
+
+    for (id, text) in [("s-1", "first"), ("s-2", "second"), ("s-3", "third")] {
+        handle_turn_steer(
+            &ws,
+            &state,
+            &ledger,
+            &contracts,
+            &active_turns,
+            &connection_turns,
+            None,
+            ConnectionUiFeatures::stdio_defaults(),
+            id.into(),
+            &steer_request(
+                id,
+                json!({
+                    "session_id": session_id,
+                    "input": [{ "kind": "text", "text": text }],
+                }),
+            ),
+        )
+        .await;
+        let frame = recv_rpc_json(&mut rx).await;
+        assert_eq!(frame["result"]["steered"], true, "frame: {frame}");
+    }
+    assert_eq!(
+        buffer.drain(),
+        vec![
+            "first".to_string(),
+            "second".to_string(),
+            "third".to_string()
+        ],
+        "steers must accumulate in arrival order"
+    );
+}
+
+/// `expected_turn_id` naming a different turn → `invalid_params`, and the
+/// input must NOT land in the buffer (codex `ExpectedTurnMismatch`).
+#[tokio::test(flavor = "current_thread")]
+async fn turn_steer_expected_turn_id_mismatch_returns_invalid_params() {
+    let session_id = SessionKey("local:steer-mismatch".into());
+    let active_turn_id = TurnId::new();
+    let active_turns: SharedActiveTurns = Arc::new(TokioMutex::new(HashMap::new()));
+    let (entry, buffer) = synthetic_active_turn(&active_turn_id, true);
+    active_turns.lock().await.insert(session_id.clone(), entry);
+    let buffer = buffer.expect("steerable entry");
+
+    let state = Arc::new(AppState::empty_for_tests());
+    let ledger = Arc::new(UiProtocolLedger::new(32));
+    let contracts = Arc::new(UiProtocolContractStores::default());
+    let connection_turns: SharedConnectionTurns = Arc::new(TokioMutex::new(HashMap::new()));
+    let (ws, mut rx) = ws_connection_for_test(32);
+
+    handle_turn_steer(
+        &ws,
+        &state,
+        &ledger,
+        &contracts,
+        &active_turns,
+        &connection_turns,
+        None,
+        ConnectionUiFeatures::stdio_defaults(),
+        "steer-mismatch".into(),
+        &steer_request(
+            "steer-mismatch",
+            json!({
+                "session_id": session_id,
+                "expected_turn_id": TurnId::new(),
+                "input": [{ "kind": "text", "text": "wrong turn" }],
+            }),
+        ),
+    )
+    .await;
+
+    let frame = recv_rpc_json(&mut rx).await;
+    let error = frame.get("error").expect("mismatch must error");
+    assert_eq!(
+        error["code"],
+        rpc_error_codes::INVALID_PARAMS,
+        "frame: {frame}"
+    );
+    assert!(
+        error["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("expected_turn_id"),
+        "frame: {frame}"
+    );
+    assert!(buffer.is_empty(), "mismatched steer must not be buffered");
+}
+
+/// A live non-steerable turn (review / M9 fixture — registry entry with no
+/// buffer) is rejected rather than silently swallowed, and does NOT fall
+/// back to a parallel turn (codex `ActiveTurnNotSteerable`).
+#[tokio::test(flavor = "current_thread")]
+async fn turn_steer_rejects_live_non_steerable_turn() {
+    let session_id = SessionKey("local:steer-nonsteerable".into());
+    let active_turn_id = TurnId::new();
+    let active_turns: SharedActiveTurns = Arc::new(TokioMutex::new(HashMap::new()));
+    let (entry, _) = synthetic_active_turn(&active_turn_id, false);
+    active_turns.lock().await.insert(session_id.clone(), entry);
+
+    let state = Arc::new(AppState::empty_for_tests());
+    let ledger = Arc::new(UiProtocolLedger::new(32));
+    let contracts = Arc::new(UiProtocolContractStores::default());
+    let connection_turns: SharedConnectionTurns = Arc::new(TokioMutex::new(HashMap::new()));
+    let (ws, mut rx) = ws_connection_for_test(32);
+
+    handle_turn_steer(
+        &ws,
+        &state,
+        &ledger,
+        &contracts,
+        &active_turns,
+        &connection_turns,
+        None,
+        ConnectionUiFeatures::stdio_defaults(),
+        "steer-ns".into(),
+        &steer_request(
+            "steer-ns",
+            json!({
+                "session_id": session_id,
+                "input": [{ "kind": "text", "text": "steer a review" }],
+            }),
+        ),
+    )
+    .await;
+
+    let frame = recv_rpc_json(&mut rx).await;
+    assert!(frame.get("error").is_some(), "frame: {frame}");
+    assert!(
+        frame["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("does not accept steering"),
+        "frame: {frame}"
+    );
+}
+
+/// Steer without text input → invalid_params (mirrors turn/start's
+/// text-input contract; the fallback path never runs).
+#[tokio::test(flavor = "current_thread")]
+async fn turn_steer_requires_text_input() {
+    let session_id = SessionKey("local:steer-empty".into());
+    let active_turns: SharedActiveTurns = Arc::new(TokioMutex::new(HashMap::new()));
+    let state = Arc::new(AppState::empty_for_tests());
+    let ledger = Arc::new(UiProtocolLedger::new(32));
+    let contracts = Arc::new(UiProtocolContractStores::default());
+    let connection_turns: SharedConnectionTurns = Arc::new(TokioMutex::new(HashMap::new()));
+    let (ws, mut rx) = ws_connection_for_test(32);
+
+    handle_turn_steer(
+        &ws,
+        &state,
+        &ledger,
+        &contracts,
+        &active_turns,
+        &connection_turns,
+        None,
+        ConnectionUiFeatures::stdio_defaults(),
+        "steer-empty".into(),
+        &steer_request(
+            "steer-empty",
+            json!({ "session_id": session_id, "input": [] }),
+        ),
+    )
+    .await;
+
+    let frame = recv_rpc_json(&mut rx).await;
+    assert_eq!(
+        frame["error"]["code"],
+        rpc_error_codes::INVALID_PARAMS,
+        "frame: {frame}"
+    );
+}
+
+/// NO active turn → the call falls back to the ordinary `turn/start`
+/// admission path: a REAL turn starts (LLM runs, registry filled, history
+/// persisted) and the result is `steered: false` + the NEW turn id (codex
+/// `NoActiveTurn` → `spawn_task(RegularTask)`).
+#[tokio::test(flavor = "current_thread")]
+async fn turn_steer_with_no_active_turn_falls_back_to_turn_start() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let provider = Arc::new(AppuiContinuationLlm::new("steer fallback reply"));
+    let (state, profile_runtime) =
+        state_with_profile_llm(temp.path(), MAIN_PROFILE_ID, provider.clone()).await;
+    let session_id = SessionKey::new("api", "steer-fallback");
+    let active_turns: SharedActiveTurns = Arc::new(TokioMutex::new(HashMap::new()));
+    let connection_turns: SharedConnectionTurns = Arc::new(TokioMutex::new(HashMap::new()));
+    let ledger = Arc::new(UiProtocolLedger::new(64));
+    let contracts = Arc::new(UiProtocolContractStores::default());
+    let (ws, mut rx) = ws_connection_for_test(256);
+
+    handle_turn_steer(
+        &ws,
+        &state,
+        &ledger,
+        &contracts,
+        &active_turns,
+        &connection_turns,
+        None,
+        ConnectionUiFeatures::stdio_defaults(),
+        "steer-fb".into(),
+        &steer_request(
+            "steer-fb",
+            json!({
+                "session_id": session_id,
+                "input": [{ "kind": "text", "text": "hello via steer" }],
+            }),
+        ),
+    )
+    .await;
+
+    let frame = recv_rpc_response_with_id(&mut rx, "steer-fb").await;
+    assert_eq!(frame["result"]["steered"], false, "frame: {frame}");
+    let new_turn_id = frame["result"]["turn_id"].clone();
+    assert!(
+        new_turn_id.is_string(),
+        "fallback must mint a turn id: {frame}"
+    );
+
+    // The fallback went through the REAL admission: the registry holds the
+    // new turn for this session.
+    {
+        let registry = active_turns.lock().await;
+        let entry = registry.get(&session_id).expect("registry entry");
+        assert_eq!(serde_json::to_value(&entry.turn_id).unwrap(), new_turn_id);
+        assert!(
+            entry.steer.is_some(),
+            "fallback turn must itself be steerable"
+        );
+    }
+
+    // ...and the turn actually RUNS: the model is called and the exchange
+    // persists into session history.
+    for _ in 0..100 {
+        if provider.call_count.load(Ordering::Relaxed) > 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        provider.call_count.load(Ordering::Relaxed) > 0,
+        "fallback must start a real turn"
+    );
+    for _ in 0..200 {
+        let messages = cached_session_messages(&state, &profile_runtime, &session_id).await;
+        if messages
+            .iter()
+            .any(|m| m.role == MessageRole::Assistant && m.content.contains("steer fallback reply"))
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let messages = cached_session_messages(&state, &profile_runtime, &session_id).await;
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.role == MessageRole::User && m.content == "hello via steer"),
+        "fallback turn must persist the steer text as the prompt: {messages:?}"
+    );
+}
+
+/// The `turn/start` occupied-session rejection is UNCHANGED by the steer
+/// refactor: admitting a second turn while one runs still fails with the
+/// same error string.
+#[tokio::test(flavor = "current_thread")]
+async fn turn_start_still_rejects_when_turn_already_running() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let provider = Arc::new(AppuiContinuationLlm::new("unused"));
+    let (state, _profile_runtime) =
+        state_with_profile_llm(temp.path(), MAIN_PROFILE_ID, provider).await;
+    let session_id = SessionKey::new("api", "steer-occupied");
+    let active_turns: SharedActiveTurns = Arc::new(TokioMutex::new(HashMap::new()));
+    let (entry, _) = synthetic_active_turn(&TurnId::new(), true);
+    active_turns.lock().await.insert(session_id.clone(), entry);
+    let connection_turns: SharedConnectionTurns = Arc::new(TokioMutex::new(HashMap::new()));
+    let ledger = Arc::new(UiProtocolLedger::new(32));
+    let contracts = Arc::new(UiProtocolContractStores::default());
+    let (ws, mut rx) = ws_connection_for_test(32);
+
+    handle_turn_start(
+        &ws,
+        &state,
+        &ledger,
+        &contracts,
+        &active_turns,
+        &connection_turns,
+        None,
+        None,
+        ConnectionUiFeatures::stdio_defaults(),
+        "start-busy".into(),
+        TurnStartParams {
+            session_id: session_id.clone(),
+            turn_id: TurnId::new(),
+            input: vec![InputItem::Text {
+                text: "second turn".into(),
+            }],
+            media: Vec::new(),
+            topic: None,
+            rewrite_for: None,
+            reasoning_effort: None,
+            live_video: false,
+        },
+    )
+    .await;
+
+    let frame = recv_rpc_response_with_id(&mut rx, "start-busy").await;
+    assert!(
+        frame["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("a turn is already running"),
+        "frame: {frame}"
+    );
+}
+
+/// LLM stub for the end-to-end mid-turn steer test. Call 0 announces it
+/// entered (so the test can steer while the model is "streaming"), waits
+/// for the go-signal, then returns a FINAL answer; the pending steer must
+/// force a second round whose request carries the steer as a plain
+/// `role: user` message after the recorded first answer.
+struct GatedSteerLlm {
+    call_count: std::sync::atomic::AtomicUsize,
+    entered: tokio::sync::Notify,
+    proceed: tokio::sync::Notify,
+    observed: StdMutex<Vec<Vec<(MessageRole, String)>>>,
+}
+
+#[async_trait::async_trait]
+impl octos_llm::LlmProvider for GatedSteerLlm {
+    async fn chat(
+        &self,
+        messages: &[Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &octos_llm::ChatConfig,
+    ) -> eyre::Result<octos_llm::ChatResponse> {
+        self.observed
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(
+                messages
+                    .iter()
+                    .map(|message| (message.role, message.content.clone()))
+                    .collect(),
+            );
+        let call = self.call_count.fetch_add(1, Ordering::SeqCst);
+        let content = if call == 0 {
+            self.entered.notify_one();
+            self.proceed.notified().await;
+            "first answer"
+        } else {
+            "second answer"
+        };
+        Ok(octos_llm::ChatResponse {
+            content: Some(content.to_string()),
+            reasoning_content: None,
+            tool_calls: Vec::new(),
+            stop_reason: octos_llm::StopReason::EndTurn,
+            usage: octos_llm::TokenUsage {
+                input_tokens: 8,
+                output_tokens: 4,
+                ..Default::default()
+            },
+            provider_index: None,
+        })
+    }
+
+    fn model_id(&self) -> &str {
+        "gated-steer-stub"
+    }
+
+    fn provider_name(&self) -> &str {
+        "stub"
+    }
+}
+
+/// End-to-end over the REAL turn runtime: `turn/start` runs a turn; while
+/// the model produces its final answer a `turn/steer` lands in the ACTIVE
+/// turn; the loop runs ONE more round whose LLM request carries the steer
+/// (drained before the call, plain user role, after the recorded first
+/// answer), and the steer row persists into durable history exactly once,
+/// stamped with the turn's thread id.
+#[tokio::test(flavor = "current_thread")]
+async fn turn_steer_end_to_end_injects_before_next_llm_call_and_persists_once() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let provider = Arc::new(GatedSteerLlm {
+        call_count: std::sync::atomic::AtomicUsize::new(0),
+        entered: tokio::sync::Notify::new(),
+        proceed: tokio::sync::Notify::new(),
+        observed: StdMutex::new(Vec::new()),
+    });
+    let (state, profile_runtime) =
+        state_with_profile_llm(temp.path(), MAIN_PROFILE_ID, provider.clone()).await;
+    let session_id = SessionKey::new("api", "steer-e2e");
+    let turn_id = TurnId::new();
+    let active_turns: SharedActiveTurns = Arc::new(TokioMutex::new(HashMap::new()));
+    let connection_turns: SharedConnectionTurns = Arc::new(TokioMutex::new(HashMap::new()));
+    let ledger = Arc::new(UiProtocolLedger::new(256));
+    let contracts = Arc::new(UiProtocolContractStores::default());
+    let (ws, mut rx) = ws_connection_for_test(256);
+
+    handle_turn_start(
+        &ws,
+        &state,
+        &ledger,
+        &contracts,
+        &active_turns,
+        &connection_turns,
+        None,
+        None,
+        ConnectionUiFeatures::stdio_defaults(),
+        "start-e2e".into(),
+        TurnStartParams {
+            session_id: session_id.clone(),
+            turn_id: turn_id.clone(),
+            input: vec![InputItem::Text {
+                text: "write the summary".into(),
+            }],
+            media: Vec::new(),
+            topic: None,
+            rewrite_for: None,
+            reasoning_effort: None,
+            live_video: false,
+        },
+    )
+    .await;
+    let accept = recv_rpc_response_with_id(&mut rx, "start-e2e").await;
+    assert_eq!(accept["result"]["accepted"], true, "frame: {accept}");
+
+    // Wait until the model is mid-call, then steer the ACTIVE turn.
+    provider.entered.notified().await;
+    handle_turn_steer(
+        &ws,
+        &state,
+        &ledger,
+        &contracts,
+        &active_turns,
+        &connection_turns,
+        None,
+        ConnectionUiFeatures::stdio_defaults(),
+        "steer-e2e".into(),
+        &steer_request(
+            "steer-e2e",
+            json!({
+                "session_id": session_id,
+                "expected_turn_id": turn_id,
+                "input": [{ "kind": "text", "text": "also cover the risks" }],
+            }),
+        ),
+    )
+    .await;
+    let steered = recv_rpc_response_with_id(&mut rx, "steer-e2e").await;
+    assert_eq!(steered["result"]["steered"], true, "frame: {steered}");
+    assert_eq!(
+        steered["result"]["turn_id"],
+        serde_json::to_value(&turn_id).unwrap(),
+        "steer must land in the ACTIVE turn"
+    );
+
+    // Release the model; the pending steer must force a second round.
+    provider.proceed.notify_one();
+    for _ in 0..300 {
+        let terminal = {
+            let registry = active_turns.lock().await;
+            match registry.get(&session_id) {
+                Some(entry) => matches!(*entry.state.lock().await, TurnState::Terminal(_)),
+                None => false,
+            }
+        };
+        if terminal {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(
+        provider.call_count.load(Ordering::SeqCst),
+        2,
+        "steer after the final answer must force exactly one more round"
+    );
+
+    // The second request carries: recorded first answer, then the steer as
+    // a plain role:user message with NO wrapper text.
+    {
+        let observed = provider
+            .observed
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(observed.len(), 2);
+        let follow_up = &observed[1];
+        let assistant_idx = follow_up
+            .iter()
+            .position(|(role, content)| {
+                *role == MessageRole::Assistant && content == "first answer"
+            })
+            .unwrap_or_else(|| panic!("first answer must be recorded: {follow_up:?}"));
+        let steer_idx = follow_up
+            .iter()
+            .position(|(role, content)| {
+                *role == MessageRole::User && content == "also cover the risks"
+            })
+            .unwrap_or_else(|| panic!("steer must reach the model verbatim: {follow_up:?}"));
+        assert!(steer_idx > assistant_idx, "steer appends after the answer");
+    }
+
+    // Durable history: the steer row persisted EXACTLY ONCE (drain-time
+    // canonical persist owns it; the end-of-turn pass must not double
+    // write), stamped with the turn's thread id.
+    let messages = cached_session_messages(&state, &profile_runtime, &session_id).await;
+    let steer_rows: Vec<&Message> = messages
+        .iter()
+        .filter(|m| m.role == MessageRole::User && m.content == "also cover the risks")
+        .collect();
+    assert_eq!(
+        steer_rows.len(),
+        1,
+        "steer row must persist exactly once: {messages:?}"
+    );
+    assert_eq!(
+        steer_rows[0].thread_id.as_deref(),
+        Some(turn_id.0.to_string()).as_deref(),
+        "steer row must carry the turn's thread id"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.role == MessageRole::Assistant && m.content.contains("second answer")),
+        "the follow-up answer must persist: {messages:?}"
+    );
 }


### PR DESCRIPTION
Implements codex-style mid-turn prompt injection ("steer"): a user message submitted while a turn is running is folded into the SAME turn at the next agent-loop iteration boundary, with no wrapper text and no interruption of the in-flight round. Mirrors the mechanism report's mapping of codex `Session::steer_input` / `TurnState.pending_input` / `run_turn`'s drain onto octos seams.

## Agent loop (octos-agent)

- **`steering.rs`**: `SteerBuffer` — append-order `Mutex<Vec<String>>` drained FIFO via `split_off(0)`; codex `TurnState.pending_input` parity. Plus `SteerDrainedCallback` for host-owned persistence.
- **`loop_runner.rs`**: drains the buffer at the **top of each `'agent_loop` iteration, before the LLM call**, appending each input as a plain `role: user` message (codex `turn.rs:225-233` + `record_user_prompt_and_emit_turn_item` — no wrapper text). The EndTurn arm gains the codex follow-up gate: `needs_follow_up = model_wants_more || buffer_nonempty` — a steer landing after the model's final answer records that answer as a normal assistant row and runs one more round in the same turn (codex `turn.rs:304-318`).
- **Interrupt untouched**: the existing interrupt mpsc stays a fully separate op (codex `Op::Interrupt` vs `Op::UserInput`).
- `Agent::with_steer_buffer` / `with_steer_drained_callback` — absent ⇒ byte-identical pre-steer behaviour.

## Serve RPC (octos-cli, `--features api`)

New raw method **`turn/steer`** — params `{session_id, expected_turn_id?, input: [InputItem]}` → result `{turn_id, steered}`:

- **Active turn** (decided + pushed atomically under the `active_turns` registry lock): input lands in that turn's buffer → `steered: true` + the **active** turn id.
- **`expected_turn_id` mismatch** → `invalid_params` (codex `ExpectedTurnMismatch`).
- **Live non-steerable turn** (review / M9 fixture) → `invalid_request` (codex `ActiveTurnNotSteerable`).
- **No active turn** → falls back through the full `turn/start` admission path (`handle_turn_start_with_accept` refactor — same body, caller-chosen accept payload) → `steered: false` + the **new** turn id (codex `NoActiveTurn` → `spawn_task(RegularTask)`). The `"a turn is already running"` occupied rejection is unchanged.

**Wiring** (`run_standalone_turn`, same seam family as `child_stream_callback`/`peer_handoff`): the per-turn buffer rides the `ActiveTurn` registry entry and the per-turn agent; the registered drained-callback persists each steer row via `persist_message_through_canonical_path` stamped with the turn's thread id — the `MessageCommitObserver` then emits the standard v2 `UserMessage` envelope (the same emit the `turn/start` prompt row gets), the `SessionManager` cache is invalidated, and the row is recorded into the context ledger so the next turn's rebuilt LLM context keeps it. Host-persisted steer rows stay **out** of `ConversationResponse.messages`, so the end-of-turn persist pass cannot double-write them. Steers that land in the narrow window after the loop's final check are drained + warn-logged at turn teardown (report §5 residual race), never mis-routed to a later turn.

**RPC checklist**: const (`APPUI_METHOD_TURN_STEER`), `APPUI_EXTRA_METHODS`, `raw_method_is_dispatched`, dispatch arm in `handle_raw_appui_rpc`, `dispatch_probe_request` params, spec §6 catalog entry in `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md`.

## Tests

Agent-side (`loop_runner_tests.rs` + `steering.rs`):
- steer injected between rounds → the **next** LLM request carries it as its own `role:user` message after the prior round's tool output; never time-travels into the already-built request
- steer after the final answer → exactly one extra round; follow-up request carries the recorded first answer then the steer
- FIFO order for rapid steers
- drained-callback ownership: callback receives the batch; rows stay out of the turn output log (and land in it when no callback is registered)

Serve-side (`ui_protocol_tests.rs`):
- active turn → buffer push, `steered: true` + active id; rapid steers accumulate FIFO
- `expected_turn_id` mismatch → `invalid_params`, nothing buffered
- live non-steerable turn → rejected; missing text input → `invalid_params`
- no active turn → fallback starts a **real** turn (stub LLM runs, registry filled, prompt persisted) returning `steered: false` + new id
- `turn/start` occupied rejection unchanged
- end-to-end over the real turn runtime: `turn/start` → steer while the model is mid-call → second round's request carries the steer verbatim after the recorded first answer → steer row persisted **exactly once**, stamped with the turn's thread id

## Gates

- `cargo test -p octos-agent --lib`: 2433 passed
- `cargo test -p octos-cli --features api --lib`: 2428 passed
- `cargo fmt --all -- --check`: clean
- clippy: warning fingerprints in every touched file byte-identical to origin/main (zero new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)