### PR TITLE
fix(pipeline): decide models by what the ROUTER resolves, not what the catalog lists

### DIFF
--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -1795,7 +1795,19 @@ impl PipelineExecutor {
             .catalog_dir
             .as_deref()
             .unwrap_or(&self.config.working_dir);
-        crate::model_assignment::assign_from_catalog_dir(&mut graph, catalog_dir);
+        // Only assign models this profile's router actually registered (#1901).
+        // Without the router, assignment rewrote resolvable lane keys into
+        // catalog models that could not resolve — the crash #1902 papered over.
+        let registered: Option<std::collections::HashSet<String>> = self
+            .config
+            .provider_router
+            .as_ref()
+            .map(|r| r.keys().into_iter().collect());
+        crate::model_assignment::assign_from_catalog_dir_filtered(
+            &mut graph,
+            catalog_dir,
+            registered.as_ref(),
+        );
 
         // ── Pipeline start: log graph structure ──
         let node_summary: Vec<String> = graph
@@ -2445,6 +2457,16 @@ impl PipelineExecutor {
             .with_known_models(crate::model_assignment::known_model_keys_from_catalog_dir(
                 catalog_dir,
             ))
+            // Narrow to what the router can actually RESOLVE (#1901 layer 5).
+            // The catalog lists models this profile never registered, so
+            // validating against it alone certified graphs that cannot run.
+            .with_resolvable_models(
+                self.config
+                    .provider_router
+                    .as_ref()
+                    .map(|r| r.keys())
+                    .unwrap_or_default(),
+            )
             .with_known_tools(tool_names)
     }
 

--- a/crates/octos-pipeline/src/model_assignment.rs
+++ b/crates/octos-pipeline/src/model_assignment.rs
@@ -133,13 +133,64 @@ impl ModelPools {
 /// touched (or `debug!` for the no-op cases) so operators can confirm
 /// the assignment fired without scraping per-node logs.
 pub fn assign_from_catalog_dir(graph: &mut PipelineGraph, data_dir: &Path) {
-    let Some(catalog) = load_catalog(data_dir) else {
+    assign_from_catalog_dir_filtered(graph, data_dir, None);
+}
+
+/// As [`assign_from_catalog_dir`], but only assigns models the provider router
+/// has actually REGISTERED (#1901).
+///
+/// Assignment rewrites DOT lane keys (`model="strong"`) to concrete catalog
+/// models, and a profile without a filtered `pipeline_models.json` falls back to
+/// the unfiltered `model_catalog.json` — 93 models, most of which the router
+/// never registered. It had no way to know that, because it was never given the
+/// router. So it happily rewrote a RESOLVABLE lane key into an UNRESOLVABLE
+/// model name, and the resolve failed downstream.
+///
+/// The key insight: when no registered concrete model exists, the right move is
+/// to leave the DOT alone. `strong` is itself a router key — that is what
+/// `available: ["cheap", "strong"]` in the old error was telling us. Rewriting
+/// it was the bug; not rewriting it resolves correctly.
+///
+/// `registered = None` keeps the old unfiltered behaviour for callers with no
+/// router (tests, legacy paths).
+pub fn assign_from_catalog_dir_filtered(
+    graph: &mut PipelineGraph,
+    data_dir: &Path,
+    registered: Option<&std::collections::HashSet<String>>,
+) {
+    let Some(mut catalog) = load_catalog(data_dir) else {
         tracing::debug!(
             data_dir = %data_dir.display(),
             "model_assignment: no catalog found, leaving DOT unchanged"
         );
         return;
     };
+
+    if let Some(registered) = registered {
+        let before = catalog.models.len();
+        catalog
+            .models
+            .retain(|m| registered.contains(m.model_key()) || registered.contains(&m.provider));
+        if catalog.models.is_empty() {
+            // Nothing in the catalog is registered, so any rewrite would produce
+            // an unresolvable model. Leaving the lane keys (`strong`/`cheap`) in
+            // place is CORRECT — the router registers those directly.
+            tracing::info!(
+                catalog_models = before,
+                registered = registered.len(),
+                "model_assignment: no catalog model is registered with the provider \
+                 router; leaving DOT lane keys unchanged so they resolve directly"
+            );
+            return;
+        }
+        if catalog.models.len() != before {
+            tracing::debug!(
+                kept = catalog.models.len(),
+                dropped = before - catalog.models.len(),
+                "model_assignment: restricted candidates to router-registered models"
+            );
+        }
+    }
 
     let Some(pools) = build_pools(&catalog) else {
         tracing::debug!("model_assignment: catalog had no healthy strong/fast models");
@@ -560,5 +611,78 @@ mod tests {
         // healthy-strong survives.
         assert_eq!(pools.strong, vec!["healthy-strong".to_string()]);
         assert_eq!(pools.fast, vec!["fast-a".to_string()]);
+    }
+}
+
+#[cfg(test)]
+mod registered_filter_tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn entry(provider: &str, model_type: &str) -> CatalogEntry {
+        CatalogEntry {
+            provider: provider.to_string(),
+            model_type: model_type.to_string(),
+            stability: 0.99,
+            score: 0.10,
+            cost_out: 0.0,
+        }
+    }
+
+    /// Assignment must never rewrite a lane key into a model the router cannot
+    /// resolve (#1901 layer 1 — the root cause).
+    ///
+    /// Assignment was given only the catalog, never the router, so it rewrote
+    /// `model="strong"` (which the router DOES register) into a concrete catalog
+    /// model it does not. Resolution then failed downstream. #1902 stopped that
+    /// failing the run, but the pipeline still silently executed on the default
+    /// provider instead of the requested lane — the bug this closes.
+    #[test]
+    fn unregistered_catalog_models_are_never_assigned() {
+        let catalog = ModelCatalog {
+            models: vec![
+                entry("openai/qwen3-max", "strong"),
+                entry("groq/llama-3.3-70b-versatile", "fast"),
+            ],
+        };
+        // The router registers only the LANES, exactly as the bug report showed:
+        // `available: ["cheap", "strong"]`.
+        let registered: HashSet<String> = ["cheap".to_string(), "strong".to_string()]
+            .into_iter()
+            .collect();
+
+        let survivors: Vec<&CatalogEntry> = catalog
+            .models
+            .iter()
+            .filter(|m| registered.contains(m.model_key()) || registered.contains(&m.provider))
+            .collect();
+
+        assert!(
+            survivors.is_empty(),
+            "no catalog model is registered, so none may be assigned; got {:?}",
+            survivors.iter().map(|m| &m.provider).collect::<Vec<_>>()
+        );
+    }
+
+    /// A registered catalog model IS still assignable — the filter must not
+    /// disable assignment wholesale.
+    #[test]
+    fn registered_catalog_models_survive_the_filter() {
+        let catalog = ModelCatalog {
+            models: vec![
+                entry("openai/qwen3-max", "strong"),
+                entry("deepseek/deepseek-v4-pro", "strong"),
+            ],
+        };
+        let registered: HashSet<String> = ["deepseek-v4-pro".to_string()].into_iter().collect();
+
+        let survivors: Vec<&CatalogEntry> = catalog
+            .models
+            .iter()
+            .filter(|m| registered.contains(m.model_key()) || registered.contains(&m.provider))
+            .collect();
+
+        assert_eq!(survivors.len(), 1, "only the registered model may survive");
+        assert_eq!(survivors[0].model_key(), "deepseek-v4-pro");
     }
 }

--- a/crates/octos-pipeline/src/validate.rs
+++ b/crates/octos-pipeline/src/validate.rs
@@ -154,6 +154,35 @@ impl ValidationContext {
         self
     }
 
+    /// Restrict the known-model set to what the provider router can ACTUALLY
+    /// resolve (#1901, layer 5).
+    ///
+    /// `with_known_models` is fed from the model CATALOG, which lists every
+    /// model the profile could theoretically use — 93 of them — regardless of
+    /// what the router registered. So a graph naming a catalogued-but-
+    /// unregistered model PASSED validation and then failed at runtime: the
+    /// pre-flight check certified a graph that cannot run. Worse, the rejection
+    /// message points at `model_catalog.json`, which is precisely where the
+    /// model IS present — sending the reader to the wrong file.
+    ///
+    /// Anything the router registers is resolvable, including the lane keys
+    /// (`cheap`/`strong`), so router keys are the correct authority. Callers
+    /// without a router (or with an empty one) keep the catalog-based set
+    /// rather than rejecting everything — validation must not become stricter
+    /// than reality when it has no way to know.
+    pub fn with_resolvable_models<I, S>(mut self, registered: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let registered: BTreeSet<String> = registered.into_iter().map(Into::into).collect();
+        if registered.is_empty() {
+            return self;
+        }
+        self.known_models = registered;
+        self
+    }
+
     pub fn with_known_models<I, S>(mut self, models: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -1055,7 +1084,22 @@ fn validate_model_name(
         Severity::Error,
         location,
         format!("unknown pipeline model '{model}'"),
-        Some("choose a model present in model_catalog.json / pipeline_models.json".into()),
+        // Deliberately does NOT say "present in model_catalog.json": once the
+        // set is router-derived, the rejected model is very often IN the
+        // catalog and simply not registered — sending the reader there is the
+        // single most misleading thing this message could do (#1901 layer 4).
+        Some(format!(
+            "'{model}' is not resolvable by this profile's provider router. \
+             Use a registered lane (e.g. `strong`, `cheap`) or a model the \
+             profile actually registers; known: [{}]",
+            context
+                .known_models
+                .iter()
+                .take(12)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
     );
 }
 
@@ -1950,5 +1994,74 @@ mod tests {
         let diags = diagnostics(&graph);
         assert!(!has_errors(&diags), "unexpected errors: {diags:?}");
         assert!(!diags.iter().any(|d| d.rule == 14));
+    }
+}
+
+#[cfg(test)]
+mod resolvable_models_tests {
+    use super::*;
+
+    /// The validator must certify RESOLVABILITY, not mere presence in the
+    /// catalog (#1901, layer 5).
+    ///
+    /// `known_models` was fed from the model catalog, which lists every model
+    /// the profile could theoretically use regardless of what the provider
+    /// router registered. So a graph naming a catalogued-but-unregistered model
+    /// PASSED pre-flight and then failed at runtime — the check certified a
+    /// graph that cannot run. After #1902 it stopped crashing and silently ran
+    /// on the default provider instead, which is worse: the validator said yes,
+    /// the run looked healthy, and the requested model was never used.
+    #[test]
+    fn catalogued_but_unregistered_models_are_rejected() {
+        // The catalog knows it; the router does not register it.
+        let ctx = ValidationContext::default()
+            .with_known_models(["qwen3-max".to_string(), "strong".to_string()])
+            .with_resolvable_models(["cheap".to_string(), "strong".to_string()]);
+
+        assert!(
+            !ctx.known_models.contains("qwen3-max"),
+            "a catalogued-but-unregistered model must NOT count as known once \
+             the router is the authority"
+        );
+        assert!(
+            ctx.known_models.contains("strong"),
+            "a registered lane key must stay known"
+        );
+    }
+
+    /// With no router (or an empty one) the catalog set is kept. Validation must
+    /// not become STRICTER than reality when it has no way to know what is
+    /// registered — that would reject working graphs.
+    #[test]
+    fn an_absent_router_leaves_the_catalog_set_intact() {
+        let ctx = ValidationContext::default()
+            .with_known_models(["qwen3-max".to_string()])
+            .with_resolvable_models(Vec::<String>::new());
+
+        assert!(
+            ctx.known_models.contains("qwen3-max"),
+            "with no router keys the catalog set must be preserved, not emptied"
+        );
+    }
+
+    /// The rejection must not send the reader to `model_catalog.json` — the
+    /// model is usually IN the catalog and merely unregistered, so that advice
+    /// points at the wrong file (#1901, layer 4).
+    #[test]
+    fn rejection_names_the_router_not_the_catalog() {
+        let ctx = ValidationContext::default().with_resolvable_models(["strong".to_string()]);
+        let mut diags = Vec::new();
+        validate_model_name("qwen3-max", &ctx, GraphLocation::Graph, &mut diags);
+
+        assert_eq!(diags.len(), 1, "an unresolvable model must be diagnosed");
+        let hint = diags[0].fix_hint.clone().unwrap_or_default();
+        assert!(
+            !hint.contains("model_catalog.json"),
+            "the hint must not point at the catalog, where the model IS present: {hint}"
+        );
+        assert!(
+            hint.contains("provider router") && hint.contains("strong"),
+            "the hint must name the router and list what IS resolvable: {hint}"
+        );
     }
 }


### PR DESCRIPTION
Closes #1901 — the remaining layers. #1902 stopped the crash; this stops the crash from being *possible*.

## One defect, in two places

Neither model **assignment** nor pre-flight **validation** had access to the provider router, so both reasoned about models that may not be runnable. The catalog lists 93 models; a profile's router may register only `cheap` and `strong`.

```
DOT: model="strong"
  ↓ assignment rewrites it to a catalog model   → "qwen3-max"
  ↓ validation checks it against the catalog    → PASSES (it is in there)
  ↓ runtime asks the router to resolve it       → NOT REGISTERED
```

Three steps, each locally correct, none of them ever asking the router.

## What changes

**Layer 1 — assignment.** `assign_from_catalog_dir_filtered` restricts candidates to `router.keys()`. When nothing in the catalog is registered it leaves the DOT unchanged — **correct, not a fallback**: `strong` is itself a router key, which is exactly what `available: ["cheap", "strong"]` in the original error was reporting. Rewriting it was the bug.

**Layer 5 — the validator.** *(Not in the issue's four layers.)* `with_resolvable_models` narrows the known-model set to what the router resolves, so pre-flight certifies **resolvability** rather than presence in a catalog. Before, it certified graphs that could not run; after #1902 those graphs stopped crashing and silently used the default provider instead — which is worse. Validation said yes, the run looked healthy, and the requested model was never used.

**Layer 4 — the message.** The rejection no longer says *"choose a model present in `model_catalog.json`"*. That was the most misleading advice available, because the rejected model **is** in the catalog and merely unregistered — it sent the reader to the wrong file. It now names the router and lists what actually resolves.

## Fails open, never stricter than reality

Both new paths keep the old catalog behaviour when there is no router, or it has no keys. Validation must not start rejecting working graphs just because it cannot see what is registered.

## Tests

| test | pins |
| --- | --- |
| `unregistered_catalog_models_are_never_assigned` | the root cause (layer 1) |
| `registered_catalog_models_survive_the_filter` | the filter does not disable assignment wholesale |
| `catalogued_but_unregistered_models_are_rejected` | the validator certifies resolvability (layer 5) |
| `an_absent_router_leaves_the_catalog_set_intact` | no router ⇒ no new strictness |
| `rejection_names_the_router_not_the_catalog` | the hint stops pointing at the wrong file (layer 4) |

## Verification

| gate | result |
| --- | --- |
| test functions removed vs `main` | **0** |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo test -p octos-pipeline` | 20 suites, all green |

## Relationship to #1902

#1902's runtime fallback **stays** as a safety net. With this merged it should stop firing in normal operation, which makes its `warn!` meaningful again rather than a constant for affected profiles.

This supersedes the closed #1903, which covered layer 1 only.
