### PR TITLE
fix(e2e): drop UX detector branches matching chrome the TUI stopped rendering

### DIFF
--- a/scripts/compare-tui-coding-ux-tmux.sh
+++ b/scripts/compare-tui-coding-ux-tmux.sh
@@ -477,7 +477,7 @@ tui_style_escape_seen() {
 tui_capture_has_ready_state() {
   local capture="$1"
   printf '%s\n' "$capture" | grep -E -q -- \
-    'state[[:space:]]+[^[:space:]]+[[:space:]]+(done|idle|error)|>_ Octos TUI[[:space:]]+idle|status[[:space:]]+Turn completed|system[[:space:]]+Turn completed|Turn error|Ask Octos to change code'
+    'state[[:space:]]+[^[:space:]]+[[:space:]]+(done|idle|error)|status[[:space:]]+Turn completed|system[[:space:]]+Turn completed|Turn error|Ask Octos to change code'
 }
 
 tui_capture_has_active_state() {
@@ -488,7 +488,7 @@ tui_capture_has_active_state() {
   # legacy regex missed and caused inline-diff detection to stall).
   local capture="$1"
   printf '%s\n' "$capture" | grep -E -q -- \
-    '>_ Octos TUI[[:space:]]+.*(Thinking|Working|Progress|Streaming)|state[[:space:]]+[^[:space:]]+[[:space:]]+(running|blocked|working|progress|streaming|Working|Progress|Streaming)|status[[:space:]]+(Turn started|Tool started|Approval requested|Approval denied|Thinking|Working|Progress|Streaming)|model[[:space:]]+Waiting for model|Approval Requested|live assistant'
+    'state[[:space:]]+[^[:space:]]+[[:space:]]+(running|blocked|working|progress|streaming|Working|Progress|Streaming)|status[[:space:]]+(Turn started|Tool started|Approval requested|Approval denied|Thinking|Working|Progress|Streaming)|model[[:space:]]+Waiting for model|Approval Requested|live assistant'
 }
 
 tui_capture_has_blocking_approval() {
@@ -735,9 +735,9 @@ run_detector_self_test() {
   local progress_capture
   local idle_capture
 
-  working_capture=$'>_ Octos TUI  Working\nComposer\n'
+  working_capture=$'state \u25d2 Working (thinking)\nComposer\n'
   progress_capture=$'status Progress\nComposer\n'
-  idle_capture=$'>_ Octos TUI  idle\nAsk Octos to change code\nComposer\n'
+  idle_capture=$'state \u25d2 idle (ready)\nAsk Octos to change code\nComposer\n'
 
   tui_capture_has_active_state "$working_capture" \
     || { printf 'detector self-test failed: Working was not active\n' >&2; return 1; }

--- a/scripts/tests/test-compare-tui-coding-ux-detectors.sh
+++ b/scripts/tests/test-compare-tui-coding-ux-detectors.sh
@@ -73,7 +73,7 @@ source "$TARGET"
 assert_active "Working state (deepseek-v4-pro-live transcript)" "$(cat <<'EOF'
 some pane content
 state ◒ Working (foo bar)
-> _ Octos TUI
+Composer
 EOF
 )"
 
@@ -106,19 +106,19 @@ EOF
 # Idle/done snapshots must NOT be considered active.
 assert_not_active "done state" "$(cat <<'EOF'
 state ◒ done (turn completed)
->_ Octos TUI  idle
+Composer
 EOF
 )"
 
 assert_not_active "idle composer" "$(cat <<'EOF'
->_ Octos TUI  idle
+state ◒ idle (ready)
 Ask Octos to change code
 EOF
 )"
 
 # Ready-state detector recognizes the same idle/done capture.
 assert_ready "ready-state idle composer" "$(cat <<'EOF'
->_ Octos TUI  idle
+state ◒ idle (ready)
 Ask Octos to change code
 EOF
 )"


### PR DESCRIPTION
Short-term half of #1925.

## The problem

`compare-tui-coding-ux-tmux.sh` decided ready/active state partly via:

```
>_ Octos TUI[[:space:]]+idle
>_ Octos TUI[[:space:]]+.*(Thinking|Working|Progress|Streaming)
```

**The TUI has not rendered that string for some time.** On `octos-tui` main, `Octos TUI` survives only in a *negative* assertion and the `--help` text — there is no `>_` literal in its `src/` at all.

It failed open rather than loudly: the branch sits in a large alternation, `state <x> <word>` matches, and the detector kept working. The self-test then *pinned* the dead vocabulary, so it was green on behaviour the product no longer has.

## The fix

Removed both branches; converted the self-test captures to the real vocabulary (`state ◒ idle (ready)`, `state ◒ Working (…)`) that #854 already established as current.

**Worth recording:** of the four self-test cases carrying the old string, **none actually depended on it.** Three had a real signal on another line, and the fourth was covered by the `Ask Octos to change code` alternative. The pinning was pure illusion — those cases would have passed with the branch already gone. I only found this because my first verification probe gave a false positive and I had to isolate it.

## Verification

Sourced the detector directly:

```
OLD chrome alone     -> NO match      (both detectors)
CURRENT chrome alone -> matches       (both detectors)
```

`scripts/tests/test-compare-tui-coding-ux-detectors.sh`: **10 passed, 0 failed** (runs offline, no tmux).

## Not addressed here

The longer-term half of #1925: giving the detector a way to *notice* it has gone stale. Nothing today distinguishes "this alternative is obsolete" from "this alternative just did not fire" — which is exactly why this sat unnoticed. Same shape as #1923.