### PR TITLE
feat(fleet): FleetKernelStore — the durable kernel store (PR 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4741,6 +4741,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "octos-fleet"
+version = "2.0.2"
+dependencies = [
+ "eyre",
+ "octos-core",
+ "redb",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "octos-llm"
 version = "2.0.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "crates/octos-plugin",
     "crates/octos-sandbox",
     "crates/octos-swarm",
+    "crates/octos-fleet",
     "crates/octos-embed-llama",
     "crates/octos-ffi",
     "crates/octos-uniffi",
@@ -65,6 +66,7 @@ octos-services = { path = "crates/octos-services" }
 octos-pipeline = { path = "crates/octos-pipeline" }
 octos-plugin = { path = "crates/octos-plugin" }
 octos-swarm = { path = "crates/octos-swarm" }
+octos-fleet = { path = "crates/octos-fleet" }
 octos-embed-llama = { path = "crates/octos-embed-llama" }
 
 # codex-rs crates (reused)

--- a/crates/octos-fleet/Cargo.toml
+++ b/crates/octos-fleet/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "octos-fleet"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Fleet kernel store: durable transactional records + one-write-txn CAS ops + recovery reconciliation"
+
+[dependencies]
+octos-core = { workspace = true }
+eyre = { workspace = true }
+redb = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/octos-fleet/src/lib.rs
+++ b/crates/octos-fleet/src/lib.rs
@@ -1,0 +1,44 @@
+//! # octos-fleet — the fleet kernel store
+//!
+//! The durable, transactional core of the fleet kernel (spec
+//! `docs/FLEET-KERNEL-V1-SPEC.md`, PR 1): one redb database plus the
+//! attempt / lease / generation state machine, the durable plan, a
+//! budget settled **inside** each transition's write-transaction, a
+//! real claim/ack outbox, and boot recovery reconciliation.
+//!
+//! This crate is deliberately **self-contained**: its only dependencies
+//! are `redb`, `serde`/`serde_json`, `tokio`, `uuid`, `eyre`, and
+//! `octos-core` (for [`octos_core::SessionKey`]). It has **zero** LLM /
+//! `octos-agent` dependency and is **not** wired into any live path —
+//! the closed task-worker, the outbox consumer, and the keeper land in
+//! later PRs. Everything here is unit-testable against a tempdir redb.
+//!
+//! ## Invariants
+//!
+//! - **One transactional store.** Every state transition
+//!   ([`FleetKernelStore::launch_child`], [`FleetKernelStore::complete_child`],
+//!   …) is a single `begin_write` that reads, checks a CAS predicate,
+//!   and writes the next state + budget settlement + outbox append
+//!   together — no cross-store window.
+//! - **Reads gate too.** All access is serialised through an `io_gate`
+//!   whose owned guard moves into `spawn_blocking`, so a cancelled
+//!   caller's non-abortable blocking write can never land unordered
+//!   against a later read (spec §1 v1.1).
+//! - **Schema-versioned.** Every persisted row carries
+//!   [`SCHEMA_VERSION`]; a higher-version row loads as `Ok(None)`.
+
+#![deny(unsafe_code)]
+
+mod records;
+mod store;
+
+pub use records::{
+    AcceptanceCriterion, AcceptanceVerdict, Attempt, AttemptStatus, ChildResultSnapshot,
+    ChildStatus, DecisionEntry, DecisionKind, DurablePlan, EvidenceRef, FleetBudget,
+    FleetChildRecord, FleetEventKind, FleetRecord, FleetStatus, Lease, OutboxEvent, PlanTask,
+    SCHEMA_VERSION, TaskState, Verifier, WorkerKind,
+};
+pub use store::{
+    AckOutcome, CompleteOutcome, FleetKernelStore, InterruptedAttempt, LaunchOutcome,
+    PlanMutateOutcome, ReconcileReport,
+};

--- a/crates/octos-fleet/src/records.rs
+++ b/crates/octos-fleet/src/records.rs
@@ -1,0 +1,429 @@
+//! Durable record types for the fleet kernel store.
+//!
+//! Every persisted record carries `schema_version` (currently
+//! [`SCHEMA_VERSION`]). The store drops any row whose version is higher
+//! than it understands (`Ok(None)` on load), so a newer daemon's rows are
+//! opaque — never mis-parsed — to an older one. Records are plain serde
+//! data: this crate has **zero** LLM / `octos-agent` dependency; the
+//! executor, keeper, and outbox consumer live in later PRs.
+
+use octos_core::SessionKey;
+use serde::{Deserialize, Serialize};
+
+/// Schema version stamped on every persisted record. Bumping this
+/// invalidates prior rows the same way the swarm dispatch ledger does:
+/// a load that sees a *higher* version returns `Ok(None)`.
+pub const SCHEMA_VERSION: u32 = 1;
+
+// ---------------------------------------------------------------------------
+// Status enums
+// ---------------------------------------------------------------------------
+
+/// Lifecycle of a fleet as a whole.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FleetStatus {
+    Active,
+    Draining,
+    Complete,
+    Failed,
+    Cancelled,
+}
+
+/// Lifecycle of a single child (== one plan task in v1).
+///
+/// `Ready` means every dependency child is `Succeeded`. `Launching` and
+/// `Running` are the two non-terminal in-flight states a live [`Attempt`]
+/// backs; recovery reconciliation returns a stranded one to `Ready`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ChildStatus {
+    Planned,
+    Ready,
+    Launching,
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+impl ChildStatus {
+    /// A child in a terminal state cannot launch or transition further
+    /// (other than an explicit cancel, which is itself terminal).
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            ChildStatus::Succeeded | ChildStatus::Failed | ChildStatus::Cancelled
+        )
+    }
+}
+
+/// Lifecycle of one durable execution attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AttemptStatus {
+    Leased,
+    Running,
+    Done,
+    Interrupted,
+}
+
+/// Plan-task state (the durable plan's view; distinct from the child's
+/// runtime [`ChildStatus`]).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TaskState {
+    Pending,
+    Ready,
+    Assigned,
+    Running,
+    Blocked { reason: String },
+    Accepted,
+    Rejected { reason: String },
+    Cancelled,
+}
+
+/// The worker kind backing a child. v1 ships only the stateless,
+/// bounded, non-interactive one-shot; the interactive session-worker is
+/// Phase 2b.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum WorkerKind {
+    #[default]
+    StatelessTask,
+}
+
+// ---------------------------------------------------------------------------
+// Fleet + budget
+// ---------------------------------------------------------------------------
+
+/// Durable, in-transaction budget. `hard=false` in v1 (soft admission
+/// control: it rejects the *next* launch, it does not abort an in-flight
+/// run). Reserved + committed are settled inside the same write-txn as
+/// the launch/complete CAS, so there is no cross-store window.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetBudget {
+    pub token_budget: u64,
+    pub tokens_reserved: u64,
+    pub tokens_committed: u64,
+    pub hard: bool,
+}
+
+impl FleetBudget {
+    /// Would reserving `projected` more tokens keep us within budget?
+    /// Uses `<=` (v1 wants inclusive admission, unlike `CostAccountant`'s
+    /// strict `>`) on **checked** arithmetic: a sum that overflows `u64`
+    /// can never fit a real budget, so it is *not* admitted — saturating
+    /// math would silently admit `MAX + MAX + 1 <= MAX` (P2-5).
+    pub fn admits(&self, projected: u64) -> bool {
+        match self
+            .tokens_reserved
+            .checked_add(self.tokens_committed)
+            .and_then(|s| s.checked_add(projected))
+        {
+            Some(total) => total <= self.token_budget,
+            None => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetRecord {
+    pub schema_version: u32,
+    pub fleet_id: String,
+    /// Server-resolved; how a `FleetEvent` finds the keeper (later PRs).
+    pub controller_session_key: SessionKey,
+    pub profile_id: String,
+    pub budget: FleetBudget,
+    pub status: FleetStatus,
+    /// Membership epoch, bumped on re-plan. Fences acceptance of a
+    /// superseded generation's late events.
+    pub generation: u64,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Child + attempt + lease
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetChildRecord {
+    pub schema_version: u32,
+    pub fleet_id: String,
+    /// `child_id == plan task_id` in v1.
+    pub child_id: String,
+    pub worker_kind: WorkerKind,
+    pub status: ChildStatus,
+    pub current_attempt_id: Option<String>,
+    pub attempts_used: u32,
+    /// Terminal outcome — an [`AcceptanceVerdict`], *not* merely "has a
+    /// result". `None` until the child reaches a terminal state.
+    pub outcome: Option<AcceptanceVerdict>,
+    pub tokens_committed: u64,
+    /// Task-ids that must be `Succeeded` before this child is `Ready`.
+    /// Denormalized from `PlanTask.deps` (child_id == task_id) so the
+    /// store's dep-resolution helper is self-contained.
+    pub deps: Vec<String>,
+    pub generation: u64,
+    pub updated_at_ms: u64,
+}
+
+/// The daemon-boot lease guarding a live attempt. `owner_epoch` is this
+/// boot's id; a foreign epoch (or an expired `expires_at_ms`) is what
+/// recovery reconciliation reclaims.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Lease {
+    pub owner_epoch: u64,
+    pub expires_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Attempt {
+    pub schema_version: u32,
+    /// The owning fleet. Denormalized onto the attempt so `mark_running`
+    /// / `complete` can reach the child row (whose key is
+    /// `{fleet_id}\0{child_id}`) from `(child_id, attempt_id)` alone.
+    /// `#[serde(default)]`: forward-compat hygiene — a field added without
+    /// a schema bump must deserialize on older rows (there is no on-disk
+    /// data for this unmerged crate, so this is purely a discipline).
+    #[serde(default)]
+    pub fleet_id: String,
+    pub child_id: String,
+    /// Fresh UUID per attempt.
+    pub attempt_id: String,
+    /// v1.1 fix: immutable, stamped at launch. The Complete predicate
+    /// needs it — attempt-id alone cannot fence a *same-generation*
+    /// retry.
+    pub generation: u64,
+    pub status: AttemptStatus,
+    pub lease: Lease,
+    /// Tokens reserved on the fleet budget at launch. Complete settles
+    /// `fleet.tokens_reserved -= reserved_tokens` in the same txn.
+    pub reserved_tokens: u64,
+    /// Verbatim replay payload (mirrors `DispatchRecord.final_result`);
+    /// never recomputed.
+    pub result_snapshot: Option<ChildResultSnapshot>,
+    pub started_at_ms: u64,
+    pub ended_at_ms: Option<u64>,
+}
+
+/// Self-contained snapshot of a completed attempt's result. Mirrors the
+/// role of `DispatchRecord.final_result` but carries no `octos-agent`
+/// types (this crate is dependency-isolated); the executor PR maps its
+/// `TaskResult` into this shape.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ChildResultSnapshot {
+    pub output: String,
+    pub success: bool,
+    pub tokens_used: u64,
+    pub files: Vec<String>,
+    pub error: Option<String>,
+}
+
+/// A child's terminal verdict. `Accepted` carries the evidence that
+/// satisfied acceptance; the two rejections carry a reason. This is the
+/// `outcome` on a terminal [`FleetChildRecord`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AcceptanceVerdict {
+    Accepted { evidence: Vec<EvidenceRef> },
+    Rejected { reason: String },
+    Terminated { reason: String },
+}
+
+// ---------------------------------------------------------------------------
+// Durable plan
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DurablePlan {
+    pub schema_version: u32,
+    pub fleet_id: String,
+    /// Bumped on every mutation; `mutate_plan` is a CAS on this value.
+    pub revision: u64,
+    pub objective: String,
+    pub tasks: Vec<PlanTask>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlanTask {
+    pub task_id: String,
+    pub title: String,
+    pub detail: String,
+    /// task_ids that must be `Accepted`/`Succeeded` first.
+    pub deps: Vec<String>,
+    pub state: TaskState,
+    pub acceptance: Vec<AcceptanceCriterion>,
+    pub evidence: Vec<EvidenceRef>,
+}
+
+/// An acceptance criterion: a description plus a checkable [`Verifier`].
+/// "Done" is data + a verifier, never a bare boolean.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcceptanceCriterion {
+    pub id: String,
+    pub description: String,
+    pub verifier: Verifier,
+}
+
+/// How a criterion is checked. `Manual` is retained in the data model
+/// for completeness; §6b of the spec drops it from the v1 *executor*
+/// (no headless mapping) — that is an executor-layer policy (PR 3), not
+/// a store-schema concern.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Verifier {
+    Manual,
+    FileExists { path: String },
+    CommandExit { cmd: String, code: i32 },
+    ValidatorRef { id: String },
+}
+
+/// A captured piece of evidence. `kind` is an open string (evidence is
+/// produced by arbitrary verifiers), unlike the closed, kernel-emitted
+/// [`DecisionKind`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvidenceRef {
+    pub kind: String,
+    pub locator: String,
+    pub sha256: String,
+    pub captured_at_ms: u64,
+}
+
+/// Append-only decision-log entry. `kind` is a closed set of
+/// kernel-emitted decisions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DecisionEntry {
+    pub schema_version: u32,
+    pub seq: u64,
+    pub at_ms: u64,
+    pub actor: String,
+    pub kind: DecisionKind,
+    pub note: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DecisionKind {
+    Plan,
+    Launch,
+    Complete,
+    Reconcile,
+    Replan,
+    Cancel,
+    Note,
+}
+
+// ---------------------------------------------------------------------------
+// Outbox
+// ---------------------------------------------------------------------------
+
+/// A durable outbox event with a *real* claim/ack protocol (not
+/// replay-only dedup). Enriched (§6b) so a consumer can route
+/// `fleet_id → controller_session_key` and reclaim a crashed claim via
+/// `claim_expires_at`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutboxEvent {
+    pub schema_version: u32,
+    pub sequence: u64,
+    pub event_id: String,
+    pub fleet_id: String,
+    pub child_id: Option<String>,
+    pub attempt_id: Option<String>,
+    pub kind: FleetEventKind,
+    #[serde(default)]
+    pub payload: serde_json::Value,
+    pub claimed_by: Option<String>,
+    /// Unique per-claim token minted by `claim_next`. `ack` must present
+    /// the matching `(claimed_by, claim_token)` — this fences a stale
+    /// consumer whose lease already expired and was reclaimed (P1-3).
+    #[serde(default)]
+    pub claim_token: Option<String>,
+    pub claim_expires_at: Option<u64>,
+    pub acked: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FleetEventKind {
+    ChildLaunching,
+    ChildRunning,
+    ChildDone,
+    FleetDrained,
+}
+
+// ---------------------------------------------------------------------------
+// Version probe
+// ---------------------------------------------------------------------------
+
+/// Cheap probe that reads *only* `schema_version` from a row before the
+/// full decode, so a higher-version row is dropped (`Ok(None)`) without
+/// risking a shape-mismatch parse error.
+#[derive(Deserialize)]
+struct VersionProbe {
+    schema_version: u32,
+}
+
+/// Decode a persisted JSON row, dropping it (`Ok(None)`) when its
+/// `schema_version` exceeds [`SCHEMA_VERSION`] — a newer daemon's row is
+/// opaque to this one, never mis-parsed. The version is probed *before*
+/// the full decode so an incompatible shape cannot surface as a parse
+/// error masquerading as corruption.
+pub(crate) fn decode_row<T: serde::de::DeserializeOwned>(json: &str) -> eyre::Result<Option<T>> {
+    let probe: VersionProbe = serde_json::from_str(json)?;
+    if probe.schema_version > SCHEMA_VERSION {
+        return Ok(None);
+    }
+    Ok(Some(serde_json::from_str(json)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budget_admits_is_inclusive_and_saturating() {
+        let budget = FleetBudget {
+            token_budget: 100,
+            tokens_reserved: 40,
+            tokens_committed: 30,
+            hard: false,
+        };
+        // 40 + 30 + 30 == 100 -> inclusive admit.
+        assert!(budget.admits(30));
+        // 40 + 30 + 31 == 101 -> reject.
+        assert!(!budget.admits(31));
+        // Saturating: an absurd projection cannot wrap to admit.
+        assert!(!budget.admits(u64::MAX));
+    }
+
+    #[test]
+    fn budget_admits_rejects_on_overflow_instead_of_saturating() {
+        // P2-5: with saturating math `MAX + MAX + 1` clamps to MAX and
+        // would spuriously admit against a MAX budget. Checked math must
+        // reject the overflow.
+        let budget = FleetBudget {
+            token_budget: u64::MAX,
+            tokens_reserved: u64::MAX,
+            tokens_committed: 0,
+            hard: false,
+        };
+        assert!(!budget.admits(1));
+    }
+
+    #[test]
+    fn records_round_trip_through_json() {
+        let verdict = AcceptanceVerdict::Accepted {
+            evidence: vec![EvidenceRef {
+                kind: "file".into(),
+                locator: "out.txt".into(),
+                sha256: "deadbeef".into(),
+                captured_at_ms: 7,
+            }],
+        };
+        let json = serde_json::to_string(&verdict).unwrap();
+        let back: AcceptanceVerdict = serde_json::from_str(&json).unwrap();
+        assert_eq!(verdict, back);
+    }
+
+    #[test]
+    fn child_status_terminal_classification() {
+        assert!(ChildStatus::Succeeded.is_terminal());
+        assert!(ChildStatus::Failed.is_terminal());
+        assert!(ChildStatus::Cancelled.is_terminal());
+        assert!(!ChildStatus::Ready.is_terminal());
+        assert!(!ChildStatus::Running.is_terminal());
+    }
+}

--- a/crates/octos-fleet/src/store.rs
+++ b/crates/octos-fleet/src/store.rs
@@ -1,0 +1,3028 @@
+//! `FleetKernelStore` — the durable transactional core of the fleet
+//! kernel.
+//!
+//! One redb database (`fleet-kernel.redb`) holds every fleet's records.
+//! **Every** state transition is a single `begin_write` transaction that
+//! reads the current row(s), checks a CAS predicate (status / generation
+//! / lease / revision), and writes the next state together with the
+//! budget settlement and the outbox append — atomically, with no
+//! cross-store window (spec §1, §6).
+//!
+//! ## Cancellation-safety (`io_gate`)
+//!
+//! redb is synchronous, so all work runs inside `spawn_blocking`. A
+//! caller future cancelled mid-`await` (e.g. a dropped keeper turn)
+//! cannot abort the already-scheduled blocking closure — so its write
+//! could land *after* the next caller's read. To order that, **every**
+//! op — reads *and* writes (spec §1 v1.1: reads must gate too) — takes
+//! `io_gate.lock_owned().await` and **moves the owned guard into the
+//! blocking closure**. The gate is acquired exactly once per public call
+//! and released when that call's single `spawn_blocking` returns; no op
+//! calls another gated op while holding it, so the design is
+//! deadlock-free.
+//!
+//! ## Key safety
+//!
+//! Composite keys are `\0`-delimited. Every persisted key component
+//! (`fleet_id` / `child_id` / `attempt_id` / `task_id` / dep) is checked
+//! by [`key_component_is_safe`] at the entry point — non-empty and free
+//! of control/NUL characters — so two different `(fleet, child)` pairs
+//! can never encode to the same key (P1-4). Lookups additionally verify
+//! the decoded record's own ids against the requested ones (defense in
+//! depth).
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use eyre::{Result, WrapErr, bail};
+use octos_core::SessionKey;
+use redb::{Database, ReadableTable, TableDefinition};
+use uuid::Uuid;
+
+use crate::records::*;
+
+const FLEETS: TableDefinition<&str, &str> = TableDefinition::new("fleets");
+const FLEET_CHILDREN: TableDefinition<&str, &str> = TableDefinition::new("fleet_children");
+const ATTEMPTS: TableDefinition<&str, &str> = TableDefinition::new("attempts");
+const PLANS: TableDefinition<&str, &str> = TableDefinition::new("plans");
+const DECISION_LOG: TableDefinition<&str, &str> = TableDefinition::new("decision_log");
+const OUTBOX: TableDefinition<&str, &str> = TableDefinition::new("outbox");
+
+const DB_FILENAME: &str = "fleet-kernel.redb";
+
+// ---------------------------------------------------------------------------
+// Outcome / report types
+// ---------------------------------------------------------------------------
+
+/// Result of a launch CAS. The three rejections are *values*, not
+/// errors: they are ordinary control flow the keeper reasons over.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LaunchOutcome {
+    Launched { attempt_id: String },
+    RejectedNotReady,
+    RejectedDoubleLaunch,
+    RejectedBudgetExceeded,
+}
+
+/// Result of a complete CAS. `Superseded` means the four-part predicate
+/// failed (a stale/late attempt); its result is dropped and no state
+/// changes — deliberately not an error (spec §3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompleteOutcome {
+    Completed,
+    Superseded,
+}
+
+/// Result of a revision-fenced plan operation (`replan`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlanMutateOutcome {
+    Mutated { revision: u64 },
+    RevisionMismatch { actual: u64 },
+}
+
+/// Result of an outbox `ack`. `StaleClaim` means the presented
+/// `(consumer, claim_token)` did not match the row's current claim — the
+/// event was reclaimed by another consumer, so this ack is ignored
+/// (P1-3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AckOutcome {
+    Acked,
+    StaleClaim,
+}
+
+/// What a boot reconciliation reclaimed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReconcileReport {
+    pub interrupted: Vec<InterruptedAttempt>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InterruptedAttempt {
+    pub fleet_id: String,
+    pub child_id: String,
+    pub attempt_id: String,
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+/// Redb-backed fleet kernel store. Cheaply cloneable (`Arc` internals);
+/// the `io_gate` serialises all DB access for cancellation-safety.
+#[derive(Clone)]
+pub struct FleetKernelStore {
+    db: Arc<Database>,
+    path: Arc<PathBuf>,
+    io_gate: Arc<tokio::sync::Mutex<()>>,
+}
+
+impl FleetKernelStore {
+    /// Open (or create) the store under `dir`, creating every table.
+    pub async fn open(dir: impl AsRef<Path>) -> Result<Self> {
+        let dir = dir.as_ref().to_path_buf();
+        tokio::fs::create_dir_all(&dir)
+            .await
+            .wrap_err("create fleet kernel dir")?;
+        let db_path = dir.join(DB_FILENAME);
+        let path_for_spawn = db_path.clone();
+        let db = tokio::task::spawn_blocking(move || -> Result<Database> {
+            let db = Database::create(&path_for_spawn).wrap_err("open fleet-kernel redb")?;
+            let wtx = db.begin_write().wrap_err("begin fleet-kernel init")?;
+            {
+                wtx.open_table(FLEETS)?;
+                wtx.open_table(FLEET_CHILDREN)?;
+                wtx.open_table(ATTEMPTS)?;
+                wtx.open_table(PLANS)?;
+                wtx.open_table(DECISION_LOG)?;
+                wtx.open_table(OUTBOX)?;
+            }
+            wtx.commit().wrap_err("commit fleet-kernel init")?;
+            Ok(db)
+        })
+        .await
+        .wrap_err("join fleet-kernel open")??;
+
+        Ok(Self {
+            db: Arc::new(db),
+            path: Arc::new(db_path),
+            io_gate: Arc::new(tokio::sync::Mutex::new(())),
+        })
+    }
+
+    /// Path to the underlying redb file.
+    pub fn path(&self) -> &Path {
+        self.path.as_ref()
+    }
+
+    // ---- creation helpers -------------------------------------------------
+
+    /// Create a fresh fleet (generation 0, `Active`, soft/hard budget).
+    /// Rejects a duplicate `fleet_id` rather than clobbering live state.
+    pub async fn create_fleet(
+        &self,
+        fleet_id: &str,
+        controller_session_key: SessionKey,
+        profile_id: &str,
+        token_budget: u64,
+        hard: bool,
+        now_ms: u64,
+    ) -> Result<()> {
+        ensure_key_safe(&[fleet_id])?;
+        let db = self.db.clone();
+        let fleet_id = fleet_id.to_string();
+        let profile_id = profile_id.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let _held = held;
+            let wtx = db.begin_write()?;
+            {
+                let mut fleets = wtx.open_table(FLEETS)?;
+                if fleets.get(fleet_id.as_str())?.is_some() {
+                    bail!("fleet {fleet_id} already exists");
+                }
+                let record = FleetRecord {
+                    schema_version: SCHEMA_VERSION,
+                    fleet_id: fleet_id.clone(),
+                    controller_session_key,
+                    profile_id,
+                    budget: FleetBudget {
+                        token_budget,
+                        tokens_reserved: 0,
+                        tokens_committed: 0,
+                        hard,
+                    },
+                    status: FleetStatus::Active,
+                    generation: 0,
+                    created_at_ms: now_ms,
+                    updated_at_ms: now_ms,
+                };
+                fleets.insert(fleet_id.as_str(), serde_json::to_string(&record)?.as_str())?;
+            }
+            wtx.commit()?;
+            Ok(())
+        })
+        .await
+        .wrap_err("join create_fleet")?
+    }
+
+    /// Create the durable plan for a fleet. **Insert-only** (P1-2): it
+    /// refuses to overwrite an existing plan (use [`FleetKernelStore::replan`]
+    /// for edits) — a blind overwrite would silently drop tasks without
+    /// advancing the generation fence.
+    pub async fn create_plan(&self, mut plan: DurablePlan) -> Result<()> {
+        ensure_key_safe(&[plan.fleet_id.as_str()])?;
+        for t in &plan.tasks {
+            ensure_key_safe(&[t.task_id.as_str()])?;
+            for d in &t.deps {
+                ensure_key_safe(&[d.as_str()])?;
+            }
+        }
+        plan.schema_version = SCHEMA_VERSION;
+        let db = self.db.clone();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let _held = held;
+            let wtx = db.begin_write()?;
+            {
+                let mut plans = wtx.open_table(PLANS)?;
+                if plans.get(plan.fleet_id.as_str())?.is_some() {
+                    bail!(
+                        "plan for fleet {} already exists; use replan",
+                        plan.fleet_id
+                    );
+                }
+                plans.insert(
+                    plan.fleet_id.as_str(),
+                    serde_json::to_string(&plan)?.as_str(),
+                )?;
+            }
+            wtx.commit()?;
+            Ok(())
+        })
+        .await
+        .wrap_err("join create_plan")?
+    }
+
+    /// Add a child (== plan task) to a fleet. `deps` are the task-ids
+    /// that must be `Succeeded` first; an empty `deps` makes the child
+    /// `Ready` immediately, otherwise it starts `Planned` and is
+    /// promoted by [`FleetKernelStore::mark_ready`]. Rejects a duplicate
+    /// child.
+    pub async fn add_child(
+        &self,
+        fleet_id: &str,
+        child_id: &str,
+        deps: Vec<String>,
+        now_ms: u64,
+    ) -> Result<()> {
+        ensure_key_safe(&[fleet_id, child_id])?;
+        for d in &deps {
+            ensure_key_safe(&[d.as_str()])?;
+        }
+        let db = self.db.clone();
+        let fleet_id = fleet_id.to_string();
+        let child_id = child_id.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let _held = held;
+            let wtx = db.begin_write()?;
+            {
+                let fleets = wtx.open_table(FLEETS)?;
+                let mut children = wtx.open_table(FLEET_CHILDREN)?;
+
+                let Some(fj) = fleets
+                    .get(fleet_id.as_str())?
+                    .map(|g| g.value().to_string())
+                else {
+                    bail!("cannot add child to unknown fleet {fleet_id}");
+                };
+                let Some(fleet) = decode_row::<FleetRecord>(&fj)? else {
+                    bail!("fleet {fleet_id} is a newer schema");
+                };
+
+                let ckey = child_key(&fleet_id, &child_id);
+                if children.get(ckey.as_str())?.is_some() {
+                    bail!("child {child_id} already exists in fleet {fleet_id}");
+                }
+
+                let status = if deps.is_empty() {
+                    ChildStatus::Ready
+                } else {
+                    ChildStatus::Planned
+                };
+                let record = FleetChildRecord {
+                    schema_version: SCHEMA_VERSION,
+                    fleet_id: fleet_id.clone(),
+                    child_id: child_id.clone(),
+                    worker_kind: WorkerKind::StatelessTask,
+                    status,
+                    current_attempt_id: None,
+                    attempts_used: 0,
+                    outcome: None,
+                    tokens_committed: 0,
+                    deps,
+                    generation: fleet.generation,
+                    updated_at_ms: now_ms,
+                };
+                children.insert(ckey.as_str(), serde_json::to_string(&record)?.as_str())?;
+            }
+            wtx.commit()?;
+            Ok(())
+        })
+        .await
+        .wrap_err("join add_child")?
+    }
+
+    /// Re-evaluate a `Planned` child's readiness: if every dependency
+    /// child is `Succeeded`, promote it to `Ready` and return `true`.
+    /// A no-op (returns `false`) for a child that is not `Planned` or
+    /// whose deps are not all met.
+    pub async fn mark_ready(&self, fleet_id: &str, child_id: &str, now_ms: u64) -> Result<bool> {
+        ensure_key_safe(&[fleet_id, child_id])?;
+        let db = self.db.clone();
+        let fleet_id = fleet_id.to_string();
+        let child_id = child_id.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<bool> {
+            let _held = held;
+            let wtx = db.begin_write()?;
+            let promoted = {
+                let mut children = wtx.open_table(FLEET_CHILDREN)?;
+                let ckey = child_key(&fleet_id, &child_id);
+                let Some(cj) = children.get(ckey.as_str())?.map(|g| g.value().to_string()) else {
+                    bail!("mark_ready: unknown child {child_id} in fleet {fleet_id}");
+                };
+                let Some(mut child) = decode_row::<FleetChildRecord>(&cj)? else {
+                    bail!("child {child_id} is a newer schema");
+                };
+                // Defense in depth (P1-4): the decoded row must own the key.
+                if child.fleet_id != fleet_id || child.child_id != child_id {
+                    bail!("mark_ready: child identity mismatch");
+                }
+                if child.status != ChildStatus::Planned {
+                    false
+                } else {
+                    let deps = child.deps.clone();
+                    let mut all_met = true;
+                    for dep in &deps {
+                        let dkey = child_key(&fleet_id, dep);
+                        // A dep counts only if its own ids match the key it
+                        // was read under AND it Succeeded (don't trust a
+                        // tampered/corrupt dependency row).
+                        let dep_ok =
+                            match children.get(dkey.as_str())?.map(|g| g.value().to_string()) {
+                                Some(dj) => decode_row::<FleetChildRecord>(&dj)?
+                                    .map(|d| {
+                                        d.fleet_id == fleet_id
+                                            && d.child_id.as_str() == dep.as_str()
+                                            && d.status == ChildStatus::Succeeded
+                                    })
+                                    .unwrap_or(false),
+                                None => false,
+                            };
+                        if !dep_ok {
+                            all_met = false;
+                            break;
+                        }
+                    }
+                    if all_met {
+                        child.status = ChildStatus::Ready;
+                        child.updated_at_ms = now_ms;
+                        children.insert(ckey.as_str(), serde_json::to_string(&child)?.as_str())?;
+                        true
+                    } else {
+                        false
+                    }
+                }
+            };
+            if promoted {
+                wtx.commit()?;
+            }
+            Ok(promoted)
+        })
+        .await
+        .wrap_err("join mark_ready")?
+    }
+
+    // ---- CAS state transitions -------------------------------------------
+
+    /// Launch a `Ready` child: one write-txn that checks the predicate
+    /// (`Ready` && no live attempt && budget admits) then writes the
+    /// child `Launching`, a fresh `Leased` [`Attempt`] (generation
+    /// stamped from the fleet), the budget reservation, and a
+    /// `ChildLaunching` outbox event — atomically. On any rejection the
+    /// child is left untouched (a budget reject does **not** leave it
+    /// `Launching`).
+    pub async fn launch_child(
+        &self,
+        fleet_id: &str,
+        child_id: &str,
+        projected_tokens: u64,
+        now_ms: u64,
+        owner_epoch: u64,
+        lease_ttl_ms: u64,
+    ) -> Result<LaunchOutcome> {
+        ensure_key_safe(&[fleet_id, child_id])?;
+        let db = self.db.clone();
+        let fleet_id = fleet_id.to_string();
+        let child_id = child_id.to_string();
+        let attempt_id = Uuid::new_v4().to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<LaunchOutcome> {
+            let _held = held;
+            let wtx = db.begin_write()?;
+            let outcome = {
+                let mut fleets = wtx.open_table(FLEETS)?;
+                let mut children = wtx.open_table(FLEET_CHILDREN)?;
+                let mut attempts = wtx.open_table(ATTEMPTS)?;
+                let mut outbox = wtx.open_table(OUTBOX)?;
+
+                let ckey = child_key(&fleet_id, &child_id);
+                let Some(cj) = children.get(ckey.as_str())?.map(|g| g.value().to_string()) else {
+                    return Ok(LaunchOutcome::RejectedNotReady);
+                };
+                let Some(mut child) = decode_row::<FleetChildRecord>(&cj)? else {
+                    return Ok(LaunchOutcome::RejectedNotReady);
+                };
+                // Defense in depth: the decoded row must own the ids we
+                // addressed it by (P1-4).
+                if child.fleet_id != fleet_id || child.child_id != child_id {
+                    return Ok(LaunchOutcome::RejectedNotReady);
+                }
+
+                // A child already in flight (Launching/Running with a live
+                // attempt) is a double-launch; anything not Ready is
+                // not-ready.
+                if child.status != ChildStatus::Ready {
+                    if matches!(child.status, ChildStatus::Launching | ChildStatus::Running)
+                        && child.current_attempt_id.is_some()
+                    {
+                        return Ok(LaunchOutcome::RejectedDoubleLaunch);
+                    }
+                    return Ok(LaunchOutcome::RejectedNotReady);
+                }
+                if child.current_attempt_id.is_some() {
+                    return Ok(LaunchOutcome::RejectedDoubleLaunch);
+                }
+
+                let Some(fj) = fleets
+                    .get(fleet_id.as_str())?
+                    .map(|g| g.value().to_string())
+                else {
+                    return Ok(LaunchOutcome::RejectedNotReady);
+                };
+                let Some(mut fleet) = decode_row::<FleetRecord>(&fj)? else {
+                    return Ok(LaunchOutcome::RejectedNotReady);
+                };
+                if fleet.fleet_id != fleet_id {
+                    return Ok(LaunchOutcome::RejectedNotReady);
+                }
+
+                // Budget predicate — checked *before* any write, so a
+                // reject cannot leave a `Launching` child with no worker.
+                if !fleet.budget.admits(projected_tokens) {
+                    return Ok(LaunchOutcome::RejectedBudgetExceeded);
+                }
+
+                // ---- all predicates pass: mutate every table in this txn ----
+                // All checked (P2-5): `admits` guaranteed the reserve fits,
+                // but compute defensively; the lease expiry and attempt
+                // counter must not silently saturate either. Computed before
+                // any write so an overflow aborts cleanly.
+                let new_reserved = fleet
+                    .budget
+                    .tokens_reserved
+                    .checked_add(projected_tokens)
+                    .ok_or_else(|| eyre::eyre!("reservation overflow launching {child_id}"))?;
+                let lease_expires = now_ms
+                    .checked_add(lease_ttl_ms)
+                    .ok_or_else(|| eyre::eyre!("lease-expiry overflow launching {child_id}"))?;
+                let attempts_used = child
+                    .attempts_used
+                    .checked_add(1)
+                    .ok_or_else(|| eyre::eyre!("attempts_used overflow for {child_id}"))?;
+
+                child.status = ChildStatus::Launching;
+                child.current_attempt_id = Some(attempt_id.clone());
+                child.attempts_used = attempts_used;
+                child.updated_at_ms = now_ms;
+                children.insert(ckey.as_str(), serde_json::to_string(&child)?.as_str())?;
+
+                let attempt = Attempt {
+                    schema_version: SCHEMA_VERSION,
+                    fleet_id: fleet_id.clone(),
+                    child_id: child_id.clone(),
+                    attempt_id: attempt_id.clone(),
+                    generation: fleet.generation,
+                    status: AttemptStatus::Leased,
+                    lease: Lease {
+                        owner_epoch,
+                        expires_at_ms: lease_expires,
+                    },
+                    reserved_tokens: projected_tokens,
+                    result_snapshot: None,
+                    started_at_ms: now_ms,
+                    ended_at_ms: None,
+                };
+                let akey = attempt_key(&child_id, &attempt_id);
+                attempts.insert(akey.as_str(), serde_json::to_string(&attempt)?.as_str())?;
+
+                fleet.budget.tokens_reserved = new_reserved;
+                fleet.updated_at_ms = now_ms;
+                fleets.insert(fleet_id.as_str(), serde_json::to_string(&fleet)?.as_str())?;
+
+                append_outbox(
+                    &mut outbox,
+                    outbox_event(
+                        FleetEventKind::ChildLaunching,
+                        &fleet_id,
+                        Some(&child_id),
+                        Some(&attempt_id),
+                    ),
+                )?;
+
+                LaunchOutcome::Launched {
+                    attempt_id: attempt_id.clone(),
+                }
+            };
+            if matches!(outcome, LaunchOutcome::Launched { .. }) {
+                wtx.commit()?;
+            }
+            Ok(outcome)
+        })
+        .await
+        .wrap_err("join launch_child")?
+    }
+
+    /// CAS a leased attempt to `Running` (`Leased → Running`) **and** its
+    /// child `Launching → Running`, in one write-txn (P2-6). It validates
+    /// the whole identity + fence — the attempt belongs to `child_id`, the
+    /// child's `current_attempt_id` is this attempt, the child is
+    /// `Launching`, the attempt is `Leased`, and `attempt.generation ==
+    /// fleet.generation` — **before writing either row**, so any mismatch
+    /// (including a pre-replan attempt whose generation is now stale) is
+    /// rejected with zero mutation.
+    pub async fn mark_running(&self, child_id: &str, attempt_id: &str) -> Result<()> {
+        ensure_key_safe(&[child_id, attempt_id])?;
+        let db = self.db.clone();
+        let child_id = child_id.to_string();
+        let attempt_id = attempt_id.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let _held = held;
+            let wtx = db.begin_write()?;
+            {
+                let mut attempts = wtx.open_table(ATTEMPTS)?;
+                let mut children = wtx.open_table(FLEET_CHILDREN)?;
+                let fleets = wtx.open_table(FLEETS)?;
+
+                // Read the attempt (owned).
+                let akey = attempt_key(&child_id, &attempt_id);
+                let Some(aj) = attempts.get(akey.as_str())?.map(|g| g.value().to_string()) else {
+                    bail!("mark_running: unknown attempt {attempt_id} for child {child_id}");
+                };
+                let Some(mut attempt) = decode_row::<Attempt>(&aj)? else {
+                    bail!("mark_running: attempt {attempt_id} is a newer schema");
+                };
+                if attempt.child_id != child_id || attempt.attempt_id != attempt_id {
+                    bail!("mark_running: attempt/child identity mismatch");
+                }
+
+                // Read the child derived from the attempt's fleet (P1-4).
+                let ckey = child_key(&attempt.fleet_id, &child_id);
+                let Some(cj) = children.get(ckey.as_str())?.map(|g| g.value().to_string()) else {
+                    bail!("mark_running: child {child_id} not found for attempt {attempt_id}");
+                };
+                let Some(mut child) = decode_row::<FleetChildRecord>(&cj)? else {
+                    bail!("mark_running: child {child_id} is a newer schema");
+                };
+                if child.fleet_id != attempt.fleet_id || child.child_id != child_id {
+                    bail!("mark_running: child identity mismatch");
+                }
+
+                // Read the fleet for the generation fence.
+                let Some(fj) = fleets
+                    .get(attempt.fleet_id.as_str())?
+                    .map(|g| g.value().to_string())
+                else {
+                    bail!("mark_running: fleet {} not found", attempt.fleet_id);
+                };
+                let Some(fleet) = decode_row::<FleetRecord>(&fj)? else {
+                    bail!("mark_running: fleet {} is a newer schema", attempt.fleet_id);
+                };
+                if fleet.fleet_id != attempt.fleet_id {
+                    bail!("mark_running: fleet identity mismatch");
+                }
+
+                // Validate EVERYTHING before writing either row (P2-6).
+                if child.current_attempt_id.as_deref() != Some(attempt_id.as_str()) {
+                    bail!("mark_running: {attempt_id} is not the child's current attempt");
+                }
+                if child.status != ChildStatus::Launching {
+                    bail!(
+                        "mark_running: child {child_id} is {:?}, not Launching",
+                        child.status
+                    );
+                }
+                if attempt.status != AttemptStatus::Leased {
+                    bail!(
+                        "mark_running: attempt {attempt_id} is {:?}, not Leased",
+                        attempt.status
+                    );
+                }
+                if attempt.generation != fleet.generation {
+                    bail!(
+                        "mark_running: attempt {attempt_id} generation {} != fleet {}",
+                        attempt.generation,
+                        fleet.generation
+                    );
+                }
+
+                // All checks passed — write both rows.
+                attempt.status = AttemptStatus::Running;
+                attempts.insert(akey.as_str(), serde_json::to_string(&attempt)?.as_str())?;
+                child.status = ChildStatus::Running;
+                children.insert(ckey.as_str(), serde_json::to_string(&child)?.as_str())?;
+            }
+            wtx.commit()?;
+            Ok(())
+        })
+        .await
+        .wrap_err("join mark_running")?
+    }
+
+    /// Complete a running attempt. The predicate requires **all four**
+    /// (spec §3 v1.1): the child's `current_attempt_id` is this attempt,
+    /// the attempt is `Running`, its `generation` equals the fleet's,
+    /// and its lease `owner_epoch` matches. On success it writes the
+    /// child terminal (`outcome = verdict`), the attempt `Done` with its
+    /// `result_snapshot`, settles the budget (`committed += actual`,
+    /// `reserved -= reserved_tokens`), and appends `ChildDone`. A
+    /// stale/superseded attempt fails the predicate and returns
+    /// [`CompleteOutcome::Superseded`] — its result is dropped, nothing
+    /// changes.
+    #[allow(clippy::too_many_arguments)] // 4-part predicate + settlement inputs are irreducible here
+    pub async fn complete_child(
+        &self,
+        fleet_id: &str,
+        child_id: &str,
+        attempt_id: &str,
+        verdict: AcceptanceVerdict,
+        snapshot: ChildResultSnapshot,
+        actual_tokens: u64,
+        owner_epoch: u64,
+        now_ms: u64,
+    ) -> Result<CompleteOutcome> {
+        ensure_key_safe(&[fleet_id, child_id, attempt_id])?;
+        let db = self.db.clone();
+        let fleet_id = fleet_id.to_string();
+        let child_id = child_id.to_string();
+        let attempt_id = attempt_id.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<CompleteOutcome> {
+            let _held = held;
+            let wtx = db.begin_write()?;
+            let outcome = {
+                let mut fleets = wtx.open_table(FLEETS)?;
+                let mut children = wtx.open_table(FLEET_CHILDREN)?;
+                let mut attempts = wtx.open_table(ATTEMPTS)?;
+                let mut outbox = wtx.open_table(OUTBOX)?;
+
+                let ckey = child_key(&fleet_id, &child_id);
+                let akey = attempt_key(&child_id, &attempt_id);
+
+                let Some(cj) = children.get(ckey.as_str())?.map(|g| g.value().to_string()) else {
+                    return Ok(CompleteOutcome::Superseded);
+                };
+                let Some(mut child) = decode_row::<FleetChildRecord>(&cj)? else {
+                    return Ok(CompleteOutcome::Superseded);
+                };
+                let Some(aj) = attempts.get(akey.as_str())?.map(|g| g.value().to_string()) else {
+                    return Ok(CompleteOutcome::Superseded);
+                };
+                let Some(mut attempt) = decode_row::<Attempt>(&aj)? else {
+                    return Ok(CompleteOutcome::Superseded);
+                };
+                let Some(fj) = fleets
+                    .get(fleet_id.as_str())?
+                    .map(|g| g.value().to_string())
+                else {
+                    return Ok(CompleteOutcome::Superseded);
+                };
+                let Some(mut fleet) = decode_row::<FleetRecord>(&fj)? else {
+                    return Ok(CompleteOutcome::Superseded);
+                };
+
+                // Identity: every decoded row must own the addressed ids
+                // (P1-4). A mismatch is treated as a superseded/foreign
+                // event, never a cross-fleet mutation.
+                if child.fleet_id != fleet_id
+                    || child.child_id != child_id
+                    || attempt.fleet_id != fleet_id
+                    || attempt.child_id != child_id
+                    || attempt.attempt_id != attempt_id
+                    || fleet.fleet_id != fleet_id
+                {
+                    return Ok(CompleteOutcome::Superseded);
+                }
+
+                // Four-part predicate — attempt-id fences effects,
+                // generation fences acceptance, the lease token proves
+                // the completer holds the current grant.
+                let is_current = child.current_attempt_id.as_deref() == Some(attempt_id.as_str());
+                let is_running = attempt.status == AttemptStatus::Running;
+                let gen_ok = attempt.generation == fleet.generation;
+                let lease_ok = attempt.lease.owner_epoch == owner_epoch;
+                if !(is_current && is_running && gen_ok && lease_ok) {
+                    return Ok(CompleteOutcome::Superseded);
+                }
+
+                // ---- passes: settle terminal state + budget + outbox ----
+                let reserved = attempt.reserved_tokens;
+                // Settle with checked math: an underflow means a
+                // reservation was double-released — an invariant break, so
+                // fail loudly rather than mask it (P2-5).
+                let new_committed = fleet
+                    .budget
+                    .tokens_committed
+                    .checked_add(actual_tokens)
+                    .ok_or_else(|| eyre::eyre!("committed-token overflow completing {child_id}"))?;
+                let new_reserved = fleet
+                    .budget
+                    .tokens_reserved
+                    .checked_sub(reserved)
+                    .ok_or_else(|| {
+                        eyre::eyre!(
+                            "reservation underflow completing {child_id}: reserved {reserved} > \
+                             fleet.tokens_reserved {}",
+                            fleet.budget.tokens_reserved
+                        )
+                    })?;
+
+                let accepted = matches!(verdict, AcceptanceVerdict::Accepted { .. });
+                child.status = if accepted {
+                    ChildStatus::Succeeded
+                } else {
+                    ChildStatus::Failed
+                };
+                child.outcome = Some(verdict);
+                child.tokens_committed = child
+                    .tokens_committed
+                    .checked_add(actual_tokens)
+                    .ok_or_else(|| eyre::eyre!("child committed-token overflow for {child_id}"))?;
+                child.updated_at_ms = now_ms;
+                children.insert(ckey.as_str(), serde_json::to_string(&child)?.as_str())?;
+
+                attempt.status = AttemptStatus::Done;
+                attempt.result_snapshot = Some(snapshot);
+                attempt.ended_at_ms = Some(now_ms);
+                attempts.insert(akey.as_str(), serde_json::to_string(&attempt)?.as_str())?;
+
+                fleet.budget.tokens_committed = new_committed;
+                fleet.budget.tokens_reserved = new_reserved;
+                fleet.updated_at_ms = now_ms;
+                fleets.insert(fleet_id.as_str(), serde_json::to_string(&fleet)?.as_str())?;
+
+                append_outbox(
+                    &mut outbox,
+                    outbox_event(
+                        FleetEventKind::ChildDone,
+                        &fleet_id,
+                        Some(&child_id),
+                        Some(&attempt_id),
+                    ),
+                )?;
+
+                CompleteOutcome::Completed
+            };
+            if matches!(outcome, CompleteOutcome::Completed) {
+                wtx.commit()?;
+            }
+            Ok(outcome)
+        })
+        .await
+        .wrap_err("join complete_child")?
+    }
+
+    /// Re-plan a fleet (P1-2): revision-fenced full replacement of the
+    /// durable plan with clean **interrupt-and-restart** semantics, all in
+    /// one write-txn. It CAS-checks `expected_revision`, increments
+    /// `fleet.generation`, and then, for every existing child:
+    ///
+    /// 1. **interrupts any live attempt** (`Leased`/`Running` → `Interrupted`)
+    ///    and releases its reservation, clearing `current_attempt_id` — so
+    ///    no attempt is left current-and-reserved yet superseded;
+    /// 2. **surviving** task → re-stamps the child to the new generation and
+    ///    recomputes its state from the NEW deps (`Ready` iff all deps are
+    ///    `Succeeded`, else `Planned`); an already-`Succeeded` survivor is
+    ///    preserved (completed work is not re-run);
+    /// 3. **removed** task → child `Cancelled`;
+    /// 4. **new / re-added** task id → a fresh `Ready`/`Planned` child (a
+    ///    re-added previously-`Cancelled` task is resurrected).
+    ///
+    /// Undecodable (higher-schema) child rows are skipped, never
+    /// blind-written over. Any attempt stamped with the old generation now
+    /// fails both [`FleetKernelStore::complete_child`] and
+    /// [`FleetKernelStore::mark_running`]'s generation checks.
+    pub async fn replan(
+        &self,
+        fleet_id: &str,
+        expected_revision: u64,
+        new_plan: DurablePlan,
+        now_ms: u64,
+    ) -> Result<PlanMutateOutcome> {
+        ensure_key_safe(&[fleet_id])?;
+        for t in &new_plan.tasks {
+            ensure_key_safe(&[t.task_id.as_str()])?;
+            for d in &t.deps {
+                ensure_key_safe(&[d.as_str()])?;
+            }
+        }
+        let db = self.db.clone();
+        let fleet_id = fleet_id.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<PlanMutateOutcome> {
+            let _held = held;
+            let mut new_plan = new_plan;
+            let wtx = db.begin_write()?;
+            let outcome = {
+                let mut fleets = wtx.open_table(FLEETS)?;
+                let mut children = wtx.open_table(FLEET_CHILDREN)?;
+                let mut attempts = wtx.open_table(ATTEMPTS)?;
+                let mut plans = wtx.open_table(PLANS)?;
+
+                // --- plan + fleet, revision-fenced, identity-checked -----
+                let Some(pj) = plans.get(fleet_id.as_str())?.map(|g| g.value().to_string()) else {
+                    bail!("replan: no plan for fleet {fleet_id}");
+                };
+                let Some(plan) = decode_row::<DurablePlan>(&pj)? else {
+                    bail!("replan: plan for {fleet_id} is a newer schema; refusing to overwrite");
+                };
+                if plan.fleet_id != fleet_id {
+                    bail!("replan: plan identity mismatch for {fleet_id}");
+                }
+                if plan.revision != expected_revision {
+                    return Ok(PlanMutateOutcome::RevisionMismatch {
+                        actual: plan.revision,
+                    });
+                }
+
+                let Some(fj) = fleets
+                    .get(fleet_id.as_str())?
+                    .map(|g| g.value().to_string())
+                else {
+                    bail!("replan: no fleet {fleet_id}");
+                };
+                let Some(mut fleet) = decode_row::<FleetRecord>(&fj)? else {
+                    bail!("replan: fleet {fleet_id} is a newer schema");
+                };
+                if fleet.fleet_id != fleet_id {
+                    bail!("replan: fleet identity mismatch for {fleet_id}");
+                }
+                let new_gen = fleet
+                    .generation
+                    .checked_add(1)
+                    .ok_or_else(|| eyre::eyre!("generation overflow re-planning {fleet_id}"))?;
+                let new_rev = expected_revision
+                    .checked_add(1)
+                    .ok_or_else(|| eyre::eyre!("revision overflow re-planning {fleet_id}"))?;
+
+                let new_ids: HashSet<String> =
+                    new_plan.tasks.iter().map(|t| t.task_id.clone()).collect();
+
+                // --- snapshot this fleet's children, keyed by the *stored*
+                // key so we never blind-write over an undecodable
+                // (higher-schema / identity-mismatched) row we cannot
+                // understand. --------------------------------------------
+                let fleet_prefix = format!("{fleet_id}\0");
+                let mut existing: Vec<FleetChildRecord> = Vec::new();
+                let mut undecodable_ids: HashSet<String> = HashSet::new();
+                for item in children.iter()? {
+                    let (k, v) = item?;
+                    let Some(cid) = k.value().strip_prefix(fleet_prefix.as_str()) else {
+                        continue; // belongs to another fleet
+                    };
+                    match decode_row::<FleetChildRecord>(v.value())? {
+                        Some(rec) if rec.fleet_id == fleet_id && rec.child_id == cid => {
+                            existing.push(rec)
+                        }
+                        // Higher-schema or identity-mismatched: opaque —
+                        // record the id so the new-task loop never recreates
+                        // (overwrites) it.
+                        _ => {
+                            undecodable_ids.insert(cid.to_string());
+                        }
+                    }
+                }
+                let existing_ids: HashSet<String> =
+                    existing.iter().map(|c| c.child_id.clone()).collect();
+                // Post-replan Succeeded set = children that Succeeded AND
+                // survive (removed ones become Cancelled). Drives consistent,
+                // order-independent readiness recomputation.
+                let succeeded_ids: HashSet<String> = existing
+                    .iter()
+                    .filter(|c| c.status == ChildStatus::Succeeded && new_ids.contains(&c.child_id))
+                    .map(|c| c.child_id.clone())
+                    .collect();
+
+                // --- interrupt-and-restart every existing child ----------
+                for mut child in existing {
+                    let ckey = child_key(&fleet_id, &child.child_id);
+
+                    // 1. Interrupt any LIVE attempt (survivor OR removed)
+                    //    and release its reservation — so no attempt is left
+                    //    current+reserved yet superseded (P1-2).
+                    let mut interrupted = false;
+                    if let Some(aid) = child.current_attempt_id.clone() {
+                        let akey = attempt_key(&child.child_id, &aid);
+                        let atj = attempts.get(akey.as_str())?.map(|g| g.value().to_string());
+                        if let Some(atj) = atj {
+                            if let Some(mut att) = decode_row::<Attempt>(&atj)? {
+                                // Own-id check (P1-4): only interrupt an
+                                // attempt whose stored ids match the key.
+                                if att.fleet_id == fleet_id
+                                    && att.child_id == child.child_id
+                                    && att.attempt_id == aid
+                                    && matches!(
+                                        att.status,
+                                        AttemptStatus::Leased | AttemptStatus::Running
+                                    )
+                                {
+                                    let reserved = att.reserved_tokens;
+                                    att.status = AttemptStatus::Interrupted;
+                                    att.ended_at_ms = Some(now_ms);
+                                    attempts.insert(
+                                        akey.as_str(),
+                                        serde_json::to_string(&att)?.as_str(),
+                                    )?;
+                                    fleet.budget.tokens_reserved = fleet
+                                        .budget
+                                        .tokens_reserved
+                                        .checked_sub(reserved)
+                                        .ok_or_else(|| {
+                                            eyre::eyre!(
+                                                "reservation underflow interrupting {}",
+                                                child.child_id
+                                            )
+                                        })?;
+                                    interrupted = true;
+                                }
+                            }
+                        }
+                    }
+                    if interrupted {
+                        child.current_attempt_id = None;
+                    }
+
+                    // 2. Bucket: survivor vs removed.
+                    child.generation = new_gen;
+                    child.updated_at_ms = now_ms;
+                    if new_ids.contains(&child.child_id) {
+                        child.deps = new_plan
+                            .tasks
+                            .iter()
+                            .find(|t| t.task_id == child.child_id)
+                            .map(|t| t.deps.clone())
+                            .unwrap_or_default();
+                        if child.status == ChildStatus::Succeeded {
+                            // Preserve completed work — keep outcome and the
+                            // pointer to its Done attempt.
+                        } else {
+                            // Recompute a fresh runnable state from the NEW
+                            // deps: fixes a survivor kept Ready with newly
+                            // unmet deps, resurrects a re-added Cancelled
+                            // child, and retries a Failed one. The stale
+                            // pointer MUST be cleared for EVERY non-Succeeded
+                            // survivor (not only live-interrupted ones) — a
+                            // Failed child's Done attempt-id would otherwise
+                            // survive and make launch_child reject the retry
+                            // as a double-launch (P1).
+                            child.current_attempt_id = None;
+                            child.outcome = None;
+                            child.status = if child.deps.iter().all(|d| succeeded_ids.contains(d)) {
+                                ChildStatus::Ready
+                            } else {
+                                ChildStatus::Planned
+                            };
+                        }
+                    } else {
+                        child.status = ChildStatus::Cancelled;
+                        child.outcome = Some(AcceptanceVerdict::Terminated {
+                            reason: "removed by replan".into(),
+                        });
+                        child.current_attempt_id = None;
+                    }
+                    children.insert(ckey.as_str(), serde_json::to_string(&child)?.as_str())?;
+                }
+
+                // --- add children for brand-new task ids (never over an
+                //     existing or undecodable row) --------------------------
+                for task in &new_plan.tasks {
+                    if existing_ids.contains(&task.task_id)
+                        || undecodable_ids.contains(&task.task_id)
+                    {
+                        continue;
+                    }
+                    let status = if task.deps.iter().all(|d| succeeded_ids.contains(d)) {
+                        ChildStatus::Ready
+                    } else {
+                        ChildStatus::Planned
+                    };
+                    let rec = FleetChildRecord {
+                        schema_version: SCHEMA_VERSION,
+                        fleet_id: fleet_id.clone(),
+                        child_id: task.task_id.clone(),
+                        worker_kind: WorkerKind::StatelessTask,
+                        status,
+                        current_attempt_id: None,
+                        attempts_used: 0,
+                        outcome: None,
+                        tokens_committed: 0,
+                        deps: task.deps.clone(),
+                        generation: new_gen,
+                        updated_at_ms: now_ms,
+                    };
+                    let ckey = child_key(&fleet_id, &task.task_id);
+                    children.insert(ckey.as_str(), serde_json::to_string(&rec)?.as_str())?;
+                }
+
+                new_plan.schema_version = SCHEMA_VERSION;
+                new_plan.fleet_id = fleet_id.clone();
+                new_plan.revision = new_rev;
+                plans.insert(
+                    fleet_id.as_str(),
+                    serde_json::to_string(&new_plan)?.as_str(),
+                )?;
+
+                fleet.generation = new_gen;
+                fleet.updated_at_ms = now_ms;
+                fleets.insert(fleet_id.as_str(), serde_json::to_string(&fleet)?.as_str())?;
+
+                PlanMutateOutcome::Mutated { revision: new_rev }
+            };
+            if matches!(outcome, PlanMutateOutcome::Mutated { .. }) {
+                wtx.commit()?;
+            }
+            Ok(outcome)
+        })
+        .await
+        .wrap_err("join replan")?
+    }
+
+    /// Boot recovery: scan children, and for each `Launching`/`Running`
+    /// child whose live attempt's lease is stale (foreign `owner_epoch`
+    /// **or** expired at `now_ms`), atomically mark the attempt
+    /// `Interrupted`, **release its reservation** from the fleet budget
+    /// (P1-1), clear `current_attempt_id`, and return the child to
+    /// `Ready`. Children of a `Cancelled` fleet are left terminal, never
+    /// resurrected (P2-7). The old attempt is never resurrected; all
+    /// reclamations commit together.
+    pub async fn reconcile(&self, now_ms: u64, owner_epoch: u64) -> Result<ReconcileReport> {
+        let db = self.db.clone();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<ReconcileReport> {
+            let _held = held;
+            let wtx = db.begin_write()?;
+            let mut report = ReconcileReport::default();
+            {
+                let mut fleets = wtx.open_table(FLEETS)?;
+                let mut children = wtx.open_table(FLEET_CHILDREN)?;
+                let mut attempts = wtx.open_table(ATTEMPTS)?;
+
+                // Collect owned candidate rows first so the iterator's
+                // borrow is released before we mutate the same table.
+                let candidates: Vec<FleetChildRecord> = {
+                    let mut out = Vec::new();
+                    for item in children.iter()? {
+                        let (k, v) = item?;
+                        if let Some(rec) = decode_row::<FleetChildRecord>(v.value())? {
+                            // Defense in depth (P1-4): the decoded record
+                            // must own the key it is stored under.
+                            if child_key(&rec.fleet_id, &rec.child_id) == k.value() {
+                                out.push(rec);
+                            }
+                        }
+                    }
+                    out
+                };
+
+                for mut child in candidates {
+                    if !matches!(child.status, ChildStatus::Launching | ChildStatus::Running) {
+                        continue;
+                    }
+                    let Some(aid) = child.current_attempt_id.clone() else {
+                        continue;
+                    };
+
+                    // Load the owning fleet: needed to skip Cancelled
+                    // fleets (P2-7) and to release the reservation (P1-1).
+                    let Some(fj) = fleets
+                        .get(child.fleet_id.as_str())?
+                        .map(|g| g.value().to_string())
+                    else {
+                        continue;
+                    };
+                    let Some(mut fleet) = decode_row::<FleetRecord>(&fj)? else {
+                        continue;
+                    };
+                    // Own-id check (P1-4): the decoded fleet must be the one
+                    // we addressed before we mutate its budget.
+                    if fleet.fleet_id != child.fleet_id {
+                        continue;
+                    }
+                    if fleet.status == FleetStatus::Cancelled {
+                        continue;
+                    }
+
+                    let akey = attempt_key(&child.child_id, &aid);
+                    let Some(aj) = attempts.get(akey.as_str())?.map(|g| g.value().to_string())
+                    else {
+                        continue;
+                    };
+                    let Some(mut attempt) = decode_row::<Attempt>(&aj)? else {
+                        continue;
+                    };
+                    // Defense in depth (P1-4): the attempt must own the ids
+                    // it was addressed by.
+                    if attempt.child_id != child.child_id
+                        || attempt.attempt_id != aid
+                        || attempt.fleet_id != child.fleet_id
+                    {
+                        continue;
+                    }
+                    if !matches!(
+                        attempt.status,
+                        AttemptStatus::Leased | AttemptStatus::Running
+                    ) {
+                        continue;
+                    }
+                    let stale = attempt.lease.owner_epoch != owner_epoch
+                        || attempt.lease.expires_at_ms < now_ms;
+                    if !stale {
+                        continue;
+                    }
+
+                    let reserved = attempt.reserved_tokens;
+                    attempt.status = AttemptStatus::Interrupted;
+                    attempt.ended_at_ms = Some(now_ms);
+                    attempts.insert(akey.as_str(), serde_json::to_string(&attempt)?.as_str())?;
+
+                    // Release the stranded reservation (P1-1). An
+                    // underflow is an accounting invariant break.
+                    fleet.budget.tokens_reserved = fleet
+                        .budget
+                        .tokens_reserved
+                        .checked_sub(reserved)
+                        .ok_or_else(|| {
+                            eyre::eyre!(
+                                "reconcile reservation underflow for {}: reserved {reserved} > {}",
+                                child.child_id,
+                                fleet.budget.tokens_reserved
+                            )
+                        })?;
+                    fleet.updated_at_ms = now_ms;
+                    fleets.insert(
+                        child.fleet_id.as_str(),
+                        serde_json::to_string(&fleet)?.as_str(),
+                    )?;
+
+                    let ckey = child_key(&child.fleet_id, &child.child_id);
+                    child.status = ChildStatus::Ready;
+                    child.current_attempt_id = None;
+                    child.updated_at_ms = now_ms;
+                    children.insert(ckey.as_str(), serde_json::to_string(&child)?.as_str())?;
+
+                    report.interrupted.push(InterruptedAttempt {
+                        fleet_id: child.fleet_id.clone(),
+                        child_id: child.child_id.clone(),
+                        attempt_id: aid,
+                    });
+                }
+            }
+            wtx.commit()?;
+            Ok(report)
+        })
+        .await
+        .wrap_err("join reconcile")?
+    }
+
+    // ---- gated reads ------------------------------------------------------
+
+    /// Fetch a fleet (dropping a higher-schema row as `Ok(None)`).
+    pub async fn get_fleet(&self, fleet_id: &str) -> Result<Option<FleetRecord>> {
+        ensure_key_safe(&[fleet_id])?;
+        let db = self.db.clone();
+        let key = fleet_id.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<Option<FleetRecord>> {
+            let _held = held;
+            let rtx = db.begin_read()?;
+            let table = rtx.open_table(FLEETS)?;
+            let Some(v) = table.get(key.as_str())? else {
+                return Ok(None);
+            };
+            Ok(decode_row::<FleetRecord>(v.value())?.filter(|r| r.fleet_id == key))
+        })
+        .await
+        .wrap_err("join get_fleet")?
+    }
+
+    /// Fetch a child.
+    pub async fn get_child(
+        &self,
+        fleet_id: &str,
+        child_id: &str,
+    ) -> Result<Option<FleetChildRecord>> {
+        ensure_key_safe(&[fleet_id, child_id])?;
+        let db = self.db.clone();
+        let fleet_id = fleet_id.to_string();
+        let child_id = child_id.to_string();
+        let key = child_key(&fleet_id, &child_id);
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<Option<FleetChildRecord>> {
+            let _held = held;
+            let rtx = db.begin_read()?;
+            let table = rtx.open_table(FLEET_CHILDREN)?;
+            let Some(v) = table.get(key.as_str())? else {
+                return Ok(None);
+            };
+            Ok(decode_row::<FleetChildRecord>(v.value())?
+                .filter(|r| r.fleet_id == fleet_id && r.child_id == child_id))
+        })
+        .await
+        .wrap_err("join get_child")?
+    }
+
+    /// List a fleet's children, sorted by `child_id`.
+    pub async fn list_children(&self, fleet_id: &str) -> Result<Vec<FleetChildRecord>> {
+        ensure_key_safe(&[fleet_id])?;
+        let db = self.db.clone();
+        let fleet_id = fleet_id.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<Vec<FleetChildRecord>> {
+            let _held = held;
+            let rtx = db.begin_read()?;
+            let table = rtx.open_table(FLEET_CHILDREN)?;
+            let mut out = Vec::new();
+            for item in table.iter()? {
+                let (_, v) = item?;
+                if let Some(rec) = decode_row::<FleetChildRecord>(v.value())? {
+                    if rec.fleet_id == fleet_id {
+                        out.push(rec);
+                    }
+                }
+            }
+            out.sort_by(|a, b| a.child_id.cmp(&b.child_id));
+            Ok(out)
+        })
+        .await
+        .wrap_err("join list_children")?
+    }
+
+    /// Fetch the durable plan.
+    pub async fn get_plan(&self, fleet_id: &str) -> Result<Option<DurablePlan>> {
+        ensure_key_safe(&[fleet_id])?;
+        let db = self.db.clone();
+        let key = fleet_id.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<Option<DurablePlan>> {
+            let _held = held;
+            let rtx = db.begin_read()?;
+            let table = rtx.open_table(PLANS)?;
+            let Some(v) = table.get(key.as_str())? else {
+                return Ok(None);
+            };
+            Ok(decode_row::<DurablePlan>(v.value())?.filter(|p| p.fleet_id == key))
+        })
+        .await
+        .wrap_err("join get_plan")?
+    }
+
+    /// Fetch a specific attempt.
+    pub async fn get_attempt(&self, child_id: &str, attempt_id: &str) -> Result<Option<Attempt>> {
+        ensure_key_safe(&[child_id, attempt_id])?;
+        let db = self.db.clone();
+        let child_id = child_id.to_string();
+        let attempt_id = attempt_id.to_string();
+        let key = attempt_key(&child_id, &attempt_id);
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<Option<Attempt>> {
+            let _held = held;
+            let rtx = db.begin_read()?;
+            let table = rtx.open_table(ATTEMPTS)?;
+            let Some(v) = table.get(key.as_str())? else {
+                return Ok(None);
+            };
+            Ok(decode_row::<Attempt>(v.value())?
+                .filter(|a| a.child_id == child_id && a.attempt_id == attempt_id))
+        })
+        .await
+        .wrap_err("join get_attempt")?
+    }
+
+    // ---- outbox -----------------------------------------------------------
+
+    /// Append an outbox event, assigning the next monotonic sequence.
+    /// Returns the assigned sequence.
+    pub async fn append_event(&self, event: OutboxEvent) -> Result<u64> {
+        ensure_key_safe(&[event.fleet_id.as_str(), event.event_id.as_str()])?;
+        if let Some(c) = &event.child_id {
+            ensure_key_safe(&[c.as_str()])?;
+        }
+        if let Some(a) = &event.attempt_id {
+            ensure_key_safe(&[a.as_str()])?;
+        }
+        let db = self.db.clone();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<u64> {
+            let _held = held;
+            let wtx = db.begin_write()?;
+            let seq = {
+                let mut outbox = wtx.open_table(OUTBOX)?;
+                append_outbox(&mut outbox, event)?
+            };
+            wtx.commit()?;
+            Ok(seq)
+        })
+        .await
+        .wrap_err("join append_event")?
+    }
+
+    /// Claim the lowest-sequence unacked event whose claim is free or
+    /// expired, stamping `claimed_by` + a fresh unique `claim_token` +
+    /// `claim_expires_at`. Returns the claimed event (carrying its
+    /// `claim_token`, which the consumer must present to
+    /// [`FleetKernelStore::ack`]). `None` when nothing is claimable.
+    pub async fn claim_next(
+        &self,
+        consumer: &str,
+        now_ms: u64,
+        ttl_ms: u64,
+    ) -> Result<Option<OutboxEvent>> {
+        let db = self.db.clone();
+        let consumer = consumer.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<Option<OutboxEvent>> {
+            let _held = held;
+            let wtx = db.begin_write()?;
+            let claimed = {
+                let mut outbox = wtx.open_table(OUTBOX)?;
+                let mut found: Option<(String, OutboxEvent)> = None;
+                for item in outbox.iter()? {
+                    let (k, v) = item?;
+                    let Some(ev) = decode_row::<OutboxEvent>(v.value())? else {
+                        continue;
+                    };
+                    let claim_free = ev.claimed_by.is_none()
+                        || ev.claim_expires_at.map(|e| e < now_ms).unwrap_or(true);
+                    if !ev.acked && claim_free {
+                        found = Some((k.value().to_string(), ev));
+                        break;
+                    }
+                }
+                match found {
+                    Some((key, mut ev)) => {
+                        let expires = now_ms
+                            .checked_add(ttl_ms)
+                            .ok_or_else(|| eyre::eyre!("claim-expiry overflow"))?;
+                        ev.claimed_by = Some(consumer);
+                        ev.claim_token = Some(Uuid::new_v4().to_string());
+                        ev.claim_expires_at = Some(expires);
+                        outbox.insert(key.as_str(), serde_json::to_string(&ev)?.as_str())?;
+                        Some(ev)
+                    }
+                    None => None,
+                }
+            };
+            if claimed.is_some() {
+                wtx.commit()?;
+            }
+            Ok(claimed)
+        })
+        .await
+        .wrap_err("join claim_next")?
+    }
+
+    /// Acknowledge (consume) an outbox event, **claim-fenced** (P1-3):
+    /// the presented `(consumer, claim_token)` must match the row's
+    /// current claim, else it returns [`AckOutcome::StaleClaim`] and
+    /// changes nothing — so a stale consumer whose lease already expired
+    /// and was reclaimed cannot ack an event out from under the new
+    /// owner. Errors if the sequence does not exist.
+    pub async fn ack(
+        &self,
+        sequence: u64,
+        consumer: &str,
+        claim_token: &str,
+    ) -> Result<AckOutcome> {
+        let db = self.db.clone();
+        let consumer = consumer.to_string();
+        let claim_token = claim_token.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<AckOutcome> {
+            let _held = held;
+            let wtx = db.begin_write()?;
+            let outcome = {
+                let mut outbox = wtx.open_table(OUTBOX)?;
+                let key = outbox_key(sequence);
+                let Some(vj) = outbox.get(key.as_str())?.map(|g| g.value().to_string()) else {
+                    bail!("ack: outbox sequence {sequence} not found");
+                };
+                let Some(mut ev) = decode_row::<OutboxEvent>(&vj)? else {
+                    bail!("outbox event {sequence} is a newer schema");
+                };
+                let claim_matches = ev.claimed_by.as_deref() == Some(consumer.as_str())
+                    && ev.claim_token.as_deref() == Some(claim_token.as_str());
+                if claim_matches {
+                    ev.acked = true;
+                    outbox.insert(key.as_str(), serde_json::to_string(&ev)?.as_str())?;
+                    AckOutcome::Acked
+                } else {
+                    AckOutcome::StaleClaim
+                }
+            };
+            if matches!(outcome, AckOutcome::Acked) {
+                wtx.commit()?;
+            }
+            Ok(outcome)
+        })
+        .await
+        .wrap_err("join ack")?
+    }
+
+    // ---- decision log -----------------------------------------------------
+
+    /// Append an entry to a fleet's append-only decision log, assigning
+    /// the next per-fleet sequence. Returns the assigned sequence.
+    pub async fn append_decision(
+        &self,
+        fleet_id: &str,
+        actor: &str,
+        kind: DecisionKind,
+        note: &str,
+        now_ms: u64,
+    ) -> Result<u64> {
+        ensure_key_safe(&[fleet_id])?;
+        let db = self.db.clone();
+        let fleet_id = fleet_id.to_string();
+        let actor = actor.to_string();
+        let note = note.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<u64> {
+            let _held = held;
+            let wtx = db.begin_write()?;
+            let seq = {
+                let mut log = wtx.open_table(DECISION_LOG)?;
+                let mut max = 0u64;
+                for item in log.iter()? {
+                    let (k, _) = item?;
+                    if let Some(s) = decision_seq(k.value(), &fleet_id) {
+                        max = max.max(s);
+                    }
+                }
+                let next = max
+                    .checked_add(1)
+                    .ok_or_else(|| eyre::eyre!("decision sequence overflow for {fleet_id}"))?;
+                let entry = DecisionEntry {
+                    schema_version: SCHEMA_VERSION,
+                    seq: next,
+                    at_ms: now_ms,
+                    actor,
+                    kind,
+                    note,
+                };
+                let key = decision_key(&fleet_id, next);
+                log.insert(key.as_str(), serde_json::to_string(&entry)?.as_str())?;
+                next
+            };
+            wtx.commit()?;
+            Ok(seq)
+        })
+        .await
+        .wrap_err("join append_decision")?
+    }
+
+    /// List a fleet's decision log in sequence order.
+    pub async fn list_decisions(&self, fleet_id: &str) -> Result<Vec<DecisionEntry>> {
+        ensure_key_safe(&[fleet_id])?;
+        let db = self.db.clone();
+        let fleet_id = fleet_id.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<Vec<DecisionEntry>> {
+            let _held = held;
+            let rtx = db.begin_read()?;
+            let table = rtx.open_table(DECISION_LOG)?;
+            let mut out = Vec::new();
+            for item in table.iter()? {
+                let (k, v) = item?;
+                if decision_seq(k.value(), &fleet_id).is_some() {
+                    if let Some(entry) = decode_row::<DecisionEntry>(v.value())? {
+                        out.push(entry);
+                    }
+                }
+            }
+            out.sort_by_key(|e| e.seq);
+            Ok(out)
+        })
+        .await
+        .wrap_err("join list_decisions")?
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Key helpers + validation + in-txn outbox append
+// ---------------------------------------------------------------------------
+
+/// A persisted key component is safe iff it is non-empty and carries no
+/// control/NUL characters — so `\0`-delimited composite keys are
+/// unambiguous and cannot be cross-addressed (P1-4). Mirrors the peer
+/// code's `peer_slug_is_safe`.
+fn key_component_is_safe(s: &str) -> bool {
+    !s.is_empty() && !s.chars().any(|c| c.is_control())
+}
+
+/// Reject any unsafe key component up front with a typed error.
+fn ensure_key_safe(components: &[&str]) -> Result<()> {
+    for c in components {
+        if !key_component_is_safe(c) {
+            bail!(
+                "invalid key component {c:?}: must be non-empty and free of control/NUL characters"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn child_key(fleet_id: &str, child_id: &str) -> String {
+    format!("{fleet_id}\0{child_id}")
+}
+
+fn attempt_key(child_id: &str, attempt_id: &str) -> String {
+    format!("{child_id}\0{attempt_id}")
+}
+
+fn decision_key(fleet_id: &str, seq: u64) -> String {
+    format!("{fleet_id}\0{seq:020}")
+}
+
+fn outbox_key(seq: u64) -> String {
+    format!("{seq:020}")
+}
+
+/// Parse the per-fleet sequence out of a `decision_log` key, if it
+/// belongs to `fleet_id`.
+fn decision_seq(key: &str, fleet_id: &str) -> Option<u64> {
+    let prefix = format!("{fleet_id}\0");
+    key.strip_prefix(&prefix)?.parse::<u64>().ok()
+}
+
+/// Build a fresh, unclaimed outbox event (sequence assigned on append).
+fn outbox_event(
+    kind: FleetEventKind,
+    fleet_id: &str,
+    child_id: Option<&str>,
+    attempt_id: Option<&str>,
+) -> OutboxEvent {
+    OutboxEvent {
+        schema_version: SCHEMA_VERSION,
+        sequence: 0,
+        event_id: Uuid::new_v4().to_string(),
+        fleet_id: fleet_id.to_string(),
+        child_id: child_id.map(str::to_string),
+        attempt_id: attempt_id.map(str::to_string),
+        kind,
+        payload: serde_json::Value::Null,
+        claimed_by: None,
+        claim_token: None,
+        claim_expires_at: None,
+        acked: false,
+    }
+}
+
+/// Append `event` to an already-open outbox table, assigning the next
+/// monotonic sequence (max existing key + 1) with **checked** math — a
+/// corrupt last key or a sequence overflow is an error, never a silent
+/// overwrite of the last row (P2-5). Kept as a free function so the
+/// launch/complete CAS ops append **inside their own write-txn** — never
+/// by re-entering the gated `append_event` (which would deadlock on the
+/// `io_gate`).
+fn append_outbox(outbox: &mut redb::Table<'_, &str, &str>, mut event: OutboxEvent) -> Result<u64> {
+    let next = match outbox.last()? {
+        Some((k, _)) => {
+            let last: u64 = k
+                .value()
+                .parse()
+                .map_err(|e| eyre::eyre!("corrupt outbox key {:?}: {e}", k.value()))?;
+            last.checked_add(1)
+                .ok_or_else(|| eyre::eyre!("outbox sequence overflow"))?
+        }
+        None => 1,
+    };
+    event.sequence = next;
+    event.schema_version = SCHEMA_VERSION;
+    let key = outbox_key(next);
+    outbox.insert(key.as_str(), serde_json::to_string(&event)?.as_str())?;
+    Ok(next)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    const EPOCH: u64 = 100;
+    const TTL: u64 = 1_000;
+
+    async fn fresh() -> (TempDir, FleetKernelStore) {
+        let dir = TempDir::new().unwrap();
+        let store = FleetKernelStore::open(dir.path()).await.unwrap();
+        (dir, store)
+    }
+
+    fn controller() -> SessionKey {
+        SessionKey::new("fleet", "controller-1")
+    }
+
+    /// A fleet with one dep-free (immediately `Ready`) child.
+    async fn fleet_with_ready_child(store: &FleetKernelStore, budget: u64) {
+        store
+            .create_fleet("f1", controller(), "default", budget, false, 0)
+            .await
+            .unwrap();
+        store.add_child("f1", "c1", vec![], 0).await.unwrap();
+    }
+
+    fn accepted() -> AcceptanceVerdict {
+        AcceptanceVerdict::Accepted {
+            evidence: vec![EvidenceRef {
+                kind: "file".into(),
+                locator: "out.txt".into(),
+                sha256: "abc123".into(),
+                captured_at_ms: 5,
+            }],
+        }
+    }
+
+    fn rejected() -> AcceptanceVerdict {
+        AcceptanceVerdict::Rejected {
+            reason: "did not pass acceptance".into(),
+        }
+    }
+
+    fn snapshot() -> ChildResultSnapshot {
+        ChildResultSnapshot {
+            output: "done".into(),
+            success: true,
+            tokens_used: 80,
+            files: vec!["out.txt".into()],
+            error: None,
+        }
+    }
+
+    fn plan_task(id: &str, deps: &[&str]) -> PlanTask {
+        PlanTask {
+            task_id: id.into(),
+            title: id.into(),
+            detail: String::new(),
+            deps: deps.iter().map(|s| s.to_string()).collect(),
+            state: TaskState::Pending,
+            acceptance: vec![],
+            evidence: vec![],
+        }
+    }
+
+    fn plan(fleet: &str, revision: u64, tasks: Vec<PlanTask>) -> DurablePlan {
+        DurablePlan {
+            schema_version: SCHEMA_VERSION,
+            fleet_id: fleet.into(),
+            revision,
+            objective: "obj".into(),
+            tasks,
+        }
+    }
+
+    /// Launch + mark_running `c1`, returning the attempt id.
+    async fn launch_running(store: &FleetKernelStore) -> String {
+        let id = match store
+            .launch_child("f1", "c1", 100, 0, EPOCH, TTL)
+            .await
+            .unwrap()
+        {
+            LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("{other:?}"),
+        };
+        store.mark_running("c1", &id).await.unwrap();
+        id
+    }
+
+    #[tokio::test]
+    async fn open_creates_tables_and_survives_reopen() {
+        let dir = TempDir::new().unwrap();
+        {
+            let store = FleetKernelStore::open(dir.path()).await.unwrap();
+            store
+                .create_fleet("f1", controller(), "default", 500, false, 1)
+                .await
+                .unwrap();
+            assert!(store.path().ends_with("fleet-kernel.redb"));
+        }
+        let reopened = FleetKernelStore::open(dir.path()).await.unwrap();
+        let fleet = reopened.get_fleet("f1").await.unwrap().expect("present");
+        assert_eq!(fleet.budget.token_budget, 500);
+        assert_eq!(fleet.status, FleetStatus::Active);
+        assert_eq!(fleet.generation, 0);
+    }
+
+    #[tokio::test]
+    async fn create_fleet_rejects_duplicate() {
+        let (_d, store) = fresh().await;
+        store
+            .create_fleet("f1", controller(), "default", 100, false, 0)
+            .await
+            .unwrap();
+        assert!(
+            store
+                .create_fleet("f1", controller(), "default", 100, false, 0)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn create_plan_is_insert_only() {
+        let (_d, store) = fresh().await;
+        store
+            .create_fleet("f1", controller(), "default", 100, false, 0)
+            .await
+            .unwrap();
+        store.create_plan(plan("f1", 0, vec![])).await.unwrap();
+        // A second create must not blindly overwrite (P1-2).
+        assert!(store.create_plan(plan("f1", 0, vec![])).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn launch_happy_path_reserves_budget_and_creates_leased_attempt() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+
+        let out = store
+            .launch_child("f1", "c1", 100, 10, EPOCH, TTL)
+            .await
+            .unwrap();
+        let attempt_id = match out {
+            LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("expected Launched, got {other:?}"),
+        };
+
+        let child = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Launching);
+        assert_eq!(
+            child.current_attempt_id.as_deref(),
+            Some(attempt_id.as_str())
+        );
+        assert_eq!(child.attempts_used, 1);
+
+        let attempt = store.get_attempt("c1", &attempt_id).await.unwrap().unwrap();
+        assert_eq!(attempt.status, AttemptStatus::Leased);
+        assert_eq!(attempt.fleet_id, "f1");
+        assert_eq!(attempt.generation, 0);
+        assert_eq!(attempt.reserved_tokens, 100);
+        assert_eq!(attempt.lease.owner_epoch, EPOCH);
+        assert_eq!(attempt.lease.expires_at_ms, 10 + TTL);
+
+        let fleet = store.get_fleet("f1").await.unwrap().unwrap();
+        assert_eq!(fleet.budget.tokens_reserved, 100);
+        assert_eq!(fleet.budget.tokens_committed, 0);
+
+        // Outbox got a ChildLaunching event.
+        let ev = store.claim_next("k", 0, 100).await.unwrap().unwrap();
+        assert_eq!(ev.kind, FleetEventKind::ChildLaunching);
+        assert_eq!(ev.child_id.as_deref(), Some("c1"));
+        assert_eq!(ev.attempt_id.as_deref(), Some(attempt_id.as_str()));
+    }
+
+    #[tokio::test]
+    async fn double_launch_is_rejected_and_does_not_double_reserve() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+
+        let attempt_id = match store
+            .launch_child("f1", "c1", 100, 0, EPOCH, TTL)
+            .await
+            .unwrap()
+        {
+            LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("expected Launched, got {other:?}"),
+        };
+
+        let second = store
+            .launch_child("f1", "c1", 100, 0, EPOCH, TTL)
+            .await
+            .unwrap();
+        assert_eq!(second, LaunchOutcome::RejectedDoubleLaunch);
+
+        let child = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Launching);
+        assert_eq!(
+            child.current_attempt_id.as_deref(),
+            Some(attempt_id.as_str())
+        );
+        assert_eq!(
+            child.attempts_used, 1,
+            "second launch must not bump the count"
+        );
+
+        let fleet = store.get_fleet("f1").await.unwrap().unwrap();
+        assert_eq!(fleet.budget.tokens_reserved, 100, "no double reservation");
+    }
+
+    #[tokio::test]
+    async fn launch_rejected_when_child_not_ready() {
+        let (_d, store) = fresh().await;
+        store
+            .create_fleet("f1", controller(), "default", 1_000, false, 0)
+            .await
+            .unwrap();
+        store
+            .add_child("f1", "c1", vec!["missing".into()], 0)
+            .await
+            .unwrap();
+
+        let out = store
+            .launch_child("f1", "c1", 100, 0, EPOCH, TTL)
+            .await
+            .unwrap();
+        assert_eq!(out, LaunchOutcome::RejectedNotReady);
+
+        let child = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Planned);
+        assert!(child.current_attempt_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn budget_exceeded_is_rejected_and_child_stays_ready() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 50).await;
+
+        let out = store
+            .launch_child("f1", "c1", 100, 0, EPOCH, TTL)
+            .await
+            .unwrap();
+        assert_eq!(out, LaunchOutcome::RejectedBudgetExceeded);
+
+        // Crucially: the child is NOT left Launching (spec §6).
+        let child = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Ready);
+        assert!(child.current_attempt_id.is_none());
+        assert_eq!(child.attempts_used, 0);
+
+        let fleet = store.get_fleet("f1").await.unwrap().unwrap();
+        assert_eq!(fleet.budget.tokens_reserved, 0);
+
+        // No attempt, no outbox event were written.
+        assert!(store.claim_next("k", 0, 100).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn budget_admits_exactly_at_the_cap() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 100).await;
+        let out = store
+            .launch_child("f1", "c1", 100, 0, EPOCH, TTL)
+            .await
+            .unwrap();
+        assert!(matches!(out, LaunchOutcome::Launched { .. }));
+    }
+
+    #[tokio::test]
+    async fn mark_running_sets_attempt_and_child_running_then_refuses_repeat() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let attempt_id = match store
+            .launch_child("f1", "c1", 100, 0, EPOCH, TTL)
+            .await
+            .unwrap()
+        {
+            LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("{other:?}"),
+        };
+
+        store.mark_running("c1", &attempt_id).await.unwrap();
+        assert_eq!(
+            store
+                .get_attempt("c1", &attempt_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            AttemptStatus::Running
+        );
+        // P2-6: the child reflects Running, not a stuck Launching.
+        assert_eq!(
+            store.get_child("f1", "c1").await.unwrap().unwrap().status,
+            ChildStatus::Running
+        );
+
+        assert!(store.mark_running("c1", &attempt_id).await.is_err());
+        assert!(store.mark_running("c1", "nope").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn complete_happy_path_settles_budget_and_appends_outbox() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let attempt_id = launch_running(&store).await;
+
+        let out = store
+            .complete_child(
+                "f1",
+                "c1",
+                &attempt_id,
+                accepted(),
+                snapshot(),
+                80,
+                EPOCH,
+                20,
+            )
+            .await
+            .unwrap();
+        assert_eq!(out, CompleteOutcome::Completed);
+
+        let child = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Succeeded);
+        assert!(matches!(
+            child.outcome,
+            Some(AcceptanceVerdict::Accepted { .. })
+        ));
+        assert_eq!(child.tokens_committed, 80);
+
+        let attempt = store.get_attempt("c1", &attempt_id).await.unwrap().unwrap();
+        assert_eq!(attempt.status, AttemptStatus::Done);
+        assert!(attempt.result_snapshot.is_some());
+        assert_eq!(attempt.ended_at_ms, Some(20));
+
+        let fleet = store.get_fleet("f1").await.unwrap().unwrap();
+        assert_eq!(fleet.budget.tokens_committed, 80);
+        assert_eq!(fleet.budget.tokens_reserved, 0, "reservation released");
+
+        // Outbox: ChildLaunching (seq 1) then ChildDone (seq 2).
+        let e1 = store.claim_next("k", 0, 100).await.unwrap().unwrap();
+        assert_eq!(e1.kind, FleetEventKind::ChildLaunching);
+        let e2 = store.claim_next("k", 0, 100).await.unwrap().unwrap();
+        assert_eq!(e2.kind, FleetEventKind::ChildDone);
+        assert_eq!(e2.sequence, 2);
+    }
+
+    #[tokio::test]
+    async fn complete_rejected_for_wrong_attempt_id_no_state_change() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let attempt_id = launch_running(&store).await;
+
+        let out = store
+            .complete_child(
+                "f1",
+                "c1",
+                "bogus-attempt",
+                accepted(),
+                snapshot(),
+                80,
+                EPOCH,
+                20,
+            )
+            .await
+            .unwrap();
+        assert_eq!(out, CompleteOutcome::Superseded);
+
+        // Real attempt + child + budget untouched; child is Running (P2-6).
+        let child = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Running);
+        let attempt = store.get_attempt("c1", &attempt_id).await.unwrap().unwrap();
+        assert_eq!(attempt.status, AttemptStatus::Running);
+        let fleet = store.get_fleet("f1").await.unwrap().unwrap();
+        assert_eq!(fleet.budget.tokens_committed, 0);
+        assert_eq!(fleet.budget.tokens_reserved, 100);
+    }
+
+    #[tokio::test]
+    async fn complete_rejected_for_wrong_owner_epoch() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let attempt_id = launch_running(&store).await;
+
+        let out = store
+            .complete_child(
+                "f1",
+                "c1",
+                &attempt_id,
+                accepted(),
+                snapshot(),
+                80,
+                EPOCH + 1,
+                20,
+            )
+            .await
+            .unwrap();
+        assert_eq!(out, CompleteOutcome::Superseded);
+        assert_eq!(
+            store
+                .get_attempt("c1", &attempt_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            AttemptStatus::Running
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_rejected_when_not_running() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let attempt_id = match store
+            .launch_child("f1", "c1", 100, 0, EPOCH, TTL)
+            .await
+            .unwrap()
+        {
+            LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("{other:?}"),
+        };
+        // Never marked Running -> still Leased -> predicate fails.
+        let out = store
+            .complete_child(
+                "f1",
+                "c1",
+                &attempt_id,
+                accepted(),
+                snapshot(),
+                80,
+                EPOCH,
+                20,
+            )
+            .await
+            .unwrap();
+        assert_eq!(out, CompleteOutcome::Superseded);
+    }
+
+    #[tokio::test]
+    async fn complete_rejected_for_stale_generation() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let attempt_id = launch_running(&store).await;
+
+        // Simulate a re-plan bumping the fleet generation while the
+        // attempt keeps its stamped generation 0.
+        let mut fleet = store.get_fleet("f1").await.unwrap().unwrap();
+        fleet.generation = 1;
+        store
+            .write_raw_fleet("f1", &serde_json::to_string(&fleet).unwrap())
+            .await
+            .unwrap();
+
+        let out = store
+            .complete_child(
+                "f1",
+                "c1",
+                &attempt_id,
+                accepted(),
+                snapshot(),
+                80,
+                EPOCH,
+                20,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            out,
+            CompleteOutcome::Superseded,
+            "generation fences acceptance"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_reclaims_foreign_owner_epoch() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let attempt_id = launch_running(&store).await;
+
+        let report = store.reconcile(1, EPOCH + 999).await.unwrap();
+        assert_eq!(report.interrupted.len(), 1);
+        assert_eq!(report.interrupted[0].child_id, "c1");
+        assert_eq!(report.interrupted[0].attempt_id, attempt_id);
+
+        let child = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Ready);
+        assert!(
+            child.current_attempt_id.is_none(),
+            "current_attempt_id cleared"
+        );
+        let attempt = store.get_attempt("c1", &attempt_id).await.unwrap().unwrap();
+        assert_eq!(attempt.status, AttemptStatus::Interrupted);
+    }
+
+    /// P1-1: an interrupted attempt's reservation must be released, or
+    /// the fleet is budget-locked forever.
+    #[tokio::test]
+    async fn reconcile_releases_interrupted_reservation_so_relaunch_is_admitted() {
+        let (_d, store) = fresh().await;
+        // Budget fits exactly one 100-token attempt.
+        fleet_with_ready_child(&store, 100).await;
+        let _first = launch_running(&store).await;
+        assert_eq!(
+            store
+                .get_fleet("f1")
+                .await
+                .unwrap()
+                .unwrap()
+                .budget
+                .tokens_reserved,
+            100
+        );
+
+        store.reconcile(1, EPOCH + 999).await.unwrap();
+        assert_eq!(
+            store
+                .get_fleet("f1")
+                .await
+                .unwrap()
+                .unwrap()
+                .budget
+                .tokens_reserved,
+            0,
+            "reservation released on interrupt"
+        );
+
+        // The freed budget lets the relaunch in.
+        let out = store
+            .launch_child("f1", "c1", 100, 2, EPOCH, TTL)
+            .await
+            .unwrap();
+        assert!(matches!(out, LaunchOutcome::Launched { .. }));
+    }
+
+    #[tokio::test]
+    async fn reconcile_reclaims_expired_lease_same_epoch() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let attempt_id = match store
+            .launch_child("f1", "c1", 100, 0, EPOCH, 10)
+            .await
+            .unwrap()
+        {
+            LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("{other:?}"),
+        };
+        store.mark_running("c1", &attempt_id).await.unwrap();
+
+        let report = store.reconcile(1_000, EPOCH).await.unwrap();
+        assert_eq!(report.interrupted.len(), 1);
+        assert_eq!(
+            store.get_child("f1", "c1").await.unwrap().unwrap().status,
+            ChildStatus::Ready
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_leaves_healthy_lease_untouched() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let _attempt_id = launch_running(&store).await;
+
+        let report = store.reconcile(500, EPOCH).await.unwrap();
+        assert!(report.interrupted.is_empty());
+        // Child was moved to Running by mark_running and is left as-is.
+        assert_eq!(
+            store.get_child("f1", "c1").await.unwrap().unwrap().status,
+            ChildStatus::Running
+        );
+    }
+
+    /// P2-7: a Cancelled fleet's stranded child must not be resurrected.
+    #[tokio::test]
+    async fn reconcile_skips_children_of_cancelled_fleet() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let attempt_id = launch_running(&store).await;
+
+        // Cancel the fleet out-of-band.
+        let mut fleet = store.get_fleet("f1").await.unwrap().unwrap();
+        fleet.status = FleetStatus::Cancelled;
+        store
+            .write_raw_fleet("f1", &serde_json::to_string(&fleet).unwrap())
+            .await
+            .unwrap();
+
+        let report = store.reconcile(9_999, EPOCH + 999).await.unwrap();
+        assert!(report.interrupted.is_empty(), "cancelled fleet is skipped");
+        // Child + attempt left as they were (not reset to Ready).
+        assert_eq!(
+            store.get_child("f1", "c1").await.unwrap().unwrap().status,
+            ChildStatus::Running
+        );
+        assert_eq!(
+            store
+                .get_attempt("c1", &attempt_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            AttemptStatus::Running
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_then_relaunch_gets_fresh_attempt() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let first = match store
+            .launch_child("f1", "c1", 100, 0, EPOCH, 10)
+            .await
+            .unwrap()
+        {
+            LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("{other:?}"),
+        };
+        store.mark_running("c1", &first).await.unwrap();
+        store.reconcile(1_000, EPOCH).await.unwrap();
+
+        let second = match store
+            .launch_child("f1", "c1", 100, 2_000, EPOCH, TTL)
+            .await
+            .unwrap()
+        {
+            LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("{other:?}"),
+        };
+        assert_ne!(first, second);
+        let child = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(child.current_attempt_id.as_deref(), Some(second.as_str()));
+        assert_eq!(child.attempts_used, 2);
+    }
+
+    /// P1-2 (core): replan interrupts a surviving running attempt,
+    /// releases its reservation (not stuck), recomputes the survivor to a
+    /// relaunchable state, cancels the removed task, and adds the new one.
+    #[tokio::test]
+    async fn replan_interrupts_surviving_running_attempt_and_frees_reservation() {
+        let (_d, store) = fresh().await;
+        store
+            .create_fleet("f1", controller(), "default", 100, false, 0)
+            .await
+            .unwrap();
+        store
+            .create_plan(plan(
+                "f1",
+                0,
+                vec![plan_task("keep", &[]), plan_task("drop", &[])],
+            ))
+            .await
+            .unwrap();
+        store.add_child("f1", "keep", vec![], 0).await.unwrap();
+        store.add_child("f1", "drop", vec![], 0).await.unwrap();
+
+        // Launch + run "keep" (reserves the whole budget).
+        let keep_att = match store
+            .launch_child("f1", "keep", 100, 0, EPOCH, TTL)
+            .await
+            .unwrap()
+        {
+            LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("{other:?}"),
+        };
+        store.mark_running("keep", &keep_att).await.unwrap();
+        assert_eq!(
+            store
+                .get_fleet("f1")
+                .await
+                .unwrap()
+                .unwrap()
+                .budget
+                .tokens_reserved,
+            100
+        );
+
+        // Re-plan: keep "keep", drop "drop", add "new".
+        let out = store
+            .replan(
+                "f1",
+                0,
+                plan("f1", 0, vec![plan_task("keep", &[]), plan_task("new", &[])]),
+                5,
+            )
+            .await
+            .unwrap();
+        assert_eq!(out, PlanMutateOutcome::Mutated { revision: 1 });
+        assert_eq!(store.get_fleet("f1").await.unwrap().unwrap().generation, 1);
+        assert_eq!(store.get_plan("f1").await.unwrap().unwrap().revision, 1);
+
+        // Surviving child's old attempt Interrupted + reservation freed +
+        // child recomputed to a relaunchable state (not stuck).
+        assert_eq!(
+            store
+                .get_attempt("keep", &keep_att)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            AttemptStatus::Interrupted
+        );
+        let keep = store.get_child("f1", "keep").await.unwrap().unwrap();
+        assert_eq!(keep.generation, 1);
+        assert_eq!(keep.status, ChildStatus::Ready, "recomputed runnable");
+        assert!(
+            keep.current_attempt_id.is_none(),
+            "not stuck on old attempt"
+        );
+        assert_eq!(
+            store
+                .get_fleet("f1")
+                .await
+                .unwrap()
+                .unwrap()
+                .budget
+                .tokens_reserved,
+            0,
+            "reservation released, not stuck"
+        );
+
+        // Removed cancelled; new added.
+        assert_eq!(
+            store.get_child("f1", "drop").await.unwrap().unwrap().status,
+            ChildStatus::Cancelled
+        );
+        assert!(store.get_child("f1", "new").await.unwrap().is_some());
+
+        // Stale attempt cannot complete; the survivor relaunches.
+        assert_eq!(
+            store
+                .complete_child(
+                    "f1",
+                    "keep",
+                    &keep_att,
+                    accepted(),
+                    snapshot(),
+                    80,
+                    EPOCH,
+                    9
+                )
+                .await
+                .unwrap(),
+            CompleteOutcome::Superseded
+        );
+        assert!(matches!(
+            store
+                .launch_child("f1", "keep", 100, 10, EPOCH, TTL)
+                .await
+                .unwrap(),
+            LaunchOutcome::Launched { .. }
+        ));
+    }
+
+    /// P1-2: a survivor that gains a new *unmet* dependency is demoted to
+    /// Planned, so it cannot launch out of order.
+    #[tokio::test]
+    async fn replan_survivor_with_new_unmet_dep_becomes_planned() {
+        let (_d, store) = fresh().await;
+        store
+            .create_fleet("f1", controller(), "default", 1_000, false, 0)
+            .await
+            .unwrap();
+        store
+            .create_plan(plan(
+                "f1",
+                0,
+                vec![plan_task("a", &[]), plan_task("b", &[])],
+            ))
+            .await
+            .unwrap();
+        store.add_child("f1", "a", vec![], 0).await.unwrap();
+        store.add_child("f1", "b", vec![], 0).await.unwrap();
+        assert_eq!(
+            store.get_child("f1", "b").await.unwrap().unwrap().status,
+            ChildStatus::Ready
+        );
+
+        // Re-plan: b now depends on the not-yet-Succeeded a.
+        store
+            .replan(
+                "f1",
+                0,
+                plan("f1", 0, vec![plan_task("a", &[]), plan_task("b", &["a"])]),
+                1,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            store.get_child("f1", "a").await.unwrap().unwrap().status,
+            ChildStatus::Ready
+        );
+        assert_eq!(
+            store.get_child("f1", "b").await.unwrap().unwrap().status,
+            ChildStatus::Planned,
+            "unmet new dep demotes the survivor"
+        );
+    }
+
+    /// P1-2: a removed child that had a live attempt releases its
+    /// reservation (not leaked) and is Cancelled.
+    #[tokio::test]
+    async fn replan_removed_live_child_releases_reservation() {
+        let (_d, store) = fresh().await;
+        store
+            .create_fleet("f1", controller(), "default", 100, false, 0)
+            .await
+            .unwrap();
+        store
+            .create_plan(plan("f1", 0, vec![plan_task("gone", &[])]))
+            .await
+            .unwrap();
+        store.add_child("f1", "gone", vec![], 0).await.unwrap();
+        let att = match store
+            .launch_child("f1", "gone", 100, 0, EPOCH, TTL)
+            .await
+            .unwrap()
+        {
+            LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("{other:?}"),
+        };
+
+        store
+            .replan("f1", 0, plan("f1", 0, vec![]), 5)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store.get_child("f1", "gone").await.unwrap().unwrap().status,
+            ChildStatus::Cancelled
+        );
+        assert_eq!(
+            store
+                .get_attempt("gone", &att)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            AttemptStatus::Interrupted
+        );
+        assert_eq!(
+            store
+                .get_fleet("f1")
+                .await
+                .unwrap()
+                .unwrap()
+                .budget
+                .tokens_reserved,
+            0,
+            "removed child's reservation released"
+        );
+    }
+
+    /// P1-2: a task removed (→ Cancelled) then re-added by a later replan
+    /// is resurrected as a fresh runnable child, not left Cancelled.
+    #[tokio::test]
+    async fn replan_readds_removed_task_as_fresh_child() {
+        let (_d, store) = fresh().await;
+        store
+            .create_fleet("f1", controller(), "default", 100, false, 0)
+            .await
+            .unwrap();
+        store
+            .create_plan(plan("f1", 0, vec![plan_task("x", &[])]))
+            .await
+            .unwrap();
+        store.add_child("f1", "x", vec![], 0).await.unwrap();
+
+        // Remove x (rev 0 -> 1): Cancelled.
+        store
+            .replan("f1", 0, plan("f1", 0, vec![]), 1)
+            .await
+            .unwrap();
+        assert_eq!(
+            store.get_child("f1", "x").await.unwrap().unwrap().status,
+            ChildStatus::Cancelled
+        );
+
+        // Re-add x (rev 1 -> 2): fresh Ready child, outcome cleared.
+        store
+            .replan("f1", 1, plan("f1", 0, vec![plan_task("x", &[])]), 2)
+            .await
+            .unwrap();
+        let x = store.get_child("f1", "x").await.unwrap().unwrap();
+        assert_eq!(x.status, ChildStatus::Ready, "resurrected");
+        assert!(x.outcome.is_none(), "fresh outcome");
+        assert_eq!(x.generation, 2);
+    }
+
+    /// P1 (normal-path retry): a `Failed` survivor's Done attempt-id must
+    /// be cleared by replan, or `launch_child` rejects the retry as a
+    /// double-launch and the task can never run again.
+    #[tokio::test]
+    async fn replan_clears_pointer_so_a_failed_survivor_can_retry() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        store
+            .create_plan(plan("f1", 0, vec![plan_task("c1", &[])]))
+            .await
+            .unwrap();
+
+        // Drive c1 to Failed; complete keeps current_attempt_id set.
+        let att = launch_running(&store).await;
+        store
+            .complete_child("f1", "c1", &att, rejected(), snapshot(), 50, EPOCH, 5)
+            .await
+            .unwrap();
+        let failed = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(failed.status, ChildStatus::Failed);
+        assert!(
+            failed.current_attempt_id.is_some(),
+            "Failed child retains its Done attempt pointer"
+        );
+
+        // Replan keeping c1 → recomputed Ready with the pointer cleared.
+        store
+            .replan("f1", 0, plan("f1", 0, vec![plan_task("c1", &[])]), 6)
+            .await
+            .unwrap();
+        let c1 = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(c1.status, ChildStatus::Ready);
+        assert!(c1.current_attempt_id.is_none(), "stale pointer cleared");
+
+        // The retry now launches instead of RejectedDoubleLaunch.
+        assert!(matches!(
+            store
+                .launch_child("f1", "c1", 100, 10, EPOCH, TTL)
+                .await
+                .unwrap(),
+            LaunchOutcome::Launched { .. }
+        ));
+    }
+
+    /// P1-4: an attempt row whose stored `attempt_id` differs from the key
+    /// it lives under cannot be completed under the key's id.
+    #[tokio::test]
+    async fn complete_rejects_attempt_with_mismatched_stored_id() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+
+        // Plant a legal-schema Running attempt under key `c1\0A` whose body
+        // claims attempt_id == "B".
+        let bad = Attempt {
+            schema_version: SCHEMA_VERSION,
+            fleet_id: "f1".into(),
+            child_id: "c1".into(),
+            attempt_id: "B".into(),
+            generation: 0,
+            status: AttemptStatus::Running,
+            lease: Lease {
+                owner_epoch: EPOCH,
+                expires_at_ms: TTL,
+            },
+            reserved_tokens: 0,
+            result_snapshot: None,
+            started_at_ms: 0,
+            ended_at_ms: None,
+        };
+        store.write_raw_attempt("c1", "A", &bad).await.unwrap();
+        // Point the child at "A" so only the own-id check can reject.
+        let mut child = store.get_child("f1", "c1").await.unwrap().unwrap();
+        child.status = ChildStatus::Running;
+        child.current_attempt_id = Some("A".into());
+        store.write_raw_child(&child).await.unwrap();
+
+        let out = store
+            .complete_child("f1", "c1", "A", accepted(), snapshot(), 10, EPOCH, 1)
+            .await
+            .unwrap();
+        assert_eq!(
+            out,
+            CompleteOutcome::Superseded,
+            "an attempt whose stored id != key is not completed under the key's id"
+        );
+        assert_eq!(
+            store.get_child("f1", "c1").await.unwrap().unwrap().status,
+            ChildStatus::Running,
+            "child was not completed"
+        );
+    }
+
+    /// P2-6: mark_running writes NOTHING when the attempt is not the
+    /// child's current attempt.
+    #[tokio::test]
+    async fn mark_running_no_mutation_when_child_current_attempt_differs() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let att = match store
+            .launch_child("f1", "c1", 100, 0, EPOCH, TTL)
+            .await
+            .unwrap()
+        {
+            LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("{other:?}"),
+        };
+        // Point the child at a ghost attempt while `att` stays Leased.
+        let mut child = store.get_child("f1", "c1").await.unwrap().unwrap();
+        child.current_attempt_id = Some("ghost".into());
+        store.write_raw_child(&child).await.unwrap();
+
+        assert!(store.mark_running("c1", &att).await.is_err());
+        // Zero mutation: attempt still Leased, child pointer unchanged.
+        assert_eq!(
+            store.get_attempt("c1", &att).await.unwrap().unwrap().status,
+            AttemptStatus::Leased
+        );
+        assert_eq!(
+            store
+                .get_child("f1", "c1")
+                .await
+                .unwrap()
+                .unwrap()
+                .current_attempt_id
+                .as_deref(),
+            Some("ghost")
+        );
+    }
+
+    /// P2-6: mark_running rejects (zero mutation) an attempt whose
+    /// generation is stale relative to the fleet.
+    #[tokio::test]
+    async fn mark_running_rejected_when_attempt_generation_is_stale() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let att = match store
+            .launch_child("f1", "c1", 100, 0, EPOCH, TTL)
+            .await
+            .unwrap()
+        {
+            LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("{other:?}"),
+        };
+        // Bump the fleet generation out from under the Leased attempt.
+        let mut fleet = store.get_fleet("f1").await.unwrap().unwrap();
+        fleet.generation = 1;
+        store
+            .write_raw_fleet("f1", &serde_json::to_string(&fleet).unwrap())
+            .await
+            .unwrap();
+
+        assert!(store.mark_running("c1", &att).await.is_err());
+        assert_eq!(
+            store.get_attempt("c1", &att).await.unwrap().unwrap().status,
+            AttemptStatus::Leased,
+            "no mutation on stale generation"
+        );
+    }
+
+    /// P1-4: a public outbox `event_id` with a control char is rejected.
+    #[tokio::test]
+    async fn append_event_rejects_control_char_event_id() {
+        let (_d, store) = fresh().await;
+        let mut ev = outbox_event(FleetEventKind::FleetDrained, "f1", None, None);
+        ev.event_id = "bad\u{7f}id".into();
+        assert!(store.append_event(ev).await.is_err());
+    }
+
+    /// P2-5: a launch whose lease expiry (`now + ttl`) would overflow is
+    /// rejected, not silently capped at u64::MAX (which would never
+    /// reconcile → leaked reservation).
+    #[tokio::test]
+    async fn launch_rejected_when_lease_expiry_would_overflow() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        assert!(
+            store
+                .launch_child("f1", "c1", 1, u64::MAX - 1, EPOCH, 2)
+                .await
+                .is_err()
+        );
+        // Nothing committed: child still Ready, budget untouched.
+        assert_eq!(
+            store.get_child("f1", "c1").await.unwrap().unwrap().status,
+            ChildStatus::Ready
+        );
+        assert_eq!(
+            store
+                .get_fleet("f1")
+                .await
+                .unwrap()
+                .unwrap()
+                .budget
+                .tokens_reserved,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn replan_is_revision_fenced() {
+        let (_d, store) = fresh().await;
+        store
+            .create_fleet("f1", controller(), "default", 100, false, 0)
+            .await
+            .unwrap();
+        store.create_plan(plan("f1", 0, vec![])).await.unwrap();
+
+        // Correct revision advances to 1.
+        let out = store
+            .replan("f1", 0, plan("f1", 0, vec![plan_task("t1", &[])]), 1)
+            .await
+            .unwrap();
+        assert_eq!(out, PlanMutateOutcome::Mutated { revision: 1 });
+
+        // Stale expected revision (0) -> rejected, nothing changes.
+        let stale = store
+            .replan("f1", 0, plan("f1", 0, vec![]), 2)
+            .await
+            .unwrap();
+        assert_eq!(stale, PlanMutateOutcome::RevisionMismatch { actual: 1 });
+        let p = store.get_plan("f1").await.unwrap().unwrap();
+        assert_eq!(p.revision, 1);
+        assert_eq!(p.tasks.len(), 1, "stale replan left the plan unchanged");
+        assert_eq!(store.get_fleet("f1").await.unwrap().unwrap().generation, 1);
+    }
+
+    #[tokio::test]
+    async fn add_child_and_mark_ready_resolve_dependencies() {
+        let (_d, store) = fresh().await;
+        store
+            .create_fleet("f1", controller(), "default", 1_000, false, 0)
+            .await
+            .unwrap();
+        store.add_child("f1", "a", vec![], 0).await.unwrap();
+        store
+            .add_child("f1", "b", vec!["a".into()], 0)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store.get_child("f1", "a").await.unwrap().unwrap().status,
+            ChildStatus::Ready
+        );
+        assert_eq!(
+            store.get_child("f1", "b").await.unwrap().unwrap().status,
+            ChildStatus::Planned
+        );
+        assert!(!store.mark_ready("f1", "b", 1).await.unwrap());
+
+        // Drive a to Succeeded.
+        let a_att = match store
+            .launch_child("f1", "a", 10, 1, EPOCH, TTL)
+            .await
+            .unwrap()
+        {
+            LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("{other:?}"),
+        };
+        store.mark_running("a", &a_att).await.unwrap();
+        store
+            .complete_child("f1", "a", &a_att, accepted(), snapshot(), 10, EPOCH, 2)
+            .await
+            .unwrap();
+
+        assert!(store.mark_ready("f1", "b", 3).await.unwrap());
+        assert_eq!(
+            store.get_child("f1", "b").await.unwrap().unwrap().status,
+            ChildStatus::Ready
+        );
+        assert!(!store.mark_ready("f1", "b", 4).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn list_children_scopes_to_fleet_and_sorts() {
+        let (_d, store) = fresh().await;
+        store
+            .create_fleet("f1", controller(), "default", 100, false, 0)
+            .await
+            .unwrap();
+        store
+            .create_fleet("f2", controller(), "default", 100, false, 0)
+            .await
+            .unwrap();
+        store.add_child("f1", "b", vec![], 0).await.unwrap();
+        store.add_child("f1", "a", vec![], 0).await.unwrap();
+        store.add_child("f2", "z", vec![], 0).await.unwrap();
+
+        let f1 = store.list_children("f1").await.unwrap();
+        assert_eq!(
+            f1.iter().map(|c| c.child_id.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
+        let f2 = store.list_children("f2").await.unwrap();
+        assert_eq!(f2.len(), 1);
+        assert_eq!(f2[0].child_id, "z");
+    }
+
+    #[tokio::test]
+    async fn outbox_append_claim_ack_and_expiry_reclaim() {
+        let (_d, store) = fresh().await;
+        let base = outbox_event(FleetEventKind::FleetDrained, "f1", None, None);
+        let s1 = store.append_event(base.clone()).await.unwrap();
+        let s2 = store.append_event(base.clone()).await.unwrap();
+        assert_eq!((s1, s2), (1, 2));
+
+        let c1 = store.claim_next("worker", 0, 100).await.unwrap().unwrap();
+        assert_eq!(c1.sequence, 1);
+        assert_eq!(c1.claimed_by.as_deref(), Some("worker"));
+        assert!(c1.claim_token.is_some());
+        let c2 = store.claim_next("worker", 0, 100).await.unwrap().unwrap();
+        assert_eq!(c2.sequence, 2);
+        assert!(store.claim_next("worker", 0, 100).await.unwrap().is_none());
+
+        // Ack seq 1 with the right claim, then reclaim seq 2 after expiry.
+        assert_eq!(
+            store
+                .ack(1, "worker", c1.claim_token.as_deref().unwrap())
+                .await
+                .unwrap(),
+            AckOutcome::Acked
+        );
+        assert!(
+            store.claim_next("worker", 50, 100).await.unwrap().is_none(),
+            "seq1 acked, seq2 claim still valid"
+        );
+        let reclaimed = store
+            .claim_next("worker2", 200, 100)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(reclaimed.sequence, 2, "expired claim on seq2 reclaimed");
+
+        assert!(
+            store.ack(999, "worker", "x").await.is_err(),
+            "ack of missing seq errors"
+        );
+    }
+
+    /// P1-3: a stale consumer whose lease expired and was reclaimed
+    /// cannot ack the event out from under the new owner.
+    #[tokio::test]
+    async fn ack_is_fenced_against_a_stale_reclaimed_consumer() {
+        let (_d, store) = fresh().await;
+        store
+            .append_event(outbox_event(FleetEventKind::FleetDrained, "f1", None, None))
+            .await
+            .unwrap();
+
+        // A claims, its lease expires, B reclaims with a fresh token.
+        let a = store.claim_next("A", 0, 100).await.unwrap().unwrap();
+        let b = store.claim_next("B", 200, 100).await.unwrap().unwrap();
+        assert_eq!(a.sequence, b.sequence);
+        assert_ne!(a.claim_token, b.claim_token);
+
+        // A's stale ack is rejected; B's ack wins.
+        assert_eq!(
+            store
+                .ack(1, "A", a.claim_token.as_deref().unwrap())
+                .await
+                .unwrap(),
+            AckOutcome::StaleClaim
+        );
+        assert_eq!(
+            store
+                .ack(1, "B", b.claim_token.as_deref().unwrap())
+                .await
+                .unwrap(),
+            AckOutcome::Acked
+        );
+    }
+
+    #[tokio::test]
+    async fn decision_log_appends_per_fleet_in_order() {
+        let (_d, store) = fresh().await;
+        let s1 = store
+            .append_decision("f1", "keeper", DecisionKind::Plan, "planned", 1)
+            .await
+            .unwrap();
+        let s2 = store
+            .append_decision("f1", "keeper", DecisionKind::Launch, "launched c1", 2)
+            .await
+            .unwrap();
+        let s_other = store
+            .append_decision("f2", "keeper", DecisionKind::Plan, "planned", 1)
+            .await
+            .unwrap();
+        assert_eq!((s1, s2, s_other), (1, 2, 1));
+
+        let log = store.list_decisions("f1").await.unwrap();
+        assert_eq!(log.len(), 2);
+        assert_eq!(log[0].seq, 1);
+        assert_eq!(log[0].kind, DecisionKind::Plan);
+        assert_eq!(log[1].kind, DecisionKind::Launch);
+    }
+
+    #[tokio::test]
+    async fn load_drops_row_with_higher_schema_version() {
+        let (_d, store) = fresh().await;
+        store
+            .create_fleet("f1", controller(), "default", 100, false, 0)
+            .await
+            .unwrap();
+        let raw = r#"{"schema_version":2,"fleet_id":"f1","controller_session_key":"fleet:controller-1","profile_id":"default","budget":{"token_budget":100,"tokens_reserved":0,"tokens_committed":0,"hard":false},"status":"Active","generation":0,"created_at_ms":0,"updated_at_ms":0}"#;
+        store.write_raw_fleet("f1", raw).await.unwrap();
+        assert!(store.get_fleet("f1").await.unwrap().is_none());
+    }
+
+    /// P1-4: control-char key components are rejected, so the two
+    /// otherwise-colliding `(fleet, child)` encodings cannot cross-address.
+    #[tokio::test]
+    async fn key_components_reject_control_chars_preventing_collision() {
+        let (_d, store) = fresh().await;
+        store
+            .create_fleet("f", controller(), "default", 100, false, 0)
+            .await
+            .unwrap();
+
+        // `(fleet="f", child="x\0c")` and `(fleet="f\0x", child="c")`
+        // would both encode to "f\0x\0c" under naive concatenation.
+        assert!(store.add_child("f", "x\0c", vec![], 0).await.is_err());
+        assert!(
+            store
+                .create_fleet("f\0x", controller(), "default", 100, false, 0)
+                .await
+                .is_err()
+        );
+        // Other control characters are rejected too.
+        assert!(store.get_child("f", "c\n").await.is_err());
+        assert!(
+            store
+                .launch_child("f", "\u{7f}", 1, 0, EPOCH, TTL)
+                .await
+                .is_err()
+        );
+    }
+
+    /// P2-5: a launch whose checked reservation sum would overflow is
+    /// rejected, not silently admitted by saturation.
+    #[tokio::test]
+    async fn launch_rejected_when_reservation_would_overflow() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, u64::MAX).await;
+        // Plant a fleet already reserving u64::MAX against a MAX budget.
+        let mut fleet = store.get_fleet("f1").await.unwrap().unwrap();
+        fleet.budget.tokens_reserved = u64::MAX;
+        store
+            .write_raw_fleet("f1", &serde_json::to_string(&fleet).unwrap())
+            .await
+            .unwrap();
+
+        let out = store
+            .launch_child("f1", "c1", 1, 0, EPOCH, TTL)
+            .await
+            .unwrap();
+        assert_eq!(out, LaunchOutcome::RejectedBudgetExceeded);
+    }
+
+    // ---- test-only raw writer ---------------------------------------------
+
+    impl FleetKernelStore {
+        /// Write a raw JSON string into the fleets table, bypassing
+        /// record construction — used to plant higher-schema, cancelled,
+        /// or bumped-generation/over-reserved rows the public API cannot
+        /// mint.
+        async fn write_raw_fleet(&self, fleet_id: &str, json: &str) -> Result<()> {
+            let db = self.db.clone();
+            let key = fleet_id.to_string();
+            let json = json.to_string();
+            let held = self.io_gate.clone().lock_owned().await;
+            tokio::task::spawn_blocking(move || -> Result<()> {
+                let _held = held;
+                let wtx = db.begin_write()?;
+                {
+                    let mut fleets = wtx.open_table(FLEETS)?;
+                    fleets.insert(key.as_str(), json.as_str())?;
+                }
+                wtx.commit()?;
+                Ok(())
+            })
+            .await
+            .wrap_err("join write_raw_fleet")?
+        }
+
+        /// Write a child record verbatim (bypassing validation) so a test
+        /// can plant a divergent `current_attempt_id`, etc.
+        async fn write_raw_child(&self, child: &FleetChildRecord) -> Result<()> {
+            let db = self.db.clone();
+            let key = child_key(&child.fleet_id, &child.child_id);
+            let json = serde_json::to_string(child)?;
+            let held = self.io_gate.clone().lock_owned().await;
+            tokio::task::spawn_blocking(move || -> Result<()> {
+                let _held = held;
+                let wtx = db.begin_write()?;
+                {
+                    let mut children = wtx.open_table(FLEET_CHILDREN)?;
+                    children.insert(key.as_str(), json.as_str())?;
+                }
+                wtx.commit()?;
+                Ok(())
+            })
+            .await
+            .wrap_err("join write_raw_child")?
+        }
+
+        /// Write an attempt record verbatim under an arbitrary key so a
+        /// test can plant a row whose stored `attempt_id` differs from the
+        /// `(child_id, attempt_id)` key it lives under.
+        async fn write_raw_attempt(
+            &self,
+            child_id: &str,
+            attempt_id: &str,
+            att: &Attempt,
+        ) -> Result<()> {
+            let db = self.db.clone();
+            let key = attempt_key(child_id, attempt_id);
+            let json = serde_json::to_string(att)?;
+            let held = self.io_gate.clone().lock_owned().await;
+            tokio::task::spawn_blocking(move || -> Result<()> {
+                let _held = held;
+                let wtx = db.begin_write()?;
+                {
+                    let mut attempts = wtx.open_table(ATTEMPTS)?;
+                    attempts.insert(key.as_str(), json.as_str())?;
+                }
+                wtx.commit()?;
+                Ok(())
+            })
+            .await
+            .wrap_err("join write_raw_attempt")?
+        }
+    }
+}


### PR DESCRIPTION
## What

**PR 1 of the fleet kernel** (`docs/FLEET-KERNEL-V1-SPEC.md`): a new standalone crate **`crates/octos-fleet`** with `FleetKernelStore` — the durable, transactional, single-write-transaction CAS store that everything else in the kernel builds on. **Zero LLM / agent dependency; not wired into any live path** (later PRs add the closed worker, the outbox consumer, and the goal keeper).

## Contents

- **Records** — `FleetRecord` (+ `FleetBudget`), `FleetChildRecord`, `Attempt` (with the immutable `generation` + `Lease` + `reserved_tokens`), `DurablePlan`/`PlanTask`/`AcceptanceCriterion`/`EvidenceRef`, `DecisionEntry`, the claim-fenced `OutboxEvent`, `AcceptanceVerdict`, `ChildResultSnapshot`, and the status enums. Every row carries `schema_version`; higher-version rows load as `Ok(None)`.
- **`FleetKernelStore`** — `fleet-kernel.redb` with six tables, lifting swarm's `io_gate` owned-guard-into-`spawn_blocking` cancellation pattern (gating **reads and writes**), and read-modify-write in **one** `begin_write` transaction for every CAS.
- **CAS ops** — `launch_child` (lease + budget reserved *in the txn*; a budget reject leaves the child `Ready`), `mark_running` (attempt+child fenced), `complete_child` (the full identity/generation/lease fence; stale → `Superseded`; settles reserve→committed), `replan` (revision-CAS + generation bump + **interrupt-and-restart** every live attempt, releasing reservations, recomputing survivors from the new deps), `reconcile` (boot recovery: interrupt expired/foreign-epoch leases, release reservations, `Ready` — skipping cancelled fleets), a claim-fenced outbox, and gated reads.

## Correctness

Composite keys reject control/NUL components and every op verifies a decoded record's own ids against its key (no cross-fleet addressing); budget math is fully `checked_*`; the generation + attempt-id + lease fence drops any stale/superseded completion. **43 unit tests** against a tempdir redb (launch/complete/reconcile/replan/budget/outbox/key-safety/schema), no LLM. `build --workspace`, `fmt --check`, `clippy -D warnings` all clean.

## Review

codex-reviewed over **four rounds** (the durable-workflow correctness is exactly where bugs hide): reservation-leak-on-interrupt, replan not advancing the generation fence, outbox `ack` not claim-fenced, NUL-key cross-fleet injection, saturating-math masking, and the failed-task retry pointer were all found and fixed; the final pass returned **SHIP** with no findings. Foundations: `docs/FLEET-RUNTIME-ADR.md`, `docs/FLEET-KERNEL-FOUNDATION-SPEC.md`, `docs/FLEET-KERNEL-V1-SPEC.md`.
