### PR TITLE
fix(peer): report an unusable peer session key instead of silently disabling the peer

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2593,18 +2593,50 @@ fn peer_wire_key(profile_id: &str, slug: &str) -> String {
 /// Split a `peer-<slug>` session key into `(profile_id, slug)`, or `None` for
 /// a non-peer or unprofiled session.
 fn peer_slug_and_profile(session_id: &SessionKey) -> Option<(&str, &str)> {
+    // NOT a peer session. The overwhelmingly common case, and the only one where
+    // `None` is uninteresting — every caller correctly skips peer bookkeeping.
     let slug = session_id
         .topic()
-        .and_then(|topic| topic.strip_prefix("peer-"))
-        .filter(|slug| !slug.is_empty())?;
+        .and_then(|topic| topic.strip_prefix("peer-"))?;
+
+    // Past this point the topic SAYS `peer-…`, so something intended a peer
+    // session. Each rejection below still returns `None` (callers must treat it
+    // as a non-peer session — that is the #436 fence), but it is now LOUD.
+    //
+    // Why: all ~10 callers do `let Some(..) = .. else { return }`, which is
+    // right for "not a peer" and silently wrong for "malformed peer key". A peer
+    // whose key is rejected here keeps running and looks healthy while its wire
+    // registration, result recording, blackboard writes, awaiting-input wake and
+    // fleet synthesis ALL no-op. That failure is invisible at every layer — the
+    // peer produces work nobody records — so the only place it can be reported
+    // is here, where the reason is still known.
+
     // #436 security — the topic-derived slug feeds `Path::join` (closed marker,
     // peers dir) and the wire-key registry. Reject an unsafe one (e.g. a
     // `peer-/tmp/x` or `peer-../x` topic) HERE so EVERY caller treats it as a
     // NON-peer session rather than a path that escapes `peers/`.
-    if !peer_slug_is_safe(slug) {
+    if slug.is_empty() || !peer_slug_is_safe(slug) {
+        warn!(
+            session = %session_id,
+            "peer session key has an unusable slug; peer bookkeeping (results, \
+             blackboard, wake, synthesis) is DISABLED for this session"
+        );
         return None;
     }
-    let profile_id = session_id.profile_id()?;
+
+    // A peer key with no profile component. Nothing downstream can address the
+    // peer without one — `peers_root` is per-profile and the wire key is
+    // `{profile}:peer:{slug}` — so this silently disables the same bookkeeping.
+    let Some(profile_id) = session_id.profile_id() else {
+        warn!(
+            session = %session_id,
+            slug,
+            "peer session key has NO profile component; peer bookkeeping \
+             (results, blackboard, wake, synthesis) is DISABLED for this \
+             session. Peer keys must be `{{profile}}:{{channel}}:{{chat}}#peer-{{slug}}`"
+        );
+        return None;
+    };
     Some((profile_id, slug))
 }
 

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -26561,6 +26561,45 @@ fn unsafe_peer_topic_slug_is_treated_as_non_peer() {
     );
 }
 
+/// A peer key with NO profile component is not addressable, and must keep
+/// parsing as a non-peer session.
+///
+/// This is the shape of a real footgun: `peers_root` is per-profile and the wire
+/// key is `{profile}:peer:{slug}`, so without a profile there is nothing to
+/// address. `peer_slug_and_profile` therefore returns `None` — and all ~10
+/// callers do `let Some(..) = .. else { return }`, which is right for "not a
+/// peer" and silently wrong here. The peer runs, looks healthy, and its result
+/// recording, blackboard writes, awaiting-input wake and fleet synthesis ALL
+/// no-op, with nothing logged anywhere.
+///
+/// The RETURN value stays `None` (callers must keep treating it as a non-peer
+/// session — that is the #436 fence). What changed is that the two
+/// intended-a-peer rejections now `warn!`, because this is the only layer that
+/// still knows WHY. This test pins the contract so the fence is not accidentally
+/// relaxed into `Some` while making the diagnostics louder.
+#[test]
+fn peer_key_without_a_profile_is_not_addressable() {
+    let no_profile = SessionKey::with_topic("api", "tab", "peer-edison");
+    assert_eq!(
+        peer_slug_and_profile(&no_profile),
+        None,
+        "a profile-less peer key has nothing to address and must not parse"
+    );
+
+    // The SAME topic WITH a profile parses — so the profile component, not the
+    // topic, is what makes a peer addressable.
+    let with_profile = SessionKey::with_profile_topic("dev", "api", "tab", "peer-edison");
+    assert_eq!(
+        peer_slug_and_profile(&with_profile),
+        Some(("dev", "edison"))
+    );
+
+    // A genuinely non-peer topic is also None: the one case where silence is
+    // correct, and which stays indistinguishable in the RETURN value on purpose.
+    let not_a_peer = SessionKey::with_profile_topic("dev", "api", "tab", "coding");
+    assert_eq!(peer_slug_and_profile(&not_a_peer), None);
+}
+
 /// FIX 5 — a pending injection to a CLOSED peer is RETIRED (cancelled +
 /// tombstoned) by the drain-gate retire path, not left pending/stranded. This
 /// exercises the exact decision (`peer_is_closed`) + action


### PR DESCRIPTION
## The bug

`peer_slug_and_profile` returns `None` for three unrelated situations:

1. the session is **not a peer session** at all
2. the topic **is** `peer-<slug>` but the slug is unsafe (the #436 path fence)
3. the topic **is** `peer-<slug>` but the key has **no profile component**

All ~10 callers do `let Some(..) = .. else { return }`. That is right for (1) and silently wrong for (2) and (3).

In those cases the peer **keeps running and looks completely healthy**, while its wire registration, result recording, blackboard writes, awaiting-input wake and fleet synthesis all no-op. Nothing is logged at any layer, so every symptom is an *absence* — the peer does the work and nobody records it. This function is the last place that still knows why.

(3) is easy to hit by hand: `peers_root` is per-profile and the wire key is `{profile}:peer:{slug}`, so a key like `api:chat#peer-foo` has nothing to address. It cost hours to diagnose during a live peer soak.

## The fix

**Behaviour is unchanged.** All three still return `None` — (2) and (3) *are* the #436 fence, and callers must keep treating them as non-peer sessions. Relaxing that would turn a diagnostics problem into a path-escape problem.

What changes is that the function now separates *"not a peer session"* from *"something intended a peer session but the key is unusable"*:

- (1) stays **silent** — the common case, and it carries no intent
- (2) and (3) `warn!` with the session key and the concrete consequence

```
peer session key has NO profile component; peer bookkeeping (results,
blackboard, wake, synthesis) is DISABLED for this session. Peer keys must be
`{profile}:{channel}:{chat}#peer-{slug}`
```

## Test

`peer_key_without_a_profile_is_not_addressable` pins the contract in **both** directions:

- a profile-less peer key must stay `None` (not addressable)
- the *same topic* with a profile must parse — so the profile component, not the topic, is what makes a peer addressable
- a genuinely non-peer topic stays `None`, indistinguishable in return value on purpose

The point of pinning both is that the fence cannot later be relaxed into `Some` by someone making the diagnostics louder.

## Verification

| gate | result |
| --- | --- |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test -p octos-cli --lib` (unfeatured, as CI runs it) | 1002 passed |
| `cargo test -p octos-cli --features api peer` | 97 passed |

The peer suite runs in CI via the `Peer staging + worktree fencing` step added in #1884 — without it these `api`-gated tests never compile.

## Not fixed here

Two further items found in the same soak, deliberately left out of this PR:

- `goal_plan` can never succeed from an interactive turn (`set_goal_workspace_binding` only runs when `goal_context.is_some()`), and fails with a "workspace root not resolved" error that points nowhere near the cause.
- Every peer worktree is named `wt`, so `git worktree list` shows `wt`, `wt1`, `wt2` with no way to tell which peer is which. Harmless for correctness after #1884/#1887 removed the global prunes — purely a diagnosability wart.
