### PR TITLE
feat(memory): `octos memory reindex` — repair missing/wrong-width embeddings

### DIFF
--- a/crates/octos-cli/src/commands/memory.rs
+++ b/crates/octos-cli/src/commands/memory.rs
@@ -33,6 +33,22 @@ enum MemoryAction {
         #[arg(long)]
         data_dir: Option<PathBuf>,
     },
+    /// Regenerate missing or wrong-width episode embeddings.
+    ///
+    /// Changing the embedding model changes the vector WIDTH, and stored
+    /// vectors cannot be converted — only regenerated. Until they are, those
+    /// episodes fall back to BM25-only recall, which is invisible at query
+    /// time (search is just quietly worse). This is the repair.
+    ///
+    /// Requires the profile's store lock: stop `octos serve` first.
+    Reindex {
+        /// Report what would be re-embedded, then exit without writing.
+        #[arg(long)]
+        dry_run: bool,
+        /// Data directory (defaults to the resolved profile data dir).
+        #[arg(long)]
+        data_dir: Option<PathBuf>,
+    },
     /// Record a host-authored remember request (full consolidation
     /// authority — no model in the loop).
     Remember {
@@ -76,6 +92,7 @@ impl MemoryCommand {
         match self.action {
             MemoryAction::Refresh { data_dir } => run_refresh(data_dir).await,
             MemoryAction::Status { data_dir } => run_status(data_dir).await,
+            MemoryAction::Reindex { dry_run, data_dir } => run_reindex(dry_run, data_dir).await,
             MemoryAction::Remember { text, data_dir } => {
                 write_host_note(data_dir, octos_memory::NoteKind::UserRequest, text, false).await
             }
@@ -120,6 +137,132 @@ impl MemoryCommand {
             }
         }
     }
+}
+
+/// Episodes embedded per provider call. The in-process llama.cpp backend
+/// amortises its fixed per-forward-pass cost across a batch (~6x at 16), and
+/// remote providers accept batched input too, so this is the difference between
+/// a reindex taking seconds and taking minutes.
+const REINDEX_BATCH: usize = 16;
+
+async fn run_reindex(dry_run: bool, data_dir: Option<PathBuf>) -> Result<()> {
+    let (data_dir, config) = resolve(data_dir).await?;
+
+    // Resolve the embedder FIRST: it decides the index width, and without one
+    // there is nothing to regenerate. Failing here costs nothing.
+    let Some(embedder) = crate::commands::chat::create_embedder(&config) else {
+        eyre::bail!(
+            "no embedding provider configured — set `embedding` in your config.\n\
+             Without one, episodes are BM25-only by design and there is nothing to reindex."
+        );
+    };
+    let dimension = embedder.dimension();
+
+    // Strict open: this needs the writer lock. `octos serve` holds it in the
+    // normal fleet, so say that plainly instead of surfacing redb's
+    // "Database already open" — the operator's next action is to stop serve.
+    let store = octos_memory::EpisodeStore::open_with_dimension(&data_dir, dimension)
+        .await
+        .wrap_err_with(|| {
+            format!(
+                "failed to open the episode store at {} — if `octos serve` (or a gateway) is \
+                 running it holds the writer lock; stop it and retry",
+                data_dir.display()
+            )
+        })?;
+
+    let before = store.vector_coverage();
+    let pending = store.episodes_needing_vectors().await?;
+
+    println!("{}", "Episode vector coverage".bold());
+    println!("  data dir      {}", data_dir.display());
+    println!("  index width   {dimension}");
+    println!(
+        "  vectorized    {} / {} ({:.0}%)",
+        before.vectorized,
+        before.total,
+        before.ratio() * 100.0
+    );
+    if before.has_dimension_mismatch() {
+        println!(
+            "  {}  {} stored vector(s) have the wrong width for this model",
+            "mismatch".yellow(),
+            before.dimension_mismatches
+        );
+    }
+
+    if pending.is_empty() {
+        println!("\n{} nothing to reindex.", "✓".green());
+        return Ok(());
+    }
+    println!("\n  {} episode(s) need embedding", pending.len());
+
+    if dry_run {
+        for (id, summary) in pending.iter().take(10) {
+            let head: String = summary.chars().take(72).collect();
+            println!("    {id}  {head}");
+        }
+        if pending.len() > 10 {
+            println!("    … and {} more", pending.len() - 10);
+        }
+        println!("\n{} dry run — nothing written.", "•".dimmed());
+        return Ok(());
+    }
+
+    let mut embedded = 0usize;
+    let mut failed = 0usize;
+    for chunk in pending.chunks(REINDEX_BATCH) {
+        let texts: Vec<&str> = chunk.iter().map(|(_, summary)| summary.as_str()).collect();
+        // One failed batch must not abandon the rest: a provider hiccup or a
+        // single pathological summary would otherwise leave the store half
+        // repaired with no indication of where it stopped.
+        let vectors = match embedder.embed(&texts).await {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("  {} batch failed: {e}", "!".yellow());
+                failed += chunk.len();
+                continue;
+            }
+        };
+        if vectors.len() != chunk.len() {
+            eprintln!(
+                "  {} provider returned {} vector(s) for {} input(s); skipping batch",
+                "!".yellow(),
+                vectors.len(),
+                chunk.len()
+            );
+            failed += chunk.len();
+            continue;
+        }
+        for ((ep_id, _), vector) in chunk.iter().zip(vectors) {
+            match store.store_embedding(ep_id, vector).await {
+                Ok(()) => embedded += 1,
+                Err(e) => {
+                    eprintln!("  {} {ep_id}: {e}", "!".yellow());
+                    failed += 1;
+                }
+            }
+        }
+        println!("  {} / {} embedded", embedded, pending.len());
+    }
+
+    let after = store.vector_coverage();
+    println!(
+        "\n{} {embedded} embedded, {failed} failed. Coverage {:.0}% → {:.0}% ({} / {}).",
+        if failed == 0 {
+            "✓".green()
+        } else {
+            "partial".yellow()
+        },
+        before.ratio() * 100.0,
+        after.ratio() * 100.0,
+        after.vectorized,
+        after.total
+    );
+    if failed > 0 {
+        println!("  Re-run to retry the {failed} that failed.");
+    }
+    Ok(())
 }
 
 async fn write_host_note(

--- a/crates/octos-memory/src/store.rs
+++ b/crates/octos-memory/src/store.rs
@@ -596,6 +596,63 @@ impl EpisodeStore {
         }
     }
 
+    /// Episodes that carry no usable vector, as `(episode_id, summary)` ready
+    /// to re-embed.
+    ///
+    /// "Usable" means a persisted embedding whose width matches this store's
+    /// index. An episode qualifies when its vector is ABSENT (saved while no
+    /// embedder was configured, or the embed call failed) or MISMATCHED (the
+    /// embedding model changed — stored vectors cannot be converted to a
+    /// different width, only regenerated).
+    ///
+    /// This is the input to `octos memory reindex`. It reads persisted state
+    /// rather than the in-memory index, so it stays correct regardless of what
+    /// the index dropped at rebuild, and the summary it returns is the exact
+    /// text the save path embeds.
+    ///
+    /// A degraded (lock-contended) handle has no database and returns empty.
+    pub async fn episodes_needing_vectors(&self) -> Result<Vec<(String, String)>> {
+        let Some(db) = self.db.clone() else {
+            return Ok(Vec::new());
+        };
+        let expected = self
+            .index
+            .read()
+            .map(|idx| idx.vector_coverage().dimension)
+            .unwrap_or(DEFAULT_DIMENSION);
+
+        tokio::task::spawn_blocking(move || {
+            let read_txn = db.begin_read()?;
+            let episodes_table = read_txn.open_table(EPISODES_TABLE)?;
+            let embeddings_table = read_txn.open_table(EMBEDDINGS_TABLE)?;
+            let mut out = Vec::new();
+
+            for entry in episodes_table.iter()? {
+                let (key, value) = entry?;
+                let ep_id = key.value().to_string();
+                let Ok(episode) = serde_json::from_str::<Episode>(value.value()) else {
+                    continue;
+                };
+                // An episode with no summary has nothing to embed; skip it
+                // rather than sending empty text to a provider.
+                if episode.summary.trim().is_empty() {
+                    continue;
+                }
+                let width = embeddings_table
+                    .get(ep_id.as_str())
+                    .ok()
+                    .flatten()
+                    .and_then(|v| bincode::deserialize::<Vec<f32>>(v.value()).ok())
+                    .map(|v| v.len());
+                if width != Some(expected) {
+                    out.push((ep_id, episode.summary));
+                }
+            }
+            Ok::<_, eyre::Report>(out)
+        })
+        .await?
+    }
+
     pub async fn store_embedding(&self, episode_id: &str, embedding: Vec<f32>) -> Result<()> {
         // Degraded fallback: skip the disk write, update the in-memory
         // embedding entry only, return success.
@@ -1051,6 +1108,118 @@ mod tests {
             "the re-embedded episode rejoins the vector index"
         );
         assert!((c.ratio() - 1.0).abs() < 1e-9);
+    }
+
+    /// The reindex worklist must contain exactly the episodes that lack a
+    /// usable vector — absent AND wrong-width — and nothing else. A false
+    /// positive re-embeds (and re-bills) work that was already fine; a false
+    /// negative leaves an episode permanently BM25-only.
+    #[tokio::test]
+    async fn episodes_needing_vectors_lists_absent_and_mismatched_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = EpisodeStore::open_with_dimension(dir.path(), 4)
+            .await
+            .unwrap();
+
+        let good = make_episode("has a correct vector", "/proj");
+        let good_id = good.id.clone();
+        store.store(good).await.unwrap();
+        store
+            .store_embedding(&good_id, vec![0.5f32; 4])
+            .await
+            .unwrap();
+
+        let absent = make_episode("never embedded", "/proj");
+        let absent_id = absent.id.clone();
+        store.store(absent).await.unwrap();
+
+        let wrong = make_episode("embedded at the old width", "/proj");
+        let wrong_id = wrong.id.clone();
+        store.store(wrong).await.unwrap();
+        store
+            .store_embedding(&wrong_id, vec![0.5f32; 1536])
+            .await
+            .unwrap();
+
+        let pending = store.episodes_needing_vectors().await.unwrap();
+        let ids: Vec<&str> = pending.iter().map(|(id, _)| id.as_str()).collect();
+
+        assert!(
+            !ids.contains(&good_id.as_str()),
+            "a correctly-sized vector must NOT be re-embedded"
+        );
+        assert!(
+            ids.contains(&absent_id.as_str()),
+            "an episode with no vector needs one"
+        );
+        assert!(
+            ids.contains(&wrong_id.as_str()),
+            "a wrong-width vector must be regenerated"
+        );
+        assert_eq!(pending.len(), 2);
+
+        // The summary comes back so the caller can embed without a second read.
+        let (_, summary) = pending.iter().find(|(id, _)| id == &absent_id).unwrap();
+        assert_eq!(summary, "never embedded");
+    }
+
+    /// Full repair loop: the worklist drains to empty and coverage recovers.
+    /// This is what `octos memory reindex` does, minus the provider.
+    #[tokio::test]
+    async fn reindexing_the_worklist_restores_full_coverage() {
+        let dir = tempfile::tempdir().unwrap();
+        // Persist at the old width.
+        {
+            let store = EpisodeStore::open_with_dimension(dir.path(), 1536)
+                .await
+                .unwrap();
+            for i in 0..5 {
+                let ep = make_episode(&format!("episode {i}"), "/proj");
+                let id = ep.id.clone();
+                store.store(ep).await.unwrap();
+                store
+                    .store_embedding(&id, vec![0.1f32; 1536])
+                    .await
+                    .unwrap();
+            }
+        }
+        // Reopen at the new width: everything is now mismatched.
+        let store = EpisodeStore::open_with_dimension(dir.path(), 768)
+            .await
+            .unwrap();
+        assert_eq!(store.vector_coverage().vectorized, 0);
+
+        let pending = store.episodes_needing_vectors().await.unwrap();
+        assert_eq!(pending.len(), 5);
+        for (id, _summary) in &pending {
+            let mut v = vec![0.0f32; 768];
+            v[0] = 1.0;
+            store.store_embedding(id, v).await.unwrap();
+        }
+
+        let after = store.vector_coverage();
+        assert_eq!(
+            after.vectorized, 5,
+            "every episode rejoins the vector index"
+        );
+        assert!((after.ratio() - 1.0).abs() < 1e-9);
+        assert!(
+            store.episodes_needing_vectors().await.unwrap().is_empty(),
+            "the worklist must drain — a non-empty list here means reindex never converges"
+        );
+    }
+
+    /// An episode with an empty summary has nothing to embed. Including it
+    /// would send empty text to a paid provider and never clear the worklist.
+    #[tokio::test]
+    async fn episodes_needing_vectors_skips_empty_summaries() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = EpisodeStore::open_with_dimension(dir.path(), 4)
+            .await
+            .unwrap();
+        let ep = make_episode("   ", "/proj");
+        store.store(ep).await.unwrap();
+        assert!(store.episodes_needing_vectors().await.unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes the one-way door left by #1816 and #1851.

Changing `embedding.provider` or the model changes the vector **width**. Stored vectors cannot be converted — only regenerated. Until now **nothing regenerated them**: `store_embedding` is called from exactly two production sites, both at episode-save time, so an episode got a vector once and never again.

So a supported action — editing a config value — put the store in a **permanently degraded state**, and the only "fix" was deleting `episodes.redb`: throwing away your memory to restore search quality. Everything needed was already on disk (`episode.summary` is persisted, and the rebuild already reads it). The capability was simply absent.

## Deliberately a command, not automatic

Re-embedding N episodes is N provider calls — real money remotely, minutes locally. Doing that silently at boot would be a surprising, expensive side effect. Elasticsearch doesn't silently reindex either. The operator decides when to pay.

```
octos memory reindex [--dry-run] [--data-dir <path>]
```

## Layering

`octos-memory` gains `episodes_needing_vectors() -> Vec<(id, summary)>` — episodes whose persisted vector is **absent** or the **wrong width**. It reads persisted state rather than index internals, so it's correct regardless of what the rebuild dropped, and returns the summary so the caller embeds without a second read.

The embedder stays out of that crate: `octos-memory` has no `octos-llm` dependency and this doesn't add one. The CLI orchestrates.

## Details that matter in practice

- **Batches of 16** — the llama.cpp path is ~6× cheaper batched than one-at-a-time
- **A failed batch is reported and skipped, not fatal.** One provider hiccup must not abandon the rest half-repaired with no indication where it stopped; the summary reports failures and says to re-run
- Guards a provider returning the wrong *number* of vectors
- **Empty summaries are skipped** — embedding `""` bills a provider and never clears the worklist
- No embedder configured is a clear error, not a silent no-op
- The lock error **leads with the operator's next action** ("stop `octos serve`"), since redb is single-writer and serve holds it in the normal fleet

## Verified end to end, not just unit-tested

Seeded a real store with 5 episodes at 1536-d, pointed a 768-d llama.cpp embedder at it, ran the command:

| step | result |
| --- | --- |
| dry-run | `0/5 (0%)`, 5 need embedding, nothing written |
| reindex | **5 embedded, 0 failed, coverage 0% → 100%** |
| re-run | `nothing to reindex` (idempotent) |
| reopen | zero mismatch warnings (durable) |
| locked | surfaces *"stop it and retry"*, not redb's raw message |

That run also confirms #1851's aggregation **on real data**: one first-mismatch warning plus one summary (`mismatched=5 vectorized=0 total=5`), where before it was one line per episode.

## Tests

3 added, 133 green:

- the worklist contains absent **and** mismatched but **not** correctly-sized vectors — a false positive re-bills work that was already fine; a false negative leaves an episode permanently BM25-only
- the full repair loop drains the worklist to empty and restores coverage
- empty summaries are excluded

`clippy --workspace --all-targets -D warnings` clean, fmt clean, `octos-cli` 991 lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)