### PR TITLE
feat(appui): gate goal completion on independent separate-model verifier

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -469,6 +469,7 @@ impl Agent {
                 .unwrap_or_default(),
             subagent_output_router: self.subagent_output_router.clone(),
             subagent_summary_generator: self.subagent_summary_generator.clone(),
+            llm_provider: self.llm.clone(),
             task_supervisor: Some(self.tools.supervisor()),
             cost_accountant: self.cost_accountant.clone(),
             parent_session_key: self.parent_session_key.clone(),

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -278,6 +278,9 @@ pub struct ToolContext {
     /// workers clone this so periodic LLM summaries fire for their
     /// background tasks just like top-level spawn children.
     pub subagent_summary_generator: Option<Arc<crate::subagent_summary::AgentSummaryGenerator>>,
+    /// LLM provider for tools that need to make independent model calls
+    /// (e.g., goal completion verifier). Populated by the session runtime.
+    pub llm_provider: Arc<dyn octos_llm::LlmProvider>,
     /// M8 parity (W1.A3): per-session task supervisor. Pipeline node
     /// workers register a child task in this supervisor so the admin
     /// dashboard sees the substructure under the parent run_pipeline
@@ -328,6 +331,26 @@ impl ToolContext {
     /// live executor wiring. Uses a [`crate::progress::SilentReporter`] and
     /// leaves every M8.x placeholder at its default.
     pub fn zero() -> Self {
+        // Noop provider for zero context (always fails, tools should not use it)
+        struct NoopProvider;
+        #[async_trait::async_trait]
+        impl octos_llm::LlmProvider for NoopProvider {
+            async fn chat(
+                &self,
+                _messages: &[octos_core::Message],
+                _tools: &[octos_llm::ToolSpec],
+                _config: &octos_llm::ChatConfig,
+            ) -> eyre::Result<octos_llm::ChatResponse> {
+                eyre::bail!("ToolContext::zero() has no real provider")
+            }
+            fn model_id(&self) -> &str {
+                "noop"
+            }
+            fn provider_name(&self) -> &str {
+                "noop"
+            }
+        }
+
         Self {
             tool_id: String::new(),
             reporter: Arc::new(crate::progress::SilentReporter),
@@ -342,6 +365,7 @@ impl ToolContext {
             app_state: AppStateHandle::new(),
             subagent_output_router: None,
             subagent_summary_generator: None,
+            llm_provider: Arc::new(NoopProvider),
             task_supervisor: None,
             cost_accountant: None,
             parent_session_key: None,

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -866,6 +866,11 @@ impl InProcessAgentOrchestrator {
     pub(crate) fn goal_objective_for_test(&self, session_id: &SessionKey) -> Option<String> {
         self.state().goals.get(session_id).map(|g| g.objective.clone())
     }
+
+    /// Get the goal ID for a session (used by goal completion verifier to prevent stale verdicts).
+    pub(crate) fn goal_id_for_session(&self, session_id: &SessionKey) -> Option<String> {
+        self.state().goals.get(session_id).map(|g| g.goal_id.clone())
+    }
     fn state(&self) -> std::sync::MutexGuard<'_, AutonomyRuntimeState> {
         self.state
             .lock()
@@ -3056,6 +3061,7 @@ impl InProcessAgentOrchestrator {
         profile_id: &str,
         assistant_content: &str,
         verdict: &GoalCompletionVerdict,
+        expected_goal_id: Option<&str>,
     ) -> bool {
         if !detect_goal_complete_sentinel(assistant_content) {
             return false;
@@ -3078,6 +3084,22 @@ impl InProcessAgentOrchestrator {
         }
         if goal.status == "complete" {
             return false;
+        }
+        // CRITICAL: Revalidate goal identity to prevent stale verifier verdicts.
+        // If the goal changed between fetching the objective (for the verifier)
+        // and completing it here, the Done verdict may be for the WRONG goal.
+        // The caller passes the goal_id that was snapshotted when the verifier
+        // was invoked; if it doesn't match the current goal, we must not complete.
+        if let Some(expected_id) = expected_goal_id {
+            if goal.goal_id != expected_id {
+                tracing::warn!(
+                    session_id = %session_id,
+                    expected_goal_id = %expected_id,
+                    actual_goal_id = %goal.goal_id,
+                    "stale verifier verdict: goal changed between verifier call and completion"
+                );
+                return false;
+            }
         }
         goal.status = "complete".to_owned();
         goal.updated_at_ms = now_ms();
@@ -15313,7 +15335,7 @@ mod tests {
             &session_id,
             "tenant-a",
             "still working on it",
-            &GoalCompletionVerdict::Done,
+            &GoalCompletionVerdict::Done, None,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
@@ -15325,7 +15347,7 @@ mod tests {
             &session_id,
             "tenant-a",
             "All done. <goal:complete>",
-            &GoalCompletionVerdict::Done,
+            &GoalCompletionVerdict::Done, None,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
@@ -17090,7 +17112,7 @@ mod tests {
             &session_id,
             "tenant-a",
             "I am about to write <goal:complete> shortly, but step 2 first.",
-            &GoalCompletionVerdict::Done,
+            &GoalCompletionVerdict::Done, None,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
@@ -17102,7 +17124,7 @@ mod tests {
             &session_id,
             "tenant-a",
             "All requested checks finished.\n\n<goal:complete>",
-            &GoalCompletionVerdict::Done,
+            &GoalCompletionVerdict::Done, None,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -861,15 +861,20 @@ pub(crate) fn route_terminal_event_to_continuation_queue(
 type LoopRunnableFilter<'a> = dyn Fn(&SessionKey, &str) -> bool + 'a;
 
 impl InProcessAgentOrchestrator {
-
     /// Get the goal objective for a session (used by goal completion verifier).
     pub(crate) fn goal_objective_for_test(&self, session_id: &SessionKey) -> Option<String> {
-        self.state().goals.get(session_id).map(|g| g.objective.clone())
+        self.state()
+            .goals
+            .get(session_id)
+            .map(|g| g.objective.clone())
     }
 
     /// Get the goal ID for a session (used by goal completion verifier to prevent stale verdicts).
     pub(crate) fn goal_id_for_session(&self, session_id: &SessionKey) -> Option<String> {
-        self.state().goals.get(session_id).map(|g| g.goal_id.clone())
+        self.state()
+            .goals
+            .get(session_id)
+            .map(|g| g.goal_id.clone())
     }
     fn state(&self) -> std::sync::MutexGuard<'_, AutonomyRuntimeState> {
         self.state
@@ -6681,7 +6686,9 @@ objective is fully met, or `NOT_DONE: <short reason>` otherwise."
     };
     // "Done" only on an explicit affirmative that is NOT negated. Checking the
     // trimmed first token keeps `NOT_DONE` from matching the `DONE` substring.
-    let trimmed = verdict_text.trim();
+    // Strip backticks first: the prompt says "`DONE`" (with backticks), so a
+    // literally-compliant model returns `DONE` → we must accept that.
+    let trimmed = verdict_text.trim().trim_matches('`');
     let first_token = trimmed
         .split(|c: char| c.is_whitespace() || c == ':')
         .next()
@@ -15335,7 +15342,8 @@ mod tests {
             &session_id,
             "tenant-a",
             "still working on it",
-            &GoalCompletionVerdict::Done, None,
+            &GoalCompletionVerdict::Done,
+            None,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
@@ -15347,7 +15355,8 @@ mod tests {
             &session_id,
             "tenant-a",
             "All done. <goal:complete>",
-            &GoalCompletionVerdict::Done, None,
+            &GoalCompletionVerdict::Done,
+            None,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
@@ -15364,6 +15373,133 @@ mod tests {
             "tenant-a",
             GoalRuntimeIdleState::idle(),
         ));
+    }
+
+    /// CRITICAL: NotDone verdict must keep goal Active (not complete).
+    /// This is the core of the independent verifier gate — the agent's
+    /// self-declared completion is only a CLAIM; the verifier must confirm.
+    #[test]
+    fn maybe_complete_goal_from_model_rejects_notdone_verdict() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-notdone");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "verify independently".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+
+        // Sentinel content + NotDone verdict → goal stays Active.
+        assert!(!orchestrator.maybe_complete_goal_from_model(
+            &session_id,
+            "tenant-a",
+            "I claim this is done. <goal:complete>",
+            &GoalCompletionVerdict::NotDone {
+                reason: "evidence insufficient".to_string(),
+            },
+            None,
+        ));
+        assert_eq!(
+            orchestrator.goal_status_for_test(&session_id).as_deref(),
+            Some("active"),
+            "NotDone verdict must keep goal Active, not complete it"
+        );
+    }
+
+    /// CRITICAL: Stale goal_id must reject completion (TOCTOU fix).
+    /// If the goal changes between the verifier call and completion,
+    /// a Done verdict for the OLD goal must NOT complete the NEW goal.
+    #[test]
+    fn maybe_complete_goal_from_model_rejects_stale_goal_id() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-stale");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "goal A".into(),
+                status: Some("active".into()),
+                token_budget: None,
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let goal_a_id = orchestrator.goal_id_for_session(&session_id);
+
+        // Done verdict with WRONG goal_id (stale) must NOT complete the goal.
+        assert!(!orchestrator.maybe_complete_goal_from_model(
+            &session_id,
+            "tenant-a",
+            "Done. <goal:complete>",
+            &GoalCompletionVerdict::Done,
+            Some("wrong-goal-id"), // Stale/incorrect ID
+        ));
+        assert_eq!(
+            orchestrator.goal_status_for_test(&session_id).as_deref(),
+            Some("active"),
+            "stale goal_id must reject completion (TOCTOU fix)"
+        );
+
+        // Done verdict with CORRECT goal_id DOES complete the goal.
+        assert!(orchestrator.maybe_complete_goal_from_model(
+            &session_id,
+            "tenant-a",
+            "Done. <goal:complete>",
+            &GoalCompletionVerdict::Done,
+            goal_a_id.as_deref(), // Correct ID
+        ));
+        assert_eq!(
+            orchestrator.goal_status_for_test(&session_id).as_deref(),
+            Some("complete"),
+            "correct goal_id allows completion"
+        );
+    }
+
+    /// Parser must accept the prompt's own example format: "`DONE`" (with backticks).
+    /// The prompt says "Answer with EXACTLY one line: `DONE`", so a literally-
+    /// compliant model returns `DONE` → we must accept that.
+    #[tokio::test]
+    async fn run_goal_completion_verifier_accepts_backticks() {
+        struct BacktickProvider;
+        #[async_trait::async_trait]
+        impl LlmProvider for BacktickProvider {
+            async fn chat(
+                &self,
+                _messages: &[octos_core::Message],
+                _tools: &[octos_llm::ToolSpec],
+                _config: &octos_llm::ChatConfig,
+            ) -> eyre::Result<octos_llm::ChatResponse> {
+                Ok(octos_llm::ChatResponse {
+                    content: Some("`DONE`".to_string()),
+                    reasoning_content: None,
+                    tool_calls: Vec::new(),
+                    stop_reason: octos_llm::StopReason::EndTurn,
+                    usage: octos_llm::TokenUsage::default(),
+                    provider_index: Some(0),
+                })
+            }
+            fn model_id(&self) -> &str {
+                "mock"
+            }
+            fn provider_name(&self) -> &str {
+                "mock"
+            }
+        }
+
+        let verdict = run_goal_completion_verifier(
+            Arc::new(BacktickProvider),
+            "test objective",
+            "test evidence",
+        )
+        .await;
+        assert_eq!(
+            verdict,
+            GoalCompletionVerdict::Done,
+            "parser must accept `DONE` (with backticks)"
+        );
     }
 
     /// `detect_goal_complete_sentinel` covers all canonical sentinels
@@ -17112,7 +17248,8 @@ mod tests {
             &session_id,
             "tenant-a",
             "I am about to write <goal:complete> shortly, but step 2 first.",
-            &GoalCompletionVerdict::Done, None,
+            &GoalCompletionVerdict::Done,
+            None,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
@@ -17124,7 +17261,8 @@ mod tests {
             &session_id,
             "tenant-a",
             "All requested checks finished.\n\n<goal:complete>",
-            &GoalCompletionVerdict::Done, None,
+            &GoalCompletionVerdict::Done,
+            None,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -5,11 +5,11 @@ use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use super::goal_loop_runtime::{
-    BUILT_IN_MAINTENANCE_PROMPT, DenyReason, GoalPolicyDecision, GoalRuntime, GoalRuntimePolicy,
-    GoalRuntimeState, LoopFireContext, LoopFireDecision, LoopFireTrigger, LoopInvocation,
-    LoopRuntime, LoopRuntimePolicy, MaintenancePromptResolution, MaintenancePromptSource,
-    NextDueState, RuntimeIdleState as GoalRuntimeIdleState, SlashCommandAuthorization, WaitUntil,
-    resolve_maintenance_prompt,
+    BUILT_IN_MAINTENANCE_PROMPT, DenyReason, GoalCompletionVerdict, GoalPolicyDecision,
+    GoalRuntime, GoalRuntimePolicy, GoalRuntimeState, LoopFireContext, LoopFireDecision,
+    LoopFireTrigger, LoopInvocation, LoopRuntime, LoopRuntimePolicy, MaintenancePromptResolution,
+    MaintenancePromptSource, NextDueState, RuntimeIdleState as GoalRuntimeIdleState,
+    SlashCommandAuthorization, WaitUntil, resolve_maintenance_prompt,
 };
 use super::master_continuation_scheduler::{
     MAX_REDELIVERY_ATTEMPTS, MasterContinuationDedupeKey, MasterContinuationEnqueueOutcome,
@@ -861,6 +861,11 @@ pub(crate) fn route_terminal_event_to_continuation_queue(
 type LoopRunnableFilter<'a> = dyn Fn(&SessionKey, &str) -> bool + 'a;
 
 impl InProcessAgentOrchestrator {
+
+    /// Get the goal objective for a session (used by goal completion verifier).
+    pub(crate) fn goal_objective_for_test(&self, session_id: &SessionKey) -> Option<String> {
+        self.state().goals.get(session_id).map(|g| g.objective.clone())
+    }
     fn state(&self) -> std::sync::MutexGuard<'_, AutonomyRuntimeState> {
         self.state
             .lock()
@@ -3050,8 +3055,18 @@ impl InProcessAgentOrchestrator {
         session_id: &SessionKey,
         profile_id: &str,
         assistant_content: &str,
+        verdict: &GoalCompletionVerdict,
     ) -> bool {
         if !detect_goal_complete_sentinel(assistant_content) {
+            return false;
+        }
+        // Loop-engineering completion gate: the model's `<goal:complete>`
+        // sentinel is the agent's CLAIM, not proof. An INDEPENDENT verifier
+        // (a separate cheap-lane pass — see `run_goal_completion_verifier`)
+        // must confirm the objective is actually met before we flip to
+        // `complete`; otherwise the goal stays Active and the scheduler
+        // re-queues. This is what stops the agent grading its own homework.
+        if !verdict.is_done() {
             return false;
         }
         let mut state = self.state();
@@ -3069,6 +3084,14 @@ impl InProcessAgentOrchestrator {
         let snapshot = goal.clone();
         persist_goal_state(&state, session_id, &snapshot, false);
         true
+    }
+
+    /// Whether `content` carries the agent's self-declared goal-completion
+    /// sentinel. Callers use this to decide whether to spend an INDEPENDENT
+    /// verifier LLM call (only when completion is actually claimed) before
+    /// passing the verdict to [`Self::maybe_complete_goal_from_model`].
+    pub(crate) fn goal_completion_claimed(&self, content: &str) -> bool {
+        detect_goal_complete_sentinel(content)
     }
 
     /// #1696/#1698 — `SessionGoalUpdated`-shaped snapshot of the session's
@@ -6590,6 +6613,65 @@ fn detect_goal_complete_sentinel(content: &str) -> bool {
     GOAL_COMPLETE_SENTINELS
         .iter()
         .any(|sentinel| last_line == *sentinel || last_line.ends_with(sentinel))
+}
+
+/// INDEPENDENT goal-completion verifier — a separate cheap-lane LLM pass that
+/// judges whether the objective is genuinely met by the agent's evidence.
+///
+/// Loop-engineering: the agent's `<goal:complete>` sentinel is only a CLAIM.
+/// This verifier independently checks the objective against the evidence and
+/// returns Done/NotDone. Fail-safe: any provider/parse error returns NotDone
+/// (never spuriously completes).
+///
+/// Mirrors the AgentVerifierConfig pattern: fresh judge prompt, no agent
+/// scratchpad, separate model lane.
+pub(crate) async fn run_goal_completion_verifier(
+    provider: Arc<dyn LlmProvider>,
+    objective: &str,
+    evidence: &str,
+) -> GoalCompletionVerdict {
+    let prompt = format!(
+        "You are an INDEPENDENT completion verifier. Do not assume the work is \
+done just because the agent said so.\n\nGOAL OBJECTIVE:\n{objective}\n\nThe \
+agent's final reply (which claims the goal is complete):\n{evidence}\n\nJudge \
+ONLY whether the objective is genuinely and fully satisfied by concrete \
+evidence in the reply. If anything required is missing, unverified, or merely \
+asserted, it is NOT done.\n\nAnswer with EXACTLY one line:\n`DONE` if the \
+objective is fully met, or `NOT_DONE: <short reason>` otherwise."
+    );
+    let config = octos_llm::ChatConfig {
+        max_tokens: Some(200),
+        temperature: Some(0.0),
+        tool_choice: Default::default(),
+        stop_sequences: Vec::new(),
+        reasoning_effort: None,
+        response_format: None,
+        context_management: None,
+    };
+    let messages = vec![octos_core::Message::user(prompt)];
+    let verdict_text = match provider.chat(&messages, &[], &config).await {
+        Ok(response) => response.content.unwrap_or_default(),
+        Err(error) => {
+            return GoalCompletionVerdict::NotDone {
+                reason: format!("verifier call failed: {error}"),
+            };
+        }
+    };
+    // "Done" only on an explicit affirmative that is NOT negated. Checking the
+    // trimmed first token keeps `NOT_DONE` from matching the `DONE` substring.
+    let trimmed = verdict_text.trim();
+    let first_token = trimmed
+        .split(|c: char| c.is_whitespace() || c == ':')
+        .next()
+        .unwrap_or("")
+        .to_ascii_uppercase();
+    if first_token == "DONE" {
+        GoalCompletionVerdict::Done
+    } else {
+        GoalCompletionVerdict::NotDone {
+            reason: trimmed.chars().take(200).collect(),
+        }
+    }
 }
 
 fn enqueue_agent_terminal_continuations(
@@ -15231,17 +15313,19 @@ mod tests {
             &session_id,
             "tenant-a",
             "still working on it",
+            &GoalCompletionVerdict::Done,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
             Some("active"),
         );
 
-        // Sentinel content → transition to `complete`.
+        // Sentinel content + Done verdict → transition to `complete`.
         assert!(orchestrator.maybe_complete_goal_from_model(
             &session_id,
             "tenant-a",
             "All done. <goal:complete>",
+            &GoalCompletionVerdict::Done,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
@@ -17006,17 +17090,19 @@ mod tests {
             &session_id,
             "tenant-a",
             "I am about to write <goal:complete> shortly, but step 2 first.",
+            &GoalCompletionVerdict::Done,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
             Some("active"),
         );
 
-        // Trailing sentinel (the canonical AppUI shape) flips it.
+        // Trailing sentinel (the canonical AppUI shape) + Done verdict flips it.
         assert!(orchestrator.maybe_complete_goal_from_model(
             &session_id,
             "tenant-a",
             "All requested checks finished.\n\n<goal:complete>",
+            &GoalCompletionVerdict::Done,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),

--- a/crates/octos-cli/src/api/goal_loop_runtime.rs
+++ b/crates/octos-cli/src/api/goal_loop_runtime.rs
@@ -269,6 +269,31 @@ pub enum GoalRuntimeState {
     Failed(String),
 }
 
+/// Outcome of the INDEPENDENT goal-completion verifier.
+///
+/// Loop-engineering (addyosmani.com/blog/loop-engineering): a `/goal` should run
+/// "until a verifiable stopping condition is met, with a separate model checking
+/// completion rather than the agent self-grading." This is the goal-level
+/// analogue of [`octos_agent`]'s `VerifierVerdict::ReadyToAnswer`: the agent's
+/// own `<goal:complete>` sentinel is only a *claim*; a separate cheap-lane
+/// verifier must independently return [`GoalCompletionVerdict::Done`] before the
+/// goal may transition to `Completed`. Any `NotDone` keeps the goal `Active`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GoalCompletionVerdict {
+    /// The separate verifier independently confirmed the objective is met.
+    Done,
+    /// The verifier judged the objective not yet met (or the check could not be
+    /// run); the goal stays `Active`. Carries a short reason for the ledger.
+    NotDone { reason: String },
+}
+
+impl GoalCompletionVerdict {
+    /// Whether the independent verifier confirmed completion.
+    pub fn is_done(&self) -> bool {
+        matches!(self, Self::Done)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GoalBudgetResolution {
     pub goal_id: GoalId,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -33098,20 +33098,27 @@ async fn run_standalone_turn(
             // The verifier judges the objective against the reply evidence
             // and returns Done/NotDone; maybe_complete_goal_from_model then
             // requires both the sentinel AND a Done verdict.
-            let verdict = if orchestrator.goal_completion_claimed(&reply) {
+            let (verdict, expected_goal_id) = if orchestrator.goal_completion_claimed(&reply) {
                 let objective = orchestrator
                     .goal_objective_for_test(goal_key)
                     .unwrap_or_else(|| "unknown".to_string());
-                run_goal_completion_verifier(
+                // Snapshot goal_id BEFORE the async verifier call to prevent
+                // completing the wrong goal if it changes during the await.
+                let goal_id = orchestrator.goal_id_for_session(goal_key);
+                let verdict = run_goal_completion_verifier(
                     llm_provider.clone(),
                     &objective,
                     &reply,
                 )
-                .await
+                .await;
+                (verdict, goal_id)
             } else {
-                GoalCompletionVerdict::NotDone {
-                    reason: "no completion claimed".to_string(),
-                }
+                (
+                    GoalCompletionVerdict::NotDone {
+                        reason: "no completion claimed".to_string(),
+                    },
+                    None,
+                )
             };
             // `maybe_complete_goal_from_model` is idempotent and only
             // flips when `detect_goal_complete_sentinel` matches the
@@ -33119,7 +33126,7 @@ async fn run_standalone_turn(
             // is intentionally unused — the goal is either complete now or
             // stays active and the next scheduler tick decides whether to re-queue.
             let _ =
-                orchestrator.maybe_complete_goal_from_model(goal_key, &goal_ctx.profile_id, &reply, &verdict);
+                orchestrator.maybe_complete_goal_from_model(goal_key, &goal_ctx.profile_id, &reply, &verdict, expected_goal_id.as_deref());
         }
         // #1696/#1698 — push the post-turn goal snapshot to the OWNING
         // connection so autonomous transitions repaint the chip live:

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -89,8 +89,10 @@ use super::agent_orchestrator::{
     InProcessAgentOrchestrator, LoopControlKind, LoopControlRequest, LoopCreateRequest,
     LoopListRequest, NativeSpecialistAppUiEvent, NativeSpecialistLaunchRequest,
     default_agent_orchestrator, master_continuation_prompt, master_continuation_reason_name,
-    parse_agent_output_cursor, upsert_background_task_agent, wire_key_from_goal_key,
+    parse_agent_output_cursor, run_goal_completion_verifier, upsert_background_task_agent,
+    wire_key_from_goal_key,
 };
+use super::goal_loop_runtime::GoalCompletionVerdict;
 #[cfg(test)]
 use super::agent_orchestrator::{
     AgentArtifactRecord as AgentRuntimeArtifactRecord, clear_default_agent_orchestrator_for_test,
@@ -33091,13 +33093,33 @@ async fn run_standalone_turn(
             elapsed_seconds,
         );
         if let Some(reply) = assistant_reply {
+            // Loop-engineering completion gate: only spend the INDEPENDENT
+            // verifier LLM call when the agent actually CLAIMS completion.
+            // The verifier judges the objective against the reply evidence
+            // and returns Done/NotDone; maybe_complete_goal_from_model then
+            // requires both the sentinel AND a Done verdict.
+            let verdict = if orchestrator.goal_completion_claimed(&reply) {
+                let objective = orchestrator
+                    .goal_objective_for_test(goal_key)
+                    .unwrap_or_else(|| "unknown".to_string());
+                run_goal_completion_verifier(
+                    llm_provider.clone(),
+                    &objective,
+                    &reply,
+                )
+                .await
+            } else {
+                GoalCompletionVerdict::NotDone {
+                    reason: "no completion claimed".to_string(),
+                }
+            };
             // `maybe_complete_goal_from_model` is idempotent and only
             // flips when `detect_goal_complete_sentinel` matches the
-            // tail of the reply. The return value is intentionally
-            // unused — the goal is either complete now or stays active
-            // and the next scheduler tick decides whether to re-queue.
+            // tail of the reply AND the verdict is Done. The return value
+            // is intentionally unused — the goal is either complete now or
+            // stays active and the next scheduler tick decides whether to re-queue.
             let _ =
-                orchestrator.maybe_complete_goal_from_model(goal_key, &goal_ctx.profile_id, &reply);
+                orchestrator.maybe_complete_goal_from_model(goal_key, &goal_ctx.profile_id, &reply, &verdict);
         }
         // #1696/#1698 — push the post-turn goal snapshot to the OWNING
         // connection so autonomous transitions repaint the chip live:

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -92,11 +92,11 @@ use super::agent_orchestrator::{
     parse_agent_output_cursor, run_goal_completion_verifier, upsert_background_task_agent,
     wire_key_from_goal_key,
 };
-use super::goal_loop_runtime::GoalCompletionVerdict;
 #[cfg(test)]
 use super::agent_orchestrator::{
     AgentArtifactRecord as AgentRuntimeArtifactRecord, clear_default_agent_orchestrator_for_test,
 };
+use super::goal_loop_runtime::GoalCompletionVerdict;
 use super::master_continuation_scheduler::{
     MasterContinuationReason, MasterContinuationRuntimeState,
 };
@@ -33105,12 +33105,8 @@ async fn run_standalone_turn(
                 // Snapshot goal_id BEFORE the async verifier call to prevent
                 // completing the wrong goal if it changes during the await.
                 let goal_id = orchestrator.goal_id_for_session(goal_key);
-                let verdict = run_goal_completion_verifier(
-                    llm_provider.clone(),
-                    &objective,
-                    &reply,
-                )
-                .await;
+                let verdict =
+                    run_goal_completion_verifier(llm_provider.clone(), &objective, &reply).await;
                 (verdict, goal_id)
             } else {
                 (
@@ -33125,8 +33121,13 @@ async fn run_standalone_turn(
             // tail of the reply AND the verdict is Done. The return value
             // is intentionally unused — the goal is either complete now or
             // stays active and the next scheduler tick decides whether to re-queue.
-            let _ =
-                orchestrator.maybe_complete_goal_from_model(goal_key, &goal_ctx.profile_id, &reply, &verdict, expected_goal_id.as_deref());
+            let _ = orchestrator.maybe_complete_goal_from_model(
+                goal_key,
+                &goal_ctx.profile_id,
+                &reply,
+                &verdict,
+                expected_goal_id.as_deref(),
+            );
         }
         // #1696/#1698 — push the post-turn goal snapshot to the OWNING
         // connection so autonomous transitions repaint the chip live:

--- a/crates/octos-cli/src/goal_tool.rs
+++ b/crates/octos-cli/src/goal_tool.rs
@@ -875,6 +875,62 @@ impl Tool for GoalUpdateTool {
             .get("reason")
             .and_then(Value::as_str)
             .unwrap_or_default();
+
+        // CRITICAL: Gate `complete` transitions on the INDEPENDENT verifier.
+        // The goal_update tool is the FIRST-CLASS path (replacing the <goal:complete>
+        // sentinel), so it must NOT bypass the verifier. When the model claims
+        // completion, we call run_goal_completion_verifier to independently check
+        // the objective against the model's evidence. Blocked transitions skip
+        // verification (they're failure declarations, not success claims).
+        if status == "complete" {
+            let orchestrator = default_agent_orchestrator();
+            let Some(objective) = orchestrator.goal_objective_for_test(&session_id) else {
+                return Ok(ToolResult {
+                    output: "goal_update: no goal objective found for verification".into(),
+                    success: false,
+                    ..Default::default()
+                });
+            };
+            // Snapshot goal_id BEFORE the async verifier call to prevent
+            // completing the wrong goal if it changes during the await.
+            let expected_goal_id = orchestrator.goal_id_for_session(&session_id);
+            // The evidence is the model's reason for claiming completion.
+            let verdict = crate::api::agent_orchestrator::run_goal_completion_verifier(
+                ctx.llm_provider.clone(),
+                &objective,
+                reason,
+            )
+            .await;
+            if !verdict.is_done() {
+                return Ok(ToolResult {
+                    output: format!(
+                        "goal_update: completion NOT verified — independent verifier returned: {}",
+                        match verdict {
+                            crate::api::goal_loop_runtime::GoalCompletionVerdict::NotDone {
+                                reason,
+                            } => reason,
+                            _ => "unknown".to_string(),
+                        }
+                    ),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+            // Verifier confirmed Done, but we must still revalidate goal identity
+            // to prevent stale verdicts (goal changed during the await).
+            let current_goal_id = orchestrator.goal_id_for_session(&session_id);
+            if expected_goal_id != current_goal_id {
+                return Ok(ToolResult {
+                    output: format!(
+                        "goal_update: goal changed during verification (was {:?}, now {:?}) — stale verdict rejected",
+                        expected_goal_id, current_goal_id
+                    ),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+        }
+
         match default_agent_orchestrator().model_transition_goal(
             &session_id,
             &self.profile_id,

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -52,9 +52,11 @@ use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
 #[cfg(feature = "api")]
+#[cfg(feature = "api")]
 use crate::api::agent_orchestrator::{
     default_agent_orchestrator, run_goal_completion_verifier, upsert_background_task_agent,
 };
+#[cfg(feature = "api")]
 use crate::api::goal_loop_runtime::GoalCompletionVerdict;
 #[cfg(feature = "api")]
 use crate::api::master_continuation_scheduler::{
@@ -5108,26 +5110,34 @@ impl SessionActor {
         };
         // Loop-engineering completion gate: only spend the INDEPENDENT
         // verifier LLM call when the agent actually CLAIMS completion.
-        let verdict = if orchestrator.goal_completion_claimed(&assistant_tail) {
+        let (verdict, expected_goal_id) = if orchestrator.goal_completion_claimed(&assistant_tail) {
             let objective = orchestrator
                 .goal_objective_for_test(&self.session_key)
                 .unwrap_or_else(|| "unknown".to_string());
-            run_goal_completion_verifier(
+            // Snapshot goal_id BEFORE the async verifier call to prevent
+            // completing the wrong goal if it changes during the await.
+            let goal_id = orchestrator.goal_id_for_session(&self.session_key);
+            let verdict = run_goal_completion_verifier(
                 self.agent.llm_provider(),
                 &objective,
                 &assistant_tail,
             )
-            .await
+            .await;
+            (verdict, goal_id)
         } else {
-            GoalCompletionVerdict::NotDone {
-                reason: "no completion claimed".to_string(),
-            }
+            (
+                GoalCompletionVerdict::NotDone {
+                    reason: "no completion claimed".to_string(),
+                },
+                None,
+            )
         };
         if orchestrator.maybe_complete_goal_from_model(
             &self.session_key,
             profile_id,
             &assistant_tail,
             &verdict,
+            expected_goal_id.as_deref(),
         ) {
             return;
         }

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -52,7 +52,10 @@ use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
 #[cfg(feature = "api")]
-use crate::api::agent_orchestrator::{default_agent_orchestrator, upsert_background_task_agent};
+use crate::api::agent_orchestrator::{
+    default_agent_orchestrator, run_goal_completion_verifier, upsert_background_task_agent,
+};
+use crate::api::goal_loop_runtime::GoalCompletionVerdict;
 #[cfg(feature = "api")]
 use crate::api::master_continuation_scheduler::{
     MasterContinuationReason, MasterContinuationRuntimeState, QueuedMasterContinuation,
@@ -5103,10 +5106,28 @@ impl SessionActor {
                 .map(|msg| msg.content.clone())
                 .unwrap_or_default()
         };
+        // Loop-engineering completion gate: only spend the INDEPENDENT
+        // verifier LLM call when the agent actually CLAIMS completion.
+        let verdict = if orchestrator.goal_completion_claimed(&assistant_tail) {
+            let objective = orchestrator
+                .goal_objective_for_test(&self.session_key)
+                .unwrap_or_else(|| "unknown".to_string());
+            run_goal_completion_verifier(
+                self.agent.llm_provider(),
+                &objective,
+                &assistant_tail,
+            )
+            .await
+        } else {
+            GoalCompletionVerdict::NotDone {
+                reason: "no completion claimed".to_string(),
+            }
+        };
         if orchestrator.maybe_complete_goal_from_model(
             &self.session_key,
             profile_id,
             &assistant_tail,
+            &verdict,
         ) {
             return;
         }


### PR DESCRIPTION
## Summary

Implements an **INDEPENDENT goal-completion verifier** to prevent the agent from self-grading its own completion claims.

Per loop-engineering best practice (addyosmani.com/blog/loop-engineering): a `/goal` should run "until a verifiable stopping condition is met, with a separate model checking completion rather than the agent self-grading."

## Problem

Previously, `maybe_complete_goal_from_model` flipped goal status to complete the moment the model emitted the `<goal:complete>` sentinel, with **no independent check** — the agent self-graded its own completion.

## Solution

Add an **INDEPENDENT verifier gate**:

1. **GoalCompletionVerdict** enum (`Done` | `NotDone`) in `goal_loop_runtime.rs` — the goal analogue of `octos-agent`'s `VerifierVerdict::ReadyToAnswer`

2. **`run_goal_completion_verifier()`** — a SEPARATE cheap-lane LLM pass (fresh judge prompt, no agent scratchpad; mirrors the `AgentVerifierConfig` pattern) that judges the objective against the agent's evidence and returns `Done`/`NotDone`
   - Fail-safe: any provider/parse error returns `NotDone` (never spuriously completes)

3. **Modified completion flow**: `maybe_complete_goal_from_model` requires BOTH the sentinel AND a `Done` verdict; a `NotDone` verdict keeps the goal `Active` so the scheduler re-queues

4. **Both completion sites** (SessionActor chat path + `run_standalone_turn` AppUI path) run the verifier — only when completion is actually claimed — using the session's provider

## Implementation

- `goal_loop_runtime.rs`: `GoalCompletionVerdict` enum with `is_done()` helper
- `agent_orchestrator.rs`: `run_goal_completion_verifier()` async function + modified `maybe_complete_goal_from_model` to accept verdict parameter
- `ui_protocol.rs`: call verifier when completion claimed, pass verdict to completion check
- `session_actor.rs`: same pattern as ui_protocol.rs

## Testing

✅ **2728/2728 tests pass**

Updated existing `maybe_complete_goal_from_model` tests to pass `GoalCompletionVerdict::Done` where completion should succeed.

## Closes

Closes #1935