### PR TITLE
docs: document the in-process GGUF embedding provider + index-dimension coupling

### DIFF
--- a/book-zh/src/architecture.md
+++ b/book-zh/src/architecture.md
@@ -401,7 +401,13 @@ pub trait EmbeddingProvider: Send + Sync {
 }
 ```
 
-**OpenAIEmbedder**：默认模型 `text-embedding-3-small`（1536 维）。`text-embedding-3-large` = 3072 维。
+两种实现：
+
+**OpenAIEmbedder**：远程，OpenAI 兼容（`provider = "openai"`）。默认模型 `text-embedding-3-small`（1536 维），`text-embedding-3-large` 为 3072 维。可选的 `dimensions` 字段用来固定原生维度不同的服务，例如 DashScope `text-embedding-v4` 默认 1024 维。
+
+**LlamaEmbedder**（`octos-embed-llama`）：进程内，通过 llama.cpp 跑任意 GGUF 嵌入模型（`provider = "llamacpp"`，配 `model_path`）。跨平台，默认用 CPU，`metal` / `cuda` feature 可以走 GPU。需要 `--features embed-llama` 才会编译进来。
+
+**索引宽度由 embedder 决定。** `EpisodeStore` 的 HNSW 索引只有一个固定宽度，`HybridIndex::insert` 会丢掉维度不匹配的向量，该 episode 退化成只有 BM25。所以打开 store 用的是 `embedder.dimension()`，不是常量。两个后果：Matryoshka 只能向下截断，768 维的模型填不满 1536 维的索引；换 provider 或换模型会让已有索引失效。不同后端的向量不能混用，上面两者实测余弦一致度是 0.96–0.99，和真正相关的文档之间的差距是同一量级。切换之后已存的 episode 必须重新生成向量。
 
 ### 语音转文字
 

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -401,7 +401,13 @@ pub trait EmbeddingProvider: Send + Sync {
 }
 ```
 
-**OpenAIEmbedder**: Default model `text-embedding-3-small` (1536 dims). `text-embedding-3-large` = 3072 dims.
+Two implementations:
+
+**OpenAIEmbedder** — remote, OpenAI-compatible (`provider = "openai"`). Default model `text-embedding-3-small` (1536 dims); `text-embedding-3-large` = 3072 dims. The optional `dimensions` request field pins providers whose native size differs (e.g. DashScope `text-embedding-v4` at 1024).
+
+**LlamaEmbedder** (`octos-embed-llama`) — in-process, any GGUF embedding model over llama.cpp (`provider = "llamacpp"` + `model_path`). Cross-platform, CPU by default; `metal` / `cuda` features offload. Off unless built with `--features embed-llama`.
+
+**The index is sized from the embedder.** `EpisodeStore` builds its HNSW index at one fixed width and `HybridIndex::insert` DROPS any vector that does not match, degrading that episode to BM25-only — so the store is opened with `embedder.dimension()`, not a constant. Two consequences: Matryoshka truncation only goes *down* (a 768-d model can never fill a 1536-d index), and changing provider or model invalidates a populated index. Embeddings from different backends are not interchangeable — measured agreement between the two above is 0.96–0.99 cosine, the same order as the gap between genuinely related documents — so stored episodes must be re-embedded after a switch.
 
 ### Transcription
 

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -121,12 +121,24 @@ The complete configuration structure with all available fields:
   // Agent settings
   "max_iterations": 50,
 
-  // Embedding (for vector search in memory)
+  // Embedding (for vector search in memory).
+  // Remote, OpenAI-compatible:
   "embedding": {
     "provider": "openai",
     "api_key_env": "OPENAI_API_KEY",
-    "base_url": null
+    "base_url": null,
+    "model": null,       // default text-embedding-3-small (1536 dims)
+    "dimensions": null   // pin the output size when the model's native size differs
   },
+  // ...or in-process, no API key, any GGUF model over llama.cpp. Needs a
+  // build with `--features embed-llama` (add embed-llama-metal / -cuda to
+  // offload); CPU otherwise. Changing provider or model changes the vector
+  // DIMENSION, which invalidates a populated index — re-embed stored
+  // episodes after switching, or their recall silently degrades to BM25.
+  // "embedding": {
+  //   "provider": "llamacpp",
+  //   "model_path": "/path/to/embeddinggemma-300M-Q8_0.gguf"
+  // },
 
   // Voice
   "voice": {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -376,7 +376,13 @@ pub trait EmbeddingProvider: Send + Sync {
 }
 ```
 
-**OpenAIEmbedder**: Default model `text-embedding-3-small` (1536 dims). `text-embedding-3-large` = 3072 dims.
+Two implementations:
+
+**OpenAIEmbedder** — remote, OpenAI-compatible (`provider = "openai"`). Default model `text-embedding-3-small` (1536 dims); `text-embedding-3-large` = 3072 dims. The optional `dimensions` request field pins providers whose native size differs (e.g. DashScope `text-embedding-v4` at 1024).
+
+**LlamaEmbedder** (`octos-embed-llama`) — in-process, any GGUF embedding model over llama.cpp (`provider = "llamacpp"` + `model_path`). Cross-platform, CPU by default; `metal` / `cuda` features offload. Off unless built with `--features embed-llama`.
+
+**The index is sized from the embedder.** `EpisodeStore` builds its HNSW index at one fixed width and `HybridIndex::insert` DROPS any vector that does not match, degrading that episode to BM25-only — so the store is opened with `embedder.dimension()`, not a constant. Two consequences: Matryoshka truncation only goes *down* (a 768-d model can never fill a 1536-d index), and changing provider or model invalidates a populated index. Embeddings from different backends are not interchangeable — measured agreement between the two above is 0.96–0.99 cosine, the same order as the gap between genuinely related documents — so stored episodes must be re-embedded after a switch.
 
 ### Transcription
 

--- a/docs/user-guide-zh.md
+++ b/docs/user-guide-zh.md
@@ -2003,12 +2003,24 @@ chmod +x .octos/skills/translator/main
   // 智能体设置
   "max_iterations": 50,
 
-  // 嵌入（用于记忆中的向量搜索）
+  // 嵌入（用于记忆中的向量搜索）。
+  // 远程，OpenAI 兼容：
   "embedding": {
     "provider": "openai",
     "api_key_env": "OPENAI_API_KEY",
-    "base_url": null
+    "base_url": null,
+    "model": null,       // 默认 text-embedding-3-small（1536 维）
+    "dimensions": null   // 模型原生维度不同时，用它固定输出维度
   },
+  // 或者进程内运行，不需要 API key，通过 llama.cpp 跑任意 GGUF 模型。
+  // 需要用 `--features embed-llama` 编译（加 embed-llama-metal / -cuda
+  // 可以走 GPU），否则用 CPU。换 provider 或换模型会改变向量维度，
+  // 已有索引会失效。切换后要重新生成已存 episode 的向量，否则它们的
+  // 召回会悄悄退化成只有 BM25。
+  // "embedding": {
+  //   "provider": "llamacpp",
+  //   "model_path": "/path/to/embeddinggemma-300M-Q8_0.gguf"
+  // },
 
   // 语音
   "voice": {

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2083,12 +2083,24 @@ Bot: [uses translate tool with text="Hello world", target_lang="JA"]
   // Agent settings
   "max_iterations": 50,
 
-  // Embedding (for vector search in memory)
+  // Embedding (for vector search in memory).
+  // Remote, OpenAI-compatible:
   "embedding": {
     "provider": "openai",
     "api_key_env": "OPENAI_API_KEY",
-    "base_url": null
+    "base_url": null,
+    "model": null,       // default text-embedding-3-small (1536 dims)
+    "dimensions": null   // pin the output size when the model's native size differs
   },
+  // ...or in-process, no API key, any GGUF model over llama.cpp. Needs a
+  // build with `--features embed-llama` (add embed-llama-metal / -cuda to
+  // offload); CPU otherwise. Changing provider or model changes the vector
+  // DIMENSION, which invalidates a populated index — re-embed stored
+  // episodes after switching, or their recall silently degrades to BM25.
+  // "embedding": {
+  //   "provider": "llamacpp",
+  //   "model_path": "/path/to/embeddinggemma-300M-Q8_0.gguf"
+  // },
 
   // Voice
   "voice": {


### PR DESCRIPTION
Shipping `octos-embed-llama` (#1816) left every embedding doc describing only the remote OpenAI path. The in-process provider existed but was findable only from the crate's own README, and `provider = "llamacpp"` appeared **nowhere a user actually configures anything**.

## What changed

**Architecture** (`docs/ARCHITECTURE.md`, `book/`, `book-zh/`) — both implementations now listed:

- **OpenAIEmbedder** — remote, OpenAI-compatible; `dimensions` pins providers whose native size differs (DashScope `text-embedding-v4` at 1024)
- **LlamaEmbedder** — in-process, any GGUF over llama.cpp, cross-platform, CPU by default, `metal`/`cuda` to offload

**Config** (`book/src/configuration.md`, `docs/user-guide.md`, `docs/user-guide-zh.md`) — the `"embedding"` block gains the previously undocumented `model` and `dimensions` fields, plus a commented-out `llamacpp` variant with `model_path`.

## The part worth documenting most

Not the new provider — the **coupling**, which is what actually bit:

The HNSW index is built at **one fixed width**, and `HybridIndex::insert` **drops** any vector that doesn't match, silently degrading that episode to BM25-only. Three consequences, all now written down:

1. The store is opened with `embedder.dimension()`, not a constant. This was the bug fixed in #1816 — a 768-d model against a hardcoded 1536-d index meant **every vector was discarded and the vector lane was dead**.
2. Matryoshka truncation only goes **down**, so a 768-d model can never fill a 1536-d index. No config makes that work.
3. **Changing provider or model invalidates a populated index.** Backends are not interchangeable — measured agreement between the two is 0.96–0.99 cosine, the same order as the gap between genuinely related documents. Stored episodes must be re-embedded, or recall quietly degrades.

That third point is the one most likely to cost someone a confusing afternoon, so it's stated at the config block where the switch is made, not only in the architecture prose.

## Verification

- No stale `mlx` / `embed-mlx` / `MlxEmbedder` references remain in any doc
- The three feature names (`embed-llama`, `embed-llama-metal`, `embed-llama-cuda`) exist verbatim in `octos-cli`'s manifest
- The referenced GGUF filename is the real artifact name, not invented
- `mdbook build` succeeds. Its one `unclosed HTML tag <f32>` warning is **pre-existing on main** — confirmed by stashing and rebuilding

Chinese docs updated alongside the English ones (`book-zh`, `user-guide-zh`), not left to drift.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)