### PR TITLE
feat(fleet): master-granted worker permissions (WorkerGrant)

### DIFF
--- a/crates/octos-agent/src/tools/grep_tool.rs
+++ b/crates/octos-agent/src/tools/grep_tool.rs
@@ -11,11 +11,16 @@ use regex::RegexBuilder;
 use serde::Deserialize;
 
 use super::{Tool, ToolContext, ToolResult};
+use crate::policy::FilesystemScope;
 
 /// Tool for searching file contents with regex.
 pub struct GrepTool {
     /// Base directory for searches.
     base_dir: PathBuf,
+    /// Effective filesystem reach for the legacy (no-`SessionScope`) path. When
+    /// `Host`, an explicit `path` arg may point OUTSIDE `base_dir` (mirrors
+    /// read_file/glob/list_dir); `Workspace` (default) confines to `base_dir`.
+    filesystem_scope: FilesystemScope,
 }
 
 impl GrepTool {
@@ -23,7 +28,16 @@ impl GrepTool {
     pub fn new(base_dir: impl Into<PathBuf>) -> Self {
         Self {
             base_dir: base_dir.into(),
+            filesystem_scope: FilesystemScope::Workspace,
         }
+    }
+
+    /// Set the effective filesystem scope. `Host` lets an explicit `path` arg
+    /// escape `base_dir`, consistent with the other cwd-bound read tools (so a
+    /// worker granted host FS can grep outside its cwd, not just read/glob).
+    pub fn with_filesystem_scope(mut self, filesystem_scope: FilesystemScope) -> Self {
+        self.filesystem_scope = filesystem_scope;
+        self
     }
 }
 
@@ -154,16 +168,21 @@ impl Tool for GrepTool {
                 None => scope.workspace().to_path_buf(),
             },
             None => match input.path.as_deref() {
-                Some(p) => match super::resolve_path(&self.base_dir, p) {
-                    Ok(root) => root,
-                    Err(_) => {
-                        return Ok(ToolResult {
-                            output: format!("Path outside working directory: {p}"),
-                            success: false,
-                            ..Default::default()
-                        });
+                // Honor the filesystem scope: `Host` lets an explicit path leave
+                // base_dir (consistent with read_file/glob/list_dir under a host
+                // FS grant); `Workspace` confines to base_dir.
+                Some(p) => {
+                    match super::resolve_path_with_scope(&self.base_dir, p, self.filesystem_scope) {
+                        Ok(root) => root,
+                        Err(_) => {
+                            return Ok(ToolResult {
+                                output: format!("Path outside working directory: {p}"),
+                                success: false,
+                                ..Default::default()
+                            });
+                        }
                     }
-                },
+                }
                 None => self.base_dir.clone(),
             },
         };
@@ -504,6 +523,47 @@ mod tests {
         assert!(result.success);
         assert!(result.output.contains("5 match"));
         assert!(result.output.contains("limited to 5"));
+    }
+
+    #[tokio::test]
+    async fn grep_host_scope_reads_outside_base_dir() {
+        // PR A fix #3: with FilesystemScope::Host (a host FS grant) an explicit
+        // `path` outside base_dir is searched — consistent with read/glob/list.
+        // The default (Workspace) still refuses it.
+        let base = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("data.txt"), "NEEDLE lives here\n").unwrap();
+
+        // Workspace scope (default): the out-of-cwd path is refused.
+        let confined = GrepTool::new(base.path());
+        let refused = confined
+            .execute(&serde_json::json!({
+                "pattern": "NEEDLE",
+                "path": outside.path().to_string_lossy(),
+            }))
+            .await
+            .unwrap();
+        assert!(
+            !refused.success,
+            "workspace scope must refuse an outside path"
+        );
+        assert!(refused.output.contains("outside working directory"));
+
+        // Host scope: the same path is searched and the match is found.
+        let host = GrepTool::new(base.path()).with_filesystem_scope(FilesystemScope::Host);
+        let found = host
+            .execute(&serde_json::json!({
+                "pattern": "NEEDLE",
+                "path": outside.path().to_string_lossy(),
+            }))
+            .await
+            .unwrap();
+        assert!(
+            found.success,
+            "host scope must search the path, got: {}",
+            found.output
+        );
+        assert!(found.output.contains("NEEDLE"), "got: {}", found.output);
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/ssrf.rs
+++ b/crates/octos-agent/src/tools/ssrf.rs
@@ -160,6 +160,45 @@ where
     Err(format!("Too many redirects (max {max_redirects})"))
 }
 
+/// Enforce a per-host allowlist (PR A fleet worker grant).
+///
+/// The allowlist is an `Option`, and the None/Some distinction is
+/// SECURITY-LOAD-BEARING (fail closed, not open):
+/// - `None` — no per-host restriction (unrestricted; the backward-compatible
+///   default for every non-fleet caller, and the `Full` network grant).
+/// - `Some(list)` — RESTRICTED to `list`. A NON-EMPTY list admits `host` only
+///   when it exactly matches (case-insensitively) a listed host or is a
+///   subdomain of one (`docs.example.com` ⊂ `example.com`). An EMPTY (or
+///   all-blank) list denies EVERYTHING — "restricted to nothing" reaches
+///   nothing, never "unrestricted". So a `Hosts([])` grant that somehow bypassed
+///   [`WorkerGrant::validate`] still fails closed here.
+///
+/// This is layered ON TOP of the private-IP block in [`check_ssrf_with_addrs`],
+/// so a fleet worker granted `Hosts([example.com])` can reach only those hosts
+/// over HTTP(S) via the web tools and nothing else.
+///
+/// Subdomain matching uses the label boundary (`.`) so `example.com` does NOT
+/// admit `notexample.com` or `example.com.evil.tld`.
+///
+/// [`WorkerGrant::validate`]: octos_fleet::WorkerGrant::validate
+pub(crate) fn check_host_allowlist(host: &str, allowlist: Option<&[String]>) -> Result<(), String> {
+    let Some(allowlist) = allowlist else {
+        return Ok(()); // unrestricted
+    };
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+    let admitted = allowlist.iter().any(|allowed| {
+        let allowed = allowed.trim().trim_end_matches('.').to_ascii_lowercase();
+        !allowed.is_empty() && (host == allowed || host.ends_with(&format!(".{allowed}")))
+    });
+    if admitted {
+        Ok(())
+    } else {
+        Err(format!(
+            "host `{host}` is not in the granted network allowlist"
+        ))
+    }
+}
+
 /// Check if a hostname is private/internal (string check + IP parse).
 pub fn is_private_host(host: &str) -> bool {
     let lower = host.to_ascii_lowercase();
@@ -347,6 +386,68 @@ mod tests {
         assert!(is_private_host("224.0.0.1"));
         // Mapped/compat forms of CGNAT must be blocked too (defense in depth).
         assert!(is_private_host("::ffff:100.64.0.1"), "mapped CGNAT");
+    }
+
+    // --- check_host_allowlist tests (PR A fleet worker grant) ---
+
+    #[test]
+    fn test_host_allowlist_none_admits_everything() {
+        // `None` = no restriction — the backward-compatible default for every
+        // non-fleet caller (and the `Full` network grant).
+        assert!(check_host_allowlist("anything.example.com", None).is_ok());
+    }
+
+    #[test]
+    fn test_host_allowlist_some_empty_denies_everything() {
+        // FAIL CLOSED: `Some([])` (restricted to nothing) reaches NOTHING —
+        // never "unrestricted". Defense-in-depth for a `Hosts([])` grant that
+        // bypassed validation (e.g. an old serde row).
+        assert!(check_host_allowlist("example.com", Some(&[])).is_err());
+        let blank = ["   ".to_string()];
+        assert!(
+            check_host_allowlist("example.com", Some(&blank)).is_err(),
+            "an all-blank list is empty → deny all"
+        );
+    }
+
+    #[test]
+    fn test_host_allowlist_exact_and_subdomain() {
+        let list = vec!["example.com".to_string()];
+        assert!(
+            check_host_allowlist("example.com", Some(&list)).is_ok(),
+            "exact"
+        );
+        assert!(
+            check_host_allowlist("docs.example.com", Some(&list)).is_ok(),
+            "subdomain admitted"
+        );
+        assert!(
+            check_host_allowlist("EXAMPLE.COM", Some(&list)).is_ok(),
+            "case-insensitive"
+        );
+        assert!(
+            check_host_allowlist("example.com.", Some(&list)).is_ok(),
+            "trailing dot normalized"
+        );
+    }
+
+    #[test]
+    fn test_host_allowlist_refuses_others_and_lookalikes() {
+        let list = vec!["example.com".to_string()];
+        assert!(check_host_allowlist("other.com", Some(&list)).is_err());
+        assert!(
+            check_host_allowlist("notexample.com", Some(&list)).is_err(),
+            "label boundary: notexample.com is NOT a subdomain of example.com"
+        );
+        assert!(
+            check_host_allowlist("example.com.evil.tld", Some(&list)).is_err(),
+            "suffix attack rejected"
+        );
+        let err = check_host_allowlist("other.com", Some(&list)).unwrap_err();
+        assert!(
+            err.contains("allowlist"),
+            "error names the allowlist: {err}"
+        );
     }
 
     #[test]

--- a/crates/octos-agent/src/tools/web_fetch.rs
+++ b/crates/octos-agent/src/tools/web_fetch.rs
@@ -16,15 +16,35 @@ const MAX_REDIRECTS: usize = 10;
 
 pub struct WebFetchTool {
     config: Option<Arc<super::tool_config::ToolConfigStore>>,
+    /// PR A — a per-host network allowlist (fleet worker grant). The
+    /// None/Some distinction is SECURITY-LOAD-BEARING: `None` = unrestricted
+    /// (the default for every non-fleet caller); `Some(list)` = RESTRICTED to
+    /// `list` (and their subdomains), enforced on the initial URL AND every
+    /// redirect hop, on top of the private-IP block. `Some([])` denies
+    /// everything (fail closed) — it is never read as "unrestricted".
+    host_allowlist: Option<Vec<String>>,
 }
 
 impl WebFetchTool {
     pub fn new() -> Self {
-        Self { config: None }
+        Self {
+            config: None,
+            host_allowlist: None,
+        }
     }
 
     pub fn with_config(mut self, config: Arc<super::tool_config::ToolConfigStore>) -> Self {
         self.config = Some(config);
+        self
+    }
+
+    /// PR A — restrict this tool to a fleet-worker grant's host allowlist. A
+    /// fetch (or redirect hop) to any host not in `hosts` (nor a subdomain of
+    /// one) is refused before a socket is opened. Passing an empty `hosts`
+    /// denies EVERYTHING (fail closed), never "unrestricted" — to leave the
+    /// tool unrestricted, simply do not call this.
+    pub fn with_host_allowlist(mut self, hosts: Vec<String>) -> Self {
+        self.host_allowlist = Some(hosts);
         self
     }
 }
@@ -106,8 +126,9 @@ impl Tool for WebFetchTool {
         }
 
         // SSRF-safe fetch: validate initial URL, disable auto-redirects,
-        // and re-validate each redirect hop against SSRF rules.
-        let response = match ssrf_safe_fetch(&input.url).await {
+        // and re-validate each redirect hop against SSRF rules PLUS the fleet
+        // grant's host allowlist (PR A).
+        let response = match ssrf_safe_fetch(&input.url, self.host_allowlist.as_deref()).await {
             Ok(r) => r,
             Err(msg) => {
                 return Ok(ToolResult {
@@ -194,18 +215,27 @@ impl Tool for WebFetchTool {
 /// Validate a URL against SSRF rules, build a pinned client, and fetch.
 /// Redirects are followed manually with SSRF validation on each hop.
 /// DNS failures are treated as blocked (fail-closed).
-async fn ssrf_safe_fetch(initial_url: &str) -> Result<reqwest::Response, String> {
+async fn ssrf_safe_fetch(
+    initial_url: &str,
+    host_allowlist: Option<&[String]>,
+) -> Result<reqwest::Response, String> {
     let mut current_url = initial_url.to_string();
 
     for _ in 0..MAX_REDIRECTS {
-        // Validate the URL and resolve DNS (fail-closed on DNS error).
-        let check = super::ssrf::check_ssrf_with_addrs(&current_url).await?;
-
         let parsed = reqwest::Url::parse(&current_url).map_err(|_| "Invalid URL".to_string())?;
         let host = parsed
             .host_str()
             .ok_or_else(|| "URL has no host".to_string())?
             .to_string();
+
+        // PR A — enforce the fleet grant's host allowlist BEFORE any DNS or
+        // socket, so a refused host never touches the network (and the
+        // deterministic "not in the granted network allowlist" error is
+        // returned, not a DNS/connection error). Empty allowlist = unrestricted.
+        super::ssrf::check_host_allowlist(&host, host_allowlist)?;
+
+        // Validate the URL and resolve DNS (fail-closed on DNS error).
+        let check = super::ssrf::check_ssrf_with_addrs(&current_url).await?;
 
         // Build a per-request client with redirects disabled and DNS pinned.
         let mut builder = Client::builder()
@@ -344,7 +374,7 @@ mod tests {
     async fn test_ssrf_redirect_to_private_ip_blocked() {
         // A redirect to a private IP must be blocked.
         // We test the ssrf_safe_fetch function directly with localhost.
-        let result = ssrf_safe_fetch("http://127.0.0.1/secret").await;
+        let result = ssrf_safe_fetch("http://127.0.0.1/secret", None).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("private"));
     }
@@ -352,8 +382,11 @@ mod tests {
     #[tokio::test]
     async fn test_ssrf_dns_failure_blocks_request() {
         // DNS failure must fail closed, not fall through to an unpinned client.
-        let result =
-            ssrf_safe_fetch("https://this-domain-does-not-exist-ssrf-test.invalid/foo").await;
+        let result = ssrf_safe_fetch(
+            "https://this-domain-does-not-exist-ssrf-test.invalid/foo",
+            None,
+        )
+        .await;
         assert!(result.is_err(), "DNS failure should block request");
         let err = result.unwrap_err();
         assert!(
@@ -364,8 +397,77 @@ mod tests {
 
     #[tokio::test]
     async fn test_ssrf_metadata_endpoint_blocked() {
-        let result = ssrf_safe_fetch("http://169.254.169.254/latest/meta-data/").await;
+        let result = ssrf_safe_fetch("http://169.254.169.254/latest/meta-data/", None).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("private"));
+    }
+
+    #[tokio::test]
+    async fn web_fetch_enforces_host_allowlist() {
+        // PR A — a fleet worker granted `Hosts([allowed.invalid])`:
+        // - a fetch to a NON-allowlisted host is refused by the allowlist
+        //   BEFORE any network (deterministic "allowlist" error, offline), and
+        // - a fetch to an ALLOWLISTED host passes the allowlist gate and only
+        //   then hits the normal SSRF/DNS path (here it fails DNS on `.invalid`,
+        //   proving it got PAST the allowlist rather than being blocked by it).
+        let tool = WebFetchTool::new().with_host_allowlist(vec!["allowed.invalid".to_string()]);
+
+        let blocked = tool
+            .execute(&serde_json::json!({"url": "https://blocked.invalid/x"}))
+            .await
+            .unwrap();
+        assert!(!blocked.success, "non-allowlisted host must be refused");
+        assert!(
+            blocked.output.contains("allowlist"),
+            "refusal must name the allowlist (no network hit): {}",
+            blocked.output,
+        );
+
+        let allowed = tool
+            .execute(&serde_json::json!({"url": "https://allowed.invalid/x"}))
+            .await
+            .unwrap();
+        assert!(!allowed.success, "allowed.invalid still fails DNS");
+        assert!(
+            !allowed.output.contains("allowlist"),
+            "an allowlisted host must pass the allowlist gate (fail later, not on allowlist): {}",
+            allowed.output,
+        );
+    }
+
+    #[tokio::test]
+    async fn web_fetch_no_allowlist_is_unrestricted() {
+        // The default (no grant → no `with_host_allowlist` call → None) imposes
+        // no host restriction — byte-for-byte the pre-PR-A tool. A private host
+        // is still blocked by the SSRF layer, not the allowlist.
+        let tool = WebFetchTool::new();
+        let result = tool
+            .execute(&serde_json::json!({"url": "http://127.0.0.1/secret"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result.output.contains("private"),
+            "no allowlist defers to SSRF private-IP block: {}",
+            result.output,
+        );
+    }
+
+    #[tokio::test]
+    async fn web_fetch_empty_host_allowlist_denies_everything() {
+        // PR A fail-closed: `with_host_allowlist(vec![])` = "restricted to
+        // nothing" must reach NOTHING (never "unrestricted"). Even a public host
+        // is refused by the allowlist BEFORE any network.
+        let tool = WebFetchTool::new().with_host_allowlist(vec![]);
+        let result = tool
+            .execute(&serde_json::json!({"url": "https://example.com/"}))
+            .await
+            .unwrap();
+        assert!(!result.success, "an empty allowlist must deny all");
+        assert!(
+            result.output.contains("allowlist"),
+            "refusal must be the allowlist (no network hit): {}",
+            result.output,
+        );
     }
 }

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -8275,7 +8275,9 @@ mod tests {
                 .expect("open episode store"),
         );
         let sandbox_factory: octos_fleet_worker::SandboxFactory =
-            Arc::new(|_cwd| Arc::new(MarkerSandbox) as Arc<dyn octos_agent::sandbox::Sandbox>);
+            Arc::new(|_cwd, _allow_network| {
+                Arc::new(MarkerSandbox) as Arc<dyn octos_agent::sandbox::Sandbox>
+            });
         let factory = Arc::new(octos_fleet_worker::AgentFactory::new(
             Arc::new(NativeMockProvider {
                 content: Ok("done".to_owned()),
@@ -8325,6 +8327,7 @@ mod tests {
             detail: "do the thing".to_owned(),
             deps: Vec::new(),
             acceptance: Vec::new(),
+            grant: octos_fleet::WorkerGrant::minimal(),
         }]
     }
 

--- a/crates/octos-cli/src/api/fleet_wake.rs
+++ b/crates/octos-cli/src/api/fleet_wake.rs
@@ -322,6 +322,7 @@ mod tests {
             detail: format!("detail {id}"),
             deps: deps.iter().map(|s| (*s).to_owned()).collect(),
             acceptance: Vec::new(),
+            grant: octos_fleet::WorkerGrant::minimal(),
         }
     }
 

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -877,20 +877,24 @@ impl ServeCommand {
                 });
             match keeper {
                 Some(rt) => {
-                    // PR-3 requires a network-isolated sandbox: the closed worker
-                    // tool set is a denylist, not a boundary, so the shell's
-                    // reach is bounded only by the sandbox. Force
-                    // `allow_network = false` regardless of the profile default.
+                    // PR-3 requires a network-isolated sandbox: the worker tool
+                    // set is a denylist, not a boundary, so the shell's reach is
+                    // bounded only by the sandbox. Base the sandbox on the profile
+                    // default with network OFF; PR A re-enables raw egress
+                    // PER-ATTEMPT only for a `Full` network grant (see the factory
+                    // closure below). `None`/`Hosts` keep it off (`Hosts` is
+                    // enforced by the granted web tools, not raw egress).
                     let mut sandbox_cfg = rt.default_sandbox.clone();
                     sandbox_cfg.allow_network = false;
                     // #1857 PR 5a fix (HIGH 1) — FAIL CLOSED: install the pool
-                    // ONLY when the forced-no-network sandbox is a REAL isolating
-                    // backend. A disabled sandbox (or `Auto` with no backend on
-                    // this host) yields `NoSandbox` = unbounded shell reach
-                    // (curl / git push / host access), breaking PR-3's
-                    // replay-safe boundary. Leave the pool unset so goal_dispatch
-                    // cleanly reports "unavailable" instead of running a fleet
-                    // worker unsandboxed with network.
+                    // ONLY when the sandbox is a REAL isolating backend. A
+                    // disabled sandbox (or `Auto` with no backend on this host)
+                    // yields `NoSandbox` = unbounded shell reach (curl / git push
+                    // / host access), breaking PR-3's replay-safe boundary. The
+                    // isolation of the BACKEND is independent of the network flag,
+                    // so probing with network off is sufficient. Leave the pool
+                    // unset so goal_dispatch cleanly reports "unavailable" instead
+                    // of running a fleet worker unsandboxed.
                     if !fleet_sandbox_is_isolating(&sandbox_cfg) {
                         tracing::error!(
                             keeper_profile = %rt.profile_id,
@@ -900,10 +904,15 @@ impl ServeCommand {
                              will report the pool unavailable."
                         );
                     } else {
+                        // PR A — the SandboxFactory takes the per-attempt
+                        // `allow_network` derived from the task's grant: `Full` →
+                        // true (raw egress for git/npm), `None`/`Hosts` → false.
                         let sandbox_factory: octos_fleet_worker::SandboxFactory =
-                            Arc::new(move |_cwd: &std::path::Path| {
+                            Arc::new(move |_cwd: &std::path::Path, allow_network: bool| {
+                                let mut cfg = sandbox_cfg.clone();
+                                cfg.allow_network = allow_network;
                                 Arc::<dyn octos_agent::sandbox::Sandbox>::from(
-                                    octos_agent::sandbox::create_sandbox(&sandbox_cfg),
+                                    octos_agent::sandbox::create_sandbox(&cfg),
                                 )
                             });
                         let factory = Arc::new(octos_fleet_worker::AgentFactory::new(
@@ -1786,6 +1795,7 @@ mod tests {
                 detail: "d".to_owned(),
                 deps: Vec::new(),
                 acceptance: Vec::new(),
+                grant: octos_fleet::WorkerGrant::minimal(),
             }],
             1,
         )

--- a/crates/octos-cli/src/goal_tool.rs
+++ b/crates/octos-cli/src/goal_tool.rs
@@ -22,7 +22,9 @@ use async_trait::async_trait;
 use eyre::Result;
 use octos_agent::tools::{Tool, ToolContext, ToolResult};
 use octos_core::SessionKey;
-use octos_fleet::{AcceptanceCriterion, TaskSpec, Verifier};
+use octos_fleet::{
+    AcceptanceCriterion, BASE_TOOLS, FsGrant, NetworkGrant, TaskSpec, Verifier, WorkerGrant,
+};
 use serde_json::{Value, json};
 
 use crate::api::agent_orchestrator::default_agent_orchestrator;
@@ -102,15 +104,132 @@ fn parse_task_specs(args: &Value) -> Result<Vec<TaskSpec>, String> {
                     .collect()
             })
             .unwrap_or_default();
+        let grant = parse_grant(task.get("grant"), &task_id)?;
         out.push(TaskSpec {
             task_id,
             title,
             detail,
             deps,
             acceptance,
+            grant,
         });
     }
     Ok(out)
+}
+
+/// PR A — parse a task's optional operator `grant` object into a
+/// [`WorkerGrant`]. The master PROVISIONS each worker like an operator: it
+/// grants exactly the network hosts / tools / paths a task needs, default-deny.
+/// An absent (or null) grant is [`WorkerGrant::minimal`] — today's closed
+/// worker (least privilege). Validated against the grantable catalog before it
+/// can reach the store, so an unknown tool (or a web tool with no network) is
+/// rejected at plan time.
+///
+/// Wire shape:
+/// `{ "network": { "mode": "none"|"hosts"|"full", "hosts": ["example.com"] },
+///    "tools": ["read_file", ..., "web_fetch"],
+///    "fs": { "read": ["/data/in"], "write": ["/data/out"] } }`
+fn parse_grant(value: Option<&Value>, task_id: &str) -> Result<WorkerGrant, String> {
+    let value = match value {
+        None | Some(Value::Null) => return Ok(WorkerGrant::minimal()),
+        Some(value) => value,
+    };
+    let obj = value
+        .as_object()
+        .ok_or_else(|| format!("task `{task_id}`: `grant` must be an object"))?;
+
+    let network = match obj.get("network") {
+        None | Some(Value::Null) => NetworkGrant::None,
+        Some(network) => parse_network(network, task_id)?,
+    };
+
+    let tools = match obj.get("tools") {
+        None | Some(Value::Null) => BASE_TOOLS.iter().map(|s| (*s).to_string()).collect(),
+        Some(Value::Array(items)) => {
+            let mut tools = Vec::with_capacity(items.len());
+            for item in items {
+                let name = item
+                    .as_str()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .ok_or_else(|| {
+                        format!("task `{task_id}`: each `grant.tools` entry must be a tool name")
+                    })?;
+                tools.push(name.to_owned());
+            }
+            tools
+        }
+        Some(_) => return Err(format!("task `{task_id}`: `grant.tools` must be an array")),
+    };
+
+    let fs = match obj.get("fs") {
+        None | Some(Value::Null) => FsGrant::Workspace,
+        Some(fs) => parse_fs(fs, task_id)?,
+    };
+
+    let grant = WorkerGrant { network, tools, fs };
+    grant
+        .validate()
+        .map_err(|e| format!("task `{task_id}`: {e}"))?;
+    Ok(grant)
+}
+
+/// Parse `{ "mode": "none"|"hosts"|"full", "hosts": [...] }` into a
+/// [`NetworkGrant`]. `hosts` mode requires a non-empty allowlist.
+fn parse_network(value: &Value, task_id: &str) -> Result<NetworkGrant, String> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| format!("task `{task_id}`: `grant.network` must be an object"))?;
+    let mode = obj
+        .get("mode")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or("none");
+    match mode {
+        "none" => Ok(NetworkGrant::None),
+        "full" => Ok(NetworkGrant::Full),
+        "hosts" => {
+            let hosts: Vec<String> = obj
+                .get("hosts")
+                .and_then(Value::as_array)
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_owned)
+                        .collect()
+                })
+                .unwrap_or_default();
+            if hosts.is_empty() {
+                return Err(format!(
+                    "task `{task_id}`: network mode `hosts` requires a non-empty `hosts` allowlist"
+                ));
+            }
+            Ok(NetworkGrant::Hosts(hosts))
+        }
+        other => Err(format!(
+            "task `{task_id}`: unknown network mode `{other}` (use `none`, `hosts`, or `full`)"
+        )),
+    }
+}
+
+/// Parse the coarse `fs` scope — the string `"workspace"` (cwd-only, the
+/// default) or `"host"` (full daemon-user read+write). v1 is deliberately
+/// binary: the native tools have no per-path allowlist, so a narrow-paths grant
+/// is not offered here (it would falsely promise narrow but deliver host-wide).
+fn parse_fs(value: &Value, task_id: &str) -> Result<FsGrant, String> {
+    let mode = value.as_str().map(str::trim).ok_or_else(|| {
+        format!("task `{task_id}`: `grant.fs` must be the string \"workspace\" or \"host\"")
+    })?;
+    match mode.to_ascii_lowercase().as_str() {
+        "workspace" => Ok(FsGrant::Workspace),
+        "host" => Ok(FsGrant::Host),
+        other => Err(format!(
+            "task `{task_id}`: unknown fs scope `{other}` (use \"workspace\" or \"host\")"
+        )),
+    }
 }
 
 /// Statuses the MODEL may set via `goal_update`. Everything else is
@@ -235,7 +354,17 @@ impl Tool for GoalPlanTool {
          to launch ready tasks. Requires a live session (the workspace root is captured then). \
          Each task runs in its OWN isolated scratch directory (replay-safe), NOT your repo \
          checkout: v1 fleet tasks do self-contained local work, not in-repo edits to the \
-         controller's files — in-repo/remote-mutating goals are out of v1 scope."
+         controller's files — in-repo/remote-mutating goals are out of v1 scope. \
+         \
+         YOU are the operator: provision each worker's capabilities with an optional per-task \
+         `grant` — least privilege by default. Omit `grant` and the worker gets exactly today's \
+         closed set (no network, the base file tools read/write/edit/glob/grep/list_dir/shell, \
+         its own scratch dir). Grant MORE only where a task needs it: `network.mode`=`hosts` \
+         with a `hosts` allowlist lets its web_fetch reach ONLY those hosts (the shell still has \
+         no raw network); `network.mode`=`full` gives raw egress (git/npm); add `web_fetch`/\
+         `web_search` to `tools` (they require a network grant); set `fs`=`host` ONLY when a task \
+         needs the full host filesystem (it is broad — the default scratch-dir scope covers most \
+         work). Grant each task the minimum it needs."
     }
 
     fn input_schema(&self) -> Value {
@@ -270,6 +399,40 @@ impl Tool for GoalPlanTool {
                                 "type": "array",
                                 "items": { "type": "string" },
                                 "description": "Shell commands (split argv, no shell) that must each exit 0 for the task to be accepted. Omit for a task with no mechanical check."
+                            },
+                            "grant": {
+                                "type": "object",
+                                "description": "Optional operator capability grant for THIS task's worker. Omit for least privilege (today's closed worker: no network, base file tools, own scratch dir). Grant more only where needed.",
+                                "properties": {
+                                    "network": {
+                                        "type": "object",
+                                        "description": "Network egress for the worker. Omit = none.",
+                                        "properties": {
+                                            "mode": {
+                                                "type": "string",
+                                                "enum": ["none", "hosts", "full"],
+                                                "description": "none = no network; hosts = only the listed hosts, via web_fetch only (the shell still has no raw network); full = raw egress (git/npm)."
+                                            },
+                                            "hosts": {
+                                                "type": "array",
+                                                "items": { "type": "string" },
+                                                "description": "Allowlisted hosts (required, non-empty, when mode=hosts). web_fetch may reach only these hosts and their subdomains."
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    },
+                                    "tools": {
+                                        "type": "array",
+                                        "items": { "type": "string" },
+                                        "description": "The tools the worker may hold. Omit = the base file tools (read_file/write_file/edit_file/glob/grep/list_dir/shell). Add web_fetch/web_search (each REQUIRES a network grant)."
+                                    },
+                                    "fs": {
+                                        "type": "string",
+                                        "enum": ["workspace", "host"],
+                                        "description": "Filesystem reach. Omit = workspace (the worker's own scratch dir only, read+write). host = FULL daemon-user filesystem read+write (broad — grant only when a task genuinely needs host access). v1 is binary: narrow per-path grants are not yet supported."
+                                    }
+                                },
+                                "additionalProperties": false
                             }
                         },
                         "required": ["task_id", "title"],
@@ -600,5 +763,122 @@ impl Tool for GoalCreateTool {
                 ..Default::default()
             }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn goal_plan_absent_grant_is_minimal() {
+        // A task with no `grant` is today's closed worker (least privilege).
+        let args = json!({
+            "tasks": [ { "task_id": "t1", "title": "do it" } ]
+        });
+        let specs = parse_task_specs(&args).expect("parses");
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].grant, WorkerGrant::minimal());
+    }
+
+    #[test]
+    fn goal_plan_parses_per_task_grant() {
+        // The master provisions a worker: hosts-restricted network + web_fetch +
+        // host filesystem. The parsed grant matches exactly.
+        let args = json!({
+            "tasks": [ {
+                "task_id": "fetch",
+                "title": "grab the report",
+                "grant": {
+                    "network": { "mode": "hosts", "hosts": ["example.com", "docs.example.com"] },
+                    "tools": ["read_file", "write_file", "web_fetch"],
+                    "fs": "host"
+                }
+            } ]
+        });
+        let specs = parse_task_specs(&args).expect("parses");
+        let grant = &specs[0].grant;
+        assert_eq!(
+            grant.network,
+            NetworkGrant::Hosts(vec!["example.com".into(), "docs.example.com".into()]),
+        );
+        assert_eq!(grant.tools, vec!["read_file", "write_file", "web_fetch"]);
+        assert_eq!(grant.fs, FsGrant::Host);
+        // A `full` grant parses to raw egress; omitted fs = Workspace.
+        let full = json!({
+            "tasks": [ {
+                "task_id": "build",
+                "title": "npm install",
+                "grant": { "network": { "mode": "full" }, "tools": ["shell", "web_fetch"] }
+            } ]
+        });
+        let specs = parse_task_specs(&full).expect("parses");
+        assert_eq!(specs[0].grant.network, NetworkGrant::Full);
+        assert_eq!(specs[0].grant.fs, FsGrant::Workspace);
+    }
+
+    #[test]
+    fn goal_plan_rejects_empty_hosts_allowlist() {
+        // Fail-closed: `hosts` with no hosts is rejected at parse (the operator
+        // meant `none`; an empty allowlist must never read as "unrestricted").
+        let args = json!({
+            "tasks": [ {
+                "task_id": "t1",
+                "title": "do it",
+                "grant": { "network": { "mode": "hosts", "hosts": [] }, "tools": ["web_fetch"] }
+            } ]
+        });
+        let err = parse_task_specs(&args).expect_err("empty hosts rejected");
+        assert!(
+            err.contains("hosts"),
+            "error names the empty allowlist: {err}"
+        );
+    }
+
+    #[test]
+    fn goal_plan_rejects_unknown_granted_tool() {
+        let args = json!({
+            "tasks": [ {
+                "task_id": "t1",
+                "title": "do it",
+                "grant": { "tools": ["read_file", "not_a_real_tool"] }
+            } ]
+        });
+        let err = parse_task_specs(&args).expect_err("unknown tool rejected");
+        assert!(
+            err.contains("not_a_real_tool"),
+            "error names the tool: {err}"
+        );
+    }
+
+    #[test]
+    fn goal_plan_rejects_web_tool_without_network() {
+        // web_fetch under the default (none) network is incoherent.
+        let args = json!({
+            "tasks": [ {
+                "task_id": "t1",
+                "title": "do it",
+                "grant": { "tools": ["read_file", "web_fetch"] }
+            } ]
+        });
+        let err = parse_task_specs(&args).expect_err("web tool without network rejected");
+        assert!(err.contains("web_fetch"), "error names the tool: {err}");
+        assert!(err.contains("network"), "error explains the fix: {err}");
+    }
+
+    #[test]
+    fn goal_plan_rejects_hosts_mode_without_hosts() {
+        let args = json!({
+            "tasks": [ {
+                "task_id": "t1",
+                "title": "do it",
+                "grant": { "network": { "mode": "hosts" }, "tools": ["read_file", "web_fetch"] }
+            } ]
+        });
+        let err = parse_task_specs(&args).expect_err("empty hosts rejected");
+        assert!(
+            err.contains("hosts"),
+            "error names the missing allowlist: {err}"
+        );
     }
 }

--- a/crates/octos-fleet-worker/src/closed_registry.rs
+++ b/crates/octos-fleet-worker/src/closed_registry.rs
@@ -1,81 +1,121 @@
-//! Module 1 — the closed, replay-safe worker tool registry (**the crux**).
+//! Module 1 — the operator-granted, replay-safe worker tool registry (**the
+//! crux**).
 //!
-//! A fleet task-worker is *provably* non-interactive: it may hold only the
-//! seven native tools that are safe to run and re-run headless (read/write/
-//! edit files, glob/grep search, list dirs, and a fail-closed shell). It
-//! must NOT be able to park (`ask_user_question`/`request_user_input`), fan
-//! out (`spawn*`/`delegate*`/`peer_*`), reach the network
-//! (`web_*`/`http`/`browser`/deep-crawl), message a channel (`message`/
-//! `send_*`), or mutate durable memory (`recall_memory`/`save_memory`/…).
+//! PR A: a fleet task-worker no longer holds a HARDCODED closed set. The master
+//! provisions each worker's capabilities explicitly at dispatch as a
+//! [`WorkerGrant`] — network, tools, filesystem — and the host builds the
+//! worker FROM that grant. The DEFAULT is least privilege:
+//! [`WorkerGrant::minimal`] is byte-for-byte the old closed worker (no network,
+//! the base seven file tools, workspace-write), so every pre-grant dispatch
+//! path is unchanged.
 //!
-//! [`build_fleet_worker_registry`] starts from an EMPTY [`ToolRegistry`]
-//! (never [`ToolRegistry::with_builtins`], which registers ~35 tools
-//! including the parking + fan-out set), registers exactly the allow-set,
-//! and then hard-removes anything else with [`ToolRegistry::apply_policy`]
-//! as a belt-and-suspenders lock on the invariant. The exhaustive audit
-//! test asserts `tool_names() == ALLOWED`, so any future dynamic tool
-//! (MCP/plugin/skill) sneaking in fails the build.
+//! A worker is still *provably* bounded to exactly what it was granted:
+//! [`build_fleet_worker_registry`] starts from an EMPTY [`ToolRegistry`] (never
+//! [`ToolRegistry::with_builtins`], which registers ~35 tools including the
+//! parking + fan-out set), registers exactly the granted tools from a KNOWN
+//! CATALOG, and then hard-removes anything else with
+//! [`ToolRegistry::apply_policy`]. The exhaustive audit test asserts
+//! `tool_names() == grant.sorted_tools()`, so the closed-worker guarantee now
+//! reads "exactly what the operator granted, nothing more" — any future dynamic
+//! (MCP/plugin/skill) tool sneaking in fails the build.
 
 use std::path::Path;
 use std::sync::Arc;
 
-use octos_agent::policy::{ApprovalPolicy, EffectivePermissions};
+use eyre::{Result, eyre};
+use octos_agent::policy::{ApprovalPolicy, EffectivePermissions, FilesystemScope};
 use octos_agent::sandbox::Sandbox;
 use octos_agent::tools::policy::ToolPolicy;
 use octos_agent::tools::{
     EditFileTool, GlobTool, GrepTool, ListDirTool, ReadFileTool, ShellTool, ToolRegistry,
-    WriteFileTool,
+    WebFetchTool, WebSearchTool, WriteFileTool,
 };
+use octos_fleet::WorkerGrant;
 
-/// The EXACT set of native tool names a closed fleet task-worker may hold.
-/// Every one is replay-safe (idempotent-enough to re-run after a crash) and
-/// none blocks on human input. The audit test asserts the built registry's
-/// `tool_names()` equals this set — no more, no less.
-pub const ALLOWED: &[&str] = &[
-    "read_file",
-    "write_file",
-    "edit_file",
-    "glob",
-    "grep",
-    "list_dir",
-    "shell",
-];
+/// The base tool set a *minimal* (least-privilege) worker holds — today's
+/// closed seven. Kept as a named constant for docs / discriminator tests;
+/// equals [`octos_fleet::BASE_TOOLS`] and `WorkerGrant::minimal().tools`. The
+/// audit no longer compares against this fixed set — it compares against the
+/// per-worker `grant.sorted_tools()`.
+pub const ALLOWED: &[&str] = octos_fleet::BASE_TOOLS;
 
-/// Build the closed, replay-safe tool registry for a fleet task-worker
-/// rooted at `cwd`, with `sandbox` backing the shell tool and each shell
-/// command's effective timeout CAPPED at `max_shell_timeout_secs` (the attempt
-/// deadline, in whole seconds) so no single foreground command outlives it.
+/// Map a [`WorkerGrant`]'s filesystem grant onto [`EffectivePermissions`].
 ///
-/// The closed tool set is a DENYLIST (it removes parking/fan-out/network
-/// *tools*), NOT a network or process boundary. The surviving `shell` can
-/// still reach the network and can still detach a child via arbitrary
-/// shell-internal backgrounding that string inspection cannot catch (e.g.
-/// `sleep 600 & true`). Both are bounded by the **sandbox**: production MUST
-/// supply a network-isolated sandbox whose process-group/container teardown
-/// reaps detached children. Passing a no-op sandbox here is an operator error
-/// (flagged with a `tracing::warn!`), analogous to `--danger-full-access`.
+/// [`FsGrant::Workspace`] (the minimal default) maps to
+/// `FilesystemScope::Workspace` with `ReadWrite`, reproducing today's
+/// `workspace_write()` closed worker exactly (cwd-only). [`FsGrant::Host`] maps
+/// to `FilesystemScope::Host` (full daemon-user read+write) — an explicit,
+/// broad operator grant.
+///
+/// **v1 limitation (coarse fs scope, honestly binary).** The native file tools'
+/// scope IS binary (`Workspace | Host`) with no per-path allowlist, so the grant
+/// is binary too — there is no silent "some paths" middle ground that would
+/// promise narrow access but deliver host-wide. A narrow per-path FS grant is a
+/// FOLLOW-UP (it needs a native-tool path-allowlist model), exactly like
+/// per-host filtering of raw network needs an egress proxy.
+///
+/// [`FsGrant::Workspace`]: octos_fleet::FsGrant::Workspace
+/// [`FsGrant::Host`]: octos_fleet::FsGrant::Host
+fn perms_from_grant(grant: &WorkerGrant) -> EffectivePermissions {
+    let mut perms =
+        EffectivePermissions::workspace_write().with_approval_policy(ApprovalPolicy::Never);
+    if grant.fs.is_host() {
+        perms.filesystem_scope = FilesystemScope::Host;
+    }
+    perms
+}
+
+/// Build the replay-safe tool registry for a fleet task-worker rooted at `cwd`,
+/// FROM the operator's [`WorkerGrant`], with `sandbox` backing the shell tool
+/// and each shell command's effective timeout CAPPED at `max_shell_timeout_secs`
+/// (the attempt deadline, in whole seconds) so no foreground command outlives
+/// it.
+///
+/// The registry holds EXACTLY the granted tools — the base file tools (scoped
+/// by `grant.fs`) plus, if granted, the network content tools (`web_fetch` /
+/// `web_search`). A tool outside the grantable catalog, or a web tool with no
+/// network grant, is a hard error (`grant.validate()`), so an incoherent grant
+/// can never produce a live worker.
+///
+/// The granted tool set is a DENYLIST at the tool boundary (it omits
+/// parking/fan-out/etc.), NOT a network or process boundary. Under a `None` /
+/// `Hosts` grant the surviving `shell` has NO network (the sandbox blocks raw
+/// egress; the ONLY network path is the granted web tools, restricted to the
+/// allowlist). Under a `Full` grant the shell reaches the network and can
+/// detach children via shell-internal backgrounding that string inspection
+/// cannot catch — both bounded by the **sandbox**. Passing a no-op sandbox here
+/// is an operator error (flagged with a `tracing::warn!`), analogous to
+/// `--danger-full-access`.
 pub fn build_fleet_worker_registry(
     cwd: &Path,
     sandbox: Arc<dyn Sandbox>,
     max_shell_timeout_secs: u64,
-) -> ToolRegistry {
+    grant: &WorkerGrant,
+) -> Result<ToolRegistry> {
+    // Reject an incoherent grant up front (unknown tool / web tool with no
+    // network) — validated at parse time too, so this is defense-in-depth: an
+    // unknown tool can never reach a live worker.
+    grant
+        .validate()
+        .map_err(|e| eyre!("fleet worker: invalid grant: {e}"))?;
+
     // P1-3-enforce (document, don't type-enforce): the API cannot police
     // sandbox quality, but a no-op sandbox leaves the shell's network reach and
     // detached children unbounded — surface it so it can't pass silently.
     if sandbox.is_noop() {
         tracing::warn!(
-            "fleet worker: building a closed registry with a NO-OP sandbox — the \
+            "fleet worker: building a granted registry with a NO-OP sandbox — the \
              shell's network reach and detached children are UNBOUNDED; production \
              must supply a network-isolated sandbox",
         );
     }
 
-    // Workspace read/write, but approvals FAIL CLOSED at the tool boundary:
-    // a shell command that the SafePolicy would ask about is denied outright
-    // (a closed worker has no human to ask). `SafePolicy` is preserved — we
-    // do NOT widen to AllowAll — so dangerous commands stay blocked.
-    let perms = EffectivePermissions::workspace_write().with_approval_policy(ApprovalPolicy::Never);
-    let scope = perms.filesystem_scope; // Workspace
+    // Filesystem reach from the grant. Approvals FAIL CLOSED at the tool
+    // boundary: a shell command the SafePolicy would ask about is denied
+    // outright (a closed worker has no human to ask). `SafePolicy` is preserved
+    // — we do NOT widen to AllowAll — so dangerous commands stay blocked.
+    let perms = perms_from_grant(grant);
+    let scope = perms.filesystem_scope; // Workspace (minimal) or Host (fs=Host)
     let access = perms.file_access; // ReadWrite
 
     let mut r = ToolRegistry::new();
@@ -83,59 +123,93 @@ pub fn build_fleet_worker_registry(
     // session-scope fallback and any project-root machinery resolve against
     // the same cwd the tools are bound to.
     r.set_workspace_root(cwd.to_path_buf());
-    r.register(
-        ShellTool::new(cwd)
-            .with_shared_sandbox(sandbox)
-            .with_policy(perms.shell_command_policy())
-            .with_approval_policy(ApprovalPolicy::Never)
-            // Refuse the string-detectable detach vectors (`background: true`
-            // and a trailing `&`) as defense-in-depth — the sandbox is the real
-            // boundary for detached children (see the fn doc).
-            .with_background_allowed(false)
-            // Hard per-command CEILING at the attempt deadline: combined with
-            // `background_allowed(false)`, no single foreground command outlives
-            // the deadline even if the LLM requests a larger `timeout_secs`.
-            .with_max_timeout_secs(max_shell_timeout_secs),
-    );
-    r.register(ReadFileTool::new(cwd).with_filesystem_scope(scope));
-    r.register(
-        WriteFileTool::new(cwd)
-            .with_filesystem_scope(scope)
-            .with_file_access(access),
-    );
-    r.register(
-        EditFileTool::new(cwd)
-            .with_filesystem_scope(scope)
-            .with_file_access(access),
-    );
-    r.register(GlobTool::new(cwd).with_filesystem_scope(scope));
-    r.register(GrepTool::new(cwd));
-    r.register(ListDirTool::new(cwd).with_filesystem_scope(scope));
 
-    // Belt-and-suspenders: hard-remove anything not in the allow-set. A no-op
-    // today (we registered exactly the allow-set and nothing auto-swaps,
-    // because no tool is named "spawn"), but it locks the invariant so a
-    // future edit that registers an extra tool cannot silently widen the
-    // worker's reach — `apply_policy` -> `retain` is a real removal.
+    // Build each granted tool from the KNOWN CATALOG. An unknown name is
+    // unreachable after `validate()` above, but the arm returns a hard error
+    // defensively rather than silently dropping a tool.
+    for name in &grant.tools {
+        match name.as_str() {
+            "shell" => r.register(
+                ShellTool::new(cwd)
+                    .with_shared_sandbox(sandbox.clone())
+                    .with_policy(perms.shell_command_policy())
+                    .with_approval_policy(ApprovalPolicy::Never)
+                    // Refuse the string-detectable detach vectors (`background:
+                    // true` and a trailing `&`) as defense-in-depth — the
+                    // sandbox is the real boundary for detached children.
+                    .with_background_allowed(false)
+                    // Hard per-command CEILING at the attempt deadline: combined
+                    // with `background_allowed(false)`, no single foreground
+                    // command outlives the deadline even if the LLM requests a
+                    // larger `timeout_secs`.
+                    .with_max_timeout_secs(max_shell_timeout_secs),
+            ),
+            "read_file" => r.register(ReadFileTool::new(cwd).with_filesystem_scope(scope)),
+            "write_file" => r.register(
+                WriteFileTool::new(cwd)
+                    .with_filesystem_scope(scope)
+                    .with_file_access(access),
+            ),
+            "edit_file" => r.register(
+                EditFileTool::new(cwd)
+                    .with_filesystem_scope(scope)
+                    .with_file_access(access),
+            ),
+            "glob" => r.register(GlobTool::new(cwd).with_filesystem_scope(scope)),
+            "grep" => r.register(GrepTool::new(cwd).with_filesystem_scope(scope)),
+            "list_dir" => r.register(ListDirTool::new(cwd).with_filesystem_scope(scope)),
+            // The network content tools — buildable ONLY under a network grant
+            // (`validate()` rejects them under `None`). `web_fetch` ENFORCES the
+            // per-host allowlist (`Hosts` → the list; `Full` → unrestricted, the
+            // private-IP block still applies). This is the ONLY network path
+            // under `Hosts` (the shell has no raw egress there).
+            "web_fetch" => {
+                let tool = match grant.network.web_allowlist() {
+                    Some(hosts) => WebFetchTool::new().with_host_allowlist(hosts.to_vec()),
+                    None => WebFetchTool::new(),
+                };
+                r.register(tool);
+            }
+            // `web_search` targets fixed search-PROVIDER endpoints (not arbitrary
+            // content hosts), so it is catalog-gated (buildable only when
+            // granted) but not itself host-allowlist-filtered in v1 — content
+            // retrieval remains allowlist-bound via `web_fetch` (documented v1
+            // limitation).
+            "web_search" => r.register(WebSearchTool::new()),
+            other => {
+                return Err(eyre!(
+                    "fleet worker: tool `{other}` is not in the grantable catalog"
+                ));
+            }
+        }
+    }
+
+    // Belt-and-suspenders: hard-remove anything not in the granted allow-set.
+    // A no-op today (we registered exactly the grant and nothing auto-swaps),
+    // but it locks the invariant so a future edit that registers an extra tool
+    // cannot silently widen the worker's reach — `apply_policy` -> `retain` is a
+    // real removal. `ToolPolicy.allow` empty = allow-all, which only happens for
+    // an (unusual) empty grant that registered nothing, so it is still bounded.
     r.apply_policy(&ToolPolicy {
-        allow: ALLOWED.iter().map(|s| s.to_string()).collect(),
+        allow: grant.tools.clone(),
         ..Default::default()
     });
-    r
+    Ok(r)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use octos_agent::sandbox::NoSandbox;
+    use octos_fleet::{FsGrant, NetworkGrant};
     use std::collections::HashSet;
     use std::path::Path;
     use std::sync::Arc;
 
     /// Tools that must NEVER appear in a closed worker registry. This is a
     /// supplementary explicit denylist; the exhaustive `tool_names() ==
-    /// ALLOWED` assertion below is the real guard (it also catches names not
-    /// listed here). Covers the parking, fan-out, peer, channel, network,
+    /// grant.sorted_tools()` assertion below is the real guard (it also catches
+    /// names not listed here). Covers the parking, fan-out, peer, channel,
     /// memory, skill, and dispatch families.
     const FORBIDDEN: &[&str] = &[
         // parking / plan / human input
@@ -166,10 +240,8 @@ mod tests {
         "message",
         "send_file",
         "send_app_card",
-        // network / external
+        // network / external (NOT granted in a minimal worker)
         "browser",
-        "web_search",
-        "web_fetch",
         "search",
         "deep_crawl",
         "http",
@@ -196,34 +268,38 @@ mod tests {
         "diff_edit",
     ];
 
-    fn allowed_sorted() -> Vec<String> {
-        let mut v: Vec<String> = ALLOWED.iter().map(|s| s.to_string()).collect();
-        v.sort();
-        v
-    }
-
     #[test]
-    fn closed_worker_registry_has_only_replay_safe_tools() {
+    fn grant_minimal_reproduces_todays_closed_worker() {
+        // PR A: the minimal grant is byte-for-byte the old closed worker — the
+        // base seven, workspace-write, no network tools. The audit compares
+        // against `grant.sorted_tools()` (== the old `ALLOWED` for minimal).
+        let grant = WorkerGrant::minimal();
         let reg = build_fleet_worker_registry(
             Path::new("/tmp/fleet-worker-audit"),
             Arc::new(NoSandbox),
             30,
-        );
+            &grant,
+        )
+        .expect("minimal grant builds");
 
-        // (2) EXHAUSTIVE: the registry contains EXACTLY the allow-set — no
-        // more, no less. This is the boundary that catches any future
-        // dynamic (MCP/plugin/skill) tool sneaking in.
+        // EXHAUSTIVE: the registry contains EXACTLY the granted tools.
         let mut names = reg.tool_names();
         names.sort();
         assert_eq!(
             names,
-            allowed_sorted(),
-            "closed worker registry must contain EXACTLY the replay-safe tools",
+            grant.sorted_tools(),
+            "a minimal-grant worker holds exactly the base replay-safe tools",
         );
+        // And that set is the old closed seven.
+        assert_eq!(grant.sorted_tools(), {
+            let mut v: Vec<String> = ALLOWED.iter().map(|s| s.to_string()).collect();
+            v.sort();
+            v
+        });
 
         let spec_names: HashSet<String> = reg.specs().into_iter().map(|s| s.name).collect();
 
-        // (1) every FORBIDDEN name is un-gettable AND absent from specs().
+        // Every FORBIDDEN name is un-gettable AND absent from specs().
         for name in FORBIDDEN {
             assert!(
                 reg.get(name).is_none(),
@@ -235,7 +311,7 @@ mod tests {
             );
         }
 
-        // (3) NOTHING in the registry blocks on human input.
+        // NOTHING in the registry blocks on human input.
         for name in reg.tool_names() {
             assert!(
                 !reg.blocks_on_human_input(&name),
@@ -243,17 +319,140 @@ mod tests {
             );
         }
 
-        // Sanity: every allowed tool is actually present + LLM-visible.
-        for name in ALLOWED {
+        // Sanity: every granted tool is present + LLM-visible.
+        for name in &grant.tools {
             assert!(
                 reg.get(name).is_some(),
-                "allowed tool {name} missing from closed registry",
+                "granted tool {name} missing from registry",
             );
             assert!(
-                spec_names.contains(*name),
-                "allowed tool {name} not exposed in specs()",
+                spec_names.contains(name),
+                "granted tool {name} not exposed in specs()",
             );
         }
+        // A minimal worker has NO web tools.
+        assert!(reg.get("web_fetch").is_none());
+        assert!(reg.get("web_search").is_none());
+    }
+
+    #[test]
+    fn grant_expands_tools_and_scopes() {
+        // A master grants +web_fetch (under a Hosts network) and Host fs → the
+        // registry gains web_fetch and the native file tools' EffectivePermissions
+        // widen to Host scope.
+        let cwd = Path::new("/tmp/fleet-expand");
+        let grant = WorkerGrant {
+            network: NetworkGrant::Hosts(vec!["example.com".into()]),
+            tools: {
+                let mut t: Vec<String> = octos_fleet::BASE_TOOLS
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect();
+                t.push("web_fetch".into());
+                t
+            },
+            fs: FsGrant::Host,
+        };
+        let reg = build_fleet_worker_registry(cwd, Arc::new(NoSandbox), 30, &grant)
+            .expect("expanded grant builds");
+
+        assert!(reg.get("web_fetch").is_some(), "granted web_fetch present");
+        let mut names = reg.tool_names();
+        names.sort();
+        assert_eq!(names, grant.sorted_tools(), "exactly the granted set");
+
+        // The Host fs grant widens native tools to Host scope.
+        assert_eq!(
+            perms_from_grant(&grant).filesystem_scope,
+            FilesystemScope::Host,
+            "an fs=Host grant opens Host scope for native tools",
+        );
+        // The minimal (Workspace) grant stays Workspace-scoped (cwd-only).
+        assert_eq!(
+            perms_from_grant(&WorkerGrant::minimal()).filesystem_scope,
+            FilesystemScope::Workspace,
+            "minimal fs stays workspace-scoped",
+        );
+    }
+
+    #[test]
+    fn grant_hosts_allowlist_enforced_on_web_tool() {
+        // A Hosts grant builds the web tool and keeps raw egress OFF — the
+        // allowlist is enforced by the web tool (tested in octos-agent), and
+        // the sandbox never gets raw network under Hosts.
+        let grant = WorkerGrant {
+            network: NetworkGrant::Hosts(vec!["example.com".into()]),
+            tools: vec!["read_file".into(), "web_fetch".into()],
+            ..WorkerGrant::minimal()
+        };
+        let reg = build_fleet_worker_registry(
+            Path::new("/tmp/fleet-hosts"),
+            Arc::new(NoSandbox),
+            30,
+            &grant,
+        )
+        .expect("hosts grant builds");
+        assert!(reg.get("web_fetch").is_some());
+        assert!(
+            !grant.network.allows_raw_egress(),
+            "Hosts must NOT grant raw sandbox egress — the shell cannot curl",
+        );
+        assert_eq!(
+            grant.network.web_allowlist(),
+            Some(&["example.com".to_string()][..]),
+            "the allowlist is threaded to the web tool",
+        );
+    }
+
+    #[test]
+    fn grant_full_enables_raw_network() {
+        // A Full grant turns on raw sandbox egress (git/npm) and builds web
+        // tools unrestricted (private-IP block still applies).
+        let grant = WorkerGrant {
+            network: NetworkGrant::Full,
+            tools: vec!["shell".into(), "web_fetch".into()],
+            ..WorkerGrant::minimal()
+        };
+        let reg = build_fleet_worker_registry(
+            Path::new("/tmp/fleet-full"),
+            Arc::new(NoSandbox),
+            30,
+            &grant,
+        )
+        .expect("full grant builds");
+        assert!(reg.get("web_fetch").is_some());
+        assert!(
+            grant.network.allows_raw_egress(),
+            "Full grants raw sandbox egress",
+        );
+        assert!(
+            grant.network.web_allowlist().is_none(),
+            "Full leaves web tools unrestricted (no host allowlist)",
+        );
+    }
+
+    #[test]
+    fn grant_unknown_tool_is_rejected_at_build() {
+        // Defense-in-depth: even if an unknown tool slips past parse validation,
+        // the build refuses it rather than dropping it silently.
+        let grant = WorkerGrant {
+            tools: vec!["read_file".into(), "definitely_not_a_tool".into()],
+            ..WorkerGrant::minimal()
+        };
+        let result = build_fleet_worker_registry(
+            Path::new("/tmp/fleet-bad"),
+            Arc::new(NoSandbox),
+            30,
+            &grant,
+        );
+        let err = result
+            .err()
+            .expect("unknown tool must be rejected")
+            .to_string();
+        assert!(
+            err.contains("definitely_not_a_tool"),
+            "error names the bad tool: {err}",
+        );
     }
 
     /// P1-1: the closed worker's shell refuses BOTH an explicit
@@ -262,7 +461,13 @@ mod tests {
     /// (before any child is spawned).
     #[tokio::test]
     async fn closed_worker_shell_refuses_background() {
-        let reg = build_fleet_worker_registry(&std::env::temp_dir(), Arc::new(NoSandbox), 30);
+        let reg = build_fleet_worker_registry(
+            &std::env::temp_dir(),
+            Arc::new(NoSandbox),
+            30,
+            &WorkerGrant::minimal(),
+        )
+        .expect("minimal grant builds");
         let shell = reg.get("shell").expect("shell tool present");
 
         let explicit = shell

--- a/crates/octos-fleet-worker/src/lib.rs
+++ b/crates/octos-fleet-worker/src/lib.rs
@@ -53,9 +53,11 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
+use eyre::Result;
 use octos_agent::sandbox::Sandbox;
 use octos_agent::{Agent, AgentConfig, ToolRegistry};
 use octos_core::AgentId;
+use octos_fleet::WorkerGrant;
 use octos_llm::LlmProvider;
 use octos_memory::EpisodeStore;
 
@@ -63,9 +65,16 @@ pub use closed_registry::{ALLOWED, build_fleet_worker_registry};
 pub use pool::{Dispatched, FleetWorkerPool, PoolConfig};
 pub use worker::{AttemptOutcome, run_attempt};
 
-/// A per-cwd sandbox factory: given a working directory, produce the
-/// [`Sandbox`] that backs the shell tool for an attempt rooted there.
-pub type SandboxFactory = Arc<dyn Fn(&Path) -> Arc<dyn Sandbox> + Send + Sync>;
+/// A per-cwd sandbox factory: given a working directory AND whether the grant
+/// permits raw network egress (`allow_network`), produce the [`Sandbox`] that
+/// backs the shell tool for an attempt rooted there.
+///
+/// PR A threads `allow_network` from the task's [`WorkerGrant`]: `None`/`Hosts`
+/// grants pass `false` (the shell has no raw egress — `Hosts` is enforced by
+/// the web tools), a `Full` grant passes `true` (raw egress for git/npm/etc.).
+/// The factory owns the isolating BACKEND (bwrap/macos/docker); only the
+/// network flag is per-attempt.
+pub type SandboxFactory = Arc<dyn Fn(&Path, bool) -> Arc<dyn Sandbox> + Send + Sync>;
 
 /// Default agent-loop iteration ceiling for a fleet task-worker.
 pub const DEFAULT_MAX_ITERATIONS: u32 = 50;
@@ -123,7 +132,7 @@ impl AgentFactory {
         Self::new(
             llm,
             memory,
-            Arc::new(|_| Arc::new(NoSandbox) as Arc<dyn Sandbox>),
+            Arc::new(|_, _| Arc::new(NoSandbox) as Arc<dyn Sandbox>),
         )
     }
 
@@ -145,22 +154,26 @@ impl AgentFactory {
     /// [`AgentFactory::build_agent`] / [`AgentFactory::build_registry_with`]),
     /// so a non-idempotent factory can never sandbox the agent while handing
     /// the validators a different (weaker) sandbox.
-    pub fn sandbox_for(&self, cwd: &Path) -> Arc<dyn Sandbox> {
-        (self.sandbox_factory)(cwd)
+    pub fn sandbox_for(&self, cwd: &Path, allow_network: bool) -> Arc<dyn Sandbox> {
+        (self.sandbox_factory)(cwd, allow_network)
     }
 
-    /// Build the closed replay-safe tool registry for `cwd` with an EXPLICIT,
-    /// caller-owned `sandbox` instance and a per-command shell timeout ceiling
-    /// of `max_shell_timeout_secs`. Threading the instance (rather than
-    /// re-invoking the factory) is what lets the agent and the acceptance-gate
-    /// [`octos_agent::ValidatorRunner`] share one sandbox.
+    /// Build the granted replay-safe tool registry for `cwd` FROM `grant`, with
+    /// an EXPLICIT, caller-owned `sandbox` instance and a per-command shell
+    /// timeout ceiling of `max_shell_timeout_secs`. Threading the instance
+    /// (rather than re-invoking the factory) is what lets the agent and the
+    /// acceptance-gate [`octos_agent::ValidatorRunner`] share one sandbox.
+    ///
+    /// Returns `Err` for an incoherent grant (unknown tool / web tool without a
+    /// network grant) — validated at parse too, so this is defense-in-depth.
     pub fn build_registry_with(
         &self,
         cwd: &Path,
         sandbox: Arc<dyn Sandbox>,
         max_shell_timeout_secs: u64,
-    ) -> ToolRegistry {
-        build_fleet_worker_registry(cwd, sandbox, max_shell_timeout_secs)
+        grant: &WorkerGrant,
+    ) -> Result<ToolRegistry> {
+        build_fleet_worker_registry(cwd, sandbox, max_shell_timeout_secs, grant)
     }
 
     /// The [`AgentConfig`] for an attempt bounded by `deadline`. The per-tool
@@ -183,18 +196,26 @@ impl AgentFactory {
         }
     }
 
-    /// Build a fresh, closed-registry [`Agent`] rooted at `cwd` under the
-    /// shared `sandbox`, bounded by `deadline` (which clamps the agent's
-    /// per-tool timeouts AND caps every shell command at the deadline).
-    pub fn build_agent(&self, cwd: &Path, sandbox: Arc<dyn Sandbox>, deadline: Duration) -> Agent {
+    /// Build a fresh, granted-registry [`Agent`] rooted at `cwd` under the
+    /// shared `sandbox`, from `grant`, bounded by `deadline` (which clamps the
+    /// agent's per-tool timeouts AND caps every shell command at the deadline).
+    ///
+    /// Returns `Err` for an incoherent grant (see [`AgentFactory::build_registry_with`]).
+    pub fn build_agent(
+        &self,
+        cwd: &Path,
+        sandbox: Arc<dyn Sandbox>,
+        deadline: Duration,
+        grant: &WorkerGrant,
+    ) -> Result<Agent> {
         let deadline_secs = deadline.as_secs().max(1);
-        Agent::new(
+        Ok(Agent::new(
             AgentId::new("fleet-worker"),
             self.llm.clone(),
-            self.build_registry_with(cwd, sandbox, deadline_secs),
+            self.build_registry_with(cwd, sandbox, deadline_secs, grant)?,
             self.memory.clone(),
         )
-        .with_config(self.agent_config(deadline))
+        .with_config(self.agent_config(deadline)))
     }
 }
 
@@ -227,13 +248,13 @@ mod tests {
         let factory = AgentFactory::new(
             Arc::new(SuccessProvider),
             memory,
-            Arc::new(move |_| {
+            Arc::new(move |_, _| {
                 seen.fetch_add(1, Ordering::SeqCst);
                 Arc::new(MarkerSandbox) as Arc<dyn Sandbox>
             }),
         );
 
-        let sb = factory.sandbox_for(Path::new("/tmp/fleet-x"));
+        let sb = factory.sandbox_for(Path::new("/tmp/fleet-x"), false);
         assert!(
             !sb.is_noop(),
             "the injected sandbox must reach the shell, not a NoSandbox default",
@@ -246,7 +267,14 @@ mod tests {
 
         // build_registry_with threads the caller-owned instance WITHOUT
         // re-invoking the factory — the shared-instance contract (P1-3-fix).
-        let _reg = factory.build_registry_with(Path::new("/tmp/fleet-x"), sb.clone(), 30);
+        let _reg = factory
+            .build_registry_with(
+                Path::new("/tmp/fleet-x"),
+                sb.clone(),
+                30,
+                &WorkerGrant::minimal(),
+            )
+            .unwrap();
         assert_eq!(
             calls.load(Ordering::SeqCst),
             1,
@@ -257,7 +285,7 @@ mod tests {
         let test_factory = AgentFactory::for_testing(Arc::new(SuccessProvider), memory2);
         assert!(
             test_factory
-                .sandbox_for(Path::new("/tmp/fleet-x"))
+                .sandbox_for(Path::new("/tmp/fleet-x"), false)
                 .is_noop(),
             "for_testing must be the NoSandbox path",
         );

--- a/crates/octos-fleet-worker/src/testutil.rs
+++ b/crates/octos-fleet-worker/src/testutil.rs
@@ -12,6 +12,7 @@ use octos_agent::sandbox::{NoSandbox, Sandbox};
 use octos_core::{Message, SessionKey};
 use octos_fleet::{
     AcceptanceCriterion, Fleet, FleetBudget, FleetKernelStore, LaunchOutcome, TaskSpec, Verifier,
+    WorkerGrant,
 };
 use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, ToolSpec};
 use octos_memory::EpisodeStore;
@@ -52,14 +53,26 @@ pub async fn fresh_memory() -> (TempDir, Arc<EpisodeStore>) {
     (dir, Arc::new(memory))
 }
 
-/// A `TaskSpec` with the given deps + acceptance.
+/// A `TaskSpec` with the given deps + acceptance and the minimal (least-privilege)
+/// worker grant — today's closed worker.
 pub fn task_spec(id: &str, deps: &[&str], acceptance: Vec<AcceptanceCriterion>) -> TaskSpec {
+    task_spec_granted(id, deps, acceptance, WorkerGrant::minimal())
+}
+
+/// A `TaskSpec` carrying an explicit [`WorkerGrant`] (for grant-driven tests).
+pub fn task_spec_granted(
+    id: &str,
+    deps: &[&str],
+    acceptance: Vec<AcceptanceCriterion>,
+    grant: WorkerGrant,
+) -> TaskSpec {
     TaskSpec {
         task_id: id.to_string(),
         title: format!("Task {id}"),
         detail: "do the thing".to_string(),
         deps: deps.iter().map(|s| s.to_string()).collect(),
         acceptance,
+        grant,
     }
 }
 
@@ -173,7 +186,7 @@ pub async fn factory_for(provider: Arc<dyn LlmProvider>) -> (TempDir, AgentFacto
     let factory = AgentFactory::new(
         provider,
         memory,
-        Arc::new(|_| Arc::new(MarkerSandbox) as Arc<dyn Sandbox>),
+        Arc::new(|_, _| Arc::new(MarkerSandbox) as Arc<dyn Sandbox>),
     );
     (dir, factory)
 }

--- a/crates/octos-fleet-worker/src/worker.rs
+++ b/crates/octos-fleet-worker/src/worker.rs
@@ -154,11 +154,18 @@ pub async fn run_attempt(
         },
     );
 
+    // PR A: the sandbox's raw network egress comes from THIS task's grant, not
+    // a hardcoded `false`. `None`/`Hosts` → no raw egress (the shell cannot
+    // `curl`; `Hosts` is enforced by the granted web tools); `Full` → raw egress
+    // (git/npm/etc.). The isolating backend is unchanged — only the network flag
+    // is per-attempt.
+    let allow_network = task_view.grant.network.allows_raw_egress();
+
     // P1-3-fix: ONE sandbox instance for the whole attempt, shared by the
-    // agent's closed registry AND the acceptance validators — so a
+    // agent's granted registry AND the acceptance validators — so a
     // non-idempotent factory can never sandbox the agent while handing the
     // validators a weaker (e.g. no-op) sandbox.
-    let sandbox = factory.sandbox_for(working_dir);
+    let sandbox = factory.sandbox_for(working_dir, allow_network);
 
     // #1857 PR 5a fix (H1, codex round 2) — ATTEMPT-TIME fail-closed. The serve
     // boot probe checks ONE sandbox instance, but the factory reconstructs the
@@ -177,50 +184,64 @@ pub async fn run_attempt(
         );
         Computed::terminated("no isolating sandbox available at attempt time".to_string())
     } else {
-        // 3. Fresh, closed-registry agent (cannot park, cannot fan out) under the
-        //    shared sandbox. Its per-tool timeouts AND per-command shell ceiling
-        //    are clamped to `deadline` (P1-2).
-        let agent = factory.build_agent(working_dir, sandbox.clone(), deadline);
-
-        // 4. Run under a HARD deadline — `run_task` is cancel-safe to drop and
-        //    has NO internal wall-clock cap, so the timeout wrapper is mandatory.
-        let start = Instant::now();
-        let run = tokio::time::timeout(deadline, agent.run_task(&task)).await;
-        let elapsed = start.elapsed();
-
-        // 5-6. Map the result to a verdict + snapshot inputs.
-        match run {
-            Err(_elapsed) => {
-                Computed::terminated(format!("deadline exceeded after {}s", deadline.as_secs()))
+        // 3. Fresh, granted-registry agent (cannot park, cannot fan out; holds
+        //    EXACTLY the operator-granted tools) under the shared sandbox. Its
+        //    per-tool timeouts AND per-command shell ceiling are clamped to
+        //    `deadline` (P1-2). An incoherent grant (rejected at parse) fails
+        //    closed here too: terminate the attempt without running.
+        match factory.build_agent(working_dir, sandbox.clone(), deadline, &task_view.grant) {
+            Err(err) => {
+                tracing::error!(
+                    %fleet_id, %task_id, %attempt_id, error = %err,
+                    "fleet worker: invalid worker grant; terminating the attempt",
+                );
+                Computed::terminated(format!("invalid worker grant: {err}"))
             }
-            Ok(Err(report)) => Computed::terminated(format!("run failed: {report}")),
-            Ok(Ok(result)) if !result.success => {
-                let reason = if result.output.trim().is_empty() {
-                    "run did not succeed".to_string()
-                } else {
-                    result.output.clone()
-                };
-                Computed::rejected(reason, &result)
-            }
-            Ok(Ok(result)) => {
-                // P1-5b: bound the acceptance phase by the REMAINING deadline so a
-                // slow `CommandExit` validator can't hold both permits past the
-                // fleet deadline. A small floor keeps a right-at-the-edge run from
-                // getting a 0ms acceptance budget.
-                let remaining = deadline
-                    .checked_sub(elapsed)
-                    .unwrap_or(Duration::ZERO)
-                    .max(ACCEPTANCE_MIN_BUDGET);
-                let (verdict, error) = run_acceptance(
-                    task_view,
-                    working_dir,
-                    factory,
-                    sandbox,
-                    deadline.as_secs().max(1),
-                    remaining,
-                )
-                .await;
-                Computed::from_verdict(verdict, error, &result)
+            Ok(agent) => {
+                // 4. Run under a HARD deadline — `run_task` is cancel-safe to
+                //    drop and has NO internal wall-clock cap, so the timeout
+                //    wrapper is mandatory.
+                let start = Instant::now();
+                let run = tokio::time::timeout(deadline, agent.run_task(&task)).await;
+                let elapsed = start.elapsed();
+
+                // 5-6. Map the result to a verdict + snapshot inputs.
+                match run {
+                    Err(_elapsed) => Computed::terminated(format!(
+                        "deadline exceeded after {}s",
+                        deadline.as_secs()
+                    )),
+                    Ok(Err(report)) => Computed::terminated(format!("run failed: {report}")),
+                    Ok(Ok(result)) if !result.success => {
+                        let reason = if result.output.trim().is_empty() {
+                            "run did not succeed".to_string()
+                        } else {
+                            result.output.clone()
+                        };
+                        Computed::rejected(reason, &result)
+                    }
+                    Ok(Ok(result)) => {
+                        // P1-5b: bound the acceptance phase by the REMAINING
+                        // deadline so a slow `CommandExit` validator can't hold
+                        // both permits past the fleet deadline. A small floor
+                        // keeps a right-at-the-edge run from getting a 0ms
+                        // acceptance budget.
+                        let remaining = deadline
+                            .checked_sub(elapsed)
+                            .unwrap_or(Duration::ZERO)
+                            .max(ACCEPTANCE_MIN_BUDGET);
+                        let (verdict, error) = run_acceptance(
+                            task_view,
+                            working_dir,
+                            factory,
+                            sandbox,
+                            deadline.as_secs().max(1),
+                            remaining,
+                        )
+                        .await;
+                        Computed::from_verdict(verdict, error, &result)
+                    }
+                }
             }
         }
     };
@@ -476,15 +497,29 @@ async fn run_acceptance(
     // it alone would leak a `sleep`ing subprocess past the recorded terminal
     // state. Subtracting each run's elapsed keeps the TOTAL phase bounded by
     // the initial `remaining`.
-    let runner = ValidatorRunner::new(
-        Arc::new(factory.build_registry_with(
-            workspace_root,
-            sandbox.clone(),
-            max_shell_timeout_secs,
-        )),
-        workspace_root.to_path_buf(),
-    )
-    .with_sandbox(sandbox);
+    // The acceptance gate runs `CommandExit` validators through the SAME granted
+    // registry the agent held (so the shell is configured identically). An
+    // incoherent grant would already have failed the agent build above; handle
+    // the Result defensively.
+    let registry = match factory.build_registry_with(
+        workspace_root,
+        sandbox.clone(),
+        max_shell_timeout_secs,
+        &task_view.grant,
+    ) {
+        Ok(registry) => registry,
+        Err(err) => {
+            let reason = format!("invalid worker grant for acceptance: {err}");
+            return (
+                AcceptanceVerdict::Terminated {
+                    reason: reason.clone(),
+                },
+                Some(reason),
+            );
+        }
+    };
+    let runner = ValidatorRunner::new(Arc::new(registry), workspace_root.to_path_buf())
+        .with_sandbox(sandbox);
     let invocation = ValidatorInvocation::new(
         ValidatorPhase::Completion,
         workspace_root.to_path_buf(),
@@ -728,6 +763,77 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn grant_network_threads_allow_network_into_sandbox() {
+        // PR A: `run_attempt` derives the sandbox's `allow_network` from the
+        // task's grant — a `Full` grant threads `true`, a minimal grant `false`.
+        // A recording sandbox factory captures the flag it is handed.
+        use std::sync::Mutex;
+        let seen: Arc<Mutex<Vec<bool>>> = Arc::new(Mutex::new(Vec::new()));
+
+        async fn run_with_grant(
+            seen: Arc<std::sync::Mutex<Vec<bool>>>,
+            grant: octos_fleet::WorkerGrant,
+        ) {
+            let (_sd, store) = fresh_store().await;
+            let fleet = create_fleet(
+                store.clone(),
+                "f1",
+                vec![task_spec_granted("a", &[], vec![], grant)],
+            )
+            .await;
+            let attempt = launch(&store, "f1", "a").await;
+
+            let (_md, memory) = fresh_memory().await;
+            let rec = seen.clone();
+            let factory = AgentFactory::new(
+                Arc::new(SuccessProvider),
+                memory,
+                Arc::new(move |_cwd, allow_network| {
+                    rec.lock().unwrap().push(allow_network);
+                    Arc::new(MarkerSandbox) as Arc<dyn Sandbox>
+                }),
+            );
+            let task_view = view_of(&fleet, "a").await;
+            let work = TempDir::new().unwrap();
+            let _ = run_attempt(
+                store.clone(),
+                "f1",
+                "a",
+                &attempt,
+                &task_view,
+                &factory,
+                work.path(),
+                Duration::from_secs(30),
+                EPOCH,
+                || NOW,
+            )
+            .await;
+        }
+
+        // Minimal grant → no raw egress.
+        run_with_grant(seen.clone(), octos_fleet::WorkerGrant::minimal()).await;
+        // Full grant → raw egress.
+        run_with_grant(
+            seen.clone(),
+            octos_fleet::WorkerGrant {
+                network: octos_fleet::NetworkGrant::Full,
+                ..octos_fleet::WorkerGrant::minimal()
+            },
+        )
+        .await;
+
+        let flags = seen.lock().unwrap().clone();
+        assert!(
+            flags.contains(&false),
+            "a minimal grant must build the sandbox with allow_network=false: {flags:?}",
+        );
+        assert!(
+            flags.contains(&true),
+            "a Full grant must build the sandbox with allow_network=true: {flags:?}",
+        );
+    }
+
+    #[tokio::test]
     async fn run_attempt_happy_path() {
         let (_sd, store) = fresh_store().await;
         let fleet = create_fleet(
@@ -814,7 +920,7 @@ mod tests {
             // MarkerSandbox (isolating test double) so the attempt-time
             // fail-closed guard (H1) lets the agent run; still counts factory
             // invocations to prove the single-shared-instance contract.
-            Arc::new(move |_| {
+            Arc::new(move |_, _| {
                 seen.fetch_add(1, Ordering::SeqCst);
                 Arc::new(MarkerSandbox) as Arc<dyn Sandbox>
             }),
@@ -876,7 +982,7 @@ mod tests {
                 calls: calls.clone(),
             }),
             memory,
-            Arc::new(|_| Arc::new(NoSandbox) as Arc<dyn Sandbox>),
+            Arc::new(|_, _| Arc::new(NoSandbox) as Arc<dyn Sandbox>),
         );
         let task_view = view_of(&fleet, "a").await;
 

--- a/crates/octos-fleet/src/fleet.rs
+++ b/crates/octos-fleet/src/fleet.rs
@@ -30,6 +30,7 @@ use std::sync::Arc;
 use eyre::Result;
 use octos_core::SessionKey;
 
+use crate::grant::WorkerGrant;
 use crate::records::{
     AcceptanceCriterion, AcceptanceVerdict, ChildResultSnapshot, ChildStatus, DecisionKind,
     DurablePlan, EvidenceRef, FleetBudget, FleetChildRecord, FleetStatus, PlanTask, SCHEMA_VERSION,
@@ -52,6 +53,10 @@ pub struct TaskSpec {
     /// task_ids that must be `Succeeded` before this task is launchable.
     pub deps: Vec<String>,
     pub acceptance: Vec<AcceptanceCriterion>,
+    /// PR A — the operator grant the master provisions this task's worker with
+    /// (network / tools / filesystem). Defaults to [`WorkerGrant::minimal`]
+    /// (today's closed worker) when the master specifies nothing.
+    pub grant: WorkerGrant,
 }
 
 impl From<TaskSpec> for PlanTask {
@@ -62,6 +67,7 @@ impl From<TaskSpec> for PlanTask {
             detail: s.detail,
             deps: s.deps,
             acceptance: s.acceptance,
+            grant: s.grant,
         }
     }
 }
@@ -123,6 +129,11 @@ pub struct TaskView {
     pub detail: String,
     pub deps: Vec<String>,
     pub acceptance: Vec<AcceptanceCriterion>,
+    /// PR A — the operator grant the worker for this task is built from,
+    /// projected from the plan's [`PlanTask::grant`]. The executor
+    /// (`octos-fleet-worker`) reads it to build the worker's registry, sandbox
+    /// network, and filesystem scope. Defaults to [`WorkerGrant::minimal`].
+    pub grant: WorkerGrant,
     // ---- state (from the child) ----
     pub status: ChildStatus,
     pub verdict: Option<AcceptanceVerdict>,
@@ -275,6 +286,7 @@ impl Fleet {
                     detail: t.detail.clone(),
                     deps: t.deps.clone(),
                     acceptance: t.acceptance.clone(),
+                    grant: t.grant.clone(),
                     status: child.map(|c| c.status).unwrap_or(ChildStatus::Planned),
                     evidence: verdict_evidence(verdict.as_ref()),
                     verdict,
@@ -927,6 +939,7 @@ mod tests {
             detail: "do the thing".into(),
             deps: deps.iter().map(|s| s.to_string()).collect(),
             acceptance: Vec::new(),
+            grant: WorkerGrant::minimal(),
         }
     }
 
@@ -1594,12 +1607,18 @@ mod tests {
                 path: "out.txt".into(),
             },
         }];
+        let granted = WorkerGrant {
+            network: crate::grant::NetworkGrant::Hosts(vec!["example.com".into()]),
+            tools: vec!["read_file".into(), "write_file".into(), "web_fetch".into()],
+            fs: crate::grant::FsGrant::default(),
+        };
         let task = TaskSpec {
             task_id: "a".into(),
             title: "Build".into(),
             detail: "make out.txt".into(),
             deps: vec![],
             acceptance: acceptance.clone(),
+            grant: granted.clone(),
         };
         let fleet = Fleet::create(
             store.clone(),
@@ -1622,6 +1641,10 @@ mod tests {
         assert_eq!(tv.title, "Build");
         assert_eq!(tv.detail, "make out.txt");
         assert_eq!(tv.acceptance.len(), 1);
+        assert_eq!(
+            tv.grant, granted,
+            "the operator grant is projected from the plan into the view (PR A)"
+        );
         assert_eq!(tv.status, ChildStatus::Ready);
         assert!(tv.verdict.is_none());
         assert!(tv.evidence.is_empty());

--- a/crates/octos-fleet/src/grant.rs
+++ b/crates/octos-fleet/src/grant.rs
@@ -1,0 +1,390 @@
+//! [`WorkerGrant`] — the operator-supplied capability grant for one fleet
+//! task-worker.
+//!
+//! PR A of the fleet kernel replaces the worker's HARDCODED permissions (a
+//! fixed closed registry + `allow_network=false`) with an explicit grant the
+//! master provisions per task, exactly as a human operator would: which
+//! network it may reach (per-host allowlist), which tools it may hold, and
+//! which filesystem paths it may touch. The default is **least privilege** —
+//! an unspecified grant is [`WorkerGrant::minimal`], byte-for-byte today's
+//! closed worker (no network, the base file tools, workspace-write) — and the
+//! master EXPANDS it explicitly, per task.
+//!
+//! This type is deliberately a **plain serde value** with no baked-in
+//! immutability: PR B (mid-task escalation) will let a worker request more and
+//! the master REPLACE the grant with a wider one; nothing here forecloses that.
+//!
+//! The type lives in `octos-fleet` (zero `octos-agent` dependency) so it can
+//! persist on the durable [`crate::PlanTask`]. The host-side realisation — how
+//! `fs` maps to `EffectivePermissions` and how a tool name is built — lives in
+//! `octos-fleet-worker`, which owns the tool catalog.
+
+use serde::{Deserialize, Serialize};
+
+/// The base replay-safe file tools every closed worker holds by default —
+/// today's `ALLOWED` seven. Each is idempotent-enough to re-run headless and
+/// none blocks on human input. [`WorkerGrant::minimal`] grants exactly these.
+pub const BASE_TOOLS: &[&str] = &[
+    "read_file",
+    "write_file",
+    "edit_file",
+    "glob",
+    "grep",
+    "list_dir",
+    "shell",
+];
+
+/// Every tool a master MAY grant a worker in PR A: the base file tools plus the
+/// two network content tools. A grant naming anything outside this catalog is
+/// rejected at validation — the operator cannot grant a tool the host cannot
+/// build. Extensible (message/etc.) in later PRs.
+pub const GRANTABLE_TOOLS: &[&str] = &[
+    "read_file",
+    "write_file",
+    "edit_file",
+    "glob",
+    "grep",
+    "list_dir",
+    "shell",
+    "web_fetch",
+    "web_search",
+];
+
+/// The network content tools — buildable ONLY under a network grant (`Hosts`
+/// or `Full`). Granting one under [`NetworkGrant::None`] is an incoherent grant
+/// (a network tool with no network) and is rejected at validation.
+pub const WEB_TOOLS: &[&str] = &["web_fetch", "web_search"];
+
+/// The network egress a worker is granted.
+///
+/// - [`NetworkGrant::None`] — zero network: the sandbox blocks egress and no
+///   web tool is built.
+/// - [`NetworkGrant::Hosts`] — the sandbox still blocks RAW egress (the shell
+///   cannot `curl`); the only network path is the granted web tools, which
+///   enforce this per-host allowlist (on top of the private-IP block). This is
+///   how a per-host allowance is made REAL rather than cosmetic.
+/// - [`NetworkGrant::Full`] — raw egress on (`allow_network=true`): the shell
+///   can reach the network (git/npm/etc.) and web tools are unrestricted (the
+///   private-IP block still applies).
+///
+/// **v1 limitation (raw network is all-or-nothing).** Per-host filtering of
+/// RAW network (e.g. `git clone`/`npm` to only certain hosts) needs an egress
+/// proxy the kernel does not yet run. `Hosts` therefore covers HTTP(S) via the
+/// web tools ONLY; `Full` is unfiltered raw egress. Documented, not solved in
+/// PR A.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NetworkGrant {
+    #[default]
+    None,
+    Hosts(Vec<String>),
+    Full,
+}
+
+impl NetworkGrant {
+    /// Whether the SANDBOX is given raw egress (`allow_network`). Only `Full`.
+    /// `Hosts` deliberately keeps raw egress OFF — its allowance is realised
+    /// solely through the granted web tools' host allowlist, so the shell can
+    /// never `curl` past the allowlist. `None` is off.
+    pub fn allows_raw_egress(&self) -> bool {
+        matches!(self, NetworkGrant::Full)
+    }
+
+    /// The host allowlist a granted web tool must enforce, if any.
+    /// `Hosts(hosts)` → `Some(hosts)`; `Full` → `None` (unrestricted, the
+    /// private-IP block still applies); `None` → `None` (no web tool is built).
+    pub fn web_allowlist(&self) -> Option<&[String]> {
+        match self {
+            NetworkGrant::Hosts(hosts) => Some(hosts),
+            _ => None,
+        }
+    }
+
+    /// Whether this grant permits building the web (network) tools at all.
+    pub fn permits_web_tools(&self) -> bool {
+        !matches!(self, NetworkGrant::None)
+    }
+}
+
+/// The filesystem reach a worker is granted.
+///
+/// **Deliberately COARSE in v1.** The native file tools' confinement is a
+/// binary [`crate::policy`-style] scope (`Workspace | Host`) with no per-path
+/// allowlist, so an honest grant is binary too:
+///
+/// - [`FsGrant::Workspace`] (the default) — the worker may read+write ONLY its
+///   own attempt working directory. This is byte-for-byte today's closed
+///   worker.
+/// - [`FsGrant::Host`] — the worker may read+write the WHOLE daemon-user
+///   filesystem (fleet data/config included). This is a broad, EXPLICIT
+///   operator choice — grant it only when a task genuinely needs host access.
+///
+/// **v1 limitation (no per-path FS scoping).** A narrow "these specific paths,
+/// distinct read vs write" grant is NOT expressible against the binary native
+/// scope, so it is a FOLLOW-UP (it needs a native-tool path-allowlist model,
+/// exactly like per-host filtering of raw network needs an egress proxy). This
+/// enum does not PRETEND to offer narrow paths — `Host` is all-or-nothing.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FsGrant {
+    /// Confined to the worker's own cwd (read+write). The least-privilege
+    /// default.
+    #[default]
+    Workspace,
+    /// Full daemon-user filesystem read+write. An explicit, broad operator
+    /// grant.
+    Host,
+}
+
+impl FsGrant {
+    /// Whether this grant reaches beyond the worker's own cwd (full host r/w).
+    pub fn is_host(&self) -> bool {
+        matches!(self, FsGrant::Host)
+    }
+}
+
+/// The whole operator grant for one worker: network + tools + filesystem.
+///
+/// `#[serde(default)]` on every field means an OLD persisted task (written
+/// before grants existed) — or a master that specifies nothing — loads as
+/// [`WorkerGrant::minimal`], preserving least-privilege by default and keeping
+/// old records readable without a schema bump.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkerGrant {
+    /// Network egress. Default [`NetworkGrant::None`].
+    #[serde(default)]
+    pub network: NetworkGrant,
+    /// The tools the worker may hold. Default [`BASE_TOOLS`].
+    #[serde(default = "base_tools_vec")]
+    pub tools: Vec<String>,
+    /// Filesystem reach. Default [`FsGrant::Workspace`] (cwd-only).
+    #[serde(default)]
+    pub fs: FsGrant,
+}
+
+fn base_tools_vec() -> Vec<String> {
+    BASE_TOOLS.iter().map(|s| (*s).to_string()).collect()
+}
+
+impl Default for WorkerGrant {
+    fn default() -> Self {
+        Self::minimal()
+    }
+}
+
+impl WorkerGrant {
+    /// The least-privilege grant == today's closed worker: no network, the
+    /// base file tools, workspace-write (cwd only). This is what an unspecified
+    /// grant resolves to, so every pre-grant dispatch path stays byte-for-byte
+    /// identical.
+    pub fn minimal() -> Self {
+        Self {
+            network: NetworkGrant::None,
+            tools: base_tools_vec(),
+            fs: FsGrant::default(),
+        }
+    }
+
+    /// The granted tool names, deduplicated + sorted — the closed-worker audit
+    /// key. The built registry's `tool_names()` must equal this exactly ("what
+    /// the operator granted, nothing more"). Dedup matches the registry, which
+    /// keys tools by name, so a grant that repeats a name still audits cleanly.
+    pub fn sorted_tools(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.tools.clone();
+        names.sort();
+        names.dedup();
+        names
+    }
+
+    /// Reject a grant the host cannot honor:
+    /// - a tool outside [`GRANTABLE_TOOLS`] (the host cannot build it),
+    /// - a web tool under [`NetworkGrant::None`] (a network tool with no
+    ///   network is incoherent — grant `Hosts`/`Full` or drop the tool), and
+    /// - an EMPTY [`NetworkGrant::Hosts`] allowlist (an operator that lists no
+    ///   hosts means [`NetworkGrant::None`]; accepting it would be a fail-OPEN
+    ///   trap — an empty allowlist must never read as "unrestricted").
+    ///
+    /// Called at parse time (the master's `goal_plan`) AND defensively at
+    /// registry-build time, so an incoherent grant can never reach a live
+    /// worker.
+    pub fn validate(&self) -> Result<(), GrantError> {
+        if let NetworkGrant::Hosts(hosts) = &self.network {
+            if hosts.iter().all(|h| h.trim().is_empty()) {
+                return Err(GrantError::EmptyHostAllowlist);
+            }
+        }
+        for tool in &self.tools {
+            if !GRANTABLE_TOOLS.contains(&tool.as_str()) {
+                return Err(GrantError::UnknownTool(tool.clone()));
+            }
+        }
+        if !self.network.permits_web_tools() {
+            for tool in &self.tools {
+                if WEB_TOOLS.contains(&tool.as_str()) {
+                    return Err(GrantError::WebToolWithoutNetwork(tool.clone()));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A typed rejection of an incoherent [`WorkerGrant`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GrantError {
+    /// A granted tool is not in [`GRANTABLE_TOOLS`].
+    UnknownTool(String),
+    /// A web tool was granted under [`NetworkGrant::None`].
+    WebToolWithoutNetwork(String),
+    /// A [`NetworkGrant::Hosts`] grant with an empty allowlist (fail-open trap).
+    EmptyHostAllowlist,
+}
+
+impl std::fmt::Display for GrantError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GrantError::UnknownTool(tool) => write!(
+                f,
+                "tool `{tool}` is not grantable (must be one of: {})",
+                GRANTABLE_TOOLS.join(", ")
+            ),
+            GrantError::WebToolWithoutNetwork(tool) => write!(
+                f,
+                "tool `{tool}` needs a network grant — set network to `hosts` (allowlist) \
+                 or `full`, or drop the tool"
+            ),
+            GrantError::EmptyHostAllowlist => write!(
+                f,
+                "network mode `hosts` needs a non-empty allowlist — an empty list denies \
+                 everything; use `none` for no network"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for GrantError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grant_minimal_is_todays_closed_worker() {
+        let g = WorkerGrant::minimal();
+        assert_eq!(g.network, NetworkGrant::None);
+        assert!(!g.network.allows_raw_egress(), "minimal has no raw egress");
+        assert!(g.network.web_allowlist().is_none());
+        // Exactly the base seven, in order.
+        assert_eq!(g.tools, BASE_TOOLS);
+        assert_eq!(g.fs, FsGrant::Workspace, "minimal is workspace-only");
+        assert!(!g.fs.is_host());
+        // Default == minimal (drives `#[serde(default)]`).
+        assert_eq!(WorkerGrant::default(), g);
+        g.validate().expect("minimal is always valid");
+    }
+
+    #[test]
+    fn grant_missing_fields_default_to_minimal() {
+        // A master (or an old record) that specifies nothing gets least
+        // privilege. Serde `default` fills every field.
+        let g: WorkerGrant = serde_json::from_str("{}").unwrap();
+        assert_eq!(g, WorkerGrant::minimal());
+        // Partial: only tools set → network + fs default.
+        let g: WorkerGrant = serde_json::from_str(r#"{"tools":["read_file","glob"]}"#).unwrap();
+        assert_eq!(g.network, NetworkGrant::None);
+        assert_eq!(g.tools, vec!["read_file".to_string(), "glob".to_string()]);
+        assert_eq!(g.fs, FsGrant::Workspace);
+    }
+
+    #[test]
+    fn grant_unknown_tool_is_rejected() {
+        let g = WorkerGrant {
+            tools: vec!["read_file".into(), "definitely_not_a_tool".into()],
+            ..WorkerGrant::minimal()
+        };
+        assert_eq!(
+            g.validate(),
+            Err(GrantError::UnknownTool("definitely_not_a_tool".into())),
+        );
+    }
+
+    #[test]
+    fn grant_web_tool_without_network_is_rejected() {
+        // A network tool under NetworkGrant::None is incoherent.
+        let g = WorkerGrant {
+            network: NetworkGrant::None,
+            tools: vec!["read_file".into(), "web_fetch".into()],
+            ..WorkerGrant::minimal()
+        };
+        assert_eq!(
+            g.validate(),
+            Err(GrantError::WebToolWithoutNetwork("web_fetch".into())),
+        );
+        // Same tool under Hosts/Full is fine.
+        let hosts = WorkerGrant {
+            network: NetworkGrant::Hosts(vec!["example.com".into()]),
+            tools: vec!["read_file".into(), "web_fetch".into()],
+            ..WorkerGrant::minimal()
+        };
+        hosts.validate().expect("web_fetch under Hosts is valid");
+    }
+
+    #[test]
+    fn grant_empty_hosts_allowlist_is_rejected() {
+        // A `Hosts` grant with an empty allowlist is a fail-OPEN trap (an empty
+        // list must never read as "unrestricted"). validate() rejects it — the
+        // operator meant `None`.
+        let empty = WorkerGrant {
+            network: NetworkGrant::Hosts(vec![]),
+            tools: vec!["read_file".into(), "web_fetch".into()],
+            ..WorkerGrant::minimal()
+        };
+        assert_eq!(empty.validate(), Err(GrantError::EmptyHostAllowlist));
+        // A list of only blanks is equally empty.
+        let blanks = WorkerGrant {
+            network: NetworkGrant::Hosts(vec!["  ".into()]),
+            tools: vec!["read_file".into()],
+            ..WorkerGrant::minimal()
+        };
+        assert_eq!(blanks.validate(), Err(GrantError::EmptyHostAllowlist));
+    }
+
+    #[test]
+    fn network_grant_egress_and_allowlist_semantics() {
+        assert!(!NetworkGrant::None.allows_raw_egress());
+        assert!(!NetworkGrant::Hosts(vec!["example.com".into()]).allows_raw_egress());
+        assert!(NetworkGrant::Full.allows_raw_egress(), "Full = raw egress");
+
+        assert_eq!(
+            NetworkGrant::Hosts(vec!["a.com".into(), "b.com".into()]).web_allowlist(),
+            Some(&["a.com".to_string(), "b.com".to_string()][..]),
+        );
+        assert!(
+            NetworkGrant::Full.web_allowlist().is_none(),
+            "Full = unrestricted"
+        );
+        assert!(NetworkGrant::None.web_allowlist().is_none());
+    }
+
+    #[test]
+    fn grant_round_trips_through_json() {
+        let g = WorkerGrant {
+            network: NetworkGrant::Hosts(vec!["example.com".into()]),
+            tools: vec!["read_file".into(), "shell".into(), "web_fetch".into()],
+            fs: FsGrant::Host,
+        };
+        let json = serde_json::to_string(&g).unwrap();
+        let back: WorkerGrant = serde_json::from_str(&json).unwrap();
+        assert_eq!(g, back);
+    }
+
+    #[test]
+    fn sorted_tools_dedups_and_sorts() {
+        let g = WorkerGrant {
+            tools: vec!["shell".into(), "read_file".into(), "shell".into()],
+            ..WorkerGrant::minimal()
+        };
+        assert_eq!(
+            g.sorted_tools(),
+            vec!["read_file".to_string(), "shell".to_string()]
+        );
+    }
+}

--- a/crates/octos-fleet/src/lib.rs
+++ b/crates/octos-fleet/src/lib.rs
@@ -42,10 +42,14 @@
 #![deny(unsafe_code)]
 
 mod fleet;
+mod grant;
 mod records;
 mod store;
 
 pub use fleet::{Fleet, FleetSummary, FleetView, PlanEdit, PlanGraphError, TaskSpec, TaskView};
+pub use grant::{
+    BASE_TOOLS, FsGrant, GRANTABLE_TOOLS, GrantError, NetworkGrant, WEB_TOOLS, WorkerGrant,
+};
 pub use records::{
     AcceptanceCriterion, AcceptanceVerdict, Attempt, AttemptStatus, ChildResultSnapshot,
     ChildStatus, DecisionEntry, DecisionKind, DurablePlan, EvidenceRef, FleetBudget,

--- a/crates/octos-fleet/src/records.rs
+++ b/crates/octos-fleet/src/records.rs
@@ -10,6 +10,8 @@
 use octos_core::SessionKey;
 use serde::{Deserialize, Serialize};
 
+use crate::grant::WorkerGrant;
+
 /// Schema version stamped on every persisted record. Bumping this
 /// invalidates prior rows the same way the swarm dispatch ledger does:
 /// a load that sees a *higher* version returns `Ok(None)`.
@@ -272,6 +274,15 @@ pub struct PlanTask {
     /// [`FleetChildRecord::deps`], re-synced by `replan`.
     pub deps: Vec<String>,
     pub acceptance: Vec<AcceptanceCriterion>,
+    /// PR A — the operator-supplied capability grant the host builds this
+    /// task's worker from (network / tools / filesystem). `#[serde(default)]`
+    /// is deliberate forward-compat, **NOT** a `SCHEMA_VERSION` bump: an old
+    /// row written before grants existed (no `grant` key) deserializes to
+    /// [`WorkerGrant::minimal`] — byte-for-byte today's closed worker — rather
+    /// than dropping the row. Least-privilege by default; the master expands it
+    /// explicitly per task.
+    #[serde(default)]
+    pub grant: WorkerGrant,
 }
 
 /// An acceptance criterion: a description plus a checkable [`Verifier`].
@@ -447,6 +458,52 @@ mod tests {
         assert!(ChildStatus::Cancelled.is_terminal());
         assert!(!ChildStatus::Ready.is_terminal());
         assert!(!ChildStatus::Running.is_terminal());
+    }
+
+    #[test]
+    fn plan_task_grant_persists_and_restores() {
+        use crate::grant::{FsGrant, NetworkGrant, WorkerGrant};
+
+        // A granted task round-trips its grant verbatim through JSON (the shape
+        // the FleetKernelStore persists).
+        let task = PlanTask {
+            task_id: "t1".into(),
+            title: "fetch".into(),
+            detail: "grab the report".into(),
+            deps: vec![],
+            acceptance: vec![],
+            grant: WorkerGrant {
+                network: NetworkGrant::Hosts(vec!["example.com".into()]),
+                tools: vec!["read_file".into(), "write_file".into(), "web_fetch".into()],
+                fs: FsGrant::Host,
+            },
+        };
+        // PlanTask is nested inside DurablePlan (which carries schema_version);
+        // it has no version field of its own, so it round-trips via plain serde.
+        let json = serde_json::to_string(&task).unwrap();
+        let back: PlanTask = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            back.grant, task.grant,
+            "grant round-trips through the store"
+        );
+
+        // An OLD row written before grants existed (no `grant` key) must still
+        // decode — `#[serde(default)]` fills `WorkerGrant::minimal()` (today's
+        // closed worker), NOT fail. This is why grant is not a SCHEMA_VERSION
+        // bump.
+        let old_json = r#"{
+            "task_id": "t0",
+            "title": "legacy",
+            "detail": "",
+            "deps": [],
+            "acceptance": []
+        }"#;
+        let legacy: PlanTask = serde_json::from_str(old_json).expect("decode old row");
+        assert_eq!(
+            legacy.grant,
+            WorkerGrant::minimal(),
+            "a task with no grant loads as the least-privilege closed worker",
+        );
     }
 
     #[test]

--- a/crates/octos-fleet/src/store.rs
+++ b/crates/octos-fleet/src/store.rs
@@ -2051,6 +2051,7 @@ mod tests {
             detail: String::new(),
             deps: deps.iter().map(|s| s.to_string()).collect(),
             acceptance: vec![],
+            grant: crate::grant::WorkerGrant::minimal(),
         }
     }
 


### PR DESCRIPTION
Replaces the fleet worker's hardcoded permissions (closed 7-tool registry + `allow_network=false`) with an operator-supplied `WorkerGrant` that the master sets per task — network (per-host allowlist), tools, and filesystem scope. Least-privilege by default: an unspecified grant reproduces today's closed worker byte-for-byte, and old persisted tasks deserialize to `minimal()`, so nothing regresses.

## What changed
- `WorkerGrant { network: None|Hosts(..)|Full, tools, fs: Workspace|Host }` on each `PlanTask` (serde-default → `minimal()`).
- Master provisions per task via `goal_plan`; the pool builds the worker from the grant (`build_fleet_worker_registry`), and `serve.rs` derives `allow_network` per attempt.
- Per-host network is enforced (not cosmetic): `Hosts` keeps raw egress off and the web tool checks the allowlist before DNS on every redirect hop, on top of the SSRF/private-IP block. `Hosts([])` fails closed.
- `fs` is a coarse `Workspace|Host` choice for v1 (the tool filesystem scope is binary); fine-grained per-path FS scoping and per-host filtering of raw egress (proxy) are documented follow-ups.

## Follow-ups (not in this PR)
- PR B: escalate-to-master mid-task (worker requests more capability → master approves → grant widens → resume).
- PR C: worktree workers, rebuilt thin on this grant.

Reviewed by codex; full workspace gates green (build, tests, fmt, clippy -D warnings, cli api-check).