### PR TITLE
chore(rename): update octos-tui → octoscode references

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ curl -fsSL https://github.com/octos-org/octos/releases/latest/download/install.s
 
 - **octos** (this repo) — the **kernel**: the agent runtime, LLM providers, tools, sandbox, memory, channels, and the API everything else speaks. Install this first — then live in a client:
 - **[octos-web](https://github.com/octos-org/octos-web)** — the full app experience in the browser (chat, voice, projects, slides, admin, and the hosted multi-tenant signup). A build ships inside the server — open `/app/`.
-- **[octos-tui](https://github.com/octos-org/octos-tui)** — the terminal experience, in the spirit of Claude Code.
+- **[octoscode](https://github.com/octos-org/octoscode)** — the terminal experience, in the spirit of Claude Code.
 
 **Stuck?** [Documentation](https://octos-org.github.io/octos/) · [Issues](https://github.com/octos-org/octos/issues)
 
@@ -140,7 +140,7 @@ octos gateway
 # Web dashboard + REST API + UI Protocol
 octos serve
 octos serve --solo     # same, plus password-free local login for the web app
-octos serve --stdio    # UI Protocol over stdio (how octos-tui embeds a backend)
+octos serve --stdio    # UI Protocol over stdio (how octoscode embeds a backend)
 ```
 
 The full CLI surface (see `octos help`):
@@ -246,7 +246,7 @@ Each binding has its own README with the full API and examples: [octos-ffi](crat
 Interactive clients talk to `octos serve` over **UI Protocol v1** — a JSON-RPC contract carried on WebSocket (`/api/ui-protocol/ws`) or stdio (`octos serve --stdio`). It covers session open with cursor replay, streamed turns, durable persistence events, tool activity, approvals, background tasks, and rollback. The protocol spec is the contract: server and clients release independently against it.
 
 - **[octos-web](https://github.com/octos-org/octos-web)** — the browser client: chat, voice/video, studio, slides, and sites. A build is embedded in the server binary at `/app/`, so `octos serve` works with zero extra deploys. (The admin dashboard is a separate SPA, embedded at `/admin/`.)
-- **[octos-tui](https://github.com/octos-org/octos-tui)** — the terminal client. Connects to a running server over WebSocket, or spawns `octos serve --stdio` as its own private backend.
+- **[octoscode](https://github.com/octos-org/octoscode)** — the terminal client. Connects to a running server over WebSocket, or spawns `octos serve --stdio` as its own private backend.
 - **`octos mcp-serve`** — the inverse direction: octos as an MCP server, callable as a sub-agent from outer orchestrators.
 - **MCP client** — octos also *consumes* external MCP servers. Declare them in `config.json` under `mcp_servers` and any octos agent (`chat`, `serve`, `gateway`, `acp`) gains their tools in its own registry — stdio (`command` + `args`) or HTTP (`url`); run `octos mcp login <url>` for OAuth-gated servers.
 
@@ -382,7 +382,7 @@ Guardrails that stay on even under `danger-full-access`/`--yolo`:
 ### Reuse an existing profile (model + API key)
 
 `--profile <id>` reads a stored serve/onboarding profile
-(`~/.octos/profiles/<id>.json`, created by `octos serve` or octos-tui) and
+(`~/.octos/profiles/<id>.json`, created by `octos serve` or octoscode) and
 reuses its provider, model, route, and API key — so you don't re-enter them:
 
 ```bash
@@ -475,7 +475,7 @@ already carries one.
 
 Beyond a single turn, octos can keep working on its own — between your messages,
 or on a schedule. Both are driven by slash commands in any client (octos-web,
-octos-tui) or channel session, and run on `octos serve` / `octos gateway`.
+octoscode) or channel session, and run on `octos serve` / `octos gateway`.
 
 ### Goals — keep going until it's done
 

--- a/api/OCTOSCODE_FEATURE_REQUIREMENTS.md
+++ b/api/OCTOSCODE_FEATURE_REQUIREMENTS.md
@@ -1,12 +1,12 @@
-# Octos TUI Feature Requirements
+# Octoscode Feature Requirements
 
 Status: proposed test contract.
-Owner: octos-tui.
+Owner: octoscode.
 Applies to: mock mode, protocol mode, live coding UX parity runs.
 
 ## Purpose
 
-This document defines the user-facing feature requirements that `octos-tui`
+This document defines the user-facing feature requirements that `octoscode`
 must satisfy before it can be treated as a production coding client for the
 Octos AppUI protocol. It is intended to be used by unit tests, snapshot tests,
 tmux harnesses, and human review.
@@ -204,7 +204,7 @@ The parent Octos tmux harness should keep the state matrix from
 
 ### Live Coding Parity Tests
 
-Run a real long coding task against the same fixture in Codex and `octos-tui`.
+Run a real long coding task against the same fixture in Codex and `octoscode`.
 The TUI passes when human review can confirm:
 
 - user intent and current model state are easier to locate than in raw logs
@@ -249,6 +249,6 @@ No TUI release should be considered UX-complete unless:
 - all P0 requirements have automated coverage or a documented manual harness
   assertion
 - no advertised interaction is unsupported
-- current `octos-core` AppUI protocol changes compile in `octos-tui`
+- current `octos-core` AppUI protocol changes compile in `octoscode`
 - live coding parity harness produces retained artifacts and a human-readable
   summary

--- a/api/OCTOS_APP_FEATURE_REQUIREMENTS.md
+++ b/api/OCTOS_APP_FEATURE_REQUIREMENTS.md
@@ -71,7 +71,7 @@ truth.
 | APP-033 | Persistence | P1 | Local app state persists sessions, cursor, selected profile, UI preferences, and safe drafts without persisting secrets in plaintext. | persistence tests |
 | APP-034 | Build and packaging | P0 | App builds on supported platforms, has reproducible release profile, and CI runs store/transport/app checks. | CI |
 | APP-035 | Observability | P1 | App records sanitized telemetry for connection failures, protocol errors, approval failures, task output failures, and panics. | telemetry tests |
-| APP-036 | Client parity | P0 | App behavior remains protocol-compatible with `octos-tui` for core flows: session, turns, approvals, diffs, tasks, replay, cwd, and errors. | shared fixture tests |
+| APP-036 | Client parity | P0 | App behavior remains protocol-compatible with `octoscode` for core flows: session, turns, approvals, diffs, tasks, replay, cwd, and errors. | shared fixture tests |
 | APP-037 | Structured user-question picker | P0 | `user_question/requested` renders a question picker (single/multi-select options plus a free-text "Other") for each of the 1–4 questions, with generic title/body fallback when the structured `questions` field is unknown. The picker sends `user_question/respond` with the correct `question_id` and per-question `answers` (selected labels + optional free text). Stale/expired questions render as decided/expired, not as pending. | UI snapshot and contract tests |
 
 ## Major Interaction Flows
@@ -191,7 +191,7 @@ Expected flow:
 
 - Connect to real `octos serve`.
 - Run a live coding turn with approval, diff preview, task output, and reconnect.
-- Compare core protocol behavior with `octos-tui` on the same fixture.
+- Compare core protocol behavior with `octoscode` on the same fixture.
 - Verify app remains responsive through a long-running coding session.
 
 ## Current Implementation Notes
@@ -222,7 +222,7 @@ Known gaps relative to this requirements document:
   only when doing so lowers test and maintenance risk.
 - True task stdout/stderr live-tail depends on the server feature; current app
   support must respect the server's snapshot-projection limitation.
-- Cross-client parity with `octos-tui` should be added as shared fixtures, not
+- Cross-client parity with `octoscode` should be added as shared fixtures, not
   hand-checked only.
 
 ## Release Gate

--- a/api/OCTOS_SERVER_FEATURE_REQUIREMENTS.md
+++ b/api/OCTOS_SERVER_FEATURE_REQUIREMENTS.md
@@ -10,7 +10,7 @@ approval gate, durable ledger, dashboard/API surfaces, and client integration.
 This document defines the server-side feature requirements that Octos must
 satisfy before the server can be treated as a production AppUI/harness runtime.
 It is intended to be used as a merge gate for `octos` main and as a shared
-contract for `octos-tui`, `octos-app`, dashboard, API clients, and future app
+contract for `octoscode`, `octos-app`, dashboard, API clients, and future app
 harnesses.
 
 The server is responsible for runtime truth. Clients may render, organize, and
@@ -204,7 +204,7 @@ Expected flow:
 - Multi-agent/swarm session where task registry shows all child work.
 - Server restart/reconnect during active or recently completed background work.
 - Dashboard/API/TUI compatibility smoke.
-- Downstream `octos-tui` and `octos-app` compile and protocol smoke after
+- Downstream `octoscode` and `octos-app` compile and protocol smoke after
   AppUI changes.
 
 ## Current Implementation Notes
@@ -226,7 +226,7 @@ preserved and tested:
 
 Known gaps to track against this document:
 
-- AppUI task-control support must be merged only with compatible `octos-tui`
+- AppUI task-control support must be merged only with compatible `octoscode`
   and `octos-app` client handling.
 - `task/output/read` is currently a snapshot projection; true disk-routed
   stdout/stderr live-tail is a separate feature.
@@ -250,5 +250,5 @@ No server branch should merge to main as AppUI/harness complete unless:
 - terminal states survive backpressure in tests
 - replay/ledger changes include stale snapshot regression coverage
 - approval and sandbox policy behavior is preserved
-- downstream `octos-tui` and `octos-app` compatibility is verified or the
+- downstream `octoscode` and `octos-app` compatibility is verified or the
   branch is explicitly marked server-only with a migration plan

--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -4,7 +4,7 @@ Status: draft spec for `M9.1`.
 
 Sprint: `coding-green`
 
-This is the first protocol document for the M9 control-plane layer. It is intentionally narrower than the eventual end-state. The goal is to define one client/runtime boundary that both `octos-tui` and future server work can target without baking unresolved M8 runtime defects into the contract.
+This is the first protocol document for the M9 control-plane layer. It is intentionally narrower than the eventual end-state. The goal is to define one client/runtime boundary that both `octoscode` and future server work can target without baking unresolved M8 runtime defects into the contract.
 
 Code sketch:
 
@@ -13,7 +13,7 @@ Code sketch:
 Related planning:
 
 - [OCTOS_M9_ISSUE_STACK_2026-04-24.md](../docs/OCTOS_M9_ISSUE_STACK_2026-04-24.md)
-- [OCTOS_TUI_ARCHITECTURE_2026-04-24.md](../docs/OCTOS_TUI_ARCHITECTURE_2026-04-24.md)
+- [OCTOSCODE_ARCHITECTURE_2026-04-24.md](../docs/OCTOSCODE_ARCHITECTURE_2026-04-24.md)
 - [OCTOS_M8_FIX_FIRST_CHECKLIST_2026-04-24.md](../docs/OCTOS_M8_FIX_FIRST_CHECKLIST_2026-04-24.md)
 
 ## 1. Goals
@@ -1100,7 +1100,7 @@ Clients must use that method list to enable or disable slash commands.
   ```json
   {
     "transport": "stdio",
-    "client": { "name": "octos-tui" },
+    "client": { "name": "octoscode" },
     "supported_features": [
       "approval.typed.v1",
       "session.workspace_cwd.v1",
@@ -1116,7 +1116,7 @@ Clients must use that method list to enable or disable slash commands.
     "type": "server_hello",
     "transport": "stdio",
     "client_transport": "stdio",
-    "client": { "name": "octos-tui" },
+    "client": { "name": "octoscode" },
     "capabilities": {
       "version": {
         "protocol": "octos-ui/v1alpha1",
@@ -2316,7 +2316,7 @@ See [OCTOS_M8_FIX_FIRST_CHECKLIST_2026-04-24.md](../docs/OCTOS_M8_FIX_FIRST_CHEC
 ## 13. Immediate Next Steps
 
 1. Keep the shared Rust types in `octos-core` aligned with this doc.
-2. Build the mock `octos-tui` scaffold against these draft types.
+2. Build the mock `octoscode` scaffold against these draft types.
 3. When M8 fixes land, start server-side `M9.1` transport wiring against the same shapes.
 
 ## 14. M9-γ Envelope

--- a/book-zh/src/advanced.md
+++ b/book-zh/src/advanced.md
@@ -496,7 +496,7 @@ Shell 命令在沙箱中运行以实现隔离。支持三种后端：
 
 ## 自主运行与会话控制
 
-除一次性对话外，图形客户端（octos-web、octos-tui）还通过 [UI Protocol](./architecture.md) 驱动一些更长时运行的行为。其中自主运行与任务产物组由协商的能力标志门控（见[能力协商](#能力协商)）；核心的轮次/会话控制（`turn/start`、`turn/interrupt`、`session/rollback`、`task/output/read`）始终可用。
+除一次性对话外，图形客户端（octos-web、octoscode）还通过 [UI Protocol](./architecture.md) 驱动一些更长时运行的行为。其中自主运行与任务产物组由协商的能力标志门控（见[能力协商](#能力协商)）；核心的轮次/会话控制（`turn/start`、`turn/interrupt`、`session/rollback`、`task/output/read`）始终可用。
 
 ### 目标（Goals）
 

--- a/book-zh/src/architecture.md
+++ b/book-zh/src/architecture.md
@@ -9,7 +9,7 @@ octos 是一个包含 27 个成员的 Rust 工作区（Edition 2024，rust-versi
 - **agent 周边**（5 个）：`octos-pipeline`（DOT 图工作流）、`octos-plugin`（插件/技能 SDK）、`octos-swarm`（多 agent 契约创作）、`octos-sandbox`、`octos-dora-mcp`。
 - **内置技能 crate**（15 个）：`crates/app-skills/` 下每个应用技能都是独立 crate——`news`、`deep-search`、`deep-crawl`、`send-email`、`account-manager`、`time`、`weather`、`smart-home`、`wechat-bridge`、`skill-evolve`，以及 `harness-starter-{generic,report,audio,coding}` 模板——再加上 `platform-skills/voice`（ASR/TTS）。
 
-（Web SPA 与终端客户端分别位于独立的 `octos-web` 和 `octos-tui` 仓库，通过 UI Protocol 与 `octos serve` 通信。）
+（Web SPA 与终端客户端分别位于独立的 `octos-web` 和 `octoscode` 仓库，通过 UI Protocol 与 `octos serve` 通信。）
 
 ```
 ┌─────────────────────────────────────────────────────────────┐

--- a/book-zh/src/introduction.md
+++ b/book-zh/src/introduction.md
@@ -23,7 +23,7 @@ Octos 有三种主要运行模式：
 `octos serve` 后端使用单一的带版本 **UI Protocol**（基于 WebSocket 或 stdio 的 JSON-RPC），因此多个前端共享同一个服务器：
 
 - **Web**（[octos-web](https://github.com/octos-org/octos-web)）：内嵌在 `/app/` 的 React SPA（聊天、Slides Studio、Sites、语音）。位于 `/admin/` 的运维**管理仪表板**是 octos 仓库中一个独立的内嵌应用（`dashboard/`）。
-- **终端**（[octos-tui](https://github.com/octos-org/octos-tui)）：通过 UI Protocol 连接的 Rust TUI（WebSocket 连到运行中的 `serve`，或拉起一个 `serve --stdio` 子进程），支持实时流式、审批、diff 与引导。
+- **终端**（[octoscode](https://github.com/octos-org/octoscode)）：通过 UI Protocol 连接的 Rust TUI（WebSocket 连到运行中的 `serve`，或拉起一个 `serve --stdio` 子进程），支持实时流式、审批、diff 与引导。
 
 ## 核心概念
 

--- a/book-zh/src/multi-agent.md
+++ b/book-zh/src/multi-agent.md
@@ -62,7 +62,7 @@ Agent 通过五个工具与对等 Agent 交互，覆盖完整生命周期 ——
 
 ## 从客户端创建与汇聚
 
-人类通过两个服务端方法驱动对等 Agent，在 octos-tui 中表现为 `/peer` 和 `/gather`：
+人类通过两个服务端方法驱动对等 Agent，在 octoscode 中表现为 `/peer` 和 `/gather`：
 
 - **`peer/prepare`** —— 以编队方式暂存 1–8 个对等 Agent（全有或全无）。纯资源预留；随后由客户端打开每个会话并启动其首轮。
 - **`peer/gather`** —— 黑板的面向人类的一侧；把各对等 Agent 的结果汇入调用方的会话。

--- a/book/src/advanced.md
+++ b/book/src/advanced.md
@@ -496,7 +496,7 @@ Split preference: paragraph boundary > newline > sentence end > space > hard cut
 
 ## Autonomy & Session Control
 
-Beyond one-shot chat, the graphical clients (octos-web, octos-tui) drive longer-running behaviors over the [UI Protocol](./architecture.md). The autonomy and task-artifact groups are gated by negotiated capability flags (see [Capability Negotiation](#capability-negotiation)); the core turn/session controls (`turn/start`, `turn/interrupt`, `session/rollback`, `task/output/read`) are always available.
+Beyond one-shot chat, the graphical clients (octos-web, octoscode) drive longer-running behaviors over the [UI Protocol](./architecture.md). The autonomy and task-artifact groups are gated by negotiated capability flags (see [Capability Negotiation](#capability-negotiation)); the core turn/session controls (`turn/start`, `turn/interrupt`, `session/rollback`, `task/output/read`) are always available.
 
 ### Goals
 

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -9,7 +9,7 @@ octos is a 27-member Rust workspace (Edition 2024, rust-version 1.85.0) providin
 - **Agent-adjacent** (5): `octos-pipeline` (DOT-graph workflows), `octos-plugin` (plugin/skill SDK), `octos-swarm` (multi-agent contract authoring), `octos-sandbox`, `octos-dora-mcp`.
 - **Bundled skill crates** (15): each app skill under `crates/app-skills/` is its own crate — `news`, `deep-search`, `deep-crawl`, `send-email`, `account-manager`, `time`, `weather`, `smart-home`, `wechat-bridge`, `skill-evolve`, and the `harness-starter-{generic,report,audio,coding}` templates — plus `platform-skills/voice` (ASR/TTS).
 
-(The web SPA and terminal client live in the separate `octos-web` and `octos-tui` repositories and talk to `octos serve` over the UI Protocol.)
+(The web SPA and terminal client live in the separate `octos-web` and `octoscode` repositories and talk to `octos serve` over the UI Protocol.)
 
 ```
 ┌─────────────────────────────────────────────────────────────┐

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -23,7 +23,7 @@ Octos operates in three primary modes:
 The `octos serve` backend speaks a single versioned **UI Protocol** (JSON-RPC over WebSocket or stdio), so several front-ends share one server:
 
 - **Web** ([octos-web](https://github.com/octos-org/octos-web)): the React SPA embedded at `/app/` (chat, Slides Studio, Sites, Voice). The operator **admin dashboard** at `/admin/` is a separate embedded app in the octos repo (`dashboard/`).
-- **Terminal** ([octos-tui](https://github.com/octos-org/octos-tui)): a Rust TUI that connects over the UI Protocol (WebSocket to a running `serve`, or a spawned `serve --stdio` child) with live streaming, approvals, diffs, and onboarding.
+- **Terminal** ([octoscode](https://github.com/octos-org/octoscode)): a Rust TUI that connects over the UI Protocol (WebSocket to a running `serve`, or a spawned `serve --stdio` child) with live streaming, approvals, diffs, and onboarding.
 
 ## Key Concepts
 

--- a/book/src/multi-agent.md
+++ b/book/src/multi-agent.md
@@ -62,7 +62,7 @@ Gracefully closes a running peer you created.
 
 ## Creating and gathering from the client
 
-Humans drive peers through two server methods, surfaced as `/peer` and `/gather` in octos-tui:
+Humans drive peers through two server methods, surfaced as `/peer` and `/gather` in octoscode:
 
 - **`peer/prepare`** — stage 1–8 peers as a fleet (all-or-nothing). Pure resource reservation; the client then opens each session and starts its first turn.
 - **`peer/gather`** — the human-facing side of the blackboard; composes the peers' results into the caller's session.

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -307,7 +307,7 @@ const MAX_ACTIVE_SKILL_ACTION_BATCHES: usize = 8;
 /// candidate path, reports existence/writability, surfaces
 /// `workspace_policy.toml` presence + parse errors, and rejects roots that
 /// escape under banned system paths. Backend-owned runtime truth so the TUI
-/// (a separate `octos-tui` repo) only stages user intent — the canonical
+/// (a separate `octoscode` repo) only stages user intent — the canonical
 /// answer is the server's.
 const APPUI_FEATURE_ONBOARDING_WORKSPACE_PROBE_V1: &str = "onboarding.workspace_probe.v1";
 const APPUI_EXTRA_METHODS: &[&str] = &[
@@ -793,7 +793,7 @@ impl WsConnection {
                             // held client->server requests, so soak verifiers that
                             // require backend `task/updated` / `agent/updated`
                             // notifications could never pass over WS. The append
-                            // is a no-op unless OCTOS_TUI_M15_UX_OUTPUT_DIR is set.
+                            // is a no-op unless OCTOSCODE_M15_UX_OUTPUT_DIR is set.
                             if let WsMessage::Text(text) = &msg {
                                 if let Ok(frame) = serde_json::from_str::<Value>(text.as_str()) {
                                     append_appui_transcript_frame("server_to_client", frame);
@@ -1977,7 +1977,7 @@ impl ConnectionUiFeatures {
             // Do NOT auto-enable `projection.envelope.v1` for stdio
             // connections. Legacy `turn/completed` is the turn-lifecycle
             // source for clients that do not consume `projection/envelope`
-            // (e.g. the octos TUI over stdio, which clears its turn-active
+            // (e.g. the octoscode over stdio, which clears its turn-active
             // state — `live_reply`, backing the send-gate — ONLY on legacy
             // `turn/completed`). The γ-cutover mutual-exclusion gate in
             // `live_event_passes_capability_filter` DROPS legacy
@@ -10412,13 +10412,13 @@ async fn raw_session_status_result(
         (None, None)
     };
     // Emit the `model` object only when the policy actually resolved a
-    // model AND provider. Clients (octos-tui) decode it into a struct whose
+    // model AND provider. Clients (octoscode) decode it into a struct whose
     // `model`/`provider` are non-optional strings, so
     // `{"model": null, "provider": null, "selected": true}` fails the whole
     // session/status/read decode and the composer footer degrades to a
     // placeholder. A missing key is handled fine by their
     // `Option<ModelStatus>` + `#[serde(default)]` — including in shipped
-    // octos-tui 0.1.5 binaries.
+    // octoscode 0.1.5 binaries.
     let resolved_model = policy.get("model").filter(|value| !value.is_null());
     let resolved_provider = policy.get("provider").filter(|value| !value.is_null());
     let model = match (resolved_model, resolved_provider) {
@@ -28142,13 +28142,13 @@ async fn run_m15_live_subagent_fixture_turn(
         .map(ToOwned::to_owned)
         .unwrap_or_else(|| MAIN_PROFILE_ID.to_owned());
     let task_id = TaskId::new();
-    let workdir = std::env::var_os("OCTOS_TUI_M15_UX_WORKDIR")
+    let workdir = std::env::var_os("OCTOSCODE_M15_UX_WORKDIR")
         .map(PathBuf::from)
         .or_else(|| appui_evidence_dir().map(|dir| dir.join("workspace")))
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
     // The supervised subagent processes are spawned with `cwd(workdir)`.
     // When the workdir is derived from the evidence dir (the default when
-    // OCTOS_TUI_M15_UX_WORKDIR is unset) it does not exist yet, so the
+    // OCTOSCODE_M15_UX_WORKDIR is unset) it does not exist yet, so the
     // process spawn fails with "No such file or directory (os error 2)"
     // and every review agent reports `m15subagentfailed`. Materialize it
     // up front so the fixture's child processes have a valid cwd.
@@ -28813,7 +28813,7 @@ fn reasoning_effort_from_wire(
 ///   after active turn" TUI/web wedge. The background `spawn_only` task reports
 ///   its real progress via `task_*` / `tool_*` / `file_*` events (all still
 ///   forwarded), never via raw foreground tokens, so dropping these loses
-///   nothing user-facing. Pairs with the octos-tui client guard that ignores
+///   nothing user-facing. Pairs with the octoscode client guard that ignores
 ///   deltas for already-terminal turns (belt + suspenders).
 ///
 /// Chars of a background REPORT result inlined into the parent conversation.
@@ -34870,7 +34870,7 @@ fn set_field_at_path(value: &mut Value, path: &[PathSeg], new_value: Value) -> b
 }
 
 fn appui_evidence_dir() -> Option<PathBuf> {
-    std::env::var_os("OCTOS_TUI_M15_UX_OUTPUT_DIR")
+    std::env::var_os("OCTOSCODE_M15_UX_OUTPUT_DIR")
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
 }
@@ -35578,7 +35578,7 @@ fn send_raw_notification_ephemeral(
     // M15-F5 (#44): mirror production child-agent lifecycle/output/artifact
     // notifications into `agent-ledger.jsonl` / `artifact-index.json` evidence
     // ledgers. NO-OP unless the live tmux soak set
-    // `OCTOS_TUI_M15_UX_OUTPUT_DIR`, so this is free in normal production.
+    // `OCTOSCODE_M15_UX_OUTPUT_DIR`, so this is free in normal production.
     record_agent_evidence(method, &params);
     let notification = octos_core::ui_protocol::RpcNotification::new(method, params);
     let frame = frame_for(&notification).ok_or(SendError::BackpressureDrop)?;
@@ -36024,7 +36024,7 @@ fn send_notification_durable(
 ) -> Result<(), SendError> {
     // M15-F5 (#44): mirror production supervised-task lifecycle updates into
     // the `task-ledger.jsonl` evidence ledger. NO-OP unless the live tmux soak
-    // set `OCTOS_TUI_M15_UX_OUTPUT_DIR`, so this is free in normal production.
+    // set `OCTOSCODE_M15_UX_OUTPUT_DIR`, so this is free in normal production.
     record_task_evidence(&notification);
     let event = ledger.append_notification_from(notification, ws.connection_id);
     let cursor = event.cursor.clone();

--- a/crates/octos-cli/src/api/ui_protocol_reasoning_effort.rs
+++ b/crates/octos-cli/src/api/ui_protocol_reasoning_effort.rs
@@ -1,6 +1,6 @@
 //! Disk-backed per-session reasoning/thinking effort store.
 //!
-//! The octos-tui sets a per-session reasoning effort (`/thinking
+//! The octoscode sets a per-session reasoning effort (`/thinking
 //! low|medium|high|max`) and attaches it to every `turn/start` via
 //! [`TurnStartParams::reasoning_effort`]. The serve must persist that choice
 //! **server-side and on disk** so it survives a full serve/TUI restart: in

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -5507,7 +5507,7 @@ async fn raw_session_status_read_omits_model_object_when_no_model_resolved() {
     assert_eq!(status["runtime_policy_stamp"]["provider"], Value::Null);
     // The contract under test: no resolved model => NO `model` key at
     // all. Emitting `{"model": null, "provider": null, "selected": true}`
-    // breaks shipped octos-tui decoders whose ModelStatus requires
+    // breaks shipped octoscode decoders whose ModelStatus requires
     // non-null `model`/`provider` strings — the whole
     // session/status/read result fails to decode and the composer
     // footer degrades to the `<server authenticated profile>`
@@ -13467,7 +13467,7 @@ fn projection_envelope_v1_off_in_stdio_defaults() {
     // connections. The γ-cutover mutual-exclusion gate
     // (`live_event_passes_capability_filter`) drops the legacy
     // `turn/completed` notification whenever `projection_envelope`
-    // is true. The octos TUI over stdio does NOT consume
+    // is true. The octoscode over stdio does NOT consume
     // `projection/envelope` and clears its turn-active state ONLY on
     // legacy `turn/completed`; auto-enabling envelopes here would
     // suppress that lifecycle signal and wedge the client (every

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -99,7 +99,7 @@ pub struct ChatCommand {
     /// JSON/TOML file.
     ///
     /// If the id names a stored serve/onboarding profile (one created by
-    /// `octos serve` or octos-tui, saved as `~/.octos/profiles/<id>.json`),
+    /// `octos serve` or octoscode, saved as `~/.octos/profiles/<id>.json`),
     /// its LLM provider/model, route, and API key (`env_vars`) are reused too —
     /// so you don't re-enter a model or key that a profile already holds.
     /// `--config`, `--provider`, and `--model` still override.
@@ -819,7 +819,7 @@ impl ChatCommand {
         // Load config. Precedence: an explicit `--config` wins; otherwise a
         // stored serve/onboarding profile named by `--profile <id>` supplies its
         // LLM provider/model + route + `env_vars` API key (so `octos chat
-        // --profile <id>` reuses an octos-tui / `serve` profile without a
+        // --profile <id>` reuses an octoscode / `serve` profile without a
         // separate flat config or a duplicated key); otherwise the ambient
         // config context.
         let serve_profile_config = load_serve_profile_config(self.profile.as_deref(), &data_dir)?;
@@ -1745,7 +1745,7 @@ pub(crate) fn resolve_profile(
 }
 
 /// Load the LLM config from a stored serve/onboarding profile so
-/// `octos chat --profile <id>` can reuse an octos-tui / `serve` profile's
+/// `octos chat --profile <id>` can reuse an octoscode / `serve` profile's
 /// provider, model, route (base URL + API type), API key (`config.env_vars`),
 /// and fallbacks — without a separate flat config or a duplicated key.
 ///

--- a/crates/octos-cli/src/commands/doctor.rs
+++ b/crates/octos-cli/src/commands/doctor.rs
@@ -242,8 +242,8 @@ fn build_report(cmd: &DoctorCommand, with_network: bool) -> Result<Report> {
     ));
     report.push(shadow_check(&located, &method, &spec));
 
-    // --- Installations (every octos + octos-tui copy, with versions) --------
-    // Parity with `octos-tui doctor`'s Installations section: enumerate BOTH
+    // --- Installations (every octos + octoscode copy, with versions) --------
+    // Parity with `octoscode doctor`'s Installations section: enumerate BOTH
     // binaries across PATH + the known install dirs so duplicate / mismatched
     // installs are visible from either doctor.
     report.extend(installations_checks(&spec));
@@ -333,24 +333,47 @@ fn build_report(cmd: &DoctorCommand, with_network: bool) -> Result<Report> {
 }
 
 // ---------------------------------------------------------------------------
-// Installations — every octos + octos-tui on the machine, with versions
+// Installations — every octos + octoscode on the machine, with versions
 // ---------------------------------------------------------------------------
 
-/// Parity with `octos-tui doctor`'s Installations section: enumerate every
-/// octos AND octos-tui copy (across `$PATH`, Homebrew, cargo, the shell
-/// installer's `~/.local/bin`, and octos-tui's `~/.octos/bin` auto-install dir),
+/// Parity with `octoscode doctor`'s Installations section: enumerate every
+/// octos AND octoscode copy (across `$PATH`, Homebrew, cargo, the shell
+/// installer's `~/.local/bin`, and octoscode's `~/.octos/bin` auto-install dir),
 /// with each copy's `--version` + inferred install method — so duplicate /
 /// mismatched installs are visible from `octos doctor` too, not just the TUI's.
 fn installations_checks(octos: &ProductSpec) -> Vec<Check> {
-    vec![
+    let mut checks = vec![
         installs_check("octos", &locate_with_octos_bin(octos)),
-        installs_check("octos-tui", &locate(&octos_tui_spec())),
-    ]
+        installs_check("octoscode", &locate(&octoscode_spec())),
+    ];
+    // The client was renamed octos-tui -> octoscode. Enumerating only the new
+    // name would report "none found" to anyone who has not upgraded yet —
+    // wrong, and worst for exactly the user who needs `doctor` to explain
+    // things. Look for the old binary too, and surface it ONLY when a copy is
+    // actually present so the section does not grow a permanent empty row.
+    // Drop this once the rename has settled.
+    let legacy = locate(&octoscode_legacy_spec());
+    if !install_rows(&legacy).is_empty() {
+        checks.push(installs_check("octos-tui (legacy name)", &legacy));
+    }
+    checks
 }
 
-/// Minimal spec for LOCATING the octos-tui client binary — only `binary_name`
+/// Minimal spec for LOCATING the octoscode client binary — only `binary_name`
 /// matters for enumeration; the rest are placeholders.
-fn octos_tui_spec() -> ProductSpec {
+fn octoscode_spec() -> ProductSpec {
+    ProductSpec::new(
+        "octoscode",
+        "octoscode",
+        "0.0.0",
+        "octos-org/octoscode",
+        "octoscode",
+    )
+}
+
+/// Pre-rename spec, so a not-yet-upgraded `octos-tui` copy is still found.
+/// See the note in [`installations_checks`].
+fn octoscode_legacy_spec() -> ProductSpec {
     ProductSpec::new(
         "octos-tui",
         "octos-tui",
@@ -360,7 +383,7 @@ fn octos_tui_spec() -> ProductSpec {
     )
 }
 
-/// `locate()` scans PATH + Homebrew/cargo/`~/.local/bin`, but octos-tui's
+/// `locate()` scans PATH + Homebrew/cargo/`~/.local/bin`, but octoscode's
 /// auto-installer drops `octos` into `~/.octos/bin`, off both — add it (deduped
 /// by canonical path).
 fn locate_with_octos_bin(spec: &ProductSpec) -> LocatedBinaries {
@@ -394,7 +417,7 @@ fn install_method_for_path(path: &Path) -> &'static str {
     } else if p.contains("/homebrew/") || p.contains("/Cellar/") || p.starts_with("/usr/local/") {
         "brew"
     } else if p.contains("/.octos/bin/") {
-        "octos-tui auto-install"
+        "octoscode auto-install"
     } else if p.contains("/.local/bin/") {
         "shell installer"
     } else if p.starts_with("/usr/bin/") || p.starts_with("/bin/") {
@@ -930,7 +953,7 @@ fn profile_checks(profiles: &[DiscoveredProfile]) -> Vec<Check> {
         checks.push(Check::pass(
             CAT_PROFILES,
             "profiles",
-            "none yet — created by octos-tui onboarding (or `octos serve` solo mode)",
+            "none yet — created by octoscode onboarding (or `octos serve` solo mode)",
         ));
         return checks;
     }
@@ -1767,19 +1790,19 @@ mod tests {
             "brew"
         );
         assert_eq!(
-            install_method_for_path(Path::new("/home/u/.local/bin/octos-tui")),
+            install_method_for_path(Path::new("/home/u/.local/bin/octoscode")),
             "shell installer"
         );
         assert_eq!(
             install_method_for_path(Path::new("/home/u/.octos/bin/octos")),
-            "octos-tui auto-install"
+            "octoscode auto-install"
         );
         assert_eq!(
             install_method_for_path(Path::new("/usr/bin/octos")),
             "system"
         );
         assert_eq!(
-            install_method_for_path(Path::new("/x/node_modules/.bin/octos-tui")),
+            install_method_for_path(Path::new("/x/node_modules/.bin/octoscode")),
             "npm"
         );
     }
@@ -1811,10 +1834,10 @@ mod tests {
     }
 
     #[test]
-    fn installations_checks_cover_both_octos_and_octos_tui() {
+    fn installations_checks_cover_both_octos_and_octoscode() {
         let checks = installations_checks(&octos_server_spec());
         assert!(checks.iter().any(|c| c.name == "octos installs"));
-        assert!(checks.iter().any(|c| c.name == "octos-tui installs"));
+        assert!(checks.iter().any(|c| c.name == "octoscode installs"));
     }
 
     #[test]

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -474,12 +474,12 @@ async fn bind_http_listener(
 }
 
 /// Stable, machine-greppable marker embedded in the "data directory is already
-/// owned by another serve" error. octos-tui (a separate repo) spawns
+/// owned by another serve" error. octoscode (a separate repo) spawns
 /// `octos serve --stdio` as a child and greps its stderr for this exact token
 /// on child-exit to recognize the single-writer conflict and STOP relaunching —
 /// instead of the silent ~5s crash-loop it used to hit when the second serve
 /// died mid-startup opening `admin_audit.redb`. MUST stay byte-stable: the
-/// client matches it verbatim (octos-tui `transport.rs` DATA_DIR_LOCKED_MARKER).
+/// client matches it verbatim (octoscode `transport.rs` DATA_DIR_LOCKED_MARKER).
 pub(crate) const DATA_DIR_LOCKED_MARKER: &str = "OCTOS_DATA_DIR_LOCKED";
 
 /// Held for the serve process's whole lifetime: an exclusive OS advisory lock
@@ -516,7 +516,7 @@ fn acquire_serve_data_dir_lock(data_dir: &std::path::Path) -> Result<ServeDataDi
         Err(error) if error.raw_os_error() == fs2::lock_contended_error().raw_os_error() => {
             Err(eyre::eyre!(
                 "{DATA_DIR_LOCKED_MARKER}: another octos server is already running for this data \
-                 directory ({}). Close the other octos-tui (or `octos serve`), or start this one \
+                 directory ({}). Close the other octoscode (or `octos serve`), or start this one \
                  against a different --data-dir.",
                 data_dir.display()
             ))
@@ -601,7 +601,7 @@ impl ServeCommand {
             Ok(guard) => guard,
             Err(error) => {
                 if error.to_string().contains(DATA_DIR_LOCKED_MARKER) {
-                    // A guaranteed clean, un-colored stderr line the octos-tui
+                    // A guaranteed clean, un-colored stderr line the octoscode
                     // client greps on child-exit (color-eyre's rendering of the
                     // returned error may interleave ANSI, so don't rely on it).
                     eprintln!(
@@ -1848,7 +1848,7 @@ mod tests {
         // `--stdio` runs session actors in-process with no gateway to
         // proxy `task/cancel` to, so the store must be present for the
         // per-turn supervisor to self-register into — otherwise AppUI
-        // task commands fail `runtime_unavailable` and octos-tui Esc/`x`
+        // task commands fail `runtime_unavailable` and octoscode Esc/`x`
         // cannot cancel a spawned background task (the reported bug).
         assert!(
             stdio_task_query_store(true).is_some(),

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -222,7 +222,7 @@ pub struct Config {
     #[serde(default)]
     pub content_routing: Option<octos_llm::RoutingConfig>,
 
-    /// AppUi (octos-app, octos-tui, etc.) session defaults applied by
+    /// AppUi (octos-app, octoscode, etc.) session defaults applied by
     /// `octos serve`. Operators can anchor every AppUi session that
     /// does not advertise the `session.workspace_cwd.v1` capability to
     /// a chosen folder via `appui.default_session_cwd` — the Tier-2

--- a/crates/octos-cli/src/runtime/launch.rs
+++ b/crates/octos-cli/src/runtime/launch.rs
@@ -53,7 +53,7 @@ pub enum LaunchDecision {
         existing_profiles: Vec<String>,
     },
     /// No profile exists on the machine at all — the client must send the
-    /// user to `octos-tui onboard`.
+    /// user to `octoscode onboard`.
     NoProfile,
 }
 

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -128,7 +128,7 @@ fn build_sub_provider_router(config: &Config) -> Option<Arc<octos_llm::ProviderR
 ///
 /// One `ProfileRuntime` per `(host process, profile_id)`. The host
 /// process is `octos serve`, `octos gateway` (each subprocess), or
-/// `octos tui` — every entry point that today reads a [`UserProfile`]
+/// `octoscode` — every entry point that today reads a [`UserProfile`]
 /// off disk and turns it into a running agent ends up holding an
 /// `Arc<ProfileRuntime>`.
 ///

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -3153,7 +3153,7 @@ pub enum LaunchDecisionKind {
     /// The folder holds conversation(s) for other profile(s) but not the
     /// resolved one — offer switch-and-resume or start-fresh.
     CrossProfile,
-    /// No profile exists on the machine — send the user to `octos-tui onboard`.
+    /// No profile exists on the machine — send the user to `octoscode onboard`.
     NoProfile,
 }
 

--- a/crates/octos-diagnostics/src/checks.rs
+++ b/crates/octos-diagnostics/src/checks.rs
@@ -2,7 +2,7 @@
 //! directory writability, and the protocol-skew **adapter** over the pure
 //! `octos_core::ui_protocol` comparator.
 //!
-//! No network here (Stage 1). The terminal checks are ported from octos-tui's
+//! No network here (Stage 1). The terminal checks are ported from octoscode's
 //! `doctor.rs`; the writability checks take their directories as parameters so
 //! callers (octos-cli) resolve the real `~/.config/octos` + `~/.octos`.
 

--- a/crates/octos-diagnostics/src/github.rs
+++ b/crates/octos-diagnostics/src/github.rs
@@ -1,7 +1,7 @@
 //! Minimal **blocking** GitHub Releases client for `update --check` and the
 //! `doctor` network category (Stage 2). Behind the `github` feature → `reqwest`.
 //!
-//! Ported, product-agnostic, from octos-tui's `cmd/github.rs`: a plain blocking
+//! Ported, product-agnostic, from octoscode's `cmd/github.rs`: a plain blocking
 //! `reqwest` GET against the public Releases API. No auth is required for public
 //! repos, but the product's token env var (`spec.github_token_env`) is honored
 //! when set to dodge the unauthenticated rate limit — optional, never a hard

--- a/crates/octos-diagnostics/src/install_method.rs
+++ b/crates/octos-diagnostics/src/install_method.rs
@@ -1,6 +1,6 @@
 //! Install-method detection, product-agnostic.
 //!
-//! Ported from octos-tui's `install_method.rs`, but every product-specific
+//! Ported from octoscode's `install_method.rs`, but every product-specific
 //! string (formula, package, repo, crate) now comes from the [`ProductSpec`]
 //! rather than being hardcoded. The path classifier ([`classify_path`]) stays
 //! pure/testable; [`detect`] wires it to the live host.
@@ -378,7 +378,7 @@ mod tests {
     #[test]
     fn should_classify_usr_local_as_unknown_when_no_brew_present() {
         // No brew present → `/usr/local` is NOT a brew prefix → Unknown (avoids
-        // printing a wrong `brew upgrade`). Mirrors octos-tui finding #1.
+        // printing a wrong `brew upgrade`). Mirrors octoscode finding #1.
         let i = input("/usr/local/bin/octos");
         assert_eq!(classify_path(&i), InstallMethod::Unknown);
     }

--- a/crates/octos-diagnostics/src/lib.rs
+++ b/crates/octos-diagnostics/src/lib.rs
@@ -2,13 +2,13 @@
 //! *planning* for the octos binaries (`octos doctor`, and later `octos update
 //! --check`).
 //!
-//! This crate is the dependency-light seam factored out of octos-tui's
-//! `doctor`/`install_method` modules (octos-tui#182, ADR
+//! This crate is the dependency-light seam factored out of octoscode's
+//! `doctor`/`install_method` modules (octoscode#182, ADR
 //! `docs/adr/octos-diagnostics-extraction-scope.md`). Stage 1 ships:
 //!
 //! - the report model ([`CheckStatus`] / [`Check`] / [`Report`]) with the
 //!   `[✓]/[!]/[✗]` glyphs, JSON support-bundle output, and exit-code policy;
-//! - a [`ProductSpec`] seam so the same logic serves both octos-tui and the
+//! - a [`ProductSpec`] seam so the same logic serves both octoscode and the
 //!   octos server — **the current version is always passed IN** by the caller,
 //!   never read from this crate's `CARGO_PKG_VERSION`;
 //! - [`InstallMethod`] classification ([`classify_path`] pure + [`detect`]

--- a/crates/octos-diagnostics/src/locate.rs
+++ b/crates/octos-diagnostics/src/locate.rs
@@ -1,6 +1,6 @@
 //! PATH resolution + shadow detection, product-agnostic.
 //!
-//! Ported from octos-tui's `doctor.rs` locate/on_path/shadow logic, with the
+//! Ported from octoscode's `doctor.rs` locate/on_path/shadow logic, with the
 //! binary name driven by [`ProductSpec`]. Carries the #189 npm fix: when the
 //! method is [`InstallMethod::Npm`] and nothing is located, both the on-PATH
 //! and shadow checks PASS (the real binary lives under `node_modules/.bin_real`

--- a/crates/octos-diagnostics/src/report.rs
+++ b/crates/octos-diagnostics/src/report.rs
@@ -1,5 +1,5 @@
 //! The product-agnostic diagnostic report model: [`CheckStatus`], [`Check`],
-//! and [`Report`]. Ported from octos-tui's `doctor.rs` but with the
+//! and [`Report`]. Ported from octoscode's `doctor.rs` but with the
 //! product-specific JSON keys (the binary's own version/schema) supplied by the
 //! caller via [`Report::to_json`] arguments rather than baked in from this
 //! crate's `CARGO_PKG_VERSION`.

--- a/crates/octos-diagnostics/src/spec.rs
+++ b/crates/octos-diagnostics/src/spec.rs
@@ -1,6 +1,6 @@
 //! [`ProductSpec`] — the product-agnostic seam.
 //!
-//! Shared diagnostics code must never hardcode `octos-tui` vs `octos`. Callers
+//! Shared diagnostics code must never hardcode `octoscode` vs `octos`. Callers
 //! describe their product once via a `ProductSpec`; everything else
 //! (install-method labels/upgrade hints, PATH/shadow locating, asset selection)
 //! reads from it.
@@ -13,7 +13,7 @@
 /// How to build the per-OS release asset name for a product. Stage 1 only needs
 /// the *shape* (Stage 2 will consume it when the GitHub client lands); we model
 /// it as a template prefix joined to the platform triple, e.g.
-/// `octos-bundle-<triple>` or `octos-tui-<triple>`.
+/// `octos-bundle-<triple>` or `octoscode-<triple>`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AssetSelector {
     /// Prefix prepended to the target triple (no trailing dash), e.g.
@@ -37,11 +37,11 @@ impl AssetSelector {
 }
 
 /// Product description threaded into every shared diagnostic. Constructed by the
-/// binary (octos-cli / octos-tui), never inferred from this crate.
+/// binary (octos-cli / octoscode), never inferred from this crate.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProductSpec {
     /// Bare binary name as run on PATH (no extension; `.exe` is appended on
-    /// Windows by the locator), e.g. `octos` or `octos-tui`.
+    /// Windows by the locator), e.g. `octos` or `octoscode`.
     pub binary_name: String,
     /// Package / display name, e.g. `octos`.
     pub package_name: String,

--- a/docs/M11-PROFILE-SESSION-RUNTIME-ADR.md
+++ b/docs/M11-PROFILE-SESSION-RUNTIME-ADR.md
@@ -113,7 +113,7 @@ API account + global config maps to `ProfileRuntime`.
 
 ### TUI — multiple terminals on one box
 
-Each `octos tui` is its own process. Two terminals get two isolated
+Each `octoscode` is its own process. Two terminals get two isolated
 state spaces by virtue of OS process separation. Inside one TUI
 process you can also have multiple sessions (split panes) sharing the
 one `ProfileRuntime`. Different OS users get extra isolation via
@@ -147,7 +147,7 @@ introduced go away — they always wanted to live somewhere else.
 ## What this is NOT
 
 - **Not a subprocess refactor.** Sessions run in-process within the
-  host (`serve` or `octos tui`). Sandbox isolation continues to live
+  host (`serve` or `octoscode`). Sandbox isolation continues to live
   at the shell-tool spawn boundary (`Bwrap`/`Macos sbpl`/`Docker`),
   not at the session level. If we ever need stronger session
   isolation (hostile multi-tenant compute), the abstraction supports a

--- a/docs/M16_UX_TMUX_SOAK_FIXTURE.txt
+++ b/docs/M16_UX_TMUX_SOAK_FIXTURE.txt
@@ -11,7 +11,7 @@ multi-agent orchestration through the real AppUI stdio path.
 It launches:
 
 - octos serve --stdio from this repo.
-- octos-tui --mode protocol --stdio-command ... through the octos-tui tmux
+- octoscode --mode protocol --stdio-command ... through the octoscode tmux
   harness.
 - A typed AppUI review/start request that asks for supervised specialist
   agents. Native specialists are resolved from
@@ -33,13 +33,13 @@ From the octos repo:
 
 Useful overrides:
 
-  OCTOS_TUI_REPO=/Users/yuechen/home/octos-tui \
+  OCTOSCODE_REPO=/Users/yuechen/home/octoscode \
   OCTOS_M16_UX_RUN_ID=m16-local \
   bash e2e/scripts/m16-live-tui-tmux-soak.sh run
 
 Set OCTOS_M16_BUILD=0 to skip building octos with the api feature.
-Set OCTOS_M16_BUILD_TUI=1 to force rebuilding octos-tui; by default the script
-uses an existing octos-tui binary and only builds it when missing.
+Set OCTOS_M16_BUILD_TUI=1 to force rebuilding octoscode; by default the script
+uses an existing octoscode binary and only builds it when missing.
 Set OCTOS_M16_UX_KEEP_SESSION=1 to leave tmux open after the run.
 
 Evidence
@@ -50,7 +50,7 @@ The default output root is:
 
 Required evidence includes:
 
-- launch-command.txt: proves octos-tui launched with octos serve --stdio.
+- launch-command.txt: proves octoscode launched with octos serve --stdio.
 - input-replay.log: records the exact terminal replay and prompt.
 - tui-capture-child-start.txt
 - tui-capture-child-progress.txt

--- a/docs/M17_LIVE_PROOF_SOAK_RUNBOOK.txt
+++ b/docs/M17_LIVE_PROOF_SOAK_RUNBOOK.txt
@@ -18,7 +18,7 @@ Notes: Proves native specialists complete, but does not by itself prove direct s
 
 Requirement: TUI tmux captures
 Current script/evidence: e2e/scripts/m16-live-tui-tmux-soak.sh
-Notes: Requires tmux and octos-tui; output includes terminal captures and m16-ux-soak-validation.json.
+Notes: Requires tmux and octoscode; output includes terminal captures and m16-ux-soak-validation.json.
 
 Requirement: AppUI transcript
 Current script/evidence: client-observed-appui-transcript.jsonl or appui-transcript.jsonl

--- a/docs/M18_APPUI_STDIO_TRANSPORT_PARITY_CONTRACT.txt
+++ b/docs/M18_APPUI_STDIO_TRANSPORT_PARITY_CONTRACT.txt
@@ -1,7 +1,7 @@
 # M18 AppUI Stdio Transport Parity Contract
 
 Status: implementation verified; GitHub issue updates blocked by expired connector token
-Owner: Octos backend plus octos-tui client workers
+Owner: Octos backend plus octoscode client workers
 Date: 2026-05-17
 
 ## Goal
@@ -121,7 +121,7 @@ Acceptance:
   Runtime-path differences such as advertised methods returning transport-only
   unsupported errors are not acceptable allowances.
 
-### M18-F: octos-tui Stdio UX And Validation
+### M18-F: octoscode Stdio UX And Validation
 
 Deliverables:
 
@@ -155,7 +155,7 @@ M18 is complete only when:
 
 1. Existing PR stack #819-#822 is merged, superseded, or closed with equivalent current-branch work landed.
 2. Backend AppUI stdio passes shared conformance tests.
-3. octos-tui passes live tmux stdio UX soak against the real backend.
+3. octoscode passes live tmux stdio UX soak against the real backend.
 4. The AppUI spec documents all supported and intentionally unsupported stdio behaviors.
 5. No issue can be closed with only a short happy-path model answer.
 
@@ -179,7 +179,7 @@ TUI verification:
   321 lib tests, 3 AppUI UX fixture tests, 2 solo-permissions tests.
 - `cargo clippy --all --workspace -- -D warnings` passed.
 - Live tmux UX soak passed:
-  `/Users/yuechen/home/octos-tui/e2e/test-results-m15-live-tmux-ux/m18-stdio-parity-20260518T011554Z/ux-validation.json`.
+  `/Users/yuechen/home/octoscode/e2e/test-results-m15-live-tmux-ux/m18-stdio-parity-20260518T011554Z/ux-validation.json`.
 
 Claude review:
 
@@ -200,7 +200,7 @@ GitHub issue update status:
 - Attempted to comment on `octos-org/octos#1028`, but the GitHub connector
   returned `401 token_expired`: "Provided authentication token is expired.
   Please try signing in again."
-- Issue comments/closures for `octos#1028`-`#1032` and `octos-tui#48`-`#49`
+- Issue comments/closures for `octos#1028`-`#1032` and `octoscode#48`-`#49`
   still need to be posted after GitHub app authentication is refreshed.
 
 ## Backing-Store Replay Soak 2026-05-18

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_011_TURN_STATE_GET.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_011_TURN_STATE_GET.md
@@ -126,7 +126,7 @@ The feature MUST always be included in the server's known feature registry once 
 
 ## Compatibility
 
-- All existing clients (octos-tui, octos-app, web SPA) continue to function unchanged. The method is opt-in via `X-Octos-Ui-Features`.
+- All existing clients (octoscode, octos-app, web SPA) continue to function unchanged. The method is opt-in via `X-Octos-Ui-Features`.
 - Legacy daemon versions that do not implement `turn/state/get` will not advertise the feature in `supported_features`, and clients will not invoke it.
 - The active-turn registry already exists and is populated for every turn started after `turn/start`. No daemon-side state migration is required.
 - Telegram, Discord, Email, Matrix, and other linear channels: unaffected. They do not expose UI Protocol; their state is observable only via REST and channel-native message ids.
@@ -150,7 +150,7 @@ The feature MUST always be included in the server's known feature registry once 
 
 ### Client-side
 
-- TUI fixture at `octos-tui/tests/...`: render activity pane after invoking `turn/state/get` against a paused turn. Assert "interrupting" surfaces.
+- TUI fixture at `octoscode/tests/...`: render activity pane after invoking `turn/state/get` against a paused turn. Assert "interrupting" surfaces.
 - Layer 1 SPA fixture (PR H): the `slow-then-fast-interleave.fixture.ts` and `m89-recovery-turn.fixture.ts` fixtures should call `turn/state/get` between events and assert the returned state matches the expected lifecycle.
 
 ### Wire contract
@@ -163,7 +163,7 @@ The feature MUST always be included in the server's known feature registry once 
 ## Rollout
 
 - **Day 1 (this UPCR)**: drafted, reviewed, accepted before any code lands.
-- **Day 2 (PR G in the structural plan)**: server handler implemented under capability gate. octos-tui adopts in the same PR. Web SPA does not adopt until PR J (Day 4).
+- **Day 2 (PR G in the structural plan)**: server handler implemented under capability gate. octoscode adopts in the same PR. Web SPA does not adopt until PR J (Day 4).
 - **Pre-release validation**: golden tests pass; `cargo test -p octos-core --features api` covers the capability-negotiation behavior.
 
 ## Risks

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_012_MESSAGE_PERSISTED.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_012_MESSAGE_PERSISTED.md
@@ -147,7 +147,7 @@ Capability feature: `event.message_persisted.v1`
 
 ### Client-side
 
-- TUI fixture at `octos-tui/tests/...`: subscribe to `message/persisted`, assert the message-list view stays consistent with `session/hydrate` after disconnect/reconnect.
+- TUI fixture at `octoscode/tests/...`: subscribe to `message/persisted`, assert the message-list view stays consistent with `session/hydrate` after disconnect/reconnect.
 - Layer 1 SPA fixture (PR H): every fixture asserts that `message/persisted` events arrive in the expected order with the expected `(turn_id, thread_id, seq)` tuples. The `rapid-fire-five-fast` fixture in particular asserts no row is mis-routed to a sibling thread.
 
 ### Wire contract

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_016_STDIO_TRANSPORT.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_016_STDIO_TRANSPORT.md
@@ -50,6 +50,6 @@ wire contract without opening a network listener.
 
 - CLI parse/build check for `octos serve --stdio`.
 - Stdio request/response smoke for `config/capabilities/list`.
-- Stdio tmux soak with `octos-tui --stdio-command "octos serve --stdio ..."`
+- Stdio tmux soak with `octoscode --stdio-command "octos serve --stdio ..."`
   covering onboarding provider save, `session/open`, `turn/start`, model output,
   and terminal capture artifacts.

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_019_AGENT_SUPERVISION.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_019_AGENT_SUPERVISION.md
@@ -223,9 +223,9 @@ Implementation note, 2026-05-16:
   Evidence:
   `/Users/yuechen/home/octos/e2e/test-results-m15-task-supervisor-mirror-stdio/20260516T224154Z`
 - Real tmux evidence now covers the same ordinary `TaskSupervisor` mirror path
-  through `octos-tui` against real `octos serve --stdio`:
+  through `octoscode` against real `octos serve --stdio`:
   `e2e/scripts/m15-task-supervisor-mirror-tmux-soak.sh run` passed after fixing
-  octos-tui to render the backend-provided agent summary/last-task detail in
+  octoscode to render the backend-provided agent summary/last-task detail in
   the visible activity row. Evidence:
   `/Users/yuechen/home/octos/e2e/test-results-m15-task-supervisor-mirror-tmux/m15-task-mirror-tmux-20260516T224202Z`
 
@@ -378,5 +378,5 @@ unchanged.
 - Plain `turn/start` review requests still allow backend-owned subagent
   scheduling.
 - WebSocket and stdio expose identical method/result/error/event shapes.
-- Octos-TUI hides inspection controls on old servers and renders task tree plus
+- Octoscode hides inspection controls on old servers and renders task tree plus
   artifact browser when capabilities are present.

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_021_AGENT_GOAL_LOOP_AUTONOMY.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_021_AGENT_GOAL_LOOP_AUTONOMY.md
@@ -85,7 +85,7 @@ Central tracker: https://github.com/octos-org/octos/issues/992
 - **M15-F5: Production autonomy live tmux soak.** TUI/e2e proof for real master
   continuations, goal continuation, loop fires, restart hydration, and
   stdio/WebSocket parity. Tracking:
-  https://github.com/octos-org/octos-tui/issues/44
+  https://github.com/octos-org/octoscode/issues/44
 
 ## Capabilities
 

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_026_COMPACTION_STARTED.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_026_COMPACTION_STARTED.md
@@ -21,7 +21,7 @@ progress/fullness bar). The change is strictly additive.
 
 ## Motivation
 
-octos-tui wants Claude-Code-style compaction UX:
+octoscode wants Claude-Code-style compaction UX:
 
 ```
 ✶ Compacting conversation… (12s · 87.4k tokens)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -240,14 +240,14 @@ OCTOS_M12_SOAK_TRANSPORT=both OCTOS_M12_SOAK_STRICT=1 \
   ./scripts/m12-solo-appui-soak.sh run
 ```
 
-Required TUI checks in `../octos-tui`:
+Required TUI checks in `../octoscode`:
 
 ```bash
 cargo test --all --workspace onboarding
 cargo test --all --workspace permissions
 scripts/run-onboarding-tmux-soak.sh solo-self-test
-OCTOS_TUI_SOAK_TRANSPORT=stdio scripts/run-onboarding-tmux-soak.sh drive-solo
-OCTOS_TUI_SOAK_TRANSPORT=stdio scripts/run-onboarding-tmux-soak.sh verify-solo
+OCTOSCODE_SOAK_TRANSPORT=stdio scripts/run-onboarding-tmux-soak.sh drive-solo
+OCTOSCODE_SOAK_TRANSPORT=stdio scripts/run-onboarding-tmux-soak.sh verify-solo
 ```
 
 The M22 release gate must fail on OTP calls in local solo onboarding, secret

--- a/docs/adr/m12-phase-d-auxiliary-rest-to-ws.md
+++ b/docs/adr/m12-phase-d-auxiliary-rest-to-ws.md
@@ -230,7 +230,7 @@ small.
   detonates the session; it surfaces as a typed RPC error on a connected,
   authenticated WS socket.
 - Clients that historically used REST for the thirteen surfaces above MUST
-  negotiate `auxiliary.rest_to_ws.v1` to access the new wire. The `octos-tui`
+  negotiate `auxiliary.rest_to_ws.v1` to access the new wire. The `octoscode`
   client speaks UI Protocol v1 natively and consumes the new methods as soon
   as the gate is set in its capability handshake.
 - The capability is strictly opt-in: even with the header absent, the gate
@@ -328,7 +328,7 @@ were **not** retired and stay REST.
 - **Server-side session TTL, refresh, and rotation logic.** The existing
   auth manager keeps owning that. This ADR only moved what the data plane
   sends over.
-- **`octos-tui`.** The TUI already speaks UI Protocol v1 natively — no
+- **`octoscode`.** The TUI already speaks UI Protocol v1 natively — no
   auxiliary REST surface to migrate. It consumes the new methods
   opportunistically but was not a release gate.
 - **Slides / sites sub-apps.** `slides/api.ts`, `sites/api.ts` still call

--- a/docs/adr/octos-diagnostics-extraction-scope.md
+++ b/docs/adr/octos-diagnostics-extraction-scope.md
@@ -1,7 +1,7 @@
-# Scope: shared `octos-diagnostics` (octos-tui#182 "Sharing" phase)
+# Scope: shared `octos-diagnostics` (octoscode#182 "Sharing" phase)
 
 **Goal:** the server (`octos-cli`) gets `octos doctor` / `octos update` by sharing the
-diagnostics + update *logic* that octos-tui already implements — without
+diagnostics + update *logic* that octoscode already implements — without
 duplicating it and without bloating `octos-core`.
 
 ## Decision: a new `octos-diagnostics` crate (NOT feature-gated `octos-core`)
@@ -19,16 +19,16 @@ unrelated crates. A dedicated crate is cleaner.
   comparator (server caps/schema vs `UI_PROTOCOL_SCHEMA_VERSION` + `FEATURE_*`).
   It is protocol semantics and needs **no new deps**, so it belongs in core. The
   `Check`-producing *adapter* over it lives in `octos-diagnostics`.
-- **Cross-repo:** octos-tui already git-deps `octos-core`; it adds a second git-dep
+- **Cross-repo:** octoscode already git-deps `octos-core`; it adds a second git-dep
   on `octos-diagnostics` at the **same pinned rev**. Add CI asserting the two revs
   match and `cargo tree -d` shows no duplicate `octos-core`.
 
 ## The `ProductSpec` seam (what makes it product-agnostic)
 
-Shared code must not hardcode `octos-tui` vs `octos`. Callers pass a `ProductSpec`:
+Shared code must not hardcode `octoscode` vs `octos`. Callers pass a `ProductSpec`:
 binary name, package name, **current version (passed IN — never `CARGO_PKG_VERSION`
 of the shared crate)**, GitHub repo, token env var, brew formula, npm package, cargo
-install cmd, cargo-dist app name, installer URL, **asset selector** (`octos-tui-*`
+install cmd, cargo-dist app name, installer URL, **asset selector** (`octoscode-*`
 vs `octos-bundle-*`).
 
 ## Split
@@ -58,11 +58,11 @@ vs `octos-bundle-*`).
 ## Network + self-update: share planning, NOT the engine (yet)
 
 The two updaters are genuinely asymmetric:
-- octos-tui: single binary, cargo-dist receipt → axoupdater.
+- octoscode: single binary, cargo-dist receipt → axoupdater.
 - octos-cli: multi-binary **bundle** tarball + skills, rollback, codesign each.
 
 So the shared layer produces an **`UpdatePlan`**; each binary runs its own driver.
-`axoupdater` sits behind a narrow feature that **only octos-tui** enables. octos-cli
+`axoupdater` sits behind a narrow feature that **only octoscode** enables. octos-cli
 keeps its existing `crates/octos-cli/src/updater.rs` initially, adapted to consume
 the shared release/planning code (and to become install-method-aware).
 
@@ -82,6 +82,6 @@ the shared release/planning code (and to become install-method-aware).
 
 Feature unification pulling heavy deps into unrelated crates · duplicate
 git-pinned `octos-core` (rev-match CI + `cargo tree -d`) · axoupdater leaking via
-defaults (keep it non-default, octos-tui-only) · **`CARGO_PKG_VERSION` is wrong
+defaults (keep it non-default, octoscode-only) · **`CARGO_PKG_VERSION` is wrong
 inside a shared crate** — pass the version in via `ProductSpec` · stale cargo-dist
 receipts · hard-coded CLI macOS-arm64 bundle asset names.

--- a/docs/design/ask-user-question-2026-06-03.md
+++ b/docs/design/ask-user-question-2026-06-03.md
@@ -4,7 +4,7 @@ Date: 2026-06-03
 
 Status: design draft (Phase 1: synchronous tool-block).
 
-Owner: octos-agent + octos-cli (AppUI/UI Protocol) + octos-tui.
+Owner: octos-agent + octos-cli (AppUI/UI Protocol) + octoscode.
 
 Related contract surfaces:
 
@@ -12,7 +12,7 @@ Related contract surfaces:
   (§7 `user_question/respond`, §8 `user_question/requested`, §4.1 UPCR-2026-023)
 - [api/OCTOS_SERVER_FEATURE_REQUIREMENTS.md](../../api/OCTOS_SERVER_FEATURE_REQUIREMENTS.md) (`SRV-041`)
 - [api/OCTOS_APP_FEATURE_REQUIREMENTS.md](../../api/OCTOS_APP_FEATURE_REQUIREMENTS.md) (`APP-037`)
-- [api/OCTOS_TUI_FEATURE_REQUIREMENTS.md](../../api/OCTOS_TUI_FEATURE_REQUIREMENTS.md) (`TUI-037`)
+- [api/OCTOSCODE_FEATURE_REQUIREMENTS.md](../../api/OCTOSCODE_FEATURE_REQUIREMENTS.md) (`TUI-037`)
 
 Existing machinery this design reuses (read these before implementing):
 
@@ -323,9 +323,9 @@ in this docs-only change.
   - Capability negotiation: advertise `user_question.v1` in
     `supported_features` when the client requests it.
 
-**octos-tui** (rendering):
+**octoscode** (rendering):
 
-- `crates/octos-tui/src/store.rs` + `src/app.rs` (mirror the approval-card
+- `crates/octoscode/src/store.rs` + `src/app.rs` (mirror the approval-card
   handling): render the question picker — one card per question, single-select
   vs multi-select, each option as a selectable line, plus an "Other" free-text
   entry. Send `user_question/respond` with the correct `question_id` and
@@ -370,7 +370,7 @@ Follow the project RED → GREEN → REFACTOR cycle. Tests by layer:
 - `should_replay_pending_user_question_on_hydrate` (reconnect path).
 - `should_degrade_to_generic_when_client_lacks_capability`.
 
-**octos-tui:**
+**octoscode:**
 
 - Render snapshot of single-select and multi-select cards + the "Other" entry.
 - Reducer test: `user_question/respond` carries the right `question_id` and

--- a/e2e/fixtures/ux-artifact-self-test/launch-command.txt
+++ b/e2e/fixtures/ux-artifact-self-test/launch-command.txt
@@ -1,1 +1,1 @@
-octos-tui --mode protocol --stdio-command 'octos serve --stdio'
+octoscode --mode protocol --stdio-command 'octos serve --stdio'

--- a/e2e/matrix/octos-ux.toml
+++ b/e2e/matrix/octos-ux.toml
@@ -6,7 +6,7 @@
 #
 # Each `[[scenario]]` table declares one UX scenario the gate can list, plan,
 # and (in follow-up PRs) actually run through real tmux against a real
-# `octos` plus real `octos-tui`.
+# `octos` plus real `octoscode`.
 #
 # Mandatory fields per scenario:
 #   id                 - kebab-case identifier, unique
@@ -40,9 +40,9 @@ tier = "fast"
 transport = "stdio"
 provider = "fixture"
 terminal = "80x24"
-tui_binary = "octos-tui"
+tui_binary = "octoscode"
 tmux_command = "ux-tui-solo-onboarding"
-required_tools = ["tmux", "octos", "octos-tui"]
+required_tools = ["tmux", "octos", "octoscode"]
 required_capabilities = ["onboarding/workspace_probe", "runtime/policy_stamp"]
 expected_artifacts = [
   "scenario.json",
@@ -73,9 +73,9 @@ tier = "fast"
 transport = "stdio"
 provider = "none"
 terminal = "80x24"
-tui_binary = "octos-tui"
+tui_binary = "octoscode"
 tmux_command = "ux-tui-provider-missing"
-required_tools = ["tmux", "octos", "octos-tui"]
+required_tools = ["tmux", "octos", "octoscode"]
 required_capabilities = ["onboarding/workspace_probe"]
 expected_artifacts = [
   "scenario.json",
@@ -96,7 +96,7 @@ acceptance = [
   "tui.first_frame_not_blank",
   "provider_missing_visible_contract",
 ]
-notes = "Uses the current octos-tui onboarding runner with no profile LLM to open /provider and preserve the recoverable provider setup capture."
+notes = "Uses the current octoscode onboarding runner with no profile LLM to open /provider and preserve the recoverable provider setup capture."
 
 [[scenario]]
 id = "permission-selection"
@@ -106,9 +106,9 @@ tier = "local"
 transport = "stdio"
 provider = "fixture"
 terminal = "80x24"
-tui_binary = "octos-tui"
+tui_binary = "octoscode"
 tmux_command = "ux-tui-permission-selection"
-required_tools = ["tmux", "octos", "octos-tui"]
+required_tools = ["tmux", "octos", "octoscode"]
 required_capabilities = ["runtime/policy_stamp", "permission/profile_select"]
 expected_artifacts = [
   "scenario.json",
@@ -130,7 +130,7 @@ acceptance = [
   "appui.no_otp_calls",
   "permission_selection_visible_contract",
 ]
-notes = "Uses the current octos-tui onboarding runner to open /permissions, apply a workspace-write never-ask policy, and preserve permission captures."
+notes = "Uses the current octoscode onboarding runner to open /permissions, apply a workspace-write never-ask policy, and preserve permission captures."
 
 [[scenario]]
 id = "stdio-happy-path"
@@ -140,9 +140,9 @@ tier = "local"
 transport = "stdio"
 provider = "fixture"
 terminal = "100x30"
-tui_binary = "octos-tui"
+tui_binary = "octoscode"
 tmux_command = "ux-tui-stdio-happy"
-required_tools = ["tmux", "octos", "octos-tui"]
+required_tools = ["tmux", "octos", "octoscode"]
 required_capabilities = ["chat/send_prompt", "chat/receive_response"]
 expected_artifacts = [
   "scenario.json",
@@ -171,9 +171,9 @@ tier = "local"
 transport = "ws"
 provider = "fixture"
 terminal = "100x30"
-tui_binary = "octos-tui"
+tui_binary = "octoscode"
 tmux_command = "ux-tui-ws-happy"
-required_tools = ["tmux", "octos", "octos-tui"]
+required_tools = ["tmux", "octos", "octoscode"]
 required_capabilities = ["chat/send_prompt", "chat/receive_response"]
 expected_artifacts = [
   "scenario.json",
@@ -202,9 +202,9 @@ tier = "local"
 transport = "stdio"
 provider = "fixture"
 terminal = "100x30"
-tui_binary = "octos-tui"
+tui_binary = "octoscode"
 tmux_command = "ux-tui-approval-denial"
-required_tools = ["tmux", "octos", "octos-tui"]
+required_tools = ["tmux", "octos", "octoscode"]
 required_capabilities = ["approval/request", "approval/deny"]
 expected_artifacts = [
   "scenario.json",
@@ -226,7 +226,7 @@ acceptance = [
   "appui.no_tool_call_after_denial",
   "approval_denial_visible_contract",
 ]
-notes = "Uses the current octos-tui onboarding runner with OCTOS_M9_PROTOCOL_FIXTURES=1 to trigger a real AppUI approval request and drive denial through the TUI."
+notes = "Uses the current octoscode onboarding runner with OCTOS_M9_PROTOCOL_FIXTURES=1 to trigger a real AppUI approval request and drive denial through the TUI."
 
 [[scenario]]
 id = "task-subagent-tree"
@@ -236,9 +236,9 @@ tier = "local"
 transport = "stdio"
 provider = "fixture"
 terminal = "120x40"
-tui_binary = "octos-tui"
+tui_binary = "octoscode"
 tmux_command = "ux-tui-task-subagent-tree"
-required_tools = ["tmux", "octos", "octos-tui"]
+required_tools = ["tmux", "octos", "octoscode"]
 required_capabilities = ["task/spawn", "task/observe"]
 expected_artifacts = [
   "scenario.json",
@@ -264,7 +264,7 @@ acceptance = [
   "tui.task_tree_rendered",
   "task_subagent_tree_visible_contract",
 ]
-notes = "Uses the current octos-tui onboarding runner with OCTOS_M15_LIVE_SUBAGENT_FIXTURE=1 to trigger the real M15 live subagent fixture and preserve task/subagent captures."
+notes = "Uses the current octoscode onboarding runner with OCTOS_M15_LIVE_SUBAGENT_FIXTURE=1 to trigger the real M15 live subagent fixture and preserve task/subagent captures."
 
 [[scenario]]
 id = "restart-reconnect"
@@ -274,9 +274,9 @@ tier = "release"
 transport = "ws"
 provider = "fixture"
 terminal = "100x30"
-tui_binary = "octos-tui"
+tui_binary = "octoscode"
 tmux_command = "ux-tui-restart-reconnect"
-required_tools = ["tmux", "octos", "octos-tui"]
+required_tools = ["tmux", "octos", "octoscode"]
 required_capabilities = ["session/resume", "session/snapshot", "session/hydrate", "protocol/replay_lossy", "transport/reconnect"]
 expected_artifacts = [
   "scenario.json",
@@ -303,7 +303,7 @@ acceptance = [
   "appui.session_state_preserved",
   "restart_reconnect_visible_contract",
 ]
-notes = "Uses the current octos-tui onboarding runner over WebSocket, restarts the real backend tmux server under the live TUI, then captures TUI reconnect state plus session/hydrate pre/post snapshots."
+notes = "Uses the current octoscode onboarding runner over WebSocket, restarts the real backend tmux server under the live TUI, then captures TUI reconnect state plus session/hydrate pre/post snapshots."
 
 [[scenario]]
 id = "narrow-layout"
@@ -313,9 +313,9 @@ tier = "release"
 transport = "stdio"
 provider = "fixture"
 terminal = "narrow"
-tui_binary = "octos-tui"
+tui_binary = "octoscode"
 tmux_command = "ux-tui-narrow-layout"
-required_tools = ["tmux", "octos", "octos-tui"]
+required_tools = ["tmux", "octos", "octoscode"]
 required_capabilities = ["chat/send_prompt"]
 expected_artifacts = [
   "scenario.json",
@@ -342,9 +342,9 @@ tier = "release"
 transport = "ws"
 provider = "fixture"
 terminal = "100x30"
-tui_binary = "octos-tui"
+tui_binary = "octoscode"
 tmux_command = "ux-tui-dropped-completion"
-required_tools = ["tmux", "octos", "octos-tui"]
+required_tools = ["tmux", "octos", "octoscode"]
 required_capabilities = ["chat/send_prompt", "chat/stream", "turn/completed", "protocol/replay_lossy", "session/snapshot"]
 expected_artifacts = [
   "scenario.json",
@@ -371,4 +371,4 @@ acceptance = [
   "appui.next_prompt_succeeds",
   "dropped_completion_backpressure_contract",
 ]
-notes = "Uses the current octos-tui onboarding runner plus a WebSocket sidecar probe to force a local dropped turn/completed writer-channel failure, replay recovery, and next-prompt success."
+notes = "Uses the current octoscode onboarding runner plus a WebSocket sidecar probe to force a local dropped turn/completed writer-channel failure, replay recovery, and next-prompt success."

--- a/e2e/matrix/onboarding.toml
+++ b/e2e/matrix/onboarding.toml
@@ -283,7 +283,7 @@ expect = { result_has = ["requested_path", "exists"] }
 name = "first-run-local-tmux"
 tier = "local"
 transport = "stdio"
-description = "Drive octos-tui through first-run wizard under live tmux (placeholder)."
+description = "Drive octoscode through first-run wizard under live tmux (placeholder)."
 validators = ["tui_first_run_capture"]
 artifacts = ["tui-capture.txt", "rpc-transcript.jsonl"]
 skip_reason = "tier-local scenarios land with the local tmux/provider follow-up."

--- a/e2e/scripts/m15-live-stdio-soak.mjs
+++ b/e2e/scripts/m15-live-stdio-soak.mjs
@@ -41,8 +41,8 @@ const child = spawn(octosBin, ['serve', '--stdio', '--data-dir', dataDir, '--cwd
   env: {
     ...process.env,
     OCTOS_M15_LIVE_SUBAGENT_FIXTURE: '1',
-    OCTOS_TUI_M15_UX_OUTPUT_DIR: evidenceDir,
-    OCTOS_TUI_M15_UX_WORKDIR: workspace,
+    OCTOSCODE_M15_UX_OUTPUT_DIR: evidenceDir,
+    OCTOSCODE_M15_UX_WORKDIR: workspace,
     RUST_BACKTRACE: process.env.RUST_BACKTRACE || '1',
   },
   stdio: ['pipe', 'pipe', 'pipe'],

--- a/e2e/scripts/m15-task-supervisor-mirror-tmux-soak.sh
+++ b/e2e/scripts/m15-task-supervisor-mirror-tmux-soak.sh
@@ -5,7 +5,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
 
 run_id="${OCTOS_M15_TASK_MIRROR_TMUX_RUN_ID:-m15-task-mirror-tmux-$(date -u +%Y%m%dT%H%M%SZ)}"
-tui_repo="${OCTOS_TUI_REPO:-/Users/yuechen/home/octos-tui}"
+tui_repo="${OCTOSCODE_REPO:-/Users/yuechen/home/octoscode}"
 tui_runner="${OCTOS_M15_TASK_MIRROR_TUI_RUNNER:-$tui_repo/scripts/run-m15-live-tmux-ux-soak.sh}"
 out_root="${OCTOS_M15_TASK_MIRROR_TMUX_OUT_ROOT:-$repo_root/e2e/test-results-m15-task-supervisor-mirror-tmux}"
 out_dir="${OCTOS_M15_TASK_MIRROR_TMUX_OUT_DIR:-$out_root/$run_id}"
@@ -14,7 +14,7 @@ data_dir="${OCTOS_M15_TASK_MIRROR_TMUX_DATA_DIR:-$runtime_root/data}"
 workdir="${OCTOS_M15_TASK_MIRROR_TMUX_WORKDIR:-$runtime_root/workspace}"
 replay_file="${OCTOS_M15_TASK_MIRROR_TMUX_REPLAY:-$out_dir/m15-task-supervisor-mirror-replay.txt}"
 octos_bin="${OCTOS_BIN:-$repo_root/target/debug/octos}"
-tui_bin="${OCTOS_TUI_BIN:-$tui_repo/target/debug/octos-tui}"
+tui_bin="${OCTOSCODE_BIN:-$tui_repo/target/debug/octoscode}"
 session_name="${OCTOS_M15_TASK_MIRROR_TMUX_SESSION:-octos-m15-task-mirror-$run_id}"
 profile_id="${OCTOS_M15_TASK_MIRROR_PROFILE:-coding}"
 session_id="${OCTOS_M15_TASK_MIRROR_SESSION_ID:-$profile_id:local:m15-task-mirror:$run_id}"
@@ -23,15 +23,15 @@ usage() {
   cat <<'USAGE'
 Usage: e2e/scripts/m15-task-supervisor-mirror-tmux-soak.sh <run|self-test|help>
 
-Runs a real tmux visual soak proving that octos-tui can display a backend
+Runs a real tmux visual soak proving that octoscode can display a backend
 TaskSupervisor task mirrored into the AppUI agent lifecycle over stdio.
 
 Environment:
-  OCTOS_TUI_REPO                         Path to octos-tui checkout. Default: /Users/yuechen/home/octos-tui.
+  OCTOSCODE_REPO                         Path to octoscode checkout. Default: /Users/yuechen/home/octoscode.
   OCTOS_BIN                              octos binary. Default: octos/target/debug/octos.
-  OCTOS_TUI_BIN                          octos-tui binary. Default: octos-tui/target/debug/octos-tui.
+  OCTOSCODE_BIN                          octoscode binary. Default: octoscode/target/debug/octoscode.
   OCTOS_M15_TASK_MIRROR_BUILD            Set 0 to skip building octos. Default: 1.
-  OCTOS_M15_TASK_MIRROR_BUILD_TUI        Set 1 to rebuild octos-tui. Default: build only if missing.
+  OCTOS_M15_TASK_MIRROR_BUILD_TUI        Set 1 to rebuild octoscode. Default: build only if missing.
   OCTOS_M15_TASK_MIRROR_TMUX_KEEP_SESSION
                                          Set 1 to keep tmux session after the run.
 USAGE
@@ -51,11 +51,11 @@ ensure_binaries() {
     (cd "$repo_root" && cargo build -p octos-cli --bin octos --features api)
   fi
   if [[ "${OCTOS_M15_TASK_MIRROR_BUILD_TUI:-0}" == "1" || ! -x "$tui_bin" ]]; then
-    (cd "$tui_repo" && cargo build --bin octos-tui)
+    (cd "$tui_repo" && cargo build --bin octoscode)
   fi
   [[ -x "$octos_bin" ]] || die "octos binary is not executable: $octos_bin"
-  [[ -x "$tui_bin" ]] || die "octos-tui binary is not executable: $tui_bin"
-  [[ -x "$tui_runner" ]] || die "octos-tui tmux runner is not executable: $tui_runner"
+  [[ -x "$tui_bin" ]] || die "octoscode binary is not executable: $tui_bin"
+  [[ -x "$tui_runner" ]] || die "octoscode tmux runner is not executable: $tui_runner"
 }
 
 write_profile_config() {
@@ -253,22 +253,22 @@ run_soak() {
   local backend_command
   backend_command="env OCTOS_M9_PROTOCOL_FIXTURES=1 DEEPSEEK_API_KEY=dummy-key-for-m15-task-supervisor-fixture $(shell_quote "$octos_bin") serve --stdio --data-dir $(shell_quote "$data_dir") --cwd $(shell_quote "$workdir")"
 
-  export OCTOS_TUI_M15_UX_RUN_ID="$run_id"
-  export OCTOS_TUI_M15_UX_OUT_DIR="$out_dir"
-  export OCTOS_TUI_M15_UX_RUNTIME_ROOT="$runtime_root"
-  export OCTOS_TUI_M15_UX_WORKDIR="$workdir"
-  export OCTOS_TUI_M15_UX_CHILD_OUT_DIR="$runtime_root/artifacts"
-  export OCTOS_TUI_M15_UX_BIN="$tui_bin"
-  export OCTOS_TUI_M15_UX_BACKEND_COMMAND="$backend_command"
-  export OCTOS_TUI_M15_UX_TMUX_SESSION="$session_name"
-  export OCTOS_TUI_M15_UX_REPLAY="$replay_file"
-  export OCTOS_TUI_M15_UX_SCENARIO="task_supervisor_mirror"
-  export OCTOS_TUI_M15_UX_FINAL_MARKER="M15_TASK_SUPERVISOR_MIRROR_FINAL_LINE"
-  export OCTOS_TUI_M15_UX_SESSION_ID="$session_id"
-  export OCTOS_TUI_M15_UX_PROFILE="$profile_id"
-  export OCTOS_TUI_M15_UX_REPLACE_SESSION=1
-  export OCTOS_TUI_M15_UX_COLS="${OCTOS_M15_TASK_MIRROR_TMUX_COLS:-120}"
-  export OCTOS_TUI_M15_UX_ROWS="${OCTOS_M15_TASK_MIRROR_TMUX_ROWS:-40}"
+  export OCTOSCODE_M15_UX_RUN_ID="$run_id"
+  export OCTOSCODE_M15_UX_OUT_DIR="$out_dir"
+  export OCTOSCODE_M15_UX_RUNTIME_ROOT="$runtime_root"
+  export OCTOSCODE_M15_UX_WORKDIR="$workdir"
+  export OCTOSCODE_M15_UX_CHILD_OUT_DIR="$runtime_root/artifacts"
+  export OCTOSCODE_M15_UX_BIN="$tui_bin"
+  export OCTOSCODE_M15_UX_BACKEND_COMMAND="$backend_command"
+  export OCTOSCODE_M15_UX_TMUX_SESSION="$session_name"
+  export OCTOSCODE_M15_UX_REPLAY="$replay_file"
+  export OCTOSCODE_M15_UX_SCENARIO="task_supervisor_mirror"
+  export OCTOSCODE_M15_UX_FINAL_MARKER="M15_TASK_SUPERVISOR_MIRROR_FINAL_LINE"
+  export OCTOSCODE_M15_UX_SESSION_ID="$session_id"
+  export OCTOSCODE_M15_UX_PROFILE="$profile_id"
+  export OCTOSCODE_M15_UX_REPLACE_SESSION=1
+  export OCTOSCODE_M15_UX_COLS="${OCTOS_M15_TASK_MIRROR_TMUX_COLS:-120}"
+  export OCTOSCODE_M15_UX_ROWS="${OCTOS_M15_TASK_MIRROR_TMUX_ROWS:-40}"
 
   "$tui_runner" start
   local status=0

--- a/e2e/scripts/m16-context-restart-tmux-soak.sh
+++ b/e2e/scripts/m16-context-restart-tmux-soak.sh
@@ -5,7 +5,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
 
 run_id="${OCTOS_M16_CONTEXT_TMUX_RUN_ID:-m16-context-reconnect-tmux-$(date -u +%Y%m%dT%H%M%SZ)}"
-tui_repo="${OCTOS_TUI_REPO:-/Users/yuechen/home/octos-tui}"
+tui_repo="${OCTOSCODE_REPO:-/Users/yuechen/home/octoscode}"
 tui_runner="${OCTOS_M16_CONTEXT_TUI_RUNNER:-$tui_repo/scripts/run-m15-live-tmux-ux-soak.sh}"
 out_root="${OCTOS_M16_CONTEXT_TMUX_OUT_ROOT:-$repo_root/e2e/test-results-m16-context-restart-tmux}"
 out_dir="${OCTOS_M16_CONTEXT_TMUX_OUT_DIR:-$out_root/$run_id}"
@@ -13,7 +13,7 @@ runtime_root="${OCTOS_M16_CONTEXT_TMUX_RUNTIME_ROOT:-/tmp/octos-m16-context-tmux
 bootstrap_dir="$out_dir/bootstrap-stdio"
 replay_file="$out_dir/context-reconnect-replay.txt"
 octos_bin="${OCTOS_BIN:-$repo_root/target/debug/octos}"
-tui_bin="${OCTOS_TUI_BIN:-$tui_repo/target/debug/octos-tui}"
+tui_bin="${OCTOSCODE_BIN:-$tui_repo/target/debug/octoscode}"
 session_name="${OCTOS_M16_CONTEXT_TMUX_SESSION:-octos-m16-context-$run_id}"
 
 usage() {
@@ -21,7 +21,7 @@ usage() {
 Usage: e2e/scripts/m16-context-restart-tmux-soak.sh <run|self-test|help>
 
 Creates a compacted ContextManager checkpoint with a direct stdio soak, then
-launches real octos-tui in tmux against a restarted octos serve --stdio backend
+launches real octoscode in tmux against a restarted octos serve --stdio backend
 and captures /status context visual evidence.
 USAGE
 }
@@ -46,11 +46,11 @@ ensure_binaries() {
     (cd "$repo_root" && cargo build -p octos-cli --bin octos --features api)
   fi
   if [[ "${OCTOS_M16_CONTEXT_BUILD_TUI:-0}" == "1" || ! -x "$tui_bin" ]]; then
-    (cd "$tui_repo" && cargo build --bin octos-tui)
+    (cd "$tui_repo" && cargo build --bin octoscode)
   fi
   [[ -x "$octos_bin" ]] || die "octos binary is not executable: $octos_bin"
-  [[ -x "$tui_bin" ]] || die "octos-tui binary is not executable: $tui_bin"
-  [[ -x "$tui_runner" ]] || die "octos-tui tmux runner is not executable: $tui_runner"
+  [[ -x "$tui_bin" ]] || die "octoscode binary is not executable: $tui_bin"
+  [[ -x "$tui_runner" ]] || die "octoscode tmux runner is not executable: $tui_runner"
 }
 
 write_replay() {
@@ -103,21 +103,21 @@ run_soak() {
   local backend_command
   backend_command="env OCTOS_CONTEXT_COMPACT_THRESHOLD_TOKENS=1 OCTOS_CONTEXT_COMPACT_KEEP_ITEMS=4 $(shell_quote "$octos_bin") serve --stdio --data-dir $(shell_quote "$data_dir") --cwd $(shell_quote "$workspace")"
 
-  export OCTOS_TUI_M15_UX_RUN_ID="$run_id"
-  export OCTOS_TUI_M15_UX_OUT_DIR="$out_dir"
-  export OCTOS_TUI_M15_UX_RUNTIME_ROOT="$runtime_root"
-  export OCTOS_TUI_M15_UX_WORKDIR="$workspace"
-  export OCTOS_TUI_M15_UX_CHILD_OUT_DIR="$runtime_root/artifacts"
-  export OCTOS_TUI_M15_UX_BIN="$tui_bin"
-  export OCTOS_TUI_M15_UX_BACKEND_COMMAND="$backend_command"
-  export OCTOS_TUI_M15_UX_TMUX_SESSION="$session_name"
-  export OCTOS_TUI_M15_UX_REPLAY="$replay_file"
-  export OCTOS_TUI_M15_UX_SCENARIO="context_restart_reconnect"
-  export OCTOS_TUI_M15_UX_SESSION_ID="$session_id"
-  export OCTOS_TUI_M15_UX_PROFILE="$profile_id"
-  export OCTOS_TUI_M15_UX_REPLACE_SESSION=1
-  export OCTOS_TUI_M15_UX_COLS="${OCTOS_M16_CONTEXT_TMUX_COLS:-120}"
-  export OCTOS_TUI_M15_UX_ROWS="${OCTOS_M16_CONTEXT_TMUX_ROWS:-40}"
+  export OCTOSCODE_M15_UX_RUN_ID="$run_id"
+  export OCTOSCODE_M15_UX_OUT_DIR="$out_dir"
+  export OCTOSCODE_M15_UX_RUNTIME_ROOT="$runtime_root"
+  export OCTOSCODE_M15_UX_WORKDIR="$workspace"
+  export OCTOSCODE_M15_UX_CHILD_OUT_DIR="$runtime_root/artifacts"
+  export OCTOSCODE_M15_UX_BIN="$tui_bin"
+  export OCTOSCODE_M15_UX_BACKEND_COMMAND="$backend_command"
+  export OCTOSCODE_M15_UX_TMUX_SESSION="$session_name"
+  export OCTOSCODE_M15_UX_REPLAY="$replay_file"
+  export OCTOSCODE_M15_UX_SCENARIO="context_restart_reconnect"
+  export OCTOSCODE_M15_UX_SESSION_ID="$session_id"
+  export OCTOSCODE_M15_UX_PROFILE="$profile_id"
+  export OCTOSCODE_M15_UX_REPLACE_SESSION=1
+  export OCTOSCODE_M15_UX_COLS="${OCTOS_M16_CONTEXT_TMUX_COLS:-120}"
+  export OCTOSCODE_M15_UX_ROWS="${OCTOS_M16_CONTEXT_TMUX_ROWS:-40}"
 
   {
     printf 'bootstrap_summary=%s\n' "$summary"

--- a/e2e/scripts/m16-live-tui-tmux-soak.sh
+++ b/e2e/scripts/m16-live-tui-tmux-soak.sh
@@ -5,7 +5,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
 
 run_id="${OCTOS_M16_UX_RUN_ID:-m16-ux-soak-$(date -u +%Y%m%dT%H%M%SZ)}"
-tui_repo="${OCTOS_TUI_REPO:-/Users/yuechen/home/octos-tui}"
+tui_repo="${OCTOSCODE_REPO:-/Users/yuechen/home/octoscode}"
 tui_runner="${OCTOS_M16_TUI_RUNNER:-$tui_repo/scripts/run-m15-live-tmux-ux-soak.sh}"
 out_root="${OCTOS_M16_UX_OUT_ROOT:-$repo_root/e2e/test-results-m16-tmux-ux}"
 out_dir="${OCTOS_M16_UX_OUT_DIR:-$out_root/$run_id}"
@@ -14,7 +14,7 @@ data_dir="${OCTOS_M16_UX_DATA_DIR:-$runtime_root/data}"
 workdir="${OCTOS_M16_UX_WORKDIR:-$runtime_root/workspace}"
 replay_file="${OCTOS_M16_UX_REPLAY:-$out_dir/m16-code-review-replay.txt}"
 octos_bin="${OCTOS_BIN:-$repo_root/target/debug/octos}"
-tui_bin="${OCTOS_TUI_BIN:-$tui_repo/target/debug/octos-tui}"
+tui_bin="${OCTOSCODE_BIN:-$tui_repo/target/debug/octoscode}"
 session_name="${OCTOS_M16_UX_TMUX_SESSION:-octos-m16-ux-$run_id}"
 profile_id="${OCTOS_M16_UX_PROFILE:-coding}"
 session_id="${OCTOS_M16_UX_SESSION_ID:-$profile_id:local:m16-ux:$run_id}"
@@ -35,15 +35,15 @@ usage() {
 Usage: e2e/scripts/m16-live-tui-tmux-soak.sh <run|self-test|help>
 
 Runs the M16 visual TUI tmux soak against a real octos serve --stdio backend.
-The script reuses the octos-tui tmux driver but writes all M16 evidence under
+The script reuses the octoscode tmux driver but writes all M16 evidence under
 octos/e2e/test-results-m16-tmux-ux/<run-id>.
 
 Key environment:
-  OCTOS_TUI_REPO              Path to octos-tui checkout. Default: /Users/yuechen/home/octos-tui.
+  OCTOSCODE_REPO              Path to octoscode checkout. Default: /Users/yuechen/home/octoscode.
   OCTOS_BIN                   octos binary. Default: octos/target/debug/octos.
-  OCTOS_TUI_BIN               octos-tui binary. Default: octos-tui/target/debug/octos-tui.
+  OCTOSCODE_BIN               octoscode binary. Default: octoscode/target/debug/octoscode.
   OCTOS_M16_BUILD             Set 0 to skip building octos with api. Default: 1.
-  OCTOS_M16_BUILD_TUI         Set 1 to rebuild octos-tui. Default: build only if missing.
+  OCTOS_M16_BUILD_TUI         Set 1 to rebuild octoscode. Default: build only if missing.
   OCTOS_M16_UX_KEEP_SESSION   Set 1 to keep tmux session after the run.
   OCTOS_M16_UX_OUT_DIR        Override evidence output directory.
 USAGE
@@ -63,10 +63,10 @@ ensure_binaries() {
     (cd "$repo_root" && cargo build -p octos-cli --bin octos --features api)
   fi
   if [[ "${OCTOS_M16_BUILD_TUI:-0}" == "1" || ! -x "$tui_bin" ]]; then
-    (cd "$tui_repo" && cargo build --bin octos-tui)
+    (cd "$tui_repo" && cargo build --bin octoscode)
   fi
   [[ -x "$octos_bin" ]] || die "octos binary is not executable: $octos_bin"
-  [[ -x "$tui_bin" ]] || die "octos-tui binary is not executable: $tui_bin"
+  [[ -x "$tui_bin" ]] || die "octoscode binary is not executable: $tui_bin"
 }
 
 write_replay() {
@@ -466,7 +466,7 @@ run_soak() {
   trap 'cleanup_on_signal 143' TERM
   if [[ "${OCTOS_M16_UX_INJECT_FAIL_AFTER_PROFILE_WRITE:-0}" != "1" ]]; then
     command -v tmux >/dev/null 2>&1 || die "tmux is required"
-    [[ -x "$tui_runner" ]] || die "octos-tui tmux runner not found or not executable: $tui_runner"
+    [[ -x "$tui_runner" ]] || die "octoscode tmux runner not found or not executable: $tui_runner"
     ensure_binaries
   fi
   write_review_workspace_fixture
@@ -488,22 +488,22 @@ run_soak() {
   local backend_command
   backend_command="env OCTOS_REVIEW_CLI_SPECIALIST_ARGV_JSON=$(shell_quote "[\"$cli_fixture\"]") OCTOS_REVIEW_MCP_TIMEOUT_SECS=30 $(shell_quote "$octos_bin") serve --stdio --data-dir $(shell_quote "$data_dir") --cwd $(shell_quote "$workdir") --swarm-backend stdio --swarm-backend-cmd $(shell_quote "$mcp_fixture")"
 
-  export OCTOS_TUI_M15_UX_RUN_ID="$run_id"
-  export OCTOS_TUI_M15_UX_OUT_DIR="$out_dir"
-  export OCTOS_TUI_M15_UX_RUNTIME_ROOT="$runtime_root"
-  export OCTOS_TUI_M15_UX_WORKDIR="$workdir"
-  export OCTOS_TUI_M15_UX_CHILD_OUT_DIR="$runtime_root/artifacts"
-  export OCTOS_TUI_M15_UX_BIN="$tui_bin"
-  export OCTOS_TUI_M15_UX_BACKEND_COMMAND="$backend_command"
-  export OCTOS_TUI_M15_UX_TMUX_SESSION="$session_name"
-  export OCTOS_TUI_M15_UX_REPLAY="$replay_file"
-  export OCTOS_TUI_M15_UX_SCENARIO="code_review_subagents"
-  export OCTOS_TUI_M15_UX_FINAL_MARKER="$final_marker"
-  export OCTOS_TUI_M15_UX_SESSION_ID="$session_id"
-  export OCTOS_TUI_M15_UX_PROFILE="$profile_id"
-  export OCTOS_TUI_M15_UX_REPLACE_SESSION=1
-  export OCTOS_TUI_M15_UX_COLS="${OCTOS_M16_UX_COLS:-120}"
-  export OCTOS_TUI_M15_UX_ROWS="${OCTOS_M16_UX_ROWS:-40}"
+  export OCTOSCODE_M15_UX_RUN_ID="$run_id"
+  export OCTOSCODE_M15_UX_OUT_DIR="$out_dir"
+  export OCTOSCODE_M15_UX_RUNTIME_ROOT="$runtime_root"
+  export OCTOSCODE_M15_UX_WORKDIR="$workdir"
+  export OCTOSCODE_M15_UX_CHILD_OUT_DIR="$runtime_root/artifacts"
+  export OCTOSCODE_M15_UX_BIN="$tui_bin"
+  export OCTOSCODE_M15_UX_BACKEND_COMMAND="$backend_command"
+  export OCTOSCODE_M15_UX_TMUX_SESSION="$session_name"
+  export OCTOSCODE_M15_UX_REPLAY="$replay_file"
+  export OCTOSCODE_M15_UX_SCENARIO="code_review_subagents"
+  export OCTOSCODE_M15_UX_FINAL_MARKER="$final_marker"
+  export OCTOSCODE_M15_UX_SESSION_ID="$session_id"
+  export OCTOSCODE_M15_UX_PROFILE="$profile_id"
+  export OCTOSCODE_M15_UX_REPLACE_SESSION=1
+  export OCTOSCODE_M15_UX_COLS="${OCTOS_M16_UX_COLS:-120}"
+  export OCTOSCODE_M15_UX_ROWS="${OCTOS_M16_UX_ROWS:-40}"
 
   "$tui_runner" start
   tmux_session_started=1

--- a/e2e/scripts/m17-live-proof-soak.sh
+++ b/e2e/scripts/m17-live-proof-soak.sh
@@ -28,7 +28,7 @@ Live key inputs:
   OCTOS_BIN                                       Default: target/debug/octos.
   OCTOS_M17_SPAWN_DIR                             Optional direct spawn_agent evidence dir.
   OCTOS_M17_BUDGET_GRACE_DIR                      Optional explicit budget grace evidence dir.
-  OCTOS_M17_SKIP_TUI=1                            Skip m16 tmux run when octos-tui/tmux are unavailable.
+  OCTOS_M17_SKIP_TUI=1                            Skip m16 tmux run when octoscode/tmux are unavailable.
 USAGE
 }
 

--- a/e2e/scripts/m18-appui-transport-parity-soak.mjs
+++ b/e2e/scripts/m18-appui-transport-parity-soak.mjs
@@ -550,8 +550,8 @@ class StdioClient extends AppUiClient {
       env: {
         ...process.env,
         OCTOS_M9_PROTOCOL_FIXTURES: '1',
-        OCTOS_TUI_M15_UX_OUTPUT_DIR: runRoot,
-        OCTOS_TUI_M15_UX_WORKDIR: workspace,
+        OCTOSCODE_M15_UX_OUTPUT_DIR: runRoot,
+        OCTOSCODE_M15_UX_WORKDIR: workspace,
         RUST_BACKTRACE: process.env.RUST_BACKTRACE || '1',
       },
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -665,8 +665,8 @@ async function startWsServer(port) {
     env: {
       ...process.env,
       OCTOS_M9_PROTOCOL_FIXTURES: '1',
-      OCTOS_TUI_M15_UX_OUTPUT_DIR: runRoot,
-      OCTOS_TUI_M15_UX_WORKDIR: workspace,
+      OCTOSCODE_M15_UX_OUTPUT_DIR: runRoot,
+      OCTOSCODE_M15_UX_WORKDIR: workspace,
       RUST_BACKTRACE: process.env.RUST_BACKTRACE || '1',
     },
     stdio: ['ignore', 'pipe', 'pipe'],

--- a/e2e/scripts/m19-ux-scenario-list.mjs
+++ b/e2e/scripts/m19-ux-scenario-list.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..', '..');
 const defaultManifestPath = path.join(repoRoot, 'e2e', 'matrix', 'octos-ux.toml');
-const siblingOctosTuiRepo = path.resolve(repoRoot, '..', 'octos-tui');
+const siblingOctoscodeRepo = path.resolve(repoRoot, '..', 'octoscode');
 const statusClasses = ['runnable', 'skipped', 'blocked', 'quarantined'];
 const initialM19ScenarioIds = [
   'stdio-happy-path',
@@ -333,26 +333,26 @@ function resolveSpecialHostTool(tool) {
         process.env.OCTOS_BIN,
         path.join(repoRoot, 'target', 'debug', executableName('octos')),
       ]);
-    case 'octos-tui-bin':
+    case 'octoscode-bin':
       return firstExecutable([
-        process.env.OCTOS_TUI_BIN,
-        path.join(siblingOctosTuiRepo, 'target', 'debug', executableName('octos-tui')),
+        process.env.OCTOSCODE_BIN,
+        path.join(siblingOctoscodeRepo, 'target', 'debug', executableName('octoscode')),
       ]);
-    case 'octos-tui-onboarding-runner':
+    case 'octoscode-onboarding-runner':
       return firstExecutable([
-        process.env.OCTOS_TUI_ONBOARDING_RUNNER,
+        process.env.OCTOSCODE_ONBOARDING_RUNNER,
         process.env.OCTOS_M19_UX_TUI_RUNNER,
-        path.join(siblingOctosTuiRepo, 'scripts', 'run-onboarding-tmux-soak.sh'),
+        path.join(siblingOctoscodeRepo, 'scripts', 'run-onboarding-tmux-soak.sh'),
       ]);
-    case 'octos-tui-m15-runner':
+    case 'octoscode-m15-runner':
       return firstExecutable([
-        process.env.OCTOS_TUI_M15_RUNNER,
-        path.join(siblingOctosTuiRepo, 'scripts', 'run-m15-live-tmux-ux-soak.sh'),
+        process.env.OCTOSCODE_M15_RUNNER,
+        path.join(siblingOctoscodeRepo, 'scripts', 'run-m15-live-tmux-ux-soak.sh'),
       ]);
-    case 'octos-tui-m18-runner':
+    case 'octoscode-m18-runner':
       return firstExecutable([
-        process.env.OCTOS_TUI_M18_RUNNER,
-        path.join(siblingOctosTuiRepo, 'scripts', 'run-m18-stdio-live-tmux-soak.sh'),
+        process.env.OCTOSCODE_M18_RUNNER,
+        path.join(siblingOctoscodeRepo, 'scripts', 'run-m18-stdio-live-tmux-soak.sh'),
       ]);
     default:
       return undefined;

--- a/e2e/scripts/ux-tmux-run.mjs
+++ b/e2e/scripts/ux-tmux-run.mjs
@@ -174,8 +174,8 @@ Environment:
   OCTOS_UX_TMUX_RUN_ID       Override run id.
   OCTOS_UX_TMUX_OUT_ROOT     Override output root. Default: e2e/test-results-ux.
   OCTOS_UX_TMUX_OUT_DIR      Override scenario output directory.
-  OCTOS_UX_TMUX_TUI_RUNNER   Override octos-tui tmux runner script.
-  OCTOS_TUI_REPO             Override octos-tui checkout. Default: ../octos-tui next to this repo.
+  OCTOS_UX_TMUX_TUI_RUNNER   Override octoscode tmux runner script.
+  OCTOSCODE_REPO             Override octoscode checkout. Default: ../octoscode next to this repo.
 `;
 }
 
@@ -266,8 +266,8 @@ function taskSubagentFixtureEnv(scenario, workdir) {
   if (scenario.runner !== 'task-subagent-tree') return {};
   return {
     OCTOS_M15_LIVE_SUBAGENT_FIXTURE: '1',
-    OCTOS_TUI_M15_UX_OUTPUT_DIR: path.join(workdir, '.octos-m15-evidence'),
-    OCTOS_TUI_M15_UX_WORKDIR: workdir,
+    OCTOSCODE_M15_UX_OUTPUT_DIR: path.join(workdir, '.octos-m15-evidence'),
+    OCTOSCODE_M15_UX_WORKDIR: workdir,
     OCTOS_M15_LIVE_SUBAGENT_DELAY_SCALE:
       process.env.OCTOS_M15_LIVE_SUBAGENT_DELAY_SCALE || '0.25',
   };
@@ -298,7 +298,7 @@ function ensureServeArg(rawArgs, requiredArg) {
 }
 
 function lowerRunnerServeArgs(scenario) {
-  const existing = process.env.OCTOS_TUI_SOAK_SERVE_ARGS || '';
+  const existing = process.env.OCTOSCODE_SOAK_SERVE_ARGS || '';
   if (!scenarioRequiresSoloServe(scenario)) return existing.trim();
   return ensureServeArg(existing, '--solo');
 }
@@ -370,14 +370,14 @@ function resolveContext({ scenarioId, selfTest }) {
   const replayFile = path.resolve(
     process.env.OCTOS_UX_TMUX_REPLAY || path.join(scenarioDir, 'input-replay.log'),
   );
-  const tuiRepo = path.resolve(process.env.OCTOS_TUI_REPO || path.join(repoRoot, '..', 'octos-tui'));
+  const tuiRepo = path.resolve(process.env.OCTOSCODE_REPO || path.join(repoRoot, '..', 'octoscode'));
   const lowerRunner = path.resolve(
     process.env.OCTOS_UX_TMUX_TUI_RUNNER
       || process.env.OCTOS_M19_UX_TUI_RUNNER
       || path.join(tuiRepo, 'scripts', 'run-onboarding-tmux-soak.sh'),
   );
   const octosBin = path.resolve(process.env.OCTOS_BIN || path.join(repoRoot, 'target', 'debug', 'octos'));
-  const tuiBin = path.resolve(process.env.OCTOS_TUI_BIN || path.join(tuiRepo, 'target', 'debug', 'octos-tui'));
+  const tuiBin = path.resolve(process.env.OCTOSCODE_BIN || path.join(tuiRepo, 'target', 'debug', 'octoscode'));
   const cols = positiveIntegerEnv('OCTOS_UX_TMUX_COLS', scenario.id === 'narrow-layout' ? 80 : 120);
   const rows = positiveIntegerEnv('OCTOS_UX_TMUX_ROWS', scenario.id === 'narrow-layout' ? 24 : 40);
   const port = positiveIntegerEnv('OCTOS_UX_TMUX_PORT', stablePortForRunId(runKey));
@@ -404,7 +404,7 @@ function resolveContext({ scenarioId, selfTest }) {
       shellQuote(workdir),
     ].join(' ');
   const websocketEndpoint = `ws://127.0.0.1:${port}/api/ui-protocol/ws`;
-  const authToken = process.env.OCTOS_UX_TMUX_AUTH_TOKEN || 'octos-tui-onboarding-soak-token';
+  const authToken = process.env.OCTOS_UX_TMUX_AUTH_TOKEN || 'octoscode-onboarding-soak-token';
   const launchCommand =
     process.env.OCTOS_UX_TMUX_LAUNCH_COMMAND
     || (scenario.transport === 'websocket'
@@ -698,10 +698,10 @@ function skipValidation(ctx) {
 
 function missingRunnerBlocker(ctx) {
   if (!fs.existsSync(ctx.lowerRunner)) {
-    return `octos-tui tmux runner is missing: ${ctx.lowerRunner}`;
+    return `octoscode tmux runner is missing: ${ctx.lowerRunner}`;
   }
   if (!isExecutable(ctx.lowerRunner)) {
-    return `octos-tui tmux runner is not executable: ${ctx.lowerRunner}`;
+    return `octoscode tmux runner is not executable: ${ctx.lowerRunner}`;
   }
   return null;
 }
@@ -713,8 +713,8 @@ function tmuxHasSession(sessionName) {
 
 function launchWebsocketTuiFallback(ctx, env) {
   const outputLog = path.join(ctx.scenarioDir, 'tui-process.log');
-  const apiKeyEnv = process.env.OCTOS_TUI_SOAK_EXPECT_API_KEY_ENV || 'AUTODL_API_KEY';
-  const apiKey = env.OCTOS_TUI_SOAK_API_KEY || 'octos-m19-placeholder-key';
+  const apiKeyEnv = process.env.OCTOSCODE_SOAK_EXPECT_API_KEY_ENV || 'AUTODL_API_KEY';
+  const apiKey = env.OCTOSCODE_SOAK_API_KEY || 'octos-m19-placeholder-key';
   const command = [
     'cd',
     shellQuote(ctx.workdir),
@@ -735,21 +735,21 @@ function launchWebsocketTuiFallback(ctx, env) {
     '--cwd',
     shellQuote(ctx.workdir),
     '--theme',
-    shellQuote(process.env.OCTOS_TUI_SOAK_THEME || 'codex'),
+    shellQuote(process.env.OCTOSCODE_SOAK_THEME || 'codex'),
     ';',
     'exit_code=$?;',
     'echo',
-    shellQuote('octos-tui exited with status'),
+    shellQuote('octoscode exited with status'),
     '"$exit_code"',
     ';',
     'echo',
-    shellQuote('octos-tui exited with status'),
+    shellQuote('octoscode exited with status'),
     '"$exit_code"',
     '>>',
     shellQuote(outputLog),
     ';',
     'sleep',
-    shellQuote(process.env.OCTOS_TUI_SOAK_EXIT_HOLD_SECS || '30'),
+    shellQuote(process.env.OCTOSCODE_SOAK_EXIT_HOLD_SECS || '30'),
   ].join(' ');
   writeText(path.join(ctx.scenarioDir, 'tui-fallback-command.txt'), `${command}\n`);
   const result = spawnSync('tmux', ['new-session', '-d', '-s', ctx.sessionName, command], {
@@ -853,9 +853,9 @@ function runRestartReconnectScenario(ctx, action, env) {
   resizeTmuxWindow(ctx);
 
   const preTurn = action('send-turn', true, {
-    OCTOS_TUI_SOAK_PROMPT:
+    OCTOSCODE_SOAK_PROMPT:
       'Before backend restart, answer briefly so the reconnect fixture has visible session state.',
-    OCTOS_TUI_SOAK_TURN_WAIT_SECS: process.env.OCTOS_TUI_SOAK_RESTART_PRE_TURN_WAIT_SECS || '10',
+    OCTOSCODE_SOAK_TURN_WAIT_SECS: process.env.OCTOSCODE_SOAK_RESTART_PRE_TURN_WAIT_SECS || '10',
   });
   if (preTurn.error) throw preTurn.error;
   if (preTurn.status !== 0) status = preTurn.status || 1;
@@ -864,8 +864,8 @@ function runRestartReconnectScenario(ctx, action, env) {
 
   if (status === 0) {
     const restart = action('restart-server', true, {
-      OCTOS_TUI_SOAK_SERVER_WAIT_SECS:
-        process.env.OCTOS_TUI_SOAK_RESTART_SERVER_WAIT_SECS || '20',
+      OCTOSCODE_SOAK_SERVER_WAIT_SECS:
+        process.env.OCTOSCODE_SOAK_RESTART_SERVER_WAIT_SECS || '20',
     });
     if (restart.error) throw restart.error;
     if (restart.status !== 0) status = restart.status || 1;
@@ -873,10 +873,10 @@ function runRestartReconnectScenario(ctx, action, env) {
 
   if (status === 0) {
     const postTurn = action('send-turn', true, {
-      OCTOS_TUI_SOAK_PROMPT:
+      OCTOSCODE_SOAK_PROMPT:
         `After backend restart, confirm the TUI reconnected and finish with ${ctx.scenario.finalMarker}.`,
-      OCTOS_TUI_SOAK_TURN_WAIT_SECS:
-        process.env.OCTOS_TUI_SOAK_RESTART_POST_TURN_WAIT_SECS || '20',
+      OCTOSCODE_SOAK_TURN_WAIT_SECS:
+        process.env.OCTOSCODE_SOAK_RESTART_POST_TURN_WAIT_SECS || '20',
     });
     if (postTurn.error) throw postTurn.error;
     if (postTurn.status !== 0) status = postTurn.status || 1;
@@ -899,15 +899,15 @@ function runDroppedCompletionBackpressureScenario(ctx, action, env) {
   resizeTmuxWindow(ctx);
 
   const drive = action('drive-dropped-completion-backpressure', true, {
-    OCTOS_TUI_SOAK_BACKPRESSURE_PROMPT: ctx.scenario.prompt,
+    OCTOSCODE_SOAK_BACKPRESSURE_PROMPT: ctx.scenario.prompt,
   });
   if (drive.error) throw drive.error;
   if (drive.status !== 0) status = drive.status || 1;
   captureTmuxPane(ctx.sessionName, path.join(ctx.scenarioDir, 'tui-capture-backpressure-final.txt'));
   if (status === 0) {
     const recovery = action('send-turn', true, {
-      OCTOS_TUI_SOAK_PROMPT: 'After forced terminal-drop recovery, reply with exactly OK.',
-      OCTOS_TUI_SOAK_TURN_WAIT_SECS: process.env.OCTOS_TUI_SOAK_BACKPRESSURE_RECOVERY_WAIT_SECS || '8',
+      OCTOSCODE_SOAK_PROMPT: 'After forced terminal-drop recovery, reply with exactly OK.',
+      OCTOSCODE_SOAK_TURN_WAIT_SECS: process.env.OCTOSCODE_SOAK_BACKPRESSURE_RECOVERY_WAIT_SECS || '8',
     });
     if (recovery.error) throw recovery.error;
     if (recovery.status !== 0) status = recovery.status || 1;
@@ -948,34 +948,34 @@ function runLowerRunner(ctx, options = {}) {
     ...process.env,
     OCTOS_REPO: repoRoot,
     OCTOS_BIN: ctx.octosBin,
-    OCTOS_TUI_BIN: ctx.tuiBin,
-    OCTOS_TUI_SOAK_RUN_ID: ctx.runId,
-    OCTOS_TUI_SOAK_ARTIFACT_DIR: ctx.scenarioDir,
-    OCTOS_TUI_SOAK_RUNTIME_ROOT: ctx.runtimeRoot,
-    OCTOS_TUI_SOAK_WORKSPACE: ctx.workdir,
-    OCTOS_TUI_SOAK_DATA_DIR: ctx.dataDir,
-    OCTOS_TUI_SOAK_TRANSPORT: ctx.scenario.transport === 'websocket' ? 'ws' : ctx.scenario.transport,
-    OCTOS_TUI_SOAK_PROFILE: ctx.profileId,
-    OCTOS_TUI_SOAK_SESSION: ctx.sessionId,
-    OCTOS_TUI_SOAK_SERVER_SESSION: `octos-onboard-server-${safeSlug(ctx.runKey)}`,
-    OCTOS_TUI_SOAK_TUI_SESSION: ctx.sessionName,
-    OCTOS_TUI_SOAK_LOCAL_NAME: process.env.OCTOS_TUI_SOAK_LOCAL_NAME || ctx.profileId,
-    OCTOS_TUI_SOAK_LOCAL_USERNAME: process.env.OCTOS_TUI_SOAK_LOCAL_USERNAME || ctx.profileId,
-    OCTOS_TUI_SOAK_LOCAL_EMAIL: process.env.OCTOS_TUI_SOAK_LOCAL_EMAIL || `${ctx.profileId}@example.invalid`,
-    OCTOS_TUI_SOAK_API_KEY: process.env.OCTOS_TUI_SOAK_API_KEY || 'octos-m19-placeholder-key',
-    OCTOS_TUI_SOAK_INIT_PROFILE_LLM:
-      process.env.OCTOS_TUI_SOAK_INIT_PROFILE_LLM || shouldInitProfileLlm,
-    OCTOS_TUI_SOAK_PORT: String(ctx.port),
-    OCTOS_TUI_SOAK_AUTH_TOKEN: ctx.authToken,
-    OCTOS_TUI_SOAK_OPEN_SESSION: 'auto',
-    OCTOS_TUI_SOAK_REQUIRE_PROFILE: '0',
-    OCTOS_TUI_SOAK_SOLO_STRICT: process.env.OCTOS_TUI_SOAK_SOLO_STRICT || '0',
-    OCTOS_TUI_SOAK_SERVE_ARGS: lowerRunnerServeArgs(ctx.scenario),
-    OCTOS_TUI_SOAK_SERVER_WAIT_SECS:
-      process.env.OCTOS_TUI_SOAK_SERVER_WAIT_SECS
+    OCTOSCODE_BIN: ctx.tuiBin,
+    OCTOSCODE_SOAK_RUN_ID: ctx.runId,
+    OCTOSCODE_SOAK_ARTIFACT_DIR: ctx.scenarioDir,
+    OCTOSCODE_SOAK_RUNTIME_ROOT: ctx.runtimeRoot,
+    OCTOSCODE_SOAK_WORKSPACE: ctx.workdir,
+    OCTOSCODE_SOAK_DATA_DIR: ctx.dataDir,
+    OCTOSCODE_SOAK_TRANSPORT: ctx.scenario.transport === 'websocket' ? 'ws' : ctx.scenario.transport,
+    OCTOSCODE_SOAK_PROFILE: ctx.profileId,
+    OCTOSCODE_SOAK_SESSION: ctx.sessionId,
+    OCTOSCODE_SOAK_SERVER_SESSION: `octos-onboard-server-${safeSlug(ctx.runKey)}`,
+    OCTOSCODE_SOAK_TUI_SESSION: ctx.sessionName,
+    OCTOSCODE_SOAK_LOCAL_NAME: process.env.OCTOSCODE_SOAK_LOCAL_NAME || ctx.profileId,
+    OCTOSCODE_SOAK_LOCAL_USERNAME: process.env.OCTOSCODE_SOAK_LOCAL_USERNAME || ctx.profileId,
+    OCTOSCODE_SOAK_LOCAL_EMAIL: process.env.OCTOSCODE_SOAK_LOCAL_EMAIL || `${ctx.profileId}@example.invalid`,
+    OCTOSCODE_SOAK_API_KEY: process.env.OCTOSCODE_SOAK_API_KEY || 'octos-m19-placeholder-key',
+    OCTOSCODE_SOAK_INIT_PROFILE_LLM:
+      process.env.OCTOSCODE_SOAK_INIT_PROFILE_LLM || shouldInitProfileLlm,
+    OCTOSCODE_SOAK_PORT: String(ctx.port),
+    OCTOSCODE_SOAK_AUTH_TOKEN: ctx.authToken,
+    OCTOSCODE_SOAK_OPEN_SESSION: 'auto',
+    OCTOSCODE_SOAK_REQUIRE_PROFILE: '0',
+    OCTOSCODE_SOAK_SOLO_STRICT: process.env.OCTOSCODE_SOAK_SOLO_STRICT || '0',
+    OCTOSCODE_SOAK_SERVE_ARGS: lowerRunnerServeArgs(ctx.scenario),
+    OCTOSCODE_SOAK_SERVER_WAIT_SECS:
+      process.env.OCTOSCODE_SOAK_SERVER_WAIT_SECS
       || (ctx.scenario.transport === 'websocket' ? '4' : '1'),
-    OCTOS_TUI_SOAK_TUI_WAIT_SECS: process.env.OCTOS_TUI_SOAK_TUI_WAIT_SECS || '2',
-    OCTOS_TUI_SOAK_EXIT_HOLD_SECS: process.env.OCTOS_TUI_SOAK_EXIT_HOLD_SECS || '30',
+    OCTOSCODE_SOAK_TUI_WAIT_SECS: process.env.OCTOSCODE_SOAK_TUI_WAIT_SECS || '2',
+    OCTOSCODE_SOAK_EXIT_HOLD_SECS: process.env.OCTOSCODE_SOAK_EXIT_HOLD_SECS || '30',
     OCTOS_M9_PROTOCOL_FIXTURES: '1',
     ...ctx.fixtureEnv,
   };
@@ -996,10 +996,10 @@ function runLowerRunner(ctx, options = {}) {
       if (status !== 0) break;
       const stepEnv = {};
       if (ctx.scenario.runner === 'provider-missing' && step === 'drive-solo') {
-        stepEnv.OCTOS_TUI_SOAK_INIT_PROFILE_LLM = '1';
+        stepEnv.OCTOSCODE_SOAK_INIT_PROFILE_LLM = '1';
       }
       if (step === 'send-turn') {
-        stepEnv.OCTOS_TUI_SOAK_PROMPT = ctx.scenario.prompt;
+        stepEnv.OCTOSCODE_SOAK_PROMPT = ctx.scenario.prompt;
       }
       const result = action(step, true, stepEnv);
       if (result.error) throw result.error;

--- a/e2e/scripts/ux-tmux-validate.mjs
+++ b/e2e/scripts/ux-tmux-validate.mjs
@@ -71,9 +71,9 @@ const KNOWN_CAPTURE_BUG_PATTERNS = [
     detail: 'tmux capture shows the real TUI pane was missing',
   },
   {
-    id: 'octos_tui_exited',
-    regex: /octos-tui exited with status/,
-    detail: 'tmux capture shows the real octos-tui process exited before validation',
+    id: 'octoscode_exited',
+    regex: /octoscode exited with status/,
+    detail: 'tmux capture shows the real octoscode process exited before validation',
   },
   {
     id: 'ui_protocol_connect_failed',
@@ -1385,8 +1385,8 @@ function checkTaskSubagentTreeScenario(artifactDir) {
   } else {
     for (const expected of [
       'OCTOS_M15_LIVE_SUBAGENT_FIXTURE=',
-      'OCTOS_TUI_M15_UX_OUTPUT_DIR=',
-      'OCTOS_TUI_M15_UX_WORKDIR=',
+      'OCTOSCODE_M15_UX_OUTPUT_DIR=',
+      'OCTOSCODE_M15_UX_WORKDIR=',
       'OCTOS_M15_LIVE_SUBAGENT_DELAY_SCALE=',
     ]) {
       if (!launchCommand.text.includes(expected)) {
@@ -1399,8 +1399,8 @@ function checkTaskSubagentTreeScenario(artifactDir) {
     problems.push('scenario fixture_env missing OCTOS_M15_LIVE_SUBAGENT_FIXTURE=1');
   }
   for (const expected of [
-    'OCTOS_TUI_M15_UX_OUTPUT_DIR',
-    'OCTOS_TUI_M15_UX_WORKDIR',
+    'OCTOSCODE_M15_UX_OUTPUT_DIR',
+    'OCTOSCODE_M15_UX_WORKDIR',
     'OCTOS_M15_LIVE_SUBAGENT_DELAY_SCALE',
   ]) {
     if (typeof fixtureEnv[expected] !== 'string' || fixtureEnv[expected].length === 0) {

--- a/e2e/scripts/validate-m15-task-supervisor-mirror-tmux.py
+++ b/e2e/scripts/validate-m15-task-supervisor-mirror-tmux.py
@@ -127,7 +127,7 @@ class Validator:
         self.add(
             "real_octos_serve_stdio_backend",
             ok,
-            "octos-tui launched against real octos serve --stdio with M9 protocol fixture enabled"
+            "octoscode launched against real octos serve --stdio with M9 protocol fixture enabled"
             if ok
             else "launch command does not prove real octos serve --stdio plus M9 fixture",
             ["launch-command.txt"],

--- a/e2e/scripts/validate-m16-tmux-orchestration.py
+++ b/e2e/scripts/validate-m16-tmux-orchestration.py
@@ -3,7 +3,7 @@
 
 This validator checks the production review/start path:
 
-- octos-tui sends review/start to octos serve --stdio.
+- octoscode sends review/start to octos serve --stdio.
 - octos emits AppUI agent lifecycle/output/artifact events.
 - native, CLI, and MCP specialists all participate.
 - tmux captures show user-visible orchestration traces.

--- a/e2e/tests/ux/backpressure-validate.test.mjs
+++ b/e2e/tests/ux/backpressure-validate.test.mjs
@@ -114,7 +114,7 @@ function makeArtifactDir({ trueDropCoverage, terminal = 'legacy' }) {
       'websocket-transcript.jsonl',
     ]),
   });
-  writeFileSync(join(dir, 'launch-command.txt'), 'octos-tui --mode protocol\n', 'utf8');
+  writeFileSync(join(dir, 'launch-command.txt'), 'octoscode --mode protocol\n', 'utf8');
   writeFileSync(join(dir, 'input-replay.log'), 'line trigger backpressure\n', 'utf8');
   writeFileSync(
     join(dir, 'server.log'),

--- a/e2e/tests/ux/restart-validate.test.mjs
+++ b/e2e/tests/ux/restart-validate.test.mjs
@@ -164,7 +164,7 @@ function makeArtifactDir() {
     real_tmux_launched: true,
     artifacts: artifactSummary(dir, [...requiredArtifacts, ...restartArtifacts]),
   });
-  writeFileSync(join(dir, 'launch-command.txt'), 'octos-tui --mode protocol\n', 'utf8');
+  writeFileSync(join(dir, 'launch-command.txt'), 'octoscode --mode protocol\n', 'utf8');
   writeFileSync(join(dir, 'input-replay.log'), 'line before restart prompt\n', 'utf8');
   writeFileSync(join(dir, 'server.log'), 'serve listening; restart fixture\n', 'utf8');
   writeFileSync(join(dir, 'tui-capture.txt'), 'Chat ready\n› \nComposer\n state Idle\n', 'utf8');

--- a/e2e/tests/ux/scenario-list.test.mjs
+++ b/e2e/tests/ux/scenario-list.test.mjs
@@ -55,7 +55,7 @@ const REQUIRED_ARTIFACTS = [
 ];
 
 function makeEnv({
-  tools = new Set(["tmux", "octos", "octos-tui"]),
+  tools = new Set(["tmux", "octos", "octoscode"]),
   envVars = new Set(),
   capabilities = new Set(),
 } = {}) {
@@ -149,7 +149,7 @@ test("duplicate scenario id raises typed error", () => {
       'transport = "stdio"\n' +
       'provider = "fixture"\n' +
       'terminal = "80x24"\n' +
-      'tui_binary = "octos-tui"\n' +
+      'tui_binary = "octoscode"\n' +
       'tmux_command = "x"\n' +
       "required_tools = []\n" +
       "required_capabilities = []\n" +
@@ -203,7 +203,7 @@ test("classifyRunnability reports skipped when host tool missing", () => {
   const manifest = loadManifest({ path: MANIFEST });
   const scenario = manifest.scenarios.find((s) => s.id === "stdio-happy-path");
   const env = makeEnv({
-    tools: new Set(["octos", "octos-tui"]), // tmux missing
+    tools: new Set(["octos", "octoscode"]), // tmux missing
     capabilities: new Set(scenario.requiredCapabilities),
   });
   const r = classifyRunnability(scenario, env);

--- a/e2e/tests/ux/validate.test.mjs
+++ b/e2e/tests/ux/validate.test.mjs
@@ -159,7 +159,7 @@ function makeArtifactDir(overrides = {}) {
       ].join("\n"),
     "utf8",
   );
-  writeFileSync(join(dir, "launch-command.txt"), "octos-tui --mode protocol\n", "utf8");
+  writeFileSync(join(dir, "launch-command.txt"), "octoscode --mode protocol\n", "utf8");
   writeFileSync(join(dir, "input-replay.log"), "line validate\n", "utf8");
   writeFileSync(join(dir, "server.log"), overrides.serverLog || "server ready\n", "utf8");
   if (overrides.cursorSamples !== undefined) {

--- a/e2e/tmux/run.sh
+++ b/e2e/tmux/run.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-OCTOS_TUI_DIR="${OCTOS_TUI_DIR:-$ROOT_DIR/../octos-tui}"
+OCTOSCODE_DIR="${OCTOSCODE_DIR:-$ROOT_DIR/../octoscode}"
 
 # shellcheck source=../../scripts/tmux-cli-driver.sh
 if [ -f "$ROOT_DIR/scripts/tmux-cli-driver.sh" ]; then
@@ -364,23 +364,23 @@ else
   exit 2
 fi
 
-OCTOS_TUI_BIN_CMD=""
+OCTOSCODE_BIN_CMD=""
 
-resolve_octos_tui_bin_cmd() {
-  if [ -n "$OCTOS_TUI_BIN_CMD" ]; then
+resolve_octoscode_bin_cmd() {
+  if [ -n "$OCTOSCODE_BIN_CMD" ]; then
     return 0
   fi
 
-  if [ -n "${OCTOS_TUI_BIN:-}" ]; then
-    OCTOS_TUI_BIN_CMD="$OCTOS_TUI_BIN"
-  elif [ -f "$OCTOS_TUI_DIR/Cargo.toml" ]; then
-    OCTOS_TUI_BIN_CMD="cargo run --manifest-path $(printf '%q' "$OCTOS_TUI_DIR/Cargo.toml") --"
-  elif [ -x "$OCTOS_TUI_DIR/target/debug/octos-tui" ]; then
-    OCTOS_TUI_BIN_CMD="$OCTOS_TUI_DIR/target/debug/octos-tui"
-  elif [ -x "$ROOT_DIR/target/debug/octos-tui" ]; then
-    OCTOS_TUI_BIN_CMD="$ROOT_DIR/target/debug/octos-tui"
+  if [ -n "${OCTOSCODE_BIN:-}" ]; then
+    OCTOSCODE_BIN_CMD="$OCTOSCODE_BIN"
+  elif [ -f "$OCTOSCODE_DIR/Cargo.toml" ]; then
+    OCTOSCODE_BIN_CMD="cargo run --manifest-path $(printf '%q' "$OCTOSCODE_DIR/Cargo.toml") --"
+  elif [ -x "$OCTOSCODE_DIR/target/debug/octoscode" ]; then
+    OCTOSCODE_BIN_CMD="$OCTOSCODE_DIR/target/debug/octoscode"
+  elif [ -x "$ROOT_DIR/target/debug/octoscode" ]; then
+    OCTOSCODE_BIN_CMD="$ROOT_DIR/target/debug/octoscode"
   else
-    echo "Unable to locate standalone octos-tui. Set OCTOS_TUI_BIN or OCTOS_TUI_DIR." >&2
+    echo "Unable to locate standalone octoscode. Set OCTOSCODE_BIN or OCTOSCODE_DIR." >&2
     exit 2
   fi
 }
@@ -425,7 +425,7 @@ run_tui_mock() {
   local name="mock-tui"
   local session
   session="$(tmux_session_name "$name")"
-  tmux_new_default "$session" bash -lc "$OCTOS_TUI_BIN_CMD --mode mock"
+  tmux_new_default "$session" bash -lc "$OCTOSCODE_BIN_CMD --mode mock"
   tmux_wait_for "$session" "Opened coding:local:prototype#m9|Ask Octos to change code" 45
   tmux_assert_capture "$session" "Opened coding:local:prototype#m9|Ask Octos to change code"
   tmux_assert_capture "$session" "Composer"
@@ -456,7 +456,7 @@ run_tui_mock_approval_kind() {
   local session
   session="$(tmux_session_name "$name")"
   tmux_new_default "$session" bash -lc \
-    "OCTOS_TUI_MOCK_APPROVAL_KIND=$(shell_quote "$kind") $OCTOS_TUI_BIN_CMD --mode mock"
+    "OCTOSCODE_MOCK_APPROVAL_KIND=$(shell_quote "$kind") $OCTOSCODE_BIN_CMD --mode mock"
   tmux_wait_for "$session" "Opened coding:local:prototype#m9|Ask Octos to change code" 45
   tmux_send "$session" "approval ${kind}"
   tmux_key "$session" Enter
@@ -483,7 +483,7 @@ run_tui_protocol_readonly() {
   local capture
   session="$(tmux_session_name "$name")"
   tmux_new_default "$session" bash -lc \
-    "$OCTOS_TUI_BIN_CMD --mode protocol --endpoint ws://127.0.0.1:9/api/ui-protocol/ws --session 'coding:local:prototype#m9' --profile-id coding --auth-token '$OCTOS_TMUX_AUTH_TOKEN' --readonly"
+    "$OCTOSCODE_BIN_CMD --mode protocol --endpoint ws://127.0.0.1:9/api/ui-protocol/ws --session 'coding:local:prototype#m9' --profile-id coding --auth-token '$OCTOS_TMUX_AUTH_TOKEN' --readonly"
   tmux_wait_for "$session" "read-only|no network connection opened|Protocol backend read-only" 45
   tmux_assert_capture "$session" "Protocol backend read-only|no network connection ope"
   tmux_assert_capture "$session" "read-only"
@@ -613,15 +613,15 @@ NODE"
 
 run_default() {
   tmux_require
-  resolve_octos_tui_bin_cmd
+  resolve_octoscode_bin_cmd
   tmux_init_artifacts
   tmux_log "artifacts: $OCTOS_TMUX_ARTIFACT_DIR"
 
   run_line_capture "octos-help" "$OCTOS_BIN_CMD --help" "Usage: octos" "Commands:" "serve"
   run_line_capture \
-    "octos-tui-help" \
-    "$OCTOS_TUI_BIN_CMD --help" \
-    "Usage: octos-tui" \
+    "octoscode-help" \
+    "$OCTOSCODE_BIN_CMD --help" \
+    "Usage: octoscode" \
     "--mode" \
     "--endpoint" \
     "--session" \
@@ -637,8 +637,8 @@ run_default() {
   run_tui_mock_approval_kind "sandbox_escalation" "danger-full-access"
   run_tui_protocol_readonly
   run_line_expect_failure \
-    "octos-tui-bad-endpoint" \
-    "$OCTOS_TUI_BIN_CMD --mode protocol --endpoint https://example.test/ui-protocol --readonly" \
+    "octoscode-bad-endpoint" \
+    "$OCTOSCODE_BIN_CMD --mode protocol --endpoint https://example.test/ui-protocol --readonly" \
     "endpoint must be a WebSocket URL"
 
   tmux_assert_no_registered_sessions
@@ -648,7 +648,7 @@ run_default() {
 
 run_live() {
   tmux_require
-  resolve_octos_tui_bin_cmd
+  resolve_octoscode_bin_cmd
   if [ "${OCTOS_TMUX_LIVE:-0}" != "1" ]; then
     tmux_log "SKIP: live lane requires OCTOS_TMUX_LIVE=1"
     exit 0
@@ -672,7 +672,7 @@ run_live() {
   server_session="$(tmux_session_name "live-server")"
   tui_session="$(tmux_session_name "live-tui")"
   server_cmd="$OCTOS_BIN_CMD serve --host $(shell_quote "$host") --port $(shell_quote "$port") --data-dir $(shell_quote "$data_dir") --cwd $(shell_quote "$ROOT_DIR") --auth-token $(shell_quote "$OCTOS_TMUX_AUTH_TOKEN")"
-  tui_cmd="$OCTOS_TUI_BIN_CMD --mode protocol --endpoint $(shell_quote "$endpoint") --cwd $(shell_quote "$ROOT_DIR") --auth-token $(shell_quote "$OCTOS_TMUX_AUTH_TOKEN")"
+  tui_cmd="$OCTOSCODE_BIN_CMD --mode protocol --endpoint $(shell_quote "$endpoint") --cwd $(shell_quote "$ROOT_DIR") --auth-token $(shell_quote "$OCTOS_TMUX_AUTH_TOKEN")"
   if [ -n "$session_id" ]; then
     tui_cmd="$tui_cmd --session $(shell_quote "$session_id") --profile-id $(shell_quote "$profile_id")"
   fi

--- a/e2e/ux/README.md
+++ b/e2e/ux/README.md
@@ -35,9 +35,9 @@ tier = "local"
 transport = "stdio"
 provider = "fixture"
 terminal = "100x30"
-tui_binary = "octos-tui"
+tui_binary = "octoscode"
 tmux_command = "ux-tui-stdio-happy"
-required_tools = ["tmux", "octos", "octos-tui"]
+required_tools = ["tmux", "octos", "octoscode"]
 required_capabilities = ["chat/send_prompt", "chat/receive_response"]
 expected_artifacts = [
   "scenario.json",

--- a/scripts/compare-tui-coding-ux-tmux.sh
+++ b/scripts/compare-tui-coding-ux-tmux.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Drive the real octos-tui protocol client and Codex through tmux on the same
+# Drive the real octoscode protocol client and Codex through tmux on the same
 # coding fixture. The Octos server is only the AppUi/UI Protocol backend; the
-# sole Octos product client under test is standalone octos-tui.
+# sole Octos product client under test is standalone octoscode.
 
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-RUN_ID="${OCTOS_TUI_UX_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+RUN_ID="${OCTOSCODE_UX_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
 RUN_STARTED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 RUN_START_EPOCH="$(date +%s)"
 export OCTOS_TMUX_RUN_ID="${OCTOS_TMUX_RUN_ID:-$RUN_ID}"
@@ -14,56 +14,56 @@ export OCTOS_TMUX_RUN_ID="${OCTOS_TMUX_RUN_ID:-$RUN_ID}"
 # shellcheck source=tmux-cli-driver.sh
 source "$ROOT_DIR/scripts/tmux-cli-driver.sh"
 
-OCTOS_TUI_DIR="${OCTOS_TUI_DIR:-$ROOT_DIR/../octos-tui}"
-LONG_MODE="${OCTOS_TUI_UX_LONG:-0}"
-if [ "$LONG_MODE" = "1" ] && [ -z "${OCTOS_TUI_UX_FIXTURE_DIR+x}" ]; then
+OCTOSCODE_DIR="${OCTOSCODE_DIR:-$ROOT_DIR/../octoscode}"
+LONG_MODE="${OCTOSCODE_UX_LONG:-0}"
+if [ "$LONG_MODE" = "1" ] && [ -z "${OCTOSCODE_UX_FIXTURE_DIR+x}" ]; then
   FIXTURE_DIR="$ROOT_DIR/e2e/fixtures/coding-agent-long-workspace"
 else
-  FIXTURE_DIR="${OCTOS_TUI_UX_FIXTURE_DIR:-$ROOT_DIR/e2e/fixtures/coding-agent-compare-multifile}"
+  FIXTURE_DIR="${OCTOSCODE_UX_FIXTURE_DIR:-$ROOT_DIR/e2e/fixtures/coding-agent-compare-multifile}"
 fi
-OUT_DIR="${OCTOS_TUI_UX_OUT_DIR:-$ROOT_DIR/e2e/test-results-tui-coding-ux/$RUN_ID}"
-PROVIDER="${OCTOS_TUI_UX_PROVIDER:-deepseek}"
-MODEL="${OCTOS_TUI_UX_MODEL:-${DEEPSEEK_MODEL:-deepseek-v4-pro}}"
+OUT_DIR="${OCTOSCODE_UX_OUT_DIR:-$ROOT_DIR/e2e/test-results-tui-coding-ux/$RUN_ID}"
+PROVIDER="${OCTOSCODE_UX_PROVIDER:-deepseek}"
+MODEL="${OCTOSCODE_UX_MODEL:-${DEEPSEEK_MODEL:-deepseek-v4-pro}}"
 case "$PROVIDER" in
   openai)
-    API_KEY_ENV="${OCTOS_TUI_UX_API_KEY_ENV:-OPENAI_API_KEY}"
+    API_KEY_ENV="${OCTOSCODE_UX_API_KEY_ENV:-OPENAI_API_KEY}"
     ;;
   deepseek)
-    API_KEY_ENV="${OCTOS_TUI_UX_API_KEY_ENV:-DEEPSEEK_API_KEY}"
+    API_KEY_ENV="${OCTOSCODE_UX_API_KEY_ENV:-DEEPSEEK_API_KEY}"
     ;;
   *)
-    API_KEY_ENV="${OCTOS_TUI_UX_API_KEY_ENV:-$(printf '%s_API_KEY' "$PROVIDER" | tr '[:lower:]' '[:upper:]')}"
+    API_KEY_ENV="${OCTOSCODE_UX_API_KEY_ENV:-$(printf '%s_API_KEY' "$PROVIDER" | tr '[:lower:]' '[:upper:]')}"
     ;;
 esac
-SERVER_PROVIDER="${OCTOS_TUI_UX_SERVER_PROVIDER:-$PROVIDER}"
-SERVER_BASE_URL="${OCTOS_TUI_UX_SERVER_BASE_URL:-}"
-SERVER_API_TYPE="${OCTOS_TUI_UX_SERVER_API_TYPE:-openai}"
-PORT="${OCTOS_TUI_UX_PORT:-$((51000 + $$ % 10000))}"
-AUTH_TOKEN="${OCTOS_TUI_UX_AUTH_TOKEN:-octos-tui-ux-token-$RUN_ID}"
-SESSION_ID="${OCTOS_TUI_UX_SESSION_ID:-coding:local:prototype#tui-compare}"
-MAX_WAIT_SHORT="${OCTOS_TUI_UX_WAIT_SHORT:-90}"
-if [ "$LONG_MODE" = "1" ] && [ -z "${OCTOS_TUI_UX_WAIT_TURN+x}" ]; then
+SERVER_PROVIDER="${OCTOSCODE_UX_SERVER_PROVIDER:-$PROVIDER}"
+SERVER_BASE_URL="${OCTOSCODE_UX_SERVER_BASE_URL:-}"
+SERVER_API_TYPE="${OCTOSCODE_UX_SERVER_API_TYPE:-openai}"
+PORT="${OCTOSCODE_UX_PORT:-$((51000 + $$ % 10000))}"
+AUTH_TOKEN="${OCTOSCODE_UX_AUTH_TOKEN:-octoscode-ux-token-$RUN_ID}"
+SESSION_ID="${OCTOSCODE_UX_SESSION_ID:-coding:local:prototype#tui-compare}"
+MAX_WAIT_SHORT="${OCTOSCODE_UX_WAIT_SHORT:-90}"
+if [ "$LONG_MODE" = "1" ] && [ -z "${OCTOSCODE_UX_WAIT_TURN+x}" ]; then
   MAX_WAIT_TURN=1800
 else
-  MAX_WAIT_TURN="${OCTOS_TUI_UX_WAIT_TURN:-900}"
+  MAX_WAIT_TURN="${OCTOSCODE_UX_WAIT_TURN:-900}"
 fi
-MAX_WAIT_APPROVAL="${OCTOS_TUI_UX_WAIT_APPROVAL:-90}"
-if [ "$LONG_MODE" = "1" ] && [ -z "${OCTOS_TUI_UX_TUI_CODING_ROUNDS+x}" ]; then
+MAX_WAIT_APPROVAL="${OCTOSCODE_UX_WAIT_APPROVAL:-90}"
+if [ "$LONG_MODE" = "1" ] && [ -z "${OCTOSCODE_UX_TUI_CODING_ROUNDS+x}" ]; then
   MAX_TUI_CODING_ROUNDS=8
 else
-  MAX_TUI_CODING_ROUNDS="${OCTOS_TUI_UX_TUI_CODING_ROUNDS:-4}"
+  MAX_TUI_CODING_ROUNDS="${OCTOSCODE_UX_TUI_CODING_ROUNDS:-4}"
 fi
-COMPAT_PROXY_PORT="${OCTOS_TUI_UX_COMPAT_PROXY_PORT:-18081}"
-RUN_TUI="${OCTOS_TUI_UX_RUN_TUI:-1}"
-RUN_CODEX="${OCTOS_TUI_UX_RUN_CODEX:-1}"
-STRICT="${OCTOS_TUI_UX_STRICT:-1}"
-TUI_DENY_KEY="${OCTOS_TUI_UX_TUI_DENY_KEY:-n}"
-FRAME_SAMPLE_ENABLED="${OCTOS_TUI_UX_FRAME_SAMPLE:-$LONG_MODE}"
-FRAME_SAMPLE_INTERVAL="${OCTOS_TUI_UX_FRAME_SAMPLE_INTERVAL:-3}"
-SERVER_ERROR_BUDGET="${OCTOS_TUI_UX_SERVER_ERROR_BUDGET:-0}"
-QUESTION_REGEX="${OCTOS_TUI_UX_QUESTION_REGEX:-\\?|？}"
-COMPLETION_REGEX="${OCTOS_TUI_UX_COMPLETION_REGEX:-test result: ok|Finished .*test.* profile|All tests passed|all tests passed}"
-SERVER_SANDBOX_POLICY="${OCTOS_TUI_UX_SERVER_SANDBOX_POLICY:-auto}"
+COMPAT_PROXY_PORT="${OCTOSCODE_UX_COMPAT_PROXY_PORT:-18081}"
+RUN_TUI="${OCTOSCODE_UX_RUN_TUI:-1}"
+RUN_CODEX="${OCTOSCODE_UX_RUN_CODEX:-1}"
+STRICT="${OCTOSCODE_UX_STRICT:-1}"
+TUI_DENY_KEY="${OCTOSCODE_UX_TUI_DENY_KEY:-n}"
+FRAME_SAMPLE_ENABLED="${OCTOSCODE_UX_FRAME_SAMPLE:-$LONG_MODE}"
+FRAME_SAMPLE_INTERVAL="${OCTOSCODE_UX_FRAME_SAMPLE_INTERVAL:-3}"
+SERVER_ERROR_BUDGET="${OCTOSCODE_UX_SERVER_ERROR_BUDGET:-0}"
+QUESTION_REGEX="${OCTOSCODE_UX_QUESTION_REGEX:-\\?|？}"
+COMPLETION_REGEX="${OCTOSCODE_UX_COMPLETION_REGEX:-test result: ok|Finished .*test.* profile|All tests passed|all tests passed}"
+SERVER_SANDBOX_POLICY="${OCTOSCODE_UX_SERVER_SANDBOX_POLICY:-auto}"
 RESOLVED_SERVER_SANDBOX_MODE=""
 COMPAT_PROXY_PID=""
 declare -a FRAME_SAMPLER_PIDS=()
@@ -88,15 +88,15 @@ if [ "$LONG_MODE" = "1" ]; then
   DEFAULT_PROMPT_RECONNECT="After client restart, continue from the current worktree state. Inspect git diff, rerun cargo test --workspace, and summarize whether worktree state and task context are clear."
 fi
 
-PROMPT_QUESTION="${OCTOS_TUI_UX_PROMPT_QUESTION:-$DEFAULT_PROMPT_QUESTION}"
-PROMPT_APPROVAL="${OCTOS_TUI_UX_PROMPT_APPROVAL:-Before coding, invoke exactly one shell command now: sudo true. Do not inspect files, do not edit files, and do not explain first.}"
-PROMPT_CODING="${OCTOS_TUI_UX_PROMPT_CODING:-$DEFAULT_PROMPT_CODING}"
-PROMPT_CONTINUE="${OCTOS_TUI_UX_PROMPT_CONTINUE:-$DEFAULT_PROMPT_CONTINUE}"
-PROMPT_SUMMARY="${OCTOS_TUI_UX_PROMPT_SUMMARY:-$DEFAULT_PROMPT_SUMMARY}"
-PROMPT_STEERING="${OCTOS_TUI_UX_PROMPT_STEERING:-$DEFAULT_PROMPT_STEERING}"
-PROMPT_INTERRUPT="${OCTOS_TUI_UX_PROMPT_INTERRUPT:-$DEFAULT_PROMPT_INTERRUPT}"
-PROMPT_RECONNECT="${OCTOS_TUI_UX_PROMPT_RECONNECT:-$DEFAULT_PROMPT_RECONNECT}"
-PROMPT_FINAL_LONG="${OCTOS_TUI_UX_PROMPT_FINAL_LONG:-$DEFAULT_PROMPT_FINAL_LONG}"
+PROMPT_QUESTION="${OCTOSCODE_UX_PROMPT_QUESTION:-$DEFAULT_PROMPT_QUESTION}"
+PROMPT_APPROVAL="${OCTOSCODE_UX_PROMPT_APPROVAL:-Before coding, invoke exactly one shell command now: sudo true. Do not inspect files, do not edit files, and do not explain first.}"
+PROMPT_CODING="${OCTOSCODE_UX_PROMPT_CODING:-$DEFAULT_PROMPT_CODING}"
+PROMPT_CONTINUE="${OCTOSCODE_UX_PROMPT_CONTINUE:-$DEFAULT_PROMPT_CONTINUE}"
+PROMPT_SUMMARY="${OCTOSCODE_UX_PROMPT_SUMMARY:-$DEFAULT_PROMPT_SUMMARY}"
+PROMPT_STEERING="${OCTOSCODE_UX_PROMPT_STEERING:-$DEFAULT_PROMPT_STEERING}"
+PROMPT_INTERRUPT="${OCTOSCODE_UX_PROMPT_INTERRUPT:-$DEFAULT_PROMPT_INTERRUPT}"
+PROMPT_RECONNECT="${OCTOSCODE_UX_PROMPT_RECONNECT:-$DEFAULT_PROMPT_RECONNECT}"
+PROMPT_FINAL_LONG="${OCTOSCODE_UX_PROMPT_FINAL_LONG:-$DEFAULT_PROMPT_FINAL_LONG}"
 
 log() {
   printf '[tui-ux] %s\n' "$*"
@@ -159,7 +159,7 @@ resolve_server_sandbox_mode() {
       printf 'outer-sandbox-fallback'
       ;;
     *)
-      printf 'unknown OCTOS_TUI_UX_SERVER_SANDBOX_POLICY=%s\n' "$SERVER_SANDBOX_POLICY" >&2
+      printf 'unknown OCTOSCODE_UX_SERVER_SANDBOX_POLICY=%s\n' "$SERVER_SANDBOX_POLICY" >&2
       exit 2
       ;;
   esac
@@ -169,7 +169,7 @@ maybe_write_harness_server_config() {
   local name="$1"
   local dir="$2"
 
-  [ "$name" = "octos_tui" ] || return 0
+  [ "$name" = "octoscode" ] || return 0
   [ "$RESOLVED_SERVER_SANDBOX_MODE" = "outer-sandbox-fallback" ] || return 0
 
   mkdir -p "$dir/.octos"
@@ -184,7 +184,7 @@ maybe_write_harness_server_config() {
   }
 }
 JSON
-  printf '[tui-ux] server sandbox: inner sandbox disabled for throwaway octos-tui lane because outer macOS sandbox blocks sandbox-exec\n' >&2
+  printf '[tui-ux] server sandbox: inner sandbox disabled for throwaway octoscode lane because outer macOS sandbox blocks sandbox-exec\n' >&2
 }
 
 cleanup_proxy() {
@@ -225,15 +225,15 @@ resolve_octos_bin() {
 }
 
 resolve_tui_bin() {
-  if [ -n "${OCTOS_TUI_BIN:-}" ]; then
-    printf '%s\n' "$OCTOS_TUI_BIN"
+  if [ -n "${OCTOSCODE_BIN:-}" ]; then
+    printf '%s\n' "$OCTOSCODE_BIN"
     return 0
   fi
-  if [ ! -x "$OCTOS_TUI_DIR/target/debug/octos-tui" ]; then
-    log "building octos-tui client"
-    cargo build --manifest-path "$OCTOS_TUI_DIR/Cargo.toml" --bin octos-tui
+  if [ ! -x "$OCTOSCODE_DIR/target/debug/octoscode" ]; then
+    log "building octoscode client"
+    cargo build --manifest-path "$OCTOSCODE_DIR/Cargo.toml" --bin octoscode
   fi
-  printf '%s\n' "$OCTOS_TUI_DIR/target/debug/octos-tui"
+  printf '%s\n' "$OCTOSCODE_DIR/target/debug/octoscode"
 }
 
 start_compat_proxy_if_needed() {
@@ -277,7 +277,7 @@ prepare_candidate() {
     cd "$dir"
     git init -q
     git add .
-    git -c user.name=octos-tui-ux -c user.email=octos-tui-ux@example.invalid \
+    git -c user.name=octoscode-ux -c user.email=octoscode-ux@example.invalid \
       commit -q -m 'initial fixture'
   )
   printf '%s\n' "$dir"
@@ -790,7 +790,7 @@ wait_for_tui_approval_outcome() {
 
 record_tui_missing_approval_prompt() {
   local session="$1"
-  append_capture_clean_to_file "$session" "$transcript" "octos-tui approval prompt missing"
+  append_capture_clean_to_file "$session" "$transcript" "octoscode approval prompt missing"
 }
 
 candidate_has_diff() {
@@ -891,7 +891,7 @@ start_secret_session() {
 "$runner"
 rc=\$?
 printf '\\n[tmux-runner-exit=%s]\\n' "\$rc"
-sleep "${OCTOS_TUI_UX_EXIT_HOLD_SECS:-900}"
+sleep "${OCTOSCODE_UX_EXIT_HOLD_SECS:-900}"
 exit "\$rc"
 EOF
   chmod +x "$keepalive"
@@ -914,7 +914,7 @@ $command
 rc=\$?
 set -e
 printf '\\n[tmux-runner-exit=%s]\\n' "\$rc"
-sleep "${OCTOS_TUI_UX_EXIT_HOLD_SECS:-900}"
+sleep "${OCTOSCODE_UX_EXIT_HOLD_SECS:-900}"
 exit "\$rc"
 EOF
   chmod +x "$runner"
@@ -936,7 +936,7 @@ tmux_paste_line() {
   buffer="octos-tmux-paste-${session//[^a-zA-Z0-9_.-]/-}"
   tmux set-buffer -b "$buffer" "$text"
   tmux paste-buffer -d -t "$session" -b "$buffer"
-  sleep "${OCTOS_TUI_UX_PASTE_ENTER_GRACE_SECS:-0.2}"
+  sleep "${OCTOSCODE_UX_PASTE_ENTER_GRACE_SECS:-0.2}"
   tmux_key "$session" Enter
 }
 
@@ -944,8 +944,8 @@ send_tui_prompt() {
   local session="$1"
   local text="$2"
   local label="${3:-prompt}"
-  local ready_timeout="${OCTOS_TUI_UX_COMPOSER_READY_TIMEOUT:-60}"
-  local submit_timeout="${OCTOS_TUI_UX_SUBMIT_TIMEOUT:-45}"
+  local ready_timeout="${OCTOSCODE_UX_COMPOSER_READY_TIMEOUT:-60}"
+  local submit_timeout="${OCTOSCODE_UX_SUBMIT_TIMEOUT:-45}"
 
   if ! wait_for_tui_composer_ready "$session" "$ready_timeout"; then
     log "TUI composer was not ready before $label"
@@ -968,9 +968,9 @@ send_codex_prompt() {
   local session="$1"
   local text="$2"
   tmux_key "$session" C-u
-  sleep "${OCTOS_TUI_UX_CODEX_CLEAR_GRACE_SECS:-0.2}"
+  sleep "${OCTOSCODE_UX_CODEX_CLEAR_GRACE_SECS:-0.2}"
   tmux_paste_line "$session" "$text"
-  sleep "${OCTOS_TUI_UX_CODEX_SUBMIT_GRACE_SECS:-1}"
+  sleep "${OCTOSCODE_UX_CODEX_SUBMIT_GRACE_SECS:-1}"
 }
 
 latest_codex_command_prompt_block() {
@@ -1020,7 +1020,7 @@ codex_deny_sudo_approval() {
     return 1
   fi
   tmux_key "$session" Escape
-  sleep "${OCTOS_TUI_UX_CODEX_DENIAL_GRACE_SECS:-2}"
+  sleep "${OCTOSCODE_UX_CODEX_DENIAL_GRACE_SECS:-2}"
   send_codex_prompt "$session" "Denied. Continue without sudo and finish the task."
   return 0
 }
@@ -1068,7 +1068,7 @@ wait_for_codex_sudo_approval_denial() {
 
 finish_session() {
   local session="$1"
-  if [ "${OCTOS_TUI_UX_KEEP_SESSIONS:-0}" = "1" ]; then
+  if [ "${OCTOSCODE_UX_KEEP_SESSIONS:-0}" = "1" ]; then
     log "kept tmux session: $session"
   else
     tmux_kill "$session"
@@ -1107,15 +1107,15 @@ drive_tui() {
   local styled_output_seen=0
   local test_rc=0
 
-  server_session="$(tmux_session_name octos-tui-server)"
-  tui_session="$(tmux_session_name octos-tui-client)"
+  server_session="$(tmux_session_name octoscode-server)"
+  tui_session="$(tmux_session_name octoscode-client)"
   endpoint="ws://127.0.0.1:$PORT/api/ui-protocol/ws"
-  server_fifo="$OUT_DIR/octos-tui-server-key.fifo"
-  server_runner="$OUT_DIR/run-octos-tui-server.sh"
+  server_fifo="$OUT_DIR/octoscode-server-key.fifo"
+  server_runner="$OUT_DIR/run-octoscode-server.sh"
   server_config="$OUT_DIR/octos-server-config.json"
-  transcript="$OUT_DIR/octos-tui-transcript.log"
-  raw_transcript="$OUT_DIR/octos-tui-raw-transcript.log"
-  server_log="$OUT_DIR/octos-tui-server.log"
+  transcript="$OUT_DIR/octoscode-transcript.log"
+  raw_transcript="$OUT_DIR/octoscode-raw-transcript.log"
+  server_log="$OUT_DIR/octoscode-server.log"
   : >"$transcript"
   : >"$raw_transcript"
 
@@ -1148,15 +1148,15 @@ EOF
     return 1
   fi
 
-  tui_command="cd '$OCTOS_TUI_DIR' && RUST_LOG=off '$tui_bin' --mode protocol --endpoint '$endpoint' --session '$SESSION_ID' --profile-id coding --cwd '$dir' --auth-token '$AUTH_TOKEN'"
+  tui_command="cd '$OCTOSCODE_DIR' && RUST_LOG=off '$tui_bin' --mode protocol --endpoint '$endpoint' --session '$SESSION_ID' --profile-id coding --cwd '$dir' --auth-token '$AUTH_TOKEN'"
   start_plain_session "$tui_session" "$tui_command"
-  start_frame_sampler "$tui_session" octos_tui
+  start_frame_sampler "$tui_session" octoscode
   frame_sampler_pid="$LAST_FRAME_SAMPLER_PID"
 
   wait_for_regex_soft "$tui_session" 'Protocol backend connected|Opened .*coding:local|app-ui octos-app-ui|Sessions' "$MAX_WAIT_SHORT" || true
-  if [ "${OCTOS_TUI_UX_ATTACH_GRACE_SECS:-0}" -gt 0 ]; then
+  if [ "${OCTOSCODE_UX_ATTACH_GRACE_SECS:-0}" -gt 0 ]; then
     log "attach now: tmux attach -r -t $tui_session"
-    sleep "${OCTOS_TUI_UX_ATTACH_GRACE_SECS:-0}"
+    sleep "${OCTOSCODE_UX_ATTACH_GRACE_SECS:-0}"
   fi
   if wait_for_regex_soft "$tui_session" 'Ask Octos to change code|›' 10 \
     && wait_for_regex_soft "$tui_session" 'Composer' 1 \
@@ -1178,20 +1178,20 @@ EOF
   if tui_style_escape_seen "$tui_session"; then
     styled_output_seen=1
   fi
-  append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui connected"
-  append_capture_raw_to_file "$tui_session" "$raw_transcript" "octos-tui connected"
+  append_capture_clean_to_file "$tui_session" "$transcript" "octoscode connected"
+  append_capture_raw_to_file "$tui_session" "$raw_transcript" "octoscode connected"
 
   if ! send_tui_prompt "$tui_session" "$PROMPT_QUESTION" "question turn"; then
-    append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui question submit failure"
+    append_capture_clean_to_file "$tui_session" "$transcript" "octoscode question submit failure"
   fi
   if wait_for_tui_regex_or_idle "$tui_session" "$QUESTION_REGEX" "$MAX_WAIT_TURN"; then
     question_seen=1
   fi
   wait_for_tui_turn_cycle "$tui_session" 240 || wait_for_tui_first_turn_complete "$tui_session" 60 || true
-  append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui question turn"
+  append_capture_clean_to_file "$tui_session" "$transcript" "octoscode question turn"
 
   if ! send_tui_prompt "$tui_session" "$PROMPT_APPROVAL" "approval probe turn"; then
-    append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui approval submit failure"
+    append_capture_clean_to_file "$tui_session" "$transcript" "octoscode approval submit failure"
   fi
   local approval_outcome=1
   set +e
@@ -1200,7 +1200,7 @@ EOF
   set -e
   if [ "$approval_outcome" -eq 0 ]; then
     approval_seen=1
-    append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui approval prompt"
+    append_capture_clean_to_file "$tui_session" "$transcript" "octoscode approval prompt"
     tmux_key "$tui_session" "$TUI_DENY_KEY"
   elif [ "$approval_outcome" -eq 2 ]; then
     record_tui_missing_approval_prompt "$tui_session"
@@ -1209,21 +1209,21 @@ EOF
     denial_seen=1
   fi
   wait_for_tui_turn_cycle "$tui_session" "$MAX_WAIT_TURN" || true
-  append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui approval turn"
+  append_capture_clean_to_file "$tui_session" "$transcript" "octoscode approval turn"
 
   if ! send_tui_prompt "$tui_session" "$PROMPT_CODING" "coding turn"; then
-    append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui coding submit failure"
+    append_capture_clean_to_file "$tui_session" "$transcript" "octoscode coding submit failure"
   fi
   wait_for_tui_turn_cycle "$tui_session" "$MAX_WAIT_TURN" || true
-  append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui coding turn"
+  append_capture_clean_to_file "$tui_session" "$transcript" "octoscode coding turn"
 
   local round=1
   while [ "$round" -le "$MAX_TUI_CODING_ROUNDS" ]; do
-    append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui round $round"
+    append_capture_clean_to_file "$tui_session" "$transcript" "octoscode round $round"
     if tui_session_has_error_state "$tui_session"; then
       break
     fi
-    if candidate_has_diff "$dir" && candidate_tests_pass_live octos_tui "$dir" "round-$round"; then
+    if candidate_has_diff "$dir" && candidate_tests_pass_live octoscode "$dir" "round-$round"; then
       completion_seen=1
       break
     fi
@@ -1233,10 +1233,10 @@ EOF
     fi
 
     if ! send_tui_prompt "$tui_session" "$PROMPT_CONTINUE" "continue round $round"; then
-      append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui continue submit failure $round"
+      append_capture_clean_to_file "$tui_session" "$transcript" "octoscode continue submit failure $round"
     fi
     wait_for_tui_turn_cycle "$tui_session" "$MAX_WAIT_TURN" || true
-    append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui continue round $round"
+    append_capture_clean_to_file "$tui_session" "$transcript" "octoscode continue round $round"
     if tui_session_has_error_state "$tui_session"; then
       break
     fi
@@ -1245,23 +1245,23 @@ EOF
 
   if [ "$LONG_MODE" = "1" ] && [ "$completion_seen" -eq 1 ]; then
     if ! send_tui_prompt "$tui_session" "$PROMPT_STEERING" "long steering turn"; then
-      append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui long steering submit failure"
+      append_capture_clean_to_file "$tui_session" "$transcript" "octoscode long steering submit failure"
     fi
     wait_for_tui_turn_cycle "$tui_session" "$MAX_WAIT_TURN" || true
-    append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui long steering turn"
-    if ! candidate_tests_pass_live octos_tui "$dir" "long-steering"; then
+    append_capture_clean_to_file "$tui_session" "$transcript" "octoscode long steering turn"
+    if ! candidate_tests_pass_live octoscode "$dir" "long-steering"; then
       completion_seen=0
     fi
 
     if ! send_tui_prompt "$tui_session" "$PROMPT_INTERRUPT" "long interrupt turn"; then
-      append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui interrupt submit failure"
+      append_capture_clean_to_file "$tui_session" "$transcript" "octoscode interrupt submit failure"
     else
-      sleep "${OCTOS_TUI_UX_INTERRUPT_AFTER_SECS:-8}"
+      sleep "${OCTOSCODE_UX_INTERRUPT_AFTER_SECS:-8}"
       tmux_key "$tui_session" C-c
       if wait_for_tui_interrupt_ack "$tui_session" 180; then
         interrupt_seen=1
       fi
-      append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui interrupt turn"
+      append_capture_clean_to_file "$tui_session" "$transcript" "octoscode interrupt turn"
       wait_for_tui_composer_ready "$tui_session" 60 || true
     fi
 
@@ -1270,20 +1270,20 @@ EOF
     tmux_kill "$tui_session"
     sleep 1
     start_plain_session "$tui_session" "$tui_command"
-    start_frame_sampler "$tui_session" octos_tui
+    start_frame_sampler "$tui_session" octoscode
     frame_sampler_pid="$LAST_FRAME_SAMPLER_PID"
     if wait_for_regex_soft "$tui_session" 'Protocol backend connected|Opened .*coding:local|app-ui octos-app-ui|Sessions|Composer|›' "$MAX_WAIT_SHORT"; then
       reconnect_seen=1
     fi
-    append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui reconnect"
-    append_capture_raw_to_file "$tui_session" "$raw_transcript" "octos-tui reconnect"
+    append_capture_clean_to_file "$tui_session" "$transcript" "octoscode reconnect"
+    append_capture_raw_to_file "$tui_session" "$raw_transcript" "octoscode reconnect"
 
     if ! send_tui_prompt "$tui_session" "$PROMPT_RECONNECT" "long reconnect turn"; then
-      append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui reconnect submit failure"
+      append_capture_clean_to_file "$tui_session" "$transcript" "octoscode reconnect submit failure"
     fi
     wait_for_tui_turn_cycle "$tui_session" "$MAX_WAIT_TURN" || true
-    append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui reconnect turn"
-    if ! candidate_tests_pass_live octos_tui "$dir" "reconnect"; then
+    append_capture_clean_to_file "$tui_session" "$transcript" "octoscode reconnect turn"
+    if ! candidate_tests_pass_live octoscode "$dir" "reconnect"; then
       completion_seen=0
     fi
   fi
@@ -1297,16 +1297,16 @@ EOF
     fi
     if [ "$(summary_bool_from_grep_filtered "$transcript" 'Session Summary|Session summary|Files changed|Validation|All [0-9]+ tests pass|all .*tests pass')" != "1" ]; then
       if ! send_tui_prompt "$tui_session" "$summary_prompt" "$summary_label"; then
-        append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui summary submit failure"
+        append_capture_clean_to_file "$tui_session" "$transcript" "octoscode summary submit failure"
       fi
       wait_for_tui_turn_cycle "$tui_session" "$MAX_WAIT_TURN" || true
-      append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui $summary_label"
+      append_capture_clean_to_file "$tui_session" "$transcript" "octoscode $summary_label"
     fi
   fi
 
-  append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui final"
-  append_capture_raw_to_file "$tui_session" "$raw_transcript" "octos-tui final"
-  frames_seen="$(frame_count_for_lane octos_tui)"
+  append_capture_clean_to_file "$tui_session" "$transcript" "octoscode final"
+  append_capture_raw_to_file "$tui_session" "$raw_transcript" "octoscode final"
+  frames_seen="$(frame_count_for_lane octoscode)"
   server_errors="$(server_error_count "$server_log")"
   if ! tmux_pane_alive "$tui_session"; then
     client_alive_seen=0
@@ -1315,7 +1315,7 @@ EOF
     fake_cursor_absent=0
   fi
   stop_frame_sampler "$frame_sampler_pid"
-  if lane_style_escape_seen octos_tui "$tui_session"; then
+  if lane_style_escape_seen octoscode "$tui_session"; then
     styled_output_seen=1
   fi
   tmux_key "$tui_session" C-q
@@ -1323,9 +1323,9 @@ EOF
   finish_session "$tui_session"
   finish_session "$server_session"
 
-  validate_candidate octos_tui "$dir" || test_rc=$?
-  write_candidate_artifacts octos_tui "$dir"
-  write_lane_summary octos_tui "$transcript" "$dir" "$question_seen" "$approval_seen" \
+  validate_candidate octoscode "$dir" || test_rc=$?
+  write_candidate_artifacts octoscode "$dir"
+  write_lane_summary octoscode "$transcript" "$dir" "$question_seen" "$approval_seen" \
     "$denial_seen" "$completion_seen" "$panes_seen" "$status_seen" "$test_rc" \
     "$client_alive_seen" "$fake_cursor_absent" "$native_cursor_composer_seen" "$styled_output_seen" \
     "$reconnect_seen" "$interrupt_seen" "$server_errors" "$frames_seen"
@@ -1451,7 +1451,7 @@ drive_codex() {
     fi
 
     send_codex_prompt "$session" "$PROMPT_INTERRUPT"
-    sleep "${OCTOS_TUI_UX_INTERRUPT_AFTER_SECS:-8}"
+    sleep "${OCTOSCODE_UX_INTERRUPT_AFTER_SECS:-8}"
     tmux_key "$session" C-c
     if wait_for_codex_signal "$session" 'interrupt|interrupted|cancelled|canceled|›|OpenAI Codex' 180; then
       interrupt_seen=1
@@ -1555,7 +1555,7 @@ plan_seen_for_lane() {
     return 0
   fi
 
-  if [ "$name" = "octos_tui" ] && lane_frame_grep octos_tui "$regex"; then
+  if [ "$name" = "octoscode" ] && lane_frame_grep octoscode "$regex"; then
     printf '1'
     return 0
   fi
@@ -1563,22 +1563,22 @@ plan_seen_for_lane() {
   printf '0'
 }
 
-octos_tui_inline_diff_seen() {
+octoscode_inline_diff_seen() {
   local transcript="$1"
   summary_bool_from_grep_filtered "$transcript" 'diff --git|(^|[[:space:]])@@|(^|[[:space:]])---[[:space:]]|(^|[[:space:]])\+\+\+[[:space:]]|Requested diff preview|Diff Preview|inline diff|diff_edit|apply_patch|^[[:space:]]*[-+][[:space:]]+[-+][[:space:]]+[0-9]+|^[[:space:]]*[-+][[:space:]]+-[[:space:]]+[0-9]+'
 }
 
-octos_tui_command_output_seen() {
+octoscode_command_output_seen() {
   local transcript="$1"
   summary_bool_from_grep_filtered "$transcript" 'Finished .*test.* profile|Running unittests|Running tests|test result:|stdout|stderr|exit status|command[[:space:]]+sudo true|kind[[:space:]]+command|Approval probe:|Sudo denied'
 }
 
-octos_tui_approval_card_seen() {
+octoscode_approval_card_seen() {
   local transcript="$1"
   summary_bool_from_grep_filtered "$transcript" 'Approval Requested|kind[[:space:]]+command|command[[:space:]]+sudo true|sudo true'
 }
 
-octos_tui_no_overlay_required() {
+octoscode_no_overlay_required() {
   local transcript="$1"
   local inline_diff_seen="$2"
 
@@ -1590,7 +1590,7 @@ octos_tui_no_overlay_required() {
   summary_bool_without_grep_filtered "$transcript" 'press[[:space:]]+d|d[[:space:]]+to[[:space:]]+(view|open)[[:space:]]+diff|open[[:space:]]+diff[[:space:]]+overlay|diff[[:space:]]+overlay|diff[[:space:]]+modal|modal[[:space:]]+diff'
 }
 
-octos_tui_chat_first_layout_seen() {
+octoscode_chat_first_layout_seen() {
   local transcript="$1"
 
   if ! grep -E -q -- 'Composer' "$transcript" 2>/dev/null \
@@ -1668,13 +1668,13 @@ write_lane_summary() {
   plan_seen="$(plan_seen_for_lane "$name" "$transcript")"
   summary_seen="$(summary_seen_for_lane "$transcript" "$test_rc" "$diff_bytes")"
 
-  if [ "$name" = "octos_tui" ]; then
+  if [ "$name" = "octoscode" ]; then
     trace_log_absent="$(summary_bool_without_grep_filtered "$transcript" 'INFO calling LLM|parallel_tools|result_sizes|tool_ids=')"
-    inline_diff_seen="$(octos_tui_inline_diff_seen "$transcript")"
-    command_output_seen="$(octos_tui_command_output_seen "$transcript")"
-    approval_card_seen="$(octos_tui_approval_card_seen "$transcript")"
-    no_overlay_required="$(octos_tui_no_overlay_required "$transcript" "$inline_diff_seen")"
-    chat_first_layout_seen="$(octos_tui_chat_first_layout_seen "$transcript")"
+    inline_diff_seen="$(octoscode_inline_diff_seen "$transcript")"
+    command_output_seen="$(octoscode_command_output_seen "$transcript")"
+    approval_card_seen="$(octoscode_approval_card_seen "$transcript")"
+    no_overlay_required="$(octoscode_no_overlay_required "$transcript" "$inline_diff_seen")"
+    chat_first_layout_seen="$(octoscode_chat_first_layout_seen "$transcript")"
   fi
 
   if [ "$diff_bytes" -le 0 ] \
@@ -1689,20 +1689,20 @@ write_lane_summary() {
     || [ "$status_seen" -ne 1 ]; then
     status="fail"
   fi
-  if [ "$name" = "octos_tui" ] && [ "$trace_log_absent" -ne 1 ]; then
+  if [ "$name" = "octoscode" ] && [ "$trace_log_absent" -ne 1 ]; then
     status="fail"
   fi
-  if [ "$name" = "octos_tui" ] && [ "$chat_first_layout_seen" -ne 1 ]; then
+  if [ "$name" = "octoscode" ] && [ "$chat_first_layout_seen" -ne 1 ]; then
     status="fail"
   fi
-  if [ "$name" = "octos_tui" ] \
+  if [ "$name" = "octoscode" ] \
     && { [ "$client_alive_seen" -ne 1 ] \
       || [ "$fake_cursor_absent" -ne 1 ] \
       || [ "$native_cursor_composer_seen" -ne 1 ] \
       || [ "$styled_output_seen" -ne 1 ]; }; then
     status="fail"
   fi
-  if [ "$LONG_MODE" = "1" ] && [ "$name" = "octos_tui" ] \
+  if [ "$LONG_MODE" = "1" ] && [ "$name" = "octoscode" ] \
     && { [ "$reconnect_seen" -ne 1 ] \
       || [ "$interrupt_seen" -ne 1 ] \
       || [ "$server_errors" -gt "$SERVER_ERROR_BUDGET" ]; }; then
@@ -1727,7 +1727,7 @@ write_lane_summary() {
     printf '%s.summary_seen=%s\n' "$name" "$summary_seen"
     printf '%s.panes_seen=%s\n' "$name" "$panes_seen"
     printf '%s.status_seen=%s\n' "$name" "$status_seen"
-    if [ "$name" = "octos_tui" ]; then
+    if [ "$name" = "octoscode" ]; then
       printf '%s.inline_diff_seen=%s\n' "$name" "$inline_diff_seen"
       printf '%s.command_output_seen=%s\n' "$name" "$command_output_seen"
       printf '%s.approval_card_seen=%s\n' "$name" "$approval_card_seen"
@@ -1754,35 +1754,35 @@ run_self_tests() {
   local transcript
   local frame_dir
 
-  test_root="$(mktemp -d "${TMPDIR:-/tmp}/octos-tui-ux-harness-test.XXXXXX")"
+  test_root="$(mktemp -d "${TMPDIR:-/tmp}/octoscode-ux-harness-test.XXXXXX")"
   OUT_DIR="$test_root"
   transcript="$OUT_DIR/transcript.log"
-  frame_dir="$OUT_DIR/frames/octos_tui"
+  frame_dir="$OUT_DIR/frames/octoscode"
   mkdir -p "$frame_dir"
 
   printf '  › State a short coding plan with checkbox steps.\n' >"$transcript"
-  if [ "$(plan_seen_for_lane octos_tui "$transcript")" != "0" ]; then
+  if [ "$(plan_seen_for_lane octoscode "$transcript")" != "0" ]; then
     printf 'self-test failed: prompt echo should not count as plan evidence\n' >&2
     rm -rf "$test_root"
     return 1
   fi
 
   printf '  Plan  live\n    [ ] 1. Run cargo test\n' >"$frame_dir/frame-00001.clean.log"
-  if [ "$(plan_seen_for_lane octos_tui "$transcript")" != "1" ]; then
+  if [ "$(plan_seen_for_lane octoscode "$transcript")" != "1" ]; then
     printf 'self-test failed: sampled frame plan evidence was not counted\n' >&2
     rm -rf "$test_root"
     return 1
   fi
 
   printf 'plain frame\n' >"$frame_dir/frame-00001.raw.log"
-  if lane_style_escape_seen octos_tui; then
+  if lane_style_escape_seen octoscode; then
     printf 'self-test failed: plain frame should not count as styled output\n' >&2
     rm -rf "$test_root"
     return 1
   fi
 
   printf '\033[38;2;110;188;255mstyled\033[0m\n' >"$frame_dir/frame-00002.raw.log"
-  if ! lane_style_escape_seen octos_tui; then
+  if ! lane_style_escape_seen octoscode; then
     printf 'self-test failed: raw frame ANSI style evidence was not counted\n' >&2
     rm -rf "$test_root"
     return 1
@@ -1790,7 +1790,7 @@ run_self_tests() {
 
   RESOLVED_SERVER_SANDBOX_MODE="outer-sandbox-fallback"
   mkdir -p "$OUT_DIR/candidate"
-  maybe_write_harness_server_config octos_tui "$OUT_DIR/candidate"
+  maybe_write_harness_server_config octoscode "$OUT_DIR/candidate"
   if ! grep -F -q '"permission_mode": "danger-full-access"' "$OUT_DIR/candidate/.octos/config.json"; then
     printf 'self-test failed: outer sandbox fallback config was not written\n' >&2
     rm -rf "$test_root"
@@ -1802,7 +1802,7 @@ run_self_tests() {
 }
 
 main() {
-  if [ "${OCTOS_TUI_UX_SELF_TEST:-0}" = "1" ]; then
+  if [ "${OCTOSCODE_UX_SELF_TEST:-0}" = "1" ]; then
     run_self_tests
     return $?
   fi
@@ -1813,7 +1813,7 @@ main() {
   require_fixture
 
   if [ -z "${!API_KEY_ENV:-}" ]; then
-    printf '%s is required for live octos-tui UX comparison runs with provider=%s model=%s.\n' \
+    printf '%s is required for live octoscode UX comparison runs with provider=%s model=%s.\n' \
       "$API_KEY_ENV" "$PROVIDER" "$MODEL" >&2
     exit 2
   fi
@@ -1842,7 +1842,7 @@ main() {
   log "fixture: $FIXTURE_DIR"
   log "long mode: $LONG_MODE"
   log "server sandbox mode: $RESOLVED_SERVER_SANDBOX_MODE"
-  log "octos-tui session: $(tmux_session_name octos-tui-client)"
+  log "octoscode session: $(tmux_session_name octoscode-client)"
   log "codex session: $(tmux_session_name codex-client)"
 
   local tui_rc=0
@@ -1853,7 +1853,7 @@ main() {
   if [ "$RUN_TUI" = "1" ]; then
     octos_bin="$(resolve_octos_bin)"
     tui_bin="$(resolve_tui_bin)"
-    drive_tui "$(prepare_candidate octos_tui)" "$octos_bin" "$tui_bin" || tui_rc=$?
+    drive_tui "$(prepare_candidate octoscode)" "$octos_bin" "$tui_bin" || tui_rc=$?
   fi
 
   if [ "$RUN_CODEX" = "1" ]; then
@@ -1890,7 +1890,7 @@ main() {
     printf 'max_tui_coding_rounds=%s\n' "$MAX_TUI_CODING_ROUNDS"
     printf 'model=%s\n' "$MODEL"
     printf 'port=%s\n' "$PORT"
-    printf 'octos_tui_rc=%s\n' "$tui_rc"
+    printf 'octoscode_rc=%s\n' "$tui_rc"
     printf 'codex_rc=%s\n' "$codex_rc"
   } >>"$OUT_DIR/summary.env"
 
@@ -1902,7 +1902,7 @@ main() {
   fi
 }
 
-if [ "${OCTOS_TUI_UX_DETECTOR_SELF_TEST:-0}" = "1" ]; then
+if [ "${OCTOSCODE_UX_DETECTOR_SELF_TEST:-0}" = "1" ]; then
   run_detector_self_test
   exit $?
 fi

--- a/scripts/m12-solo-appui-soak.sh
+++ b/scripts/m12-solo-appui-soak.sh
@@ -47,7 +47,7 @@ Environment:
                               because local solo live runs cannot change deployment mode.
 
 The live runner captures, per transport:
-  tui-capture.txt is owned by octos-tui's tmux runner; this backend runner captures
+  tui-capture.txt is owned by octoscode's tmux runner; this backend runner captures
   server.log, appui-transcript.jsonl, runtime-policy-stamp.json,
   tool-registry-snapshot.json, approval-events.jsonl, and filesystem-probe.json.
 USAGE

--- a/scripts/tests/test-compare-tui-coding-ux-detectors.sh
+++ b/scripts/tests/test-compare-tui-coding-ux-detectors.sh
@@ -7,7 +7,7 @@
 # `state ◒ Working (...)` which the legacy `running|blocked` regex
 # missed) does not slip back in unnoticed.
 #
-# Runs entirely offline. No tmux, no octos-tui process. The script is
+# Runs entirely offline. No tmux, no octoscode process. The script is
 # sourced so the detector helpers are loaded as bash functions; the
 # soak `main` invocation is guarded by `BASH_SOURCE` so sourcing does
 # not start the long-running flow.


### PR DESCRIPTION
Companion to [octos-tui#493](https://github.com/octos-org/octos-tui/pull/493), which renames the client. 67 files: docs, specs, book-zh, scripts, and the doc comments in `crates/` describing the client.

**Merge this after #493**, or the docs point at a name that does not exist yet.

## One functional change, not just prose

`octos doctor` enumerates installed client binaries **by name** (`octoscode_spec`, formerly `octos_tui_spec` in `commands/doctor.rs`). Renaming that alone would report *"none found"* to anyone who has not upgraded — wrong, and worst for exactly the user running `doctor` to work out why things are broken.

It now also looks for the pre-rename binary and surfaces it as `octos-tui (legacy name)`, but **only when a copy is actually present**, so the Installations section does not grow a permanent empty row. Drop it once the rename settles.

Also: `api/OCTOS_TUI_FEATURE_REQUIREMENTS.md` → `api/OCTOSCODE_FEATURE_REQUIREMENTS.md`, and two soak env vars in `serve.rs` (`OCTOS_TUI_M15_UX_*` → `OCTOSCODE_M15_UX_*`) to stay in lockstep with the client's harness rename.

## Deliberately NOT changed — and this is worth a look

Four e2e files assert on the TUI's rendered chrome:

- `e2e/fixtures/ux-artifact-self-test/tui-capture.txt`
- `e2e/tests/ux/validate.test.mjs`
- `scripts/compare-tui-coding-ux-tmux.sh`
- `scripts/tests/test-compare-tui-coding-ux-detectors.sh`

They match `>_ Octos TUI  idle` — but **the client has not rendered that string for some time.** On `octos-tui` main the only occurrences are a *negative* assertion (`assert!(!text.contains("Octos TUI"))`) and the `--help` text.

The detectors sit inside large alternations, so the dead branch never fails and nobody noticed. It is silently stale, with its own root cause, and renaming the string would just move a stale assertion to a *new* stale string. Left for a separate fix.

## Gate

`cargo check -p octos-cli --features api --tests` clean · 30 doctor tests pass · fmt clean.

Two things I chased down and ruled out:
- `session_actor::master_continuation_tick_reenters_actor_loop` failed once, then passed **3/3** on re-run. It is flaky, and this branch touches neither `session_actor` nor its inputs.
- The 4 clippy warnings in `api/admin.rs` are **identical on clean main** — a file this branch never touches.