### PR TITLE
fix(agent): Esc no longer orphans a command's process group

### DIFF
--- a/crates/octos-agent/src/tools/coding_tools.rs
+++ b/crates/octos-agent/src/tools/coding_tools.rs
@@ -375,7 +375,11 @@ impl ExecCommandTool {
         // timeout arm needs it to kill the process tree (dropping the wait
         // future does NOT kill a tokio child).
         let child_pid = child.id();
+        // Armed for the whole wait: a dropped future (user interrupt ->
+        // `agent_task.abort()`) reaches neither arm below. See `ChildGroupGuard`.
+        let mut group_guard = ChildGroupGuard::new(child_pid);
         let result = timeout(Duration::from_secs(timeout_secs), child.wait_with_output()).await;
+        group_guard.disarm();
         match result {
             Ok(Ok(output)) => {
                 let mut text = String::new();
@@ -1797,7 +1801,12 @@ impl Tool for BashTool {
         // SIGTERM -> brief grace -> SIGKILL (Unix) or `taskkill /F /T`
         // (Windows). Mirrors `ShellTool`'s kill-on-timeout path.
         let child_pid = child.id();
-        match timeout(Duration::from_secs(timeout_secs), child.wait_with_output()).await {
+        // Armed for the whole wait: a dropped future (user interrupt ->
+        // `agent_task.abort()`) reaches neither arm below. See `ChildGroupGuard`.
+        let mut group_guard = ChildGroupGuard::new(child_pid);
+        let waited = timeout(Duration::from_secs(timeout_secs), child.wait_with_output()).await;
+        group_guard.disarm();
+        match waited {
             Ok(Ok(output)) => {
                 let mut text = String::new();
                 text.push_str(&String::from_utf8_lossy(&output.stdout));
@@ -1835,6 +1844,67 @@ impl Tool for BashTool {
                     success: false,
                     ..Default::default()
                 })
+            }
+        }
+    }
+}
+
+/// Kills a child's process group if dropped while still armed.
+///
+/// [`kill_timed_out_child`] only runs on the TIMEOUT arm of the `match` below.
+/// When the whole future is dropped instead, neither that arm nor tokio's own
+/// cleanup fires — `tokio::process::Child` does not kill on drop — and the
+/// child's entire process group survives.
+///
+/// That is not a hypothetical path: it is exactly what a user interrupt does.
+/// Esc on the serve path calls `agent_task.abort()`, which drops this future,
+/// so `bash("npm run dev")` kept running after the UI said the turn had
+/// stopped — holding its ports and still able to write to the workspace. The
+/// guard closes that by making cleanup a property of the scope rather than of
+/// one match arm.
+///
+/// Disarm on every path that has already reaped or killed the child.
+struct ChildGroupGuard(Option<u32>);
+
+impl ChildGroupGuard {
+    fn new(child_pid: Option<u32>) -> Self {
+        Self(child_pid)
+    }
+
+    /// The normal paths (clean exit, spawn error, timeout ladder) have already
+    /// dealt with the child; leave it alone.
+    fn disarm(&mut self) {
+        self.0 = None;
+    }
+}
+
+impl Drop for ChildGroupGuard {
+    fn drop(&mut self) {
+        let Some(pid) = self.0 else {
+            return;
+        };
+        // `Drop` cannot await, but the graceful ladder needs a grace period
+        // between SIGTERM and SIGKILL. Hand it to a detached task when a
+        // runtime is still available — cancellation drops this guard while the
+        // runtime is very much alive, so that is the normal case. Only if there
+        // is no runtime (shutdown) fall back to a synchronous hard kill, which
+        // is a better end state than leaking the group.
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                handle.spawn(kill_timed_out_child(Some(pid)));
+            }
+            Err(_) => {
+                #[cfg(unix)]
+                {
+                    signal_process_group(pid, "-9");
+                    signal_process(pid, "-9");
+                }
+                #[cfg(windows)]
+                {
+                    let _ = std::process::Command::new("taskkill")
+                        .args(["/F", "/T", "/PID", &pid.to_string()])
+                        .status();
+                }
             }
         }
     }

--- a/crates/octos-agent/src/tools/coding_tools_tests.rs
+++ b/crates/octos-agent/src/tools/coding_tools_tests.rs
@@ -2485,3 +2485,143 @@ async fn image_generation_rejects_whitespace_only_prompt() {
     assert_eq!(meta["error_kind"], json!("coding_tool_denied"));
     assert_eq!(meta["reason"], json!("missing_prompt"));
 }
+
+// ---------------------------------------------------------------------------
+// Cancellation must not orphan a child's process group.
+//
+// The kill ladder only runs on the TIMEOUT arm. A user interrupt drops the
+// whole future instead (`agent_task.abort()`), and `tokio::process::Child` does
+// not kill on drop — so before `ChildGroupGuard` an Esc'd `bash("npm run dev")`
+// kept running, holding ports and able to write to the workspace.
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+mod cancellation_kills_child_group {
+    use super::*;
+    use std::process::Stdio;
+    use std::time::{Duration, Instant};
+
+    /// Spawn a long-lived child in its OWN process group, exactly as the tools
+    /// do, and hand back its pid.
+    fn spawn_group_leader() -> (tokio::process::Child, u32) {
+        let mut cmd = tokio::process::Command::new("sh");
+        cmd.arg("-c")
+            .arg("sleep 300")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0);
+        let child = cmd.spawn().expect("spawn sleeper");
+        let pid = child.id().expect("child pid");
+        (child, pid)
+    }
+
+    /// `kill -0` the group until it disappears, or give up.
+    ///
+    /// Deliberately `async` with `tokio::time::sleep`: the guard hands its kill
+    /// ladder to a spawned task, and a blocking `std::thread::sleep` here would
+    /// starve the current-thread test runtime so that task never runs — the
+    /// test would fail against a working fix.
+    async fn wait_until_group_gone(pid: u32, within: Duration) -> bool {
+        let deadline = Instant::now() + within;
+        while Instant::now() < deadline {
+            if !process_group_exists(pid) {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        !process_group_exists(pid)
+    }
+
+    #[tokio::test]
+    async fn dropping_an_armed_guard_kills_the_process_group() {
+        let (child, pid) = spawn_group_leader();
+        assert!(process_group_exists(pid), "sleeper should be running");
+
+        {
+            let _guard = ChildGroupGuard::new(Some(pid));
+            drop(child); // tokio does NOT kill on drop — the guard must.
+        }
+
+        assert!(
+            wait_until_group_gone(pid, Duration::from_secs(5)).await,
+            "process group {pid} survived a dropped guard — an interrupted \
+             command would keep running and mutating the workspace"
+        );
+    }
+
+    #[tokio::test]
+    async fn disarmed_guard_leaves_the_process_alone() {
+        // The normal paths reap or kill the child themselves; the guard must
+        // not double-kill, and must not kill a pid that has been recycled.
+        let (mut child, pid) = spawn_group_leader();
+        {
+            let mut guard = ChildGroupGuard::new(Some(pid));
+            guard.disarm();
+        }
+        // Still alive after the disarmed guard dropped.
+        assert!(
+            process_group_exists(pid),
+            "a disarmed guard must not kill the child"
+        );
+        let _ = child.kill().await;
+        let _ = child.wait().await;
+        let _ = signal_process_group(pid, "-9");
+    }
+
+    /// End-to-end: abort the tool future the way the serve path does on Esc,
+    /// and assert the command it launched is actually gone.
+    ///
+    /// The command reports its OWN pid through a file rather than being found
+    /// by name: `sh -c "sleep 300 # marker"` **execs** `sleep`, so a marker in
+    /// the command string never reaches any argv and `pgrep -f` cannot see it.
+    /// Because two commands are chained here the shell does not exec, so `$$`
+    /// is the surviving shell — which is also the process-group leader, exactly
+    /// what the guard must kill.
+    #[tokio::test]
+    async fn aborting_the_bash_tool_kills_the_command_it_launched() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pidfile = dir.path().join("probe.pid");
+        // AllowAll: `ApprovalPolicy::Never` FAILS any command the policy would
+        // ask about, which would stop the probe before it ever ran.
+        let tool = BashTool::new(dir.path(), Arc::new(crate::sandbox::NoSandbox))
+            .with_policy(Arc::new(crate::policy::AllowAllPolicy));
+        let args = json!({
+            "cmd": format!("echo $$ > {}; sleep 300", pidfile.display()),
+        });
+
+        let handle = tokio::spawn(async move { tool.execute(&args).await });
+
+        // Wait for the probe to actually be running before aborting.
+        let mut probe_pid = None;
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            if let Ok(text) = std::fs::read_to_string(&pidfile) {
+                if let Ok(pid) = text.trim().parse::<u32>() {
+                    if process_exists(pid) {
+                        probe_pid = Some(pid);
+                        break;
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        let probe_pid = probe_pid.expect("probe never started; test cannot conclude");
+
+        // This is what Esc does on the serve path.
+        handle.abort();
+        let _ = handle.await;
+
+        let gone = wait_until_group_gone(probe_pid, Duration::from_secs(10)).await;
+        // Clean up before asserting so a failure cannot leak a sleeper.
+        if !gone {
+            let _ = signal_process_group(probe_pid, "-9");
+            let _ = signal_process(probe_pid, "-9");
+        }
+        assert!(
+            gone,
+            "aborting the turn left process group {probe_pid} alive — an \
+             interrupted `npm run dev` would keep holding ports and writing \
+             to the workspace"
+        );
+    }
+}


### PR DESCRIPTION
Follow-up to the interrupt review. Of everything those reviews surfaced, this was the only finding that causes real damage rather than a wrong-looking UI.

## The bug

The kill ladder only ran on the **timeout** arm of the wait. A user interrupt takes a different path: Esc on the serve path calls `agent_task.abort()`, which **drops** the future — and `tokio::process::Child` does not kill on drop. Neither the ladder nor tokio's cleanup fired, so the child's whole process group survived the turn.

Concretely: `bash("npm run dev")` interrupted with Esc kept running while the UI reported the turn stopped — holding its ports and still able to write to the workspace.

## The fix

Make cleanup a property of the **scope** rather than of one match arm. `ChildGroupGuard` is armed with the child pid for the whole wait and disarmed once a normal path (clean exit, spawn error, timeout ladder) has reaped or killed the child. Still armed at drop ⇒ it kills the group. Both call sites that use `process_group(0)` are covered — ShellTool/ExecCommandTool and BashTool.

`Drop` cannot await and the graceful ladder needs a grace period between SIGTERM and SIGKILL, so the guard hands it to a detached task when a runtime is available. Cancellation drops the guard while the runtime is very much alive, so that is the normal case; with no runtime (shutdown) it falls back to a synchronous hard kill, which beats leaking the group.

## Tests

Two guard tests plus an end-to-end one that aborts a real `BashTool` future the way the serve path does and asserts the launched command is gone. **Verified RED** by neutering the guard — the e2e test reports `aborting the turn left process group N alive`.

Two things the tests had to get right, both of which produced false failures against a *working* fix before being corrected:

- **The wait loop must be async.** The guard spawns its ladder, so a blocking `std::thread::sleep` starves the current-thread test runtime and the kill task never runs.
- **The probe cannot be found with `pgrep -f`.** `sh -c "sleep 300 # marker"` **execs** `sleep`, so the marker never reaches any argv. The command reports its own `$$` through a pidfile instead; chaining two commands stops the shell exec'ing, so that pid is the surviving group leader.

Unix-only tests (the guard itself is cross-platform; Windows uses `taskkill /F /T`).

Verified: `clippy --workspace --all-targets -D warnings` clean, fmt clean, octos-agent 2443 lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)