### PR TITLE
fix(test): tolerate a slow rustfmt in the two post-edit formatting tests

### DIFF
--- a/crates/octos-agent/src/tools/diff_edit.rs
+++ b/crates/octos-agent/src/tools/diff_edit.rs
@@ -491,6 +491,25 @@ mod tests {
             .await
             .unwrap();
         assert!(result.success, "diff must apply: {}", result.output);
+
+        // Post-edit formatting is BEST-EFFORT behind a hard 5s
+        // `format::FORMAT_TIMEOUT`, and a loaded runner can blow that just
+        // SPAWNING rustfmt — `check-windows` hit exactly this on run
+        // 30763300877 with the suite otherwise finishing 2320 tests in 62s. A
+        // timeout is a legitimate production outcome (`FormatOutcome::TimedOut`),
+        // not a defect, so asserting formatting HAPPENED is only meaningful when
+        // the formatter actually got to run. Same idiom as the
+        // rustfmt-not-on-PATH skip above: verify what still holds, then stop.
+        if result.output.contains("timed out") {
+            eprintln!("skipping formatter assertions: rustfmt exceeded FORMAT_TIMEOUT");
+            let on_disk = std::fs::read_to_string(dir.path().join("lib.rs")).unwrap();
+            assert!(
+                on_disk.contains("let x=2"),
+                "the edit must survive even when formatting times out: {on_disk}"
+            );
+            return;
+        }
+
         assert!(
             result.output.contains("reformatted"),
             "output must state the file was reformatted: {}",

--- a/crates/octos-agent/src/tools/edit_file.rs
+++ b/crates/octos-agent/src/tools/edit_file.rs
@@ -1271,11 +1271,25 @@ mod tests {
             "formatter failure must NOT fail the edit: {}",
             result.output
         );
-        assert!(
-            result.output.contains("failed"),
-            "output must note the formatter failure: {}",
-            result.output
-        );
+
+        // This asserts rustfmt FAILED (non-zero on broken syntax), which needs
+        // rustfmt to actually run. Post-edit formatting is best-effort behind a
+        // hard 5s `format::FORMAT_TIMEOUT`, and a loaded runner can exceed that
+        // just spawning it — `check-windows` did on run 30763300877. A timeout
+        // is a legitimate outcome (`FormatOutcome::TimedOut`), and it reports
+        // "timed out" rather than "failed", so the note assertion is only
+        // meaningful when the formatter got to run and exit. The edit-preserved
+        // check below holds either way and still runs.
+        let formatter_ran = !result.output.contains("timed out");
+        if !formatter_ran {
+            eprintln!("skipping formatter-failure assertion: rustfmt exceeded FORMAT_TIMEOUT");
+        } else {
+            assert!(
+                result.output.contains("failed"),
+                "output must note the formatter failure: {}",
+                result.output
+            );
+        }
         assert_eq!(
             std::fs::read_to_string(dir.path().join("broken.rs")).unwrap(),
             "fn main( { let a=2 \n",


### PR DESCRIPTION
`check-windows` failed on `main` (run 30763300877) with two `octos-agent` tests:

```
tools::diff_edit::tests::should_format_after_diff_edit_when_enabled
tools::edit_file::tests::should_keep_edit_success_when_formatter_fails

output must state the file was reformatted: Applied 1 hunk(s) to lib.rs
Note: post-edit formatting with rustfmt timed out after 5s and was killed;
      the edit itself was applied unchanged.
```

## Cause

Post-edit formatting is **best-effort** behind a hard 5s `format::FORMAT_TIMEOUT`. A loaded Windows runner can exceed that just *spawning* rustfmt — note the same suite finished **2320 tests in 62s**, so the machine was not slow overall; only the process spawn was.

A timeout is a legitimate production outcome (`FormatOutcome::TimedOut`), not a defect. So asserting that formatting *happened* is only meaningful when the formatter actually got to run.

## Fix

Both tests **already** skip when rustfmt is *absent*:

```rust
if !crate::format::binary_on_path("rustfmt") {
    eprintln!("skipping: rustfmt not on PATH");
    return;
}
```

They now treat rustfmt being *too slow* the same way — assert everything that still holds (the edit applied, and survived on disk byte-for-byte), and skip only the formatter-dependent claims. Coverage is unchanged wherever rustfmt completes, i.e. every healthy machine and every Linux/macOS runner.

`FORMAT_TIMEOUT` is deliberately **untouched**. Loosening production behaviour to make a test pass would be backwards; 5s is a deliberate bound on a best-effort convenience.

## Verified both directions, not inferred

| scenario | result |
| --- | --- |
| happy path (rustfmt runs) | both tests pass |
| forced timeout (`FORMAT_TIMEOUT` temporarily `1ns`) | both tests pass |
| forced timeout **without** this fix | both **fail** |

That last row reproduces CI byte-for-byte:

```
output must state the file was reformatted: Applied 1 hunk(s) to lib.rs
output must note the formatter failure: Successfully edited broken.rs
```

Identical to the `check-windows` log, so the failure mode is confirmed rather than guessed.

## Gate

| | |
| --- | --- |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p octos-agent --all-targets -- -D warnings` | clean |
| `cargo test -p octos-agent --lib` | 2486 passed |
| `cargo test -p octos-agent --lib format::` | 16 passed |

## Note

This is the first failure `check-windows` has caught since #1885 made it blocking — and it is a **flaky** one. The answer is to fix the flaky assertions, not to re-mute the job. Worth knowing that the tradeoff #1885 called out ("a Windows break now blocks PRs") showed up immediately, and that it surfaced a genuine test-quality problem rather than a false alarm.
