### PR TITLE
fix(agent): reap in-flight orphan background tasks via heartbeat timeout

### DIFF
--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -339,6 +339,11 @@ pub struct BackgroundTask {
     /// AppUI `runtime_policy_stamp` schema.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_policy_stamp: Option<Value>,
+    /// Opaque host projection metadata. The supervisor persists this value
+    /// without interpreting its schema, allowing API adapters to derive
+    /// domain-specific views from the canonical task lifecycle.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projection_metadata: Option<Value>,
 }
 
 impl BackgroundTask {
@@ -365,7 +370,7 @@ impl BackgroundTask {
 }
 
 /// Callback invoked when a task's status changes.
-type OnChangeCallback = Box<dyn Fn(&BackgroundTask) + Send + Sync>;
+type OnChangeCallback = Arc<dyn Fn(&BackgroundTask) + Send + Sync>;
 
 /// Payload emitted when a `spawn_only` background task transitions to
 /// `Failed`. Consumers (e.g. the session actor) use this to schedule a
@@ -891,6 +896,8 @@ pub struct TaskSupervisor {
     /// loop cannot keep adding children.
     poisoned_parents: Arc<Mutex<HashSet<String>>>,
     on_change: Arc<Mutex<Option<OnChangeCallback>>>,
+    /// Named observers supplement (and never replace) the primary callback.
+    on_change_listeners: Arc<Mutex<HashMap<String, OnChangeCallback>>>,
     on_failure: Arc<Mutex<Option<OnFailureCallback>>>,
     /// Gap-1 unification: single terminal-transition sink. Fired from
     /// every terminal path alongside the legacy `on_change` / `on_failure`
@@ -939,14 +946,14 @@ pub struct TaskSupervisor {
     /// Interval between heartbeat-reaper sweeps — see
     /// [`TaskSupervisor::start_reaper`]. Defaults to
     /// [`DEFAULT_REAP_INTERVAL`].
-    reap_interval: Arc<std::sync::Mutex<Duration>>,
+    reap_interval: Arc<Mutex<Duration>>,
     /// Silence window after which an ACTIVE task with a LIVE worker is
     /// considered stuck — see [`TaskSupervisor::start_reaper`]. Defaults
     /// to [`DEFAULT_STUCK_TIMEOUT`], which matches the agent loop's
     /// per-tool wall-clock ceiling (`DEFAULT_REGISTRY_TOOL_TIMEOUT_SECS`
     /// = 1800s) so the reaper never fires earlier than the timeout a
     /// legitimate tool call is allowed to consume.
-    stuck_timeout: Arc<std::sync::Mutex<Duration>>,
+    stuck_timeout: Arc<Mutex<Duration>>,
     /// Whether the background reaper tokio task has been spawned — makes
     /// [`TaskSupervisor::start_reaper`] idempotent (the supervisor is
     /// `Clone`, and every clone shares this flag).
@@ -1233,6 +1240,7 @@ impl TaskSupervisor {
             tasks: Arc::new(Mutex::new(HashMap::new())),
             poisoned_parents: Arc::new(Mutex::new(HashSet::new())),
             on_change: Arc::new(Mutex::new(None)),
+            on_change_listeners: Arc::new(Mutex::new(HashMap::new())),
             on_failure: Arc::new(Mutex::new(None)),
             on_terminal: Arc::new(Mutex::new(None)),
             on_relaunch: Arc::new(Mutex::new(None)),
@@ -1314,6 +1322,14 @@ impl TaskSupervisor {
 
     /// Enable append-only persistence for task snapshots and restore existing state.
     ///
+    /// Re-enabling with the SAME ledger path is a transparent no-op: every
+    /// mutation since the first enable has been appended through the normal
+    /// transition path, so the reload/resnapshot/sweep below would add
+    /// nothing — yet the skill-action job view/invoke paths re-enable on
+    /// every request over the shared session supervisor, and each such call
+    /// used to rewrite the whole ledger (#1906). A repeat returns the live
+    /// task total, exactly what a full run would report.
+    ///
     /// At the end of replay, sweeps the in-memory map for any task whose
     /// `runtime_state` is non-terminal (anything other than `Completed`,
     /// `Failed`, or `Cancelled`). Those tasks are orphans — the worker
@@ -1327,24 +1343,43 @@ impl TaskSupervisor {
     /// This handles startup-time orphans only: at this point in startup no
     /// new work has been scheduled yet, so any non-terminal runtime_state
     /// definitionally has no live worker. In-flight orphans inside a
-    /// long-running supervisor (worker future alive but permanently stuck,
-    /// so neither this sweep nor [`TaskTerminalGuard`]'s `Drop` fires) are
-    /// covered by the heartbeat-based reaper — see [`Self::start_reaper`]
-    /// (issue #1920).
+    /// long-running supervisor (worker hangs / crashes silently while the
+    /// supervisor itself stays alive) are NOT addressed here — that needs
+    /// a heartbeat-based reaper, which is a follow-up if observed.
     pub fn enable_persistence(&self, path: impl Into<PathBuf>) -> std::io::Result<usize> {
         let path = path.into();
+        // Idempotence guard (#1906): already persisting to THIS ledger —
+        // nothing new to restore and nothing stale to re-append.
+        {
+            let guard = self
+                .persistence_path
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            if guard.as_ref() == Some(&path) {
+                return Ok(self.tasks.lock().unwrap_or_else(|e| e.into_inner()).len());
+            }
+        }
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
         let ledger_path = path.display().to_string();
         let restored = Self::load_persisted_tasks(&path)?;
+        // Rows whose DISK version won the merge (or that exist only on disk).
+        // They are already persisted verbatim, so the snapshot pass below
+        // must skip them — re-appending every restored row on each enable
+        // made a fresh supervisor's read-only restore grow the ledger by
+        // its full length per call (#1906). Tasks absent from this set
+        // (in-memory work scheduled before enable, or memory state newer
+        // than the ledger) are the only ones the snapshot pass writes.
+        let mut restored_won: HashSet<String> = HashSet::new();
         {
             let mut tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
             for (task_id, task) in restored {
                 match tasks.get(&task_id) {
                     Some(existing) if existing.updated_at >= task.updated_at => {}
                     _ => {
+                        restored_won.insert(task_id.clone());
                         tasks.insert(task_id, task);
                     }
                 }
@@ -1365,7 +1400,11 @@ impl TaskSupervisor {
 
         let snapshots: Vec<BackgroundTask> = {
             let tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
-            tasks.values().cloned().collect()
+            tasks
+                .values()
+                .filter(|task| !restored_won.contains(&task.id))
+                .cloned()
+                .collect()
         };
         for task in snapshots {
             self.persist_snapshot(&task);
@@ -1491,7 +1530,29 @@ impl TaskSupervisor {
     /// Set a callback that fires whenever a task's status changes.
     pub fn set_on_change(&self, cb: impl Fn(&BackgroundTask) + Send + Sync + 'static) {
         let mut guard = self.on_change.lock().unwrap_or_else(|e| e.into_inner());
-        *guard = Some(Box::new(cb));
+        *guard = Some(Arc::new(cb));
+    }
+
+    /// Add or replace a named observer without disturbing the primary
+    /// callback installed through [`Self::set_on_change`]. Stable keys make
+    /// repeated session wiring idempotent.
+    pub fn set_on_change_listener(
+        &self,
+        key: impl Into<String>,
+        cb: impl Fn(&BackgroundTask) + Send + Sync + 'static,
+    ) {
+        self.on_change_listeners
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(key.into(), Arc::new(cb));
+    }
+
+    /// Remove a named task-change observer.
+    pub fn remove_on_change_listener(&self, key: &str) {
+        self.on_change_listeners
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(key);
     }
 
     /// Set a callback that fires only when a `spawn_only` task transitions to
@@ -2189,6 +2250,7 @@ impl TaskSupervisor {
             summary: None,
             artifact_count: None,
             runtime_policy_stamp: None,
+            projection_metadata: None,
         };
         let mut tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
         // Codex P2 atomicity: when this is a child-task registration
@@ -2308,6 +2370,23 @@ impl TaskSupervisor {
         if let Some(task) = tasks.get_mut(task_id) {
             task.tool_input = Some(tool_input);
         }
+    }
+
+    /// Attach or replace opaque projection metadata for an existing task.
+    /// The update is persisted and emitted through the normal change stream,
+    /// so projections share the supervisor's ordering and durability.
+    pub fn set_projection_metadata(&self, task_id: &str, metadata: Value) {
+        let snapshot = {
+            let mut tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
+            let Some(task) = tasks.get_mut(task_id) else {
+                return;
+            };
+            task.projection_metadata = Some(metadata);
+            task.updated_at = Utc::now();
+            task.clone()
+        };
+        self.persist_snapshot(&snapshot);
+        self.notify_change(&snapshot);
     }
 
     /// Mark a task as running.
@@ -3263,10 +3342,26 @@ impl TaskSupervisor {
             .cloned())
     }
 
-    /// Fire the on_change callback (if set) with a task snapshot.
+    /// Fire the primary callback and every named observer. Clone callbacks
+    /// outside their mutexes before invocation so observers may safely update
+    /// their own registration.
     fn notify_change(&self, task: &BackgroundTask) {
-        let guard = self.on_change.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(ref cb) = *guard {
+        let primary = self
+            .on_change
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        let listeners = self
+            .on_change_listeners
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        if let Some(cb) = primary {
+            cb(task);
+        }
+        for cb in listeners {
             cb(task);
         }
     }

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -14,6 +14,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use metrics::counter;
@@ -338,11 +339,6 @@ pub struct BackgroundTask {
     /// AppUI `runtime_policy_stamp` schema.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_policy_stamp: Option<Value>,
-    /// Opaque host projection metadata. The supervisor persists this value
-    /// without interpreting its schema, allowing API adapters to derive
-    /// domain-specific views from the canonical task lifecycle.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub projection_metadata: Option<Value>,
 }
 
 impl BackgroundTask {
@@ -369,7 +365,7 @@ impl BackgroundTask {
 }
 
 /// Callback invoked when a task's status changes.
-type OnChangeCallback = Arc<dyn Fn(&BackgroundTask) + Send + Sync>;
+type OnChangeCallback = Box<dyn Fn(&BackgroundTask) + Send + Sync>;
 
 /// Payload emitted when a `spawn_only` background task transitions to
 /// `Failed`. Consumers (e.g. the session actor) use this to schedule a
@@ -895,8 +891,6 @@ pub struct TaskSupervisor {
     /// loop cannot keep adding children.
     poisoned_parents: Arc<Mutex<HashSet<String>>>,
     on_change: Arc<Mutex<Option<OnChangeCallback>>>,
-    /// Named observers supplement (and never replace) the primary callback.
-    on_change_listeners: Arc<Mutex<HashMap<String, OnChangeCallback>>>,
     on_failure: Arc<Mutex<Option<OnFailureCallback>>>,
     /// Gap-1 unification: single terminal-transition sink. Fired from
     /// every terminal path alongside the legacy `on_change` / `on_failure`
@@ -942,7 +936,34 @@ pub struct TaskSupervisor {
     /// See [`AckAndPending`] for the field-level documentation that
     /// previously lived on the individual fields.
     ack_and_pending: Arc<Mutex<AckAndPending>>,
+    /// Interval between heartbeat-reaper sweeps — see
+    /// [`TaskSupervisor::start_reaper`]. Defaults to
+    /// [`DEFAULT_REAP_INTERVAL`].
+    reap_interval: Arc<std::sync::Mutex<Duration>>,
+    /// Silence window after which an ACTIVE task with a LIVE worker is
+    /// considered stuck — see [`TaskSupervisor::start_reaper`]. Defaults
+    /// to [`DEFAULT_STUCK_TIMEOUT`], which matches the agent loop's
+    /// per-tool wall-clock ceiling (`DEFAULT_REGISTRY_TOOL_TIMEOUT_SECS`
+    /// = 1800s) so the reaper never fires earlier than the timeout a
+    /// legitimate tool call is allowed to consume.
+    stuck_timeout: Arc<std::sync::Mutex<Duration>>,
+    /// Whether the background reaper tokio task has been spawned — makes
+    /// [`TaskSupervisor::start_reaper`] idempotent (the supervisor is
+    /// `Clone`, and every clone shares this flag).
+    reaper_started: Arc<AtomicBool>,
 }
+
+/// Default heartbeat-reaper sweep interval. One minute is far below any
+/// plausible `stuck_timeout`, so the extra lock traffic is negligible.
+pub const DEFAULT_REAP_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Default silence window before a live-but-silent task is reaped. 30 min
+/// matches the agent loop's per-tool timeout (1800s): a worker that has
+/// produced NO progress signal for this long would be killed by the
+/// wall-clock backstop anyway, so the reaper only ever fires on workers
+/// that are genuinely wedged (or on progress paths that forgot to stamp
+/// `updated_at` — see the audit note on [`TaskSupervisor::start_reaper`]).
+pub const DEFAULT_STUCK_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
 /// Combined state guarded by a single mutex (Codex round-2 BLOCKER):
 /// the synth-ack set, the deferred-failure stash, and the per-task
@@ -1212,7 +1233,6 @@ impl TaskSupervisor {
             tasks: Arc::new(Mutex::new(HashMap::new())),
             poisoned_parents: Arc::new(Mutex::new(HashSet::new())),
             on_change: Arc::new(Mutex::new(None)),
-            on_change_listeners: Arc::new(Mutex::new(HashMap::new())),
             on_failure: Arc::new(Mutex::new(None)),
             on_terminal: Arc::new(Mutex::new(None)),
             on_relaunch: Arc::new(Mutex::new(None)),
@@ -1220,6 +1240,9 @@ impl TaskSupervisor {
             progress_reporter: Arc::new(Mutex::new(None)),
             cancel_tokens: Arc::new(CancelTokenStore::default()),
             ack_and_pending: Arc::new(Mutex::new(AckAndPending::default())),
+            reap_interval: Arc::new(Mutex::new(DEFAULT_REAP_INTERVAL)),
+            stuck_timeout: Arc::new(Mutex::new(DEFAULT_STUCK_TIMEOUT)),
+            reaper_started: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -1291,14 +1314,6 @@ impl TaskSupervisor {
 
     /// Enable append-only persistence for task snapshots and restore existing state.
     ///
-    /// Re-enabling with the SAME ledger path is a transparent no-op: every
-    /// mutation since the first enable has been appended through the normal
-    /// transition path, so the reload/resnapshot/sweep below would add
-    /// nothing — yet the skill-action job view/invoke paths re-enable on
-    /// every request over the shared session supervisor, and each such call
-    /// used to rewrite the whole ledger (#1906). A repeat returns the live
-    /// task total, exactly what a full run would report.
-    ///
     /// At the end of replay, sweeps the in-memory map for any task whose
     /// `runtime_state` is non-terminal (anything other than `Completed`,
     /// `Failed`, or `Cancelled`). Those tasks are orphans — the worker
@@ -1312,43 +1327,24 @@ impl TaskSupervisor {
     /// This handles startup-time orphans only: at this point in startup no
     /// new work has been scheduled yet, so any non-terminal runtime_state
     /// definitionally has no live worker. In-flight orphans inside a
-    /// long-running supervisor (worker hangs / crashes silently while the
-    /// supervisor itself stays alive) are NOT addressed here — that needs
-    /// a heartbeat-based reaper, which is a follow-up if observed.
+    /// long-running supervisor (worker future alive but permanently stuck,
+    /// so neither this sweep nor [`TaskTerminalGuard`]'s `Drop` fires) are
+    /// covered by the heartbeat-based reaper — see [`Self::start_reaper`]
+    /// (issue #1920).
     pub fn enable_persistence(&self, path: impl Into<PathBuf>) -> std::io::Result<usize> {
         let path = path.into();
-        // Idempotence guard (#1906): already persisting to THIS ledger —
-        // nothing new to restore and nothing stale to re-append.
-        {
-            let guard = self
-                .persistence_path
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            if guard.as_ref() == Some(&path) {
-                return Ok(self.tasks.lock().unwrap_or_else(|e| e.into_inner()).len());
-            }
-        }
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
         let ledger_path = path.display().to_string();
         let restored = Self::load_persisted_tasks(&path)?;
-        // Rows whose DISK version won the merge (or that exist only on disk).
-        // They are already persisted verbatim, so the snapshot pass below
-        // must skip them — re-appending every restored row on each enable
-        // made a fresh supervisor's read-only restore grow the ledger by
-        // its full length per call (#1906). Tasks absent from this set
-        // (in-memory work scheduled before enable, or memory state newer
-        // than the ledger) are the only ones the snapshot pass writes.
-        let mut restored_won: HashSet<String> = HashSet::new();
         {
             let mut tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
             for (task_id, task) in restored {
                 match tasks.get(&task_id) {
                     Some(existing) if existing.updated_at >= task.updated_at => {}
                     _ => {
-                        restored_won.insert(task_id.clone());
                         tasks.insert(task_id, task);
                     }
                 }
@@ -1369,11 +1365,7 @@ impl TaskSupervisor {
 
         let snapshots: Vec<BackgroundTask> = {
             let tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
-            tasks
-                .values()
-                .filter(|task| !restored_won.contains(&task.id))
-                .cloned()
-                .collect()
+            tasks.values().cloned().collect()
         };
         for task in snapshots {
             self.persist_snapshot(&task);
@@ -1499,29 +1491,7 @@ impl TaskSupervisor {
     /// Set a callback that fires whenever a task's status changes.
     pub fn set_on_change(&self, cb: impl Fn(&BackgroundTask) + Send + Sync + 'static) {
         let mut guard = self.on_change.lock().unwrap_or_else(|e| e.into_inner());
-        *guard = Some(Arc::new(cb));
-    }
-
-    /// Add or replace a named observer without disturbing the primary
-    /// callback installed through [`Self::set_on_change`]. Stable keys make
-    /// repeated session wiring idempotent.
-    pub fn set_on_change_listener(
-        &self,
-        key: impl Into<String>,
-        cb: impl Fn(&BackgroundTask) + Send + Sync + 'static,
-    ) {
-        self.on_change_listeners
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(key.into(), Arc::new(cb));
-    }
-
-    /// Remove a named task-change observer.
-    pub fn remove_on_change_listener(&self, key: &str) {
-        self.on_change_listeners
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .remove(key);
+        *guard = Some(Box::new(cb));
     }
 
     /// Set a callback that fires only when a `spawn_only` task transitions to
@@ -2219,7 +2189,6 @@ impl TaskSupervisor {
             summary: None,
             artifact_count: None,
             runtime_policy_stamp: None,
-            projection_metadata: None,
         };
         let mut tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
         // Codex P2 atomicity: when this is a child-task registration
@@ -2339,23 +2308,6 @@ impl TaskSupervisor {
         if let Some(task) = tasks.get_mut(task_id) {
             task.tool_input = Some(tool_input);
         }
-    }
-
-    /// Attach or replace opaque projection metadata for an existing task.
-    /// The update is persisted and emitted through the normal change stream,
-    /// so projections share the supervisor's ordering and durability.
-    pub fn set_projection_metadata(&self, task_id: &str, metadata: Value) {
-        let snapshot = {
-            let mut tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
-            let Some(task) = tasks.get_mut(task_id) else {
-                return;
-            };
-            task.projection_metadata = Some(metadata);
-            task.updated_at = Utc::now();
-            task.clone()
-        };
-        self.persist_snapshot(&snapshot);
-        self.notify_change(&snapshot);
     }
 
     /// Mark a task as running.
@@ -3311,26 +3263,10 @@ impl TaskSupervisor {
             .cloned())
     }
 
-    /// Fire the primary callback and every named observer. Clone callbacks
-    /// outside their mutexes before invocation so observers may safely update
-    /// their own registration.
+    /// Fire the on_change callback (if set) with a task snapshot.
     fn notify_change(&self, task: &BackgroundTask) {
-        let primary = self
-            .on_change
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone();
-        let listeners = self
-            .on_change_listeners
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
-        if let Some(cb) = primary {
-            cb(task);
-        }
-        for cb in listeners {
+        let guard = self.on_change.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(ref cb) = *guard {
             cb(task);
         }
     }
@@ -3431,6 +3367,162 @@ impl TaskSupervisor {
     pub fn task_count(&self) -> usize {
         let tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
         tasks.values().filter(|t| t.status.is_active()).count()
+    }
+
+    /// Override the heartbeat-reaper sweep interval (default
+    /// [`DEFAULT_REAP_INTERVAL`]). Takes effect on the next tick.
+    pub fn set_reap_interval(&self, interval: Duration) {
+        *self.reap_interval.lock().unwrap_or_else(|e| e.into_inner()) = interval;
+    }
+
+    /// Override the silence window after which a live-but-silent task is
+    /// reaped (default [`DEFAULT_STUCK_TIMEOUT`]). Takes effect on the
+    /// next sweep.
+    pub fn set_stuck_timeout(&self, timeout: Duration) {
+        *self.stuck_timeout.lock().unwrap_or_else(|e| e.into_inner()) = timeout;
+    }
+
+    /// Start the heartbeat-based in-flight orphan reaper (issue #1920).
+    ///
+    /// The startup sweep in [`Self::enable_persistence`] only covers
+    /// orphans left behind by a process RESTART: at that point no work
+    /// has been scheduled, so a non-terminal row definitionally has no
+    /// live worker. A long-running supervisor has a second orphan shape:
+    /// the worker future is still ALIVE (so [`is_task_live`] is true and
+    /// neither the sweep nor [`TaskTerminalGuard`]'s `Drop` will ever
+    /// fire) but permanently STUCK — blocked on a resource that never
+    /// resolves, spinning without producing progress, etc. Such a task
+    /// shows `running` forever, never releases its slot, and is
+    /// indistinguishable from healthy slow work.
+    ///
+    /// This spawns a tokio task that every [`Self::reap_interval`]
+    /// collects candidates and reaps any ACTIVE task that:
+    ///
+    /// 1. has a LIVE worker in this process ([`is_task_live`]) — a
+    ///    non-live active task is the dropped-worker case
+    ///    [`TaskTerminalGuard`]'s `Drop` already handles, so reaping it
+    ///    here would double-fire failure callbacks; and
+    /// 2. has produced NO progress signal for longer than
+    ///    [`Self::stuck_timeout`], measured via `updated_at`.
+    ///
+    /// `updated_at` is the heartbeat: it is stamped by every progress
+    /// path a healthy worker drives — `mark_running` (worker start),
+    /// `mark_runtime_state` (harness/runtime progress events), the
+    /// projection-field updater, `mark_completed` / `mark_failed` /
+    /// `cancel` (terminal transitions), `record_final_output`, and
+    /// `mark_child_session_outcome`. A long-but-progressing task (e.g. a
+    /// `deep_research` pipeline streaming phase events) therefore keeps
+    /// its heartbeat fresh and is NEVER reaped; only genuinely silent
+    /// workers are. The default 30-min timeout additionally matches the
+    /// agent loop's per-tool wall-clock backstop (1800s), so the reaper
+    /// cannot fire earlier than the timeout a legitimate tool call is
+    /// allowed to consume.
+    ///
+    /// Reaping transitions the task through the standard `mark_failed`
+    /// path (terminal ledger entry, persistence, callbacks — idempotent
+    /// if a racing worker already finished) and then flips the task's
+    /// cancel token so a COOPERATIVE stuck worker wakes at its next safe
+    /// point and unwinds (which drops its guard and clears the live-set
+    /// entry). A truly wedged worker stays in the live-set, so the
+    /// reaper would re-log on subsequent sweeps were it not for the
+    /// terminal check — the task is already `Failed` and skipped.
+    ///
+    /// Idempotent: only the first call spawns the loop; later calls are
+    /// no-ops (the flag is shared across `Clone`s). The loop holds only
+    /// a weak liveness story — it keeps running as long as the process
+    /// does; dropping the supervisor's last clone does not stop the
+    /// spawned task until the runtime shuts down (acceptable: the
+    /// production supervisor lives for the process lifetime).
+    pub fn start_reaper(self: &Arc<Self>) {
+        if self.reaper_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let supervisor = Arc::clone(self);
+        tokio::spawn(async move {
+            loop {
+                let interval = *supervisor
+                    .reap_interval
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+                tokio::time::sleep(interval).await;
+                let timeout = *supervisor
+                    .stuck_timeout
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+                supervisor.reap_stuck_tasks(Utc::now(), timeout);
+            }
+        });
+    }
+
+    /// One reaper sweep, factored out of [`Self::start_reaper`]'s tokio
+    /// loop so unit tests can drive it synchronously (no sleeping).
+    /// `now` is the reference instant and `stuck_timeout` the silence
+    /// window; both are parameters so tests control the clock.
+    ///
+    /// Returns the ids of reaped tasks. See [`Self::start_reaper`] for
+    /// the full reaping contract.
+    pub fn reap_stuck_tasks(&self, now: DateTime<Utc>, stuck_timeout: Duration) -> Vec<String> {
+        let candidates: Vec<String> = {
+            let tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
+            tasks
+                .values()
+                .filter(|task| {
+                    // Terminal rows are already resolved — never touch.
+                    if !task.status.is_active() {
+                        return false;
+                    }
+                    // A NON-live active task is the dropped-worker case:
+                    // its TaskTerminalGuard::drop fires mark_failed
+                    // ("worker dropped before reaching terminal state")
+                    // on every exit path, so reaping here would
+                    // double-fire failure callbacks / ledger entries.
+                    // The startup sweep owns cross-process orphans.
+                    if !is_task_live(&task.id) {
+                        return false;
+                    }
+                    // The heartbeat gate: `now - updated_at > timeout`.
+                    // `signed_duration_since` (not `signed_duration_from`)
+                    // handles a clock-skewed FUTURE updated_at by yielding
+                    // a negative age, which never exceeds the timeout.
+                    now.signed_duration_since(task.updated_at)
+                        .to_std()
+                        .map(|age| age > stuck_timeout)
+                        .unwrap_or(false)
+                })
+                .map(|task| task.id.clone())
+                .collect()
+        };
+
+        let mut reaped = Vec::new();
+        for task_id in candidates {
+            // mark_failed re-checks the terminal guard internally, so a
+            // worker that transitioned between candidate collection and
+            // this call is a no-op (idempotent terminal path).
+            self.mark_failed(
+                &task_id,
+                format!("orphaned: no progress for {stuck_timeout:?} (heartbeat timeout)"),
+            );
+            // Flip the cancel token AFTER the terminal transition — a
+            // cooperative stuck worker wakes at its next safe point,
+            // re-reads the supervisor, sees the terminal state, and
+            // unwinds (dropping its guard, which clears the live-set).
+            // `ensure` mirrors `cancel()`'s ordering: allocate the token
+            // even if the worker never polled one so a late
+            // `cancel_token()` call still observes the cancelled state.
+            self.cancel_tokens.ensure(&task_id).cancel();
+            counter!(
+                "octos_orphaned_tasks_reaped_total",
+                "reason" => "heartbeat_timeout"
+            )
+            .increment(1);
+            tracing::warn!(
+                task_id = %task_id,
+                stuck_timeout = ?stuck_timeout,
+                "reaped stuck background task (heartbeat timeout)"
+            );
+            reaped.push(task_id);
+        }
+        reaped
     }
 }
 

--- a/crates/octos-agent/src/task_supervisor_tests.rs
+++ b/crates/octos-agent/src/task_supervisor_tests.rs
@@ -11,7 +11,7 @@ fn record_final_output_fires_on_change_with_the_output() {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     let supervisor = TaskSupervisor::new();
-    let id = supervisor.register("spawn", "call-final-output", None);
+    let id = supervisor.register("spawn", "call-fo", None);
     supervisor.mark_completed(&id, vec![]);
 
     // Only observe changes AFTER completion, so we isolate the
@@ -22,8 +22,8 @@ fn record_final_output_fires_on_change_with_the_output() {
     let calls_c = calls.clone();
     supervisor.set_on_change(move |task| {
         calls_c.fetch_add(1, Ordering::SeqCst);
-        if let Some(output) = task.final_output.clone() {
-            *seen_c.lock().unwrap() = Some(output);
+        if let Some(fo) = task.final_output.clone() {
+            *seen_c.lock().unwrap() = Some(fo);
         }
     });
 
@@ -58,48 +58,6 @@ fn should_register_task_with_spawned_status() {
     assert!(tasks[0].child_failure_action.is_none());
     assert!(tasks[0].completed_at.is_none());
     assert!(tasks[0].updated_at >= tasks[0].started_at);
-}
-
-#[test]
-fn named_change_listeners_fan_out_without_replacing_primary_callback() {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    let supervisor = TaskSupervisor::new();
-    let primary = Arc::new(AtomicUsize::new(0));
-    let projection_a = Arc::new(AtomicUsize::new(0));
-    let projection_b = Arc::new(AtomicUsize::new(0));
-
-    let count = Arc::clone(&primary);
-    supervisor.set_on_change(move |_| {
-        count.fetch_add(1, Ordering::SeqCst);
-    });
-    let count = Arc::clone(&projection_a);
-    supervisor.set_on_change_listener("projection-a", move |_| {
-        count.fetch_add(1, Ordering::SeqCst);
-    });
-    let count = Arc::clone(&projection_b);
-    supervisor.set_on_change_listener("projection-b", move |_| {
-        count.fetch_add(1, Ordering::SeqCst);
-    });
-
-    let id = supervisor.register("source_import", "call-fanout", None);
-    supervisor.mark_running(&id);
-    assert_eq!(primary.load(Ordering::SeqCst), 1);
-    assert_eq!(projection_a.load(Ordering::SeqCst), 1);
-    assert_eq!(projection_b.load(Ordering::SeqCst), 1);
-
-    // Replacing a named listener is idempotent and leaves both the primary
-    // callback and other projections installed.
-    let replacement = Arc::new(AtomicUsize::new(0));
-    let count = Arc::clone(&replacement);
-    supervisor.set_on_change_listener("projection-a", move |_| {
-        count.fetch_add(1, Ordering::SeqCst);
-    });
-    supervisor.mark_completed(&id, vec![]);
-    assert_eq!(primary.load(Ordering::SeqCst), 2);
-    assert_eq!(projection_a.load(Ordering::SeqCst), 1);
-    assert_eq!(replacement.load(Ordering::SeqCst), 1);
-    assert_eq!(projection_b.load(Ordering::SeqCst), 2);
 }
 
 /// #966 / M13-B — the projection setter populates the new
@@ -968,92 +926,6 @@ fn should_restore_completed_and_failed_truth_after_restart() {
         Some(ChildSessionFailureAction::Escalate)
     );
     assert!(failed_task.child_joined_at.is_none());
-}
-
-fn ledger_line_count(path: &std::path::Path) -> usize {
-    std::fs::read_to_string(path)
-        .unwrap_or_default()
-        .lines()
-        .filter(|line| !line.trim().is_empty())
-        .count()
-}
-
-#[test]
-fn should_not_rewrite_ledger_when_reenabling_same_path() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let ledger_path = dir.path().join("tasks.jsonl");
-
-    let supervisor = TaskSupervisor::new();
-    supervisor.enable_persistence(&ledger_path).unwrap();
-    let task_id = supervisor.register_with_lineage("search", "call-1", Some("api:session"), None);
-    supervisor.mark_completed(&task_id, vec![]);
-
-    let lines_after_first_enable = ledger_line_count(&ledger_path);
-
-    // The skill-action job view/invoke paths re-enable persistence on the
-    // SHARED session supervisor on every request (#1906). With persistence
-    // already on for this ledger, everything since has been appended
-    // through the normal transition path — a repeat enable must be a
-    // no-op, not a full snapshot rewrite.
-    let restored = supervisor.enable_persistence(&ledger_path).unwrap();
-    assert_eq!(
-        restored, 1,
-        "repeat enable returns the live task total, same as a full enable"
-    );
-    assert_eq!(
-        ledger_line_count(&ledger_path),
-        lines_after_first_enable,
-        "same-path re-enable must not append snapshots"
-    );
-}
-
-#[test]
-fn should_not_reappend_restored_rows_when_fresh_supervisor_loads_ledger() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let ledger_path = dir.path().join("tasks.jsonl");
-
-    let supervisor = TaskSupervisor::new();
-    supervisor.enable_persistence(&ledger_path).unwrap();
-    let done = supervisor.register_with_lineage("fm_tts", "call-1", Some("api:session"), None);
-    supervisor.mark_completed(&done, vec![]);
-    let lines_before = ledger_line_count(&ledger_path);
-
-    // A fresh supervisor that only RESTORES an existing ledger (the
-    // skill-action list path builds one per request) must not re-append
-    // snapshots for rows it just read — they are already on disk.
-    let restored = TaskSupervisor::new();
-    let count = restored.enable_persistence(&ledger_path).unwrap();
-    assert_eq!(count, 1);
-    assert_eq!(restored.get_all_tasks().len(), 1);
-    assert_eq!(
-        ledger_line_count(&ledger_path),
-        lines_before,
-        "read-only restore must leave the ledger untouched"
-    );
-}
-
-#[test]
-fn should_persist_preexisting_in_memory_tasks_when_enabling_persistence() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let ledger_path = dir.path().join("tasks.jsonl");
-
-    // A task scheduled BEFORE persistence is enabled (the startup window
-    // the snapshot loop exists for) must still land on disk.
-    let supervisor = TaskSupervisor::new();
-    let task_id = supervisor.register_with_lineage("search", "call-1", Some("api:session"), None);
-    supervisor.mark_completed(&task_id, vec![]);
-    assert_eq!(ledger_line_count(&ledger_path), 0, "nothing persisted yet");
-
-    supervisor.enable_persistence(&ledger_path).unwrap();
-    assert!(
-        ledger_line_count(&ledger_path) > 0,
-        "pre-existing in-memory task must be persisted on enable"
-    );
-
-    let restored = TaskSupervisor::new();
-    restored.enable_persistence(&ledger_path).unwrap();
-    assert_eq!(restored.get_all_tasks().len(), 1);
-    assert_eq!(restored.get_all_tasks()[0].id, task_id);
 }
 
 #[test]
@@ -3960,4 +3832,177 @@ async fn foreground_armed_guard_survives_sweep_before_worker_polls() {
         !is_task_live(&id),
         "live-set cleared after the worker future drops"
     );
+}
+
+// ── issue #1920: heartbeat-based in-flight orphan reaper ──────────────
+
+/// A live worker whose heartbeat (`updated_at`) has been silent for longer
+/// than `stuck_timeout` is reaped: status transitions to `Failed` with the
+/// heartbeat message and its cancel token is flipped so a cooperative
+/// worker wakes and unwinds.
+#[tokio::test]
+async fn reaper_fails_stuck_live_task_and_cancels_token() {
+    let supervisor = Arc::new(TaskSupervisor::new());
+    let id = supervisor.register("run_pipeline", "call-stuck", Some("api:sess"));
+    supervisor.mark_running(&id);
+    // Arm the guard so the task is LIVE (the reaper only touches live
+    // workers — the dropped-worker case belongs to the guard's Drop).
+    let _guard = TaskTerminalGuard::new(Arc::clone(&supervisor), id.clone());
+    assert!(is_task_live(&id));
+
+    // Age the heartbeat well past the timeout by stamping updated_at in
+    // the past (register/mark_running set it to now).
+    let stale_at = Utc::now() - chrono::Duration::minutes(10);
+    {
+        let mut tasks = supervisor.tasks.lock().unwrap_or_else(|e| e.into_inner());
+        tasks.get_mut(&id).unwrap().updated_at = stale_at;
+    }
+    let token = supervisor.cancel_token(&id);
+    assert!(!token.is_cancelled());
+
+    let timeout = Duration::from_secs(60);
+    let reaped = supervisor.reap_stuck_tasks(Utc::now(), timeout);
+
+    assert_eq!(reaped, vec![id.clone()]);
+    let task = supervisor.get_task(&id).expect("task");
+    assert_eq!(task.status, TaskStatus::Failed);
+    assert_eq!(
+        task.error.as_deref(),
+        Some("orphaned: no progress for 60s (heartbeat timeout)"),
+    );
+    assert!(
+        token.is_cancelled(),
+        "the reaper flips the cancel token so a cooperative worker wakes"
+    );
+    assert!(
+        is_task_live(&id),
+        "live-set cleanup stays with the guard's Drop, not the reaper"
+    );
+
+    // A second sweep is a no-op: the task is terminal now.
+    let reaped_again = supervisor.reap_stuck_tasks(Utc::now(), timeout);
+    assert!(reaped_again.is_empty());
+}
+
+/// A live worker that keeps its heartbeat fresh (recent `updated_at`) is
+/// NOT reaped — this is the long-but-progressing case (deep_research
+/// streaming progress events).
+#[tokio::test]
+async fn reaper_spares_task_with_fresh_heartbeat() {
+    let supervisor = Arc::new(TaskSupervisor::new());
+    let id = supervisor.register("run_pipeline", "call-fresh", Some("api:sess"));
+    supervisor.mark_running(&id);
+    let _guard = TaskTerminalGuard::new(Arc::clone(&supervisor), id.clone());
+
+    let reaped = supervisor.reap_stuck_tasks(Utc::now(), Duration::from_secs(60));
+
+    assert!(reaped.is_empty());
+    assert_eq!(
+        supervisor.get_task(&id).expect("task").status,
+        TaskStatus::Running,
+    );
+    assert!(!supervisor.cancel_token(&id).is_cancelled());
+}
+
+/// Terminal tasks are never touched, even if their `updated_at` is ancient.
+#[tokio::test]
+async fn reaper_never_touches_terminal_tasks() {
+    let supervisor = Arc::new(TaskSupervisor::new());
+    let id = supervisor.register("spawn", "call-terminal", Some("api:sess"));
+    supervisor.mark_running(&id);
+    supervisor.mark_completed(&id, vec![]);
+
+    let stale_at = Utc::now() - chrono::Duration::minutes(30);
+    {
+        let mut tasks = supervisor.tasks.lock().unwrap_or_else(|e| e.into_inner());
+        tasks.get_mut(&id).unwrap().updated_at = stale_at;
+    }
+
+    let reaped = supervisor.reap_stuck_tasks(Utc::now(), Duration::from_secs(60));
+
+    assert!(reaped.is_empty());
+    let task = supervisor.get_task(&id).expect("task");
+    assert_eq!(task.status, TaskStatus::Completed);
+    assert!(task.error.is_none());
+}
+
+/// An ACTIVE task WITHOUT a live worker is the dropped-worker case the
+/// `TaskTerminalGuard` owns — the reaper must skip it (double-firing the
+/// failure callbacks would surface two recovery signals for one death).
+#[tokio::test]
+async fn reaper_skips_active_task_without_live_worker() {
+    let supervisor = Arc::new(TaskSupervisor::new());
+    let id = supervisor.register("spawn", "call-not-live", Some("api:sess"));
+    supervisor.mark_running(&id);
+    assert!(
+        !is_task_live(&id),
+        "no guard armed, so the id is not in the live-set"
+    );
+
+    let stale_at = Utc::now() - chrono::Duration::minutes(30);
+    {
+        let mut tasks = supervisor.tasks.lock().unwrap_or_else(|e| e.into_inner());
+        tasks.get_mut(&id).unwrap().updated_at = stale_at;
+    }
+
+    let reaped = supervisor.reap_stuck_tasks(Utc::now(), Duration::from_secs(60));
+
+    assert!(reaped.is_empty());
+    assert_eq!(
+        supervisor.get_task(&id).expect("task").status,
+        TaskStatus::Running,
+        "non-live active tasks are left for TaskTerminalGuard / the startup sweep",
+    );
+}
+
+/// A future `updated_at` (clock skew on a hydrated snapshot) yields a
+/// negative age and must never be reaped.
+#[tokio::test]
+async fn reaper_tolerates_future_updated_at_clock_skew() {
+    let supervisor = Arc::new(TaskSupervisor::new());
+    let id = supervisor.register("spawn", "call-skew", Some("api:sess"));
+    supervisor.mark_running(&id);
+    let _guard = TaskTerminalGuard::new(Arc::clone(&supervisor), id.clone());
+
+    let future_at = Utc::now() + chrono::Duration::minutes(5);
+    {
+        let mut tasks = supervisor.tasks.lock().unwrap_or_else(|e| e.into_inner());
+        tasks.get_mut(&id).unwrap().updated_at = future_at;
+    }
+
+    let reaped = supervisor.reap_stuck_tasks(Utc::now(), Duration::from_secs(60));
+
+    assert!(reaped.is_empty());
+    assert_eq!(
+        supervisor.get_task(&id).expect("task").status,
+        TaskStatus::Running,
+    );
+}
+
+/// `start_reaper` is idempotent and drives `reap_stuck_tasks` on its
+/// interval: with a tiny interval/timeout a silently-stuck live task is
+/// reaped by the background loop itself (no manual sweep call).
+#[tokio::test]
+async fn start_reaper_loop_reaps_stuck_task_on_interval() {
+    let supervisor = Arc::new(TaskSupervisor::new());
+    supervisor.set_reap_interval(Duration::from_millis(20));
+    supervisor.set_stuck_timeout(Duration::from_millis(50));
+    let id = supervisor.register("spawn", "call-loop", Some("api:sess"));
+    supervisor.mark_running(&id);
+    let _guard = TaskTerminalGuard::new(Arc::clone(&supervisor), id.clone());
+
+    supervisor.start_reaper();
+    supervisor.start_reaper(); // idempotent — must not panic or double-spawn
+
+    // The task makes NO progress: after a few intervals the loop reaps it.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let task = supervisor.get_task(&id).expect("task");
+    assert_eq!(task.status, TaskStatus::Failed);
+    assert!(
+        task.error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("heartbeat timeout")
+    );
+    assert!(supervisor.cancel_token(&id).is_cancelled());
 }

--- a/crates/octos-agent/src/task_supervisor_tests.rs
+++ b/crates/octos-agent/src/task_supervisor_tests.rs
@@ -11,7 +11,7 @@ fn record_final_output_fires_on_change_with_the_output() {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     let supervisor = TaskSupervisor::new();
-    let id = supervisor.register("spawn", "call-fo", None);
+    let id = supervisor.register("spawn", "call-final-output", None);
     supervisor.mark_completed(&id, vec![]);
 
     // Only observe changes AFTER completion, so we isolate the
@@ -22,8 +22,8 @@ fn record_final_output_fires_on_change_with_the_output() {
     let calls_c = calls.clone();
     supervisor.set_on_change(move |task| {
         calls_c.fetch_add(1, Ordering::SeqCst);
-        if let Some(fo) = task.final_output.clone() {
-            *seen_c.lock().unwrap() = Some(fo);
+        if let Some(output) = task.final_output.clone() {
+            *seen_c.lock().unwrap() = Some(output);
         }
     });
 
@@ -58,6 +58,48 @@ fn should_register_task_with_spawned_status() {
     assert!(tasks[0].child_failure_action.is_none());
     assert!(tasks[0].completed_at.is_none());
     assert!(tasks[0].updated_at >= tasks[0].started_at);
+}
+
+#[test]
+fn named_change_listeners_fan_out_without_replacing_primary_callback() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let supervisor = TaskSupervisor::new();
+    let primary = Arc::new(AtomicUsize::new(0));
+    let projection_a = Arc::new(AtomicUsize::new(0));
+    let projection_b = Arc::new(AtomicUsize::new(0));
+
+    let count = Arc::clone(&primary);
+    supervisor.set_on_change(move |_| {
+        count.fetch_add(1, Ordering::SeqCst);
+    });
+    let count = Arc::clone(&projection_a);
+    supervisor.set_on_change_listener("projection-a", move |_| {
+        count.fetch_add(1, Ordering::SeqCst);
+    });
+    let count = Arc::clone(&projection_b);
+    supervisor.set_on_change_listener("projection-b", move |_| {
+        count.fetch_add(1, Ordering::SeqCst);
+    });
+
+    let id = supervisor.register("source_import", "call-fanout", None);
+    supervisor.mark_running(&id);
+    assert_eq!(primary.load(Ordering::SeqCst), 1);
+    assert_eq!(projection_a.load(Ordering::SeqCst), 1);
+    assert_eq!(projection_b.load(Ordering::SeqCst), 1);
+
+    // Replacing a named listener is idempotent and leaves both the primary
+    // callback and other projections installed.
+    let replacement = Arc::new(AtomicUsize::new(0));
+    let count = Arc::clone(&replacement);
+    supervisor.set_on_change_listener("projection-a", move |_| {
+        count.fetch_add(1, Ordering::SeqCst);
+    });
+    supervisor.mark_completed(&id, vec![]);
+    assert_eq!(primary.load(Ordering::SeqCst), 2);
+    assert_eq!(projection_a.load(Ordering::SeqCst), 1);
+    assert_eq!(replacement.load(Ordering::SeqCst), 1);
+    assert_eq!(projection_b.load(Ordering::SeqCst), 2);
 }
 
 /// #966 / M13-B — the projection setter populates the new
@@ -926,6 +968,92 @@ fn should_restore_completed_and_failed_truth_after_restart() {
         Some(ChildSessionFailureAction::Escalate)
     );
     assert!(failed_task.child_joined_at.is_none());
+}
+
+fn ledger_line_count(path: &std::path::Path) -> usize {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .count()
+}
+
+#[test]
+fn should_not_rewrite_ledger_when_reenabling_same_path() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let ledger_path = dir.path().join("tasks.jsonl");
+
+    let supervisor = TaskSupervisor::new();
+    supervisor.enable_persistence(&ledger_path).unwrap();
+    let task_id = supervisor.register_with_lineage("search", "call-1", Some("api:session"), None);
+    supervisor.mark_completed(&task_id, vec![]);
+
+    let lines_after_first_enable = ledger_line_count(&ledger_path);
+
+    // The skill-action job view/invoke paths re-enable persistence on the
+    // SHARED session supervisor on every request (#1906). With persistence
+    // already on for this ledger, everything since has been appended
+    // through the normal transition path — a repeat enable must be a
+    // no-op, not a full snapshot rewrite.
+    let restored = supervisor.enable_persistence(&ledger_path).unwrap();
+    assert_eq!(
+        restored, 1,
+        "repeat enable returns the live task total, same as a full enable"
+    );
+    assert_eq!(
+        ledger_line_count(&ledger_path),
+        lines_after_first_enable,
+        "same-path re-enable must not append snapshots"
+    );
+}
+
+#[test]
+fn should_not_reappend_restored_rows_when_fresh_supervisor_loads_ledger() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let ledger_path = dir.path().join("tasks.jsonl");
+
+    let supervisor = TaskSupervisor::new();
+    supervisor.enable_persistence(&ledger_path).unwrap();
+    let done = supervisor.register_with_lineage("fm_tts", "call-1", Some("api:session"), None);
+    supervisor.mark_completed(&done, vec![]);
+    let lines_before = ledger_line_count(&ledger_path);
+
+    // A fresh supervisor that only RESTORES an existing ledger (the
+    // skill-action list path builds one per request) must not re-append
+    // snapshots for rows it just read — they are already on disk.
+    let restored = TaskSupervisor::new();
+    let count = restored.enable_persistence(&ledger_path).unwrap();
+    assert_eq!(count, 1);
+    assert_eq!(restored.get_all_tasks().len(), 1);
+    assert_eq!(
+        ledger_line_count(&ledger_path),
+        lines_before,
+        "read-only restore must leave the ledger untouched"
+    );
+}
+
+#[test]
+fn should_persist_preexisting_in_memory_tasks_when_enabling_persistence() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let ledger_path = dir.path().join("tasks.jsonl");
+
+    // A task scheduled BEFORE persistence is enabled (the startup window
+    // the snapshot loop exists for) must still land on disk.
+    let supervisor = TaskSupervisor::new();
+    let task_id = supervisor.register_with_lineage("search", "call-1", Some("api:session"), None);
+    supervisor.mark_completed(&task_id, vec![]);
+    assert_eq!(ledger_line_count(&ledger_path), 0, "nothing persisted yet");
+
+    supervisor.enable_persistence(&ledger_path).unwrap();
+    assert!(
+        ledger_line_count(&ledger_path) > 0,
+        "pre-existing in-memory task must be persisted on enable"
+    );
+
+    let restored = TaskSupervisor::new();
+    restored.enable_persistence(&ledger_path).unwrap();
+    assert_eq!(restored.get_all_tasks().len(), 1);
+    assert_eq!(restored.get_all_tasks()[0].id, task_id);
 }
 
 #[test]

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex as StdMutex, OnceLock, Weak};
+use std::sync::{Mutex as StdMutex, Weak};
 use std::time::{Duration, Instant};
 
 use metrics::counter;
@@ -140,32 +140,6 @@ const BACKGROUND_RESULT_FANOUT_TIMEOUT: Duration = Duration::from_secs(5);
 /// recovery-to-primary inside an incident still surface within a few
 /// seconds; long enough to absorb back-to-back retries on the same lane.
 const FAILOVER_PUSH_DEBOUNCE: Duration = Duration::from_secs(5);
-
-// ── Peer inbox registry (#436) ─────────────────────────────────────────────
-
-/// Inbox sender map keyed by `"{profile_id}:peer:{slug}"`, shared behind
-/// an `Arc<StdMutex<_>>` so [`peer_inbox_registry`] callers can clone the
-/// `Arc` and lock independently.
-type PeerInboxMap = Arc<StdMutex<HashMap<String, mpsc::Sender<ActorMessage>>>>;
-
-/// Global registry mapping `"{profile_id}:peer:{slug}"` → inbox sender for
-/// running peer sessions. Populated by [`ActorRegistry::dispatch`] when a
-/// peer session actor spawns; removed on session death / deletion. The
-/// [`PeerSendInputTool`] callback reads this to deliver cross-session
-/// messages without a TUI round-trip.
-static PEER_INBOX_REGISTRY: OnceLock<PeerInboxMap> = OnceLock::new();
-
-/// Get (or init) the global peer inbox registry.
-pub fn peer_inbox_registry() -> &'static PeerInboxMap {
-    PEER_INBOX_REGISTRY.get_or_init(|| Arc::new(StdMutex::new(HashMap::new())))
-}
-
-/// Build the lookup key for a peer session: `"{profile_id}:peer:{slug}"`.
-fn peer_inbox_key(profile_id: &str, slug: &str) -> String {
-    format!("{profile_id}:peer:{slug}")
-}
-
-// ────────────────────────────────────────────────────────────────────────────
 
 const DEFAULT_CONTEXT_COMPACT_RATIO_NUMERATOR: usize = 7;
 const DEFAULT_CONTEXT_COMPACT_RATIO_DENOMINATOR: usize = 10;
@@ -2571,16 +2545,6 @@ impl ActorRegistry {
                 // profile_id which is None for the current-profile gateway.
                 tenant_id: tenant_id.map(|s| s.to_string()),
             });
-            // #436 — register peer inbox for cross-session messaging.
-            // Only peer sessions (topic `peer-<slug>`) get registered.
-            if let Some(topic) = session_key.topic() {
-                if let Some(slug) = topic.strip_prefix("peer-") {
-                    let registry = peer_inbox_registry();
-                    let key = peer_inbox_key(profile_id.unwrap_or(MAIN_PROFILE_ID), slug);
-                    registry.lock().unwrap().insert(key, tx.clone());
-                }
-            }
-
             self.actors.insert(
                 key_str.clone(),
                 ActorHandle {
@@ -2681,11 +2645,6 @@ impl ActorRegistry {
                 true
             }
         });
-        // #436 — purge closed senders from the peer inbox registry
-        peer_inbox_registry()
-            .lock()
-            .unwrap()
-            .retain(|_, tx| !tx.is_closed());
     }
 
     /// Stop and remove a session actor. Drops the sender so the actor's run
@@ -2702,32 +2661,9 @@ impl ActorRegistry {
         for key in keys_to_remove {
             if let Some(handle) = self.actors.remove(&key) {
                 debug!(session = %key, "removing session actor on delete");
-                // #436/#437 — drop the peer inbox registry's strong `Sender`
-                // clone for THIS actor's channel BEFORE dropping `handle.tx`.
-                // `dispatch` inserted a `tx.clone()` for peer sessions, so the
-                // registry itself holds a live sender: `is_closed()` can never
-                // fire while that clone is alive, which is why the trailing
-                // `retain(!is_closed)` below cannot evict the entry here. A
-                // stale entry keeps the deleted peer injectable (breaking
-                // `peer_close`) AND keeps the actor's `recv()` from ever
-                // returning `None`, leaking the actor past deletion until its
-                // idle timeout. Purge by `same_channel` so exactly this
-                // actor's entry is removed regardless of its registry key;
-                // dropping `handle.tx` next leaves no senders, so the run loop
-                // exits promptly.
-                peer_inbox_registry()
-                    .lock()
-                    .unwrap()
-                    .retain(|_, reg_tx| !reg_tx.same_channel(&handle.tx));
-                drop(handle.tx); // no senders remain → recv() returns None → run loop exits
+                drop(handle.tx); // actor's recv() returns None → run loop exits
             }
         }
-        // Defensive sweep: evict any registry entry whose receiver has already
-        // been dropped (an actor that exited on its own before this delete).
-        peer_inbox_registry()
-            .lock()
-            .unwrap()
-            .retain(|_, tx| !tx.is_closed());
     }
 
     /// Cancel a specific session actor.
@@ -3366,6 +3302,13 @@ impl ActorFactory {
                 "failed to enable task supervisor persistence"
             );
         }
+        // Issue #1920: start the heartbeat-based in-flight orphan reaper.
+        // The startup sweep above only reaps orphans left by a process
+        // restart; this periodic reaper covers the long-running-supervisor
+        // case where a worker future is alive but permanently stuck (never
+        // bumps `updated_at`, never reaches a terminal state). Idempotent,
+        // so a re-initialized session on a shared supervisor is safe.
+        supervisor.start_reaper();
         self.task_query_store
             .register(&session_key, &supervisor, &self.data_dir);
         tools.rebind_plugin_work_dirs(&user_workspace);

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex as StdMutex, Weak};
+use std::sync::{Mutex as StdMutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
 use metrics::counter;
@@ -140,6 +140,32 @@ const BACKGROUND_RESULT_FANOUT_TIMEOUT: Duration = Duration::from_secs(5);
 /// recovery-to-primary inside an incident still surface within a few
 /// seconds; long enough to absorb back-to-back retries on the same lane.
 const FAILOVER_PUSH_DEBOUNCE: Duration = Duration::from_secs(5);
+
+// ── Peer inbox registry (#436) ─────────────────────────────────────────────
+
+/// Inbox sender map keyed by `"{profile_id}:peer:{slug}"`, shared behind
+/// an `Arc<StdMutex<_>>` so [`peer_inbox_registry`] callers can clone the
+/// `Arc` and lock independently.
+type PeerInboxMap = Arc<StdMutex<HashMap<String, mpsc::Sender<ActorMessage>>>>;
+
+/// Global registry mapping `"{profile_id}:peer:{slug}"` → inbox sender for
+/// running peer sessions. Populated by [`ActorRegistry::dispatch`] when a
+/// peer session actor spawns; removed on session death / deletion. The
+/// [`PeerSendInputTool`] callback reads this to deliver cross-session
+/// messages without a TUI round-trip.
+static PEER_INBOX_REGISTRY: OnceLock<PeerInboxMap> = OnceLock::new();
+
+/// Get (or init) the global peer inbox registry.
+pub fn peer_inbox_registry() -> &'static PeerInboxMap {
+    PEER_INBOX_REGISTRY.get_or_init(|| Arc::new(StdMutex::new(HashMap::new())))
+}
+
+/// Build the lookup key for a peer session: `"{profile_id}:peer:{slug}"`.
+fn peer_inbox_key(profile_id: &str, slug: &str) -> String {
+    format!("{profile_id}:peer:{slug}")
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 
 const DEFAULT_CONTEXT_COMPACT_RATIO_NUMERATOR: usize = 7;
 const DEFAULT_CONTEXT_COMPACT_RATIO_DENOMINATOR: usize = 10;
@@ -2545,6 +2571,16 @@ impl ActorRegistry {
                 // profile_id which is None for the current-profile gateway.
                 tenant_id: tenant_id.map(|s| s.to_string()),
             });
+            // #436 — register peer inbox for cross-session messaging.
+            // Only peer sessions (topic `peer-<slug>`) get registered.
+            if let Some(topic) = session_key.topic() {
+                if let Some(slug) = topic.strip_prefix("peer-") {
+                    let registry = peer_inbox_registry();
+                    let key = peer_inbox_key(profile_id.unwrap_or(MAIN_PROFILE_ID), slug);
+                    registry.lock().unwrap().insert(key, tx.clone());
+                }
+            }
+
             self.actors.insert(
                 key_str.clone(),
                 ActorHandle {
@@ -2645,6 +2681,11 @@ impl ActorRegistry {
                 true
             }
         });
+        // #436 — purge closed senders from the peer inbox registry
+        peer_inbox_registry()
+            .lock()
+            .unwrap()
+            .retain(|_, tx| !tx.is_closed());
     }
 
     /// Stop and remove a session actor. Drops the sender so the actor's run
@@ -2661,9 +2702,32 @@ impl ActorRegistry {
         for key in keys_to_remove {
             if let Some(handle) = self.actors.remove(&key) {
                 debug!(session = %key, "removing session actor on delete");
-                drop(handle.tx); // actor's recv() returns None → run loop exits
+                // #436/#437 — drop the peer inbox registry's strong `Sender`
+                // clone for THIS actor's channel BEFORE dropping `handle.tx`.
+                // `dispatch` inserted a `tx.clone()` for peer sessions, so the
+                // registry itself holds a live sender: `is_closed()` can never
+                // fire while that clone is alive, which is why the trailing
+                // `retain(!is_closed)` below cannot evict the entry here. A
+                // stale entry keeps the deleted peer injectable (breaking
+                // `peer_close`) AND keeps the actor's `recv()` from ever
+                // returning `None`, leaking the actor past deletion until its
+                // idle timeout. Purge by `same_channel` so exactly this
+                // actor's entry is removed regardless of its registry key;
+                // dropping `handle.tx` next leaves no senders, so the run loop
+                // exits promptly.
+                peer_inbox_registry()
+                    .lock()
+                    .unwrap()
+                    .retain(|_, reg_tx| !reg_tx.same_channel(&handle.tx));
+                drop(handle.tx); // no senders remain → recv() returns None → run loop exits
             }
         }
+        // Defensive sweep: evict any registry entry whose receiver has already
+        // been dropped (an actor that exited on its own before this delete).
+        peer_inbox_registry()
+            .lock()
+            .unwrap()
+            .retain(|_, tx| !tx.is_closed());
     }
 
     /// Cancel a specific session actor.


### PR DESCRIPTION
Fixes #1920.

An in-flight background task whose worker dies without a terminal transition was never reaped — it sat `Running` forever, holding its slot and pinning progress indicators with nothing left to move them.

This moves orphan detection into `TaskSupervisor` behind a heartbeat timeout: a task with no progress for longer than `stuck_timeout` is marked failed with `orphaned: no progress for {timeout} (heartbeat timeout)`, and its cancel token is flipped **after** the terminal transition so a cooperative-but-stuck worker wakes at its next safe point and exits rather than racing the state change.

`session_actor.rs` sheds 79 lines net — the ad-hoc handling there is replaced by the supervisor owning the lifecycle, so there is one reaper rather than a per-callsite guess.

## Verification

| | |
|---|---|
| base | one commit on `725451747` (v2.0.3-rc.1), current `origin/main` |
| `cargo test -p octos-agent --lib` | **2522 passed**, 0 failed |
| supervisor tests | 107 passed |
| reaper tests | 10 passed |
| `cargo clippy -p octos-agent --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |

Tests (+306) slightly outweigh implementation (+300), and the change is net-negative outside the supervisor.