### PR TITLE
fix(ci): unbreak main — clippy, plugin drift guard, Windows git_worktree; scope peer rollback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,14 @@ jobs:
       - name: gateway_runtime regression (octos-cli)
         run: cargo test -p octos-cli gateway_runtime::tests --features api -- --nocapture
 
+      # Peer staging/fencing lives in the `api`-gated ui_protocol module, so the
+      # unfeatured runs above never compile it — same reason as the §6 guard.
+      # These cover slug reservation, worktree fencing, and the rollback
+      # isolation guard (one peer's cleanup must not delete a SIBLING's
+      # worktree, which a repo-global `git worktree prune` used to do).
+      - name: Peer staging + worktree fencing (octos-cli)
+        run: cargo test -p octos-cli --features api peer
+
   # Lightweight check that exercises the `matrix` feature gate. The default
   # `FEATURES` env above intentionally omits `matrix` to keep the main `check`
   # job lean, but the Dockerfile and several release configurations enable it.
@@ -609,11 +617,17 @@ jobs:
     # Windows break is now visible at review time instead of after merge.
     #
     # The original reason recorded here — 2 `octos-core` `session_scope`
-    # failures — was fixed by #1838; `Test octos-core` is green on `main`. As of
-    # run 30423603951 the job stops at `Test octos-plugin`
-    # (`lifecycle::tests::run_phase_injects_octos_skill_dir_env`), which #1860
-    # addresses. Keep this note pinned to the CURRENT blocker: a stale one reads
-    # as "known, tracked, someone's on it" long after nobody is.
+    # failures — was fixed by #1838, and the `octos-plugin` blocker noted next
+    # (`run_phase_injects_octos_skill_dir_env`) by #1860. As of run 30695951586
+    # the two remaining failures were: 12 `octos-core` `git_worktree::tests::*`
+    # (`GIT_BIN` resolved only `/usr/bin/git` | `/bin/git`, so EVERY controller
+    # git spawn failed on Windows and `is_git_repo` reported "not a repository"),
+    # and `octos-plugin`'s `blocked_env_vars_match_agent_sandbox` (it scraped
+    # `BLOCKED_ENV_VARS` out of a file the constant had moved away from). Both
+    # are fixed; this job is EXPECTED green. If it stays green, delete the
+    # `continue-on-error` below and this note. Keep the note pinned to the
+    # CURRENT blocker: a stale one reads as "known, tracked, someone's on it"
+    # long after nobody is.
     #
     # Non-blocking ONLY on PRs. On push to `main` it stays hard-failing, so
     # `build-windows` (which `needs:` this job) still refuses to ship a Windows

--- a/crates/octos-agent/src/validators_tests.rs
+++ b/crates/octos-agent/src/validators_tests.rs
@@ -2196,12 +2196,12 @@ fn kill_child_process_uses_absolute_paths() {
     assert!(
         KILL_BIN.is_absolute(),
         "the timeout-kill must invoke `kill` by ABSOLUTE path (no $PATH lookup), got {:?}",
-        &*KILL_BIN
+        *KILL_BIN
     );
     assert!(
         PS_BIN.is_absolute(),
         "process enumeration must invoke `ps` by ABSOLUTE path (no $PATH lookup), got {:?}",
-        &*PS_BIN
+        *PS_BIN
     );
 
     // The resolver never falls back to a bare (PATH-looked-up) name: even when no

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -11758,28 +11758,31 @@ async fn raw_peer_prepare(
     Ok(Value::Object(result))
 }
 
-/// Roll back a half-staged peer fleet: remove every reserved dir, then
-/// best-effort `git worktree prune` + `branch -D peer/<slug>` for each (a
-/// worktree that WAS created for an earlier fleet member must not leak when
-/// a later member fails; both are no-ops for members that never got one).
+/// Roll back a half-staged peer fleet: unregister and remove every reserved
+/// member, then best-effort `branch -D peer/<slug>` for each (a worktree that
+/// WAS created for an earlier fleet member must not leak when a later member
+/// fails; all are no-ops for members that never got one).
+///
+/// Each member is torn down through [`remove_peer_worktree`], which is scoped to
+/// that member's own path — NOT the repo-global `git worktree prune` this used
+/// to run, which also deleted the fence of any peer outside this fleet that
+/// happened to be mid-`worktree add`.
 async fn cleanup_staged_peers(workspace_root: &Path, staged: &[(String, PathBuf)]) {
-    for (_, dir) in staged {
-        let _ = std::fs::remove_dir_all(dir);
-    }
     if staged.is_empty() {
         return;
     }
     let root = workspace_root.to_path_buf();
+    let dirs: Vec<PathBuf> = staged.iter().map(|(_, dir)| dir.clone()).collect();
     let branches: Vec<String> = staged
         .iter()
         .map(|(slug, _)| format!("peer/{slug}"))
         .collect();
     let _ = tokio::task::spawn_blocking(move || {
-        let _ = std::process::Command::new("git")
-            .arg("-C")
-            .arg(&root)
-            .args(["worktree", "prune"])
-            .output();
+        for dir in &dirs {
+            // Unregister BEFORE deleting: `git worktree remove` resolves by path.
+            remove_peer_worktree(&root, dir);
+            let _ = std::fs::remove_dir_all(dir);
+        }
         for branch in &branches {
             let _ = std::process::Command::new("git")
                 .arg("-C")
@@ -11931,17 +11934,96 @@ fn stage_peer(
     })
 }
 
-/// Roll back ONE half-staged peer: remove its reserved dir, then
-/// best-effort `git worktree prune` + `branch -D peer/<slug>` (both no-ops
-/// for a member that never got a worktree). The single-member synchronous
-/// sibling of [`cleanup_staged_peers`], used inside [`stage_peer`].
-fn cleanup_staged_peer(workspace_root: &Path, slug: &str, dir: &Path) {
-    let _ = std::fs::remove_dir_all(dir);
-    let _ = std::process::Command::new("git")
+/// The `.git` COMMON dir of `workspace_root` — where per-worktree admin dirs
+/// live. Resolved via git (not `join(".git")`) because `.git` is a FILE when the
+/// workspace is itself a worktree, and the admin dirs then live in the parent
+/// repo. `None` when `workspace_root` is not a repo.
+fn git_common_dir(workspace_root: &Path) -> Option<PathBuf> {
+    let out = std::process::Command::new("git")
         .arg("-C")
         .arg(workspace_root)
-        .args(["worktree", "prune"])
-        .output();
+        .args(["rev-parse", "--git-common-dir"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8(out.stdout).ok()?;
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(raw);
+    // `--git-common-dir` may answer relatively (`.git`) — anchor it.
+    Some(if path.is_absolute() {
+        path
+    } else {
+        workspace_root.join(path)
+    })
+}
+
+/// Drop ONLY the worktree belonging to peer dir `dir`.
+///
+/// Deliberately NOT `git worktree prune`, which is what this used to do: prune
+/// is repo-GLOBAL and removes the admin entry of EVERY worktree whose checkout
+/// is currently missing. `git worktree add` registers the admin entry BEFORE the
+/// checkout is fully in place, so a sibling peer staged concurrently sits in
+/// exactly that window — one peer's rollback silently destroyed another peer's
+/// fence, leaving its branch checked out nowhere. Every peer checkout is named
+/// `wt` (`peers/<slug>/wt`), so git disambiguates the admin dirs as `wt`, `wt1`,
+/// … — which is why this showed up as "the SECOND peer lost its worktree".
+///
+/// Both steps here are scoped STRICTLY to paths under `dir`, so a sibling is
+/// never touched no matter what state it is in.
+fn remove_peer_worktree(workspace_root: &Path, dir: &Path) {
+    // Normal path: the checkout exists, so git can unregister it by PATH.
+    let checkout = dir.join("wt");
+    if checkout.is_dir() {
+        let _ = std::process::Command::new("git")
+            .arg("-C")
+            .arg(workspace_root)
+            .args(["worktree", "remove", "--force"])
+            .arg(&checkout)
+            .output();
+    }
+    // Fallback: a checkout that never finished (or a `remove` git refused)
+    // leaves an admin entry behind, and a lingering entry keeps `branch -D`
+    // from succeeding — which would burn the slug for any retry. Sweep it by
+    // hand, matching ONLY entries whose `gitdir` points inside `dir`.
+    let Some(common) = git_common_dir(workspace_root) else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(common.join("worktrees")) else {
+        return;
+    };
+    // Compare canonicalized too: on macOS a temp/staging path reaches git as
+    // `/private/var/…` while `dir` is the `/var/…` symlink (or vice versa), and
+    // a purely lexical match would silently sweep nothing.
+    let canonical = std::fs::canonicalize(dir).ok();
+    for entry in entries.flatten() {
+        let Ok(target) = std::fs::read_to_string(entry.path().join("gitdir")) else {
+            continue;
+        };
+        let target = Path::new(target.trim());
+        let mine = target.starts_with(dir)
+            || canonical
+                .as_deref()
+                .is_some_and(|canonical| target.starts_with(canonical));
+        if mine {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+}
+
+/// Roll back ONE half-staged peer: unregister its OWN worktree, remove its
+/// reserved dir, then best-effort `branch -D peer/<slug>` (all no-ops for a
+/// member that never got a worktree). The single-member synchronous sibling of
+/// [`cleanup_staged_peers`], used inside [`stage_peer`].
+fn cleanup_staged_peer(workspace_root: &Path, slug: &str, dir: &Path) {
+    // BEFORE `remove_dir_all`: `git worktree remove` needs the checkout on disk
+    // to unregister it by path.
+    remove_peer_worktree(workspace_root, dir);
+    let _ = std::fs::remove_dir_all(dir);
     let branch = format!("peer/{slug}");
     let _ = std::process::Command::new("git")
         .arg("-C")

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -25803,6 +25803,119 @@ fn stage_peer_reserves_slug_writes_brief_and_releases_on_failure() {
     );
 }
 
+/// Rolling back ONE peer must never touch a SIBLING's worktree fence.
+///
+/// `cleanup_staged_peer` used to run a repo-GLOBAL `git worktree prune`, which
+/// deletes the admin entry of EVERY worktree whose checkout is missing — not
+/// just the one being rolled back. `git worktree add` creates the admin entry
+/// BEFORE the checkout is fully in place, so a sibling staged concurrently was
+/// visible to prune in exactly that window and lost its fence: its branch was
+/// left checked-out-nowhere and the peer ran in a broken worktree. Every peer
+/// checkout is named `wt` (`peers/<slug>/wt`), so git disambiguates the admin
+/// dirs as `wt`, `wt1`, … — which is why this surfaced as "the SECOND peer's
+/// worktree disappeared".
+///
+/// The window is a race, but its consequence is deterministic: a peer whose
+/// checkout is absent when a sibling cleans up must survive. That is what this
+/// asserts — hiding the checkout stands in for "mid-`worktree add`".
+#[test]
+fn cleanup_of_one_peer_must_not_destroy_a_sibling_worktree() {
+    fn git(dir: &std::path::Path, args: &[&str]) -> String {
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let peers = tmp.path().join("peers");
+    let repo = tmp.path().join("project");
+    std::fs::create_dir_all(&repo).unwrap();
+    git(&repo, &["init", "-q"]);
+    git(
+        &repo,
+        &[
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ],
+    );
+
+    // The SURVIVOR: a fully staged, fenced peer.
+    let keeper = stage_peer(&peers, &repo, "Keeper", None, None, "Stay.", true)
+        .expect("sibling staging must succeed");
+    assert!(keeper.cwd.join(".git").exists(), "sibling fence is real");
+
+    // A second peer, so the admin dirs actually collide on basename `wt`
+    // (`wt` and `wt1`) exactly as they do in production.
+    let doomed =
+        stage_peer(&peers, &repo, "Doomed", None, None, "Rolled back.", true).expect("staging");
+
+    // Stand in for "sibling is mid-`worktree add`": its admin entry exists but
+    // its checkout is not on disk yet.
+    let hidden = tmp.path().join("keeper-checkout-parked");
+    std::fs::rename(&keeper.cwd, &hidden).unwrap();
+
+    // Roll back ONLY the doomed peer.
+    cleanup_staged_peer(&repo, &doomed.slug, &peers.join(&doomed.slug));
+
+    std::fs::rename(&hidden, &keeper.cwd).unwrap();
+
+    // The rollback must have removed its OWN fence…
+    let listed = git(&repo, &["worktree", "list"]);
+    assert!(
+        !listed.contains("peers/doomed"),
+        "the rolled-back peer's worktree must be gone, got:\n{listed}"
+    );
+    assert!(
+        !peers.join("doomed").exists(),
+        "the rolled-back peer's dir must be gone"
+    );
+
+    // …and left the SIBLING's fence completely intact.
+    assert!(
+        listed.contains(&keeper.cwd.to_string_lossy().into_owned())
+            || listed.contains("peers/keeper"),
+        "a sibling's worktree must survive another peer's rollback, got:\n{listed}"
+    );
+    assert!(
+        keeper.cwd.join(".git").exists(),
+        "sibling checkout must still be a live worktree"
+    );
+    // The decisive check: git must still resolve the sibling's worktree. A
+    // pruned admin entry leaves the checkout on disk but orphaned, so this is
+    // what actually distinguishes "survived" from "looks like it survived".
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&keeper.cwd)
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "sibling worktree must still be usable by git: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout).trim(),
+        "peer/keeper",
+        "sibling must still be on its own fence branch"
+    );
+}
+
 /// #1801 v3 depth-1 guard: `peer_handoff` wiring is skipped for sessions
 /// whose topic is `peer-<slug>` — a peer must never see the tool at all.
 #[test]

--- a/crates/octos-core/src/git_worktree.rs
+++ b/crates/octos-core/src/git_worktree.rs
@@ -35,10 +35,12 @@
 //!   worker-planted `git` in a controller-`$PATH` dir is never run), (2) STRIPS
 //!   provider/API-key + injection env vars ([`crate::env_hygiene`] — so no
 //!   controller secret is inherited), and (3) sets hooks
-//!   (`core.hooksPath=/dev/null`), fsmonitor (`core.fsmonitor=`), and
-//!   global/system config (`GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=/dev/null`) to
-//!   empty, so no hook/fsmonitor fires and no global/system-config `filter.*`
-//!   runs on a controller op.
+//!   (`core.hooksPath=<null device>`), fsmonitor (`core.fsmonitor=`), and
+//!   global/system config
+//!   (`GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM=<null device>`) to empty, so no
+//!   hook/fsmonitor fires and no global/system-config `filter.*` runs on a
+//!   controller op. The null device is [`NULL_DEVICE`] — `/dev/null`, or `NUL`
+//!   on Windows.
 //! - **(b) no host-side checkout + in-sandbox populate/commit:** every controller
 //!   `git worktree add` uses `--no-checkout`, so a worker-planted LOCAL
 //!   `.git/config` `filter.*.smudge` never runs host-side as the daemon. The
@@ -58,33 +60,71 @@ use std::process::Command;
 
 use eyre::{Result, WrapErr, eyre};
 
-/// `-c core.hooksPath=/dev/null`: disables ALL git hooks for a controller-side
-/// invocation (`/dev/null` can never be a hooks directory, so no hook is ever
-/// found). One part of the code-exec fence — see the module note and
-/// [`git_command`].
+/// The platform's null device: a path that can never be a directory and never
+/// holds config. `/dev/null` on Unix, `NUL` on Windows — a reserved device name,
+/// so it is the exact analogue.
+///
+/// On Windows the old hardcoded `/dev/null` did still mask config and hooks, but
+/// only by ACCIDENT: it is not the null device there, merely a path that happens
+/// not to exist. That is a property of the filesystem, not a guarantee — create
+/// `C:\dev\null` and the fence silently opens. `NUL` cannot be a directory or a
+/// readable config no matter what is on disk.
+#[cfg(not(windows))]
+const NULL_DEVICE: &str = "/dev/null";
+#[cfg(windows)]
+const NULL_DEVICE: &str = "NUL";
+
+/// `-c core.hooksPath=<null device>`: disables ALL git hooks for a
+/// controller-side invocation (the null device can never be a hooks directory,
+/// so no hook is ever found). One part of the code-exec fence — see the module
+/// note and [`git_command`].
+#[cfg(not(windows))]
 const NO_HOOKS: &str = "core.hooksPath=/dev/null";
+#[cfg(windows)]
+const NO_HOOKS: &str = "core.hooksPath=NUL";
 
 /// `-c core.fsmonitor=`: override any worker-set local `core.fsmonitor` to EMPTY
 /// so no fsmonitor hook program can run on a controller-side git op (defensive
 /// belt — these ops don't scan the index, but override unconditionally).
 const NO_FSMONITOR: &str = "core.fsmonitor=";
 
+/// Candidate absolute `git` paths, most-preferred first. Every entry MUST be a
+/// location a fleet worker cannot write to (see [`GIT_BIN`]).
+///
+/// On Windows the analogue of `/usr/bin` is `%ProgramFiles%\Git`, which requires
+/// Administrator to write. `%LOCALAPPDATA%\Programs\Git` — where Git for Windows
+/// installs in per-user mode — is deliberately EXCLUDED for exactly the reason
+/// Homebrew is on Unix: it is user-writable, which is the plant vector. A host
+/// with only a per-user git therefore fails closed (git not found) rather than
+/// running a binary the worker could have replaced.
+#[cfg(not(windows))]
+const GIT_CANDIDATES: &[&str] = &["/usr/bin/git", "/bin/git"];
+#[cfg(windows)]
+const GIT_CANDIDATES: &[&str] = &[
+    r"C:\Program Files\Git\cmd\git.exe",
+    r"C:\Program Files\Git\bin\git.exe",
+    r"C:\Program Files (x86)\Git\cmd\git.exe",
+    r"C:\Program Files (x86)\Git\bin\git.exe",
+];
+
 /// Absolute path to the `git` binary, resolved ONCE from NON-worker-writable
 /// system locations — NEVER via `$PATH`. A fleet worker's NATIVE tools have
 /// full-FS (`FilesystemScope::Host`) write, so a bare `git` (PATH-resolved) would
 /// let it plant a fake `git` earlier in the controller's `$PATH` (or in a
 /// user-writable dir like `/opt/homebrew/bin`) and have the CONTROLLER, running
-/// UNSANDBOXED, execute it. Pin to `/usr/bin/git` / `/bin/git` (root-owned /
-/// SIP-protected — not worker-writable); the fallback stays ABSOLUTE so there is
-/// never a `$PATH` lookup. Mirrors the timeout-kill's `KILL_BIN`/`PS_BIN`.
-/// (Homebrew/`/usr/local` are deliberately NOT candidates — they are
-/// user/daemon-writable, which is exactly the plant vector.)
+/// UNSANDBOXED, execute it. Pin to [`GIT_CANDIDATES`] (root-owned / SIP-protected
+/// on Unix, Administrator-only on Windows — not worker-writable); the fallback
+/// stays ABSOLUTE so there is never a `$PATH` lookup. Mirrors the timeout-kill's
+/// `KILL_BIN`/`PS_BIN`. (Homebrew/`/usr/local` are deliberately NOT candidates —
+/// they are user/daemon-writable, which is exactly the plant vector.)
 static GIT_BIN: std::sync::LazyLock<PathBuf> = std::sync::LazyLock::new(|| {
-    ["/usr/bin/git", "/bin/git"]
-        .into_iter()
+    GIT_CANDIDATES
+        .iter()
         .map(PathBuf::from)
         .find(|p| p.exists())
-        .unwrap_or_else(|| PathBuf::from("/usr/bin/git"))
+        // Keep the fallback ABSOLUTE: a missing git must fail as "cannot spawn
+        // this exact path", never degrade into a `$PATH` lookup.
+        .unwrap_or_else(|| PathBuf::from(GIT_CANDIDATES[0]))
 });
 
 /// Build the base `git -C <repo> …` command with the controller-side code-exec
@@ -122,8 +162,8 @@ fn git_command(repo: &Path) -> Command {
     // SAME set the worker-sandboxed git ops strip. Done BEFORE re-applying the
     // git-specific env below, so those overrides can never be stripped.
     crate::env_hygiene::sanitize_git_command_env(&mut cmd);
-    cmd.env("GIT_CONFIG_GLOBAL", "/dev/null")
-        .env("GIT_CONFIG_SYSTEM", "/dev/null");
+    cmd.env("GIT_CONFIG_GLOBAL", NULL_DEVICE)
+        .env("GIT_CONFIG_SYSTEM", NULL_DEVICE);
     cmd
 }
 
@@ -376,6 +416,14 @@ fn worktree_admin_dir(checkout: &Path) -> Option<PathBuf> {
 /// code (a clean tree, or a worker's own broken filter, exits non-zero without
 /// being an infra error) — the authoritative "did a deliverable land?" check is
 /// [`branch_advanced_past`], read host-side.
+///
+/// PLATFORM: the returned string is POSIX `sh` (`&&`, `if ! …; then …; fi`,
+/// single-quote escaping) and is only valid where the worker sandbox runs a
+/// POSIX shell. `cmd /C` — the Windows shell fallback — cannot execute it, so
+/// fleet worktree WORKERS are Unix-only. The controller-side helpers in this
+/// module (which spawn git directly, no shell) are cross-platform, and their
+/// tests run everywhere; the tests that exercise THIS contract by shelling out
+/// to `sh` are `#[cfg(unix)]`.
 pub fn deliverable_commit_command(message: &str) -> String {
     let msg = sh_single_quote(message);
     // `-c core.hooksPath=/dev/null` on BOTH ops (belt): disables ALL git hooks so
@@ -728,11 +776,31 @@ mod tests {
     /// uses `--no-checkout`, so the working tree starts EMPTY and the worker must
     /// restore it (`git reset --hard`) before working. Every test that inspects
     /// or commits files in the checkout runs this first, as the real worker does.
+    /// Unix: run the REAL command string through `sh`, exactly as the worker's
+    /// sandbox does — the fidelity is the point.
+    #[cfg(unix)]
     fn populate(checkout: &Path) -> bool {
         Command::new("sh")
             .arg("-c")
             .arg(worktree_populate_command())
             .current_dir(checkout)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    /// Windows: `worktree_populate_command()` is POSIX `sh` and there is no
+    /// shell to run it in, so perform the SAME git op natively. This is a test
+    /// fixture (restore the `--no-checkout` working tree so `commit_in` has
+    /// something to commit), not a claim that worktree workers run on Windows —
+    /// it exists so the CONTROLLER-side tests, which are cross-platform, are not
+    /// gated out by an incidental `sh` dependency.
+    #[cfg(windows)]
+    fn populate(checkout: &Path) -> bool {
+        Command::new("git")
+            .arg("-C")
+            .arg(checkout)
+            .args(["-c", NO_HOOKS, "reset", "-q", "--hard"])
             .status()
             .map(|s| s.success())
             .unwrap_or(false)
@@ -845,6 +913,9 @@ mod tests {
         );
     }
 
+    // POSIX-sh contract: drives the worker's `sh -c` command strings
+    // (`populate`/`run_deliverable_command`), which `cmd /C` cannot run.
+    #[cfg(unix)]
     #[test]
     fn prepare_reconciles_existing_branch_and_checkout_resuming_from_branch() {
         let repo = tempfile::tempdir().unwrap();
@@ -887,6 +958,9 @@ mod tests {
         );
     }
 
+    // POSIX-sh contract: drives the worker's `sh -c` command strings
+    // (`populate`/`run_deliverable_command`), which `cmd /C` cannot run.
+    #[cfg(unix)]
     #[test]
     fn prepare_reclaims_a_locked_leftover_worktree() {
         // HIGH #5: a dead attempt left a LOCKED worktree. A single
@@ -928,6 +1002,7 @@ mod tests {
 
     /// Run [`deliverable_commit_command`] in `checkout` via `sh -c` (simulating
     /// the worker's sandbox running it). Returns whether it exited 0.
+    #[cfg(unix)]
     fn run_deliverable_command(checkout: &Path, message: &str) -> bool {
         Command::new("sh")
             .arg("-c")
@@ -938,6 +1013,9 @@ mod tests {
             .unwrap_or(false)
     }
 
+    // POSIX-sh contract: drives the worker's `sh -c` command strings
+    // (`populate`/`run_deliverable_command`), which `cmd /C` cannot run.
+    #[cfg(unix)]
     #[test]
     fn deliverable_commit_command_lands_uncommitted_changes() {
         // §4b: a worker wrote a file but did NOT commit. The auto-commit command
@@ -981,6 +1059,9 @@ mod tests {
         );
     }
 
+    // POSIX-sh contract: drives the worker's `sh -c` command strings
+    // (`populate`/`run_deliverable_command`), which `cmd /C` cannot run.
+    #[cfg(unix)]
     #[test]
     fn deliverable_command_noop_and_branch_empty_when_nothing_produced() {
         // §4b: a worker that produced nothing leaves the branch at base — the
@@ -1014,6 +1095,9 @@ mod tests {
         assert_eq!(head, prepared.base_commit, "branch stays at base");
     }
 
+    // POSIX-sh contract: drives the worker's `sh -c` command strings
+    // (`populate`/`run_deliverable_command`), which `cmd /C` cannot run.
+    #[cfg(unix)]
     #[test]
     fn deliverable_commit_command_escapes_the_message() {
         // The commit MESSAGE is single-quote-escaped, so a message containing a
@@ -1137,8 +1221,7 @@ mod tests {
             .map(|a| a.to_string_lossy().into_owned())
             .collect();
         assert!(
-            args.windows(2)
-                .any(|w| w[0] == "-c" && w[1] == "core.hooksPath=/dev/null"),
+            args.windows(2).any(|w| w[0] == "-c" && w[1] == NO_HOOKS),
             "must disable hooks, args: {args:?}",
         );
         assert!(
@@ -1157,13 +1240,13 @@ mod tests {
             .collect();
         assert_eq!(
             envs.get("GIT_CONFIG_GLOBAL"),
-            Some(&Some("/dev/null".to_string())),
-            "must mask GLOBAL config to /dev/null",
+            Some(&Some(NULL_DEVICE.to_string())),
+            "must mask GLOBAL config to the null device",
         );
         assert_eq!(
             envs.get("GIT_CONFIG_SYSTEM"),
-            Some(&Some("/dev/null".to_string())),
-            "must mask SYSTEM config to /dev/null",
+            Some(&Some(NULL_DEVICE.to_string())),
+            "must mask SYSTEM config to the null device",
         );
     }
 
@@ -1181,7 +1264,7 @@ mod tests {
         assert!(
             GIT_BIN.is_absolute(),
             "GIT_BIN must be absolute, got {:?}",
-            &*GIT_BIN
+            *GIT_BIN
         );
     }
 
@@ -1253,16 +1336,19 @@ mod tests {
         // The git-specific overrides REMAIN (config masking intact).
         assert!(
             envs.iter()
-                .any(|(k, v)| k == "GIT_CONFIG_GLOBAL" && v.as_deref() == Some("/dev/null")),
+                .any(|(k, v)| k == "GIT_CONFIG_GLOBAL" && v.as_deref() == Some(NULL_DEVICE)),
             "GIT_CONFIG_GLOBAL override must remain: {envs:?}",
         );
         assert!(
             envs.iter()
-                .any(|(k, v)| k == "GIT_CONFIG_SYSTEM" && v.as_deref() == Some("/dev/null")),
+                .any(|(k, v)| k == "GIT_CONFIG_SYSTEM" && v.as_deref() == Some(NULL_DEVICE)),
             "GIT_CONFIG_SYSTEM override must remain: {envs:?}",
         );
     }
 
+    // POSIX-sh contract: drives the worker's `sh -c` command strings
+    // (`populate`/`run_deliverable_command`), which `cmd /C` cannot run.
+    #[cfg(unix)]
     #[test]
     fn global_filter_is_neutralized_on_controller_ops() {
         // CRITICAL (codex re-review, fix 3): a `filter.*.clean` defined in GLOBAL
@@ -1340,6 +1426,9 @@ mod tests {
         );
     }
 
+    // Whole body is unix-only (needs `symlink`), like its sibling below —
+    // gating the test itself keeps the Windows build warning-free.
+    #[cfg(unix)]
     #[test]
     fn prepare_rejects_symlinked_checkout() {
         let repo = tempfile::tempdir().unwrap();
@@ -1350,14 +1439,11 @@ mod tests {
         let parent = work.path().join("f1");
         std::fs::create_dir_all(&parent).unwrap();
         let checkout = parent.join("a");
-        #[cfg(unix)]
-        {
-            std::os::unix::fs::symlink(work.path(), &checkout).unwrap();
-            assert!(
-                prepare_fleet_worktree(repo.path(), work.path(), "fleet/f1/a", &checkout).is_err(),
-                "a symlinked checkout path must be refused",
-            );
-        }
+        std::os::unix::fs::symlink(work.path(), &checkout).unwrap();
+        assert!(
+            prepare_fleet_worktree(repo.path(), work.path(), "fleet/f1/a", &checkout).is_err(),
+            "a symlinked checkout path must be refused",
+        );
     }
 
     #[cfg(unix)]

--- a/crates/octos-plugin/tests/lifecycle_sandbox.rs
+++ b/crates/octos-plugin/tests/lifecycle_sandbox.rs
@@ -400,18 +400,25 @@ async fn pick_and_place_lifecycle_example_runs_end_to_end() {
     }
 }
 
-/// Sync test: asserts the BLOCKED_ENV_VARS list in `octos-plugin` matches
-/// the canonical list in `octos-agent/src/sandbox/mod.rs`. Failing this
-/// means the two lists have drifted and need to be reconciled.
+/// Sync test: asserts the BLOCKED_ENV_VARS list in `octos-plugin` matches the
+/// canonical list. That list USED to live in `octos-agent/src/sandbox/mod.rs`;
+/// #1881 moved it down to `octos-core::env_hygiene` (so octos-core's own
+/// controller-side git ops sanitize against the same set) and left a `pub use`
+/// re-export behind. This test scrapes the SOURCE TEXT, so the re-export broke
+/// it — it panicked with "could not locate BLOCKED_ENV_VARS", meaning the
+/// cross-crate invariant silently stopped being checked. Read the canonical
+/// definition, and fail with a pointer if it moves again.
 #[test]
 fn blocked_env_vars_match_agent_sandbox() {
-    let agent_source = include_str!("../../octos-agent/src/sandbox/mod.rs");
+    let agent_source = include_str!("../../octos-core/src/env_hygiene.rs");
     // Extract the slice literal: `pub const BLOCKED_ENV_VARS: &[&str] = &[...];`
     let re = regex::Regex::new(r"(?s)pub const BLOCKED_ENV_VARS:\s*&\[&str\]\s*=\s*&\[(.*?)\];")
         .unwrap();
-    let caps = re
-        .captures(agent_source)
-        .expect("could not locate BLOCKED_ENV_VARS in agent sandbox source");
+    let caps = re.captures(agent_source).expect(
+        "could not locate the BLOCKED_ENV_VARS definition in octos-core/src/env_hygiene.rs — \
+         if the canonical list moved again, repoint this test's include_str! at its new home \
+         (a re-export will NOT match: this scrapes the literal definition)",
+    );
     let body = &caps[1];
     let item_re = regex::Regex::new(r#""([A-Z0-9_]+)""#).unwrap();
     let agent_vars: Vec<String> = item_re


### PR DESCRIPTION
`main` is red on `check`, `check-arm` and `check-windows` (run 30695951586). Three independent causes, plus a peer-staging bug found while soaking peer agents.

## 1. clippy — `check` / `check-arm`

`useless_borrows_in_formatting` on `&*KILL_BIN` / `&*PS_BIN`.

Drop the borrow but **keep the deref** (`*KILL_BIN`): these are `LazyLock<PathBuf>`, so formatting the binding itself prints `LazyLock("/bin/kill")` instead of the path. The identical shape at `&*GIT_BIN` is fixed pre-emptively so CI doesn't just move the failure to `octos-core`.

Not reproducible locally — the lint postdates clippy 0.1.95, and CI is on 1.97.

## 2. `octos-plugin` drift guard was DEAD

`blocked_env_vars_match_agent_sandbox` scrapes the `BLOCKED_ENV_VARS` **source text** out of `octos-agent/src/sandbox/mod.rs`. #1881 moved the definition down to `octos-core::env_hygiene` and left a `pub use` behind — a re-export the regex cannot match, so the test panicked with `could not locate BLOCKED_ENV_VARS`.

The cross-crate invariant had silently stopped being checked. Repointed at the definition, and it now fails with a pointer if the constant moves again.

## 3. `git_worktree` was unusable on Windows

All 12 `git_worktree::tests::*` failures cascade from **one** cause: `GIT_BIN` only ever resolved `/usr/bin/git` | `/bin/git`, so every controller-side git spawn failed and `is_git_repo` answered "not a repository":

```
prepare: controller workspace C:\Users\RUNNER~1\AppData\Local\Temp\.tmpgshQ6A is not a git repository
```

Ported the **threat model**, not the literal paths. The invariant is "resolve an absolute git from somewhere a full-FS-write worker cannot plant a binary" — so Windows uses `%ProgramFiles%\Git` (Administrator-only) and deliberately **excludes** the per-user `%LOCALAPPDATA%\Programs\Git` install for exactly the reason Homebrew is excluded on Unix. A host with only a per-user git fails closed.

Null device is now `NUL` on Windows. `/dev/null` did still mask config there, but only by naming a path that happens not to exist — a filesystem accident, not a guarantee.

`deliverable_commit_command` emits POSIX `sh` by contract, so fleet worktree **workers** are genuinely Unix-only; that is now documented rather than papered over. The 6 tests that shell out to `sh` are `#[cfg(unix)]`; the 6 controller-side ones run everywhere.

Verified with `cargo check -p octos-core --target x86_64-pc-windows-msvc --tests` — clean, 0 errors and 0 warnings. That cross-check caught a real error that reading alone had missed (`commit_in` reaches `sh` transitively via `populate`).

## 4. Peer rollback destroyed SIBLING worktrees

`cleanup_staged_peer` ran a repo-**global** `git worktree prune`, which drops the admin entry of every worktree whose checkout is momentarily absent. `git worktree add` registers the admin entry **before** the checkout exists, so a peer staged concurrently sits in exactly that window and loses its fence — branch left checked out nowhere.

Every peer checkout is named `wt` (`peers/<slug>/wt`), so git disambiguates the admin dirs as `wt`, `wt1`, … — which is why this surfaced as "the second peer's worktree disappeared".

Replaced with a teardown scoped to the peer's own path (`git worktree remove` by path, plus an admin-entry sweep matching only gitdirs under that peer), so a sibling is never touched whatever state it is in. Same fix in the fleet path (`cleanup_staged_peers`).

RED → GREEN: the new test failed with `git worktree list` showing only the main repo — both fences gone — and passes now.

## CI wiring

The peer regression test needs `--features api`, which the unfeatured `cargo test -p octos-cli --lib` never compiles, so it would have guarded nothing. Wired in explicitly, same rationale as the existing §6 catalog guard step. Runs 96 tests in 1.4s.

Also refreshed the `check-windows` stale-blocker note, which the job's own comment asks to keep current.

## Verification

| gate | result |
| --- | --- |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo check -p octos-core --target x86_64-pc-windows-msvc --tests` | clean |
| `cargo test -p octos-core` | 348 passed |
| `cargo test -p octos-plugin` | 81 passed |
| `cargo test -p octos-cli --features api peer` | 96 passed |

Two things only CI can close: the clippy lint does not exist in local clippy 0.1.95, and the Windows fix is verified by type-check rather than by running the Windows suite. `check-windows` is expected green — if it holds, its `continue-on-error` can be dropped.

## Found but NOT fixed (out of scope)

- The same global-prune pattern exists at `crates/octos-core/src/git_worktree.rs:508`/`530` and `crates/octos-agent/src/tools/spawn.rs:195`. Weaker instance — targeted removal and `clear_stale_admin_entry` already run first, so prune is a belt there — but the same latent race.
- The `api` feature is never clippy-linted in CI and has ~30 pre-existing findings (unused imports, dead code, `needless_borrow`). Untouched.
