### PR TITLE
feat(acp): persist sessions and implement session/load

### DIFF
--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -1341,7 +1341,27 @@ async fn run_prompt_turn(
                         .iter()
                         .find(|m| matches!(m.role, octos_core::MessageRole::User))
                         .and_then(|m| m.thread_id.clone().or_else(|| m.client_message_id.clone()))
-                        .unwrap_or_else(|| uuid::Uuid::now_v7().to_string());
+                        .unwrap_or_else(|| {
+                            // No user row to inherit from, so there is nothing to
+                            // stamp these rows onto. Minting an id keeps the write
+                            // fail-OPEN rather than dropping the turn, but it
+                            // creates exactly the orphan the store's fail-closed
+                            // check exists to prevent: assistant/tool rows in a
+                            // thread containing no user message. Expected to be
+                            // unreachable — say so out loud rather than silently
+                            // converting "we do not know the thread" into
+                            // "invent one", which is what made the original
+                            // thread-id bug so expensive to find.
+                            let minted = uuid::Uuid::now_v7().to_string();
+                            tracing::warn!(
+                                thread_id = %minted,
+                                rows = fresh.len(),
+                                "ACP turn produced no user row; persisting its \
+                                 messages under a MINTED thread id — they will \
+                                 load as a thread with no user message"
+                            );
+                            minted
+                        });
 
                     let mut guard = store.lock().await;
                     for mut message in fresh {

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -80,6 +80,9 @@ use octos_llm::{EmbeddingProvider, LlmProvider};
 use octos_memory::{EpisodeStore, MemoryStore};
 use tokio::sync::Mutex;
 
+use octos_bus::session::SessionManager;
+use octos_core::SessionKey;
+
 use super::Executable;
 use crate::config::Config;
 
@@ -143,6 +146,15 @@ impl Executable for AcpCommand {
 /// Everything a spawned prompt turn needs, shared behind the session map.
 struct AcpSession {
     agent: Arc<Agent>,
+    /// Where this conversation is persisted. ACP sessions were memory-only, so a
+    /// crash or supervisor restart lost the whole conversation — the agent came
+    /// back mid-task with no idea what it had been doing while the fleet reported
+    /// it healthy. SessionManager already backs the REST and WebSocket paths;
+    /// `SessionKey` is a newtype over "channel:chat_id", so "acp" is simply
+    /// another channel alongside the existing ones.
+    session_key: SessionKey,
+    /// Held on the session rather than threaded through run_prompt_turn's callers.
+    session_store: Option<Arc<Mutex<SessionManager>>>,
     /// Conversation history accumulated across prompt turns in this session.
     history: Mutex<Vec<octos_core::Message>>,
     /// Flipped to `true` by a `session/cancel` notification; the agent's
@@ -163,6 +175,19 @@ trait SessionAgentFactory: Send + Sync {
     /// Build a runnable agent rooted at `cwd`, returning it plus the shared
     /// shutdown flag wired into it (flipped on `session/cancel`).
     async fn build(&self, cwd: PathBuf) -> Result<(Arc<Agent>, Arc<AtomicBool>)>;
+
+    /// Where ACP conversations are persisted, if anywhere. `None` means sessions
+    /// will not survive a restart — the test factory, or a store that failed to open.
+    fn session_store(&self) -> Option<Arc<Mutex<SessionManager>>> {
+        None
+    }
+
+    /// Profile dimension for this factory's session keys. Sessions elsewhere are
+    /// profile-scoped; an unscoped ACP key would collide across profiles running
+    /// the same session id and would not isolate them.
+    fn session_profile_id(&self) -> String {
+        octos_core::MAIN_PROFILE_ID.to_string()
+    }
 }
 
 /// Build the tool registry shared by every ACP session: built-ins rooted at
@@ -252,6 +277,8 @@ struct AcpSharedStores {
     embedder: Option<Arc<dyn EmbeddingProvider>>,
     agent_config: AgentConfig,
     memory_refresh_enabled: bool,
+    /// Opened once per process; shared by every session.
+    sessions_store: Option<Arc<Mutex<SessionManager>>>,
     max_inject_tokens: usize,
     data_dir: PathBuf,
     config: Config,
@@ -346,6 +373,20 @@ impl AcpSharedStores {
             embedder,
             agent_config,
             memory_refresh_enabled,
+            // Degrades to None with a loud log rather than failing the agent: an
+            // unpersisted session is worse than a persisted one and far better
+            // than none. Silent non-persistence is the bug this exists to fix,
+            // so it must not be reintroduced here.
+            sessions_store: match SessionManager::open(&data_dir.join("sessions")) {
+                Ok(store) => Some(Arc::new(Mutex::new(store))),
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        "session store unavailable; ACP conversations will NOT survive a restart"
+                    );
+                    None
+                }
+            },
             max_inject_tokens,
             data_dir,
             config,
@@ -620,6 +661,18 @@ impl SessionAgentFactory for ConfigAgentFactory {
         &self.default_cwd
     }
 
+    fn session_store(&self) -> Option<Arc<Mutex<SessionManager>>> {
+        // Only present once the shared stores exist, which happens on the first
+        // session/new. Before that there is nothing to persist anyway.
+        self.shared.get().and_then(|s| s.sessions_store.clone())
+    }
+
+    fn session_profile_id(&self) -> String {
+        self.profile
+            .clone()
+            .unwrap_or_else(|| octos_core::MAIN_PROFILE_ID.to_string())
+    }
+
     async fn build(&self, cwd: PathBuf) -> Result<(Arc<Agent>, Arc<AtomicBool>)> {
         // Normalize the client-supplied cwd (resolve `..` + symlinks) up front so
         // the per-cwd cache key is stable and the session scope's `..`-rejecting
@@ -792,6 +845,8 @@ async fn spawn_acp_agent(
 ) -> std::result::Result<(), AcpError> {
     let factory_for_new = factory.clone();
     let sessions_for_new = sessions.clone();
+    let factory_for_load = factory.clone();
+    let sessions_for_load = sessions.clone();
     let sessions_for_prompt = sessions.clone();
     let sessions_for_cancel = sessions;
 
@@ -820,6 +875,18 @@ async fn spawn_acp_agent(
         .on_receive_request(
             async move |req: NewSessionRequest, responder, _cx: ConnectionTo<Client>| {
                 match handle_new_session(factory_for_new.as_ref(), &sessions_for_new, req).await {
+                    Ok(resp) => responder.respond(resp),
+                    Err(err) => responder.respond_with_error(err),
+                }
+            },
+            on_receive_request!(),
+        )
+        // session/load: rebuild a session and replay its stored history, so a
+        // conversation survives a crash or a supervisor restart.
+        .on_receive_request(
+            async move |req: LoadSessionRequest, responder, _cx: ConnectionTo<Client>| {
+                match handle_load_session(factory_for_load.as_ref(), &sessions_for_load, req).await
+                {
                     Ok(resp) => responder.respond(resp),
                     Err(err) => responder.respond_with_error(err),
                 }
@@ -861,6 +928,9 @@ pub struct TestAgentFactory {
     llm: Arc<dyn LlmProvider>,
     memory_dir: PathBuf,
     default_cwd: PathBuf,
+    /// Absent by default, so existing tests keep their in-memory behaviour. Set
+    /// via `with_session_store` to exercise persistence and session/load.
+    session_store: Option<Arc<Mutex<SessionManager>>>,
 }
 
 #[doc(hidden)]
@@ -872,12 +942,26 @@ impl TestAgentFactory {
             llm,
             memory_dir,
             default_cwd,
+            session_store: None,
         }
+    }
+
+    /// Persist this factory's sessions under `dir`, so a test can prove a
+    /// conversation survives being reloaded into a fresh transport.
+    pub fn with_session_store(mut self, dir: &std::path::Path) -> Self {
+        self.session_store = SessionManager::open(dir)
+            .ok()
+            .map(|store| Arc::new(Mutex::new(store)));
+        self
     }
 }
 
 #[async_trait::async_trait]
 impl SessionAgentFactory for TestAgentFactory {
+    fn session_store(&self) -> Option<Arc<Mutex<SessionManager>>> {
+        self.session_store.clone()
+    }
+
     fn default_cwd(&self) -> &std::path::Path {
         &self.default_cwd
     }
@@ -1005,8 +1089,13 @@ fn build_initialize_response(req: &InitializeRequest) -> InitializeResponse {
     // Image/audio/embedded-context are left false (v1 extracts text only).
     let prompt = PromptCapabilities::new();
     let caps = AgentCapabilities::new()
-        // We accept `session/load` no better than `session/new` today, so do
-        // NOT advertise loadSession (leave it false / default).
+        // Advertised because session/load now genuinely restores: it reads the
+        // conversation back from SessionManager, which session/prompt writes each
+        // turn through to. It stayed false while load was a stub, and must go back
+        // to false if that store is ever removed — a client that sees the
+        // capability will call it, and a load that silently returns nothing is
+        // worse than a method_not_found.
+        .load_session(true)
         .prompt_capabilities(prompt);
 
     let negotiated = if req.protocol_version == ProtocolVersion::V1 {
@@ -1043,8 +1132,17 @@ async fn handle_new_session(
         .map_err(|e| agent_client_protocol::util::internal_error(format!("build agent: {e}")))?;
 
     let session_id = new_session_id();
+    // A fresh session/new starts empty. session/load is what restores a prior
+    // conversation; hydrating here too would silently resurrect history for a
+    // client that explicitly asked for a new session.
     let session = Arc::new(AcpSession {
         agent,
+        session_key: SessionKey::with_profile(
+            &factory.session_profile_id(),
+            "acp",
+            session_id.0.as_ref(),
+        ),
+        session_store: factory.session_store(),
         history: Mutex::new(Vec::new()),
         shutdown,
     });
@@ -1173,8 +1271,16 @@ async fn run_prompt_turn(
             // still holds the earlier turns (we only cloned it above, never
             // cleared it), so APPEND — replacing would drop every earlier turn
             // and the agent would forget context after the second prompt.
+            // Captured under the same guard that appends, not re-read afterwards.
+            //
+            // Taking the index here and re-locking later to slice from it let two
+            // turns interleaving on one session compute overlapping ranges and
+            // write the same messages twice. Holding one guard across append and
+            // capture means each turn takes exactly the rows it appended.
+            let fresh: Vec<octos_core::Message>;
             {
                 let mut h = session.history.lock().await;
+                let persisted_upto = h.len();
                 let assistant_reply = resp.content.clone();
                 h.extend(resp.messages);
                 // For a plain-text turn, `resp.messages` carries the user row but
@@ -1191,6 +1297,7 @@ async fn run_prompt_turn(
                     h.last(),
                     Some(last) if last.role == octos_core::MessageRole::Assistant && last.content == assistant_reply
                 );
+                #[allow(clippy::needless_late_init)]
                 if !cancelled && !assistant_reply.is_empty() && !already_persisted {
                     h.push(octos_core::Message {
                         role: octos_core::MessageRole::Assistant,
@@ -1203,6 +1310,53 @@ async fn run_prompt_turn(
                         thread_id: None,
                         timestamp: chrono::Utc::now(),
                     });
+                }
+                fresh = h
+                    .get(persisted_upto..)
+                    .map(<[_]>::to_vec)
+                    .unwrap_or_default();
+            }
+
+            // Write this turn through to the store so it outlives the process.
+            //
+            // Everything above only mutated an in-memory Vec, which is why a kill -9 left
+            // the agent with no idea what it had been doing while the fleet reported it
+            // healthy. Only what this turn added is written: the store appends, so
+            // re-sending earlier turns would duplicate them.
+            //
+            // A store failure is logged, never fatal — losing persistence must not also
+            // lose the turn the agent just completed.
+            if let Some(store) = session.session_store.as_ref() {
+                if !fresh.is_empty() {
+                    // Every message this turn produced shares one thread id.
+                    //
+                    // The store is fail-closed for Assistant and Tool rows:
+                    // derive_thread_id_for_new_write rejects them outright unless the
+                    // caller has stamped the originating turn's thread_id, because a
+                    // derived one picked the wrong sibling user under rapid-fire
+                    // turns. Unstamped, the user row persisted and the assistant row
+                    // was rejected — a stored conversation with the answers missing,
+                    // which is worse than none.
+                    let turn_thread = fresh
+                        .iter()
+                        .find(|m| matches!(m.role, octos_core::MessageRole::User))
+                        .and_then(|m| m.thread_id.clone().or_else(|| m.client_message_id.clone()))
+                        .unwrap_or_else(|| uuid::Uuid::now_v7().to_string());
+
+                    let mut guard = store.lock().await;
+                    for mut message in fresh {
+                        if message.thread_id.is_none() {
+                            message.thread_id = Some(turn_thread.clone());
+                        }
+                        // Carry on rather than break: the rows are independent, and
+                        // dropping the rest because one failed loses more than it saves.
+                        if let Err(e) = guard.add_message(&session.session_key, message).await {
+                            tracing::warn!(
+                                error = %e, session = %session.session_key.0,
+                                "failed to persist an ACP message; it will not survive a restart"
+                            );
+                        }
+                    }
                 }
             }
             // Distinguish a client-driven cancel from a natural end-of-turn.
@@ -1247,15 +1401,98 @@ async fn handle_cancel(sessions: &SessionMap, notif: CancelNotification) {
     }
 }
 
-/// Handle `session/load` — NOT supported in v1: octos does not persist ACP
-/// sessions across process restarts. Kept as a documented stub so the intent is
-/// explicit; not wired into the builder (an unregistered method returns
-/// `method_not_found` automatically).
-#[allow(dead_code)]
-fn handle_load_session_unsupported(
-    _req: LoadSessionRequest,
+/// Handle `session/load`: rebuild a session and replay its stored history.
+///
+/// ACP sessions were memory-only, so a crash or supervisor restart lost the whole
+/// conversation. `session/prompt` now writes each turn through to `SessionManager`;
+/// this is the read side that makes that worth doing.
+async fn handle_load_session(
+    factory: &dyn SessionAgentFactory,
+    sessions: &SessionMap,
+    req: LoadSessionRequest,
 ) -> std::result::Result<LoadSessionResponse, AcpError> {
-    Err(AcpError::method_not_found())
+    // Never replace a session that is already live, and do not build an agent we
+    // would then discard.
+    //
+    // A bare insert dropped the existing entry and with it the `shutdown` flag an
+    // in-flight turn is watching, so a `session/cancel` for that turn flipped a flag
+    // nobody read and cancellation silently stopped working. Loading an id the agent
+    // already holds is a no-op: it is by definition already loaded, and a
+    // reconnecting client should not lose its running turn.
+    //
+    // The check comes first because factory.build() opens the episode store, and a
+    // second open on a live session fails on the redb lock.
+    if sessions.lock().await.contains_key(&req.session_id) {
+        tracing::info!(
+            session = %req.session_id.0,
+            "session/load for an already-active session; keeping the live one"
+        );
+        return Ok(LoadSessionResponse::default());
+    }
+
+    let cwd = if req.cwd.as_os_str().is_empty() {
+        factory.default_cwd().to_path_buf()
+    } else {
+        req.cwd.clone()
+    };
+
+    let (agent, shutdown) = factory
+        .build(cwd)
+        .await
+        .map_err(|e| agent_client_protocol::util::internal_error(format!("build agent: {e}")))?;
+
+    let session_key = SessionKey::with_profile(
+        &factory.session_profile_id(),
+        "acp",
+        req.session_id.0.as_ref(),
+    );
+    let session_store = factory.session_store();
+
+    // An id the store has never seen loads as an empty session rather than an
+    // error. The likeliest cause is that the store was unavailable when the
+    // session was written, and refusing would strand an agent that can still work
+    // — just without its past. The warning is what makes that visible.
+    let history = match session_store.as_ref() {
+        Some(store) => {
+            let guard = store.lock().await;
+            match guard.load(&session_key).await {
+                Some(stored) => {
+                    tracing::info!(
+                        session = %session_key.0,
+                        messages = stored.messages.len(),
+                        "restored an ACP session from the store"
+                    );
+                    stored.messages
+                }
+                None => {
+                    tracing::warn!(
+                        session = %session_key.0,
+                        "session/load found no stored conversation; starting empty"
+                    );
+                    Vec::new()
+                }
+            }
+        }
+        None => {
+            tracing::warn!("session/load with no session store; starting empty");
+            Vec::new()
+        }
+    };
+
+    let session = Arc::new(AcpSession {
+        agent,
+        session_key,
+        session_store,
+        history: Mutex::new(history),
+        shutdown,
+    });
+
+    sessions
+        .lock()
+        .await
+        .insert(req.session_id.clone(), session);
+
+    Ok(LoadSessionResponse::default())
 }
 
 /// Generate a fresh, unique ACP session id.
@@ -1813,8 +2050,12 @@ mod tests {
         // Text-only prompt capabilities: image/audio/embedded_context all false.
         assert!(!resp.agent_capabilities.prompt_capabilities.image);
         assert!(!resp.agent_capabilities.prompt_capabilities.audio);
-        // We do not advertise loadSession in v1.
-        assert!(!resp.agent_capabilities.load_session);
+        // loadSession is advertised now that session/load genuinely restores a
+        // conversation from SessionManager. Advertising it while load was a stub
+        // would have been worse than not advertising: a client that sees the
+        // capability calls it, and a load that silently returns nothing looks like
+        // an agent that has forgotten everything.
+        assert!(resp.agent_capabilities.load_session);
     }
 
     #[test]

--- a/crates/octos-cli/tests/acp_integration.rs
+++ b/crates/octos-cli/tests/acp_integration.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 
 use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::schema::v1::{
-    ContentBlock, InitializeRequest, NewSessionRequest, PromptRequest, SessionNotification,
-    SessionUpdate, StopReason, TextContent,
+    ContentBlock, InitializeRequest, LoadSessionRequest, NewSessionRequest, PromptRequest,
+    SessionNotification, SessionUpdate, StopReason, TextContent,
 };
 use agent_client_protocol::{Client, ConnectionTo};
 
@@ -445,4 +445,205 @@ fn should_emit_only_valid_json_on_stdout_when_running_acp() {
             panic!("non-JSON line on the ACP stdout stream (would -32700 in Zed): {line:?} ({e})")
         });
     }
+}
+
+/// A conversation must survive the process that created it.
+///
+/// ACP sessions were memory-only: `AcpSession.history` was a `Mutex<Vec<Message>>`
+/// and nothing wrote it anywhere. A kill -9 or a supervisor restart left the agent
+/// with no idea what it had been doing, while the fleet reported it healthy —
+/// silent amnesia mid-task, which is worse than staying down.
+///
+/// This drives two independent transports over one store: the first holds a
+/// conversation, the second loads that session id and must see the earlier turns.
+#[tokio::test]
+async fn should_restore_a_conversation_through_session_load() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cwd = tmp.path().to_path_buf();
+    let memory_dir = tmp.path().join("memory");
+    let sessions_dir = tmp.path().join("sessions");
+    std::fs::create_dir_all(&memory_dir).unwrap();
+
+    // ---- first process: one turn, then drop the transport entirely ----
+    let seen_one: Arc<Mutex<Vec<Vec<String>>>> = Arc::new(Mutex::new(Vec::new()));
+    let llm_one: Arc<dyn octos_llm::LlmProvider> = Arc::new(RecordingLlm {
+        seen: seen_one.clone(),
+        replies: vec!["REMEMBER_THIS".to_string()],
+        calls: std::sync::atomic::AtomicUsize::new(0),
+    });
+    let factory_one = TestAgentFactory::new(llm_one, memory_dir.clone(), cwd.clone())
+        .with_session_store(&sessions_dir);
+
+    let cwd_one = cwd.clone();
+    let session_id = Client
+        .builder()
+        .name("octos-acp-persist-1")
+        .on_receive_notification(
+            async move |_n: SessionNotification,
+                        _cx: ConnectionTo<agent_client_protocol::Agent>| Ok(()),
+            agent_client_protocol::on_receive_notification!(),
+        )
+        .connect_with(
+            OctosAcpAgentTransport::new(factory_one),
+            |connection: ConnectionTo<agent_client_protocol::Agent>| async move {
+                connection
+                    .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                    .block_task()
+                    .await?;
+                let new_session = connection
+                    .send_request(NewSessionRequest::new(cwd_one.clone()))
+                    .block_task()
+                    .await?;
+                let id = new_session.session_id.clone();
+                connection
+                    .send_request(PromptRequest::new(
+                        id.clone(),
+                        vec![ContentBlock::from("FIRST_QUESTION")],
+                    ))
+                    .block_task()
+                    .await?;
+                Ok::<_, agent_client_protocol::Error>(id)
+            },
+        )
+        .await
+        .expect("first session");
+
+    // ---- second process: same store, same id, fresh everything else ----
+    let seen_two: Arc<Mutex<Vec<Vec<String>>>> = Arc::new(Mutex::new(Vec::new()));
+    let llm_two: Arc<dyn octos_llm::LlmProvider> = Arc::new(RecordingLlm {
+        seen: seen_two.clone(),
+        replies: vec!["SECOND_REPLY".to_string()],
+        calls: std::sync::atomic::AtomicUsize::new(0),
+    });
+    let factory_two =
+        TestAgentFactory::new(llm_two, memory_dir, cwd.clone()).with_session_store(&sessions_dir);
+
+    let cwd_two = cwd.clone();
+    let id_two = session_id.clone();
+    Client
+        .builder()
+        .name("octos-acp-persist-2")
+        .on_receive_notification(
+            async move |_n: SessionNotification,
+                        _cx: ConnectionTo<agent_client_protocol::Agent>| Ok(()),
+            agent_client_protocol::on_receive_notification!(),
+        )
+        .connect_with(
+            OctosAcpAgentTransport::new(factory_two),
+            |connection: ConnectionTo<agent_client_protocol::Agent>| async move {
+                connection
+                    .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                    .block_task()
+                    .await?;
+                connection
+                    .send_request(LoadSessionRequest::new(id_two.clone(), cwd_two.clone()))
+                    .block_task()
+                    .await?;
+                connection
+                    .send_request(PromptRequest::new(
+                        id_two.clone(),
+                        vec![ContentBlock::from("SECOND_QUESTION")],
+                    ))
+                    .block_task()
+                    .await?;
+                Ok::<_, agent_client_protocol::Error>(())
+            },
+        )
+        .await
+        .expect("second session");
+
+    // The second process's LLM must have been handed the first turn as context.
+    let calls = seen_two.lock().await;
+    let last = calls.last().expect("the reloaded session ran a turn");
+    let joined = last.join("\n");
+    assert!(
+        joined.contains("FIRST_QUESTION"),
+        "session/load did not restore the earlier user turn; saw: {joined}"
+    );
+    assert!(
+        joined.contains("REMEMBER_THIS"),
+        "session/load did not restore the earlier assistant turn; saw: {joined}"
+    );
+}
+
+/// `session/load` must not evict a session that is already live.
+///
+/// A bare insert dropped the existing entry and with it the `shutdown` flag an
+/// in-flight turn watches, so a `session/cancel` for that turn flipped a flag
+/// nobody read and cancellation silently stopped working. Loading an id the agent
+/// already holds is a no-op.
+#[tokio::test]
+async fn should_not_evict_a_live_session_on_reload() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cwd = tmp.path().to_path_buf();
+    let memory_dir = tmp.path().join("memory");
+    let sessions_dir = tmp.path().join("sessions");
+    std::fs::create_dir_all(&memory_dir).unwrap();
+
+    let seen: Arc<Mutex<Vec<Vec<String>>>> = Arc::new(Mutex::new(Vec::new()));
+    let llm: Arc<dyn octos_llm::LlmProvider> = Arc::new(RecordingLlm {
+        seen: seen.clone(),
+        replies: vec!["FIRST".to_string(), "SECOND".to_string()],
+        calls: std::sync::atomic::AtomicUsize::new(0),
+    });
+    let factory =
+        TestAgentFactory::new(llm, memory_dir, cwd.clone()).with_session_store(&sessions_dir);
+
+    let prompt_cwd = cwd.clone();
+    Client
+        .builder()
+        .name("octos-acp-reload-client")
+        .on_receive_notification(
+            async move |_n: SessionNotification,
+                        _cx: ConnectionTo<agent_client_protocol::Agent>| { Ok(()) },
+            agent_client_protocol::on_receive_notification!(),
+        )
+        .connect_with(
+            OctosAcpAgentTransport::new(factory),
+            |connection: ConnectionTo<agent_client_protocol::Agent>| async move {
+                connection
+                    .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                    .block_task()
+                    .await?;
+                let new_session = connection
+                    .send_request(NewSessionRequest::new(prompt_cwd.clone()))
+                    .block_task()
+                    .await?;
+                let id = new_session.session_id;
+
+                connection
+                    .send_request(PromptRequest::new(
+                        id.clone(),
+                        vec![ContentBlock::from("TURN_ONE")],
+                    ))
+                    .block_task()
+                    .await?;
+
+                // Reload the id the agent is already holding.
+                connection
+                    .send_request(LoadSessionRequest::new(id.clone(), prompt_cwd.clone()))
+                    .block_task()
+                    .await?;
+
+                // The session must still work, and still carry its earlier turn.
+                connection
+                    .send_request(PromptRequest::new(
+                        id.clone(),
+                        vec![ContentBlock::from("TURN_TWO")],
+                    ))
+                    .block_task()
+                    .await?;
+                Ok::<_, agent_client_protocol::Error>(())
+            },
+        )
+        .await
+        .expect("reload should not break the session");
+
+    let calls = seen.lock().await;
+    let last = calls.last().expect("second turn ran");
+    let joined = last.join("\n");
+    assert!(
+        joined.contains("TURN_ONE"),
+        "reloading a live session lost its history; saw: {joined}"
+    );
 }


### PR DESCRIPTION
Supersedes #1894, which was closed with review notes. All four are addressed; GitHub would not reopen it because the branch head was force-pushed after closing.

Relates to #1886 (same area: ACP wiring that exists everywhere except ACP).

## Problem

ACP sessions are memory-only. `AcpSession.history` is a `Mutex<Vec<Message>>` that nothing writes anywhere, so a crash or a supervisor restart loses the whole conversation — the agent comes back mid-task with no idea what it was doing, while whatever supervises it reports it healthy. Silent amnesia is worse than staying down, because nothing looks wrong.

`SessionManager` already backs the REST and WebSocket paths. It was simply not reachable from ACP.

## Review findings from #1894, all fixed

**Formatting** — `cargo fmt`; `--check` clean.

**Duplicate-write race** — the delta was captured as an index under one guard and sliced under another, so two turns interleaving on one session computed overlapping ranges and wrote the same rows twice. Rows are now taken under the same guard that appends them.

**`session/load` evicting a live session** — a bare insert dropped the existing entry and with it the `shutdown` flag an in-flight turn watches, so a `session/cancel` for that turn flipped a flag nobody read and cancellation silently stopped working. Loading an id the agent already holds is now a no-op.

The check runs *before* `factory.build()`. My first attempt put it after, and the new test failed on a redb lock — `EpisodeStore::open` cannot run twice on a live session. Checking first is both correct and avoids building an agent that would be discarded.

**Profile-less `SessionKey`** — now `with_profile`, taking the factory's profile and falling back to `MAIN_PROFILE_ID`.

## The `thread_id` contract

`add_message_with_seq` is fail-closed for Assistant and Tool rows: it rejects them unless the caller stamps the originating turn's `thread_id`. Unstamped, the user row persisted and the assistant row was rejected — a stored conversation with the answers missing.

Each turn now stamps one id across the rows it produced. **I inferred this from the rejection rather than from documentation**, so please confirm one-id-per-turn is what that path expects.

## Failure handling, deliberately soft

- a store that will not open degrades to `None` with an error log rather than stopping the agent
- a failed write is logged per message rather than aborting the turn
- an unknown session id loads as empty with a warning

Losing persistence must not also lose the work, or refuse to serve.

## Testing

Two integration tests, each failing without its fix: one drives two independent transports over a single store and requires the second to see the first's turns; the other reloads a live session and requires it to keep working.

```
982 lib tests · 5 ACP integration tests · fmt clean
```

Also exercised on a release binary built with the CI feature set: `kill -9` the host process, the supervisor restarts it, the session resumes, and the agent recalls a codeword set before the kill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)