### PR TITLE
test(plugin): compare blocked env vars with core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4848,7 +4848,7 @@ version = "2.0.2"
 dependencies = [
  "eyre",
  "metrics",
- "regex",
+ "octos-core",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/octos-plugin/Cargo.toml
+++ b/crates/octos-plugin/Cargo.toml
@@ -18,9 +18,9 @@ tokio = { workspace = true }
 metrics = { workspace = true }
 
 [dev-dependencies]
+octos-core = { workspace = true }
 tempfile = { workspace = true }
 tokio-test = { workspace = true }
-regex = { workspace = true }
 
 # RFC-2 CI entrypoint — used by scripts/validate-skill-manifests.sh.
 [[bin]]

--- a/crates/octos-plugin/src/lifecycle.rs
+++ b/crates/octos-plugin/src/lifecycle.rs
@@ -35,11 +35,10 @@ use tokio::process::Command;
 
 /// Environment variables blocked inside lifecycle step execution.
 ///
-/// Mirrors `octos-agent/src/sandbox/mod.rs::BLOCKED_ENV_VARS`. The two lists
-/// MUST stay in sync — the `blocked_env_vars_match_agent_sandbox` test in
-/// `tests/lifecycle_sandbox.rs` compiles the agent source in and asserts
-/// the two lists are element-wise equal. If you add/remove a variable here,
-/// update the agent source too (and vice versa).
+/// Mirrors `octos_core::BLOCKED_ENV_VARS`. The two lists MUST stay in sync —
+/// the `blocked_env_vars_match_core_canonical_list` test in
+/// `tests/lifecycle_sandbox.rs` compares the exported constants directly. If
+/// you add or remove a variable here, update the canonical core list too.
 pub const BLOCKED_ENV_VARS: &[&str] = &[
     // Linux: shared library injection
     "LD_PRELOAD",

--- a/crates/octos-plugin/tests/lifecycle_sandbox.rs
+++ b/crates/octos-plugin/tests/lifecycle_sandbox.rs
@@ -3,7 +3,7 @@
 //! The contract for the hardware lifecycle executor (issue #448) enumerates
 //! seven acceptance tests. This file implements all of them, plus a
 //! synchronization test that asserts `BLOCKED_ENV_VARS` in `octos-plugin`
-//! matches the canonical list in `octos-agent/src/sandbox/mod.rs`.
+//! matches the canonical list exported by `octos-core`.
 //!
 //! The hardest test is `should_kill_child_when_step_timeout_exceeded`: it
 //! runs a shell command that spawns a long-lived marker process (`sleep`
@@ -400,34 +400,16 @@ async fn pick_and_place_lifecycle_example_runs_end_to_end() {
     }
 }
 
-/// Sync test: asserts the BLOCKED_ENV_VARS list in `octos-plugin` matches
-/// the canonical list in `octos-agent/src/sandbox/mod.rs`. Failing this
-/// means the two lists have drifted and need to be reconciled.
+/// Sync test: asserts the BLOCKED_ENV_VARS list in `octos-plugin` matches the
+/// canonical list exported by `octos-core`. Comparing the constants directly
+/// keeps this test independent of where or how the canonical list is defined.
 #[test]
-fn blocked_env_vars_match_agent_sandbox() {
-    let agent_source = include_str!("../../octos-agent/src/sandbox/mod.rs");
-    // Extract the slice literal: `pub const BLOCKED_ENV_VARS: &[&str] = &[...];`
-    let re = regex::Regex::new(r"(?s)pub const BLOCKED_ENV_VARS:\s*&\[&str\]\s*=\s*&\[(.*?)\];")
-        .unwrap();
-    let caps = re
-        .captures(agent_source)
-        .expect("could not locate BLOCKED_ENV_VARS in agent sandbox source");
-    let body = &caps[1];
-    let item_re = regex::Regex::new(r#""([A-Z0-9_]+)""#).unwrap();
-    let agent_vars: Vec<String> = item_re
-        .captures_iter(body)
-        .map(|c| c[1].to_string())
-        .collect();
-
-    let plugin_vars: Vec<String> = octos_plugin::BLOCKED_ENV_VARS
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
-
+fn blocked_env_vars_match_core_canonical_list() {
     assert_eq!(
-        plugin_vars, agent_vars,
-        "octos-plugin BLOCKED_ENV_VARS drifted from octos-agent::sandbox::BLOCKED_ENV_VARS. \
-         Update both lists together."
+        octos_plugin::BLOCKED_ENV_VARS,
+        octos_core::BLOCKED_ENV_VARS,
+        "octos-plugin BLOCKED_ENV_VARS drifted from octos-core's canonical list. \
+         Update both constants together."
     );
 }
 


### PR DESCRIPTION
## Summary
- compare the plugin BLOCKED_ENV_VARS list directly with the canonical octos-core export
- replace the obsolete regex source parser with an octos-core test dependency
- update lifecycle documentation to identify octos-core as the canonical source

## Root cause
Main moved the canonical constant from octos-agent into octos-core, while the plugin synchronization test still parsed octos-agent source text and required the old array literal. The production re-export remained valid, but the stale test failed on Linux and Windows.

## Validation
- cargo test -p octos-plugin --test lifecycle_sandbox blocked_env_vars_match_core_canonical_list -- --exact
- cargo test -p octos-plugin
- cargo fmt --all -- --check
- cargo clippy -p octos-plugin --all-targets -- -D warnings
- git diff --check

This fixes the baseline failure currently surfacing in PR #1880 after it synchronized with main.