### PR TITLE
feat(llm): add Atlas Cloud provider

### DIFF
--- a/crates/octos-cli/src/auth/token.rs
+++ b/crates/octos-cli/src/auth/token.rs
@@ -10,6 +10,7 @@ pub fn paste_token_flow(provider: &str) -> Result<AuthCredential> {
         "anthropic" => "ANTHROPIC_API_KEY",
         "gemini" | "google" => "GEMINI_API_KEY",
         "deepseek" => "DEEPSEEK_API_KEY",
+        "atlascloud" | "atlas-cloud" => "ATLASCLOUD_API_KEY",
         _ => "API_KEY",
     };
 

--- a/crates/octos-cli/src/commands/init.rs
+++ b/crates/octos-cli/src/commands/init.rs
@@ -90,6 +90,14 @@ const PROVIDERS: &[ProviderInfo] = &[
         api_types: &[],
     },
     ProviderInfo {
+        name: "atlascloud",
+        display: "Atlas Cloud",
+        api_key_env: "ATLASCLOUD_API_KEY",
+        base_url: Some("https://api.atlascloud.ai/v1"),
+        api_type: None,
+        api_types: &[],
+    },
+    ProviderInfo {
         name: "moonshot",
         display: "Moonshot (Kimi)",
         api_key_env: "KIMI_API_KEY",
@@ -692,6 +700,7 @@ fn default_model_for(provider: &str, catalog: &BTreeMap<String, Vec<String>>) ->
     match provider {
         "openai" => return Ok("gpt-4.1-mini".to_string()),
         "anthropic" => return Ok("claude-sonnet-4-20250514".to_string()),
+        "atlascloud" => return Ok("deepseek-ai/deepseek-v4-pro".to_string()),
         _ => {}
     }
     if let Some(first) = catalog.get(provider).and_then(|m| m.first()) {
@@ -1154,6 +1163,10 @@ mod tests {
         let catalog = embedded_catalog_models();
         assert!(default_model_for("anthropic", &catalog).is_ok());
         assert!(default_model_for("deepseek", &catalog).is_ok());
+        assert_eq!(
+            default_model_for("atlascloud", &catalog).unwrap(),
+            "deepseek-ai/deepseek-v4-pro"
+        );
         let err = default_model_for("no-such-provider", &BTreeMap::new()).unwrap_err();
         assert!(err.to_string().contains("model"), "guidance in {err}");
     }

--- a/crates/octos-llm/src/registry/atlascloud.rs
+++ b/crates/octos-llm/src/registry/atlascloud.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+
+use eyre::Result;
+
+use crate::openai::OpenAIProvider;
+use crate::provider::LlmProvider;
+
+use super::{CreateParams, ProviderEntry};
+
+const DEFAULT_MODEL: &str = "deepseek-ai/deepseek-v4-pro";
+const DEFAULT_BASE_URL: &str = "https://api.atlascloud.ai/v1";
+
+pub const ENTRY: ProviderEntry = ProviderEntry {
+    name: "atlascloud",
+    aliases: &["atlas-cloud"],
+    default_model: Some(DEFAULT_MODEL),
+    api_key_env: Some("ATLASCLOUD_API_KEY"),
+    key_env_aliases: &[],
+    default_base_url: Some(DEFAULT_BASE_URL),
+    requires_api_key: true,
+    requires_base_url: false,
+    requires_model: false,
+    detect_patterns: &[],
+    create,
+};
+
+fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
+    let http_timeout = p.http_timeout();
+    let key = p
+        .api_key
+        .ok_or_else(|| eyre::eyre!("ATLASCLOUD_API_KEY not set"))?;
+    let model = p.model.unwrap_or_else(|| DEFAULT_MODEL.into());
+    let url = p.base_url.unwrap_or_else(|| DEFAULT_BASE_URL.into());
+    let mut provider = OpenAIProvider::new(&key, &model)
+        .with_provider_label("atlascloud")
+        .with_base_url(&url);
+    if let Some(hints) = p.model_hints {
+        provider = provider.with_hints(hints);
+    }
+    if let Some((t, c)) = http_timeout {
+        provider = provider.with_http_timeout(t, c);
+    }
+    Ok(Arc::new(provider))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creates_provider_with_default_route() {
+        let provider = create(CreateParams {
+            api_key: Some("test-key".into()),
+            model: None,
+            base_url: None,
+            model_hints: None,
+            llm_timeout_secs: None,
+            llm_connect_timeout_secs: None,
+        })
+        .expect("atlascloud provider should construct");
+
+        assert_eq!(provider.model_id(), DEFAULT_MODEL);
+        assert!(provider.provider_name().starts_with("atlascloud"));
+    }
+}

--- a/crates/octos-llm/src/registry/mod.rs
+++ b/crates/octos-llm/src/registry/mod.rs
@@ -13,6 +13,7 @@ use crate::provider::LlmProvider;
 // ── Provider sub-modules ────────────────────────────────────────────────────
 
 mod anthropic;
+mod atlascloud;
 mod dashscope;
 mod deepseek;
 mod gemini;
@@ -121,6 +122,7 @@ static ALL: &[ProviderEntry] = &[
     vertex::ENTRY,
     r9s::ENTRY,
     openrouter::ENTRY,
+    atlascloud::ENTRY,
     deepseek::ENTRY,
     groq::ENTRY,
     // Coding-plan families FIRST so an explicit `moonshot-coding` / `zai-coding`
@@ -191,6 +193,7 @@ mod tests {
     #[test]
     fn lookup_by_name() {
         assert!(lookup("anthropic").is_some());
+        assert!(lookup("atlascloud").is_some());
         assert!(lookup("deepseek").is_some());
         assert!(lookup("vllm").is_some());
     }
@@ -220,6 +223,9 @@ mod tests {
 
         let e = lookup("r9s.ai").unwrap();
         assert_eq!(e.name, "r9s");
+
+        let e = lookup("atlas-cloud").unwrap();
+        assert_eq!(e.name, "atlascloud");
     }
 
     #[test]
@@ -236,7 +242,16 @@ mod tests {
 
     #[test]
     fn all_entries_count() {
-        assert_eq!(all_entries().len(), 18);
+        assert_eq!(all_entries().len(), 19);
+    }
+
+    #[test]
+    fn atlascloud_entry_uses_openai_compatible_defaults() {
+        let e = lookup("atlascloud").expect("atlascloud provider should be registered");
+        assert_eq!(e.default_model, Some("deepseek-ai/deepseek-v4-pro"));
+        assert_eq!(e.api_key_env, Some("ATLASCLOUD_API_KEY"));
+        assert_eq!(e.default_base_url, Some("https://api.atlascloud.ai/v1"));
+        assert!(e.requires_api_key);
     }
 
     /// The coding-plan families resolve to their coding endpoints + default

--- a/dashboard/src/providers.json
+++ b/dashboard/src/providers.json
@@ -128,20 +128,9 @@
   "atlascloud": {
     "env": "ATLASCLOUD_API_KEY",
     "models": [
-      {
-        "id": "deepseek-ai/deepseek-v4-pro",
-        "input": 0.0,
-        "output": 0.0,
-        "max_output": 384000,
-        "endpoints": [
-          {
-            "id": "atlascloud",
-            "label": "Atlas Cloud",
-            "base_url": "https://api.atlascloud.ai/v1",
-            "api_key_env": "ATLASCLOUD_API_KEY"
-          }
-        ]
-      }
+      { "id": "deepseek-ai/deepseek-v4-pro", "input": 0.0, "output": 0.0, "max_output": 384000, "endpoints": [
+        { "id": "atlascloud", "label": "Atlas Cloud", "base_url": "https://api.atlascloud.ai/v1", "api_key_env": "ATLASCLOUD_API_KEY" }
+      ] }
     ]
   },
   "groq": {

--- a/dashboard/src/providers.json
+++ b/dashboard/src/providers.json
@@ -125,6 +125,25 @@
       ] }
     ]
   },
+  "atlascloud": {
+    "env": "ATLASCLOUD_API_KEY",
+    "models": [
+      {
+        "id": "deepseek-ai/deepseek-v4-pro",
+        "input": 0.0,
+        "output": 0.0,
+        "max_output": 384000,
+        "endpoints": [
+          {
+            "id": "atlascloud",
+            "label": "Atlas Cloud",
+            "base_url": "https://api.atlascloud.ai/v1",
+            "api_key_env": "ATLASCLOUD_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
   "groq": {
     "env": "GROQ_API_KEY",
     "models": [

--- a/model_catalog.json
+++ b/model_catalog.json
@@ -2048,6 +2048,27 @@
           "api_key_env": "ZAI_API_KEY"
         }
       ]
+    },
+    {
+      "provider": "atlascloud/deepseek-ai/deepseek-v4-pro",
+      "type": "strong",
+      "stability": 1.0,
+      "tool_avg_ms": 0,
+      "p95_ms": 0,
+      "score": 0.0,
+      "ds_output": 0,
+      "cost_in": 0.0,
+      "cost_out": 0.0,
+      "context_window": 1048576,
+      "max_output": 384000,
+      "endpoints": [
+        {
+          "id": "atlascloud",
+          "label": "Atlas Cloud",
+          "base_url": "https://api.atlascloud.ai/v1",
+          "api_key_env": "ATLASCLOUD_API_KEY"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- add Atlas Cloud to the native LLM provider registry with OpenAI-compatible defaults
- expose Atlas Cloud in interactive init, credential capture, and the dashboard model selector
- cover registry metadata, alias lookup, factory construction, and non-interactive defaults

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p octos-llm registry::tests --lib` (10 passed)
- `cargo test -p octos-cli commands::init::tests --lib` (19 passed)
- `npm run typecheck`
- `npm test` (54 passed)
- `npm run build`
- live `octos chat --provider atlascloud` returned a non-empty response using `deepseek-ai/deepseek-v4-pro`
