### PR TITLE
fix(windows): gate Unix-only agent/plugin tests behind #[cfg(unix)]

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -66,6 +66,7 @@ use octos_llm::{
 };
 use octos_memory::EpisodeStore;
 
+#[cfg(unix)]
 use crate::plugins::PluginTool;
 use crate::{AgentConfig, AgentVerifierConfig};
 
@@ -499,11 +500,14 @@ impl LlmProvider for GateVerifier {
         "mock-verifier"
     }
 }
+#[cfg(unix)]
 use crate::plugins::manifest::PluginToolDef;
 use crate::prompt_context::{
     PromptContextManager, PromptContextPhase, PromptContextReport, PromptContextRequest,
 };
-use crate::tools::{Tool, ToolRegistry, ToolResult, TurnAttachmentContext};
+#[cfg(unix)]
+use crate::tools::TurnAttachmentContext;
+use crate::tools::{Tool, ToolRegistry, ToolResult};
 
 struct FilesToSendOnlyTool {
     file_path: PathBuf,
@@ -942,10 +946,12 @@ impl LlmProvider for PodcastGenerateTwiceProvider {
     }
 }
 
+#[cfg(unix)]
 struct ConsecutiveVoiceSaveProvider {
     calls: AtomicUsize,
 }
 
+#[cfg(unix)]
 #[async_trait]
 impl LlmProvider for ConsecutiveVoiceSaveProvider {
     async fn chat(
@@ -5375,11 +5381,13 @@ async fn should_not_emit_turn_failure_when_hook_denies_llm_call_under_failfast()
 /// Records the message contents of every LLM call and returns EndTurn
 /// immediately. Used to assert what the model actually saw and that it was
 /// (or was not) called at all.
+#[cfg(unix)]
 struct RecordingEndProvider {
     chat_calls: Arc<AtomicUsize>,
     observed: Arc<StdMutex<Vec<Vec<String>>>>,
 }
 
+#[cfg(unix)]
 #[async_trait]
 impl LlmProvider for RecordingEndProvider {
     async fn chat(

--- a/crates/octos-agent/src/hooks.rs
+++ b/crates/octos-agent/src/hooks.rs
@@ -1699,6 +1699,7 @@ mod tests {
 
     /// Convenience constructor for path-filter tests so the cases that follow
     /// stay focused on the filtering behaviour itself.
+    #[cfg(unix)]
     fn hook_with_path_filter(event: HookEvent, patterns: Vec<&str>) -> HookConfig {
         HookConfig {
             event,
@@ -1942,6 +1943,7 @@ mod tests {
     // ----- UserPromptSubmit hook tests -----
 
     /// Convenience constructor for the UserPromptSubmit tests below.
+    #[cfg(unix)]
     fn user_prompt_hook(command: Vec<&str>, timeout_ms: u64) -> HookConfig {
         HookConfig {
             event: HookEvent::UserPromptSubmit,

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -229,7 +229,10 @@ impl PluginTool {
 
     /// The plugin's own execution timeout (seconds-resolution `Duration`).
     /// Exposed for the loader tests to assert the manifest-timeout clamp.
-    #[cfg(test)]
+    /// Its only callers are `#[cfg(unix)]` loader tests (they chmod +x a
+    /// real shell script), so this accessor must match their gating or it's
+    /// dead code on Windows.
+    #[cfg(all(test, unix))]
     pub(crate) fn timeout(&self) -> Duration {
         self.timeout
     }

--- a/crates/octos-agent/src/plugins/tool_tests.rs
+++ b/crates/octos-agent/src/plugins/tool_tests.rs
@@ -2245,16 +2245,21 @@ async fn strict_env_allowlist_retains_path() {
 
 // ---- risk approval gate ----
 
+#[cfg(unix)]
 use async_trait::async_trait;
+#[cfg(unix)]
 use std::sync::Mutex;
 
+#[cfg(unix)]
 use crate::tools::ToolApprovalRequester;
 
+#[cfg(unix)]
 struct RecordingRequester {
     decision: ToolApprovalDecision,
     last: Arc<Mutex<Option<ToolApprovalRequest>>>,
 }
 
+#[cfg(unix)]
 impl RecordingRequester {
     fn new(decision: ToolApprovalDecision) -> (Arc<Self>, Arc<Mutex<Option<ToolApprovalRequest>>>) {
         let last = Arc::new(Mutex::new(None));
@@ -2266,6 +2271,7 @@ impl RecordingRequester {
     }
 }
 
+#[cfg(unix)]
 #[async_trait]
 impl ToolApprovalRequester for RecordingRequester {
     async fn request_approval(&self, request: ToolApprovalRequest) -> ToolApprovalDecision {
@@ -2532,7 +2538,11 @@ fn should_thread_session_approval_context_into_plugin_tools_on_rebind() {
 
     let dir = tempfile::tempdir().expect("create temp dir");
     let script_path = dir.path().join("script.sh");
-    write_test_script(&script_path, "#!/bin/sh\necho '{}'\n");
+    // Never executed — this test only checks approval-context threading
+    // through the registry rebind, so the placeholder just needs to exist
+    // on disk. `write_test_script` (real shebang + chmod +x) is Unix-only;
+    // an empty file keeps this test running on Windows too.
+    std::fs::write(&script_path, "").unwrap();
     let mut def = make_tool_def("risky", "risky");
     def.risk = Some("high".into());
 
@@ -2893,6 +2903,7 @@ fn multi_tenant_scope_at(
     .expect("build multi-tenant scope")
 }
 
+#[cfg(unix)]
 fn ctx_with_scope(scope: SessionScope) -> ToolContext {
     let mut ctx = ToolContext::zero();
     ctx.session_scope = Some(Arc::new(scope));

--- a/crates/octos-agent/src/tools/spawn_tests.rs
+++ b/crates/octos-agent/src/tools/spawn_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+#[cfg(unix)]
 use crate::{HookConfig, HookEvent};
 
 #[test]

--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -50,6 +50,7 @@ const DEFAULT_COMMAND_TIMEOUT_MS: u64 = 30_000;
 /// stalling the whole contract gate.
 const DEFAULT_HTTP_PROBE_TIMEOUT_MS: u64 = 5_000;
 const MAX_EVIDENCE_BYTES: usize = 512 * 1024;
+#[cfg(unix)]
 const KILL_GRACE_PERIOD: Duration = Duration::from_millis(300);
 
 /// Default ominix-api URL when the `OMINIX_API_URL` env override is absent.

--- a/crates/octos-agent/tests/cli_agent_backend.rs
+++ b/crates/octos-agent/tests/cli_agent_backend.rs
@@ -2,6 +2,8 @@
 //! lane that invokes one-shot headless agents (`claude -p`,
 //! `codex exec`) and maps process results onto [`DispatchOutcome`].
 
+#![cfg(unix)]
+
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};

--- a/crates/octos-agent/tests/domain_hook.rs
+++ b/crates/octos-agent/tests/domain_hook.rs
@@ -12,6 +12,8 @@
 //! - A before-hook can read `domain_data.force_n` from stdin JSON and exit 1
 //!   to deny a `BeforeSpawnVerify` event.
 
+#![cfg(unix)]
+
 use std::io::Write as _;
 use std::os::unix::fs::PermissionsExt;
 use std::sync::Arc;

--- a/crates/octos-agent/tests/skill_install_with_lifecycle.rs
+++ b/crates/octos-agent/tests/skill_install_with_lifecycle.rs
@@ -8,6 +8,8 @@
 //! E) uninstall (deactivate) runs shutdown phase
 //! F) HTTP discovery failure aborts install — no tools partially registered
 
+#![cfg(unix)]
+
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 

--- a/crates/octos-cli/src/commands/doctor.rs
+++ b/crates/octos-cli/src/commands/doctor.rs
@@ -332,9 +332,6 @@ fn build_report(cmd: &DoctorCommand, with_network: bool) -> Result<Report> {
     Ok(report)
 }
 
-// Network category (Stage 2, `github` feature): GitHub API reachability + a
-// best-effort newer-release check. Both are advisory — a network/API failure
-// produces a `[!]` WARN, never a `[✗]` FAIL, so `doctor` never blocks offline.
 // ---------------------------------------------------------------------------
 // Installations — every octos + octos-tui on the machine, with versions
 // ---------------------------------------------------------------------------

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -1239,9 +1239,11 @@ mod tests {
     use crate::profiles::{
         GatewaySettings, LlmModelSelectionConfig, LlmProfileConfig, LlmRouteConfig, ProfileConfig,
     };
+    #[cfg(unix)]
     use crate::runtime::SessionRuntime;
     use chrono::Utc;
     use octos_agent::SandboxConfig;
+    #[cfg(unix)]
     use octos_core::SessionKey;
     use std::collections::HashMap;
 

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -143,17 +143,20 @@ const FAILOVER_PUSH_DEBOUNCE: Duration = Duration::from_secs(5);
 
 // ── Peer inbox registry (#436) ─────────────────────────────────────────────
 
+/// Inbox sender map keyed by `"{profile_id}:peer:{slug}"`, shared behind
+/// an `Arc<StdMutex<_>>` so [`peer_inbox_registry`] callers can clone the
+/// `Arc` and lock independently.
+type PeerInboxMap = Arc<StdMutex<HashMap<String, mpsc::Sender<ActorMessage>>>>;
+
 /// Global registry mapping `"{profile_id}:peer:{slug}"` → inbox sender for
 /// running peer sessions. Populated by [`ActorRegistry::dispatch`] when a
 /// peer session actor spawns; removed on session death / deletion. The
 /// [`PeerSendInputTool`] callback reads this to deliver cross-session
 /// messages without a TUI round-trip.
-static PEER_INBOX_REGISTRY: OnceLock<Arc<StdMutex<HashMap<String, mpsc::Sender<ActorMessage>>>>> =
-    OnceLock::new();
+static PEER_INBOX_REGISTRY: OnceLock<PeerInboxMap> = OnceLock::new();
 
 /// Get (or init) the global peer inbox registry.
-pub fn peer_inbox_registry() -> &'static Arc<StdMutex<HashMap<String, mpsc::Sender<ActorMessage>>>>
-{
+pub fn peer_inbox_registry() -> &'static PeerInboxMap {
     PEER_INBOX_REGISTRY.get_or_init(|| Arc::new(StdMutex::new(HashMap::new())))
 }
 

--- a/crates/octos-cli/src/session_actor_tests.rs
+++ b/crates/octos-cli/src/session_actor_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use async_trait::async_trait;
+#[cfg(unix)]
 use octos_agent::{HookConfig, HookEvent};
 use octos_llm::{AdaptiveConfig, ChatConfig, ChatResponse, StopReason, TokenUsage, ToolSpec};
 use std::sync::atomic::AtomicUsize;

--- a/crates/octos-plugin/tests/lifecycle_sandbox.rs
+++ b/crates/octos-plugin/tests/lifecycle_sandbox.rs
@@ -14,7 +14,6 @@
 
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use octos_plugin::{
     HardwareLifecycle, LifecycleExecutor, LifecyclePhase, LifecycleStep, NoSandbox, Sandbox,
@@ -161,7 +160,7 @@ async fn should_apply_blocked_env_vars_to_lifecycle_steps() {
 #[cfg(unix)]
 #[tokio::test]
 async fn should_kill_child_when_step_timeout_exceeded() {
-    use std::time::Instant;
+    use std::time::{Duration, Instant};
 
     let tmp = tempfile::tempdir().unwrap();
     let pid_path = tmp.path().join("marker.pid");

--- a/crates/octos-services/src/config_context.rs
+++ b/crates/octos-services/src/config_context.rs
@@ -123,9 +123,9 @@ fn default_data_dir() -> PathBuf {
 fn xdg_config_home() -> PathBuf {
     #[cfg(windows)]
     {
-        return dirs::config_dir()
+        dirs::config_dir()
             .map(|d| d.join("octos"))
-            .unwrap_or_else(default_data_dir);
+            .unwrap_or_else(default_data_dir)
     }
     #[cfg(not(windows))]
     {

--- a/crates/octos-swarm/tests/swarm_dispatch.rs
+++ b/crates/octos-swarm/tests/swarm_dispatch.rs
@@ -1458,6 +1458,7 @@ async fn should_not_burn_retry_budget_on_progress_rounds() {
 }
 
 #[tokio::test]
+#[cfg(unix)]
 async fn should_dispatch_through_cli_backend_with_retry_on_nonzero_exit() {
     // The CLI backend lane end-to-end through the real dispatcher: a
     // one-shot script that fails on its first invocation (non-zero

--- a/typos.toml
+++ b/typos.toml
@@ -55,6 +55,8 @@ strng = "strng"
 # Basic Regular Expression — referenced in slides validator spec comments
 # explaining the regex escape behavior for find -name patterns.
 BRE = "BRE"
+# POSIX open(2) flag (O_WRONLY), not a misspelling of "wrongly"
+WRONLY = "WRONLY"
 
 [files]
 extend-exclude = ["**/*.js", "**/*.css", "**/*.html", "examples/*/static/**/*.*"]


### PR DESCRIPTION
## Summary
- Split out of #1821 during final review: several pre-existing tests assume a Unix process/shell model (real shebang scripts + chmod +x, `os::unix::fs::PermissionsExt`, Unix signal-based hook/kill behavior) and don't compile on Windows at all — `write_test_script not found in this scope` is a hard compile error that currently blocks `cargo test --workspace` on Windows before a single test runs.
- Gates those tests behind `#[cfg(unix)]` (whole-file `#![cfg(unix)]` for the three integration-test files that are Unix-only end to end) so the workspace's test targets compile on Windows.
- Also folds in a few unrelated drive-by fixes noticed while getting a clean workspace build: an orphaned doc-comment in `doctor.rs`, a type alias for `peer_gather.rs`'s test recorder, and a needless-return clippy fix in `config_context.rs`'s Windows XDG path helper.

## Scope note
This fixes **compilation only**. Getting the suite to compile on Windows for the first time surfaced a substantial number of pre-existing **runtime** test failures unrelated to this change (env-var/home-directory test isolation in `octos-services`/`octos-cli`, worktree/spawn/shell path handling in `octos-agent` — ~50 tests total). Verified these reproduce identically on unmodified `main`, so they predate this branch. Fixing them is a separate, much larger effort and intentionally out of scope here.

## Test plan
- [x] `cargo build --workspace` — clean, no new warnings
- [x] `cargo clippy --workspace --all-targets` — clean, no warnings
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p octos-agent -p octos-plugin -p octos-swarm -p octos-services -p octos-cli` — compiles (previously a hard compile error on Windows); pre-existing runtime failures confirmed identical on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)