### PR TITLE
fix(pipeline): degrade gracefully when model key is not in provider router

### DIFF
--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -1756,7 +1756,20 @@ impl SpawnTool {
         let (base, default_cw): (Arc<dyn LlmProvider>, Option<u32>) =
             match (model, &self.provider_router) {
                 (Some(model_key), Some(router)) => {
-                    let provider = router.resolve(model_key)?;
+                    // An unresolvable model key must degrade to the parent
+                    // provider, matching the pipeline handler's fallback —
+                    // model-assignment may name catalog models this profile's
+                    // router never registered, and that must not fail the spawn.
+                    let provider = match router.resolve(model_key) {
+                        Ok(p) => p,
+                        Err(_) => {
+                            warn!(
+                                model = model_key,
+                                "sub-agent model not in provider router; using parent provider"
+                            );
+                            self.llm.clone()
+                        }
+                    };
                     // Look up default_context_window from metadata
                     let key = model_key.split_once('/').map_or(model_key, |(k, _)| k);
                     let default_cw = router

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -1762,9 +1762,12 @@ impl SpawnTool {
                     // router never registered, and that must not fail the spawn.
                     let provider = match router.resolve(model_key) {
                         Ok(p) => p,
-                        Err(_) => {
+                        // Keep the router's error — it lists the registered
+                        // keys, which is what makes the gap actionable.
+                        Err(err) => {
                             warn!(
                                 model = model_key,
+                                %err,
                                 "sub-agent model not in provider router; using parent provider"
                             );
                             self.llm.clone()

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -1124,9 +1124,14 @@ fn resolve_provider(
         // must not fail the whole pipeline.
         (Some(key), Some(r)) => match r.resolve(key) {
             Ok(provider) => Ok(provider),
-            Err(_) => {
+            // Keep the router's error: it names the keys that ARE registered
+            // (`available: [..]`), which is the one thing an operator needs to
+            // fix the gap. Dropping it leaves a warning that says what failed
+            // but not what would have worked.
+            Err(err) => {
                 warn!(
                     model = key,
+                    %err,
                     "pipeline model not in provider router; using default provider"
                 );
                 Ok(default.clone())

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -1117,7 +1117,21 @@ fn resolve_provider(
     model_key: Option<&str>,
 ) -> Result<Arc<dyn LlmProvider>> {
     match (model_key, router) {
-        (Some(key), Some(r)) => r.resolve(key),
+        // A missing/unknown model key must degrade to the default provider,
+        // matching CodergenHandler::resolve_provider (handler.rs) — the
+        // model-assignment pass may rewrite lane keys (e.g. `strong`) to
+        // catalog models this profile's router never registered, and that
+        // must not fail the whole pipeline.
+        (Some(key), Some(r)) => match r.resolve(key) {
+            Ok(provider) => Ok(provider),
+            Err(_) => {
+                warn!(
+                    model = key,
+                    "pipeline model not in provider router; using default provider"
+                );
+                Ok(default.clone())
+            }
+        },
         (Some(key), None) => {
             warn!(
                 model = key,

--- a/crates/octos-pipeline/src/executor_tests.rs
+++ b/crates/octos-pipeline/src/executor_tests.rs
@@ -2781,3 +2781,67 @@ async fn parallel_subnode_panic_emits_node_completed_via_guard_drop() {
         "the parallel worker must have started; got {events:?}"
     );
 }
+
+/// A pipeline node whose model key is NOT registered in the provider router
+/// must degrade to the default provider rather than kill the run (#1901).
+///
+/// `model_assignment` rewrites DOT lane keys (`model="strong"`) to concrete
+/// catalog models, and a profile without a filtered `pipeline_models.json`
+/// falls back to the UNFILTERED catalog — so it can name models the router
+/// never registered. `resolve_provider` propagated that with `?`, failing the
+/// whole pipeline, while `CodergenHandler::resolve_provider` (handler.rs) has
+/// always degraded in the same situation. The rotating model name in the error
+/// (`qwen3-max`, then `qwen-plus`, …) came from `ModelPools::nth_strong`
+/// round-robining the catalog, which is what made it look intermittent.
+///
+/// Mirrors handler.rs's `resolve_provider_falls_back_to_coding_llm_when_key_absent`
+/// so the two paths cannot drift apart again.
+#[tokio::test]
+async fn resolve_provider_falls_back_to_default_when_key_absent() {
+    struct NamedMock(&'static str);
+
+    #[async_trait::async_trait]
+    impl LlmProvider for NamedMock {
+        async fn chat(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            unreachable!("resolve_provider must not call chat()")
+        }
+        fn model_id(&self) -> &str {
+            self.0
+        }
+        fn provider_name(&self) -> &str {
+            self.0
+        }
+    }
+
+    let default: Arc<dyn LlmProvider> = Arc::new(NamedMock("pipeline-default"));
+    let router = Arc::new(ProviderRouter::new());
+    router.register("strong", Arc::new(NamedMock("research-strong")));
+
+    // The bug: an assigned-but-unregistered model must NOT fail the run.
+    let fallback = resolve_provider(&default, Some(&router), Some("qwen3-max"))
+        .expect("an unresolvable model key must not error the pipeline");
+    assert_eq!(
+        fallback.model_id(),
+        "pipeline-default",
+        "an unregistered model key must degrade to the default provider"
+    );
+
+    // A registered key still resolves to its own lane — the fallback must not
+    // swallow everything.
+    let resolved = resolve_provider(&default, Some(&router), Some("strong"))
+        .expect("a registered key must resolve");
+    assert_eq!(
+        resolved.model_id(),
+        "research-strong",
+        "a resolvable key must use its lane, not the default"
+    );
+
+    // No key at all: unchanged behaviour.
+    let none = resolve_provider(&default, Some(&router), None).expect("no key must resolve");
+    assert_eq!(none.model_id(), "pipeline-default");
+}


### PR DESCRIPTION
Fixes #1901

## Problem

`deep_research` (and any pipeline using `dynamic_parallel` planner nodes or spawned sub-agents with model overrides) can crash with:

```
no provider registered for key 'qwen3-max' (available: ["cheap", "strong"])
```

The failing key rotates per run (`qwen3-max` → `qwen-plus` → `openai/o3` → `llama-3.3-70b-versatile`).

## Root cause

The model-assignment pass rewrites DOT lane keys (`model="strong"`) to concrete catalog models. Profiles without a filtered `pipeline_models.json` fall back to the unfiltered `model_catalog.json`, so assignment can pick models the `ProviderRouter` never registered. Two call sites then failed hard on `router.resolve(key)`:

- `executor.rs::resolve_provider` — dynamic_parallel planner propagated the error with `?`, killing the pipeline
- `spawn.rs::resolve_sub_provider` — sub-agent spawn propagated the error with `?`

Meanwhile `handler.rs::CodergenHandler::resolve_provider` already handles the identical situation by degrading to the default provider with a `warn!`.

## Fix

Align both call sites with the handler's semantics: unknown model key → `warn!` + default/parent provider. A best-effort model assignment must never fail a pipeline run.

## Testing

- `cargo check -p octos-pipeline -p octos-agent` ✅
- `cargo test -p octos-pipeline --lib` ✅ 341 passed, 0 failed
- `cargo test -p octos-agent --lib spawn` ✅ 156 passed, 0 failed

## Follow-ups (out of scope)

- Filter assignment candidates against `router.keys()` in `model_assignment.rs`
- Include the original lane key in the `router.rs` error message