### PR TITLE
test(octos-agent): fix the three test defects keeping check-arm red and test-octos-agent flaky

### DIFF
--- a/crates/octos-agent/src/plugins/tool_tests.rs
+++ b/crates/octos-agent/src/plugins/tool_tests.rs
@@ -1378,8 +1378,8 @@ async fn execute_spawns_subprocess_and_captures_output() {
     );
 
     let def = make_tool_def("echo_tool", "echoes input");
-    let tool = PluginTool::new("test-plugin".into(), def, script_path)
-        .with_timeout(TEST_PLUGIN_TIMEOUT);
+    let tool =
+        PluginTool::new("test-plugin".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let args = json!({"msg": "hello"});
     let result = tool.execute(&args).await.expect("execute should succeed");
@@ -1410,8 +1410,8 @@ async fn execute_structured_progress_event_updates_task_supervisor() {
     );
 
     let def = make_tool_def("structured_tool", "writes harness events");
-    let tool = PluginTool::new("test-plugin".into(), def, script_path)
-        .with_timeout(TEST_PLUGIN_TIMEOUT);
+    let tool =
+        PluginTool::new("test-plugin".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let sink = crate::harness_events::HarnessEventSink::new(
         supervisor.clone(),
@@ -2986,8 +2986,7 @@ async fn plugin_uses_scope_workspace_when_present() {
     let def = make_tool_def("scope_cwd", "echo CWD");
     // Crucially: NO `.with_work_dir(...)`. The scope is the only
     // source of truth.
-    let tool =
-        PluginTool::new("plug".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
+    let tool = PluginTool::new("plug".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let ctx = ctx_with_scope(scope);
     let result = crate::tools::TOOL_CTX

--- a/crates/octos-agent/src/plugins/tool_tests.rs
+++ b/crates/octos-agent/src/plugins/tool_tests.rs
@@ -3,6 +3,18 @@ use crate::SilentReporter;
 use serde_json::json;
 use std::sync::Arc;
 
+/// Plugin timeout for tests whose script finishes in milliseconds and which
+/// are NOT exercising the timeout path. It is headroom, not an assertion —
+/// nothing here is supposed to reach it.
+///
+/// It used to be 5s, which a loaded host can exceed just by scheduling the
+/// subprocess: five `plugins::tool::tests` cases went red together with
+/// `PluginTimeout` from `tool.rs:2966` during a repeat run on a busy machine,
+/// none of them related to timeouts. The one test that genuinely wants the
+/// timeout to fire (`execute_timeout_returns_error`) keeps its own 1s value
+/// against a script that sleeps 60s, so this constant does not weaken it.
+const TEST_PLUGIN_TIMEOUT: Duration = Duration::from_secs(120);
+
 fn make_tool_def(name: &str, desc: &str) -> PluginToolDef {
     PluginToolDef {
         name: name.to_string(),
@@ -1367,7 +1379,7 @@ async fn execute_spawns_subprocess_and_captures_output() {
 
     let def = make_tool_def("echo_tool", "echoes input");
     let tool = PluginTool::new("test-plugin".into(), def, script_path)
-        .with_timeout(Duration::from_secs(5));
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let args = json!({"msg": "hello"});
     let result = tool.execute(&args).await.expect("execute should succeed");
@@ -1399,7 +1411,7 @@ async fn execute_structured_progress_event_updates_task_supervisor() {
 
     let def = make_tool_def("structured_tool", "writes harness events");
     let tool = PluginTool::new("test-plugin".into(), def, script_path)
-        .with_timeout(Duration::from_secs(5));
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let sink = crate::harness_events::HarnessEventSink::new(
         supervisor.clone(),
@@ -1468,7 +1480,7 @@ async fn execute_does_not_expose_secret_extra_env_without_tool_allowlist() {
             "OPENAI_API_KEY".into(),
             "sk-octos-plugin-regression".into(),
         )])
-        .with_timeout(Duration::from_secs(5));
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let result = tool.execute(&json!({})).await.expect("should succeed");
 
@@ -1494,7 +1506,7 @@ async fn execute_exposes_secret_extra_env_with_tool_allowlist() {
             "OPENAI_API_KEY".into(),
             "sk-octos-plugin-allowed".into(),
         )])
-        .with_timeout(Duration::from_secs(5));
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let result = tool.execute(&json!({})).await.expect("should succeed");
 
@@ -1511,7 +1523,7 @@ async fn execute_fallback_on_non_json_stdout() {
     write_test_script(&script_path, "#!/bin/sh\necho 'plain text output'\n");
 
     let def = make_tool_def("plain_tool", "plain output");
-    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let result = tool.execute(&json!({})).await.expect("should succeed");
 
@@ -1551,7 +1563,7 @@ async fn execute_fallback_detects_generated_pptx_as_file_to_send() {
     };
     let tool = PluginTool::new("p".into(), def, script_path)
         .with_work_dir(dir.path().to_path_buf())
-        .with_timeout(Duration::from_secs(5));
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let result = tool
         .execute(&json!({"out": output_rel}))
@@ -1593,7 +1605,7 @@ async fn execute_fallback_waits_briefly_for_generated_pptx_to_appear() {
     };
     let tool = PluginTool::new("p".into(), def, script_path)
         .with_work_dir(dir.path().to_path_buf())
-        .with_timeout(Duration::from_secs(5));
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let result = tool
         .execute(&json!({"out": output_rel}))
@@ -1638,7 +1650,7 @@ async fn execute_fallback_skips_missing_generated_pptx() {
     };
     let tool = PluginTool::new("p".into(), def, script_path)
         .with_work_dir(dir.path().to_path_buf())
-        .with_timeout(Duration::from_secs(5));
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let result = tool
         .execute(&json!({"out": output_rel}))
@@ -2167,7 +2179,7 @@ async fn strict_env_allowlist_drops_non_listed_extra_env() {
             ("FOO_ALLOWED_PLUGIN".into(), "yes".into()),
             ("FOO_BLOCKED_PLUGIN".into(), "should_be_stripped".into()),
         ])
-        .with_timeout(Duration::from_secs(5));
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let result = tool.execute(&json!({})).await.expect("should succeed");
 
@@ -2204,7 +2216,7 @@ async fn empty_env_allowlist_keeps_legacy_extra_env_passthrough() {
     // No `env` allowlist declared → empty list → legacy gate.
     let tool = PluginTool::new("p".into(), def, script_path)
         .with_extra_env(vec![("MY_BASE_URL".into(), "passes_through".into())])
-        .with_timeout(Duration::from_secs(5));
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let result = tool.execute(&json!({})).await.expect("should succeed");
 
@@ -2232,7 +2244,7 @@ async fn strict_env_allowlist_retains_path() {
 
     let mut def = make_tool_def("path_tool", "prints PATH");
     def.env.push("FOO_ALLOWED_PLUGIN".into());
-    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let result = tool.execute(&json!({})).await.expect("should succeed");
     assert!(result.success);
@@ -2292,7 +2304,7 @@ async fn high_risk_plugin_tool_requests_approval() {
 
     let mut def = make_tool_def("danger_tool", "danger");
     def.risk = Some("high".into());
-    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let (requester, last) = RecordingRequester::new(ToolApprovalDecision::Approve);
     let requester_arc: Arc<dyn ToolApprovalRequester> = requester;
@@ -2325,7 +2337,7 @@ async fn high_risk_plugin_tool_denied_returns_deny_message() {
 
     let mut def = make_tool_def("danger_tool_deny", "danger");
     def.risk = Some("critical".into());
-    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let (requester, _last) = RecordingRequester::new(ToolApprovalDecision::Deny);
     let requester_arc: Arc<dyn ToolApprovalRequester> = requester;
@@ -2356,7 +2368,7 @@ async fn low_risk_plugin_tool_does_not_request_approval() {
 
     let mut def = make_tool_def("safe_tool", "safe");
     def.risk = Some("low".into());
-    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let (requester, last) = RecordingRequester::new(ToolApprovalDecision::Deny);
     let requester_arc: Arc<dyn ToolApprovalRequester> = requester;
@@ -2387,7 +2399,7 @@ async fn unspecified_risk_plugin_tool_does_not_request_approval() {
     );
 
     let def = make_tool_def("plain_tool", "plain");
-    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let (requester, last) = RecordingRequester::new(ToolApprovalDecision::Deny);
     let requester_arc: Arc<dyn ToolApprovalRequester> = requester;
@@ -2425,7 +2437,7 @@ async fn should_deny_high_risk_plugin_without_prompt_when_approval_policy_never(
     let mut def = make_tool_def("danger_never", "danger");
     def.risk = Some("high".into());
     let tool = PluginTool::new("p".into(), def, script_path)
-        .with_timeout(Duration::from_secs(5))
+        .with_timeout(TEST_PLUGIN_TIMEOUT)
         .with_approval_policy(ApprovalPolicy::Never);
 
     let (requester, last) = RecordingRequester::new(ToolApprovalDecision::Approve);
@@ -2468,7 +2480,7 @@ async fn should_auto_allow_high_risk_plugin_without_prompt_when_danger_full_acce
     let mut def = make_tool_def("danger_yolo", "danger");
     def.risk = Some("critical".into());
     let tool = PluginTool::new("p".into(), def, script_path)
-        .with_timeout(Duration::from_secs(5))
+        .with_timeout(TEST_PLUGIN_TIMEOUT)
         .with_approval_policy(ApprovalPolicy::Never)
         .with_auto_approve_high_risk(true);
 
@@ -2508,7 +2520,7 @@ async fn should_request_approval_for_high_risk_plugin_when_approval_policy_ask()
     let mut def = make_tool_def("danger_ask", "danger");
     def.risk = Some("high".into());
     let tool = PluginTool::new("p".into(), def, script_path)
-        .with_timeout(Duration::from_secs(5))
+        .with_timeout(TEST_PLUGIN_TIMEOUT)
         .with_approval_policy(ApprovalPolicy::Ask);
 
     let (requester, last) = RecordingRequester::new(ToolApprovalDecision::Approve);
@@ -2601,7 +2613,7 @@ async fn high_risk_without_approval_bridge_denies_safely() {
 
     let mut def = make_tool_def("danger_tool_no_bridge", "danger");
     def.risk = Some("HIGH".into());
-    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
 
     // No TOOL_APPROVAL_CTX scoped → try_with returns Err → deny.
     let result = tool
@@ -2666,7 +2678,7 @@ async fn unknown_risk_literal_does_not_force_approval() {
 
     let mut def = make_tool_def("medium_tool", "medium");
     def.risk = Some("medium".into());
-    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let (requester, last) = RecordingRequester::new(ToolApprovalDecision::Deny);
     let requester_arc: Arc<dyn ToolApprovalRequester> = requester;
@@ -2797,7 +2809,7 @@ async fn execute_with_named_outputs_threads_field_into_tool_result() {
     );
 
     let def = make_tool_def("publish_tool", "publish");
-    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let result = tool.execute(&json!({})).await.expect("execute should ok");
     assert!(result.success);
@@ -2822,7 +2834,7 @@ async fn execute_with_malformed_named_outputs_returns_failure() {
     );
 
     let def = make_tool_def("bad_tool", "emits bad named outputs");
-    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let result = tool.execute(&json!({})).await.expect("execute should ok");
     assert!(!result.success);
@@ -2846,7 +2858,7 @@ async fn execute_without_named_outputs_leaves_tool_result_none() {
     );
 
     let def = make_tool_def("legacy_tool", "legacy");
-    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let result = tool.execute(&json!({})).await.expect("execute should ok");
     assert!(result.success);
@@ -2952,7 +2964,7 @@ async fn plugin_uses_scope_workspace_when_present() {
     // Crucially: NO `.with_work_dir(...)`. The scope is the only
     // source of truth.
     let tool =
-        PluginTool::new("plug".into(), def, script_path).with_timeout(Duration::from_secs(5));
+        PluginTool::new("plug".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let ctx = ctx_with_scope(scope);
     let result = crate::tools::TOOL_CTX
@@ -3003,7 +3015,7 @@ async fn high_risk_plugin_approval_cwd_reflects_scope_workspace() {
 
     let mut def = make_tool_def("approval_cwd_tool", "danger");
     def.risk = Some("high".into());
-    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+    let tool = PluginTool::new("p".into(), def, script_path).with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let (requester, last) = RecordingRequester::new(ToolApprovalDecision::Approve);
     let requester_arc: Arc<dyn ToolApprovalRequester> = requester;
@@ -3065,7 +3077,7 @@ async fn plugin_rescues_workspace_root_under_hinted_skill_output_rebind() {
     );
     let tool = PluginTool::new("plug".into(), input_path_def("script_path"), bin_path)
         .with_work_dir(skill_output.clone())
-        .with_timeout(Duration::from_secs(5));
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let ctx = ctx_with_scope(scope);
     let result = crate::tools::TOOL_CTX
@@ -3118,7 +3130,7 @@ async fn plugin_refuses_absolute_escape_in_hinted_session() {
     );
     let tool = PluginTool::new("plug".into(), input_path_def("audio_path"), script.clone())
         .with_work_dir(hinted_work_dir.path().to_path_buf())
-        .with_timeout(Duration::from_secs(5));
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let ctx = ctx_with_scope(scope);
     let bait_abs = bait_path.to_string_lossy().to_string();
@@ -3175,7 +3187,7 @@ async fn plugin_prefers_registry_rebound_work_dir_over_scope() {
     let def = make_tool_def("hint_cwd", "echo CWD");
     let tool = PluginTool::new("plug".into(), def, script_path)
         .with_work_dir(hinted_work_dir.path().to_path_buf())
-        .with_timeout(Duration::from_secs(5));
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
 
     let ctx = ctx_with_scope(scope);
     let result = crate::tools::TOOL_CTX
@@ -3215,7 +3227,7 @@ async fn plugin_falls_back_to_self_work_dir_when_no_scope() {
     let def = make_tool_def("legacy_cwd", "echo CWD");
     let tool = PluginTool::new("plug".into(), def, script_path)
         .with_work_dir(dir.path().to_path_buf())
-        .with_timeout(Duration::from_secs(5));
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
 
     // No scope threaded — execute via the default `TOOL_CTX::zero`
     // shape (the global TOOL_CTX::try_with returns Err so the

--- a/crates/octos-agent/src/plugins/tool_tests.rs
+++ b/crates/octos-agent/src/plugins/tool_tests.rs
@@ -1760,28 +1760,45 @@ async fn dropped_execute_future_kills_child_no_orphan() {
     // branch that saves us — only dropping the future can kill the child.
     let tool = PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(600));
 
-    // Simulate the registry dispatch boundary: wrap the tool future in a
-    // short timeout. On elapse the future is dropped (its `Child` with it).
-    // Use a 3s window (generous even under heavy parallel test load) so the
-    // child reliably runs `echo $$ > pidfile` and reaches `sleep` BEFORE
-    // the timeout drops the future — otherwise we could not observe the
-    // pid to assert on. The cancellation-safety property is unaffected by
-    // the window length.
+    // Simulate the registry dispatch boundary: the pending tool future is
+    // dropped, taking its `Child` with it. We must not drop until the child
+    // has actually run `echo $$ > pidfile`, or there is no pid to assert on.
+    //
+    // Drive the future in slices and wait on the *pidfile* rather than on a
+    // fixed window. A fixed window cannot be both cheap and safe here: this
+    // future never completes, so the entire window is always consumed, which
+    // means buying reliability with a longer one directly lengthens every
+    // run. The previous 3s window — commented "generous even under heavy
+    // parallel test load" — still lost the race ~2 runs in 20 on an *idle*
+    // machine, panicking with "child should have recorded its pid before
+    // sleeping". Waiting on the observable event removes the race outright
+    // and finishes in tens of milliseconds instead of a fixed 3s.
     let args = json!({});
-    let fut = tool.execute(&args);
-    let res = tokio::time::timeout(Duration::from_secs(3), fut).await;
-    assert!(
-        res.is_err(),
-        "expected the short registry-style timeout to elapse (future dropped)"
-    );
-    // `res` (the dropped future) is gone here — the `Child` was owned by it.
-
-    // The child should have written its pid before sleeping. It had the
-    // full 3s window above to do so.
-    let pid: u32 = std::fs::read_to_string(&pidfile)
-        .ok()
-        .and_then(|s| s.trim().parse::<u32>().ok())
-        .expect("child should have recorded its pid before sleeping");
+    let mut fut = Box::pin(tool.execute(&args));
+    let pid: u32 = {
+        let started = std::time::Instant::now();
+        loop {
+            // Let the future make progress. It is supposed to hang.
+            if tokio::time::timeout(Duration::from_millis(20), &mut fut)
+                .await
+                .is_ok()
+            {
+                panic!("plugin future completed; it must stay pending");
+            }
+            if let Some(p) = std::fs::read_to_string(&pidfile)
+                .ok()
+                .and_then(|s| s.trim().parse::<u32>().ok())
+            {
+                break p;
+            }
+            assert!(
+                started.elapsed() < Duration::from_secs(60),
+                "child never recorded its pid"
+            );
+        }
+    };
+    // THE EVENT UNDER TEST: dropping the pending future must kill the child.
+    drop(fut);
 
     // Poll: the drop-kill + tokio reaper should make the child dead. Allow
     // a brief window for SIGKILL delivery + reap.
@@ -1860,29 +1877,35 @@ async fn dropped_execute_future_kills_child_and_grandchild_no_orphan() {
     // kill branch.
     let tool = PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(600));
 
-    // Simulate the registry dispatch boundary: a short timeout drops the
-    // future (and its `Child`) on elapse. 3s window so the script reliably
-    // records both pids before the drop.
+    // Same deterministic hand-off as the single-child case above: drive the
+    // pending future in slices until BOTH pids are on disk, then drop. The
+    // old shape polled the pidfile *after* the drop, which cannot help — a
+    // dropped future has already killed the tree, so a script that had not
+    // written yet never will. Hence the "got: \"\"" flake.
     let args = json!({});
-    let fut = tool.execute(&args);
-    let res = tokio::time::timeout(Duration::from_secs(3), fut).await;
-    assert!(
-        res.is_err(),
-        "expected the short registry-style timeout to elapse (future dropped)"
-    );
-
+    let mut fut = Box::pin(tool.execute(&args));
     // Read BOTH recorded pids (grandchild first, then direct child).
     let contents = {
-        let mut last = String::new();
-        for _ in 0..100 {
-            last = std::fs::read_to_string(&pidfile).unwrap_or_default();
-            if last.lines().filter(|l| !l.trim().is_empty()).count() >= 2 {
-                break;
+        let started = std::time::Instant::now();
+        loop {
+            if tokio::time::timeout(Duration::from_millis(20), &mut fut)
+                .await
+                .is_ok()
+            {
+                panic!("plugin future completed; it must stay pending");
             }
-            tokio::time::sleep(Duration::from_millis(20)).await;
+            let last = std::fs::read_to_string(&pidfile).unwrap_or_default();
+            if last.lines().filter(|l| !l.trim().is_empty()).count() >= 2 {
+                break last;
+            }
+            assert!(
+                started.elapsed() < Duration::from_secs(60),
+                "plugin never recorded both pids, got: {last:?}"
+            );
         }
-        last
     };
+    // THE EVENT UNDER TEST: dropping the pending future must reap the tree.
+    drop(fut);
     let pids: Vec<u32> = contents
         .lines()
         .filter_map(|l| l.trim().parse::<u32>().ok())

--- a/crates/octos-agent/src/tools/shell.rs
+++ b/crates/octos-agent/src/tools/shell.rs
@@ -888,6 +888,13 @@ impl Tool for ShellTool {
 mod tests {
     use super::*;
 
+    /// Runaway guard for the "poll until the background task reaches state X"
+    /// loops below. NOT a latency assertion: each loop breaks the instant the
+    /// supervisor reports a terminal status, so a generous ceiling costs a passing
+    /// run nothing, and a genuinely broken run still fails — just later.
+    /// Mirrors `spawn_tests::BACKGROUND_DEADLINE`.
+    const BACKGROUND_DEADLINE: std::time::Duration = std::time::Duration::from_secs(60);
+
     #[test]
     fn shell_tool_is_exclusive() {
         // Shell must serialize relative to peers (M8.8) — a mutating command
@@ -1385,7 +1392,7 @@ mod tests {
                     panic!("background task failed: {:?}", t.error);
                 }
             }
-            if started.elapsed() > std::time::Duration::from_secs(15) {
+            if started.elapsed() > BACKGROUND_DEADLINE {
                 let statuses: Vec<_> = supervisor
                     .get_tasks_for_session("api:test-session")
                     .iter()
@@ -1468,7 +1475,7 @@ mod tests {
                     panic!("expected failure, task completed");
                 }
             }
-            if started.elapsed() > std::time::Duration::from_secs(15) {
+            if started.elapsed() > BACKGROUND_DEADLINE {
                 panic!("background failure not observed in 15s");
             }
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;

--- a/crates/octos-agent/src/tools/spawn_tests.rs
+++ b/crates/octos-agent/src/tools/spawn_tests.rs
@@ -2,6 +2,19 @@ use super::*;
 #[cfg(unix)]
 use crate::{HookConfig, HookEvent};
 
+/// Runaway guard for the "poll until the background task reaches state X"
+/// loops below. It is NOT a latency assertion: on a passing run the loop
+/// returns as soon as the state arrives, so a generous ceiling costs nothing,
+/// and on a genuinely broken run the test still fails — just later.
+///
+/// It used to be 5s, which sits under the noise floor of a loaded CI runner:
+/// `test_background_spawn_fails_when_contract_owned_workflow_is_not_ready`
+/// failed with "did not fail in time" on ubuntu-latest in run 30387949499
+/// while the only change under test was one line of `.github/workflows/ci.yml`.
+/// These loops spawn real subprocesses, so their wall-clock cost tracks host
+/// load rather than anything the test controls.
+const BACKGROUND_DEADLINE: std::time::Duration = std::time::Duration::from_secs(60);
+
 #[test]
 fn frame_subagent_task_leads_with_identity_and_directive() {
     let out = frame_subagent_task("review-octos-web", "Clone and review the repo.");
@@ -168,10 +181,10 @@ async fn background_deliverable_auto_materializes_inline_final_output() {
                 panic!("spawn failed: {:?}", t.error);
             }
         }
-        if started.elapsed() >= std::time::Duration::from_secs(15) {
+        if started.elapsed() >= BACKGROUND_DEADLINE {
             let tasks = supervisor.get_tasks_for_session("api:test-session");
             panic!(
-                "did not complete in 15s; tasks = {:?}",
+                "did not complete in {BACKGROUND_DEADLINE:?}; tasks = {:?}",
                 tasks
                     .iter()
                     .map(|t| (t.status.as_str(), t.error.clone()))
@@ -490,7 +503,7 @@ async fn test_background_spawn_tracks_supervisor_lifecycle() {
             }
         }
         assert!(
-            started.elapsed() < std::time::Duration::from_secs(5),
+            started.elapsed() < BACKGROUND_DEADLINE,
             "background spawn task did not complete in time"
         );
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -640,7 +653,7 @@ async fn test_background_spawn_uses_contract_selected_slides_artifact_for_persis
             }
         }
         assert!(
-            started.elapsed() < std::time::Duration::from_secs(5),
+            started.elapsed() < BACKGROUND_DEADLINE,
             "background spawn task did not complete in time"
         );
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -758,7 +771,7 @@ async fn test_background_spawn_fails_when_contract_owned_workflow_is_not_ready()
             }
         }
         assert!(
-            started.elapsed() < std::time::Duration::from_secs(5),
+            started.elapsed() < BACKGROUND_DEADLINE,
             "background spawn task did not fail in time"
         );
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -839,7 +852,7 @@ async fn test_background_spawn_emits_failure_hook_for_contract_failure() {
             }
         }
         assert!(
-            started.elapsed() < std::time::Duration::from_secs(5),
+            started.elapsed() < BACKGROUND_DEADLINE,
             "background spawn failure hook did not arrive in time"
         );
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -1658,7 +1671,7 @@ async fn test_background_spawn_persists_workflow_phase_transitions() {
             }
         }
         assert!(
-            started.elapsed() < std::time::Duration::from_secs(5),
+            started.elapsed() < BACKGROUND_DEADLINE,
             "background spawn task did not complete in time"
         );
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -1821,7 +1834,7 @@ async fn test_background_spawn_emits_child_session_lifecycle_events() {
         }
 
         assert!(
-            started.elapsed() < std::time::Duration::from_secs(5),
+            started.elapsed() < BACKGROUND_DEADLINE,
             "child-session lifecycle events did not arrive in time"
         );
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -1899,7 +1912,7 @@ async fn test_background_spawn_emits_verify_and_complete_hooks() {
         }
 
         assert!(
-            started.elapsed() < std::time::Duration::from_secs(5),
+            started.elapsed() < BACKGROUND_DEADLINE,
             "spawn lifecycle hooks did not arrive in time"
         );
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -2157,7 +2170,7 @@ async fn background_child_transcript_streams_to_router_and_final_output_is_recor
             }
         }
         assert!(
-            started.elapsed() < std::time::Duration::from_secs(5),
+            started.elapsed() < BACKGROUND_DEADLINE,
             "background child did not complete in time"
         );
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -2259,7 +2272,7 @@ async fn child_stream_callback_gets_start_offsets_and_router_file_has_no_duplica
             }
         }
         assert!(
-            started.elapsed() < std::time::Duration::from_secs(5),
+            started.elapsed() < BACKGROUND_DEADLINE,
             "background child did not complete in time"
         );
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -2447,7 +2460,7 @@ async fn background_deliverable_surfaces_shell_written_file_in_output_files() {
             }
         }
         assert!(
-            started.elapsed() < std::time::Duration::from_secs(5),
+            started.elapsed() < BACKGROUND_DEADLINE,
             "background deliverable spawn did not complete in time"
         );
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -2517,7 +2530,7 @@ async fn background_deliverable_uses_configured_root_without_touching_workspace_
             }
         }
         assert!(
-            started.elapsed() < std::time::Duration::from_secs(5),
+            started.elapsed() < BACKGROUND_DEADLINE,
             "background deliverable spawn did not complete in time"
         );
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -2649,7 +2662,7 @@ async fn background_without_deliverable_does_not_surface_shell_write() {
             }
         }
         assert!(
-            started.elapsed() < std::time::Duration::from_secs(5),
+            started.elapsed() < BACKGROUND_DEADLINE,
             "background spawn did not complete in time"
         );
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;

--- a/crates/octos-agent/tests/mcp_agent_backend.rs
+++ b/crates/octos-agent/tests/mcp_agent_backend.rs
@@ -27,6 +27,20 @@ use octos_agent::tools::mcp_agent::{
     StdioMcpAgent, build_backend_from_config, build_dispatch_event_payload, dispatch_with_metrics,
 };
 
+/// Headroom for spawn + MCP handshake + reply in the stdio dispatch tests that
+/// are NOT about timing. It is not an assertion — nothing here should reach it.
+///
+/// `StdioMcpAgent::dispatch_inner` wraps the *whole* run in this budget, so 5s
+/// had to cover `/bin/sh` startup, the initialize round-trip, the
+/// notification-skip loop (which forks `printf | grep` per iteration), a
+/// `printf | sed` fork, and the tools/call reply — all on a CI runner that may
+/// be running the rest of the suite at full parallelism.
+///
+/// The two tests that genuinely exercise the timeout path set their own budget
+/// via `with_dispatch_timeout` (300ms / 150ms) and pass
+/// `dispatch_timeout_secs: None`, so this constant cannot weaken them.
+const STDIO_DISPATCH_TIMEOUT_SECS: u64 = 120;
+
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 /// Build a throwaway shell-script MCP server that answers two requests:
@@ -214,7 +228,7 @@ async fn should_dispatch_to_stdio_mcp_agent_and_return_contract_artifact() {
         cmd: script.display().to_string(),
         args: vec![],
         env: HashMap::new(),
-        dispatch_timeout_secs: Some(5),
+        dispatch_timeout_secs: Some(STDIO_DISPATCH_TIMEOUT_SECS),
     };
     let backend =
         build_backend_from_config(&config, Some(dir.path())).expect("build stdio backend");
@@ -393,7 +407,7 @@ async fn should_apply_blocked_env_vars_to_stdio_subprocess() {
         cmd: script.display().to_string(),
         args: vec![],
         env: extra,
-        dispatch_timeout_secs: Some(5),
+        dispatch_timeout_secs: Some(STDIO_DISPATCH_TIMEOUT_SECS),
     };
     let backend = StdioMcpAgent::from_config(&config)
         .unwrap()
@@ -473,7 +487,7 @@ async fn should_emit_sub_agent_dispatch_event_on_typed_payload() {
         cmd: script.display().to_string(),
         args: vec![],
         env: HashMap::new(),
-        dispatch_timeout_secs: Some(5),
+        dispatch_timeout_secs: Some(STDIO_DISPATCH_TIMEOUT_SECS),
     };
     let backend =
         build_backend_from_config(&config, Some(dir.path())).expect("build stdio backend");
@@ -558,7 +572,7 @@ printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text
         cmd: script_path.display().to_string(),
         args: vec![],
         env: HashMap::new(),
-        dispatch_timeout_secs: Some(5),
+        dispatch_timeout_secs: Some(STDIO_DISPATCH_TIMEOUT_SECS),
     };
     let backend = StdioMcpAgent::from_config(&config)
         .unwrap()

--- a/crates/octos-agent/tests/mcp_agent_backend.rs
+++ b/crates/octos-agent/tests/mcp_agent_backend.rs
@@ -94,6 +94,14 @@ done
 read init
 printf '%s\n' '{{"jsonrpc":"2.0","id":1,"result":{{"serverInfo":{{}}}}}}'
 read call
+# Spec-compliant clients send notifications/initialized between the
+# initialize response and the first request. Skip notification frames
+# until the real tools/call arrives — otherwise this `read` consumes the
+# notification, the script answers and exits, and the client's still-
+# pending tools/call write hits a closed pipe (TransportError).
+while printf '%s' "$call" | grep -q '"method":"notifications/'; do
+  read call
+done
 printf '%s\n' '{{"jsonrpc":"2.0","id":2,"result":{{"content":[{{"type":"text","text":"probed"}}]}}}}'
 "#,
         log = log_path.display()
@@ -213,7 +221,9 @@ async fn should_dispatch_to_stdio_mcp_agent_and_return_contract_artifact() {
     let request = DispatchRequest::new("run_task", serde_json::json!({"task": "hello"}));
     let response = backend.dispatch(request).await;
 
-    assert_eq!(response.outcome, DispatchOutcome::Success);
+    // Carry the whole response: a bare `left: TransportError` says nothing
+    // about *why* the transport failed.
+    assert_eq!(response.outcome, DispatchOutcome::Success, "{response:?}");
     assert!(
         response.output.contains("fake-agent:run_task"),
         "unexpected output: {}",
@@ -252,7 +262,9 @@ async fn should_dispatch_to_remote_mcp_agent_and_return_contract_artifact() {
     let response = backend.dispatch(request).await;
     join.abort();
 
-    assert_eq!(response.outcome, DispatchOutcome::Success);
+    // Carry the whole response: a bare `left: TransportError` says nothing
+    // about *why* the transport failed.
+    assert_eq!(response.outcome, DispatchOutcome::Success, "{response:?}");
     assert_eq!(response.output, "remote-agent");
     assert_eq!(
         response.files_to_send,
@@ -390,7 +402,9 @@ async fn should_apply_blocked_env_vars_to_stdio_subprocess() {
     let response = backend
         .dispatch(DispatchRequest::new("run_task", serde_json::json!({})))
         .await;
-    assert_eq!(response.outcome, DispatchOutcome::Success);
+    // Carry the whole response: a bare `left: TransportError` says nothing
+    // about *why* the transport failed.
+    assert_eq!(response.outcome, DispatchOutcome::Success, "{response:?}");
 
     let log_contents = std::fs::read_to_string(&log).expect("read env probe log");
     // Empty value after the `=` proves the blocked name was scrubbed
@@ -518,6 +532,14 @@ set -eu
 read init
 printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"serverInfo":{}}}'
 read call
+# Spec-compliant clients send notifications/initialized between the
+# initialize response and the first request. Skip notification frames
+# until the real tools/call arrives — otherwise this `read` consumes the
+# notification, the script answers and exits, and the client's still-
+# pending tools/call write hits a closed pipe (TransportError).
+while printf '%s' "$call" | grep -q '"method":"notifications/'; do
+  read call
+done
 # Pretend the sub-agent ran several internal tools — but only the final
 # JSON-RPC frame is emitted on stdout. Everything else is logged on
 # stderr so even a leaky harness cannot accidentally surface it.
@@ -549,7 +571,9 @@ printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text
         ))
         .await;
 
-    assert_eq!(response.outcome, DispatchOutcome::Success);
+    // Carry the whole response: a bare `left: TransportError` says nothing
+    // about *why* the transport failed.
+    assert_eq!(response.outcome, DispatchOutcome::Success, "{response:?}");
     assert_eq!(response.output, "final-artifact-only");
     // Internal chatter never appears in the DispatchResponse.
     assert!(

--- a/crates/octos-cli/src/session_actor_tests.rs
+++ b/crates/octos-cli/src/session_actor_tests.rs
@@ -1,5 +1,12 @@
 use super::*;
 use async_trait::async_trait;
+
+/// Runaway guard for the "poll until the hook subprocess has appended its
+/// JSONL line" loop. NOT a latency assertion: the loop breaks on content the
+/// instant the line appears, so a generous ceiling costs a passing run
+/// nothing, and a broken run (hook never fires) still fails — just later.
+/// Mirrors `octos_agent`'s `spawn_tests::BACKGROUND_DEADLINE`.
+const HOOK_DEADLINE: Duration = Duration::from_secs(60);
 #[cfg(unix)]
 use octos_agent::{HookConfig, HookEvent};
 use octos_llm::{AdaptiveConfig, ChatConfig, ChatResponse, StopReason, TokenUsage, ToolSpec};
@@ -745,7 +752,11 @@ fn capture_hook(event: HookEvent, log_path: &std::path::Path) -> HookConfig {
             "sh".into(),
             log_path.to_string_lossy().into_owned(),
         ],
-        timeout_ms: 5000,
+        // Headroom only — neither hook test asserts that a hook times out, and
+        // on expiry `hooks.rs` kills the child, so the JSONL line never lands
+        // and the poll loop below cannot recover no matter how long it waits.
+        // This must stay in step with `HOOK_DEADLINE`.
+        timeout_ms: 60_000,
         tool_filter: vec![],
         path_filter: Vec::new(),
         requires_bin: None,
@@ -2907,7 +2918,7 @@ async fn test_forced_background_turn_emits_turn_end_hook() {
         }
 
         assert!(
-            started.elapsed() < Duration::from_secs(5),
+            started.elapsed() < HOOK_DEADLINE,
             "forced-background turn-end hook did not arrive in time"
         );
         tokio::time::sleep(Duration::from_millis(50)).await;


### PR DESCRIPTION
Three independent defects in `octos-agent`'s own tests. None touch product code; none weaken an assertion.

## 1. `check-arm` — deterministic, and it is one test

Runs [30338440845](https://github.com/octos-org/octos/actions/runs/30338440845) and [30390862121](https://github.com/octos-org/octos/actions/runs/30390862121) each passed **2447 tests and failed exactly one**:

```
should_isolate_sub_agent_internal_context_from_parent ... FAILED
assertion `left == right` failed
  left: TransportError
 right: Success
test result: FAILED. 7 passed; 1 failed ... finished in 0.33s
```

Byte-identical across both runs, so this is not a flake. And `0.33s` rules out the 5s `dispatch_timeout_secs`.

The job log prints the fake server's three `sub-agent internal: ...` stderr lines immediately before the failure, so the script **did** exec and **did** run to completion. The fault is protocol, not process startup.

`dispatch_stdio` sends `notifications/initialized` between the initialize response and the first request (`mcp_agent.rs:884`). The fake server did a bare second `read call`, so it consumed the *notification* as if it were the `tools/call`, printed its reply, and exited. The client's actual `tools/call` write then landed on a closed pipe → `TransportError`.

**The control group is in the same file.** `write_stdio_responder_script` already carries a skip loop for exactly this, and its tests pass on ARM in both runs. This applies that same loop to the two servers that lacked it: the failing inline script, and `write_stdio_env_probe_script` — which has the identical gap and also asserts `Success`, so it is latent rather than sound.

## 2. Hardcoded 5s deadlines that CI load can exceed

`test_background_spawn_fails_when_contract_owned_workflow_is_not_ready` went red with `background spawn task did not fail in time` in [run 30387949499](https://github.com/octos-org/octos/actions/runs/30387949499), where the only change under test was one line of `ci.yml`. That job had not failed once in the prior 25 runs, and it passed on rerun.

- `spawn_tests.rs`: 13 `elapsed() < Duration::from_secs(5)` guards → one named `BACKGROUND_DEADLINE` (60s). These are runaway guards, not latency assertions: a passing run exits the loop as soon as the state arrives, so a larger ceiling costs nothing, and a broken run still fails, just later.
- `plugins/tool_tests.rs`: 29 `.with_timeout(Duration::from_secs(5))` on scripts that finish in milliseconds → `TEST_PLUGIN_TIMEOUT` (120s). Under contention these surfaced as `PluginTimeout` from `tool.rs:2966`.

**Deliberately not changed**, because for these the clock *is* the thing under test:
- `execute_timeout_returns_error` keeps `from_secs(1)` against a script that sleeps 60s.
- The two `from_secs(600)` drop-guard tests and the `from_secs(120)` builder assertion.
- The four `coding_tools_tests.rs` `elapsed() < from_secs(3)` checks, which pair with `timeout_ms: 1000` and assert the timeout feature *works*. Raising those would delete the test.

## 3. A race in the drop-kills-child tests

`dropped_execute_future_kills_child{,_and_grandchild}_no_orphan` dropped the pending future after a fixed `timeout(3s, fut)` and then read pids the script was supposed to have written. If the subprocess had not reached `echo $$ > pidfile` in that window, the drop killed it first:

```
panicked at: child should have recorded its pid before sleeping
panicked at: expected the plugin to record both grandchild and child pids, got: ""
```

Measured **2 failures in 20 runs on an idle machine**, despite a comment claiming 3s was "generous even under heavy parallel test load". The grandchild variant polled the pidfile *after* the drop, which cannot help — once the future is dropped the tree is already reaped.

Widening the window was not an option: these futures never complete, so the window is always consumed in full. A 60s window would add 60s per test to every run.

Instead they now drive the future in 20ms slices, wait on the observable event, then `drop(fut)` explicitly as the event under test.

## Verification

| | |
|---|---|
| `plugins::tool::tests` | 116 passed |
| `tools::spawn::tests` | 92 passed |
| drop-kills-child pair | **40/40**, up from 18/20 — and 0.59s instead of a fixed 6s |
| `mcp_agent_backend` | 25/25 |
| `cargo clippy -p octos-agent --all-targets -- -D warnings` | exit 0, zero warnings |

**Honest limits.** Items 2 and 3 are verified by direct before/after measurement. Item 1 is not: the failure has only ever reproduced on Linux/ARM CI, and this box is macOS/arm64. It is a structural fix inferred from the divergence against a passing control in the same file, and it needs a `check-arm` run to confirm. Note that `check-arm` does not run on pull requests (`if: github.event_name != 'pull_request'`), so this PR's own CI will **not** exercise it — it needs a `workflow_dispatch` on this branch.

This does not make `main` green on its own; `check-windows` is independently red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)