### PR TITLE
fix(memory): make dropped-vector degradation visible instead of inferable

### DIFF
--- a/crates/octos-memory/src/hybrid_search.rs
+++ b/crates/octos-memory/src/hybrid_search.rs
@@ -26,6 +26,58 @@ pub struct HybridIndex {
     vector_weight: f32,
     /// Weight for BM25 text relevance in hybrid scoring (0.0-1.0).
     bm25_weight: f32,
+    /// Vectors rejected because their width did not match [`Self::dimension`].
+    ///
+    /// Counted rather than logged per occurrence: the store's open path
+    /// re-inserts EVERY persisted episode, so after an embedding-model change a
+    /// per-episode warning meant one line per episode at boot. Thousands of
+    /// identical warnings are easier to miss than one, and log truncation can
+    /// eat the lot. [`Self::insert`] warns once, then counts.
+    dimension_mismatches: usize,
+    /// Whether the first mismatch has already been logged.
+    mismatch_logged: bool,
+}
+
+/// How much of the index is actually reachable by vector search.
+///
+/// The failure this exists to surface is invisible at query time: a vector
+/// whose width does not match the index is dropped and that episode silently
+/// falls back to BM25-only recall. Nothing about the search result says so — it
+/// is just quietly worse. This makes the state queryable so a health check can
+/// report it instead of leaving it to be inferred from log archaeology.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VectorCoverage {
+    /// Documents in the index (including BM25-only ones).
+    pub total: usize,
+    /// Documents that made it into the HNSW vector index.
+    pub vectorized: usize,
+    /// Vectors rejected for a width mismatch since this index was built.
+    pub dimension_mismatches: usize,
+    /// The width this index accepts.
+    pub dimension: usize,
+}
+
+impl VectorCoverage {
+    /// Documents searchable by BM25 only.
+    pub fn bm25_only(&self) -> usize {
+        self.total.saturating_sub(self.vectorized)
+    }
+
+    /// Fraction of documents reachable by vector search, `0.0..=1.0`.
+    /// An empty index reports `1.0` — nothing is missing.
+    pub fn ratio(&self) -> f64 {
+        if self.total == 0 {
+            return 1.0;
+        }
+        self.vectorized as f64 / self.total as f64
+    }
+
+    /// True when at least one vector was rejected for a width mismatch, i.e.
+    /// the configured embedding model disagrees with the index this store was
+    /// built at. Re-embedding is the only fix; the vectors cannot be converted.
+    pub fn has_dimension_mismatch(&self) -> bool {
+        self.dimension_mismatches > 0
+    }
 }
 
 const BM25_K1: f64 = 1.2;
@@ -146,6 +198,8 @@ impl HybridIndex {
             dimension,
             vector_weight: DEFAULT_VECTOR_WEIGHT,
             bm25_weight: DEFAULT_BM25_WEIGHT,
+            dimension_mismatches: 0,
+            mismatch_logged: false,
         }
     }
 
@@ -164,6 +218,25 @@ impl HybridIndex {
     /// degrades to BM25-only insertion), the BM25 inverted index can
     /// outgrow the HNSW graph; callers MUST NOT assume the corpus
     /// size is capped at `HNSW_CAPACITY`.
+    /// Snapshot of how much of this index is reachable by vector search.
+    ///
+    /// `len()` counts DOCUMENTS; this counts how many of them actually carry a
+    /// vector, which is the number that degrades silently when the embedding
+    /// model and the index disagree.
+    pub fn vector_coverage(&self) -> VectorCoverage {
+        VectorCoverage {
+            total: self.ids.iter().filter(|id| !id.is_empty()).count(),
+            vectorized: self
+                .has_embedding
+                .iter()
+                .zip(&self.ids)
+                .filter(|(has, id)| **has && !id.is_empty())
+                .count(),
+            dimension_mismatches: self.dimension_mismatches,
+            dimension: self.dimension,
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.ids.len()
     }
@@ -236,11 +309,21 @@ impl HybridIndex {
         }
 
         // Insert embedding into HNSW if provided, dimension matches, and not at capacity
-        if let Some(e) = embedding {
-            if e.len() != self.dimension {
+        if let Some(e) = embedding
+            && e.len() != self.dimension
+        {
+            // Warn on the FIRST mismatch only, then count. The store's open
+            // path re-inserts every persisted episode, so warning per
+            // occurrence produced one line per episode after a model change.
+            // `vector_coverage()` reports the total; the store logs a summary
+            // once its rebuild finishes.
+            self.dimension_mismatches += 1;
+            if !self.mismatch_logged {
+                self.mismatch_logged = true;
                 tracing::warn!(
                     "embedding dimension mismatch for {episode_id}: got {}, index expects {} — \
-                     vector dropped, episode indexed BM25-only (check embedding model vs index dimension)",
+                     vector dropped, episode indexed BM25-only (check embedding model vs index \
+                     dimension). Further mismatches are counted, not logged; see vector_coverage()",
                     e.len(),
                     self.dimension
                 );
@@ -604,6 +687,91 @@ fn l2_normalize(v: &[f32]) -> Option<Vec<f32>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The counter must survive the exact scenario it exists for: a model
+    /// change, where the store re-inserts every persisted episode and each one
+    /// carries a now-wrong width.
+    #[test]
+    fn vector_coverage_counts_every_dimension_mismatch() {
+        let mut index = HybridIndex::new(4);
+        // Three good, two the wrong width (as if the model changed under us).
+        index.insert("ok1", "alpha beta", Some(&[1.0, 0.0, 0.0, 0.0]));
+        index.insert("bad1", "gamma delta", Some(&[1.0, 0.0]));
+        index.insert("ok2", "epsilon zeta", Some(&[0.0, 1.0, 0.0, 0.0]));
+        index.insert("bad2", "eta theta", Some(&[1.0, 0.0, 0.0, 0.0, 0.0, 0.0]));
+        index.insert("ok3", "iota kappa", Some(&[0.0, 0.0, 1.0, 0.0]));
+
+        let c = index.vector_coverage();
+        assert_eq!(c.total, 5);
+        assert_eq!(c.vectorized, 3, "only the correctly-sized vectors index");
+        assert_eq!(
+            c.dimension_mismatches, 2,
+            "both mismatches counted, not just the logged one"
+        );
+        assert_eq!(c.bm25_only(), 2);
+        assert_eq!(c.dimension, 4);
+        assert!(c.has_dimension_mismatch());
+        assert!((c.ratio() - 0.6).abs() < 1e-9);
+    }
+
+    /// A healthy index must not look degraded — the signal is useless if it
+    /// fires when nothing is wrong.
+    #[test]
+    fn vector_coverage_is_clean_when_dimensions_agree() {
+        let mut index = HybridIndex::new(2);
+        index.insert("a", "alpha", Some(&[1.0, 0.0]));
+        index.insert("b", "beta", Some(&[0.0, 1.0]));
+
+        let c = index.vector_coverage();
+        assert_eq!((c.total, c.vectorized, c.dimension_mismatches), (2, 2, 0));
+        assert!(!c.has_dimension_mismatch());
+        assert!((c.ratio() - 1.0).abs() < 1e-9);
+        assert_eq!(c.bm25_only(), 0);
+    }
+
+    /// An episode saved with no embedding at all is BM25-only but is NOT a
+    /// mismatch — conflating the two would make the health signal cry wolf on
+    /// every text-only episode.
+    #[test]
+    fn vector_coverage_separates_absent_vectors_from_mismatched_ones() {
+        let mut index = HybridIndex::new(2);
+        index.insert("has_vec", "alpha", Some(&[1.0, 0.0]));
+        index.insert("no_vec", "beta", None);
+
+        let c = index.vector_coverage();
+        assert_eq!(c.total, 2);
+        assert_eq!(c.vectorized, 1);
+        assert_eq!(
+            c.bm25_only(),
+            1,
+            "the vector-less episode still counts as BM25-only"
+        );
+        assert_eq!(c.dimension_mismatches, 0, "absent != mismatched");
+        assert!(!c.has_dimension_mismatch());
+    }
+
+    /// Empty index reports full coverage rather than 0/0 = NaN.
+    #[test]
+    fn vector_coverage_ratio_is_one_when_empty() {
+        let c = HybridIndex::new(4).vector_coverage();
+        assert_eq!((c.total, c.vectorized), (0, 0));
+        assert!((c.ratio() - 1.0).abs() < 1e-9);
+        assert!(c.ratio().is_finite());
+    }
+
+    /// Tombstoned entries must leave both sides of the ratio, or removing an
+    /// episode would make coverage look worse than it is.
+    #[test]
+    fn vector_coverage_excludes_removed_episodes() {
+        let mut index = HybridIndex::new(2);
+        index.insert("a", "alpha", Some(&[1.0, 0.0]));
+        index.insert("b", "beta", Some(&[0.0, 1.0]));
+        assert!(index.remove("a"));
+
+        let c = index.vector_coverage();
+        assert_eq!((c.total, c.vectorized), (1, 1));
+        assert!((c.ratio() - 1.0).abs() < 1e-9);
+    }
 
     #[test]
     fn test_tokenize() {

--- a/crates/octos-memory/src/lib.rs
+++ b/crates/octos-memory/src/lib.rs
@@ -12,7 +12,7 @@ mod memory_store;
 mod store;
 
 pub use episode::{Episode, EpisodeOutcome, EpisodeSource};
-pub use hybrid_search::{HybridIndex, HybridScore};
+pub use hybrid_search::{HybridIndex, HybridScore, VectorCoverage};
 pub use memory_store::{
     DEFAULT_MAX_INJECT_TOKENS, ExtractionItem, MemoryStore, NoteKind, NoteOrigin, StagingNote,
     UsageMap, UsageStat, estimate_tokens, extract_abstract, is_reserved_memory_name,

--- a/crates/octos-memory/src/store.rs
+++ b/crates/octos-memory/src/store.rs
@@ -235,7 +235,29 @@ impl EpisodeStore {
                     }
                 }
 
-                debug!(path = %data_dir.display(), "opened episode store");
+                // One summary instead of one line per episode. `insert` warns on
+                // the first mismatch and counts the rest, so without this a
+                // model change was either a single warning buried in the boot
+                // log or (before) thousands of identical ones.
+                let coverage = index.vector_coverage();
+                if coverage.has_dimension_mismatch() {
+                    warn!(
+                        path = %data_dir.display(),
+                        expected_dimension = coverage.dimension,
+                        mismatched = coverage.dimension_mismatches,
+                        vectorized = coverage.vectorized,
+                        total = coverage.total,
+                        "episode store rebuilt with dimension-mismatched embeddings dropped — \
+                         those episodes are BM25-only until re-embedded. This happens when the \
+                         configured embedding model changed; stored vectors cannot be converted."
+                    );
+                }
+                debug!(
+                    path = %data_dir.display(),
+                    vectorized = coverage.vectorized,
+                    total = coverage.total,
+                    "opened episode store"
+                );
                 Ok(Some((db, index)))
             })
             .await?;
@@ -549,6 +571,31 @@ impl EpisodeStore {
     /// empty for the same reason as [`Self::store`] — they need
     /// disk-backed bodies. Follows the same "writes accepted, reads
     /// empty" contract.
+    /// How much of the episodic index is reachable by vector search.
+    ///
+    /// Surfaces the one failure mode that is invisible at query time: when the
+    /// configured embedding model's width disagrees with the index, those
+    /// vectors are dropped and the episodes fall back to BM25-only recall.
+    /// Search does not report this — it just gets worse — so a health check
+    /// should read it. `dimension_mismatches > 0` means re-embedding is needed;
+    /// stored vectors cannot be converted to a different width.
+    ///
+    /// A degraded (lock-contended) handle reports an empty index.
+    pub fn vector_coverage(&self) -> crate::VectorCoverage {
+        match self.index.read() {
+            Ok(index) => index.vector_coverage(),
+            Err(e) => {
+                warn!("index read lock poisoned, reporting empty coverage: {e}");
+                crate::VectorCoverage {
+                    total: 0,
+                    vectorized: 0,
+                    dimension_mismatches: 0,
+                    dimension: 0,
+                }
+            }
+        }
+    }
+
     pub async fn store_embedding(&self, episode_id: &str, embedding: Vec<f32>) -> Result<()> {
         // Degraded fallback: skip the disk write, update the in-memory
         // embedding entry only, return success.
@@ -918,6 +965,92 @@ mod tests {
             0.0,
             "mismatched vector must not enter the index"
         );
+    }
+
+    /// The scenario this whole signal exists for: someone switches embedding
+    /// model, restarts, and every persisted vector is now the wrong width.
+    /// Before, that was a wall of per-episode warnings and no way to ask how
+    /// bad it was. Reopening at a different width must report it precisely.
+    #[tokio::test]
+    async fn reopening_at_a_different_dimension_reports_the_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Session 1: a 1536-d model (the OpenAI default).
+        {
+            let store = EpisodeStore::open_with_dimension(dir.path(), 1536)
+                .await
+                .unwrap();
+            for i in 0..3 {
+                let ep = make_episode(&format!("episode {i}"), "/proj");
+                let id = ep.id.clone();
+                store.store(ep).await.unwrap();
+                store
+                    .store_embedding(&id, vec![0.1f32; 1536])
+                    .await
+                    .unwrap();
+            }
+            let c = store.vector_coverage();
+            assert_eq!((c.total, c.vectorized), (3, 3), "all three vectorized");
+            assert!(!c.has_dimension_mismatch());
+        }
+
+        // Session 2: switched to a 768-d model. The persisted 1536-d vectors
+        // cannot be converted, so they are dropped on rebuild.
+        {
+            let store = EpisodeStore::open_with_dimension(dir.path(), 768)
+                .await
+                .unwrap();
+            let c = store.vector_coverage();
+            assert_eq!(c.dimension, 768);
+            assert_eq!(c.total, 3, "the episodes themselves survive");
+            assert_eq!(c.vectorized, 0, "none of the old vectors fit the new index");
+            assert_eq!(
+                c.dimension_mismatches, 3,
+                "every dropped vector is counted, not just the first (which is the only one logged)"
+            );
+            assert_eq!(c.bm25_only(), 3);
+            assert!(
+                c.has_dimension_mismatch(),
+                "a health check must be able to see this"
+            );
+            assert!((c.ratio() - 0.0).abs() < 1e-9);
+        }
+    }
+
+    /// Re-embedding at the new width is the documented remedy — it has to
+    /// actually clear the signal, or the advice is wrong.
+    #[tokio::test]
+    async fn re_embedding_restores_vector_coverage() {
+        let dir = tempfile::tempdir().unwrap();
+        let ep = make_episode("needs re-embedding", "/proj");
+        let ep_id = ep.id.clone();
+        {
+            let store = EpisodeStore::open_with_dimension(dir.path(), 1536)
+                .await
+                .unwrap();
+            store.store(ep).await.unwrap();
+            store
+                .store_embedding(&ep_id, vec![0.1f32; 1536])
+                .await
+                .unwrap();
+        }
+
+        let store = EpisodeStore::open_with_dimension(dir.path(), 768)
+            .await
+            .unwrap();
+        assert!(store.vector_coverage().has_dimension_mismatch());
+
+        // Re-embed at the width the index actually wants.
+        let mut v = vec![0.0f32; 768];
+        v[0] = 1.0;
+        store.store_embedding(&ep_id, v).await.unwrap();
+
+        let c = store.vector_coverage();
+        assert_eq!(
+            c.vectorized, 1,
+            "the re-embedded episode rejoins the vector index"
+        );
+        assert!((c.ratio() - 1.0).abs() < 1e-9);
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #1816. That fixed the actual bug — the episodic index was hardcoded to 1536 while the embedder could be 768, so every vector was discarded and the vector lane was dead. What it left behind was a **visibility** problem: when the index and the configured model disagree, vectors are dropped and those episodes fall back to BM25-only recall, and **nothing says so at query time**. Search just gets quietly worse.

Two concrete weaknesses, both closed here.

## 1. The warning drowned itself

`HybridIndex::insert` warned on every mismatch. The store's open path re-inserts **every** persisted episode, so changing embedding model produced **one warning per episode** at boot — thousands of identical lines for a large store. A wall of repeated warnings is easier to miss than a single one, and log truncation can eat the lot.

Now `insert` warns on the **first** mismatch (pointing at `vector_coverage()`) and counts the rest, and `EpisodeStore`'s rebuild emits **one summary** with the totals. One line on open, not N.

## 2. There was no way to ask the question

`has_embedding` was private and the only public accessor was `len()`, which counts **documents**, not vectors. Nothing could report *"3412 of 5000 episodes have no vector"* — not a health check, not the dashboard. The degradation was observable only by log archaeology.

New `VectorCoverage { total, vectorized, dimension_mismatches, dimension }` with `bm25_only()`, `ratio()`, `has_dimension_mismatch()` — exposed as `HybridIndex::vector_coverage()` and `EpisodeStore::vector_coverage()`.

Three distinctions it gets right on purpose:

- **Absent ≠ mismatched.** An episode saved with no embedding is BM25-only but is not a fault; conflating them would make the signal cry wolf on every text-only episode.
- **Tombstoned entries leave both sides of the ratio**, so deleting an episode doesn't make coverage look worse than it is.
- **An empty index reports `ratio() == 1.0`**, not `0/0`.

## Not wired into a consumer — deliberately

`octos doctor` has no memory section, and it **cannot simply open the store** to add one: redb is single-writer, so doctor would either fail or force degraded mode while `octos serve` holds the lock.

The right consumer is something that *already* holds the store — a serve-side RPC or status surface — which is a protocol decision, not part of this fix. The API is here for it.

## Tests

7 added, 130 green. Counting is **verified RED** by neutering the increment — the unit counter test and both end-to-end store tests fail.

The two end-to-end tests cover the real scenario rather than the mechanism: open at 1536, persist vectors, reopen at 768, assert all three are counted and reported. Then re-embed at the new width and assert coverage recovers — so the remedy the docs recommend is *proven*, not asserted.

`clippy --workspace --all-targets -D warnings` clean, fmt clean, `octos-cli` and `octos-agent` still build against the changed API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)