### PR TITLE
fix(peer): stage peers as clones so git actually works inside the fence

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -11893,32 +11893,82 @@ fn stage_peer(
                 "peer '{slug}' staging directory is no longer a real directory"
             )));
         }
-        let output = std::process::Command::new("git")
-            .arg("-C")
-            .arg(workspace_root)
-            .arg("worktree")
-            .arg("add")
-            .arg("-b")
-            .arg(&branch)
-            .arg(&worktree_path)
-            .output();
-        let output = match output {
-            Ok(output) => output,
-            Err(err) => {
-                cleanup_staged_peer(workspace_root, &slug, &peer_dir);
-                return Err(RpcError::invalid_params(format!(
-                    "failed to run git: {err}"
-                )));
+        // A CLONE, not `git worktree add`. A worktree's `.git` is a FILE
+        // pointing at `<repo>/.git/worktrees/<name>`, which lives OUTSIDE the
+        // peer's sandboxed workspace — so every git command inside a worktree
+        // peer failed with `fatal: not a git repository ... exit 128`, and the
+        // model "recovered" by running `git init`, destroying the fence. The
+        // branch then stayed at the seed commit and no deliverable ever landed.
+        // A clone puts the whole `.git` INSIDE `peers/<slug>/wt`, so git works
+        // with no sandbox widening, and one peer cannot reach another's refs.
+        //
+        // `--no-hardlinks` because isolation is the entire point here: the
+        // default local-clone optimisation shares object-file inodes with the
+        // parent, so a peer writing into its own `.git` could corrupt the
+        // source repo's objects. Costs a real object copy per peer; revisit
+        // with evidence if staging latency becomes the problem.
+        let run_git = |args: &[&std::ffi::OsStr]| -> Result<(), String> {
+            match std::process::Command::new("git").args(args).output() {
+                Err(err) => Err(format!("failed to run git: {err}")),
+                Ok(out) if out.status.success() => Ok(()),
+                Ok(out) => Err(String::from_utf8_lossy(&out.stderr).trim().to_owned()),
             }
         };
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+        let as_os = |s: &str| std::ffi::OsString::from(s);
+        let clone_args: Vec<std::ffi::OsString> = vec![
+            as_os("clone"),
+            as_os("--quiet"),
+            as_os("--no-hardlinks"),
+            workspace_root.as_os_str().to_os_string(),
+            worktree_path.as_os_str().to_os_string(),
+        ];
+        let clone_ref: Vec<&std::ffi::OsStr> = clone_args.iter().map(AsRef::as_ref).collect();
+        if let Err(detail) = run_git(&clone_ref) {
             cleanup_staged_peer(workspace_root, &slug, &peer_dir);
             return Err(RpcError::invalid_params(format!(
-                "git worktree add failed (is {} a git repo?): {}",
+                "git clone failed (is {} a git repo?): {}",
                 workspace_root.display(),
-                stderr
+                detail
             )));
+        }
+        // The fence branch now lives in the peer's OWN clone.
+        let branch_args: Vec<std::ffi::OsString> = vec![
+            as_os("-C"),
+            worktree_path.as_os_str().to_os_string(),
+            as_os("checkout"),
+            as_os("-q"),
+            as_os("-b"),
+            as_os(&branch),
+        ];
+        let branch_ref: Vec<&std::ffi::OsStr> = branch_args.iter().map(AsRef::as_ref).collect();
+        if let Err(detail) = run_git(&branch_ref) {
+            cleanup_staged_peer(workspace_root, &slug, &peer_dir);
+            return Err(RpcError::invalid_params(format!(
+                "git checkout -b {branch} failed in the peer clone: {detail}"
+            )));
+        }
+        // A clone does NOT inherit the source's LOCAL config, so a peer would
+        // have no commit identity and every `git commit` would fail. Carry the
+        // parent's over when it has one; otherwise git falls back to global.
+        for key in ["user.name", "user.email"] {
+            let read = std::process::Command::new("git")
+                .arg("-C")
+                .arg(workspace_root)
+                .args(["config", "--get", key])
+                .output();
+            let Ok(out) = read else { continue };
+            if !out.status.success() {
+                continue;
+            }
+            let value = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+            if value.is_empty() {
+                continue;
+            }
+            let _ = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&worktree_path)
+                .args(["config", key, &value])
+                .output();
         }
         worktree_path
     } else {
@@ -12044,6 +12094,63 @@ fn remove_peer_worktree(workspace_root: &Path, dir: &Path) {
         if mine {
             let _ = std::fs::remove_dir_all(entry.path());
         }
+    }
+}
+
+/// Fetch a peer's fence branch out of its own clone and into the workspace repo.
+///
+/// Peers are staged as CLONES (see `stage_peer`), so `peer/<slug>` exists only
+/// inside `peers/<slug>/wt`. Without this the work is invisible from the
+/// workspace — `git branch` would not list it and the deliverable would look
+/// like it never happened. Run on close, once the peer is done writing.
+///
+/// Best-effort by design: a peer that never committed, was staged without a
+/// worktree, or whose clone is gone simply has nothing to collect, and none of
+/// those should fail the close.
+fn collect_peer_branch(peer_dir: &Path, slug: &str) {
+    let clone = peer_dir.join("wt");
+    if !clone.join(".git").exists() {
+        return;
+    }
+    // The clone's `origin` IS the workspace repo it was cloned from, so the
+    // destination is self-describing — no need to thread a workspace root
+    // through the close callback, and it stays correct even if the session's
+    // workspace moved after staging.
+    let origin = match std::process::Command::new("git")
+        .arg("-C")
+        .arg(&clone)
+        .args(["config", "--get", "remote.origin.url"])
+        .output()
+    {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).trim().to_owned(),
+        _ => return,
+    };
+    if origin.is_empty() {
+        return;
+    }
+    let workspace_root = PathBuf::from(origin);
+    let branch = format!("peer/{slug}");
+    // `+` forces the update: a re-opened peer that committed again must not be
+    // refused for a non-fast-forward.
+    let refspec = format!("+{branch}:{branch}");
+    match std::process::Command::new("git")
+        .arg("-C")
+        .arg(&workspace_root)
+        .args(["fetch", "--no-tags", "--quiet"])
+        .arg(&clone)
+        .arg(&refspec)
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            tracing::info!(slug, branch = %branch, "collected peer branch from its clone");
+        }
+        Ok(out) => tracing::warn!(
+            slug,
+            branch = %branch,
+            stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+            "could not collect the peer branch (it may have committed nothing)"
+        ),
+        Err(error) => tracing::warn!(slug, %error, "failed to run git to collect the peer branch"),
     }
 }
 
@@ -13758,6 +13865,12 @@ fn build_peer_close_callback(
                 "failed to write close marker for peer '{slug}': {err}"
             ));
         }
+        // The fence branch lives in the peer's own clone, so pull it into the
+        // workspace repo now that the peer is done — otherwise its work is
+        // invisible from the workspace and looks like it never happened.
+        // AFTER the marker: collection is best-effort and must never leave a
+        // peer un-closed.
+        collect_peer_branch(&peer_dir, &slug);
         // #436 leak fix — the marker now refuses NEW sends; actively CANCEL +
         // tombstone any injection queued for this peer BEFORE the close so
         // nothing stays stranded in the durable queue (the drain gates skip a

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -25803,116 +25803,82 @@ fn stage_peer_reserves_slug_writes_brief_and_releases_on_failure() {
     );
 }
 
-/// Rolling back ONE peer must never touch a SIBLING's worktree fence.
+/// Rolling back ONE peer must never touch a SIBLING's fence.
 ///
-/// `cleanup_staged_peer` used to run a repo-GLOBAL `git worktree prune`, which
-/// deletes the admin entry of EVERY worktree whose checkout is missing — not
-/// just the one being rolled back. `git worktree add` creates the admin entry
-/// BEFORE the checkout is fully in place, so a sibling staged concurrently was
-/// visible to prune in exactly that window and lost its fence: its branch was
-/// left checked-out-nowhere and the peer ran in a broken worktree. Every peer
-/// checkout is named `wt` (`peers/<slug>/wt`), so git disambiguates the admin
-/// dirs as `wt`, `wt1`, … — which is why this surfaced as "the SECOND peer's
-/// worktree disappeared".
+/// HISTORY: `cleanup_staged_peer` used to run a repo-GLOBAL
+/// `git worktree prune`, which deletes the admin entry of EVERY worktree whose
+/// checkout is momentarily missing — and `git worktree add` registers that entry
+/// BEFORE the checkout exists, so a sibling staged concurrently sat in exactly
+/// that window and lost its fence. Every peer checkout was named `wt`, so git
+/// disambiguated the admin dirs as `wt`, `wt1`, … and it surfaced as "the SECOND
+/// peer's worktree disappeared".
 ///
-/// The window is a race, but its consequence is deterministic: a peer whose
-/// checkout is absent when a sibling cleans up must survive. That is what this
-/// asserts — hiding the checkout stands in for "mid-`worktree add`".
+/// Peers are now staged as CLONES, which removes the shared `.git` that bug
+/// lived in — so this can no longer assert on `git worktree list` (a clone is
+/// not registered in the parent at all). The INVARIANT is unchanged and still
+/// worth pinning: tearing down one peer must leave a sibling fully usable.
 #[test]
-fn cleanup_of_one_peer_must_not_destroy_a_sibling_worktree() {
-    fn git(dir: &std::path::Path, args: &[&str]) -> String {
-        let out = std::process::Command::new("git")
+fn cleanup_of_one_peer_must_not_destroy_a_sibling_fence() {
+    fn git(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
+        std::process::Command::new("git")
             .arg("-C")
             .arg(dir)
             .args(args)
             .output()
-            .unwrap();
-        assert!(
-            out.status.success(),
-            "git {args:?}: {}",
-            String::from_utf8_lossy(&out.stderr)
-        );
-        String::from_utf8_lossy(&out.stdout).into_owned()
+            .unwrap()
     }
 
     let tmp = tempfile::tempdir().unwrap();
     let peers = tmp.path().join("peers");
     let repo = tmp.path().join("project");
     std::fs::create_dir_all(&repo).unwrap();
-    git(&repo, &["init", "-q"]);
-    git(
-        &repo,
-        &[
-            "-c",
-            "user.email=t@t",
-            "-c",
-            "user.name=t",
-            "commit",
-            "--allow-empty",
-            "-m",
-            "init",
-        ],
+    assert!(git(&repo, &["init", "-q"]).status.success());
+    assert!(
+        git(&repo, &["config", "user.email", "t@t"])
+            .status
+            .success()
+    );
+    assert!(
+        git(&repo, &["config", "user.name", "ymote"])
+            .status
+            .success()
+    );
+    assert!(
+        git(&repo, &["commit", "--allow-empty", "-q", "-m", "init"])
+            .status
+            .success()
     );
 
-    // The SURVIVOR: a fully staged, fenced peer.
     let keeper = stage_peer(&peers, &repo, "Keeper", None, None, "Stay.", true)
         .expect("sibling staging must succeed");
-    assert!(keeper.cwd.join(".git").exists(), "sibling fence is real");
-
-    // A second peer, so the admin dirs actually collide on basename `wt`
-    // (`wt` and `wt1`) exactly as they do in production.
     let doomed =
         stage_peer(&peers, &repo, "Doomed", None, None, "Rolled back.", true).expect("staging");
-
-    // Stand in for "sibling is mid-`worktree add`": its admin entry exists but
-    // its checkout is not on disk yet.
-    let hidden = tmp.path().join("keeper-checkout-parked");
-    std::fs::rename(&keeper.cwd, &hidden).unwrap();
 
     // Roll back ONLY the doomed peer.
     cleanup_staged_peer(&repo, &doomed.slug, &peers.join(&doomed.slug));
 
-    std::fs::rename(&hidden, &keeper.cwd).unwrap();
-
-    // The rollback must have removed its OWN fence…
-    let listed = git(&repo, &["worktree", "list"]);
     assert!(
-        !listed.contains("peers/doomed"),
-        "the rolled-back peer's worktree must be gone, got:\n{listed}"
-    );
-    assert!(
-        !peers.join("doomed").exists(),
+        !peers.join(&doomed.slug).exists(),
         "the rolled-back peer's dir must be gone"
     );
 
-    // …and left the SIBLING's fence completely intact.
+    // The sibling must still be a USABLE git repo on its own fence branch.
+    // Checking the directory still exists is not enough — a half-torn-down
+    // fence looks identical on disk until git is asked to resolve it.
     assert!(
-        listed.contains(&keeper.cwd.to_string_lossy().into_owned())
-            || listed.contains("peers/keeper"),
-        "a sibling's worktree must survive another peer's rollback, got:\n{listed}"
+        keeper.cwd.join(".git").is_dir(),
+        "the sibling's fence must survive intact"
     );
+    let head = git(&keeper.cwd, &["rev-parse", "--abbrev-ref", "HEAD"]);
     assert!(
-        keeper.cwd.join(".git").exists(),
-        "sibling checkout must still be a live worktree"
-    );
-    // The decisive check: git must still resolve the sibling's worktree. A
-    // pruned admin entry leaves the checkout on disk but orphaned, so this is
-    // what actually distinguishes "survived" from "looks like it survived".
-    let out = std::process::Command::new("git")
-        .arg("-C")
-        .arg(&keeper.cwd)
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .output()
-        .unwrap();
-    assert!(
-        out.status.success(),
-        "sibling worktree must still be usable by git: {}",
-        String::from_utf8_lossy(&out.stderr)
+        head.status.success(),
+        "the sibling must still be usable by git: {}",
+        String::from_utf8_lossy(&head.stderr)
     );
     assert_eq!(
-        String::from_utf8_lossy(&out.stdout).trim(),
+        String::from_utf8_lossy(&head.stdout).trim(),
         "peer/keeper",
-        "sibling must still be on its own fence branch"
+        "the sibling must still be on its own fence branch"
     );
 }
 
@@ -26558,6 +26524,127 @@ fn unsafe_peer_topic_slug_is_treated_as_non_peer() {
         peer_wire_registry().resolve(&peer_wire_key("dev", "/tmp/x")),
         None,
         "an unsafe peer topic must not register a wire key"
+    );
+}
+
+/// A worktree peer's git state must live INSIDE its own workspace, so git
+/// actually works there.
+///
+/// Regression guard for the bug that made worktree peers useless. They were
+/// staged with `git worktree add`, whose `.git` is a FILE pointing at
+/// `<repo>/.git/worktrees/<name>` — OUTSIDE the peer's sandboxed workspace. The
+/// sandbox confines a peer to `peers/<slug>/wt`, so every git command failed:
+///
+/// ```text
+/// fatal: not a git repository: .../work/.git/worktrees/wt      Exit code: 128
+/// ```
+///
+/// The model then "recovered" by running `git init`, destroying the fence, and
+/// the branch stayed at the seed commit — a worktree peer produced a branch and
+/// never landed anything on it. Live-observed on BOTH peers of a two-peer run.
+///
+/// The old tests could not catch this: they asserted the fence was CREATED,
+/// never that a peer could USE it. So this asserts the property the sandbox
+/// actually needs — the RESOLVED git dir is contained in the peer's own
+/// workspace — plus a real commit and a collection round-trip.
+#[test]
+fn peer_fence_git_dir_is_inside_the_peer_workspace() {
+    fn git(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
+        std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .unwrap()
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let peers = tmp.path().join("peers");
+    let repo = tmp.path().join("project");
+    std::fs::create_dir_all(&repo).unwrap();
+    assert!(git(&repo, &["init", "-q"]).status.success());
+    assert!(
+        git(&repo, &["config", "user.email", "t@t"])
+            .status
+            .success()
+    );
+    assert!(
+        git(&repo, &["config", "user.name", "ymote"])
+            .status
+            .success()
+    );
+    std::fs::write(repo.join("seed.txt"), b"seed\n").unwrap();
+    assert!(git(&repo, &["add", "-A"]).status.success());
+    assert!(git(&repo, &["commit", "-q", "-m", "seed"]).status.success());
+
+    let staged =
+        stage_peer(&peers, &repo, "Fenced", None, None, "Own fence.", true).expect("staging");
+    let cwd = &staged.cwd;
+
+    // THE fix: `.git` is a real directory in the peer's workspace, not a file
+    // redirecting outside it.
+    assert!(
+        cwd.join(".git").is_dir(),
+        "the peer's .git must be a real directory inside its workspace, not a \
+         worktree pointer file to the parent repo"
+    );
+
+    // The property the sandbox needs: the RESOLVED git dir is contained in the
+    // peer's own workspace, so confining the peer to `cwd` cannot break git.
+    let out = git(cwd, &["rev-parse", "--absolute-git-dir"]);
+    assert!(out.status.success(), "git must work inside the peer fence");
+    let git_dir = std::path::PathBuf::from(String::from_utf8_lossy(&out.stdout).trim().to_owned());
+    let contained = std::fs::canonicalize(&git_dir)
+        .unwrap_or_else(|_| git_dir.clone())
+        .starts_with(std::fs::canonicalize(cwd).unwrap_or_else(|_| cwd.clone()));
+    assert!(
+        contained,
+        "the peer's git dir must resolve INSIDE its workspace, got {}",
+        git_dir.display()
+    );
+
+    // On its own fence branch...
+    let head = git(cwd, &["rev-parse", "--abbrev-ref", "HEAD"]);
+    assert_eq!(
+        String::from_utf8_lossy(&head.stdout).trim(),
+        "peer/fenced",
+        "the peer must start on its own fence branch"
+    );
+
+    // ...and able to actually commit. A clone does NOT inherit the source's
+    // LOCAL config, so this also covers the carried-over commit identity —
+    // without it every peer commit fails on "unable to auto-detect email".
+    std::fs::write(cwd.join("work.txt"), b"peer output\n").unwrap();
+    assert!(git(cwd, &["add", "-A"]).status.success());
+    let commit = git(cwd, &["commit", "-q", "-m", "peer deliverable"]);
+    assert!(
+        commit.status.success(),
+        "a peer must be able to commit inside its fence: {}",
+        String::from_utf8_lossy(&commit.stderr)
+    );
+
+    // The commit is NOT in the workspace repo yet — it lives in the peer's
+    // clone until collection.
+    assert!(
+        !git(&repo, &["rev-parse", "--verify", "-q", "peer/fenced"])
+            .status
+            .success(),
+        "the fence branch must not appear in the workspace before collection"
+    );
+
+    // Collection pulls it back, so the deliverable is visible from the workspace.
+    collect_peer_branch(&peers.join(&staged.slug), &staged.slug);
+    assert!(
+        git(&repo, &["rev-parse", "--verify", "-q", "peer/fenced"])
+            .status
+            .success(),
+        "collect_peer_branch must land the fence branch in the workspace repo"
+    );
+    let subject = git(&repo, &["log", "-1", "--format=%s", "peer/fenced"]);
+    assert_eq!(
+        String::from_utf8_lossy(&subject.stdout).trim(),
+        "peer deliverable",
+        "the collected branch must carry the peer's commit"
     );
 }
 


### PR DESCRIPTION
## The bug

**Worktree peers could not use git at all.**

`git worktree add` leaves a `.git` **file** pointing at `<repo>/.git/worktrees/<name>` — outside the peer's sandboxed workspace. The peer sandbox confines it to `peers/<slug>/wt` with `read_allow_paths: []`, so every git command failed:

```
fatal: not a git repository: .../work/.git/worktrees/wt      Exit code: 128
```

The model then "recovered" by running `git init`, destroying the fence and leaving a standalone repo on `main`. **The branch stayed at the seed commit** — a worktree peer produced a branch and never landed anything on it, which is the entire point of the feature.

Found by a live two-peer soak on real hardware. It hit **both** peers deterministically (5 occurrences across `wt` and `wt1`). `worktree: false` peers were unaffected, which fits exactly.

Unit tests could not catch it: they asserted the fence was **created**, never that a peer could **use** it.

## The fix

Peers are staged with `git clone`, so `.git` is a real directory **inside** the peer's workspace. Git works with no sandbox widening, and one peer cannot reach another's refs.

Chosen over the two alternatives deliberately:

| option | why not |
| --- | --- |
| grant the peer sandbox write on the shared `.git` | any LLM-spawned peer could rewrite a sibling's branch |
| `FilesystemScope::Host` (what fleet worktree workers get) | that is *operator-granted* full trust; it does not transfer to depth-1 peers spawned by a model |

Two consequences the worktree hid, both handled:

- **Commit identity.** A clone does not inherit the source's *local* config, so peers would have had none and every commit would fail on "unable to auto-detect email". The parent's `user.name`/`user.email` are carried over.
- **Branch visibility.** `peer/<slug>` now lives only in the clone, so `collect_peer_branch` fetches it back into the workspace on close. It derives the destination from the clone's own `origin` remote rather than threading a workspace root through the close callback — self-describing, and still correct if the session's workspace moved after staging.

`--no-hardlinks` is deliberate: the default local-clone optimisation shares object-file inodes with the parent, so a peer writing into its own `.git` could corrupt the source repo. Isolation is the whole reason for this approach. It costs a real object copy per peer — revisit with evidence if staging latency becomes the problem.

**Side effect worth noting:** this removes the shared `.git` entirely, so the `wt`/`wt1` admin-dir collision and the cross-peer prune races fixed in #1884 and #1887 can no longer exist by construction.

## Tests

**New — `peer_fence_git_dir_is_inside_the_peer_workspace`.** Asserts the property the sandbox actually needs: the **resolved** git dir is contained in the peer's workspace. Plus a real commit (which also covers the carried-over identity) and a collection round-trip.

Verified in both directions:

```
old (git worktree add): FAILED — "the peer's .git must be a real directory
                                  inside its workspace, not a worktree pointer file"
new (git clone):        ok
```

**Rewritten — #1884's sibling test.** Its `git worktree list` premise is gone, since a clone is not registered in the parent at all. The invariant it guards is unchanged and still pinned: tearing down one peer must leave a sibling **usable**, now asserted by resolving `HEAD` inside it rather than by listing worktrees.

## Verification

| gate | result |
| --- | --- |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test -p octos-cli --features api peer` | 98 passed |
| `cargo test -p octos-cli --lib` | 1002 passed |

## Not yet done

**This has not been re-soaked live.** The unit test proves the fence is usable; only a live run proves peers actually commit to their fences end to end, which is the thing that was broken. That is the obvious next step and I'd rather flag it than imply it's covered.
