### PR TITLE
fix(acp): replay + sanitize + de-race session/load, un-nest session store

### DIFF
--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -312,6 +312,40 @@ struct AcpBootstrap {
     skill_read_zones: Vec<PathBuf>,
 }
 
+/// Open the ACP session store, degrading to `None` with a loud log rather than
+/// failing the agent: an unpersisted session is worse than a persisted one and
+/// far better than none. Silent non-persistence is the bug this exists to fix,
+/// so it must not be reintroduced here.
+///
+/// Rooted at `data_dir` itself — the SAME root gateway/serve/api_channel hand
+/// [`SessionManager::open`], because it appends its own `sessions/` segment.
+/// Pre-joining `sessions/` here nested ACP transcripts at
+/// `sessions/sessions/`, where no other surface (and no fixed build) would
+/// ever look (#1909).
+fn open_acp_session_store(data_dir: &std::path::Path) -> Option<Arc<Mutex<SessionManager>>> {
+    // Heads-up for transcripts written by the nested-path bug: they stay put —
+    // moving them across the store's flat/users layouts is riskier than
+    // leaving them for manual cleanup.
+    let legacy = data_dir.join("sessions").join("sessions");
+    if legacy.is_dir() {
+        tracing::warn!(
+            path = %legacy.display(),
+            "found ACP transcripts written under the pre-#1909 nested \
+             sessions/sessions path; they are NOT loaded — move or delete them manually"
+        );
+    }
+    match SessionManager::open(data_dir) {
+        Ok(store) => Some(Arc::new(Mutex::new(store))),
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                "session store unavailable; ACP conversations will NOT survive a restart"
+            );
+            None
+        }
+    }
+}
+
 impl AcpSharedStores {
     /// Open the process-global stores + build the failover provider chain. Runs
     /// exactly once; the redb episode store is opened here and never re-opened.
@@ -373,20 +407,7 @@ impl AcpSharedStores {
             embedder,
             agent_config,
             memory_refresh_enabled,
-            // Degrades to None with a loud log rather than failing the agent: an
-            // unpersisted session is worse than a persisted one and far better
-            // than none. Silent non-persistence is the bug this exists to fix,
-            // so it must not be reintroduced here.
-            sessions_store: match SessionManager::open(&data_dir.join("sessions")) {
-                Ok(store) => Some(Arc::new(Mutex::new(store))),
-                Err(e) => {
-                    tracing::error!(
-                        error = %e,
-                        "session store unavailable; ACP conversations will NOT survive a restart"
-                    );
-                    None
-                }
-            },
+            sessions_store: open_acp_session_store(&data_dir),
             max_inject_tokens,
             data_dir,
             config,
@@ -884,8 +905,9 @@ async fn spawn_acp_agent(
         // session/load: rebuild a session and replay its stored history, so a
         // conversation survives a crash or a supervisor restart.
         .on_receive_request(
-            async move |req: LoadSessionRequest, responder, _cx: ConnectionTo<Client>| {
-                match handle_load_session(factory_for_load.as_ref(), &sessions_for_load, req).await
+            async move |req: LoadSessionRequest, responder, cx: ConnectionTo<Client>| {
+                match handle_load_session(factory_for_load.as_ref(), &sessions_for_load, req, &cx)
+                    .await
                 {
                     Ok(resp) => responder.respond(resp),
                     Err(err) => responder.respond_with_error(err),
@@ -1165,7 +1187,9 @@ fn handle_prompt(
     responder: agent_client_protocol::Responder<PromptResponse>,
 ) -> std::result::Result<(), AcpError> {
     // Look up the session synchronously (try_lock avoids awaiting in the
-    // dispatch loop; the map is only briefly held by session/new + cancel).
+    // dispatch loop; session/new + cancel hold the map only briefly, while
+    // session/load holds it across its build — contended prompts take the
+    // deferred path below and resolve inside the spawned turn task).
     let session = {
         let map = match sessions.try_lock() {
             Ok(map) => map,
@@ -1430,7 +1454,39 @@ async fn handle_load_session(
     factory: &dyn SessionAgentFactory,
     sessions: &SessionMap,
     req: LoadSessionRequest,
+    cx: &ConnectionTo<Client>,
 ) -> std::result::Result<LoadSessionResponse, AcpError> {
+    let history = load_session_locked(factory, sessions, &req).await?;
+    // The response carries no history — ACP expects the transcript replayed as
+    // `session/update` notifications BEFORE the load resolves, or a
+    // reconnecting client renders an empty conversation (#1909).
+    replay_history(cx, &req.session_id, &history);
+    Ok(LoadSessionResponse::default())
+}
+
+/// The restore half of `session/load`: resolve (or rebuild) the session and
+/// return the transcript the caller must replay to the client.
+async fn load_session_locked(
+    factory: &dyn SessionAgentFactory,
+    sessions: &SessionMap,
+    req: &LoadSessionRequest,
+) -> std::result::Result<Vec<octos_core::Message>, AcpError> {
+    // ONE map lock across check → build → restore → insert (#1909). The old
+    // contains_key → build().await → insert sequence dropped the guard
+    // between check and insert, so a concurrent load of the same id slipped
+    // past the emptiness check while the first was still building and then
+    // OVERWROTE its session — evicting the `shutdown` flag an in-flight turn
+    // could be watching, the exact harm the already-live branch exists to
+    // prevent. Holding the lock makes a racing load observe the live session
+    // instead of replacing it (and keeps it from double-building an agent,
+    // whose second redb open would fail outright).
+    //
+    // Contention is safe by construction: `factory.build` and the store read
+    // never re-acquire THIS map, prompt lookup uses try_lock with a deferred
+    // fallback, and cancel/new only wait for the lock. Lock ordering here is
+    // map → history → store; no path takes those in reverse.
+    let mut map = sessions.lock().await;
+
     // Never replace a session that is already live, and do not build an agent we
     // would then discard.
     //
@@ -1442,12 +1498,15 @@ async fn handle_load_session(
     //
     // The check comes first because factory.build() opens the episode store, and a
     // second open on a live session fails on the redb lock.
-    if sessions.lock().await.contains_key(&req.session_id) {
+    //
+    // The live session's OWN history is what gets replayed — a client that
+    // re-loads an active id still expects the transcript back.
+    if let Some(live) = map.get(&req.session_id) {
         tracing::info!(
             session = %req.session_id.0,
             "session/load for an already-active session; keeping the live one"
         );
-        return Ok(LoadSessionResponse::default());
+        return Ok(live.history.lock().await.clone());
     }
 
     let cwd = if req.cwd.as_os_str().is_empty() {
@@ -1477,12 +1536,39 @@ async fn handle_load_session(
             let guard = store.lock().await;
             match guard.load(&session_key).await {
                 Some(stored) => {
-                    tracing::info!(
-                        session = %session_key.0,
-                        messages = stored.messages.len(),
-                        "restored an ACP session from the store"
-                    );
-                    stored.messages
+                    // Sanitize BEFORE the transcript touches an LLM or a client
+                    // (#1909). The store is append-only JSONL, so a crash can
+                    // leave residue the provider rejects (an assistant tool_call
+                    // whose result never landed → 400 on the next turn) or that
+                    // replays as UI debris (orphaned thinking-only rows,
+                    // whitespace-only rows, a tool card that never completes).
+                    // Every other resume path runs this same ResumePolicy.
+                    //
+                    // workspace_root is None deliberately: ResumePolicy's
+                    // worktree check writes an mtime marker into the root —
+                    // right for agent-managed worktrees, wrong for the user's
+                    // own project dir an ACP client points at (it would dirty
+                    // git status on every load).
+                    match octos_bus::ResumePolicy::sanitize(stored.messages, None, None) {
+                        Ok(outcome) => {
+                            tracing::info!(
+                                session = %session_key.0,
+                                report = %outcome.report,
+                                "restored an ACP session from the store"
+                            );
+                            outcome.messages
+                        }
+                        Err(error) => {
+                            // Only WorktreeMissing can fail, and only when a
+                            // workspace_root is provided — unreachable with None
+                            // above. If a future variant appears, refuse the
+                            // load loudly rather than resume a transcript the
+                            // policy judged unsafe.
+                            return Err(agent_client_protocol::util::internal_error(format!(
+                                "transcript sanitize refused resume: {error}"
+                            )));
+                        }
+                    }
                 }
                 None => {
                     tracing::warn!(
@@ -1503,16 +1589,13 @@ async fn handle_load_session(
         agent,
         session_key,
         session_store,
-        history: Mutex::new(history),
+        history: Mutex::new(history.clone()),
         shutdown,
     });
 
-    sessions
-        .lock()
-        .await
-        .insert(req.session_id.clone(), session);
+    map.insert(req.session_id.clone(), session);
 
-    Ok(LoadSessionResponse::default())
+    Ok(history)
 }
 
 /// Generate a fresh, unique ACP session id.
@@ -1691,9 +1774,270 @@ pub(crate) fn project_progress_event_deduped(
     progress_event_to_acp(event)
 }
 
+/// Project one stored transcript row into the `session/update` sequence that
+/// rebuilds it client-side on `session/load`. Pure counterpart of
+/// [`progress_event_to_acp`] for the replay path.
+///
+/// Mapping:
+/// - User text             -> `UserMessageChunk`
+/// - Assistant reasoning   -> `AgentThoughtChunk` (before the text chunk)
+/// - Assistant text        -> `AgentMessageChunk`
+/// - Assistant tool_calls  -> `ToolCall` (InProgress), one per call
+/// - Tool result           -> `ToolCallUpdate` (Completed + output)
+/// - System / empty rows   -> nothing (system prompts are agent-side context,
+///   not user-visible transcript; empty chunks render as blank bubbles)
+fn message_to_replay_updates(message: &octos_core::Message) -> Vec<SessionUpdate> {
+    let chunk = |text: &str| ContentChunk::new(ContentBlock::from(text.to_string()));
+    match message.role {
+        octos_core::MessageRole::User => {
+            if message.content.trim().is_empty() {
+                Vec::new()
+            } else {
+                vec![SessionUpdate::UserMessageChunk(chunk(&message.content))]
+            }
+        }
+        octos_core::MessageRole::Assistant => {
+            let mut updates = Vec::new();
+            if let Some(reasoning) = message.reasoning_content.as_deref() {
+                if !reasoning.trim().is_empty() {
+                    updates.push(SessionUpdate::AgentThoughtChunk(chunk(reasoning)));
+                }
+            }
+            if !message.content.trim().is_empty() {
+                updates.push(SessionUpdate::AgentMessageChunk(chunk(&message.content)));
+            }
+            if let Some(calls) = message.tool_calls.as_ref() {
+                for call in calls {
+                    updates.push(SessionUpdate::ToolCall(
+                        ToolCall::new(call.id.clone(), call.name.clone())
+                            .kind(tool_kind_for(&call.name))
+                            .status(ToolCallStatus::InProgress),
+                    ));
+                }
+            }
+            updates
+        }
+        octos_core::MessageRole::Tool => {
+            let Some(tool_call_id) = message.tool_call_id.clone() else {
+                return Vec::new();
+            };
+            let mut fields = ToolCallUpdateFields::new().status(ToolCallStatus::Completed);
+            if !message.content.is_empty() {
+                fields = fields.content(vec![ToolCallContent::from(ContentBlock::from(
+                    message.content.clone(),
+                ))]);
+            }
+            vec![SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+                tool_call_id,
+                fields,
+            ))]
+        }
+        // System rows (base prompt, compaction summaries) and anything else.
+        _ => Vec::new(),
+    }
+}
+
+/// Replay a loaded transcript to the client as `session/update` notifications.
+///
+/// ACP REQUIRES this on `session/load`: the response carries no history, so
+/// without the replay a reconnecting client renders an empty conversation even
+/// though the agent restored it (#1909). Best-effort per frame — a send
+/// failure is logged, never fatal to the load.
+fn replay_history(
+    cx: &ConnectionTo<Client>,
+    session_id: &SessionId,
+    history: &[octos_core::Message],
+) {
+    let mut sent = 0usize;
+    for message in history {
+        for update in message_to_replay_updates(message) {
+            let notif = SessionNotification::new(session_id.clone(), update);
+            if let Err(err) = cx.send_notification(notif) {
+                tracing::warn!(error = %err, "failed to send ACP session/update during load replay");
+            } else {
+                sent += 1;
+            }
+        }
+    }
+    if sent > 0 {
+        tracing::info!(
+            session = %session_id.0,
+            frames = sent,
+            "replayed an ACP transcript on session/load"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A stored user message, thread-stamped the way `run_prompt_turn` stamps
+    /// every row of a turn (the store is fail-closed for unstamped rows).
+    fn stored_user(content: &str, thread: &str) -> octos_core::Message {
+        octos_core::Message {
+            role: octos_core::MessageRole::User,
+            content: content.into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: Some(thread.into()),
+            timestamp: chrono::Utc::now(),
+        }
+    }
+
+    /// #1909: the ACP store must be rooted at the SAME dir gateway / serve /
+    /// api_channel hand `SessionManager::open` (which appends its own
+    /// `sessions/` segment). ACP pre-joined `sessions/`, nesting transcripts
+    /// at `sessions/sessions/` where no other surface — and no fixed build —
+    /// would ever look.
+    #[tokio::test]
+    async fn should_share_session_store_layout_with_other_surfaces() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = SessionKey::with_profile(octos_core::MAIN_PROFILE_ID, "acp", "layout-check");
+
+        let store = open_acp_session_store(dir.path()).expect("ACP store opens");
+        {
+            let mut guard = store.lock().await;
+            guard
+                .add_message(&key, stored_user("hello", "t-layout"))
+                .await
+                .expect("message persists");
+        }
+
+        // The gateway/serve way of opening the SAME store must see the row.
+        let other = SessionManager::open(dir.path()).expect("gateway-style open");
+        let saw = other
+            .load(&key)
+            .await
+            .map(|s| s.messages.iter().any(|m| m.content == "hello"))
+            .unwrap_or(false);
+        assert!(
+            saw,
+            "a store opened the gateway/serve way must see ACP transcripts \
+             (sessions/sessions nesting, #1909)"
+        );
+    }
+
+    /// A stored assistant message, thread-stamped like [`stored_user`].
+    fn stored_assistant(content: &str, thread: &str) -> octos_core::Message {
+        octos_core::Message {
+            role: octos_core::MessageRole::Assistant,
+            content: content.into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: Some(thread.into()),
+            timestamp: chrono::Utc::now(),
+        }
+    }
+
+    fn replay_text(update: &SessionUpdate) -> Option<&str> {
+        match update {
+            SessionUpdate::UserMessageChunk(c)
+            | SessionUpdate::AgentMessageChunk(c)
+            | SessionUpdate::AgentThoughtChunk(c) => match &c.content {
+                ContentBlock::Text(t) => Some(&t.text),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn should_map_user_message_to_user_message_chunk_when_replaying_history() {
+        let updates = message_to_replay_updates(&stored_user("USER_TEXT", "t"));
+        assert_eq!(updates.len(), 1);
+        assert!(
+            matches!(updates[0], SessionUpdate::UserMessageChunk(_)),
+            "user rows replay as UserMessageChunk, got {:?}",
+            updates[0]
+        );
+        assert_eq!(replay_text(&updates[0]), Some("USER_TEXT"));
+    }
+
+    #[test]
+    fn should_map_assistant_reasoning_then_text_when_replaying_history() {
+        let mut msg = stored_assistant("ASSISTANT_TEXT", "t");
+        msg.reasoning_content = Some("THOUGHT".into());
+        let updates = message_to_replay_updates(&msg);
+        assert_eq!(updates.len(), 2);
+        assert!(
+            matches!(updates[0], SessionUpdate::AgentThoughtChunk(_)),
+            "reasoning replays first, as a thought chunk: {:?}",
+            updates[0]
+        );
+        assert!(
+            matches!(updates[1], SessionUpdate::AgentMessageChunk(_)),
+            "the visible reply replays as a message chunk: {:?}",
+            updates[1]
+        );
+        assert_eq!(replay_text(&updates[0]), Some("THOUGHT"));
+        assert_eq!(replay_text(&updates[1]), Some("ASSISTANT_TEXT"));
+    }
+
+    #[test]
+    fn should_map_tool_call_and_result_to_call_then_completed_update_when_replaying() {
+        let mut call_msg = stored_assistant("", "t");
+        call_msg.tool_calls = Some(vec![octos_core::ToolCall {
+            id: "call-1".into(),
+            name: "shell".into(),
+            arguments: serde_json::json!({}),
+            metadata: None,
+        }]);
+        let updates = message_to_replay_updates(&call_msg);
+        assert_eq!(updates.len(), 1, "one ToolCall frame per call");
+        match &updates[0] {
+            SessionUpdate::ToolCall(call) => {
+                assert_eq!(call.tool_call_id.0.as_ref(), "call-1");
+                assert_eq!(call.title, "shell");
+                assert!(matches!(call.status, ToolCallStatus::InProgress));
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
+
+        let mut result_msg = stored_assistant("OUTPUT", "t");
+        result_msg.role = octos_core::MessageRole::Tool;
+        result_msg.tool_call_id = Some("call-1".into());
+        let updates = message_to_replay_updates(&result_msg);
+        assert_eq!(updates.len(), 1);
+        match &updates[0] {
+            SessionUpdate::ToolCallUpdate(u) => {
+                assert_eq!(u.tool_call_id.0.as_ref(), "call-1");
+                assert!(matches!(u.fields.status, Some(ToolCallStatus::Completed)));
+                let content = u.fields.content.as_ref().expect("output content present");
+                assert_eq!(content.len(), 1);
+            }
+            other => panic!("expected ToolCallUpdate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_skip_system_and_empty_messages_when_replaying_history() {
+        let mut system = stored_user("BASE PROMPT", "t");
+        system.role = octos_core::MessageRole::System;
+        system.thread_id = None;
+        assert!(
+            message_to_replay_updates(&system).is_empty(),
+            "system rows are agent-side context, not replayed transcript"
+        );
+        assert!(
+            message_to_replay_updates(&stored_user("   ", "t")).is_empty(),
+            "whitespace-only user rows render as blank bubbles — skip"
+        );
+        assert!(
+            message_to_replay_updates(&stored_assistant("", "t")).is_empty(),
+            "payload-free assistant rows produce no frames"
+        );
+        // A tool-result row with no tool_call_id is malformed — skip, don't panic.
+        let mut orphan = stored_assistant("OUTPUT", "t");
+        orphan.role = octos_core::MessageRole::Tool;
+        assert!(message_to_replay_updates(&orphan).is_empty());
+    }
 
     /// The ACP assembler wires the long-term memory bank (chat parity), so the
     /// agent is no longer a bare-builtins skeleton. Exercises the real
@@ -2463,6 +2807,131 @@ mod tests {
             !fresh.iter().any(|c| c.contains("done")),
             "the cancelled turn's aborted assistant reply must NOT persist into the \
              fresh prompt's history; fresh-turn messages: {fresh:?}"
+        );
+    }
+
+    /// Factory whose FIRST `build()` blocks until the test releases it
+    /// (announcing entry first), so two concurrent `session/load`s interleave
+    /// deterministically: load #1 provably inside `build()` while load #2
+    /// arrives. `builds` counts invocations — the race is observable as
+    /// `builds > 1`, no sleep-based guessing on the outcome side.
+    struct GatedBuildFactory {
+        llm: Arc<dyn octos_llm::LlmProvider>,
+        memory_dir: PathBuf,
+        default_cwd: PathBuf,
+        builds: Arc<std::sync::atomic::AtomicUsize>,
+        first_build_entered: Arc<tokio::sync::Notify>,
+        release_first_build: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl SessionAgentFactory for GatedBuildFactory {
+        fn default_cwd(&self) -> &std::path::Path {
+            &self.default_cwd
+        }
+        async fn build(&self, cwd: PathBuf) -> Result<(Arc<Agent>, Arc<AtomicBool>)> {
+            if self.builds.fetch_add(1, Ordering::SeqCst) == 0 {
+                self.first_build_entered.notify_one();
+                self.release_first_build.notified().await;
+            }
+            let memory = Arc::new(EpisodeStore::open(&self.memory_dir).await?);
+            let tools = ToolRegistry::with_builtins_and_sandbox(
+                &cwd,
+                create_sandbox(&octos_agent::SandboxConfig::default()),
+            );
+            let shutdown = Arc::new(AtomicBool::new(false));
+            let agent = Agent::new(
+                AgentId::new("acp-race-test"),
+                self.llm.clone(),
+                tools,
+                memory,
+            )
+            .with_shutdown(shutdown.clone());
+            Ok((Arc::new(agent), shutdown))
+        }
+    }
+
+    /// #1909: two concurrent `session/load`s for the same id must not both
+    /// build. The old contains_key → build().await → insert sequence dropped
+    /// the map guard between check and insert, so load #2 slipped past the
+    /// emptiness check while load #1 was still building and then OVERWROTE
+    /// #1's session — evicting the `shutdown` flag an in-flight turn could be
+    /// watching, the exact harm the already-live branch exists to prevent.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn should_not_build_twice_when_concurrent_loads_race() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cwd = tmp.path().to_path_buf();
+        let memory_dir = tmp.path().join("memory");
+        std::fs::create_dir_all(&memory_dir).unwrap();
+
+        let llm: Arc<dyn octos_llm::LlmProvider> = Arc::new(BarrierLlm {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            // Never exercised: no prompt turn runs in this test, so chat()
+            // is never called and the barrier branch never triggers.
+            entered: Arc::new(tokio::sync::Notify::new()),
+            release: Arc::new(tokio::sync::Notify::new()),
+            seen: Arc::new(Mutex::new(Vec::new())),
+        });
+        let builds = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let factory = Arc::new(GatedBuildFactory {
+            llm,
+            memory_dir,
+            default_cwd: cwd.clone(),
+            builds: builds.clone(),
+            first_build_entered: entered.clone(),
+            release_first_build: release.clone(),
+        });
+        let sessions: SessionMap = Arc::new(Mutex::new(HashMap::new()));
+        let sid = SessionId::new("race-me");
+        let req = LoadSessionRequest::new(sid.clone(), cwd.clone());
+
+        // Load #1: runs until its build is gated.
+        let load_one = {
+            let factory = factory.clone();
+            let sessions = sessions.clone();
+            let req = req.clone();
+            tokio::spawn(
+                async move { load_session_locked(factory.as_ref(), &sessions, &req).await },
+            )
+        };
+        // Wait until #1 is provably INSIDE build(), then fire load #2.
+        entered.notified().await;
+        let load_two = {
+            let factory = factory.clone();
+            let sessions = sessions.clone();
+            let req = req.clone();
+            tokio::spawn(
+                async move { load_session_locked(factory.as_ref(), &sessions, &req).await },
+            )
+        };
+
+        // Give #2 every chance to sneak past the check: it must not start a
+        // second build while #1 is in flight.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert_eq!(
+            builds.load(Ordering::SeqCst),
+            1,
+            "load #2 started a second agent build while load #1 was still building"
+        );
+
+        release.notify_one();
+        let r1 = load_one.await.expect("load #1 task joins");
+        let r2 = load_two.await.expect("load #2 task joins");
+        assert!(r1.is_ok(), "load #1 succeeds: {r1:?}");
+        assert!(
+            r2.is_ok(),
+            "load #2 must also succeed (as a no-op over the live session): {r2:?}"
+        );
+        assert_eq!(
+            builds.load(Ordering::SeqCst),
+            1,
+            "exactly one agent built across the racing loads"
+        );
+        assert!(
+            sessions.lock().await.contains_key(&sid),
+            "the winning load's session is the one that stays live"
         );
     }
 }

--- a/crates/octos-cli/tests/acp_integration.rs
+++ b/crates/octos-cli/tests/acp_integration.rs
@@ -121,6 +121,17 @@ fn agent_message_text(update: &SessionUpdate) -> Option<String> {
     }
 }
 
+/// Pull the text out of a user-message `session/update`, if that's what it is.
+fn user_message_text(update: &SessionUpdate) -> Option<String> {
+    match update {
+        SessionUpdate::UserMessageChunk(chunk) => match &chunk.content {
+            ContentBlock::Text(t) => Some(t.text.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn should_stream_assistant_message_and_end_turn_when_driven_through_acp_initialize_new_session_prompt()
  {
@@ -566,6 +577,117 @@ async fn should_restore_a_conversation_through_session_load() {
     );
 }
 
+/// #1909: `session/load` must REPLAY the restored transcript as `session/update`
+/// notifications — the response carries no history, so without a replay a
+/// reconnecting client renders an empty conversation even though the agent
+/// restored it (the client then prompts from zero context and the agent
+/// answers as if it forgot everything).
+///
+/// Same two-transport shape as `should_restore_a_conversation_through_session_load`,
+/// but the second client RECORDS the updates and asserts the earlier turns were
+/// replayed by the time `session/load` responded.
+#[tokio::test]
+async fn should_replay_stored_history_as_session_updates_on_load() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cwd = tmp.path().to_path_buf();
+    let memory_dir = tmp.path().join("memory");
+    let sessions_dir = tmp.path().join("sessions");
+    std::fs::create_dir_all(&memory_dir).unwrap();
+
+    // ---- first process: one persisted turn ----
+    let llm_one: Arc<dyn octos_llm::LlmProvider> = Arc::new(MockLlm {
+        reply: "REMEMBER_THIS".to_string(),
+    });
+    let factory_one = TestAgentFactory::new(llm_one, memory_dir.clone(), cwd.clone())
+        .with_session_store(&sessions_dir);
+
+    let cwd_one = cwd.clone();
+    let session_id = Client
+        .builder()
+        .name("octos-acp-replay-1")
+        .on_receive_notification(
+            async move |_n: SessionNotification,
+                        _cx: ConnectionTo<agent_client_protocol::Agent>| Ok(()),
+            agent_client_protocol::on_receive_notification!(),
+        )
+        .connect_with(
+            OctosAcpAgentTransport::new(factory_one),
+            |connection: ConnectionTo<agent_client_protocol::Agent>| async move {
+                connection
+                    .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                    .block_task()
+                    .await?;
+                let new_session = connection
+                    .send_request(NewSessionRequest::new(cwd_one.clone()))
+                    .block_task()
+                    .await?;
+                let id = new_session.session_id.clone();
+                connection
+                    .send_request(PromptRequest::new(
+                        id.clone(),
+                        vec![ContentBlock::from("FIRST_QUESTION")],
+                    ))
+                    .block_task()
+                    .await?;
+                Ok::<_, agent_client_protocol::Error>(id)
+            },
+        )
+        .await
+        .expect("first session");
+
+    // ---- second process: same store, load, recording every session/update ----
+    let llm_two: Arc<dyn octos_llm::LlmProvider> = Arc::new(MockLlm {
+        reply: "SECOND_REPLY".to_string(),
+    });
+    let factory_two =
+        TestAgentFactory::new(llm_two, memory_dir, cwd.clone()).with_session_store(&sessions_dir);
+
+    let updates: Arc<Mutex<Vec<SessionUpdate>>> = Arc::new(Mutex::new(Vec::new()));
+    let updates_for_handler = updates.clone();
+    let id_two = session_id.clone();
+    let cwd_two = cwd.clone();
+    Client
+        .builder()
+        .name("octos-acp-replay-2")
+        .on_receive_notification(
+            async move |n: SessionNotification, _cx: ConnectionTo<agent_client_protocol::Agent>| {
+                updates_for_handler.lock().await.push(n.update);
+                Ok(())
+            },
+            agent_client_protocol::on_receive_notification!(),
+        )
+        .connect_with(
+            OctosAcpAgentTransport::new(factory_two),
+            |connection: ConnectionTo<agent_client_protocol::Agent>| async move {
+                connection
+                    .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                    .block_task()
+                    .await?;
+                // By the time session/load RESPONDS, the replay must have
+                // landed — the frames precede the response on the connection.
+                connection
+                    .send_request(LoadSessionRequest::new(id_two.clone(), cwd_two.clone()))
+                    .block_task()
+                    .await?;
+                Ok::<_, agent_client_protocol::Error>(())
+            },
+        )
+        .await
+        .expect("second session");
+
+    let recorded = updates.lock().await;
+    let user_texts: Vec<String> = recorded.iter().filter_map(user_message_text).collect();
+    let agent_texts: Vec<String> = recorded.iter().filter_map(agent_message_text).collect();
+    assert!(
+        user_texts.iter().any(|t| t.contains("FIRST_QUESTION")),
+        "session/load must replay the user turn as a UserMessageChunk; recorded: {recorded:?}"
+    );
+    assert!(
+        agent_texts.iter().any(|t| t.contains("REMEMBER_THIS")),
+        "session/load must replay the assistant turn as an AgentMessageChunk; recorded: {recorded:?}"
+    );
+}
+
 /// `session/load` must not evict a session that is already live.
 ///
 /// A bare insert dropped the existing entry and with it the `shutdown` flag an
@@ -645,5 +767,153 @@ async fn should_not_evict_a_live_session_on_reload() {
     assert!(
         joined.contains("TURN_ONE"),
         "reloading a live session lost its history; saw: {joined}"
+    );
+}
+
+/// #1909: a stored transcript must be SANITIZED on load, before it touches the
+/// LLM or the client. The store is append-only JSONL, so a crash can leave an
+/// assistant tool_call whose result never landed — feeding that back to the
+/// provider is a 400 ("tool_use without tool_result"), and replaying it renders
+/// a tool card that never completes in the client. Every other resume path runs
+/// `ResumePolicy`; ACP's `session/load` must too.
+#[tokio::test]
+async fn should_sanitize_stored_history_when_loading_a_session() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cwd = tmp.path().to_path_buf();
+    let memory_dir = tmp.path().join("memory");
+    let sessions_dir = tmp.path().join("sessions");
+    std::fs::create_dir_all(&memory_dir).unwrap();
+
+    let session_id = agent_client_protocol::schema::v1::SessionId::new("octos-seeded");
+    let key = octos_core::SessionKey::with_profile(
+        octos_core::MAIN_PROFILE_ID,
+        "acp",
+        session_id.0.as_ref(),
+    );
+
+    // Seed the store directly: one healthy user + assistant pair, one assistant
+    // tool_call with NO matching result (crash residue), one whitespace-only
+    // assistant row. All thread-stamped so the fail-closed write path accepts
+    // them.
+    {
+        let mut mgr = octos_bus::session::SessionManager::open(&sessions_dir).expect("open store");
+        let msg = |role: octos_core::MessageRole, content: &str| octos_core::Message {
+            role,
+            content: content.into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: Some("t-seed".into()),
+            timestamp: chrono::Utc::now(),
+        };
+        mgr.add_message(&key, msg(octos_core::MessageRole::User, "SEED_USER"))
+            .await
+            .expect("user row");
+        let mut ghost = msg(octos_core::MessageRole::Assistant, "");
+        ghost.tool_calls = Some(vec![octos_core::ToolCall {
+            id: "ghost-call".into(),
+            name: "shell".into(),
+            arguments: serde_json::json!({}),
+            metadata: None,
+        }]);
+        mgr.add_message(&key, ghost)
+            .await
+            .expect("ghost tool-call row");
+        mgr.add_message(&key, msg(octos_core::MessageRole::Assistant, "   "))
+            .await
+            .expect("whitespace row");
+        mgr.add_message(
+            &key,
+            msg(octos_core::MessageRole::Assistant, "SEED_ASSISTANT"),
+        )
+        .await
+        .expect("assistant row");
+    }
+
+    let seen: Arc<Mutex<Vec<Vec<String>>>> = Arc::new(Mutex::new(Vec::new()));
+    let llm: Arc<dyn octos_llm::LlmProvider> = Arc::new(RecordingLlm {
+        seen: seen.clone(),
+        replies: vec!["AFTER_LOAD".to_string()],
+        calls: std::sync::atomic::AtomicUsize::new(0),
+    });
+    let factory =
+        TestAgentFactory::new(llm, memory_dir, cwd.clone()).with_session_store(&sessions_dir);
+
+    let updates: Arc<Mutex<Vec<SessionUpdate>>> = Arc::new(Mutex::new(Vec::new()));
+    let updates_for_handler = updates.clone();
+    let id_for_client = session_id.clone();
+    let cwd_for_client = cwd.clone();
+    Client
+        .builder()
+        .name("octos-acp-sanitize-client")
+        .on_receive_notification(
+            async move |n: SessionNotification, _cx: ConnectionTo<agent_client_protocol::Agent>| {
+                updates_for_handler.lock().await.push(n.update);
+                Ok(())
+            },
+            agent_client_protocol::on_receive_notification!(),
+        )
+        .connect_with(
+            OctosAcpAgentTransport::new(factory),
+            |connection: ConnectionTo<agent_client_protocol::Agent>| async move {
+                connection
+                    .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                    .block_task()
+                    .await?;
+                connection
+                    .send_request(LoadSessionRequest::new(
+                        id_for_client.clone(),
+                        cwd_for_client.clone(),
+                    ))
+                    .block_task()
+                    .await?;
+                connection
+                    .send_request(PromptRequest::new(
+                        id_for_client.clone(),
+                        vec![ContentBlock::from("NEXT_QUESTION")],
+                    ))
+                    .block_task()
+                    .await?;
+                Ok::<_, agent_client_protocol::Error>(())
+            },
+        )
+        .await
+        .expect("load + prompt");
+
+    // The replay must not contain a ToolCall frame for the unresolved call —
+    // the client would render a tool card that never completes.
+    let recorded = updates.lock().await;
+    assert!(
+        !recorded
+            .iter()
+            .any(|u| matches!(u, SessionUpdate::ToolCall(_))),
+        "the unresolved tool call must be sanitized away before replay; recorded: {recorded:?}"
+    );
+    let user_texts: Vec<String> = recorded.iter().filter_map(user_message_text).collect();
+    let agent_texts: Vec<String> = recorded.iter().filter_map(agent_message_text).collect();
+    assert!(
+        user_texts.iter().any(|t| t.contains("SEED_USER")),
+        "healthy rows still replay; recorded: {recorded:?}"
+    );
+    assert!(
+        agent_texts.iter().any(|t| t.contains("SEED_ASSISTANT")),
+        "healthy rows still replay; recorded: {recorded:?}"
+    );
+
+    // And the LLM must never see the orphan rows on the next prompt: no
+    // empty/whitespace-only payloads in the handed-over transcript.
+    let calls = seen.lock().await;
+    let last = calls.last().expect("a turn ran after load");
+    assert!(
+        last.iter().any(|c| c.contains("SEED_USER"))
+            && last.iter().any(|c| c.contains("SEED_ASSISTANT")),
+        "healthy rows reach the LLM: {last:?}"
+    );
+    let blanks = last.iter().filter(|c| c.trim().is_empty()).count();
+    assert_eq!(
+        blanks, 0,
+        "sanitized history must not hand the LLM payload-free rows: {last:?}"
     );
 }


### PR DESCRIPTION
Follow-up to #1895 (merged before its review landed). Closes #1909, which tracks the four issues found on main:

## The four fixes

1. **Session store path nesting** — `SessionManager::open` appends its own `sessions/` segment, but ACP passed `data_dir.join("sessions")`, so ACP transcripts landed in `sessions/sessions/` where gateway/serve (and any fixed build) would never look. Now rooted at `data_dir` like every other surface (`open_acp_session_store` helper); a legacy nested dir triggers a loud warn and is left for manual cleanup — auto-moving across the store's flat/users layouts is riskier than the data is old (feature shipped hours earlier).

2. **No replay on `session/load`** — the handler returned `LoadSessionResponse::default()` with zero `session/update` notifications, so a reconnecting client rendered an *empty* conversation the agent had actually restored (the client then prompts from zero context). The transcript now replays before the load resolves: user → `UserMessageChunk`, assistant reasoning/text → `AgentThoughtChunk`/`AgentMessageChunk`, tool calls/results → `ToolCall` + completed `ToolCallUpdate`. System rows and empty payloads are skipped.

3. **TOCTOU on the session map** — `contains_key` → `build().await` → `insert` dropped the map guard between check and insert: a concurrent load of the same id slipped past the check mid-build and overwrote the winning session, evicting the `shutdown` flag an in-flight turn watches (the exact harm the already-live branch exists to prevent) and double-building an agent whose second redb open would fail. The load path now holds **one map lock across check → build → restore → insert** (`load_session_locked`); racing loads observe the live session. Contention is safe by construction: prompt lookup uses `try_lock` with the existing deferred fallback, and lock ordering is map → history → store with no reverse path.

4. **No transcript sanitization** — loaded history went straight to the LLM/client raw, so crash residue (an assistant `tool_call` whose result never landed) meant provider 400s ("tool_use without tool_result") on the next turn and never-completing tool cards on replay. Load now runs the same `ResumePolicy::sanitize` every other resume path runs, with `workspace_root: None` — the policy's mtime-marker side effect is for agent-managed worktrees, not the user's own project dir an ACP editor points at (it would dirty git status on every load).

## Tests (TDD, RED→GREEN per fix)

- `should_share_session_store_layout_with_other_surfaces` — gateway-style open must see ACP transcripts
- 4 replay-mapping units (`message_to_replay_updates` is pure)
- `should_not_build_twice_when_concurrent_loads_race` — gated-build factory; two racing loads must produce exactly one build
- `should_replay_stored_history_as_session_updates_on_load` — replay lands before the load response
- `should_sanitize_stored_history_when_loading_a_session` — seeded ghost tool_call never reaches replay or LLM

All 28 `commands::acp` lib tests + 7 `acp_integration` tests pass; `cargo clippy -p octos-cli --lib --tests` clean; `cargo fmt -p octos-cli` applied.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>