### PR TITLE
ci(check-arm): time out the octos-agent steps so a hang leaves logs behind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,8 +505,36 @@ jobs:
         run: cargo test -p octos-sandbox
       - name: Test octos-swarm
         run: cargo test -p octos-swarm
-      # RUST_TEST_THREADS=1 on the octos-agent steps ONLY.
+      # RUST_TEST_THREADS=1 + timeout-minutes on the octos-agent steps ONLY.
       #
+      # STATUS: RUST_TEST_THREADS=1 (#1890) did NOT fix this — the job still
+      # died at `Test octos-agent (lib)` on run 30757917006. Step-duration data
+      # disproved the OOM-from-parallelism theory it was based on:
+      #
+      #   run 30733580733  no serialisation  steps 16-21 ALL done in ~16 min  PASS
+      #   run 30737982761  no serialisation  step 16 alone ran 46 min         KILLED
+      #   run 30757917006  serialised        step 16 alone ran 46.7 min       KILLED
+      #
+      # Serialising changed nothing (46 -> 46.7 min), so contention is not the
+      # cause. On the PASSING run step 16 finished in minutes; on failures it
+      # never finishes. Step 16 HANGS, and GitHub eventually kills the
+      # unresponsive runner.
+      #
+      # `timeout-minutes` is the diagnostic that unblocks this. A killed runner
+      # uploads NO logs (`gh run view --log` => "log not found" on every failed
+      # attempt), so each failure destroys its own evidence and we have learned
+      # nothing from three of them. A step timeout fails the step CLEANLY, the
+      # runner survives, and the logs are preserved. Under
+      # RUST_TEST_THREADS=1 libtest prints each test name BEFORE running it, so
+      # the last `test ... ` line with no result names the hanging test
+      # outright. Serialisation was not the fix, but it makes the hang legible.
+      #
+      # 35 min is chosen to sit BELOW the ~46 min at which the runner dies while
+      # staying well above the ~16 min a healthy run needs. If a serialised run
+      # genuinely needs longer, this trips early — and a clean timeout WITH logs
+      # is still strictly better than a dead runner with none.
+      #
+      # Original note (the theory that did not hold), kept for context:
       # These two steps repeatedly killed the ARM runner outright:
       # "The hosted runner lost communication with the server ... starves it for
       # CPU/Memory". Every failure died at `Test octos-agent (lib)` after steps
@@ -525,10 +553,12 @@ jobs:
       # Scoped to these steps, not the job env: steps 1-15 pass fine in parallel
       # and serialising them would only make an already ~67 min job slower.
       - name: Test octos-agent (lib)
+        timeout-minutes: 35
         env:
           RUST_TEST_THREADS: "1"
         run: cargo test -p octos-agent --lib
       - name: Test octos-agent (integration)
+        timeout-minutes: 35
         env:
           RUST_TEST_THREADS: "1"
         run: cargo test -p octos-agent --tests


### PR DESCRIPTION
**This is instrumentation, not a fix.** It does not stop `check-arm` failing — it makes the next failure diagnosable.

## #1890 did not work, and its theory was wrong

I merged `RUST_TEST_THREADS: "1"` on the theory that concurrent tests were starving the ARM runner, reasoning from GitHub's annotation text plus the documented x86 OOM precedent. Run 30757917006 died at `Test octos-agent (lib)` exactly as before.

Step-duration data — which I should have gathered *before* shipping that — disproves the theory:

| run | serialised? | step 16 | outcome |
| --- | --- | --- | --- |
| 30733580733 | no | steps 16–**21** ALL done in ~16 min | ✅ pass |
| 30737982761 | no | step 16 alone ran **46 min** | ❌ runner killed |
| 30757917006 | **yes** | step 16 alone ran **46.7 min** | ❌ runner killed |

Serialising moved it by 0.7 min. Contention between concurrent tests is not the cause.

The real signal is the **passing** run: step 16 finished in minutes there, and on both failures it never finishes at all. **Step 16 hangs**, and GitHub then kills the unresponsive runner for being unresponsive.

## Why three failures taught us nothing

A killed runner uploads no logs:

```
$ gh run view --job 91523210598 --log
log not found: 91523210598
```

Every failed attempt answers that. **Each failure destroys its own evidence**, which is why this has been "a flake" for weeks instead of a diagnosis.

## What this changes

`timeout-minutes: 35` on both `octos-agent` steps. The step fails cleanly, the runner survives, and **the logs are preserved**.

Under `RUST_TEST_THREADS: "1"` libtest prints each test name *before* running it, so the last `test ... ` line with no result **names the hanging test outright**. Serialisation was not the fix, but it makes the hang legible — so #1890 is kept rather than reverted.

35 min sits below the ~46 min at which the runner dies, and well above the ~16 min a healthy run needs. If a serialised run genuinely needs longer, this trips early — and a clean timeout with logs is still strictly better than a dead runner without.

## Caveats

- `check-arm` is gated `if: github.event_name != 'pull_request'`, so this PR's own checks cannot exercise it. The next push to `main` is the test.
- This will not make `main` green. It converts an opaque runner death into a diagnosable failure, so the *next* one identifies the culprit.
- Pre-existing, not a regression: `check-arm` failed 3× on `8fc662027` and once on `cb7985465`, before any of tonight's work.
