### PR TITLE
fix(goal): say why goal_plan cannot run here instead of blaming session liveness

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -3351,10 +3351,22 @@ impl InProcessAgentOrchestrator {
             }));
         }
         let Some(root) = root else {
+            // The old message said "create the plan on a live session", which
+            // sends the reader to check session liveness — never the cause. The
+            // binding is captured under `if let Some(goal_ctx) = goal_context`
+            // (ui_protocol, "THE LOAD-BEARING SEAM"), so ONLY a goal turn
+            // captures it. An interactive turn never does, which means calling
+            // `goal_plan` straight from chat fails here 100% of the time no
+            // matter how live the session is. Name the real precondition and the
+            // actual remedy.
             return Err(
-                "workspace root not resolved for this goal — create the plan on a live session. \
-                 The controller root is captured at goal-turn start and is required so a \
-                 fleet-completion wake can rehydrate the keeper after a restart."
+                "workspace root not resolved for this goal, so `goal_plan` cannot run here. \
+                 The controller root is captured at GOAL-TURN start (it is required so a \
+                 fleet-completion wake can rehydrate the keeper after a restart), and an \
+                 INTERACTIVE turn never captures it — so calling `goal_plan` directly from \
+                 chat always fails, however live the session is. Start the goal instead \
+                 (`session/goal/set`, or `/goal` in the TUI) and let the keeper call \
+                 `goal_plan` on its own turn."
                     .to_owned(),
             );
         };


### PR DESCRIPTION
## The problem

Calling `goal_plan` from an interactive turn always fails with:

> workspace root not resolved for this goal — **create the plan on a live session**. The controller root is captured at goal-turn start and is required so a fleet-completion wake can rehydrate the keeper after a restart.

The advice is unactionable. The session *is* live. No amount of liveness fixes it.

The controller workspace root is captured here (`ui_protocol.rs`, the comment calls it *"THE LOAD-BEARING SEAM"*):

```rust
if let Some(goal_ctx) = goal_context.as_ref() {
    default_agent_orchestrator().set_goal_workspace_binding(...);
}
```

So **only a goal turn captures it**. An interactive turn never does — meaning `goal_plan` called straight from chat fails 100% of the time, and the message points at the one thing that is never the cause. During a live fleet soak this cost real time; the actual precondition was only found by reading the capture site.

## The fix

Message-only. It now names the real precondition, states plainly that an interactive turn can never satisfy it, keeps the existing rationale, and gives the remedy that actually works:

> workspace root not resolved for this goal, so `goal_plan` cannot run here. The controller root is captured at **GOAL-TURN** start (it is required so a fleet-completion wake can rehydrate the keeper after a restart), and an **INTERACTIVE** turn never captures it — so calling `goal_plan` directly from chat always fails, however live the session is. Start the goal instead (`session/goal/set`, or `/goal` in the TUI) and let the keeper call `goal_plan` on its own turn.

`session/goal/set` is what actually worked during the soak: the keeper self-starts and calls `goal_plan` on its own turn.

## What this deliberately does NOT do

It does not widen the capture so `goal_plan` works interactively.

That would mean binding a goal the turn carries no key for, inside the #1857 invariants about rehydrating keepers across restarts and stamping the exact root a `ChildDone` wake replays — and the goal/fleet path cannot be exercised from a unit test, so the change would ship unverified. `goal_plan` is *designed* to run inside a goal turn; the defect was that the error never said so.

If interactive planning is wanted as a feature, that is a separate change with its own test strategy.

## Verification

| gate | result |
| --- | --- |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test -p octos-cli --lib` | 1002 passed |
| `cargo test -p octos-cli --features api goal` | 87 passed |

No test pinned the old wording (checked before editing), so nothing silently depended on the old string.
