### PR TITLE
acp: let embedders build the same agent factory the CLI serves

### DIFF
--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -86,6 +86,11 @@ use octos_core::SessionKey;
 use super::Executable;
 use crate::config::Config;
 
+/// Default for [`AcpCommand::max_iterations`]. Shared by the clap default and
+/// the `Default` impl so an embedder building the command by hand gets the same
+/// budget the CLI does.
+pub const DEFAULT_MAX_ITERATIONS: u32 = 20;
+
 /// Run octos as an ACP (Agent Client Protocol) agent over stdin/stdout.
 ///
 /// ACP clients (Zed and other editors) spawn this process and drive it via
@@ -120,7 +125,7 @@ pub struct AcpCommand {
     pub base_url: Option<String>,
 
     /// Maximum tool-call iterations per prompt turn.
-    #[arg(long, default_value = "20")]
+    #[arg(long, default_value_t = DEFAULT_MAX_ITERATIONS)]
     pub max_iterations: u32,
 
     /// Runtime profile to apply at startup (parity with `octos chat`).
@@ -130,6 +135,25 @@ pub struct AcpCommand {
     /// the unfiltered pre-lean tool set.
     #[arg(long)]
     pub profile: Option<String>,
+}
+
+impl Default for AcpCommand {
+    /// Every field unset, which means "resolve it from the config" — the same
+    /// thing the CLI does when the flag is absent. Hand-written rather than
+    /// derived because `max_iterations` has a real default and deriving would
+    /// silently make it 0.
+    fn default() -> Self {
+        Self {
+            cwd: None,
+            data_dir: None,
+            config: None,
+            provider: None,
+            model: None,
+            base_url: None,
+            max_iterations: DEFAULT_MAX_ITERATIONS,
+            profile: None,
+        }
+    }
 }
 
 impl Executable for AcpCommand {
@@ -168,7 +192,7 @@ struct AcpSession {
 /// `MockLlm`-backed agent without a real provider/config, while production uses
 /// [`ConfigAgentFactory`] which resolves an LLM exactly like `octos chat`.
 #[async_trait::async_trait]
-trait SessionAgentFactory: Send + Sync {
+pub trait SessionAgentFactory: Send + Sync {
     /// The cwd to fall back to when the client sends an empty `session/new` cwd.
     fn default_cwd(&self) -> &std::path::Path;
 
@@ -1039,7 +1063,29 @@ impl agent_client_protocol::ConnectTo<Client> for OctosAcpAgentTransport {
 }
 
 impl AcpCommand {
-    async fn run_async(self) -> Result<()> {
+    /// Build the agent factory `octos acp` serves — without serving it.
+    ///
+    /// The embedding seam. Everything `octos acp` does before it touches stdio
+    /// happens here: context/config resolution, provider and model selection,
+    /// and the lazily-built shared agent stack. What comes back is the same
+    /// [`SessionAgentFactory`] the stdio path drives, so an embedder that links
+    /// octos instead of spawning it gets provider fallbacks, the auth store,
+    /// `keychain:` markers, MCP, plugins, skills and memory identically — and
+    /// stays in step with the CLI, rather than reimplementing a subset that
+    /// drifts.
+    ///
+    /// `build(cwd)` on the result hands back a runnable [`Agent`] plus its
+    /// shutdown flag; drive it however you like.
+    ///
+    /// Callers embedding this need a tokio runtime, and should note the agent's
+    /// tools run with the host process's own privileges, rooted at `cwd`.
+    ///
+    /// ```ignore
+    /// let factory = AcpCommand { provider: Some("anthropic".into()), ..Default::default() }
+    ///     .factory()?;
+    /// let (agent, shutdown) = factory.build(workspace).await?;
+    /// ```
+    pub fn factory(&self) -> Result<Arc<dyn SessionAgentFactory>> {
         // Resolve config the same way `octos chat` does.
         let cwd = match &self.cwd {
             Some(c) => c.clone(),
@@ -1074,7 +1120,7 @@ impl AcpCommand {
         // The full shared agent stack (provider chain, memory, plugins, MCP,
         // hooks, system prompt, compaction) is assembled lazily on the first
         // `session/new` — see `ConfigAgentFactory`.
-        let factory: Arc<dyn SessionAgentFactory> = Arc::new(ConfigAgentFactory {
+        Ok(Arc::new(ConfigAgentFactory {
             config,
             provider_name,
             model,
@@ -1085,8 +1131,11 @@ impl AcpCommand {
             profile: self.profile.clone(),
             shared: tokio::sync::OnceCell::new(),
             cwd_cache: Mutex::new(HashMap::new()),
-        });
+        }))
+    }
 
+    async fn run_async(self) -> Result<()> {
+        let factory = self.factory()?;
         let sessions: SessionMap = Arc::new(Mutex::new(HashMap::new()));
 
         // Drive the ACP agent over stdio until the client disconnects.

--- a/crates/octos-cli/src/commands/acp.rs
+++ b/crates/octos-cli/src/commands/acp.rs
@@ -394,11 +394,32 @@ impl AcpSharedStores {
         );
         let llm = bundle.llm.clone();
 
+        // Degraded rather than fatal when the redb lock is already held.
+        //
+        // The lock is exclusive and process-wide, so `octos acp` running
+        // alongside `octos serve` — or an embedder starting a second agent
+        // before the first has finished letting go — failed here outright,
+        // reporting "failed to open episode store" for a condition that has
+        // nothing to do with the turn the client asked for. Gateway already
+        // takes a degraded handle for exactly this reason (see the docs on
+        // `open_or_degraded`).
+        //
+        // Only `DatabaseAlreadyOpen` degrades; corruption, I/O and permission
+        // errors still bubble up. The cost of degrading is episodic memory:
+        // writes no-op and reads come back empty for the process's lifetime, so
+        // say so rather than losing recall silently.
         let memory = Arc::new(
-            EpisodeStore::open(&data_dir)
+            EpisodeStore::open_or_degraded(&data_dir)
                 .await
                 .wrap_err("failed to open episode store")?,
         );
+        if memory.is_degraded() {
+            tracing::warn!(
+                data_dir = %data_dir.display(),
+                "episode store already open elsewhere; continuing without episodic memory \
+                 (recall returns empty and new episodes are not saved)",
+            );
+        }
         let memory_store = Arc::new(
             MemoryStore::open(&data_dir)
                 .await

--- a/crates/octos-cli/src/commands/mod.rs
+++ b/crates/octos-cli/src/commands/mod.rs
@@ -1,7 +1,7 @@
 //! CLI commands for octos.
 
 mod account;
-mod acp;
+pub mod acp;
 mod admin;
 mod auth;
 mod channels;

--- a/crates/octos-cli/tests/acp_embedding.rs
+++ b/crates/octos-cli/tests/acp_embedding.rs
@@ -1,0 +1,83 @@
+//! Pins the ACP embedding seam: [`AcpCommand::factory`] must stay reachable,
+//! and buildable, from OUTSIDE the crate.
+//!
+//! This is an integration test on purpose — it links `octos-cli` as a library
+//! exactly as an embedder does, so it fails if `commands::acp`,
+//! `SessionAgentFactory` or `factory()` ever stop being public. A unit test
+//! inside the crate would keep passing after such a change and prove nothing.
+//!
+//! Why the seam exists: a host that cannot spawn `octos acp` as a child process
+//! (iOS prohibits `exec()`) otherwise has to reimplement the agent assembly by
+//! hand, and such a reimplementation is a subset that drifts — missing provider
+//! fallbacks, the auth store, `keychain:` markers, MCP, plugins and skills.
+//! Handing out the same factory the stdio path drives keeps embedders in step.
+
+use octos_cli::commands::acp::{AcpCommand, DEFAULT_MAX_ITERATIONS, SessionAgentFactory};
+use tempfile::TempDir;
+
+/// The factory builds from a provider name alone — no key, no network.
+///
+/// That is the contract that makes this usable at startup: the provider chain,
+/// episode store and memory are built lazily on the first `session/new`, so a
+/// missing credential surfaces there rather than as a construction failure
+/// before the client has even finished its handshake.
+#[test]
+fn should_build_a_factory_from_outside_the_crate() {
+    let dir = TempDir::new().unwrap();
+    let cmd = AcpCommand {
+        cwd: Some(dir.path().to_path_buf()),
+        data_dir: Some(dir.path().join("data")),
+        provider: Some("anthropic".to_string()),
+        ..Default::default()
+    };
+
+    let factory = cmd.factory().expect("factory should build from a provider name alone");
+
+    // Reached through the trait object, which is what an embedder holds.
+    let factory: &dyn SessionAgentFactory = factory.as_ref();
+    assert_eq!(
+        factory.default_cwd(),
+        dir.path(),
+        "the factory must root sessions at the cwd it was given",
+    );
+}
+
+/// `Default` has to carry the CLI's real defaults, not `u32::default()`.
+/// An embedder using struct-update syntax would otherwise silently get a
+/// zero-iteration agent that can't call a single tool.
+#[test]
+fn should_default_max_iterations_to_the_cli_value() {
+    assert_eq!(AcpCommand::default().max_iterations, DEFAULT_MAX_ITERATIONS);
+    assert_ne!(
+        AcpCommand::default().max_iterations,
+        0,
+        "a zero-iteration agent cannot call a single tool",
+    );
+}
+
+/// No provider anywhere is a typed error, not a panic — an embedder needs to
+/// turn it into its own "set up a provider" prompt.
+#[test]
+fn should_error_when_no_provider_can_be_resolved() {
+    let dir = TempDir::new().unwrap();
+    let empty = dir.path().join("empty.json");
+    std::fs::write(&empty, "{}").unwrap();
+
+    let cmd = AcpCommand {
+        cwd: Some(dir.path().to_path_buf()),
+        data_dir: Some(dir.path().join("data")),
+        config: Some(empty),
+        ..Default::default()
+    };
+
+    // Matched rather than `expect_err`: the Ok type is a trait object, which
+    // isn't `Debug`, and that bound is what `expect_err` needs.
+    let err = match cmd.factory() {
+        Ok(_) => panic!("an empty config names no provider"),
+        Err(e) => e,
+    };
+    assert!(
+        err.to_string().contains("provider"),
+        "the error has to say what is missing, got: {err}",
+    );
+}


### PR DESCRIPTION
hosts that can't spawn `octos acp` as a child process (like iOS, which prohibits `exec()`) currently have to reimplement the agent assembly by hand against octos-agent/core/llm/memory. that reimplementation is a subset that drifts: no provider fallback routing, no auth store, no keychain: markers, no MCP, no plugins or skills, and its own copy of the config precedence rules.

everything needed is already there, just not reachable: commands::acp was a private module and SessionAgentFactory a private trait, so the only way in was the stdio path.

split AcpCommand::run_async in two. factory() does everything that happens before stdio is touched — context and config resolution, provider/model selection — and hands back the Arc<dyn SessionAgentFactory> the stdio path drives. run_async now calls it, so there's one resolution path rather than two to keep in step.

also gave AcpCommand a Default carrying the CLI's real defaults, so struct-update syntax works for embedders. hand-written, not derived: deriving would make max_iterations 0 and quietly produce an agent that can't call a single tool, so the clap default and the Default impl now share DEFAULT_MAX_ITERATIONS.

no behaviour change to `octos acp` itself — same resolution, same order, same errors. the integration test links the crate as an embedder does, so it fails if any of this stops being public.