### PR TITLE
fix(agent): make repeated enable_persistence calls cheap (#1906)

### DIFF
--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -1291,6 +1291,14 @@ impl TaskSupervisor {
 
     /// Enable append-only persistence for task snapshots and restore existing state.
     ///
+    /// Re-enabling with the SAME ledger path is a transparent no-op: every
+    /// mutation since the first enable has been appended through the normal
+    /// transition path, so the reload/resnapshot/sweep below would add
+    /// nothing — yet the skill-action job view/invoke paths re-enable on
+    /// every request over the shared session supervisor, and each such call
+    /// used to rewrite the whole ledger (#1906). A repeat returns the live
+    /// task total, exactly what a full run would report.
+    ///
     /// At the end of replay, sweeps the in-memory map for any task whose
     /// `runtime_state` is non-terminal (anything other than `Completed`,
     /// `Failed`, or `Cancelled`). Those tasks are orphans — the worker
@@ -1309,18 +1317,38 @@ impl TaskSupervisor {
     /// a heartbeat-based reaper, which is a follow-up if observed.
     pub fn enable_persistence(&self, path: impl Into<PathBuf>) -> std::io::Result<usize> {
         let path = path.into();
+        // Idempotence guard (#1906): already persisting to THIS ledger —
+        // nothing new to restore and nothing stale to re-append.
+        {
+            let guard = self
+                .persistence_path
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            if guard.as_ref() == Some(&path) {
+                return Ok(self.tasks.lock().unwrap_or_else(|e| e.into_inner()).len());
+            }
+        }
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
         let ledger_path = path.display().to_string();
         let restored = Self::load_persisted_tasks(&path)?;
+        // Rows whose DISK version won the merge (or that exist only on disk).
+        // They are already persisted verbatim, so the snapshot pass below
+        // must skip them — re-appending every restored row on each enable
+        // made a fresh supervisor's read-only restore grow the ledger by
+        // its full length per call (#1906). Tasks absent from this set
+        // (in-memory work scheduled before enable, or memory state newer
+        // than the ledger) are the only ones the snapshot pass writes.
+        let mut restored_won: HashSet<String> = HashSet::new();
         {
             let mut tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
             for (task_id, task) in restored {
                 match tasks.get(&task_id) {
                     Some(existing) if existing.updated_at >= task.updated_at => {}
                     _ => {
+                        restored_won.insert(task_id.clone());
                         tasks.insert(task_id, task);
                     }
                 }
@@ -1341,7 +1369,11 @@ impl TaskSupervisor {
 
         let snapshots: Vec<BackgroundTask> = {
             let tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
-            tasks.values().cloned().collect()
+            tasks
+                .values()
+                .filter(|task| !restored_won.contains(&task.id))
+                .cloned()
+                .collect()
         };
         for task in snapshots {
             self.persist_snapshot(&task);

--- a/crates/octos-agent/src/task_supervisor_tests.rs
+++ b/crates/octos-agent/src/task_supervisor_tests.rs
@@ -970,6 +970,92 @@ fn should_restore_completed_and_failed_truth_after_restart() {
     assert!(failed_task.child_joined_at.is_none());
 }
 
+fn ledger_line_count(path: &std::path::Path) -> usize {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .count()
+}
+
+#[test]
+fn should_not_rewrite_ledger_when_reenabling_same_path() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let ledger_path = dir.path().join("tasks.jsonl");
+
+    let supervisor = TaskSupervisor::new();
+    supervisor.enable_persistence(&ledger_path).unwrap();
+    let task_id = supervisor.register_with_lineage("search", "call-1", Some("api:session"), None);
+    supervisor.mark_completed(&task_id, vec![]);
+
+    let lines_after_first_enable = ledger_line_count(&ledger_path);
+
+    // The skill-action job view/invoke paths re-enable persistence on the
+    // SHARED session supervisor on every request (#1906). With persistence
+    // already on for this ledger, everything since has been appended
+    // through the normal transition path — a repeat enable must be a
+    // no-op, not a full snapshot rewrite.
+    let restored = supervisor.enable_persistence(&ledger_path).unwrap();
+    assert_eq!(
+        restored, 1,
+        "repeat enable returns the live task total, same as a full enable"
+    );
+    assert_eq!(
+        ledger_line_count(&ledger_path),
+        lines_after_first_enable,
+        "same-path re-enable must not append snapshots"
+    );
+}
+
+#[test]
+fn should_not_reappend_restored_rows_when_fresh_supervisor_loads_ledger() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let ledger_path = dir.path().join("tasks.jsonl");
+
+    let supervisor = TaskSupervisor::new();
+    supervisor.enable_persistence(&ledger_path).unwrap();
+    let done = supervisor.register_with_lineage("fm_tts", "call-1", Some("api:session"), None);
+    supervisor.mark_completed(&done, vec![]);
+    let lines_before = ledger_line_count(&ledger_path);
+
+    // A fresh supervisor that only RESTORES an existing ledger (the
+    // skill-action list path builds one per request) must not re-append
+    // snapshots for rows it just read — they are already on disk.
+    let restored = TaskSupervisor::new();
+    let count = restored.enable_persistence(&ledger_path).unwrap();
+    assert_eq!(count, 1);
+    assert_eq!(restored.get_all_tasks().len(), 1);
+    assert_eq!(
+        ledger_line_count(&ledger_path),
+        lines_before,
+        "read-only restore must leave the ledger untouched"
+    );
+}
+
+#[test]
+fn should_persist_preexisting_in_memory_tasks_when_enabling_persistence() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let ledger_path = dir.path().join("tasks.jsonl");
+
+    // A task scheduled BEFORE persistence is enabled (the startup window
+    // the snapshot loop exists for) must still land on disk.
+    let supervisor = TaskSupervisor::new();
+    let task_id = supervisor.register_with_lineage("search", "call-1", Some("api:session"), None);
+    supervisor.mark_completed(&task_id, vec![]);
+    assert_eq!(ledger_line_count(&ledger_path), 0, "nothing persisted yet");
+
+    supervisor.enable_persistence(&ledger_path).unwrap();
+    assert!(
+        ledger_line_count(&ledger_path) > 0,
+        "pre-existing in-memory task must be persisted on enable"
+    );
+
+    let restored = TaskSupervisor::new();
+    restored.enable_persistence(&ledger_path).unwrap();
+    assert_eq!(restored.get_all_tasks().len(), 1);
+    assert_eq!(restored.get_all_tasks()[0].id, task_id);
+}
+
 #[test]
 fn should_pass_through_mark_completed_for_skill_reported_files() {
     // Supervisor no longer validates artifact content — it records the


### PR DESCRIPTION
Closes #1906.

## Problem

`TaskSupervisor::enable_persistence` is designed as a startup-only operation, but the skill-action job paths call it on **every request**:

- `raw_skill_action_invoke` (ui_protocol.rs:11738) and `load_skill_action_job_view` (ui_protocol.rs:11820) on the shared session supervisor
- `load_skill_action_jobs` (skill_action_jobs.rs:160) building a fresh supervisor per call

Each call re-read the whole JSONL ledger and **unconditionally re-appended a snapshot per task** — every poll grew the ledger by its full length, and the next read paid for all of it: quadratic growth in file size and replay latency over a session's lifetime.

## Fix (semantics preserved)

1. **Same-path re-enable is a transparent no-op.** With persistence already on for that ledger, every mutation since has been appended through the normal transition path, so reload/resnapshot/sweep adds nothing. Returns the live task total — exactly what a full run would report, so callers see no difference.
2. **The post-merge snapshot pass skips rows whose disk version won the merge** (or that exist only on disk) — they're already persisted verbatim. Only in-memory work scheduled before enable (the startup window the pass exists for) or memory state newer than the ledger gets written.

The **orphan sweep is unchanged**: first enable still reaps prior-process orphans (the behavior the skill-action restore path deliberately relies on), and the existing liveness gate keeps live in-process tasks safe on any path.

## Tests

Three new tests in `task_supervisor_tests.rs`:

- `should_not_rewrite_ledger_when_reenabling_same_path` — repeat enable leaves the ledger line count untouched
- `should_not_reappend_restored_rows_when_fresh_supervisor_loads_ledger` — a fresh supervisor's read-only restore appends nothing
- `should_persist_preexisting_in_memory_tasks_when_enabling_persistence` — pre-enable in-memory tasks still land on disk (startup contract)

## Verification

- `task_supervisor` tests: 105/105
- `octos-agent` lib: 2512 passed / 1 flaky (`plugins::tool` metadata test — green in isolation, untouched by this change)
- `octos-cli --features api` skill_action: 27/27
- `cargo fmt --all -- --check` + `clippy` clean

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>