### PR TITLE
feat(fleet): boot-resume — a fleet survives an octos restart

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -1081,6 +1081,19 @@ impl InProcessAgentOrchestrator {
         }
     }
 
+    /// Whether a durable supervisor store is configured. The fleet boot-resume
+    /// pass uses this to make a [`Self::commit_fleet_keeper_wake`] result
+    /// unambiguous: WITH a store, a `NotDurable` result can ONLY be a
+    /// persistence rollback (a `Queued` continuation whose persist errored is
+    /// cancelled — see the `Err` arm above), whereas WITHOUT a store
+    /// `NotDurable` is the benign in-memory-only wake. So the pass counts a
+    /// no-store `NotDurable` as a (this-boot-only) success but must NOT count a
+    /// with-store `NotDurable`, which means the wake was rolled back and the
+    /// fleet will not auto-resume.
+    pub(crate) fn has_supervisor_store(&self) -> bool {
+        self.state().supervisor_store.is_some()
+    }
+
     /// Solo-boot loop safety. Loops restored from a PRIOR process's
     /// supervisor store resume firing REAL model turns with nobody having
     /// asked this process for them — a forgotten test loop can burn a turn
@@ -3229,6 +3242,25 @@ impl InProcessAgentOrchestrator {
         Ok(Fleet::bind(store, fleet_id))
     }
 
+    /// The `fleet_id` currently BOUND to `controller`'s goal, or `None` if no
+    /// goal is set for that key. `controller` is the fleet's
+    /// `controller_session_key`, which `goal_plan` binds to the SCOPED goal key
+    /// — the same key the goals map is keyed by — so this is a direct lookup
+    /// (never re-scope an already-scoped key).
+    ///
+    /// The fleet boot-resume pass uses this to skip an ORPHANED fleet: a
+    /// `goal_clear` removes a goal WITHOUT terminalizing its fleet, and a
+    /// re-plan rebinds the controller to a fresh fleet — in both cases the
+    /// keeper's `goal_dispatch` resolves ONLY the current goal's fleet (see
+    /// [`Self::resolve_owned_fleet`]), so a superseded fleet has no keeper to
+    /// drive it and waking it is useless (and would surface stale metadata).
+    pub(crate) fn goal_bound_fleet_id(&self, controller: &SessionKey) -> Option<String> {
+        self.state()
+            .goals
+            .get(controller)
+            .and_then(|goal| goal.fleet_id.clone())
+    }
+
     /// #1857 PR 5a — `goal_plan` tool: lazily create the durable fleet this goal
     /// drives and decompose the objective onto `tasks`. Idempotent — a goal that
     /// already has a `fleet_id` returns "already planned" rather than recreating
@@ -4038,6 +4070,44 @@ impl InProcessAgentOrchestrator {
         }
     }
 
+    /// Test-only: bind `controller`'s goal to `fleet_id` by inserting a minimal
+    /// active goal record — NO persistence, NO goal-continuation enqueue — so a
+    /// fleet boot-resume test can exercise the orphan guard
+    /// ([`Self::goal_bound_fleet_id`]) without the live goal-turn machinery (a
+    /// real `set_goal(active)` would also enqueue a `GoalContinue`). Overwrites
+    /// any existing goal at the (scoped) key.
+    #[cfg(test)]
+    pub(crate) fn bind_goal_fleet_for_test(
+        &self,
+        controller: &SessionKey,
+        profile_id: &str,
+        fleet_id: &str,
+    ) {
+        let key = self.scoped_goal_key(controller);
+        self.state().goals.insert(
+            key,
+            AutonomyGoalRecord {
+                profile_id: profile_id.to_owned(),
+                goal_id: "goal_test".to_owned(),
+                objective: "obj".to_owned(),
+                status: "active".to_owned(),
+                token_budget: 1_000_000,
+                tokens_used: 0,
+                time_used_seconds: 0,
+                created_at_ms: 0,
+                updated_at_ms: 0,
+                continuations_used: 0,
+                last_continued_at_ms: 0,
+                rate_window_start_ms: 0,
+                rate_window_count: 0,
+                wrap_up_emitted: false,
+                consecutive_failed_turns: 0,
+                fleet_id: Some(fleet_id.to_owned()),
+                controller_workspace_root: None,
+            },
+        );
+    }
+
     /// PR 5a — the goal's stashed controller workspace root (re-scoped).
     #[cfg(test)]
     pub(crate) fn goal_workspace_root_for_test(&self, session_id: &SessionKey) -> Option<String> {
@@ -4261,6 +4331,34 @@ impl InProcessAgentOrchestrator {
         self.state()
             .continuations
             .pending_count_for_session(&session_id.to_string(), profile_id)
+    }
+
+    /// Test-only: snapshot the pending fleet-keeper (`External(fleet_keeper_wake)`)
+    /// continuations as `(session_id, dedupe_key, fleet_id metadata)`. Filters
+    /// out unrelated continuations (e.g. a goal's `GoalContinue`) so a
+    /// boot-resume test can assert exactly which fleets were woken and that
+    /// their dedupe keys are distinct.
+    #[cfg(test)]
+    pub(crate) fn pending_fleet_keeper_wakes_for_test(
+        &self,
+    ) -> Vec<(String, String, Option<String>)> {
+        self.state()
+            .continuations
+            .pending_items()
+            .filter(|it| {
+                matches!(
+                    &it.reason,
+                    MasterContinuationReason::External(kind) if kind == FLEET_KEEPER_EXTERNAL_KIND
+                )
+            })
+            .map(|it| {
+                (
+                    it.session_id.as_str().to_owned(),
+                    it.dedupe_key.as_str().to_owned(),
+                    it.metadata.get(FLEET_KEEPER_META_FLEET_ID).cloned(),
+                )
+            })
+            .collect()
     }
 
     #[cfg(test)]

--- a/crates/octos-cli/src/api/fleet_wake.rs
+++ b/crates/octos-cli/src/api/fleet_wake.rs
@@ -45,7 +45,7 @@ use tokio::time::MissedTickBehavior;
 use super::agent_orchestrator::{
     FLEET_KEEPER_EXTERNAL_KIND, FLEET_KEEPER_GROUP, FLEET_KEEPER_META_FLEET_ID,
     FLEET_KEEPER_META_OBJECTIVE, FLEET_KEEPER_META_READY, FLEET_KEEPER_META_TASK_LINES,
-    FLEET_KEEPER_META_WORKSPACE_ROOT, default_agent_orchestrator,
+    FLEET_KEEPER_META_WORKSPACE_ROOT, InProcessAgentOrchestrator, default_agent_orchestrator,
 };
 use super::master_continuation_scheduler::{MasterContinuationReason, MasterContinuationRequest};
 
@@ -288,6 +288,137 @@ pub(crate) fn spawn_fleet_outbox_consumer(store: FleetKernelStore) {
             }
         }
     });
+}
+
+/// The stable, boot-namespaced dedupe key for a fleet's boot-resume keeper wake.
+///
+/// Deliberately NOT the outbox consumer's sequence-based
+/// [`fleet_keeper_dedupe_key`]: the literal `boot-resume` terminal can never
+/// numerically collide a real outbox `sequence` (the consumer's key ends in a
+/// `u64`), and the key is stable per fleet across boots — so a boot wake that
+/// was persisted on a prior boot but not yet drained collapses with the fresh
+/// one instead of double-queuing.
+///
+/// The `fleet_id` is IN the key (not just the controller): controller↔fleet is
+/// NOT 1:1 — `goal_clear` removes a goal WITHOUT terminalizing its fleet, so a
+/// cleared-then-replanned controller can transiently own two `Active` fleets
+/// with `Ready` children. A controller-only key would make their two boot
+/// wakes collide and silently discard one; keying on `fleet_id` keeps distinct
+/// fleets distinct (belt-and-suspenders alongside the orphan guard in
+/// [`enqueue_fleet_boot_resume_wakes`], which normally wakes only the bound
+/// fleet).
+fn fleet_boot_resume_dedupe_key(controller: &SessionKey, fleet_id: &str) -> String {
+    format!("external/{FLEET_KEEPER_EXTERNAL_KIND}/{controller}/boot-resume/{fleet_id}")
+}
+
+/// Boot-resume — "a fleet survives an octos restart". After the boot reconcile
+/// flips a restart-interrupted fleet's in-flight children back to `Ready`,
+/// NOTHING re-dispatches them: reconcile emits no outbox event, so the outbox
+/// consumer (the only other keeper-wake driver) never fires and the fleet stalls
+/// forever. This closes that gap — for every live fleet with a launchable child
+/// ([`FleetKernelStore::fleets_with_ready_children`]) it enqueues ONE keeper
+/// wake, reusing the SAME continuation + PR-4b workspace seed the outbox
+/// consumer builds, under a stable boot-namespaced dedupe key. The global
+/// master-continuation drain (already running, ~5s poll) picks the wakes up on
+/// its next tick → PR-4b reseed pre-pass → `run_standalone_turn` → the keeper's
+/// `goal_dispatch` re-launches the ready set.
+///
+/// - **Orphan guard** — only a fleet STILL bound to its controller's current
+///   goal is woken. `goal_clear` removes a goal without terminalizing its
+///   fleet, and a re-plan rebinds the controller to a new fleet; in both cases
+///   the keeper's `goal_dispatch` resolves ONLY the current goal's fleet, so a
+///   superseded fleet has no keeper to drive it — waking it is useless and
+///   would surface stale metadata. Such fleets are skipped + logged.
+/// - **Double-wake** (a fleet the outbox consumer also wakes) is harmless: the
+///   `launch_child` CAS + `resolve_and_collect_ready` + the per-session
+///   active-turn guard admit at most one no-op keeper turn, never a
+///   double-dispatch.
+/// - **Not solo-gated** (matches the outbox consumer, which wakes on
+///   `ChildDone` regardless of `--solo`): this recovers already-committed
+///   in-flight work, not a fresh autonomous goal.
+/// - **Rootless fleet** (`controller_workspace_root == None`): the wake carries
+///   no workspace root, so the seed pre-pass drops it
+///   ([`InProcessAgentOrchestrator::pending_fleet_keeper_seeds`]) — the same
+///   not-headlessly-rehydratable limitation as the consumer path, not a
+///   regression.
+///
+/// Returns the number of fleets for which a wake was DURABLY (or, with no
+/// supervisor store, at least in-memory) enqueued — a persistence failure that
+/// rolls the wake back is NOT counted (see below).
+pub(crate) async fn enqueue_fleet_boot_resume_wakes(
+    store: &FleetKernelStore,
+    orchestrator: &InProcessAgentOrchestrator,
+    now_ms: u64,
+) -> eyre::Result<usize> {
+    let fleets = store.fleets_with_ready_children(now_ms).await?;
+    // With a supervisor store, a `NotDurable` commit can ONLY be a persistence
+    // rollback (a failed persist cancels the in-memory enqueue); without one it
+    // is the benign in-memory-only path. Captured once — it does not change
+    // mid-pass.
+    let has_store = orchestrator.has_supervisor_store();
+    let mut enqueued = 0usize;
+    for rec in fleets {
+        // Orphan guard: skip a fleet no longer bound to its controller's current
+        // goal (cleared or re-planned). No keeper will resolve it, so a wake is
+        // wasted and carries stale metadata.
+        let bound = orchestrator.goal_bound_fleet_id(&rec.controller_session_key);
+        if bound.as_deref() != Some(rec.fleet_id.as_str()) {
+            tracing::warn!(
+                fleet_id = %rec.fleet_id,
+                controller = %rec.controller_session_key,
+                bound = ?bound,
+                "fleet boot-resume: skipping an orphaned fleet not bound to its controller's \
+                 current goal (goal cleared or re-planned); no keeper will drive it"
+            );
+            continue;
+        }
+
+        let snap = render_fleet_snapshot(store, &rec.fleet_id, now_ms).await;
+        // Reuse the consumer's request builder — it writes the PR-4b workspace
+        // seed when a root is present — then OVERRIDE its sequence-based dedupe
+        // key with the stable, fleet-scoped boot key. `sequence` is unused here
+        // (the key it would produce is replaced below), so pass 0.
+        let req = fleet_keeper_continuation_request(
+            &rec.controller_session_key,
+            &rec.profile_id,
+            &rec.fleet_id,
+            0,
+            &snap,
+            rec.controller_workspace_root.as_deref(),
+        )
+        .with_dedupe_key(fleet_boot_resume_dedupe_key(
+            &rec.controller_session_key,
+            &rec.fleet_id,
+        ));
+        match orchestrator.commit_fleet_keeper_wake(req) {
+            // Persisted to the durable store — survives a further restart.
+            WakeCommit::Durable => enqueued += 1,
+            // No supervisor store → the wake is in-memory only: it still drives
+            // THIS boot's drain (all boot-resume needs), it just won't survive
+            // another restart. Benign — count it.
+            WakeCommit::NotDurable if !has_store => enqueued += 1,
+            // A supervisor store IS configured yet the commit is NotDurable —
+            // the ONLY cause is a persistence error that ROLLED BACK the
+            // in-memory enqueue. There is now NO wake and NO retry, and
+            // reconcile emitted no outbox event either, so this fleet will NOT
+            // auto-resume this boot. Surface it honestly; do NOT count it as a
+            // success (never report false progress that masks a stall).
+            WakeCommit::NotDurable => tracing::warn!(
+                fleet_id = %rec.fleet_id,
+                controller = %rec.controller_session_key,
+                "fleet boot-resume wake FAILED to persist and was rolled back; this fleet will \
+                 NOT auto-resume this boot — it stays Ready with no keeper wake until the next \
+                 fleet event or a restart"
+            ),
+        }
+    }
+    if enqueued > 0 {
+        tracing::info!(
+            fleets = enqueued,
+            "fleet boot-resume: enqueued keeper wakes for restart-stranded fleets"
+        );
+    }
+    Ok(enqueued)
 }
 
 #[cfg(test)]
@@ -1023,6 +1154,315 @@ mod tests {
         assert!(
             !prompt.contains("An external master continuation was requested"),
             "must not hit the generic external fallback: {prompt}"
+        );
+    }
+
+    // ---- boot-resume (a fleet survives an octos restart) ------------------
+
+    use crate::api::agent_orchestrator::InProcessAgentOrchestrator;
+
+    /// Bind `controller`'s current goal to `fleet_id` (a PLAIN, unscoped key, so
+    /// the goal key equals the fleet's `controller_session_key`). The boot-resume
+    /// orphan guard only wakes a fleet still bound to its controller's goal, so a
+    /// test expecting a wake must bind first.
+    fn bind_goal(orch: &InProcessAgentOrchestrator, controller: &SessionKey, fleet_id: &str) {
+        orch.bind_goal_fleet_for_test(controller, "profile-x", fleet_id);
+    }
+
+    #[tokio::test]
+    async fn boot_resume_enqueues_a_keeper_wake_for_a_stalled_fleet() {
+        // After boot reconcile leaves a live fleet's children `Ready` (but emits
+        // no outbox event), the boot-resume pass enqueues ONE keeper wake on the
+        // fleet's controller, carrying the workspace_root seed, so the global
+        // drain re-drives it.
+        let (dir, store) = test_store().await;
+        let controller = SessionKey::new("api", "keeper-boot");
+        // The controller workspace root must be a REAL directory so the PR-4b
+        // seed pre-pass (`pending_fleet_keeper_seeds`, is_dir-validated) accepts
+        // it — proving the boot wake reaches the headless-rehydration path.
+        let root = dir.path().to_string_lossy().into_owned();
+        make_fleet_with_root(&store, "fleet-boot", &controller, "ship it", Some(&root)).await;
+
+        let orch = InProcessAgentOrchestrator::default();
+        orch.configure_supervisor_store(dir.path().join("supervisor"))
+            .expect("configure supervisor store");
+        bind_goal(&orch, &controller, "fleet-boot");
+
+        let enqueued = enqueue_fleet_boot_resume_wakes(&store, &orch, 1_000)
+            .await
+            .expect("boot resume");
+        assert_eq!(
+            enqueued, 1,
+            "one live, bound fleet with a ready child → one wake"
+        );
+
+        assert_eq!(
+            orch.pending_continuation_count_for_session_for_test(&controller, "profile-x"),
+            1,
+            "exactly one keeper continuation on the fleet's controller session"
+        );
+
+        // The wake carries the workspace_root seed → it reaches the PR-4b drain
+        // pre-pass, which yields exactly one rooted seed for this controller.
+        let seeds = orch.pending_fleet_keeper_seeds();
+        assert_eq!(seeds.len(), 1, "one rooted keeper seed");
+        assert_eq!(
+            seeds[0].wire, controller,
+            "seed is for the fleet's controller"
+        );
+        assert_eq!(
+            seeds[0].root, root,
+            "seed carries the persisted workspace root"
+        );
+    }
+
+    #[tokio::test]
+    async fn boot_resume_skips_complete_and_cancelled_fleets() {
+        // The helper wakes EXACTLY the fleets the query returns. `fleet-live`
+        // has a ready child → woken; `fleet-idle`'s only ready task is already
+        // in flight (no launchable child) → skipped by the query. (The literal
+        // Complete / Cancelled status exclusion is covered authoritatively by
+        // the store test `fleets_with_ready_children_finds_active_fleets_with_ready_tasks`,
+        // where terminal-status fleets are mintable via `write_raw_fleet`;
+        // terminal fleet status has no public transition at this layer.)
+        let (dir, store) = test_store().await;
+        let root = dir.path().to_string_lossy().into_owned();
+
+        let live = SessionKey::new("api", "keeper-live");
+        make_fleet_with_root(&store, "fleet-live", &live, "obj", Some(&root)).await;
+
+        let idle = SessionKey::new("api", "keeper-idle");
+        make_fleet_with_root(&store, "fleet-idle", &idle, "obj", Some(&root)).await;
+        // Launch t1 so it is in-flight (Launching, live attempt); t2 stays
+        // Planned (dep unmet) — the fleet now has NO launchable child.
+        let outcome = store
+            .launch_child("fleet-idle", "t1", 100, 0, 1, 1_000)
+            .await
+            .expect("launch");
+        assert!(
+            matches!(outcome, octos_fleet::LaunchOutcome::Launched { .. }),
+            "t1 should launch: {outcome:?}"
+        );
+
+        let orch = InProcessAgentOrchestrator::default();
+        orch.configure_supervisor_store(dir.path().join("supervisor"))
+            .expect("configure supervisor store");
+        // Both fleets are bound to their controllers, so only the query decides.
+        bind_goal(&orch, &live, "fleet-live");
+        bind_goal(&orch, &idle, "fleet-idle");
+
+        let enqueued = enqueue_fleet_boot_resume_wakes(&store, &orch, 1_000)
+            .await
+            .expect("boot resume");
+        assert_eq!(
+            enqueued, 1,
+            "only the live fleet with a ready child is woken"
+        );
+        assert_eq!(
+            orch.pending_continuation_count_for_session_for_test(&live, "profile-x"),
+            1,
+            "the live fleet's keeper is woken"
+        );
+        assert_eq!(
+            orch.pending_continuation_count_for_session_for_test(&idle, "profile-x"),
+            0,
+            "a fleet with no launchable child is NOT woken"
+        );
+    }
+
+    #[tokio::test]
+    async fn boot_resume_wake_dedupes_across_two_boots() {
+        // The boot dedupe key is stable per (controller, fleet), so a boot-resume
+        // pass run twice against the same continuation state (a restart re-running
+        // the pass before the first wake drained, then restoring the persisted
+        // wake) collapses to ONE continuation rather than double-queuing.
+        let (dir, store) = test_store().await;
+        let controller = SessionKey::new("api", "keeper-twoboot");
+        let root = dir.path().to_string_lossy().into_owned();
+        make_fleet_with_root(&store, "fleet-tb", &controller, "obj", Some(&root)).await;
+
+        let orch = InProcessAgentOrchestrator::default();
+        orch.configure_supervisor_store(dir.path().join("supervisor"))
+            .expect("configure supervisor store");
+        bind_goal(&orch, &controller, "fleet-tb");
+
+        enqueue_fleet_boot_resume_wakes(&store, &orch, 1_000)
+            .await
+            .expect("boot 1");
+        enqueue_fleet_boot_resume_wakes(&store, &orch, 2_000)
+            .await
+            .expect("boot 2");
+
+        assert_eq!(
+            orch.pending_continuation_count_for_session_for_test(&controller, "profile-x"),
+            1,
+            "the stable per-fleet boot key collapses two boot passes to one continuation"
+        );
+    }
+
+    #[tokio::test]
+    async fn boot_resume_key_differs_from_consumer_sequence_key() {
+        // The boot key is namespaced apart from the consumer's sequence-based
+        // key (`.../{sequence}`), so a boot wake and a real ChildDone wake for
+        // the SAME (controller, fleet) never false-collapse onto each other.
+        let (dir, store) = test_store().await;
+        let controller = SessionKey::new("api", "keeper-key");
+        let root = dir.path().to_string_lossy().into_owned();
+        make_fleet_with_root(&store, "fleet-key", &controller, "obj", Some(&root)).await;
+
+        let orch = InProcessAgentOrchestrator::default();
+        orch.configure_supervisor_store(dir.path().join("supervisor"))
+            .expect("configure supervisor store");
+        bind_goal(&orch, &controller, "fleet-key");
+
+        enqueue_fleet_boot_resume_wakes(&store, &orch, 1_000)
+            .await
+            .expect("boot resume");
+        // A consumer-style wake for the same controller+fleet with a real sequence.
+        let snap = render_fleet_snapshot(&store, "fleet-key", 1_000).await;
+        let seq_req = fleet_keeper_continuation_request(
+            &controller,
+            "profile-x",
+            "fleet-key",
+            7,
+            &snap,
+            Some(&root),
+        );
+        orch.commit_fleet_keeper_wake(seq_req);
+
+        assert_eq!(
+            orch.pending_continuation_count_for_session_for_test(&controller, "profile-x"),
+            2,
+            "boot key and sequence key are distinct → two continuations, no false collapse"
+        );
+    }
+
+    #[test]
+    fn boot_resume_dedupe_key_disambiguates_two_fleets_on_one_controller() {
+        // HIGH fix (a): controller↔fleet is NOT 1:1 (`goal_clear` leaves a fleet
+        // Active), so a cleared-then-replanned controller can transiently own two
+        // Active fleets. Their boot keys must be DISTINCT (else one wake is
+        // silently discarded), while staying stable per fleet across boots.
+        let c = SessionKey::new("api", "keeper-collide");
+        assert_ne!(
+            fleet_boot_resume_dedupe_key(&c, "fleet-A"),
+            fleet_boot_resume_dedupe_key(&c, "fleet-B"),
+            "distinct fleets on one controller must not share a boot dedupe key"
+        );
+        assert_eq!(
+            fleet_boot_resume_dedupe_key(&c, "fleet-A"),
+            fleet_boot_resume_dedupe_key(&c, "fleet-A"),
+            "the key is stable per fleet across boots"
+        );
+    }
+
+    #[tokio::test]
+    async fn boot_resume_skips_an_orphaned_fleet_not_bound_to_the_current_goal() {
+        // HIGH fix (b) + the collision scenario: a controller whose goal G1 was
+        // cleared and re-planned as G2 transiently owns TWO Active fleets with
+        // Ready children (F1 orphaned, F2 current). Only F2 (bound to the current
+        // goal) is woken — F1 is skipped (no keeper would ever resolve it). The
+        // fleet-scoped key (fix a) also guarantees the two never collide.
+        let (dir, store) = test_store().await;
+        let controller = SessionKey::new("api", "keeper-orphan");
+        let root = dir.path().to_string_lossy().into_owned();
+        make_fleet_with_root(&store, "fleet-old", &controller, "obj-old", Some(&root)).await;
+        make_fleet_with_root(&store, "fleet-new", &controller, "obj-new", Some(&root)).await;
+
+        let orch = InProcessAgentOrchestrator::default();
+        orch.configure_supervisor_store(dir.path().join("supervisor"))
+            .expect("configure supervisor store");
+        // The controller's CURRENT goal is bound to fleet-new; fleet-old is the
+        // orphaned remnant of a cleared goal (still Active in the store).
+        bind_goal(&orch, &controller, "fleet-new");
+
+        let enqueued = enqueue_fleet_boot_resume_wakes(&store, &orch, 1_000)
+            .await
+            .expect("boot resume");
+        assert_eq!(enqueued, 1, "only the currently-bound fleet is woken");
+
+        let wakes = orch.pending_fleet_keeper_wakes_for_test();
+        assert_eq!(
+            wakes.len(),
+            1,
+            "exactly one boot wake (the orphan is skipped)"
+        );
+        assert_eq!(
+            wakes[0].2.as_deref(),
+            Some("fleet-new"),
+            "the wake targets the bound (current-goal) fleet, not the orphan"
+        );
+    }
+
+    #[tokio::test]
+    async fn boot_resume_wakes_each_bound_fleet_with_a_distinct_key() {
+        // Two controllers, each with its own bound Active fleet → BOTH get wakes,
+        // under distinct dedupe keys (no collision, no discard).
+        let (dir, store) = test_store().await;
+        let root = dir.path().to_string_lossy().into_owned();
+        let c1 = SessionKey::new("api", "keeper-m1");
+        let c2 = SessionKey::new("api", "keeper-m2");
+        make_fleet_with_root(&store, "fleet-m1", &c1, "obj1", Some(&root)).await;
+        make_fleet_with_root(&store, "fleet-m2", &c2, "obj2", Some(&root)).await;
+
+        let orch = InProcessAgentOrchestrator::default();
+        orch.configure_supervisor_store(dir.path().join("supervisor"))
+            .expect("configure supervisor store");
+        bind_goal(&orch, &c1, "fleet-m1");
+        bind_goal(&orch, &c2, "fleet-m2");
+
+        let enqueued = enqueue_fleet_boot_resume_wakes(&store, &orch, 1_000)
+            .await
+            .expect("boot resume");
+        assert_eq!(enqueued, 2, "both bound fleets are woken");
+
+        let mut keys: Vec<String> = orch
+            .pending_fleet_keeper_wakes_for_test()
+            .into_iter()
+            .map(|(_, dedupe_key, _)| dedupe_key)
+            .collect();
+        keys.sort();
+        keys.dedup();
+        assert_eq!(keys.len(), 2, "two distinct boot dedupe keys");
+    }
+
+    #[tokio::test]
+    async fn boot_resume_does_not_report_success_on_persistence_failure() {
+        // HIGH fix 2: with a supervisor store, a durable-persist FAILURE makes
+        // `commit_fleet_keeper_wake` ROLL BACK the in-memory enqueue → no wake,
+        // no retry. The pass must NOT count that as enqueued (never mask a stall
+        // with false success).
+        let (dir, store) = test_store().await;
+        let controller = SessionKey::new("api", "keeper-persistfail");
+        let root = dir.path().to_string_lossy().into_owned();
+        make_fleet_with_root(&store, "fleet-pf", &controller, "obj", Some(&root)).await;
+
+        let orch = InProcessAgentOrchestrator::default();
+        let sup = dir.path().join("supervisor");
+        orch.configure_supervisor_store(&sup)
+            .expect("configure supervisor store");
+        bind_goal(&orch, &controller, "fleet-pf");
+
+        // Sabotage the durable write: plant a DIRECTORY where the event-ledger
+        // FILE must be, so `record_continuation_queued` fails → the commit rolls
+        // back (a persistence error, NOT the benign no-store in-memory path).
+        std::fs::create_dir_all(&sup).expect("sup dir");
+        let events = sup.join("supervisor-events.jsonl");
+        let _ = std::fs::remove_file(&events);
+        std::fs::create_dir_all(&events).expect("plant ledger-path directory");
+
+        let enqueued = enqueue_fleet_boot_resume_wakes(&store, &orch, 1_000)
+            .await
+            .expect("boot resume returns Ok even when a wake fails to persist");
+
+        assert_eq!(
+            enqueued, 0,
+            "a rolled-back (failed-persist) wake must NOT be reported as enqueued"
+        );
+        assert_eq!(
+            orch.pending_continuation_count_for_session_for_test(&controller, "profile-x"),
+            0,
+            "the failed wake was rolled back → no pending continuation lingers"
         );
     }
 }

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -956,6 +956,43 @@ impl ServeCommand {
             }
         }
 
+        // Boot-resume — "a fleet survives an octos restart". The boot reconcile
+        // above flipped any restart-interrupted fleet's in-flight children back
+        // to `Ready`, but emitted NO outbox event — so the outbox consumer never
+        // wakes the keeper and an in-progress fleet would STALL forever after a
+        // restart (nothing re-dispatches its ready tasks). Now that the worker
+        // pool is installed, enqueue a keeper wake for every live fleet with a
+        // launchable child; the global master-continuation drain (started below,
+        // ~5s poll) picks them up on its next tick → PR-4b reseed pre-pass →
+        // `run_standalone_turn` → the keeper's `goal_dispatch` re-launches the
+        // ready set. Gated on a reconciled store AND an installed pool (no pool ⇒
+        // nothing to dispatch onto). Re-fetch the store here: the local binding
+        // was moved into the outbox consumer / worker pool above.
+        let boot_resume_orchestrator = crate::api::agent_orchestrator::default_agent_orchestrator();
+        let boot_resume_store =
+            if fleet_reconciled && boot_resume_orchestrator.fleet_pool().is_some() {
+                boot_resume_orchestrator.fleet_store()
+            } else {
+                None
+            };
+        if let Some(store) = boot_resume_store {
+            let now_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+            match crate::api::fleet_wake::enqueue_fleet_boot_resume_wakes(
+                &store,
+                boot_resume_orchestrator,
+                now_ms,
+            )
+            .await
+            {
+                Ok(n) if n > 0 => tracing::info!(
+                    fleets = n,
+                    "fleet boot-resume: re-woke keepers for restart-stranded fleets"
+                ),
+                Ok(_) => {}
+                Err(error) => tracing::warn!(%error, "fleet boot-resume wake pass failed"),
+            }
+        }
+
         let session_cache = Arc::new(
             crate::runtime::SessionRuntimeCache::new(64, std::time::Duration::from_secs(1800))
                 // Per-project session storage (opt-in, default off). When set,

--- a/crates/octos-fleet/src/store.rs
+++ b/crates/octos-fleet/src/store.rs
@@ -640,6 +640,70 @@ impl FleetKernelStore {
         .wrap_err("join resolve_and_collect_ready")?
     }
 
+    /// Every **live** fleet (`Active`/`Draining`) that currently has at least
+    /// one launchable child. This is the boot-resume driver: a fleet
+    /// interrupted by a restart has its in-flight children reset to `Ready` by
+    /// [`Self::reconcile`], but reconcile emits NO outbox event, so the outbox
+    /// consumer never wakes the keeper and nothing re-dispatches. This query
+    /// finds exactly the fleets whose keeper must be re-woken at boot.
+    ///
+    /// Two-phase to respect the non-reentrant `io_gate`: phase 1 takes the gate
+    /// ONCE to snapshot the live fleet records from the `FLEETS` table
+    /// (mirroring [`Self::list_children`]'s iterator) and then RELEASES it;
+    /// phase 2 calls [`Self::resolve_and_collect_ready`] per candidate — each
+    /// re-acquires the gate for its own one-write-txn, so it MUST run outside
+    /// phase 1's guard. Reusing `resolve_and_collect_ready` rather than a naive
+    /// `status == Ready` scan is deliberate: it heals a missed `Planned → Ready`
+    /// promotion in-txn (a dep that `Succeeded` pre-crash whose dependent never
+    /// promoted), so a fleet stranded in exactly that state is still detected.
+    /// A candidate whose ready set comes back empty (all children terminal or
+    /// in-flight) is dropped; terminal fleets (`Complete`/`Failed`/`Cancelled`)
+    /// are excluded up front by the status filter.
+    pub async fn fleets_with_ready_children(&self, now_ms: u64) -> Result<Vec<FleetRecord>> {
+        // Phase 1 (one io_gate acquisition): snapshot the live fleet records.
+        let candidates: Vec<FleetRecord> = {
+            let db = self.db.clone();
+            let held = self.io_gate.clone().lock_owned().await;
+            tokio::task::spawn_blocking(move || -> Result<Vec<FleetRecord>> {
+                let _held = held;
+                let rtx = db.begin_read()?;
+                let table = rtx.open_table(FLEETS)?;
+                let mut out = Vec::new();
+                for item in table.iter()? {
+                    let (k, v) = item?;
+                    if let Some(rec) = decode_row::<FleetRecord>(v.value())? {
+                        // Identity check (defense in depth, mirrors get_fleet):
+                        // the row must own the key it lives under. Filter to the
+                        // two live states — terminal fleets never re-dispatch.
+                        if rec.fleet_id == k.value()
+                            && matches!(rec.status, FleetStatus::Active | FleetStatus::Draining)
+                        {
+                            out.push(rec);
+                        }
+                    }
+                }
+                Ok(out)
+            })
+            .await
+            .wrap_err("join fleets_with_ready_children")??
+        };
+
+        // Phase 2 (gate released): resolve+collect each candidate's ready set.
+        // Each call re-acquires the io_gate for its own write-txn, so it runs
+        // OUTSIDE phase 1's guard (the Mutex is non-reentrant). Non-empty ⇒ the
+        // fleet has launchable work and its keeper needs a wake.
+        let mut out = Vec::new();
+        for rec in candidates {
+            let ready = self
+                .resolve_and_collect_ready(&rec.fleet_id, now_ms)
+                .await?;
+            if !ready.is_empty() {
+                out.push(rec);
+            }
+        }
+        Ok(out)
+    }
+
     // ---- CAS state transitions -------------------------------------------
 
     /// Launch a `Ready` child: one write-txn that checks the predicate
@@ -3985,6 +4049,141 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(out, LaunchOutcome::RejectedBudgetExceeded);
+    }
+
+    #[tokio::test]
+    async fn fleets_with_ready_children_finds_active_fleets_with_ready_tasks() {
+        let (_d, store) = fresh().await;
+
+        // Helper: plant a fleet then force its status (the public API mints
+        // only `Active`; terminal transitions arrive in later PRs, so a test
+        // reaches for the raw writer to exercise the boot-resume status filter).
+        async fn force_status(store: &FleetKernelStore, fleet_id: &str, status: FleetStatus) {
+            let mut f = store.get_fleet(fleet_id).await.unwrap().unwrap();
+            f.status = status;
+            store
+                .write_raw_fleet(fleet_id, &serde_json::to_string(&f).unwrap())
+                .await
+                .unwrap();
+        }
+        // Helper: force a child terminal (Succeeded) without the full lifecycle.
+        async fn force_succeeded(store: &FleetKernelStore, fleet_id: &str, child_id: &str) {
+            let mut c = store.get_child(fleet_id, child_id).await.unwrap().unwrap();
+            c.status = ChildStatus::Succeeded;
+            c.current_attempt_id = None;
+            store.write_raw_child(&c).await.unwrap();
+        }
+
+        // f-ready: an Active fleet with a dep-free (immediately Ready) child.
+        store
+            .create_fleet("f-ready", controller(), None, "default", 1_000, false, 0)
+            .await
+            .unwrap();
+        store.add_child("f-ready", "c1", vec![], 0).await.unwrap();
+
+        // f-draining: a live (Draining) fleet with a Ready child — also woken.
+        store
+            .create_fleet("f-draining", controller(), None, "default", 1_000, false, 0)
+            .await
+            .unwrap();
+        store
+            .add_child("f-draining", "c1", vec![], 0)
+            .await
+            .unwrap();
+        force_status(&store, "f-draining", FleetStatus::Draining).await;
+
+        // f-complete: a terminal fleet, even WITH a Ready child, is excluded by
+        // the status filter (the fleet is done; it must not re-dispatch).
+        store
+            .create_fleet("f-complete", controller(), None, "default", 1_000, false, 0)
+            .await
+            .unwrap();
+        store
+            .add_child("f-complete", "c1", vec![], 0)
+            .await
+            .unwrap();
+        force_status(&store, "f-complete", FleetStatus::Complete).await;
+
+        // f-cancelled: likewise excluded by the status filter.
+        store
+            .create_fleet(
+                "f-cancelled",
+                controller(),
+                None,
+                "default",
+                1_000,
+                false,
+                0,
+            )
+            .await
+            .unwrap();
+        store
+            .add_child("f-cancelled", "c1", vec![], 0)
+            .await
+            .unwrap();
+        force_status(&store, "f-cancelled", FleetStatus::Cancelled).await;
+
+        // f-done: Active but every child terminal → empty ready set → excluded.
+        store
+            .create_fleet("f-done", controller(), None, "default", 1_000, false, 0)
+            .await
+            .unwrap();
+        store.add_child("f-done", "c1", vec![], 0).await.unwrap();
+        force_succeeded(&store, "f-done", "c1").await;
+
+        // f-heal: the healed-promotion edge — c1 Succeeded (pre-crash) but its
+        // dependent c2 never promoted (still Planned). `resolve_and_collect_ready`
+        // promotes c2 in-txn, so the fleet IS detected as needing a wake.
+        store
+            .create_fleet("f-heal", controller(), None, "default", 1_000, false, 0)
+            .await
+            .unwrap();
+        store.add_child("f-heal", "c1", vec![], 0).await.unwrap();
+        store
+            .add_child("f-heal", "c2", vec!["c1".into()], 0)
+            .await
+            .unwrap();
+        force_succeeded(&store, "f-heal", "c1").await;
+        assert_eq!(
+            store
+                .get_child("f-heal", "c2")
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            ChildStatus::Planned,
+            "precondition: the dependent is still Planned (a missed promotion)"
+        );
+
+        let mut ids: Vec<String> = store
+            .fleets_with_ready_children(9_999)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|r| r.fleet_id)
+            .collect();
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec![
+                "f-draining".to_string(),
+                "f-heal".to_string(),
+                "f-ready".to_string()
+            ],
+            "only live (Active|Draining) fleets with a ready/heal-promotable child are returned"
+        );
+
+        // The heal was applied in-txn: the missed dependent is now Ready.
+        assert_eq!(
+            store
+                .get_child("f-heal", "c2")
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            ChildStatus::Ready,
+            "resolve_and_collect_ready promoted the missed dependent in-txn"
+        );
     }
 
     // ---- test-only raw writer ---------------------------------------------


### PR DESCRIPTION
Closes the durability gap: at serve boot, `reconcile` returns a restart-interrupted fleet's in-flight tasks to `Ready` but enqueues no keeper wake (the only wake driver is the task-completion outbox consumer), so a running fleet with no pending completion event STALLS forever. Now, after reconcile, a boot pass enqueues a keeper wake for every live fleet with `Ready` children, reusing the existing keeper-wake + PR-4b seed path.

## Pieces
- `FleetKernelStore::fleets_with_ready_children` — two-phase (io_gate is non-reentrant): snapshot `Active|Draining` fleets, then reuse `resolve_and_collect_ready` per fleet (heals missed promotions, returns only genuinely-ready).
- `enqueue_fleet_boot_resume_wakes` (fleet_wake.rs) — per fleet, build the wake via the existing `render_fleet_snapshot` + `fleet_keeper_continuation_request` (carries `controller_workspace_root` → the PR-4b workspace/scope seed) under a fleet-scoped boot dedupe key.
- Serve call site after the pool block, before the drain starts.

## Safety
- **Dedupe key** `external/fleet_keeper_wake/{controller}/boot-resume/{fleet_id}` — fleet-scoped (two fleets on one controller don't collide), can't collide the consumer's sequence key, stable across boots.
- **Orphan guard** — only wakes a fleet still bound to its controller's current goal (mirrors `resolve_owned_fleet`), so a cleared/superseded fleet isn't woken with stale metadata.
- **Persistence honesty** — a rolled-back wake (persist failure) is not counted and is warned; serve never logs false "re-woke" on a stall.
- Double-wake harmless (launch CAS + ready-resolve + per-session turn guard); not solo-gated (matches the consumer); rootless-fleet wake dropped by the seed pre-pass (documented).

Reviewed by codex (shippable); gates green (octos-fleet + octos-cli --features api suites; 9 new tests).