### PR TITLE
fix(worktree): scope worktree teardown to its own checkout, never a global prune

### DIFF
--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -178,7 +178,7 @@ fn prune_worker_worktree(repo_root: &Path, worktree: &WorkerWorktree) {
                 path = %worktree.path.display(),
                 stderr = %String::from_utf8_lossy(&output.stderr).trim(),
                 "spawn: git worktree remove failed for refused spawn; \
-                 falling back to manual prune"
+                 falling back to manual cleanup"
             );
             if worktree.path.exists() {
                 if let Err(error) = std::fs::remove_dir_all(&worktree.path) {
@@ -189,11 +189,12 @@ fn prune_worker_worktree(repo_root: &Path, worktree: &WorkerWorktree) {
                     );
                 }
             }
-            let _ = Command::new("git")
-                .arg("-C")
-                .arg(repo_root)
-                .args(["worktree", "prune"])
-                .output();
+            // Clear THIS worktree's admin entry only. A repo-global
+            // `git worktree prune` (what this used to do) also unregisters any
+            // worktree whose checkout is not on disk yet — the normal state
+            // mid-`git worktree add` — so a refused spawn could destroy a
+            // concurrently-created fleet checkout or peer fence in the same repo.
+            octos_core::clear_worktree_admin_entry(repo_root, &worktree.path);
         }
         Err(error) => {
             warn!(

--- a/crates/octos-core/src/git_worktree.rs
+++ b/crates/octos-core/src/git_worktree.rs
@@ -325,7 +325,7 @@ pub fn prepare_fleet_worktree(
     // Reconcile a leftover checkout/branch from a prior (interrupted) attempt —
     // robust to a LOCKED leftover (HIGH #5).
     if checkout_exists || branch_exists {
-        force_free_checkout(&canonical_root, &git_dir, work_root, checkout);
+        force_free_checkout(&canonical_root, Some(&git_dir), work_root, checkout);
     }
 
     // Re-add. Keep the branch (resume from its last commit) if it exists;
@@ -498,32 +498,32 @@ pub fn branch_advanced_past(repo_root: &Path, branch: &str, base_commit: &str) -
 /// reviews and merges. Every git op runs hooks-disabled (module SECURITY note).
 pub fn remove_checkout_keep_branch(repo_root: &Path, work_root: &Path, checkout: &Path) {
     // Compute the git common dir best-effort so a stale (possibly locked) admin
-    // entry can be cleared. If it fails we still do the worktree remove/prune.
+    // entry can be cleared. If it fails, everything else still runs — only the
+    // admin-entry clearing is skipped (there is no safe repo-global substitute;
+    // see `force_free_checkout`).
     let git_dir = git_common_dir(repo_root).ok();
-    match &git_dir {
-        Some(gd) => force_free_checkout(repo_root, gd, work_root, checkout),
-        None => {
-            // No git_dir: still best-effort unlock + double-force remove + prune,
-            // and a CONTAINED dir cleanup, just without admin-entry clearing.
-            let checkout_str = checkout.to_string_lossy();
-            let _ = run_git(repo_root, &["worktree", "unlock", &checkout_str]);
-            let _ = run_git(
-                repo_root,
-                &["worktree", "remove", "--force", "--force", &checkout_str],
-            );
-            remove_contained_dir(work_root, checkout);
-            let _ = run_git(repo_root, &["worktree", "prune"]);
-        }
-    }
+    force_free_checkout(repo_root, git_dir.as_deref(), work_root, checkout);
 }
 
 /// Free a (possibly LOCKED) worktree checkout, KEEPING the branch (HIGH #5):
 /// `unlock` (locked worktrees refuse a single `--force`), then
 /// `remove --force --force`, then a CONTAINED (#2) dir cleanup for a leftover,
-/// then `prune`, then clear any stale admin entry `prune` left behind (a locked
-/// entry survives prune and would keep the branch recorded as checked-out,
-/// wedging every relaunch). All git ops run hooks-disabled.
-fn force_free_checkout(repo: &Path, git_dir: &Path, work_root: &Path, checkout: &Path) {
+/// then clear any stale admin entry left behind (a locked entry survives, and
+/// would keep the branch recorded as checked-out, wedging every relaunch).
+/// All git ops run hooks-disabled.
+///
+/// Every step is scoped to THIS `checkout`. There is deliberately no
+/// `git worktree prune`: prune is repo-GLOBAL and deletes the admin entry of
+/// every worktree whose checkout is momentarily missing, and `git worktree add`
+/// registers its entry BEFORE the checkout exists — so a prune here silently
+/// unregistered any worktree being created concurrently, leaving its branch
+/// checked out nowhere. That reaches across FEATURES (fleet checkouts and peer
+/// fences share one repo), and `clear_stale_admin_entry` already covers this
+/// checkout's own stale entry, which is all prune was wanted for.
+///
+/// `git_dir` is `None` only when the common dir could not be resolved; the
+/// admin-entry clearing is then skipped rather than widened to a global prune.
+fn force_free_checkout(repo: &Path, git_dir: Option<&Path>, work_root: &Path, checkout: &Path) {
     let checkout_str = checkout.to_string_lossy();
     // A locked worktree needs an explicit unlock (or `--force` TWICE). Both are
     // best-effort — errors ("not locked", "not a working tree") are expected.
@@ -534,10 +534,24 @@ fn force_free_checkout(repo: &Path, git_dir: &Path, work_root: &Path, checkout: 
     );
     // Clear a leftover checkout dir ONLY if provably contained in fleet-work.
     remove_contained_dir(work_root, checkout);
-    let _ = run_git(repo, &["worktree", "prune"]);
     // Clear a stale (possibly locked) admin entry still pointing at this
     // checkout, so a relaunch can reclaim the task-stable branch.
-    clear_stale_admin_entry(git_dir, checkout);
+    if let Some(git_dir) = git_dir {
+        clear_stale_admin_entry(git_dir, checkout);
+    }
+}
+
+/// Clear the worktree admin entry for `checkout` and NOTHING else.
+///
+/// The safe replacement for a repo-global `git worktree prune` on any cleanup
+/// path: prune also unregisters worktrees that merely have no checkout on disk
+/// yet, which is the normal state mid-`git worktree add`. See
+/// [`force_free_checkout`]. Best-effort — a repo whose common dir cannot be
+/// resolved is left untouched.
+pub fn clear_worktree_admin_entry(repo_root: &Path, checkout: &Path) {
+    if let Ok(git_dir) = git_common_dir(repo_root) {
+        clear_stale_admin_entry(&git_dir, checkout);
+    }
 }
 
 /// `remove_dir_all(checkout)` ONLY when it is proven contained in `fleet-work`
@@ -1401,6 +1415,69 @@ mod tests {
         assert!(
             control_ran,
             "sanity: the control (global visible) must run the filter, else the test is vacuous",
+        );
+    }
+
+    /// Freeing ONE checkout must not unregister a SIBLING worktree.
+    ///
+    /// `remove_checkout_keep_branch` used to run a repo-GLOBAL
+    /// `git worktree prune`, which deletes the admin entry of EVERY worktree
+    /// whose checkout is currently missing — not just the one being freed. And
+    /// `git worktree add` registers the admin entry BEFORE the checkout is
+    /// populated, so any worktree being created concurrently sits in exactly
+    /// that window. The victim is left with its branch checked out nowhere.
+    ///
+    /// This is cross-FEATURE, not just cross-task: fleet checkouts
+    /// (`work_root/<fleet>/<task>`) and peer fences (`peers/<slug>/wt`) live in
+    /// the SAME repo, so a fleet cleanup could unregister a peer's in-flight
+    /// worktree. The targeted `clear_stale_admin_entry` already handles this
+    /// checkout's own stale entry, so the global prune was pure blast radius.
+    ///
+    /// The race is a window, but its consequence is deterministic: a sibling
+    /// whose checkout is absent must survive. Hiding it stands in for
+    /// "mid-`worktree add`".
+    #[test]
+    fn removing_one_checkout_must_not_unregister_a_sibling_worktree() {
+        let repo = tempfile::tempdir().unwrap();
+        if !git_init_repo(repo.path()) {
+            return;
+        }
+        let work = tempfile::tempdir().unwrap();
+
+        // The SURVIVOR and the one being freed — distinct paths, same repo.
+        let sibling = work.path().join("f1").join("keeper");
+        prepare_fleet_worktree(repo.path(), work.path(), "fleet/f1/keeper", &sibling)
+            .expect("prepare sibling");
+        let doomed = work.path().join("f1").join("doomed");
+        prepare_fleet_worktree(repo.path(), work.path(), "fleet/f1/doomed", &doomed)
+            .expect("prepare doomed");
+
+        // Stand in for "the sibling is mid-`worktree add`": its admin entry
+        // exists, its checkout is not on disk yet.
+        let parked = work.path().join("keeper-parked");
+        std::fs::rename(&sibling, &parked).unwrap();
+
+        remove_checkout_keep_branch(repo.path(), work.path(), &doomed);
+
+        std::fs::rename(&parked, &sibling).unwrap();
+
+        // The freed checkout is gone…
+        let listed = run_git(repo.path(), &["worktree", "list"]).unwrap_or_default();
+        assert!(
+            !listed.contains("doomed"),
+            "the freed checkout must be unregistered, got:\n{listed}"
+        );
+
+        // …and the SIBLING is still a live worktree. Checking `git worktree
+        // list` alone is not enough: a pruned entry leaves the directory on
+        // disk, so resolve HEAD from INSIDE it, which only works while the
+        // admin entry survives.
+        let head = run_git(&sibling, &["rev-parse", "--abbrev-ref", "HEAD"]);
+        assert_eq!(
+            head.unwrap_or_default(),
+            "fleet/f1/keeper",
+            "a sibling worktree must survive another checkout being freed; \
+             worktree list was:\n{listed}"
         );
     }
 

--- a/crates/octos-core/src/lib.rs
+++ b/crates/octos-core/src/lib.rs
@@ -28,9 +28,9 @@ pub use env_hygiene::{
 pub use error::{Error, ErrorKind, Result};
 pub use gateway::{InboundMessage, METADATA_SENDER_USER_ID, MessageOrigin, OutboundMessage};
 pub use git_worktree::{
-    PreparedWorktree, branch_advanced_past, deliverable_commit_command, git_ref_exists,
-    is_git_repo, prepare_fleet_worktree, probe_git_repo, remove_checkout_keep_branch,
-    worktree_populate_command,
+    PreparedWorktree, branch_advanced_past, clear_worktree_admin_entry, deliverable_commit_command,
+    git_ref_exists, is_git_repo, prepare_fleet_worktree, probe_git_repo,
+    remove_checkout_keep_branch, worktree_populate_command,
 };
 pub use message::AgentMessage;
 pub use session_scope::{


### PR DESCRIPTION
Closes the other half of the race #1884 fixed for peers.

## The bug

`git worktree prune` is repo-**global**: it deletes the admin entry of *every* worktree whose checkout is currently missing. And `git worktree add` registers the admin entry **before** the checkout is populated — so any worktree being created concurrently sits in exactly that window, and gets silently unregistered. The victim is left with its branch checked out nowhere; the directory survives, so nothing looks obviously wrong.

This reaches **across features**, not just across tasks. Fleet checkouts (`work_root/<fleet>/<task>`) and peer fences (`peers/<slug>/wt`) live in the same repo, so a fleet-side teardown could destroy a peer's in-flight fence. #1884 removed the peer-side prunes; the fleet side could still do it in the other direction.

## Worse than "a cleanup path"

I originally scoped these as weaker instances than the peer bug, on the grounds that targeted removal runs first. That was wrong for one of them, and the compiler surfaced it when I changed the signature:

`prepare_fleet_worktree` also reaches this code, through `force_free_checkout`, to reconcile a leftover from a prior attempt. So **creating** a fleet worktree ran a repo-global prune — precisely when a sibling is most likely to be mid-`add`.

## The fix

`clear_stale_admin_entry` already clears this checkout's own stale entry, matching on the **full canonical path** (`canonical_leaf` canonicalizes the parent and re-attaches the leaf — it is not a basename match, so it cannot hit a sibling). That is all the prune was wanted for, so the global call was pure blast radius.

Removed from all three sites:

| site | note |
| --- | --- |
| `force_free_checkout` | reached by teardown **and** `prepare_fleet_worktree` |
| `remove_checkout_keep_branch`, no-`git_dir` branch | duplicated the whole body just to add a prune |
| `spawn.rs` refused-spawn fallback | now uses the new exported helper |

`force_free_checkout` takes `git_dir: Option<&Path>`, which collapses the duplicated branch into one code path. When the common dir cannot be resolved it now **skips** admin clearing rather than widening to a global prune — there is no safe repo-global substitute.

New export `octos_core::clear_worktree_admin_entry(repo_root, checkout)` gives `octos-agent` the same targeted primitive.

After this, `grep -rn '"worktree", "prune"' crates/` returns nothing.

## RED first

`removing_one_checkout_must_not_unregister_a_sibling_worktree` parks a sibling's checkout (standing in for mid-`worktree add`), frees a *different* checkout, and asserts the sibling survives. Before the fix:

```
assertion `left == right` failed: a sibling worktree must survive another checkout being freed
  left: ""
 right: "fleet/f1/keeper"
```

The sibling was fully unregistered. It passes now.

The test resolves `HEAD` from **inside** the sibling deliberately: a pruned entry leaves the directory on disk, so asserting on `git worktree list` alone would not distinguish "survived" from "looks like it survived".

## Verification

| gate | result |
| --- | --- |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo check -p octos-core --target x86_64-pc-windows-msvc --tests` | clean |
| `cargo test -p octos-core` | 349 passed |
| `cargo test -p octos-agent --lib spawn` | 156 passed |

## Residual

The admin-entry sweep is skipped when `git rev-parse --git-common-dir` fails. That is strictly better than before (a global prune could destroy unrelated worktrees), and in practice that call only fails when the path is not a repo — where there are no admin entries to clean anyway.
