### PR TITLE
fix: allowlist OFlags::WRONLY as a typos false positive

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -55,6 +55,8 @@ strng = "strng"
 # Basic Regular Expression — referenced in slides validator spec comments
 # explaining the regex escape behavior for find -name patterns.
 BRE = "BRE"
+# POSIX open(2) flag (O_WRONLY), not a misspelling of "wrongly"
+WRONLY = "WRONLY"
 
 [files]
 extend-exclude = ["**/*.js", "**/*.css", "**/*.html", "examples/*/static/**/*.*"]


### PR DESCRIPTION
## Summary
- \`crates/octos-cli/src/api/ui_protocol.rs\` uses the POSIX \`O_WRONLY\` open flag (\`OFlags::WRONLY\`), which the \`typos\` CI check flags as a misspelling of "wrongly".
- Allowlists it in \`typos.toml\` following the existing \`extend-words\` pattern already used for other legitimate-but-flagged identifiers in this file.

Currently blocking the \`typos\` check on any PR touching that file (e.g. #1821, #1822).

## Test plan
- [x] Matches the established \`extend-words\` allowlist pattern in \`typos.toml\`
- [ ] CI \`typos\` job passes on this PR