### PR TITLE
fix(peer): stop priming the caller to end its turn after a handoff (#1918)

### DIFF
--- a/crates/octos-agent/src/tools/peer_handoff.rs
+++ b/crates/octos-agent/src/tools/peer_handoff.rs
@@ -119,16 +119,20 @@ impl Tool for PeerHandoffTool {
     }
 
     fn description(&self) -> &str {
-        "Promote work OUT of this conversation into a sovereign peer session with \
-         its own durable brief, workspace, and lifecycle. Give the peer a short, \
-         unique NAME — it is the peer's primary address (\"let Edison do X\"); you \
-         reach it later by name with peer_send_input / peer_close / peer_gather. \
-         Use when the work outlives this turn, needs its own workspace or safety \
-         envelope, or the user may steer it separately. You will NOT receive the \
-         result in this turn — the peer reports to the user's session strip and the \
-         shared blackboard. For work whose result THIS turn needs to continue \
-         reasoning, use spawn instead. The brief is a complete task contract: \
-         include all context the peer needs (it cannot see this conversation)."
+        "Hand a SELF-CONTAINED piece of work to a sovereign peer session with its \
+         own durable brief, workspace, and lifecycle, and keep working yourself. \
+         Give the peer a short, unique NAME — it is the peer's primary address \
+         (\"let Edison do X\"); you reach it later by name with peer_send_input / \
+         peer_close / peer_gather. Use when the work outlives this turn, needs its \
+         own workspace or safety envelope, or the user may steer it separately. \
+         You will NOT receive the result in this turn — the peer reports to the \
+         user's session strip and the shared blackboard. Handing work off does NOT \
+         end your turn: delegating is what lets you make progress on your own \
+         remaining work in parallel, so continue it immediately unless the peer \
+         took over everything you had left. For work whose result THIS turn needs \
+         to continue reasoning, use spawn instead. The brief is a complete task \
+         contract: include all context the peer needs (it cannot see this \
+         conversation)."
     }
 
     fn tags(&self) -> &[&str] {
@@ -227,7 +231,10 @@ impl Tool for PeerHandoffTool {
                     "Staged peer '{name}' (slug {slug}, brief at {brief_path}, cwd {cwd}). \
                      Address it later by name with peer_send_input / peer_close. The user's \
                      client opens it in the background; its result lands on the blackboard \
-                     at peers/{slug}/result.md. Do not wait for it.",
+                     at peers/{slug}/result.md. Do not wait for it — and do not \
+                     stop here: if you still have work of your own, continue it \
+                     now in this same turn. Only finish if the peer took over \
+                     everything that was left.",
                     slug = staged.slug,
                     brief_path = staged.brief_path,
                     cwd = staged.cwd,
@@ -437,7 +444,53 @@ mod tests {
         assert!(result.output.contains("/data/peers/ci-fix/brief.md"));
         assert!(result.output.contains("cwd /work/peers/ci-fix/wt"));
         assert!(result.output.contains("peers/ci-fix/result.md"));
-        assert!(result.output.contains("Do not wait for it."));
+        assert!(result.output.contains("Do not wait for it"));
+    }
+
+    /// #1918: the master stalled after every handoff — it read "promote work
+    /// OUT" + "you will NOT receive the result in this turn" + "Do not wait for
+    /// it" as "your work is finished", and only resumed when the user nudged it.
+    /// Every signal pointed at ending the turn and nothing pointed back.
+    ///
+    /// "Do not wait" answers whether to BLOCK; it never answered whether to
+    /// CONTINUE. Both surfaces must now say so explicitly, because they are the
+    /// only two the model sees — octos has no central role prompt to carry this.
+    /// The result matters most: it is in context at the exact moment the model
+    /// chooses between another tool call and ending the turn.
+    #[tokio::test]
+    async fn should_tell_the_caller_to_keep_working_after_a_handoff() {
+        let (tool, _seen) = tool_with_recorder();
+        let result = tool
+            .execute(&json!({
+                "name": "Edison",
+                "brief": "Investigate the flaky bus test.",
+            }))
+            .await
+            .expect("handoff stages");
+
+        assert!(result.success);
+        let output = &result.output;
+        assert!(
+            output.contains("do not stop here"),
+            "the handoff result must tell the caller to continue its own work, got: {output}"
+        );
+        assert!(
+            output.contains("Only finish if the peer took over"),
+            "the result must name the ONE case where ending the turn is right, \
+             else 'keep working' reads as 'never finish', got: {output}"
+        );
+
+        // The description is the other half: it primed the stall by framing a
+        // handoff as work leaving the caller.
+        let description = tool.description();
+        assert!(
+            description.contains("keep working yourself"),
+            "the description must not imply the caller's work ends here"
+        );
+        assert!(
+            description.contains("does NOT end your turn"),
+            "the description must state that a handoff does not end the turn"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #1918.

Every signal the model saw after `peer_handoff` pointed at "your work is finished", and nothing pointed back:

| surface | text |
|---|---|
| description | "**Promote work OUT** of this conversation" |
| description | "You will **NOT receive the result in this turn**" |
| result | "**Do not wait for it.**" |

So the master treated a handoff as transferring ownership of its work and ended the turn, resuming only on a user nudge — serializing exactly the work delegation exists to parallelize.

**"Do not wait" answers whether to BLOCK. It never answered whether to CONTINUE.**

## Changes

**The result text** carries most of the weight — it is in context at the moment the model chooses between another tool call and ending the turn, whereas the description is read once when the tool list is built. It now ends:

> Do not wait for it — and do not stop here: if you still have work of your own, continue it now in this same turn. **Only finish if the peer took over everything that was left.**

That last sentence is load-bearing. Without it "keep working" reads as "never finish", and handing off the *primary* task is a case where stopping is right.

**The description** reframes the opening from "Promote work OUT of this conversation" to "Hand a SELF-CONTAINED piece of work … and keep working yourself", and states plainly that a handoff does not end the turn.

## What I deliberately did not change

- **The handoff-vs-spawn axis.** #1918 suggests distinguishing primary vs auxiliary tasks, but the description already splits on *does THIS turn need the result* — and the model was applying that correctly. A side question genuinely does not feed the turn's reasoning, so `peer_handoff` was the right tool. The defect was inferring "nothing to wait for" as "nothing to do". Adding a second axis would collide with the existing one.
- **`spawn`.** #1918 mentions it, but spawn returns into the turn by design; a stall there would be a functional defect, not a framing one, and wants its own issue with a transcript.
- **A structural nudge** (#1918 direction 3). It needs a notion of "pending local work" that the agent does not have — the closest is the staged-submit queue, which holds user prompts, not the model's own unfinished intent.

## Scope of the test

The new test pins the **wording**, not the behaviour. The bug is an LLM judgement and can only be confirmed live: hand a side task to a peer mid-task and watch whether the master resumes on its own. I have not verified that.

There is no central role prompt in `octos-agent` to carry this guidance, so these two surfaces are the only levers available.

2521 octos-agent lib tests pass; `cargo fmt --all --check` and `scripts/lint-tool-descriptions.py` clean (21 tools / 14 manifests).