### PR TITLE
feat(fleet): escalate-to-master mid-task — worker requests capability, master grants

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -2056,6 +2056,29 @@ impl Agent {
     }
     /// Run a task to completion (used by spawn tool).
     pub async fn run_task(&self, task: &Task) -> Result<TaskResult> {
+        self.run_task_inner(task, None).await
+    }
+
+    /// Like [`Agent::run_task`], but stores the turn-cumulative token counts
+    /// into `tracker` after every LLM response. A caller that runs the task
+    /// under an external wall-clock timeout — which DROPS the future and
+    /// discards the returned [`TaskResult`] — can then still read the REAL
+    /// tokens the run spent. The fleet worker uses this to settle a mid-task
+    /// escalation's budget honestly even on the timeout / run-error path (never
+    /// `0`), mirroring the conversation loop's real-time tracker.
+    pub async fn run_task_with_tracker(
+        &self,
+        task: &Task,
+        tracker: &TokenTracker,
+    ) -> Result<TaskResult> {
+        self.run_task_inner(task, Some(tracker)).await
+    }
+
+    async fn run_task_inner(
+        &self,
+        task: &Task,
+        tracker: Option<&TokenTracker>,
+    ) -> Result<TaskResult> {
         let task_start = Instant::now();
         let span = info_span!(
             "task",
@@ -2182,7 +2205,7 @@ impl Agent {
                     response.usage.output_tokens,
                     response.usage.cache_read_tokens,
                     response.usage.cache_write_tokens,
-                    None,
+                    tracker,
                     // Attributed per attempt inside `call_llm_with_hooks`
                     // (cross-provider retries priced at their own slot).
                     attributed_cost,

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -29,7 +29,8 @@ use octos_core::ui_protocol::{
 };
 use octos_core::{AgentId, MAIN_PROFILE_ID, SessionKey, TaskId};
 use octos_fleet::{
-    AcceptanceVerdict, Fleet, FleetBudget, FleetKernelStore, LaunchOutcome, TaskSpec,
+    AcceptanceVerdict, CompleteOutcome, DenyEscalationOutcome, Fleet, FleetBudget,
+    FleetKernelStore, LaunchOutcome, PlanEdit, PlanMutateOutcome, TaskSpec, WorkerGrant,
 };
 use octos_fleet_worker::FleetWorkerPool;
 use octos_llm::LlmProvider;
@@ -3499,6 +3500,279 @@ impl InProcessAgentOrchestrator {
         Ok(result)
     }
 
+    /// PR B — `goal_grant` tool: APPROVE a worker's mid-task escalation. The
+    /// keeper widens the blocked task's [`WorkerGrant`] to the KEEPER-chosen
+    /// grant (the worker's request is advisory) and resumes it, then re-dispatches
+    /// the now-ready task so a fresh attempt rebuilds from the wider grant.
+    ///
+    /// Security: the ownership gate ([`Self::resolve_owned_fleet`]) runs BEFORE
+    /// any edit — a stale/foreign binding can never have its grant widened. The
+    /// keeper-chosen grant is re-`validate()`d here (unknown tool / web-without-
+    /// network / empty-hosts rejected exactly as at plan time), so an escalation
+    /// can never inject a grant the host cannot honor. Only THIS path mutates
+    /// `PlanTask.grant`; the worker itself never can.
+    pub(crate) async fn model_grant_escalation(
+        &self,
+        session_id: &SessionKey,
+        profile_id: &str,
+        task_id: &str,
+        grant: Option<WorkerGrant>,
+        now_ms: u64,
+    ) -> Result<Value, String> {
+        let key = self.scoped_goal_key(session_id);
+        // Fetch the pool BEFORE the state lock so its bound keeper profile can
+        // fence a cross-profile goal (mirrors `model_dispatch_fleet`).
+        let pool = self.fleet_pool();
+        let fleet_id = {
+            let state = self.state();
+            let Some(goal) = state.goals.get(&key) else {
+                return Err("no goal is set for this session".to_owned());
+            };
+            if goal.profile_id != profile_id {
+                return Err("goal is outside this profile's scope".to_owned());
+            }
+            if let Some(pool) = &pool {
+                if goal.profile_id != pool.keeper_profile_id() {
+                    return Err(format!(
+                        "fleet grants are only available for the keeper profile `{}` in v1 \
+                         (this goal is on profile `{}`)",
+                        pool.keeper_profile_id(),
+                        goal.profile_id,
+                    ));
+                }
+            }
+            goal.fleet_id
+                .clone()
+                .ok_or_else(|| "this goal has no fleet plan yet — nothing to grant".to_owned())?
+        };
+        let Some(store) = self.fleet_store() else {
+            return Err("fleet kernel store is not available".to_owned());
+        };
+        // THE ownership gate — before any edit, mirrors dispatch/snapshot.
+        let fleet = Self::resolve_owned_fleet(Arc::new(store), &fleet_id, &key, profile_id).await?;
+
+        // The task must be Blocked on a pending escalation — reject a grant on a
+        // task that isn't actually waiting (a stale/duplicate approval).
+        let view = fleet
+            .view()
+            .await
+            .map_err(|e| format!("failed to read fleet: {e}"))?;
+        let Some(task) = view.tasks.iter().find(|t| t.task_id == task_id) else {
+            return Err(format!("task `{task_id}` is not in this goal's fleet"));
+        };
+        // Verify the child is actually `Blocked` (not merely that a request field
+        // exists): a task the operator already resolved is not grantable. This is
+        // the out-of-txn early-out; `set_task_grant` re-checks `Blocked` INSIDE
+        // the write-txn (the authoritative CAS against a racing deny).
+        if task.status != octos_fleet::ChildStatus::Blocked {
+            return Err(format!(
+                "task `{task_id}` is not Blocked on an escalation (status {:?}) — nothing to grant",
+                task.status
+            ));
+        }
+        let Some(requested) = task.pending_escalation.as_ref().map(|e| &e.requested_grant) else {
+            return Err(format!(
+                "task `{task_id}` has no pending escalation to grant (status {:?})",
+                task.status
+            ));
+        };
+        // The keeper picks the actual grant. If it supplied none, approve the
+        // worker's requested grant AS-IS (advisory → chosen). Either way it is
+        // re-`validate()`d — an incoherent grant never reaches the plan/worker,
+        // and the keeper can always grant LESS than requested.
+        let chosen = grant.unwrap_or_else(|| requested.clone());
+        chosen
+            .validate()
+            .map_err(|e| format!("invalid grant: {e}"))?;
+
+        // Apply the targeted grant-widen + Blocked→Ready resume (revision-fenced;
+        // NOT a replan). Then re-dispatch the newly-ready task.
+        match fleet
+            .apply_edit(
+                PlanEdit::SetGrant {
+                    task_id: task_id.to_owned(),
+                    grant: chosen,
+                },
+                view.revision,
+                now_ms,
+            )
+            .await
+        {
+            Ok(PlanMutateOutcome::Mutated { revision }) => {
+                let dispatch = self
+                    .model_dispatch_fleet(session_id, profile_id, now_ms)
+                    .await?;
+                Ok(json!({
+                    "status": "granted",
+                    "fleet_id": fleet_id,
+                    "task_id": task_id,
+                    "revision": revision,
+                    "dispatch": dispatch,
+                }))
+            }
+            Ok(PlanMutateOutcome::RevisionMismatch { actual }) => Err(format!(
+                "the fleet plan changed under this grant (expected revision {}, found {actual}); \
+                 re-read with goal_get and retry",
+                view.revision
+            )),
+            // The in-txn `Blocked` CAS refused: a concurrent `goal_deny` (or a
+            // prior grant) resolved this task first, so the grant is REJECTED with
+            // no mutation — grant and deny are mutually exclusive.
+            Ok(PlanMutateOutcome::RejectedNotBlocked { .. }) => Err(format!(
+                "task `{task_id}` is no longer Blocked (a deny or another grant won the race); \
+                 the grant was NOT applied — re-read with goal_get"
+            )),
+            Ok(other) => Err(format!("unexpected grant outcome: {other:?}")),
+            Err(e) => {
+                // A structural error (e.g. UnknownTask) surfaces as a plain message.
+                Err(format!("failed to apply grant: {e}"))
+            }
+        }
+    }
+
+    /// PR B — `goal_deny` tool: REFUSE a worker's mid-task escalation. Moves the
+    /// blocked task's child `Blocked → Failed` (TERMINAL) with the keeper's
+    /// reason. Terminality is load-bearing: a `Blocked` child is non-terminal
+    /// and holds `is_complete` open, so a denial that left it `Blocked` would
+    /// WEDGE the fleet — the goal could never complete.
+    ///
+    /// Security: the same [`Self::resolve_owned_fleet`] ownership gate as
+    /// `goal_grant`/`goal_dispatch` runs before the store op — a foreign binding
+    /// can never have its child failed.
+    pub(crate) async fn model_deny_escalation(
+        &self,
+        session_id: &SessionKey,
+        profile_id: &str,
+        task_id: &str,
+        reason: &str,
+        now_ms: u64,
+    ) -> Result<Value, String> {
+        let key = self.scoped_goal_key(session_id);
+        let pool = self.fleet_pool();
+        let fleet_id = {
+            let state = self.state();
+            let Some(goal) = state.goals.get(&key) else {
+                return Err("no goal is set for this session".to_owned());
+            };
+            if goal.profile_id != profile_id {
+                return Err("goal is outside this profile's scope".to_owned());
+            }
+            if let Some(pool) = &pool {
+                if goal.profile_id != pool.keeper_profile_id() {
+                    return Err(format!(
+                        "fleet denials are only available for the keeper profile `{}` in v1 \
+                         (this goal is on profile `{}`)",
+                        pool.keeper_profile_id(),
+                        goal.profile_id,
+                    ));
+                }
+            }
+            goal.fleet_id
+                .clone()
+                .ok_or_else(|| "this goal has no fleet plan yet — nothing to deny".to_owned())?
+        };
+        let Some(store) = self.fleet_store() else {
+            return Err("fleet kernel store is not available".to_owned());
+        };
+        // THE ownership gate — before the terminal deny.
+        let fleet = Self::resolve_owned_fleet(Arc::new(store), &fleet_id, &key, profile_id).await?;
+        match fleet
+            .store()
+            .deny_escalation(&fleet_id, task_id, reason, now_ms)
+            .await
+        {
+            Ok(DenyEscalationOutcome {
+                settled: CompleteOutcome::Completed,
+                fleet_un_completable,
+            }) => {
+                // PR B (codex round-4, defect 2) — drive the goal terminal from the
+                // DURABLE deny's OWN returned completability, computed in the same
+                // write-txn — NOT a separate `fleet.view()` after the deny. The
+                // denied task is now terminally `Failed`, so it strands any
+                // dependents `Planned` and the fleet can never auto-complete; a
+                // post-hoc view/read that got cancelled or errored would have left
+                // the goal `active` forever. Because the transition depends only on
+                // the value the durable op returned, a denied task ALWAYS resolves
+                // the goal even if a later read would fail. (The `goal_get` snapshot
+                // stays as a backstop for the non-deny paths.)
+                if fleet_un_completable {
+                    let _ = self.model_transition_goal(
+                        session_id,
+                        profile_id,
+                        "blocked",
+                        &format!(
+                            "fleet cannot complete — task `{task_id}` was denied and will not \
+                             re-run without a replan",
+                        ),
+                    );
+                }
+                Ok(json!({
+                    "status": "denied",
+                    "fleet_id": fleet_id,
+                    "task_id": task_id,
+                    "task_status": "Failed",
+                }))
+            }
+            // The child wasn't Blocked (already resumed/failed/never escalated) —
+            // an inert no-op, surfaced clearly rather than pretending to fail it.
+            Ok(DenyEscalationOutcome {
+                settled: CompleteOutcome::Superseded,
+                ..
+            }) => Err(format!(
+                "task `{task_id}` has no pending escalation to deny (it is not Blocked)"
+            )),
+            Err(e) => Err(format!("failed to deny escalation: {e}")),
+        }
+    }
+
+    /// PR B (codex round-3, defect 2) — resolve the goal to its terminal status
+    /// from the CURRENT fleet completion state. Shared by `model_fleet_snapshot`
+    /// (the lazy `goal_get` backstop) and `model_deny_escalation` (the eager deny
+    /// path), so the un-completable rule lives in ONE place and a denied/failed
+    /// task drives the goal terminal identically whether or not the keeper reads
+    /// `goal_get`.
+    ///
+    /// - `complete` (every task `Succeeded`/`Accepted`) → transition the goal
+    ///   `complete`;
+    /// - else any `failed_tasks` (a terminally-`Failed` task can never become
+    ///   `Succeeded`, so `is_complete` is false forever and any dependents wedge
+    ///   `Planned`) → transition the goal `blocked`.
+    ///
+    /// Returns whether the fleet is un-completable (a failed task strands it) so a
+    /// caller (the snapshot) can surface it. Idempotent: `model_transition_goal`
+    /// no-ops once the goal is already `complete`, and a `blocked → blocked`
+    /// re-transition is harmless — so the eager deny path and the snapshot backstop
+    /// can both run without conflict.
+    fn drive_goal_terminal_transition(
+        &self,
+        session_id: &SessionKey,
+        profile_id: &str,
+        complete: bool,
+        failed_tasks: &[&str],
+    ) -> bool {
+        let un_completable = !complete && !failed_tasks.is_empty();
+        if complete {
+            let _ = self.model_transition_goal(
+                session_id,
+                profile_id,
+                "complete",
+                "all fleet tasks accepted",
+            );
+        } else if un_completable {
+            let _ = self.model_transition_goal(
+                session_id,
+                profile_id,
+                "blocked",
+                &format!(
+                    "fleet cannot complete — task(s) failed and will not re-run without a \
+                     replan: {}",
+                    failed_tasks.join(", ")
+                ),
+            );
+        }
+        un_completable
+    }
+
     /// #1857 PR 5a — the fleet plan view for the `goal_get` tool: objective,
     /// per-task title/status/verdict, the ready set, and status counts.
     /// `Ok(None)` when this goal drives no fleet (so `goal_get` renders just the
@@ -3549,14 +3823,30 @@ impl InProcessAgentOrchestrator {
         // Completion self-detection: no `FleetDrained` in production, so the
         // keeper marks its OWN goal complete once every task is accepted. The
         // transition is idempotent (a second call errors and is ignored).
-        if complete {
-            let _ = self.model_transition_goal(
-                session_id,
-                profile_id,
-                "complete",
-                "all fleet tasks accepted",
-            );
-        }
+        //
+        // PR B (codex round-2) — un-completable self-detection. A terminally
+        // `Failed` task (a normal acceptance failure OR a `goal_deny`ed
+        // escalation) can NEVER become `Succeeded`, so `is_complete` — which
+        // requires ALL `Succeeded` — is false FOREVER, and any dependents wedge
+        // `Planned`. Without this the goal would stay perpetually `active`. Mirror
+        // the completion self-detection: mark the goal `blocked` (a terminal,
+        // model-allowed status) so it reaches a terminal state. The keeper is
+        // woken by the same `ChildDone` the deny/complete paths emit and may still
+        // replan to recover (`goal_plan`/`goal_dispatch` work on a blocked goal;
+        // a subsequent all-`Succeeded` fleet re-transitions it to `complete`).
+        let failed_tasks: Vec<&str> = view
+            .tasks
+            .iter()
+            .filter(|t| t.status == octos_fleet::ChildStatus::Failed)
+            .map(|t| t.task_id.as_str())
+            .collect();
+        // Shared with the eager deny path (`model_deny_escalation`): the SAME
+        // un-completable rule + goal-terminal transition. Here it is the BACKSTOP
+        // (a normally-`Failed` task reached via the keeper's goal_get wake still
+        // resolves the goal); the deny path drives it eagerly so a keeper that
+        // never reads goal_get is also covered.
+        let un_completable =
+            self.drive_goal_terminal_transition(session_id, profile_id, complete, &failed_tasks);
         let tasks: Vec<Value> = view
             .tasks
             .iter()
@@ -3567,12 +3857,24 @@ impl InProcessAgentOrchestrator {
                     Some(AcceptanceVerdict::Terminated { .. }) => "terminated",
                     None => "",
                 };
-                json!({
+                let mut task = json!({
                     "task_id": t.task_id,
                     "title": t.title,
                     "status": format!("{:?}", t.status),
                     "verdict": verdict,
-                })
+                });
+                // PR B — surface a pending escalation so the keeper NOTICES it on
+                // its next goal_get and decides (goal_grant / goal_deny). A
+                // Blocked task carries the worker's advisory requested grant +
+                // reason; this is how the request reaches the operator.
+                if let Some(esc) = &t.pending_escalation {
+                    task["pending_escalation"] = json!({
+                        "reason": esc.reason,
+                        "requested_grant": grant_to_json(&esc.requested_grant),
+                        "decision_needed": "call goal_grant (widen + resume) or goal_deny (fail the task)",
+                    });
+                }
+                task
             })
             .collect();
         Ok(Some(json!({
@@ -3580,6 +3882,11 @@ impl InProcessAgentOrchestrator {
             "objective": view.objective,
             "status": format!("{:?}", view.status),
             "complete": complete,
+            // PR B — the fleet has a terminally-failed task and can never
+            // auto-complete; the goal was transitioned `blocked`. The keeper may
+            // replan (drop/adjust the failed task) to recover.
+            "un_completable": un_completable,
+            "failed_tasks": failed_tasks,
             "ready": ready,
             "tasks": tasks,
             "counts": summary.map(|s| json!({
@@ -3587,6 +3894,7 @@ impl InProcessAgentOrchestrator {
                 "planned": s.planned,
                 "ready": s.ready,
                 "running": s.running,
+                "blocked": s.blocked,
                 "succeeded": s.succeeded,
                 "failed": s.failed,
                 "cancelled": s.cancelled,
@@ -5489,6 +5797,28 @@ fn now_ms() -> i64 {
 
 fn now_ms_u64() -> u64 {
     now_ms().try_into().unwrap_or(0)
+}
+
+/// PR B — render a [`WorkerGrant`] to the wire JSON shape the goal tools speak
+/// (`{ network: {mode, hosts}, tools: [...], fs: "workspace"|"host" }`), so a
+/// surfaced escalation's advisory requested grant reads back the same way the
+/// keeper would specify it in `goal_grant`.
+fn grant_to_json(grant: &WorkerGrant) -> Value {
+    use octos_fleet::{FsGrant, NetworkGrant};
+    let network = match &grant.network {
+        NetworkGrant::None => json!({ "mode": "none" }),
+        NetworkGrant::Full => json!({ "mode": "full" }),
+        NetworkGrant::Hosts(hosts) => json!({ "mode": "hosts", "hosts": hosts }),
+    };
+    let fs = match grant.fs {
+        FsGrant::Workspace => "workspace",
+        FsGrant::Host => "host",
+    };
+    json!({
+        "network": network,
+        "tools": grant.tools,
+        "fs": fs,
+    })
 }
 
 fn autonomy_error_code(kind: &str) -> i64 {
@@ -9017,6 +9347,553 @@ mod tests {
         assert_eq!(
             foreign.controller_session_key,
             SessionKey::new("api", "other-controller"),
+        );
+    }
+
+    // ---- PR B: escalate-to-master mid-task (goal_grant / goal_deny) --------
+
+    /// Drive `task_id` into `Blocked` on a pending escalation by launching +
+    /// mark_running + `record_escalation` directly on the store (epoch 1, the
+    /// mock pool's owner epoch, so a later grant re-dispatch is consistent).
+    async fn block_task_on_escalation(
+        store: &FleetKernelStore,
+        fleet_id: &str,
+        task_id: &str,
+    ) -> octos_fleet::EscalationRequest {
+        let attempt = match store
+            .launch_child(fleet_id, task_id, 100, now_ms_u64(), 1, 60_000)
+            .await
+            .unwrap()
+        {
+            LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("launch {task_id}: {other:?}"),
+        };
+        store.mark_running(task_id, &attempt).await.unwrap();
+        let request = octos_fleet::EscalationRequest {
+            requested_grant: octos_fleet::WorkerGrant {
+                network: octos_fleet::NetworkGrant::Hosts(vec!["example.com".into()]),
+                tools: vec!["read_file".into(), "web_fetch".into()],
+                ..octos_fleet::WorkerGrant::minimal()
+            },
+            reason: "needs example.com".into(),
+        };
+        let out = store
+            .record_escalation(
+                fleet_id,
+                task_id,
+                &attempt,
+                request.clone(),
+                80,
+                1,
+                now_ms_u64(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(out, CompleteOutcome::Completed);
+        request
+    }
+
+    /// Plan a one-task fleet under a live goal and return its fleet_id. Shared
+    /// setup for the escalation tests.
+    async fn seed_planned_goal(
+        orchestrator: &InProcessAgentOrchestrator,
+        wire: &SessionKey,
+        work: &std::path::Path,
+    ) -> String {
+        seed_goal(orchestrator, wire, "tenant-a");
+        let scoped = orchestrator.scoped_goal_key(wire);
+        orchestrator.set_goal_workspace_root(&scoped, Some(work.to_string_lossy().into_owned()));
+        let plan = orchestrator
+            .model_create_fleet_plan(wire, "tenant-a", plan_tasks(), 1_000)
+            .await
+            .expect("plan");
+        plan["fleet_id"].as_str().unwrap().to_owned()
+    }
+
+    /// `goal_grant` widens a blocked task's grant (through the ownership gate)
+    /// and re-dispatches it: the plan carries the wider grant and the child
+    /// leaves `Blocked`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn goal_grant_widens_and_redispatches() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let (_sd, store) = fleet_test_store().await;
+        orchestrator.set_fleet_store(store.clone());
+        let work = tempfile::TempDir::new().unwrap();
+        let (_md, pool) = mock_fleet_pool(store.clone(), work.path(), 100).await;
+        orchestrator.set_fleet_pool(pool);
+
+        let wire = SessionKey::new("api", "keeper-grant");
+        let fleet_id = seed_planned_goal(&orchestrator, &wire, work.path()).await;
+        block_task_on_escalation(&store, &fleet_id, "t1").await;
+        assert_eq!(
+            store
+                .get_child(&fleet_id, "t1")
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            octos_fleet::ChildStatus::Blocked,
+        );
+
+        // The keeper approves a WIDER grant (adds web_fetch under a Hosts list).
+        let grant = octos_fleet::WorkerGrant {
+            network: octos_fleet::NetworkGrant::Hosts(vec!["example.com".into()]),
+            tools: vec![
+                "read_file".into(),
+                "write_file".into(),
+                "shell".into(),
+                "web_fetch".into(),
+            ],
+            ..octos_fleet::WorkerGrant::minimal()
+        };
+        let out = orchestrator
+            .model_grant_escalation(&wire, "tenant-a", "t1", Some(grant.clone()), now_ms_u64())
+            .await
+            .expect("grant");
+        assert_eq!(out["status"], json!("granted"), "grant applied: {out}");
+        let dispatched = out["dispatch"]["dispatched"]
+            .as_array()
+            .expect("dispatched array");
+        assert!(
+            dispatched.iter().any(|d| d["task_id"] == json!("t1")),
+            "the resumed task must be re-dispatched: {out}",
+        );
+
+        // The plan now carries the widened grant; the child left Blocked with no
+        // pending escalation.
+        let plan = store.get_plan(&fleet_id).await.unwrap().unwrap();
+        let t1 = plan.tasks.iter().find(|t| t.task_id == "t1").unwrap();
+        assert_eq!(
+            t1.grant, grant,
+            "the widened grant is persisted on the plan"
+        );
+        let child = store.get_child(&fleet_id, "t1").await.unwrap().unwrap();
+        assert!(child.pending_escalation.is_none(), "escalation cleared");
+        assert_ne!(
+            child.status,
+            octos_fleet::ChildStatus::Blocked,
+            "the child resumed out of Blocked",
+        );
+    }
+
+    /// `goal_grant` re-validates the keeper-chosen grant: an incoherent grant
+    /// (unknown tool) is rejected and the task stays Blocked (nothing applied).
+    #[tokio::test]
+    async fn goal_grant_rejects_invalid_grant() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let (_sd, store) = fleet_test_store().await;
+        orchestrator.set_fleet_store(store.clone());
+        let work = tempfile::TempDir::new().unwrap();
+
+        let wire = SessionKey::new("api", "keeper-badgrant");
+        let fleet_id = seed_planned_goal(&orchestrator, &wire, work.path()).await;
+        block_task_on_escalation(&store, &fleet_id, "t1").await;
+
+        let bad = octos_fleet::WorkerGrant {
+            tools: vec!["read_file".into(), "definitely_not_a_tool".into()],
+            ..octos_fleet::WorkerGrant::minimal()
+        };
+        let err = orchestrator
+            .model_grant_escalation(&wire, "tenant-a", "t1", Some(bad), now_ms_u64())
+            .await
+            .expect_err("an invalid grant must be rejected");
+        assert!(err.contains("invalid grant"), "unexpected error: {err}");
+        // Nothing applied — the task is STILL Blocked with its request intact.
+        let child = store.get_child(&fleet_id, "t1").await.unwrap().unwrap();
+        assert_eq!(child.status, octos_fleet::ChildStatus::Blocked);
+        assert!(child.pending_escalation.is_some());
+    }
+
+    /// `goal_deny` moves the blocked task `Blocked → Failed` (terminal), so the
+    /// fleet no longer wedges on it.
+    #[tokio::test]
+    async fn goal_deny_fails_the_task() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let (_sd, store) = fleet_test_store().await;
+        orchestrator.set_fleet_store(store.clone());
+        let work = tempfile::TempDir::new().unwrap();
+
+        let wire = SessionKey::new("api", "keeper-deny");
+        let fleet_id = seed_planned_goal(&orchestrator, &wire, work.path()).await;
+        block_task_on_escalation(&store, &fleet_id, "t1").await;
+
+        let out = orchestrator
+            .model_deny_escalation(
+                &wire,
+                "tenant-a",
+                "t1",
+                "no budget for that host",
+                now_ms_u64(),
+            )
+            .await
+            .expect("deny");
+        assert_eq!(out["status"], json!("denied"), "denied: {out}");
+        let child = store.get_child(&fleet_id, "t1").await.unwrap().unwrap();
+        assert_eq!(
+            child.status,
+            octos_fleet::ChildStatus::Failed,
+            "denial is terminal — the fleet cannot wedge on a Blocked child",
+        );
+        assert!(child.pending_escalation.is_none());
+        assert!(child.status.is_terminal());
+
+        // codex round-3 (defect 2): the goal must reach a TERMINAL state, not stay
+        // perpetually `active`. The deny path now drives this EAGERLY — the goal is
+        // `blocked` IMMEDIATELY after the deny, with NO goal_get needed.
+        assert_eq!(
+            orchestrator.goal_status_for_test(&wire).as_deref(),
+            Some("blocked"),
+            "the deny path drives the goal terminal eagerly (no goal_get needed)",
+        );
+        // The goal_get snapshot remains a correct BACKSTOP: it re-detects the
+        // un-completable fleet (idempotent) and still surfaces the failed task.
+        let snap = orchestrator
+            .model_fleet_snapshot(&wire, "tenant-a")
+            .await
+            .expect("snapshot")
+            .expect("present");
+        assert_eq!(
+            snap["un_completable"],
+            json!(true),
+            "snapshot flags the un-completable fleet: {snap}",
+        );
+        assert_eq!(snap["complete"], json!(false));
+        assert_eq!(
+            snap["failed_tasks"],
+            json!(["t1"]),
+            "the failed task is surfaced",
+        );
+        assert_eq!(
+            orchestrator.goal_status_for_test(&wire).as_deref(),
+            Some("blocked"),
+            "a denied task must drive the goal to a terminal state, never perpetual active",
+        );
+    }
+
+    /// codex round-3 (defect 2): a `goal_deny` must drive the goal to a TERMINAL
+    /// state IMMEDIATELY — the deny path itself detects the now-un-completable
+    /// fleet and transitions the goal `blocked`, with NO `goal_get` call. Without
+    /// this, a keeper that ends its wake without reading `goal_get` leaves the
+    /// goal perpetually `active` and the failed prerequisite strands its
+    /// dependents `Planned` forever.
+    #[tokio::test]
+    async fn deny_drives_goal_terminal_without_goal_get() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let (_sd, store) = fleet_test_store().await;
+        orchestrator.set_fleet_store(store.clone());
+        let work = tempfile::TempDir::new().unwrap();
+
+        let wire = SessionKey::new("api", "keeper-deny-eager");
+        let fleet_id = seed_planned_goal(&orchestrator, &wire, work.path()).await;
+        block_task_on_escalation(&store, &fleet_id, "t1").await;
+        assert_eq!(
+            orchestrator.goal_status_for_test(&wire).as_deref(),
+            Some("active"),
+            "the goal is active while its task is Blocked on an escalation",
+        );
+
+        orchestrator
+            .model_deny_escalation(
+                &wire,
+                "tenant-a",
+                "t1",
+                "no budget for that host",
+                now_ms_u64(),
+            )
+            .await
+            .expect("deny");
+
+        // The goal is ALREADY terminal — WITHOUT any goal_get / model_fleet_snapshot
+        // call. The deny path drove it eagerly.
+        assert_eq!(
+            orchestrator.goal_status_for_test(&wire).as_deref(),
+            Some("blocked"),
+            "deny must drive the goal terminal eagerly — no goal_get needed to resolve it",
+        );
+    }
+
+    /// codex round-4 (defect 2): the goal-terminal transition is driven by the
+    /// DURABLE deny's OWN returned completability (computed inside the deny
+    /// write-txn), NOT a separate `fleet.view()`/`is_complete` after the deny. So
+    /// a denied task ALWAYS resolves the goal — a post-deny read that got
+    /// cancelled or errored can no longer skip the transition. A two-task plan (a
+    /// dependent stranded by the failure) exercises the real completability path
+    /// end-to-end; the goal is `blocked` from the deny alone, no follow-up read.
+    #[tokio::test]
+    async fn deny_resolves_goal_even_if_view_would_fail() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let (_sd, store) = fleet_test_store().await;
+        orchestrator.set_fleet_store(store.clone());
+        let work = tempfile::TempDir::new().unwrap();
+
+        let wire = SessionKey::new("api", "keeper-deny-durable");
+        // Plan a two-task fleet: `b` depends on `a`. `a` escalates then is denied,
+        // stranding `b` — so the fleet is un-completable and the deny txn's scan
+        // over BOTH children returns that.
+        seed_goal(&orchestrator, &wire, "tenant-a");
+        let scoped = orchestrator.scoped_goal_key(&wire);
+        orchestrator
+            .set_goal_workspace_root(&scoped, Some(work.path().to_string_lossy().into_owned()));
+        let tasks = vec![
+            TaskSpec {
+                task_id: "a".into(),
+                title: "first".into(),
+                detail: String::new(),
+                deps: vec![],
+                acceptance: vec![],
+                grant: octos_fleet::WorkerGrant::minimal(),
+            },
+            TaskSpec {
+                task_id: "b".into(),
+                title: "second".into(),
+                detail: String::new(),
+                deps: vec!["a".into()],
+                acceptance: vec![],
+                grant: octos_fleet::WorkerGrant::minimal(),
+            },
+        ];
+        let plan = orchestrator
+            .model_create_fleet_plan(&wire, "tenant-a", tasks, 1_000)
+            .await
+            .expect("plan");
+        let fleet_id = plan["fleet_id"].as_str().unwrap().to_owned();
+
+        block_task_on_escalation(&store, &fleet_id, "a").await;
+        assert_eq!(
+            orchestrator.goal_status_for_test(&wire).as_deref(),
+            Some("active"),
+        );
+
+        // Deny `a`. The goal must resolve to `blocked` from the deny's returned
+        // completability alone — the deny path calls NO fleet.view(), so no
+        // fallible post-deny read stands between the durable failure and the
+        // goal-terminal transition.
+        orchestrator
+            .model_deny_escalation(&wire, "tenant-a", "a", "no budget", now_ms_u64())
+            .await
+            .expect("deny");
+
+        assert_eq!(
+            orchestrator.goal_status_for_test(&wire).as_deref(),
+            Some("blocked"),
+            "deny resolves the goal from the durable returned completability, not a post-hoc view",
+        );
+    }
+
+    /// Fix 2 backstop: a task that failed NORMALLY (acceptance rejected via
+    /// `complete_child`, not a deny) and is reached via the keeper's `goal_get`
+    /// snapshot ALSO resolves the goal. The shared un-completable rule keys off
+    /// `status == Failed` regardless of HOW the task failed — so the refactor that
+    /// extracted the eager deny driver did not break the snapshot backstop.
+    #[tokio::test]
+    async fn normally_failed_task_resolves_goal_via_snapshot_backstop() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let (_sd, store) = fleet_test_store().await;
+        orchestrator.set_fleet_store(store.clone());
+        let work = tempfile::TempDir::new().unwrap();
+
+        let wire = SessionKey::new("api", "keeper-normalfail");
+        let fleet_id = seed_planned_goal(&orchestrator, &wire, work.path()).await;
+
+        // Fail t1 the NORMAL way: launch → run → complete with a Rejected verdict
+        // (an acceptance failure), so the child ends terminally `Failed` WITHOUT
+        // any escalation/deny.
+        let attempt = match store
+            .launch_child(&fleet_id, "t1", 100, now_ms_u64(), 1, 60_000)
+            .await
+            .unwrap()
+        {
+            LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("launch t1: {other:?}"),
+        };
+        store.mark_running("t1", &attempt).await.unwrap();
+        let settled = store
+            .complete_child(
+                &fleet_id,
+                "t1",
+                &attempt,
+                AcceptanceVerdict::Rejected {
+                    reason: "acceptance failed".into(),
+                },
+                octos_fleet::ChildResultSnapshot::default(),
+                50,
+                1,
+                now_ms_u64(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(settled, CompleteOutcome::Completed);
+        assert_eq!(
+            store
+                .get_child(&fleet_id, "t1")
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            octos_fleet::ChildStatus::Failed,
+        );
+
+        // The goal is still `active` (a normal completion emits a ChildDone wake
+        // but does not itself touch the goal). The keeper's goal_get snapshot is
+        // the BACKSTOP that resolves it.
+        assert_eq!(
+            orchestrator.goal_status_for_test(&wire).as_deref(),
+            Some("active"),
+        );
+        let snap = orchestrator
+            .model_fleet_snapshot(&wire, "tenant-a")
+            .await
+            .expect("snapshot")
+            .expect("present");
+        assert_eq!(snap["un_completable"], json!(true), "snapshot: {snap}");
+        assert_eq!(snap["failed_tasks"], json!(["t1"]));
+        assert_eq!(
+            orchestrator.goal_status_for_test(&wire).as_deref(),
+            Some("blocked"),
+            "a normally-failed task must resolve the goal via the snapshot backstop",
+        );
+    }
+
+    /// codex round-2 (defect 4) — grant and deny are MUTUALLY EXCLUSIVE at the
+    /// orchestrator: once a task is denied (Failed), a grant is refused (the
+    /// out-of-txn `Blocked` check AND the in-txn CAS both reject it).
+    #[tokio::test]
+    async fn grant_after_deny_is_rejected() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let (_sd, store) = fleet_test_store().await;
+        orchestrator.set_fleet_store(store.clone());
+        let work = tempfile::TempDir::new().unwrap();
+
+        let wire = SessionKey::new("api", "keeper-grantdeny");
+        let fleet_id = seed_planned_goal(&orchestrator, &wire, work.path()).await;
+        block_task_on_escalation(&store, &fleet_id, "t1").await;
+
+        // Deny wins.
+        orchestrator
+            .model_deny_escalation(&wire, "tenant-a", "t1", "no", now_ms_u64())
+            .await
+            .expect("deny");
+
+        // A grant afterwards must be refused — the task is no longer Blocked.
+        let err = orchestrator
+            .model_grant_escalation(&wire, "tenant-a", "t1", None, now_ms_u64())
+            .await
+            .expect_err("grant after deny must be rejected");
+        assert!(
+            err.contains("not Blocked"),
+            "unexpected grant-after-deny error: {err}",
+        );
+        // The denied task keeps its minimal grant (the request was never applied).
+        let plan = store.get_plan(&fleet_id).await.unwrap().unwrap();
+        let t1 = plan.tasks.iter().find(|t| t.task_id == "t1").unwrap();
+        assert_eq!(t1.grant, octos_fleet::WorkerGrant::minimal());
+    }
+
+    /// The ownership gate covers BOTH new tools: a stale/foreign `goal.fleet_id`
+    /// binding is refused by grant AND deny before any mutation.
+    #[tokio::test]
+    async fn grant_escalation_requires_ownership() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let (_sd, store) = fleet_test_store().await;
+        orchestrator.set_fleet_store(store.clone());
+        let store = Arc::new(store);
+
+        let wire = SessionKey::new("api", "keeper-ownership");
+        seed_goal(&orchestrator, &wire, "tenant-a");
+
+        // A fleet owned by a DIFFERENT controller, that goal.fleet_id is then
+        // (corruptly) pointed at.
+        Fleet::create(
+            store.clone(),
+            "foreign-escalate",
+            SessionKey::new("api", "other-controller"),
+            Some("/repos/other".to_owned()),
+            "tenant-a",
+            FleetBudget {
+                token_budget: 1_000_000,
+                tokens_reserved: 0,
+                tokens_committed: 0,
+                hard: false,
+            },
+            "not this goal's work",
+            plan_tasks(),
+            1,
+        )
+        .await
+        .expect("create foreign fleet");
+        orchestrator.set_goal_fleet_id_for_test(&wire, "foreign-escalate");
+
+        // grant must refuse before touching the plan.
+        let grant_err = orchestrator
+            .model_grant_escalation(&wire, "tenant-a", "t1", None, now_ms_u64())
+            .await
+            .expect_err("grant must refuse a foreign fleet binding");
+        assert!(
+            grant_err.contains("does not belong to this goal"),
+            "unexpected grant error: {grant_err}",
+        );
+        // deny must refuse too.
+        let deny_err = orchestrator
+            .model_deny_escalation(&wire, "tenant-a", "t1", "x", now_ms_u64())
+            .await
+            .expect_err("deny must refuse a foreign fleet binding");
+        assert!(
+            deny_err.contains("does not belong to this goal"),
+            "unexpected deny error: {deny_err}",
+        );
+        // The foreign fleet's task is untouched (never failed, never granted).
+        let child = store
+            .get_child("foreign-escalate", "t1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(child.status, octos_fleet::ChildStatus::Ready);
+    }
+
+    /// `goal_get`'s fleet snapshot surfaces a pending escalation (Blocked status
+    /// + reason + advisory requested grant) so the keeper notices and decides.
+    #[tokio::test]
+    async fn goal_get_surfaces_pending_escalation() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let (_sd, store) = fleet_test_store().await;
+        orchestrator.set_fleet_store(store.clone());
+        let work = tempfile::TempDir::new().unwrap();
+
+        let wire = SessionKey::new("api", "keeper-surface");
+        let fleet_id = seed_planned_goal(&orchestrator, &wire, work.path()).await;
+        block_task_on_escalation(&store, &fleet_id, "t1").await;
+
+        let snap = orchestrator
+            .model_fleet_snapshot(&wire, "tenant-a")
+            .await
+            .expect("snapshot must not error for an owned fleet")
+            .expect("fleet snapshot present");
+        // Not complete while blocked; the counts show the blocked child.
+        assert_eq!(snap["complete"], json!(false));
+        assert_eq!(
+            snap["counts"]["blocked"],
+            json!(1),
+            "counts show blocked: {snap}"
+        );
+
+        let t1 = snap["tasks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|t| t["task_id"] == json!("t1"))
+            .expect("t1 in snapshot");
+        assert_eq!(t1["status"], json!("Blocked"));
+        let esc = &t1["pending_escalation"];
+        assert_eq!(esc["reason"], json!("needs example.com"), "surfaced: {t1}");
+        assert_eq!(esc["requested_grant"]["network"]["mode"], json!("hosts"));
+        assert!(
+            esc["decision_needed"].is_string(),
+            "the keeper is told which decision to make: {esc}",
+        );
+        // The goal stays active while the task is blocked on the operator.
+        assert_eq!(
+            orchestrator.goal_status_for_test(&wire).as_deref(),
+            Some("active"),
         );
     }
 

--- a/crates/octos-cli/src/goal_tool.rs
+++ b/crates/octos-cli/src/goal_tool.rs
@@ -128,7 +128,10 @@ fn parse_task_specs(args: &Value) -> Result<Vec<TaskSpec>, String> {
 /// Wire shape:
 /// `{ "network": { "mode": "none"|"hosts"|"full", "hosts": ["example.com"] },
 ///    "tools": ["read_file", ..., "web_fetch"],
-///    "fs": { "read": ["/data/in"], "write": ["/data/out"] } }`
+///    "fs": "workspace"|"host" }`
+///
+/// `fs` is the coarse binary scope (v1 has no per-path allowlist — see
+/// [`parse_fs`]), NOT a `{read, write}` path object.
 fn parse_grant(value: Option<&Value>, task_id: &str) -> Result<WorkerGrant, String> {
     let value = match value {
         None | Some(Value::Null) => return Ok(WorkerGrant::minimal()),
@@ -269,7 +272,10 @@ impl Tool for GoalGetTool {
          goal_plan), also returns a `fleet` object with the objective, per-task \
          title/status/verdict, the ready set, and status counts — call this after a \
          fleet-completion wake to see progress and, when every task is accepted, the goal \
-         auto-transitions to complete. Returns status=none when no goal is set."
+         auto-transitions to complete. A task with status `Blocked` and a `pending_escalation` \
+         (a worker's `reason` + advisory `requested_grant`) is waiting on YOUR operator decision: \
+         call goal_grant (widen its grant + resume it) or goal_deny (fail it). Returns status=none \
+         when no goal is set."
     }
 
     fn input_schema(&self) -> Value {
@@ -513,7 +519,9 @@ impl Tool for GoalDispatchTool {
          Each launched task runs to completion in the background and wakes this goal when it \
          finishes, so the loop is: goal_dispatch → (workers run) → wake → goal_get to see \
          progress → goal_dispatch again for the newly-ready tasks, until goal_get reports all \
-         tasks accepted. Safe to call repeatedly — already-running tasks are not relaunched."
+         tasks accepted. Safe to call repeatedly — already-running tasks are not relaunched. If a \
+         woken task is `Blocked` on a `pending_escalation`, resolve it with goal_grant or goal_deny \
+         (not goal_dispatch) before it can run again."
     }
 
     fn input_schema(&self) -> Value {
@@ -550,6 +558,237 @@ impl Tool for GoalDispatchTool {
             }),
             Err(message) => Ok(ToolResult {
                 output: format!("goal_dispatch: {message}"),
+                success: false,
+                ..Default::default()
+            }),
+        }
+    }
+}
+
+/// PR B — `goal_grant`: APPROVE a worker's mid-task escalation, widen the task's
+/// grant, and resume it.
+pub struct GoalGrantTool {
+    profile_id: String,
+}
+
+impl GoalGrantTool {
+    pub fn new(profile_id: impl Into<String>) -> Self {
+        Self {
+            profile_id: profile_id.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for GoalGrantTool {
+    fn name(&self) -> &str {
+        "goal_grant"
+    }
+
+    fn description(&self) -> &str {
+        "APPROVE a fleet worker's mid-task escalation: widen the blocked task's operator grant \
+         and resume it (a fresh attempt re-runs with the new capability; its scratch dir \
+         persists). Use when goal_get shows a task with status `Blocked` and a `pending_escalation` \
+         — read the worker's `reason` and its advisory `requested_grant`, then decide. Pass the \
+         `task_id`. Omit `grant` to approve the worker's requested grant as-is, OR pass a `grant` \
+         (same shape as goal_plan's task grant) to grant LESS — you are the operator and may narrow \
+         what it asked for (e.g. a tighter host allowlist). The grant is validated exactly as at \
+         plan time. To refuse instead, use goal_deny."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "The Blocked task whose escalation you are approving."
+                },
+                "grant": {
+                    "type": "object",
+                    "description": "Optional operator grant to apply (same shape as goal_plan's task grant: network/tools/fs). Omit to approve the worker's requested grant as-is; provide to grant LESS.",
+                    "properties": {
+                        "network": {
+                            "type": "object",
+                            "properties": {
+                                "mode": { "type": "string", "enum": ["none", "hosts", "full"] },
+                                "hosts": { "type": "array", "items": { "type": "string" } }
+                            },
+                            "additionalProperties": false
+                        },
+                        "tools": { "type": "array", "items": { "type": "string" } },
+                        "fs": { "type": "string", "enum": ["workspace", "host"] }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "required": ["task_id"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, args: &Value) -> Result<ToolResult> {
+        self.execute_with_context(&ToolContext::zero(), args).await
+    }
+
+    async fn execute_with_context(&self, ctx: &ToolContext, args: &Value) -> Result<ToolResult> {
+        let Some(session_id) = session_from_ctx(ctx) else {
+            return Ok(ToolResult {
+                output: "goal_grant: no session context for this turn".into(),
+                success: false,
+                ..Default::default()
+            });
+        };
+        let Some(task_id) = args
+            .get("task_id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        else {
+            return Ok(ToolResult {
+                output: "goal_grant: `task_id` is required".into(),
+                success: false,
+                ..Default::default()
+            });
+        };
+        // Absent/null grant → approve as-requested (None); a supplied grant is
+        // parsed + validated exactly like a plan-time grant.
+        let grant = match args.get("grant") {
+            None | Some(Value::Null) => None,
+            Some(value) => match parse_grant(Some(value), task_id) {
+                Ok(grant) => Some(grant),
+                Err(message) => {
+                    return Ok(ToolResult {
+                        output: format!("goal_grant: {message}"),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            },
+        };
+        match default_agent_orchestrator()
+            .model_grant_escalation(
+                &session_id,
+                &self.profile_id,
+                task_id,
+                grant,
+                fleet_now_ms(),
+            )
+            .await
+        {
+            Ok(outcome) => Ok(ToolResult {
+                output: format!(
+                    "goal_grant:\n{}",
+                    serde_json::to_string_pretty(&outcome).unwrap_or_else(|_| outcome.to_string())
+                ),
+                success: true,
+                ..Default::default()
+            }),
+            Err(message) => Ok(ToolResult {
+                output: format!("goal_grant: {message}"),
+                success: false,
+                ..Default::default()
+            }),
+        }
+    }
+}
+
+/// PR B — `goal_deny`: REFUSE a worker's mid-task escalation, failing the task.
+pub struct GoalDenyTool {
+    profile_id: String,
+}
+
+impl GoalDenyTool {
+    pub fn new(profile_id: impl Into<String>) -> Self {
+        Self {
+            profile_id: profile_id.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for GoalDenyTool {
+    fn name(&self) -> &str {
+        "goal_deny"
+    }
+
+    fn description(&self) -> &str {
+        "REFUSE a fleet worker's mid-task escalation: the blocked task cannot proceed without a \
+         capability you are not willing to grant, so FAIL it (terminal). Use when goal_get shows a \
+         Blocked task with a `pending_escalation` you decide not to approve. Pass the `task_id` and \
+         a short `reason`. This is terminal — the task will not re-run; the fleet then completes \
+         around it (a Blocked task left undecided would wedge the goal forever, so decide every \
+         escalation with either goal_grant or goal_deny). To approve instead, use goal_grant."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "The Blocked task whose escalation you are refusing."
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "One-line reason for refusing (recorded on the failed task)."
+                }
+            },
+            "required": ["task_id"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, args: &Value) -> Result<ToolResult> {
+        self.execute_with_context(&ToolContext::zero(), args).await
+    }
+
+    async fn execute_with_context(&self, ctx: &ToolContext, args: &Value) -> Result<ToolResult> {
+        let Some(session_id) = session_from_ctx(ctx) else {
+            return Ok(ToolResult {
+                output: "goal_deny: no session context for this turn".into(),
+                success: false,
+                ..Default::default()
+            });
+        };
+        let Some(task_id) = args
+            .get("task_id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        else {
+            return Ok(ToolResult {
+                output: "goal_deny: `task_id` is required".into(),
+                success: false,
+                ..Default::default()
+            });
+        };
+        let reason = args
+            .get("reason")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or("escalation refused by the operator");
+        match default_agent_orchestrator()
+            .model_deny_escalation(
+                &session_id,
+                &self.profile_id,
+                task_id,
+                reason,
+                fleet_now_ms(),
+            )
+            .await
+        {
+            Ok(outcome) => Ok(ToolResult {
+                output: format!(
+                    "goal_deny:\n{}",
+                    serde_json::to_string_pretty(&outcome).unwrap_or_else(|_| outcome.to_string())
+                ),
+                success: true,
+                ..Default::default()
+            }),
+            Err(message) => Ok(ToolResult {
+                output: format!("goal_deny: {message}"),
                 success: false,
                 ..Default::default()
             }),

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -1013,6 +1013,12 @@ impl ProfileRuntime {
             // (above) folds in the fleet plan view + self-detects completion.
             tools.register(crate::goal_tool::GoalPlanTool::new(profile.id.clone()));
             tools.register(crate::goal_tool::GoalDispatchTool::new(profile.id.clone()));
+            // PR B — the keeper's escalation controls: approve a worker's
+            // mid-task grant-widen request (`goal_grant`, resumes the task) or
+            // refuse it (`goal_deny`, fails the task). A Blocked task surfaced by
+            // goal_get needs exactly one of these.
+            tools.register(crate::goal_tool::GoalGrantTool::new(profile.id.clone()));
+            tools.register(crate::goal_tool::GoalDenyTool::new(profile.id.clone()));
         }
 
         // Step 17: re-apply tool policy AFTER plugin / memory-bank

--- a/crates/octos-fleet-worker/Cargo.toml
+++ b/crates/octos-fleet-worker/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 description = "Closed, non-interactive fleet task worker: audited replay-safe tool registry + bounded pool over the fleet kernel store"
 
 [dependencies]
+async-trait.workspace = true
 eyre.workspace = true
 octos-agent.workspace = true
 octos-core.workspace = true
@@ -18,7 +19,6 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-async-trait.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 

--- a/crates/octos-fleet-worker/src/closed_registry.rs
+++ b/crates/octos-fleet-worker/src/closed_registry.rs
@@ -32,6 +32,8 @@ use octos_agent::tools::{
 };
 use octos_fleet::WorkerGrant;
 
+use crate::escalate::{EscalateTool, EscalationSlot};
+
 /// The base tool set a *minimal* (least-privilege) worker holds — today's
 /// closed seven. Kept as a named constant for docs / discriminator tests;
 /// equals [`octos_fleet::BASE_TOOLS`] and `WorkerGrant::minimal().tools`. The
@@ -91,6 +93,7 @@ pub fn build_fleet_worker_registry(
     sandbox: Arc<dyn Sandbox>,
     max_shell_timeout_secs: u64,
     grant: &WorkerGrant,
+    escalation: EscalationSlot,
 ) -> Result<ToolRegistry> {
     // Reject an incoherent grant up front (unknown tool / web tool with no
     // network) — validated at parse time too, so this is defense-in-depth: an
@@ -184,14 +187,25 @@ pub fn build_fleet_worker_registry(
         }
     }
 
-    // Belt-and-suspenders: hard-remove anything not in the granted allow-set.
-    // A no-op today (we registered exactly the grant and nothing auto-swaps),
-    // but it locks the invariant so a future edit that registers an extra tool
-    // cannot silently widen the worker's reach — `apply_policy` -> `retain` is a
-    // real removal. `ToolPolicy.allow` empty = allow-all, which only happens for
-    // an (unusual) empty grant that registered nothing, so it is still bounded.
+    // PR B — the always-on `escalate` safety valve. Registered UNCONDITIONALLY,
+    // AFTER the grant loop, and NOT grant-gated: even a minimal-grant worker must
+    // be able to ASK for more capability when a task hits the edge of its grant.
+    // It only RECORDS a request (into the shared slot) and returns — it never
+    // parks (`blocks_on_human_input == false`) and never self-widens the grant
+    // (only the keeper's `goal_grant` mutates `PlanTask.grant`).
+    r.register(EscalateTool::new(escalation));
+
+    // Belt-and-suspenders: hard-remove anything not in the granted allow-set
+    // PLUS the always-on `escalate` valve. A no-op today (we registered exactly
+    // the grant + escalate and nothing auto-swaps), but it locks the invariant so
+    // a future edit that registers an extra tool cannot silently widen the
+    // worker's reach — `apply_policy` -> `retain` is a real removal. The allow
+    // list is never empty here (it always contains `escalate`), so it can never
+    // collapse into the empty=allow-all case.
+    let mut allow = grant.tools.clone();
+    allow.push("escalate".to_string());
     r.apply_policy(&ToolPolicy {
-        allow: grant.tools.clone(),
+        allow,
         ..Default::default()
     });
     Ok(r)
@@ -204,7 +218,22 @@ mod tests {
     use octos_fleet::{FsGrant, NetworkGrant};
     use std::collections::HashSet;
     use std::path::Path;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
+
+    /// A fresh, empty escalation slot for a test build.
+    fn slot() -> EscalationSlot {
+        Arc::new(Mutex::new(None))
+    }
+
+    /// The audit key for a worker registry: the granted tools PLUS the always-on
+    /// `escalate` valve, deduped + sorted.
+    fn sorted_with_escalate(grant: &WorkerGrant) -> Vec<String> {
+        let mut names = grant.sorted_tools();
+        names.push("escalate".to_string());
+        names.sort();
+        names.dedup();
+        names
+    }
 
     /// Tools that must NEVER appear in a closed worker registry. This is a
     /// supplementary explicit denylist; the exhaustive `tool_names() ==
@@ -279,23 +308,34 @@ mod tests {
             Arc::new(NoSandbox),
             30,
             &grant,
+            slot(),
         )
         .expect("minimal grant builds");
 
-        // EXHAUSTIVE: the registry contains EXACTLY the granted tools.
+        // EXHAUSTIVE: the registry contains EXACTLY the granted tools PLUS the
+        // always-on `escalate` valve (PR B) — nothing more.
         let mut names = reg.tool_names();
         names.sort();
         assert_eq!(
             names,
-            grant.sorted_tools(),
-            "a minimal-grant worker holds exactly the base replay-safe tools",
+            sorted_with_escalate(&grant),
+            "a minimal-grant worker holds exactly the base replay-safe tools + escalate",
         );
-        // And that set is the old closed seven.
+        // And the GRANTED subset is the old closed seven (escalate is separate).
         assert_eq!(grant.sorted_tools(), {
             let mut v: Vec<String> = ALLOWED.iter().map(|s| s.to_string()).collect();
             v.sort();
             v
         });
+        // The escalate valve is present, LLM-visible, and never parks.
+        assert!(
+            reg.get("escalate").is_some(),
+            "escalate is always available"
+        );
+        assert!(
+            !reg.blocks_on_human_input("escalate"),
+            "escalate must NOT block on human input — it records and returns",
+        );
 
         let spec_names: HashSet<String> = reg.specs().into_iter().map(|s| s.name).collect();
 
@@ -336,6 +376,41 @@ mod tests {
     }
 
     #[test]
+    fn escalate_tool_is_always_available_even_at_minimal_grant() {
+        // PR B — the safety valve is NOT grant-gated: even the least-privilege
+        // worker holds `escalate`, and the audit key is `sorted_tools() +
+        // escalate`. A grant that names NO extra tools still gets the valve.
+        for grant in [
+            WorkerGrant::minimal(),
+            WorkerGrant {
+                tools: vec!["read_file".into()],
+                ..WorkerGrant::minimal()
+            },
+        ] {
+            let reg = build_fleet_worker_registry(
+                Path::new("/tmp/fleet-escalate-valve"),
+                Arc::new(NoSandbox),
+                30,
+                &grant,
+                slot(),
+            )
+            .expect("grant builds");
+            assert!(
+                reg.get("escalate").is_some(),
+                "escalate must exist for grant {:?}",
+                grant.tools,
+            );
+            let mut names = reg.tool_names();
+            names.sort();
+            assert_eq!(
+                names,
+                sorted_with_escalate(&grant),
+                "audit = granted tools + escalate",
+            );
+        }
+    }
+
+    #[test]
     fn grant_expands_tools_and_scopes() {
         // A master grants +web_fetch (under a Hosts network) and Host fs → the
         // registry gains web_fetch and the native file tools' EffectivePermissions
@@ -353,13 +428,17 @@ mod tests {
             },
             fs: FsGrant::Host,
         };
-        let reg = build_fleet_worker_registry(cwd, Arc::new(NoSandbox), 30, &grant)
+        let reg = build_fleet_worker_registry(cwd, Arc::new(NoSandbox), 30, &grant, slot())
             .expect("expanded grant builds");
 
         assert!(reg.get("web_fetch").is_some(), "granted web_fetch present");
         let mut names = reg.tool_names();
         names.sort();
-        assert_eq!(names, grant.sorted_tools(), "exactly the granted set");
+        assert_eq!(
+            names,
+            sorted_with_escalate(&grant),
+            "exactly the granted set + escalate",
+        );
 
         // The Host fs grant widens native tools to Host scope.
         assert_eq!(
@@ -390,6 +469,7 @@ mod tests {
             Arc::new(NoSandbox),
             30,
             &grant,
+            slot(),
         )
         .expect("hosts grant builds");
         assert!(reg.get("web_fetch").is_some());
@@ -418,6 +498,7 @@ mod tests {
             Arc::new(NoSandbox),
             30,
             &grant,
+            slot(),
         )
         .expect("full grant builds");
         assert!(reg.get("web_fetch").is_some());
@@ -444,6 +525,7 @@ mod tests {
             Arc::new(NoSandbox),
             30,
             &grant,
+            slot(),
         );
         let err = result
             .err()
@@ -466,6 +548,7 @@ mod tests {
             Arc::new(NoSandbox),
             30,
             &WorkerGrant::minimal(),
+            slot(),
         )
         .expect("minimal grant builds");
         let shell = reg.get("shell").expect("shell tool present");

--- a/crates/octos-fleet-worker/src/escalate.rs
+++ b/crates/octos-fleet-worker/src/escalate.rs
@@ -1,0 +1,283 @@
+//! The always-on `escalate` safety valve (PR B).
+//!
+//! A closed fleet worker is provisioned with a least-privilege
+//! [`octos_fleet::WorkerGrant`]. When a task genuinely needs a capability it was
+//! NOT granted — a host, a tool, host filesystem — the worker cannot self-widen
+//! (only the keeper's `goal_grant` mutates the grant). Instead it calls
+//! `escalate`: a fire-and-**return** tool that RECORDS a
+//! [`octos_fleet::EscalationRequest`] into a shared slot and returns
+//! immediately. It does NOT block on input (the closed worker has no human to
+//! ask and can never park) — the contrast with the FORBIDDEN
+//! `ask_user_question`/`peer_handoff`. After the turn, [`crate::run_attempt`]
+//! reads the slot and, if set, settles the attempt NON-terminally
+//! (`record_escalation` → child `Blocked`), yielding it to the keeper.
+//!
+//! The tool is **always registered** (never grant-gated): the safety valve must
+//! exist even for a minimal-grant worker, so a task that hits the edge of ANY
+//! grant can ask. The requested grant is **advisory** — the tool records what
+//! the model asked for; the keeper decides the actual grant.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use eyre::Result;
+use octos_agent::tools::{Tool, ToolResult};
+use octos_fleet::{EscalationRequest, FsGrant, NetworkGrant, WorkerGrant};
+use serde_json::{Value, json};
+
+/// The shared one-shot signal the [`EscalateTool`] writes into. `run_attempt`
+/// creates one per attempt, threads a clone into the tool at build time, and
+/// reads it AFTER the agent turn returns — so the recorded escalation wins
+/// deterministically regardless of how the turn ended (EndTurn / deadline /
+/// budget). `std::sync::Mutex` (not tokio) because the tool's `execute` writes
+/// it synchronously and `run_attempt` reads it outside any await.
+pub type EscalationSlot = Arc<Mutex<Option<EscalationRequest>>>;
+
+/// The `escalate` tool: record a mid-task request for a wider grant + yield.
+pub struct EscalateTool {
+    slot: EscalationSlot,
+}
+
+impl EscalateTool {
+    pub fn new(slot: EscalationSlot) -> Self {
+        Self { slot }
+    }
+}
+
+#[async_trait]
+impl Tool for EscalateTool {
+    fn name(&self) -> &str {
+        "escalate"
+    }
+
+    fn description(&self) -> &str {
+        "Request MORE capability from the master (operator) when THIS task cannot proceed with \
+         the capabilities you were granted — a host you cannot reach, a tool you do not hold, or \
+         filesystem access you lack. This RECORDS your request and YIELDS: your attempt stops, \
+         the master reviews it, and if approved the task RE-RUNS from scratch with the widened \
+         grant (your scratch dir persists). You canNOT widen your own grant — only the master \
+         can. Give a specific `reason` (what you tried, exactly what capability you need and \
+         why). Optionally describe the `requested_grant` you'd need (advisory — the master \
+         decides the actual grant and may grant less). Use this ONLY when you are genuinely \
+         blocked on a missing capability, not for ordinary difficulty."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "type": "string",
+                    "description": "Why you are blocked: what you attempted and exactly which capability you need."
+                },
+                "requested_grant": {
+                    "type": "object",
+                    "description": "Optional advisory grant you believe you need (same shape as goal_plan's task grant). The master decides the actual grant and may grant less.",
+                    "properties": {
+                        "network": {
+                            "type": "object",
+                            "properties": {
+                                "mode": {
+                                    "type": "string",
+                                    "enum": ["none", "hosts", "full"]
+                                },
+                                "hosts": {
+                                    "type": "array",
+                                    "items": { "type": "string" }
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "tools": {
+                            "type": "array",
+                            "items": { "type": "string" }
+                        },
+                        "fs": {
+                            "type": "string",
+                            "enum": ["workspace", "host"]
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "required": ["reason"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, args: &Value) -> Result<ToolResult> {
+        let reason = args
+            .get("reason")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .unwrap_or_default()
+            .to_string();
+        if reason.is_empty() {
+            return Ok(ToolResult {
+                output: "escalate: `reason` is required — describe what you tried and exactly \
+                         which capability you need."
+                    .to_string(),
+                success: false,
+                ..Default::default()
+            });
+        }
+        let requested_grant = parse_requested_grant(args.get("requested_grant"));
+        // Record into the shared slot; last write wins. `run_attempt` reads this
+        // AFTER the turn and settles the attempt escalated (record_escalation),
+        // so the escalation wins no matter how the turn ends (determinism).
+        *self.slot.lock().unwrap_or_else(|e| e.into_inner()) = Some(EscalationRequest {
+            requested_grant,
+            reason,
+        });
+        Ok(ToolResult {
+            output: "escalation recorded. Your attempt will yield to the master (operator) for a \
+                     grant decision; if approved, this task re-runs with the widened capability. \
+                     You do not need to do anything else."
+                .to_string(),
+            success: true,
+            ..Default::default()
+        })
+    }
+}
+
+/// Parse the ADVISORY `requested_grant` wire object (same shape as goal_plan's
+/// task grant) into a [`WorkerGrant`], leniently. Unlike the plan-time parser
+/// this NEVER errors — the request only informs the keeper's decision, which
+/// re-validates the grant IT chooses. Missing / malformed fields fall back to
+/// least privilege so the recorded request is always coherent.
+fn parse_requested_grant(value: Option<&Value>) -> WorkerGrant {
+    let Some(obj) = value.and_then(Value::as_object) else {
+        return WorkerGrant::minimal();
+    };
+
+    let network = obj
+        .get("network")
+        .and_then(Value::as_object)
+        .map(|net| {
+            let mode = net
+                .get("mode")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .unwrap_or("none");
+            match mode {
+                "full" => NetworkGrant::Full,
+                "hosts" => {
+                    let hosts: Vec<String> = net
+                        .get("hosts")
+                        .and_then(Value::as_array)
+                        .map(|items| {
+                            items
+                                .iter()
+                                .filter_map(Value::as_str)
+                                .map(str::trim)
+                                .filter(|s| !s.is_empty())
+                                .map(str::to_owned)
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    // An empty allowlist is meaningless as a REQUEST; record it
+                    // as None (the keeper picks the real grant anyway).
+                    if hosts.is_empty() {
+                        NetworkGrant::None
+                    } else {
+                        NetworkGrant::Hosts(hosts)
+                    }
+                }
+                _ => NetworkGrant::None,
+            }
+        })
+        .unwrap_or_default();
+
+    let tools: Vec<String> = obj
+        .get("tools")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_owned)
+                .collect()
+        })
+        .filter(|t: &Vec<String>| !t.is_empty())
+        .unwrap_or_else(|| WorkerGrant::minimal().tools);
+
+    let fs = match obj.get("fs").and_then(Value::as_str).map(str::trim) {
+        Some("host") => FsGrant::Host,
+        _ => FsGrant::Workspace,
+    };
+
+    WorkerGrant { network, tools, fs }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slot() -> EscalationSlot {
+        Arc::new(Mutex::new(None))
+    }
+
+    #[tokio::test]
+    async fn escalate_records_request_into_the_slot_and_does_not_park() {
+        let slot = slot();
+        let tool = EscalateTool::new(slot.clone());
+        // The tool must NOT block on human input — a closed worker can never park.
+        assert!(!tool.blocks_on_human_input());
+
+        let out = tool
+            .execute(&json!({
+                "reason": "cannot reach example.com to fetch the report",
+                "requested_grant": {
+                    "network": { "mode": "hosts", "hosts": ["example.com"] },
+                    "tools": ["read_file", "web_fetch"]
+                }
+            }))
+            .await
+            .unwrap();
+        assert!(out.success, "escalate returns success (fire-and-return)");
+
+        let recorded = slot.lock().unwrap().clone().expect("slot set");
+        assert_eq!(
+            recorded.reason,
+            "cannot reach example.com to fetch the report"
+        );
+        assert_eq!(
+            recorded.requested_grant.network,
+            NetworkGrant::Hosts(vec!["example.com".into()]),
+        );
+        assert!(recorded.requested_grant.tools.contains(&"web_fetch".into()));
+    }
+
+    #[tokio::test]
+    async fn escalate_requires_a_reason() {
+        let slot = slot();
+        let tool = EscalateTool::new(slot.clone());
+        let out = tool.execute(&json!({})).await.unwrap();
+        assert!(!out.success, "a reason is required");
+        assert!(slot.lock().unwrap().is_none(), "no request recorded");
+    }
+
+    #[test]
+    fn parse_requested_grant_defaults_to_minimal_when_absent() {
+        assert_eq!(parse_requested_grant(None), WorkerGrant::minimal());
+        // A malformed grant never errors — it falls back to least privilege.
+        assert_eq!(
+            parse_requested_grant(Some(&json!("garbage"))),
+            WorkerGrant::minimal(),
+        );
+    }
+
+    #[test]
+    fn parse_requested_grant_reads_full_and_host() {
+        let g = parse_requested_grant(Some(&json!({
+            "network": { "mode": "full" },
+            "tools": ["shell", "web_search"],
+            "fs": "host"
+        })));
+        assert_eq!(g.network, NetworkGrant::Full);
+        assert_eq!(g.fs, FsGrant::Host);
+        assert_eq!(g.tools, vec!["shell".to_string(), "web_search".to_string()]);
+    }
+}

--- a/crates/octos-fleet-worker/src/lib.rs
+++ b/crates/octos-fleet-worker/src/lib.rs
@@ -43,6 +43,7 @@
 #![deny(unsafe_code)]
 
 mod closed_registry;
+mod escalate;
 mod pool;
 mod worker;
 
@@ -62,6 +63,7 @@ use octos_llm::LlmProvider;
 use octos_memory::EpisodeStore;
 
 pub use closed_registry::{ALLOWED, build_fleet_worker_registry};
+pub use escalate::{EscalateTool, EscalationSlot};
 pub use pool::{Dispatched, FleetWorkerPool, PoolConfig};
 pub use worker::{AttemptOutcome, run_attempt};
 
@@ -166,14 +168,20 @@ impl AgentFactory {
     ///
     /// Returns `Err` for an incoherent grant (unknown tool / web tool without a
     /// network grant) — validated at parse too, so this is defense-in-depth.
+    ///
+    /// `escalation` is the shared slot the always-on `escalate` valve writes
+    /// into; the agent path threads the attempt's real slot (which
+    /// [`run_attempt`] reads after the turn), while the acceptance-validator
+    /// path passes a throwaway (validators never call tools).
     pub fn build_registry_with(
         &self,
         cwd: &Path,
         sandbox: Arc<dyn Sandbox>,
         max_shell_timeout_secs: u64,
         grant: &WorkerGrant,
+        escalation: EscalationSlot,
     ) -> Result<ToolRegistry> {
-        build_fleet_worker_registry(cwd, sandbox, max_shell_timeout_secs, grant)
+        build_fleet_worker_registry(cwd, sandbox, max_shell_timeout_secs, grant, escalation)
     }
 
     /// The [`AgentConfig`] for an attempt bounded by `deadline`. The per-tool
@@ -207,12 +215,13 @@ impl AgentFactory {
         sandbox: Arc<dyn Sandbox>,
         deadline: Duration,
         grant: &WorkerGrant,
+        escalation: EscalationSlot,
     ) -> Result<Agent> {
         let deadline_secs = deadline.as_secs().max(1);
         Ok(Agent::new(
             AgentId::new("fleet-worker"),
             self.llm.clone(),
-            self.build_registry_with(cwd, sandbox, deadline_secs, grant)?,
+            self.build_registry_with(cwd, sandbox, deadline_secs, grant, escalation)?,
             self.memory.clone(),
         )
         .with_config(self.agent_config(deadline)))
@@ -273,6 +282,7 @@ mod tests {
                 sb.clone(),
                 30,
                 &WorkerGrant::minimal(),
+                Arc::new(std::sync::Mutex::new(None)),
             )
             .unwrap();
         assert_eq!(

--- a/crates/octos-fleet-worker/src/pool.rs
+++ b/crates/octos-fleet-worker/src/pool.rs
@@ -39,9 +39,12 @@ use eyre::{Result, eyre};
 use tokio::sync::{Mutex, Semaphore};
 use tokio::task::JoinHandle;
 
+use octos_agent::TokenTracker;
 use octos_core::safe_filename;
 use octos_fleet::{AcceptanceVerdict, ChildResultSnapshot, Fleet, FleetKernelStore, LaunchOutcome};
 
+use crate::escalate::EscalationSlot;
+use crate::worker::{escalation_tokens_with_floor, tracked_tokens};
 use crate::{AgentFactory, AttemptOutcome, run_attempt};
 
 /// Static configuration for a [`FleetWorkerPool`].
@@ -232,17 +235,40 @@ impl FleetWorkerPool {
         let per_fleet_concurrency = self.cfg.per_fleet_concurrency;
         let deadline = self.cfg.deadline;
         let owner_epoch = self.cfg.owner_epoch;
+        // PR B (codex round-4, defect 1) — the exact reservation `launch_child`
+        // just placed (== the attempt's `reserved_tokens`), threaded into both
+        // `run_attempt` and the LaunchGuard as the RELIABLE never-zero escalation
+        // floor (no fallible store re-fetch at settle time).
+        let reserved_tokens = self.cfg.projected_tokens;
         let fleet_id = fleet_id.to_string();
         let task_id = task_id.to_string();
+
+        // PR B — the escalation slot, created SYNCHRONOUSLY here (before the
+        // guard, no await) and shared into BOTH `run_attempt` (→ the agent's
+        // `escalate` valve) AND the LaunchGuard. So if this run is cancelled
+        // AFTER the agent recorded an escalation but BEFORE `run_attempt` settled
+        // it, the guard settles ESCALATED (child Blocked), not `Terminated` —
+        // a cancel/timeout can never DROP a recorded escalation.
+        let escalation_slot: EscalationSlot = Arc::new(std::sync::Mutex::new(None));
+
+        // PR B (codex round-3, defect 1) — the shared token tracker, created here
+        // (before the guard, no await) alongside the escalation slot and shared
+        // into BOTH `run_attempt` (→ the agent's `run_task_with_tracker`, which
+        // folds each response's cumulative spend into it) AND the LaunchGuard. So a
+        // cancel that drops this run AFTER the agent recorded an escalation but
+        // BEFORE `run_attempt` settled it lets the guard settle the REAL tokens the
+        // agent spent (never 0) — a 0-commit would let the fresh post-grant attempt
+        // double-spend the budget.
+        let tracker: Arc<TokenTracker> = Arc::new(TokenTracker::new());
 
         // P1-4a: arm the drop-guard SYNCHRONOUSLY here — there is NO `.await`
         // between `launch_child` returning `Launched` and this line — then MOVE
         // it into the spawned future. So even a future that is dropped before
         // its first poll (e.g. current-thread runtime: `dispatch().await` then
         // `handle.abort()`) still drops its captured guard → `Drop` fires the
-        // `Terminated` cleanup. The whole `[launch → complete]` window is
-        // guarded with no gap. The store's four-part CAS makes the cleanup a
-        // no-op if the attempt was already settled/superseded.
+        // `Terminated` (or `Escalated`) cleanup. The whole `[launch → complete]`
+        // window is guarded with no gap. The store's four-part CAS makes the
+        // cleanup a no-op if the attempt was already settled/superseded.
         let guard = LaunchGuard {
             store: store.clone(),
             fleet_id: fleet_id.clone(),
@@ -250,6 +276,9 @@ impl FleetWorkerPool {
             attempt_id: attempt_id.clone(),
             owner_epoch,
             clock: clock.clone(),
+            escalation: escalation_slot.clone(),
+            tracker: tracker.clone(),
+            reserved_tokens,
             armed: true,
         };
 
@@ -286,6 +315,9 @@ impl FleetWorkerPool {
                 &working_dir,
                 deadline,
                 owner_epoch,
+                escalation_slot,
+                tracker,
+                reserved_tokens,
                 move || (run_clock)(),
             )
             .await;
@@ -314,18 +346,23 @@ impl FleetWorkerPool {
 /// - `Completed` / `Superseded` — the attempt reached a durable terminal state.
 /// - `Aborted` — `mark_running` returned `Superseded`, a genuine lost race, so
 ///   the attempt belongs to someone else.
+/// - `Escalated` (PR B) — `record_escalation` settled the attempt
+///   NON-terminally (child `Blocked`); it is SETTLED (its lease released, its
+///   tokens committed), so the guard must DISARM — a `Drop` `Terminated`
+///   completion would double-settle (and would clobber the Blocked child).
 ///
 /// A [`AttemptOutcome::RecordError`] — our own store CAS
-/// (`mark_running`/`complete_child`) hit an infra error, so the attempt may
-/// still be live AND ours — must KEEP the guard armed (returns `false`) so its
-/// `Drop` best-effort completes it and can't wedge the child in `Launching`
-/// (round-4 P1).
+/// (`mark_running`/`complete_child`/`record_escalation`) hit an infra error, so
+/// the attempt may still be live AND ours — must KEEP the guard armed (returns
+/// `false`) so its `Drop` best-effort completes it and can't wedge the child in
+/// `Launching` (round-4 P1).
 fn should_disarm(outcome: &AttemptOutcome) -> bool {
     matches!(
         outcome,
         AttemptOutcome::Completed { .. }
             | AttemptOutcome::Superseded
             | AttemptOutcome::Aborted { .. }
+            | AttemptOutcome::Escalated { .. }
     )
 }
 
@@ -354,6 +391,18 @@ struct LaunchGuard {
     attempt_id: String,
     owner_epoch: u64,
     clock: Arc<dyn Fn() -> u64 + Send + Sync>,
+    /// PR B — the shared escalation slot. On a cancel-drop, if the agent already
+    /// recorded an escalation here, the guard settles ESCALATED (child Blocked),
+    /// not `Terminated` — so a cancel/timeout can never drop a recorded request.
+    escalation: EscalationSlot,
+    /// PR B (codex round-3, defect 1) — the SAME token tracker `run_attempt`
+    /// handed the agent, so a cancel-drop escalation settle commits the REAL
+    /// spend (with the attempt's reserved tokens as a never-zero floor), not 0.
+    tracker: Arc<TokenTracker>,
+    /// PR B (codex round-4, defect 1) — the attempt's reservation
+    /// (`PoolConfig::projected_tokens`), the RELIABLE never-zero escalation floor
+    /// on a cancel-drop settle (no fallible store re-fetch).
+    reserved_tokens: u64,
     armed: bool,
 }
 
@@ -381,21 +430,65 @@ impl Drop for LaunchGuard {
             return;
         };
         let store = self.store.clone();
+        let tracker = self.tracker.clone();
+        let reserved_tokens = self.reserved_tokens;
         let fleet_id = std::mem::take(&mut self.fleet_id);
         let task_id = std::mem::take(&mut self.task_id);
         let attempt_id = std::mem::take(&mut self.attempt_id);
         let owner_epoch = self.owner_epoch;
         let now = (self.clock)();
+        // PR B — if the agent recorded an escalation before this run was
+        // cancelled, PRECEDENCE goes to the escalation: settle NON-terminally
+        // (child Blocked), never `Terminated`. Take it out of the slot so the
+        // decision is made synchronously here (no await between the check and
+        // the spawn). `record_escalation`'s own four-part CAS no-ops if
+        // `run_attempt` already committed it.
+        let pending = self
+            .escalation
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take();
         const INTERRUPTED: &str = "attempt interrupted before completion";
         runtime.spawn(async move {
-            // `complete_child` requires the attempt to be `Running`. A pre-poll
-            // abort leaves it `Launching` (its `mark_running` never ran), so
-            // best-effort advance it first. `mark_running` is a CAS (needs
-            // Launching + current attempt): it succeeds for a still-Launching
-            // attempt, and harmlessly errors for one already Running (the
-            // normal interrupted case) or superseded — either way
-            // `complete_child`'s own four-part CAS then settles or no-ops.
+            // `complete_child`/`record_escalation` both require the attempt to be
+            // `Running`. A pre-poll abort leaves it `Launching` (its
+            // `mark_running` never ran), so best-effort advance it first.
+            // `mark_running` is a CAS (needs Launching + current attempt): it
+            // succeeds for a still-Launching attempt, and harmlessly errors for
+            // one already Running (the normal interrupted case) or superseded —
+            // either way the settle op's own four-part CAS then settles or no-ops.
             let _ = store.mark_running(&task_id, &attempt_id).await;
+            if let Some(request) = pending {
+                // Cancelled AFTER an escalation was recorded. Settle the REAL
+                // tokens the agent spent — read live from the SAME shared tracker
+                // `run_attempt` handed the agent (an atomic, always reliable) —
+                // with the attempt's RESERVED tokens (threaded in reliably from the
+                // pool config, NOT re-fetched) as a never-zero floor, exactly like
+                // the normal `run_attempt` escalation path. It is impossible to
+                // settle 0 while real tokens were used: a 0-commit here would
+                // release the reservation while committing nothing, letting the
+                // fresh post-grant attempt double-spend the budget.
+                let tracked = tracked_tokens(&tracker);
+                let tokens = escalation_tokens_with_floor(tracked, reserved_tokens);
+                if let Err(err) = store
+                    .record_escalation(
+                        &fleet_id,
+                        &task_id,
+                        &attempt_id,
+                        request,
+                        tokens,
+                        owner_epoch,
+                        now,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        %fleet_id, %task_id, %attempt_id, error = %err,
+                        "fleet worker: drop-guard escalation settle failed (advisory; recovery reconciles)",
+                    );
+                }
+                return;
+            }
             let snapshot = ChildResultSnapshot {
                 output: String::new(),
                 success: false,
@@ -642,6 +735,134 @@ mod tests {
             final_status,
             ChildStatus::Failed,
             "an interrupted attempt must end Failed via the drop-guard",
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn escalation_survives_a_cancel_via_the_guard() {
+        // codex round-2 (defect 1): if the run is CANCELLED after the agent
+        // recorded an escalation but before `run_attempt` settled it, the
+        // LaunchGuard must settle ESCALATED (child Blocked), NOT `Terminated` —
+        // a cancel/timeout can never DROP a recorded escalation.
+        let (_sd, store) = fresh_store().await;
+        create_fleet(store.clone(), "f1", vec![task_spec("a", &[], vec![])]).await;
+
+        let work = TempDir::new().unwrap();
+        // Escalate on turn 1, then sleep 30s (turn 2) so the slot is SET and the
+        // run is still alive when we abort it.
+        let (_md, factory) = factory_for(Arc::new(EscalateProvider::then_sleeping(
+            "blocked past the cancel",
+            Duration::from_secs(30),
+        )))
+        .await;
+        let pool = FleetWorkerPool::new(
+            store.clone(),
+            Arc::new(factory),
+            pool_config(&work, 4, 4),
+            fixed_clock(),
+        );
+
+        let d = pool.dispatch("f1", "a").await.unwrap();
+        assert!(matches!(d.launch, LaunchOutcome::Launched { .. }));
+        let handle = d.handle.unwrap();
+
+        // Wait until the child is Running (the agent turn started), then give
+        // turn 1 + the escalate tool time to SET the slot.
+        wait_for_status(&store, "f1", "a", ChildStatus::Running).await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        // Cancel mid-run: the guard fires and must settle ESCALATED.
+        handle.abort();
+
+        // The child must reach Blocked (via the guard's escalation settle), and
+        // must NEVER be dropped to Failed (a Terminated completion).
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let status = store.get_child("f1", "a").await.unwrap().unwrap().status;
+            assert_ne!(
+                status,
+                ChildStatus::Failed,
+                "a cancel dropped the escalation to a Terminated/Failed completion",
+            );
+            if status == ChildStatus::Blocked {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "child never reached Blocked (last: {status:?})",
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let child = store.get_child("f1", "a").await.unwrap().unwrap();
+        assert!(
+            child.pending_escalation.is_some(),
+            "the recorded escalation request is preserved through the cancel",
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn escalation_cancel_drop_commits_real_tokens_not_zero() {
+        // codex round-3 (defect 1): the LaunchGuard's cancel-drop escalation
+        // settle must commit the REAL tokens the yielded attempt spent — read from
+        // the SAME shared tracker the agent updated, with the reserved tokens as a
+        // never-zero floor — NOT 0. A 0-commit would release the reservation while
+        // committing nothing, so after the keeper grants a wider grant the FRESH
+        // attempt could re-reserve and spend the same budget twice (double-spend).
+        let (_sd, store) = fresh_store().await;
+        create_fleet(store.clone(), "f1", vec![task_spec("a", &[], vec![])]).await;
+
+        let work = TempDir::new().unwrap();
+        // Escalate on turn 1 (so the tracker records that turn's real tokens),
+        // then sleep 30s so the slot is SET and the run is still alive when we
+        // abort it INSIDE the guarded region.
+        let (_md, factory) = factory_for(Arc::new(EscalateProvider::then_sleeping(
+            "blocked past the cancel",
+            Duration::from_secs(30),
+        )))
+        .await;
+        let pool = FleetWorkerPool::new(
+            store.clone(),
+            Arc::new(factory),
+            pool_config(&work, 4, 4),
+            fixed_clock(),
+        );
+
+        let d = pool.dispatch("f1", "a").await.unwrap();
+        assert!(matches!(d.launch, LaunchOutcome::Launched { .. }));
+        let handle = d.handle.unwrap();
+
+        // Wait until Running, then give turn 1 + the escalate tool time to SET the
+        // slot AND fold that turn's tokens into the shared tracker.
+        wait_for_status(&store, "f1", "a", ChildStatus::Running).await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        // Cancel mid-run: the guard fires and must settle ESCALATED with REAL
+        // tokens (not 0).
+        handle.abort();
+
+        // Wait for the guard's escalation settle to land (child Blocked).
+        wait_for_status(&store, "f1", "a", ChildStatus::Blocked).await;
+
+        // Budget honesty: the cancel-drop settle committed the REAL tokens the
+        // yielded attempt spent (> 0), and released its reservation — so the
+        // fleet's committed budget already reflects the spend before any re-run.
+        let fleet_rec = store.get_fleet("f1").await.unwrap().unwrap();
+        assert!(
+            fleet_rec.budget.tokens_committed > 0,
+            "the cancel-drop escalation settle must commit REAL tokens, never 0 \
+             (committed={})",
+            fleet_rec.budget.tokens_committed,
+        );
+        assert_eq!(
+            fleet_rec.budget.tokens_reserved, 0,
+            "the yielded attempt's reservation is released on the cancel-drop settle",
+        );
+        // The child carries the pending request (it truly escalated, not Terminated).
+        let child = store.get_child("f1", "a").await.unwrap().unwrap();
+        assert!(child.pending_escalation.is_some());
+        assert_eq!(
+            child.tokens_committed, fleet_rec.budget.tokens_committed,
+            "the child's committed tokens mirror the fleet settle",
         );
     }
 

--- a/crates/octos-fleet-worker/src/testutil.rs
+++ b/crates/octos-fleet-worker/src/testutil.rs
@@ -273,6 +273,127 @@ impl LlmProvider for WriteFileProvider {
     }
 }
 
+/// Calls the always-on `escalate` tool on the first turn (requesting a wider
+/// grant), then ends. Proves an escalation mid-turn yields the attempt
+/// NON-terminally. `then_sleep` optionally holds AFTER escalating so a test can
+/// drive the turn to the DEADLINE and prove the escalation still wins
+/// (determinism), rather than ending cleanly with EndTurn.
+pub struct EscalateProvider {
+    pub reason: String,
+    pub then_sleep: Option<Duration>,
+    calls: AtomicUsize,
+}
+
+impl EscalateProvider {
+    pub fn new(reason: &str) -> Self {
+        Self {
+            reason: reason.to_string(),
+            then_sleep: None,
+            calls: AtomicUsize::new(0),
+        }
+    }
+
+    /// After escalating, sleep `hold` so the attempt hits the deadline while the
+    /// slot is already set — the escalation must still win.
+    pub fn then_sleeping(reason: &str, hold: Duration) -> Self {
+        Self {
+            reason: reason.to_string(),
+            then_sleep: Some(hold),
+            calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for EscalateProvider {
+    async fn chat(&self, _m: &[Message], _t: &[ToolSpec], _c: &ChatConfig) -> Result<ChatResponse> {
+        if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            return Ok(ChatResponse {
+                content: None,
+                reasoning_content: None,
+                tool_calls: vec![octos_core::ToolCall {
+                    id: "call_escalate".to_string(),
+                    name: "escalate".to_string(),
+                    arguments: serde_json::json!({
+                        "reason": self.reason,
+                        "requested_grant": {
+                            "network": { "mode": "hosts", "hosts": ["example.com"] },
+                            "tools": ["read_file", "write_file", "shell", "web_fetch"],
+                        },
+                    }),
+                    metadata: None,
+                }],
+                stop_reason: StopReason::ToolUse,
+                usage: usage(),
+                provider_index: None,
+            });
+        }
+        if let Some(hold) = self.then_sleep {
+            tokio::time::sleep(hold).await;
+        }
+        Ok(end_turn("escalated; awaiting the operator"))
+    }
+    fn model_id(&self) -> &str {
+        "mock"
+    }
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+/// Writes `path` via `write_file`, then ends — but only when a specific grant
+/// tool is available. Used to prove a fresh attempt after a grant widen rebuilds
+/// with the NEW capabilities: it records which tool NAMES it was offered.
+pub struct RecordingWriteProvider {
+    pub path: String,
+    pub seen_tools: Arc<std::sync::Mutex<Vec<String>>>,
+    calls: AtomicUsize,
+}
+
+impl RecordingWriteProvider {
+    pub fn new(path: &str, seen_tools: Arc<std::sync::Mutex<Vec<String>>>) -> Self {
+        Self {
+            path: path.to_string(),
+            seen_tools,
+            calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for RecordingWriteProvider {
+    async fn chat(&self, _m: &[Message], t: &[ToolSpec], _c: &ChatConfig) -> Result<ChatResponse> {
+        if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            // Record the tool names the fresh attempt was offered — the audit
+            // point for "rebuilt from the widened grant".
+            *self.seen_tools.lock().unwrap() = t.iter().map(|s| s.name.clone()).collect();
+            return Ok(ChatResponse {
+                content: None,
+                reasoning_content: None,
+                tool_calls: vec![octos_core::ToolCall {
+                    id: "call_write".to_string(),
+                    name: "write_file".to_string(),
+                    arguments: serde_json::json!({
+                        "path": self.path,
+                        "content": "post-grant artifact\n",
+                    }),
+                    metadata: None,
+                }],
+                stop_reason: StopReason::ToolUse,
+                usage: usage(),
+                provider_index: None,
+            });
+        }
+        Ok(end_turn("wrote the artifact after the grant widen"))
+    }
+    fn model_id(&self) -> &str {
+        "mock"
+    }
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
 /// Sleeps past the attempt deadline on the first `chat`, so the `timeout`
 /// wrapper in `run_attempt` fires.
 pub struct SleepProvider {

--- a/crates/octos-fleet-worker/src/worker.rs
+++ b/crates/octos-fleet-worker/src/worker.rs
@@ -40,9 +40,11 @@
 //!   hostile concurrent mutator of the task's own workspace.
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use octos_agent::TokenTracker;
 use octos_agent::sandbox::Sandbox;
 use octos_agent::validators::{
     ValidatorInvocation, ValidatorOutcome, ValidatorPhase, ValidatorRunner, ValidatorStatus,
@@ -50,11 +52,60 @@ use octos_agent::validators::{
 use octos_agent::workspace_policy::{Validator, ValidatorPhaseKind, ValidatorSpec};
 use octos_core::{Message, Task, TaskContext, TaskKind, TaskResult, TokenUsage};
 use octos_fleet::{
-    AcceptanceVerdict, ChildResultSnapshot, CompleteOutcome, EvidenceRef, Fleet, FleetKernelStore,
-    MarkRunningOutcome, TaskView, Verifier,
+    AcceptanceVerdict, ChildResultSnapshot, CompleteOutcome, EscalationRequest, EvidenceRef, Fleet,
+    FleetKernelStore, MarkRunningOutcome, TaskView, Verifier,
 };
 
 use crate::AgentFactory;
+use crate::escalate::EscalationSlot;
+
+/// Settle an escalation NON-terminally via the store's four-part fence, mapping
+/// the store outcome to an [`AttemptOutcome`]. Shared by `run_attempt` (the
+/// normal path) so the mapping lives in one place.
+#[allow(clippy::too_many_arguments)] // store + ids + request + settlement inputs are irreducible here
+async fn settle_escalation(
+    store: &FleetKernelStore,
+    fleet_id: &str,
+    task_id: &str,
+    attempt_id: &str,
+    request: EscalationRequest,
+    actual_tokens: u64,
+    owner_epoch: u64,
+    now_ms: u64,
+) -> AttemptOutcome {
+    match store
+        .record_escalation(
+            fleet_id,
+            task_id,
+            attempt_id,
+            request.clone(),
+            actual_tokens,
+            owner_epoch,
+            now_ms,
+        )
+        .await
+    {
+        Ok(CompleteOutcome::Completed) => {
+            tracing::info!(
+                %fleet_id, %task_id, %attempt_id, tokens = actual_tokens,
+                "fleet worker: attempt escalated — child Blocked pending an operator grant decision",
+            );
+            AttemptOutcome::Escalated { request }
+        }
+        // A stale/superseded attempt lost the fence: NOT ours (relaunch/recovery
+        // owns it), so the pool disarms.
+        Ok(CompleteOutcome::Superseded) => AttemptOutcome::Superseded,
+        Err(err) => {
+            tracing::error!(
+                %fleet_id, %task_id, %attempt_id, error = %err,
+                "fleet worker: record_escalation errored",
+            );
+            AttemptOutcome::RecordError {
+                reason: err.to_string(),
+            }
+        }
+    }
+}
 
 /// Minimum acceptance-phase budget (P1-5b floor). A run that finishes right at
 /// the deadline still gets this small window to verify, rather than a 0ms
@@ -88,13 +139,21 @@ pub enum AttemptOutcome {
     /// so the pool KEEPS the guard armed (its `Drop` un-wedges the child) and
     /// the caller logs and lets recovery reconcile.
     RecordError { reason: String },
+    /// PR B — the attempt yielded on a mid-task ESCALATION: it recorded a
+    /// request for a wider grant and `record_escalation` settled it
+    /// NON-terminally (child `Blocked` + `pending_escalation`, the yielded
+    /// attempt's REAL tokens committed). The keeper's `goal_grant`/`goal_deny`
+    /// decides what happens next. This is a SETTLED terminal disposition for the
+    /// attempt, so the pool disarms the guard (no double-settle) — the child is
+    /// simply parked on the operator, not wedged in `Launching`.
+    Escalated { request: EscalationRequest },
 }
 
 /// Run one launched attempt to a recorded terminal state. See the module
 /// docs for the sequence. `actual_now_ms` is the wall clock threaded into
 /// the store's `complete_child` (settlement timestamp) and the follow-on
 /// readiness promotion.
-#[allow(clippy::too_many_arguments)] // store + ids + view + factory + deadline + epoch + clock are irreducible
+#[allow(clippy::too_many_arguments)] // store + ids + view + factory + deadline + epoch + clock + escalation slot are irreducible
 pub async fn run_attempt(
     store: Arc<FleetKernelStore>,
     fleet_id: &str,
@@ -105,6 +164,20 @@ pub async fn run_attempt(
     working_dir: &Path,
     deadline: Duration,
     owner_epoch: u64,
+    // PR B — the shared escalation slot the always-on `escalate` valve writes
+    // into. Created by the pool BEFORE arming the LaunchGuard and passed to BOTH,
+    // so a cancel that drops this run still settles escalated (not `Terminated`).
+    escalation_slot: EscalationSlot,
+    // PR B — the shared token tracker the agent folds each response's cumulative
+    // spend into (via `run_task_with_tracker`). Created by the pool alongside the
+    // escalation slot and shared into the LaunchGuard, so a cancel-drop escalation
+    // settle reads the REAL spend from the SAME tracker this run updated — never 0.
+    tracker: Arc<TokenTracker>,
+    // PR B (codex round-4, defect 1) — the tokens this attempt RESERVED at launch
+    // (the pool's `projected_tokens`, == the attempt's `reserved_tokens`), threaded
+    // in reliably as the never-zero escalation floor so the settle never depends on
+    // a fallible re-fetch. See [`escalation_tokens_with_floor`].
+    reserved_tokens: u64,
     actual_now_ms: impl Fn() -> u64,
 ) -> AttemptOutcome {
     // 1. CAS Leased/Launching -> Running, distinguishing a genuine lost race
@@ -167,6 +240,15 @@ pub async fn run_attempt(
     // validators a weaker (e.g. no-op) sandbox.
     let sandbox = factory.sandbox_for(working_dir, allow_network);
 
+    // PR B — the agent folds each response's cumulative spend into `tracker` (via
+    // `run_task_with_tracker`), so an escalation that ends on the TIMEOUT /
+    // run-error path — where the dropped `TaskResult` discards its token count —
+    // still settles the REAL tokens used, never 0. `escalate` is a tool call, so
+    // an escalation implies at least one response landed and the tracker is
+    // populated; a 0-commit would let the fresh post-grant attempt spend the same
+    // budget twice. Both `escalation_slot` AND `tracker` are caller-supplied (the
+    // pool shares them with the LaunchGuard, so a cancel-drop settles honestly).
+
     // #1857 PR 5a fix (H1, codex round 2) — ATTEMPT-TIME fail-closed. The serve
     // boot probe checks ONE sandbox instance, but the factory reconstructs the
     // sandbox PER attempt and `SandboxMode::Auto` can fall through to `NoSandbox`
@@ -189,7 +271,13 @@ pub async fn run_attempt(
         //    per-tool timeouts AND per-command shell ceiling are clamped to
         //    `deadline` (P1-2). An incoherent grant (rejected at parse) fails
         //    closed here too: terminate the attempt without running.
-        match factory.build_agent(working_dir, sandbox.clone(), deadline, &task_view.grant) {
+        match factory.build_agent(
+            working_dir,
+            sandbox.clone(),
+            deadline,
+            &task_view.grant,
+            escalation_slot.clone(),
+        ) {
             Err(err) => {
                 tracing::error!(
                     %fleet_id, %task_id, %attempt_id, error = %err,
@@ -200,12 +288,57 @@ pub async fn run_attempt(
             Ok(agent) => {
                 // 4. Run under a HARD deadline — `run_task` is cancel-safe to
                 //    drop and has NO internal wall-clock cap, so the timeout
-                //    wrapper is mandatory.
+                //    wrapper is mandatory. `run_task_with_tracker` folds each
+                //    response's cumulative tokens into `tracker` as it goes, so a
+                //    timeout that DROPS the future still leaves the real spend
+                //    readable (budget honesty on the escalation settle below).
                 let start = Instant::now();
-                let run = tokio::time::timeout(deadline, agent.run_task(&task)).await;
+                let run =
+                    tokio::time::timeout(deadline, agent.run_task_with_tracker(&task, &tracker))
+                        .await;
                 let elapsed = start.elapsed();
 
-                // 5-6. Map the result to a verdict + snapshot inputs.
+                // 4a. DETERMINISM (codex round-2): read the escalation slot
+                //     IMMEDIATELY after the turn, BEFORE `run_acceptance`. If the
+                //     agent escalated, the attempt YIELDS — SKIP acceptance
+                //     entirely (its `CommandExit` validators + side effects must
+                //     NOT run, and a cancel during that window must not let the
+                //     LaunchGuard record `Terminated`) and settle NON-terminally.
+                //     The escalation WINS over any verdict the turn produced.
+                let escalation = escalation_slot
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .clone();
+                if let Some(request) = escalation {
+                    // Budget honesty: the REAL tokens the yielded attempt used —
+                    // the final `TaskResult` count when the turn returned cleanly,
+                    // else the tracker, which the agent updated after every
+                    // response so it holds the cumulative spend even when a
+                    // timeout dropped the `TaskResult`. Take the max so neither
+                    // under-reports, with the attempt's reserved tokens as a
+                    // never-zero floor (see `escalation_tokens_with_floor`). The
+                    // pool's LaunchGuard uses the SAME helper on a cancel-drop.
+                    let result_tokens = match &run {
+                        Ok(Ok(result)) => total_tokens(&result.token_usage),
+                        _ => 0,
+                    };
+                    let tracked = result_tokens.max(tracked_tokens(&tracker));
+                    let tokens = escalation_tokens_with_floor(tracked, reserved_tokens);
+                    return settle_escalation(
+                        &store,
+                        fleet_id,
+                        task_id,
+                        attempt_id,
+                        request,
+                        tokens,
+                        owner_epoch,
+                        actual_now_ms(),
+                    )
+                    .await;
+                }
+
+                // 5-6. Not escalated — map the result to a verdict + snapshot
+                //      inputs (acceptance runs only on the clean success path).
                 match run {
                     Err(_elapsed) => Computed::terminated(format!(
                         "deadline exceeded after {}s",
@@ -246,9 +379,13 @@ pub async fn run_attempt(
         }
     };
 
+    // An escalation (if any) was already settled + returned INSIDE the agent arm
+    // above, BEFORE acceptance ran — so reaching here means the turn did NOT
+    // escalate and the normal verdict applies.
+    let now = actual_now_ms();
+
     // 7. Record the real outcome + snapshot to the store DIRECTLY (not
     //    `Fleet::record_outcome`, which cannot carry the snapshot).
-    let now = actual_now_ms();
     let snapshot = ChildResultSnapshot {
         output: computed.output,
         success: matches!(computed.verdict, AcceptanceVerdict::Accepted { .. }),
@@ -362,6 +499,38 @@ fn total_tokens(usage: &TokenUsage) -> u64 {
     u64::from(usage.input_tokens)
         + u64::from(usage.output_tokens)
         + u64::from(usage.reasoning_tokens)
+}
+
+/// The live cumulative spend the agent folded into `tracker` after every LLM
+/// response (input + output). Read outside any await — the fields are atomics.
+/// The pool's [`crate::pool`] LaunchGuard reads the SAME tracker on a cancel so
+/// its escalation settle commits the real spend, not 0.
+pub(crate) fn tracked_tokens(tracker: &TokenTracker) -> u64 {
+    u64::from(tracker.input_tokens.load(Ordering::Relaxed))
+        + u64::from(tracker.output_tokens.load(Ordering::Relaxed))
+}
+
+/// The tokens an escalation settle should commit — it must be IMPOSSIBLE to
+/// settle 0 while real tokens were used. `tracked` is the yielded attempt's REAL
+/// live spend, read directly from the shared [`TokenTracker`] the agent updates
+/// after every response (an atomic, so always reliable) — on the normal path
+/// max'd with the final `TaskResult`. `reserved` is the attempt's RESERVED
+/// tokens (the budget-admission estimate), passed in RELIABLY by the pool (it is
+/// `PoolConfig::projected_tokens`, the exact amount `launch_child` reserved) —
+/// NOT re-fetched via a fallible store read that could zero the floor.
+///
+/// - `tracked > 0` (real work happened): settle `tracked` — the true spend,
+///   never 0, and never inflated to the reservation.
+/// - `tracked == 0` (genuinely no tracked spend, e.g. a cancel before any
+///   response): fall back to `reserved` as the never-zero floor, so a fresh
+///   post-grant attempt can't double-spend the budget.
+///
+/// A 0-settle is therefore possible ONLY when the attempt genuinely reserved 0
+/// AND used 0 — nothing was spent, so there is nothing to re-spend. Shared by
+/// `run_attempt` (the normal escalation path) and the pool's LaunchGuard (the
+/// cancel path) so BOTH settle honestly from reliable inputs.
+pub(crate) fn escalation_tokens_with_floor(tracked: u64, reserved: u64) -> u64 {
+    if tracked > 0 { tracked } else { reserved }
 }
 
 /// Render the task brief the worker agent sees: title + detail + the
@@ -506,6 +675,10 @@ async fn run_acceptance(
         sandbox.clone(),
         max_shell_timeout_secs,
         &task_view.grant,
+        // Acceptance validators never call tools, so the escalate valve here is
+        // never invoked — a throwaway slot suffices (the agent path threads the
+        // real one). Acceptance only runs on a NON-escalated turn anyway.
+        Arc::new(Mutex::new(None)),
     ) {
         Ok(registry) => registry,
         Err(err) => {
@@ -710,6 +883,19 @@ mod tests {
     use std::time::Duration;
     use tempfile::TempDir;
 
+    /// A fresh, empty escalation slot for a `run_attempt` call. The agent writes
+    /// into it via the `escalate` valve; `run_attempt` reads it after the turn.
+    fn slot() -> EscalationSlot {
+        Arc::new(Mutex::new(None))
+    }
+
+    /// A fresh, shared token tracker for a `run_attempt` call. The pool creates
+    /// one per attempt and shares it into the LaunchGuard; these direct-call
+    /// tests only need the agent to have somewhere to fold its token counts.
+    fn tracker() -> Arc<TokenTracker> {
+        Arc::new(TokenTracker::new())
+    }
+
     #[test]
     fn file_exists_confined_rejects_symlink_escape() {
         // P1-5a: a real in-workspace file passes; an absent file is
@@ -805,6 +991,9 @@ mod tests {
                 work.path(),
                 Duration::from_secs(30),
                 EPOCH,
+                slot(),
+                tracker(),
+                PROJECTED,
                 || NOW,
             )
             .await;
@@ -858,6 +1047,9 @@ mod tests {
             work.path(),
             Duration::from_secs(30),
             EPOCH,
+            slot(),
+            tracker(),
+            PROJECTED,
             || NOW,
         )
         .await;
@@ -937,6 +1129,9 @@ mod tests {
             work.path(),
             Duration::from_secs(30),
             EPOCH,
+            slot(),
+            tracker(),
+            PROJECTED,
             || NOW,
         )
         .await;
@@ -996,6 +1191,9 @@ mod tests {
             work.path(),
             Duration::from_secs(30),
             EPOCH,
+            slot(),
+            tracker(),
+            PROJECTED,
             || NOW,
         )
         .await;
@@ -1050,6 +1248,9 @@ mod tests {
             work.path(),
             Duration::from_secs(2),
             EPOCH,
+            slot(),
+            tracker(),
+            PROJECTED,
             || NOW,
         )
         .await;
@@ -1120,6 +1321,9 @@ mod tests {
             work.path(),
             Duration::from_secs(2),
             EPOCH,
+            slot(),
+            tracker(),
+            PROJECTED,
             || NOW,
         )
         .await;
@@ -1170,6 +1374,9 @@ mod tests {
             work.path(),
             Duration::from_secs(30),
             EPOCH,
+            slot(),
+            tracker(),
+            PROJECTED,
             || NOW,
         )
         .await;
@@ -1219,6 +1426,9 @@ mod tests {
             work.path(),
             Duration::from_secs(30),
             EPOCH,
+            slot(),
+            tracker(),
+            PROJECTED,
             || NOW,
         )
         .await;
@@ -1264,6 +1474,9 @@ mod tests {
             work.path(),
             Duration::from_secs(30),
             EPOCH,
+            slot(),
+            tracker(),
+            PROJECTED,
             || NOW,
         )
         .await;
@@ -1305,6 +1518,9 @@ mod tests {
             work.path(),
             Duration::from_millis(200),
             EPOCH,
+            slot(),
+            tracker(),
+            PROJECTED,
             || NOW,
         )
         .await;
@@ -1352,6 +1568,9 @@ mod tests {
             work.path(),
             Duration::from_secs(30),
             EPOCH,
+            slot(),
+            tracker(),
+            PROJECTED,
             || NOW,
         )
         .await;
@@ -1402,6 +1621,9 @@ mod tests {
             work.path(),
             Duration::from_secs(30),
             EPOCH,
+            slot(),
+            tracker(),
+            PROJECTED,
             || NOW,
         )
         .await;
@@ -1427,5 +1649,395 @@ mod tests {
         );
         let b_attempt = launch(&store, "f1", "b").await;
         assert!(!b_attempt.is_empty(), "successor must be launchable");
+    }
+
+    #[tokio::test]
+    async fn escalate_records_request_and_yields_attempt() {
+        // A worker that calls the always-on `escalate` tool must yield its
+        // attempt NON-terminally: run_attempt settles via record_escalation
+        // (child Blocked + pending_escalation, real tokens committed), NOT the
+        // normal verdict map — even though the turn ended cleanly (EndTurn).
+        let (_sd, store) = fresh_store().await;
+        let fleet = create_fleet(store.clone(), "f1", vec![task_spec("a", &[], vec![])]).await;
+        let attempt = launch(&store, "f1", "a").await;
+
+        let work = TempDir::new().unwrap();
+        let (_md, factory) =
+            factory_for(Arc::new(EscalateProvider::new("cannot reach example.com"))).await;
+        let task_view = view_of(&fleet, "a").await;
+
+        let outcome = run_attempt(
+            store.clone(),
+            "f1",
+            "a",
+            &attempt,
+            &task_view,
+            &factory,
+            work.path(),
+            Duration::from_secs(30),
+            EPOCH,
+            slot(),
+            tracker(),
+            PROJECTED,
+            || NOW,
+        )
+        .await;
+
+        // The disposition is Escalated (NOT Completed) — the verdict is ignored.
+        match &outcome {
+            AttemptOutcome::Escalated { request } => {
+                assert_eq!(request.reason, "cannot reach example.com");
+                assert_eq!(
+                    request.requested_grant.network,
+                    octos_fleet::NetworkGrant::Hosts(vec!["example.com".into()]),
+                );
+            }
+            other => panic!("expected Escalated, got {other:?}"),
+        }
+
+        // Child is Blocked (non-terminal) with the pending request; the attempt
+        // Interrupted; the REAL tokens are committed (budget honesty).
+        let child = store.get_child("f1", "a").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Blocked);
+        assert!(
+            child.pending_escalation.is_some(),
+            "request recorded on child"
+        );
+        let att = store.get_attempt("a", &attempt).await.unwrap().unwrap();
+        assert_eq!(att.status, AttemptStatus::Interrupted);
+        let fleet_rec = store.get_fleet("f1").await.unwrap().unwrap();
+        assert!(
+            fleet_rec.budget.tokens_committed > 0,
+            "record_escalation must settle the REAL tokens used, not 0",
+        );
+        assert_eq!(fleet_rec.budget.tokens_reserved, 0, "reservation released");
+    }
+
+    #[test]
+    fn escalation_floor_never_loses_real_usage_uses_reservation_only_when_absent() {
+        // codex round-4 (defect 1): the pure floor. Real tracked usage always
+        // wins (never 0, never inflated to the reservation); the reservation is
+        // the floor ONLY when the tracker is genuinely 0; a 0-settle is possible
+        // ONLY when BOTH are 0 (nothing spent → nothing to re-spend).
+        assert_eq!(
+            escalation_tokens_with_floor(10, 0),
+            10,
+            "real usage with a 0 reservation must settle the usage, never 0",
+        );
+        assert_eq!(
+            escalation_tokens_with_floor(10, 500),
+            10,
+            "real usage is NOT inflated to the reservation (only floor when absent)",
+        );
+        assert_eq!(
+            escalation_tokens_with_floor(0, 100),
+            100,
+            "no tracked usage floors to the reservation (never under-settle it)",
+        );
+        assert_eq!(
+            escalation_tokens_with_floor(0, 0),
+            0,
+            "reserved 0 AND used 0 → 0 is the only acceptable 0-settle",
+        );
+    }
+
+    #[tokio::test]
+    async fn escalation_settle_never_zero_when_tokens_used() {
+        // codex round-4 (defect 1): a real-usage attempt that escalates must NEVER
+        // commit 0 — even when it RESERVED 0 tokens. The settle reads the live
+        // shared tracker (the agent's real spend) reliably; it can only settle 0
+        // when reserved==0 AND nothing was tracked. Here the provider reports real
+        // usage, so the committed tokens must be > 0 despite the 0 reservation —
+        // otherwise the reservation would be released while committing nothing and
+        // a fresh post-grant attempt could double-spend.
+        let (_sd, store) = fresh_store().await;
+        let fleet = create_fleet(store.clone(), "f1", vec![task_spec("a", &[], vec![])]).await;
+
+        // Launch with a ZERO reservation (projected_tokens = 0) — the corner the
+        // reservation floor cannot cover, so real usage MUST carry the settle.
+        let attempt = match store
+            .launch_child("f1", "a", 0, NOW, EPOCH, TTL)
+            .await
+            .unwrap()
+        {
+            octos_fleet::LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("expected Launched, got {other:?}"),
+        };
+
+        let work = TempDir::new().unwrap();
+        // Escalates on turn 1 with real usage (7 in + 3 out = 10 tracked tokens).
+        let (_md, factory) = factory_for(Arc::new(EscalateProvider::new(
+            "blocked, but I did real work",
+        )))
+        .await;
+        let task_view = view_of(&fleet, "a").await;
+
+        let outcome = run_attempt(
+            store.clone(),
+            "f1",
+            "a",
+            &attempt,
+            &task_view,
+            &factory,
+            work.path(),
+            Duration::from_secs(30),
+            EPOCH,
+            slot(),
+            tracker(),
+            0, // reserved_tokens: this attempt reserved ZERO
+            || NOW,
+        )
+        .await;
+        assert!(
+            matches!(outcome, AttemptOutcome::Escalated { .. }),
+            "got {outcome:?}",
+        );
+
+        // Despite the 0 reservation, the REAL tracked usage was committed (> 0).
+        let fleet_rec = store.get_fleet("f1").await.unwrap().unwrap();
+        assert!(
+            fleet_rec.budget.tokens_committed > 0,
+            "a real-usage escalation must commit > 0 even with a 0 reservation (committed={})",
+            fleet_rec.budget.tokens_committed,
+        );
+        assert_eq!(
+            store.get_child("f1", "a").await.unwrap().unwrap().status,
+            ChildStatus::Blocked,
+        );
+    }
+
+    #[tokio::test]
+    async fn escalation_wins_regardless_of_turn_end() {
+        // DETERMINISM: even when the turn ends by hitting the DEADLINE (not a
+        // clean EndTurn), a recorded escalation still wins — run_attempt settles
+        // escalated, never Terminated. The provider escalates on turn 1, then
+        // sleeps 30s so the 2s deadline fires while the slot is already set.
+        let (_sd, store) = fresh_store().await;
+        let fleet = create_fleet(store.clone(), "f1", vec![task_spec("a", &[], vec![])]).await;
+        let attempt = launch(&store, "f1", "a").await;
+
+        let work = TempDir::new().unwrap();
+        let (_md, factory) = factory_for(Arc::new(EscalateProvider::then_sleeping(
+            "blocked past the deadline",
+            Duration::from_secs(30),
+        )))
+        .await;
+        let task_view = view_of(&fleet, "a").await;
+
+        let outcome = run_attempt(
+            store.clone(),
+            "f1",
+            "a",
+            &attempt,
+            &task_view,
+            &factory,
+            work.path(),
+            Duration::from_secs(2),
+            EPOCH,
+            slot(),
+            tracker(),
+            PROJECTED,
+            || NOW,
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, AttemptOutcome::Escalated { .. }),
+            "a deadline-ended turn with a set escalation slot must still escalate, got {outcome:?}",
+        );
+        let child = store.get_child("f1", "a").await.unwrap().unwrap();
+        assert_eq!(
+            child.status,
+            ChildStatus::Blocked,
+            "the escalation wins over the deadline terminate",
+        );
+        // BUDGET HONESTY (codex round-2): even though the turn ended by TIMEOUT
+        // (the TaskResult was dropped), the escalation settled the REAL tokens the
+        // agent spent BEFORE the timeout — captured live via the CostUpdate
+        // reporter — NOT 0. A 0-commit would let the fresh post-grant attempt
+        // spend the whole budget twice.
+        let fleet_rec = store.get_fleet("f1").await.unwrap().unwrap();
+        assert!(
+            fleet_rec.budget.tokens_committed > 0,
+            "a timeout-escalation must settle the REAL tokens used, never 0",
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn escalation_skips_acceptance_no_validator_side_effect() {
+        // DETERMINISM (codex round-2): an escalated attempt must SKIP the
+        // acceptance gate entirely — its `CommandExit` validators (and their side
+        // effects) must NOT run. Proof: a CommandExit whose command WRITES a
+        // marker; on an escalated turn the marker is NEVER written.
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_sd, store) = fresh_store().await;
+        let scratch = TempDir::new().unwrap();
+        let script = scratch.path().join("mark.sh");
+        let marker = scratch.path().join("acceptance-ran.marker");
+        std::fs::write(&script, format!("#!/bin/sh\n: > {}\n", marker.display())).unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let fleet = create_fleet(
+            store.clone(),
+            "f1",
+            vec![task_spec("a", &[], command_exit(&script.to_string_lossy()))],
+        )
+        .await;
+        let attempt = launch(&store, "f1", "a").await;
+
+        let work = TempDir::new().unwrap();
+        // The provider escalates on turn 1 then ends — so the run RETURNS success,
+        // which would normally trigger acceptance. Because run_attempt reads the
+        // slot BEFORE acceptance, the validator (marker script) must NOT run.
+        let (_md, factory) = factory_for(Arc::new(EscalateProvider::new("blocked"))).await;
+        let task_view = view_of(&fleet, "a").await;
+
+        let outcome = run_attempt(
+            store.clone(),
+            "f1",
+            "a",
+            &attempt,
+            &task_view,
+            &factory,
+            work.path(),
+            Duration::from_secs(30),
+            EPOCH,
+            slot(),
+            tracker(),
+            PROJECTED,
+            || NOW,
+        )
+        .await;
+        assert!(
+            matches!(outcome, AttemptOutcome::Escalated { .. }),
+            "got {outcome:?}",
+        );
+        // Give any (erroneously-spawned) validator time to write before asserting.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(
+            !marker.exists(),
+            "acceptance validator ran on an escalated attempt — its side effect leaked",
+        );
+        assert_eq!(
+            store.get_child("f1", "a").await.unwrap().unwrap().status,
+            ChildStatus::Blocked,
+        );
+    }
+
+    #[tokio::test]
+    async fn fresh_attempt_after_grant_widen_rebuilds_from_new_grant() {
+        // The whole loop: a minimal-grant worker escalates → Blocked; the keeper
+        // widens the grant (SetGrant → Ready); a FRESH attempt rebuilds its
+        // registry from the NEW grant, so it is now offered the widened tools
+        // (web_fetch) it lacked before.
+        let (_sd, store) = fresh_store().await;
+        let fleet = create_fleet(store.clone(), "f1", vec![task_spec("a", &[], vec![])]).await;
+
+        // Attempt 1: minimal grant → escalate → Blocked.
+        let a1 = launch(&store, "f1", "a").await;
+        let work = TempDir::new().unwrap();
+        let (_md1, esc_factory) = factory_for(Arc::new(EscalateProvider::new(
+            "need web_fetch for example.com",
+        )))
+        .await;
+        let view1 = view_of(&fleet, "a").await;
+        assert!(
+            !view1.grant.tools.contains(&"web_fetch".to_string()),
+            "attempt 1 is minimal — no web_fetch",
+        );
+        let out1 = run_attempt(
+            store.clone(),
+            "f1",
+            "a",
+            &a1,
+            &view1,
+            &esc_factory,
+            work.path(),
+            Duration::from_secs(30),
+            EPOCH,
+            slot(),
+            tracker(),
+            PROJECTED,
+            || NOW,
+        )
+        .await;
+        assert!(
+            matches!(out1, AttemptOutcome::Escalated { .. }),
+            "got {out1:?}"
+        );
+
+        // Keeper approves a WIDER grant (adds web_fetch under a Hosts allowlist)
+        // via the targeted SetGrant edit → Blocked → Ready.
+        let widened = octos_fleet::WorkerGrant {
+            network: octos_fleet::NetworkGrant::Hosts(vec!["example.com".into()]),
+            tools: vec![
+                "read_file".into(),
+                "write_file".into(),
+                "shell".into(),
+                "web_fetch".into(),
+            ],
+            ..octos_fleet::WorkerGrant::minimal()
+        };
+        let rev = fleet.view().await.unwrap().revision;
+        let edit = fleet
+            .apply_edit(
+                octos_fleet::PlanEdit::SetGrant {
+                    task_id: "a".into(),
+                    grant: widened.clone(),
+                },
+                rev,
+                NOW,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            edit,
+            octos_fleet::PlanMutateOutcome::Mutated { .. }
+        ));
+
+        // Attempt 2: FRESH launch (the child is Ready again) — its registry must
+        // be rebuilt from the WIDER grant, so the agent is offered web_fetch.
+        let a2 = launch(&store, "f1", "a").await;
+        assert_ne!(a1, a2, "a fresh attempt id");
+        let view2 = view_of(&fleet, "a").await;
+        assert_eq!(view2.grant, widened, "attempt 2 carries the widened grant");
+        let seen: Arc<std::sync::Mutex<Vec<String>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let (_md2, write_factory) = factory_for(Arc::new(RecordingWriteProvider::new(
+            "out.txt",
+            seen.clone(),
+        )))
+        .await;
+        let work2 = TempDir::new().unwrap();
+        let out2 = run_attempt(
+            store.clone(),
+            "f1",
+            "a",
+            &a2,
+            &view2,
+            &write_factory,
+            work2.path(),
+            Duration::from_secs(30),
+            EPOCH,
+            slot(),
+            tracker(),
+            PROJECTED,
+            || NOW,
+        )
+        .await;
+        assert!(
+            matches!(out2, AttemptOutcome::Completed { .. }),
+            "the re-run must complete, got {out2:?}",
+        );
+        let offered = seen.lock().unwrap().clone();
+        assert!(
+            offered.contains(&"web_fetch".to_string()),
+            "the fresh attempt must be rebuilt from the WIDENED grant (web_fetch offered): {offered:?}",
+        );
+        assert!(
+            offered.contains(&"escalate".to_string()),
+            "the escalate valve is still always present: {offered:?}",
+        );
     }
 }

--- a/crates/octos-fleet/src/fleet.rs
+++ b/crates/octos-fleet/src/fleet.rs
@@ -33,7 +33,8 @@ use octos_core::SessionKey;
 use crate::grant::WorkerGrant;
 use crate::records::{
     AcceptanceCriterion, AcceptanceVerdict, ChildResultSnapshot, ChildStatus, DecisionKind,
-    DurablePlan, EvidenceRef, FleetBudget, FleetChildRecord, FleetStatus, PlanTask, SCHEMA_VERSION,
+    DurablePlan, EscalationRequest, EvidenceRef, FleetBudget, FleetChildRecord, FleetStatus,
+    PlanTask, SCHEMA_VERSION,
 };
 use crate::store::{CompleteOutcome, FleetKernelStore, PlanMutateOutcome};
 
@@ -97,6 +98,13 @@ pub enum PlanEdit {
         task_id: String,
         into: Vec<TaskSpec>,
     },
+    /// PR B — WIDEN a task's operator [`WorkerGrant`] and resume its blocked
+    /// child (`Blocked → Ready`), clearing its `pending_escalation`. This is the
+    /// keeper's `goal_grant` after a worker escalated mid-task. Like `Retitle`
+    /// it is TARGETED — it bumps only the plan `revision` (never `generation`)
+    /// and touches only this task's row, NOT a `replan` blast: the yielded
+    /// attempt is already settled, so there is no live attempt to interrupt.
+    SetGrant { task_id: String, grant: WorkerGrant },
 }
 
 // ---------------------------------------------------------------------------
@@ -139,6 +147,12 @@ pub struct TaskView {
     pub verdict: Option<AcceptanceVerdict>,
     pub evidence: Vec<EvidenceRef>,
     pub current_attempt_id: Option<String>,
+    /// PR B — the pending mid-task escalation, projected from the child's
+    /// [`FleetChildRecord::pending_escalation`]. `Some` while `status ==
+    /// Blocked`: how the keeper NOTICES a worker's grant-widen request on its
+    /// next `goal_get` turn (the request's advisory grant + reason). Cleared
+    /// once the keeper's `goal_grant`/`goal_deny` resolves it.
+    pub pending_escalation: Option<EscalationRequest>,
 }
 
 /// Counts of the current plan's tasks by child state, for synthesis /
@@ -157,6 +171,10 @@ pub struct FleetSummary {
     pub ready: usize,
     pub launching: usize,
     pub running: usize,
+    /// PR B — children yielded on a pending escalation (non-terminal), awaiting
+    /// an operator `goal_grant`/`goal_deny`. Counted separately so a synthesis /
+    /// progress render distinguishes "waiting on the operator" from in-flight.
+    pub blocked: usize,
     pub succeeded: usize,
     pub failed: usize,
     pub cancelled: usize,
@@ -291,6 +309,7 @@ impl Fleet {
                     evidence: verdict_evidence(verdict.as_ref()),
                     verdict,
                     current_attempt_id: child.and_then(|c| c.current_attempt_id.clone()),
+                    pending_escalation: child.and_then(|c| c.pending_escalation.clone()),
                 }
             })
             .collect();
@@ -395,6 +414,34 @@ impl Fleet {
                 self.note(
                     DecisionKind::Note,
                     &format!("retitle task {task_id}"),
+                    now_ms,
+                )
+                .await;
+            }
+            return Ok(outcome);
+        }
+
+        // PR B — SetGrant: targeted grant-widen + Blocked→Ready resume. Like
+        // Retitle it must NOT interrupt other children or bump generation, so it
+        // routes to the dedicated `set_task_grant` store op, never `replan`.
+        if let PlanEdit::SetGrant { task_id, grant } = &edit {
+            if !plan.tasks.iter().any(|t| &t.task_id == task_id) {
+                return Err(PlanGraphError::UnknownTask(task_id.clone()).into());
+            }
+            let outcome = self
+                .store
+                .set_task_grant(
+                    &self.fleet_id,
+                    expected_revision,
+                    task_id,
+                    grant.clone(),
+                    now_ms,
+                )
+                .await?;
+            if matches!(outcome, PlanMutateOutcome::Mutated { .. }) {
+                self.note(
+                    DecisionKind::Note,
+                    &format!("grant widen + resume task {task_id}"),
                     now_ms,
                 )
                 .await;
@@ -526,6 +573,7 @@ impl Fleet {
             ready: 0,
             launching: 0,
             running: 0,
+            blocked: 0,
             succeeded: 0,
             failed: 0,
             cancelled: 0,
@@ -541,6 +589,7 @@ impl Fleet {
                 ChildStatus::Ready => s.ready += 1,
                 ChildStatus::Launching => s.launching += 1,
                 ChildStatus::Running => s.running += 1,
+                ChildStatus::Blocked => s.blocked += 1,
                 ChildStatus::Succeeded => s.succeeded += 1,
                 ChildStatus::Failed => s.failed += 1,
                 ChildStatus::Cancelled => s.cancelled += 1,
@@ -742,6 +791,17 @@ fn apply_edit_to_tasks(
                 .ok_or_else(|| PlanGraphError::UnknownTask(task_id.clone()))?;
             t.deps = deps;
             Ok(format!("retarget deps of task {task_id}"))
+        }
+        // PR B: SetGrant is spec-only (like Retitle) and is early-returned by
+        // `apply_edit` to `set_task_grant`, so it never reaches this structural
+        // path. The arm exists for exhaustiveness and does the pure spec change.
+        PlanEdit::SetGrant { task_id, grant } => {
+            let t = tasks
+                .iter_mut()
+                .find(|t| t.task_id == task_id)
+                .ok_or_else(|| PlanGraphError::UnknownTask(task_id.clone()))?;
+            t.grant = grant;
+            Ok(format!("set grant of task {task_id}"))
         }
         PlanEdit::SplitTask { task_id, into } => {
             if into.is_empty() {
@@ -982,6 +1042,408 @@ mod tests {
             .record_outcome(task, &attempt, verdict, 80, EPOCH, now)
             .await
             .unwrap()
+    }
+
+    /// Drive a `Ready` task into `Blocked` via a recorded escalation: launch →
+    /// mark_running → `record_escalation` (80 real tokens). Returns the request
+    /// that was recorded, for assertions.
+    async fn escalate_child(fleet: &Fleet, task: &str, now: u64) -> crate::EscalationRequest {
+        let store = fleet.store();
+        let attempt = match store
+            .launch_child(fleet.fleet_id(), task, 100, now, EPOCH, TTL)
+            .await
+            .unwrap()
+        {
+            LaunchOutcome::Launched { attempt_id } => attempt_id,
+            other => panic!("launch {task}: {other:?}"),
+        };
+        store.mark_running(task, &attempt).await.unwrap();
+        let request = crate::EscalationRequest {
+            requested_grant: WorkerGrant {
+                network: crate::grant::NetworkGrant::Hosts(vec!["example.com".into()]),
+                tools: vec!["read_file".into(), "web_fetch".into()],
+                ..WorkerGrant::minimal()
+            },
+            reason: format!("{task} needs example.com"),
+        };
+        let out = store
+            .record_escalation(
+                fleet.fleet_id(),
+                task,
+                &attempt,
+                request.clone(),
+                80,
+                EPOCH,
+                now,
+            )
+            .await
+            .unwrap();
+        assert_eq!(out, CompleteOutcome::Completed);
+        request
+    }
+
+    #[tokio::test]
+    async fn set_grant_edit_widens_task_grant_and_readies_it() {
+        let (_d, store) = fresh().await;
+        let fleet = Fleet::create(
+            store.clone(),
+            "f1",
+            controller(),
+            None,
+            "default",
+            budget(10_000),
+            "obj",
+            vec![spec("a", &[]), spec("b", &[])],
+            0,
+        )
+        .await
+        .unwrap();
+        // Drive `a` to Blocked; `b` stays a fresh Ready, minimal-grant control.
+        escalate_child(&fleet, "a", 1).await;
+        let before = fleet.view().await.unwrap();
+        assert_eq!(before.revision, 0);
+        assert_eq!(before.generation, 0);
+        let a_before = before.tasks.iter().find(|t| t.task_id == "a").unwrap();
+        assert_eq!(a_before.status, ChildStatus::Blocked);
+        assert!(
+            a_before.pending_escalation.is_some(),
+            "a is blocked on a request"
+        );
+
+        // The keeper grants a WIDER grant (web_fetch under a Hosts allowlist).
+        let wider = WorkerGrant {
+            network: crate::grant::NetworkGrant::Hosts(vec!["example.com".into()]),
+            tools: vec!["read_file".into(), "write_file".into(), "web_fetch".into()],
+            ..WorkerGrant::minimal()
+        };
+        let out = fleet
+            .apply_edit(
+                PlanEdit::SetGrant {
+                    task_id: "a".into(),
+                    grant: wider.clone(),
+                },
+                0,
+                7,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            out,
+            PlanMutateOutcome::Mutated { revision: 1 },
+            "SetGrant bumps only the revision",
+        );
+
+        let after = fleet.view().await.unwrap();
+        assert_eq!(after.revision, 1, "revision bumped");
+        assert_eq!(
+            after.generation, 0,
+            "SetGrant must NOT bump the generation (no replan blast)",
+        );
+        let a = after.tasks.iter().find(|t| t.task_id == "a").unwrap();
+        assert_eq!(a.status, ChildStatus::Ready, "Blocked → Ready");
+        assert_eq!(a.grant, wider, "the widened grant is applied");
+        assert!(
+            a.pending_escalation.is_none(),
+            "the escalation is cleared on apply",
+        );
+        // `b` is untouched (no blast radius): still Ready, still minimal.
+        let b = after.tasks.iter().find(|t| t.task_id == "b").unwrap();
+        assert_eq!(b.status, ChildStatus::Ready);
+        assert_eq!(b.grant, WorkerGrant::minimal());
+        // The resumed task is launchable again.
+        assert!(
+            fleet
+                .ready_tasks(9)
+                .await
+                .unwrap()
+                .contains(&"a".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn blocked_child_keeps_goal_active() {
+        let (_d, store) = fresh().await;
+        let fleet = Fleet::create(
+            store.clone(),
+            "f1",
+            controller(),
+            None,
+            "default",
+            budget(10_000),
+            "obj",
+            vec![spec("a", &[])],
+            0,
+        )
+        .await
+        .unwrap();
+        escalate_child(&fleet, "a", 1).await;
+        // A Blocked (non-terminal, unaccepted) child holds completion open: the
+        // goal stays ACTIVE while it waits on the operator.
+        assert!(
+            !fleet.is_complete().await.unwrap(),
+            "a Blocked child must keep the fleet incomplete (goal stays active)",
+        );
+        let s = fleet.summary().await.unwrap();
+        assert_eq!(s.blocked, 1, "the summary counts the blocked child");
+        assert_eq!(s.succeeded, 0);
+    }
+
+    #[tokio::test]
+    async fn deny_moves_blocked_to_failed_terminal() {
+        let (_d, store) = fresh().await;
+        let fleet = Fleet::create(
+            store.clone(),
+            "f1",
+            controller(),
+            None,
+            "default",
+            budget(10_000),
+            "obj",
+            vec![spec("a", &[])],
+            0,
+        )
+        .await
+        .unwrap();
+        escalate_child(&fleet, "a", 1).await;
+
+        // Deny: the child must go Blocked → Failed (TERMINAL), else it wedges
+        // the fleet forever (is_complete never trips on a non-terminal child).
+        let out = store
+            .deny_escalation("f1", "a", "no budget for that host", 9)
+            .await
+            .unwrap();
+        assert_eq!(out.settled, CompleteOutcome::Completed);
+        // codex round-4 (defect 2): the deny txn ITSELF reports the fleet is now
+        // un-completable (a Failed task strands it) so the keeper resolves the
+        // goal without a separate read.
+        assert!(
+            out.fleet_un_completable,
+            "denying the only task makes the fleet un-completable",
+        );
+
+        let v = fleet.view().await.unwrap();
+        let a = v.tasks.iter().find(|t| t.task_id == "a").unwrap();
+        assert_eq!(a.status, ChildStatus::Failed, "denial is terminal");
+        assert!(a.status.is_terminal(), "a denied child is terminal");
+        assert!(matches!(
+            a.verdict,
+            Some(AcceptanceVerdict::Rejected { .. })
+        ));
+        assert!(a.pending_escalation.is_none(), "escalation cleared on deny");
+        // A denied child is not launchable — the fleet doesn't wedge on it.
+        assert!(fleet.ready_tasks(9).await.unwrap().is_empty());
+
+        // A second deny is an inert no-op (the child already resumed/failed) — and
+        // a no-op reports no completability change.
+        let again = store.deny_escalation("f1", "a", "again", 10).await.unwrap();
+        assert_eq!(again.settled, CompleteOutcome::Superseded);
+        assert!(
+            !again.fleet_un_completable,
+            "a no-op deny reports fleet_un_completable = false (nothing changed)",
+        );
+    }
+
+    #[tokio::test]
+    async fn deny_reports_un_completable_over_a_multi_task_plan() {
+        // codex round-4 (defect 2): the completability the deny txn RETURNS is
+        // computed by SCANNING the plan's children — not just the denied one. A
+        // two-task fleet (`b` depends on `a`): denying the escalated `a` makes the
+        // fleet un-completable (a Failed task PLUS a still-Planned task), and the
+        // scan reads BOTH children — `a` from the txn-local record it just wrote,
+        // `b` from the children table.
+        let (_d, store) = fresh().await;
+        let fleet = Fleet::create(
+            store.clone(),
+            "f1",
+            controller(),
+            None,
+            "default",
+            budget(10_000),
+            "obj",
+            vec![spec("a", &[]), spec("b", &["a"])],
+            0,
+        )
+        .await
+        .unwrap();
+        escalate_child(&fleet, "a", 1).await;
+
+        let out = store.deny_escalation("f1", "a", "no", 9).await.unwrap();
+        assert_eq!(out.settled, CompleteOutcome::Completed);
+        assert!(
+            out.fleet_un_completable,
+            "denying `a` strands dependent `b` — the scanned plan is un-completable",
+        );
+        // `b` never became Ready (its prerequisite failed), so the fleet is wedged
+        // absent a replan — exactly what the returned flag tells the keeper.
+        assert!(fleet.ready_tasks(9).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn deny_emits_a_childdone_wake_and_bumps_revision() {
+        // codex round-2 (defect 3+4): deny must EMIT a ChildDone wake (so the
+        // keeper re-evaluates instead of the goal wedging active) AND bump the
+        // plan revision (so a concurrent grant@N fails its CAS).
+        let (_d, store) = fresh().await;
+        let fleet = Fleet::create(
+            store.clone(),
+            "f1",
+            controller(),
+            None,
+            "default",
+            budget(10_000),
+            "obj",
+            vec![spec("a", &[])],
+            0,
+        )
+        .await
+        .unwrap();
+        escalate_child(&fleet, "a", 1).await;
+        let rev_before = fleet.view().await.unwrap().revision;
+
+        store.deny_escalation("f1", "a", "no", 9).await.unwrap();
+
+        // The plan revision advanced (mutual exclusion with a racing grant).
+        assert_eq!(
+            fleet.view().await.unwrap().revision,
+            rev_before + 1,
+            "deny bumps the plan revision",
+        );
+        // At least two ChildDone events exist (one from the escalation, one from
+        // the deny) — the deny wake is what re-drives the keeper.
+        let mut child_done = 0;
+        for _ in 0..8 {
+            match store.claim_next("k", 0, 100).await.unwrap() {
+                Some(ev) if ev.kind == crate::records::FleetEventKind::ChildDone => child_done += 1,
+                Some(_) => {}
+                None => break,
+            }
+        }
+        assert!(
+            child_done >= 2,
+            "deny must emit a ChildDone wake (saw {child_done} total)",
+        );
+    }
+
+    #[tokio::test]
+    async fn grant_after_deny_is_rejected_not_applied() {
+        // codex round-2 (defect 4): grant and deny are MUTUALLY EXCLUSIVE. Once
+        // deny fails the child, a grant (even one that read `Blocked`) must be
+        // REFUSED — the denied capability can never reach the plan.
+        let (_d, store) = fresh().await;
+        let fleet = Fleet::create(
+            store.clone(),
+            "f1",
+            controller(),
+            None,
+            "default",
+            budget(10_000),
+            "obj",
+            vec![spec("a", &[])],
+            0,
+        )
+        .await
+        .unwrap();
+        escalate_child(&fleet, "a", 1).await;
+        // Deny wins: Blocked → Failed + revision bump (0 → 1).
+        store.deny_escalation("f1", "a", "no", 2).await.unwrap();
+
+        let wider = WorkerGrant {
+            network: crate::grant::NetworkGrant::Hosts(vec!["example.com".into()]),
+            tools: vec!["read_file".into(), "web_fetch".into()],
+            ..WorkerGrant::minimal()
+        };
+        // A grant at the NEW revision (child now Failed, not Blocked) → the in-txn
+        // Blocked CAS refuses it (RejectedNotBlocked), no mutation.
+        let rev = fleet.view().await.unwrap().revision;
+        let refused = fleet
+            .apply_edit(
+                PlanEdit::SetGrant {
+                    task_id: "a".into(),
+                    grant: wider.clone(),
+                },
+                rev,
+                3,
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(refused, PlanMutateOutcome::RejectedNotBlocked { .. }),
+            "grant on a non-Blocked (denied) child must be refused: {refused:?}",
+        );
+        // A grant at the STALE (pre-deny) revision → RevisionMismatch (belt).
+        let stale = fleet
+            .apply_edit(
+                PlanEdit::SetGrant {
+                    task_id: "a".into(),
+                    grant: wider.clone(),
+                },
+                0,
+                4,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(stale, PlanMutateOutcome::RevisionMismatch { .. }));
+        // The denied capability was NEVER applied — the task keeps its minimal
+        // grant and stays terminally Failed.
+        let v = fleet.view().await.unwrap();
+        let a = v.tasks.iter().find(|t| t.task_id == "a").unwrap();
+        assert_eq!(a.status, ChildStatus::Failed);
+        assert_eq!(
+            a.grant,
+            WorkerGrant::minimal(),
+            "the denied grant must never be applied",
+        );
+    }
+
+    #[tokio::test]
+    async fn replan_clears_a_blocked_survivors_pending_escalation() {
+        // codex round-2 (defect 4): a replan that re-readies a Blocked survivor
+        // MUST clear its stale `pending_escalation` — the advisory grant may name
+        // capabilities the operator never approved.
+        let (_d, store) = fresh().await;
+        let fleet = Fleet::create(
+            store.clone(),
+            "f1",
+            controller(),
+            None,
+            "default",
+            budget(10_000),
+            "obj",
+            vec![spec("a", &[])],
+            0,
+        )
+        .await
+        .unwrap();
+        escalate_child(&fleet, "a", 1).await;
+        assert!(
+            fleet
+                .view()
+                .await
+                .unwrap()
+                .tasks
+                .iter()
+                .find(|t| t.task_id == "a")
+                .unwrap()
+                .pending_escalation
+                .is_some(),
+        );
+
+        // A structural replan (AddTask) resets the Blocked survivor.
+        fleet
+            .apply_edit(PlanEdit::AddTask(spec("b", &[])), 0, 5)
+            .await
+            .unwrap();
+        let v = fleet.view().await.unwrap();
+        let a = v.tasks.iter().find(|t| t.task_id == "a").unwrap();
+        assert!(
+            a.pending_escalation.is_none(),
+            "replan must clear the stale escalation on a re-readied Blocked child",
+        );
+        assert_eq!(
+            a.status,
+            ChildStatus::Ready,
+            "the Blocked survivor is re-readied by the replan",
+        );
     }
 
     #[tokio::test]
@@ -2131,10 +2593,11 @@ mod tests {
         assert!(store.get_fleet("f1").await.unwrap().is_none());
     }
 
-    /// P2-b: records are stamped at schema_version 2 (so a PR-1 binary drops
-    /// them via the higher-version guard rather than mis-parsing).
+    /// P2-b: records are stamped at the CURRENT [`SCHEMA_VERSION`] (so an older
+    /// binary drops them via the higher-version guard rather than mis-parsing).
+    /// PR B bumped 2 → 3 for the `ChildStatus::Blocked` variant.
     #[tokio::test]
-    async fn records_are_written_at_schema_version_two() {
+    async fn records_are_written_at_current_schema_version() {
         let (_d, store) = fresh().await;
         Fleet::create(
             store.clone(),
@@ -2149,10 +2612,10 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(SCHEMA_VERSION, 2);
+        assert_eq!(SCHEMA_VERSION, 3);
         assert_eq!(
             store.get_plan("f1").await.unwrap().unwrap().schema_version,
-            2
+            SCHEMA_VERSION,
         );
         assert_eq!(
             store
@@ -2161,7 +2624,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .schema_version,
-            2
+            SCHEMA_VERSION,
         );
     }
 

--- a/crates/octos-fleet/src/lib.rs
+++ b/crates/octos-fleet/src/lib.rs
@@ -52,11 +52,11 @@ pub use grant::{
 };
 pub use records::{
     AcceptanceCriterion, AcceptanceVerdict, Attempt, AttemptStatus, ChildResultSnapshot,
-    ChildStatus, DecisionEntry, DecisionKind, DurablePlan, EvidenceRef, FleetBudget,
-    FleetChildRecord, FleetEventKind, FleetRecord, FleetStatus, Lease, OutboxEvent, PlanTask,
-    SCHEMA_VERSION, Verifier, WorkerKind,
+    ChildStatus, DecisionEntry, DecisionKind, DurablePlan, EscalationRequest, EvidenceRef,
+    FleetBudget, FleetChildRecord, FleetEventKind, FleetRecord, FleetStatus, Lease, OutboxEvent,
+    PlanTask, SCHEMA_VERSION, Verifier, WorkerKind,
 };
 pub use store::{
-    AckOutcome, CompleteOutcome, FleetKernelStore, FleetSnapshot, InterruptedAttempt,
-    LaunchOutcome, MarkRunningOutcome, PlanMutateOutcome, ReconcileReport,
+    AckOutcome, CompleteOutcome, DenyEscalationOutcome, FleetKernelStore, FleetSnapshot,
+    InterruptedAttempt, LaunchOutcome, MarkRunningOutcome, PlanMutateOutcome, ReconcileReport,
 };

--- a/crates/octos-fleet/src/records.rs
+++ b/crates/octos-fleet/src/records.rs
@@ -20,7 +20,16 @@ use crate::grant::WorkerGrant;
 /// and `evidence` fields (the plan/child duality reconciliation). Stamping
 /// v2 means a PR-1 binary drops a v2 row via the higher-version guard rather
 /// than failing to deserialize the now-absent fields.
-pub const SCHEMA_VERSION: u32 = 2;
+///
+/// Bumped 2 → 3 in PR B (escalate-to-master): [`ChildStatus`] gained the
+/// non-terminal `Blocked` variant. Unlike the `pending_escalation` /
+/// `controller_workspace_root` field additions (forward-compatible via
+/// `#[serde(default)]`, so NOT a bump), a NEW ENUM VARIANT is an *incompatible*
+/// change: a v2 binary decoding a row whose `status` is `"Blocked"` would fail
+/// with an unknown-variant error rather than gracefully dropping it. Stamping v3
+/// means such a row loads as `Ok(None)` (higher-version guard) on an older
+/// binary — dropped, never mis-parsed.
+pub const SCHEMA_VERSION: u32 = 3;
 
 // ---------------------------------------------------------------------------
 // Status enums
@@ -41,12 +50,25 @@ pub enum FleetStatus {
 /// `Ready` means every dependency child is `Succeeded`. `Launching` and
 /// `Running` are the two non-terminal in-flight states a live [`Attempt`]
 /// backs; recovery reconciliation returns a stranded one to `Ready`.
+///
+/// `Blocked` (PR B) is a NON-terminal state a worker's attempt yields into when
+/// it hits the edge of its [`crate::WorkerGrant`] and escalates: the yielded
+/// attempt is already settled (its tokens committed), the child records a
+/// [`FleetChildRecord::pending_escalation`], and it waits for the keeper's
+/// operator decision. A `goal_grant` widens the grant and moves it `Blocked →
+/// Ready` (a fresh attempt rebuilds from the wider grant); a `goal_deny` moves
+/// it `Blocked → Failed` (terminal — a Blocked child must never wedge the fleet,
+/// since `is_complete` never trips while one is non-terminal-but-unaccepted).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ChildStatus {
     Planned,
     Ready,
     Launching,
     Running,
+    /// Non-terminal: the attempt yielded to request an operator grant widen
+    /// ([`FleetChildRecord::pending_escalation`]); awaits `goal_grant` (→
+    /// `Ready`) or `goal_deny` (→ `Failed`).
+    Blocked,
     Succeeded,
     Failed,
     Cancelled,
@@ -54,7 +76,10 @@ pub enum ChildStatus {
 
 impl ChildStatus {
     /// A child in a terminal state cannot launch or transition further
-    /// (other than an explicit cancel, which is itself terminal).
+    /// (other than an explicit cancel, which is itself terminal). `Blocked`
+    /// is deliberately NOT terminal: it is a pause awaiting an operator
+    /// decision, so it holds `is_complete` open (the goal stays active) yet
+    /// can still transition to `Ready` (granted) or `Failed` (denied).
     pub fn is_terminal(self) -> bool {
         matches!(
             self,
@@ -174,8 +199,40 @@ pub struct FleetChildRecord {
     /// Denormalized from `PlanTask.deps` (child_id == task_id) so the
     /// store's dep-resolution helper is self-contained.
     pub deps: Vec<String>,
+    /// PR B — the pending mid-task escalation, set when a worker's attempt
+    /// yields via the `escalate` tool (status → [`ChildStatus::Blocked`]). It
+    /// is the worker's REQUEST for a wider grant; the keeper reads it (surfaced
+    /// through [`crate::TaskView::pending_escalation`]) and decides. `Some`
+    /// while a child is `Blocked`; cleared when the keeper's `goal_grant` (→
+    /// `Ready`) or `goal_deny` (→ `Failed`) resolves it — so a re-run child
+    /// never carries a stale request. `#[serde(default)]` is deliberate
+    /// forward-compat, **NOT** a `SCHEMA_VERSION` bump: an old row written
+    /// before escalation existed (no key) deserializes to `None` rather than
+    /// dropping the row (mirrors how `grant`/`controller_workspace_root` were
+    /// added).
+    #[serde(default)]
+    pub pending_escalation: Option<EscalationRequest>,
     pub generation: u64,
     pub updated_at_ms: u64,
+}
+
+/// A worker's mid-task request to WIDEN its [`crate::WorkerGrant`] (PR B). The
+/// worker records this via the always-on `escalate` tool when it hits the edge
+/// of its grant (a host/tool/fs it wasn't given) and yields its attempt; the
+/// keeper reads it and decides.
+///
+/// `requested_grant` is **ADVISORY** — it is what the worker asked for, not what
+/// it gets. The worker can NEVER self-widen: only the keeper's `goal_grant`
+/// mutates [`crate::PlanTask::grant`], and it re-runs `grant.validate()` on the
+/// grant IT chooses (which may be less than requested). This request only
+/// informs the operator's decision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EscalationRequest {
+    /// The grant the worker asked for (advisory — the keeper may grant less).
+    pub requested_grant: WorkerGrant,
+    /// Why the worker needs it (the model's own justification), for the
+    /// operator's decision.
+    pub reason: String,
 }
 
 /// The daemon-boot lease guarding a live attempt. `owner_epoch` is this
@@ -458,6 +515,66 @@ mod tests {
         assert!(ChildStatus::Cancelled.is_terminal());
         assert!(!ChildStatus::Ready.is_terminal());
         assert!(!ChildStatus::Running.is_terminal());
+        // PR B: Blocked is a pause awaiting an operator decision — NOT terminal,
+        // so it holds `is_complete` open (the goal stays active).
+        assert!(!ChildStatus::Blocked.is_terminal());
+    }
+
+    #[test]
+    fn child_record_pending_escalation_round_trips_and_old_row_defaults_none() {
+        use crate::grant::{NetworkGrant, WorkerGrant};
+
+        // A blocked child carrying a pending escalation round-trips verbatim.
+        let rec = FleetChildRecord {
+            schema_version: SCHEMA_VERSION,
+            fleet_id: "f1".into(),
+            child_id: "t1".into(),
+            worker_kind: WorkerKind::StatelessTask,
+            status: ChildStatus::Blocked,
+            current_attempt_id: None,
+            attempts_used: 1,
+            outcome: None,
+            tokens_committed: 80,
+            deps: vec![],
+            pending_escalation: Some(EscalationRequest {
+                requested_grant: WorkerGrant {
+                    network: NetworkGrant::Hosts(vec!["example.com".into()]),
+                    tools: vec!["read_file".into(), "web_fetch".into()],
+                    ..WorkerGrant::minimal()
+                },
+                reason: "needs example.com to fetch the report".into(),
+            }),
+            generation: 0,
+            updated_at_ms: 5,
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: FleetChildRecord = decode_row(&json).unwrap().unwrap();
+        assert_eq!(back, rec, "the pending escalation round-trips through JSON");
+
+        // An OLD row written before escalation existed (no `pending_escalation`
+        // key) must still decode — `#[serde(default)]` fills `None`, NOT fail.
+        // This is why the field is NOT a `SCHEMA_VERSION` bump.
+        let old_json = r#"{
+            "schema_version": 2,
+            "fleet_id": "f1",
+            "child_id": "t1",
+            "worker_kind": "StatelessTask",
+            "status": "Ready",
+            "current_attempt_id": null,
+            "attempts_used": 0,
+            "outcome": null,
+            "tokens_committed": 0,
+            "deps": [],
+            "generation": 0,
+            "updated_at_ms": 0
+        }"#;
+        let legacy: FleetChildRecord = decode_row(old_json)
+            .expect("decode old row")
+            .expect("row kept, not dropped");
+        assert_eq!(
+            legacy.pending_escalation, None,
+            "a child with no escalation field loads as None"
+        );
     }
 
     #[test]

--- a/crates/octos-fleet/src/store.rs
+++ b/crates/octos-fleet/src/store.rs
@@ -40,6 +40,7 @@ use octos_core::SessionKey;
 use redb::{Database, ReadableTable, TableDefinition};
 use uuid::Uuid;
 
+use crate::grant::WorkerGrant;
 use crate::records::*;
 
 const FLEETS: TableDefinition<&str, &str> = TableDefinition::new("fleets");
@@ -74,6 +75,24 @@ pub enum CompleteOutcome {
     Superseded,
 }
 
+/// Result of [`FleetKernelStore::deny_escalation`]. Carries the settle outcome
+/// AND — computed IN THE SAME write-txn, over the durable post-deny child states
+/// — whether the fleet can no longer auto-complete. PR B (codex round-4, defect
+/// 2): the keeper drives the goal terminal from `fleet_un_completable` DIRECTLY,
+/// so the resolution can never be skipped by a separate fallible read after the
+/// durable deny.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DenyEscalationOutcome {
+    /// `Completed` when the `Blocked → Failed` transition committed; `Superseded`
+    /// when the child was not `Blocked` (an inert no-op deny).
+    pub settled: CompleteOutcome,
+    /// Whether the fleet is now un-completable — no task can drive it to
+    /// all-`Succeeded` because a `Failed` task strands it (mirrors the goal
+    /// snapshot's `!complete && any-failed` rule, computed on the durable state).
+    /// `false` on a `Superseded` no-op (nothing changed).
+    pub fleet_un_completable: bool,
+}
+
 /// Result of a `mark_running` CAS. `Superseded` means the identity/predicate
 /// fence failed — a genuine lost race (the attempt is stale/superseded or not
 /// the child's current attempt), so nothing changes; deliberately **not** an
@@ -102,6 +121,15 @@ pub enum PlanMutateOutcome {
     /// out-of-txn pre-check and the CAS cannot slip a dep-change past the
     /// freeze (round-2 P1). No mutation.
     RejectedTerminalDepChange {
+        task_id: String,
+    },
+    /// PR B — a `SetGrant` (grant-widen + resume) targeted a child that is NOT
+    /// `Blocked` — detected **inside** the `set_task_grant` write-txn, so a
+    /// child that a concurrent `deny_escalation` moved `Blocked → Failed` (or
+    /// that a prior grant already resumed) between the caller's out-of-txn read
+    /// and the CAS cannot have the denied/stale grant applied. No mutation: the
+    /// grant is REFUSED (grant and deny are mutually exclusive).
+    RejectedNotBlocked {
         task_id: String,
     },
 }
@@ -378,6 +406,7 @@ impl FleetKernelStore {
                         outcome: None,
                         tokens_committed: 0,
                         deps: t.deps.clone(),
+                        pending_escalation: None,
                         generation: 0,
                         updated_at_ms: now_ms,
                     };
@@ -451,6 +480,7 @@ impl FleetKernelStore {
                     outcome: None,
                     tokens_committed: 0,
                     deps,
+                    pending_escalation: None,
                     generation: fleet.generation,
                     updated_at_ms: now_ms,
                 };
@@ -1016,6 +1046,181 @@ impl FleetKernelStore {
         .wrap_err("join complete_child")?
     }
 
+    /// PR B — record a mid-task ESCALATION: settle a running attempt into a
+    /// NON-terminal [`ChildStatus::Blocked`] with a [`EscalationRequest`], so
+    /// the keeper can widen the grant (`goal_grant` → `Ready`) or deny it
+    /// (`goal_deny` → `Failed`).
+    ///
+    /// It reuses `complete_child`'s EXACT four-part fence (the child's
+    /// `current_attempt_id` is this attempt, the attempt is `Running`, its
+    /// `generation` equals the fleet's, and its lease `owner_epoch` matches) —
+    /// so a stale / superseded / cross-fleet attempt is a no-op
+    /// ([`CompleteOutcome::Superseded`]). It differs from `complete_child` only
+    /// in the effect: on success it
+    ///
+    /// - settles the **REAL** tokens the yielded attempt used (`committed +=
+    ///   actual_tokens`, `reserved -= reserved_tokens`) — NOT `0`. Budget
+    ///   honesty matters here precisely because the child is NON-terminal: a
+    ///   FRESH attempt runs after the grant widen, so the budget it is admitted
+    ///   against must already reflect the tokens the yielded attempt spent (a
+    ///   `0`-commit would let a worker spend the whole budget, escalate, and
+    ///   spend it again);
+    /// - marks the attempt `Interrupted` (it yielded, it did not complete) and
+    ///   **clears** `current_attempt_id`, so the Blocked→Ready transition can
+    ///   launch a clean fresh attempt;
+    /// - sets the child `Blocked` + `pending_escalation` (its `outcome` stays
+    ///   `None` — Blocked is not terminal, so there is no verdict yet);
+    /// - appends the SAME [`FleetEventKind::ChildDone`] the completion path
+    ///   does, so the EXISTING keeper wake fires with no new machinery.
+    #[allow(clippy::too_many_arguments)] // 4-part predicate + escalation payload + settlement inputs are irreducible here
+    pub async fn record_escalation(
+        &self,
+        fleet_id: &str,
+        child_id: &str,
+        attempt_id: &str,
+        request: EscalationRequest,
+        actual_tokens: u64,
+        owner_epoch: u64,
+        now_ms: u64,
+    ) -> Result<CompleteOutcome> {
+        ensure_key_safe(&[fleet_id, child_id, attempt_id])?;
+        let db = self.db.clone();
+        let fleet_id = fleet_id.to_string();
+        let child_id = child_id.to_string();
+        let attempt_id = attempt_id.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<CompleteOutcome> {
+            let _held = held;
+            let wtx = db.begin_write()?;
+            let outcome = {
+                let mut fleets = wtx.open_table(FLEETS)?;
+                let mut children = wtx.open_table(FLEET_CHILDREN)?;
+                let mut attempts = wtx.open_table(ATTEMPTS)?;
+                let mut outbox = wtx.open_table(OUTBOX)?;
+
+                let ckey = child_key(&fleet_id, &child_id);
+                let akey = attempt_key(&child_id, &attempt_id);
+
+                let Some(cj) = children.get(ckey.as_str())?.map(|g| g.value().to_string()) else {
+                    return Ok(CompleteOutcome::Superseded);
+                };
+                let Some(mut child) = decode_row::<FleetChildRecord>(&cj)? else {
+                    return Ok(CompleteOutcome::Superseded);
+                };
+                let Some(aj) = attempts.get(akey.as_str())?.map(|g| g.value().to_string()) else {
+                    return Ok(CompleteOutcome::Superseded);
+                };
+                let Some(mut attempt) = decode_row::<Attempt>(&aj)? else {
+                    return Ok(CompleteOutcome::Superseded);
+                };
+                let Some(fj) = fleets
+                    .get(fleet_id.as_str())?
+                    .map(|g| g.value().to_string())
+                else {
+                    return Ok(CompleteOutcome::Superseded);
+                };
+                let Some(mut fleet) = decode_row::<FleetRecord>(&fj)? else {
+                    return Ok(CompleteOutcome::Superseded);
+                };
+
+                // Identity: every decoded row must own the addressed ids (P1-4).
+                if child.fleet_id != fleet_id
+                    || child.child_id != child_id
+                    || attempt.fleet_id != fleet_id
+                    || attempt.child_id != child_id
+                    || attempt.attempt_id != attempt_id
+                    || fleet.fleet_id != fleet_id
+                {
+                    return Ok(CompleteOutcome::Superseded);
+                }
+
+                // Same four-part predicate as `complete_child` — a stale / late
+                // / superseded attempt cannot escalate.
+                let is_current = child.current_attempt_id.as_deref() == Some(attempt_id.as_str());
+                let is_running = attempt.status == AttemptStatus::Running;
+                let gen_ok = attempt.generation == fleet.generation;
+                let lease_ok = attempt.lease.owner_epoch == owner_epoch;
+                if !(is_current && is_running && gen_ok && lease_ok) {
+                    return Ok(CompleteOutcome::Superseded);
+                }
+
+                // ---- passes: settle REAL tokens + Blocked (non-terminal) ----
+                let reserved = attempt.reserved_tokens;
+                let new_committed = fleet
+                    .budget
+                    .tokens_committed
+                    .checked_add(actual_tokens)
+                    .ok_or_else(|| eyre::eyre!("committed-token overflow escalating {child_id}"))?;
+                let new_reserved = fleet
+                    .budget
+                    .tokens_reserved
+                    .checked_sub(reserved)
+                    .ok_or_else(|| {
+                        eyre::eyre!(
+                            "reservation underflow escalating {child_id}: reserved {reserved} > \
+                             fleet.tokens_reserved {}",
+                            fleet.budget.tokens_reserved
+                        )
+                    })?;
+
+                // Blocked is NON-terminal: no verdict, but the yielded attempt's
+                // real token spend IS committed so the fresh attempt's budget is
+                // honest. Clear `current_attempt_id` so Blocked→Ready launches
+                // clean.
+                child.status = ChildStatus::Blocked;
+                // PR B (codex round-3, defect 3) — RE-STAMP the row to the current
+                // schema. `Blocked` is a v3-only enum variant, so a row carrying it
+                // MUST say v3: a legacy v2 child (written before the upgrade, still
+                // stamped `schema_version: 2`) that escalates would otherwise persist
+                // `{schema_version: 2, status: "Blocked"}` — and a rolled-back v2
+                // binary, seeing `2 <= 2`, attempts a full decode and ERRORS on the
+                // unknown `Blocked` variant instead of dropping the row as newer.
+                // Stamping v3 makes `decode_row` on the old binary drop it (`3 > 2`).
+                // This is THE write that introduces `Blocked`, so it is the one that
+                // must guarantee the invariant "any persisted `Blocked` row is v3".
+                child.schema_version = SCHEMA_VERSION;
+                child.pending_escalation = Some(request);
+                child.current_attempt_id = None;
+                child.tokens_committed = child
+                    .tokens_committed
+                    .checked_add(actual_tokens)
+                    .ok_or_else(|| eyre::eyre!("child committed-token overflow for {child_id}"))?;
+                child.updated_at_ms = now_ms;
+                children.insert(ckey.as_str(), serde_json::to_string(&child)?.as_str())?;
+
+                // The attempt yielded — Interrupted, not Done (no result).
+                attempt.status = AttemptStatus::Interrupted;
+                attempt.ended_at_ms = Some(now_ms);
+                attempts.insert(akey.as_str(), serde_json::to_string(&attempt)?.as_str())?;
+
+                fleet.budget.tokens_committed = new_committed;
+                fleet.budget.tokens_reserved = new_reserved;
+                fleet.updated_at_ms = now_ms;
+                fleets.insert(fleet_id.as_str(), serde_json::to_string(&fleet)?.as_str())?;
+
+                // The SAME wake the completion path fires — the keeper reads the
+                // pending escalation off the fleet view on its next turn.
+                append_outbox(
+                    &mut outbox,
+                    outbox_event(
+                        FleetEventKind::ChildDone,
+                        &fleet_id,
+                        Some(&child_id),
+                        Some(&attempt_id),
+                    ),
+                )?;
+
+                CompleteOutcome::Completed
+            };
+            if matches!(outcome, CompleteOutcome::Completed) {
+                wtx.commit()?;
+            }
+            Ok(outcome)
+        })
+        .await
+        .wrap_err("join record_escalation")?
+    }
+
     /// Re-plan a fleet (P1-2): revision-fenced full replacement of the
     /// durable plan with clean **interrupt-and-restart** semantics, all in
     /// one write-txn. It CAS-checks `expected_revision`, increments
@@ -1233,6 +1438,13 @@ impl FleetKernelStore {
                             // as a double-launch (P1).
                             child.current_attempt_id = None;
                             child.outcome = None;
+                            // PR B — a replan that resets a `Blocked` survivor must
+                            // CLEAR its `pending_escalation`: the child is being
+                            // freshly re-readied against the new plan, so a stale
+                            // request (whose advisory grant may name capabilities
+                            // the operator never approved) must not linger onto the
+                            // fresh attempt or a later grant/deny decision.
+                            child.pending_escalation = None;
                             child.status = if child.deps.iter().all(|d| succeeded_ids.contains(d)) {
                                 ChildStatus::Ready
                             } else {
@@ -1245,6 +1457,7 @@ impl FleetKernelStore {
                             reason: "removed by replan".into(),
                         });
                         child.current_attempt_id = None;
+                        child.pending_escalation = None;
                     }
                     children.insert(ckey.as_str(), serde_json::to_string(&child)?.as_str())?;
                 }
@@ -1273,6 +1486,7 @@ impl FleetKernelStore {
                         outcome: None,
                         tokens_committed: 0,
                         deps: task.deps.clone(),
+                        pending_escalation: None,
                         generation: new_gen,
                         updated_at_ms: now_ms,
                     };
@@ -1367,6 +1581,276 @@ impl FleetKernelStore {
         })
         .await
         .wrap_err("join retitle_task")?
+    }
+
+    /// PR B — apply an operator grant WIDEN to one task and resume its blocked
+    /// child, in one revision-fenced write-txn. This is the `goal_grant` store
+    /// op: the keeper approved a worker's mid-task escalation, so the task's
+    /// [`PlanTask::grant`] is replaced with the keeper-chosen grant and the
+    /// yielded child is transitioned `Blocked → Ready` (its
+    /// `pending_escalation` cleared) — a fresh attempt then rebuilds its
+    /// registry + sandbox from the NEW, wider grant.
+    ///
+    /// It is DELIBERATELY targeted, NOT a [`FleetKernelStore::replan`]: it bumps
+    /// only the plan `revision` (never `fleet.generation`) and touches only THIS
+    /// task's row — no blast radius across other children, no re-ready of every
+    /// non-`Succeeded` child. A generation bump is unnecessary because the
+    /// yielded attempt is ALREADY settled (`record_escalation` interrupted it
+    /// and cleared `current_attempt_id` before this edit): there is no live
+    /// attempt to fence off.
+    ///
+    /// CAS on `expected_revision` (stale → [`PlanMutateOutcome::RevisionMismatch`],
+    /// nothing changes). Errors if the task is absent from the plan. The child
+    /// transition is applied only when the child is `Blocked` (the escalation
+    /// case); a non-`Blocked` child keeps its status (the grant still updates),
+    /// so a grant edit is inert on execution state outside the escalation flow.
+    pub async fn set_task_grant(
+        &self,
+        fleet_id: &str,
+        expected_revision: u64,
+        task_id: &str,
+        grant: WorkerGrant,
+        now_ms: u64,
+    ) -> Result<PlanMutateOutcome> {
+        ensure_key_safe(&[fleet_id, task_id])?;
+        let db = self.db.clone();
+        let fleet_id = fleet_id.to_string();
+        let task_id = task_id.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<PlanMutateOutcome> {
+            let _held = held;
+            let wtx = db.begin_write()?;
+            let outcome = {
+                let mut plans = wtx.open_table(PLANS)?;
+                let mut children = wtx.open_table(FLEET_CHILDREN)?;
+
+                let Some(pj) = plans.get(fleet_id.as_str())?.map(|g| g.value().to_string()) else {
+                    bail!("set_task_grant: no plan for fleet {fleet_id}");
+                };
+                let Some(mut plan) = decode_row::<DurablePlan>(&pj)? else {
+                    bail!("set_task_grant: plan for {fleet_id} is a newer schema");
+                };
+                if plan.fleet_id != fleet_id {
+                    bail!("set_task_grant: plan identity mismatch for {fleet_id}");
+                }
+                if plan.revision != expected_revision {
+                    return Ok(PlanMutateOutcome::RevisionMismatch {
+                        actual: plan.revision,
+                    });
+                }
+                let Some(task_idx) = plan.tasks.iter().position(|t| t.task_id == task_id) else {
+                    bail!("set_task_grant: task {task_id} not in fleet {fleet_id}'s plan");
+                };
+
+                // PR B (codex round-2) — CAS on the child being `Blocked` INSIDE
+                // the txn, BEFORE mutating the plan. The grant+resume applies ONLY
+                // to a child still awaiting the operator: if a concurrent
+                // `deny_escalation` moved it `Blocked → Failed` (and bumped the
+                // revision), or a prior grant already resumed it, this child is no
+                // longer `Blocked` and the (possibly stale/denied) grant is
+                // REFUSED with ZERO mutation. Grant and deny are mutually
+                // exclusive. Materialize the read into an owned String first so no
+                // access guard borrows `children` across the later `insert`.
+                let ckey = child_key(&fleet_id, &task_id);
+                let cj = children.get(ckey.as_str())?.map(|g| g.value().to_string());
+                let refused = PlanMutateOutcome::RejectedNotBlocked {
+                    task_id: task_id.clone(),
+                };
+                let Some(cj) = cj else {
+                    return Ok(refused);
+                };
+                let Some(mut child) = decode_row::<FleetChildRecord>(&cj)? else {
+                    return Ok(refused);
+                };
+                if child.fleet_id != fleet_id
+                    || child.child_id != task_id
+                    || child.status != ChildStatus::Blocked
+                {
+                    return Ok(refused);
+                }
+
+                // Blocked confirmed — apply the grant to the plan, bump the
+                // revision, and resume the child (Blocked → Ready, request
+                // cleared). A Ready child MUST have no live attempt or
+                // launch_child rejects the relaunch as a double-launch.
+                let new_rev = expected_revision
+                    .checked_add(1)
+                    .ok_or_else(|| eyre::eyre!("revision overflow granting {fleet_id}"))?;
+                plan.tasks[task_idx].grant = grant;
+                plan.revision = new_rev;
+                plan.schema_version = SCHEMA_VERSION;
+                plans.insert(fleet_id.as_str(), serde_json::to_string(&plan)?.as_str())?;
+
+                child.status = ChildStatus::Ready;
+                child.pending_escalation = None;
+                child.current_attempt_id = None;
+                child.updated_at_ms = now_ms;
+                children.insert(ckey.as_str(), serde_json::to_string(&child)?.as_str())?;
+
+                PlanMutateOutcome::Mutated { revision: new_rev }
+            };
+            if matches!(outcome, PlanMutateOutcome::Mutated { .. }) {
+                wtx.commit()?;
+            }
+            Ok(outcome)
+        })
+        .await
+        .wrap_err("join set_task_grant")?
+    }
+
+    /// PR B — deny a worker's mid-task escalation, moving its blocked child
+    /// `Blocked → Failed` (TERMINAL), in one write-txn. This is the `goal_deny`
+    /// store op: the keeper refused the requested grant widen, so the task
+    /// cannot proceed. Terminality is load-bearing — a `Blocked` child is
+    /// non-terminal and holds `is_complete` open forever, so a denial that left
+    /// it `Blocked` would WEDGE the fleet. The child is stamped a
+    /// [`AcceptanceVerdict::Rejected`] with the keeper's reason and its
+    /// `pending_escalation` cleared.
+    ///
+    /// A no-op ([`CompleteOutcome::Superseded`]) if the child is not `Blocked`
+    /// (nothing to deny) — so a double-deny, or a deny racing a grant, cannot
+    /// clobber a child that already resumed.
+    ///
+    /// PR B (codex round-4, defect 2) — it also computes, IN THE SAME write-txn,
+    /// whether the fleet is now un-completable (a `Failed` task strands it) and
+    /// returns it on the [`DenyEscalationOutcome`]. The keeper drives the goal
+    /// terminal DIRECTLY from that returned value, so the goal-terminal resolution
+    /// can never be skipped by a separate fallible read after the durable deny.
+    pub async fn deny_escalation(
+        &self,
+        fleet_id: &str,
+        child_id: &str,
+        reason: &str,
+        now_ms: u64,
+    ) -> Result<DenyEscalationOutcome> {
+        ensure_key_safe(&[fleet_id, child_id])?;
+        let db = self.db.clone();
+        let fleet_id = fleet_id.to_string();
+        let child_id = child_id.to_string();
+        let reason = reason.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<DenyEscalationOutcome> {
+            let _held = held;
+            // A no-op deny changed nothing, so the fleet's completability is
+            // untouched (`false`).
+            let superseded = DenyEscalationOutcome {
+                settled: CompleteOutcome::Superseded,
+                fleet_un_completable: false,
+            };
+            let wtx = db.begin_write()?;
+            let outcome = {
+                let mut children = wtx.open_table(FLEET_CHILDREN)?;
+                let mut plans = wtx.open_table(PLANS)?;
+                let mut outbox = wtx.open_table(OUTBOX)?;
+                let ckey = child_key(&fleet_id, &child_id);
+                let Some(cj) = children.get(ckey.as_str())?.map(|g| g.value().to_string()) else {
+                    return Ok(superseded);
+                };
+                let Some(mut child) = decode_row::<FleetChildRecord>(&cj)? else {
+                    return Ok(superseded);
+                };
+                // Only a Blocked child can be denied (identity-checked, P1-4).
+                if child.fleet_id != fleet_id
+                    || child.child_id != child_id
+                    || child.status != ChildStatus::Blocked
+                {
+                    return Ok(superseded);
+                }
+                child.status = ChildStatus::Failed;
+                child.outcome = Some(AcceptanceVerdict::Rejected {
+                    reason: format!("escalation denied: {reason}"),
+                });
+                child.pending_escalation = None;
+                child.current_attempt_id = None;
+                child.updated_at_ms = now_ms;
+                children.insert(ckey.as_str(), serde_json::to_string(&child)?.as_str())?;
+
+                // PR B (codex round-2) — BUMP the plan revision so a concurrent
+                // `set_task_grant` that read this child `Blocked` at revision N
+                // fails its revision CAS: the grant and the deny cannot both
+                // commit, so a denied capability can never be applied. (The
+                // grant's in-txn `Blocked` CAS is the belt; this bump is the
+                // suspenders — whichever commits first, the other is refused.)
+                // A missing plan row is a corruption we do not silently create.
+                // Materialize the read into an owned String FIRST so no access
+                // guard borrows `plans` across the later `insert`.
+                //
+                // PR B (codex round-4, defect 2) — the SAME plan drives the
+                // completability computation below (its task list is the ground
+                // truth for "can this fleet still reach all-Succeeded?").
+                let pj = plans.get(fleet_id.as_str())?.map(|g| g.value().to_string());
+                let mut fleet_un_completable = false;
+                if let Some(pj) = pj {
+                    if let Some(mut plan) = decode_row::<DurablePlan>(&pj)? {
+                        if plan.fleet_id == fleet_id {
+                            plan.revision = plan.revision.checked_add(1).ok_or_else(|| {
+                                eyre::eyre!("revision overflow denying escalation for {fleet_id}")
+                            })?;
+                            plan.schema_version = SCHEMA_VERSION;
+                            plans.insert(
+                                fleet_id.as_str(),
+                                serde_json::to_string(&plan)?.as_str(),
+                            )?;
+
+                            // Completability, computed on the durable POST-deny
+                            // child states — mirrors the goal snapshot's rule
+                            // (`!all-Succeeded && any-Failed`). The just-denied
+                            // child is `Failed` (already written), so this is
+                            // always `true` here; computing it over the real plan
+                            // (rather than assuming) keeps it faithful if the plan
+                            // shape changes. The denied child is read from the
+                            // local `child` (avoids a redundant re-decode); the
+                            // rest are read back (owned String first, so no access
+                            // guard borrows `children` across iterations).
+                            let mut all_succeeded = true;
+                            let mut any_failed = false;
+                            for task in &plan.tasks {
+                                let status = if task.task_id == child_id {
+                                    child.status
+                                } else {
+                                    let tkey = child_key(&fleet_id, &task.task_id);
+                                    match children
+                                        .get(tkey.as_str())?
+                                        .map(|g| g.value().to_string())
+                                    {
+                                        Some(j) => decode_row::<FleetChildRecord>(&j)?
+                                            .map(|c| c.status)
+                                            .unwrap_or(ChildStatus::Planned),
+                                        None => ChildStatus::Planned,
+                                    }
+                                };
+                                if status != ChildStatus::Succeeded {
+                                    all_succeeded = false;
+                                }
+                                if status == ChildStatus::Failed {
+                                    any_failed = true;
+                                }
+                            }
+                            fleet_un_completable = !all_succeeded && any_failed;
+                        }
+                    }
+                }
+
+                // PR B (codex round-2) — EMIT the same ChildDone wake the
+                // completion/escalation paths do, so the keeper is woken to
+                // re-evaluate a denied task (its goal reaches a terminal state
+                // instead of staying perpetually active on the now-Failed child).
+                append_outbox(
+                    &mut outbox,
+                    outbox_event(FleetEventKind::ChildDone, &fleet_id, Some(&child_id), None),
+                )?;
+                DenyEscalationOutcome {
+                    settled: CompleteOutcome::Completed,
+                    fleet_un_completable,
+                }
+            };
+            if matches!(outcome.settled, CompleteOutcome::Completed) {
+                wtx.commit()?;
+            }
+            Ok(outcome)
+        })
+        .await
+        .wrap_err("join deny_escalation")?
     }
 
     /// Boot recovery: scan children, and for each `Launching`/`Running`
@@ -2345,6 +2829,159 @@ mod tests {
         assert_eq!(e2.sequence, 2);
     }
 
+    fn escalation_request() -> EscalationRequest {
+        EscalationRequest {
+            requested_grant: crate::grant::WorkerGrant {
+                network: crate::grant::NetworkGrant::Hosts(vec!["example.com".into()]),
+                tools: vec!["read_file".into(), "web_fetch".into()],
+                ..crate::grant::WorkerGrant::minimal()
+            },
+            reason: "needs example.com to fetch the report".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn record_escalation_blocks_child_non_terminally_and_emits_childdone() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let attempt_id = launch_running(&store).await;
+
+        // The yielded attempt used 80 REAL tokens — they must be committed
+        // (NOT 0), so a fresh attempt after the grant widen has an honest budget.
+        let out = store
+            .record_escalation("f1", "c1", &attempt_id, escalation_request(), 80, EPOCH, 20)
+            .await
+            .unwrap();
+        assert_eq!(out, CompleteOutcome::Completed);
+
+        // Child is Blocked (NON-terminal) with the pending request; no verdict.
+        let child = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Blocked);
+        assert!(!child.status.is_terminal(), "Blocked must be non-terminal");
+        assert!(
+            child.outcome.is_none(),
+            "a Blocked child has no verdict yet"
+        );
+        assert_eq!(
+            child.pending_escalation.as_ref().map(|e| e.reason.as_str()),
+            Some("needs example.com to fetch the report"),
+        );
+        assert_eq!(
+            child.current_attempt_id, None,
+            "the yielded attempt is cleared so Blocked→Ready can relaunch clean",
+        );
+        assert_eq!(child.tokens_committed, 80);
+
+        // The attempt is Interrupted (it yielded, did not complete).
+        let attempt = store.get_attempt("c1", &attempt_id).await.unwrap().unwrap();
+        assert_eq!(attempt.status, AttemptStatus::Interrupted);
+        assert_eq!(attempt.ended_at_ms, Some(20));
+
+        // Budget: REAL tokens committed (not 0), reservation released.
+        let fleet = store.get_fleet("f1").await.unwrap().unwrap();
+        assert_eq!(
+            fleet.budget.tokens_committed, 80,
+            "record_escalation must settle the REAL tokens used, never 0",
+        );
+        assert_eq!(fleet.budget.tokens_reserved, 0, "reservation released");
+
+        // Outbox: ChildLaunching (seq 1) then the SAME ChildDone wake (seq 2).
+        let e1 = store.claim_next("k", 0, 100).await.unwrap().unwrap();
+        assert_eq!(e1.kind, FleetEventKind::ChildLaunching);
+        let e2 = store.claim_next("k", 0, 100).await.unwrap().unwrap();
+        assert_eq!(
+            e2.kind,
+            FleetEventKind::ChildDone,
+            "escalation fires the EXISTING ChildDone wake — no new machinery",
+        );
+    }
+
+    #[tokio::test]
+    async fn record_escalation_is_a_no_op_for_a_stale_attempt() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let attempt_id = launch_running(&store).await;
+
+        // Wrong attempt id → the four-part fence rejects it (no state change).
+        let bogus = store
+            .record_escalation(
+                "f1",
+                "c1",
+                "not-the-attempt",
+                escalation_request(),
+                80,
+                EPOCH,
+                5,
+            )
+            .await
+            .unwrap();
+        assert_eq!(bogus, CompleteOutcome::Superseded);
+        // A foreign owner_epoch (a superseded lease) is likewise a no-op.
+        let stale_lease = store
+            .record_escalation(
+                "f1",
+                "c1",
+                &attempt_id,
+                escalation_request(),
+                80,
+                EPOCH + 1,
+                5,
+            )
+            .await
+            .unwrap();
+        assert_eq!(stale_lease, CompleteOutcome::Superseded);
+
+        // The child is untouched (still Running, no escalation, no commit).
+        let child = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Running);
+        assert!(child.pending_escalation.is_none());
+        assert_eq!(child.tokens_committed, 0);
+        let fleet = store.get_fleet("f1").await.unwrap().unwrap();
+        assert_eq!(fleet.budget.tokens_committed, 0);
+    }
+
+    #[tokio::test]
+    async fn escalating_a_legacy_v2_child_restamps_to_v3() {
+        // codex round-3 (defect 3): a LEGACY v2 child row (written before the v3
+        // upgrade) that escalates must be RE-STAMPED to the current schema on
+        // write. `Blocked` is a v3-only enum variant; without the re-stamp the row
+        // would persist `{schema_version: 2, status: "Blocked"}`, and a rolled-back
+        // v2 binary (seeing `2 <= 2`) would attempt a full decode and ERROR on the
+        // unknown `Blocked` variant instead of dropping it as newer. `decode_row`
+        // only drops rows whose version EXCEEDS the binary's — so a `Blocked` row
+        // must be v3 for an older binary to drop it cleanly.
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let attempt_id = launch_running(&store).await;
+
+        // Plant the child row at the LEGACY v2 schema (as the pre-upgrade binary
+        // would have written it), preserving its live Running state + attempt so
+        // the four-part escalation fence still passes.
+        let mut legacy = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(
+            legacy.schema_version, SCHEMA_VERSION,
+            "sanity: a freshly launched child is stamped at the current schema",
+        );
+        legacy.schema_version = 2;
+        store.write_raw_child(&legacy).await.unwrap();
+
+        // Escalate — the write MUST re-stamp the row to the current schema.
+        let out = store
+            .record_escalation("f1", "c1", &attempt_id, escalation_request(), 80, EPOCH, 20)
+            .await
+            .unwrap();
+        assert_eq!(out, CompleteOutcome::Completed);
+
+        let child = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Blocked);
+        assert_eq!(
+            child.schema_version, SCHEMA_VERSION,
+            "a legacy v2 row carrying the new `Blocked` variant must be re-stamped \
+             v3 — so an older binary drops it as newer rather than erroring on the \
+             unknown variant",
+        );
+    }
+
     #[tokio::test]
     async fn complete_rejected_for_wrong_attempt_id_no_state_change() {
         let (_d, store) = fresh().await;
@@ -3295,7 +3932,7 @@ mod tests {
             .create_fleet("f1", controller(), None, "default", 100, false, 0)
             .await
             .unwrap();
-        let raw = r#"{"schema_version":3,"fleet_id":"f1","controller_session_key":"fleet:controller-1","profile_id":"default","budget":{"token_budget":100,"tokens_reserved":0,"tokens_committed":0,"hard":false},"status":"Active","generation":0,"created_at_ms":0,"updated_at_ms":0}"#;
+        let raw = r#"{"schema_version":4,"fleet_id":"f1","controller_session_key":"fleet:controller-1","profile_id":"default","budget":{"token_budget":100,"tokens_reserved":0,"tokens_committed":0,"hard":false},"status":"Active","generation":0,"created_at_ms":0,"updated_at_ms":0}"#;
         store.write_raw_fleet("f1", raw).await.unwrap();
         assert!(store.get_fleet("f1").await.unwrap().is_none());
     }


### PR DESCRIPTION
The dynamic half of the operator-permission model (builds on PR A #1875). A fleet worker that hits the edge of its operator-granted `WorkerGrant` requests more capability from the master; the master approves (widening the task's grant) or denies; the task re-runs with the new grant. Least-privilege by default (A) + capability that grows only on operator-approved demonstrated need (B) = the master governs each worker's permissions on the fly, like a human operator.

## The loop
`escalate` tool (always-on safety valve) records a request + yields the attempt as non-terminal `Blocked` → the existing `ChildDone` wake brings the keeper in → `goal_get` surfaces the request → keeper calls `goal_grant` (widen via `PlanEdit::SetGrant`, `Blocked→Ready`) or `goal_deny` (`Blocked→Failed`, terminal) → a fresh attempt rebuilds registry+sandbox from the widened grant. Interrupt-and-restart (no live-turn parking); workspace progress persists across the restart.

## Correctness invariants
- **Determinism:** escalation is read before acceptance and wins however the turn ends (EndTurn/deadline/cancel) — an escalated attempt skips acceptance; the `LaunchGuard` settles escalated on a cancel-drop.
- **Budget honesty:** real tokens committed via a shared `TokenTracker` (never 0, even on cancel/timeout), floored to the reservation — no double-spend on the fresh attempt.
- **Terminal denial:** deny drives the goal terminal from the durable txn's returned completability (no fallible post-hoc read) — a denied task never wedges the goal active.
- **Atomicity:** `set_task_grant` CAS-checks `Blocked` in-txn; deny bumps revision — grant and deny are mutually exclusive (a denied capability can never be applied).
- **No self-widen:** the worker can request but only the master's `goal_grant` mutates the grant; both keeper tools gate on `resolve_owned_fleet` and re-validate the grant.
- `SCHEMA_VERSION` 2→3 for the new `Blocked` variant (rollback-safe, incl. restamping legacy rows).

Reviewed across multiple codex rounds; workspace gates green (build, fmt, clippy -D warnings; fleet + fleet-worker suites pass). Two pre-existing paused-clock flakes in the master-continuation subsystem pass in isolation (load-induced, not from this PR).