### PR TITLE
feat(fleet): closed non-interactive task worker + bounded pool (PR 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4755,6 +4755,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "octos-fleet-worker"
+version = "2.0.2"
+dependencies = [
+ "async-trait",
+ "eyre",
+ "octos-agent",
+ "octos-core",
+ "octos-fleet",
+ "octos-llm",
+ "octos-memory",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "octos-llm"
 version = "2.0.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "crates/octos-sandbox",
     "crates/octos-swarm",
     "crates/octos-fleet",
+    "crates/octos-fleet-worker",
     "crates/octos-embed-llama",
     "crates/octos-ffi",
     "crates/octos-uniffi",

--- a/crates/octos-agent/src/tools/shell.rs
+++ b/crates/octos-agent/src/tools/shell.rs
@@ -50,6 +50,20 @@ pub struct ShellTool {
     /// Task-ledger path recorded as lineage on registered background tasks so
     /// they can be restored across a restart, mirroring the spawn tool.
     task_ledger_path: Option<PathBuf>,
+    /// When `false`, a background/detached command — an explicit
+    /// `background: true` arg OR a trailing `&` — is refused outright instead
+    /// of being spawned detached. A detached child outlives the agent turn and
+    /// dodges any per-attempt deadline, so a closed, non-interactive worker
+    /// (e.g. the fleet task-worker) sets this `false` to stay replay-safe.
+    /// Defaults to `true` — unchanged behaviour for every existing caller.
+    background_allowed: bool,
+    /// Optional hard CEILING on a single command's effective timeout. When set,
+    /// the per-command timeout is `min(requested-or-default, max_timeout)` — an
+    /// upper bound that overrides a LARGER LLM-provided `timeout_secs`, so a
+    /// closed worker can guarantee no foreground command outlives its attempt
+    /// deadline. `None` = no extra cap (only the outer `[1, 600]s` clamp
+    /// applies) — unchanged behaviour for every existing caller.
+    max_timeout: Option<Duration>,
 }
 
 impl ShellTool {
@@ -64,7 +78,34 @@ impl ShellTool {
             task_supervisor: None,
             session_key: None,
             task_ledger_path: None,
+            background_allowed: true,
+            max_timeout: None,
         }
+    }
+
+    /// Cap the effective per-command timeout at `cap_secs` (a hard CEILING).
+    ///
+    /// The effective timeout becomes `min(requested-or-default, cap_secs)`, so
+    /// this overrides a LARGER LLM-provided `timeout_secs` (which the agent
+    /// loop can otherwise raise up to the outer 600s clamp). A closed worker
+    /// sets this to its attempt deadline so — together with
+    /// `with_background_allowed(false)` — no single foreground command can
+    /// outlive the deadline. `cap_secs` is floored to 1. Default: no extra cap.
+    pub fn with_max_timeout_secs(mut self, cap_secs: u64) -> Self {
+        self.max_timeout = Some(Duration::from_secs(cap_secs.max(1)));
+        self
+    }
+
+    /// Allow or forbid background/detached execution (default: allowed).
+    ///
+    /// With `allowed = false`, any background request — an explicit
+    /// `background: true` arg or a trailing `&` — is refused with a failed
+    /// [`ToolResult`] rather than spawned detached. A closed worker that must
+    /// not outlive its per-attempt deadline (the fleet task-worker) sets this
+    /// so a `sh -c "cmd &"` cannot orphan work past the attempt.
+    pub fn with_background_allowed(mut self, allowed: bool) -> Self {
+        self.background_allowed = allowed;
+        self
     }
 
     /// Set the timeout for commands.
@@ -730,6 +771,29 @@ impl Tool for ShellTool {
             Decision::Allow => {}
         }
 
+        // A closed worker (`background_allowed == false`) refuses the two
+        // string-detectable ways to detach: the explicit `background: true`
+        // arg and a trailing `&` (checked before the background branch below,
+        // so neither falls through to a foreground run that self-detaches).
+        // This is best-effort defense-in-depth, NOT a boundary: arbitrary
+        // shell-internal backgrounding (`sleep 600 & true`, `sh -c "cmd &"`)
+        // cannot be caught by string inspection — the SANDBOX's process-group
+        // teardown is what actually bounds a detached child.
+        if is_background_command(&input.command, input.background) && !self.background_allowed {
+            tracing::warn!(
+                command = %input.command,
+                "background/detached shell execution is disabled for this worker",
+            );
+            return Ok(ToolResult {
+                output: format!(
+                    "background/detached execution is disabled for this worker: {}",
+                    input.command
+                ),
+                success: false,
+                ..Default::default()
+            });
+        }
+
         // Background execution: a trailing `&` or an explicit `background: true`
         // arg asks the command to run detached. Register it as a tracked
         // supervisor task (so it surfaces in `/ps` and the sub-agent dock),
@@ -744,10 +808,17 @@ impl Tool for ShellTool {
         // Clamp timeout to [1, 600] seconds to prevent abuse
         const MIN_TIMEOUT: u64 = 1;
         const MAX_TIMEOUT: u64 = 600;
-        let timeout_duration = input
+        let mut timeout_duration = input
             .timeout_secs
             .map(|s| Duration::from_secs(s.clamp(MIN_TIMEOUT, MAX_TIMEOUT)))
             .unwrap_or(self.timeout);
+        // Apply the hard per-command ceiling (if configured): the effective
+        // timeout can only be LOWERED by it, never raised. This is what keeps a
+        // closed worker's foreground command bounded by its attempt deadline
+        // even when the LLM requests a larger `timeout_secs`.
+        if let Some(cap) = self.max_timeout {
+            timeout_duration = timeout_duration.min(cap);
+        }
 
         // Execute command (through sandbox).
         // Spawn the child, grab its PID, then timeout on wait_with_output().
@@ -1427,6 +1498,74 @@ mod tests {
             supervisor.get_tasks_for_session("api:bg-arg").len(),
             1,
             "explicit background arg must register a task"
+        );
+    }
+
+    #[tokio::test]
+    async fn background_disabled_refuses_explicit_and_trailing_ampersand() {
+        // A worker that forbids background execution must refuse BOTH an
+        // explicit `background: true` arg and a trailing `&`, returning a
+        // failed result WITHOUT spawning a detached child (a `sh -c "cmd &"`
+        // must not fall through to a foreground run that self-detaches).
+        let tool = ShellTool::new(std::env::temp_dir()).with_background_allowed(false);
+
+        let explicit = tool
+            .execute(&serde_json::json!({"command": "sleep 30", "background": true}))
+            .await
+            .unwrap();
+        assert!(!explicit.success, "explicit background must be refused");
+        assert!(
+            explicit.output.contains("disabled"),
+            "unexpected output: {}",
+            explicit.output
+        );
+
+        let ampersand = tool
+            .execute(&serde_json::json!({"command": "sleep 30 &"}))
+            .await
+            .unwrap();
+        assert!(!ampersand.success, "trailing-& background must be refused");
+        assert!(
+            ampersand.output.contains("disabled"),
+            "unexpected output: {}",
+            ampersand.output
+        );
+
+        // The default (background allowed) is unchanged: a foreground command
+        // still runs to completion.
+        let allowed = ShellTool::new(std::env::temp_dir());
+        let fg = allowed
+            .execute(&serde_json::json!({"command": "echo ok"}))
+            .await
+            .unwrap();
+        assert!(
+            fg.success,
+            "foreground command must still run: {}",
+            fg.output
+        );
+    }
+
+    #[tokio::test]
+    async fn max_timeout_secs_caps_a_larger_requested_timeout() {
+        // A hard 1s ceiling must override a larger requested `timeout_secs`:
+        // `sleep 30` with `timeout_secs: 30` under `with_max_timeout_secs(1)`
+        // is killed at ~1s, so a closed worker's foreground command cannot
+        // outlive its deadline even when the LLM asks for a big timeout.
+        let tool = ShellTool::new(std::env::temp_dir()).with_max_timeout_secs(1);
+        let started = std::time::Instant::now();
+        let result = tool
+            .execute(&serde_json::json!({"command": "sleep 30", "timeout_secs": 30}))
+            .await
+            .unwrap();
+        assert!(!result.success, "a capped, timed-out command must fail");
+        assert!(
+            result.output.contains("timed out after 1 seconds"),
+            "expected a 1s timeout (cap applied), got: {}",
+            result.output
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "the 1s cap must bound the wait well under the requested 30s",
         );
     }
 

--- a/crates/octos-fleet-worker/Cargo.toml
+++ b/crates/octos-fleet-worker/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "octos-fleet-worker"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Closed, non-interactive fleet task worker: audited replay-safe tool registry + bounded pool over the fleet kernel store"
+
+[dependencies]
+eyre.workspace = true
+octos-agent.workspace = true
+octos-core.workspace = true
+octos-fleet.workspace = true
+octos-llm.workspace = true
+octos-memory.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+async-trait.workspace = true
+tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/octos-fleet-worker/src/closed_registry.rs
+++ b/crates/octos-fleet-worker/src/closed_registry.rs
@@ -1,0 +1,308 @@
+//! Module 1 — the closed, replay-safe worker tool registry (**the crux**).
+//!
+//! A fleet task-worker is *provably* non-interactive: it may hold only the
+//! seven native tools that are safe to run and re-run headless (read/write/
+//! edit files, glob/grep search, list dirs, and a fail-closed shell). It
+//! must NOT be able to park (`ask_user_question`/`request_user_input`), fan
+//! out (`spawn*`/`delegate*`/`peer_*`), reach the network
+//! (`web_*`/`http`/`browser`/deep-crawl), message a channel (`message`/
+//! `send_*`), or mutate durable memory (`recall_memory`/`save_memory`/…).
+//!
+//! [`build_fleet_worker_registry`] starts from an EMPTY [`ToolRegistry`]
+//! (never [`ToolRegistry::with_builtins`], which registers ~35 tools
+//! including the parking + fan-out set), registers exactly the allow-set,
+//! and then hard-removes anything else with [`ToolRegistry::apply_policy`]
+//! as a belt-and-suspenders lock on the invariant. The exhaustive audit
+//! test asserts `tool_names() == ALLOWED`, so any future dynamic tool
+//! (MCP/plugin/skill) sneaking in fails the build.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use octos_agent::policy::{ApprovalPolicy, EffectivePermissions};
+use octos_agent::sandbox::Sandbox;
+use octos_agent::tools::policy::ToolPolicy;
+use octos_agent::tools::{
+    EditFileTool, GlobTool, GrepTool, ListDirTool, ReadFileTool, ShellTool, ToolRegistry,
+    WriteFileTool,
+};
+
+/// The EXACT set of native tool names a closed fleet task-worker may hold.
+/// Every one is replay-safe (idempotent-enough to re-run after a crash) and
+/// none blocks on human input. The audit test asserts the built registry's
+/// `tool_names()` equals this set — no more, no less.
+pub const ALLOWED: &[&str] = &[
+    "read_file",
+    "write_file",
+    "edit_file",
+    "glob",
+    "grep",
+    "list_dir",
+    "shell",
+];
+
+/// Build the closed, replay-safe tool registry for a fleet task-worker
+/// rooted at `cwd`, with `sandbox` backing the shell tool and each shell
+/// command's effective timeout CAPPED at `max_shell_timeout_secs` (the attempt
+/// deadline, in whole seconds) so no single foreground command outlives it.
+///
+/// The closed tool set is a DENYLIST (it removes parking/fan-out/network
+/// *tools*), NOT a network or process boundary. The surviving `shell` can
+/// still reach the network and can still detach a child via arbitrary
+/// shell-internal backgrounding that string inspection cannot catch (e.g.
+/// `sleep 600 & true`). Both are bounded by the **sandbox**: production MUST
+/// supply a network-isolated sandbox whose process-group/container teardown
+/// reaps detached children. Passing a no-op sandbox here is an operator error
+/// (flagged with a `tracing::warn!`), analogous to `--danger-full-access`.
+pub fn build_fleet_worker_registry(
+    cwd: &Path,
+    sandbox: Arc<dyn Sandbox>,
+    max_shell_timeout_secs: u64,
+) -> ToolRegistry {
+    // P1-3-enforce (document, don't type-enforce): the API cannot police
+    // sandbox quality, but a no-op sandbox leaves the shell's network reach and
+    // detached children unbounded — surface it so it can't pass silently.
+    if sandbox.is_noop() {
+        tracing::warn!(
+            "fleet worker: building a closed registry with a NO-OP sandbox — the \
+             shell's network reach and detached children are UNBOUNDED; production \
+             must supply a network-isolated sandbox",
+        );
+    }
+
+    // Workspace read/write, but approvals FAIL CLOSED at the tool boundary:
+    // a shell command that the SafePolicy would ask about is denied outright
+    // (a closed worker has no human to ask). `SafePolicy` is preserved — we
+    // do NOT widen to AllowAll — so dangerous commands stay blocked.
+    let perms = EffectivePermissions::workspace_write().with_approval_policy(ApprovalPolicy::Never);
+    let scope = perms.filesystem_scope; // Workspace
+    let access = perms.file_access; // ReadWrite
+
+    let mut r = ToolRegistry::new();
+    // Mirror `with_builtins`: record the workspace root so the agent's
+    // session-scope fallback and any project-root machinery resolve against
+    // the same cwd the tools are bound to.
+    r.set_workspace_root(cwd.to_path_buf());
+    r.register(
+        ShellTool::new(cwd)
+            .with_shared_sandbox(sandbox)
+            .with_policy(perms.shell_command_policy())
+            .with_approval_policy(ApprovalPolicy::Never)
+            // Refuse the string-detectable detach vectors (`background: true`
+            // and a trailing `&`) as defense-in-depth — the sandbox is the real
+            // boundary for detached children (see the fn doc).
+            .with_background_allowed(false)
+            // Hard per-command CEILING at the attempt deadline: combined with
+            // `background_allowed(false)`, no single foreground command outlives
+            // the deadline even if the LLM requests a larger `timeout_secs`.
+            .with_max_timeout_secs(max_shell_timeout_secs),
+    );
+    r.register(ReadFileTool::new(cwd).with_filesystem_scope(scope));
+    r.register(
+        WriteFileTool::new(cwd)
+            .with_filesystem_scope(scope)
+            .with_file_access(access),
+    );
+    r.register(
+        EditFileTool::new(cwd)
+            .with_filesystem_scope(scope)
+            .with_file_access(access),
+    );
+    r.register(GlobTool::new(cwd).with_filesystem_scope(scope));
+    r.register(GrepTool::new(cwd));
+    r.register(ListDirTool::new(cwd).with_filesystem_scope(scope));
+
+    // Belt-and-suspenders: hard-remove anything not in the allow-set. A no-op
+    // today (we registered exactly the allow-set and nothing auto-swaps,
+    // because no tool is named "spawn"), but it locks the invariant so a
+    // future edit that registers an extra tool cannot silently widen the
+    // worker's reach — `apply_policy` -> `retain` is a real removal.
+    r.apply_policy(&ToolPolicy {
+        allow: ALLOWED.iter().map(|s| s.to_string()).collect(),
+        ..Default::default()
+    });
+    r
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use octos_agent::sandbox::NoSandbox;
+    use std::collections::HashSet;
+    use std::path::Path;
+    use std::sync::Arc;
+
+    /// Tools that must NEVER appear in a closed worker registry. This is a
+    /// supplementary explicit denylist; the exhaustive `tool_names() ==
+    /// ALLOWED` assertion below is the real guard (it also catches names not
+    /// listed here). Covers the parking, fan-out, peer, channel, network,
+    /// memory, skill, and dispatch families.
+    const FORBIDDEN: &[&str] = &[
+        // parking / plan / human input
+        "ask_user_question",
+        "request_user_input",
+        "update_plan",
+        "write_stdin",
+        // fan-out / sub-agent lifecycle
+        "spawn",
+        "spawn_agent",
+        "delegate",
+        "delegate_task",
+        "send_input",
+        "resume_agent",
+        "wait_agent",
+        "close_agent",
+        "read_task_output",
+        "check_background_tasks",
+        // peers
+        "peer_handoff",
+        "peer_gather",
+        "peer_list",
+        "peer_send_input",
+        "peer_close",
+        "peer_respond",
+        // channel / messaging
+        "cron",
+        "message",
+        "send_file",
+        "send_app_card",
+        // network / external
+        "browser",
+        "web_search",
+        "web_fetch",
+        "search",
+        "deep_crawl",
+        "http",
+        "synthesize_research",
+        // skills / dispatch
+        "manage_skills",
+        "mofa_make",
+        "mofa_describe_content_type",
+        // memory
+        "recall_memory",
+        "save_memory",
+        "memory_note",
+        "record_memory_use",
+        // misc non-replay-safe
+        "view_image",
+        "tool_search",
+        "tool_suggest",
+        "image_generation",
+        // extra shell/edit variants that with_builtins also registers but the
+        // closed worker deliberately excludes
+        "exec_command",
+        "bash",
+        "apply_patch",
+        "diff_edit",
+    ];
+
+    fn allowed_sorted() -> Vec<String> {
+        let mut v: Vec<String> = ALLOWED.iter().map(|s| s.to_string()).collect();
+        v.sort();
+        v
+    }
+
+    #[test]
+    fn closed_worker_registry_has_only_replay_safe_tools() {
+        let reg = build_fleet_worker_registry(
+            Path::new("/tmp/fleet-worker-audit"),
+            Arc::new(NoSandbox),
+            30,
+        );
+
+        // (2) EXHAUSTIVE: the registry contains EXACTLY the allow-set — no
+        // more, no less. This is the boundary that catches any future
+        // dynamic (MCP/plugin/skill) tool sneaking in.
+        let mut names = reg.tool_names();
+        names.sort();
+        assert_eq!(
+            names,
+            allowed_sorted(),
+            "closed worker registry must contain EXACTLY the replay-safe tools",
+        );
+
+        let spec_names: HashSet<String> = reg.specs().into_iter().map(|s| s.name).collect();
+
+        // (1) every FORBIDDEN name is un-gettable AND absent from specs().
+        for name in FORBIDDEN {
+            assert!(
+                reg.get(name).is_none(),
+                "forbidden tool {name} must not be gettable from the closed registry",
+            );
+            assert!(
+                !spec_names.contains(*name),
+                "forbidden tool {name} must not appear in specs()",
+            );
+        }
+
+        // (3) NOTHING in the registry blocks on human input.
+        for name in reg.tool_names() {
+            assert!(
+                !reg.blocks_on_human_input(&name),
+                "tool {name} blocks on human input — a closed worker must never park",
+            );
+        }
+
+        // Sanity: every allowed tool is actually present + LLM-visible.
+        for name in ALLOWED {
+            assert!(
+                reg.get(name).is_some(),
+                "allowed tool {name} missing from closed registry",
+            );
+            assert!(
+                spec_names.contains(*name),
+                "allowed tool {name} not exposed in specs()",
+            );
+        }
+    }
+
+    /// P1-1: the closed worker's shell refuses BOTH an explicit
+    /// `background: true` arg and a trailing `&`. A detached child would
+    /// outlive the attempt and dodge the deadline, so both forms fail closed
+    /// (before any child is spawned).
+    #[tokio::test]
+    async fn closed_worker_shell_refuses_background() {
+        let reg = build_fleet_worker_registry(&std::env::temp_dir(), Arc::new(NoSandbox), 30);
+        let shell = reg.get("shell").expect("shell tool present");
+
+        let explicit = shell
+            .execute(&serde_json::json!({"command": "sleep 30", "background": true}))
+            .await
+            .unwrap();
+        assert!(
+            !explicit.success,
+            "explicit background must be refused, got: {}",
+            explicit.output
+        );
+
+        let ampersand = shell
+            .execute(&serde_json::json!({"command": "sleep 30 &"}))
+            .await
+            .unwrap();
+        assert!(
+            !ampersand.success,
+            "trailing-& background must be refused, got: {}",
+            ampersand.output
+        );
+    }
+
+    /// Discriminator: proves the audit above is not vacuous — the FULL
+    /// builtin registry DOES carry the parking + fan-out tools the closed
+    /// set forbids, so the exhaustive assertion genuinely rejects them.
+    #[test]
+    fn with_builtins_registry_would_contain_ask_user_question() {
+        let reg = ToolRegistry::with_builtins(Path::new("/tmp/fleet-worker-discriminator"));
+        assert!(
+            reg.get("ask_user_question").is_some(),
+            "with_builtins must register ask_user_question (else the audit is vacuous)",
+        );
+        assert!(
+            reg.blocks_on_human_input("ask_user_question"),
+            "ask_user_question must block on human input",
+        );
+        assert!(
+            reg.get("spawn_agent").is_some(),
+            "with_builtins must register spawn_agent",
+        );
+    }
+}

--- a/crates/octos-fleet-worker/src/lib.rs
+++ b/crates/octos-fleet-worker/src/lib.rs
@@ -1,0 +1,298 @@
+//! octos-fleet-worker — the closed, non-interactive fleet task worker.
+//!
+//! This crate is the executor half of the fleet kernel (see `octos-fleet`
+//! for the durable store). It provides:
+//!
+//! - [`build_fleet_worker_registry`] — the **closed** replay-safe tool
+//!   registry (the crux: a worker that provably cannot park or fan out);
+//! - [`run_attempt`] — the per-attempt executor that runs one plan task
+//!   under a hard deadline, gates it on acceptance criteria, and records
+//!   the real outcome to the [`octos_fleet::FleetKernelStore`];
+//! - [`FleetWorkerPool`] — the bounded pool that launches a ready task and
+//!   runs its attempt under global + per-fleet concurrency permits.
+//!
+//! It deliberately does NOT own the pool lifecycle, consume the outbox,
+//! wake the keeper, or expose any LLM tool — those land in later PRs.
+//!
+//! # The sandbox is the boundary (not the tool list)
+//!
+//! The closed registry is a *denylist* of tool names — it removes parking,
+//! fan-out, and network *tools*. It is NOT a network or process boundary: the
+//! surviving `shell` can still reach the network (`curl`, `wget`, a non-force
+//! `git push`) and can still detach a child via arbitrary shell-internal
+//! backgrounding (`sleep 600 & true`, `sh -c "cmd &"`) that string inspection
+//! cannot catch. Both are bounded only by the **sandbox** and its process-group
+//! /container teardown, which is why [`AgentFactory::new`] requires an explicit
+//! sandbox factory (no silent no-op default) and production MUST supply a
+//! network-isolated sandbox — an operator requirement the API cannot enforce at
+//! the type level (a no-op sandbox is flagged with a `tracing::warn!`).
+//! [`AgentFactory::for_testing`] is the only no-op path and is gated behind
+//! `cfg(test)`.
+//!
+//! # Deadline enforcement
+//!
+//! [`run_attempt`] wraps the agent run in a hard [`tokio::time::timeout`],
+//! [`AgentFactory`] clamps the agent's per-tool timeouts to the deadline, the
+//! worker shell also carries a hard per-command CEILING at the deadline (so a
+//! foreground command cannot outlive it even if the LLM requests a larger
+//! `timeout_secs`), the string-detectable background vectors are refused, and
+//! the acceptance phase is itself bounded by the remaining deadline. The
+//! residual: a child detached by arbitrary shell-internal backgrounding, or a
+//! tool task the agent loop detaches on its own timeout, is reaped only by the
+//! sandbox's process-group teardown — not by this crate.
+#![deny(unsafe_code)]
+
+mod closed_registry;
+mod pool;
+mod worker;
+
+#[cfg(test)]
+mod testutil;
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use octos_agent::sandbox::Sandbox;
+use octos_agent::{Agent, AgentConfig, ToolRegistry};
+use octos_core::AgentId;
+use octos_llm::LlmProvider;
+use octos_memory::EpisodeStore;
+
+pub use closed_registry::{ALLOWED, build_fleet_worker_registry};
+pub use pool::{Dispatched, FleetWorkerPool, PoolConfig};
+pub use worker::{AttemptOutcome, run_attempt};
+
+/// A per-cwd sandbox factory: given a working directory, produce the
+/// [`Sandbox`] that backs the shell tool for an attempt rooted there.
+pub type SandboxFactory = Arc<dyn Fn(&Path) -> Arc<dyn Sandbox> + Send + Sync>;
+
+/// Default agent-loop iteration ceiling for a fleet task-worker.
+pub const DEFAULT_MAX_ITERATIONS: u32 = 50;
+
+/// Builds fresh, closed-registry [`Agent`]s (and matching validator
+/// registries) for fleet task attempts.
+///
+/// Every agent is minted with the same shared LLM provider and episodic
+/// memory, a per-cwd sandbox from the EXPLICIT `sandbox_factory` (the shell's
+/// network reach is bounded by the sandbox, not the closed tool list — see the
+/// crate docs), the closed replay-safe tool registry, and an [`AgentConfig`]
+/// with `save_episodes: false` (a fleet worker's episodic write-back is owned
+/// by the keeper, not the throwaway attempt) whose per-tool timeouts are
+/// clamped to the attempt deadline.
+#[derive(Clone)]
+pub struct AgentFactory {
+    llm: Arc<dyn LlmProvider>,
+    memory: Arc<EpisodeStore>,
+    sandbox_factory: SandboxFactory,
+    max_iterations: u32,
+    max_tokens: Option<u32>,
+}
+
+impl AgentFactory {
+    /// A factory over a shared provider + episodic store and an EXPLICIT
+    /// per-cwd sandbox factory.
+    ///
+    /// The sandbox is mandatory by design: the closed tool set is a denylist,
+    /// not a boundary, so the shell's reach (`curl`/`wget`/`git push`) is
+    /// bounded only by the sandbox. Production MUST pass a network-isolated
+    /// sandbox (bwrap/docker/macos). There is deliberately no silent no-op
+    /// default — [`AgentFactory::for_testing`] is the only [`NoSandbox`] path.
+    pub fn new(
+        llm: Arc<dyn LlmProvider>,
+        memory: Arc<EpisodeStore>,
+        sandbox_factory: SandboxFactory,
+    ) -> Self {
+        Self {
+            llm,
+            memory,
+            sandbox_factory,
+            max_iterations: DEFAULT_MAX_ITERATIONS,
+            max_tokens: None,
+        }
+    }
+
+    /// TEST-ONLY constructor whose shell tool runs with NO sandbox
+    /// ([`NoSandbox`]). This is the ONLY no-op-sandbox path in the crate and is
+    /// gated behind `cfg(test)`, so no production build can ship an
+    /// un-sandboxed fleet worker. Everywhere else use [`AgentFactory::new`]
+    /// with a real sandbox factory.
+    #[cfg(test)]
+    pub fn for_testing(llm: Arc<dyn LlmProvider>, memory: Arc<EpisodeStore>) -> Self {
+        use octos_agent::sandbox::NoSandbox;
+        Self::new(
+            llm,
+            memory,
+            Arc::new(|_| Arc::new(NoSandbox) as Arc<dyn Sandbox>),
+        )
+    }
+
+    /// Override the agent-loop iteration ceiling.
+    pub fn with_max_iterations(mut self, max_iterations: u32) -> Self {
+        self.max_iterations = max_iterations;
+        self
+    }
+
+    /// Override the per-attempt total-token ceiling (`None` = unlimited).
+    pub fn with_max_tokens(mut self, max_tokens: Option<u32>) -> Self {
+        self.max_tokens = max_tokens;
+        self
+    }
+
+    /// The per-cwd [`Sandbox`] backing this factory's shell tool. `run_attempt`
+    /// calls this ONCE per attempt and threads the single instance into both
+    /// the agent registry and the acceptance validators (see
+    /// [`AgentFactory::build_agent`] / [`AgentFactory::build_registry_with`]),
+    /// so a non-idempotent factory can never sandbox the agent while handing
+    /// the validators a different (weaker) sandbox.
+    pub fn sandbox_for(&self, cwd: &Path) -> Arc<dyn Sandbox> {
+        (self.sandbox_factory)(cwd)
+    }
+
+    /// Build the closed replay-safe tool registry for `cwd` with an EXPLICIT,
+    /// caller-owned `sandbox` instance and a per-command shell timeout ceiling
+    /// of `max_shell_timeout_secs`. Threading the instance (rather than
+    /// re-invoking the factory) is what lets the agent and the acceptance-gate
+    /// [`octos_agent::ValidatorRunner`] share one sandbox.
+    pub fn build_registry_with(
+        &self,
+        cwd: &Path,
+        sandbox: Arc<dyn Sandbox>,
+        max_shell_timeout_secs: u64,
+    ) -> ToolRegistry {
+        build_fleet_worker_registry(cwd, sandbox, max_shell_timeout_secs)
+    }
+
+    /// The [`AgentConfig`] for an attempt bounded by `deadline`. The per-tool
+    /// timeouts (`tool_timeout_secs` and the interactive default) are CLAMPED
+    /// to the deadline so no single tool call can outlive the fleet deadline by
+    /// more than its own now-bounded timeout. See the crate docs for the
+    /// residual soft-deadline caveat.
+    pub(crate) fn agent_config(&self, deadline: Duration) -> AgentConfig {
+        let deadline_secs = deadline.as_secs().max(1);
+        let base = AgentConfig::default();
+        AgentConfig {
+            max_iterations: self.max_iterations,
+            max_tokens: self.max_tokens,
+            save_episodes: false,
+            tool_timeout_secs: base.tool_timeout_secs.min(deadline_secs),
+            default_interactive_tool_timeout_secs: base
+                .default_interactive_tool_timeout_secs
+                .min(deadline_secs),
+            ..base
+        }
+    }
+
+    /// Build a fresh, closed-registry [`Agent`] rooted at `cwd` under the
+    /// shared `sandbox`, bounded by `deadline` (which clamps the agent's
+    /// per-tool timeouts AND caps every shell command at the deadline).
+    pub fn build_agent(&self, cwd: &Path, sandbox: Arc<dyn Sandbox>, deadline: Duration) -> Agent {
+        let deadline_secs = deadline.as_secs().max(1);
+        Agent::new(
+            AgentId::new("fleet-worker"),
+            self.llm.clone(),
+            self.build_registry_with(cwd, sandbox, deadline_secs),
+            self.memory.clone(),
+        )
+        .with_config(self.agent_config(deadline))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testutil::{SuccessProvider, fresh_memory};
+    use octos_agent::sandbox::NoSandbox;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::process::Command;
+
+    /// A non-no-op marker sandbox: inherits the default `is_noop() == false`,
+    /// so a factory that threads it proves the injected sandbox reaches the
+    /// shell path rather than being replaced by a silent `NoSandbox`.
+    struct MarkerSandbox;
+    impl Sandbox for MarkerSandbox {
+        fn wrap_command(&self, shell_command: &str, cwd: &Path) -> Command {
+            NoSandbox.wrap_command(shell_command, cwd)
+        }
+    }
+
+    /// P1-3: the sandbox factory passed to `new` is actually threaded to the
+    /// shell path — there is no silent `NoSandbox` default overriding it — and
+    /// `for_testing` is the ONLY no-op-sandbox path.
+    #[tokio::test]
+    async fn sandbox_factory_is_threaded_not_defaulted() {
+        let (_m1, memory) = fresh_memory().await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let seen = calls.clone();
+        let factory = AgentFactory::new(
+            Arc::new(SuccessProvider),
+            memory,
+            Arc::new(move |_| {
+                seen.fetch_add(1, Ordering::SeqCst);
+                Arc::new(MarkerSandbox) as Arc<dyn Sandbox>
+            }),
+        );
+
+        let sb = factory.sandbox_for(Path::new("/tmp/fleet-x"));
+        assert!(
+            !sb.is_noop(),
+            "the injected sandbox must reach the shell, not a NoSandbox default",
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "sandbox_for must invoke the injected factory",
+        );
+
+        // build_registry_with threads the caller-owned instance WITHOUT
+        // re-invoking the factory — the shared-instance contract (P1-3-fix).
+        let _reg = factory.build_registry_with(Path::new("/tmp/fleet-x"), sb.clone(), 30);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "build_registry_with must NOT re-invoke the sandbox factory",
+        );
+
+        let (_m2, memory2) = fresh_memory().await;
+        let test_factory = AgentFactory::for_testing(Arc::new(SuccessProvider), memory2);
+        assert!(
+            test_factory
+                .sandbox_for(Path::new("/tmp/fleet-x"))
+                .is_noop(),
+            "for_testing must be the NoSandbox path",
+        );
+    }
+
+    /// P1-2: the agent config clamps per-tool timeouts to the attempt deadline,
+    /// so no single tool call is configured to outlive it.
+    #[tokio::test]
+    async fn tool_timeouts_are_clamped_to_the_deadline() {
+        let (_m, memory) = fresh_memory().await;
+        let factory = AgentFactory::for_testing(Arc::new(SuccessProvider), memory);
+
+        let deadline = Duration::from_secs(5);
+        let cfg = factory.agent_config(deadline);
+        assert!(
+            cfg.tool_timeout_secs <= deadline.as_secs(),
+            "tool_timeout_secs {} must be <= deadline {}s",
+            cfg.tool_timeout_secs,
+            deadline.as_secs(),
+        );
+        assert!(
+            cfg.default_interactive_tool_timeout_secs <= deadline.as_secs(),
+            "interactive tool timeout {} must be <= deadline {}s",
+            cfg.default_interactive_tool_timeout_secs,
+            deadline.as_secs(),
+        );
+        assert!(!cfg.save_episodes, "fleet attempts must not save episodes");
+
+        // A deadline longer than the stock ceilings leaves them unchanged.
+        let long = Duration::from_secs(100_000);
+        let base = AgentConfig::default();
+        assert_eq!(
+            factory.agent_config(long).tool_timeout_secs,
+            base.tool_timeout_secs,
+            "a long deadline must not inflate the stock tool timeout",
+        );
+    }
+}

--- a/crates/octos-fleet-worker/src/pool.rs
+++ b/crates/octos-fleet-worker/src/pool.rs
@@ -1,0 +1,771 @@
+//! Module 3 — [`FleetWorkerPool`]: the bounded launcher.
+//!
+//! `dispatch` is *preflight → launch → permit-bounded background run*:
+//!
+//! 1. **Preflight (before any durable state):** read the task's brief from the
+//!    fleet view and create its working dir. Doing this BEFORE `launch_child`
+//!    means a failure leaves NO durable attempt — a bad `workspace_root` or a
+//!    missing task can never wedge a child in `Launching` (P1-4a).
+//! 2. **Launch:** CAS a `Ready` child to launched (a typed [`LaunchOutcome`],
+//!    never an error).
+//! 3. On `Launched`, arm a **drop-guard** over the `[launch → complete]` region
+//!    — SYNCHRONOUSLY, with no `.await` between `launch_child` and arming it,
+//!    then MOVE it into the spawned future (P1-4a) so even a future dropped
+//!    before its first poll (`dispatch().await` then `handle.abort()` on a
+//!    current-thread runtime) still fires the guard's `Terminated` cleanup and
+//!    can't leave the child `Launching`. The spawned run then acquires the
+//!    PER-FLEET permit BEFORE the global permit (P2-1: a task blocked on its
+//!    fleet's bound must not hold a global slot and head-of-line starve other
+//!    fleets) and runs the attempt holding both; it disarms the guard only when
+//!    the attempt is settled-or-not-ours, keeping it armed on a `RecordError`
+//!    (P1-4b).
+//!
+//! Concurrency is clamped to ≥1 at construction (P2-1: a zero permit would
+//! launch-then-wait-forever). Production drops the returned [`JoinHandle`]
+//! (launch-and-return); tests await it.
+//!
+//! **Shutdown residual (P1-4c):** the guard's cleanup is spawned only if a
+//! Tokio runtime is in scope ([`tokio::runtime::Handle::try_current`], so a
+//! sync drop never panics); during runtime/process shutdown it may not run, and
+//! recovery then falls to BOOT reconciliation of the stale lease (the owning
+//! daemon's contract, a later PR).
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use eyre::{Result, eyre};
+use tokio::sync::{Mutex, Semaphore};
+use tokio::task::JoinHandle;
+
+use octos_core::safe_filename;
+use octos_fleet::{AcceptanceVerdict, ChildResultSnapshot, Fleet, FleetKernelStore, LaunchOutcome};
+
+use crate::{AgentFactory, AttemptOutcome, run_attempt};
+
+/// Static configuration for a [`FleetWorkerPool`].
+///
+/// The agent-loop knobs (`max_iterations` / `max_tokens`) live on the
+/// [`AgentFactory`], the single source of truth for how an attempt's agent
+/// is built — they are deliberately NOT duplicated here.
+#[derive(Debug, Clone)]
+pub struct PoolConfig {
+    /// Max attempts running across ALL fleets at once.
+    pub global_concurrency: usize,
+    /// Max attempts running per single fleet at once.
+    pub per_fleet_concurrency: usize,
+    /// Hard wall-clock deadline for one attempt's agent run.
+    pub deadline: Duration,
+    /// This daemon boot's lease owner epoch (fences stale completions).
+    pub owner_epoch: u64,
+    /// Lease TTL stamped at launch (recovery reclaims an expired lease).
+    pub lease_ttl_ms: u64,
+    /// Tokens reserved on the fleet budget at launch (soft admission).
+    pub projected_tokens: u64,
+    /// Base directory under which each attempt gets its own working dir
+    /// (`<workspace_root>/<fleet>/<task>`), used as the tool cwd + the
+    /// acceptance-gate root.
+    pub workspace_root: PathBuf,
+}
+
+/// The result of a [`FleetWorkerPool::dispatch`]: the typed launch decision
+/// plus, on `Launched`, the background run's [`JoinHandle`]. A `Rejected*`
+/// launch carries `handle: None` (no work was spawned).
+#[derive(Debug)]
+pub struct Dispatched {
+    pub launch: LaunchOutcome,
+    pub handle: Option<JoinHandle<AttemptOutcome>>,
+}
+
+/// A bounded pool of closed task-workers over one [`FleetKernelStore`].
+pub struct FleetWorkerPool {
+    store: Arc<FleetKernelStore>,
+    factory: Arc<AgentFactory>,
+    cfg: PoolConfig,
+    global_sem: Arc<Semaphore>,
+    /// Per-fleet permit semaphores, shared into each spawned run so the
+    /// (awaiting) lookup happens INSIDE the guarded future, not before it
+    /// (P1-4a). `Arc` so the spawned `'static` future can hold it.
+    per_fleet: Arc<Mutex<HashMap<String, Arc<Semaphore>>>>,
+    clock: Arc<dyn Fn() -> u64 + Send + Sync>,
+}
+
+impl FleetWorkerPool {
+    /// Build a pool. `clock` supplies wall-clock milliseconds for launch and
+    /// completion settlement.
+    pub fn new(
+        store: Arc<FleetKernelStore>,
+        factory: Arc<AgentFactory>,
+        cfg: PoolConfig,
+        clock: Arc<dyn Fn() -> u64 + Send + Sync>,
+    ) -> Self {
+        // P2-1: a zero permit would launch the child then wait forever on a
+        // permit that never frees. Clamp to ≥1 so the pool always makes
+        // progress; a misconfigured `0` self-heals to serial execution.
+        if cfg.global_concurrency == 0 || cfg.per_fleet_concurrency == 0 {
+            tracing::warn!(
+                global = cfg.global_concurrency,
+                per_fleet = cfg.per_fleet_concurrency,
+                "fleet worker pool: zero concurrency clamped to 1 (would otherwise hang)",
+            );
+        }
+        let global_sem = Arc::new(Semaphore::new(cfg.global_concurrency.max(1)));
+        Self {
+            store,
+            factory,
+            cfg,
+            global_sem,
+            per_fleet: Arc::new(Mutex::new(HashMap::new())),
+            clock,
+        }
+    }
+
+    /// Get-or-create a fleet's permit semaphore in `map` (clamped ≥1, P2-1).
+    /// A free fn over the shared `map` + concurrency so the spawned run can do
+    /// the lookup INSIDE its guarded future (P1-4a) without borrowing `self`.
+    async fn per_fleet_sem(
+        map: &Mutex<HashMap<String, Arc<Semaphore>>>,
+        fleet_id: &str,
+        per_fleet_concurrency: usize,
+    ) -> Arc<Semaphore> {
+        map.lock()
+            .await
+            .entry(fleet_id.to_string())
+            .or_insert_with(|| Arc::new(Semaphore::new(per_fleet_concurrency.max(1))))
+            .clone()
+    }
+
+    /// Launch a ready task and, on success, spawn its permit-bounded run.
+    ///
+    /// Returns immediately with the typed [`LaunchOutcome`]; on `Launched`
+    /// the [`Dispatched::handle`] resolves to the attempt's [`AttemptOutcome`]
+    /// once the background run finishes.
+    ///
+    /// Fallible PREFLIGHT (reading the task view + creating the working dir)
+    /// runs BEFORE `launch_child`, so a failure returns an `Err` with NO
+    /// durable attempt — the child stays `Ready` and is never wedged in
+    /// `Launching` (P1-4a).
+    pub async fn dispatch(&self, fleet_id: &str, task_id: &str) -> Result<Dispatched> {
+        // ---- PREFLIGHT (before any durable state) ----
+        let view = Fleet::bind(self.store.clone(), fleet_id.to_string())
+            .view()
+            .await?;
+        let Some(task_view) = view.tasks.into_iter().find(|t| t.task_id == task_id) else {
+            return Err(eyre!(
+                "task {task_id} is absent from fleet {fleet_id}'s plan"
+            ));
+        };
+        let working_dir = self
+            .cfg
+            .workspace_root
+            .join(safe_filename(fleet_id))
+            .join(safe_filename(task_id));
+        tokio::fs::create_dir_all(&working_dir).await.map_err(|e| {
+            eyre!(
+                "preflight: create working dir {} failed: {e}",
+                working_dir.display()
+            )
+        })?;
+
+        // ---- LAUNCH (durable state) ----
+        let now = (self.clock)();
+        let launch = self
+            .store
+            .launch_child(
+                fleet_id,
+                task_id,
+                self.cfg.projected_tokens,
+                now,
+                self.cfg.owner_epoch,
+                self.cfg.lease_ttl_ms,
+            )
+            .await?;
+
+        let LaunchOutcome::Launched { attempt_id } = &launch else {
+            // RejectedNotReady / RejectedDoubleLaunch / RejectedBudgetExceeded:
+            // no work is spawned.
+            return Ok(Dispatched {
+                launch,
+                handle: None,
+            });
+        };
+        let attempt_id = attempt_id.clone();
+
+        let store = self.store.clone();
+        let factory = self.factory.clone();
+        let clock = self.clock.clone();
+        let global_sem = self.global_sem.clone();
+        let per_fleet = self.per_fleet.clone();
+        let per_fleet_concurrency = self.cfg.per_fleet_concurrency;
+        let deadline = self.cfg.deadline;
+        let owner_epoch = self.cfg.owner_epoch;
+        let fleet_id = fleet_id.to_string();
+        let task_id = task_id.to_string();
+
+        // P1-4a: arm the drop-guard SYNCHRONOUSLY here — there is NO `.await`
+        // between `launch_child` returning `Launched` and this line — then MOVE
+        // it into the spawned future. So even a future that is dropped before
+        // its first poll (e.g. current-thread runtime: `dispatch().await` then
+        // `handle.abort()`) still drops its captured guard → `Drop` fires the
+        // `Terminated` cleanup. The whole `[launch → complete]` window is
+        // guarded with no gap. The store's four-part CAS makes the cleanup a
+        // no-op if the attempt was already settled/superseded.
+        let guard = LaunchGuard {
+            store: store.clone(),
+            fleet_id: fleet_id.clone(),
+            task_id: task_id.clone(),
+            attempt_id: attempt_id.clone(),
+            owner_epoch,
+            clock: clock.clone(),
+            armed: true,
+        };
+
+        let handle = tokio::spawn(async move {
+            // `guard` is captured by-move into this future (referenced below),
+            // so it is OWNED by the future and dropped with it — including if
+            // the future is dropped before its first poll (P1-4a).
+
+            // Per-fleet sem lookup happens INSIDE the guarded future (its await
+            // no longer sits between launch and the guard). P2-1: acquire the
+            // PER-FLEET permit BEFORE the global one — a task blocked on its
+            // fleet's bound must not hold a global slot (head-of-line starving
+            // other fleets). Hold BOTH for the whole run.
+            let fleet_sem = Self::per_fleet_sem(&per_fleet, &fleet_id, per_fleet_concurrency).await;
+            let Ok(_fleet) = fleet_sem.acquire_owned().await else {
+                return AttemptOutcome::Aborted {
+                    reason: "per-fleet semaphore closed".to_string(),
+                };
+            };
+            let Ok(_global) = global_sem.acquire_owned().await else {
+                return AttemptOutcome::Aborted {
+                    reason: "global semaphore closed".to_string(),
+                };
+            };
+
+            let run_clock = clock.clone();
+            let outcome = run_attempt(
+                store,
+                &fleet_id,
+                &task_id,
+                &attempt_id,
+                &task_view,
+                &factory,
+                &working_dir,
+                deadline,
+                owner_epoch,
+                move || (run_clock)(),
+            )
+            .await;
+
+            // P1-4b: disarm ONLY when the attempt is settled-or-not-ours (see
+            // `should_disarm`). A `RecordError` — our own store CAS
+            // (`mark_running`/`complete_child`) hit an infra error, so the
+            // attempt may still be live and ours — KEEPS the guard armed so
+            // `Drop` un-wedges it.
+            if should_disarm(&outcome) {
+                guard.disarm();
+            }
+            outcome
+        });
+
+        Ok(Dispatched {
+            launch,
+            handle: Some(handle),
+        })
+    }
+}
+
+/// Whether an [`AttemptOutcome`] means the [`LaunchGuard`] should be DISARMED
+/// (the attempt is settled or provably not ours, so no drop-cleanup is owed):
+///
+/// - `Completed` / `Superseded` — the attempt reached a durable terminal state.
+/// - `Aborted` — `mark_running` returned `Superseded`, a genuine lost race, so
+///   the attempt belongs to someone else.
+///
+/// A [`AttemptOutcome::RecordError`] — our own store CAS
+/// (`mark_running`/`complete_child`) hit an infra error, so the attempt may
+/// still be live AND ours — must KEEP the guard armed (returns `false`) so its
+/// `Drop` best-effort completes it and can't wedge the child in `Launching`
+/// (round-4 P1).
+fn should_disarm(outcome: &AttemptOutcome) -> bool {
+    matches!(
+        outcome,
+        AttemptOutcome::Completed { .. }
+            | AttemptOutcome::Superseded
+            | AttemptOutcome::Aborted { .. }
+    )
+}
+
+/// Drop-guard over the `[launch → complete]` region (P1-4).
+///
+/// If the in-flight run exits WITHOUT disarming — a panic, a runtime cancel,
+/// an early abort (even before the future's first poll, since the guard is
+/// captured by the future — P1-4a), or a `RecordError` where our own
+/// `complete_child` failed (P1-4b) — it best-effort completes the attempt
+/// `Terminated`, so a launched child can never wedge in `Launching`. The
+/// store's four-part CAS (fleet + task + attempt + owner-epoch) renders the
+/// completion a no-op when the attempt was already settled or superseded.
+///
+/// **Shutdown residual (P1-4c):** the cleanup is spawned onto the current
+/// Tokio runtime via [`tokio::runtime::Handle::try_current`] — so a `Drop`
+/// with no runtime (e.g. a synchronous unit test) does not panic. During
+/// runtime/process shutdown the in-process cleanup may not run at all (a
+/// dropped/never-polled cleanup task, or no runtime). Recovery then falls to
+/// BOOT reconciliation: `FleetKernelStore::reconcile` interrupts the stale
+/// (foreign-`owner_epoch`) lease on the next boot. That boot-reconcile contract
+/// is the owning daemon's (a later wiring PR), not this crate's.
+struct LaunchGuard {
+    store: Arc<FleetKernelStore>,
+    fleet_id: String,
+    task_id: String,
+    attempt_id: String,
+    owner_epoch: u64,
+    clock: Arc<dyn Fn() -> u64 + Send + Sync>,
+    armed: bool,
+}
+
+impl LaunchGuard {
+    /// Consume the guard on the normal path so its [`Drop`] is a no-op.
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for LaunchGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // P1-4c: only spawn if a runtime is in scope. A `Drop` outside any
+        // runtime (a sync unit test, or process shutdown) would otherwise
+        // PANIC in `tokio::spawn`; here it degrades to boot reconciliation.
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            tracing::warn!(
+                fleet_id = %self.fleet_id, task_id = %self.task_id, attempt_id = %self.attempt_id,
+                "fleet worker: drop-guard could not complete the attempt (no runtime); \
+                 boot reconciliation will interrupt the stale lease",
+            );
+            return;
+        };
+        let store = self.store.clone();
+        let fleet_id = std::mem::take(&mut self.fleet_id);
+        let task_id = std::mem::take(&mut self.task_id);
+        let attempt_id = std::mem::take(&mut self.attempt_id);
+        let owner_epoch = self.owner_epoch;
+        let now = (self.clock)();
+        const INTERRUPTED: &str = "attempt interrupted before completion";
+        runtime.spawn(async move {
+            // `complete_child` requires the attempt to be `Running`. A pre-poll
+            // abort leaves it `Launching` (its `mark_running` never ran), so
+            // best-effort advance it first. `mark_running` is a CAS (needs
+            // Launching + current attempt): it succeeds for a still-Launching
+            // attempt, and harmlessly errors for one already Running (the
+            // normal interrupted case) or superseded — either way
+            // `complete_child`'s own four-part CAS then settles or no-ops.
+            let _ = store.mark_running(&task_id, &attempt_id).await;
+            let snapshot = ChildResultSnapshot {
+                output: String::new(),
+                success: false,
+                tokens_used: 0,
+                files: Vec::new(),
+                error: Some(INTERRUPTED.to_string()),
+            };
+            if let Err(err) = store
+                .complete_child(
+                    &fleet_id,
+                    &task_id,
+                    &attempt_id,
+                    AcceptanceVerdict::Terminated {
+                        reason: INTERRUPTED.to_string(),
+                    },
+                    snapshot,
+                    0,
+                    owner_epoch,
+                    now,
+                )
+                .await
+            {
+                tracing::warn!(
+                    %fleet_id, %task_id, %attempt_id, error = %err,
+                    "fleet worker: drop-guard completion failed (advisory; recovery reconciles)",
+                );
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testutil::*;
+    use octos_fleet::ChildStatus;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tempfile::TempDir;
+
+    fn pool_config(work: &TempDir, global: usize, per_fleet: usize) -> PoolConfig {
+        PoolConfig {
+            global_concurrency: global,
+            per_fleet_concurrency: per_fleet,
+            deadline: Duration::from_secs(30),
+            owner_epoch: EPOCH,
+            lease_ttl_ms: TTL,
+            projected_tokens: PROJECTED,
+            workspace_root: work.path().to_path_buf(),
+        }
+    }
+
+    fn fixed_clock() -> Arc<dyn Fn() -> u64 + Send + Sync> {
+        Arc::new(|| NOW)
+    }
+
+    /// Poll a child's status until it equals `want` (or panic after 5s).
+    async fn wait_for_status(
+        store: &FleetKernelStore,
+        fleet_id: &str,
+        task_id: &str,
+        want: ChildStatus,
+    ) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let status = store
+                .get_child(fleet_id, task_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status;
+            if status == want {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "child {task_id} did not reach {want:?} within 5s (last: {status:?})",
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    /// Poll a child until it reaches a terminal status (or panic after 5s).
+    async fn wait_for_terminal(
+        store: &FleetKernelStore,
+        fleet_id: &str,
+        task_id: &str,
+    ) -> ChildStatus {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let status = store
+                .get_child(fleet_id, task_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status;
+            if matches!(status, ChildStatus::Succeeded | ChildStatus::Failed) {
+                return status;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "child {task_id} did not reach a terminal state within 5s (last: {status:?})",
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    #[test]
+    fn record_error_keeps_guard_armed_others_disarm() {
+        // round-4 P1: the outcome→disarm mapping. Settled-or-not-ours outcomes
+        // disarm; a store-CAS infra error (`RecordError`) KEEPS the guard armed
+        // so its `Drop` un-wedges a possibly-still-live attempt.
+        assert!(should_disarm(&AttemptOutcome::Completed {
+            verdict: AcceptanceVerdict::Accepted {
+                evidence: Vec::new()
+            },
+        }));
+        assert!(should_disarm(&AttemptOutcome::Superseded));
+        assert!(should_disarm(&AttemptOutcome::Aborted {
+            reason: "mark_running superseded".to_string(),
+        }));
+        assert!(
+            !should_disarm(&AttemptOutcome::RecordError {
+                reason: "mark_running errored: redb down".to_string(),
+            }),
+            "an infra RecordError must keep the guard armed for Drop cleanup",
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_double_launch_is_rejected() {
+        let (_sd, store) = fresh_store().await;
+        create_fleet(store.clone(), "f1", vec![task_spec("a", &[], vec![])]).await;
+
+        let work = TempDir::new().unwrap();
+        let (_md, factory) = factory_for(Arc::new(SuccessProvider)).await;
+        let pool = FleetWorkerPool::new(
+            store.clone(),
+            Arc::new(factory),
+            pool_config(&work, 4, 4),
+            fixed_clock(),
+        );
+
+        let first = pool.dispatch("f1", "a").await.unwrap();
+        assert!(
+            matches!(first.launch, LaunchOutcome::Launched { .. }),
+            "first dispatch must launch, got {:?}",
+            first.launch,
+        );
+
+        // The child is now in flight with a live attempt: a second dispatch
+        // of the same task is a double-launch and spawns NO work.
+        let second = pool.dispatch("f1", "a").await.unwrap();
+        assert_eq!(second.launch, LaunchOutcome::RejectedDoubleLaunch);
+        assert!(
+            second.handle.is_none(),
+            "rejected dispatch must not spawn a run"
+        );
+
+        // Let the first attempt finish cleanly.
+        let outcome = first.handle.unwrap().await.unwrap();
+        assert!(
+            matches!(outcome, AttemptOutcome::Completed { .. }),
+            "got {outcome:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_preflight_rejects_bad_workspace_root_without_launching() {
+        // P1-4a: a workspace_root that is an existing FILE makes the preflight
+        // `create_dir_all(<file>/f1/a)` fail BEFORE launch_child — so dispatch
+        // errors and NO durable attempt is created: the child stays Ready and
+        // is never wedged in `Launching`.
+        let (_sd, store) = fresh_store().await;
+        create_fleet(store.clone(), "f1", vec![task_spec("a", &[], vec![])]).await;
+
+        let tmp = TempDir::new().unwrap();
+        let file_root = tmp.path().join("not-a-dir");
+        tokio::fs::write(&file_root, b"x").await.unwrap();
+
+        let cfg = PoolConfig {
+            global_concurrency: 4,
+            per_fleet_concurrency: 4,
+            deadline: Duration::from_secs(30),
+            owner_epoch: EPOCH,
+            lease_ttl_ms: TTL,
+            projected_tokens: PROJECTED,
+            workspace_root: file_root,
+        };
+        let (_md, factory) = factory_for(Arc::new(SuccessProvider)).await;
+        let pool = FleetWorkerPool::new(store.clone(), Arc::new(factory), cfg, fixed_clock());
+
+        let result = pool.dispatch("f1", "a").await;
+        assert!(
+            result.is_err(),
+            "preflight must reject a file workspace_root, got {result:?}",
+        );
+
+        // No durable attempt: the child is still Ready (never Launching).
+        let child = store.get_child("f1", "a").await.unwrap().unwrap();
+        assert_eq!(
+            child.status,
+            ChildStatus::Ready,
+            "child must stay Ready after a rejected preflight, not wedge in Launching",
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn interrupted_attempt_ends_terminal_not_stuck_launching() {
+        // P1-4b: an attempt cancelled mid-run must NOT stay `Launching`/
+        // `Running` forever — the drop-guard best-effort completes it
+        // `Terminated`, so the child ends terminal (`Failed`).
+        let (_sd, store) = fresh_store().await;
+        create_fleet(store.clone(), "f1", vec![task_spec("a", &[], vec![])]).await;
+
+        let work = TempDir::new().unwrap();
+        // Sleeps 30s so the attempt is mid-run when we abort it.
+        let (_md, factory) = factory_for(Arc::new(SleepProvider {
+            hold: Duration::from_secs(30),
+        }))
+        .await;
+        let pool = FleetWorkerPool::new(
+            store.clone(),
+            Arc::new(factory),
+            pool_config(&work, 4, 4),
+            fixed_clock(),
+        );
+
+        let d = pool.dispatch("f1", "a").await.unwrap();
+        assert!(matches!(d.launch, LaunchOutcome::Launched { .. }));
+        let handle = d.handle.unwrap();
+
+        // Wait until the attempt has reached mark_running (child Running) so
+        // the interruption lands squarely inside the guarded region.
+        wait_for_status(&store, "f1", "a", ChildStatus::Running).await;
+
+        // Cancel the in-flight run mid-sleep: the guard must fire.
+        handle.abort();
+
+        // The child must reach a terminal state (Failed), not stay Launching.
+        let final_status = wait_for_terminal(&store, "f1", "a").await;
+        assert_eq!(
+            final_status,
+            ChildStatus::Failed,
+            "an interrupted attempt must end Failed via the drop-guard",
+        );
+    }
+
+    #[tokio::test]
+    async fn pre_poll_abort_does_not_leak_launching_child() {
+        // P1-4a: on a current-thread runtime, `dispatch().await` schedules the
+        // run future but does NOT poll it before we `abort()`. Because the
+        // guard is armed synchronously at dispatch (no await after launch) and
+        // MOVED into the future, dropping the never-polled future still fires
+        // the Terminated cleanup — so the child does not wedge in `Launching`.
+        let (_sd, store) = fresh_store().await;
+        create_fleet(store.clone(), "f1", vec![task_spec("a", &[], vec![])]).await;
+
+        let work = TempDir::new().unwrap();
+        let (_md, factory) = factory_for(Arc::new(SuccessProvider)).await;
+        let pool = FleetWorkerPool::new(
+            store.clone(),
+            Arc::new(factory),
+            pool_config(&work, 4, 4),
+            fixed_clock(),
+        );
+
+        let d = pool.dispatch("f1", "a").await.unwrap();
+        assert!(matches!(d.launch, LaunchOutcome::Launched { .. }));
+        let handle = d.handle.unwrap();
+        // Abort BEFORE the spawned future is ever polled (no yield since
+        // dispatch returned).
+        handle.abort();
+
+        // The guard must still drive the child terminal (Failed), not leak it
+        // in Launching.
+        let status = wait_for_terminal(&store, "f1", "a").await;
+        assert_eq!(
+            status,
+            ChildStatus::Failed,
+            "a pre-poll abort must not leak a Launching child",
+        );
+    }
+
+    #[tokio::test]
+    async fn zero_concurrency_is_clamped_not_hung() {
+        // P2-1: zero global AND per-fleet concurrency would launch the child
+        // then wait forever on a permit that never frees. The pool clamps zero
+        // to 1, so the attempt runs to completion.
+        let (_sd, store) = fresh_store().await;
+        create_fleet(store.clone(), "f1", vec![task_spec("a", &[], vec![])]).await;
+
+        let work = TempDir::new().unwrap();
+        let (_md, factory) = factory_for(Arc::new(SuccessProvider)).await;
+        let pool = FleetWorkerPool::new(
+            store.clone(),
+            Arc::new(factory),
+            pool_config(&work, 0, 0),
+            fixed_clock(),
+        );
+
+        let d = pool.dispatch("f1", "a").await.unwrap();
+        assert!(matches!(d.launch, LaunchOutcome::Launched { .. }));
+        let outcome = tokio::time::timeout(Duration::from_secs(10), d.handle.unwrap())
+            .await
+            .expect("zero concurrency must not hang (clamped to 1)")
+            .unwrap();
+        assert!(
+            matches!(outcome, AttemptOutcome::Completed { .. }),
+            "got {outcome:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_not_ready_task_is_rejected() {
+        let (_sd, store) = fresh_store().await;
+        // b depends on a, so b is not Ready.
+        create_fleet(
+            store.clone(),
+            "f1",
+            vec![task_spec("a", &[], vec![]), task_spec("b", &["a"], vec![])],
+        )
+        .await;
+
+        let work = TempDir::new().unwrap();
+        let (_md, factory) = factory_for(Arc::new(SuccessProvider)).await;
+        let pool = FleetWorkerPool::new(
+            store.clone(),
+            Arc::new(factory),
+            pool_config(&work, 4, 4),
+            fixed_clock(),
+        );
+
+        let dispatched = pool.dispatch("f1", "b").await.unwrap();
+        assert_eq!(dispatched.launch, LaunchOutcome::RejectedNotReady);
+        assert!(dispatched.handle.is_none());
+    }
+
+    #[tokio::test]
+    async fn pool_bounds_concurrency() {
+        let (_sd, store) = fresh_store().await;
+        // Five independent (dep-free) tasks — all Ready at once.
+        let tasks = ["t0", "t1", "t2", "t3", "t4"]
+            .iter()
+            .map(|id| task_spec(id, &[], vec![]))
+            .collect();
+        create_fleet(store.clone(), "f1", tasks).await;
+
+        let active = Arc::new(AtomicUsize::new(0));
+        let max = Arc::new(AtomicUsize::new(0));
+        let provider = Arc::new(ConcurrencyProvider {
+            active: active.clone(),
+            max: max.clone(),
+            hold: Duration::from_millis(150),
+        });
+
+        let work = TempDir::new().unwrap();
+        let (_md, factory) = factory_for(provider).await;
+        // global cap 2, per-fleet cap high so the GLOBAL cap is the binding one.
+        let pool = FleetWorkerPool::new(
+            store.clone(),
+            Arc::new(factory),
+            pool_config(&work, 2, 5),
+            fixed_clock(),
+        );
+
+        let mut handles = Vec::new();
+        for id in ["t0", "t1", "t2", "t3", "t4"] {
+            let d = pool.dispatch("f1", id).await.unwrap();
+            assert!(
+                matches!(d.launch, LaunchOutcome::Launched { .. }),
+                "{id} must launch"
+            );
+            handles.push(d.handle.unwrap());
+        }
+
+        let mut completed = 0;
+        for h in handles {
+            let outcome = h.await.unwrap();
+            assert!(
+                matches!(outcome, AttemptOutcome::Completed { .. }),
+                "got {outcome:?}"
+            );
+            completed += 1;
+        }
+
+        assert_eq!(completed, 5, "all five attempts must complete");
+        let observed = max.load(Ordering::SeqCst);
+        assert!(
+            observed <= 2,
+            "observed max concurrency {observed} exceeded the global bound of 2",
+        );
+        assert!(
+            observed >= 2,
+            "expected the pool to actually run 2 attempts in parallel (observed {observed})",
+        );
+        // All five children reached Succeeded.
+        for id in ["t0", "t1", "t2", "t3", "t4"] {
+            assert_eq!(
+                store.get_child("f1", id).await.unwrap().unwrap().status,
+                ChildStatus::Succeeded,
+                "{id} must be Succeeded",
+            );
+        }
+    }
+}

--- a/crates/octos-fleet-worker/src/testutil.rs
+++ b/crates/octos-fleet-worker/src/testutil.rs
@@ -1,0 +1,263 @@
+//! Shared test helpers: in-memory-ish store/fleet builders and scripted
+//! mock LLM providers. Compiled only under `#[cfg(test)]`.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use eyre::Result;
+use octos_core::{Message, SessionKey};
+use octos_fleet::{
+    AcceptanceCriterion, Fleet, FleetBudget, FleetKernelStore, LaunchOutcome, TaskSpec, Verifier,
+};
+use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, ToolSpec};
+use octos_memory::EpisodeStore;
+use tempfile::TempDir;
+
+use crate::AgentFactory;
+
+pub const EPOCH: u64 = 100;
+pub const TTL: u64 = 10_000;
+pub const PROJECTED: u64 = 100;
+pub const NOW: u64 = 1_000;
+
+pub fn controller() -> SessionKey {
+    SessionKey::new("fleet", "keeper-1")
+}
+
+pub fn budget(cap: u64) -> FleetBudget {
+    FleetBudget {
+        token_budget: cap,
+        tokens_reserved: 0,
+        tokens_committed: 0,
+        hard: false,
+    }
+}
+
+/// A fresh kernel store in its own tempdir (kept alive by the returned guard).
+pub async fn fresh_store() -> (TempDir, Arc<FleetKernelStore>) {
+    let dir = TempDir::new().unwrap();
+    let store = FleetKernelStore::open(dir.path()).await.unwrap();
+    (dir, Arc::new(store))
+}
+
+/// A fresh episodic store in its own tempdir.
+pub async fn fresh_memory() -> (TempDir, Arc<EpisodeStore>) {
+    let dir = TempDir::new().unwrap();
+    let memory = EpisodeStore::open(dir.path()).await.unwrap();
+    (dir, Arc::new(memory))
+}
+
+/// A `TaskSpec` with the given deps + acceptance.
+pub fn task_spec(id: &str, deps: &[&str], acceptance: Vec<AcceptanceCriterion>) -> TaskSpec {
+    TaskSpec {
+        task_id: id.to_string(),
+        title: format!("Task {id}"),
+        detail: "do the thing".to_string(),
+        deps: deps.iter().map(|s| s.to_string()).collect(),
+        acceptance,
+    }
+}
+
+/// One hard `FileExists` acceptance criterion on `path`.
+pub fn file_exists(path: &str) -> Vec<AcceptanceCriterion> {
+    vec![AcceptanceCriterion {
+        id: "file".to_string(),
+        description: format!("{path} must be written"),
+        verifier: Verifier::FileExists {
+            path: path.to_string(),
+        },
+    }]
+}
+
+/// One `ValidatorRef` acceptance criterion — unsupported by the v1 executor,
+/// so the gate must fail closed on it (never pass on the agent's self-report).
+pub fn validator_ref(id: &str) -> Vec<AcceptanceCriterion> {
+    vec![AcceptanceCriterion {
+        id: "vref".to_string(),
+        description: format!("validator {id} must pass"),
+        verifier: Verifier::ValidatorRef { id: id.to_string() },
+    }]
+}
+
+/// One `CommandExit(0)` acceptance criterion running `cmd` (whitespace argv,
+/// NO shell — the validator runs the split program + args directly).
+pub fn command_exit(cmd: &str) -> Vec<AcceptanceCriterion> {
+    vec![AcceptanceCriterion {
+        id: "cmd".to_string(),
+        description: format!("`{cmd}` must exit 0"),
+        verifier: Verifier::CommandExit {
+            cmd: cmd.to_string(),
+            code: 0,
+        },
+    }]
+}
+
+/// Create a fleet + plan from `tasks` (generous budget, `now = NOW`).
+pub async fn create_fleet(
+    store: Arc<FleetKernelStore>,
+    fleet_id: &str,
+    tasks: Vec<TaskSpec>,
+) -> Fleet {
+    Fleet::create(
+        store,
+        fleet_id,
+        controller(),
+        "default",
+        budget(1_000_000),
+        "objective",
+        tasks,
+        NOW,
+    )
+    .await
+    .unwrap()
+}
+
+/// Launch a `Ready` child and return its attempt id (panics otherwise).
+pub async fn launch(store: &FleetKernelStore, fleet_id: &str, task_id: &str) -> String {
+    match store
+        .launch_child(fleet_id, task_id, PROJECTED, NOW, EPOCH, TTL)
+        .await
+        .unwrap()
+    {
+        LaunchOutcome::Launched { attempt_id } => attempt_id,
+        other => panic!("expected Launched for {task_id}, got {other:?}"),
+    }
+}
+
+/// An [`AgentFactory`] over `provider` and a throwaway episodic store, built
+/// via the test-only [`AgentFactory::for_testing`] (no-op sandbox). The
+/// returned [`TempDir`] must be held for the store's lifetime.
+pub async fn factory_for(provider: Arc<dyn LlmProvider>) -> (TempDir, AgentFactory) {
+    let (dir, memory) = fresh_memory().await;
+    (dir, AgentFactory::for_testing(provider, memory))
+}
+
+fn usage() -> octos_llm::TokenUsage {
+    octos_llm::TokenUsage {
+        input_tokens: 7,
+        output_tokens: 3,
+        ..Default::default()
+    }
+}
+
+fn end_turn(text: &str) -> ChatResponse {
+    ChatResponse {
+        content: Some(text.to_string()),
+        reasoning_content: None,
+        tool_calls: vec![],
+        stop_reason: StopReason::EndTurn,
+        usage: usage(),
+        provider_index: None,
+    }
+}
+
+/// Always ends the turn with a successful text answer, calling NO tools.
+/// Used to prove the acceptance gate rejects a run that produced no artifact.
+pub struct SuccessProvider;
+
+#[async_trait]
+impl LlmProvider for SuccessProvider {
+    async fn chat(&self, _m: &[Message], _t: &[ToolSpec], _c: &ChatConfig) -> Result<ChatResponse> {
+        Ok(end_turn("done, nothing to write"))
+    }
+    fn model_id(&self) -> &str {
+        "mock"
+    }
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+/// Writes `path` via the `write_file` tool on the first turn, then ends.
+pub struct WriteFileProvider {
+    pub path: String,
+    calls: AtomicUsize,
+}
+
+impl WriteFileProvider {
+    pub fn new(path: &str) -> Self {
+        Self {
+            path: path.to_string(),
+            calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for WriteFileProvider {
+    async fn chat(&self, _m: &[Message], _t: &[ToolSpec], _c: &ChatConfig) -> Result<ChatResponse> {
+        if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            return Ok(ChatResponse {
+                content: None,
+                reasoning_content: None,
+                tool_calls: vec![octos_core::ToolCall {
+                    id: "call_write".to_string(),
+                    name: "write_file".to_string(),
+                    arguments: serde_json::json!({
+                        "path": self.path,
+                        "content": "fleet worker artifact\n",
+                    }),
+                    metadata: None,
+                }],
+                stop_reason: StopReason::ToolUse,
+                usage: usage(),
+                provider_index: None,
+            });
+        }
+        Ok(end_turn("wrote the artifact"))
+    }
+    fn model_id(&self) -> &str {
+        "mock"
+    }
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+/// Sleeps past the attempt deadline on the first `chat`, so the `timeout`
+/// wrapper in `run_attempt` fires.
+pub struct SleepProvider {
+    pub hold: Duration,
+}
+
+#[async_trait]
+impl LlmProvider for SleepProvider {
+    async fn chat(&self, _m: &[Message], _t: &[ToolSpec], _c: &ChatConfig) -> Result<ChatResponse> {
+        tokio::time::sleep(self.hold).await;
+        Ok(end_turn("finished after a long nap"))
+    }
+    fn model_id(&self) -> &str {
+        "mock"
+    }
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+/// Records max observed concurrency: increments `active` on entry, folds it
+/// into `max`, holds `hold`, then decrements and ends. Used to prove the
+/// pool never runs more than `global_concurrency` attempts at once.
+pub struct ConcurrencyProvider {
+    pub active: Arc<AtomicUsize>,
+    pub max: Arc<AtomicUsize>,
+    pub hold: Duration,
+}
+
+#[async_trait]
+impl LlmProvider for ConcurrencyProvider {
+    async fn chat(&self, _m: &[Message], _t: &[ToolSpec], _c: &ChatConfig) -> Result<ChatResponse> {
+        let now = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max.fetch_max(now, Ordering::SeqCst);
+        tokio::time::sleep(self.hold).await;
+        self.active.fetch_sub(1, Ordering::SeqCst);
+        Ok(end_turn("done"))
+    }
+    fn model_id(&self) -> &str {
+        "mock"
+    }
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}

--- a/crates/octos-fleet-worker/src/worker.rs
+++ b/crates/octos-fleet-worker/src/worker.rs
@@ -1,0 +1,1240 @@
+//! Module 2 — `run_attempt`: the per-attempt executor.
+//!
+//! It receives an already-launched `attempt_id` (the pool launches; this
+//! runs it to a recorded terminal state) and:
+//!
+//! 1. CASes the attempt `Leased/Launching → Running` — a `Superseded` outcome
+//!    is a lost race (`Aborted`), a store `Err` is infra (`RecordError`);
+//! 2. builds a [`Task`] from the task's brief + acceptance criteria;
+//! 3. mints a fresh closed-registry [`octos_agent::Agent`];
+//! 4. runs it under a HARD [`tokio::time::timeout`] (the agent loop has no
+//!    internal wall-clock deadline);
+//! 5. maps the result to an [`AcceptanceVerdict`] — a timeout/infra-error is
+//!    `Terminated`, a `success:false` stop is `Rejected`, a `success:true`
+//!    run is gated on acceptance (`Accepted`/`Rejected`);
+//! 6. records the real outcome + snapshot to the store, then unblocks
+//!    dependents.
+//!
+//! # Known v1 limitations (documented, not yet fixed)
+//!
+//! - **Token under-commit on non-success paths (P2-2).** A timeout or infra
+//!   error drops the [`octos_core::TaskResult`], so its [`TokenUsage`] is lost
+//!   and the attempt commits `0` tokens against the fleet budget (see
+//!   [`Computed::terminated`]). Upstream `turn_state` also does not fold
+//!   `reasoning_tokens`, so even a committed count can under-report. This is a
+//!   soft-budget v1 limitation (kernel spec §6): the budget is advisory, so an
+//!   under-commit only weakens admission pressure, never correctness.
+//!   Best-effort usage capture on the timeout path is a possible follow-up.
+//! - **`split_whitespace` argv for `CommandExit` (P3).** A `CommandExit`
+//!   verifier's command is split on whitespace into program + argv with NO
+//!   shell, which is injection-resistant but quoting-naive: `test -f "out
+//!   file.txt"` splits into four tokens and would falsely reject. Acceptance
+//!   commands must use un-quoted, whitespace-free argv tokens for v1.
+//! - **`FileExists` confinement is point-in-time (TOCTOU, P2).**
+//!   [`check_file_exists_confined`] resolves + containment-checks the path
+//!   (`canonicalize`) and then `metadata`s it as two separate syscalls; a
+//!   concurrent writer could swap an in-workspace file for an external symlink
+//!   between the two, and `metadata` would follow it. This is acceptable ONLY
+//!   under v1's single-writer-per-task-workspace assumption: the confinement is
+//!   a point-in-time check, not a race-proof absolute guarantee against a
+//!   hostile concurrent mutator of the task's own workspace.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use octos_agent::sandbox::Sandbox;
+use octos_agent::validators::{
+    ValidatorInvocation, ValidatorOutcome, ValidatorPhase, ValidatorRunner, ValidatorStatus,
+};
+use octos_agent::workspace_policy::{Validator, ValidatorPhaseKind, ValidatorSpec};
+use octos_core::{Message, Task, TaskContext, TaskKind, TaskResult, TokenUsage};
+use octos_fleet::{
+    AcceptanceVerdict, ChildResultSnapshot, CompleteOutcome, EvidenceRef, Fleet, FleetKernelStore,
+    MarkRunningOutcome, TaskView, Verifier,
+};
+
+use crate::AgentFactory;
+
+/// Minimum acceptance-phase budget (P1-5b floor). A run that finishes right at
+/// the deadline still gets this small window to verify, rather than a 0ms
+/// timeout. Real deadlines dwarf it, so it only binds at the deadline edge.
+const ACCEPTANCE_MIN_BUDGET: Duration = Duration::from_secs(2);
+
+/// Slack added on top of a command validator's own `timeout_ms` for the coarse
+/// outer backstop (round-4 P1). The per-validator `timeout_ms` is what actually
+/// kills the subprocess (its cancellation-safe internal `timeout` +
+/// `kill_child_process`); the backstop only guards against a validator that
+/// hangs OUTSIDE that awaited kill path, so it must be comfortably longer than
+/// the validator's internal SIGTERM→SIGKILL grace or it would preempt the kill.
+const ACCEPTANCE_BACKSTOP_GRACE: Duration = Duration::from_secs(2);
+
+/// Terminal disposition of a single attempt run — returned for logging and
+/// tests, never persisted (the durable record is written to the store).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttemptOutcome {
+    /// The attempt completed and its verdict was recorded (child terminal).
+    Completed { verdict: AcceptanceVerdict },
+    /// The completion CAS found the attempt stale/superseded: its result was
+    /// dropped and no state changed (deliberately not an error).
+    Superseded,
+    /// `mark_running` returned `Superseded` — the attempt was stale/superseded
+    /// (a lost race) before the run started, so it is genuinely NOT ours: it
+    /// was NOT completed and the pool disarms the guard. Recovery/relaunch
+    /// reconciles it.
+    Aborted { reason: String },
+    /// A store CAS itself errored (`mark_running` or `complete_child` hit an
+    /// I/O / parse / invariant break): the attempt may still be live and ours,
+    /// so the pool KEEPS the guard armed (its `Drop` un-wedges the child) and
+    /// the caller logs and lets recovery reconcile.
+    RecordError { reason: String },
+}
+
+/// Run one launched attempt to a recorded terminal state. See the module
+/// docs for the sequence. `actual_now_ms` is the wall clock threaded into
+/// the store's `complete_child` (settlement timestamp) and the follow-on
+/// readiness promotion.
+#[allow(clippy::too_many_arguments)] // store + ids + view + factory + deadline + epoch + clock are irreducible
+pub async fn run_attempt(
+    store: Arc<FleetKernelStore>,
+    fleet_id: &str,
+    task_id: &str,
+    attempt_id: &str,
+    task_view: &TaskView,
+    factory: &AgentFactory,
+    working_dir: &Path,
+    deadline: Duration,
+    owner_epoch: u64,
+    actual_now_ms: impl Fn() -> u64,
+) -> AttemptOutcome {
+    // 1. CAS Leased/Launching -> Running, distinguishing a genuine lost race
+    //    from an infra error (round-4 P1):
+    //    - `Superseded` — the attempt is stale/superseded or not the child's
+    //      current one: genuinely NOT ours, so `Aborted` (the pool disarms the
+    //      guard; relaunch/recovery owns the fallout).
+    //    - `Err` — a real store/infra failure: the still-`Launching` attempt may
+    //      still be ours, so `RecordError` (the pool KEEPS the guard armed so
+    //      its `Drop` un-wedges the child). Never conflate the two.
+    match store.mark_running(task_id, attempt_id).await {
+        Ok(MarkRunningOutcome::Running) => {}
+        Ok(MarkRunningOutcome::Superseded) => {
+            tracing::warn!(
+                %fleet_id, %task_id, %attempt_id,
+                "fleet worker: mark_running superseded (attempt not ours); aborting without completing",
+            );
+            return AttemptOutcome::Aborted {
+                reason: "mark_running superseded".to_string(),
+            };
+        }
+        Err(err) => {
+            tracing::error!(
+                %fleet_id, %task_id, %attempt_id, error = %err,
+                "fleet worker: mark_running infra error; keeping guard armed for drop-cleanup",
+            );
+            return AttemptOutcome::RecordError {
+                reason: format!("mark_running errored: {err}"),
+            };
+        }
+    }
+
+    // 2. Build the Task from the rendered brief + acceptance criteria.
+    let task = Task::new(
+        TaskKind::Custom {
+            name: "fleet_task".to_string(),
+            params: serde_json::json!({
+                "fleet_id": fleet_id,
+                "task_id": task_id,
+                "attempt_id": attempt_id,
+            }),
+        },
+        TaskContext {
+            working_dir: working_dir.to_path_buf(),
+            working_memory: vec![Message::user(render_brief(task_view))],
+            ..Default::default()
+        },
+    );
+
+    // P1-3-fix: ONE sandbox instance for the whole attempt, shared by the
+    // agent's closed registry AND the acceptance validators — so a
+    // non-idempotent factory can never sandbox the agent while handing the
+    // validators a weaker (e.g. no-op) sandbox.
+    let sandbox = factory.sandbox_for(working_dir);
+
+    // 3. Fresh, closed-registry agent (cannot park, cannot fan out) under the
+    //    shared sandbox. Its per-tool timeouts AND per-command shell ceiling
+    //    are clamped to `deadline` (P1-2).
+    let agent = factory.build_agent(working_dir, sandbox.clone(), deadline);
+
+    // 4. Run under a HARD deadline — `run_task` is cancel-safe to drop and
+    //    has NO internal wall-clock cap, so the timeout wrapper is mandatory.
+    let start = Instant::now();
+    let run = tokio::time::timeout(deadline, agent.run_task(&task)).await;
+    let elapsed = start.elapsed();
+
+    // 5-6. Map the result to a verdict + snapshot inputs.
+    let computed = match run {
+        Err(_elapsed) => {
+            Computed::terminated(format!("deadline exceeded after {}s", deadline.as_secs()))
+        }
+        Ok(Err(report)) => Computed::terminated(format!("run failed: {report}")),
+        Ok(Ok(result)) if !result.success => {
+            let reason = if result.output.trim().is_empty() {
+                "run did not succeed".to_string()
+            } else {
+                result.output.clone()
+            };
+            Computed::rejected(reason, &result)
+        }
+        Ok(Ok(result)) => {
+            // P1-5b: bound the acceptance phase by the REMAINING deadline so a
+            // slow `CommandExit` validator can't hold both permits past the
+            // fleet deadline. A small floor keeps a right-at-the-edge run from
+            // getting a 0ms acceptance budget.
+            let remaining = deadline
+                .checked_sub(elapsed)
+                .unwrap_or(Duration::ZERO)
+                .max(ACCEPTANCE_MIN_BUDGET);
+            let (verdict, error) = run_acceptance(
+                task_view,
+                working_dir,
+                factory,
+                sandbox,
+                deadline.as_secs().max(1),
+                remaining,
+            )
+            .await;
+            Computed::from_verdict(verdict, error, &result)
+        }
+    };
+
+    // 7. Record the real outcome + snapshot to the store DIRECTLY (not
+    //    `Fleet::record_outcome`, which cannot carry the snapshot).
+    let now = actual_now_ms();
+    let snapshot = ChildResultSnapshot {
+        output: computed.output,
+        success: matches!(computed.verdict, AcceptanceVerdict::Accepted { .. }),
+        tokens_used: computed.actual_tokens,
+        files: computed.files,
+        error: computed.error,
+    };
+    match store
+        .complete_child(
+            fleet_id,
+            task_id,
+            attempt_id,
+            computed.verdict.clone(),
+            snapshot,
+            computed.actual_tokens,
+            owner_epoch,
+            now,
+        )
+        .await
+    {
+        Ok(CompleteOutcome::Completed) => {
+            // Unblock dependents. `ready_tasks` is self-healing + atomic, so a
+            // failure here is advisory — recovery/the keeper re-derives it.
+            if let Err(err) = Fleet::bind(store.clone(), fleet_id).ready_tasks(now).await {
+                tracing::warn!(
+                    %fleet_id, error = %err,
+                    "fleet worker: post-completion ready_tasks failed (advisory)",
+                );
+            }
+            AttemptOutcome::Completed {
+                verdict: computed.verdict,
+            }
+        }
+        Ok(CompleteOutcome::Superseded) => AttemptOutcome::Superseded,
+        Err(err) => {
+            tracing::error!(
+                %fleet_id, %task_id, %attempt_id, error = %err,
+                "fleet worker: complete_child errored",
+            );
+            AttemptOutcome::RecordError {
+                reason: err.to_string(),
+            }
+        }
+    }
+}
+
+/// The verdict plus the fields fed into the [`ChildResultSnapshot`].
+struct Computed {
+    verdict: AcceptanceVerdict,
+    output: String,
+    files: Vec<String>,
+    error: Option<String>,
+    actual_tokens: u64,
+}
+
+impl Computed {
+    /// Timeout / infra error — no `TaskResult` to draw from, so `0` tokens are
+    /// committed (P2-2 soft-budget v1 limitation; see the module docs).
+    fn terminated(reason: String) -> Self {
+        Self {
+            verdict: AcceptanceVerdict::Terminated {
+                reason: reason.clone(),
+            },
+            output: String::new(),
+            files: Vec::new(),
+            error: Some(reason),
+            actual_tokens: 0,
+        }
+    }
+
+    /// A `success:false` run stop (budget / max-tokens / content-filter).
+    fn rejected(reason: String, result: &TaskResult) -> Self {
+        Self {
+            verdict: AcceptanceVerdict::Rejected {
+                reason: reason.clone(),
+            },
+            output: result.output.clone(),
+            files: files_to_strings(result),
+            error: Some(reason),
+            actual_tokens: total_tokens(&result.token_usage),
+        }
+    }
+
+    /// A `success:true` run mapped through the acceptance gate.
+    fn from_verdict(
+        verdict: AcceptanceVerdict,
+        error: Option<String>,
+        result: &TaskResult,
+    ) -> Self {
+        Self {
+            verdict,
+            output: result.output.clone(),
+            files: files_to_strings(result),
+            error,
+            actual_tokens: total_tokens(&result.token_usage),
+        }
+    }
+}
+
+fn files_to_strings(result: &TaskResult) -> Vec<String> {
+    result
+        .files_modified
+        .iter()
+        .map(|p| p.display().to_string())
+        .collect()
+}
+
+/// The meaningful token fields, summed: input + output + reasoning. Cache
+/// read/write tokens are excluded (they are not fresh work).
+fn total_tokens(usage: &TokenUsage) -> u64 {
+    u64::from(usage.input_tokens)
+        + u64::from(usage.output_tokens)
+        + u64::from(usage.reasoning_tokens)
+}
+
+/// Render the task brief the worker agent sees: title + detail + the
+/// acceptance criteria as text (so the agent knows what "done" means).
+fn render_brief(task_view: &TaskView) -> String {
+    let mut brief = format!("# Task: {}\n", task_view.title);
+    if !task_view.detail.trim().is_empty() {
+        brief.push('\n');
+        brief.push_str(task_view.detail.trim());
+        brief.push('\n');
+    }
+    if !task_view.acceptance.is_empty() {
+        brief.push_str("\n## Acceptance criteria — ALL must hold\n");
+        for crit in &task_view.acceptance {
+            let how = match &crit.verifier {
+                Verifier::FileExists { path } => format!("file `{path}` must exist"),
+                Verifier::CommandExit { cmd, code } => {
+                    format!("`{cmd}` must exit with code {code}")
+                }
+                Verifier::ValidatorRef { id } => format!("validator `{id}` must pass"),
+                Verifier::Manual => "manual verification".to_string(),
+            };
+            brief.push_str(&format!("- {} ({})\n", crit.description, how));
+        }
+    }
+    brief
+}
+
+/// Run the mechanical acceptance gate over the task's criteria. Returns the
+/// verdict and, on rejection, a human-readable reason.
+///
+/// - `FileExists{path}` is evaluated IN THE WORKER (P1-5a) via
+///   [`check_file_exists_confined`]: lexically confined, then `canonicalize`d
+///   and asserted to stay UNDER the canonical workspace root as a regular file
+///   — so an in-workspace symlink (`out.txt -> /etc/passwd`) cannot escape the
+///   way the symlink-following `ValidatorRunner` FileExists check would.
+/// - `CommandExit{cmd, code:0}` → a required [`ValidatorSpec::Command`] run
+///   through the [`ValidatorRunner`] (split into program + argv, NO shell;
+///   passes iff exit `0`, so a non-zero expected `code` is unsupported).
+///
+/// **Fail-closed (P1-5a):** any criterion the executor cannot mechanically
+/// verify — `Manual`, `ValidatorRef`, `CommandExit{code != 0}`, an empty
+/// command, an absent file, or a workspace-escaping `FileExists` — REJECTS the
+/// gate. Criteria carry no `required` flag, so all are treated as required; we
+/// never drop-to-pass on the agent's own self-report. Only a task with NO
+/// criteria at all falls back to the run's own `success` as the gate.
+///
+/// Command validators run under the SHARED `sandbox` instance the agent ran
+/// under (P1-3-fix / P1-5c), and the whole `CommandExit` phase is bounded by
+/// `remaining` (P1-5b) so it can't hold permits past the fleet deadline.
+async fn run_acceptance(
+    task_view: &TaskView,
+    workspace_root: &Path,
+    factory: &AgentFactory,
+    sandbox: Arc<dyn Sandbox>,
+    max_shell_timeout_secs: u64,
+    mut remaining: Duration,
+) -> (AcceptanceVerdict, Option<String>) {
+    let mut command_validators: Vec<Validator> = Vec::new();
+    let mut evidence: Vec<EvidenceRef> = Vec::new();
+    // Fail-closed: criteria we cannot mechanically verify (or that fail /
+    // escape the workspace) reject the gate — we never drop-to-pass.
+    let mut unverifiable: Vec<String> = Vec::new();
+
+    for crit in &task_view.acceptance {
+        match &crit.verifier {
+            Verifier::FileExists { path } => {
+                match check_file_exists_confined(workspace_root, path) {
+                    Ok(Some(canonical)) => evidence.push(EvidenceRef {
+                        kind: "file_exists".to_string(),
+                        locator: canonical.display().to_string(),
+                        sha256: String::new(),
+                        captured_at_ms: 0,
+                    }),
+                    Ok(None) => unverifiable.push(format!(
+                        "{}: file `{path}` not found under the workspace",
+                        crit.id
+                    )),
+                    Err(reason) => unverifiable.push(format!("{}: {reason}", crit.id)),
+                }
+            }
+            Verifier::CommandExit { cmd, code } if *code == 0 => {
+                let mut parts = cmd.split_whitespace();
+                match parts.next() {
+                    Some(prog) => command_validators.push(mechanical(
+                        &crit.id,
+                        ValidatorSpec::Command {
+                            cmd: prog.to_string(),
+                            args: parts.map(str::to_string).collect(),
+                        },
+                    )),
+                    None => unverifiable.push(format!("{}: empty CommandExit command", crit.id)),
+                }
+            }
+            other => unverifiable.push(format!(
+                "{}: unsupported verifier {other:?} (v1 executor)",
+                crit.id
+            )),
+        }
+    }
+
+    // (a) Any unverifiable/failed criterion fails the gate closed — an executor
+    //     that cannot check "done" must not certify it done.
+    if !unverifiable.is_empty() {
+        let reason = format!(
+            "acceptance cannot be verified — {}",
+            unverifiable.join("; ")
+        );
+        tracing::warn!(
+            %reason,
+            "fleet worker: acceptance gate fails closed on unsupported/failed criteria",
+        );
+        return (
+            AcceptanceVerdict::Rejected {
+                reason: reason.clone(),
+            },
+            Some(reason),
+        );
+    }
+
+    // No `CommandExit` validators — any `FileExists` criteria already passed
+    // in-worker, so the (possibly empty) evidence set IS the gate.
+    if command_validators.is_empty() {
+        return (AcceptanceVerdict::Accepted { evidence }, None);
+    }
+
+    // (P1-5c) Command validators under the SHARED sandbox. (round-4 P1) Drive
+    // them ONE AT A TIME with a SHRINKING remaining budget: each validator's
+    // own `timeout_ms` is set to the remaining deadline, so the validator's
+    // cancellation-safe internal `timeout` + `kill_child_process` actually
+    // group-kills the subprocess AT the deadline. Dropping an outer
+    // `tokio::time::timeout` future does NOT kill a Tokio child, so relying on
+    // it alone would leak a `sleep`ing subprocess past the recorded terminal
+    // state. Subtracting each run's elapsed keeps the TOTAL phase bounded by
+    // the initial `remaining`.
+    let runner = ValidatorRunner::new(
+        Arc::new(factory.build_registry_with(
+            workspace_root,
+            sandbox.clone(),
+            max_shell_timeout_secs,
+        )),
+        workspace_root.to_path_buf(),
+    )
+    .with_sandbox(sandbox);
+    let invocation = ValidatorInvocation::new(
+        ValidatorPhase::Completion,
+        workspace_root.to_path_buf(),
+        "fleet-worker".to_string(),
+    );
+
+    let deadline_terminated = || {
+        let reason = "acceptance deadline exceeded".to_string();
+        (
+            AcceptanceVerdict::Terminated {
+                reason: reason.clone(),
+            },
+            Some(reason),
+        )
+    };
+
+    let mut outcomes: Vec<ValidatorOutcome> = Vec::with_capacity(command_validators.len());
+    for mut validator in command_validators {
+        if remaining.is_zero() {
+            // Earlier validators consumed the whole acceptance budget — fail
+            // closed on the deadline rather than run one with a 0ms timeout.
+            return deadline_terminated();
+        }
+        // Bound THIS validator by the remaining budget so its OWN timeout+kill
+        // fire at the deadline (min with any pre-configured timeout).
+        let budget_ms = u64::try_from(remaining.as_millis())
+            .unwrap_or(u64::MAX)
+            .max(1);
+        validator.timeout_ms = Some(match validator.timeout_ms {
+            Some(configured) => configured.min(budget_ms),
+            None => budget_ms,
+        });
+
+        let started = Instant::now();
+        // Coarse outer backstop ONLY (grace beyond the per-validator budget so
+        // the validator's own internal timeout+kill wins the race and returns a
+        // `Timeout` outcome). It guards a validator hanging outside that awaited
+        // kill path — never the killing itself.
+        let slice = std::slice::from_ref(&validator);
+        let batch = tokio::time::timeout(
+            remaining + ACCEPTANCE_BACKSTOP_GRACE,
+            runner.run_all(&invocation, slice),
+        )
+        .await;
+        remaining = remaining.saturating_sub(started.elapsed());
+        match batch {
+            Ok(mut got) => outcomes.append(&mut got),
+            // The backstop fired (a validator hung past its own killing budget):
+            // we can't prove the subprocess died, so fail closed on the deadline.
+            Err(_elapsed) => return deadline_terminated(),
+        }
+    }
+
+    // A validator group-killed at its deadline reports `Timeout` — that is a
+    // deadline overrun (Terminated), distinct from a clean `Fail` (Rejected).
+    if outcomes
+        .iter()
+        .any(|o| o.status == ValidatorStatus::Timeout)
+    {
+        return deadline_terminated();
+    }
+
+    let passed = outcomes.iter().all(|o| o.required_gate_passed());
+
+    if passed {
+        evidence.extend(outcomes.iter().map(|o| {
+            EvidenceRef {
+                kind: o.kind.clone(),
+                locator: o
+                    .evidence_path
+                    .as_ref()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|| o.validator_id.clone()),
+                sha256: String::new(),
+                captured_at_ms: o.started_at.timestamp_millis().max(0) as u64,
+            }
+        }));
+        (AcceptanceVerdict::Accepted { evidence }, None)
+    } else {
+        let failed: Vec<String> = outcomes
+            .iter()
+            .filter(|o| !o.required_gate_passed())
+            .map(|o| format!("{}: {}", o.validator_id, o.reason))
+            .collect();
+        let reason = format!("acceptance failed — {}", failed.join("; "));
+        (
+            AcceptanceVerdict::Rejected {
+                reason: reason.clone(),
+            },
+            Some(reason),
+        )
+    }
+}
+
+/// Evaluate a `FileExists` criterion IN THE WORKER, resistant to symlink
+/// escape (P1-5a). Confines `path` lexically (via [`confined_relative`]), then
+/// resolves it under `workspace_root` following symlinks (`canonicalize`) and
+/// asserts the canonical target stays UNDER the canonical workspace root and is
+/// a regular file.
+///
+/// Returns `Ok(Some(canonical))` when the file exists and is confined,
+/// `Ok(None)` when it is simply absent (fail-closed "not found"), and `Err`
+/// when it exists but escapes the workspace or isn't a regular file.
+///
+/// **Point-in-time only (TOCTOU, P2).** The containment `canonicalize` and the
+/// follow-up `metadata` are distinct syscalls, so a concurrent writer that
+/// swaps an in-workspace file for an external symlink between them can have
+/// `metadata` follow the symlink. This is sound ONLY under v1's
+/// single-writer-per-task-workspace assumption (see the module "Known v1
+/// limitations"); it is a point-in-time confinement, not a race-proof absolute
+/// guarantee against a hostile concurrent mutator of the task's own workspace.
+fn check_file_exists_confined(
+    workspace_root: &Path,
+    path: &str,
+) -> Result<Option<PathBuf>, String> {
+    confined_relative(path)?;
+    let target = workspace_root.join(path);
+    // `canonicalize` follows symlinks and requires existence; a missing target
+    // (or a dangling symlink) is "not found", not an escape.
+    let canonical = match std::fs::canonicalize(&target) {
+        Ok(p) => p,
+        Err(_) => return Ok(None),
+    };
+    let canonical_root = std::fs::canonicalize(workspace_root)
+        .map_err(|e| format!("cannot canonicalize workspace root: {e}"))?;
+    if !canonical.starts_with(&canonical_root) {
+        return Err(format!(
+            "file `{path}` resolves OUTSIDE the workspace (symlink escape)"
+        ));
+    }
+    match std::fs::metadata(&canonical) {
+        Ok(m) if m.is_file() => Ok(Some(canonical)),
+        Ok(_) => Err(format!("`{path}` exists but is not a regular file")),
+        Err(e) => Err(format!("cannot stat `{path}`: {e}")),
+    }
+}
+
+/// Reject a `FileExists` acceptance path that isn't lexically confined to the
+/// task workspace. An absolute path (`/etc/passwd`) or one with a `..`
+/// component (`../../etc/passwd`) could assert outside the worker's cwd. This
+/// is the LEXICAL half; [`check_file_exists_confined`] adds symlink-resolved
+/// confinement on top.
+fn confined_relative(path: &str) -> Result<(), String> {
+    use std::path::Component;
+    let p = Path::new(path);
+    if p.is_absolute() {
+        return Err(format!(
+            "FileExists path `{path}` must be workspace-relative, not absolute"
+        ));
+    }
+    for comp in p.components() {
+        match comp {
+            Component::ParentDir => {
+                return Err(format!(
+                    "FileExists path `{path}` must not escape the workspace with `..`"
+                ));
+            }
+            Component::Prefix(_) | Component::RootDir => {
+                return Err(format!(
+                    "FileExists path `{path}` must be workspace-relative"
+                ));
+            }
+            Component::Normal(_) | Component::CurDir => {}
+        }
+    }
+    Ok(())
+}
+
+/// A hard-required completion-phase validator for `spec`.
+fn mechanical(id: &str, spec: ValidatorSpec) -> Validator {
+    Validator {
+        id: id.to_string(),
+        required: true,
+        soft_fail: false,
+        timeout_ms: None,
+        phase: ValidatorPhaseKind::Completion,
+        spec,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testutil::*;
+    use octos_agent::sandbox::NoSandbox;
+    use octos_fleet::{AttemptStatus, ChildStatus};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    #[test]
+    fn file_exists_confined_rejects_symlink_escape() {
+        // P1-5a: a real in-workspace file passes; an absent file is
+        // fail-closed "not found"; an in-workspace symlink pointing OUTSIDE
+        // the workspace is rejected (the escape the lexical check misses).
+        let dir = TempDir::new().unwrap();
+        let ws = dir.path();
+        std::fs::write(ws.join("real.txt"), b"x").unwrap();
+        assert!(matches!(
+            check_file_exists_confined(ws, "real.txt"),
+            Ok(Some(_))
+        ));
+        assert!(matches!(
+            check_file_exists_confined(ws, "nope.txt"),
+            Ok(None)
+        ));
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink("/etc/passwd", ws.join("escape.txt")).unwrap();
+            assert!(
+                check_file_exists_confined(ws, "escape.txt").is_err(),
+                "in-workspace symlink escaping the workspace must be rejected",
+            );
+        }
+        // Lexical escapes are still rejected up front.
+        assert!(check_file_exists_confined(ws, "/etc/passwd").is_err());
+        assert!(check_file_exists_confined(ws, "../escape").is_err());
+    }
+
+    #[test]
+    fn confined_relative_accepts_workspace_paths_and_rejects_escapes() {
+        // Confined, workspace-relative paths pass.
+        assert!(confined_relative("out.txt").is_ok());
+        assert!(confined_relative("sub/dir/out.txt").is_ok());
+        assert!(confined_relative("./out.txt").is_ok());
+        // Absolute + `..`-escaping paths are rejected.
+        assert!(confined_relative("/etc/passwd").is_err());
+        assert!(confined_relative("../escape.txt").is_err());
+        assert!(confined_relative("sub/../../escape.txt").is_err());
+    }
+
+    async fn view_of(fleet: &Fleet, task_id: &str) -> TaskView {
+        fleet
+            .view()
+            .await
+            .unwrap()
+            .tasks
+            .into_iter()
+            .find(|t| t.task_id == task_id)
+            .expect("task in view")
+    }
+
+    #[tokio::test]
+    async fn run_attempt_happy_path() {
+        let (_sd, store) = fresh_store().await;
+        let fleet = create_fleet(
+            store.clone(),
+            "f1",
+            vec![task_spec("a", &[], file_exists("out.txt"))],
+        )
+        .await;
+        let attempt = launch(&store, "f1", "a").await;
+
+        let work = TempDir::new().unwrap();
+        let (_md, factory) = factory_for(Arc::new(WriteFileProvider::new("out.txt"))).await;
+        let task_view = view_of(&fleet, "a").await;
+
+        let outcome = run_attempt(
+            store.clone(),
+            "f1",
+            "a",
+            &attempt,
+            &task_view,
+            &factory,
+            work.path(),
+            Duration::from_secs(30),
+            EPOCH,
+            || NOW,
+        )
+        .await;
+
+        assert!(
+            matches!(
+                outcome,
+                AttemptOutcome::Completed {
+                    verdict: AcceptanceVerdict::Accepted { .. }
+                }
+            ),
+            "expected Completed/Accepted, got {outcome:?}",
+        );
+
+        // The artifact really landed under the worker cwd.
+        assert!(
+            work.path().join("out.txt").exists(),
+            "acceptance file missing"
+        );
+
+        // Child terminal Succeeded; snapshot carries the real result; budget advanced.
+        let child = store.get_child("f1", "a").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Succeeded);
+        let att = store.get_attempt("a", &attempt).await.unwrap().unwrap();
+        assert_eq!(att.status, AttemptStatus::Done);
+        let snap = att.result_snapshot.expect("snapshot recorded");
+        assert!(snap.success, "snapshot must record success");
+        assert!(snap.tokens_used > 0, "tokens must be recorded");
+        let fleet_rec = store.get_fleet("f1").await.unwrap().unwrap();
+        assert!(
+            fleet_rec.budget.tokens_committed > 0,
+            "fleet.tokens_committed must advance",
+        );
+        assert_eq!(fleet_rec.budget.tokens_reserved, 0, "reservation released");
+    }
+
+    #[tokio::test]
+    async fn attempt_creates_one_shared_sandbox_instance() {
+        // P1-3-fix: the sandbox factory is invoked EXACTLY once per attempt —
+        // the single instance is shared by the agent registry and the
+        // acceptance validators. (Round-1 re-invoked the factory for the
+        // validator registry, so a non-idempotent factory could sandbox the
+        // agent yet hand the validators a weaker sandbox.)
+        let (_sd, store) = fresh_store().await;
+        let fleet = create_fleet(
+            store.clone(),
+            "f1",
+            vec![task_spec("a", &[], command_exit("true"))],
+        )
+        .await;
+        let attempt = launch(&store, "f1", "a").await;
+
+        let work = TempDir::new().unwrap();
+        let (_md, memory) = fresh_memory().await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let seen = calls.clone();
+        let factory = AgentFactory::new(
+            Arc::new(SuccessProvider),
+            memory,
+            Arc::new(move |_| {
+                seen.fetch_add(1, Ordering::SeqCst);
+                Arc::new(NoSandbox) as Arc<dyn Sandbox>
+            }),
+        );
+        let task_view = view_of(&fleet, "a").await;
+
+        let outcome = run_attempt(
+            store.clone(),
+            "f1",
+            "a",
+            &attempt,
+            &task_view,
+            &factory,
+            work.path(),
+            Duration::from_secs(30),
+            EPOCH,
+            || NOW,
+        )
+        .await;
+        assert!(
+            matches!(
+                outcome,
+                AttemptOutcome::Completed {
+                    verdict: AcceptanceVerdict::Accepted { .. }
+                }
+            ),
+            "CommandExit `true` must be accepted, got {outcome:?}",
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "the sandbox factory must be invoked exactly once per attempt (shared instance)",
+        );
+    }
+
+    #[tokio::test]
+    async fn acceptance_command_terminates_past_deadline() {
+        // P1-5b: a CommandExit validator that sleeps past the remaining
+        // deadline makes the attempt end Terminated (child Failed), not hang.
+        let (_sd, store) = fresh_store().await;
+        let fleet = create_fleet(
+            store.clone(),
+            "f1",
+            vec![task_spec("a", &[], command_exit("sleep 20"))],
+        )
+        .await;
+        let attempt = launch(&store, "f1", "a").await;
+
+        let work = TempDir::new().unwrap();
+        // SuccessProvider finishes instantly, so acceptance gets ~the whole
+        // 2s deadline — which the `sleep 20` command overruns.
+        let (_md, factory) = factory_for(Arc::new(SuccessProvider)).await;
+        let task_view = view_of(&fleet, "a").await;
+
+        let started = std::time::Instant::now();
+        let outcome = run_attempt(
+            store.clone(),
+            "f1",
+            "a",
+            &attempt,
+            &task_view,
+            &factory,
+            work.path(),
+            Duration::from_secs(2),
+            EPOCH,
+            || NOW,
+        )
+        .await;
+        assert!(
+            matches!(
+                outcome,
+                AttemptOutcome::Completed {
+                    verdict: AcceptanceVerdict::Terminated { .. }
+                }
+            ),
+            "acceptance overrun must Terminate, got {outcome:?}",
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(15),
+            "must not wait for the full 20s command sleep",
+        );
+        let child = store.get_child("f1", "a").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Failed);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn acceptance_command_kills_subprocess_past_deadline() {
+        // P1 (round-4): the acceptance timeout must KILL the validator
+        // subprocess, not merely drop the outer future — Tokio does NOT kill a
+        // child on drop. A CommandExit that sleeps PAST the deadline and THEN
+        // writes a marker must be group-killed at the deadline (so the marker is
+        // NEVER written), rather than leaking a live `sleep` that mutates the
+        // (reused) task workspace after the recorded terminal state.
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_sd, store) = fresh_store().await;
+
+        // Held tempdir so both the script path and the marker outlive the run.
+        // The script sleeps 4s, THEN writes the marker; its own kill (fired by
+        // the validator's per-run timeout) must preempt that write.
+        let scratch = TempDir::new().unwrap();
+        let script = scratch.path().join("killme.sh");
+        let marker = scratch.path().join("marker.done");
+        std::fs::write(
+            &script,
+            format!("#!/bin/sh\nsleep 4\n: > {}\n", marker.display()),
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let fleet = create_fleet(
+            store.clone(),
+            "f1",
+            vec![task_spec("a", &[], command_exit(&script.to_string_lossy()))],
+        )
+        .await;
+        let attempt = launch(&store, "f1", "a").await;
+
+        let work = TempDir::new().unwrap();
+        // SuccessProvider finishes instantly, so acceptance gets ~the whole 2s
+        // deadline — which the `sleep 4` command overruns and is killed at.
+        let (_md, factory) = factory_for(Arc::new(SuccessProvider)).await;
+        let task_view = view_of(&fleet, "a").await;
+
+        let outcome = run_attempt(
+            store.clone(),
+            "f1",
+            "a",
+            &attempt,
+            &task_view,
+            &factory,
+            work.path(),
+            Duration::from_secs(2),
+            EPOCH,
+            || NOW,
+        )
+        .await;
+        assert!(
+            matches!(
+                outcome,
+                AttemptOutcome::Completed {
+                    verdict: AcceptanceVerdict::Terminated { .. }
+                }
+            ),
+            "acceptance overrun must Terminate, got {outcome:?}",
+        );
+
+        // Wait WELL PAST the script's 4s sleep: a leaked (un-killed) subprocess
+        // would have written the marker by now; a group-killed one never does.
+        tokio::time::sleep(Duration::from_secs(4)).await;
+        assert!(
+            !marker.exists(),
+            "validator subprocess was NOT killed — it survived the deadline and \
+             wrote its marker (dropping the outer future does not kill a Tokio child)",
+        );
+    }
+
+    #[tokio::test]
+    async fn run_attempt_rejects_when_acceptance_fails() {
+        let (_sd, store) = fresh_store().await;
+        let fleet = create_fleet(
+            store.clone(),
+            "f1",
+            vec![task_spec("a", &[], file_exists("out.txt"))],
+        )
+        .await;
+        let attempt = launch(&store, "f1", "a").await;
+
+        let work = TempDir::new().unwrap();
+        // SuccessProvider ends the turn WITHOUT writing out.txt, so the run
+        // succeeds but the FileExists gate fails.
+        let (_md, factory) = factory_for(Arc::new(SuccessProvider)).await;
+        let task_view = view_of(&fleet, "a").await;
+
+        let outcome = run_attempt(
+            store.clone(),
+            "f1",
+            "a",
+            &attempt,
+            &task_view,
+            &factory,
+            work.path(),
+            Duration::from_secs(30),
+            EPOCH,
+            || NOW,
+        )
+        .await;
+
+        assert!(
+            matches!(
+                outcome,
+                AttemptOutcome::Completed {
+                    verdict: AcceptanceVerdict::Rejected { .. }
+                }
+            ),
+            "expected Completed/Rejected, got {outcome:?}",
+        );
+        let child = store.get_child("f1", "a").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Failed);
+        let att = store.get_attempt("a", &attempt).await.unwrap().unwrap();
+        let snap = att.result_snapshot.expect("snapshot recorded");
+        assert!(!snap.success, "rejected snapshot must record failure");
+        assert!(snap.error.is_some(), "rejection reason must be recorded");
+    }
+
+    #[tokio::test]
+    async fn run_attempt_rejects_unsupported_validator_ref() {
+        // P1-5a: a `ValidatorRef`-only task must NOT pass on the run's own
+        // self-report — the executor cannot verify it, so the gate fails
+        // closed (Rejected), even though the run succeeded.
+        let (_sd, store) = fresh_store().await;
+        let fleet = create_fleet(
+            store.clone(),
+            "f1",
+            vec![task_spec("a", &[], validator_ref("tests"))],
+        )
+        .await;
+        let attempt = launch(&store, "f1", "a").await;
+
+        let work = TempDir::new().unwrap();
+        let (_md, factory) = factory_for(Arc::new(SuccessProvider)).await;
+        let task_view = view_of(&fleet, "a").await;
+
+        let outcome = run_attempt(
+            store.clone(),
+            "f1",
+            "a",
+            &attempt,
+            &task_view,
+            &factory,
+            work.path(),
+            Duration::from_secs(30),
+            EPOCH,
+            || NOW,
+        )
+        .await;
+
+        assert!(
+            matches!(
+                outcome,
+                AttemptOutcome::Completed {
+                    verdict: AcceptanceVerdict::Rejected { .. }
+                }
+            ),
+            "unsupported ValidatorRef must fail closed, got {outcome:?}",
+        );
+        let child = store.get_child("f1", "a").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn run_attempt_rejects_out_of_workspace_file_exists() {
+        // P1-5b: a `FileExists` on an ABSOLUTE path (e.g. `/etc/passwd`, which
+        // really exists on the host) must NOT be accepted — the acceptance
+        // gate is confined to the task workspace, so it fails closed.
+        let (_sd, store) = fresh_store().await;
+        let fleet = create_fleet(
+            store.clone(),
+            "f1",
+            vec![task_spec("a", &[], file_exists("/etc/passwd"))],
+        )
+        .await;
+        let attempt = launch(&store, "f1", "a").await;
+
+        let work = TempDir::new().unwrap();
+        let (_md, factory) = factory_for(Arc::new(SuccessProvider)).await;
+        let task_view = view_of(&fleet, "a").await;
+
+        let outcome = run_attempt(
+            store.clone(),
+            "f1",
+            "a",
+            &attempt,
+            &task_view,
+            &factory,
+            work.path(),
+            Duration::from_secs(30),
+            EPOCH,
+            || NOW,
+        )
+        .await;
+
+        assert!(
+            !matches!(
+                outcome,
+                AttemptOutcome::Completed {
+                    verdict: AcceptanceVerdict::Accepted { .. }
+                }
+            ),
+            "an absolute-path FileExists must not be accepted, got {outcome:?}",
+        );
+        let child = store.get_child("f1", "a").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Failed);
+    }
+
+    #[tokio::test]
+    async fn run_attempt_terminates_on_deadline() {
+        let (_sd, store) = fresh_store().await;
+        let fleet = create_fleet(store.clone(), "f1", vec![task_spec("a", &[], vec![])]).await;
+        let attempt = launch(&store, "f1", "a").await;
+
+        let work = TempDir::new().unwrap();
+        // Sleeps 30s; the 200ms deadline must fire first.
+        let (_md, factory) = factory_for(Arc::new(SleepProvider {
+            hold: Duration::from_secs(30),
+        }))
+        .await;
+        let task_view = view_of(&fleet, "a").await;
+
+        let outcome = run_attempt(
+            store.clone(),
+            "f1",
+            "a",
+            &attempt,
+            &task_view,
+            &factory,
+            work.path(),
+            Duration::from_millis(200),
+            EPOCH,
+            || NOW,
+        )
+        .await;
+
+        assert!(
+            matches!(
+                outcome,
+                AttemptOutcome::Completed {
+                    verdict: AcceptanceVerdict::Terminated { .. }
+                }
+            ),
+            "expected Completed/Terminated, got {outcome:?}",
+        );
+        let child = store.get_child("f1", "a").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Failed);
+        let att = store.get_attempt("a", &attempt).await.unwrap().unwrap();
+        let snap = att.result_snapshot.expect("snapshot recorded");
+        assert!(!snap.success);
+        assert!(
+            snap.error.unwrap().contains("deadline"),
+            "error must name the deadline",
+        );
+    }
+
+    #[tokio::test]
+    async fn run_attempt_aborts_on_lost_mark_running() {
+        let (_sd, store) = fresh_store().await;
+        let fleet = create_fleet(store.clone(), "f1", vec![task_spec("a", &[], vec![])]).await;
+        let attempt = launch(&store, "f1", "a").await;
+        // Externally advance the child to Running so run_attempt's own
+        // mark_running (which requires child Launching) loses the race.
+        store.mark_running("a", &attempt).await.unwrap();
+
+        let work = TempDir::new().unwrap();
+        let (_md, factory) = factory_for(Arc::new(SuccessProvider)).await;
+        let task_view = view_of(&fleet, "a").await;
+
+        let outcome = run_attempt(
+            store.clone(),
+            "f1",
+            "a",
+            &attempt,
+            &task_view,
+            &factory,
+            work.path(),
+            Duration::from_secs(30),
+            EPOCH,
+            || NOW,
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, AttemptOutcome::Aborted { .. }),
+            "got {outcome:?}"
+        );
+        // It must NOT have completed: child still Running, attempt still
+        // Running with no snapshot.
+        let child = store.get_child("f1", "a").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Running);
+        let att = store.get_attempt("a", &attempt).await.unwrap().unwrap();
+        assert_eq!(att.status, AttemptStatus::Running);
+        assert!(
+            att.result_snapshot.is_none(),
+            "aborted attempt must not record a snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn two_dep_chain_promotes_successor_after_completion() {
+        let (_sd, store) = fresh_store().await;
+        let fleet = create_fleet(
+            store.clone(),
+            "f1",
+            vec![task_spec("a", &[], vec![]), task_spec("b", &["a"], vec![])],
+        )
+        .await;
+        // b depends on a, so it starts Planned.
+        assert_eq!(
+            store.get_child("f1", "b").await.unwrap().unwrap().status,
+            ChildStatus::Planned,
+        );
+
+        let attempt = launch(&store, "f1", "a").await;
+        let work = TempDir::new().unwrap();
+        let (_md, factory) = factory_for(Arc::new(SuccessProvider)).await;
+        let task_view = view_of(&fleet, "a").await;
+
+        let outcome = run_attempt(
+            store.clone(),
+            "f1",
+            "a",
+            &attempt,
+            &task_view,
+            &factory,
+            work.path(),
+            Duration::from_secs(30),
+            EPOCH,
+            || NOW,
+        )
+        .await;
+        assert!(
+            matches!(
+                outcome,
+                AttemptOutcome::Completed {
+                    verdict: AcceptanceVerdict::Accepted { .. }
+                }
+            ),
+            "got {outcome:?}",
+        );
+
+        // a Succeeded and, via the post-completion ready_tasks, b is promoted
+        // Ready and now launchable.
+        assert_eq!(
+            store.get_child("f1", "a").await.unwrap().unwrap().status,
+            ChildStatus::Succeeded,
+        );
+        assert_eq!(
+            store.get_child("f1", "b").await.unwrap().unwrap().status,
+            ChildStatus::Ready,
+        );
+        let b_attempt = launch(&store, "f1", "b").await;
+        assert!(!b_attempt.is_empty(), "successor must be launchable");
+    }
+}

--- a/crates/octos-fleet/src/lib.rs
+++ b/crates/octos-fleet/src/lib.rs
@@ -54,5 +54,5 @@ pub use records::{
 };
 pub use store::{
     AckOutcome, CompleteOutcome, FleetKernelStore, FleetSnapshot, InterruptedAttempt,
-    LaunchOutcome, PlanMutateOutcome, ReconcileReport,
+    LaunchOutcome, MarkRunningOutcome, PlanMutateOutcome, ReconcileReport,
 };

--- a/crates/octos-fleet/src/store.rs
+++ b/crates/octos-fleet/src/store.rs
@@ -74,6 +74,19 @@ pub enum CompleteOutcome {
     Superseded,
 }
 
+/// Result of a `mark_running` CAS. `Superseded` means the identity/predicate
+/// fence failed — a genuine lost race (the attempt is stale/superseded or not
+/// the child's current attempt), so nothing changes; deliberately **not** an
+/// error, exactly like [`CompleteOutcome::Superseded`]. `Err` is reserved for a
+/// real infra failure (redb read/commit/join or a corrupt-row parse), which
+/// leaves it ambiguous whether the still-`Launching` attempt is ours — the
+/// caller must NOT treat that as "not ours".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarkRunningOutcome {
+    Running,
+    Superseded,
+}
+
 /// Result of a revision-fenced plan operation (`replan` / `retitle_task`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PlanMutateOutcome {
@@ -745,42 +758,56 @@ impl FleetKernelStore {
     /// fleet.generation` — **before writing either row**, so any mismatch
     /// (including a pre-replan attempt whose generation is now stale) is
     /// rejected with zero mutation.
-    pub async fn mark_running(&self, child_id: &str, attempt_id: &str) -> Result<()> {
+    ///
+    /// Returns the typed [`MarkRunningOutcome`] (mirrors [`CompleteOutcome`]):
+    /// an identity/existence/predicate miss (a genuine lost race — the attempt
+    /// is superseded or not the child's current one) is
+    /// [`MarkRunningOutcome::Superseded`], **not** an `Err`. `Err` is reserved
+    /// for a real infra failure (redb read/commit/join, or a corrupt-row parse
+    /// surfaced by `?`) — which leaves the still-`Launching` attempt possibly
+    /// ours, so the caller must not disarm its cleanup on that path.
+    pub async fn mark_running(
+        &self,
+        child_id: &str,
+        attempt_id: &str,
+    ) -> Result<MarkRunningOutcome> {
         ensure_key_safe(&[child_id, attempt_id])?;
         let db = self.db.clone();
         let child_id = child_id.to_string();
         let attempt_id = attempt_id.to_string();
         let held = self.io_gate.clone().lock_owned().await;
-        tokio::task::spawn_blocking(move || -> Result<()> {
+        tokio::task::spawn_blocking(move || -> Result<MarkRunningOutcome> {
             let _held = held;
             let wtx = db.begin_write()?;
-            {
+            let outcome = {
                 let mut attempts = wtx.open_table(ATTEMPTS)?;
                 let mut children = wtx.open_table(FLEET_CHILDREN)?;
                 let fleets = wtx.open_table(FLEETS)?;
 
-                // Read the attempt (owned).
+                // Read the attempt (owned). A missing row / newer-schema row /
+                // identity mismatch is a superseded-or-foreign attempt, never an
+                // infra error — mirror `complete_child` (only `?` yields `Err`).
                 let akey = attempt_key(&child_id, &attempt_id);
                 let Some(aj) = attempts.get(akey.as_str())?.map(|g| g.value().to_string()) else {
-                    bail!("mark_running: unknown attempt {attempt_id} for child {child_id}");
+                    return Ok(MarkRunningOutcome::Superseded);
                 };
                 let Some(mut attempt) = decode_row::<Attempt>(&aj)? else {
-                    bail!("mark_running: attempt {attempt_id} is a newer schema");
+                    return Ok(MarkRunningOutcome::Superseded);
                 };
                 if attempt.child_id != child_id || attempt.attempt_id != attempt_id {
-                    bail!("mark_running: attempt/child identity mismatch");
+                    return Ok(MarkRunningOutcome::Superseded);
                 }
 
                 // Read the child derived from the attempt's fleet (P1-4).
                 let ckey = child_key(&attempt.fleet_id, &child_id);
                 let Some(cj) = children.get(ckey.as_str())?.map(|g| g.value().to_string()) else {
-                    bail!("mark_running: child {child_id} not found for attempt {attempt_id}");
+                    return Ok(MarkRunningOutcome::Superseded);
                 };
                 let Some(mut child) = decode_row::<FleetChildRecord>(&cj)? else {
-                    bail!("mark_running: child {child_id} is a newer schema");
+                    return Ok(MarkRunningOutcome::Superseded);
                 };
                 if child.fleet_id != attempt.fleet_id || child.child_id != child_id {
-                    bail!("mark_running: child identity mismatch");
+                    return Ok(MarkRunningOutcome::Superseded);
                 }
 
                 // Read the fleet for the generation fence.
@@ -788,37 +815,23 @@ impl FleetKernelStore {
                     .get(attempt.fleet_id.as_str())?
                     .map(|g| g.value().to_string())
                 else {
-                    bail!("mark_running: fleet {} not found", attempt.fleet_id);
+                    return Ok(MarkRunningOutcome::Superseded);
                 };
                 let Some(fleet) = decode_row::<FleetRecord>(&fj)? else {
-                    bail!("mark_running: fleet {} is a newer schema", attempt.fleet_id);
+                    return Ok(MarkRunningOutcome::Superseded);
                 };
                 if fleet.fleet_id != attempt.fleet_id {
-                    bail!("mark_running: fleet identity mismatch");
+                    return Ok(MarkRunningOutcome::Superseded);
                 }
 
-                // Validate EVERYTHING before writing either row (P2-6).
-                if child.current_attempt_id.as_deref() != Some(attempt_id.as_str()) {
-                    bail!("mark_running: {attempt_id} is not the child's current attempt");
-                }
-                if child.status != ChildStatus::Launching {
-                    bail!(
-                        "mark_running: child {child_id} is {:?}, not Launching",
-                        child.status
-                    );
-                }
-                if attempt.status != AttemptStatus::Leased {
-                    bail!(
-                        "mark_running: attempt {attempt_id} is {:?}, not Leased",
-                        attempt.status
-                    );
-                }
-                if attempt.generation != fleet.generation {
-                    bail!(
-                        "mark_running: attempt {attempt_id} generation {} != fleet {}",
-                        attempt.generation,
-                        fleet.generation
-                    );
+                // Validate EVERYTHING before writing either row (P2-6). Each is
+                // a CAS-predicate fence — a miss is a lost race (`Superseded`).
+                if child.current_attempt_id.as_deref() != Some(attempt_id.as_str())
+                    || child.status != ChildStatus::Launching
+                    || attempt.status != AttemptStatus::Leased
+                    || attempt.generation != fleet.generation
+                {
+                    return Ok(MarkRunningOutcome::Superseded);
                 }
 
                 // All checks passed — write both rows.
@@ -826,9 +839,15 @@ impl FleetKernelStore {
                 attempts.insert(akey.as_str(), serde_json::to_string(&attempt)?.as_str())?;
                 child.status = ChildStatus::Running;
                 children.insert(ckey.as_str(), serde_json::to_string(&child)?.as_str())?;
+
+                MarkRunningOutcome::Running
+            };
+            // Only a real state change commits; a `Superseded` returned above
+            // never reaches here (it exits the closure, dropping `wtx` unwritten).
+            if matches!(outcome, MarkRunningOutcome::Running) {
+                wtx.commit()?;
             }
-            wtx.commit()?;
-            Ok(())
+            Ok(outcome)
         })
         .await
         .wrap_err("join mark_running")?
@@ -2257,8 +2276,16 @@ mod tests {
             ChildStatus::Running
         );
 
-        assert!(store.mark_running("c1", &attempt_id).await.is_err());
-        assert!(store.mark_running("c1", "nope").await.is_err());
+        // A repeat (child now Running, not Launching) and an unknown attempt
+        // are BOTH lost-race misses now — `Superseded`, not an infra `Err`.
+        assert_eq!(
+            store.mark_running("c1", &attempt_id).await.unwrap(),
+            MarkRunningOutcome::Superseded,
+        );
+        assert_eq!(
+            store.mark_running("c1", "nope").await.unwrap(),
+            MarkRunningOutcome::Superseded,
+        );
     }
 
     #[tokio::test]
@@ -2958,7 +2985,11 @@ mod tests {
         child.current_attempt_id = Some("ghost".into());
         store.write_raw_child(&child).await.unwrap();
 
-        assert!(store.mark_running("c1", &att).await.is_err());
+        // Not the child's current attempt → a lost-race `Superseded`, not `Err`.
+        assert_eq!(
+            store.mark_running("c1", &att).await.unwrap(),
+            MarkRunningOutcome::Superseded,
+        );
         // Zero mutation: attempt still Leased, child pointer unchanged.
         assert_eq!(
             store.get_attempt("c1", &att).await.unwrap().unwrap().status,
@@ -2998,7 +3029,11 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(store.mark_running("c1", &att).await.is_err());
+        // Stale generation → a lost-race `Superseded`, not an infra `Err`.
+        assert_eq!(
+            store.mark_running("c1", &att).await.unwrap(),
+            MarkRunningOutcome::Superseded,
+        );
         assert_eq!(
             store.get_attempt("c1", &att).await.unwrap().unwrap().status,
             AttemptStatus::Leased,


### PR DESCRIPTION
## PR 3 — Closed non-interactive task worker + bounded pool

The **crux** of the fleet kernel: the audited executor that first makes the durable substrate (PR 1 store, PR 2 plan API) actually *run work* — provably unable to block on a human or fan out, with every effect bounded by a deadline and a sandbox. New crate `octos-fleet-worker` (+ two small reusable touches to `octos-agent`/`octos-fleet`); not wired into any live path yet (PR 4 = outbox consumer + wake; PR 5 = `goal_dispatch` + keeper).

### What it provides
- **`closed_registry`** — `build_fleet_worker_registry`: an empty `ToolRegistry` with exactly 7 replay-safe native tools (read/write/edit/glob/grep/list_dir/shell), `ApprovalPolicy::Never`, background execution disabled. An **exhaustive** audit test asserts `tool_names() == ALLOWED` (catches even dynamic MCP/plugin names) and that nothing `blocks_on_human_input`.
- **`worker`** — `run_attempt`: preflight → `launch_child` → fresh Agent under the closed registry → `timeout(deadline, run_task)` → acceptance (`FileExists` confined + canonicalized; `CommandExit(0)` sandboxed and deadline-bounded with real subprocess kill) → `Terminated`/`Rejected`/`Accepted` → `complete_child` (real snapshot) → `ready_tasks`. A `LaunchGuard` un-wedges the child on any panic/cancel between launch and completion.
- **`pool`** — `FleetWorkerPool`: global + per-fleet `Semaphore` (acquired per-fleet-first to avoid cross-fleet starvation; clamped ≥1); `dispatch` = launch + permit-bounded background run.

### Provable guarantees (the point of the crux)
- **Cannot park**: closed registry excludes `ask_user_question`/approvals; `ApprovalPolicy::Never` fails-closed at the tool boundary; task-locals don't cross the pool's `spawn`.
- **Bounded effects**: deadline wraps the run; the shell per-command timeout is capped to the deadline; acceptance validators are deadline-bounded and group-kill their subprocess on overrun; background/detached shell is refused (and the network-isolated sandbox is the operator-required boundary for shell's remaining reach).
- **Failure-atomic liveness**: preflight before durable launch; a drop-guard `Terminated`-completes on panic/cancel; `mark_running` distinguishes a lost-race (`Superseded`) from an infra error (keeps the guard armed) so no child wedges `Launching`.
- **Acceptance is fail-closed**: unverifiable criteria (`Manual`/`ValidatorRef`/non-zero-exit) → `Rejected`, never a silent `Accepted`; `FileExists` is workspace-confined against symlink escape.

### Tests & review
`octos-fleet-worker` 25 · `octos-fleet` 75 · `octos-agent` shell 78 — all green; `cargo build --workspace`, fmt, and `clippy -D warnings` (3 crates) clean. **Four adversarial review rounds** hardened it: R1 no-fan-out/replay/liveness, R2 in-txn/guard-timing, R3 subprocess-kill + sandbox-instance + symlink, R4 typed `mark_running` + real subprocess group-kill → **shippable**. Documented v1 limitations (soft token budget on timeout, `split_whitespace` argv, `FileExists` point-in-time confinement, sandbox as operator requirement) are noted in-module.
