### PR TITLE
ci: make check-windows blocking — a green badge on a red suite is worse than no badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,31 +611,26 @@ jobs:
     # ~15 min it is the cheapest job in the matrix covering code no other PR
     # check can even see.
     #
-    # NON-BLOCKING for now, because it is currently RED for a pre-existing
-    # reason. Making it blocking today would wedge every PR on a bug it did not
-    # introduce. It still surfaces on the PR, which is the point — a NEW
-    # Windows break is now visible at review time instead of after merge.
+    # BLOCKING. This job carried `continue-on-error: ${{ github.event_name ==
+    # 'pull_request' }}` while it was red on `main` for pre-existing reasons
+    # (`session_scope` → #1838, `run_phase_injects_octos_skill_dir_env` → #1860,
+    # then `git_worktree`'s `GIT_BIN` + `octos-plugin`'s drift guard → #1884).
+    # Those are all fixed and the job is green on `main`, which is the condition
+    # that note set for removing the flag.
     #
-    # The original reason recorded here — 2 `octos-core` `session_scope`
-    # failures — was fixed by #1838, and the `octos-plugin` blocker noted next
-    # (`run_phase_injects_octos_skill_dir_env`) by #1860. As of run 30695951586
-    # the two remaining failures were: 12 `octos-core` `git_worktree::tests::*`
-    # (`GIT_BIN` resolved only `/usr/bin/git` | `/bin/git`, so EVERY controller
-    # git spawn failed on Windows and `is_git_repo` reported "not a repository"),
-    # and `octos-plugin`'s `blocked_env_vars_match_agent_sandbox` (it scraped
-    # `BLOCKED_ENV_VARS` out of a file the constant had moved away from). Both
-    # are fixed; this job is EXPECTED green. If it stays green, delete the
-    # `continue-on-error` below and this note. Keep the note pinned to the
-    # CURRENT blocker: a stale one reads as "known, tracked, someone's on it"
-    # long after nobody is.
+    # It is gone rather than merely stale, because `continue-on-error` at JOB
+    # level makes GitHub report the job's conclusion as `success` even when its
+    # steps fail — so the PR checklist read `check-windows  pass` on a suite
+    # that was actually RED. That is not a muted gate, it is a misleading one,
+    # and it burned real time: #1883's branch sat at `341 passed; 1 failed`
+    # (`global_filter_is_neutralized_on_controller_ops`) while reporting green,
+    # and #1884 reported green before anyone had confirmed the Windows fix
+    # worked. Both were only caught by opening the raw job log.
     #
-    # Non-blocking ONLY on PRs. On push to `main` it stays hard-failing, so
-    # `build-windows` (which `needs:` this job) still refuses to ship a Windows
-    # artifact from a red suite — a blanket `continue-on-error: true` would have
-    # silently re-enabled those releases.
-    #
-    # Drop this line entirely once the job is green on `main`.
-    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    # Consequence to accept: a Windows break now blocks PRs. If `main` ever goes
+    # red on Windows again, prefer fixing it or narrowing the failing test to
+    # `#[cfg(unix)]` over re-muting the whole job — a check that cannot fail
+    # tells you nothing.
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Removes `continue-on-error: ${{ github.event_name == 'pull_request' }}` from `check-windows`.

## Why this matters more than "a stale flag"

`continue-on-error` at **job** level makes GitHub record the job's conclusion as `success` even when steps inside it fail. The PR checklist therefore printed

```
check-windows    pass
```

on a Windows suite that was **red**. It is not a muted gate — it is one that actively reports the opposite of the truth.

That cost real time today, twice:

- **#1883's branch** showed `check-windows  pass` while the job log said:
  ```
  global_filter_is_neutralized_on_controller_ops ... FAILED
  sanity: the control (global visible) must run the filter, else the test is vacuous
  test result: FAILED. 341 passed; 1 failed
  ```
  Its Windows portability fix did not work. Nothing surfaced that — it was found only by opening the raw log to compare two approaches.

- **#1884** reported `pass` for that job before its Windows fix had been confirmed by anything at all. Trusting the badge would have meant claiming a fix worked with zero evidence.

## Why now

The flag was the right call when added: the job was red on `main` for pre-existing reasons, and blocking would have wedged every PR on a bug it did not introduce. Those are all fixed:

| blocker | fixed by |
| --- | --- |
| 2 `octos-core` `session_scope` failures | #1838 |
| `run_phase_injects_octos_skill_dir_env` | #1860 |
| 12 `git_worktree::tests::*` (`GIT_BIN` unresolvable on Windows) | #1884 |
| `blocked_env_vars_match_agent_sandbox` (drift guard scraping a moved constant) | #1884 |

`check-windows` is now green on `main` **unmasked** — the flag evaluates false on push, so run 30715780192's success is the job's real conclusion. That is precisely the condition the job's own note set: *"Drop this line entirely once the job is green on `main`."*

## Blast radius

Only `check-windows` changes behavior — it now blocks PRs.

`build-windows` still `needs:` it and still only runs on `push`, where `check-windows` was already hard-failing. So nothing about release artifacts changes.

This PR is itself the first thing gated by the new rule.

## The tradeoff, stated plainly

A Windows break now blocks PRs, and the job takes ~15 min. If `main` goes red on Windows again, PRs wedge — the exact scenario the flag was added for.

The comment now records the intended response: **fix it, or narrow the failing test to `#[cfg(unix)]`** when it encodes a POSIX-only contract (as `deliverable_commit_command`'s `sh` tests do), rather than re-muting the whole job. A check that cannot fail tells you nothing.
