### PR TITLE
chore(gateway): rename QueueMode::Steer → Latest; "steer" stays a parse alias

### DIFF
--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -1462,7 +1462,14 @@ pub enum QueueMode {
     #[default]
     Collect,
     /// Keep only the latest message, discard older queued messages.
-    Steer,
+    ///
+    /// Renamed from `steer`: that word means mid-turn INJECTION everywhere
+    /// else in this codebase (`turn/steer`, the agent's `SteerBuffer`),
+    /// where nothing is dropped — the opposite of this variant. The serde
+    /// alias keeps existing configs parsing; the `/queue` chat command
+    /// accepts both spellings.
+    #[serde(alias = "steer")]
+    Latest,
     /// Cancel the current run and process the new message immediately.
     Interrupt,
     /// If the current LLM call exceeds the patience threshold and a new message
@@ -1486,7 +1493,9 @@ pub struct GatewayConfig {
     #[serde(default)]
     pub system_prompt: Option<String>,
 
-    /// Message queue mode: "followup" (default) or "collect".
+    /// Message queue mode for messages arriving while a run is active:
+    /// "followup" | "collect" (default) | "latest" | "interrupt" |
+    /// "speculative". See [`QueueMode`].
     #[serde(default)]
     pub queue_mode: QueueMode,
 
@@ -2153,6 +2162,24 @@ pub fn detect_provider(model: &str) -> Option<&'static str> {
 
 #[cfg(test)]
 mod tests {
+    /// `QueueMode::Latest` was renamed from `steer` (the word collides with
+    /// `turn/steer`, which injects rather than discards). Existing configs
+    /// and `/queue steer` must keep working; new ones use `latest`.
+    #[test]
+    fn queue_mode_latest_parses_both_spellings_and_defaults_to_collect() {
+        use super::QueueMode;
+        let latest: QueueMode = serde_json::from_str("\"latest\"").expect("canonical name");
+        assert_eq!(latest, QueueMode::Latest);
+        let steer: QueueMode = serde_json::from_str("\"steer\"").expect("legacy alias");
+        assert_eq!(steer, QueueMode::Latest);
+        // Round-trip now WRITES the canonical spelling.
+        assert_eq!(
+            serde_json::to_string(&QueueMode::Latest).expect("serialize"),
+            "\"latest\""
+        );
+        assert_eq!(QueueMode::default(), QueueMode::Collect);
+    }
+
     use super::*;
 
     /// Crate-wide lock for EVERY test that pivots the global `HOME` /

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -6133,7 +6133,7 @@ impl SessionActor {
     ///
     /// Usage:
     ///   /queue                          — show current mode
-    ///   /queue followup|collect|steer|interrupt
+    ///   /queue followup|collect|latest|interrupt
     async fn handle_queue_command(&mut self, args: &[&str]) {
         if args.is_empty() {
             self.send_reply(&format!("Queue mode: {:?}", self.queue_mode))
@@ -6144,12 +6144,15 @@ impl SessionActor {
         let mode = match args[0] {
             "followup" => QueueMode::Followup,
             "collect" => QueueMode::Collect,
-            "steer" => QueueMode::Steer,
+            // "steer" stays accepted as the old spelling of `latest` — but the
+            // canonical name avoids colliding with `turn/steer`, which INJECTS
+            // into the running turn rather than discarding anything.
+            "latest" | "steer" => QueueMode::Latest,
             "interrupt" => QueueMode::Interrupt,
             "spec" | "speculative" => QueueMode::Speculative,
             other => {
                 self.send_reply(&format!(
-                    "Unknown mode: {other}. Use: followup, collect, steer, interrupt, spec"
+                    "Unknown mode: {other}. Use: followup, collect, latest, interrupt, spec"
                 ))
                 .await;
                 return;
@@ -6587,7 +6590,7 @@ impl SessionActor {
                     combined_attachment_prompt,
                 )
             }
-            QueueMode::Steer | QueueMode::Interrupt => {
+            QueueMode::Latest | QueueMode::Interrupt => {
                 // Coalescing delay: give rapid follow-up messages time to arrive
                 tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 

--- a/crates/octos-cli/src/session_actor_tests.rs
+++ b/crates/octos-cli/src/session_actor_tests.rs
@@ -5286,7 +5286,7 @@ async fn test_queue_mode_collect_batches() {
 
 /// Steer mode keeps only the newest queued message, discards older ones.
 #[tokio::test]
-async fn test_queue_mode_steer_keeps_newest() {
+async fn test_queue_mode_latest_keeps_newest() {
     let dir = tempfile::TempDir::new().unwrap();
 
     // Agent: 1st call slow (2s), 2nd call fast
@@ -5299,7 +5299,7 @@ async fn test_queue_mode_steer_keeps_newest() {
     ));
 
     let (tx, mut rx, handle, _session_mgr) =
-        setup_actor_with_mode(agent_llm, QueueMode::Steer, None, false, &dir).await;
+        setup_actor_with_mode(agent_llm, QueueMode::Latest, None, false, &dir).await;
 
     // Send first message → goes through 500ms coalescing delay, then starts 2s processing
     tx.send(make_inbound("first message")).await.unwrap();


### PR DESCRIPTION
The same word meant **opposite things** in the same codebase:

| "steer" | behavior |
|---|---|
| `turn/steer` + agent `SteerBuffer` | inject into the **running** turn — nothing dropped |
| gateway `QueueMode::Steer` | keep only the newest queued message, **discard** older ones |

Not hypothetical — it just misled the project owner into reading TUI steering as latest-wins-and-drop. `latest` says what the gateway variant actually does.

**Compatibility is total:** `#[serde(alias = "steer")]` keeps every existing config parsing (round-trips now write `latest`); the `/queue` chat command accepts both spellings and advertises the canonical one; the match arm rename is behavior-identical.

Also fixes the stale `queue_mode` field doc (claimed default `followup`, listed 2 of 5 modes — the `#[default]` is `Collect`). New test pins both spellings, the canonical serialization, and the real default.

The 4 clippy(api) warnings are the pre-existing `api/admin.rs` ones, identical on clean main.