### PR TITLE
ci: stop check-arm killing its own runner on the octos-agent tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,9 +505,32 @@ jobs:
         run: cargo test -p octos-sandbox
       - name: Test octos-swarm
         run: cargo test -p octos-swarm
+      # RUST_TEST_THREADS=1 on the octos-agent steps ONLY.
+      #
+      # These two steps repeatedly killed the ARM runner outright:
+      # "The hosted runner lost communication with the server ... starves it for
+      # CPU/Memory". Every failure died at `Test octos-agent (lib)` after steps
+      # 1-15 passed, at ~68 min, on runs 30733580733 and 30737982761 — and it
+      # passed on the runs in between, which is what an on-the-edge OOM looks
+      # like rather than a random flake.
+      #
+      # `test-octos-agent` (x86) already hit exactly this and documents the
+      # mechanism: the validator-timeout tests spawn `sh -c "... sleep 30"`
+      # children, and under thread-per-core parallelism enough pile up that
+      # GitHub terminates the runner for resource use. That job mitigates with
+      # CARGO_BUILD_JOBS=1 + RUST_TEST_THREADS=1 AND splits lib/integration onto
+      # separate runners so each gets a fresh 16GB. check-arm runs the SAME
+      # suites with none of that, in one job, on a 16GB ARM runner.
+      #
+      # Scoped to these steps, not the job env: steps 1-15 pass fine in parallel
+      # and serialising them would only make an already ~67 min job slower.
       - name: Test octos-agent (lib)
+        env:
+          RUST_TEST_THREADS: "1"
         run: cargo test -p octos-agent --lib
       - name: Test octos-agent (integration)
+        env:
+          RUST_TEST_THREADS: "1"
         run: cargo test -p octos-agent --tests
       - name: Test octos-cli (lib)
         run: cargo test -p octos-cli --lib


### PR DESCRIPTION
## Symptom

`check-arm` has been red on roughly half of recent `main` pushes, always identically:

> The hosted runner lost communication with the server. Anything in your workflow that terminates the runner process, **starves it for CPU/Memory**, or blocks its network access can cause this error.

Both of tonight's failures have the same fingerprint:

| | run 30733580733 | run 30737982761 |
| --- | --- | --- |
| died at | step 16 `Test octos-agent (lib)` | same |
| steps 1–15 | all green | same |
| duration | 69 min | 68 min |
| annotation | runner lost communication / starved | same |

And it **passed** on the runs in between (`cdfd82785`, `936a58a29`, `7c29adf44`). Alternating pass/fail on an unchanged step is what an on-the-edge OOM looks like — not randomness. Recent history: `8fc662027` ✗✗✗, `cb7985465` ✗, `cdfd82785` ✓, `83179a67a` ✗, `936a58a29` ✓, `7c29adf44` ✓, `d92236361` ✗.

## Cause — already documented in this file

`test-octos-agent` hit the identical wall on x86 and records the mechanism:

> `--test-threads=1`: `validator_runner.rs::should_kill_child_process_on_validator_timeout` spawns a `sh -c "... sleep 30"` child to test the kill path. Under the default thread-per-core parallelism, multiple validator-timeout tests pile up concurrent sleep children and **the ubuntu-latest runner gets terminated by GitHub for resource use**.

That is verbatim what `check-arm` is experiencing. That job mitigates with `CARGO_BUILD_JOBS: "1"` + `RUST_TEST_THREADS: "1"`, and splits lib/integration onto separate runners so *"each gets a fresh 16GB allocation"*.

`check-arm` runs those same suites with **none** of it:

- `CARGO_BUILD_JOBS: "2"` bounds only the **build** — the comment even says "to avoid OOM on 16GB ARM runners", so the hazard was known
- nothing bounds **test** parallelism
- everything runs in **one** job on **one** 16GB ARM runner

So it was running a workload already proven to kill a runner, without the mitigation that was written for exactly that workload.

## Fix

`RUST_TEST_THREADS: "1"` on the two `octos-agent` steps.

Scoped to those steps rather than the job `env` on purpose: steps 1–15 pass fine in parallel, and serialising them would only make an already ~67 min job slower for no benefit.

## Honest limitation

**This cannot be verified before merge.** `check-arm` is gated on `if: github.event_name != 'pull_request'`, so it does not run on PRs — deliberately, since it costs ~67 min. The next push to `main` is the test.

If it still dies at that step, the next lever is splitting `check-arm`'s agent steps onto their own runner, mirroring the `test-mode: [lib, integration]` matrix `test-octos-agent` already uses for the same reason.

## Why bother

`check-arm` hard-fails on `main` (no `continue-on-error`), so every one of these leaves `main` red and forces a manual rerun. It is currently the largest single source of red on `main` — the three fixes merged tonight (#1884, #1883, #1885) cleared the *code* causes, and this is the infrastructure one left over.
