### PR TITLE
feat(smart-home): move device control/state into the backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CARGO_TERM_COLOR: always
   FEATURES: "api,telegram,discord,dingtalk,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3"
-  SKILL_CRATES: "-p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather -p skill-evolve"
+  SKILL_CRATES: "-p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather -p smart-home -p skill-evolve"
 
 jobs:
   dashboard:
@@ -666,7 +666,7 @@ jobs:
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather smart_home; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-aarch64-apple-darwin.tar.gz *
@@ -706,7 +706,7 @@ jobs:
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather smart_home; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-x86_64-unknown-linux-gnu.tar.gz *
@@ -748,7 +748,7 @@ jobs:
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather smart_home; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-aarch64-unknown-linux-gnu.tar.gz *
@@ -791,7 +791,7 @@ jobs:
         shell: bash
         run: |
           mkdir dist
-          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather smart_home; do
             cp "target/release/${b}.exe" dist/ 2>/dev/null || true
           done
           cd dist && 7z a ../octos-bundle-x86_64-pc-windows-msvc.zip *

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -69,12 +69,12 @@ jobs:
           cargo build --release -p octos-sandbox
 
       - name: Build app-skill binaries
-        run: cargo build --release -p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather
+        run: cargo build --release -p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather -p smart-home
 
       - name: Bundle release tarball
         run: |
           mkdir dist
-          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather smart_home; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           # Canonical model catalog (model-provisioning SSOT) ships next to the binary.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   FEATURES: "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3"
-  SKILL_CRATES: "-p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather"
+  SKILL_CRATES: "-p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather -p smart-home"
 
 jobs:
   build-macos-arm:
@@ -59,7 +59,7 @@ jobs:
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather smart_home; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-aarch64-apple-darwin.tar.gz *
@@ -104,7 +104,7 @@ jobs:
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather smart_home; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-x86_64-unknown-linux-gnu.tar.gz *
@@ -151,7 +151,7 @@ jobs:
       - name: Bundle
         run: |
           mkdir dist
-          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather smart_home; do
             cp "target/release/$b" dist/ 2>/dev/null || true
           done
           cd dist && tar czf ../octos-bundle-aarch64-unknown-linux-gnu.tar.gz *
@@ -201,7 +201,7 @@ jobs:
         shell: bash
         run: |
           mkdir dist
-          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather; do
+          for b in octos octos-sandbox news_fetch deep-search deep_crawl send_email account_manager voice clock weather smart_home; do
             cp "target/release/${b}.exe" dist/ 2>/dev/null || true
           done
           cd dist && 7z a ../octos-bundle-x86_64-pc-windows-msvc.zip *

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to octos will be documented in this file.
 ## [Unreleased]
 
+### Features
+
+- Smart Home control — list and control smart-home devices (lights, thermostats, curtains, etc.) via a per-profile bridge (e.g. Home Assistant), through both the UI Protocol (`smart_home/*` WS methods, backing octos-web's Smart Home panel) and a new bundled `smart-home` agent skill (`smart_home_list_devices`, `smart_home_control_device`). Camera video streaming stays a human-facing, WebSocket-only feature and is not exposed to the agent.
+
 ### Changed
 
 - Per-tenant frps tunnel authentication via `metadatas.token`. Each tenant now has its own `tunnel_token` (UUID generated at registration) validated by the octos frps server plugin; the previous shared FRPS auth token is no longer needed and `auth.token` is set to `""` on both frps and frpc. `scripts/install.sh` and `scripts/install.ps1` recover the per-tenant token from an existing `/etc/frp/frpc.toml` on rerun and have updated prompt wording to reflect the per-tenant model.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4621,6 +4621,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "uuid",
+ "wiremock",
  "zip",
 ]
 
@@ -6693,6 +6694,15 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smart-home"
+version = "1.0.0"
+dependencies = [
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "smawk"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/app-skills/account-manager",
     "crates/app-skills/time",
     "crates/app-skills/weather",
+    "crates/app-skills/smart-home",
     "crates/app-skills/wechat-bridge",
     "crates/app-skills/skill-evolve",
     "crates/app-skills/harness-starter-generic",

--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -442,6 +442,14 @@ Launch (per-project session UX, gated `session.workspace_cwd.v1`):
 
 - `launch/resolve`
 
+Smart-home bridge integration (gated `smart_home.v1`; auth-bound — omitted
+from the stdio capability set and reported unsupported per § stdio policy,
+same as `memory/overview` / `cron/list` above):
+
+- `smart_home/status.get`, `smart_home/device.list`,
+  `smart_home/device.command`, `smart_home/camera.stream_start`,
+  `smart_home/camera.stream_stop`
+
 Runtime, auth, profile, and onboarding inspection (server-handled
 `APPUI_EXTRA_METHODS`):
 

--- a/book-zh/src/architecture.md
+++ b/book-zh/src/architecture.md
@@ -2,12 +2,12 @@
 
 ## 概述
 
-octos 是一个包含 26 个成员的 Rust 工作区（Edition 2024，rust-version 1.85.0），提供编码 Agent CLI 和多频道消息网关。通过 rustls 实现纯 Rust TLS（无 OpenSSL 依赖）。错误处理使用 `eyre`/`color-eyre`。
+octos 是一个包含 27 个成员的 Rust 工作区（Edition 2024，rust-version 1.85.0），提供编码 Agent CLI 和多频道消息网关。通过 rustls 实现纯 Rust TLS（无 OpenSSL 依赖）。错误处理使用 `eyre`/`color-eyre`。
 
 **工作区成员**（取自 `Cargo.toml`）：
 - **分层核心**（7 个）：`octos-core`（共享类型）→ `octos-memory` + `octos-llm` → `octos-agent`（agent 循环、工具、沙箱、MCP、压缩）→ `octos-cli`（命令、配置、serve/API），外加 `octos-bus`（14 个渠道、会话、合并、cron）与 `octos-diagnostics`（支撑 `octos doctor`）。
 - **agent 周边**（5 个）：`octos-pipeline`（DOT 图工作流）、`octos-plugin`（插件/技能 SDK）、`octos-swarm`（多 agent 契约创作）、`octos-sandbox`、`octos-dora-mcp`。
-- **内置技能 crate**（14 个）：`crates/app-skills/` 下每个应用技能都是独立 crate——`news`、`deep-search`、`deep-crawl`、`send-email`、`account-manager`、`time`、`weather`、`wechat-bridge`、`skill-evolve`，以及 `harness-starter-{generic,report,audio,coding}` 模板——再加上 `platform-skills/voice`（ASR/TTS）。
+- **内置技能 crate**（15 个）：`crates/app-skills/` 下每个应用技能都是独立 crate——`news`、`deep-search`、`deep-crawl`、`send-email`、`account-manager`、`time`、`weather`、`smart-home`、`wechat-bridge`、`skill-evolve`，以及 `harness-starter-{generic,report,audio,coding}` 模板——再加上 `platform-skills/voice`（ASR/TTS）。
 
 （Web SPA 与终端客户端分别位于独立的 `octos-web` 和 `octos-tui` 仓库，通过 UI Protocol 与 `octos serve` 通信。）
 

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -2,12 +2,12 @@
 
 ## Overview
 
-octos is a 26-member Rust workspace (Edition 2024, rust-version 1.85.0) providing both a coding agent CLI and a multi-channel messaging gateway. Pure Rust TLS via rustls (no OpenSSL). Error handling via `eyre`/`color-eyre`.
+octos is a 27-member Rust workspace (Edition 2024, rust-version 1.85.0) providing both a coding agent CLI and a multi-channel messaging gateway. Pure Rust TLS via rustls (no OpenSSL). Error handling via `eyre`/`color-eyre`.
 
 **Workspace members** (from `Cargo.toml`):
 - **Layered core** (7): `octos-core` (shared types) → `octos-memory` + `octos-llm` → `octos-agent` (agent loop, tools, sandbox, MCP, compaction) → `octos-cli` (commands, config, serve/API), plus `octos-bus` (14 channels, sessions, coalescing, cron) and `octos-diagnostics` (powers `octos doctor`).
 - **Agent-adjacent** (5): `octos-pipeline` (DOT-graph workflows), `octos-plugin` (plugin/skill SDK), `octos-swarm` (multi-agent contract authoring), `octos-sandbox`, `octos-dora-mcp`.
-- **Bundled skill crates** (14): each app skill under `crates/app-skills/` is its own crate — `news`, `deep-search`, `deep-crawl`, `send-email`, `account-manager`, `time`, `weather`, `wechat-bridge`, `skill-evolve`, and the `harness-starter-{generic,report,audio,coding}` templates — plus `platform-skills/voice` (ASR/TTS).
+- **Bundled skill crates** (15): each app skill under `crates/app-skills/` is its own crate — `news`, `deep-search`, `deep-crawl`, `send-email`, `account-manager`, `time`, `weather`, `smart-home`, `wechat-bridge`, `skill-evolve`, and the `harness-starter-{generic,report,audio,coding}` templates — plus `platform-skills/voice` (ASR/TTS).
 
 (The web SPA and terminal client live in the separate `octos-web` and `octos-tui` repositories and talk to `octos serve` over the UI Protocol.)
 

--- a/crates/app-skills/smart-home/Cargo.toml
+++ b/crates/app-skills/smart-home/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "smart-home"
+version = "1.0.0"
+edition = "2021"
+description = "Standalone smart-home skill: list and control devices via the profile's configured bridge"
+authors = ["octos"]
+
+[[bin]]
+name = "smart_home"
+path = "src/main.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+reqwest = { version = "0.12", features = ["blocking", "rustls-tls", "json"], default-features = false }
+
+[package.metadata.release]
+release = false

--- a/crates/app-skills/smart-home/SKILL.md
+++ b/crates/app-skills/smart-home/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: smart-home
+description: List and control smart-home devices (lights, thermostats, switches, covers, speakers) via the profile's configured bridge. Triggers: smart home, turn on/off, lights, thermostat, dim, brightness, temperature, unlock, devices, 智能家居, 开灯, 关灯, 空调, 窗帘, 灯光, 设备.
+version: 1.0.0
+author: octos
+always: false
+---
+
+# Smart Home
+
+List and control smart-home devices through the bridge configured on this
+profile (e.g. Home Assistant or a compatible gateway). Camera video is not
+available through this skill — it is a UI-only feature in the octos-web
+dashboard.
+
+Requires a bridge to be configured for the profile first (Settings →
+Smart Home). If it isn't configured yet, tools will report that clearly
+instead of failing silently.
+
+## Tools
+
+### smart_home_list_devices
+
+Returns every device the bridge knows about, with its current state
+(on/off, brightness, temperature, and other fields the device reports).
+Use this first to find a device's exact `device_id` before controlling it.
+
+```json
+{"room": "Living Room"}
+```
+
+**Parameters:**
+- `room` (optional): Filter to devices in a given room, case-insensitive. Omit to list everything.
+
+### smart_home_control_device
+
+Sends a command to one device by ID.
+
+```json
+{"device_id": "light.living_room_lamp", "params": {"on": true, "brightness": 60}}
+```
+
+**Parameters:**
+- `device_id` (required): Exact ID from `smart_home_list_devices`.
+- `params` (required): Object of fields to set. Common examples:
+  - `{"on": true}` / `{"on": false}` — power switches, lights, plugs
+  - `{"brightness": 0-100}` — dimmable lights
+  - `{"temperature": <number>}` — thermostats
+  - `{"volume": 0-100}` — speakers, TVs
+  - `{"position": 0-100}` — covers, blinds, curtains
+  - `{"color": "#rrggbb"}` — color-capable lights
+  - `{"mode": "..."}` — multi-mode appliances (fans, HVAC, etc.)
+
+  Supported fields vary by device kind — use the fields already present on
+  that device in `smart_home_list_devices`'s output as a guide.

--- a/crates/app-skills/smart-home/manifest.json
+++ b/crates/app-skills/smart-home/manifest.json
@@ -1,0 +1,42 @@
+{
+  "name": "smart-home",
+  "version": "1.0.0",
+  "author": "octos",
+  "description": "List and control smart-home devices via the profile's configured bridge (e.g. Home Assistant)",
+  "timeout_secs": 10,
+  "requires_network": true,
+  "tools": [
+    {
+      "name": "smart_home_list_devices",
+      "description": "List smart-home devices known to the configured bridge, with their current state (on/off, brightness, temperature, etc.). Use this before controlling a device to find its exact device_id.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "room": {
+            "type": "string",
+            "description": "Optional room name to filter devices by (case-insensitive, e.g. 'Living Room'). Omit to list all devices."
+          }
+        }
+      }
+    },
+    {
+      "name": "smart_home_control_device",
+      "description": "Send a command to a smart-home device by ID. Use smart_home_list_devices first to find the device_id. Common params: {\"on\": true|false} to turn on/off, {\"brightness\": 0-100} for lights, {\"temperature\": <number>} for thermostats, {\"volume\": 0-100} for speakers/TVs, {\"position\": 0-100} for covers/blinds, {\"color\": \"#rrggbb\"} for color lights, {\"mode\": \"...\"} for multi-mode appliances. Exact supported params depend on the device kind — check the device's current fields from smart_home_list_devices as a guide to what it supports.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "device_id": {
+            "type": "string",
+            "description": "Exact device ID as returned by smart_home_list_devices."
+          },
+          "params": {
+            "type": "object",
+            "description": "Command parameters to send, e.g. {\"on\": true} or {\"brightness\": 50}.",
+            "additionalProperties": true
+          }
+        },
+        "required": ["device_id", "params"]
+      }
+    }
+  ]
+}

--- a/crates/app-skills/smart-home/src/main.rs
+++ b/crates/app-skills/smart-home/src/main.rs
@@ -1,0 +1,495 @@
+//! Smart-home skill: list and control devices via the profile's configured
+//! bridge (e.g. Home Assistant).
+//!
+//! Protocol: `./smart_home <tool_name>` with JSON on stdin, JSON on stdout.
+//!
+//! Deliberately does not proxy through the running octos server: like
+//! `account-manager`, this reads the profile JSON directly from
+//! `$OCTOS_HOME/profiles/<id>.json` and talks to the bridge itself,
+//! mirroring the wire contract in
+//! `crates/octos-cli/src/api/smart_home_bridge.rs` (`GET {base}/devices`,
+//! `POST {base}/devices/{id}` form-encoded, Bearer auth, same
+//! token/token_env resolution precedence). Camera streaming is deliberately
+//! NOT exposed here: an LLM tool call can't consume a live video stream, so
+//! that stays a human-driven, WS-only feature in octos-web
+//! (`smart_home/camera.*`).
+
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde::Deserialize;
+use serde_json::{json, Map, Value};
+
+#[derive(Deserialize)]
+struct UserProfile {
+    #[serde(default)]
+    config: ProfileConfig,
+}
+
+#[derive(Deserialize, Default)]
+struct ProfileConfig {
+    #[serde(default)]
+    smart_home: Option<SmartHomeConfig>,
+    #[serde(default)]
+    env_vars: HashMap<String, String>,
+}
+
+#[derive(Deserialize, Default)]
+struct SmartHomeConfig {
+    #[serde(default)]
+    bridge_url: Option<String>,
+    #[serde(default)]
+    token: Option<String>,
+    #[serde(default)]
+    token_env: Option<String>,
+}
+
+struct BridgeConfig {
+    base_url: String,
+    token: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ListDevicesInput {
+    #[serde(default)]
+    room: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ControlDeviceInput {
+    device_id: String,
+    params: Value,
+}
+
+#[derive(Deserialize, Default)]
+struct DeviceListResponse {
+    #[serde(default)]
+    devices: Vec<Value>,
+    #[serde(default)]
+    ok: Option<bool>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let tool_name = args.get(1).map(|s| s.as_str()).unwrap_or("unknown");
+
+    let mut buf = String::new();
+    if let Err(e) = std::io::stdin().read_to_string(&mut buf) {
+        fail(&format!("Failed to read stdin: {e}"));
+    }
+
+    match tool_name {
+        "smart_home_list_devices" => handle_list_devices(&buf),
+        "smart_home_control_device" => handle_control_device(&buf),
+        _ => fail(&format!(
+            "Unknown tool '{tool_name}'. Expected: smart_home_list_devices, smart_home_control_device"
+        )),
+    }
+}
+
+fn fail(msg: &str) -> ! {
+    println!("{}", json!({"output": msg, "success": false}));
+    std::process::exit(1);
+}
+
+fn http_client() -> reqwest::blocking::Client {
+    reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(6))
+        .connect_timeout(Duration::from_secs(3))
+        .build()
+        .expect("failed to build HTTP client")
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var("HOME")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| std::env::var("USERPROFILE").ok().map(PathBuf::from))
+}
+
+/// Reads `$OCTOS_HOME/profiles/$OCTOS_PROFILE_ID.json` directly (same
+/// convention as the `account-manager` skill) and resolves the profile's
+/// smart-home bridge config from it.
+fn resolve_bridge() -> Result<BridgeConfig, String> {
+    let octos_home = match std::env::var("OCTOS_HOME") {
+        Ok(v) if !v.is_empty() => PathBuf::from(v),
+        _ => match home_dir() {
+            Some(h) => h.join(".octos"),
+            None => {
+                return Err("OCTOS_HOME is not set and cannot determine home directory".to_string())
+            }
+        },
+    };
+
+    let profile_id = match std::env::var("OCTOS_PROFILE_ID") {
+        Ok(v) if !v.is_empty() => v,
+        _ => {
+            return Err(
+                "OCTOS_PROFILE_ID is not set — this tool must be run from a gateway".to_string(),
+            )
+        }
+    };
+
+    let profile_path = octos_home
+        .join("profiles")
+        .join(format!("{profile_id}.json"));
+    let content = std::fs::read_to_string(&profile_path)
+        .map_err(|e| format!("cannot read profile '{profile_id}': {e}"))?;
+    let profile: UserProfile = serde_json::from_str(&content)
+        .map_err(|e| format!("cannot parse profile '{profile_id}': {e}"))?;
+
+    resolve_bridge_config(
+        &profile.config.smart_home.unwrap_or_default(),
+        &profile.config.env_vars,
+    )
+    .ok_or_else(|| {
+        "smart-home bridge is not configured for this profile. Configure it in Settings first."
+            .to_string()
+    })
+}
+
+/// Mirrors `octos_cli::api::smart_home_bridge::resolve_bridge_config`
+/// exactly: an explicit `token` wins; otherwise `token_env` is looked up in
+/// the profile's OWN `config.env_vars` map (never the OS process
+/// environment).
+fn resolve_bridge_config(
+    smart_home: &SmartHomeConfig,
+    env_vars: &HashMap<String, String>,
+) -> Option<BridgeConfig> {
+    let base_url = smart_home.bridge_url.clone()?;
+    let token = smart_home.token.clone().or_else(|| {
+        smart_home
+            .token_env
+            .as_ref()
+            .and_then(|name| env_vars.get(name).cloned())
+    });
+    Some(BridgeConfig { base_url, token })
+}
+
+fn base(config: &BridgeConfig) -> String {
+    config.base_url.trim_end_matches('/').to_string()
+}
+
+fn apply_auth(
+    builder: reqwest::blocking::RequestBuilder,
+    config: &BridgeConfig,
+) -> reqwest::blocking::RequestBuilder {
+    match &config.token {
+        Some(token) if !token.is_empty() => builder.bearer_auth(token),
+        _ => builder,
+    }
+}
+
+/// Percent-encode a path segment (RFC 3986 unreserved set passes through
+/// unchanged).
+fn encode_path_segment(segment: &str) -> String {
+    let mut out = String::with_capacity(segment.len());
+    for byte in segment.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+fn json_value_to_form_string(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn handle_list_devices(input_json: &str) {
+    let input: ListDevicesInput = if input_json.trim().is_empty() {
+        ListDevicesInput { room: None }
+    } else {
+        match serde_json::from_str(input_json) {
+            Ok(v) => v,
+            Err(e) => fail(&format!("Invalid input: {e}")),
+        }
+    };
+
+    let bridge = match resolve_bridge() {
+        Ok(b) => b,
+        Err(msg) => fail(&msg),
+    };
+
+    let client = http_client();
+    let url = format!("{}/devices", base(&bridge));
+    let resp = match apply_auth(client.get(&url), &bridge).send() {
+        Ok(r) => r,
+        Err(e) => fail(&format!("Bridge request failed: {e}")),
+    };
+    let status = resp.status();
+    let data: DeviceListResponse = match resp.json() {
+        Ok(v) => v,
+        Err(e) => fail(&format!("Invalid bridge response: {e}")),
+    };
+    if !status.is_success() {
+        fail(&data.error.unwrap_or_else(|| format!("HTTP {status}")));
+    }
+    if data.ok == Some(false) {
+        fail(&data.error.unwrap_or_else(|| "bridge error".to_string()));
+    }
+
+    let room_filter = input.room.as_ref().map(|r| r.to_lowercase());
+    let devices: Vec<&Value> = data
+        .devices
+        .iter()
+        .filter(|d| match &room_filter {
+            None => true,
+            Some(room) => d
+                .get("room")
+                .and_then(|v| v.as_str())
+                .map(|r| r.to_lowercase() == *room)
+                .unwrap_or(false),
+        })
+        .collect();
+
+    if devices.is_empty() {
+        let msg = match &input.room {
+            Some(room) => format!("No devices found in room '{room}'."),
+            None => "No devices found.".to_string(),
+        };
+        println!("{}", json!({"output": msg, "success": true}));
+        return;
+    }
+
+    let lines: Vec<String> = devices.iter().map(|d| format_device(d)).collect();
+    println!("{}", json!({"output": lines.join("\n"), "success": true}));
+}
+
+fn format_device(device: &Value) -> String {
+    let id = device.get("id").and_then(|v| v.as_str()).unwrap_or("?");
+    let name = device.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+    let kind = device.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+    let on = device.get("on").and_then(|v| v.as_bool()).unwrap_or(false);
+    let state = if on { "on" } else { "off" };
+
+    let mut parts = vec![if kind.is_empty() {
+        format!("{name} (id: {id}) — {state}")
+    } else {
+        format!("{name} (id: {id}, {kind}) — {state}")
+    }];
+
+    if let Some(room) = device.get("room").and_then(|v| v.as_str()) {
+        parts.push(format!("room: {room}"));
+    }
+    if device.get("online").and_then(|v| v.as_bool()) == Some(false) {
+        parts.push("OFFLINE".to_string());
+    }
+    for key in [
+        "brightness",
+        "volume",
+        "temperature",
+        "humidity",
+        "position",
+        "speed",
+    ] {
+        if let Some(n) = device.get(key).and_then(|v| v.as_f64()) {
+            parts.push(format!("{key}: {n}"));
+        }
+    }
+    if let Some(color) = device.get("color").and_then(|v| v.as_str()) {
+        parts.push(format!("color: {color}"));
+    }
+    if let Some(mode) = device.get("mode").and_then(|v| v.as_str()) {
+        parts.push(format!("mode: {mode}"));
+    }
+    if device.get("muted").and_then(|v| v.as_bool()) == Some(true) {
+        parts.push("muted".to_string());
+    }
+
+    parts.join(" | ")
+}
+
+fn handle_control_device(input_json: &str) {
+    let input: ControlDeviceInput = match serde_json::from_str(input_json) {
+        Ok(v) => v,
+        Err(e) => fail(&format!("Invalid input: {e}")),
+    };
+
+    if input.device_id.trim().is_empty() {
+        fail("'device_id' must not be empty");
+    }
+    let params: Map<String, Value> = match input.params {
+        Value::Object(map) if !map.is_empty() => map,
+        Value::Object(_) => fail("'params' must not be empty, e.g. {\"on\": true}"),
+        _ => fail("'params' must be a JSON object, e.g. {\"on\": true}"),
+    };
+
+    let bridge = match resolve_bridge() {
+        Ok(b) => b,
+        Err(msg) => fail(&msg),
+    };
+
+    let client = http_client();
+    let url = format!(
+        "{}/devices/{}",
+        base(&bridge),
+        encode_path_segment(&input.device_id)
+    );
+    let form: Vec<(String, String)> = params
+        .iter()
+        .map(|(k, v)| (k.clone(), json_value_to_form_string(v)))
+        .collect();
+
+    let resp = match apply_auth(client.post(&url), &bridge).form(&form).send() {
+        Ok(r) => r,
+        Err(e) => fail(&format!("Bridge request failed: {e}")),
+    };
+    let status = resp.status();
+    if !status.is_success() {
+        let error = resp
+            .json::<Value>()
+            .ok()
+            .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(String::from))
+            .unwrap_or_else(|| format!("HTTP {status}"));
+        fail(&error);
+    }
+
+    let params_display = params
+        .iter()
+        .map(|(k, v)| format!("{k}={}", json_value_to_form_string(v)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!(
+        "{}",
+        json!({
+            "output": format!("Sent to {}: {params_display}", input.device_id),
+            "success": true
+        })
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_bridge_config_returns_none_when_bridge_url_absent() {
+        let smart_home = SmartHomeConfig::default();
+        let env_vars = HashMap::new();
+        assert!(resolve_bridge_config(&smart_home, &env_vars).is_none());
+    }
+
+    #[test]
+    fn resolve_bridge_config_prefers_explicit_token_over_token_env() {
+        let smart_home = SmartHomeConfig {
+            bridge_url: Some("http://localhost:8787".to_string()),
+            token: Some("explicit-token".to_string()),
+            token_env: Some("SH_TOKEN".to_string()),
+        };
+        let mut env_vars = HashMap::new();
+        env_vars.insert("SH_TOKEN".to_string(), "env-token".to_string());
+        let resolved = resolve_bridge_config(&smart_home, &env_vars).unwrap();
+        assert_eq!(resolved.token.as_deref(), Some("explicit-token"));
+    }
+
+    #[test]
+    fn resolve_bridge_config_falls_back_to_token_env_from_profile_env_vars() {
+        let smart_home = SmartHomeConfig {
+            bridge_url: Some("http://localhost:8787".to_string()),
+            token: None,
+            token_env: Some("SH_TOKEN".to_string()),
+        };
+        let mut env_vars = HashMap::new();
+        env_vars.insert("SH_TOKEN".to_string(), "resolved-token".to_string());
+        let resolved = resolve_bridge_config(&smart_home, &env_vars).unwrap();
+        assert_eq!(resolved.base_url, "http://localhost:8787");
+        assert_eq!(resolved.token.as_deref(), Some("resolved-token"));
+    }
+
+    #[test]
+    fn resolve_bridge_config_none_token_when_token_env_name_not_in_profile_env_vars() {
+        // Proves the OS process environment is never consulted: even though
+        // token_env names "SH_TOKEN", only the PROFILE's own env_vars map is
+        // checked (std::env::var is never called for this lookup), so an
+        // empty profile env_vars map must resolve to no token.
+        let smart_home = SmartHomeConfig {
+            bridge_url: Some("http://localhost:8787".to_string()),
+            token: None,
+            token_env: Some("SH_TOKEN".to_string()),
+        };
+        let env_vars = HashMap::new();
+        let resolved = resolve_bridge_config(&smart_home, &env_vars).unwrap();
+        assert_eq!(resolved.token, None);
+    }
+
+    #[test]
+    fn json_value_to_form_string_passes_strings_through_unchanged() {
+        assert_eq!(json_value_to_form_string(&json!("hello")), "hello");
+    }
+
+    #[test]
+    fn json_value_to_form_string_stringifies_bools_and_numbers() {
+        assert_eq!(json_value_to_form_string(&json!(true)), "true");
+        assert_eq!(json_value_to_form_string(&json!(50)), "50");
+        assert_eq!(json_value_to_form_string(&json!(21.5)), "21.5");
+    }
+
+    #[test]
+    fn encode_path_segment_percent_encodes_reserved_bytes() {
+        assert_eq!(encode_path_segment("a b"), "a%20b");
+        assert_eq!(
+            encode_path_segment("light.living_room-1"),
+            "light.living_room-1"
+        );
+    }
+
+    #[test]
+    fn format_device_includes_name_id_kind_room_and_state() {
+        let device = json!({
+            "id": "tv1",
+            "name": "Living Room TV",
+            "kind": "tv",
+            "on": true,
+            "room": "Living Room"
+        });
+        let line = format_device(&device);
+        assert!(line.contains("Living Room TV"));
+        assert!(line.contains("tv1"));
+        assert!(line.contains("tv"));
+        assert!(line.contains("on"));
+        assert!(line.contains("Living Room"));
+    }
+
+    #[test]
+    fn format_device_shows_off_state_when_on_is_false() {
+        let device = json!({"id": "l1", "name": "Lamp", "on": false});
+        let line = format_device(&device);
+        assert!(line.contains("— off"));
+    }
+
+    #[test]
+    fn format_device_flags_offline_devices() {
+        let device = json!({"id": "d1", "name": "Sensor", "on": false, "online": false});
+        let line = format_device(&device);
+        assert!(line.contains("OFFLINE"));
+    }
+
+    #[test]
+    fn format_device_includes_present_numeric_fields() {
+        let device = json!({"id": "l1", "name": "Lamp", "on": true, "brightness": 60});
+        let line = format_device(&device);
+        assert!(line.contains("brightness: 60"));
+    }
+
+    #[test]
+    fn format_device_omits_absent_optional_fields() {
+        let device = json!({"id": "l1", "name": "Lamp", "on": true});
+        let line = format_device(&device);
+        assert!(!line.contains("brightness"));
+        assert!(!line.contains("OFFLINE"));
+        assert!(!line.contains("muted"));
+    }
+}

--- a/crates/octos-agent/src/bundled_app_skills.rs
+++ b/crates/octos-agent/src/bundled_app_skills.rs
@@ -48,6 +48,12 @@ pub const BUNDLED_APP_SKILLS: &[(&str, &str, &str, &str)] = &[
         include_str!("../../app-skills/weather/SKILL.md"),
         include_str!("../../app-skills/weather/manifest.json"),
     ),
+    (
+        "smart-home",
+        "smart_home",
+        include_str!("../../app-skills/smart-home/SKILL.md"),
+        include_str!("../../app-skills/smart-home/manifest.json"),
+    ),
     // voice-skill removed — voice TTS/ASR is handled by platform-skill "voice".
     // Voice cloning is handled by mofa-fm.
     // pipeline-guard removed — its before_tool_call hook was a category

--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -187,6 +187,7 @@ octos-llm = { workspace = true, features = ["test-utils"] }
 octos-store = { workspace = true, features = ["test-util"] }
 octos-services = { workspace = true, features = ["test-util"] }
 tokio-tungstenite.workspace = true
+wiremock = { workspace = true }
 
 [[test]]
 name = "build_output_dir_validation"

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -5071,6 +5071,61 @@ mod tests {
         );
     }
 
+    // Task #15: smart-home bridge config needs no dedicated REST route — it
+    // rides the same generic `config` JSON-merge-patch every other
+    // `ProfileConfig` section uses (see `my_profile_config_patch_preserves_existing_sections`
+    // above). This proves the wire round trip end to end: the response masks
+    // the token (never the URL), while the persisted profile keeps the real
+    // token so the bridge client (`smart_home_bridge.rs`) can still use it.
+    #[tokio::test]
+    async fn my_profile_config_patch_applies_and_masks_smart_home_section() {
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        profile_store
+            .save(&make_user_profile("tenant", "Tenant Owner"))
+            .unwrap();
+        let state = Arc::new(state);
+
+        let Json(resp) = update_my_profile(
+            State(state.clone()),
+            HeaderMap::new(),
+            axum::Extension(AuthIdentity::User {
+                id: "tenant".into(),
+                role: UserRole::User,
+            }),
+            serde_json::json!({
+                "config": {
+                    "smart_home": {
+                        "bridge_url": "http://192.168.1.50:8787",
+                        "token": "supersecret-token-value"
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+
+        let smart_home = resp.profile.config.smart_home.expect("smart_home present");
+        assert_eq!(
+            smart_home.bridge_url.as_deref(),
+            Some("http://192.168.1.50:8787"),
+            "bridge_url is not a secret and must round-trip in the clear"
+        );
+        let masked_token = smart_home.token.expect("token present in response");
+        assert_ne!(
+            masked_token, "supersecret-token-value",
+            "the response must mask the token"
+        );
+
+        let stored = profile_store.get("tenant").unwrap().expect("profile");
+        let stored_smart_home = stored.config.smart_home.expect("smart_home persisted");
+        assert_eq!(
+            stored_smart_home.token.as_deref(),
+            Some("supersecret-token-value"),
+            "the persisted profile must keep the real token, not the masked display value"
+        );
+    }
+
     #[tokio::test]
     async fn my_profile_rejects_service_account_json_under_custom_env_off_macos() {
         // Regression for the dashboard "Custom" bypass: a raw Vertex SA JSON

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -29,6 +29,8 @@ pub mod preview_tokens;
 pub mod purge;
 mod router;
 pub(crate) mod session_ingress;
+mod smart_home_bridge;
+mod smart_home_panel;
 pub(crate) mod solo_auth;
 pub(crate) mod specialist_runner;
 mod static_files;

--- a/crates/octos-cli/src/api/smart_home_bridge.rs
+++ b/crates/octos-cli/src/api/smart_home_bridge.rs
@@ -1,0 +1,433 @@
+//! Smart-home bridge HTTP client.
+//!
+//! Talks to a user-configured, self-hosted smart-home bridge (e.g. a Home
+//! Assistant instance fronted by a small REST shim) over plain HTTP, using
+//! the exact contract octos-web's browser client used to call directly:
+//! `GET /devices`, `POST /devices/{id}` (form-encoded), `POST
+//! /cameras/{id}/stream` (form-encoded), `POST /cameras/{id}/stop`.
+//!
+//! This deliberately does not route through `octos_agent::tools::ssrf`: that
+//! guard exists to stop the LLM agent being tricked into fetching
+//! attacker-chosen internal URLs via `web_fetch`/`browser` tool calls. A
+//! smart-home bridge URL is admin-configured (typed into the profile's own
+//! settings), not agent-supplied — a different trust boundary, same
+//! reasoning as the plain `reqwest::Client` used by
+//! `ominix_runtime::probe_health` for another local/admin-configured service.
+//!
+//! Scope: self-hosted / same-LAN bridges only (see
+//! `crate::profiles::SmartHomeConfig` doc comment).
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+const BRIDGE_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct SmartHomeDevice {
+    pub id: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub home: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub room: Option<String>,
+    #[serde(default)]
+    pub kind: String,
+    #[serde(default)]
+    pub on: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub online: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub readonly: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub brightness: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub volume: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub humidity: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub position: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub speed: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub muted: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_capable: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_protocol: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DeviceListResponse {
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub devices: Vec<SmartHomeDevice>,
+    #[serde(default)]
+    pub ok: Option<bool>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CameraStreamInfo {
+    #[serde(default)]
+    pub ok: Option<bool>,
+    #[serde(default)]
+    pub protocol: Option<String>,
+    #[serde(default)]
+    pub playback_url: Option<String>,
+    #[serde(default)]
+    pub stream_url: Option<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+/// Resolved bridge connection details for one profile.
+#[derive(Debug, Clone)]
+pub struct BridgeConfig {
+    pub base_url: String,
+    pub token: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum BridgeError {
+    /// No bridge_url configured for this profile.
+    NotConfigured,
+    /// Transport-level failure (DNS, connect, timeout, malformed response).
+    Request(String),
+    /// The bridge answered but reported an error (non-2xx or `ok: false`).
+    Bridge(String),
+}
+
+impl std::fmt::Display for BridgeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BridgeError::NotConfigured => write!(f, "smart-home bridge is not configured"),
+            BridgeError::Request(msg) => write!(f, "{msg}"),
+            BridgeError::Bridge(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl std::error::Error for BridgeError {}
+
+fn apply_auth(builder: reqwest::RequestBuilder, config: &BridgeConfig) -> reqwest::RequestBuilder {
+    match &config.token {
+        Some(token) if !token.is_empty() => builder.bearer_auth(token),
+        _ => builder,
+    }
+}
+
+fn base(config: &BridgeConfig) -> String {
+    config.base_url.trim_end_matches('/').to_string()
+}
+
+/// Percent-encode a path segment (RFC 3986 unreserved set passes through
+/// unchanged). Device IDs are backend-registered slugs in practice; this is
+/// defensive since they're interpolated directly into the URL path.
+fn encode_path_segment(segment: &str) -> String {
+    let mut out = String::with_capacity(segment.len());
+    for byte in segment.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+fn json_value_to_form_string(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        other => other.to_string(),
+    }
+}
+
+pub async fn fetch_devices(
+    client: &reqwest::Client,
+    config: &BridgeConfig,
+) -> Result<DeviceListResponse, BridgeError> {
+    let url = format!("{}/devices", base(config));
+    let resp = apply_auth(client.get(&url), config)
+        .timeout(BRIDGE_REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| BridgeError::Request(e.to_string()))?;
+    let status = resp.status();
+    let data: DeviceListResponse = resp
+        .json()
+        .await
+        .map_err(|e| BridgeError::Request(format!("invalid bridge response: {e}")))?;
+    if !status.is_success() {
+        return Err(BridgeError::Bridge(
+            data.error.unwrap_or_else(|| format!("HTTP {status}")),
+        ));
+    }
+    if data.ok == Some(false) {
+        return Err(BridgeError::Bridge(
+            data.error.unwrap_or_else(|| "bridge error".to_string()),
+        ));
+    }
+    Ok(data)
+}
+
+pub async fn send_device_command(
+    client: &reqwest::Client,
+    config: &BridgeConfig,
+    device_id: &str,
+    params: &serde_json::Map<String, serde_json::Value>,
+) -> Result<(), BridgeError> {
+    let url = format!(
+        "{}/devices/{}",
+        base(config),
+        encode_path_segment(device_id)
+    );
+    let form: Vec<(String, String)> = params
+        .iter()
+        .map(|(k, v)| (k.clone(), json_value_to_form_string(v)))
+        .collect();
+    let resp = apply_auth(client.post(&url), config)
+        .timeout(BRIDGE_REQUEST_TIMEOUT)
+        .form(&form)
+        .send()
+        .await
+        .map_err(|e| BridgeError::Request(e.to_string()))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let error = resp
+            .json::<serde_json::Value>()
+            .await
+            .ok()
+            .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(String::from))
+            .unwrap_or_else(|| format!("HTTP {status}"));
+        return Err(BridgeError::Bridge(error));
+    }
+    Ok(())
+}
+
+pub async fn start_camera_stream(
+    client: &reqwest::Client,
+    config: &BridgeConfig,
+    device_id: &str,
+    quality: Option<u32>,
+) -> Result<CameraStreamInfo, BridgeError> {
+    let url = format!(
+        "{}/cameras/{}/stream",
+        base(config),
+        encode_path_segment(device_id)
+    );
+    let form = vec![("quality".to_string(), quality.unwrap_or(2).to_string())];
+    let resp = apply_auth(client.post(&url), config)
+        .timeout(BRIDGE_REQUEST_TIMEOUT)
+        .form(&form)
+        .send()
+        .await
+        .map_err(|e| BridgeError::Request(e.to_string()))?;
+    let status = resp.status();
+    let data: CameraStreamInfo = resp
+        .json()
+        .await
+        .map_err(|e| BridgeError::Request(format!("invalid bridge response: {e}")))?;
+    if !status.is_success() {
+        return Err(BridgeError::Bridge(
+            data.error.unwrap_or_else(|| format!("HTTP {status}")),
+        ));
+    }
+    Ok(data)
+}
+
+pub async fn stop_camera_stream(
+    client: &reqwest::Client,
+    config: &BridgeConfig,
+    device_id: &str,
+) -> Result<(), BridgeError> {
+    let url = format!(
+        "{}/cameras/{}/stop",
+        base(config),
+        encode_path_segment(device_id)
+    );
+    let resp = apply_auth(client.post(&url), config)
+        .timeout(BRIDGE_REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| BridgeError::Request(e.to_string()))?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(BridgeError::Bridge(format!("HTTP {status}")));
+    }
+    Ok(())
+}
+
+/// Resolve a profile's smart-home bridge config into a `BridgeConfig`,
+/// resolving `token`/`token_env` the same way `SmartHomeConfig::to_env_vars`
+/// does. Returns `None` when no bridge_url is configured.
+pub fn resolve_bridge_config(
+    smart_home: &crate::profiles::SmartHomeConfig,
+    env_vars: &std::collections::HashMap<String, String>,
+) -> Option<BridgeConfig> {
+    let base_url = smart_home.bridge_url.clone()?;
+    let token = smart_home.token.clone().or_else(|| {
+        smart_home
+            .token_env
+            .as_ref()
+            .and_then(|name| env_vars.get(name).cloned())
+    });
+    Some(BridgeConfig { base_url, token })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn config(base_url: String) -> BridgeConfig {
+        BridgeConfig {
+            base_url,
+            token: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn should_fetch_devices_from_bridge_when_reachable() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/devices"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "source": "home_assistant",
+                "ok": true,
+                "devices": [{"id": "tv1", "name": "Living Room TV", "kind": "tv", "on": true}]
+            })))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let result = fetch_devices(&client, &config(server.uri())).await.unwrap();
+        assert_eq!(result.devices.len(), 1);
+        assert_eq!(result.devices[0].id, "tv1");
+        assert_eq!(result.source.as_deref(), Some("home_assistant"));
+    }
+
+    #[tokio::test]
+    async fn should_return_bridge_error_when_response_not_ok() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/devices"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "ok": false,
+                "error": "bridge offline",
+                "devices": []
+            })))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let err = fetch_devices(&client, &config(server.uri()))
+            .await
+            .unwrap_err();
+        assert_eq!(err.to_string(), "bridge offline");
+    }
+
+    #[tokio::test]
+    async fn should_return_request_error_when_bridge_unreachable() {
+        let client = reqwest::Client::new();
+        // Port 1 is reserved and will refuse connections immediately.
+        let err = fetch_devices(&client, &config("http://127.0.0.1:1".to_string()))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BridgeError::Request(_)));
+    }
+
+    #[tokio::test]
+    async fn should_send_bearer_auth_when_token_configured() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/devices"))
+            .and(header("Authorization", "Bearer secret-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "ok": true,
+                "devices": []
+            })))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let cfg = BridgeConfig {
+            base_url: server.uri(),
+            token: Some("secret-token".to_string()),
+        };
+        fetch_devices(&client, &cfg).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn should_send_device_command_as_form_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/devices/tv1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let mut params = serde_json::Map::new();
+        params.insert("on".to_string(), json!(true));
+        send_device_command(&client, &config(server.uri()), "tv1", &params)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn should_percent_encode_device_id_in_path() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/devices/a%20b"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+            .mount(&server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let params = serde_json::Map::new();
+        // wiremock matches the raw wire path, so this proves the device id
+        // is actually percent-encoded ("a%20b"), not sent with a literal space.
+        send_device_command(&client, &config(server.uri()), "a b", &params)
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn should_resolve_bridge_config_none_when_bridge_url_absent() {
+        let smart_home = crate::profiles::SmartHomeConfig::default();
+        let env_vars = std::collections::HashMap::new();
+        assert!(resolve_bridge_config(&smart_home, &env_vars).is_none());
+    }
+
+    #[test]
+    fn should_resolve_bridge_config_token_from_token_env() {
+        let smart_home = crate::profiles::SmartHomeConfig {
+            bridge_url: Some("http://localhost:8787".to_string()),
+            token: None,
+            token_env: Some("SH_TOKEN".to_string()),
+        };
+        let mut env_vars = std::collections::HashMap::new();
+        env_vars.insert("SH_TOKEN".to_string(), "resolved-token".to_string());
+        let resolved = resolve_bridge_config(&smart_home, &env_vars).unwrap();
+        assert_eq!(resolved.base_url, "http://localhost:8787");
+        assert_eq!(resolved.token.as_deref(), Some("resolved-token"));
+    }
+}

--- a/crates/octos-cli/src/api/smart_home_panel.rs
+++ b/crates/octos-cli/src/api/smart_home_panel.rs
@@ -1,0 +1,361 @@
+//! `smart_home/*` WS methods' backend logic: resolve the caller's profile,
+//! then talk to their configured smart-home bridge via
+//! [`crate::api::smart_home_bridge`]. Function shape (`State` + `HeaderMap` +
+//! `Extension<AuthIdentity>`) mirrors `cron_panel`/`memory_panel` for the
+//! profile-resolution prefix, reached only over the UI Protocol
+//! (`smart_home/*` methods, gated on `smart_home.v1`) via the thin
+//! `handle_smart_home_*` wrappers in `ui_protocol.rs` — there is no
+//! registered REST route for these (same WS-only convention `cron_panel`'s
+//! module doc describes for its own retired `/api/my/cron*` routes).
+//! `device_id`/`params`/`quality` are taken as plain arguments rather than
+//! `AxumPath`/`Json` extractors since they always come from an
+//! already-deserialized WS Params struct, never a raw HTTP request.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use serde_json::{Value, json};
+
+use super::AppState;
+use super::router::AuthIdentity;
+use super::smart_home_bridge::{self, BridgeConfig, BridgeError};
+use crate::api::auth_handlers::resolve_my_profile_id;
+
+type PanelError = (StatusCode, Json<Value>);
+
+fn err(status: StatusCode, reason: &str) -> PanelError {
+    (status, Json(json!({ "ok": false, "reason": reason })))
+}
+
+fn bridge_error_response(error: BridgeError) -> PanelError {
+    match error {
+        BridgeError::NotConfigured => err(StatusCode::NOT_FOUND, "not_configured"),
+        BridgeError::Request(detail) => (
+            StatusCode::BAD_GATEWAY,
+            Json(json!({ "ok": false, "reason": "bridge_unreachable", "detail": detail })),
+        ),
+        BridgeError::Bridge(detail) => (
+            StatusCode::BAD_GATEWAY,
+            Json(json!({ "ok": false, "reason": "bridge_error", "detail": detail })),
+        ),
+    }
+}
+
+/// Resolve the caller's `BridgeConfig`, if their profile has one configured.
+async fn resolve_my_bridge(
+    state: &AppState,
+    identity: &AuthIdentity,
+    headers: &HeaderMap,
+) -> Result<Option<BridgeConfig>, PanelError> {
+    let ps = state
+        .profile_store
+        .as_ref()
+        .ok_or_else(|| err(StatusCode::SERVICE_UNAVAILABLE, "profiles_unavailable"))?;
+    let profile_id = resolve_my_profile_id(identity, ps, state, headers)
+        .map_err(|status| err(status, "auth"))?;
+    let profile = ps
+        .get(&profile_id)
+        .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "profile_read_failed"))?
+        .ok_or_else(|| err(StatusCode::NOT_FOUND, "profile_not_found"))?;
+    let smart_home = profile.config.smart_home.unwrap_or_default();
+    Ok(smart_home_bridge::resolve_bridge_config(
+        &smart_home,
+        &profile.config.env_vars,
+    ))
+}
+
+async fn resolve_my_configured_bridge(
+    state: &AppState,
+    identity: &AuthIdentity,
+    headers: &HeaderMap,
+) -> Result<BridgeConfig, PanelError> {
+    resolve_my_bridge(state, identity, headers)
+        .await?
+        .ok_or_else(|| bridge_error_response(BridgeError::NotConfigured))
+}
+
+pub async fn my_smart_home_status(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::Extension(identity): axum::Extension<AuthIdentity>,
+) -> Result<Json<Value>, PanelError> {
+    let bridge = resolve_my_bridge(&state, &identity, &headers).await?;
+    Ok(Json(json!({ "configured": bridge.is_some() })))
+}
+
+pub async fn my_smart_home_devices(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::Extension(identity): axum::Extension<AuthIdentity>,
+) -> Result<Json<Value>, PanelError> {
+    let bridge = resolve_my_configured_bridge(&state, &identity, &headers).await?;
+    smart_home_bridge::fetch_devices(&state.http_client, &bridge)
+        .await
+        .map(|devices| Json(serde_json::to_value(devices).unwrap_or_else(|_| json!({}))))
+        .map_err(bridge_error_response)
+}
+
+pub async fn my_smart_home_device_command(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::Extension(identity): axum::Extension<AuthIdentity>,
+    device_id: String,
+    params: serde_json::Map<String, Value>,
+) -> Result<Json<Value>, PanelError> {
+    let bridge = resolve_my_configured_bridge(&state, &identity, &headers).await?;
+    smart_home_bridge::send_device_command(&state.http_client, &bridge, &device_id, &params)
+        .await
+        .map(|()| Json(json!({})))
+        .map_err(bridge_error_response)
+}
+
+pub async fn my_smart_home_camera_stream_start(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::Extension(identity): axum::Extension<AuthIdentity>,
+    device_id: String,
+    quality: Option<u32>,
+) -> Result<Json<Value>, PanelError> {
+    let bridge = resolve_my_configured_bridge(&state, &identity, &headers).await?;
+    smart_home_bridge::start_camera_stream(&state.http_client, &bridge, &device_id, quality)
+        .await
+        .map(|info| Json(serde_json::to_value(info).unwrap_or_else(|_| json!({}))))
+        .map_err(bridge_error_response)
+}
+
+pub async fn my_smart_home_camera_stream_stop(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::Extension(identity): axum::Extension<AuthIdentity>,
+    device_id: String,
+) -> Result<Json<Value>, PanelError> {
+    let bridge = resolve_my_configured_bridge(&state, &identity, &headers).await?;
+    smart_home_bridge::stop_camera_stream(&state.http_client, &bridge, &device_id)
+        .await
+        .map(|()| Json(json!({})))
+        .map_err(bridge_error_response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::profiles::{ProfileConfig, ProfileStore, SmartHomeConfig, UserProfile};
+    use crate::user_store::UserRole;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn user_identity(id: &str) -> axum::Extension<AuthIdentity> {
+        axum::Extension(AuthIdentity::User {
+            id: id.into(),
+            role: UserRole::User,
+        })
+    }
+
+    fn make_profile(id: &str, smart_home: Option<SmartHomeConfig>) -> UserProfile {
+        UserProfile {
+            id: id.into(),
+            name: id.into(),
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig {
+                smart_home,
+                ..ProfileConfig::default()
+            },
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    fn temp_state(profile: &UserProfile) -> (tempfile::TempDir, Arc<AppState>) {
+        let dir = tempfile::tempdir().unwrap();
+        let profile_store = Arc::new(ProfileStore::open_unified(dir.path()).unwrap());
+        profile_store.save(profile).unwrap();
+        let state = Arc::new(AppState {
+            profile_store: Some(profile_store),
+            ..AppState::empty_for_tests()
+        });
+        (dir, state)
+    }
+
+    #[tokio::test]
+    async fn my_smart_home_status_reports_not_configured_without_bridge() {
+        let profile = make_profile("tenant", None);
+        let (_dir, state) = temp_state(&profile);
+        let Json(body) =
+            my_smart_home_status(State(state), HeaderMap::new(), user_identity("tenant"))
+                .await
+                .unwrap();
+        assert_eq!(body["configured"], json!(false));
+    }
+
+    #[tokio::test]
+    async fn my_smart_home_status_reports_configured_with_bridge() {
+        let profile = make_profile(
+            "tenant",
+            Some(SmartHomeConfig {
+                bridge_url: Some("http://localhost:8787".into()),
+                token: None,
+                token_env: None,
+            }),
+        );
+        let (_dir, state) = temp_state(&profile);
+        let Json(body) =
+            my_smart_home_status(State(state), HeaderMap::new(), user_identity("tenant"))
+                .await
+                .unwrap();
+        assert_eq!(body["configured"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn my_smart_home_devices_returns_not_configured_error_without_bridge() {
+        let profile = make_profile("tenant", None);
+        let (_dir, state) = temp_state(&profile);
+        let (status, Json(body)) =
+            my_smart_home_devices(State(state), HeaderMap::new(), user_identity("tenant"))
+                .await
+                .unwrap_err();
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body["reason"], json!("not_configured"));
+    }
+
+    #[tokio::test]
+    async fn my_smart_home_devices_forwards_bridge_device_list() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/devices"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "ok": true,
+                "devices": [{"id": "tv1", "name": "Living Room TV", "kind": "tv", "on": true}]
+            })))
+            .mount(&server)
+            .await;
+        let profile = make_profile(
+            "tenant",
+            Some(SmartHomeConfig {
+                bridge_url: Some(server.uri()),
+                token: None,
+                token_env: None,
+            }),
+        );
+        let (_dir, state) = temp_state(&profile);
+        let Json(body) =
+            my_smart_home_devices(State(state), HeaderMap::new(), user_identity("tenant"))
+                .await
+                .unwrap();
+        assert_eq!(body["devices"][0]["id"], json!("tv1"));
+    }
+
+    #[tokio::test]
+    async fn my_smart_home_devices_maps_bridge_unreachable_to_bad_gateway() {
+        let profile = make_profile(
+            "tenant",
+            Some(SmartHomeConfig {
+                bridge_url: Some("http://127.0.0.1:1".into()),
+                token: None,
+                token_env: None,
+            }),
+        );
+        let (_dir, state) = temp_state(&profile);
+        let (status, Json(body)) =
+            my_smart_home_devices(State(state), HeaderMap::new(), user_identity("tenant"))
+                .await
+                .unwrap_err();
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+        assert_eq!(body["reason"], json!("bridge_unreachable"));
+    }
+
+    #[tokio::test]
+    async fn my_smart_home_device_command_posts_to_bridge() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/devices/tv1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+            .mount(&server)
+            .await;
+        let profile = make_profile(
+            "tenant",
+            Some(SmartHomeConfig {
+                bridge_url: Some(server.uri()),
+                token: None,
+                token_env: None,
+            }),
+        );
+        let (_dir, state) = temp_state(&profile);
+        let mut params = serde_json::Map::new();
+        params.insert("on".into(), json!(true));
+        let Json(_) = my_smart_home_device_command(
+            State(state),
+            HeaderMap::new(),
+            user_identity("tenant"),
+            "tv1".into(),
+            params,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn my_smart_home_camera_stream_start_and_stop_round_trip() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/cameras/cam1/stream"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "ok": true,
+                "protocol": "hls",
+                "playback_url": "http://bridge/hls/cam1.m3u8"
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/cameras/cam1/stop"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+            .mount(&server)
+            .await;
+        let profile = make_profile(
+            "tenant",
+            Some(SmartHomeConfig {
+                bridge_url: Some(server.uri()),
+                token: None,
+                token_env: None,
+            }),
+        );
+        let (_dir, state) = temp_state(&profile);
+        let Json(body) = my_smart_home_camera_stream_start(
+            State(state.clone()),
+            HeaderMap::new(),
+            user_identity("tenant"),
+            "cam1".into(),
+            Some(2),
+        )
+        .await
+        .unwrap();
+        assert_eq!(body["protocol"], json!("hls"));
+
+        let Json(_) = my_smart_home_camera_stream_stop(
+            State(state),
+            HeaderMap::new(),
+            user_identity("tenant"),
+            "cam1".into(),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn my_smart_home_devices_rejects_unknown_profile_identity() {
+        let profile = make_profile("tenant", None);
+        let (_dir, state) = temp_state(&profile);
+        let (status, _) = my_smart_home_devices(
+            State(state),
+            HeaderMap::new(),
+            user_identity("someone-else"),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -337,6 +337,11 @@ const APPUI_STDIO_AUTH_BOUND_UNAVAILABLE_METHODS: &[&str] = &[
     octos_core::ui_protocol::methods::MEMORY_ENTITY,
     octos_core::ui_protocol::methods::CRON_LIST,
     octos_core::ui_protocol::methods::CRON_TOGGLE,
+    octos_core::ui_protocol::methods::SMART_HOME_STATUS_GET,
+    octos_core::ui_protocol::methods::SMART_HOME_DEVICE_LIST,
+    octos_core::ui_protocol::methods::SMART_HOME_DEVICE_COMMAND,
+    octos_core::ui_protocol::methods::SMART_HOME_CAMERA_STREAM_START,
+    octos_core::ui_protocol::methods::SMART_HOME_CAMERA_STREAM_STOP,
 ];
 type WsSink = futures::stream::SplitSink<WebSocket, WsMessage>;
 type SharedActiveTurns = Arc<tokio::sync::Mutex<HashMap<SessionKey, ActiveTurn>>>;
@@ -6381,6 +6386,66 @@ async fn ui_protocol_connection(
                 )
                 .await;
             }
+            UiCommand::SmartHomeStatusGet(params) => {
+                handle_smart_home_status_get(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    true,
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::SmartHomeDeviceList(params) => {
+                handle_smart_home_device_list(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    true,
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::SmartHomeDeviceCommand(params) => {
+                handle_smart_home_device_command(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    true,
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::SmartHomeCameraStreamStart(params) => {
+                handle_smart_home_camera_stream_start(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    true,
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::SmartHomeCameraStreamStop(params) => {
+                handle_smart_home_camera_stream_stop(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    true,
+                    id,
+                    params,
+                )
+                .await;
+            }
         }
     }
 
@@ -7020,6 +7085,66 @@ where
                     &state,
                     None,
                     connection_profile_id_owned.as_deref(),
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::SmartHomeStatusGet(params) => {
+                handle_smart_home_status_get(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    None,
+                    false,
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::SmartHomeDeviceList(params) => {
+                handle_smart_home_device_list(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    None,
+                    false,
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::SmartHomeDeviceCommand(params) => {
+                handle_smart_home_device_command(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    None,
+                    false,
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::SmartHomeCameraStreamStart(params) => {
+                handle_smart_home_camera_stream_start(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    None,
+                    false,
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::SmartHomeCameraStreamStop(params) => {
+                handle_smart_home_camera_stream_stop(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    None,
+                    false,
                     id,
                     params,
                 )
@@ -13588,6 +13713,11 @@ fn session_ingress_callable_method(method: &str) -> bool {
             | octos_core::ui_protocol::methods::CRON_LIST
             | octos_core::ui_protocol::methods::CRON_TOGGLE
             | octos_core::ui_protocol::methods::SESSION_FORK
+            | octos_core::ui_protocol::methods::SMART_HOME_STATUS_GET
+            | octos_core::ui_protocol::methods::SMART_HOME_DEVICE_LIST
+            | octos_core::ui_protocol::methods::SMART_HOME_DEVICE_COMMAND
+            | octos_core::ui_protocol::methods::SMART_HOME_CAMERA_STREAM_START
+            | octos_core::ui_protocol::methods::SMART_HOME_CAMERA_STREAM_STOP
     )
 }
 
@@ -13616,7 +13746,12 @@ fn validate_session_ingress_command_scope(
         | UiCommand::MemoryEntity(_)
         | UiCommand::CronList(_)
         | UiCommand::CronToggle(_)
-        | UiCommand::SessionFork(_) => {
+        | UiCommand::SessionFork(_)
+        | UiCommand::SmartHomeStatusGet(_)
+        | UiCommand::SmartHomeDeviceList(_)
+        | UiCommand::SmartHomeDeviceCommand(_)
+        | UiCommand::SmartHomeCameraStreamStart(_)
+        | UiCommand::SmartHomeCameraStreamStop(_) => {
             return Err(RpcError::invalid_request(
                 "session ingress credentials may only call session-scoped methods",
             ));
@@ -22217,6 +22352,223 @@ async fn handle_router_get_metrics(
         }
     };
     let _ = send_rpc_result(ws, id, value);
+}
+
+/// Thin WS wrapper over `smart_home_panel::my_smart_home_status`, mirroring
+/// `handle_memory_overview`/`handle_cron_list`.
+async fn handle_smart_home_status_get(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
+    close_on_auth_unavailable: bool,
+    id: String,
+    _params: octos_core::ui_protocol::SmartHomeStatusGetParams,
+) {
+    let method = octos_core::ui_protocol::methods::SMART_HOME_STATUS_GET;
+    let Some(identity) = identity.cloned() else {
+        if close_on_auth_unavailable {
+            let _ = close_ws_with_code(ws, 1008, "auth_expired");
+        }
+        let _ = send_rpc_error(ws, Some(id), auth_unavailable_error(method));
+        return;
+    };
+    let result = super::smart_home_panel::my_smart_home_status(
+        State(state.clone()),
+        headers.clone(),
+        Extension(identity),
+    )
+    .await;
+    match result {
+        Ok(axum::Json(body)) => send_aux_rpc_result(ws, id, method, body),
+        Err((status, axum::Json(body))) => {
+            let detail = body
+                .get("reason")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            let context = RestResourceContext::resource("smart_home", "");
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                rest_status_to_rpc_error(method, status, detail, &context),
+            );
+        }
+    }
+}
+
+async fn handle_smart_home_device_list(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
+    close_on_auth_unavailable: bool,
+    id: String,
+    _params: octos_core::ui_protocol::SmartHomeDeviceListParams,
+) {
+    let method = octos_core::ui_protocol::methods::SMART_HOME_DEVICE_LIST;
+    let Some(identity) = identity.cloned() else {
+        if close_on_auth_unavailable {
+            let _ = close_ws_with_code(ws, 1008, "auth_expired");
+        }
+        let _ = send_rpc_error(ws, Some(id), auth_unavailable_error(method));
+        return;
+    };
+    let result = super::smart_home_panel::my_smart_home_devices(
+        State(state.clone()),
+        headers.clone(),
+        Extension(identity),
+    )
+    .await;
+    match result {
+        Ok(axum::Json(devices)) => {
+            send_aux_rpc_result(ws, id, method, json!({ "devices": devices }))
+        }
+        Err((status, axum::Json(body))) => {
+            let detail = body
+                .get("reason")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            let context = RestResourceContext::resource("smart_home_device", "");
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                rest_status_to_rpc_error(method, status, detail, &context),
+            );
+        }
+    }
+}
+
+async fn handle_smart_home_device_command(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
+    close_on_auth_unavailable: bool,
+    id: String,
+    params: octos_core::ui_protocol::SmartHomeDeviceCommandParams,
+) {
+    let method = octos_core::ui_protocol::methods::SMART_HOME_DEVICE_COMMAND;
+    let Some(identity) = identity.cloned() else {
+        if close_on_auth_unavailable {
+            let _ = close_ws_with_code(ws, 1008, "auth_expired");
+        }
+        let _ = send_rpc_error(ws, Some(id), auth_unavailable_error(method));
+        return;
+    };
+    let Some(command_params) = params.params.as_object().cloned() else {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            RpcError::invalid_params(format!("{method}: params must be a JSON object")),
+        );
+        return;
+    };
+    let result = super::smart_home_panel::my_smart_home_device_command(
+        State(state.clone()),
+        headers.clone(),
+        Extension(identity),
+        params.device_id.clone(),
+        command_params,
+    )
+    .await;
+    match result {
+        Ok(_) => send_aux_rpc_result(ws, id, method, json!({})),
+        Err((status, axum::Json(body))) => {
+            let detail = body
+                .get("reason")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            let context = RestResourceContext::resource("smart_home_device", params.device_id);
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                rest_status_to_rpc_error(method, status, detail, &context),
+            );
+        }
+    }
+}
+
+async fn handle_smart_home_camera_stream_start(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
+    close_on_auth_unavailable: bool,
+    id: String,
+    params: octos_core::ui_protocol::SmartHomeCameraStreamStartParams,
+) {
+    let method = octos_core::ui_protocol::methods::SMART_HOME_CAMERA_STREAM_START;
+    let Some(identity) = identity.cloned() else {
+        if close_on_auth_unavailable {
+            let _ = close_ws_with_code(ws, 1008, "auth_expired");
+        }
+        let _ = send_rpc_error(ws, Some(id), auth_unavailable_error(method));
+        return;
+    };
+    let result = super::smart_home_panel::my_smart_home_camera_stream_start(
+        State(state.clone()),
+        headers.clone(),
+        Extension(identity),
+        params.device_id.clone(),
+        params.quality,
+    )
+    .await;
+    match result {
+        Ok(axum::Json(stream)) => send_aux_rpc_result(ws, id, method, json!({ "stream": stream })),
+        Err((status, axum::Json(body))) => {
+            let detail = body
+                .get("reason")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            let context = RestResourceContext::resource("smart_home_camera", params.device_id);
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                rest_status_to_rpc_error(method, status, detail, &context),
+            );
+        }
+    }
+}
+
+async fn handle_smart_home_camera_stream_stop(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
+    close_on_auth_unavailable: bool,
+    id: String,
+    params: octos_core::ui_protocol::SmartHomeCameraStreamStopParams,
+) {
+    let method = octos_core::ui_protocol::methods::SMART_HOME_CAMERA_STREAM_STOP;
+    let Some(identity) = identity.cloned() else {
+        if close_on_auth_unavailable {
+            let _ = close_ws_with_code(ws, 1008, "auth_expired");
+        }
+        let _ = send_rpc_error(ws, Some(id), auth_unavailable_error(method));
+        return;
+    };
+    let result = super::smart_home_panel::my_smart_home_camera_stream_stop(
+        State(state.clone()),
+        headers.clone(),
+        Extension(identity),
+        params.device_id.clone(),
+    )
+    .await;
+    match result {
+        Ok(_) => send_aux_rpc_result(ws, id, method, json!({})),
+        Err((status, axum::Json(body))) => {
+            let detail = body
+                .get("reason")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            let context = RestResourceContext::resource("smart_home_camera", params.device_id);
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                rest_status_to_rpc_error(method, status, detail, &context),
+            );
+        }
+    }
 }
 
 fn task_relaunch_rpc_error(task_id: &TaskId, error: octos_agent::TaskRelaunchError) -> RpcError {

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -14036,6 +14036,11 @@ fn session_ingress_callable_method_matches_the_deny_surfaces() {
         octos_core::ui_protocol::methods::CRON_LIST,
         octos_core::ui_protocol::methods::CRON_TOGGLE,
         octos_core::ui_protocol::methods::SESSION_FORK,
+        octos_core::ui_protocol::methods::SMART_HOME_STATUS_GET,
+        octos_core::ui_protocol::methods::SMART_HOME_DEVICE_LIST,
+        octos_core::ui_protocol::methods::SMART_HOME_DEVICE_COMMAND,
+        octos_core::ui_protocol::methods::SMART_HOME_CAMERA_STREAM_START,
+        octos_core::ui_protocol::methods::SMART_HOME_CAMERA_STREAM_STOP,
     ] {
         assert!(
             !session_ingress_callable_method(m),

--- a/crates/octos-cli/src/process_manager.rs
+++ b/crates/octos-cli/src/process_manager.rs
@@ -511,6 +511,16 @@ impl ProcessManager {
             }
         }
 
+        // Inject smart-home bridge config as env vars for the smart-home
+        // plugin skill, same gap-bridging as the email block above.
+        if let Some(ref smart_home) = profile.config.smart_home {
+            for (key, value) in smart_home.to_env_vars(&profile.config.env_vars) {
+                if !profile.config.env_vars.contains_key(&key) {
+                    cmd.env(&key, &value);
+                }
+            }
+        }
+
         // Pass env vars from profile config, resolving keychain markers and
         // filtering out dangerous ones.
         tracing::debug!(profile = %profile.id, "start: resolving env vars");

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -115,6 +115,9 @@ pub struct ProfileConfig {
     /// Email sending configuration (SMTP or Feishu/Lark).
     #[serde(default)]
     pub email: Option<EmailSettings>,
+    /// Smart-home bridge integration (self-hosted/LAN-reachable bridge only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub smart_home: Option<SmartHomeConfig>,
     /// API protocol type: "openai" or "anthropic". Overrides provider default.
     #[serde(default)]
     pub api_type: Option<String>,
@@ -595,6 +598,8 @@ pub struct ProfileConfigPatch {
     #[serde(default)]
     pub email: PatchField<EmailSettings>,
     #[serde(default)]
+    pub smart_home: PatchField<SmartHomeConfig>,
+    #[serde(default)]
     pub env_vars: Option<HashMap<String, String>>,
     #[serde(default)]
     pub hooks: Option<Vec<octos_agent::HookConfig>>,
@@ -778,6 +783,45 @@ impl EmailSettings {
     }
 }
 
+/// Smart-home bridge integration for a profile.
+///
+/// Scope: self-hosted / same-LAN bridges only (e.g. a Home Assistant bridge
+/// reachable at `http://192.168.x.x:8787`). Cloud-tenant deployments where the
+/// backend isn't on the user's home network are out of scope for now.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SmartHomeConfig {
+    /// Base URL of the smart-home bridge (e.g. `http://192.168.1.50:8787`).
+    /// Not a secret — left in the clear by `mask_secrets`.
+    #[serde(default)]
+    pub bridge_url: Option<String>,
+    /// Bridge auth token (literal value, preferred over token_env).
+    #[serde(default)]
+    pub token: Option<String>,
+    /// Env var name holding the bridge auth token (legacy/reference pattern).
+    #[serde(default)]
+    pub token_env: Option<String>,
+}
+
+impl SmartHomeConfig {
+    /// Return env var pairs that the `smart-home` plugin skill and the
+    /// backend's own bridge client expect.
+    /// `env_vars` is the profile's env_vars map used to resolve `token_env`.
+    pub fn to_env_vars(&self, env_vars: &HashMap<String, String>) -> Vec<(String, String)> {
+        let mut out = Vec::new();
+        if let Some(ref url) = self.bridge_url {
+            out.push(("SMART_HOME_BRIDGE_URL".into(), url.clone()));
+        }
+        if let Some(ref token) = self.token {
+            out.push(("SMART_HOME_BRIDGE_TOKEN".into(), token.clone()));
+        } else if let Some(ref token_env) = self.token_env {
+            if let Some(token_val) = env_vars.get(token_env) {
+                out.push(("SMART_HOME_BRIDGE_TOKEN".into(), token_val.clone()));
+            }
+        }
+        out
+    }
+}
+
 impl ProfileConfig {
     pub fn primary_llm(&self) -> Option<&LlmModelSelectionConfig> {
         self.llm.as_ref().and_then(|llm| llm.primary.as_ref())
@@ -839,6 +883,11 @@ impl ProfileConfig {
             PatchField::Absent => {}
             PatchField::Clear => self.email = None,
             PatchField::Value(email) => self.email = Some(email),
+        }
+        match patch.smart_home {
+            PatchField::Absent => {}
+            PatchField::Clear => self.smart_home = None,
+            PatchField::Value(smart_home) => self.smart_home = Some(smart_home),
         }
         if let Some(env_vars) = patch.env_vars {
             self.env_vars = env_vars;
@@ -2191,8 +2240,22 @@ pub fn mask_secrets(profile: &UserProfile) -> UserProfile {
     if let Some(email) = &mut masked.config.email {
         mask_email_secrets(email);
     }
+    if let Some(smart_home) = &mut masked.config.smart_home {
+        mask_smart_home_secrets(smart_home);
+    }
     masked.config.normalize_llm_contract();
     masked
+}
+
+/// Mask the literal secret in `config.smart_home`.
+///
+/// `token` holds a real credential; `bridge_url` is not a secret (just a LAN
+/// address the user needs to see/edit), and `token_env` holds only an env var
+/// NAME, so both stay in the clear.
+fn mask_smart_home_secrets(smart_home: &mut SmartHomeConfig) {
+    if let Some(token) = &mut smart_home.token {
+        *token = mask_value(token);
+    }
 }
 
 /// Mask the literal secrets in `config.email`.
@@ -3015,6 +3078,121 @@ pub fn api_channel_port(profile: &UserProfile) -> Option<u16> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn should_include_bridge_url_in_env_vars_when_set() {
+        let config = SmartHomeConfig {
+            bridge_url: Some("http://localhost:8787".into()),
+            ..Default::default()
+        };
+        let env_vars = HashMap::new();
+        let out = config.to_env_vars(&env_vars);
+        assert!(
+            out.contains(&(
+                "SMART_HOME_BRIDGE_URL".to_string(),
+                "http://localhost:8787".to_string()
+            )),
+            "expected SMART_HOME_BRIDGE_URL in {out:?}"
+        );
+    }
+
+    #[test]
+    fn should_resolve_token_env_when_literal_token_absent() {
+        let config = SmartHomeConfig {
+            bridge_url: None,
+            token: None,
+            token_env: Some("SH_TOKEN".into()),
+        };
+        let mut env_vars = HashMap::new();
+        env_vars.insert("SH_TOKEN".to_string(), "secret123".to_string());
+        let out = config.to_env_vars(&env_vars);
+        assert!(
+            out.contains(&(
+                "SMART_HOME_BRIDGE_TOKEN".to_string(),
+                "secret123".to_string()
+            )),
+            "expected resolved token in {out:?}"
+        );
+    }
+
+    #[test]
+    fn should_prefer_literal_token_over_token_env() {
+        let config = SmartHomeConfig {
+            bridge_url: None,
+            token: Some("literal-token".into()),
+            token_env: Some("SH_TOKEN".into()),
+        };
+        let mut env_vars = HashMap::new();
+        env_vars.insert("SH_TOKEN".to_string(), "should-not-be-used".to_string());
+        let out = config.to_env_vars(&env_vars);
+        assert!(
+            out.contains(&(
+                "SMART_HOME_BRIDGE_TOKEN".to_string(),
+                "literal-token".to_string()
+            )),
+            "expected literal token to win in {out:?}"
+        );
+    }
+
+    #[test]
+    fn should_mask_smart_home_token_but_not_url_when_masking_profile() {
+        let profile = UserProfile {
+            id: "test".into(),
+            name: "Test".into(),
+            public_subdomain: None,
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            config: ProfileConfig {
+                smart_home: Some(SmartHomeConfig {
+                    bridge_url: Some("http://192.168.1.50:8787".into()),
+                    token: Some("supersecret-token-value".into()),
+                    token_env: None,
+                }),
+                ..Default::default()
+            },
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let profile = mask_secrets(&profile);
+        let smart_home = profile.config.smart_home.expect("smart_home present");
+        assert_eq!(
+            smart_home.bridge_url.as_deref(),
+            Some("http://192.168.1.50:8787"),
+            "bridge_url is not a secret and must not be masked"
+        );
+        let masked_token = smart_home.token.expect("token present");
+        assert_ne!(masked_token, "supersecret-token-value");
+        assert_eq!(masked_token, "supe***lue");
+    }
+
+    #[test]
+    fn should_apply_smart_home_patch_value_and_clear() {
+        let mut config = ProfileConfig::default();
+        let patch = ProfileConfigPatch {
+            smart_home: PatchField::Value(SmartHomeConfig {
+                bridge_url: Some("http://localhost:8787".into()),
+                token: None,
+                token_env: None,
+            }),
+            ..Default::default()
+        };
+        config.apply_patch(patch);
+        assert_eq!(
+            config
+                .smart_home
+                .as_ref()
+                .and_then(|s| s.bridge_url.clone()),
+            Some("http://localhost:8787".to_string())
+        );
+
+        let clear_patch = ProfileConfigPatch {
+            smart_home: PatchField::Clear,
+            ..Default::default()
+        };
+        config.apply_patch(clear_patch);
+        assert!(config.smart_home.is_none());
+    }
 
     fn llm_selection(
         family_id: &str,

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -143,17 +143,20 @@ const FAILOVER_PUSH_DEBOUNCE: Duration = Duration::from_secs(5);
 
 // ── Peer inbox registry (#436) ─────────────────────────────────────────────
 
+/// Inbox sender map keyed by `"{profile_id}:peer:{slug}"`, shared behind
+/// an `Arc<StdMutex<_>>` so [`peer_inbox_registry`] callers can clone the
+/// `Arc` and lock independently.
+type PeerInboxMap = Arc<StdMutex<HashMap<String, mpsc::Sender<ActorMessage>>>>;
+
 /// Global registry mapping `"{profile_id}:peer:{slug}"` → inbox sender for
 /// running peer sessions. Populated by [`ActorRegistry::dispatch`] when a
 /// peer session actor spawns; removed on session death / deletion. The
 /// [`PeerSendInputTool`] callback reads this to deliver cross-session
 /// messages without a TUI round-trip.
-static PEER_INBOX_REGISTRY: OnceLock<Arc<StdMutex<HashMap<String, mpsc::Sender<ActorMessage>>>>> =
-    OnceLock::new();
+static PEER_INBOX_REGISTRY: OnceLock<PeerInboxMap> = OnceLock::new();
 
 /// Get (or init) the global peer inbox registry.
-pub fn peer_inbox_registry() -> &'static Arc<StdMutex<HashMap<String, mpsc::Sender<ActorMessage>>>>
-{
+pub fn peer_inbox_registry() -> &'static PeerInboxMap {
     PEER_INBOX_REGISTRY.get_or_init(|| Arc::new(StdMutex::new(HashMap::new())))
 }
 

--- a/crates/octos-cli/tests/smart_home_ws_e2e.rs
+++ b/crates/octos-cli/tests/smart_home_ws_e2e.rs
@@ -1,0 +1,349 @@
+//! Genuine end-to-end coverage for the `smart_home/*` UI Protocol WS
+//! methods (backend half of the smart-home device control/state
+//! migration): a real TCP-bound `octos serve` router — NOT
+//! `tower::oneshot`, which cannot perform a WS upgrade at all (see
+//! `ws_token_url_decode.rs`) — driven by a real `tokio-tungstenite` WS
+//! client, backed by a real `wiremock` HTTP server standing in for a
+//! self-hosted smart-home bridge.
+//!
+//! Unlike `smart_home_panel.rs`'s unit tests (which call the
+//! `my_smart_home_*` handlers directly as plain async functions) and
+//! `ws_token_url_decode.rs` (which only asserts on the HTTP status of a
+//! WS upgrade attempt), these tests exercise the FULL real path for
+//! every method: WS admin-token auth -> JSON-RPC dispatch ->
+//! per-profile bridge-config resolution -> real HTTP call to the bridge
+//! -> JSON-RPC response serialized back over the socket.
+
+#![cfg(feature = "api")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::{Sink, SinkExt, Stream, StreamExt};
+use octos_cli::api::{AppState, build_router};
+use octos_cli::profiles::{ProfileConfig, ProfileStore, SmartHomeConfig, UserProfile};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const ADMIN_TOKEN: &str = "e2e-smart-home-admin-token";
+/// `resolve_my_profile_id` maps `AuthIdentity::Admin` to this fixed
+/// profile ID (`auth_handlers::ADMIN_PROFILE_ID`, private to the crate) —
+/// pre-saving a profile under this ID lets the test control its
+/// `smart_home` config instead of relying on the auto-created default.
+const ADMIN_PROFILE_ID: &str = "admin";
+
+fn admin_profile(smart_home: Option<SmartHomeConfig>) -> UserProfile {
+    UserProfile {
+        id: ADMIN_PROFILE_ID.into(),
+        name: ADMIN_PROFILE_ID.into(),
+        enabled: true,
+        data_dir: None,
+        parent_id: None,
+        public_subdomain: None,
+        config: ProfileConfig {
+            smart_home,
+            ..ProfileConfig::default()
+        },
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    }
+}
+
+/// Build an `AppState` whose admin identity (the bootstrap `auth_token`
+/// path in `resolve_identity`) resolves to a profile with the given
+/// smart-home bridge config already saved.
+fn state_with_admin_bridge(dir: &TempDir, smart_home: Option<SmartHomeConfig>) -> Arc<AppState> {
+    let store = Arc::new(ProfileStore::open_unified(dir.path()).unwrap());
+    store.save(&admin_profile(smart_home)).unwrap();
+    Arc::new(AppState {
+        profile_store: Some(store),
+        auth_token: Some(ADMIN_TOKEN.into()),
+        ..AppState::empty_for_tests()
+    })
+}
+
+async fn spawn_api(state: Arc<AppState>) -> (String, tokio::task::JoinHandle<()>) {
+    let app = build_router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+    tokio::task::yield_now().await;
+    (format!("127.0.0.1:{}", addr.port()), server)
+}
+
+async fn connect_ui_protocol(
+    addr: &str,
+) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
+    let url =
+        format!("ws://{addr}/api/ui-protocol/ws?token={ADMIN_TOKEN}&ui_feature=smart_home.v1");
+    let (ws, _response) = connect_async(url).await.unwrap();
+    ws
+}
+
+/// Send one JSON-RPC request and return the parsed response body.
+/// Generic over the WS stream type so every test can share one helper
+/// without spelling out `WebSocketStream<MaybeTlsStream<TcpStream>>`.
+async fn rpc<S>(ws: &mut S, id: &str, method_name: &str, params: Value) -> Value
+where
+    S: Sink<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
+    S: Stream<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
+{
+    ws.send(Message::Text(
+        json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method_name,
+            "params": params,
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+    let next = tokio::time::timeout(Duration::from_secs(3), ws.next())
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {method_name} response"));
+    let Some(next) = next else {
+        panic!("websocket ended before {method_name} response");
+    };
+    let response = match next {
+        Ok(msg) => msg,
+        Err(e) => panic!("failed to read {method_name} response: {e}"),
+    };
+    let Message::Text(body) = response else {
+        panic!("expected JSON-RPC text response for {method_name}, got {response:?}");
+    };
+    serde_json::from_str(&body).unwrap()
+}
+
+#[tokio::test]
+async fn smart_home_status_get_reports_not_configured_without_bridge() {
+    let dir = TempDir::new().unwrap();
+    let state = state_with_admin_bridge(&dir, None);
+    let (addr, server) = spawn_api(state).await;
+    let mut ws = connect_ui_protocol(&addr).await;
+
+    let body = rpc(
+        &mut ws,
+        "status",
+        octos_core::ui_protocol::methods::SMART_HOME_STATUS_GET,
+        json!({}),
+    )
+    .await;
+    assert_eq!(body["result"]["configured"], json!(false));
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn smart_home_status_get_reports_configured_with_bridge() {
+    let dir = TempDir::new().unwrap();
+    let state = state_with_admin_bridge(
+        &dir,
+        Some(SmartHomeConfig {
+            bridge_url: Some("http://127.0.0.1:1".into()),
+            token: None,
+            token_env: None,
+        }),
+    );
+    let (addr, server) = spawn_api(state).await;
+    let mut ws = connect_ui_protocol(&addr).await;
+
+    let body = rpc(
+        &mut ws,
+        "status",
+        octos_core::ui_protocol::methods::SMART_HOME_STATUS_GET,
+        json!({}),
+    )
+    .await;
+    assert_eq!(body["result"]["configured"], json!(true));
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn smart_home_device_list_round_trips_through_real_bridge() {
+    let bridge = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/devices"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "ok": true,
+            "source": "home_assistant",
+            "devices": [
+                {"id": "real_tv", "name": "Living Room TV", "kind": "tv", "on": true}
+            ]
+        })))
+        .mount(&bridge)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let state = state_with_admin_bridge(
+        &dir,
+        Some(SmartHomeConfig {
+            bridge_url: Some(bridge.uri()),
+            token: None,
+            token_env: None,
+        }),
+    );
+    let (addr, server) = spawn_api(state).await;
+    let mut ws = connect_ui_protocol(&addr).await;
+
+    let body = rpc(
+        &mut ws,
+        "devices",
+        octos_core::ui_protocol::methods::SMART_HOME_DEVICE_LIST,
+        json!({}),
+    )
+    .await;
+    assert_eq!(
+        body["result"]["devices"]["devices"][0]["id"],
+        json!("real_tv"),
+        "expected the bridge's device list forwarded byte-for-byte over WS, got {body}"
+    );
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn smart_home_device_list_maps_not_configured_to_json_rpc_error() {
+    let dir = TempDir::new().unwrap();
+    let state = state_with_admin_bridge(&dir, None);
+    let (addr, server) = spawn_api(state).await;
+    let mut ws = connect_ui_protocol(&addr).await;
+
+    let body = rpc(
+        &mut ws,
+        "devices-error",
+        octos_core::ui_protocol::methods::SMART_HOME_DEVICE_LIST,
+        json!({}),
+    )
+    .await;
+    assert!(
+        body["error"].is_object(),
+        "expected a JSON-RPC error for an unconfigured bridge, got {body}"
+    );
+    assert_eq!(body["error"]["data"]["kind"], json!("not_found"));
+    assert_eq!(
+        body["error"]["data"]["resource_type"],
+        json!("smart_home_device")
+    );
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn smart_home_device_command_posts_to_real_bridge() {
+    let bridge = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/devices/real_tv"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+        .mount(&bridge)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let state = state_with_admin_bridge(
+        &dir,
+        Some(SmartHomeConfig {
+            bridge_url: Some(bridge.uri()),
+            token: None,
+            token_env: None,
+        }),
+    );
+    let (addr, server) = spawn_api(state).await;
+    let mut ws = connect_ui_protocol(&addr).await;
+
+    let body = rpc(
+        &mut ws,
+        "command",
+        octos_core::ui_protocol::methods::SMART_HOME_DEVICE_COMMAND,
+        json!({ "device_id": "real_tv", "params": { "action": "volume_up" } }),
+    )
+    .await;
+    assert!(
+        body["error"].is_null(),
+        "expected smart_home/device.command to succeed, got {body}"
+    );
+    assert_eq!(body["result"], json!({}));
+
+    // Confirm the bridge actually received the real request, proving the
+    // WS param round-tripped through profile resolution and the HTTP
+    // client rather than the mock accepting any POST.
+    let received = bridge.received_requests().await.unwrap();
+    assert_eq!(received.len(), 1);
+    assert_eq!(received[0].method.as_str(), "POST");
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn smart_home_camera_stream_start_and_stop_round_trip() {
+    let bridge = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/cameras/cam1/stream"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "ok": true,
+            "protocol": "rtc",
+            "playback_url": "http://127.0.0.1:1984/stream.html?src=cam1"
+        })))
+        .mount(&bridge)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/cameras/cam1/stop"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+        .mount(&bridge)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let state = state_with_admin_bridge(
+        &dir,
+        Some(SmartHomeConfig {
+            bridge_url: Some(bridge.uri()),
+            token: None,
+            token_env: None,
+        }),
+    );
+    let (addr, server) = spawn_api(state).await;
+    let mut ws = connect_ui_protocol(&addr).await;
+
+    let start_body = rpc(
+        &mut ws,
+        "stream-start",
+        octos_core::ui_protocol::methods::SMART_HOME_CAMERA_STREAM_START,
+        json!({ "device_id": "cam1", "quality": 2 }),
+    )
+    .await;
+    assert_eq!(start_body["result"]["stream"]["protocol"], json!("rtc"));
+    assert_eq!(
+        start_body["result"]["stream"]["playback_url"],
+        json!("http://127.0.0.1:1984/stream.html?src=cam1")
+    );
+
+    let stop_body = rpc(
+        &mut ws,
+        "stream-stop",
+        octos_core::ui_protocol::methods::SMART_HOME_CAMERA_STREAM_STOP,
+        json!({ "device_id": "cam1" }),
+    )
+    .await;
+    assert!(
+        stop_body["error"].is_null(),
+        "expected clean stop, got {stop_body}"
+    );
+
+    server.abort();
+    let _ = server.await;
+}

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -256,6 +256,15 @@ pub const UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1: &str = "event.voice_audio.v1";
 /// on the legacy `tool/completed` `structured_metadata` path.
 pub const UI_PROTOCOL_FEATURE_PLAN_TODOS_V1: &str = "plan.todos.v1";
 
+/// Smart-home bridge control (self-hosted/LAN bridge only). Gates
+/// `smart_home/status.get`, `smart_home/device.list`,
+/// `smart_home/device.command`, `smart_home/camera.stream_start`, and
+/// `smart_home/camera.stream_stop`. Device control/state moved server-side
+/// so the profile's bridge credentials never reach the browser; camera video
+/// itself still streams directly browser-to-bridge (these methods only
+/// return the playback URL).
+pub const UI_PROTOCOL_FEATURE_SMART_HOME_V1: &str = "smart_home.v1";
+
 /// Server-known feature registry. Used by
 /// [`UiProtocolCapabilities::for_negotiated_features`] (UPCR-2026-007) to
 /// intersect a client's `X-Octos-Ui-Features` request with the names the
@@ -286,6 +295,7 @@ pub const UI_PROTOCOL_KNOWN_FEATURES: &[&str] = &[
     UI_PROTOCOL_FEATURE_USER_QUESTION_V1,
     UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1,
     UI_PROTOCOL_FEATURE_PLAN_TODOS_V1,
+    UI_PROTOCOL_FEATURE_SMART_HOME_V1,
 ];
 
 /// Returns the feature flag that gates `method` per spec § 7 capability
@@ -345,6 +355,11 @@ fn method_capability_gate(method: &str) -> Option<&'static str> {
         | methods::LOOP_FIRE_NOW => Some(UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1),
         methods::REVIEW_START => Some(UI_PROTOCOL_FEATURE_REVIEW_START_V1),
         methods::USER_QUESTION_RESPOND => Some(UI_PROTOCOL_FEATURE_USER_QUESTION_V1),
+        methods::SMART_HOME_STATUS_GET
+        | methods::SMART_HOME_DEVICE_LIST
+        | methods::SMART_HOME_DEVICE_COMMAND
+        | methods::SMART_HOME_CAMERA_STREAM_START
+        | methods::SMART_HOME_CAMERA_STREAM_STOP => Some(UI_PROTOCOL_FEATURE_SMART_HOME_V1),
         _ => None,
     }
 }
@@ -1226,6 +1241,24 @@ pub mod methods {
     /// [`PEER_STAGED`]: `session_id` is the ORIGINATING session; durable so
     /// reconnect replay redelivers it, and clients dedup by the closed peer.
     pub const PEER_CLOSED: &str = "peer/closed";
+
+    // ---- Smart-home bridge integration ----
+    // Device control/state moved server-side from octos-web's client-only
+    // widget so bridge credentials never reach the browser. Camera video
+    // stays a direct browser-to-bridge stream; these methods only return
+    // the playback URL. All five are capability-gated on
+    // `UI_PROTOCOL_FEATURE_SMART_HOME_V1`.
+
+    /// Bridge configuration/reachability status for the current profile.
+    pub const SMART_HOME_STATUS_GET: &str = "smart_home/status.get";
+    /// Device list + state, proxied from the configured bridge.
+    pub const SMART_HOME_DEVICE_LIST: &str = "smart_home/device.list";
+    /// Send a device command (on/off, temperature, mode, action, ...).
+    pub const SMART_HOME_DEVICE_COMMAND: &str = "smart_home/device.command";
+    /// Start a camera stream; returns the bridge's playback URL.
+    pub const SMART_HOME_CAMERA_STREAM_START: &str = "smart_home/camera.stream_start";
+    /// Stop a camera stream.
+    pub const SMART_HOME_CAMERA_STREAM_STOP: &str = "smart_home/camera.stream_stop";
 }
 
 /// Reason codes for `approval/cancelled` notifications. The registry is
@@ -1296,6 +1329,11 @@ pub const UI_PROTOCOL_COMMAND_METHODS: &[&str] = &[
     methods::ROUTER_SET_MODE,
     methods::ROUTER_GET_METRICS,
     methods::LAUNCH_RESOLVE,
+    methods::SMART_HOME_STATUS_GET,
+    methods::SMART_HOME_DEVICE_LIST,
+    methods::SMART_HOME_DEVICE_COMMAND,
+    methods::SMART_HOME_CAMERA_STREAM_START,
+    methods::SMART_HOME_CAMERA_STREAM_STOP,
 ];
 
 /// Notification methods defined by the v1alpha1 protocol model.
@@ -1407,6 +1445,11 @@ pub const UI_PROTOCOL_FIRST_SERVER_METHODS: &[&str] = &[
     methods::ROUTER_SET_MODE,
     methods::ROUTER_GET_METRICS,
     methods::LAUNCH_RESOLVE,
+    methods::SMART_HOME_STATUS_GET,
+    methods::SMART_HOME_DEVICE_LIST,
+    methods::SMART_HOME_DEVICE_COMMAND,
+    methods::SMART_HOME_CAMERA_STREAM_START,
+    methods::SMART_HOME_CAMERA_STREAM_STOP,
 ];
 
 /// Protocol methods known but not implemented by the first server/runtime slice.
@@ -1486,6 +1529,7 @@ impl UiProtocolCapabilities {
             UI_PROTOCOL_FEATURE_CONTEXT_LIFECYCLE_V1,
             UI_PROTOCOL_FEATURE_USER_QUESTION_V1,
             UI_PROTOCOL_FEATURE_PLAN_TODOS_V1,
+            UI_PROTOCOL_FEATURE_SMART_HOME_V1,
         ])
     }
 
@@ -3000,6 +3044,78 @@ pub struct SessionListResult {
     pub sessions: Value,
 }
 
+// ----- Smart-home bridge integration -----
+//
+// Mirrors the REST-facing bridge client in
+// `crates/octos-cli/src/api/smart_home_bridge.rs`. Result payloads that
+// carry bridge data are typed as opaque [`Value`] containers — same
+// rationale as the M12 Phase D-1 frames above: octos-core cannot depend on
+// octos-cli (`SmartHomeDevice`, `DeviceListResponse`, `CameraStreamInfo` live
+// there), so the bridge's JSON contract stays the single source of truth in
+// octos-cli and this crate stays a schema-agnostic envelope layer. Gated on
+// [`UI_PROTOCOL_FEATURE_SMART_HOME_V1`].
+
+/// Params for `smart_home/status.get`. Empty request — reports whether this
+/// profile has a bridge configured without exposing its URL/token.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SmartHomeStatusGetParams {}
+
+/// Result for `smart_home/status.get`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SmartHomeStatusGetResult {
+    pub configured: bool,
+}
+
+/// Params for `smart_home/device.list`. Empty request.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SmartHomeDeviceListParams {}
+
+/// Result for `smart_home/device.list`. `devices` is the bridge's
+/// `DeviceListResponse` JSON body, forwarded byte-for-byte.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SmartHomeDeviceListResult {
+    pub devices: Value,
+}
+
+/// Params for `smart_home/device.command`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SmartHomeDeviceCommandParams {
+    pub device_id: String,
+    /// Command payload, forwarded to the bridge as a form-encoded POST body
+    /// (see `send_device_command`), e.g. `{"on": true}`.
+    pub params: Value,
+}
+
+/// Result for `smart_home/device.command`. Empty on success — bridge/request
+/// failures surface as a JSON-RPC error response instead.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SmartHomeDeviceCommandResult {}
+
+/// Params for `smart_home/camera.stream_start`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SmartHomeCameraStreamStartParams {
+    pub device_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quality: Option<u32>,
+}
+
+/// Result for `smart_home/camera.stream_start`. `stream` is the bridge's
+/// `CameraStreamInfo` JSON body, forwarded byte-for-byte.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SmartHomeCameraStreamStartResult {
+    pub stream: Value,
+}
+
+/// Params for `smart_home/camera.stream_stop`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SmartHomeCameraStreamStopParams {
+    pub device_id: String,
+}
+
+/// Result for `smart_home/camera.stream_stop`. Empty on success.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SmartHomeCameraStreamStopResult {}
+
 /// Params for `launch/resolve` — the pre-session launch probe. Given the
 /// project `cwd` and the optionally requested profile, the server decides
 /// whether to resume the folder's conversation, activate a new one, or surface
@@ -4024,6 +4140,12 @@ pub enum UiCommand {
     RouterGetMetrics(RouterGetMetricsParams),
     // ---- launch/resolve: pre-session launch probe ----
     LaunchResolve(LaunchResolveParams),
+    // ---- Smart-home bridge integration ----
+    SmartHomeStatusGet(SmartHomeStatusGetParams),
+    SmartHomeDeviceList(SmartHomeDeviceListParams),
+    SmartHomeDeviceCommand(SmartHomeDeviceCommandParams),
+    SmartHomeCameraStreamStart(SmartHomeCameraStreamStartParams),
+    SmartHomeCameraStreamStop(SmartHomeCameraStreamStopParams),
 }
 
 impl UiCommand {
@@ -4071,6 +4193,11 @@ impl UiCommand {
             Self::RouterSetMode(_) => methods::ROUTER_SET_MODE,
             Self::RouterGetMetrics(_) => methods::ROUTER_GET_METRICS,
             Self::LaunchResolve(_) => methods::LAUNCH_RESOLVE,
+            Self::SmartHomeStatusGet(_) => methods::SMART_HOME_STATUS_GET,
+            Self::SmartHomeDeviceList(_) => methods::SMART_HOME_DEVICE_LIST,
+            Self::SmartHomeDeviceCommand(_) => methods::SMART_HOME_DEVICE_COMMAND,
+            Self::SmartHomeCameraStreamStart(_) => methods::SMART_HOME_CAMERA_STREAM_START,
+            Self::SmartHomeCameraStreamStop(_) => methods::SMART_HOME_CAMERA_STREAM_STOP,
         }
     }
 
@@ -4122,6 +4249,11 @@ impl UiCommand {
             Self::RouterSetMode(params) => serde_json::to_value(params),
             Self::RouterGetMetrics(params) => serde_json::to_value(params),
             Self::LaunchResolve(params) => serde_json::to_value(params),
+            Self::SmartHomeStatusGet(params) => serde_json::to_value(params),
+            Self::SmartHomeDeviceList(params) => serde_json::to_value(params),
+            Self::SmartHomeDeviceCommand(params) => serde_json::to_value(params),
+            Self::SmartHomeCameraStreamStart(params) => serde_json::to_value(params),
+            Self::SmartHomeCameraStreamStop(params) => serde_json::to_value(params),
         }?;
 
         Ok(RpcRequest::new(id, method, params))
@@ -4217,6 +4349,21 @@ impl UiCommand {
             methods::ROUTER_GET_METRICS => {
                 Ok(Self::RouterGetMetrics(decode_params(method, params)?))
             }
+            methods::SMART_HOME_STATUS_GET => Ok(Self::SmartHomeStatusGet(decode_optional_params(
+                method, params,
+            )?)),
+            methods::SMART_HOME_DEVICE_LIST => Ok(Self::SmartHomeDeviceList(
+                decode_optional_params(method, params)?,
+            )),
+            methods::SMART_HOME_DEVICE_COMMAND => {
+                Ok(Self::SmartHomeDeviceCommand(decode_params(method, params)?))
+            }
+            methods::SMART_HOME_CAMERA_STREAM_START => Ok(Self::SmartHomeCameraStreamStart(
+                decode_params(method, params)?,
+            )),
+            methods::SMART_HOME_CAMERA_STREAM_STOP => Ok(Self::SmartHomeCameraStreamStop(
+                decode_params(method, params)?,
+            )),
             _ => Err(RpcError::method_not_found(method)),
         }
     }

--- a/crates/octos-core/src/ui_protocol_tests.rs
+++ b/crates/octos-core/src/ui_protocol_tests.rs
@@ -772,6 +772,11 @@ fn ui_protocol_v1_wire_contract_is_golden() {
             "router/set_mode",
             "router/get_metrics",
             "launch/resolve",
+            "smart_home/status.get",
+            "smart_home/device.list",
+            "smart_home/device.command",
+            "smart_home/camera.stream_start",
+            "smart_home/camera.stream_stop",
         ]
     );
     assert_eq!(
@@ -885,6 +890,11 @@ fn ui_protocol_v1_wire_contract_is_golden() {
             "router/set_mode",
             "router/get_metrics",
             "launch/resolve",
+            "smart_home/status.get",
+            "smart_home/device.list",
+            "smart_home/device.command",
+            "smart_home/camera.stream_start",
+            "smart_home/camera.stream_stop",
         ]
     );
     assert_eq!(UI_PROTOCOL_FIRST_SERVER_UNSUPPORTED_METHODS.len(), 0);
@@ -965,7 +975,12 @@ fn ui_protocol_v1_representative_wire_payloads_are_golden() {
                 "cron/toggle",
                 "router/set_mode",
                 "router/get_metrics",
-                "launch/resolve"
+                "launch/resolve",
+                "smart_home/status.get",
+                "smart_home/device.list",
+                "smart_home/device.command",
+                "smart_home/camera.stream_start",
+                "smart_home/camera.stream_stop"
             ],
             "supported_notifications": [
                 "session/open",
@@ -1037,7 +1052,8 @@ fn ui_protocol_v1_representative_wire_payloads_are_golden() {
                 "harness.task_artifacts.v1",
                 "user_question.v1",
                 "event.voice_audio.v1",
-                "plan.todos.v1"
+                "plan.todos.v1",
+                "smart_home.v1"
             ]
         })
     );
@@ -6767,5 +6783,173 @@ fn tool_started_topic_field_round_trips_on_the_wire() {
     assert!(
         wire["params"].get("topic").is_none(),
         "absent topic field must stay omitted on the wire (no v0 breakage)"
+    );
+}
+
+/// Smart-home bridge integration: `smart_home/status.get` and
+/// `smart_home/device.list` both accept an omitted (`{}`/null) params
+/// object, matching the `session/list`-style empty-request convention.
+#[test]
+fn smart_home_status_get_and_device_list_accept_omitted_params() {
+    assert_eq!(
+        UiCommand::from_method_and_params(methods::SMART_HOME_STATUS_GET, Value::Null)
+            .expect("decode smart_home/status.get with omitted params"),
+        UiCommand::SmartHomeStatusGet(SmartHomeStatusGetParams {})
+    );
+    assert_eq!(
+        UiCommand::from_method_and_params(methods::SMART_HOME_DEVICE_LIST, json!({}))
+            .expect("decode smart_home/device.list with empty object params"),
+        UiCommand::SmartHomeDeviceList(SmartHomeDeviceListParams {})
+    );
+}
+
+/// `smart_home/status.get` result round-trips its `configured` flag.
+#[test]
+fn smart_home_status_get_result_round_trips() {
+    let result = SmartHomeStatusGetResult { configured: true };
+    let json = serde_json::to_string(&result).expect("serialize result");
+    let parsed: SmartHomeStatusGetResult = serde_json::from_str(&json).expect("deserialize result");
+    assert_eq!(parsed, result);
+}
+
+/// `smart_home/device.list` command round-trips through the RPC envelope,
+/// and its result forwards the bridge's device-list JSON byte-for-byte
+/// (opaque `Value`, same pattern as `SessionListResult`).
+#[test]
+fn smart_home_device_list_command_and_result_round_trip() {
+    let command = UiCommand::SmartHomeDeviceList(SmartHomeDeviceListParams {});
+    assert_eq!(command.method(), methods::SMART_HOME_DEVICE_LIST);
+
+    let rpc = command
+        .clone()
+        .into_rpc_request("req-device-list")
+        .expect("serialize smart_home/device.list");
+    let json = serde_json::to_string(&rpc).expect("to_string");
+    let parsed_rpc: RpcRequest<Value> = serde_json::from_str(&json).expect("from_str");
+    let decoded = UiCommand::from_rpc_request(parsed_rpc).expect("decode smart_home/device.list");
+    assert_eq!(decoded, command);
+
+    let result = SmartHomeDeviceListResult {
+        devices: json!({
+            "source": "home_assistant",
+            "ok": true,
+            "devices": [{"id": "tv1", "name": "Living Room TV", "kind": "tv", "on": true}]
+        }),
+    };
+    let json = serde_json::to_string(&result).expect("serialize result");
+    let parsed: SmartHomeDeviceListResult =
+        serde_json::from_str(&json).expect("deserialize result");
+    assert_eq!(parsed, result);
+}
+
+/// `smart_home/device.command` requires `device_id` + `params` and
+/// round-trips through the RPC envelope.
+#[test]
+fn smart_home_device_command_round_trips() {
+    let mut params = serde_json::Map::new();
+    params.insert("on".into(), json!(true));
+    let command = UiCommand::SmartHomeDeviceCommand(SmartHomeDeviceCommandParams {
+        device_id: "tv1".into(),
+        params: Value::Object(params),
+    });
+    assert_eq!(command.method(), methods::SMART_HOME_DEVICE_COMMAND);
+
+    let rpc = command
+        .clone()
+        .into_rpc_request("req-device-command")
+        .expect("serialize smart_home/device.command");
+    assert_eq!(rpc.params["device_id"], json!("tv1"));
+    assert_eq!(rpc.params["params"]["on"], json!(true));
+
+    let json = serde_json::to_string(&rpc).expect("to_string");
+    let parsed_rpc: RpcRequest<Value> = serde_json::from_str(&json).expect("from_str");
+    let decoded =
+        UiCommand::from_rpc_request(parsed_rpc).expect("decode smart_home/device.command");
+    assert_eq!(decoded, command);
+}
+
+/// `smart_home/camera.stream_start` round-trips its optional `quality`
+/// field and its result forwards the bridge's `CameraStreamInfo` JSON.
+#[test]
+fn smart_home_camera_stream_start_command_and_result_round_trip() {
+    let command = UiCommand::SmartHomeCameraStreamStart(SmartHomeCameraStreamStartParams {
+        device_id: "cam1".into(),
+        quality: Some(2),
+    });
+    assert_eq!(command.method(), methods::SMART_HOME_CAMERA_STREAM_START);
+
+    let rpc = command
+        .clone()
+        .into_rpc_request("req-stream-start")
+        .expect("serialize smart_home/camera.stream_start");
+    assert_eq!(rpc.params["quality"], json!(2));
+
+    let json = serde_json::to_string(&rpc).expect("to_string");
+    let parsed_rpc: RpcRequest<Value> = serde_json::from_str(&json).expect("from_str");
+    let decoded =
+        UiCommand::from_rpc_request(parsed_rpc).expect("decode smart_home/camera.stream_start");
+    assert_eq!(decoded, command);
+
+    // Omitted quality stays omitted on the wire (server picks a default).
+    let bare = UiCommand::SmartHomeCameraStreamStart(SmartHomeCameraStreamStartParams {
+        device_id: "cam1".into(),
+        quality: None,
+    });
+    let rpc = bare
+        .into_rpc_request("req-stream-start-bare")
+        .expect("serialize bare");
+    assert!(rpc.params.get("quality").is_none());
+
+    let result = SmartHomeCameraStreamStartResult {
+        stream: json!({"ok": true, "protocol": "hls", "playback_url": "http://bridge/hls/cam1.m3u8"}),
+    };
+    let json = serde_json::to_string(&result).expect("serialize result");
+    let parsed: SmartHomeCameraStreamStartResult =
+        serde_json::from_str(&json).expect("deserialize result");
+    assert_eq!(parsed, result);
+}
+
+/// `smart_home/camera.stream_stop` round-trips through the RPC envelope.
+#[test]
+fn smart_home_camera_stream_stop_command_round_trips() {
+    let command = UiCommand::SmartHomeCameraStreamStop(SmartHomeCameraStreamStopParams {
+        device_id: "cam1".into(),
+    });
+    assert_eq!(command.method(), methods::SMART_HOME_CAMERA_STREAM_STOP);
+
+    let rpc = command
+        .clone()
+        .into_rpc_request("req-stream-stop")
+        .expect("serialize smart_home/camera.stream_stop");
+    let json = serde_json::to_string(&rpc).expect("to_string");
+    let parsed_rpc: RpcRequest<Value> = serde_json::from_str(&json).expect("from_str");
+    let decoded =
+        UiCommand::from_rpc_request(parsed_rpc).expect("decode smart_home/camera.stream_stop");
+    assert_eq!(decoded, command);
+}
+
+/// The `smart_home.v1` feature gates all 5 smart-home methods, and is
+/// advertised in `full_protocol()` but withheld from a server that hasn't
+/// negotiated it — same pattern as `user_question_methods_and_feature_are_registered`.
+#[test]
+fn smart_home_methods_are_gated_on_smart_home_v1() {
+    for method in [
+        methods::SMART_HOME_STATUS_GET,
+        methods::SMART_HOME_DEVICE_LIST,
+        methods::SMART_HOME_DEVICE_COMMAND,
+        methods::SMART_HOME_CAMERA_STREAM_START,
+        methods::SMART_HOME_CAMERA_STREAM_STOP,
+    ] {
+        assert_eq!(
+            method_capability_gate(method),
+            Some(UI_PROTOCOL_FEATURE_SMART_HOME_V1),
+            "{method} must be gated on smart_home.v1"
+        );
+    }
+
+    let full = UiProtocolCapabilities::full_protocol();
+    assert!(
+        full.supported_features
+            .contains(&UI_PROTOCOL_FEATURE_SMART_HOME_V1.to_string())
     );
 }

--- a/crates/octos-services/src/updater.rs
+++ b/crates/octos-services/src/updater.rs
@@ -331,6 +331,7 @@ impl Updater {
                     "voice",
                     "clock",
                     "weather",
+                    "smart-home",
                 ];
                 for skill in &skills {
                     let dir = skills_dir.join(skill);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@ For the next hardening/generalization round after the runtime refactor, see [OCT
 **Workspace members**:
 - **10 octos-* crates**: octos-core, octos-memory, octos-llm, octos-agent, octos-bus, octos-cli, octos-pipeline, octos-plugin, **octos-sandbox** (Windows AppContainer helper binary), **octos-swarm** (PM/swarm dispatcher, ledger, topology)
 - **14 app-skill workspace crates**, of which **9 are auto-bootstrapped at gateway startup** (the contents of `BUNDLED_APP_SKILLS` in `crates/octos-agent/src/bundled_app_skills.rs`):
-  - **Bundled (9)**: news, deep-search, deep-crawl, send-email, account-manager, time (binary `clock`), weather, pipeline-guard, skill-evolve
+  - **Bundled (9)**: news, deep-search, deep-crawl, send-email, account-manager, time (binary `clock`), weather, smart-home, skill-evolve
   - **Not bundled (5) — workspace example/utility crates only**: `harness-starter-{audio, coding, generic, report}` (templates for new skill authors), `wechat-bridge` (transport helper, not a tool-providing skill)
 - **1 platform-skill crate**: voice (auto-bootstrapped)
 
@@ -602,7 +602,7 @@ Triggered when estimated tokens exceed 80% of context window / 1.2 safety margin
 | `account-manager` | `account_manager` | Sub-account ops |
 | `time` | `clock` | Time/timezone |
 | `weather` | `weather` | Weather API |
-| `pipeline-guard` | `pipeline-guard` | DOT pipeline before-hook validator |
+| `smart-home` | `smart_home` | List/control smart-home devices via profile bridge |
 | `skill-evolve` | `skill-evolve` | Patch-management for skill SKILL.md drift |
 
 `PLATFORM_SKILLS` adds one more entry — `voice` — bootstrapped once by `octos serve` at admin-bot startup, shared across all gateway profiles, only installed when its OminiX-API backend is reachable. Voice cloning is **not** part of the platform voice skill — it is handled by the separate `mofa-fm` skill (`fm_tts`).
@@ -1562,7 +1562,7 @@ crates/
 ├── app-skills/    (14 workspace crates; only 9 are auto-bootstrapped via
 │                    BUNDLED_APP_SKILLS:
 │                      news, deep-search, deep-crawl, send-email,
-│                      account-manager, time, weather, pipeline-guard,
+│                      account-manager, time, weather, smart-home,
 │                      skill-evolve.
 │                    Workspace-only (not bundled):
 │                      harness-starter-{audio, coding, generic, report},

--- a/docs/user-guide-zh.md
+++ b/docs/user-guide-zh.md
@@ -26,7 +26,7 @@
     - [时钟](#126-时钟)
     - [天气](#127-天气)
     - [微信桥接](#128-微信桥接wechat-bridge)
-    - [Pipeline Guard](#129-pipeline-guard)
+    - [智能家居](#129-智能家居)
     - [Skill Evolve](#1210-skill-evolve)
     - [Harness Starter](#1211-harness-starter启动模板)
 13. [平台技能 (ASR/TTS)](#13-平台技能-asrtts)
@@ -1084,7 +1084,7 @@ octos cron enable <job-id> --disable
 
 内置应用技能作为编译好的二进制文件随 `octos` 一起发布。Gateway 启动时会写入 `<octos_home>/bundled-app-skills/<name>/`，运维或用户自定义技能安装到当前 profile 的 `~/.octos/profiles/<profile>/data/skills/`，因此重新部署不会覆盖自定义内容。完整列表见 `BUNDLED_APP_SKILLS`（`crates/octos-agent/src/bundled_app_skills.rs`）：
 
-> **自动安装的内置技能：** news、deep-search、deep-crawl、send-email、account-manager、time（二进制名 `clock`）、weather、pipeline-guard、skill-evolve。加上平台技能 `voice`。
+> **自动安装的内置技能：** news、deep-search、deep-crawl、send-email、account-manager、time（二进制名 `clock`）、weather、smart-home、skill-evolve。加上平台技能 `voice`。
 
 下文的 12.8（微信桥接）和 12.11（启动模板）描述的是 `crates/app-skills/` 下**仅在 workspace 中作为示例的 crate**，并未列入 `BUNDLED_APP_SKILLS`。它们以源码形式随仓库分发，作为模板或传输助手，不会被 gateway 自动安装为运行时技能。
 
@@ -1459,12 +1459,44 @@ export LARK_FROM_ADDRESS="your-feishu-email@company.com"
 
 为微信个人号提供 WebSocket 桥接 —— 通过 WebSocket 与微信客户端通信并把消息转发给 gateway。
 
-### 12.9 Pipeline Guard
+### 12.9 智能家居
 
-**类型：** Hook（不是工具）
-**事件：** `before_tool_call`（过滤：`run_pipeline`）
+**工具名称：** `smart_home_list_devices`、`smart_home_control_device`
+**超时：** 10 秒
+**前置条件：** 需要先为该 profile 配置好桥接（设置 → 智能家居）
+**上下文触发：** 当对话提到"智能家居"、"设备"、"灯"、"空调"、"开灯"、"关灯"、"窗帘"等关键词时激活
 
-在 `run_pipeline` 执行前校验 DOT 图并注入最佳模型分配。作为 before-hook 运行（10s 超时），可以拒绝畸形的 pipeline 提交。
+通过当前 profile 配置的桥接（如 Home Assistant）列出并控制智能家居设备（灯具、空调、窗帘、音箱等）。直接从 profile 读取桥接 URL 和 token —— 不经过正在运行的 gateway 转发。摄像头视频串流仍然是 octos-web 中面向人类、仅通过 WebSocket 提供的功能，不对 agent 开放。
+
+#### smart_home_list_devices 参数
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `room` | 字符串 | *（无）* | 可选的房间名过滤（不区分大小写） |
+
+#### smart_home_control_device 参数
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `device_id` | 字符串 | *（必填）* | 目标设备 ID，来自 `smart_home_list_devices` 的返回结果 |
+| `params` | 对象 | *（必填）* | 命令字段，如 `{"on": true}`、`{"brightness": 80}`、`{"temperature": 22}` |
+
+#### 聊天使用示例
+
+```
+用户：客厅里有哪些智能设备？
+
+机器人：[使用 smart_home_list_devices，room="客厅"]
+       客厅台灯 (id: lamp_1, light) — on | brightness: 80
+       客厅空调 (id: ac_1, thermostat) — on | temperature: 24
+```
+
+```
+用户：把客厅的灯调暗一点
+
+机器人：[使用 smart_home_control_device，device_id="lamp_1"，params={"brightness": 30}]
+       Sent to lamp_1: brightness=30
+```
 
 ### 12.10 Skill Evolve
 
@@ -2101,7 +2133,7 @@ chmod +x .octos/skills/translator/main
 │   ├── account-manager/        # 子账户管理
 │   ├── time/                   # 时间 / 时区（二进制名 "clock"）
 │   ├── weather/                # Open-Meteo 天气
-│   ├── pipeline-guard/         # DOT pipeline 前置 hook 校验
+│   ├── smart-home/             # 通过 profile 桥接列出/控制设备
 │   └── skill-evolve/           # SKILL.md 补丁队列（前台）
 ├── skills/                     # 用户安装的自定义技能
 │   │                           #（优先级：项目 > 配置 > 全局；重新部署不覆盖）。

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -26,7 +26,7 @@ A comprehensive guide for deploying, configuring, and using the Octos AI agent p
     - [Clock](#126-clock)
     - [Weather](#127-weather)
     - [WeChat Bridge](#128-wechat-bridge)
-    - [Pipeline Guard](#129-pipeline-guard)
+    - [Smart Home](#129-smart-home)
     - [Skill Evolve](#1210-skill-evolve)
     - [Harness Starters](#1211-harness-starters)
 13. [Platform Skills (ASR/TTS)](#13-platform-skills-asrtts)
@@ -1155,7 +1155,7 @@ Check for new issues in the GitHub repo and summarize any urgent ones.
 
 Bundled app skills ship as compiled binaries alongside the `octos` binary. On gateway startup they are written into `<octos_home>/bundled-app-skills/<name>/`, while operator or user customizations are installed into the active profile's `~/.octos/profiles/<profile>/data/skills/` directory so a re-deploy never overwrites them. The full list lives in `BUNDLED_APP_SKILLS` (`crates/octos-agent/src/bundled_app_skills.rs`):
 
-> **Bundled (auto-installed):** news, deep-search, deep-crawl, send-email, account-manager, time (binary `clock`), weather, pipeline-guard, skill-evolve. Plus the platform-skill `voice`.
+> **Bundled (auto-installed):** news, deep-search, deep-crawl, send-email, account-manager, time (binary `clock`), weather, smart-home, skill-evolve. Plus the platform-skill `voice`.
 
 Sections 12.8 (WeChat Bridge) and 12.11 (Harness Starters) below describe **workspace example crates** under `crates/app-skills/` that are *not* in `BUNDLED_APP_SKILLS` — they ship in the source tree as templates / transport helpers, not as auto-installed runtime skills.
 
@@ -1538,12 +1538,44 @@ Bot: [uses get_forecast with city="New York, US", days=5]
 
 WebSocket bridge for WeChat personal accounts. Connects to the WeChat client via WebSocket and forwards messages to the gateway.
 
-### 12.9 Pipeline Guard
+### 12.9 Smart Home
 
-**Type:** Hook (not a tool)
-**Event:** `before_tool_call` (filter: `run_pipeline`)
+**Tools:** `smart_home_list_devices`, `smart_home_control_device`
+**Timeout:** 10 seconds
+**Requires:** A bridge configured for the profile first (Settings → Smart Home)
+**Context-triggered:** Activated when conversation mentions "smart home", "device", "light", "thermostat", "智能家居", "开灯", "关灯", "空调", "窗帘"
 
-Validates DOT graphs and injects optimal model assignments before `run_pipeline` executes. Runs as a before-hook with 10s timeout — can deny malformed pipeline submissions.
+Lists and controls smart-home devices (lights, thermostats, curtains, speakers, etc.) through the bridge configured for the active profile (e.g. Home Assistant). Reads the bridge URL and token directly from the profile — does not proxy through the running gateway. Camera video streaming stays a human-facing, WebSocket-only feature in octos-web and is not exposed to the agent.
+
+#### smart_home_list_devices Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `room` | string | *(none)* | Optional room name filter (case-insensitive) |
+
+#### smart_home_control_device Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `device_id` | string | *(required)* | Target device ID, as returned by `smart_home_list_devices` |
+| `params` | object | *(required)* | Command fields, e.g. `{"on": true}`, `{"brightness": 80}`, `{"temperature": 22}` |
+
+#### Sample Chat Usage
+
+```
+User: What smart home devices do I have in the living room?
+
+Bot: [uses smart_home_list_devices with room="living room"]
+     Living Room Lamp (id: lamp_1, light) — on | brightness: 80
+     Living Room AC (id: ac_1, thermostat) — on | temperature: 24
+```
+
+```
+User: 把客厅的灯调暗一点
+
+Bot: [uses smart_home_control_device with device_id="lamp_1", params={"brightness": 30}]
+     Sent to lamp_1: brightness=30
+```
 
 ### 12.10 Skill Evolve
 
@@ -2191,7 +2223,7 @@ Bot: [uses translate tool with text="Hello world", target_lang="JA"]
 │   ├── account-manager/        # sub-account ops
 │   ├── time/                   # time / timezone (binary "clock")
 │   ├── weather/                # Open-Meteo weather
-│   ├── pipeline-guard/         # DOT-pipeline before-hook validator
+│   ├── smart-home/             # List/control devices via profile bridge
 │   └── skill-evolve/           # SKILL.md patch queue (foreground)
 ├── skills/                     # User-installed custom skills (precedence:
 │   │                           #  project > profile > global; not overwritten

--- a/nix/packages/app-skills.nix
+++ b/nix/packages/app-skills.nix
@@ -23,6 +23,7 @@ let
     "account-manager"
     "clock"
     "weather"
+    "smart-home"
   ];
   skillBins = [
     "news_fetch"
@@ -32,6 +33,7 @@ let
     "account_manager"
     "clock"
     "weather"
+    "smart_home"
   ];
 in
 

--- a/packaging/npm/install.js
+++ b/packaging/npm/install.js
@@ -2,7 +2,7 @@
 // postinstall: download the prebuilt octos release bundle for this platform,
 // extract every binary into vendor/, and assert the full skill set is present.
 //
-// The bundle ships `octos` alongside its 8 skill binaries. At `octos serve`
+// The bundle ships `octos` alongside its 9 skill binaries. At `octos serve`
 // startup, bootstrap discovers those skills as SIBLINGS of the resolved
 // `octos` executable, so they must all land in the same dir (vendor/).
 //
@@ -35,6 +35,7 @@ const EXPECTED_BINS = [
   "voice",
   "clock",
   "weather",
+  "smart_home",
 ];
 
 function fail(msg) {

--- a/scripts/milestone-ci.sh
+++ b/scripts/milestone-ci.sh
@@ -5,7 +5,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
 FEATURES="${FEATURES:-api,telegram,discord,dingtalk,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3}"
-SKILL_CRATES="${SKILL_CRATES:--p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather -p skill-evolve}"
+SKILL_CRATES="${SKILL_CRATES:--p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather -p smart-home -p skill-evolve}"
 
 usage() {
   cat <<'EOF'

--- a/typos.toml
+++ b/typos.toml
@@ -55,6 +55,8 @@ strng = "strng"
 # Basic Regular Expression — referenced in slides validator spec comments
 # explaining the regex escape behavior for find -name patterns.
 BRE = "BRE"
+# POSIX open(2) flag (O_WRONLY), not a misspelling of "wrongly"
+WRONLY = "WRONLY"
 
 [files]
 extend-exclude = ["**/*.js", "**/*.css", "**/*.html", "examples/*/static/**/*.*"]


### PR DESCRIPTION
## Summary
- Move smart-home device listing/control (and camera stream start/stop signaling) server-side: octos now talks to a self-hosted, per-profile-configured smart-home bridge (Home Assistant-style HTTP shim) directly, instead of the browser hitting it over a REST proxy.
- New `SmartHomeConfig` (bridge_url/token/token_env) on `ProfileConfig`, with secret masking (token only — bridge_url and token_env name are not secrets) and env-var resolution (`SMART_HOME_BRIDGE_URL`/`SMART_HOME_BRIDGE_TOKEN`), plus REST profile-patch support (`PUT /api/my/profile`).
- New `smart_home/*` UI Protocol WS methods (`status.get`, `device.list`, `device.command`, `camera.stream_start`, `camera.stream_stop`), gated on a `smart_home.v1` feature token, dispatched via thin wrappers mirroring the existing `cron_panel`/`memory_panel` pattern.
- Camera **video streaming** stays a human-facing, WebSocket-only concern (playback URL handoff only) — intentionally **not** exposed to the agent tool surface.
- New bundled `app-skills/smart-home` agent skill (list/control devices) built on the same bridge client.
- Explicitly out of the shared-SSRF-protection path (`tools/ssrf.rs`): this is an admin-configured, self-hosted/same-LAN bridge URL, a different trust boundary than agent-supplied URLs.

## Testing
- `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace`, `cargo fmt --all -- --check` — all clean (pre-existing, unrelated `deep-search` CRLF test failures on Windows confirmed reproducible independent of this branch).
- Existing `wiremock`-based unit tests for the bridge HTTP client and the `smart_home_panel` REST-shaped handlers (fetch/command/camera-stream, auth, percent-encoding, error mapping).
- New `crates/octos-cli/tests/smart_home_ws_e2e.rs`: a genuine end-to-end integration test — a real TCP-bound `axum::serve` router (not `tower::oneshot`, which cannot perform a WS upgrade) driven by a real `tokio-tungstenite` client, backed by a real `wiremock` HTTP bridge. Exercises all 5 `smart_home/*` methods through the real WS-auth → JSON-RPC dispatch → profile-resolution → bridge-HTTP-call path, including the not-configured error mapping.
- Manual full-stack pass: built the real `octos serve` binary, ran it against a standalone mock bridge HTTP server, pointed the real `octos-web` dev server (companion branch) at it, and drove the actual `/home` UI in a real browser — confirmed the device list renders from the real backend+bridge and a device command (`Vol +` → `volume_up`) round-trips through real dispatch code to a real HTTP POST on the mock bridge (`POST /devices/real_tv`, form-encoded).

## Test plan
- [x] Workspace build/test/clippy/fmt clean
- [x] Bridge HTTP client unit tests (pre-existing)
- [x] `smart_home_panel` handler unit tests (pre-existing)
- [x] New real WS+HTTP end-to-end integration test (this PR)
- [x] Manual full-stack local verification (real backend binary + real frontend dev server + real browser)
- [x] Companion PR: octos-org/octos-web#286

🤖 Generated with [Claude Code](https://claude.com/claude-code)