### PR TITLE
feat(peer): wake an idle master when a staged peer awaits input

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -169,6 +169,27 @@ pub(crate) const PEER_FLEET_SYNTHESIS_META_SLUGS: &str = "peer_fleet_slugs";
 /// Group id stamped onto peer-fleet-synthesis continuations (queue triage).
 const PEER_FLEET_SYNTHESIS_GROUP: &str = "peer-fleet-synthesis";
 
+/// Peer awaiting-input WAKE — kind label for the `External(_)` master
+/// continuation that WAKES an idle master when one of its staged peers PARKS on
+/// an approval/question (i.e. becomes genuinely `awaiting_input`). This closes
+/// the "master is the human-in-the-loop" gap: today a peer's block is visible
+/// via `peer_list awaiting_input`, but nothing NOTIFIES the master — it has to
+/// already be taking turns and choose to check. The wake enqueues an autonomous
+/// master turn (drained ONLY when the master is idle-eligible) that directs the
+/// master to `peer_list` → `peer_respond`. Sibling of the fleet-synthesis wake;
+/// flows through the same hardened `External` drain path.
+pub(crate) const PEER_AWAITING_INPUT_EXTERNAL_KIND: &str = "peer_awaiting_input";
+/// Metadata key carrying the parked peer's slug (names the peer in the nudge).
+pub(crate) const PEER_AWAITING_INPUT_META_SLUG: &str = "peer_awaiting_input_slug";
+/// Metadata key carrying the park kind — `"approval"` or `"question"`.
+pub(crate) const PEER_AWAITING_INPUT_META_KIND: &str = "peer_awaiting_input_kind";
+/// Metadata key carrying a short one-line summary of what the peer is blocked
+/// on (prompt context only; the master reads the authoritative parked set via
+/// `peer_list`).
+pub(crate) const PEER_AWAITING_INPUT_META_PROMPT: &str = "peer_awaiting_input_prompt";
+/// Group id stamped onto peer-awaiting-input wakes (queue triage).
+const PEER_AWAITING_INPUT_GROUP: &str = "peer-awaiting-input";
+
 /// #436 P1 (#3) — real delivery status for a `peer_send_input` injection so the
 /// tool never acks success on a durable-persist failure.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -216,6 +237,28 @@ fn peer_send_input_dedupe_key(session: &SessionKey, occurrence_id: &str) -> Stri
 /// cleared and a fresh one completed, far beyond the 30s window).
 fn peer_fleet_synthesis_dedupe_key(master_session: &SessionKey) -> String {
     format!("external/{PEER_FLEET_SYNTHESIS_EXTERNAL_KIND}/{master_session}")
+}
+
+/// The dedupe key for a peer awaiting-input WAKE — keyed on the master
+/// (originator) session AND the park's unique pending id (the `ApprovalId` /
+/// `QuestionId`, a fresh UUID minted per park). PER-PENDING-ID by design:
+///
+/// * Two DISTINCT parks carry two distinct pending ids → two distinct keys →
+///   two wakes, so each block wakes the master at least once while it is still
+///   pending.
+/// * A retry of the SAME park re-uses its pending id → the second enqueue
+///   collapses onto the first (either as a live pending duplicate, or via the
+///   `RECENT_CLAIM_GUARD_WINDOW` once the wake has been drained).
+///
+/// The pending id is the unique per-occurrence id the `External`-producer
+/// invariant requires (a park's id never re-fires under a different park), so
+/// there is NO re-arm hazard: the recent-claim guard can only ever suppress the
+/// SAME park's key, never a different peer's fresh park. The tradeoff is that N
+/// simultaneous parks under one master enqueue N wakes; the first woken turn
+/// handles the whole `peer_list` batch and any surplus wakes are harmless
+/// no-ops (the master calls `peer_list`, finds nothing pending, ends).
+fn peer_awaiting_input_dedupe_key(master_session: &SessionKey, pending_id: &str) -> String {
+    format!("external/{PEER_AWAITING_INPUT_EXTERNAL_KIND}/{master_session}/{pending_id}")
 }
 
 #[derive(Debug, Clone)]
@@ -2493,6 +2536,51 @@ impl InProcessAgentOrchestrator {
         let key =
             MasterContinuationDedupeKey::from(peer_fleet_synthesis_dedupe_key(master_session));
         self.state().continuations.clear_recent_external_claim(&key);
+    }
+
+    /// Peer awaiting-input WAKE — enqueue ONE autonomous continuation on the
+    /// master (originator) session so an IDLE master is notified to answer a
+    /// peer that just PARKED on an approval/question. The park decision (a REAL
+    /// park past the auto-resolve short-circuit, a peer session, an originator
+    /// that resolves) is made by the caller in `ui_protocol.rs`; this method
+    /// only performs the enqueue.
+    ///
+    /// The dedupe key is PER-PENDING-ID ([`peer_awaiting_input_dedupe_key`]), so
+    /// distinct parks each wake the master while the SAME park dedupes; the
+    /// unique pending id satisfies the `External`-producer occurrence invariant,
+    /// so there is no re-arm hazard.
+    ///
+    /// In-memory enqueue (no durable persist): losing a wake TRIGGER across a
+    /// restart is benign — the peer re-parks on its next turn and the master can
+    /// always `peer_list` — so, like fleet-synthesis and unlike a user's
+    /// `peer_send_input` message, it need not survive a crash. The scheduler's
+    /// `is_idle_eligible` gate (checked at drain) means the wake never fires
+    /// while the MASTER itself is mid-turn or blocked on its own input/approval.
+    pub(crate) fn enqueue_peer_awaiting_input_continuation(
+        &self,
+        master_session: &SessionKey,
+        profile_id: &str,
+        slug: &str,
+        pending_id: &str,
+        park_kind: &str,
+        prompt_summary: &str,
+    ) -> MasterContinuationEnqueueOutcome {
+        let request = MasterContinuationRequest::new(
+            PEER_AWAITING_INPUT_GROUP,
+            master_session.to_string(),
+            profile_id.to_owned(),
+            MasterContinuationReason::External(PEER_AWAITING_INPUT_EXTERNAL_KIND.to_owned()),
+            SystemTime::now(),
+        )
+        .with_metadata(PEER_AWAITING_INPUT_META_SLUG, slug.to_owned())
+        .with_metadata(PEER_AWAITING_INPUT_META_KIND, park_kind.to_owned())
+        .with_metadata(PEER_AWAITING_INPUT_META_PROMPT, prompt_summary.to_owned())
+        // The explicit per-pending-id key below is authoritative; the metadata
+        // above never widens it (a same-park retry with a re-summarized prompt
+        // still dedupes on the pending id).
+        .with_dedupe_key(peer_awaiting_input_dedupe_key(master_session, pending_id));
+        let mut state = self.state();
+        state.continuations.enqueue(request)
     }
 
     /// codex #1 — true when peer `slug` (under `profile_id`) has a
@@ -6327,6 +6415,34 @@ pub(crate) fn master_continuation_prompt(continuation: &QueuedMasterContinuation
                 group = continuation.group_id.as_str(),
             )
         }
+        // Peer awaiting-input WAKE — one of this master's staged peers PARKED on
+        // an approval/question and is now `awaiting_input`. Nudge the master to
+        // answer it. This is a `[system-internal]` envelope (like the
+        // fleet-synthesis arm) — the master acts as the human-in-the-loop; it
+        // reads the AUTHORITATIVE parked set via `peer_list` and answers via
+        // `peer_respond`, so the metadata below is only a hint (a spurious wake
+        // after the peer already resolved is a harmless no-op: `peer_list` shows
+        // nothing awaiting and the turn ends).
+        MasterContinuationReason::External(kind) if kind == PEER_AWAITING_INPUT_EXTERNAL_KIND => {
+            let slug = continuation
+                .metadata
+                .get(PEER_AWAITING_INPUT_META_SLUG)
+                .map(String::as_str)
+                .unwrap_or("unknown");
+            let park_kind = continuation
+                .metadata
+                .get(PEER_AWAITING_INPUT_META_KIND)
+                .map(String::as_str)
+                .unwrap_or("input");
+            let prompt = continuation
+                .metadata
+                .get(PEER_AWAITING_INPUT_META_PROMPT)
+                .map(String::as_str)
+                .unwrap_or("");
+            format!(
+                "[system-internal]\nA peer you staged is awaiting your input — peer \"{slug}\" ({park_kind}): \"{prompt}\". Call the `peer_list` tool to see EVERY peer awaiting input, then use `peer_respond` to answer them. Answer only what is genuinely blocked; if `peer_list` shows nothing awaiting input, that block was already handled — just end the turn."
+            )
+        }
         MasterContinuationReason::External(kind) => format!(
             "[system-internal]\nAn external master continuation was requested.\n\nKind: {kind}\nGroup: {group}\nMetadata:\n{metadata}\n\nHandle the continuation conservatively and summarize the visible state for the user.",
             group = continuation.group_id.as_str(),
@@ -9091,6 +9207,195 @@ mod tests {
         assert!(
             prompt.contains("slugs` filter"),
             "prompt must instruct the slugs filter: {prompt}"
+        );
+    }
+
+    /// Peer awaiting-input WAKE — a peer parking enqueues ONE autonomous
+    /// continuation on the ORIGINATOR (master), carrying the peer slug + kind,
+    /// and it drains when the master is idle.
+    #[test]
+    fn peer_awaiting_input_wake_enqueues_on_originator() {
+        let orchestrator = default_agent_orchestrator();
+        let master = SessionKey::with_profile("tenant-wake-enq", "api", "master-wake");
+        let profile = "tenant-wake-enq";
+
+        let outcome = orchestrator.enqueue_peer_awaiting_input_continuation(
+            &master,
+            profile,
+            "edison",
+            "approval-id-1",
+            "approval",
+            "shell: rm build cache",
+        );
+        assert!(
+            outcome.queued().is_some(),
+            "a peer park must enqueue a wake on the originator",
+        );
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_session_for_test(&master, profile),
+            1,
+            "exactly one wake queued for the master",
+        );
+
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &master,
+            profile,
+            MasterContinuationRuntimeState::idle(),
+            4,
+        );
+        let wake = drained
+            .iter()
+            .find(|c| {
+                matches!(&c.reason, MasterContinuationReason::External(kind)
+                    if kind == PEER_AWAITING_INPUT_EXTERNAL_KIND)
+            })
+            .expect("the wake must drain when the master is idle");
+        assert_eq!(
+            wake.metadata
+                .get(PEER_AWAITING_INPUT_META_SLUG)
+                .map(String::as_str),
+            Some("edison"),
+            "the wake carries the parked peer's slug",
+        );
+        assert_eq!(
+            wake.metadata
+                .get(PEER_AWAITING_INPUT_META_KIND)
+                .map(String::as_str),
+            Some("approval"),
+            "the wake carries the park kind",
+        );
+    }
+
+    /// Peer awaiting-input WAKE — two DISTINCT parks (distinct pending ids)
+    /// enqueue TWO wakes: the per-pending-id key never collapses distinct
+    /// blocks, so each is surfaced to the master at least once.
+    #[test]
+    fn peer_awaiting_input_two_distinct_parks_enqueue_two_wakes() {
+        let orchestrator = default_agent_orchestrator();
+        let master = SessionKey::with_profile("tenant-wake-two", "api", "master-two");
+        let profile = "tenant-wake-two";
+
+        assert!(
+            orchestrator
+                .enqueue_peer_awaiting_input_continuation(
+                    &master,
+                    profile,
+                    "edison",
+                    "pending-A",
+                    "approval",
+                    "one",
+                )
+                .queued()
+                .is_some(),
+            "first park queues",
+        );
+        assert!(
+            orchestrator
+                .enqueue_peer_awaiting_input_continuation(
+                    &master,
+                    profile,
+                    "tesla",
+                    "pending-B",
+                    "question",
+                    "two",
+                )
+                .queued()
+                .is_some(),
+            "a DISTINCT park (different pending id) queues a SECOND wake",
+        );
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_session_for_test(&master, profile),
+            2,
+            "two distinct parks → two wakes",
+        );
+    }
+
+    /// Peer awaiting-input WAKE — a RETRY of the same park (same pending id)
+    /// dedupes onto the already-queued wake: no continuation spam.
+    #[test]
+    fn peer_awaiting_input_same_park_retried_dedupes() {
+        let orchestrator = default_agent_orchestrator();
+        let master = SessionKey::with_profile("tenant-wake-dup", "api", "master-dup");
+        let profile = "tenant-wake-dup";
+
+        assert!(
+            orchestrator
+                .enqueue_peer_awaiting_input_continuation(
+                    &master,
+                    profile,
+                    "edison",
+                    "pending-same",
+                    "approval",
+                    "first",
+                )
+                .queued()
+                .is_some(),
+            "first enqueue of a park queues",
+        );
+        assert!(
+            orchestrator
+                .enqueue_peer_awaiting_input_continuation(
+                    &master,
+                    profile,
+                    "edison",
+                    "pending-same",
+                    "approval",
+                    "retry",
+                )
+                .is_duplicate(),
+            "the SAME park (same pending id) dedupes — even with a different summary",
+        );
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_session_for_test(&master, profile),
+            1,
+            "a retried park never stacks a second wake",
+        );
+    }
+
+    /// Peer awaiting-input WAKE — the rendered master turn names the parked peer
+    /// slug + kind and directs the master at `peer_list` / `peer_respond`.
+    #[test]
+    fn peer_awaiting_input_prompt_names_slug_and_directs_peer_list() {
+        let orchestrator = default_agent_orchestrator();
+        let master = SessionKey::with_profile("tenant-wake-prompt", "api", "master-wprompt");
+        let profile = "tenant-wake-prompt";
+        orchestrator.enqueue_peer_awaiting_input_continuation(
+            &master,
+            profile,
+            "edison",
+            "approval-id-9",
+            "question",
+            "Which datastore should I migrate to?",
+        );
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &master,
+            profile,
+            MasterContinuationRuntimeState::idle(),
+            4,
+        );
+        let wake = drained
+            .iter()
+            .find(|c| {
+                matches!(&c.reason, MasterContinuationReason::External(kind)
+                    if kind == PEER_AWAITING_INPUT_EXTERNAL_KIND)
+            })
+            .expect("wake continuation must drain when the master is idle");
+        let prompt = master_continuation_prompt(wake);
+        assert!(
+            prompt.contains("edison"),
+            "prompt must name the parked peer's slug: {prompt}"
+        );
+        assert!(
+            prompt.contains("question"),
+            "prompt must state the park kind: {prompt}"
+        );
+        assert!(
+            prompt.contains("peer_list"),
+            "prompt must direct the master to peer_list: {prompt}"
+        );
+        assert!(
+            prompt.contains("peer_respond"),
+            "prompt must direct the master to peer_respond: {prompt}"
         );
     }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -5043,6 +5043,25 @@ impl octos_agent::ToolApprovalRequester for UiProtocolApprovalRequester {
         // peer_respond read authoritatively. Nothing is written to the peer's
         // filesystem here, so a peer can never park invisibly on an fs failure.
 
+        // #peer-awaiting-wake — the peer is now GENUINELY parked (its pending
+        // oneshot is registered by `request_runtime` above). WAKE its originator
+        // (master) with an autonomous continuation so an IDLE master is notified
+        // to answer it via peer_list → peer_respond, instead of only discovering
+        // the block if it happens to be taking turns. This runs ONLY on the real
+        // park path: the scope-policy AUTO-RESOLVE short-circuit returned far
+        // above (before `request_runtime`), so an auto-approved request never
+        // reaches here and never wakes the master. No-op for a non-peer session
+        // or an unresolvable originator. The enqueue is a quick scheduler push —
+        // it does NOT block; we await `response_rx` below exactly as before, and
+        // the woken master resolves that oneshot from a different task.
+        wake_master_on_peer_awaiting_input(
+            self.state.as_ref(),
+            &self.session_id,
+            &approval_id.0.to_string(),
+            PeerPendingKind::Approval,
+            &peer_pending_prompt_summary(&event.title, &event.body),
+        );
+
         // Approvals are durable: if the WS drop strands the request, the
         // ledger still records it and the client can rehydrate.
         if let Err(err) = send_notification_durable(
@@ -5219,6 +5238,10 @@ struct SessionUserQuestionRequester {
     ws: WsConnection,
     ledger: Arc<UiProtocolLedger>,
     contracts: Arc<UiProtocolContractStores>,
+    /// #peer-awaiting-wake — held so a peer parking on a question can resolve
+    /// its `peers/<slug>/originator` (via `state.profiles`) and WAKE the master.
+    /// (The approval requester already holds `state`; this mirrors it.)
+    state: Arc<AppState>,
     session_id: SessionKey,
     turn_id: TurnId,
 }
@@ -5323,6 +5346,23 @@ impl octos_agent::UserQuestionRequester for SessionUserQuestionRequester {
         // which peer_list / peer_respond read authoritatively. No peer-filesystem
         // write happens here, so an OPEN peer can never park invisibly. (A closed
         // peer that re-parks is the documented close-while-parked exception.)
+
+        // #peer-awaiting-wake — the peer is now GENUINELY parked (its pending
+        // oneshot is registered by `request_runtime` above). WAKE its originator
+        // (master) so an IDLE master is notified to answer via peer_list →
+        // peer_respond. Unlike the approval requester there is no auto-resolve
+        // short-circuit for questions — every question genuinely parks — so the
+        // wake fires for each. No-op for a non-peer session or an unresolvable
+        // originator. The enqueue does NOT block; we await `response_rx` below
+        // exactly as before, and the woken master resolves it from a different
+        // task.
+        wake_master_on_peer_awaiting_input(
+            self.state.as_ref(),
+            &self.session_id,
+            &question_id.0.to_string(),
+            PeerPendingKind::Question,
+            &peer_pending_prompt_summary(&event.title, &event.body),
+        );
 
         // The event is durable: if the WS drop strands the request, the ledger
         // still records it and a reconnecting client can rehydrate. We cancel
@@ -11726,6 +11766,469 @@ fn peer_pending_summaries(
     questions.sort_by(|a, b| a.id.cmp(&b.id));
     approvals.append(&mut questions);
     approvals
+}
+
+/// Outcome of a peer awaiting-input WAKE attempt — a test-visible summary of
+/// whether (and why) the master was notified. `Woke`/`AlreadyQueued` mean a peer
+/// genuinely parked; the rest are the fail-closed no-wake reasons.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PeerAwaitingWakeOutcome {
+    /// A wake continuation was newly enqueued on the master (originator).
+    Woke,
+    /// The wake collapsed onto an already-queued wake for the SAME park (same
+    /// pending id) — the master is already scheduled to handle it.
+    AlreadyQueued,
+    /// The parking session is not a peer session (topic is not `peer-<slug>`),
+    /// so there is no master to notify — a non-peer park never wakes anyone.
+    NotPeer,
+    /// The peer is not staged / not resolvable under `peers/` — no wake.
+    NoStagedPeer,
+    /// The peer has no recorded `originator` (master). Fail-closed: no wake.
+    NoOriginator,
+    /// The recorded `originator` is present but not a LEGITIMATE master session
+    /// — wrong/absent profile, or itself a peer session (a peer can never answer
+    /// via `peer_respond` under the depth-1 guard). Fail-closed: no wake, so a
+    /// malformed/hostile originator can never strand a continuation on the wrong
+    /// or an unanswerable session.
+    InvalidOriginator,
+}
+
+/// Short, single-line summary of what a peer is blocked on, for the wake nudge.
+/// Collapses all whitespace and caps length — the master reads the AUTHORITATIVE
+/// parked set via `peer_list`, so this is only a hint (and peer-supplied
+/// title/body is untrusted display text that must not blow up the prompt).
+fn peer_awaiting_wake_prompt_summary(prompt: &str) -> String {
+    const WAKE_PROMPT_SUMMARY_CAP: usize = 160;
+    let one_line = prompt.split_whitespace().collect::<Vec<_>>().join(" ");
+    capped_utf8(one_line, WAKE_PROMPT_SUMMARY_CAP).0
+}
+
+/// #peer-awaiting-wake CORE — enqueue an AUTONOMOUS master continuation that
+/// WAKES the peer's originator (master) the moment the peer PARKS on an
+/// approval/question (becomes genuinely `awaiting_input`). Resolves the peer's
+/// slug/profile from `peer_session`, reads the recorded `originator` from
+/// `peers/<slug>/originator` (the SAME source `peer_send_input`/`peer_respond`
+/// authorize against — symlink-safe via [`staged_peer_dir`]), VALIDATES it is a
+/// legitimate master session (right profile, not itself a peer), and pushes ONE
+/// [`PEER_AWAITING_INPUT_EXTERNAL_KIND`] continuation onto that master through
+/// the SAME scheduler `peer_fleet_synthesis` uses. Filesystem-only +
+/// `AppState`-free, so it is unit-testable with a tempdir.
+///
+/// The enqueue is a quick, non-blocking scheduler push: the caller (a park-point
+/// requester) awaits its own oneshot as normal, and the woken master resolves it
+/// from a DIFFERENT task via `peer_respond`. The scheduler's `is_idle_eligible`
+/// gate (checked at drain) means the wake never fires while the MASTER itself is
+/// mid-turn or blocked on its own input/approval.
+fn enqueue_peer_awaiting_input_wake(
+    peers_root: &Path,
+    peer_session: &SessionKey,
+    pending_id: &str,
+    park_kind: PeerPendingKind,
+    prompt: &str,
+) -> PeerAwaitingWakeOutcome {
+    // ONLY a peer session parks a peer. A non-peer (e.g. the master's OWN)
+    // session parking must never wake anyone.
+    let Some((profile_id, slug)) = peer_slug_and_profile(peer_session) else {
+        return PeerAwaitingWakeOutcome::NotPeer;
+    };
+    // Route the originator read through `staged_peer_dir` so a hostile/stray
+    // `peers/<slug>` symlink can never redirect the read outside `peers_root`.
+    let Some(peer_dir) = staged_peer_dir(peers_root, slug) else {
+        return PeerAwaitingWakeOutcome::NoStagedPeer;
+    };
+    let Some(master) =
+        peer_io::read_peer_file(&peer_dir, "originator", peer_io::PEER_FILE_READ_CAP_SMALL)
+    else {
+        return PeerAwaitingWakeOutcome::NoOriginator;
+    };
+    let master = master.trim();
+    if master.is_empty() {
+        return PeerAwaitingWakeOutcome::NoOriginator;
+    }
+    let master_key = SessionKey(master.to_owned());
+    // VALIDATE the recorded originator is a legitimate MASTER session before
+    // targeting a wake at it — never trust the string blindly. `peer/prepare`
+    // writes its supplied `session_id` verbatim as the `originator`, so it can be
+    // malformed, wrong-profile, or itself a PEER session. Treat it as an
+    // authorization locator (exactly as `peer_respond`/`peer_send_input` do), not
+    // a blind target: require a profile that EQUALS the peer's (peers run under
+    // their master's profile) AND a topic that is NOT a peer topic — a peer can
+    // NEVER answer via `peer_respond` (depth-1 guard), so a wake aimed at one
+    // would strand the blocked peer, and a wrong-profile/garbage value would
+    // strand a continuation on the wrong or a nonexistent session. Any failure →
+    // skip silently, exactly like a missing originator (the peer just emits no
+    // wake). The `peer-` prefix is checked on the RAW topic (not
+    // `peer_slug_and_profile`, which also gates slug safety) so even a malformed
+    // `peer-<unsafe>` originator topic is rejected.
+    if master_key.profile_id() != Some(profile_id)
+        || master_key
+            .topic()
+            .is_some_and(|topic| topic.starts_with("peer-"))
+    {
+        return PeerAwaitingWakeOutcome::InvalidOriginator;
+    }
+    let summary = peer_awaiting_wake_prompt_summary(prompt);
+    let outcome = default_agent_orchestrator().enqueue_peer_awaiting_input_continuation(
+        &master_key,
+        profile_id,
+        slug,
+        pending_id,
+        park_kind.as_str(),
+        &summary,
+    );
+    if outcome.is_duplicate() {
+        PeerAwaitingWakeOutcome::AlreadyQueued
+    } else {
+        tracing::debug!(
+            master = %master_key,
+            profile = profile_id,
+            slug,
+            kind = park_kind.as_str(),
+            "peer parked on input — enqueued autonomous wake on master",
+        );
+        PeerAwaitingWakeOutcome::Woke
+    }
+}
+
+/// Resolve the peer's `peers_root` from `state.profiles` and enqueue the
+/// awaiting-input wake on its originator. The thin `AppState` seam over
+/// [`enqueue_peer_awaiting_input_wake`] that the park-point requesters call.
+/// No-op for a non-peer session or an unregistered profile.
+fn wake_master_on_peer_awaiting_input(
+    state: &AppState,
+    peer_session: &SessionKey,
+    pending_id: &str,
+    park_kind: PeerPendingKind,
+    prompt: &str,
+) {
+    let Some((profile_id, _slug)) = peer_slug_and_profile(peer_session) else {
+        return;
+    };
+    let Some(runtime) = state.profiles.get(profile_id) else {
+        return;
+    };
+    let peers_root = runtime.data_dir.join("peers");
+    let _ =
+        enqueue_peer_awaiting_input_wake(&peers_root, peer_session, pending_id, park_kind, prompt);
+}
+
+#[cfg(test)]
+mod peer_awaiting_wake_tests {
+    use super::*;
+    use crate::api::agent_orchestrator::PEER_AWAITING_INPUT_EXTERNAL_KIND;
+
+    /// Stage a peer dir (`<peers_root>/<slug>/` with `brief.md`) and optionally
+    /// record its `originator`. Mirrors the `stage_peer` staging contract that
+    /// `staged_peer_dir` validates.
+    fn stage_peer_with_originator(peers_root: &Path, slug: &str, originator: Option<&str>) {
+        let dir = peers_root.join(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("brief.md"), "do the thing").unwrap();
+        if let Some(originator) = originator {
+            std::fs::write(dir.join("originator"), originator).unwrap();
+        }
+    }
+
+    fn peer_session(profile: &str, chat: &str, slug: &str) -> SessionKey {
+        SessionKey::with_profile_topic(profile, "api", chat, &format!("peer-{slug}"))
+    }
+
+    /// A peer parking on an APPROVAL wakes its originator (master) with a
+    /// continuation carrying the peer slug + `approval` kind.
+    #[test]
+    fn peer_approval_park_wakes_master_on_originator() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peers_root = tmp.path();
+        let profile = "tenant-wake-core-appr";
+        let master = "tenant-wake-core-appr:api:master";
+        stage_peer_with_originator(peers_root, "edison", Some(master));
+
+        let session = peer_session(profile, "edison-wire", "edison");
+        let outcome = enqueue_peer_awaiting_input_wake(
+            peers_root,
+            &session,
+            "approval-1",
+            PeerPendingKind::Approval,
+            "shell: delete build cache",
+        );
+        assert_eq!(outcome, PeerAwaitingWakeOutcome::Woke);
+
+        let orchestrator = default_agent_orchestrator();
+        let master_key = SessionKey(master.to_owned());
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_session_for_test(&master_key, profile),
+            1,
+            "a peer approval park enqueues exactly one wake on its originator",
+        );
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &master_key,
+            profile,
+            MasterContinuationRuntimeState::idle(),
+            4,
+        );
+        let wake = drained
+            .iter()
+            .find(|c| {
+                matches!(&c.reason, MasterContinuationReason::External(k)
+                    if k == PEER_AWAITING_INPUT_EXTERNAL_KIND)
+            })
+            .expect("the approval wake must be queued on the master");
+        let prompt = master_continuation_prompt(wake);
+        assert!(prompt.contains("edison"), "prompt names the slug: {prompt}");
+        assert!(
+            prompt.contains("approval"),
+            "prompt states the approval kind: {prompt}"
+        );
+        assert!(
+            prompt.contains("peer_list") && prompt.contains("peer_respond"),
+            "prompt directs peer_list/peer_respond: {prompt}"
+        );
+    }
+
+    /// A peer parking on a QUESTION wakes its originator with a `question`-kind
+    /// continuation.
+    #[test]
+    fn peer_question_park_wakes_master_on_originator() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peers_root = tmp.path();
+        let profile = "tenant-wake-core-q";
+        let master = "tenant-wake-core-q:api:master";
+        stage_peer_with_originator(peers_root, "tesla", Some(master));
+
+        let session = peer_session(profile, "tesla-wire", "tesla");
+        let outcome = enqueue_peer_awaiting_input_wake(
+            peers_root,
+            &session,
+            "question-1",
+            PeerPendingKind::Question,
+            "Which region should I deploy to?",
+        );
+        assert_eq!(outcome, PeerAwaitingWakeOutcome::Woke);
+
+        let orchestrator = default_agent_orchestrator();
+        let master_key = SessionKey(master.to_owned());
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &master_key,
+            profile,
+            MasterContinuationRuntimeState::idle(),
+            4,
+        );
+        let wake = drained
+            .iter()
+            .find(|c| {
+                matches!(&c.reason, MasterContinuationReason::External(k)
+                    if k == PEER_AWAITING_INPUT_EXTERNAL_KIND)
+            })
+            .expect("the question wake must be queued on the master");
+        assert!(
+            master_continuation_prompt(wake).contains("question"),
+            "prompt states the question kind",
+        );
+    }
+
+    /// A NON-peer session parking (topic is not `peer-<slug>`) must NOT wake
+    /// anyone — there is no master behind an ordinary session.
+    #[test]
+    fn non_peer_session_park_does_not_wake() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peers_root = tmp.path();
+        // An ordinary (non-peer) session: a master's OWN turn parking.
+        let session = SessionKey::with_profile("tenant-wake-core-nonpeer", "api", "master");
+        let outcome = enqueue_peer_awaiting_input_wake(
+            peers_root,
+            &session,
+            "approval-x",
+            PeerPendingKind::Approval,
+            "anything",
+        );
+        assert_eq!(
+            outcome,
+            PeerAwaitingWakeOutcome::NotPeer,
+            "a non-peer session must never wake a master",
+        );
+    }
+
+    /// A peer with NO recorded originator fails closed: no wake (nothing to
+    /// notify).
+    #[test]
+    fn peer_without_originator_does_not_wake() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peers_root = tmp.path();
+        let profile = "tenant-wake-core-noorig";
+        stage_peer_with_originator(peers_root, "ghost", None);
+
+        let session = peer_session(profile, "ghost-wire", "ghost");
+        let outcome = enqueue_peer_awaiting_input_wake(
+            peers_root,
+            &session,
+            "approval-y",
+            PeerPendingKind::Approval,
+            "anything",
+        );
+        assert_eq!(outcome, PeerAwaitingWakeOutcome::NoOriginator);
+    }
+
+    /// A recorded originator that is itself a PEER session (topic `peer-...`)
+    /// must NOT wake: a peer can never answer via `peer_respond` (depth-1 guard),
+    /// so a wake aimed at one would strand the blocked peer. `peer/prepare`
+    /// writes its supplied session_id verbatim, so this is a real input.
+    #[test]
+    fn peer_session_originator_does_not_wake() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peers_root = tmp.path();
+        let profile = "tenant-wake-core-peerorig";
+        // The originator string is ANOTHER peer session under the same profile.
+        let peer_originator = format!("{profile}:api:other-wire#peer-other");
+        stage_peer_with_originator(peers_root, "edison", Some(&peer_originator));
+
+        let session = peer_session(profile, "edison-wire", "edison");
+        let outcome = enqueue_peer_awaiting_input_wake(
+            peers_root,
+            &session,
+            "approval-z",
+            PeerPendingKind::Approval,
+            "anything",
+        );
+        assert_eq!(
+            outcome,
+            PeerAwaitingWakeOutcome::InvalidOriginator,
+            "a peer-session originator can never answer — no wake",
+        );
+        // And nothing was enqueued anywhere for that peer-session key.
+        let orchestrator = default_agent_orchestrator();
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_session_for_test(
+                &SessionKey(peer_originator),
+                profile,
+            ),
+            0,
+            "no continuation may land on a peer-session originator",
+        );
+    }
+
+    /// A recorded originator under a DIFFERENT profile than the peer's must NOT
+    /// wake — peers run under their master's profile, so a profile mismatch is a
+    /// malformed/hostile originator that would strand a continuation on the wrong
+    /// (or a nonexistent) session.
+    #[test]
+    fn wrong_profile_originator_does_not_wake() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peers_root = tmp.path();
+        let profile = "tenant-wake-core-wrongprof";
+        // A well-formed MASTER session, but under a DIFFERENT profile.
+        let foreign_master = "some-other-tenant:api:master";
+        stage_peer_with_originator(peers_root, "edison", Some(foreign_master));
+
+        let session = peer_session(profile, "edison-wire", "edison");
+        let outcome = enqueue_peer_awaiting_input_wake(
+            peers_root,
+            &session,
+            "approval-w",
+            PeerPendingKind::Approval,
+            "anything",
+        );
+        assert_eq!(
+            outcome,
+            PeerAwaitingWakeOutcome::InvalidOriginator,
+            "a wrong-profile originator must not wake",
+        );
+        let orchestrator = default_agent_orchestrator();
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_session_for_test(
+                &SessionKey(foreign_master.to_owned()),
+                profile,
+            ),
+            0,
+            "no continuation may land on a wrong-profile originator",
+        );
+        // Belt-and-suspenders: nor under the foreign profile either.
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_session_for_test(
+                &SessionKey(foreign_master.to_owned()),
+                "some-other-tenant",
+            ),
+            0,
+        );
+    }
+
+    /// A profile-LESS originator (a bare `channel:chat`, no `{profile}:` prefix)
+    /// must NOT wake — it has no profile to match the peer's.
+    #[test]
+    fn profileless_originator_does_not_wake() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peers_root = tmp.path();
+        let profile = "tenant-wake-core-noprof";
+        stage_peer_with_originator(peers_root, "edison", Some("garbage-no-profile"));
+
+        let session = peer_session(profile, "edison-wire", "edison");
+        let outcome = enqueue_peer_awaiting_input_wake(
+            peers_root,
+            &session,
+            "approval-v",
+            PeerPendingKind::Approval,
+            "anything",
+        );
+        assert_eq!(outcome, PeerAwaitingWakeOutcome::InvalidOriginator);
+    }
+
+    /// Two DISTINCT parks (distinct pending ids) wake the master twice; a RETRY
+    /// of the SAME park dedupes.
+    #[test]
+    fn distinct_parks_wake_twice_same_park_dedupes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let peers_root = tmp.path();
+        let profile = "tenant-wake-core-dedupe";
+        let master = "tenant-wake-core-dedupe:api:master";
+        stage_peer_with_originator(peers_root, "edison", Some(master));
+        stage_peer_with_originator(peers_root, "tesla", Some(master));
+
+        let orchestrator = default_agent_orchestrator();
+        let master_key = SessionKey(master.to_owned());
+
+        // Two distinct parks (different peers, different pending ids).
+        assert_eq!(
+            enqueue_peer_awaiting_input_wake(
+                peers_root,
+                &peer_session(profile, "edison-wire", "edison"),
+                "pending-A",
+                PeerPendingKind::Approval,
+                "first",
+            ),
+            PeerAwaitingWakeOutcome::Woke,
+        );
+        assert_eq!(
+            enqueue_peer_awaiting_input_wake(
+                peers_root,
+                &peer_session(profile, "tesla-wire", "tesla"),
+                "pending-B",
+                PeerPendingKind::Question,
+                "second",
+            ),
+            PeerAwaitingWakeOutcome::Woke,
+        );
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_session_for_test(&master_key, profile),
+            2,
+            "two distinct parks → two wakes",
+        );
+
+        // A RETRY of the FIRST park (same pending id) dedupes — no third wake.
+        assert_eq!(
+            enqueue_peer_awaiting_input_wake(
+                peers_root,
+                &peer_session(profile, "edison-wire", "edison"),
+                "pending-A",
+                PeerPendingKind::Approval,
+                "retry",
+            ),
+            PeerAwaitingWakeOutcome::AlreadyQueued,
+        );
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_session_for_test(&master_key, profile),
+            2,
+            "a retried park never stacks a redundant wake",
+        );
+    }
 }
 
 /// The peer's TRUSTED session key (#P1-1): the wire it runs its turns under,
@@ -27747,6 +28250,7 @@ async fn run_standalone_turn(
                 ws: ws.clone(),
                 ledger: ledger.clone(),
                 contracts: contracts.clone(),
+                state: state.clone(),
                 session_id: session_id.clone(),
                 turn_id: turn_id.clone(),
             }) as Arc<dyn octos_agent::UserQuestionRequester>

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -22649,6 +22649,234 @@ async fn state_with_profile_llm_and_sandbox(
     (state, profile_runtime)
 }
 
+// ---- #peer-awaiting-wake — real requester integration ----
+//
+// Drive the REAL `UiProtocolApprovalRequester::request_approval` /
+// `SessionUserQuestionRequester::request_user_question` from a PEER session and
+// assert the peer's park wakes its originator (master) via the process-global
+// master-continuation scheduler — the exact seam `peer_fleet_synthesis` uses.
+// No live LLM: the requester parks on its oneshot and we cancel it to unwind.
+
+/// Stage `<peers_root>/<slug>/` with `brief.md` + `originator` so
+/// `staged_peer_dir` accepts it and the wake can resolve the master.
+fn stage_wake_peer(peers_root: &std::path::Path, slug: &str, originator: &str) {
+    let dir = peers_root.join(slug);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("brief.md"), "do the thing").unwrap();
+    std::fs::write(dir.join("originator"), originator).unwrap();
+}
+
+/// Poll the global orchestrator until `master` has >= `expected` pending
+/// continuations (or time out ~1s). The wake enqueue is synchronous inside the
+/// requester (before it awaits its oneshot), so this settles in a few yields.
+async fn wait_for_pending_count(master: &SessionKey, profile: &str, expected: usize) -> usize {
+    let orchestrator = default_agent_orchestrator();
+    for _ in 0..200 {
+        let n = orchestrator.pending_continuation_count_for_session_for_test(master, profile);
+        if n >= expected {
+            return n;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    orchestrator.pending_continuation_count_for_session_for_test(master, profile)
+}
+
+#[tokio::test]
+async fn real_peer_approval_park_wakes_originator() {
+    use octos_agent::ToolApprovalRequester as _;
+    let temp = tempfile::tempdir().unwrap();
+    let profile = "tenant-wake-rt-appr";
+    let (state, runtime) = state_with_profile(temp.path(), profile).await;
+    let peers_root = runtime.data_dir.join("peers");
+    let master = format!("{profile}:api:master");
+    stage_wake_peer(&peers_root, "edison", &master);
+
+    let (ws_tx, _ws_rx) = mpsc::channel(64);
+    let ws = WsConnection::new(ws_tx);
+    let ledger = Arc::new(UiProtocolLedger::new(64));
+    let contracts = Arc::new(UiProtocolContractStores::default());
+    let session_id = SessionKey::with_profile_topic(profile, "api", "edison-wire", "peer-edison");
+    let turn_id = TurnId::new();
+
+    let requester = UiProtocolApprovalRequester {
+        ws,
+        ledger,
+        contracts: contracts.clone(),
+        state: state.clone(),
+        session_id: session_id.clone(),
+        turn_id: turn_id.clone(),
+        features: ConnectionUiFeatures::default(),
+    };
+    let request = octos_agent::ToolApprovalRequest {
+        tool_id: "call-1".to_owned(),
+        tool_name: "shell".to_owned(),
+        title: "Run a shell command".to_owned(),
+        body: "rm -rf ./build-cache".to_owned(),
+        command: Some("rm -rf ./build-cache".to_owned()),
+        cwd: None,
+    };
+    let handle = tokio::spawn(async move { requester.request_approval(request).await });
+
+    let master_key = SessionKey(master.clone());
+    let n = wait_for_pending_count(&master_key, profile, 1).await;
+    assert_eq!(
+        n, 1,
+        "the real approval park must wake its originator exactly once"
+    );
+
+    // Inspect the queued wake: right reason kind + parked slug.
+    let drained = default_agent_orchestrator().drain_ready_continuations_for_session(
+        &master_key,
+        profile,
+        MasterContinuationRuntimeState::idle(),
+        4,
+    );
+    let wake = drained
+        .iter()
+        .find(|c| {
+            matches!(&c.reason, MasterContinuationReason::External(k)
+                if k == crate::api::agent_orchestrator::PEER_AWAITING_INPUT_EXTERNAL_KIND)
+        })
+        .expect("a peer_awaiting_input wake must be queued on the master");
+    assert!(
+        master_continuation_prompt(wake).contains("edison"),
+        "the wake prompt names the parked peer",
+    );
+
+    // Unblock the parked requester so the spawned task can finish.
+    contracts
+        .approvals
+        .cancel_pending_for_turn(&session_id, &turn_id, "test-teardown");
+    let decision = handle.await.unwrap();
+    assert_eq!(decision, octos_agent::ToolApprovalDecision::Deny);
+}
+
+#[tokio::test]
+async fn real_auto_resolved_approval_does_not_wake() {
+    use octos_agent::ToolApprovalRequester as _;
+    let temp = tempfile::tempdir().unwrap();
+    let profile = "tenant-wake-rt-auto";
+    let (state, runtime) = state_with_profile(temp.path(), profile).await;
+    let peers_root = runtime.data_dir.join("peers");
+    let master = format!("{profile}:api:master");
+    // Stage a VALID peer+originator, so the ONLY reason no wake fires is the
+    // auto-resolve short-circuit (not a missing originator).
+    stage_wake_peer(&peers_root, "edison", &master);
+
+    let (ws_tx, _ws_rx) = mpsc::channel(64);
+    let ws = WsConnection::new(ws_tx);
+    let ledger = Arc::new(UiProtocolLedger::new(64));
+    let contracts = Arc::new(UiProtocolContractStores::default());
+    let session_id = SessionKey::with_profile_topic(profile, "api", "edison-wire", "peer-edison");
+    let turn_id = TurnId::new();
+
+    // Pre-record a session-wide auto-approve for `shell`, so this approval is
+    // resolved by policy and NEVER parks (never reaches request_runtime).
+    contracts.scopes.record(
+        &session_id,
+        ApprovalScopeKind::ApproveForTool,
+        match_key_for(ApprovalScopeKind::ApproveForTool, "shell", &turn_id),
+        ApprovalDecision::Approve,
+    );
+
+    let requester = UiProtocolApprovalRequester {
+        ws,
+        ledger,
+        contracts: contracts.clone(),
+        state: state.clone(),
+        session_id: session_id.clone(),
+        turn_id: turn_id.clone(),
+        features: ConnectionUiFeatures::default(),
+    };
+    let request = octos_agent::ToolApprovalRequest {
+        tool_id: "call-1".to_owned(),
+        tool_name: "shell".to_owned(),
+        title: "Run a shell command".to_owned(),
+        body: "echo hi".to_owned(),
+        command: Some("echo hi".to_owned()),
+        cwd: None,
+    };
+    // Auto-resolve returns immediately (no oneshot to await), so call directly.
+    let decision = requester.request_approval(request).await;
+    assert_eq!(
+        decision,
+        octos_agent::ToolApprovalDecision::Approve,
+        "the scope policy must auto-approve",
+    );
+
+    let master_key = SessionKey(master.clone());
+    assert_eq!(
+        default_agent_orchestrator()
+            .pending_continuation_count_for_session_for_test(&master_key, profile),
+        0,
+        "an AUTO-RESOLVED approval never parks, so it must NOT wake the master",
+    );
+}
+
+#[tokio::test]
+async fn real_peer_question_park_wakes_originator() {
+    use octos_agent::UserQuestionRequester as _;
+    let temp = tempfile::tempdir().unwrap();
+    let profile = "tenant-wake-rt-q";
+    let (state, runtime) = state_with_profile(temp.path(), profile).await;
+    let peers_root = runtime.data_dir.join("peers");
+    let master = format!("{profile}:api:master");
+    stage_wake_peer(&peers_root, "tesla", &master);
+
+    let (ws_tx, _ws_rx) = mpsc::channel(64);
+    let ws = WsConnection::new(ws_tx);
+    let ledger = Arc::new(UiProtocolLedger::new(64));
+    let contracts = Arc::new(UiProtocolContractStores::default());
+    let session_id = SessionKey::with_profile_topic(profile, "api", "tesla-wire", "peer-tesla");
+    let turn_id = TurnId::new();
+
+    let requester = SessionUserQuestionRequester {
+        ws,
+        ledger,
+        contracts: contracts.clone(),
+        state: state.clone(),
+        session_id: session_id.clone(),
+        turn_id: turn_id.clone(),
+    };
+    let request = octos_agent::UserQuestionRequest {
+        questions: Vec::new(),
+        title: "Pick a datastore".to_owned(),
+        body: "Postgres or SQLite?".to_owned(),
+    };
+    let handle = tokio::spawn(async move { requester.request_user_question(request).await });
+
+    let master_key = SessionKey(master.clone());
+    let n = wait_for_pending_count(&master_key, profile, 1).await;
+    assert_eq!(
+        n, 1,
+        "the real question park must wake its originator exactly once"
+    );
+
+    let drained = default_agent_orchestrator().drain_ready_continuations_for_session(
+        &master_key,
+        profile,
+        MasterContinuationRuntimeState::idle(),
+        4,
+    );
+    let wake = drained
+        .iter()
+        .find(|c| {
+            matches!(&c.reason, MasterContinuationReason::External(k)
+                if k == crate::api::agent_orchestrator::PEER_AWAITING_INPUT_EXTERNAL_KIND)
+        })
+        .expect("a peer_awaiting_input wake must be queued on the master");
+    assert!(
+        master_continuation_prompt(wake).contains("question"),
+        "the wake prompt states the question kind",
+    );
+
+    contracts
+        .user_questions
+        .cancel_pending_for_turn(&session_id, &turn_id, "test-teardown");
+    let outcome = handle.await.unwrap();
+    assert_eq!(outcome, octos_agent::UserQuestionOutcome::Cancelled);
+}
+
 struct AppuiContinuationLlm {
     response: String,
     call_count: std::sync::atomic::AtomicUsize,


### PR DESCRIPTION
## What

Completes the master-as-human-in-the-loop loop from #1843. Previously a peer that PARKED on an approval / `ask_user_question` was **visible** to the master (`peer_list awaiting_input`) and **answerable** (`peer_respond`) — but nothing **notified** the master. An idle master (fanned out and waiting) was never woken; it had to already be taking turns and choose to check.

This adds the **wake**: the moment a peer parks, it schedules an **autonomous master continuation** on that peer's originator, so an idle master is woken, reads `peer_list`, and answers via `peer_respond` — hands-off.

```
peer parks → master WOKEN → master reads peer_list → peer_respond → peer resumes
```

## How

Mirrors the existing `peer_fleet_synthesis` continuation (which fires when a fleet *finishes*): a new `PEER_AWAITING_INPUT_EXTERNAL_KIND` continuation is enqueued on the peer's originator right after the requester registers the pending oneshot. The woken master turn gets a `[system-internal]` nudge naming the peer + prompt and pointing at `peer_list`/`peer_respond`.

**Guard rails:**
- **Only real parks** — placed *after* the auto-resolve short-circuit, so a scope-policy auto-approved (never-parked) approval does not wake.
- **Only peer sessions** — a non-peer session's approval/question never wakes.
- **Validated originator** — the `peers/<slug>/originator` is treated as an authorization locator, not used verbatim: the wake fires only if the originator is a **same-profile, non-`peer-` master session** (fail-closed skip otherwise), so a malformed / wrong-profile / peer-session originator can never wake the wrong session or strand the blocked peer.
- **Deduped per pending-id** (the approval/question UUID = the scheduler's required unique occurrence id) — a distinct park always wakes, a retry dedupes, no re-arm bug (per-originator coalescing was deliberately rejected). Surplus wakes on simultaneous parks are harmless no-ops (the first woken turn clears the whole `peer_list` batch).
- **Idle-gated** by the scheduler's existing `is_idle_eligible` — never fires while the master itself has a pending input/approval.

No lock is held across the requester's `await` (no added park latency beyond a bounded, symlink-safe originator read), and a stale wake (peer resolved before the master drains) is a harmless no-op.

## Testing & review

- **15 feature tests** — orchestrator enqueue/dedupe, tempdir-core (approval/question park wakes; non-peer / missing-originator / peer-session-originator / wrong-profile / profileless → no wake; distinct-vs-retry), and real-requester integration (live approval + question parks wake the originator; auto-resolved approval does NOT). Peer suites: `-p octos-cli --features api` 95, `-p octos-agent` 39. `build --workspace`, `fmt --check`, clippy all clean.
- codex-reviewed: hot-path, dedupe/idle-gating/races/no-deadlock all confirmed sound; one medium (originator used verbatim) found and fixed with the same-profile/non-peer validation above.
