### PR TITLE
fix(ui-protocol): sequence projected voice attachments

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -1394,11 +1394,15 @@ impl UiProtocolLedger {
             .max(1) as u64
     }
 
-    /// Next per-thread v1 sequence, used when a legacy terminal or attachment
-    /// is projected directly into a v2 envelope before its v1 dual-emit is
-    /// appended. Only source rows preceding this event's ledger cursor count;
-    /// otherwise a replay after later writes could assign a different v2 seq.
-    /// This is read-only and does not reserve or mutate sequence state.
+    /// Next per-thread sequence for a wire-projected legacy terminal or
+    /// attachment. A legacy source can be followed by its durable v1 companion,
+    /// but consecutive attachment sources can also arrive without a companion
+    /// between them. Count those projection-only rows after the latest durable
+    /// envelope so they cannot all reuse the same `(thread_id, seq)` identity.
+    ///
+    /// Only rows preceding this source cursor participate, which keeps replay
+    /// deterministic after later writes. This is read-only and does not reserve
+    /// or mutate the authoritative allocator.
     pub(crate) fn projection_v2_next_envelope_seq(
         &self,
         session_id: &SessionKey,
@@ -1410,31 +1414,78 @@ impl UiProtocolLedger {
             .inner
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        inner
+        let entries = inner
             .sessions
             .get(&storage_id)
             .into_iter()
             .flat_map(|state| state.entries.iter())
-            .filter_map(|entry| {
-                if entry.seq >= before_cursor_seq {
-                    return None;
+            .filter(|entry| entry.seq < before_cursor_seq)
+            .collect::<Vec<_>>();
+
+        let (durable_seq, durable_cursor_seq) = entries
+            .iter()
+            .filter_map(|entry| match &entry.event {
+                UiProtocolLedgerEvent::Notification(UiNotification::Envelope(envelope))
+                    if envelope.envelope.thread_id == thread_id =>
+                {
+                    Some((envelope.envelope.seq, entry.seq))
+                }
+                UiProtocolLedgerEvent::Notification(UiNotification::EnvelopeV2(envelope))
+                    if envelope.envelope.thread_id == thread_id =>
+                {
+                    Some((envelope.envelope.seq, entry.seq))
+                }
+                _ => None,
+            })
+            .max_by_key(|(envelope_seq, cursor_seq)| (*envelope_seq, *cursor_seq))
+            .unwrap_or((0, 0));
+
+        let has_background_child_before = |cursor_seq: u64| {
+            entries.iter().any(|entry| {
+                if entry.seq >= cursor_seq {
+                    return false;
                 }
                 match &entry.event {
-                    UiProtocolLedgerEvent::Notification(UiNotification::Envelope(envelope))
-                        if envelope.envelope.thread_id == thread_id =>
-                    {
-                        Some(envelope.envelope.seq)
+                    UiProtocolLedgerEvent::Notification(UiNotification::EnvelopeV2(envelope)) => {
+                        matches!(
+                            &envelope.envelope.payload,
+                            PayloadV2::BackgroundChildCompleted {
+                                parent_turn_id,
+                                ..
+                            } if parent_turn_id == thread_id
+                        )
                     }
-                    UiProtocolLedgerEvent::Notification(UiNotification::EnvelopeV2(envelope))
-                        if envelope.envelope.thread_id == thread_id =>
-                    {
-                        Some(envelope.envelope.seq)
+                    UiProtocolLedgerEvent::Notification(UiNotification::TurnSpawnComplete(
+                        spawn,
+                    )) => {
+                        spawn.turn_id.as_ref().map(|turn_id| turn_id.0.to_string())
+                            == Some(thread_id.to_owned())
                     }
-                    _ => None,
+                    _ => false,
                 }
             })
-            .max()
-            .unwrap_or(0)
+        };
+
+        let projected_only_count = entries
+            .iter()
+            .filter(|entry| entry.seq > durable_cursor_seq)
+            .filter(|entry| match &entry.event {
+                UiProtocolLedgerEvent::Notification(UiNotification::TurnCompleted(event)) => {
+                    event.turn_id.0.to_string() == thread_id
+                }
+                UiProtocolLedgerEvent::Notification(UiNotification::TurnError(event)) => {
+                    event.turn_id.0.to_string() == thread_id
+                }
+                UiProtocolLedgerEvent::Notification(UiNotification::FileAttached(event)) => {
+                    event.turn_id.0.to_string() == thread_id
+                        && !has_background_child_before(entry.seq)
+                }
+                _ => false,
+            })
+            .count() as u64;
+
+        durable_seq
+            .saturating_add(projected_only_count)
             .saturating_add(1)
     }
 

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -22576,6 +22576,111 @@ fn v2_projects_errored_and_interrupted_terminals() {
     }
 }
 
+#[test]
+fn should_assign_unique_v2_seq_to_terminal_and_consecutive_attachments() {
+    let ledger = UiProtocolLedger::new(16);
+    let session_id = SessionKey("local:envelope-v2-voice-audio".into());
+    let turn_id = TurnId::new();
+    let thread_id = turn_id.0.to_string();
+
+    ledger.append_notification(UiNotification::EnvelopeV2(EnvelopeV2Notification {
+        session_id: session_id.clone(),
+        topic: None,
+        envelope: EnvelopeV2 {
+            thread_id: thread_id.clone(),
+            seq: 1,
+            cursor: None,
+            turn_id: thread_id.clone(),
+            client_message_id: None,
+            payload: PayloadV2::AssistantPersisted {
+                text: "第一句。第二句。".into(),
+                assistant_segment_id: format!("{thread_id}:assistant:1"),
+                meta: MessageMeta {
+                    message_id: "voice-reply".into(),
+                    persisted_at: Utc::now(),
+                    media: vec![],
+                },
+            },
+        },
+    }));
+
+    let terminal_source =
+        ledger.append_notification(UiNotification::TurnCompleted(TurnCompletedEvent {
+            session_id: session_id.clone(),
+            topic: None,
+            turn_id: turn_id.clone(),
+            cursor: None,
+            tokens_in: None,
+            tokens_out: None,
+            session_result: None,
+        }));
+    // Production dual-emission persists the v1 terminal companion after the
+    // legacy terminal source. It advances the durable base for later files,
+    // so that already-represented source must not be counted twice.
+    ledger.append_notification(UiNotification::Envelope(
+        octos_core::ui_protocol::EnvelopeNotification {
+            session_id: session_id.clone(),
+            topic: None,
+            envelope: octos_core::ui_protocol::Envelope {
+                thread_id: thread_id.clone(),
+                seq: 2,
+                client_message_id: None,
+                payload: Payload::TurnCompleted {
+                    token_usage: EnvelopeTokenUsage::default(),
+                },
+            },
+        },
+    ));
+
+    let file_sources = [
+        UiNotification::FileAttached(octos_core::ui_protocol::FileAttachedEvent {
+            session_id: session_id.clone(),
+            topic: None,
+            turn_id: turn_id.clone(),
+            path: "reply-first.mp3".into(),
+            tool_call_id: None,
+            mime: Some("audio/mpeg".into()),
+        }),
+        UiNotification::FileAttached(octos_core::ui_protocol::FileAttachedEvent {
+            session_id: session_id.clone(),
+            topic: None,
+            turn_id,
+            path: "reply-second.mp3".into(),
+            tool_call_id: None,
+            mime: Some("audio/mpeg".into()),
+        }),
+    ]
+    .map(|notification| ledger.append_notification(notification));
+    let sources = [
+        terminal_source,
+        file_sources[0].clone(),
+        file_sources[1].clone(),
+    ];
+
+    let projected_seqs = || {
+        sources
+            .iter()
+            .map(|source| {
+                let projected = project_v2_ledger_event(&ledger, &source.event, &source.cursor)
+                    .expect("legacy source has a v2 projection");
+                let UiProtocolLedgerEvent::Notification(UiNotification::EnvelopeV2(envelope)) =
+                    projected
+                else {
+                    panic!("legacy source must project to EnvelopeV2");
+                };
+                envelope.envelope.seq
+            })
+            .collect::<Vec<_>>()
+    };
+
+    assert_eq!(projected_seqs(), vec![2, 3, 4]);
+    assert_eq!(
+        projected_seqs(),
+        vec![2, 3, 4],
+        "replaying the same durable rows must assign the same sequence",
+    );
+}
+
 /// UPCR-2026-014 M9-γ per-payload dual-emit: every legacy
 /// notification surfaced by `forward_progress_event` triggers a
 /// parallel `projection/envelope` ledger append. The test exercises


### PR DESCRIPTION
## Summary
- assign deterministic unique v2 sequence numbers to consecutive projected voice attachments
- count projection-only terminal and attachment rows after the latest durable envelope
- preserve replay determinism by limiting sequence calculation to rows before the source cursor

## Root cause
Consecutive legacy `file/attached` sources could be projected with the same `(thread_id, seq)`. Canonical clients deduplicated the later TTS sentence attachments, so playback stopped after the first sentence.

Frontend companion: https://github.com/octos-org/octos-web/pull/306

## Tests
- `cargo test -p octos-cli --features api --lib should_assign_unique_v2_seq_to_terminal_and_consecutive_attachments`
- `cargo check -p octos-cli --features api`
- `cargo fmt --all -- --check`
- `cargo clippy -p octos-cli --features api --lib -- -D warnings`