### PR TITLE
fix(security): fd-anchor all peer-file I/O — symlink/TOCTOU/FIFO-safe (#1824)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2439,24 +2439,24 @@ mod peer_io {
             };
             // fdopendir on the anchored fd — entries come from THIS inode, never
             // a re-walked path, so a swapped `<slug>` can't redirect the scan.
-            let Ok(dir) = Dir::read_from(&dirfd) else {
+            let Ok(mut dir) = Dir::read_from(&dirfd) else {
                 return 0;
             };
             let prefix = prefix.as_bytes();
             let mut count = 0usize;
             let mut scanned = 0usize;
-            for entry in dir {
-                // A read error ends the scan (don't spin); the count so far is a
-                // safe lower bound.
-                let Ok(entry) = entry else {
+            // Fetch AT MOST `cap` entries: the budget is checked BEFORE each
+            // read, so the cap+1'th entry is never even fetched.
+            while scanned < cap {
+                let Some(next) = dir.next() else {
                     break;
                 };
-                // Bound the RAW scan before any filtering so a hostile flood of
-                // entries can't stall the turn.
+                // A mid-scan read error is a FAILURE, not a short scan: return 0
+                // (the documented contract), never a partial count.
+                let Ok(entry) = next else {
+                    return 0;
+                };
                 scanned += 1;
-                if scanned > cap {
-                    break;
-                }
                 if !entry.file_name().to_bytes().starts_with(prefix) {
                     continue;
                 }
@@ -2612,19 +2612,21 @@ mod peer_io {
             if !peer_dir_ok(peer_dir) {
                 return 0;
             }
-            let Ok(read_dir) = std::fs::read_dir(peer_dir) else {
+            let Ok(mut read_dir) = std::fs::read_dir(peer_dir) else {
                 return 0;
             };
             let mut count = 0usize;
             let mut scanned = 0usize;
-            for entry in read_dir {
-                let Ok(entry) = entry else {
+            // Fetch AT MOST `cap` entries (budget checked before each read); a
+            // mid-scan read error returns 0, never a partial count.
+            while scanned < cap {
+                let Some(next) = read_dir.next() else {
                     break;
                 };
+                let Ok(entry) = next else {
+                    return 0;
+                };
                 scanned += 1;
-                if scanned > cap {
-                    break;
-                }
                 if !entry.file_name().to_string_lossy().starts_with(prefix) {
                     continue;
                 }
@@ -2916,6 +2918,25 @@ mod peer_io_tests {
             peer_dir_count_prefixed(&link, "result-", PEER_DIR_SCAN_CAP),
             0,
             "a symlinked peer dir must not be followed for enumeration"
+        );
+        // Any open/read failure returns 0 (the documented contract), never a
+        // partial count — here an absent dir; a mid-scan readdir error takes the
+        // same `return 0` path.
+        assert_eq!(
+            peer_dir_count_prefixed(&dir.path().join("absent"), "result-", PEER_DIR_SCAN_CAP),
+            0,
+            "a missing peer dir must count 0"
+        );
+        // The budget is checked BEFORE each read: cap 0 fetches nothing (→ 0),
+        // and cap 1 fetches at most one entry so the count never exceeds the cap.
+        assert_eq!(
+            peer_dir_count_prefixed(peer, "result-", 0),
+            0,
+            "cap 0 must fetch no entries"
+        );
+        assert!(
+            peer_dir_count_prefixed(peer, "result-", 1) <= 1,
+            "the raw scan must stop at exactly the cap"
         );
     }
 }
@@ -11101,6 +11122,21 @@ fn stage_peer(
     let cwd = if worktree {
         let worktree_path = peer_dir.join("wt");
         let branch = format!("peer/{slug}");
+        // Best-effort re-validation immediately before handing the path to git:
+        // narrows (to near-zero) the window in which `<slug>` could be swapped
+        // to a symlink after reservation, which would redirect git's worktree
+        // creation outside `peers_root`. NOTE: this does NOT fully close it —
+        // git re-resolves `peers/<slug>/wt` by path itself, so a residual
+        // path-resolution TOCTOU is inherent to handing a path to a subprocess
+        // (tracked as a follow-up; #1824). Accurate scope: all peer-FILE
+        // read/write/enumeration I/O is fd-anchored; only this git-worktree
+        // creation path is best-effort re-validated.
+        if !peer_io::peer_dir_exists(&peer_dir) {
+            cleanup_staged_peer(workspace_root, &slug, &peer_dir);
+            return Err(RpcError::invalid_params(format!(
+                "peer '{slug}' staging directory is no longer a real directory"
+            )));
+        }
         let output = std::process::Command::new("git")
             .arg("-C")
             .arg(workspace_root)

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2157,7 +2157,7 @@ fn staged_peer_dir(peers_root: &Path, slug: &str) -> Option<PathBuf> {
     if meta.file_type().is_symlink() || !meta.is_dir() {
         return None;
     }
-    if !dir.join("brief.md").is_file() {
+    if !peer_io::peer_regular_file_exists(&dir, "brief.md") {
         return None;
     }
     Some(dir)
@@ -2238,6 +2238,25 @@ mod peer_io {
         imp::append_peer_line(peer_dir, leaf, line)
     }
 
+    /// `true` when the peer leaf exists as a REGULAR file, resolved under the
+    /// peer dir fd with a no-follow stat (`S_ISREG` required). A symlinked/FIFO/
+    /// dir/device leaf — or a symlinked peer dir — reads as absent. Replaces the
+    /// path-following `dir.join(leaf).is_file()` status probes so an existence
+    /// gate (e.g. the `closed` close-marker) can't be redirected by a parent- or
+    /// leaf-swap (#1824).
+    pub(super) fn peer_regular_file_exists(peer_dir: &Path, leaf: &str) -> bool {
+        imp::peer_file_mtime(peer_dir, leaf).is_some()
+    }
+
+    /// The mtime of a peer leaf REGULAR file, resolved under the peer dir fd
+    /// with the same no-follow `S_ISREG` gate as [`peer_regular_file_exists`].
+    /// `None` for a symlinked/FIFO/dir leaf, a symlinked peer dir, or a stat
+    /// error. Used where the mtime AFFECTS behavior (the ready-note freshness
+    /// gate), so a swapped leaf can neither park nor mislead it.
+    pub(super) fn peer_file_mtime(peer_dir: &Path, leaf: &str) -> Option<std::time::SystemTime> {
+        imp::peer_file_mtime(peer_dir, leaf)
+    }
+
     #[cfg(unix)]
     mod imp {
         use std::io::{Read, Write};
@@ -2245,7 +2264,7 @@ mod peer_io {
         use std::os::unix::fs::OpenOptionsExt;
         use std::path::Path;
 
-        use rustix::fs::{AtFlags, Mode, OFlags, openat, renameat, unlinkat};
+        use rustix::fs::{AtFlags, Mode, OFlags, fsync, openat, renameat, unlinkat};
 
         /// Open the peer dir as an `O_NOFOLLOW|O_DIRECTORY` fd: a symlinked
         /// `<slug>` is refused here (belt-and-braces over `staged_peer_dir`'s
@@ -2323,6 +2342,9 @@ mod peer_io {
                 let _ = unlinkat(&dir, tmp.as_str(), AtFlags::empty());
                 return Err(err.into());
             }
+            // Best-effort dir fsync so the rename entry itself is crash-durable
+            // (the tmp file's data was already fsync'd above).
+            let _ = fsync(&dir);
             Ok(())
         }
 
@@ -2357,6 +2379,28 @@ mod peer_io {
                 ));
             }
             file.write_all(line.as_bytes())
+        }
+
+        pub(super) fn peer_file_mtime(
+            peer_dir: &Path,
+            leaf: &str,
+        ) -> Option<std::time::SystemTime> {
+            let dir = open_peer_dir(peer_dir).ok()?;
+            // Anchored no-follow open + fstat (NONBLOCK so a planted FIFO can't
+            // park the probe); regular files only, then read the mtime off the
+            // opened handle. No content is read.
+            let fd = openat(
+                &dir,
+                leaf,
+                OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC | OFlags::NONBLOCK,
+                Mode::empty(),
+            )
+            .ok()?;
+            let meta = std::fs::File::from(fd).metadata().ok()?;
+            if !meta.is_file() {
+                return None;
+            }
+            meta.modified().ok()
         }
     }
 
@@ -2461,6 +2505,20 @@ mod peer_io {
                 .open(&path)?;
             file.write_all(line.as_bytes())
         }
+
+        pub(super) fn peer_file_mtime(
+            peer_dir: &Path,
+            leaf: &str,
+        ) -> Option<std::time::SystemTime> {
+            if !peer_dir_ok(peer_dir) {
+                return None;
+            }
+            let meta = std::fs::symlink_metadata(peer_dir.join(leaf)).ok()?;
+            if meta.file_type().is_symlink() || !meta.is_file() {
+                return None;
+            }
+            meta.modified().ok()
+        }
     }
 }
 
@@ -2470,8 +2528,8 @@ mod peer_io_tests {
     use std::time::Duration;
 
     use super::peer_io::{
-        PEER_FILE_READ_CAP_LARGE, PEER_FILE_READ_CAP_SMALL, append_peer_line, read_peer_file,
-        write_peer_file_atomic,
+        PEER_FILE_READ_CAP_LARGE, PEER_FILE_READ_CAP_SMALL, append_peer_line, peer_file_mtime,
+        peer_regular_file_exists, read_peer_file, write_peer_file_atomic,
     };
 
     // octos#1824: a symlinked leaf must NOT be followed — the anchored openat
@@ -2621,6 +2679,90 @@ mod peer_io_tests {
         );
         assert_eq!(std::fs::read_to_string(&other).unwrap(), "untouched");
     }
+
+    // octos#1824 status probes: the anchored existence/mtime gate counts only
+    // REGULAR files — a symlinked or FIFO leaf (or absent) is not "present".
+    #[test]
+    fn peer_regular_file_exists_gates_on_regular_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let peer = dir.path();
+        // Regular file → present, with a readable mtime.
+        std::fs::write(peer.join("closed"), "x").unwrap();
+        assert!(peer_regular_file_exists(peer, "closed"));
+        assert!(peer_file_mtime(peer, "closed").is_some());
+        // Absent → not present.
+        assert!(!peer_regular_file_exists(peer, "result.md"));
+        assert!(peer_file_mtime(peer, "result.md").is_none());
+        // Symlinked leaf → not present (not followed), even to a real file.
+        std::fs::write(peer.join("target"), "y").unwrap();
+        std::os::unix::fs::symlink("target", peer.join("result.md")).unwrap();
+        assert!(!peer_regular_file_exists(peer, "result.md"));
+        assert!(peer_file_mtime(peer, "result.md").is_none());
+        // FIFO leaf → not present, PROMPTLY (NONBLOCK open + regular-file
+        // reject); a blocking probe would trip the timeout.
+        let status = std::process::Command::new("mkfifo")
+            .arg(peer.join("fifo"))
+            .status()
+            .expect("mkfifo");
+        assert!(status.success());
+        let peer_buf = peer.to_path_buf();
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(peer_regular_file_exists(&peer_buf, "fifo"));
+        });
+        let got = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("existence probe must not block on a FIFO leaf");
+        assert!(!got, "a FIFO leaf must not count as a regular file");
+    }
+
+    // octos#1824 `.notified` freshness stamp: round-trips through the anchored
+    // helpers, and neither read nor write follows a symlinked leaf.
+    #[test]
+    fn notified_stamp_round_trips_and_refuses_symlinked_leaf() {
+        let dir = tempfile::tempdir().unwrap();
+        let peer = dir.path();
+        write_peer_file_atomic(peer, ".notified", "1700000000").unwrap();
+        assert_eq!(
+            read_peer_file(peer, ".notified", PEER_FILE_READ_CAP_SMALL).as_deref(),
+            Some("1700000000")
+        );
+
+        // Plant a symlinked `.notified` pointing OUTSIDE the peer dir.
+        let outside = dir.path().join("outside");
+        std::fs::write(&outside, "original").unwrap();
+        std::fs::remove_file(peer.join(".notified")).unwrap();
+        std::os::unix::fs::symlink(&outside, peer.join(".notified")).unwrap();
+
+        // Read refuses to follow it.
+        assert_eq!(
+            read_peer_file(peer, ".notified", PEER_FILE_READ_CAP_SMALL),
+            None,
+            "a symlinked `.notified` must not be followed on read"
+        );
+        // Write does not follow it either: renameat REPLACES the symlink with a
+        // fresh regular file, so the target outside the peer dir is untouched.
+        write_peer_file_atomic(peer, ".notified", "9999").unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&outside).unwrap(),
+            "original",
+            "the stamp write must not reach the symlink target"
+        );
+        assert_eq!(
+            read_peer_file(peer, ".notified", PEER_FILE_READ_CAP_SMALL).as_deref(),
+            Some("9999"),
+            "after replacing the symlink the stamp reads back its new value"
+        );
+        assert!(
+            !peer
+                .join(".notified")
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the symlink must have been replaced by a regular file"
+        );
+    }
 }
 
 /// `true` when `peers/<slug>/closed` exists — the durable marker written by
@@ -2630,7 +2772,8 @@ mod peer_io_tests {
 /// Routes through [`staged_peer_dir`] so a symlinked / unsafe slug is never
 /// followed.
 fn peer_is_closed(peers_root: &Path, slug: &str) -> bool {
-    staged_peer_dir(peers_root, slug).is_some_and(|dir| dir.join("closed").is_file())
+    staged_peer_dir(peers_root, slug)
+        .is_some_and(|dir| peer_io::peer_regular_file_exists(&dir, "closed"))
 }
 
 /// Resolve a peer IDENTIFIER (its display NAME or its slug) to the slug. A name
@@ -11371,12 +11514,9 @@ fn read_peer_blackboard(peers_root: &Path, slugs: Option<&[String]>) -> Vec<Peer
             else {
                 continue;
             };
-            let result_path = dir.join("result.md");
             let result =
                 peer_io::read_peer_file(&dir, "result.md", peer_io::PEER_FILE_READ_CAP_LARGE);
-            let result_updated_unix = std::fs::metadata(&result_path)
-                .ok()
-                .and_then(|meta| meta.modified().ok())
+            let result_updated_unix = peer_io::peer_file_mtime(&dir, "result.md")
                 .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
                 .map(|elapsed| elapsed.as_secs());
             let (brief, brief_truncated) = capped_utf8(brief, PEER_GATHER_BRIEF_CAP);
@@ -11402,7 +11542,7 @@ fn read_peer_blackboard(peers_root: &Path, slugs: Option<&[String]>) -> Vec<Peer
                 result_truncated,
                 result_updated_unix,
                 has_worktree: dir.join("wt").is_dir(),
-                closed: dir.join("closed").is_file(),
+                closed: peer_io::peer_regular_file_exists(&dir, "closed"),
                 turn_history: parse_peer_turns_index(&dir),
                 // #peer-model — the recorded model lane, if any (fd-anchored
                 // no-follow read so a symlinked/FIFO `model` leaf is refused;
@@ -11789,26 +11929,26 @@ fn peer_results_ready_note(peers_root: &Path, session_id: &SessionKey) -> Option
     let mut dirs: Vec<_> = read_dir.flatten().collect();
     dirs.sort_by_key(|entry| entry.file_name());
     let session = session_id.to_string();
-    // (slug, stamp path, result mtime) per ready peer.
+    // (slug, peer dir, result mtime) per ready peer. The peer dir is carried so
+    // the `.notified` stamp write below anchors on it (never a bare path).
     let mut ready: Vec<(String, PathBuf, u64)> = Vec::new();
     for entry in dirs {
         let slug = entry.file_name().to_string_lossy().into_owned();
         let Some(dir) = staged_peer_dir(peers_root, &slug) else {
             continue;
         };
-        // Stat-first: no result file means nothing to announce, skip
-        // before touching any other file.
-        let Some(result_mtime) = std::fs::metadata(dir.join("result.md"))
-            .ok()
-            .and_then(|meta| meta.modified().ok())
+        // Stat-first (anchored mtime): no result file means nothing to
+        // announce, skip before touching any other file.
+        let Some(result_mtime) = peer_io::peer_file_mtime(&dir, "result.md")
             .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
             .map(|elapsed| elapsed.as_secs())
         else {
             continue;
         };
-        let stamp_path = dir.join(".notified");
-        let covered = std::fs::read_to_string(&stamp_path)
-            .ok()
+        // The `.notified` freshness stamp is per-slug — a FIFO here would park
+        // this ready-note path, and a leaf swap could feed a bogus cursor; read
+        // it through the anchored no-follow/regular-file helper (#1824).
+        let covered = peer_io::read_peer_file(&dir, ".notified", peer_io::PEER_FILE_READ_CAP_SMALL)
             .and_then(|stamp| stamp.trim().parse::<u64>().ok());
         if covered.is_some_and(|covered| covered >= result_mtime) {
             continue;
@@ -11821,7 +11961,7 @@ fn peer_results_ready_note(peers_root: &Path, session_id: &SessionKey) -> Option
         if originator.trim() != session {
             continue;
         }
-        ready.push((slug, stamp_path, result_mtime));
+        ready.push((slug, dir, result_mtime));
     }
     if ready.is_empty() {
         return None;
@@ -11829,9 +11969,9 @@ fn peer_results_ready_note(peers_root: &Path, session_id: &SessionKey) -> Option
     // Stamp EVERY peer the note covers — the "+N more" ones included: the
     // note tells the model results are ready and `peer_gather` reads them
     // all. Best-effort; a failed stamp only risks one repeat nudge.
-    for (_, stamp_path, result_mtime) in &ready {
+    for (_, dir, result_mtime) in &ready {
         if let Err(err) =
-            crate::memory_consolidate::apply::atomic_write(stamp_path, &result_mtime.to_string())
+            peer_io::write_peer_file_atomic(dir, ".notified", &result_mtime.to_string())
         {
             tracing::warn!(?err, "failed to write peer .notified stamp");
         }
@@ -12016,7 +12156,7 @@ fn collect_owned_peer_results(peers_root: &Path, master: &str) -> Option<Vec<(St
             continue;
         };
         // Retired peer: neither blocks nor keeps the fleet alive.
-        if dir.join("closed").is_file() {
+        if peer_io::peer_regular_file_exists(&dir, "closed") {
             continue;
         }
         // Originator gate — only peers THIS master staged. After the atomic
@@ -12031,7 +12171,7 @@ fn collect_owned_peer_results(peers_root: &Path, master: &str) -> Option<Vec<(St
         if originator.trim() != master {
             continue;
         }
-        owned.push((slug, dir.join("result.md").is_file()));
+        owned.push((slug, peer_io::peer_regular_file_exists(&dir, "result.md")));
     }
     Some(owned)
 }

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2195,6 +2195,11 @@ mod peer_io {
     /// name, or a compact line index — all KB-scale.
     pub(super) const PEER_FILE_READ_CAP_SMALL: usize = 64 * 1024;
 
+    /// Raw directory-scan budget for [`peer_dir_count_prefixed`]. A legitimate
+    /// peer has a handful of `result-<n>.md` files; this only bounds a hostile
+    /// flood so a directory stuffed with entries can't stall a turn.
+    pub(super) const PEER_DIR_SCAN_CAP: usize = 100_000;
+
     /// Process-unique suffix source for temp filenames, so concurrent
     /// atomic writes to the same leaf never collide on the `O_EXCL` create.
     static TMP_UNIQ: AtomicU64 = AtomicU64::new(0);
@@ -2257,14 +2262,34 @@ mod peer_io {
         imp::peer_file_mtime(peer_dir, leaf)
     }
 
+    /// Count REGULAR-file entries whose name starts with `prefix`, enumerating
+    /// the peer dir through its own `O_NOFOLLOW|O_DIRECTORY` fd (`fdopendir`) —
+    /// never a path `read_dir`, so swapping `<slug>` to a symlink after
+    /// [`staged_peer_dir`] cannot redirect the scan into an attacker's tree
+    /// (#1824). A symlinked/dir/FIFO entry matching the prefix is NOT counted
+    /// (so it can't inflate a version number), and the raw scan stops after
+    /// `cap` entries so a hostile flood can't stall the turn. Any failure
+    /// (symlinked peer dir, open/read error) → 0.
+    pub(super) fn peer_dir_count_prefixed(peer_dir: &Path, prefix: &str, cap: usize) -> usize {
+        imp::peer_dir_count_prefixed(peer_dir, prefix, cap)
+    }
+
+    /// `true` when `peer_dir` exists as a REAL (non-symlink) directory, opened
+    /// `O_NOFOLLOW|O_DIRECTORY` — a symlinked `<slug>` is refused. Anchored
+    /// replacement for a path-following `is_dir()` gate on a per-slug peer dir.
+    pub(super) fn peer_dir_exists(peer_dir: &Path) -> bool {
+        imp::peer_dir_exists(peer_dir)
+    }
+
     #[cfg(unix)]
     mod imp {
+        use std::ffi::CStr;
         use std::io::{Read, Write};
         use std::os::fd::OwnedFd;
         use std::os::unix::fs::OpenOptionsExt;
         use std::path::Path;
 
-        use rustix::fs::{AtFlags, Mode, OFlags, fsync, openat, renameat, unlinkat};
+        use rustix::fs::{AtFlags, Dir, FileType, Mode, OFlags, fsync, openat, renameat, unlinkat};
 
         /// Open the peer dir as an `O_NOFOLLOW|O_DIRECTORY` fd: a symlinked
         /// `<slug>` is refused here (belt-and-braces over `staged_peer_dir`'s
@@ -2402,6 +2427,65 @@ mod peer_io {
             }
             meta.modified().ok()
         }
+
+        pub(super) fn peer_dir_exists(peer_dir: &Path) -> bool {
+            // O_NOFOLLOW|O_DIRECTORY succeeds only for a REAL non-symlink dir.
+            open_peer_dir(peer_dir).is_ok()
+        }
+
+        pub(super) fn peer_dir_count_prefixed(peer_dir: &Path, prefix: &str, cap: usize) -> usize {
+            let Ok(dirfd) = open_peer_dir(peer_dir) else {
+                return 0;
+            };
+            // fdopendir on the anchored fd — entries come from THIS inode, never
+            // a re-walked path, so a swapped `<slug>` can't redirect the scan.
+            let Ok(dir) = Dir::read_from(&dirfd) else {
+                return 0;
+            };
+            let prefix = prefix.as_bytes();
+            let mut count = 0usize;
+            let mut scanned = 0usize;
+            for entry in dir {
+                // A read error ends the scan (don't spin); the count so far is a
+                // safe lower bound.
+                let Ok(entry) = entry else {
+                    break;
+                };
+                // Bound the RAW scan before any filtering so a hostile flood of
+                // entries can't stall the turn.
+                scanned += 1;
+                if scanned > cap {
+                    break;
+                }
+                if !entry.file_name().to_bytes().starts_with(prefix) {
+                    continue;
+                }
+                // Regular files only — a symlinked/dir/FIFO `result-*` entry
+                // must not inflate the version count.
+                match entry.file_type() {
+                    FileType::RegularFile => count += 1,
+                    // d_type unavailable on this FS → classify with a no-follow
+                    // stat before counting.
+                    FileType::Unknown if entry_is_regular(&dirfd, entry.file_name()) => count += 1,
+                    _ => {}
+                }
+            }
+            count
+        }
+
+        /// No-follow `S_ISREG` check of `name` relative to the peer dir fd, for
+        /// the rare filesystem that returns `DT_UNKNOWN` from `readdir`.
+        fn entry_is_regular(dirfd: &OwnedFd, name: &CStr) -> bool {
+            openat(
+                dirfd,
+                name,
+                OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC | OFlags::NONBLOCK,
+                Mode::empty(),
+            )
+            .ok()
+            .and_then(|fd| std::fs::File::from(fd).metadata().ok())
+            .is_some_and(|meta| meta.is_file())
+        }
     }
 
     #[cfg(not(unix))]
@@ -2519,6 +2603,39 @@ mod peer_io {
             }
             meta.modified().ok()
         }
+
+        pub(super) fn peer_dir_exists(peer_dir: &Path) -> bool {
+            peer_dir_ok(peer_dir)
+        }
+
+        pub(super) fn peer_dir_count_prefixed(peer_dir: &Path, prefix: &str, cap: usize) -> usize {
+            if !peer_dir_ok(peer_dir) {
+                return 0;
+            }
+            let Ok(read_dir) = std::fs::read_dir(peer_dir) else {
+                return 0;
+            };
+            let mut count = 0usize;
+            let mut scanned = 0usize;
+            for entry in read_dir {
+                let Ok(entry) = entry else {
+                    break;
+                };
+                scanned += 1;
+                if scanned > cap {
+                    break;
+                }
+                if !entry.file_name().to_string_lossy().starts_with(prefix) {
+                    continue;
+                }
+                if std::fs::symlink_metadata(entry.path())
+                    .is_ok_and(|m| !m.file_type().is_symlink() && m.is_file())
+                {
+                    count += 1;
+                }
+            }
+            count
+        }
     }
 }
 
@@ -2528,8 +2645,9 @@ mod peer_io_tests {
     use std::time::Duration;
 
     use super::peer_io::{
-        PEER_FILE_READ_CAP_LARGE, PEER_FILE_READ_CAP_SMALL, append_peer_line, peer_file_mtime,
-        peer_regular_file_exists, read_peer_file, write_peer_file_atomic,
+        PEER_DIR_SCAN_CAP, PEER_FILE_READ_CAP_LARGE, PEER_FILE_READ_CAP_SMALL, append_peer_line,
+        peer_dir_count_prefixed, peer_dir_exists, peer_file_mtime, peer_regular_file_exists,
+        read_peer_file, write_peer_file_atomic,
     };
 
     // octos#1824: a symlinked leaf must NOT be followed — the anchored openat
@@ -2761,6 +2879,43 @@ mod peer_io_tests {
                 .file_type()
                 .is_symlink(),
             "the symlink must have been replaced by a regular file"
+        );
+    }
+
+    // octos#1824: `result-*` version enumeration is fd-anchored and counts only
+    // REGULAR prefixed files — a symlinked or non-prefixed entry can't inflate
+    // the count, and a symlinked peer dir yields 0 (no follow).
+    #[test]
+    fn peer_dir_count_prefixed_counts_only_regular_prefixed_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let peer = dir.path();
+        std::fs::write(peer.join("result-1.md"), "a").unwrap();
+        std::fs::write(peer.join("result-2.md"), "b").unwrap();
+        std::fs::write(peer.join("result.md"), "latest").unwrap(); // no `result-` prefix
+        std::fs::write(peer.join("brief.md"), "brief").unwrap(); // other prefix
+        std::fs::create_dir(peer.join("result-dir")).unwrap(); // dir, not a file
+        // A symlinked `result-*` entry must NOT be counted (not followed).
+        std::fs::write(dir.path().join("outside"), "x").unwrap();
+        std::os::unix::fs::symlink(dir.path().join("outside"), peer.join("result-9.md")).unwrap();
+
+        assert_eq!(
+            peer_dir_count_prefixed(peer, "result-", PEER_DIR_SCAN_CAP),
+            2,
+            "only the two REGULAR `result-<n>.md` files may count"
+        );
+
+        // A real peer dir exists; a symlinked one is refused and enumerates to 0.
+        assert!(peer_dir_exists(peer));
+        let link = dir.path().join("peerlink");
+        std::os::unix::fs::symlink(peer, &link).unwrap();
+        assert!(
+            !peer_dir_exists(&link),
+            "a symlinked peer dir must be refused"
+        );
+        assert_eq!(
+            peer_dir_count_prefixed(&link, "result-", PEER_DIR_SCAN_CAP),
+            0,
+            "a symlinked peer dir must not be followed for enumeration"
         );
     }
 }
@@ -11333,9 +11488,8 @@ fn write_peer_result_if_peer_session(
     let Some(peer_dir) = staged_peer_dir(&runtime.data_dir.join("peers"), slug) else {
         return;
     };
-    if !peer_dir.is_dir() {
-        return;
-    }
+    // No redundant `peer_dir.is_dir()` here — `staged_peer_dir` already proved a
+    // real non-symlink dir, and every write below re-anchors on the dir fd.
     const PEER_RESULT_MAX_BYTES: usize = 256 * 1024;
     let mut body = content;
     let mut truncated = "";
@@ -11394,15 +11548,12 @@ fn write_peer_result_if_peer_session(
     }
 }
 
-/// Count how many `result-*.md` files already exist in the peer directory.
+/// Count how many `result-<n>.md` version files exist in the peer directory,
+/// via the fd-anchored, regular-file-only, scan-capped enumerator so swapping
+/// `<slug>` to a symlink can neither redirect the scan into another tree nor
+/// inflate the derived version number (#1824).
 fn count_peer_result_versions(peer_dir: &std::path::Path) -> u32 {
-    let Ok(read_dir) = std::fs::read_dir(peer_dir) else {
-        return 0;
-    };
-    read_dir
-        .flatten()
-        .filter(|entry| entry.file_name().to_string_lossy().starts_with("result-"))
-        .count() as u32
+    peer_io::peer_dir_count_prefixed(peer_dir, "result-", peer_io::PEER_DIR_SCAN_CAP) as u32
 }
 
 /// Parse `turns.txt` into `[(turn_count, outcome, updated_unix)]`.
@@ -26240,8 +26391,10 @@ async fn run_standalone_turn(
                         ));
                     };
                     // A deleted peer must not silently swallow injections into a
-                    // queue nothing will drain: require the staged dir to exist.
-                    if !send_peers_root.join(&slug).is_dir() {
+                    // queue nothing will drain: require the staged dir to exist,
+                    // anchored (O_NOFOLLOW|O_DIRECTORY) so a symlink swapped in
+                    // for the removed `<slug>` can't spoof the gate (#1824).
+                    if !peer_io::peer_dir_exists(&send_peers_root.join(&slug)) {
                         return Err(format!(
                             "peer '{slug}' no longer exists (its staged directory was removed)"
                         ));

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2163,6 +2163,466 @@ fn staged_peer_dir(peers_root: &Path, slug: &str) -> Option<PathBuf> {
     Some(dir)
 }
 
+/// fd-anchored, symlink/FIFO/DoS-safe I/O for the per-session peer files under
+/// `peers/<slug>/` (octos#1824). [`staged_peer_dir`] validates the `<slug>`
+/// directory by PATH; a subsequent path-based `std::fs` read/write then races a
+/// parent swap — an attacker who can write under `peers/` replaces `<slug>` (or
+/// a leaf) with a symlink between the check and the I/O, and the plain read/
+/// `atomic_write` follows the swap. It also accepts a FIFO/device leaf, so a
+/// hostile `model`/`brief.md` FIFO parks a turn on an unbounded blocking read.
+///
+/// Every op here re-opens the peer DIR fd `O_NOFOLLOW|O_DIRECTORY` (so a
+/// symlinked `<slug>` is refused, not followed) and resolves the LEAF relative
+/// to that pinned inode with `openat`/`renameat`/`unlinkat` — no path is ever
+/// re-walked after the anchor, closing the parent-swap race. Reads open
+/// `O_NOFOLLOW|O_NONBLOCK`, `fstat` the opened handle, require a regular file
+/// (`S_ISREG` — a FIFO/device/dir/symlink is refused before any `read`), and
+/// bound the read to a cap. This mirrors the anchored pattern already used by
+/// `api::memory_panel` for the memory-panel reads.
+mod peer_io {
+    use std::path::Path;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Read cap for the large peer files (`brief.md`, `result.md`). Over-cap
+    /// content reads as absent (`None`) rather than a truncated prefix, matching
+    /// `memory_panel`'s over-cap posture. 1 MiB is far above any legitimate
+    /// brief/result (the write side caps `result.md` at 256 KiB and the gather
+    /// display re-caps to tens of KiB).
+    pub(super) const PEER_FILE_READ_CAP_LARGE: usize = 1024 * 1024;
+
+    /// Read cap for the small control files (`model`, `originator`, `name`,
+    /// `turns.txt`, `closed`). These hold a lane key, a session id, a display
+    /// name, or a compact line index — all KB-scale.
+    pub(super) const PEER_FILE_READ_CAP_SMALL: usize = 64 * 1024;
+
+    /// Process-unique suffix source for temp filenames, so concurrent
+    /// atomic writes to the same leaf never collide on the `O_EXCL` create.
+    static TMP_UNIQ: AtomicU64 = AtomicU64::new(0);
+
+    /// A `.<leaf>.tmp-<pid>-<uniq>` sibling name for the atomic temp file. The
+    /// leading `.` keeps it out of `result-*` globs (e.g.
+    /// `count_peer_result_versions`), which a bare `<leaf>.tmp` would otherwise
+    /// pollute for `result-<n>.md`.
+    fn tmp_name(leaf: &str) -> String {
+        let uniq = TMP_UNIQ.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        format!(".{leaf}.tmp-{pid}-{uniq}")
+    }
+
+    /// Read a peer leaf file, anchored on the peer dir fd. Returns the content
+    /// when the leaf is a REGULAR file no larger than `cap` bytes; `None` for a
+    /// symlinked dir/leaf, a FIFO/device/dir leaf, an over-cap file, invalid
+    /// UTF-8, or any I/O error.
+    pub(super) fn read_peer_file(peer_dir: &Path, leaf: &str, cap: usize) -> Option<String> {
+        imp::read_peer_file(peer_dir, leaf, cap)
+    }
+
+    /// Atomically replace a peer leaf file (temp + fsync + rename), every step
+    /// relative to the peer dir fd. A symlinked dir/leaf is refused (never
+    /// followed); on any write/rename error the temp file is best-effort
+    /// removed.
+    pub(super) fn write_peer_file_atomic(
+        peer_dir: &Path,
+        leaf: &str,
+        content: &str,
+    ) -> std::io::Result<()> {
+        imp::write_peer_file_atomic(peer_dir, leaf, content)
+    }
+
+    /// Append `line` to a peer leaf file (the `turns.txt` index), anchored on
+    /// the peer dir fd. Creates the file if absent; refuses a symlinked dir/
+    /// leaf and a non-regular (FIFO/device) leaf. Opened `O_NONBLOCK` so a
+    /// planted FIFO fails fast instead of parking the writer on the missing
+    /// reader.
+    pub(super) fn append_peer_line(peer_dir: &Path, leaf: &str, line: &str) -> std::io::Result<()> {
+        imp::append_peer_line(peer_dir, leaf, line)
+    }
+
+    #[cfg(unix)]
+    mod imp {
+        use std::io::{Read, Write};
+        use std::os::fd::OwnedFd;
+        use std::os::unix::fs::OpenOptionsExt;
+        use std::path::Path;
+
+        use rustix::fs::{AtFlags, Mode, OFlags, openat, renameat, unlinkat};
+
+        /// Open the peer dir as an `O_NOFOLLOW|O_DIRECTORY` fd: a symlinked
+        /// `<slug>` is refused here (belt-and-braces over `staged_peer_dir`'s
+        /// path check, and the anchor that makes the leaf ops race-free).
+        fn open_peer_dir(peer_dir: &Path) -> std::io::Result<OwnedFd> {
+            std::fs::OpenOptions::new()
+                .read(true)
+                .custom_flags(
+                    libc::O_NOFOLLOW | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NONBLOCK,
+                )
+                .open(peer_dir)
+                .map(OwnedFd::from)
+        }
+
+        pub(super) fn read_peer_file(peer_dir: &Path, leaf: &str, cap: usize) -> Option<String> {
+            let dir = open_peer_dir(peer_dir).ok()?;
+            // NONBLOCK: a FIFO opened plain `O_RDONLY` blocks until a writer
+            // appears — a planted FIFO must never park the caller (#1824).
+            let fd = openat(
+                &dir,
+                leaf,
+                OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC | OFlags::NONBLOCK,
+                Mode::empty(),
+            )
+            .ok()?;
+            let file = std::fs::File::from(fd);
+            // fstat the OPENED handle (no stat-by-path race). Regular files
+            // only: a FIFO/device/dir/socket is refused before any `read`.
+            let meta = file.metadata().ok()?;
+            if !meta.is_file() {
+                return None;
+            }
+            let cap = cap as u64;
+            // Bound the ACTUAL read, not just the fstat snapshot: `take(cap+1)`
+            // detects an over-cap file (a full cap+1 bytes) and rejects it
+            // rather than serving a truncated prefix. Invalid UTF-8 → `None`
+            // (matching the prior `read_to_string`).
+            let mut content = String::new();
+            let read = Read::take(file, cap + 1)
+                .read_to_string(&mut content)
+                .ok()?;
+            if read as u64 > cap {
+                return None;
+            }
+            Some(content)
+        }
+
+        pub(super) fn write_peer_file_atomic(
+            peer_dir: &Path,
+            leaf: &str,
+            content: &str,
+        ) -> std::io::Result<()> {
+            let dir = open_peer_dir(peer_dir)?;
+            let tmp = super::tmp_name(leaf);
+            // O_EXCL|O_NOFOLLOW: create a fresh regular temp beside the leaf,
+            // never following/clobbering a pre-existing name.
+            let fd = openat(
+                &dir,
+                tmp.as_str(),
+                OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+                Mode::RUSR | Mode::WUSR,
+            )
+            .map_err(std::io::Error::from)?;
+            let mut file = std::fs::File::from(fd);
+            let written = file
+                .write_all(content.as_bytes())
+                .and_then(|()| file.sync_all());
+            if let Err(err) = written {
+                let _ = unlinkat(&dir, tmp.as_str(), AtFlags::empty());
+                return Err(err);
+            }
+            // renameat relative to the SAME dir fd — atomic in-dir replace that
+            // a parent swap cannot redirect.
+            if let Err(err) = renameat(&dir, tmp.as_str(), &dir, leaf) {
+                let _ = unlinkat(&dir, tmp.as_str(), AtFlags::empty());
+                return Err(err.into());
+            }
+            Ok(())
+        }
+
+        pub(super) fn append_peer_line(
+            peer_dir: &Path,
+            leaf: &str,
+            line: &str,
+        ) -> std::io::Result<()> {
+            let dir = open_peer_dir(peer_dir)?;
+            // O_APPEND create; O_NOFOLLOW refuses a symlinked leaf; O_NONBLOCK
+            // makes a planted FIFO fail fast (ENXIO, no reader) instead of
+            // parking the writer.
+            let fd = openat(
+                &dir,
+                leaf,
+                OFlags::WRONLY
+                    | OFlags::CREATE
+                    | OFlags::APPEND
+                    | OFlags::NOFOLLOW
+                    | OFlags::CLOEXEC
+                    | OFlags::NONBLOCK,
+                Mode::RUSR | Mode::WUSR,
+            )
+            .map_err(std::io::Error::from)?;
+            let mut file = std::fs::File::from(fd);
+            // Regular files only: refuse a device/FIFO leaf that slipped past
+            // the open (e.g. a FIFO with a live reader).
+            if !file.metadata()?.is_file() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "peer leaf is not a regular file",
+                ));
+            }
+            file.write_all(line.as_bytes())
+        }
+    }
+
+    #[cfg(not(unix))]
+    mod imp {
+        use std::io::{Read, Write};
+        use std::path::Path;
+
+        /// Refuse a symlinked peer dir; require a real directory. Non-unix
+        /// serve is dev-only (matching the `symlink_metadata` fallback
+        /// `memory_panel` uses for the same reads), so a path-anchored check
+        /// with a documented multi-syscall TOCTOU window is acceptable here.
+        fn peer_dir_ok(peer_dir: &Path) -> bool {
+            std::fs::symlink_metadata(peer_dir)
+                .map(|m| !m.file_type().is_symlink() && m.is_dir())
+                .unwrap_or(false)
+        }
+
+        pub(super) fn read_peer_file(peer_dir: &Path, leaf: &str, cap: usize) -> Option<String> {
+            if !peer_dir_ok(peer_dir) {
+                return None;
+            }
+            let path = peer_dir.join(leaf);
+            let meta = std::fs::symlink_metadata(&path).ok()?;
+            if meta.file_type().is_symlink() || !meta.is_file() {
+                return None;
+            }
+            let cap = cap as u64;
+            let file = std::fs::File::open(&path).ok()?;
+            let mut content = String::new();
+            let read = Read::take(file, cap + 1)
+                .read_to_string(&mut content)
+                .ok()?;
+            if read as u64 > cap {
+                return None;
+            }
+            Some(content)
+        }
+
+        pub(super) fn write_peer_file_atomic(
+            peer_dir: &Path,
+            leaf: &str,
+            content: &str,
+        ) -> std::io::Result<()> {
+            if !peer_dir_ok(peer_dir) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "peer dir is not a real directory",
+                ));
+            }
+            let path = peer_dir.join(leaf);
+            if std::fs::symlink_metadata(&path).is_ok_and(|m| m.file_type().is_symlink()) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "refusing to follow a symlinked peer leaf",
+                ));
+            }
+            let tmp = peer_dir.join(super::tmp_name(leaf));
+            {
+                let mut file = std::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&tmp)?;
+                if let Err(err) = file
+                    .write_all(content.as_bytes())
+                    .and_then(|()| file.sync_all())
+                {
+                    let _ = std::fs::remove_file(&tmp);
+                    return Err(err);
+                }
+            }
+            if let Err(err) = std::fs::rename(&tmp, &path) {
+                let _ = std::fs::remove_file(&tmp);
+                return Err(err);
+            }
+            Ok(())
+        }
+
+        pub(super) fn append_peer_line(
+            peer_dir: &Path,
+            leaf: &str,
+            line: &str,
+        ) -> std::io::Result<()> {
+            if !peer_dir_ok(peer_dir) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "peer dir is not a real directory",
+                ));
+            }
+            let path = peer_dir.join(leaf);
+            if let Ok(meta) = std::fs::symlink_metadata(&path) {
+                if meta.file_type().is_symlink() || !meta.is_file() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "peer leaf is not a regular file",
+                    ));
+                }
+            }
+            let mut file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)?;
+            file.write_all(line.as_bytes())
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod peer_io_tests {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    use super::peer_io::{
+        PEER_FILE_READ_CAP_LARGE, PEER_FILE_READ_CAP_SMALL, append_peer_line, read_peer_file,
+        write_peer_file_atomic,
+    };
+
+    // octos#1824: a symlinked leaf must NOT be followed — the anchored openat
+    // is O_NOFOLLOW, so a `model`/`brief.md` symlink pointing at a real file
+    // reads as absent instead of leaking the target's content.
+    #[test]
+    fn symlinked_leaf_is_refused_not_followed() {
+        let dir = tempfile::tempdir().unwrap();
+        let peer = dir.path();
+        std::fs::write(peer.join("secret"), "SENSITIVE").unwrap();
+        for leaf in ["model", "brief.md"] {
+            std::os::unix::fs::symlink("secret", peer.join(leaf)).unwrap();
+            assert_eq!(
+                read_peer_file(peer, leaf, PEER_FILE_READ_CAP_LARGE),
+                None,
+                "a symlinked `{leaf}` leaf must not be followed"
+            );
+        }
+    }
+
+    // octos#1824: a FIFO leaf must be rejected PROMPTLY (NONBLOCK open +
+    // regular-file reject) — never block the caller on the missing writer.
+    #[test]
+    fn fifo_leaf_reads_none_without_hanging() {
+        let dir = tempfile::tempdir().unwrap();
+        let peer = dir.path().to_path_buf();
+        let status = std::process::Command::new("mkfifo")
+            .arg(peer.join("model"))
+            .status()
+            .expect("mkfifo");
+        assert!(status.success());
+
+        // Run the read on a worker thread and require it to return quickly: a
+        // blocking open (no NONBLOCK) would never send, tripping the timeout.
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let out = read_peer_file(&peer, "model", PEER_FILE_READ_CAP_SMALL);
+            let _ = tx.send(out);
+        });
+        let result = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("read must not block on a FIFO leaf");
+        assert_eq!(result, None, "FIFO content must not be served");
+    }
+
+    // A real regular file round-trips through the atomic writer + anchored
+    // reader, landing at the intended leaf.
+    #[test]
+    fn regular_file_round_trips_to_the_named_leaf() {
+        let dir = tempfile::tempdir().unwrap();
+        let peer = dir.path();
+        write_peer_file_atomic(peer, "result.md", "hello peer").unwrap();
+        write_peer_file_atomic(peer, "name", "Kestrel").unwrap();
+        assert_eq!(
+            read_peer_file(peer, "result.md", PEER_FILE_READ_CAP_LARGE).as_deref(),
+            Some("hello peer")
+        );
+        assert_eq!(
+            read_peer_file(peer, "name", PEER_FILE_READ_CAP_SMALL).as_deref(),
+            Some("Kestrel"),
+            "each leaf must read back its OWN content"
+        );
+        // The atomic temp must not linger under the peer dir.
+        let leftover = std::fs::read_dir(peer)
+            .unwrap()
+            .filter_map(Result::ok)
+            .any(|e| e.file_name().to_string_lossy().contains(".tmp-"));
+        assert!(
+            !leftover,
+            "atomic temp file must be renamed away, not left behind"
+        );
+    }
+
+    // An over-cap file reads as absent, and the read is BOUNDED: a tiny cap on
+    // a much larger file must not slurp the whole thing.
+    #[test]
+    fn oversized_file_is_refused_and_read_is_bounded() {
+        let dir = tempfile::tempdir().unwrap();
+        let peer = dir.path();
+        let cap = 16usize;
+        // Exactly at cap → served.
+        write_peer_file_atomic(peer, "at_cap", &"a".repeat(cap)).unwrap();
+        assert_eq!(
+            read_peer_file(peer, "at_cap", cap).map(|s| s.len()),
+            Some(cap),
+            "a file exactly at the cap must be served whole"
+        );
+        // One over cap → refused (not a truncated prefix).
+        write_peer_file_atomic(peer, "over_cap", &"a".repeat(cap + 1)).unwrap();
+        assert_eq!(
+            read_peer_file(peer, "over_cap", cap),
+            None,
+            "an over-cap file must read as absent"
+        );
+        // Far over cap → still bounded (proves take(cap+1), not a full read).
+        std::fs::write(peer.join("huge"), "b".repeat(cap * 4096)).unwrap();
+        assert_eq!(read_peer_file(peer, "huge", cap), None);
+    }
+
+    // A peer_dir that is itself a symlink fails BOTH ops safely — the
+    // O_NOFOLLOW|O_DIRECTORY anchor refuses to open a symlinked `<slug>`.
+    #[test]
+    fn symlinked_peer_dir_fails_both_ops_safely() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        std::fs::write(real.join("name"), "present").unwrap();
+        let link = dir.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        assert_eq!(
+            read_peer_file(&link, "name", PEER_FILE_READ_CAP_SMALL),
+            None,
+            "reads through a symlinked peer dir must be refused"
+        );
+        assert!(
+            write_peer_file_atomic(&link, "name", "evil").is_err(),
+            "writes through a symlinked peer dir must be refused"
+        );
+        // The refused write must not have touched the real file.
+        assert_eq!(
+            std::fs::read_to_string(real.join("name")).unwrap(),
+            "present",
+            "a refused write must not reach the symlink target"
+        );
+    }
+
+    // The `turns.txt` append is anchored too: it round-trips for a real file
+    // and refuses a symlinked leaf.
+    #[test]
+    fn append_round_trips_and_refuses_symlinked_leaf() {
+        let dir = tempfile::tempdir().unwrap();
+        let peer = dir.path();
+        append_peer_line(peer, "turns.txt", "1 completed 100\n").unwrap();
+        append_peer_line(peer, "turns.txt", "2 completed 200\n").unwrap();
+        assert_eq!(
+            read_peer_file(peer, "turns.txt", PEER_FILE_READ_CAP_SMALL).as_deref(),
+            Some("1 completed 100\n2 completed 200\n")
+        );
+
+        let other = dir.path().join("elsewhere");
+        std::fs::write(&other, "untouched").unwrap();
+        std::os::unix::fs::symlink(&other, peer.join("evil.txt")).unwrap();
+        assert!(
+            append_peer_line(peer, "evil.txt", "x\n").is_err(),
+            "append must refuse a symlinked leaf"
+        );
+        assert_eq!(std::fs::read_to_string(&other).unwrap(), "untouched");
+    }
+}
+
 /// `true` when `peers/<slug>/closed` exists — the durable marker written by
 /// `peer_close` retiring a peer. Shared by the continuation-drain freshness
 /// gates and the reconnect-retarget skip so a closed peer is never a live
@@ -2193,7 +2653,9 @@ fn resolve_peer_name_to_slug(peers_root: &Path, ident: &str) -> Option<String> {
             let Some(dir) = staged_peer_dir(peers_root, &slug) else {
                 continue;
             };
-            if let Ok(name) = std::fs::read_to_string(dir.join("name")) {
+            if let Some(name) =
+                peer_io::read_peer_file(&dir, "name", peer_io::PEER_FILE_READ_CAP_SMALL)
+            {
                 if name.trim().to_lowercase() == lowered {
                     return Some(slug);
                 }
@@ -2301,13 +2763,13 @@ fn peer_send_input_authorized(
             "peer session '{slug}' is not a staged peer; cannot authorize input"
         ));
     };
-    match std::fs::read_to_string(dir.join("originator")) {
-        Ok(recorded) if recorded.trim() == caller_session => Ok(()),
-        Ok(_) => Err(format!(
+    match peer_io::read_peer_file(&dir, "originator", peer_io::PEER_FILE_READ_CAP_SMALL) {
+        Some(recorded) if recorded.trim() == caller_session => Ok(()),
+        Some(_) => Err(format!(
             "not the owner of peer session '{slug}' — only the session that \
              staged this peer may send it input"
         )),
-        Err(_) => Err(format!(
+        None => Err(format!(
             "peer session '{slug}' has no recorded owner; cannot authorize input"
         )),
     }
@@ -10027,7 +10489,9 @@ fn existing_peer_name_conflict(peers_root: &Path, name: &str, slug: &str) -> boo
         // `name` read through `staged_peer_dir` so a symlinked entry is never
         // followed and never falsely registers as a conflict.
         if let Some(dir) = staged_peer_dir(peers_root, &entry_slug) {
-            if let Ok(existing) = std::fs::read_to_string(dir.join("name")) {
+            if let Some(existing) =
+                peer_io::read_peer_file(&dir, "name", peer_io::PEER_FILE_READ_CAP_SMALL)
+            {
                 if existing.trim().to_lowercase() == target {
                     return true;
                 }
@@ -10376,9 +10840,7 @@ fn stage_peer(
     // leaving a silently unowned member that a sibling's completion could omit
     // from the fleet and fire synthesis prematurely.
     if let Some(originator) = originator {
-        if let Err(err) =
-            crate::memory_consolidate::apply::atomic_write(&peer_dir.join("originator"), originator)
-        {
+        if let Err(err) = peer_io::write_peer_file_atomic(&peer_dir, "originator", originator) {
             cleanup_staged_peer(workspace_root, &slug, &peer_dir);
             return Err(RpcError::internal_error(format!(
                 "failed to record peer originator: {err}"
@@ -10387,7 +10849,7 @@ fn stage_peer(
     }
 
     let brief_path = peer_dir.join("brief.md");
-    if let Err(err) = crate::memory_consolidate::apply::atomic_write(&brief_path, brief) {
+    if let Err(err) = peer_io::write_peer_file_atomic(&peer_dir, "brief.md", brief) {
         cleanup_staged_peer(workspace_root, &slug, &peer_dir);
         return Err(RpcError::internal_error(format!(
             "failed to write brief: {err}"
@@ -10397,9 +10859,7 @@ fn stage_peer(
     // Store the display NAME so the peer is addressable by it and readers
     // (`read_peer_blackboard` / `resolve_peer_name_to_slug`) can surface it.
     if let Some(name) = name {
-        if let Err(err) =
-            crate::memory_consolidate::apply::atomic_write(&peer_dir.join("name"), name)
-        {
+        if let Err(err) = peer_io::write_peer_file_atomic(&peer_dir, "name", name) {
             cleanup_staged_peer(workspace_root, &slug, &peer_dir);
             return Err(RpcError::internal_error(format!(
                 "failed to write peer name: {err}"
@@ -10533,37 +10993,17 @@ fn build_peer_handoff_callback(
 /// an off-tenant target (mirrors `read_file_no_follow` for the sync peer-file
 /// layer). On non-Unix, re-checks `symlink_metadata` first. `None` on any error
 /// (missing, symlink, unreadable).
-fn read_text_no_follow(path: &Path) -> Option<String> {
-    use std::io::Read;
-    let mut opts = std::fs::OpenOptions::new();
-    opts.read(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        opts.custom_flags(libc::O_NOFOLLOW);
-    }
-    #[cfg(not(unix))]
-    {
-        if path.symlink_metadata().is_ok_and(|meta| meta.is_symlink()) {
-            return None;
-        }
-    }
-    let mut file = opts.open(path).ok()?;
-    let mut content = String::new();
-    file.read_to_string(&mut content).ok()?;
-    Some(content)
-}
-
 /// #peer-model — read a peer's optional model LANE key from
 /// `peers/<slug>/model` (written by the `peer_handoff` staging callback when
 /// the master named a VALID `sub_provider` lane). Routed through
-/// [`staged_peer_dir`] (real, non-symlink dir with `brief.md`) AND an
-/// `O_NOFOLLOW` read of the leaf so neither a symlinked dir nor a symlinked
-/// `model` file is ever followed. Returns the trimmed lane key, or `None` when
+/// [`staged_peer_dir`] (real, non-symlink dir with `brief.md`) AND the
+/// fd-anchored [`peer_io::read_peer_file`] (openat `O_NOFOLLOW` under the pinned
+/// dir fd, regular-file only) so neither a symlinked dir nor a symlinked/FIFO
+/// `model` leaf is ever followed. Returns the trimmed lane key, or `None` when
 /// the dir is not a real staged peer, the file is absent/symlinked, or empty.
 fn read_peer_model_lane(peers_root: &Path, slug: &str) -> Option<String> {
     let dir = staged_peer_dir(peers_root, slug)?;
-    let lane = read_text_no_follow(&dir.join("model"))?;
+    let lane = peer_io::read_peer_file(&dir, "model", peer_io::PEER_FILE_READ_CAP_SMALL)?;
     let lane = lane.trim();
     (!lane.is_empty()).then(|| lane.to_owned())
 }
@@ -10573,9 +11013,10 @@ fn read_peer_model_lane(peers_root: &Path, slug: &str) -> Option<String> {
 /// requested). Validates the (trimmed) lane against the CURRENT
 /// `available_lanes`; a match is written symlink-safely under the RE-VALIDATED
 /// [`staged_peer_dir`] (never `brief_path.parent()`, which races a parent
-/// swap) via the atomic temp+rename write (no-follow at the target). Both an
-/// unknown lane and a failed record are TRUTHFUL: they say the peer will run on
-/// the primary model, matching what the turn actually does.
+/// swap) via the fd-anchored atomic writer ([`peer_io::write_peer_file_atomic`],
+/// no-follow openat + renameat under the pinned dir fd). Both an unknown lane
+/// and a failed record are TRUTHFUL: they say the peer will run on the primary
+/// model, matching what the turn actually does.
 fn record_peer_model_lane(
     peers_root: &Path,
     slug: &str,
@@ -10595,7 +11036,8 @@ fn record_peer_model_lane(
         ));
     }
     let recorded = match staged_peer_dir(peers_root, slug) {
-        Some(dir) => crate::memory_consolidate::apply::atomic_write(&dir.join("model"), lane),
+        Some(dir) => peer_io::write_peer_file_atomic(&dir, "model", lane)
+            .map_err(|err| eyre::eyre!("failed to write peer model lane: {err}")),
         None => Err(eyre::eyre!("staged peer dir not found for slug {slug}")),
     };
     if let Err(err) = recorded {
@@ -10782,16 +11224,16 @@ fn write_peer_result_if_peer_session(
         "---\nslug: {slug}\noutcome: {outcome_str}\nupdated_unix: {updated_unix}\nturn: {turn_count}\n---\n\n{body}{truncated}\n"
     );
 
-    // Backward-compatible latest copy — peer_gather reads this path.
-    if let Err(err) =
-        crate::memory_consolidate::apply::atomic_write(&peer_dir.join("result.md"), &text)
-    {
+    // Backward-compatible latest copy — peer_gather reads this path. Written
+    // through the fd-anchored atomic writer (openat/renameat under the pinned
+    // peer dir fd) so a parent swap cannot redirect it (#1824).
+    if let Err(err) = peer_io::write_peer_file_atomic(&peer_dir, "result.md", &text) {
         tracing::warn!(?err, slug, "failed to write peer result");
     }
 
     // Versioned copy — historical record for multi-turn persistent peers.
-    let versioned_path = peer_dir.join(format!("result-{turn_count}.md"));
-    if let Err(err) = crate::memory_consolidate::apply::atomic_write(&versioned_path, &text) {
+    let versioned_leaf = format!("result-{turn_count}.md");
+    if let Err(err) = peer_io::write_peer_file_atomic(&peer_dir, &versioned_leaf, &text) {
         tracing::warn!(
             ?err,
             slug,
@@ -10801,15 +11243,10 @@ fn write_peer_result_if_peer_session(
     }
 
     // Append to the turn index so peer_list and dashboard can discover
-    // historical results without globbing.
-    let turns_path = peer_dir.join("turns.txt");
+    // historical results without globbing. fd-anchored append (O_NOFOLLOW +
+    // regular-file only) so a symlinked/FIFO `turns.txt` is refused (#1824).
     let index_line = format!("{turn_count} {outcome_str} {updated_unix}\n");
-    if let Err(err) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&turns_path)
-        .and_then(|mut f| std::io::Write::write_all(&mut f, index_line.as_bytes()))
-    {
+    if let Err(err) = peer_io::append_peer_line(&peer_dir, "turns.txt", &index_line) {
         tracing::warn!(?err, slug, turn_count, "failed to append to turns.txt");
     }
 }
@@ -10828,7 +11265,7 @@ fn count_peer_result_versions(peer_dir: &std::path::Path) -> u32 {
 /// Parse `turns.txt` into `[(turn_count, outcome, updated_unix)]`.
 /// Returns `None` when the file doesn't exist.
 fn parse_peer_turns_index(peer_dir: &std::path::Path) -> Option<Vec<(u32, String, u64)>> {
-    let text = std::fs::read_to_string(peer_dir.join("turns.txt")).ok()?;
+    let text = peer_io::read_peer_file(peer_dir, "turns.txt", peer_io::PEER_FILE_READ_CAP_SMALL)?;
     if text.trim().is_empty() {
         return Some(Vec::new());
     }
@@ -10929,11 +11366,14 @@ fn read_peer_blackboard(peers_root: &Path, slugs: Option<&[String]>) -> Vec<Peer
             let Some(dir) = staged_peer_dir(peers_root, &slug) else {
                 continue;
             };
-            let Ok(brief) = std::fs::read_to_string(dir.join("brief.md")) else {
+            let Some(brief) =
+                peer_io::read_peer_file(&dir, "brief.md", peer_io::PEER_FILE_READ_CAP_LARGE)
+            else {
                 continue;
             };
             let result_path = dir.join("result.md");
-            let result = std::fs::read_to_string(&result_path).ok();
+            let result =
+                peer_io::read_peer_file(&dir, "result.md", peer_io::PEER_FILE_READ_CAP_LARGE);
             let result_updated_unix = std::fs::metadata(&result_path)
                 .ok()
                 .and_then(|meta| meta.modified().ok())
@@ -10949,8 +11389,7 @@ fn read_peer_blackboard(peers_root: &Path, slugs: Option<&[String]>) -> Vec<Peer
             };
             // Display name: `peers/<slug>/name`, trimmed; legacy peers with no
             // `name` file fall back to the slug so the row always has an address.
-            let name = std::fs::read_to_string(dir.join("name"))
-                .ok()
+            let name = peer_io::read_peer_file(&dir, "name", peer_io::PEER_FILE_READ_CAP_SMALL)
                 .map(|n| n.trim().to_owned())
                 .filter(|n| !n.is_empty())
                 .unwrap_or_else(|| slug.clone());
@@ -10965,12 +11404,16 @@ fn read_peer_blackboard(peers_root: &Path, slugs: Option<&[String]>) -> Vec<Peer
                 has_worktree: dir.join("wt").is_dir(),
                 closed: dir.join("closed").is_file(),
                 turn_history: parse_peer_turns_index(&dir),
-                // #peer-model — the recorded model lane, if any (O_NOFOLLOW
-                // read so a symlinked `model` leaf is refused; trimmed, empty
-                // treated as absent).
-                model_lane: read_text_no_follow(&dir.join("model"))
-                    .map(|lane| lane.trim().to_owned())
-                    .filter(|lane| !lane.is_empty()),
+                // #peer-model — the recorded model lane, if any (fd-anchored
+                // no-follow read so a symlinked/FIFO `model` leaf is refused;
+                // trimmed, empty treated as absent).
+                model_lane: peer_io::read_peer_file(
+                    &dir,
+                    "model",
+                    peer_io::PEER_FILE_READ_CAP_SMALL,
+                )
+                .map(|lane| lane.trim().to_owned())
+                .filter(|lane| !lane.is_empty()),
             });
         }
     }
@@ -11264,9 +11707,7 @@ fn build_peer_close_callback(
             .map(|elapsed| elapsed.as_secs())
             .unwrap_or(0);
         let body = format!("{origin_session}\n{now_unix}\n");
-        if let Err(err) =
-            crate::memory_consolidate::apply::atomic_write(&peer_dir.join("closed"), &body)
-        {
+        if let Err(err) = peer_io::write_peer_file_atomic(&peer_dir, "closed", &body) {
             return Err(format!(
                 "failed to write close marker for peer '{slug}': {err}"
             ));
@@ -11372,7 +11813,9 @@ fn peer_results_ready_note(peers_root: &Path, session_id: &SessionKey) -> Option
         if covered.is_some_and(|covered| covered >= result_mtime) {
             continue;
         }
-        let Ok(originator) = std::fs::read_to_string(dir.join("originator")) else {
+        let Some(originator) =
+            peer_io::read_peer_file(&dir, "originator", peer_io::PEER_FILE_READ_CAP_SMALL)
+        else {
             continue;
         };
         if originator.trim() != session {
@@ -11580,7 +12023,9 @@ fn collect_owned_peer_results(peers_root: &Path, master: &str) -> Option<Vec<(St
         // owner-before-brief write in `stage_peer`, a visible (brief.md) member
         // always has a readable originator, so a member of THIS master is never
         // silently dropped from the ownership scan.
-        let Ok(originator) = std::fs::read_to_string(dir.join("originator")) else {
+        let Some(originator) =
+            peer_io::read_peer_file(&dir, "originator", peer_io::PEER_FILE_READ_CAP_SMALL)
+        else {
             continue;
         };
         if originator.trim() != master {
@@ -11629,7 +12074,11 @@ async fn maybe_enqueue_peer_fleet_synthesis(state: &Arc<AppState>, peer_session:
     let Some(finished_dir) = staged_peer_dir(&peers_root, finished_slug) else {
         return;
     };
-    let Ok(master) = std::fs::read_to_string(finished_dir.join("originator")) else {
+    let Some(master) = peer_io::read_peer_file(
+        &finished_dir,
+        "originator",
+        peer_io::PEER_FILE_READ_CAP_SMALL,
+    ) else {
         return;
     };
     let master = master.trim().to_owned();


### PR DESCRIPTION
Closes #1824.

Hardens all per-slug peer-file I/O under `peers/<slug>/` (brief.md, result.md, result-{n}.md, originator, name, turns.txt, model, closed, .notified) against symlink-follow, parent-dir-swap TOCTOU, and FIFO/DoS.

**New `peer_io` module** — opens the peer DIR fd once (`O_NOFOLLOW|O_DIRECTORY`) and does every leaf op relative to that pinned inode via `rustix::fs::{openat,renameat,unlinkat,statat,Dir}`, so a `<slug>`→symlink swap after `staged_peer_dir` validates the dir can't redirect the I/O:
- **Reads** — `O_NOFOLLOW|O_NONBLOCK` + fstat `S_ISREG` (reject symlink/FIFO/device/dir) + capped (1 MiB brief/result, 64 KiB small). A hostile FIFO can't hang a turn; a huge file can't be read unbounded.
- **Writes** — atomic `openat`-tmp `O_CREAT|O_EXCL|O_NOFOLLOW` → fsync → `renameat` under the dir fd → dir fsync (crash-durable).
- **Status probes** anchored too: the `closed` close-gate, existence checks, behavior-affecting mtime, and the `result-*` version enumeration (`fdopendir`, regular-file-only, 100k scan cap, fail-closed on read error).
- `#[cfg(not(unix))]`: symlink_metadata + regular-file fallback (matches octos's O_NOFOLLOW-on-unix / symlink-check-on-windows convention).

**Scope:** peer-FILE read/write/enumeration I/O is fully fd-anchored. The `git worktree add peers/<slug>/wt` path is best-effort re-validated immediately before the subprocess; its residual path-resolution TOCTOU is inherent to handing a path to `git` (git re-resolves it) and is a tracked follow-up. Out of scope: `.synthesized-<master>` (peers-root, not per-slug), cosmetic `wt` `is_dir`.

9 `peer_io` tests (symlink/FIFO refused, round-trips, over-cap, symlinked-dir, enumeration, exists/mtime). `octos-cli --features api` lib **2504/0**, fmt + clippy clean. codex-reviewed (3 rounds).
