### PR TITLE
ci: TEMPORARY baseline probe for e2e-tool-regression (do not merge)

### DIFF
--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -9847,3 +9847,6 @@ fn format_thinking_prefix(reasoning: Option<&str>) -> String {
 #[cfg(test)]
 #[path = "session_actor_tests.rs"]
 mod tests;
+
+// CI baseline probe: comment-only touch so the e2e path filter (which
+// matches `session_actor`) runs the e2e suite against unmodified main.


### PR DESCRIPTION
**Draft, do not merge. Will be closed once e2e reports.**

## Why

`e2e-tool-regression` failed on #1921 (52 of 66 Playwright specs). Before attributing that to #1921 I need a baseline — and there isn't one.

The job is gated on a path filter matching `(activate_tools|sandbox|shell\.rs|tools/mod|session_actor|exec_env)`. When the filter does not match, **every substantive step is skipped — build, serve, npm ci, run — and the job still reports SUCCESS.** So a green `e2e-tool-regression` on most PRs means nothing was executed.

Across the last 25 runs in this repo, the only run where the e2e step actually executed is #1921's.

## What this is

A comment-only append to `session_actor.rs` — enough to trip the path filter, changing no behaviour whatsoever. Whatever e2e does here is what it does on unmodified `main` (`725451747`).

## What it tells us

- **Fails the same way** → the gate is broken independently of #1921 (the job starts `octos serve` with no LLM provider configured, and every failing assertion received `""`), and deserves its own issue. #1921 is then clear.
- **Passes** → #1921 genuinely regressed something and I need to keep digging.

cc #1921