### PR TITLE
chore(release): v2.0.3-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "octos-agent"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "octos-bus"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "aes",
  "async-imap",
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "octos-cli"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "agent-client-protocol",
  "argon2",
@@ -4682,7 +4682,7 @@ dependencies = [
 
 [[package]]
 name = "octos-core"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "chrono",
  "eyre",
@@ -4697,7 +4697,7 @@ dependencies = [
 
 [[package]]
 name = "octos-diagnostics"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4709,14 +4709,14 @@ dependencies = [
 
 [[package]]
 name = "octos-dora-mcp"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "octos-agent",
 ]
 
 [[package]]
 name = "octos-embed-llama"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4730,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "octos-ffi"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "libc",
  "octos-agent",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4760,7 +4760,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet-worker"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4777,7 +4777,7 @@ dependencies = [
 
 [[package]]
 name = "octos-llm"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -4801,7 +4801,7 @@ dependencies = [
 
 [[package]]
 name = "octos-memory"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "bincode",
  "chrono",
@@ -4821,7 +4821,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pipeline"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4845,7 +4845,7 @@ dependencies = [
 
 [[package]]
 name = "octos-plugin"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "eyre",
  "metrics",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pyo3"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "octos-ffi",
  "pyo3",
@@ -4882,7 +4882,7 @@ dependencies = [
 
 [[package]]
 name = "octos-server"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "octos-services"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -4940,7 +4940,7 @@ dependencies = [
 
 [[package]]
 name = "octos-store"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "base64",
  "chrono",
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "octos-swarm"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "octos-uniffi"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "octos-ffi",
  "uniffi",
@@ -4988,7 +4988,7 @@ dependencies = [
 
 [[package]]
 name = "octos-wasm"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -5004,7 +5004,7 @@ dependencies = [
 
 [[package]]
 name = "octos-workflows"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "chrono",
  "eyre",
@@ -8418,7 +8418,7 @@ dependencies = [
 
 [[package]]
 name = "wechat-bridge"
-version = "2.0.2"
+version = "2.0.3-rc.1"
 dependencies = [
  "clap",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.2"
+version = "2.0.3-rc.1"
 edition = "2024"
 rust-version = "1.85.0"
 authors = ["octos team"]


### PR DESCRIPTION
## [2.0.3-rc.1] - 2026-08-04

26 commits since v2.0.2. The theme of this RC is **peer agents becoming genuinely
usable** — the previous release created peer fences that peers could not actually
work inside — plus session persistence for ACP and per-run isolation for pipelines.

### Highlights

- **Peer agents work end-to-end.** Peers are now staged as *clones* rather than
  worktrees (#1898). A worktree's `.git` is a file pointing outside the sandbox, so
  every git command inside a peer fence failed with exit 128 — the model would then
  run `git init` and destroy the fence, leaving the branch stuck at seed. Peer work
  is now published to the fence branch **every turn** rather than only on close
  (#1899), so a peer's deliverables are no longer stranded if it never closes.
- **ACP session persistence.** Sessions persist across restarts and `session/load`
  is implemented (#1895), with replay, sanitization and de-racing on load (#1910).
- **Pipelines isolate their runs.** Each pipeline run gets its own working directory
  (#1907), so `findings-*.md` from concurrent or prior deep-research runs no longer
  mix into a later synthesis step.
- **MCP transports survive tool-policy narrowing** (#1900) — the registry now owns
  them, so narrowing the tool set no longer tears down live MCP servers.

### Features

- **api**: Advertise solo profile existence and derive credentials from name (#1905)
- **acp**: Persist sessions and implement `session/load` (#1895)
- **appui**: Manifest skill actions and background jobs (#1637)
- **voice**: Profile-scoped speech synthesis endpoint (#1880)

### Bug Fixes

- **peer**: Stage peers as clones so git actually works inside the fence (#1898)
- **peer**: Publish a peer's fence branch every turn, not only on close (#1899)
- **peer**: Report an unusable peer session key instead of silently disabling the peer (#1888)
- **worktree**: Scope worktree teardown to its own checkout, never a global prune (#1887)
- **pipeline**: Isolate per-run working dir so findings don't mix across runs (#1907)
- **pipeline**: Degrade gracefully when a model key is not in the provider router (#1902)
- **mcp**: Let the registry own MCP transports so narrowing cannot kill them (#1900)
- **acp**: Replay + sanitize + de-race `session/load`, un-nest session store (#1910)
- **agent**: k3 agentic-loop fixes — spiral signature, KV-cache-friendly tier-1, model-id gaps, compaction instruction priority (#1892)
- **agent**: Make repeated `enable_persistence` calls cheap (#1906) (#1908)
- **gemini**: Recover missing Gemini 3 thought signatures (#1897)
- **gemini**: Repair missing array item schemas (#1876)
- **api**: Redact credentials from request logs (#1874)
- **api**: Support exact AppUI browser origins (#1873)
- **goal**: Say why `goal_plan` cannot run here instead of blaming session liveness (#1889)
- **test**: Tolerate a slow rustfmt in the two post-edit formatting tests (#1893)

### Security

- Credentials are redacted from request logs (#1874).
- AppUI browser origins are matched exactly rather than by prefix (#1873).

### CI

- **check-windows is now blocking** (#1885). It was `continue-on-error` on PRs, so
  the badge reported green over a red suite — worse than having no badge.
- Unify action versions, gate clippy at `-D warnings`, auto-retry check-arm (#1911)
- check-arm: revert both mitigations — measured, and it is not our workload (#1896),
  after timing out the octos-agent steps (#1891) and stopping the runner self-kill (#1890)

### Refactor

- **plugin**: Compare `BLOCKED_ENV_VARS` constants directly instead of scraping source (#1883)

### Known limitations

- `check-arm` failures remain a GitHub ARM runner infrastructure problem, not a
  workload problem — measured at 29.3s on matched hardware versus a 46-minute dead
  runner. #1911 adds auto-retry as mitigation, not a fix.
- Pipeline `synthesize` cost still scales with findings count. Per-run isolation
  removed cross-run contamination but did not make synthesis cheap: a 5-finding
  deep-research run spent 621s in synthesize against the 1800s ceiling.