### PR TITLE
test(bus): make outside-root fixture cross-platform

### DIFF
--- a/crates/octos-bus/tests/file_handle_resolve_tool_path.rs
+++ b/crates/octos-bus/tests/file_handle_resolve_tool_path.rs
@@ -317,12 +317,14 @@ fn row_9_parent_traversal_rejected() {
 #[test]
 fn row_10_absolute_outside_all_allowed_roots_rejected() {
     let rig = Rig::new("row10");
-    // /etc/passwd is a stable target outside every test root. We
-    // don't read the file — only require that the resolver refuses.
+    // A named file directly under the system temp directory is a
+    // sibling of the workspace/profile tempdirs and `octos-uploads`,
+    // so it is a portable absolute target outside every allowed root.
+    let outside = tempfile::NamedTempFile::new().expect("outside temp file");
     let err = expect_err(resolve_tool_path(
         rig.workspace_root(),
         Some(rig.profile_root()),
-        "/etc/passwd",
+        &outside.path().to_string_lossy(),
     ));
     assert_eq!(err, ToolPathError::OutsideAllowedRoots);
 }


### PR DESCRIPTION
## What changed

Replace the Unix-only `/etc/passwd` fixture in the row-10 file-handle resolver test with a real named temporary file outside the workspace, profile, and upload roots.

Closes #1840.

## Why

`/etc/passwd` is absolute on Unix. On Windows, a rooted path without a drive or UNC prefix is not an absolute `Path`, so the resolver enters relative-path validation and classifies its root component as `Traversal`. The test was asserting Unix path semantics rather than the intended outside-root contract.

The replacement is an existing platform-native absolute path and keeps the production resolver unchanged.

## Impact

- row 10 continues to require `OutsideAllowedRoots`
- row 9 remains the separate parent-traversal contract
- no production behavior changes
- Windows `check-windows` can proceed past the `octos-bus` path-resolver suite once the preceding #1838 fixes are present

## Validation

- `git diff --check`
- final diff is one test file, +5/-3
- failure reproduced in https://github.com/octos-org/octos/actions/runs/30278411155/job/90018340610

This checkout does not have a Rust toolchain. Required CI command:

```sh
cargo test -p octos-bus --test file_handle_resolve_tool_path row_10_absolute_outside_all_allowed_roots_rejected
```

## Delivery order

This PR is independent and can merge first. Then #1838 can refresh from `main`; its Windows run already proves the preceding Core and LLM suites green and will be able to continue beyond this Bus fixture.
