### PR TITLE
ci: stop check-riscv from wedging every main run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,11 +502,31 @@ jobs:
         run: cargo test --workspace --doc
 
   check-riscv:
-    # Push-only for the same reason as check-arm, plus a live problem: this job
-    # has not COMPLETED in recent history — it runs to the 24 h ceiling and is
-    # cancelled (see runs 30087155881, 30025529065). Until that is diagnosed it
-    # must not gate anything; putting it on PRs would wedge every PR for a day.
-    if: github.event_name != 'pull_request'
+    # MANUAL ONLY — this job is the reason `main` has had no CI signal for weeks.
+    #
+    # There is no runner for the `ubuntu-24.04-riscv` label. Every dispatch sits
+    # in `queued` with `runner_id: 0`, `runner_name: ""` and `steps: []` until
+    # GitHub's fixed 24 h *queue* ceiling kills it. Job 89914973597 in run
+    # 30244166464: 2026-07-27T07:33:57Z → 2026-07-28T07:33:58Z, zero steps, no
+    # runner ever assigned. All 22 such jobs in the last 50 `main` runs died at
+    # exactly 24:00:00–01. Not one has ever executed a step.
+    #
+    # Note this is a QUEUE limit, so `timeout-minutes` does NOT bound it —
+    # that only starts counting once a runner picks the job up.
+    #
+    # While queued it holds the whole run in-progress, and `cancel-in-progress`
+    # is false for `push` and `schedule`, so that one run owns the
+    # `ci-CI-refs/heads/main` concurrency slot for a full day. Every push behind
+    # it is cancelled while still pending — 22 of the last 50 `main` runs were
+    # cancelled having dispatched zero jobs.
+    #
+    # `schedule` is deliberately excluded too: the nightly cron runs on `main`
+    # and lands in the SAME concurrency group, so a schedule-only riscv job
+    # would re-wedge the slot for 24 h once a day.
+    #
+    # Restore `github.event_name != 'pull_request'` once a riscv64 runner is
+    # actually registered for this repo.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04-riscv
     env:
       CARGO_BUILD_JOBS: "2"


### PR DESCRIPTION
## What

Gate `check-riscv` to `workflow_dispatch` only.

## Why

`check-riscv` targets `ubuntu-24.04-riscv`, for which this repo has no runner. Every dispatch sits in `queued` with `runner_id: 0`, `runner_name: ""` and `steps: []` until GitHub's fixed **24 h queue ceiling** kills it.

Evidence — 22 such jobs in the last 50 `main` runs, every one dying at exactly 24:00:00–01, not one ever executing a step:

| run | check-riscv start → end | delta |
|---|---|---|
| 30244166464 | 2026-07-27T07:33:57Z → 2026-07-28T07:33:58Z | 24:00:01 |
| 30193035902 | 2026-07-26T07:33:56Z → 2026-07-27T07:33:57Z | 24:00:01 |
| 30154649774 | 2026-07-25T10:32:43Z → 2026-07-26T10:32:43Z | 24:00:00 |
| 30087155881 | 2026-07-24T10:43:34Z → 2026-07-25T10:43:34Z | 24:00:00 |
| 30338440845 | 2026-07-28T07:33:59Z → still `queued` | — |

While queued it holds the whole run in-progress. `cancel-in-progress` is `false` for `push` and `schedule`, so that one run owns the `ci-CI-refs/heads/main` concurrency slot for a full day, and every push behind it is cancelled **while still pending**:

| pending run | created | cancelled at | next run created |
|---|---|---|---|
| 30376238316 | 07-28T16:01:21Z | 07-28T17:03:24Z | 30381135943 @ 17:03:22Z |
| 30381135943 | 07-28T17:03:22Z | 07-28T17:28:24Z | 30383029606 @ 17:28:23Z |
| 30383029606 | 07-28T17:28:23Z | 07-28T17:28:43Z | 30383053402 @ 17:28:42Z |
| 30383053402 | 07-28T17:28:42Z | 07-28T18:00:30Z | 30385463673 @ 18:00:29Z |

22 of the last 50 `main` runs were cancelled having dispatched **zero jobs**. Tally of the last 50: 26 failure, 22 cancelled, 1 queued, 1 pending — **zero successes**.

## Two things that are easy to get wrong

- **`timeout-minutes` would not have helped.** It bounds a job's *run* time, counted from when a runner picks it up. This job never reaches a runner, so there is nothing to bound. The observed ceiling is uniformly 24 h across 22 independent jobs — that is GitHub's queue limit, not a configurable value.
- **`schedule` is excluded deliberately.** The nightly cron runs on `main` and lands in the *same* concurrency group, so a schedule-only riscv job would re-wedge the slot for 24 h once a day.

`(d) per-SHA concurrency group` was also considered and rejected: it stops the cancellation cascade but leaves every run hanging 24 h, trading 22 cancelled runs for 22 simultaneously-hung ones.

Nothing `needs:` this job, so gating it changes no other job's behaviour.

## Scope — this does NOT make `main` green

It only lets a `main` run reach an honest conclusion in ~40 min instead of hanging for a day. Two real failures remain, both reproducible in run 30338440845 where every other job passed:

- `check-windows` — 49 failing tests, being handled separately.
- `check-arm` — `should_isolate_sub_agent_internal_context_from_parent` (`crates/octos-agent/tests/mcp_agent_backend.rs:552`).

Last green CI run on `main` was 2026-03-20 (run 23354740047).

## Verification

- `ci.yml` still parses; 18 jobs, unchanged.
- No job declares `needs: check-riscv`.
- The change is inert on PRs (the job was already skipped there), so **this PR's own green light does not prove the fix** — the proof is the first `main` push run after merge actually completing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)