### PR TITLE
fix(windows): resolve Git Bash for site bootstrap

### DIFF
--- a/crates/octos-cli/src/project_templates.rs
+++ b/crates/octos-cli/src/project_templates.rs
@@ -901,6 +901,7 @@ fn run_site_bootstrap(
     let scripts_dir = skill_dir.join("scripts");
     std::fs::create_dir_all(project_dir)
         .map_err(|e| format!("create site project dir failed: {e}"))?;
+    let bash = resolve_site_bootstrap_bash()?;
 
     // Windows CI runs these bootstrap scripts through Git Bash (MSYS2),
     // whose coreutils treat `\` as a literal character rather than a path
@@ -914,7 +915,7 @@ fn run_site_bootstrap(
     let out_dir_arg = to_bash(project_dir.to_path_buf());
 
     let output = if metadata.template == "quarto-lesson" {
-        Command::new("bash")
+        Command::new(&bash)
             .arg(to_bash(scripts_dir.join("bootstrap_quarto_lesson.sh")))
             .arg("--out-dir")
             .arg(&out_dir_arg)
@@ -925,7 +926,7 @@ fn run_site_bootstrap(
             .output()
             .map_err(|e| format!("spawn Quarto bootstrap failed: {e}"))?
     } else {
-        Command::new("bash")
+        Command::new(&bash)
             .arg(to_bash(scripts_dir.join("bootstrap_template.sh")))
             .arg("--template")
             .arg(&metadata.template)
@@ -962,6 +963,61 @@ fn run_site_bootstrap(
     }
 
     Ok(())
+}
+
+/// Resolve the shell used by the site bootstrap scripts.
+///
+/// Windows ships `System32\bash.exe` as the WSL launcher. On hosts without
+/// a WSL distribution, resolving a bare `bash` from `PATH` starts that
+/// launcher and the script never runs. Git for Windows is already required
+/// by site workspace initialization, so derive its MSYS2 Bash from Git's own
+/// exec path instead of relying on ambiguous process search order.
+fn resolve_site_bootstrap_bash() -> Result<PathBuf, String> {
+    #[cfg(not(windows))]
+    {
+        Ok(PathBuf::from("bash"))
+    }
+
+    #[cfg(windows)]
+    {
+        let output = Command::new("git")
+            .arg("--exec-path")
+            .output()
+            .map_err(|e| format!("resolve Git Bash failed: spawn `git --exec-path`: {e}"))?;
+        if !output.status.success() {
+            return Err(format!(
+                "resolve Git Bash failed: `git --exec-path` exited with {} \
+                 stdout={:?} stderr={:?}",
+                output.status,
+                String::from_utf8_lossy(&output.stdout).trim(),
+                String::from_utf8_lossy(&output.stderr).trim(),
+            ));
+        }
+
+        let raw_exec_path = String::from_utf8_lossy(&output.stdout);
+        let exec_path = PathBuf::from(raw_exec_path.trim());
+        if exec_path.as_os_str().is_empty() {
+            return Err("resolve Git Bash failed: `git --exec-path` returned an empty path".into());
+        }
+
+        // Standard 64-bit, 32-bit, and PortableGit layouts report an exec
+        // path below `<git-root>/mingw{32,64}/libexec/git-core`. Walk upward
+        // so the same lookup also covers installations with a custom prefix.
+        for ancestor in exec_path.ancestors() {
+            for relative in ["bin/bash.exe", "usr/bin/bash.exe"] {
+                let candidate = ancestor.join(relative);
+                if candidate.is_file() {
+                    return Ok(candidate);
+                }
+            }
+        }
+
+        Err(format!(
+            "resolve Git Bash failed: no `bin/bash.exe` or `usr/bin/bash.exe` \
+             found above Git exec path {}; install or repair Git for Windows",
+            exec_path.display(),
+        ))
+    }
 }
 
 fn site_bootstrap_base_path(metadata: &SiteProjectMetadata) -> &str {
@@ -1258,6 +1314,32 @@ printf '%s' "$BASE_PATH" >"$OUT_DIR/base_path.txt"
             std::fs::read_to_string(project_dir.join("base_path.txt")).unwrap(),
             "./",
             "React/Vite build assets must be relative so signed preview URLs load JS/CSS through /api/preview-signed/<token>/..."
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn should_resolve_git_bash_instead_of_the_wsl_launcher_on_windows() {
+        let bash = resolve_site_bootstrap_bash().expect("Git Bash resolves");
+        let output = Command::new(&bash)
+            .args(["--noprofile", "--norc", "-c", "uname -s"])
+            .output()
+            .expect("resolved Bash runs");
+
+        assert!(
+            output.status.success(),
+            "resolved Bash failed: path={} status={} stdout={:?} stderr={:?}",
+            bash.display(),
+            output.status,
+            String::from_utf8_lossy(&output.stdout).trim(),
+            String::from_utf8_lossy(&output.stderr).trim(),
+        );
+        let uname = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            uname.trim().starts_with("MINGW") || uname.trim().starts_with("MSYS"),
+            "site bootstrap must use Git Bash/MSYS, not WSL: path={} uname={:?}",
+            bash.display(),
+            uname.trim(),
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #1860. That PR normalized the arguments passed to the site bootstrap scripts, but Windows still launches them with a bare `bash`.

On `windows-latest`, process lookup resolves that name to `C:\Windows\System32\bash.exe`, the WSL launcher. Hosts without an installed WSL distribution fail before the script runs, so `should_use_relative_asset_base_when_bootstrapping_react_vite_site` remains red and the failure is inherited by otherwise unrelated branches such as #1864.

## Fix

- On Windows, ask the already-required Git installation for `git --exec-path` and locate its own `bin/bash.exe` or `usr/bin/bash.exe`.
- Use that explicit Git Bash/MSYS2 path for both Quarto and regular site bootstrap scripts, avoiding PATH/WSL ambiguity.
- Keep Unix behavior unchanged (`bash` from PATH).
- Return an actionable error if Git for Windows is missing or incomplete.
- Add a Windows regression test that runs the resolved shell and requires `uname -s` to identify MINGW/MSYS rather than WSL/Linux.

## Validation

- `git diff --check`
- Manual Windows resolution on this host:
  - `git --exec-path` → `C:\Program Files\Git\mingw64\libexec\git-core`
  - resolved shell → `C:\Program Files\Git\bin\bash.exe`
  - `uname -s` → `MINGW64_NT-10.0-26200`
- Independent patch review: no blocker/P1.

- GitHub CI: formatting, clippy, Linux `test-octos-cli`, and the complete `check-windows` job all passed ([run 30449233323](https://github.com/octos-org/octos/actions/runs/30449233323)). The Windows job covers both the existing bootstrap regression and the new Git Bash shell-identity test.

All required checks are green; this is ready for review.