### PR TITLE
fix(windows): preserve embedded web base URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,19 @@ jobs:
             throw 'uninstall dry run did not include purge behavior'
           }
 
+  web-app-base-url-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Test embedded web base URL
+        shell: bash
+        run: '"$BASH" scripts/tests/test-build-web-app-base-url.sh'
+
   check:
     runs-on: ubuntu-latest
     env:

--- a/scripts/build-web-app.sh
+++ b/scripts/build-web-app.sh
@@ -34,7 +34,33 @@ if [ ! -d node_modules ]; then
 fi
 
 echo "Building octos-web (BASE_URL=$BASE_PATH) → $OUT_DIR"
-BASE_URL="$BASE_PATH" npm run build
+# Git for Windows runs native npm/node through MSYS2. Without an exclusion,
+# MSYS2 treats the POSIX-looking BASE_URL as a filesystem path and rewrites
+# `/app/` to e.g. `C:/Program Files/Git/app/`, which Vite then bakes into every
+# asset URL and the React Router basename.
+msys2_env_conv_excl="${MSYS2_ENV_CONV_EXCL:-}"
+if [ -n "$msys2_env_conv_excl" ]; then
+    msys2_env_conv_excl="${msys2_env_conv_excl};BASE_URL"
+else
+    msys2_env_conv_excl="BASE_URL"
+fi
+MSYS2_ENV_CONV_EXCL="$msys2_env_conv_excl" BASE_URL="$BASE_PATH" npm run build
+
+# Fail the release build before rust-embed can package a shell whose primary
+# Vite assets point outside `/app/`. This is intentionally an output check,
+# not just an environment check, so CI guards the artifact users receive.
+INDEX_FILE="$WEB_DIR/dist/index.html"
+if [ ! -f "$INDEX_FILE" ]; then
+    echo "error: octos-web build did not produce $INDEX_FILE" >&2
+    exit 1
+fi
+if ! grep -Fq "src=\"${BASE_PATH}assets/" "$INDEX_FILE" \
+    || ! grep -Fq "href=\"${BASE_PATH}assets/" "$INDEX_FILE"; then
+    echo "error: octos-web assets are not rooted at $BASE_PATH" >&2
+    echo "  generated index references:" >&2
+    grep -Eo '(src|href)="[^"]+"' "$INDEX_FILE" >&2 || true
+    exit 1
+fi
 
 # Replace the embed dir atomically-ish: clear then copy the fresh dist.
 rm -rf "$OUT_DIR"

--- a/scripts/tests/test-build-web-app-base-url.sh
+++ b/scripts/tests/test-build-web-app-base-url.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Regression test for Git-for-Windows MSYS2 environment conversion in
+# scripts/build-web-app.sh. Runs offline with a tiny npm fixture.
+
+set -eEuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TARGET="$REPO_ROOT/scripts/build-web-app.sh"
+
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/octos-web-base-url.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+
+mkdir -p \
+    "$fixture/scripts" \
+    "$fixture/octos-web/node_modules" \
+    "$fixture/crates/octos-cli/static"
+cp "$TARGET" "$fixture/scripts/build-web-app.sh"
+
+cat >"$fixture/octos-web/package.json" <<'JSON'
+{
+  "name": "octos-web-base-url-fixture",
+  "private": true,
+  "scripts": {
+    "build": "node build.mjs"
+  }
+}
+JSON
+
+cat >"$fixture/octos-web/build.mjs" <<'JS'
+import { mkdirSync, writeFileSync } from "node:fs";
+
+const base = process.env.BASE_URL;
+mkdirSync("dist/assets", { recursive: true });
+writeFileSync("dist/assets/app.js", "");
+writeFileSync("dist/assets/app.css", "");
+writeFileSync(
+  "dist/index.html",
+  `<script type="module" src="${base}assets/app.js"></script>` +
+    `<link rel="stylesheet" href="${base}assets/app.css">`,
+);
+JS
+
+# On Windows, force the same native npm.cmd boundary used by release builds.
+# On Unix, wrapping the regular npm executable keeps the fixture portable.
+if command -v npm.cmd >/dev/null 2>&1; then
+    real_npm="$(command -v npm.cmd)"
+else
+    real_npm="$(command -v npm)"
+fi
+mkdir -p "$fixture/bin"
+{
+    echo '#!/bin/sh'
+    printf 'exec %q "$@"\n' "$real_npm"
+} >"$fixture/bin/npm"
+chmod +x "$fixture/bin/npm"
+
+PATH="$fixture/bin:$PATH" "$BASH" "$fixture/scripts/build-web-app.sh"
+
+embedded_index="$fixture/crates/octos-cli/static/web/index.html"
+grep -Fq 'src="/app/assets/app.js"' "$embedded_index"
+grep -Fq 'href="/app/assets/app.css"' "$embedded_index"
+
+echo "OK: embedded web assets remain rooted at /app/"


### PR DESCRIPTION
## Summary

Part of #1832 and the Core-side fix for [octos-web#272](https://github.com/octos-org/octos-web/issues/272).

- preserve `BASE_URL=/app/` when Git for Windows launches native npm/node by excluding `BASE_URL` from MSYS2 environment conversion
- fail the build before `rust_embed` packaging if Vite's generated JS/CSS references are not rooted at `/app/assets/`
- add an offline regression fixture that crosses the real `npm.cmd` boundary on Windows
- add a blocking `windows-latest` CI job for that fixture

## Root cause

`scripts/build-web-app.sh` runs under Git Bash in the Windows release workflow but invokes native `npm.exe`. MSYS2 treats `/app/` as a POSIX filesystem path and rewrites the environment value to `C:/Program Files/Git/app/`; Vite then bakes that host path into the packaged application.

## Validation

- refreshed through current `main` (`44ee3eae`), including the merged Git-Bash resolver from #1867
- Git Bash syntax checks passed
- regression fixture passed through the native `npm.cmd` boundary after the refresh
- full octos-web build completed (4,067 modules)
- generated references were rooted at `/app/` and contained no `Program Files/Git/app` pollution
- copied embedded `index.html` SHA-256 matched the build output
- workflow YAML parse and `git diff --check` passed
- [refreshed-head CI run 30475164803](https://github.com/octos-org/octos/actions/runs/30475164803): every required check passed, including `web-app-base-url-windows` and the 55m46s full `check-windows` gate

## Scope

This restores the default same-origin embedded asset path on Windows. It intentionally does not claim to complete #1832's separate reverse-proxy Origin/authentication configuration acceptance criteria; that is being handled as an independent security-sensitive change rather than expanding this asset-path PR.