### PR TITLE
ci: run the Windows check on PRs; cancel superseded PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,14 @@ on:
   schedule:
     - cron: "0 10 * * *"
 
+# Cancel a PR's in-flight run when it is superseded by a new push. Without this
+# every amend queues another full matrix behind the old one, and the
+# self-hosted/large runners (ARM, RISC-V) are the ones that back up. Never
+# cancels `main`: those runs gate the release artifacts.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CARGO_TERM_COLOR: always
@@ -431,6 +439,11 @@ jobs:
         run: cargo check -p octos-cli --no-default-features --features api,telegram,discord,dingtalk,slack,whatsapp,feishu,email,matrix,audio_mp3
 
   check-arm:
+    # Deliberately NOT on PRs, unlike check-windows: the workspace has ZERO
+    # `cfg(target_arch)` sites, so there is no arch-specific code for this to
+    # catch that the x86 jobs do not already compile — and it costs ~67 min.
+    # It stays on `main` (and the nightly schedule) to catch toolchain- or
+    # dependency-level ARM breakage, which is the real risk here.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04-arm
     env:
@@ -489,6 +502,10 @@ jobs:
         run: cargo test --workspace --doc
 
   check-riscv:
+    # Push-only for the same reason as check-arm, plus a live problem: this job
+    # has not COMPLETED in recent history — it runs to the 24 h ceiling and is
+    # cancelled (see runs 30087155881, 30025529065). Until that is diagnosed it
+    # must not gate anything; putting it on PRs would wedge every PR for a day.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04-riscv
     env:
@@ -547,7 +564,27 @@ jobs:
         run: cargo test --workspace --doc
 
   check-windows:
-    if: github.event_name != 'pull_request'
+    # Runs on PRs, unlike its ARM/RISC-V siblings below. The workspace has 42
+    # `cfg(windows)` sites that NEVER compile on the Linux runners every other
+    # PR job uses, so a Windows-only break was invisible until after merge. At
+    # ~15 min it is the cheapest job in the matrix covering code no other PR
+    # check can even see.
+    #
+    # NON-BLOCKING for now, because it is currently RED for a pre-existing
+    # reason: `octos-core` `session_scope` has 2 Windows-only test failures
+    # (5-for-5 on recent `main` runs, long before this job moved to PRs).
+    # Making it blocking today would wedge every PR on a bug it did not
+    # introduce. It still surfaces on the PR, which is the point — a NEW
+    # Windows break is now visible at review time instead of after merge.
+    #
+    # Non-blocking ONLY on PRs. On push to `main` it stays hard-failing, so
+    # `build-windows` (which `needs:` this job) still refuses to ship a Windows
+    # artifact from a red suite — a blanket `continue-on-error: true` would have
+    # silently re-enabled those releases.
+    #
+    # Drop this line entirely once the two tests are fixed; see the tracking
+    # note in `crates/octos-core/src/session_scope.rs`.
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6

--- a/crates/octos-core/src/session_scope.rs
+++ b/crates/octos-core/src/session_scope.rs
@@ -912,6 +912,31 @@ impl SessionScope {
 ///
 /// The input must already be lexically normalised (no `..`) so the
 /// re-attached suffix names a real would-be on-disk location.
+/// KNOWN WINDOWS DEFECT — this function and [`canonical_root_lossy`] disagree
+/// about how far to canonicalise, and on Windows that difference is visible.
+///
+/// For a path whose root does NOT exist on disk:
+/// * this walks up to the first existing ancestor. On Windows that is `C:\`,
+///   which always exists, and `std::fs::canonicalize` returns it in VERBATIM
+///   form (`\\?\C:\`), so the result is `\\?\C:\...`.
+/// * `canonical_root_lossy` gives up and returns its input unchanged, e.g.
+///   `C:/octos/repos/some-repo`.
+///
+/// `starts_with` between a verbatim and a non-verbatim path is always false, so
+/// [`SessionScope::classify_canonical_path`] returns `OutOfScope` for a path
+/// that is plainly inside the workspace. On Unix the same walk ends at `/`,
+/// where canonicalisation is a no-op, so the asymmetry never shows.
+///
+/// This is why `session_scope`'s `multi_tenant_at_workspace_*` tests fail on
+/// Windows (5-for-5 on recent `main` runs), which in turn is why `check-windows`
+/// is non-blocking on PRs in `.github/workflows/ci.yml`.
+///
+/// NOT fixed here deliberately: `classify_canonical_path` is a sandbox-escape
+/// boundary, and the fix (normalising the verbatim prefix on both sides) needs
+/// to be validated ON Windows, not reasoned about from a Unix host. In
+/// production the workspace root normally exists, so both sides canonicalise to
+/// verbatim consistently and the misclassification does not fire — it is
+/// reachable when the root is missing.
 pub fn canonicalize_lossy(path: &Path) -> PathBuf {
     if let Ok(canon) = std::fs::canonicalize(path) {
         return canon;


### PR DESCRIPTION
Closes the gap where a PR passes every visible check and still breaks a platform, discovered only after merge. That is not hypothetical — `#1814` merged green and left `main` red on `check`, `check-arm` **and** `check-windows`.

## `check-windows` now runs on PRs

The workspace has **42 `cfg(windows)` sites** that never compile on the Linux runners every other PR job uses. Windows-only breakage was structurally invisible at review time. At ~15 min it is the cheapest job in the matrix and the only one covering code no other PR check can even see.

**Non-blocking on PRs**, because it is already red for a pre-existing reason (below). It reports; it does not wedge.

`continue-on-error` is scoped to `github.event_name == 'pull_request'` rather than set flat — `build-windows` `needs:` this job, and a blanket `true` would have silently resumed shipping Windows release artifacts from a failing suite.

## `check-arm` / `check-riscv` stay push-only — deliberately

I did not blanket-remove the `if:`, because the two remaining jobs are not like Windows:

- **ARM** costs **~67 min** and the workspace has **zero `cfg(target_arch)` sites** — there is no arch-specific code for it to catch that the x86 jobs do not already compile. Its real value is toolchain/dependency drift, which `main` + the nightly schedule cover.
- **RISC-V** is worse than expensive: it has not *completed* in recent history, running to the 24 h ceiling and being cancelled (runs `30087155881`, `30025529065`). On PRs it would wedge every PR for a day. **This looks like a live bug worth its own issue.**

Both now carry a comment explaining why, so the next person does not "fix" the asymmetry.

## Concurrency group

There was none, so every amended PR queued another full matrix behind the old one — the ARM/RISC-V runners are exactly what backs up, and `main` runs were observed sitting in `queued`. Superseded **PR** runs are now cancelled; `main` never is, since those gate release artifacts.

This should more than offset the added Windows cost.

## Pre-existing Windows failure — documented, not patched

`octos-core` `session_scope` fails 2 tests on Windows, **5-for-5** on recent `main` runs (long predating this PR).

Root cause: `canonicalize_lossy` walks up to the first existing ancestor — on Windows that is `C:\`, and `std::fs::canonicalize` returns it **verbatim** (`\\?\C:\`) — while `canonical_root_lossy` gives up and returns its input unchanged. `starts_with` across verbatim/non-verbatim is always false, so a path plainly inside the workspace classifies `OutOfScope`. On Unix the walk ends at `/`, where canonicalisation is a no-op, so the asymmetry never shows.

**Left unfixed on purpose.** `classify_canonical_path` is a sandbox-escape boundary, and the fix (normalising the verbatim prefix on both sides) must be validated *on Windows*, not reasoned about from a Unix host. Recorded as a doc comment on the function itself so it is findable from the code, not only from CI config.

In production the workspace root normally exists, so both sides canonicalise to verbatim consistently and the misclassification does not fire — it is reachable when the root is missing.

## Verification

Workflow YAML parses; job conditions confirmed via parser (`check-windows` always / `arm` + `riscv` push-only / `build-windows` still push-gated on `check-windows`). `octos-core` 314 tests green, fmt + clippy clean.

This PR is also its own test: `check-windows` should now appear in the checks list below, which it would not have before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)