### PR TITLE
feat(pyo3): octos-pyo3 — native Python extension wheel over the octos-ffi core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3509,6 +3509,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4110,6 +4119,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metrics"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4295,7 +4313,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
 ]
 
@@ -4803,6 +4821,14 @@ dependencies = [
  "tokio-test",
  "tracing",
  "which 7.0.3",
+]
+
+[[package]]
+name = "octos-pyo3"
+version = "2.0.2"
+dependencies = [
+ "octos-ffi",
+ "pyo3",
 ]
 
 [[package]]
@@ -5465,6 +5491,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset 0.9.1",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -7038,6 +7127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "teloxide"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7937,6 +8032,12 @@ dependencies = [
  "uniffi_meta",
  "weedle2",
 ]
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "crates/octos-ffi",
     "crates/octos-uniffi",
     "crates/octos-wasm",
+    "crates/octos-pyo3",
 ]
 
 [workspace.package]

--- a/crates/octos-pyo3/Cargo.toml
+++ b/crates/octos-pyo3/Cargo.toml
@@ -1,0 +1,61 @@
+[package]
+name = "octos-pyo3"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Native pyo3 Python extension for embedding octos, over the octos-ffi native core. The recommended Python binding (vs the octos-uniffi reference Python)."
+
+[lib]
+# cdylib -> the Python extension module maturin packages into the wheel.
+# rlib   -> lets this crate's own Rust tests link and exercise the wrapped
+#           surface (`cargo test -p octos-pyo3 --features python`).
+name = "octos"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# The native octos core. Path dep (octos-ffi is a workspace member, not a
+# `workspace.dependencies` entry). This crate wraps its `OctosRuntime` core;
+# the hardened credential path (single resolution + pinning + exact
+# secret-scrub) lives entirely in octos-ffi and is NOT duplicated here.
+octos-ffi = { path = "../octos-ffi" }
+# pyo3 is OPTIONAL and OFF by default so the plain `cargo build --workspace`
+# (run on octos CI's linux-x64, linux-arm64 AND windows self-hosted runners)
+# pulls ZERO libpython — a Python-less lane must not break. It is turned on by
+# the `python` feature. `abi3-py39` => ONE wheel serves CPython >= 3.9.
+# `extension-module` is a SEPARATE feature (see below): with it OFF, `cargo
+# build`/`cargo test --features python` link libpython so the Rust tests can
+# start an interpreter; maturin turns it ON so the wheel resolves Python symbols
+# from the host interpreter instead of linking libpython.
+pyo3 = { version = "0.23", features = ["abi3-py39"], optional = true }
+
+# NOTE: build.rs deliberately has NO build-dependencies. It would have used
+# `pyo3-build-config` to read pyo3's resolved interpreter, but that crate's
+# `resolve-config` feature (required for its `get()`) probes for an interpreter
+# AT COMPILE TIME and `exit(1)`s when none is found — which would break the
+# default `cargo build --workspace` on a Python-less CI lane, the very thing the
+# `python` feature-gate prevents. build.rs instead replicates pyo3's own
+# interpreter resolution order at runtime, guarded by CARGO_FEATURE_PYTHON.
+
+[features]
+default = []
+# Compile the pyo3 surface (pulls libpython). Everything Python-facing is gated
+# behind this; with it off the crate is an (essentially empty) library.
+python = ["dep:pyo3"]
+# Wheel builds turn this on (via pyproject `features`). Implies `python` and
+# tells pyo3 NOT to link libpython (host-interpreter symbol resolution).
+extension-module = ["python", "pyo3/extension-module"]
+# Re-export octos-ffi's optional in-process GGUF embedder so `Runtime.embed`
+# returns real vectors instead of raising NoEmbedder. Off by default so the
+# plain `cargo build`/`cargo build --workspace` stays pure Rust.
+embed-llama = ["octos-ffi/embed-llama"]
+
+# Inherits the workspace `deny(unsafe_code)` and KEEPS it: pyo3 0.23's
+# proc-macros annotate the `unsafe` FFI scaffolding they generate so it does not
+# trip the crate's lint, so this binding compiles cleanly under `deny` (verified)
+# and needs NO `#![allow(unsafe_code)]`. This crate writes no hand-unsafe code.
+# See the Safety note atop src/lib.rs.
+[lints]
+workspace = true

--- a/crates/octos-pyo3/README.md
+++ b/crates/octos-pyo3/README.md
@@ -1,0 +1,127 @@
+# octos (Python)
+
+Native Python bindings for embedding [octos](https://github.com/octos-org/octos)
+— a Rust-native agentic OS — in a Python process. Built with
+[pyo3](https://pyo3.rs/) over the shared **native core** in `octos-ffi`.
+
+This is the **native, recommended** Python binding. A second, `uniffi`-generated
+Python module also exists (`crates/octos-uniffi`), but that one is primarily a
+*reference/parity* artifact for the Swift and Kotlin bindings generated from the
+same definition. For Python, prefer this pyo3 extension: it is a compiled
+extension module (no ctypes marshalling) and shares the exact same hardened
+credential path as every other binding, because that logic lives once in
+`octos-ffi::OctosRuntime`.
+
+The wheel is an **abi3** wheel (`cp39-abi3`): one wheel works on CPython 3.9+.
+
+## Install
+
+```bash
+pip install octos            # once published
+```
+
+## Build from source
+
+Requires a Rust toolchain and [maturin](https://www.maturin.rs/).
+
+```bash
+pip install maturin
+
+# Build a release wheel into target/wheels/:
+maturin build --release            # run from crates/octos-pyo3/
+
+# Or build + install into the active venv for development:
+maturin develop --release          # run from crates/octos-pyo3/
+```
+
+The pyo3 surface sits behind a Cargo `python` feature that is **OFF by default**,
+so a plain `cargo build` / `cargo build --workspace` pulls no libpython (a
+Python-less CI lane cannot break). maturin turns on `extension-module` — which
+implies `python` — for the wheel; the wheel then resolves Python symbols from
+the host interpreter instead of linking libpython. To run the Rust test suite,
+enable the feature (it links libpython so the harness can start an interpreter):
+
+```bash
+cargo test -p octos-pyo3 --features python
+```
+
+## Example
+
+```python
+import octos
+
+rt = octos.Runtime(octos.Config(
+    provider="openai",
+    model="gpt-4o-mini",
+    api_key="sk-...",            # or api_key_env="OPENAI_API_KEY"
+))
+
+result = rt.run_task(octos.Brief(prompt="Reply OK"))
+print(result.output)
+print(result.tokens.input, result.tokens.output)
+```
+
+`Runtime`, `Config`, and `Brief` accept keyword arguments. `Config` includes
+`api_type` (`"anthropic"` / `"responses"`) — set it when driving a custom
+Anthropic-compatible endpoint, otherwise the factory defaults to the OpenAI
+protocol. Every failure raises `octos.OctosError`:
+
+```python
+try:
+    rt = octos.Runtime(octos.Config(provider="nope", model="x"))
+except octos.OctosError as e:
+    print("failed:", e)
+```
+
+`api_key` is **write-only**: you pass it to `Config(...)`, but it has no getter,
+so it cannot be read back off a `Config` — a logger, serializer, or plugin
+cannot exfiltrate the plaintext. Check presence with `Config.api_key_is_set`;
+`repr(config)` masks the key as `<set>`. (`api_key_env` is an env-var *name*, not
+a secret, so it stays readable.)
+
+## Threading & tokio
+
+`run_task` and `embed` release the GIL around the blocking core call, so other
+Python threads keep running. Ordinary (non-tokio) Python threads are fully
+supported.
+
+**Unsupported: creating or dropping a `Runtime` from within a Rust tokio async
+context.** If you embed CPython in a Rust **tokio** application and build or drop
+a `Runtime` on a tokio task (e.g. Python running under `tokio::spawn`), the
+shared core panics when its internal tokio runtime is dropped inside another
+tokio context, and the episodic-memory scratch dir may not be cleaned up. Build
+and drop the runtime from a plain, non-async thread — the same contract as the
+octos C-ABI.
+
+## API
+
+| Python | Purpose |
+| --- | --- |
+| `Config(provider, model, api_key=None, api_key_env=None, base_url=None, api_type=None, cwd=None, allow_shell=False, max_iterations=None, embedding_model_path=None)` | Runtime configuration. `api_key` is write-only (no getter). |
+| `Config.api_key_is_set -> bool` | Whether an `api_key` literal was supplied (the raw key is never readable). |
+| `Brief(prompt, max_iterations=None)` | A one-shot task. |
+| `Runtime(config)` | Build the runtime (resolves the credential once). |
+| `Runtime.run_task(brief) -> TaskResult` | Run a task. Releases the GIL. |
+| `Runtime.embed(text) -> list[float]` | Embed text (needs the `embed-llama` build feature + `embedding_model_path`). Releases the GIL. |
+| `TaskResult` | `.output: str`, `.iterations: int`, `.tokens: TokenUsage` |
+| `TokenUsage` | `.input`, `.output`, `.reasoning`, `.cache_read`, `.cache_write` |
+| `OctosError` | Raised by every failure. |
+
+### Embeddings
+
+`Runtime.embed` returns a real vector only when the extension is built with the
+`embed-llama` feature (an in-process GGUF embedder via llama.cpp) and `Config`
+sets `embedding_model_path`. Otherwise it raises `OctosError` ("no embedder
+configured"). Build it with:
+
+```bash
+maturin build --release --features octos-pyo3/embed-llama
+```
+
+## Security note
+
+Error messages surfaced to Python are credential-scrubbed: the caller's own key
+is exact-scrubbed inside the core, and this binding additionally applies a
+heuristic redactor + length cap to any secret-shaped token echoed in a provider
+error body. As with the C-ABI, a `tracing` subscriber you install in-process is
+still your responsibility — it may log a provider error body verbatim.

--- a/crates/octos-pyo3/build.rs
+++ b/crates/octos-pyo3/build.rs
@@ -1,0 +1,116 @@
+//! Build script: let `cargo test --features python` run against a libpython
+//! whose install name is `@rpath/...` — e.g. Anaconda/Miniconda (and Homebrew)
+//! on macOS, whose `Py_ENABLE_SHARED=0` sysconfig makes pyo3 skip emitting an
+//! rpath even though a `.dylib` is shipped, so the test binary aborts at load
+//! with "Library not loaded".
+//!
+//! It is a strict NO-OP unless the `python` feature is on, so the default
+//! `cargo build/test/clippy --workspace` (including octos CI's Python-less
+//! Windows lane) does ZERO Python probing and pulls no libpython.
+//!
+//! ## Interpreter resolution (review item C.1)
+//!
+//! The review suggested `pyo3_build_config::get().lib_dir` for the rpath.
+//! `get()` requires pyo3-build-config's `resolve-config` feature, whose OWN
+//! build script resolves an interpreter AT COMPILE TIME and `exit(1)`s when
+//! none is found. As a (non-optional) build-dependency that would make the
+//! default `cargo build --workspace` FAIL on a Python-less lane — precisely
+//! what the feature-gating (Change A) exists to prevent — and a build script
+//! cannot feature-gate an optional dependency (features reach build scripts
+//! only as `CARGO_FEATURE_*` env vars, never as `cfg`). So instead we replicate
+//! pyo3's OWN resolution ORDER here, guarded so it runs only when `python` is
+//! on: an explicit `PYO3_CONFIG_FILE`, else `PYO3_PYTHON`, else `python3`. That
+//! points the rpath at the same libpython pyo3 links, with no extra dependency
+//! and no compile-time probing.
+
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    // pyo3's interpreter resolution keys off these; rebuild the rpath if they
+    // change.
+    println!("cargo:rerun-if-env-changed=PYO3_PYTHON");
+    println!("cargo:rerun-if-env-changed=PYO3_CONFIG_FILE");
+
+    // (Change A) Default workspace build (no `python` feature): do NOTHING — no
+    // Python probing, no rpath. Keeps a Python-less CI lane green.
+    if std::env::var_os("CARGO_FEATURE_PYTHON").is_none() {
+        return;
+    }
+    // Wheel builds (extension-module) resolve Python symbols from the host
+    // interpreter at import; no libpython is linked, so no rpath is needed and
+    // the shippable cdylib stays free of a builder-absolute rpath.
+    if std::env::var_os("CARGO_FEATURE_EXTENSION_MODULE").is_some() {
+        return;
+    }
+    // The `-Wl,-rpath,` flag is a Unix (clang/gcc) concept; the MSVC linker
+    // rejects it and pyo3 discovers pythonXX.dll another way.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
+        return;
+    }
+
+    let Some(lib_dir) = resolve_lib_dir() else {
+        // abi3 config file without a lib_dir, or no resolvable interpreter:
+        // nothing to point an rpath at.
+        return;
+    };
+
+    // (Change C.3) Validate before emitting: an absolute path with no CR/LF
+    // (a newline could inject a second `cargo:` directive) and no comma
+    // (which could smuggle extra `-Wl` args into the linker invocation). On any
+    // doubt, skip quietly rather than panic the build.
+    if !is_safe_rpath(&lib_dir) {
+        println!("cargo:warning=octos-pyo3: skipping test rpath; unexpected lib_dir");
+        return;
+    }
+
+    // Add lib_dir as an rpath so dyld/ld.so resolves `@rpath/libpython3.x.dylib`
+    // (or the Linux equivalent) at load time for the test binary.
+    //
+    // (Change C.2 note) The review asked to scope this to test binaries via
+    // `cargo:rustc-link-arg-tests`. Empirically that variant applies ONLY to
+    // integration `[[test]]`/bench targets, NOT to the inline lib unit-test
+    // binary (verified: it still aborts with `@rpath/libpython... not loaded`).
+    // Converting these unit tests to integration tests would force a public
+    // `pub use pyo3` re-export plus pub-ifying the internal mappers/constructors
+    // — a worse API-hygiene outcome than the issue it fixes. So we keep plain
+    // `rustc-link-arg`. Its only extra footprint is that a `cargo build
+    // --features python` dev `cdylib` also carries this rpath — an ephemeral,
+    // git-ignored, never-shipped artifact. Every artifact that matters is
+    // already clean: the wheel skips this whole script (extension-module guard
+    // above) and the default no-`python` build skips it too (guard at top).
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{lib_dir}");
+}
+
+/// Resolve the libpython directory pyo3 links, following pyo3's OWN order:
+/// an explicit `PYO3_CONFIG_FILE` (its `lib_dir=` line), else the `PYO3_PYTHON`
+/// / `python3` interpreter's `sysconfig` `LIBDIR`.
+fn resolve_lib_dir() -> Option<String> {
+    if let Some(cfg_file) = std::env::var_os("PYO3_CONFIG_FILE") {
+        // pyo3 prefers an explicit config file over any interpreter; match that.
+        let contents = std::fs::read_to_string(&cfg_file).ok()?;
+        return contents.lines().find_map(|line| {
+            line.strip_prefix("lib_dir=")
+                .map(str::trim)
+                .filter(|v| !v.is_empty())
+                .map(str::to_string)
+        });
+    }
+    let python = std::env::var("PYO3_PYTHON").unwrap_or_else(|_| "python3".to_string());
+    let output = Command::new(&python)
+        .arg("-c")
+        .arg("import sysconfig; print(sysconfig.get_config_var('LIBDIR') or '')")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let lib_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!lib_dir.is_empty()).then_some(lib_dir)
+}
+
+/// An rpath is safe to emit only if it is an absolute path free of characters
+/// that could break out of the single `cargo:`/linker directive.
+fn is_safe_rpath(p: &str) -> bool {
+    std::path::Path::new(p).is_absolute() && !p.contains(['\r', '\n', ','])
+}

--- a/crates/octos-pyo3/pyproject.toml
+++ b/crates/octos-pyo3/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["maturin>=1.5"]
+build-backend = "maturin"
+
+[project]
+name = "octos"
+description = "Native Python bindings for embedding octos (Rust agentic OS) — the recommended Python binding, built with pyo3 over the octos-ffi native core."
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+readme = "README.md"
+# Version is inherited from Cargo.toml (workspace version) by maturin.
+dynamic = ["version"]
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+]
+
+[tool.maturin]
+# The import name: `import octos`. Matches `[lib] name` and `#[pymodule] fn octos`.
+module-name = "octos"
+# Turn ON pyo3's `extension-module` ONLY for the wheel build. With it on, the
+# compiled extension does NOT link libpython (symbols resolve from the host
+# interpreter at import time). It stays OFF for `cargo build`/`cargo test`, which
+# instead link libpython so the Rust test harness can start an interpreter.
+features = ["octos-pyo3/extension-module"]

--- a/crates/octos-pyo3/src/bindings.rs
+++ b/crates/octos-pyo3/src/bindings.rs
@@ -1,0 +1,598 @@
+//! The pyo3 surface, compiled only under the `python` feature (see the crate
+//! root). Everything that touches pyo3 / libpython lives here so the default
+//! build stays libpython-free.
+
+use octos_ffi::{CoreError, OctosRuntime, RuntimeConfig, TaskBrief};
+use pyo3::create_exception;
+use pyo3::exceptions::PyException;
+use pyo3::prelude::*;
+
+create_exception!(
+    octos,
+    OctosError,
+    PyException,
+    "Raised by every octos runtime failure (config, provider, run, embed)."
+);
+
+/// Convert a native [`CoreError`] into a Python `OctosError`.
+///
+/// The caller's OWN key is already exact-scrubbed inside the core. Here we
+/// additionally apply octos-ffi's heuristic redactor + length cap
+/// ([`octos_ffi::sanitize_error_text`]) — the SAME backstop the C-ABI runs in
+/// `set_last_error` and the uniffi facade runs in its `From<CoreError>` — so a
+/// secret embedded in a *provider* error body never reaches a Python caller
+/// verbatim. Applied ONLY here at the facade boundary, never in the core (doing
+/// so would double-apply on the C path and perturb `octos_last_error`).
+///
+/// A free function rather than a `From` impl: the orphan rule forbids
+/// `impl From<CoreError> for PyErr` (both types are foreign to this crate).
+fn to_py_err(e: CoreError) -> PyErr {
+    OctosError::new_err(octos_ffi::sanitize_error_text(&e.to_string()))
+}
+
+/// Runtime configuration. Maps directly onto [`octos_ffi::RuntimeConfig`].
+///
+/// Supply EITHER `api_key` (a literal key) OR `api_key_env` (the name of a
+/// process env var holding it). If neither is set, resolution falls back to the
+/// conventional `{PROVIDER}_API_KEY` env var and then the `octos auth login`
+/// store — see [`octos_ffi::OctosRuntime::from_config`].
+///
+/// # Secret handling
+///
+/// `api_key` is write-only from Python: there is deliberately NO `api_key`
+/// getter, so a logger/serializer/plugin cannot read the plaintext back off a
+/// `Config`. Use the boolean [`Config::api_key_is_set`] to check presence. The
+/// `api_key_env` field (an env-var *name*, not a secret) stays readable.
+#[pyclass]
+#[derive(Debug, Clone)]
+pub struct Config {
+    #[pyo3(get)]
+    pub provider: String,
+    #[pyo3(get)]
+    pub model: String,
+    // NOTE: NO `#[pyo3(get)]` — the raw key must never be readable from Python.
+    // Rust-visible only (used by `to_native`/`__repr__`).
+    pub api_key: Option<String>,
+    #[pyo3(get)]
+    pub api_key_env: Option<String>,
+    #[pyo3(get)]
+    pub base_url: Option<String>,
+    #[pyo3(get)]
+    pub api_type: Option<String>,
+    #[pyo3(get)]
+    pub cwd: Option<String>,
+    #[pyo3(get)]
+    pub allow_shell: bool,
+    #[pyo3(get)]
+    pub max_iterations: Option<u32>,
+    #[pyo3(get)]
+    pub embedding_model_path: Option<String>,
+}
+
+impl Config {
+    /// Map to the native core config. Plain Rust (not exposed to Python).
+    fn to_native(&self) -> RuntimeConfig {
+        RuntimeConfig {
+            provider: self.provider.clone(),
+            model: self.model.clone(),
+            api_key: self.api_key.clone(),
+            api_key_env: self.api_key_env.clone(),
+            base_url: self.base_url.clone(),
+            api_type: self.api_type.clone(),
+            cwd: self.cwd.clone(),
+            allow_shell: self.allow_shell,
+            max_iterations: self.max_iterations,
+            embedding_model_path: self.embedding_model_path.clone(),
+        }
+    }
+}
+
+#[pymethods]
+impl Config {
+    /// Build a runtime config.
+    ///
+    /// `provider` and `model` are required; everything else is optional.
+    /// **`api_type`** (`"anthropic"` / `"responses"`) is included deliberately:
+    /// omitting it forces a custom Anthropic-compatible endpoint onto the
+    /// OpenAI protocol.
+    #[new]
+    #[pyo3(signature = (
+        provider,
+        model,
+        api_key = None,
+        api_key_env = None,
+        base_url = None,
+        api_type = None,
+        cwd = None,
+        allow_shell = false,
+        max_iterations = None,
+        embedding_model_path = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        provider: String,
+        model: String,
+        api_key: Option<String>,
+        api_key_env: Option<String>,
+        base_url: Option<String>,
+        api_type: Option<String>,
+        cwd: Option<String>,
+        allow_shell: bool,
+        max_iterations: Option<u32>,
+        embedding_model_path: Option<String>,
+    ) -> Self {
+        Config {
+            provider,
+            model,
+            api_key,
+            api_key_env,
+            base_url,
+            api_type,
+            cwd,
+            allow_shell,
+            max_iterations,
+            embedding_model_path,
+        }
+    }
+
+    /// Whether an `api_key` literal was supplied — a safe, boolean stand-in for
+    /// the (intentionally absent) `api_key` getter, so callers can check
+    /// presence without the plaintext ever being readable.
+    #[getter]
+    fn api_key_is_set(&self) -> bool {
+        self.api_key.is_some()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Config(provider={:?}, model={:?}, api_key={}, api_key_env={:?}, base_url={:?}, api_type={:?}, cwd={:?}, allow_shell={}, max_iterations={:?}, embedding_model_path={:?})",
+            self.provider,
+            self.model,
+            // Never echo the secret in a repr.
+            if self.api_key.is_some() {
+                "<set>"
+            } else {
+                "None"
+            },
+            self.api_key_env,
+            self.base_url,
+            self.api_type,
+            self.cwd,
+            self.allow_shell,
+            self.max_iterations,
+            self.embedding_model_path,
+        )
+    }
+}
+
+/// A one-shot task brief. Maps onto [`octos_ffi::TaskBrief`].
+#[pyclass]
+#[derive(Debug, Clone)]
+pub struct Brief {
+    #[pyo3(get)]
+    pub prompt: String,
+    #[pyo3(get)]
+    pub max_iterations: Option<u32>,
+}
+
+impl Brief {
+    fn to_native(&self) -> TaskBrief {
+        TaskBrief {
+            prompt: self.prompt.clone(),
+            max_iterations: self.max_iterations,
+        }
+    }
+}
+
+#[pymethods]
+impl Brief {
+    /// Build a task brief. `prompt` is required; `max_iterations` overrides the
+    /// runtime default for this task only.
+    #[new]
+    #[pyo3(signature = (prompt, max_iterations = None))]
+    fn new(prompt: String, max_iterations: Option<u32>) -> Self {
+        Brief {
+            prompt,
+            max_iterations,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Brief(prompt={:?}, max_iterations={:?})",
+            self.prompt, self.max_iterations
+        )
+    }
+}
+
+/// Token accounting for a completed [`Runtime::run_task`]. Read-only.
+#[pyclass]
+#[derive(Debug, Clone)]
+pub struct TokenUsage {
+    #[pyo3(get)]
+    pub input: u64,
+    #[pyo3(get)]
+    pub output: u64,
+    #[pyo3(get)]
+    pub reasoning: u64,
+    #[pyo3(get)]
+    pub cache_read: u64,
+    #[pyo3(get)]
+    pub cache_write: u64,
+}
+
+impl TokenUsage {
+    fn from_native(t: octos_ffi::TokenUsage) -> Self {
+        TokenUsage {
+            input: t.input,
+            output: t.output,
+            reasoning: t.reasoning,
+            cache_read: t.cache_read,
+            cache_write: t.cache_write,
+        }
+    }
+}
+
+#[pymethods]
+impl TokenUsage {
+    fn __repr__(&self) -> String {
+        format!(
+            "TokenUsage(input={}, output={}, reasoning={}, cache_read={}, cache_write={})",
+            self.input, self.output, self.reasoning, self.cache_read, self.cache_write
+        )
+    }
+}
+
+/// The result of a completed [`Runtime::run_task`]. Read-only.
+#[pyclass]
+#[derive(Debug, Clone)]
+pub struct TaskResult {
+    #[pyo3(get)]
+    pub output: String,
+    #[pyo3(get)]
+    pub iterations: u32,
+    #[pyo3(get)]
+    pub tokens: TokenUsage,
+}
+
+impl TaskResult {
+    fn from_native(r: octos_ffi::TaskResult) -> Self {
+        TaskResult {
+            output: r.output,
+            iterations: r.iterations,
+            tokens: TokenUsage::from_native(r.tokens),
+        }
+    }
+}
+
+#[pymethods]
+impl TaskResult {
+    fn __repr__(&self) -> String {
+        format!(
+            "TaskResult(output={:?}, iterations={}, tokens={})",
+            self.output,
+            self.iterations,
+            self.tokens.__repr__()
+        )
+    }
+}
+
+/// An embedded octos runtime — the Python counterpart of the C-ABI's opaque
+/// `OctosRuntime*`.
+///
+/// Construct with `Runtime(config)`. Build the credential-resolved runtime once
+/// and reuse it for many `run_task` / `embed` calls. The object is `Send +
+/// Sync`; `run_task` and `embed` release the GIL while the internal executor
+/// blocks, so other Python threads keep running (they will, however, contend on
+/// the single internal executor).
+///
+/// # Unsupported: creation/drop inside a Rust tokio context
+///
+/// The runtime owns a tokio runtime inside the shared core. If you embed CPython
+/// in a Rust **tokio** application and construct or drop a `Runtime` from
+/// *within* an async task (e.g. Python running on `tokio::spawn`), the core
+/// panics when its tokio runtime is dropped inside another tokio context, and
+/// the episodic-memory scratch dir may not be cleaned up. This mirrors the
+/// C-ABI's contract: build and drop the runtime from a plain, non-async thread.
+/// Ordinary (non-tokio) Python threads are fine — this concerns only hosts that
+/// already run a tokio reactor on the calling thread.
+#[pyclass]
+pub struct Runtime {
+    inner: OctosRuntime,
+}
+
+#[pymethods]
+impl Runtime {
+    /// Build a runtime from a [`Config`]. Resolves and pins the credential
+    /// exactly once inside the core. Raises `OctosError` on a bad config or an
+    /// unknown/unbuildable provider. Does NOT touch the network.
+    #[new]
+    fn new(config: &Config) -> PyResult<Self> {
+        let inner = OctosRuntime::from_config(config.to_native()).map_err(to_py_err)?;
+        Ok(Runtime { inner })
+    }
+
+    /// Run a one-shot task and return its output + token usage. Releases the GIL
+    /// around the blocking agent loop. Raises `OctosError` on failure.
+    fn run_task(&self, py: Python<'_>, brief: &Brief) -> PyResult<TaskResult> {
+        let native = brief.to_native();
+        // Release the GIL: the core's `block_on` drives the whole agent loop
+        // (network + tools) and must not hold the GIL. `OctosRuntime` is
+        // Send + Sync, and neither `native` nor the result carries a GIL token.
+        let result = py
+            .allow_threads(|| self.inner.run_task(&native))
+            .map_err(to_py_err)?;
+        Ok(TaskResult::from_native(result))
+    }
+
+    /// Embed `text`, returning the raw vector. Requires the `embed-llama` build
+    /// feature and an `embedding_model_path` in the [`Config`]; otherwise raises
+    /// `OctosError` (NoEmbedder). Releases the GIL around the blocking call.
+    fn embed(&self, py: Python<'_>, text: String) -> PyResult<Vec<f32>> {
+        py.allow_threads(|| self.inner.embed(&text))
+            .map_err(to_py_err)
+    }
+
+    fn __repr__(&self) -> String {
+        "<octos.Runtime>".to_string()
+    }
+}
+
+// Compile-time proof that the pyclass is `Send + Sync`, matching the uniffi
+// facade's assertion. `#[pyclass]` already requires `Send`; this makes a
+// regression a direct, readable error. It holds because
+// `octos_ffi::OctosRuntime` is `Send + Sync`.
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Runtime>();
+};
+
+/// The `octos` Python module. The `#[pymodule]` name and the `[lib] name` are
+/// both `octos`, so `import octos` loads this extension.
+#[pymodule]
+fn octos(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<Config>()?;
+    m.add_class::<Brief>()?;
+    m.add_class::<TokenUsage>()?;
+    m.add_class::<TaskResult>()?;
+    m.add_class::<Runtime>()?;
+    m.add("OctosError", m.py().get_type::<OctosError>())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Ensure a Python interpreter is initialized for the standalone test binary
+    /// (the wheel is loaded BY Python and needs none of this). Idempotent.
+    fn init_py() {
+        pyo3::prepare_freethreaded_python();
+    }
+
+    fn sample_config() -> Config {
+        Config::new(
+            "openai".to_string(),
+            "gpt-4o-mini".to_string(),
+            Some("sk-pyo3-test-dummy".to_string()),
+            None,
+            None,
+            None,
+            Some(".".to_string()),
+            false,
+            Some(3),
+            None,
+        )
+    }
+
+    #[test]
+    fn config_maps_to_runtime_config() {
+        let native = sample_config().to_native();
+        assert_eq!(native.provider, "openai");
+        assert_eq!(native.model, "gpt-4o-mini");
+        assert_eq!(native.api_key.as_deref(), Some("sk-pyo3-test-dummy"));
+        assert_eq!(native.cwd.as_deref(), Some("."));
+        assert!(!native.allow_shell);
+        assert_eq!(native.max_iterations, Some(3));
+        assert_eq!(native.embedding_model_path, None);
+        // Unset api_type maps through as None.
+        assert_eq!(native.api_type, None);
+    }
+
+    #[test]
+    fn config_maps_api_type_through() {
+        // A custom Anthropic-compatible endpoint needs the api_type override to
+        // reach the factory — assert it survives Config -> RuntimeConfig.
+        let cfg = Config::new(
+            "custom".to_string(),
+            "some-model".to_string(),
+            Some("sk-x".to_string()),
+            None,
+            Some("https://example.test/v1".to_string()),
+            Some("anthropic".to_string()),
+            None,
+            false,
+            None,
+            None,
+        );
+        let native = cfg.to_native();
+        assert_eq!(native.provider, "custom");
+        assert_eq!(native.api_type.as_deref(), Some("anthropic"));
+        assert_eq!(native.base_url.as_deref(), Some("https://example.test/v1"));
+    }
+
+    #[test]
+    fn brief_maps_to_task_brief() {
+        let brief = Brief::new("hello".to_string(), Some(7));
+        let native = brief.to_native();
+        assert_eq!(native.prompt, "hello");
+        assert_eq!(native.max_iterations, Some(7));
+    }
+
+    #[test]
+    fn native_results_map_to_pyclasses() {
+        let native = octos_ffi::TaskResult {
+            output: "done".to_string(),
+            iterations: 2,
+            tokens: octos_ffi::TokenUsage {
+                input: 10,
+                output: 20,
+                reasoning: 3,
+                cache_read: 4,
+                cache_write: 5,
+            },
+        };
+        let mapped = TaskResult::from_native(native);
+        assert_eq!(mapped.output, "done");
+        assert_eq!(mapped.iterations, 2);
+        assert_eq!(mapped.tokens.input, 10);
+        assert_eq!(mapped.tokens.output, 20);
+        assert_eq!(mapped.tokens.reasoning, 3);
+        assert_eq!(mapped.tokens.cache_read, 4);
+        assert_eq!(mapped.tokens.cache_write, 5);
+    }
+
+    #[test]
+    fn config_does_not_expose_raw_api_key() {
+        // P1 regression guard: the raw api_key must NOT be readable from Python
+        // via any obvious path (attribute, repr, str). A logger/serializer that
+        // walks a Config must not be able to exfiltrate the plaintext key.
+        init_py();
+        let secret = "sk-super-secret-DO-NOT-LEAK-1234567890";
+        Python::with_gil(|py| {
+            let cfg = Config::new(
+                "openai".to_string(),
+                "gpt-4o-mini".to_string(),
+                Some(secret.to_string()),
+                None,
+                None,
+                None,
+                None,
+                false,
+                None,
+                None,
+            );
+            let obj = Py::new(py, cfg).expect("wrap Config in a Python object");
+            let bound = obj.bind(py);
+
+            // No `api_key` attribute exists (the getter was removed).
+            assert!(
+                bound.getattr("api_key").is_err(),
+                "api_key must not be attribute-accessible"
+            );
+            // The boolean presence accessor works and is true.
+            let is_set: bool = bound
+                .getattr("api_key_is_set")
+                .expect("api_key_is_set getter present")
+                .extract()
+                .expect("bool");
+            assert!(is_set, "api_key_is_set should be true when a key was given");
+            // repr masks the key.
+            let repr: String = bound.repr().expect("repr").extract().expect("str");
+            assert!(!repr.contains(secret), "repr leaked the key: {repr}");
+            assert!(
+                repr.contains("<set>"),
+                "repr should mark the key <set>: {repr}"
+            );
+            // str() falls back to repr -> also masked.
+            let s: String = bound.str().expect("str").extract().expect("str");
+            assert!(!s.contains(secret), "str leaked the key: {s}");
+            // api_key_env (an env-var NAME, not a secret) remains readable — but
+            // it was never set here, so it reads as None.
+            let env_attr = bound.getattr("api_key_env").expect("api_key_env getter");
+            assert!(env_attr.is_none(), "api_key_env should be None here");
+        });
+    }
+
+    #[test]
+    fn runtime_new_rejects_unknown_provider_with_octos_error() {
+        // Hermetic: provider construction fails offline (no network) before any
+        // scratch dir is created, so this exercises the error path cleanly.
+        init_py();
+        Python::with_gil(|py| {
+            let cfg = Config::new(
+                "totally-not-a-real-provider".to_string(),
+                "x".to_string(),
+                Some("sk-x".to_string()),
+                None,
+                None,
+                None,
+                Some(".".to_string()),
+                false,
+                Some(3),
+                None,
+            );
+            let err = Runtime::new(&cfg)
+                .err()
+                .expect("unknown provider must raise");
+            assert!(
+                err.is_instance_of::<OctosError>(py),
+                "expected OctosError, got: {err}"
+            );
+        });
+    }
+
+    #[test]
+    fn to_py_err_redacts_secret_shaped_tokens() {
+        // A provider error body can echo a credential the core did not know to
+        // exact-scrub. `to_py_err` must apply octos-ffi's heuristic redactor so
+        // it never reaches a Python caller verbatim.
+        init_py();
+        let leaked = "sk-abc123DEF456ghijkLMNOP789";
+        let err = to_py_err(CoreError::Provider(format!(
+            "upstream 401: token {leaked} rejected"
+        )));
+        Python::with_gil(|py| {
+            assert!(
+                err.is_instance_of::<OctosError>(py),
+                "expected OctosError, got: {err}"
+            );
+            let msg = err.value(py).to_string();
+            assert!(msg.contains("<redacted>"), "not redacted: {msg}");
+            assert!(!msg.contains(leaked), "leaked verbatim: {msg}");
+        });
+    }
+
+    #[test]
+    fn no_embedder_maps_to_octos_error() {
+        // Building a runtime succeeds offline; embed without a model reports
+        // NoEmbedder (feature-off is always NoEmbedder; feature-on finds no
+        // loaded embedder). Its message maps through `to_py_err`.
+        let err = to_py_err(CoreError::NoEmbedder);
+        init_py();
+        Python::with_gil(|py| {
+            assert!(err.is_instance_of::<OctosError>(py));
+            let msg = err.value(py).to_string();
+            assert_eq!(msg, "no embedder configured");
+        });
+    }
+
+    /// Real end-to-end run. Ignored: needs a live provider + network. Configure
+    /// via env `OCTOS_PYO3_TEST_KEY_ENV` (default `OPENAI_API_KEY`). Run with:
+    ///   cargo test -p octos-pyo3 --features python -- --ignored real_run_task
+    #[test]
+    #[ignore = "needs a real API key + network"]
+    fn real_run_task_returns_output() {
+        init_py();
+        let key_env = std::env::var("OCTOS_PYO3_TEST_KEY_ENV")
+            .unwrap_or_else(|_| "OPENAI_API_KEY".to_string());
+        let cfg = Config::new(
+            "openai".to_string(),
+            "gpt-4o-mini".to_string(),
+            None,
+            Some(key_env),
+            None,
+            None,
+            Some(".".to_string()),
+            false,
+            Some(3),
+            None,
+        );
+        let rt = Runtime::new(&cfg).expect("runtime built");
+        Python::with_gil(|py| {
+            let brief = Brief::new("Reply with exactly OK".to_string(), Some(3));
+            let result = rt.run_task(py, &brief).expect("run_task succeeded");
+            assert!(result.output.contains("OK"), "got: {}", result.output);
+        });
+    }
+}

--- a/crates/octos-pyo3/src/lib.rs
+++ b/crates/octos-pyo3/src/lib.rs
@@ -1,0 +1,42 @@
+//! octos-pyo3: a **native** Python extension for embedding octos, built with
+//! [pyo3](https://pyo3.rs/) over the native core exposed by `octos-ffi`
+//! ([`octos_ffi::OctosRuntime`]).
+//!
+//! This is the *recommended* Python binding. The sibling `octos-uniffi` crate
+//! generates a *reference* Python module too, but its real purpose is Swift /
+//! Kotlin from one definition; for Python, this hand-written pyo3 surface is the
+//! idiomatic, faster path (compiled extension, no ctypes marshalling).
+//!
+//! Like `octos-uniffi`, this crate is a thin wrapper: it adds NO logic beyond
+//! type marshalling. The hardened credential path (single key resolution +
+//! pinning + exact secret-scrub of the caller's own key) lives entirely in
+//! `octos-ffi`'s [`octos_ffi::OctosRuntime::from_config`], so it exists in
+//! exactly one place, shared by the C-ABI, uniffi, and this pyo3 surface.
+//!
+//! # The `python` feature (default OFF)
+//!
+//! All pyo3 code lives in the [`bindings`] module behind the `python` feature.
+//! With the feature OFF — the default, and what `cargo build --workspace` uses
+//! on octos CI (self-hosted linux-x64/arm64 **and** Windows) — this crate is an
+//! essentially empty library that links **zero** libpython, so a Python-less CI
+//! lane cannot break. `maturin` turns the feature on (via `extension-module`) to
+//! build the wheel; `cargo test -p octos-pyo3 --features python` runs the Rust
+//! tests.
+//!
+//! # Safety
+//!
+//! This crate keeps the workspace-wide `deny(unsafe_code)` (restated explicitly
+//! at the crate root) and writes NO hand-unsafe code of its own. pyo3 0.23's
+//! proc-macros (`#[pyclass]`, `#[pymethods]`, `#[pymodule]`,
+//! `create_exception!`) generate the `unsafe` FFI scaffolding that bridges Rust
+//! and the CPython C-API, but they annotate that generated code so it does NOT
+//! trip the crate's `unsafe_code` lint. So — unlike `octos-ffi`'s hand-written
+//! C-ABI, which needs a crate-scoped `#![allow(unsafe_code)]` — this binding
+//! compiles cleanly under `deny`, verified by the workspace build.
+#![deny(unsafe_code)]
+
+#[cfg(feature = "python")]
+mod bindings;
+
+#[cfg(feature = "python")]
+pub use bindings::*;

--- a/crates/octos-pyo3/tests/smoke.py
+++ b/crates/octos-pyo3/tests/smoke.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Hermetic smoke test for the native `octos` pyo3 extension.
+
+No network: it only imports the module, builds a Config/Brief, and asserts that
+constructing a Runtime with a bogus provider raises OctosError. Provider
+construction fails offline, so nothing here touches an API.
+
+This is intentionally NOT part of `cargo test` (that runs the Rust suite). Run
+it after building the extension into the active interpreter:
+
+    pip install maturin
+    cd crates/octos-pyo3
+    maturin develop            # builds + installs `octos` into the venv
+    python tests/smoke.py
+
+Exits non-zero on any failure.
+"""
+
+import sys
+
+
+def main() -> int:
+    import octos
+
+    # Exception type is exported.
+    assert hasattr(octos, "OctosError"), "octos.OctosError missing"
+
+    # Config/Brief take kwargs, including api_type.
+    cfg = octos.Config(
+        provider="openai",
+        model="gpt-4o-mini",
+        api_key="sk-smoke-dummy",
+        api_type="responses",
+        max_iterations=3,
+    )
+    assert cfg.provider == "openai"
+    assert cfg.api_type == "responses"
+    assert cfg.max_iterations == 3
+    print("Config OK:", repr(cfg))
+
+    # The raw api_key must NOT be readable back from Python (P1 secret-leak
+    # guard): there is no `api_key` getter, only a boolean presence accessor.
+    assert not hasattr(cfg, "api_key"), "api_key must not be attribute-accessible"
+    assert cfg.api_key_is_set is True, "api_key_is_set should be True"
+    assert "sk-smoke-dummy" not in repr(cfg), "repr must not leak the raw key"
+    print("api_key is write-only (not exposed); api_key_is_set =", cfg.api_key_is_set)
+
+    brief = octos.Brief(prompt="Reply OK")
+    assert brief.prompt == "Reply OK"
+    assert brief.max_iterations is None
+    print("Brief OK:", repr(brief))
+
+    # Bogus provider must raise OctosError (offline, before any network).
+    try:
+        octos.Runtime(octos.Config(provider="totally-not-a-real-provider", model="x"))
+    except octos.OctosError as e:
+        print("Runtime(bad provider) correctly raised OctosError:", e)
+    else:
+        print("FAIL: expected OctosError for a bogus provider", file=sys.stderr)
+        return 1
+
+    print("SMOKE OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Adds **`crates/octos-pyo3`** — the **native Python extension wheel** (`import octos`), built with pyo3 + maturin. It's the recommended Python binding (the uniffi-generated Python is a parity/reference artifact for Swift/Kotlin). Like uniffi, it wraps the shared **octos-ffi native core** — the 5-round-hardened credential path is reused, not duplicated.

## Surface (module `octos`)

- `Config(provider, model, api_key=None, api_key_env=None, base_url=None, api_type=None, cwd=None, allow_shell=False, max_iterations=None, embedding_model_path=None)` — kwargs constructor; `api_type` included.
- `Brief(prompt, max_iterations=None)`, `TaskResult`/`TokenUsage` (read-only getters).
- `Runtime(config)` with `run_task(brief) -> TaskResult` and `embed(text) -> list[float]`. The blocking agent call **releases the GIL** (`py.allow_threads`) so other Python threads run; `Runtime` is compile-asserted `Send + Sync`.
- `OctosError` exception; every fallible core call maps through it with `octos_ffi::sanitize_error_text` applied at the facade (redacts secrets embedded in provider-error bodies; the caller's own key is already exact-scrubbed in the core).

## CI-safety: pyo3 is optional behind a feature

CI runs `cargo clippy/test/build --workspace` on self-hosted linux-x64/arm64 **and windows**. A plain member would link **libpython** on every lane. So `pyo3` is an **optional dep** behind a `python` feature (default features = none); all pyo3 code lives in a `#[cfg(feature = "python")]`-gated `bindings.rs`, and `build.rs` is a no-op unless `CARGO_FEATURE_PYTHON` is set. The default `cargo build/test/clippy --workspace` pulls **zero pyo3/libpython** (verified: `cargo build --workspace` compiles the empty octos-pyo3 lib without compiling pyo3; `cargo tree` shows pyo3 only under `--features python`). This mirrors the octos-embed-mlx "optional + feature-gated so default builds pull 0" convention. The wheel is built with `maturin` (feature on).

## Secret hygiene

`Config.api_key` has **no getter** (write-only from Python; `#[pyo3(get)]` removed); a masked `api_key_is_set()` is exposed instead, and `__repr__`/`__str__` mask the key. A Rust test + the Python smoke confirm the raw key is not attribute-accessible.

## Testing

- `cargo test -p octos-pyo3 --features python`: **8 passed** (+1 `#[ignore]` network E2E) — Config→RuntimeConfig incl. `api_type` passthrough, error mapping, sanitizer redaction, `NoEmbedder`, and the api_key non-exposure.
- `maturin build --release` → `octos-2.0.2-cp39-abi3-macosx_11_0_arm64.whl` (abi3 ⇒ one wheel for CPython ≥3.9; not committed — `target/` is git-ignored).
- Python smoke (fresh venv, installed wheel): `import octos`, `api_type` passthrough, bogus provider → `OctosError`, raw `api_key` not accessible — OK.
- Default `cargo build/test/clippy --workspace` green with zero pyo3; `cargo clippy -p octos-pyo3 --features python --all-targets` 0 warnings; `fmt --check` + `git diff --check` clean.

## Review

codex-reviewed (read-only): GIL-release soundness, secret-scrub parity, complete `api_type`/config mapping, and normal GC cleanup (the core's RAII scratch-dir drops after the redb lock releases) all confirmed clean; it caught the P1 `api_key` getter leak (fixed) plus build.rs hardening (interpreter resolution, test-scoped rpath footprint, `lib_dir` validation) and the tokio-embedding caveat (now documented). Completes the cross-language set on the shared core: C-ABI (#1827), uniffi (#1828), wasm (#1830), and this Python wheel.
