### PR TITLE
ci(windows): make one check-windows run report the whole truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,19 +591,23 @@ jobs:
     # check can even see.
     #
     # NON-BLOCKING for now, because it is currently RED for a pre-existing
-    # reason: `octos-core` `session_scope` has 2 Windows-only test failures
-    # (5-for-5 on recent `main` runs, long before this job moved to PRs).
-    # Making it blocking today would wedge every PR on a bug it did not
+    # reason. Making it blocking today would wedge every PR on a bug it did not
     # introduce. It still surfaces on the PR, which is the point — a NEW
     # Windows break is now visible at review time instead of after merge.
+    #
+    # The original reason recorded here — 2 `octos-core` `session_scope`
+    # failures — was fixed by #1838; `Test octos-core` is green on `main`. As of
+    # run 30423603951 the job stops at `Test octos-plugin`
+    # (`lifecycle::tests::run_phase_injects_octos_skill_dir_env`), which #1860
+    # addresses. Keep this note pinned to the CURRENT blocker: a stale one reads
+    # as "known, tracked, someone's on it" long after nobody is.
     #
     # Non-blocking ONLY on PRs. On push to `main` it stays hard-failing, so
     # `build-windows` (which `needs:` this job) still refuses to ship a Windows
     # artifact from a red suite — a blanket `continue-on-error: true` would have
     # silently re-enabled those releases.
     #
-    # Drop this line entirely once the two tests are fixed; see the tracking
-    # note in `crates/octos-core/src/session_scope.rs`.
+    # Drop this line entirely once the job is green on `main`.
     continue-on-error: ${{ github.event_name == 'pull_request' }}
     runs-on: windows-latest
     steps:
@@ -615,45 +619,87 @@ jobs:
         with:
           shared-key: windows
 
-      - name: Build (workspace + all features)
-        run: |
-          cargo build --workspace
-          cargo build -p octos-cli --features ${{ env.FEATURES }}
+      # One command per step, on purpose. Windows steps run under pwsh, which
+      # does NOT abort on a failing native command — GitHub appends only
+      # `exit $LASTEXITCODE`, so a multi-line `run:` block reports the exit
+      # code of its LAST line and silently swallows every failure before it.
+      # The Linux jobs above are safe (bash runs with `-eo pipefail`); these
+      # two blocks were the only multi-command steps in this job.
+      - name: Build (workspace)
+        run: cargo build --workspace
+
+      - name: Build (octos-cli + all features)
+        run: cargo build -p octos-cli --features ${{ env.FEATURES }}
 
       # Sharded per-crate tests — same rationale as the `check` job.
+      #
+      # Every test step runs even after an earlier one fails. GitHub aborts a
+      # job at the first failing step, so a single red crate hid every crate
+      # after it — PR #1860 fixed ~48 Windows failures and the job STILL only
+      # reported one, with steps 18-20 never executing. That turned Windows
+      # into a one-failure-per-40-minute-run guessing game.
+      #
+      # `!cancelled()` keeps the step running on failure but NOT after a manual
+      # cancel or job timeout. The job's own conclusion is unchanged: any red
+      # step still fails the job, so this weakens no gate — it only makes one
+      # run report the whole truth.
       - name: Test octos-core
+        if: ${{ !cancelled() }}
         run: cargo test -p octos-core
       - name: Test octos-memory
+        if: ${{ !cancelled() }}
         run: cargo test -p octos-memory
       - name: Test octos-llm (lib)
+        if: ${{ !cancelled() }}
         run: cargo test -p octos-llm --lib
       - name: Test octos-llm (integration)
+        if: ${{ !cancelled() }}
         run: cargo test -p octos-llm --tests
       - name: Test octos-bus
+        if: ${{ !cancelled() }}
         run: cargo test -p octos-bus
       - name: Test octos-pipeline
+        if: ${{ !cancelled() }}
         run: cargo test -p octos-pipeline
       - name: Test octos-plugin
+        if: ${{ !cancelled() }}
         run: cargo test -p octos-plugin
       - name: Test octos-sandbox
+        if: ${{ !cancelled() }}
         run: cargo test -p octos-sandbox
       - name: Test octos-swarm
+        if: ${{ !cancelled() }}
         run: cargo test -p octos-swarm
       - name: Test octos-agent (lib)
+        if: ${{ !cancelled() }}
         run: cargo test -p octos-agent --lib
       - name: Test octos-agent (integration)
+        if: ${{ !cancelled() }}
         run: cargo test -p octos-agent --tests
       - name: Test octos-cli (lib)
+        if: ${{ !cancelled() }}
         run: cargo test -p octos-cli --lib
       - name: Test octos-cli (integration)
+        if: ${{ !cancelled() }}
         run: cargo test -p octos-cli --tests
-      - name: Test harness starter skills
-        run: |
-          cargo test -p harness-starter-generic
-          cargo test -p harness-starter-report
-          cargo test -p harness-starter-audio
-          cargo test -p harness-starter-coding
+      - name: Test harness starter generic
+        if: ${{ !cancelled() }}
+        run: cargo test -p harness-starter-generic
+
+      - name: Test harness starter report
+        if: ${{ !cancelled() }}
+        run: cargo test -p harness-starter-report
+
+      - name: Test harness starter audio
+        if: ${{ !cancelled() }}
+        run: cargo test -p harness-starter-audio
+
+      - name: Test harness starter coding
+        if: ${{ !cancelled() }}
+        run: cargo test -p harness-starter-coding
+
       - name: Doc tests
+        if: ${{ !cancelled() }}
         run: cargo test --workspace --doc
 
   # ── Release artifact builds (main only) ──────────────────────────


### PR DESCRIPTION
check-windows answers at most **one question per ~40-minute run**, for two independent reasons. Both are fixed here; neither weakens the gate.

## 1. The job aborts at the first failing step

On `main` run [30423603951](https://github.com/octos-org/octos/actions/runs/30423603951) the job stopped at step 12 (`Test octos-plugin`) and steps 13–20 report **`skipped`** — 8 crates plus doc tests, no result at all:

```
 11  success   Test octos-pipeline
 12  failure   Test octos-plugin
 13  skipped   Test octos-sandbox
 ...
 20  skipped   Doc tests
```

#1860 fixed ~48 Windows failures and its run *still* surfaced only one. That makes Windows a one-failure-per-run guessing game.

`if: ${{ !cancelled() }}` on every test step keeps them running past a failure but **not** past a manual cancel or a job timeout. **The job's conclusion is unchanged** — any red step still fails it. This only makes one run report the whole truth.

## 2. pwsh silently swallowed all-but-the-last failure

Windows steps run under pwsh, which does **not** abort on a failing native command. GitHub appends only `exit $LASTEXITCODE`, so a multi-line `run:` block is decided entirely by its **last** line.

`Test harness starter skills` ran four `cargo test` invocations that way. Directly observed in job `90353158888`: the first three each failed a test and **all four ran to completion** — the step exited 1 only because the fourth also failed. Had `harness-starter-coding` passed, three red crates would have reported SUCCESS.

`Build (workspace + all features)` had the same shape. Both are now one command per step. The Linux jobs are unaffected — bash runs with `-eo pipefail`.

## Also

Refreshes the `continue-on-error` rationale, which still blamed the two `octos-core` `session_scope` tests that #1838 already fixed (`Test octos-core` is green on `main`). A stale "known issue" note reads as tracked long after nobody is tracking it. The drop condition is now simply "green on `main`".

## Verification

- `yaml.safe_load` parses the file.
- check-windows: 23 steps, **18** carry the guard — all 14 `Test *`, the 4 split harness steps, and `Doc tests`.
- **No step runs more than one command.**
- The two `Build` steps deliberately have **no** guard: nothing downstream is meaningful if the build fails.
- Workflow-only change; no Rust source touched.

## Expected effect

The next check-windows run should still be red, but red *with a full inventory* instead of one line — which is what #1860 and the react-vite fix need in order to converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)