### PR TITLE
fix: factor PEER_INBOX_REGISTRY's type into a PeerInboxMap alias

### DIFF
--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -143,17 +143,20 @@ const FAILOVER_PUSH_DEBOUNCE: Duration = Duration::from_secs(5);
 
 // ── Peer inbox registry (#436) ─────────────────────────────────────────────
 
+/// Inbox sender map keyed by `"{profile_id}:peer:{slug}"`, shared behind
+/// an `Arc<StdMutex<_>>` so [`peer_inbox_registry`] callers can clone the
+/// `Arc` and lock independently.
+type PeerInboxMap = Arc<StdMutex<HashMap<String, mpsc::Sender<ActorMessage>>>>;
+
 /// Global registry mapping `"{profile_id}:peer:{slug}"` → inbox sender for
 /// running peer sessions. Populated by [`ActorRegistry::dispatch`] when a
 /// peer session actor spawns; removed on session death / deletion. The
 /// [`PeerSendInputTool`] callback reads this to deliver cross-session
 /// messages without a TUI round-trip.
-static PEER_INBOX_REGISTRY: OnceLock<Arc<StdMutex<HashMap<String, mpsc::Sender<ActorMessage>>>>> =
-    OnceLock::new();
+static PEER_INBOX_REGISTRY: OnceLock<PeerInboxMap> = OnceLock::new();
 
 /// Get (or init) the global peer inbox registry.
-pub fn peer_inbox_registry() -> &'static Arc<StdMutex<HashMap<String, mpsc::Sender<ActorMessage>>>>
-{
+pub fn peer_inbox_registry() -> &'static PeerInboxMap {
     PEER_INBOX_REGISTRY.get_or_init(|| Arc::new(StdMutex::new(HashMap::new())))
 }
 


### PR DESCRIPTION
## Summary
- `cargo clippy --workspace --all-targets -- -D warnings` — the exact invocation the `check` CI job runs — currently fails workspace-wide on `clippy::type_complexity` for `PEER_INBOX_REGISTRY`'s `Arc<StdMutex<HashMap<String, mpsc::Sender<ActorMessage>>>>` type (introduced by the peer-agents merge, 9c99834f).
- This blocks the required `check` job on **every** PR against `main` right now, including unrelated ones (discovered while preparing #1821/#1822).
- Fix: factor the type into a `PeerInboxMap` alias, exactly as clippy's own diagnostic suggests. Pure syntactic change, no behavior change.

## Test plan
- [x] `cargo clippy -p octos-cli --all-targets --no-deps -- -D warnings` clean for this file
- [x] `cargo build -p octos-cli --features api` succeeds
- [x] `cargo test -p octos-cli --features api --lib peer_inbox` — `peer_inbox_registry_registers_on_dispatch_and_purges_on_remove` passes
- [x] `cargo fmt -p octos-cli -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)