### PR TITLE
fix(mcp): let the registry own MCP transports so narrowing cannot kill them

### DIFF
--- a/crates/octos-agent/src/mcp.rs
+++ b/crates/octos-agent/src/mcp.rs
@@ -332,9 +332,14 @@ struct McpToolSpec {
 
 /// A running set of MCP server connections and the tools they expose.
 pub struct McpClient {
-    /// Kept alive so the underlying transports (and stdio child processes) stay
-    /// open for as long as any registered tool references them.
-    #[allow(dead_code)]
+    /// The live transports (and their stdio child processes).
+    ///
+    /// These are MOVED into the registry by [`McpClient::register_tools`], which
+    /// then owns them for its lifetime. That matters: `register_tools` consumes
+    /// `self`, so this field is dropped as soon as registration returns — it
+    /// never kept anything alive on its own, despite once claiming to. The
+    /// registered tools were the only owners, so any `retain()` that removed the
+    /// last MCP tool cancelled the transport and killed the child (#1886).
     services: Vec<(String, McpService)>,
     tools: Vec<McpToolSpec>,
 }
@@ -525,6 +530,13 @@ impl McpClient {
     /// names collide with built-in tool names are rejected so a remote server
     /// cannot silently replace core functionality.
     pub fn register_tools(self, registry: &mut ToolRegistry) {
+        // Hand the transports to the registry BEFORE the tools, so it owns them
+        // even if every tool below is later filtered out. Without this the tools
+        // are the sole owners and profile narrowing tears down the connection
+        // (#1886) — a visibility filter must not end a child process.
+        for (_server, service) in self.services {
+            registry.keep_mcp_service_alive(service as Arc<dyn std::any::Any + Send + Sync>);
+        }
         for spec in self.tools {
             if Self::PROTECTED_NAMES.contains(&spec.name.as_str()) {
                 warn!(

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -134,6 +134,19 @@ pub struct ToolRegistry {
     cached_specs: std::sync::Mutex<Option<Vec<ToolSpec>>>,
     /// Tool names that came from plugin binaries (for auto-send hook filtering).
     plugin_tools: HashSet<String>,
+    /// Live MCP transport handles, owned for the registry's whole lifetime.
+    ///
+    /// `McpService` is an `Arc<RunningService<..>>` and every `McpTool` holds a
+    /// clone, so before this existed the registered TOOLS were the only owners.
+    /// Any `retain()` that dropped the last MCP tool therefore dropped the last
+    /// `Arc`, cancelling the transport and killing the stdio child — profile
+    /// narrowing silently tore down a server the operator had explicitly
+    /// configured (#1886). Tool VISIBILITY must not control transport LIFETIME,
+    /// so the registry holds its own reference that `retain()` never touches.
+    ///
+    /// Type-erased: the registry does not care what kind of handle this is, only
+    /// that dropping the tools must not drop the connection.
+    mcp_services: Vec<Arc<dyn std::any::Any + Send + Sync>>,
     /// Tools whose execution is auto-redirected to a background tokio task
     /// in the execution loop (see `is_spawn_only` + the spawn_only branch
     /// in `agent/execution.rs`). These tools ARE visible in `specs()` and
@@ -224,6 +237,7 @@ impl ToolRegistry {
             active_context: None,
             cached_specs: std::sync::Mutex::new(None),
             plugin_tools: HashSet::new(),
+            mcp_services: Vec::new(),
             spawn_only: HashSet::new(),
             spawn_only_messages: HashMap::new(),
             background_result_sender: None,
@@ -754,6 +768,19 @@ impl ToolRegistry {
     /// `bg_tools.execute_with_context` which fails async because the tool
     /// itself is gone from the registry — so the foreground turn observes a
     /// fake "started successfully". See PR #688 follow-up MEDIUM #3.
+    /// Take ownership of a live MCP transport so it outlives any filtering of
+    /// the tools it provides — see [`ToolRegistry::mcp_services`]. Without this
+    /// the tools are the only owners and narrowing kills the child process.
+    pub fn keep_mcp_service_alive(&mut self, service: Arc<dyn std::any::Any + Send + Sync>) {
+        self.mcp_services.push(service);
+    }
+
+    /// How many MCP transports this registry keeps alive, so a caller can assert
+    /// they survived a filter that removed their tools.
+    pub fn live_mcp_transport_count(&self) -> usize {
+        self.mcp_services.len()
+    }
+
     pub fn retain(&mut self, f: impl Fn(&str) -> bool) {
         self.tools.retain(|name, _| f(name));
         self.spawn_only.retain(|name| self.tools.contains_key(name));
@@ -975,6 +1002,10 @@ impl ToolRegistry {
 
         let mut snapshot = Self {
             tools,
+            // Carried, not reset: a snapshot that EXCLUDES the MCP tools would
+            // otherwise replace the last owner and let the transport die when
+            // the original registry drops. Cheap — one Arc per server.
+            mcp_services: self.mcp_services.clone(),
             workspace_root: self.workspace_root.clone(),
             provider_policy: self.provider_policy.clone(),
             context_filter: self.context_filter.clone(),
@@ -3267,6 +3298,57 @@ mod profile_filter_tests {
                 .iter()
                 .map(|e| &e.content_type)
                 .collect::<Vec<_>>()
+        );
+    }
+
+    /// Profile narrowing must NOT tear down an MCP transport (#1886).
+    ///
+    /// `McpService` is an `Arc<RunningService<..>>` and every `McpTool` held a
+    /// clone, so the registered TOOLS were the only owners. `filter_by_profile`
+    /// is a `retain()`, and MCP tool names are absent from a lean profile's
+    /// allow-list, so narrowing dropped the last `Arc` — cancelling the
+    /// transport and killing the stdio child roughly 1ms after startup. The
+    /// operator got an agent silently missing tools they had explicitly
+    /// configured, and the only trace was two INFO lines that read like an
+    /// ordinary shutdown.
+    ///
+    /// The registry now owns the handle independently, so this asserts the real
+    /// property via a DROP FLAG rather than a count that could go stale: after a
+    /// retain that removes everything, the transport is still alive.
+    #[test]
+    fn retaining_no_tools_must_not_drop_a_live_mcp_transport() {
+        struct Transport(Arc<std::sync::atomic::AtomicBool>);
+        impl Drop for Transport {
+            fn drop(&mut self) {
+                self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
+        let dropped = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let mut registry = ToolRegistry::new();
+        registry.keep_mcp_service_alive(Arc::new(Transport(dropped.clone())));
+        assert_eq!(registry.live_mcp_transport_count(), 1);
+
+        // The narrowing case: evict every tool, exactly as a lean profile's
+        // allow-list does to MCP tool names.
+        registry.retain(|_| false);
+
+        assert!(
+            !dropped.load(std::sync::atomic::Ordering::SeqCst),
+            "evicting every tool must NOT drop the MCP transport — that is the \
+             bug: a visibility filter killing the server's child process"
+        );
+        assert_eq!(
+            registry.live_mcp_transport_count(),
+            1,
+            "the registry must still own the transport after narrowing"
+        );
+
+        // ...and it IS released with the registry, so this is not a leak.
+        drop(registry);
+        assert!(
+            dropped.load(std::sync::atomic::Ordering::SeqCst),
+            "the transport must be released when the registry drops"
         );
     }
 }


### PR DESCRIPTION
Closes #1886.

## The bug

Configured MCP servers started, registered their tools, and were then **silently torn down by profile narrowing**. The operator lost tools they had explicitly configured, with no warning and no error — the only trace being two INFO lines that read like a normal shutdown:

```
INFO MCP server started server="node" tools=11
INFO task cancelled
INFO Child exited gracefully exit status: 0
```

`McpService` is an `Arc<RunningService<..>>` and every `McpTool` holds a clone. `filter_by_profile` is a `retain()` over the profile's allow-list, and MCP tool names are absent from the lean `coding` list — so narrowing dropped the last `Arc`, cancelling the transport and killing the stdio child roughly 1ms after startup.

## Why not the two fixes the issue proposed

#1886 suggested exempting MCP tools from narrowing, or warning loudly when it evicts one. Neither addresses the actual defect: **tool visibility was controlling transport lifetime**. A `retain()` ending a child process is a side effect nobody would predict, and it would recur through any future `retain()` caller.

The root cause sits one line further back than the issue states:

```rust
pub fn register_tools(self, registry: &mut ToolRegistry)
```

`register_tools` takes **`self` by value**, so `McpClient` — and its `services` field — is dropped the moment registration returns. Combined with `#[allow(dead_code)]`, that field **never kept anything alive**, despite a doc comment claiming it did. The registered tools were the only owners.

## The fix

`register_tools` now **moves the transports into the registry**, which owns them in a keep-alive that `retain()` never touches. Narrowing goes back to meaning what it says: hiding tools.

- **Snapshots carry the keep-alive.** A snapshot that *excludes* the MCP tools would otherwise replace the last owner and let the transport die when the original registry drops. One `Arc` clone per server.
- **Type-erased handle** (`Arc<dyn Any + Send + Sync>`) — the registry does not care what it holds, only that dropping the tools must not drop the connection. Also keeps `tools/registry.rs` free of an `mcp` dependency.
- **The misleading doc comment on `services` is fixed**, which the issue rightly flagged as inviting the reading that the field was the owner.

## Test

`retaining_no_tools_must_not_drop_a_live_mcp_transport` asserts the property with a **drop flag**, not a count that could go stale:

- after `retain(|_| false)` removes every tool, the transport is **still alive**
- the registry still owns it
- and it **is** released when the registry drops — so this is a keep-alive, not a leak

## Verification

| gate | result |
| --- | --- |
| test functions removed vs `main` | **0** |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test -p octos-agent --lib` | 2510 passed |

Windows cross-check is **inconclusive locally**, not clean: `cargo check --target x86_64-pc-windows-msvc` fails in the `ring` / `aws-lc-sys` build scripts, which need a real Windows toolchain. That is an environment limit of cross-checking a TLS-linked crate, not a code failure — `check-windows` in CI covers it.

## Note

The issue notes this is not ACP-specific, and that is right: `register_tools` is called the same way from `runtime/profile.rs`, `commands/chat.rs`, and the gateway, all followed by the same narrowing path. Fixing it at the registry covers every caller rather than one entry point.
