### PR TITLE
fix(peer): publish a peer's fence branch every turn, not only on close

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -13281,6 +13281,21 @@ fn write_peer_result_if_peer_session(
     if let Err(err) = peer_io::append_peer_line(&peer_dir, "turns.txt", &index_line) {
         tracing::warn!(?err, slug, turn_count, "failed to append to turns.txt");
     }
+
+    // Publish this turn's commits to the workspace repo NOW, not only on close.
+    //
+    // A peer's fence branch lives in its own clone, so until it is fetched back
+    // the work is invisible from the workspace — `git branch` does not list it
+    // and it reads as though the peer produced nothing. Collecting only on close
+    // meant a peer that was never closed (the common case: peers usually just
+    // finish) kept its deliverable stranded in the clone. Live soak showed
+    // exactly that: the closed peer's branch landed, the un-closed peer's did
+    // not, despite both having committed.
+    //
+    // Here is the right moment — the peer has just finished a turn, so whatever
+    // it committed exists. Best-effort and idempotent: the fetch is a forced
+    // refspec, so re-running it per turn simply fast-forwards.
+    collect_peer_branch(&peer_dir, slug);
 }
 
 /// Count how many `result-<n>.md` version files exist in the peer directory,

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -26648,6 +26648,87 @@ fn peer_fence_git_dir_is_inside_the_peer_workspace() {
     );
 }
 
+/// Collecting a peer's fence must be idempotent and must not require a close.
+///
+/// `collect_peer_branch` originally ran ONLY on `peer_close`, so a peer that
+/// simply finished — the common case — kept its deliverable stranded in its own
+/// clone: committed, intact, and invisible from the workspace. A live soak showed
+/// exactly that split, with the closed peer's branch landing and the un-closed
+/// peer's not, despite both having committed. It now runs after every peer turn,
+/// which means it must survive being called repeatedly.
+#[test]
+fn collecting_a_peer_fence_is_repeatable_and_tracks_new_commits() {
+    fn git(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
+        std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .unwrap()
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let peers = tmp.path().join("peers");
+    let repo = tmp.path().join("project");
+    std::fs::create_dir_all(&repo).unwrap();
+    assert!(git(&repo, &["init", "-q"]).status.success());
+    assert!(
+        git(&repo, &["config", "user.email", "t@t"])
+            .status
+            .success()
+    );
+    assert!(
+        git(&repo, &["config", "user.name", "ymote"])
+            .status
+            .success()
+    );
+    assert!(
+        git(&repo, &["commit", "--allow-empty", "-q", "-m", "seed"])
+            .status
+            .success()
+    );
+
+    let staged =
+        stage_peer(&peers, &repo, "Turnwise", None, None, "Commit twice.", true).expect("staging");
+    let dir = peers.join(&staged.slug);
+
+    // Nothing committed yet: collecting must be a harmless no-op, not an error
+    // and not a spurious branch.
+    collect_peer_branch(&dir, &staged.slug);
+
+    // Turn 1.
+    std::fs::write(staged.cwd.join("a.txt"), b"one\n").unwrap();
+    assert!(git(&staged.cwd, &["add", "-A"]).status.success());
+    assert!(
+        git(&staged.cwd, &["commit", "-q", "-m", "turn one"])
+            .status
+            .success()
+    );
+    collect_peer_branch(&dir, &staged.slug);
+    let after_one = git(&repo, &["log", "-1", "--format=%s", "peer/turnwise"]);
+    assert_eq!(
+        String::from_utf8_lossy(&after_one.stdout).trim(),
+        "turn one",
+        "a peer's work must be visible in the workspace WITHOUT being closed"
+    );
+
+    // Turn 2 — the same collection must fast-forward, not fail on non-ff.
+    std::fs::write(staged.cwd.join("b.txt"), b"two\n").unwrap();
+    assert!(git(&staged.cwd, &["add", "-A"]).status.success());
+    assert!(
+        git(&staged.cwd, &["commit", "-q", "-m", "turn two"])
+            .status
+            .success()
+    );
+    collect_peer_branch(&dir, &staged.slug);
+    let after_two = git(&repo, &["log", "-1", "--format=%s", "peer/turnwise"]);
+    assert_eq!(
+        String::from_utf8_lossy(&after_two.stdout).trim(),
+        "turn two",
+        "repeat collection must advance the branch to the peer's latest commit"
+    );
+}
+
 /// A peer key with NO profile component is not addressable, and must keep
 /// parsing as a non-peer session.
 ///


### PR DESCRIPTION
Follow-up to #1898, found by re-soaking it on real hardware.

## The gap

#1898 made peers clones so git works inside the fence, and collected the fence branch back into the workspace on `peer_close`. **Close is the wrong moment** — and the rarest one. Peers usually just *finish*; nothing requires anyone to close them.

So a peer that was never closed kept its deliverable stranded in its own clone: committed, intact, and invisible from the workspace. `git branch` did not list it, which reads exactly like a peer that produced nothing — the same symptom #1898 set out to kill, one step further along.

The live soak showed the split precisely. **Both** worktree peers committed; only the **closed** one's branch reached the workspace:

```
peer/beta   -> "beta deliverable"    (closed)
peer/alpha  -> MISSING               (never closed — 2 commits sat in its clone)
```

Alpha's work was never lost — `alpha deliverable` and `append ALPHA-EXTRA` were both in its clone, with `alpha.txt` carrying both lines. It was simply unpublished.

## The fix

Collection now runs at the end of **every peer turn**, in `write_peer_result_if_peer_session`. That is the right moment: the peer has just finished a turn, so whatever it committed exists. `peer_dir` and `slug` are already in scope there, so no plumbing.

The fetch uses a forced refspec, so running it per turn simply fast-forwards rather than failing on non-fast-forward.

Collection on close stays — it is harmless and idempotent, and still covers a peer whose final turn did not go through the result path.

## Test

`collecting_a_peer_fence_is_repeatable_and_tracks_new_commits` pins all three states a per-turn call must survive:

1. collecting with **nothing committed** — a harmless no-op, no spurious branch
2. collecting after the first commit **without any close** — the branch must be visible in the workspace
3. collecting **again** after a second commit — must advance, not fail non-fast-forward

That second assertion is the regression this PR exists for.

## Verification

| gate | result |
| --- | --- |
| test functions removed vs `main` | **0** |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test -p octos-cli --features api peer` | 99 passed |
| `cargo test -p octos-cli --lib` | 1002 passed |

## Still to do

Worth a re-soak: the proof is Alpha's branch appearing in the workspace **without** ever being closed, which is the exact case that failed the last run. The unit test covers the mechanism; only a live run covers the whole path.
