### PR TITLE
feat(peer): per-peer model lane via profile sub_provider keys

### DIFF
--- a/crates/octos-agent/src/tools/peer_handoff.rs
+++ b/crates/octos-agent/src/tools/peer_handoff.rs
@@ -43,6 +43,14 @@ pub struct PeerHandoffRequest {
     pub name: String,
     /// Whether the host should fence the peer in its own git worktree.
     pub worktree: bool,
+    /// Optional model LANE for this peer: the KEY of a `sub_provider`
+    /// configured in the master's profile (e.g. `"cheap"`, `"strong"`).
+    /// `None` (or an empty/whitespace value, normalized to `None` by
+    /// [`PeerHandoffTool::execute`]) keeps the peer on the profile's primary
+    /// model. The host validates the key against the profile's configured
+    /// lanes and, on a match, records it beside the brief so the peer's turns
+    /// resolve that provider; an unknown key is a warning, not a failure.
+    pub model: Option<String>,
 }
 
 /// Staged-peer facts the host callback returns on success.
@@ -58,6 +66,12 @@ pub struct PeerHandoffStaged {
     pub cwd: String,
     /// Fence branch (`peer/<slug>`) when a worktree was created.
     pub worktree_branch: Option<String>,
+    /// Optional model-lane note the host surfaces back to the model in the
+    /// tool's success output — e.g. a warning that the requested `model` lane
+    /// was not found among the profile's configured `sub_providers` (so the
+    /// peer falls back to the primary model). `None` when no lane was
+    /// requested or the requested lane resolved cleanly.
+    pub model_note: Option<String>,
 }
 
 /// Host staging callback. Synchronous by design: the tool needs the staged
@@ -86,6 +100,8 @@ struct Input {
     name: String,
     #[serde(default)]
     worktree: bool,
+    #[serde(default)]
+    model: Option<String>,
 }
 
 fn failure(output: impl Into<String>) -> ToolResult {
@@ -147,6 +163,10 @@ impl Tool for PeerHandoffTool {
                 "worktree": {
                     "type": "boolean",
                     "description": "Fence the peer in its own git worktree on branch peer/<slug> (default false). Use for code changes that must not collide with this session's working tree."
+                },
+                "model": {
+                    "type": "string",
+                    "description": "Optional model lane for this peer — the KEY of a sub_provider configured in your profile (e.g. \"cheap\", \"strong\"). Omit to use the profile's primary model."
                 }
             }
         })
@@ -187,14 +207,23 @@ impl Tool for PeerHandoffTool {
                  contract; keep the payload in the workspace and reference it by path."
             )));
         }
+        // Normalize the optional model lane: trim and drop an empty/whitespace
+        // value to `None` so the host only ever sees a real lane key.
+        let model = input
+            .model
+            .as_deref()
+            .map(str::trim)
+            .filter(|lane| !lane.is_empty())
+            .map(str::to_owned);
         let request = PeerHandoffRequest {
             brief: brief.to_owned(),
             name: name.to_owned(),
             worktree: input.worktree,
+            model,
         };
         match (self.stage)(request) {
-            Ok(staged) => Ok(ToolResult {
-                output: format!(
+            Ok(staged) => {
+                let mut output = format!(
                     "Staged peer '{name}' (slug {slug}, brief at {brief_path}, cwd {cwd}). \
                      Address it later by name with peer_send_input / peer_close. The user's \
                      client opens it in the background; its result lands on the blackboard \
@@ -202,10 +231,19 @@ impl Tool for PeerHandoffTool {
                     slug = staged.slug,
                     brief_path = staged.brief_path,
                     cwd = staged.cwd,
-                ),
-                success: true,
-                ..Default::default()
-            }),
+                );
+                // Surface any model-lane note (e.g. an unknown lane fell back to
+                // the primary model) back to the model in the same result.
+                if let Some(note) = &staged.model_note {
+                    output.push(' ');
+                    output.push_str(note);
+                }
+                Ok(ToolResult {
+                    output,
+                    success: true,
+                    ..Default::default()
+                })
+            }
             Err(err) => Ok(failure(err)),
         }
     }
@@ -229,6 +267,7 @@ mod tests {
                 brief_path: "/data/peers/ci-fix/brief.md".to_owned(),
                 cwd: "/work/peers/ci-fix/wt".to_owned(),
                 worktree_branch: request.worktree.then(|| "peer/ci-fix".to_owned()),
+                model_note: None,
             })
         }));
         (tool, seen)
@@ -386,6 +425,7 @@ mod tests {
                 brief: "Fix the flaky bus test; repro in crates/octos-bus.".to_owned(),
                 name: "CI Fix".to_owned(),
                 worktree: true,
+                model: None,
             },
             "brief/name are trimmed, worktree passes through"
         );
@@ -417,7 +457,93 @@ mod tests {
                 brief: "Just the brief.".to_owned(),
                 name: "Solo".to_owned(),
                 worktree: false,
+                model: None,
             }
+        );
+    }
+
+    #[tokio::test]
+    async fn should_thread_model_lane_through_to_callback_trimmed() {
+        let (tool, seen) = tool_with_recorder();
+
+        let result = tool
+            .execute(&json!({
+                "brief": "Grunt work.",
+                "name": "Grunt",
+                "model": "  strong  ",
+            }))
+            .await
+            .unwrap();
+        assert!(result.success, "unexpected failure: {}", result.output);
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(
+            seen[0].model.as_deref(),
+            Some("strong"),
+            "model lane is trimmed and threaded into the staging request"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_normalize_blank_model_lane_to_none() {
+        let (tool, seen) = tool_with_recorder();
+
+        let result = tool
+            .execute(&json!({
+                "brief": "Grunt work.",
+                "name": "Grunt",
+                "model": "   \n\t ",
+            }))
+            .await
+            .unwrap();
+        assert!(result.success);
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(
+            seen[0].model, None,
+            "a blank/whitespace model lane normalizes to None (use the primary model)"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_append_model_note_from_host_to_success_output() {
+        // The host may report that the requested lane was unknown; the note is
+        // appended to the (still successful) staging result verbatim.
+        let tool = PeerHandoffTool::new(Arc::new(|request: PeerHandoffRequest| {
+            let note = request
+                .model
+                .as_ref()
+                .map(|lane| format!("model lane '{lane}' not found — using the primary model."));
+            Ok(PeerHandoffStaged {
+                slug: "grunt".to_owned(),
+                topic: "peer-grunt".to_owned(),
+                brief_path: "/data/peers/grunt/brief.md".to_owned(),
+                cwd: "/work".to_owned(),
+                worktree_branch: None,
+                model_note: note,
+            })
+        }));
+
+        let result = tool
+            .execute(&json!({
+                "brief": "Grunt work.",
+                "name": "Grunt",
+                "model": "bogus",
+            }))
+            .await
+            .unwrap();
+        assert!(result.success, "an unknown lane warns, it does not fail");
+        assert!(
+            result.output.contains("Staged peer 'Grunt'"),
+            "the staged confirmation is still present: {}",
+            result.output
+        );
+        assert!(
+            result
+                .output
+                .contains("model lane 'bogus' not found — using the primary model."),
+            "the host's model-lane note is appended to the output: {}",
+            result.output
         );
     }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -10495,46 +10495,16 @@ fn build_peer_handoff_callback(
             request.worktree,
         )
         .map_err(|err| err.message)?;
-        // #peer-model — optional model lane. Record a VALID lane
-        // (`peers/<slug>/model`) beside the brief so the peer's turns resolve
-        // that `sub_provider`; an unknown lane is a warning (the peer falls
-        // back to the primary model), not a failure. Best-effort write: a
-        // failed record leaves the peer on the primary model, never unstaged.
-        let model_note = match request
-            .model
-            .as_deref()
-            .map(str::trim)
-            .filter(|lane| !lane.is_empty())
-        {
-            Some(lane) if available_lanes.iter().any(|key| key == lane) => {
-                if let Some(peer_dir) = staged.brief_path.parent() {
-                    if let Err(err) = crate::memory_consolidate::apply::atomic_write(
-                        &peer_dir.join("model"),
-                        lane,
-                    ) {
-                        tracing::warn!(
-                            ?err,
-                            slug = %staged.slug,
-                            lane,
-                            "failed to record peer model lane; peer will use the primary model"
-                        );
-                    }
-                }
-                None
-            }
-            Some(lane) => {
-                let available = if available_lanes.is_empty() {
-                    "none configured".to_owned()
-                } else {
-                    available_lanes.join(", ")
-                };
-                Some(format!(
-                    "model lane '{lane}' not found (available: {available}) — \
-                     this peer will use the primary model."
-                ))
-            }
-            None => None,
-        };
+        // #peer-model — optional model lane. Record a VALID lane symlink-safely
+        // under the re-validated staged dir; an unknown lane (or a failed
+        // record) is a truthful warning (the peer runs on the primary model),
+        // never a staging failure.
+        let model_note = record_peer_model_lane(
+            &peers_root,
+            &staged.slug,
+            request.model.as_deref(),
+            &available_lanes,
+        );
         // Durable so reconnect replay still delivers the open request; the
         // client dedups by an already-open session for the topic.
         emit_staged(PeerStagedEvent {
@@ -10558,46 +10528,133 @@ fn build_peer_handoff_callback(
     })
 }
 
+/// #peer-model — read a small text file through an `O_NOFOLLOW` open (Unix) so
+/// a symlink leaf swapped into a validated peer dir cannot redirect the read to
+/// an off-tenant target (mirrors `read_file_no_follow` for the sync peer-file
+/// layer). On non-Unix, re-checks `symlink_metadata` first. `None` on any error
+/// (missing, symlink, unreadable).
+fn read_text_no_follow(path: &Path) -> Option<String> {
+    use std::io::Read;
+    let mut opts = std::fs::OpenOptions::new();
+    opts.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.custom_flags(libc::O_NOFOLLOW);
+    }
+    #[cfg(not(unix))]
+    {
+        if path.symlink_metadata().is_ok_and(|meta| meta.is_symlink()) {
+            return None;
+        }
+    }
+    let mut file = opts.open(path).ok()?;
+    let mut content = String::new();
+    file.read_to_string(&mut content).ok()?;
+    Some(content)
+}
+
 /// #peer-model — read a peer's optional model LANE key from
 /// `peers/<slug>/model` (written by the `peer_handoff` staging callback when
 /// the master named a VALID `sub_provider` lane). Routed through
-/// [`staged_peer_dir`] so a symlinked / unsafe slug is never followed. Returns
-/// the trimmed lane key, or `None` when the dir is not a real staged peer, the
-/// file is absent, or it is empty.
+/// [`staged_peer_dir`] (real, non-symlink dir with `brief.md`) AND an
+/// `O_NOFOLLOW` read of the leaf so neither a symlinked dir nor a symlinked
+/// `model` file is ever followed. Returns the trimmed lane key, or `None` when
+/// the dir is not a real staged peer, the file is absent/symlinked, or empty.
 fn read_peer_model_lane(peers_root: &Path, slug: &str) -> Option<String> {
     let dir = staged_peer_dir(peers_root, slug)?;
-    let lane = std::fs::read_to_string(dir.join("model")).ok()?;
+    let lane = read_text_no_follow(&dir.join("model"))?;
     let lane = lane.trim();
     (!lane.is_empty()).then(|| lane.to_owned())
 }
 
+/// #peer-model — record a requested model lane for a freshly-staged peer,
+/// returning the tool-visible note (`None` = recorded cleanly, or no lane was
+/// requested). Validates the (trimmed) lane against the CURRENT
+/// `available_lanes`; a match is written symlink-safely under the RE-VALIDATED
+/// [`staged_peer_dir`] (never `brief_path.parent()`, which races a parent
+/// swap) via the atomic temp+rename write (no-follow at the target). Both an
+/// unknown lane and a failed record are TRUTHFUL: they say the peer will run on
+/// the primary model, matching what the turn actually does.
+fn record_peer_model_lane(
+    peers_root: &Path,
+    slug: &str,
+    requested: Option<&str>,
+    available_lanes: &[String],
+) -> Option<String> {
+    let lane = requested.map(str::trim).filter(|lane| !lane.is_empty())?;
+    if !available_lanes.iter().any(|key| key == lane) {
+        let available = if available_lanes.is_empty() {
+            "none configured".to_owned()
+        } else {
+            available_lanes.join(", ")
+        };
+        return Some(format!(
+            "model lane '{lane}' not found (available: {available}) — \
+             this peer will use the primary model."
+        ));
+    }
+    let recorded = match staged_peer_dir(peers_root, slug) {
+        Some(dir) => crate::memory_consolidate::apply::atomic_write(&dir.join("model"), lane),
+        None => Err(eyre::eyre!("staged peer dir not found for slug {slug}")),
+    };
+    if let Err(err) = recorded {
+        tracing::warn!(
+            ?err,
+            slug,
+            lane,
+            "failed to record peer model lane; peer will use the primary model"
+        );
+        return Some(format!(
+            "could not record model lane '{lane}' — this peer will use the primary model."
+        ));
+    }
+    None
+}
+
+/// #peer-model — select the `sub_provider` for a lane KEY. LAST match wins,
+/// mirroring `ProviderRouter::register_with_full_meta` (last-registered wins),
+/// so a profile with duplicate lane keys runs a peer on the SAME model a
+/// pipeline sub-provider lane would resolve to.
+fn select_peer_lane<'a>(
+    config: &'a crate::config::Config,
+    lane: &str,
+) -> Option<&'a crate::config::SubProviderConfig> {
+    config.sub_providers.iter().rev().find(|sp| sp.key == lane)
+}
+
+/// #peer-model — derive the per-lane [`crate::config::Config`] for building a
+/// lane provider. The lane's `api_key_env` is applied UNCONDITIONALLY (even
+/// when `None`): a lane that omits its own key must CLEAR the primary's
+/// `api_key_env` and fall back to its OWN provider's default env var (e.g.
+/// `ANTHROPIC_API_KEY`), never borrow the primary provider's credential.
+fn lane_provider_config(
+    config: &crate::config::Config,
+    sp: &crate::config::SubProviderConfig,
+) -> crate::config::Config {
+    let mut c = config.clone();
+    c.api_key_env = sp.api_key_env.clone();
+    c
+}
+
 /// #peer-model — build the LLM provider for a named model LANE from the
 /// profile config, mirroring `build_sub_provider_router`'s per-lane
-/// construction EXACTLY: find the `sub_provider` whose `key` matches, apply its
-/// `api_key_env` override, build via `create_provider_with_api_type`, and wrap
-/// in `RetryProvider`. Returns `None` (caller falls back to the primary model)
+/// construction: select the lane's `sub_provider` (last-wins), build via
+/// `create_provider_with_api_type` with the lane's own credential, and wrap in
+/// `RetryProvider`. Returns `None` (caller falls back to the primary model)
 /// when no lane matches or the provider fails to build.
 fn build_peer_lane_provider(
     config: &crate::config::Config,
     lane: &str,
 ) -> Option<Arc<dyn octos_llm::LlmProvider>> {
-    let Some(sp) = config.sub_providers.iter().find(|sp| sp.key == lane) else {
+    let Some(sp) = select_peer_lane(config, lane) else {
         tracing::warn!(
             lane,
             "peer model lane not found among the profile's sub_providers — using the primary model"
         );
         return None;
     };
-    // Per-sub-provider key override (matches `build_sub_provider_router`): an
-    // explicit `api_key_env` selects a distinct credential; otherwise inherit
-    // the profile's default for the provider.
-    let sp_config = if sp.api_key_env.is_some() {
-        let mut c = config.clone();
-        c.api_key_env = sp.api_key_env.clone();
-        c
-    } else {
-        config.clone()
-    };
+    let sp_config = lane_provider_config(config, sp);
     match crate::commands::chat::create_provider_with_api_type(
         &sp.provider,
         &sp_config,
@@ -10908,10 +10965,10 @@ fn read_peer_blackboard(peers_root: &Path, slugs: Option<&[String]>) -> Vec<Peer
                 has_worktree: dir.join("wt").is_dir(),
                 closed: dir.join("closed").is_file(),
                 turn_history: parse_peer_turns_index(&dir),
-                // #peer-model — the recorded model lane, if any (trimmed,
-                // empty treated as absent).
-                model_lane: std::fs::read_to_string(dir.join("model"))
-                    .ok()
+                // #peer-model — the recorded model lane, if any (O_NOFOLLOW
+                // read so a symlinked `model` leaf is refused; trimmed, empty
+                // treated as absent).
+                model_lane: read_text_no_follow(&dir.join("model"))
                     .map(|lane| lane.trim().to_owned())
                     .filter(|lane| !lane.is_empty()),
             });
@@ -11086,7 +11143,7 @@ fn build_peer_gather_callback(peers_root: PathBuf) -> octos_agent::PeerGatherCal
 /// "… and N more" line (read specific peers with peer_gather slugs).
 const PEER_LIST_MAX_ROWS: usize = 200;
 
-fn compose_peer_list_text(rows: &[PeerBlackboardRow]) -> String {
+fn compose_peer_list_text(rows: &[PeerBlackboardRow], available_lanes: &[String]) -> String {
     if rows.is_empty() {
         return "(no peers staged)".to_owned();
     }
@@ -11105,13 +11162,17 @@ fn compose_peer_list_text(rows: &[PeerBlackboardRow]) -> String {
             .map_or_else(|| "—".to_owned(), |ts| ts.to_string());
         let turns = row.turn_history.as_ref().map_or(0, Vec::len);
         let worktree = if row.has_worktree { "  worktree" } else { "" };
-        // #peer-model — annotate the peer's model lane when it runs on a
-        // named `sub_provider` instead of the profile's primary model.
-        let model = row
-            .model_lane
-            .as_deref()
-            .map(|lane| format!("  · model={lane}"))
-            .unwrap_or_default();
+        // #peer-model — annotate the peer's model lane, resolved against the
+        // CURRENT `sub_providers` so the index matches what the turn actually
+        // does: a lane whose key no longer exists is flagged as falling back to
+        // the primary model, not printed as if it were live.
+        let model = match row.model_lane.as_deref() {
+            Some(lane) if available_lanes.iter().any(|key| key == lane) => {
+                format!("  · model={lane}")
+            }
+            Some(lane) => format!("  · model={lane} (unavailable→primary)"),
+            None => String::new(),
+        };
         // Address by NAME; show the slug in parens when it differs.
         let addr = if row.name == row.slug {
             row.slug.clone()
@@ -11141,12 +11202,17 @@ fn peer_list_allowed_for_session(_session_id: &SessionKey) -> bool {
 /// Mirrors [`build_peer_gather_callback`] but composes the compact status
 /// index ([`compose_peer_list_text`]) over the SAME row reader
 /// ([`read_peer_blackboard`]); it takes no slugs — it always lists every peer.
-fn build_peer_list_callback(peers_root: PathBuf) -> octos_agent::PeerListCallback {
+/// `available_lanes` (the profile's CURRENT `sub_provider` keys) lets the index
+/// flag a peer whose recorded model lane no longer resolves (#peer-model).
+fn build_peer_list_callback(
+    peers_root: PathBuf,
+    available_lanes: Vec<String>,
+) -> octos_agent::PeerListCallback {
     Arc::new(move || {
-        Ok(compose_peer_list_text(&read_peer_blackboard(
-            &peers_root,
-            None,
-        )))
+        Ok(compose_peer_list_text(
+            &read_peer_blackboard(&peers_root, None),
+            &available_lanes,
+        ))
     })
 }
 
@@ -25482,7 +25548,18 @@ async fn run_standalone_turn(
         // gather (ALL serve sessions, including peer- topics). Use peer_list
         // to see what exists / what's finished; peer_gather to read output.
         if peer_list_allowed_for_session(&session_id) {
-            let list = build_peer_list_callback(session_runtime.profile.data_dir.join("peers"));
+            // #peer-model — the CURRENT lane keys so the index flags a peer
+            // whose recorded lane no longer resolves (unavailable→primary).
+            let list = build_peer_list_callback(
+                session_runtime.profile.data_dir.join("peers"),
+                session_runtime
+                    .profile
+                    .config
+                    .sub_providers
+                    .iter()
+                    .map(|sp| sp.key.clone())
+                    .collect(),
+            );
             tool_registry.register(octos_agent::PeerListTool::new(list));
         }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -10461,6 +10461,12 @@ fn build_peer_handoff_callback(
     workspace_root: PathBuf,
     originating_session: SessionKey,
     profile_id: String,
+    // #peer-model — the KEYS of the profile's configured `sub_providers`
+    // (model lanes). A `peer_handoff` naming a matching lane records it beside
+    // the brief so the peer runs its turns on that provider; an unknown lane
+    // is surfaced as a warning note (the peer falls back to the primary
+    // model), never a failure.
+    available_lanes: Vec<String>,
     handoffs_this_turn: Arc<AtomicU32>,
     emit_staged: Arc<dyn Fn(PeerStagedEvent) + Send + Sync>,
 ) -> octos_agent::PeerHandoffCallback {
@@ -10489,6 +10495,46 @@ fn build_peer_handoff_callback(
             request.worktree,
         )
         .map_err(|err| err.message)?;
+        // #peer-model — optional model lane. Record a VALID lane
+        // (`peers/<slug>/model`) beside the brief so the peer's turns resolve
+        // that `sub_provider`; an unknown lane is a warning (the peer falls
+        // back to the primary model), not a failure. Best-effort write: a
+        // failed record leaves the peer on the primary model, never unstaged.
+        let model_note = match request
+            .model
+            .as_deref()
+            .map(str::trim)
+            .filter(|lane| !lane.is_empty())
+        {
+            Some(lane) if available_lanes.iter().any(|key| key == lane) => {
+                if let Some(peer_dir) = staged.brief_path.parent() {
+                    if let Err(err) = crate::memory_consolidate::apply::atomic_write(
+                        &peer_dir.join("model"),
+                        lane,
+                    ) {
+                        tracing::warn!(
+                            ?err,
+                            slug = %staged.slug,
+                            lane,
+                            "failed to record peer model lane; peer will use the primary model"
+                        );
+                    }
+                }
+                None
+            }
+            Some(lane) => {
+                let available = if available_lanes.is_empty() {
+                    "none configured".to_owned()
+                } else {
+                    available_lanes.join(", ")
+                };
+                Some(format!(
+                    "model lane '{lane}' not found (available: {available}) — \
+                     this peer will use the primary model."
+                ))
+            }
+            None => None,
+        };
         // Durable so reconnect replay still delivers the open request; the
         // client dedups by an already-open session for the topic.
         emit_staged(PeerStagedEvent {
@@ -10507,8 +10553,105 @@ fn build_peer_handoff_callback(
             brief_path: staged.brief_path.to_string_lossy().into_owned(),
             cwd: staged.cwd.to_string_lossy().into_owned(),
             worktree_branch: staged.worktree_branch,
+            model_note,
         })
     })
+}
+
+/// #peer-model — read a peer's optional model LANE key from
+/// `peers/<slug>/model` (written by the `peer_handoff` staging callback when
+/// the master named a VALID `sub_provider` lane). Routed through
+/// [`staged_peer_dir`] so a symlinked / unsafe slug is never followed. Returns
+/// the trimmed lane key, or `None` when the dir is not a real staged peer, the
+/// file is absent, or it is empty.
+fn read_peer_model_lane(peers_root: &Path, slug: &str) -> Option<String> {
+    let dir = staged_peer_dir(peers_root, slug)?;
+    let lane = std::fs::read_to_string(dir.join("model")).ok()?;
+    let lane = lane.trim();
+    (!lane.is_empty()).then(|| lane.to_owned())
+}
+
+/// #peer-model — build the LLM provider for a named model LANE from the
+/// profile config, mirroring `build_sub_provider_router`'s per-lane
+/// construction EXACTLY: find the `sub_provider` whose `key` matches, apply its
+/// `api_key_env` override, build via `create_provider_with_api_type`, and wrap
+/// in `RetryProvider`. Returns `None` (caller falls back to the primary model)
+/// when no lane matches or the provider fails to build.
+fn build_peer_lane_provider(
+    config: &crate::config::Config,
+    lane: &str,
+) -> Option<Arc<dyn octos_llm::LlmProvider>> {
+    let Some(sp) = config.sub_providers.iter().find(|sp| sp.key == lane) else {
+        tracing::warn!(
+            lane,
+            "peer model lane not found among the profile's sub_providers — using the primary model"
+        );
+        return None;
+    };
+    // Per-sub-provider key override (matches `build_sub_provider_router`): an
+    // explicit `api_key_env` selects a distinct credential; otherwise inherit
+    // the profile's default for the provider.
+    let sp_config = if sp.api_key_env.is_some() {
+        let mut c = config.clone();
+        c.api_key_env = sp.api_key_env.clone();
+        c
+    } else {
+        config.clone()
+    };
+    match crate::commands::chat::create_provider_with_api_type(
+        &sp.provider,
+        &sp_config,
+        sp.model.clone(),
+        sp.base_url.clone(),
+        sp.api_type.as_deref(),
+    ) {
+        Ok(p) => {
+            let provider: Arc<dyn octos_llm::LlmProvider> =
+                Arc::new(octos_llm::RetryProvider::new(p));
+            Some(provider)
+        }
+        Err(err) => {
+            tracing::warn!(
+                lane,
+                provider = %sp.provider,
+                error = %err,
+                "failed to build peer model lane provider — using the primary model"
+            );
+            None
+        }
+    }
+}
+
+/// #peer-model — resolve the model-lane provider for `slug` under `peers_root`
+/// using `config`: read the recorded lane key, then build its provider. `None`
+/// at any missing step so the caller falls back to the primary model. Split
+/// out of [`peer_lane_provider_for`] so the lane read + selection + build is
+/// unit-testable without a full `SessionRuntime`.
+fn resolve_peer_lane_provider(
+    peers_root: &Path,
+    slug: &str,
+    config: &crate::config::Config,
+) -> Option<Arc<dyn octos_llm::LlmProvider>> {
+    let lane = read_peer_model_lane(peers_root, slug)?;
+    build_peer_lane_provider(config, &lane)
+}
+
+/// #peer-model — the per-peer model LANE resolver used by the WS turn path.
+/// When THIS session is a peer whose staging recorded a `peers/<slug>/model`
+/// lane matching a configured `sub_provider`, run the peer's turns on THAT
+/// provider instead of the profile's primary. Returns `None` — so the caller
+/// falls back to the primary model — for a non-peer session, a peer with no
+/// recorded lane, an unmatched lane key, or a lane whose provider fails to
+/// build. The peer STAYS on the master's profile (blackboard, ownership,
+/// `peer_gather`, synthesis all keyed to the master's profile unchanged); only
+/// the model-within-the-profile differs.
+fn peer_lane_provider_for(
+    session_id: &SessionKey,
+    session_runtime: &crate::runtime::SessionRuntime,
+) -> Option<Arc<dyn octos_llm::LlmProvider>> {
+    let (_profile_id, slug) = peer_slug_and_profile(session_id)?;
+    let peers_root = session_runtime.profile.data_dir.join("peers");
+    resolve_peer_lane_provider(&peers_root, slug, &session_runtime.profile.config)
 }
 
 /// #1801 v2: peer sessions leave a durable result on the blackboard — a
@@ -10697,6 +10840,10 @@ struct PeerBlackboardRow {
     /// #435: parsed `turns.txt` entries: `[(turn_count, outcome, updated_unix)]`.
     /// `None` when the file doesn't exist (single-turn-or-less peer).
     turn_history: Option<Vec<(u32, String, u64)>>,
+    /// #peer-model — the model LANE key from `peers/<slug>/model` (a configured
+    /// `sub_provider` this peer runs its turns on), trimmed; `None` for a peer
+    /// on the profile's primary model.
+    model_lane: Option<String>,
 }
 
 /// #1801: row-reading core of the peer blackboard — every staged peer dir
@@ -10761,6 +10908,12 @@ fn read_peer_blackboard(peers_root: &Path, slugs: Option<&[String]>) -> Vec<Peer
                 has_worktree: dir.join("wt").is_dir(),
                 closed: dir.join("closed").is_file(),
                 turn_history: parse_peer_turns_index(&dir),
+                // #peer-model — the recorded model lane, if any (trimmed,
+                // empty treated as absent).
+                model_lane: std::fs::read_to_string(dir.join("model"))
+                    .ok()
+                    .map(|lane| lane.trim().to_owned())
+                    .filter(|lane| !lane.is_empty()),
             });
         }
     }
@@ -10952,6 +11105,13 @@ fn compose_peer_list_text(rows: &[PeerBlackboardRow]) -> String {
             .map_or_else(|| "—".to_owned(), |ts| ts.to_string());
         let turns = row.turn_history.as_ref().map_or(0, Vec::len);
         let worktree = if row.has_worktree { "  worktree" } else { "" };
+        // #peer-model — annotate the peer's model lane when it runs on a
+        // named `sub_provider` instead of the profile's primary model.
+        let model = row
+            .model_lane
+            .as_deref()
+            .map(|lane| format!("  · model={lane}"))
+            .unwrap_or_default();
         // Address by NAME; show the slug in parens when it differs.
         let addr = if row.name == row.slug {
             row.slug.clone()
@@ -10959,7 +11119,7 @@ fn compose_peer_list_text(rows: &[PeerBlackboardRow]) -> String {
             format!("{} ({})", row.name, row.slug)
         };
         lines.push(format!(
-            "- {addr}  {status}  updated {updated}  turns {turns}{worktree}"
+            "- {addr}  {status}  updated {updated}  turns {turns}{worktree}{model}"
         ));
     }
     if rows.len() > PEER_LIST_MAX_ROWS {
@@ -24453,7 +24613,13 @@ async fn run_standalone_turn(
     }
 
     let workspace_root: Option<PathBuf> = Some(session_runtime.workspace_root.clone());
-    let llm_provider: Arc<dyn octos_llm::LlmProvider> = session_runtime.profile.llm.clone();
+    // #peer-model — a peer session whose staging recorded a valid model LANE
+    // (`peers/<slug>/model`) runs its turns on that `sub_provider` instead of
+    // the profile's primary; every other session (and any missing/unmatched/
+    // unbuildable lane) falls back to the profile's primary provider.
+    let llm_provider: Arc<dyn octos_llm::LlmProvider> =
+        peer_lane_provider_for(&session_id, &session_runtime)
+            .unwrap_or_else(|| session_runtime.profile.llm.clone());
     let memory_store: Arc<octos_memory::EpisodeStore> = session_runtime.profile.memory.clone();
     let mut agent_config = session_runtime.agent.agent_config();
     // Per-session reasoning/thinking effort (TUI `/thinking`), persisted
@@ -25283,6 +25449,15 @@ async fn run_standalone_turn(
                 session_runtime.workspace_root.clone(),
                 session_id.clone(),
                 session_runtime.profile.profile_id.clone(),
+                // #peer-model — the configured `sub_provider` lane keys a
+                // `peer_handoff` may name; validated in the callback.
+                session_runtime
+                    .profile
+                    .config
+                    .sub_providers
+                    .iter()
+                    .map(|sp| sp.key.clone())
+                    .collect(),
                 Arc::new(AtomicU32::new(0)),
                 emit_staged,
             );

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -25669,7 +25669,7 @@ fn peer_list_and_gather_surface_display_name() {
     )
     .unwrap();
 
-    let list_cb = build_peer_list_callback(peers.clone());
+    let list_cb = build_peer_list_callback(peers.clone(), Vec::new());
     let list = list_cb().unwrap();
     assert!(
         list.contains("Edison"),
@@ -25889,7 +25889,7 @@ fn peer_list_caps_rows_and_summarizes_overflow() {
     }
     let over = PEER_LIST_MAX_ROWS + 5;
     let rows: Vec<_> = (0..over).map(|i| row(&format!("p{i:04}"))).collect();
-    let text = compose_peer_list_text(&rows);
+    let text = compose_peer_list_text(&rows, &[]);
     assert!(
         text.starts_with(&format!("peers ({over}):")),
         "header reports the true count: {:?}",
@@ -25903,7 +25903,7 @@ fn peer_list_caps_rows_and_summarizes_overflow() {
     );
 
     // Under the cap: every row inline, no summary line.
-    let few = compose_peer_list_text(&[row("only")]);
+    let few = compose_peer_list_text(&[row("only")], &[]);
     assert!(few.contains("- only"), "{few}");
     assert!(
         !few.contains("more"),
@@ -26209,18 +26209,29 @@ fn peer_lane_resolution_skips_non_peer_session() {
     assert_eq!(peer_slug_and_profile(&peer), Some(("dev", "synth")));
 }
 
-/// #peer-model (part 4): `peer_list` annotates a peer running on a model lane
-/// and leaves a primary-model peer unannotated.
+/// #peer-model (part 4a): `peer_list` annotates a peer on a CURRENTLY-configured
+/// lane, flags a peer whose recorded lane no longer resolves as
+/// `unavailable→primary`, and leaves a primary-model peer unannotated.
 #[test]
-fn compose_peer_list_text_annotates_model_lane() {
+fn compose_peer_list_text_annotates_and_flags_stale_model_lane() {
     let rows = vec![
         peer_list_row("synth", Some("strong")),
+        peer_list_row("stale", Some("gone")),
         peer_list_row("grunt", None),
     ];
-    let text = compose_peer_list_text(&rows);
+    // Only "strong" is currently configured.
+    let text = compose_peer_list_text(&rows, &["strong".to_owned()]);
     assert!(
         text.contains("- synth  running  updated —  turns 0  · model=strong"),
-        "a lane peer is annotated with its lane: {text:?}"
+        "a live lane peer is annotated with its lane: {text:?}"
+    );
+    let stale_line = text
+        .lines()
+        .find(|line| line.starts_with("- stale"))
+        .expect("stale row present");
+    assert!(
+        stale_line.contains("· model=gone (unavailable→primary)"),
+        "a lane that no longer resolves is flagged, matching what the turn does: {stale_line:?}"
     );
     let grunt_line = text
         .lines()
@@ -26229,6 +26240,144 @@ fn compose_peer_list_text_annotates_model_lane() {
     assert!(
         !grunt_line.contains("model="),
         "a primary-model peer has no lane annotation: {grunt_line:?}"
+    );
+}
+
+/// #peer-model (codex-1): a lane that OMITS its own `api_key_env` must CLEAR the
+/// primary's (never inherit the primary provider's credential); a lane WITH one
+/// uses it.
+#[test]
+fn lane_provider_config_clears_primary_api_key_env_when_lane_omits_it() {
+    let mut primary = crate::config::Config::default();
+    primary.api_key_env = Some("PRIMARY_PROVIDER_KEY".to_owned());
+
+    // A lane on a DIFFERENT provider with NO api_key_env of its own.
+    let lane = crate::config::SubProviderConfig {
+        key: "strong".to_owned(),
+        provider: "anthropic".to_owned(),
+        model: Some("claude-x".to_owned()),
+        api_key_env: None,
+        base_url: None,
+        description: None,
+        default_context_window: None,
+        max_output_tokens: None,
+        api_type: None,
+    };
+    assert_eq!(
+        lane_provider_config(&primary, &lane).api_key_env,
+        None,
+        "a lane without its own api_key_env CLEARS the primary's (falls back to the lane provider's default env), not inherits it"
+    );
+
+    // A lane WITH its own api_key_env uses that.
+    let lane_keyed = crate::config::SubProviderConfig {
+        api_key_env: Some("LANE_KEY".to_owned()),
+        ..lane.clone()
+    };
+    assert_eq!(
+        lane_provider_config(&primary, &lane_keyed)
+            .api_key_env
+            .as_deref(),
+        Some("LANE_KEY"),
+        "a lane with its own api_key_env uses it"
+    );
+}
+
+/// #peer-model (codex-3): duplicate lane keys resolve to the LAST match,
+/// mirroring `ProviderRouter`'s last-wins registration.
+#[test]
+fn select_peer_lane_prefers_last_duplicate_key() {
+    let mut config = crate::config::Config::default();
+    let base = crate::config::SubProviderConfig {
+        key: "strong".to_owned(),
+        provider: "openai".to_owned(),
+        model: Some("first".to_owned()),
+        api_key_env: None,
+        base_url: None,
+        description: None,
+        default_context_window: None,
+        max_output_tokens: None,
+        api_type: None,
+    };
+    config.sub_providers = vec![
+        base.clone(),
+        crate::config::SubProviderConfig {
+            provider: "anthropic".to_owned(),
+            model: Some("second".to_owned()),
+            ..base.clone()
+        },
+    ];
+    let sp = select_peer_lane(&config, "strong").expect("lane found");
+    assert_eq!(
+        sp.model.as_deref(),
+        Some("second"),
+        "the LAST duplicate wins (matches ProviderRouter register-last-wins)"
+    );
+    assert_eq!(sp.provider, "anthropic");
+    assert!(select_peer_lane(&config, "cheap").is_none());
+}
+
+/// #peer-model (codex-2): a symlinked `model` leaf is refused by BOTH the
+/// turn-path read and peer_list's independent read — never followed.
+#[cfg(unix)]
+#[test]
+fn read_peer_model_lane_refuses_symlinked_model_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path().join("peers");
+    let dir = stage_peer_dir_with(&peers_root, "synth");
+    // Point `model` at an external file via a symlink.
+    let secret = tmp.path().join("elsewhere");
+    std::fs::write(&secret, "strong").unwrap();
+    std::os::unix::fs::symlink(&secret, dir.join("model")).unwrap();
+
+    assert_eq!(
+        read_peer_model_lane(&peers_root, "synth"),
+        None,
+        "the turn-path read refuses a symlinked model file"
+    );
+    let row = read_peer_blackboard(&peers_root, None)
+        .into_iter()
+        .find(|r| r.slug == "synth")
+        .expect("row present");
+    assert_eq!(
+        row.model_lane, None,
+        "peer_list's independent read also refuses the symlinked model file"
+    );
+}
+
+/// #peer-model (codex-4b): when the lane record WRITE fails, the tool note must
+/// say the peer fell back to the primary model — not report success.
+#[test]
+fn record_peer_model_lane_reports_fallback_when_write_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path().join("peers");
+    let dir = stage_peer_dir_with(&peers_root, "synth");
+    // Force the atomic write to fail: `model` already exists as a DIRECTORY, so
+    // the temp+rename cannot replace it with a file.
+    std::fs::create_dir(dir.join("model")).unwrap();
+
+    let note = record_peer_model_lane(&peers_root, "synth", Some("strong"), &["strong".to_owned()])
+        .expect("a failed record yields a note");
+    assert!(
+        note.contains("primary model"),
+        "a failed record is truthful about the fallback: {note}"
+    );
+    // A clean record (no pre-existing obstruction) yields no note.
+    let clean = stage_peer_dir_with(&peers_root, "synth2");
+    assert_eq!(
+        record_peer_model_lane(
+            &peers_root,
+            "synth2",
+            Some("strong"),
+            &["strong".to_owned()]
+        ),
+        None,
+        "a clean record produces no warning note"
+    );
+    assert_eq!(
+        std::fs::read_to_string(clean.join("model")).unwrap(),
+        "strong",
+        "the lane is recorded on a clean write"
     );
 }
 

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -22421,6 +22421,7 @@ async fn make_m11e_profile_with_llm_and_sandbox(
     Arc::new(crate::runtime::ProfileRuntime {
         profile_id: profile_id.to_string(),
         data_dir: data_dir.to_path_buf(),
+        config: crate::config::Config::default(),
         llm,
         adaptive_router: None,
         runtime_qos_catalog: None,
@@ -25237,6 +25238,7 @@ fn peer_handoff_callback_caps_at_four_and_emits_staged_events() {
         workspace.clone(),
         originating.clone(),
         "dev".to_owned(),
+        Vec::new(),
         Arc::new(AtomicU32::new(0)),
         Arc::new(move |event| emitted_sink.lock().unwrap().push(event)),
     );
@@ -25247,6 +25249,7 @@ fn peer_handoff_callback_caps_at_four_and_emits_staged_events() {
             // Unique per iteration — named peers reject duplicates.
             name: format!("Lane {n}"),
             worktree: false,
+            model: None,
         })
         .unwrap_or_else(|err| panic!("handoff {n} within the cap must stage: {err}"));
         assert_eq!(staged.topic, format!("peer-{}", staged.slug));
@@ -25261,6 +25264,7 @@ fn peer_handoff_callback_caps_at_four_and_emits_staged_events() {
         brief: "One too many.".to_owned(),
         name: "One too many".to_owned(),
         worktree: false,
+        model: None,
     })
     .expect_err("5th handoff must be rejected");
     assert_eq!(err, "peer handoff limit reached for this turn (4)");
@@ -25880,6 +25884,7 @@ fn peer_list_caps_rows_and_summarizes_overflow() {
             has_worktree: false,
             closed: false,
             turn_history: None,
+            model_lane: None,
         }
     }
     let over = PEER_LIST_MAX_ROWS + 5;
@@ -25955,6 +25960,7 @@ fn peer_originator_recorded_by_handoff_callback() {
         workspace,
         originating.clone(),
         "dev".to_owned(),
+        Vec::new(),
         Arc::new(AtomicU32::new(0)),
         Arc::new(|_event| {}),
     );
@@ -25962,11 +25968,268 @@ fn peer_originator_recorded_by_handoff_callback() {
         brief: "Fix the flaky bus test.".to_owned(),
         name: "CI Fix".to_owned(),
         worktree: false,
+        model: None,
     })
     .expect("stage");
     let originator =
         std::fs::read_to_string(peers_root.join(&staged.slug).join("originator")).unwrap();
     assert_eq!(originator, originating.to_string());
+}
+
+// ----------------------------------------------------------------------------
+// #peer-model — per-peer model lane (a peer runs its turns on a named
+// `sub_provider` lane configured in the master's profile).
+// ----------------------------------------------------------------------------
+
+/// A staged peer dir the lane readers accept: a real dir carrying the
+/// `brief.md` staging contract, plus the caller's extra files.
+fn stage_peer_dir_with(peers_root: &std::path::Path, slug: &str) -> std::path::PathBuf {
+    let dir = peers_root.join(slug);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("brief.md"), "brief").unwrap();
+    dir
+}
+
+/// A minimal profile config carrying ONE model lane (`key`) whose credential
+/// resolves offline through `env_vars` — enough to exercise lane selection +
+/// provider construction without a network call.
+fn config_with_lane(key: &str) -> crate::config::Config {
+    let mut config = crate::config::Config::default();
+    config.env_vars.insert(
+        "PEER_LANE_TEST_KEY".to_owned(),
+        "sk-peer-lane-test".to_owned(),
+    );
+    config.sub_providers = vec![crate::config::SubProviderConfig {
+        key: key.to_owned(),
+        provider: "openai".to_owned(),
+        model: Some("gpt-4o-mini".to_owned()),
+        api_key_env: Some("PEER_LANE_TEST_KEY".to_owned()),
+        base_url: None,
+        description: None,
+        default_context_window: None,
+        max_output_tokens: None,
+        api_type: None,
+    }];
+    config
+}
+
+fn peer_list_row(slug: &str, model_lane: Option<&str>) -> PeerBlackboardRow {
+    PeerBlackboardRow {
+        slug: slug.to_owned(),
+        name: slug.to_owned(),
+        brief: String::new(),
+        brief_truncated: false,
+        result: None,
+        result_truncated: false,
+        result_updated_unix: None,
+        has_worktree: false,
+        closed: false,
+        turn_history: None,
+        model_lane: model_lane.map(str::to_owned),
+    }
+}
+
+/// #peer-model (part 2): a `peer_handoff` naming a CONFIGURED lane records it
+/// beside the brief (`peers/<slug>/model`) and produces no warning note.
+#[test]
+fn peer_handoff_callback_records_valid_model_lane() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path().join("data").join("peers");
+    let workspace = tmp.path().join("work");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let originating = octos_core::SessionKey::with_profile_topic("dev", "local", "tui", "coding");
+    let callback = build_peer_handoff_callback(
+        peers_root.clone(),
+        workspace,
+        originating,
+        "dev".to_owned(),
+        vec!["cheap".to_owned(), "strong".to_owned()],
+        Arc::new(AtomicU32::new(0)),
+        Arc::new(|_event| {}),
+    );
+
+    let staged = callback(octos_agent::PeerHandoffRequest {
+        brief: "Synthesize the peers' findings.".to_owned(),
+        name: "Synth".to_owned(),
+        worktree: false,
+        model: Some("strong".to_owned()),
+    })
+    .expect("a valid lane still stages the peer");
+
+    let recorded = std::fs::read_to_string(peers_root.join(&staged.slug).join("model")).unwrap();
+    assert_eq!(
+        recorded, "strong",
+        "the valid lane is recorded beside the brief"
+    );
+    assert!(
+        staged.model_note.is_none(),
+        "a valid lane produces no warning note: {:?}",
+        staged.model_note
+    );
+}
+
+/// #peer-model (part 2): a `peer_handoff` naming an UNKNOWN lane still stages
+/// the peer, records NO model file (so it uses the primary model), and returns
+/// a note naming the bad lane, the available lanes, and the fallback.
+#[test]
+fn peer_handoff_callback_notes_unknown_model_lane_but_still_stages() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path().join("data").join("peers");
+    let workspace = tmp.path().join("work");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let originating = octos_core::SessionKey::with_profile_topic("dev", "local", "tui", "coding");
+    let callback = build_peer_handoff_callback(
+        peers_root.clone(),
+        workspace,
+        originating,
+        "dev".to_owned(),
+        vec!["cheap".to_owned(), "strong".to_owned()],
+        Arc::new(AtomicU32::new(0)),
+        Arc::new(|_event| {}),
+    );
+
+    let staged = callback(octos_agent::PeerHandoffRequest {
+        brief: "Grind the grunt work.".to_owned(),
+        name: "Grunt".to_owned(),
+        worktree: false,
+        model: Some("gpt-mega".to_owned()),
+    })
+    .expect("an unknown lane warns, it does not fail staging");
+
+    assert!(
+        std::path::Path::new(&staged.brief_path).is_file(),
+        "the peer is still staged despite the unknown lane"
+    );
+    assert!(
+        !peers_root.join(&staged.slug).join("model").exists(),
+        "an unknown lane is not recorded on disk"
+    );
+    let note = staged.model_note.expect("an unknown lane yields a note");
+    assert!(note.contains("gpt-mega"), "note names the bad lane: {note}");
+    assert!(
+        note.contains("cheap, strong"),
+        "note lists the available lanes: {note}"
+    );
+    assert!(
+        note.contains("primary model"),
+        "note explains the fallback: {note}"
+    );
+}
+
+/// #peer-model (part 3): the lane read trims the file and treats a missing or
+/// empty `model` file as "no lane" (primary model).
+#[test]
+fn read_peer_model_lane_trims_and_treats_empty_as_absent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path().join("peers");
+
+    let padded = stage_peer_dir_with(&peers_root, "synth");
+    std::fs::write(padded.join("model"), "  strong \n").unwrap();
+    assert_eq!(
+        read_peer_model_lane(&peers_root, "synth").as_deref(),
+        Some("strong"),
+        "the recorded lane is trimmed"
+    );
+
+    stage_peer_dir_with(&peers_root, "bare");
+    assert_eq!(
+        read_peer_model_lane(&peers_root, "bare"),
+        None,
+        "no model file → no lane"
+    );
+
+    let blank = stage_peer_dir_with(&peers_root, "blank");
+    std::fs::write(blank.join("model"), "   \n").unwrap();
+    assert_eq!(
+        read_peer_model_lane(&peers_root, "blank"),
+        None,
+        "a whitespace-only model file → no lane"
+    );
+}
+
+/// #peer-model (part 3): a peer naming a CONFIGURED lane resolves that lane's
+/// provider (selection + build succeed offline via `env_vars`).
+#[test]
+fn resolve_peer_lane_provider_selects_configured_lane() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path().join("peers");
+    let dir = stage_peer_dir_with(&peers_root, "synth");
+    std::fs::write(dir.join("model"), "strong").unwrap();
+
+    let config = config_with_lane("strong");
+    assert!(
+        resolve_peer_lane_provider(&peers_root, "synth", &config).is_some(),
+        "a peer naming a configured lane resolves that lane's provider"
+    );
+}
+
+/// #peer-model (part 3): an UNMATCHED lane key falls back to the primary model
+/// (None) — the pure selection-miss branch.
+#[test]
+fn resolve_peer_lane_provider_none_for_unmatched_lane() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path().join("peers");
+    let dir = stage_peer_dir_with(&peers_root, "synth");
+    std::fs::write(dir.join("model"), "nonesuch").unwrap();
+
+    // Only "strong" is configured; the recorded "nonesuch" matches nothing.
+    let config = config_with_lane("strong");
+    assert!(
+        resolve_peer_lane_provider(&peers_root, "synth", &config).is_none(),
+        "an unmatched lane falls back to the primary model (None)"
+    );
+}
+
+/// #peer-model (part 3): a peer with NO recorded lane falls back to the
+/// primary model (None) even when lanes are configured.
+#[test]
+fn resolve_peer_lane_provider_none_without_model_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path().join("peers");
+    stage_peer_dir_with(&peers_root, "synth");
+
+    let config = config_with_lane("strong");
+    assert!(
+        resolve_peer_lane_provider(&peers_root, "synth", &config).is_none(),
+        "no model file → primary model (None)"
+    );
+}
+
+/// #peer-model (part 3): the wrapper returns None for a NON-peer session — it
+/// relies on `peer_slug_and_profile`, which rejects a plain coding session and
+/// accepts a `peer-<slug>` topic.
+#[test]
+fn peer_lane_resolution_skips_non_peer_session() {
+    let plain = octos_core::SessionKey::with_profile_topic("dev", "local", "tui", "coding");
+    assert!(
+        peer_slug_and_profile(&plain).is_none(),
+        "a non-peer session is never a lane target"
+    );
+    let peer = octos_core::SessionKey::with_profile_topic("dev", "local", "tui", "peer-synth");
+    assert_eq!(peer_slug_and_profile(&peer), Some(("dev", "synth")));
+}
+
+/// #peer-model (part 4): `peer_list` annotates a peer running on a model lane
+/// and leaves a primary-model peer unannotated.
+#[test]
+fn compose_peer_list_text_annotates_model_lane() {
+    let rows = vec![
+        peer_list_row("synth", Some("strong")),
+        peer_list_row("grunt", None),
+    ];
+    let text = compose_peer_list_text(&rows);
+    assert!(
+        text.contains("- synth  running  updated —  turns 0  · model=strong"),
+        "a lane peer is annotated with its lane: {text:?}"
+    );
+    let grunt_line = text
+        .lines()
+        .find(|line| line.starts_with("- grunt"))
+        .expect("grunt row present");
+    assert!(
+        !grunt_line.contains("model="),
+        "a primary-model peer has no lane annotation: {grunt_line:?}"
+    );
 }
 
 /// Mailbox nudge (#1801 v3): `peer/prepare` records the originator for every

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -756,6 +756,7 @@ mod tests {
         Arc::new(ProfileRuntime {
             profile_id: "_main".to_string(),
             data_dir,
+            config: crate::config::Config::default(),
             llm: Arc::new(StubLlm),
             adaptive_router: None,
             runtime_qos_catalog: None,

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -171,6 +171,16 @@ pub struct ProfileRuntime {
     /// session-scope bootstrap code don't have to re-derive it.
     pub data_dir: PathBuf,
 
+    /// The profile's resolved [`crate::config::Config`] (as produced by
+    /// `config_from_profile` at bootstrap, with host memory/plugins merged).
+    /// Most runtime state is pre-extracted into the typed fields below; this
+    /// is retained for the few paths that must resolve a lane provider
+    /// LAZILY from `config.sub_providers` (with the profile's credential /
+    /// timeout config), e.g. a peer session that runs its turns on a named
+    /// `sub_provider` model lane (`peers/<slug>/model`). Kept whole rather
+    /// than re-deriving a `Config` off disk on the hot path.
+    pub config: crate::config::Config,
+
     /// The fully-wrapped LLM provider chain for this profile.
     /// Includes retry, provider failover, and (if `adaptive_router`
     /// is `Some`) adaptive routing. Every session for this profile
@@ -1133,6 +1143,10 @@ impl ProfileRuntime {
         Ok(Arc::new(Self {
             profile_id: profile.id.clone(),
             data_dir: data_dir.to_path_buf(),
+            // Retained whole for lazy per-lane provider resolution (e.g. a
+            // peer running on a named `sub_provider` model lane); the typed
+            // fields below carry the pre-extracted hot-path state.
+            config: config.clone(),
             llm,
             adaptive_router,
             runtime_qos_catalog,

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -1133,6 +1133,7 @@ mod tests {
         Arc::new(ProfileRuntime {
             profile_id: "_main".to_string(),
             data_dir,
+            config: crate::config::Config::default(),
             llm: Arc::new(StubLlm),
             adaptive_router: None,
             runtime_qos_catalog: None,
@@ -1807,6 +1808,7 @@ mod tests {
         Arc::new(ProfileRuntime {
             profile_id: "_main".to_string(),
             data_dir,
+            config: crate::config::Config::default(),
             llm: Arc::new(StubLlm),
             adaptive_router: None,
             runtime_qos_catalog: None,

--- a/crates/octos-cli/tests/coding_multi_session.rs
+++ b/crates/octos-cli/tests/coding_multi_session.rs
@@ -195,6 +195,7 @@ async fn make_m11g_profile(profile_id: &str, data_dir: &std::path::Path) -> Arc<
     Arc::new(ProfileRuntime {
         profile_id: profile_id.to_string(),
         data_dir: data_dir.to_path_buf(),
+        config: octos_cli::config::Config::default(),
         snapshots: None,
         llm: Arc::new(ReadFileStubLlm),
         adaptive_router: None,


### PR DESCRIPTION
## Per-peer model lane

A peer can run its turns on a **different model** than the master by naming a `sub_provider` **lane key** in the master's profile — `peer_handoff(name, brief, model: "strong")`. The peer stays on the master's profile (blackboard, ownership, `peer_gather`, auto-synthesis all unchanged); only the model-within-the-profile differs. Enables "cheap model for grunt peers, strong model for the synthesizer."

### How it works
- `peer_handoff` gains an optional `model` = a `sub_providers[].key` (e.g. `cheap`/`strong`). Omit → profile primary.
- Staging writes the lane to `peers/<slug>/model` (through `staged_peer_dir`; read via an `O_NOFOLLOW` helper).
- Each peer turn, `run_standalone_turn` resolves the provider from that lane (same `create_provider_with_api_type` + `RetryProvider` path `deep_research` uses) instead of `profile.llm`, with a robust fallback to primary — non-peer / no-lane / unmatched key / build-error all fall back, no panic.
- `peer_list` renders `· model=<lane>` (and `(unavailable→primary)` if the key was since removed).
- Unknown lane at handoff → peer still staged; the tool output notes it'll use primary.

### Review (codex, 2 rounds — 4 findings fixed)
- **[HIGH]** a lane omitting `api_key_env` no longer borrows the *primary* provider's credential (unconditional clear → the lane's own provider default).
- symlink-safe `model` read (`O_NOFOLLOW`) + write via `staged_peer_dir` (not `brief_path.parent()`).
- duplicate lane keys → **last-match** (matches `ProviderRouter` last-wins registration).
- truthful `peer_list` (resolves vs current lanes) + a write-failure note.
- +11 tests. `octos-cli --features api` lib **2495/0**; fmt + clippy clean.

### Follow-ups (not in this PR)
- **Repo-wide peer-file I/O hardening**: fd-anchored `openat`/`renameat` + regular-file/FIFO rejection + read caps across **all** peer files (brief.md / result.md / originator / name / turns.txt / model). The parent-dir-swap TOCTOU + FIFO exposure codex flagged are pre-existing patterns shared by every peer file; `model` is already the most-hardened (leaf `O_NOFOLLOW`). Best fixed consistently in one pass.
- `peer_list` should mark a lane unavailable when its provider can't *build* (needs a preflight or turn-time status).
- Provider caching per (profile, lane) — currently a fresh provider per peer turn (fine for low-frequency peers; loses connection reuse).
- Runtime-failure fallback for a lane that builds but errors mid-turn (arguably correct to fail, since the lane was chosen explicitly).
- octos-tui `/peer --model` client flag.

Scope: octos server only.
