### PR TITLE
fix(appui): compact oversized context at session/open, not just pre-turn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,13 @@ jobs:
       - name: gateway_runtime regression (octos-cli)
         run: cargo test -p octos-cli gateway_runtime::tests --features api -- --nocapture
 
+      # Session-open context hydration lives in the `api`-gated ui_protocol
+      # module (same reason as the §6 guard): the open-time snapshot must run
+      # the pre-turn threshold compaction so a rebuilt ledger never publishes
+      # an over-window gauge (`ctx 1.2M/1M` field report, 2026-08-07).
+      - name: Session-open context compaction (octos-cli)
+        run: cargo test -p octos-cli --features api session_open_snapshot -- --nocapture
+
       # Peer staging/fencing lives in the `api`-gated ui_protocol module, so the
       # unfeatured runs above never compile it — same reason as the §6 guard.
       # These cover slug reservation, worktree fencing, and the rollback

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -4155,6 +4155,128 @@ fn appui_context_prompt_policy(llm_provider: &dyn octos_llm::LlmProvider) -> Pro
     }
 }
 
+/// Threshold-gated compaction body shared by the pre-turn prompt path and the
+/// session-open snapshot. Compacts `manager` IN PLACE when its estimate
+/// exceeds the provider-derived threshold and returns the lifecycle
+/// started/completed notifications describing the pass; empty when the
+/// estimate is already under threshold.
+fn appui_compact_context_if_over_threshold(
+    manager: &mut ContextManager,
+    session_id: &SessionKey,
+    llm_provider: &Arc<dyn octos_llm::LlmProvider>,
+    llm_compaction_enabled: bool,
+    trigger: &str,
+) -> Vec<UiNotification> {
+    let threshold = appui_context_compact_threshold_tokens(llm_provider.as_ref());
+    let policy = appui_context_prompt_policy(llm_provider.as_ref());
+    let state = manager.state();
+    if state.token_estimate <= threshold {
+        return Vec::new();
+    }
+    let mut lifecycle_notifications = Vec::new();
+    // UPCR-2026-026: the started event precedes the (synchronous) pass;
+    // clients render the in-progress state from it and must tolerate
+    // started/completed arriving in one delivery batch.
+    lifecycle_notifications.push(UiNotification::ContextCompactionStarted(
+        ContextCompactionStartedEvent {
+            session_id: session_id.clone(),
+            context_state: ui_context_state_for(session_id, manager),
+            trigger: trigger.to_owned(),
+            threshold_tokens: threshold,
+        },
+    ));
+    let before = manager.for_prompt(&policy);
+    let summary_budget = threshold.clamp(256, 4096) as u32;
+    let summary = if llm_compaction_enabled {
+        appui_compaction_summary(llm_provider, &before.messages, summary_budget)
+    } else {
+        octos_agent::compaction::compact_messages(&before.messages, summary_budget)
+    };
+    let record = manager.compact_context(
+        summary,
+        CompactContextPolicy {
+            trigger: trigger.to_owned(),
+            keep_recent_items: appui_context_compact_keep_items(),
+            ..CompactContextPolicy::default()
+        },
+    );
+    info!(
+        session = %session_id.0,
+        compaction_id = %record.compaction_id.as_str(),
+        checkpoint_id = %record.checkpoint_id.as_str(),
+        input_generation = record.input_generation,
+        output_generation = ?record.output_generation,
+        token_estimate_before = record.token_estimate_before,
+        token_estimate_after = ?record.token_estimate_after,
+        trigger,
+        "appui context manager compact_context installed before model prompt"
+    );
+    lifecycle_notifications.push(appui_context_compaction_notification(
+        session_id, manager, &record,
+    ));
+    lifecycle_notifications
+}
+
+/// Session-open flavor of [`appui_context_inspection_snapshot`]: same
+/// load → publish → persist, but first runs the SAME threshold compaction the
+/// pre-turn path would run on the next message. Without this, a session whose
+/// ledger was REBUILT from a long raw history (legacy/stale/invalid snapshot)
+/// publishes an over-window estimate that sits on the client's context gauge
+/// from open until the first turn — field report 2026-08-07: a freshly booted
+/// serve hydrated a 3k-message session to a 1.17M-token ledger and the TUI
+/// read `ctx 1.2M/1M` while idle.
+///
+/// `llm_provider` is the SAME provider the session's turns resolve (peer lane
+/// → profile primary); its `context_window()` derives the threshold. `None`
+/// (no materialized session runtime) fails OPEN — publish as-is — because
+/// compacting against a guessed default window could destructively
+/// over-compact a long-window session's context.
+///
+/// The compaction here is always the DETERMINISTIC summarizer
+/// (`llm_compaction_enabled=false`): `session/open` is an interactive RPC and
+/// must not spend an LLM call per session at boot. Lifecycle
+/// started/completed notifications are intentionally not delivered from this
+/// path — the open result carries (and `publish_appui_context_status`
+/// broadcasts) the post-compaction STATE, which is what drives the gauge; the
+/// progress events only narrate mid-turn passes.
+fn appui_context_open_snapshot(
+    data_dir: &Path,
+    session_id: &SessionKey,
+    history: &[Message],
+    llm_provider: Option<&Arc<dyn octos_llm::LlmProvider>>,
+) -> (Value, UiContextState) {
+    let (mut manager, ledger_status) =
+        load_or_rebuild_context_manager(data_dir, session_id.to_string(), None, history);
+    tracing::debug!(
+        session = %session_id.0,
+        ledger_status = ?ledger_status,
+        "appui context manager loaded for session open"
+    );
+    if let Some(provider) = llm_provider {
+        let _ = appui_compact_context_if_over_threshold(
+            &mut manager,
+            session_id,
+            provider,
+            false,
+            "appui_open",
+        );
+    }
+    publish_appui_context_status(session_id, &manager);
+    if let Err(error) =
+        persist_context_manager_snapshot(data_dir, &session_id.to_string(), &manager)
+    {
+        warn!(
+            session = %session_id.0,
+            error = %error,
+            "failed to persist appui context manager open snapshot"
+        );
+    }
+    (
+        appui_context_status_value(&manager),
+        ui_context_state_for(session_id, &manager),
+    )
+}
+
 fn appui_context_history_for_agent(
     data_dir: &Path,
     session_id: &SessionKey,
@@ -4169,57 +4291,19 @@ fn appui_context_history_for_agent(
 ) {
     let (mut manager, ledger_status) =
         load_or_rebuild_context_manager(data_dir, session_id.to_string(), None, history);
-    let mut lifecycle_notifications = Vec::new();
     tracing::debug!(
         session = %session_id.0,
         ledger_status = ?ledger_status,
         "appui context manager loaded for turn"
     );
-    let threshold = appui_context_compact_threshold_tokens(llm_provider.as_ref());
     let policy = appui_context_prompt_policy(llm_provider.as_ref());
-    let state = manager.state();
-    if state.token_estimate > threshold {
-        // UPCR-2026-026: the started event precedes the (synchronous) pass;
-        // clients render the in-progress state from it and must tolerate
-        // started/completed arriving in one delivery batch.
-        lifecycle_notifications.push(UiNotification::ContextCompactionStarted(
-            ContextCompactionStartedEvent {
-                session_id: session_id.clone(),
-                context_state: ui_context_state_for(session_id, &manager),
-                trigger: trigger.to_owned(),
-                threshold_tokens: threshold,
-            },
-        ));
-        let before = manager.for_prompt(&policy);
-        let summary_budget = threshold.clamp(256, 4096) as u32;
-        let summary = if llm_compaction_enabled {
-            appui_compaction_summary(llm_provider, &before.messages, summary_budget)
-        } else {
-            octos_agent::compaction::compact_messages(&before.messages, summary_budget)
-        };
-        let record = manager.compact_context(
-            summary,
-            CompactContextPolicy {
-                trigger: trigger.to_owned(),
-                keep_recent_items: appui_context_compact_keep_items(),
-                ..CompactContextPolicy::default()
-            },
-        );
-        info!(
-            session = %session_id.0,
-            compaction_id = %record.compaction_id.as_str(),
-            checkpoint_id = %record.checkpoint_id.as_str(),
-            input_generation = record.input_generation,
-            output_generation = ?record.output_generation,
-            token_estimate_before = record.token_estimate_before,
-            token_estimate_after = ?record.token_estimate_after,
-            trigger,
-            "appui context manager compact_context installed before model prompt"
-        );
-        lifecycle_notifications.push(appui_context_compaction_notification(
-            session_id, &manager, &record,
-        ));
-    }
+    let mut lifecycle_notifications = appui_compact_context_if_over_threshold(
+        &mut manager,
+        session_id,
+        llm_provider,
+        llm_compaction_enabled,
+        trigger,
+    );
     publish_appui_context_status(session_id, &manager);
     if let Err(error) =
         persist_context_manager_snapshot(data_dir, &session_id.to_string(), &manager)
@@ -18141,6 +18225,12 @@ async fn open_session_result(
     // UI without being mistaken for an explicit cwd on a later cache lookup.
     let mut effective_workspace_root: Option<PathBuf> = None;
     let mut effective_runtime_hint: Option<PathBuf> = None;
+    // The provider the open-time context snapshot derives its compaction
+    // threshold from — the SAME peer-lane→profile-primary resolution the
+    // session's turns use. Stays `None` when no session runtime
+    // materializes (profile-less open), which makes the snapshot fail open
+    // (publish without compacting) rather than guess a window.
+    let mut open_context_provider: Option<Arc<dyn octos_llm::LlmProvider>> = None;
     if let Some(profile_runtime) =
         resolve_session_profile_runtime(state, active_profile_id.as_deref())
     {
@@ -18175,6 +18265,10 @@ async fn open_session_result(
                 // this session's turns later append) under the per-cwd
                 // storage identity. No-op when the store wasn't relocated.
                 register_session_ledger_scope(ledger, &runtime);
+                open_context_provider = Some(
+                    peer_lane_provider_for(&params.session_id, &runtime)
+                        .unwrap_or_else(|| runtime.profile.llm.clone()),
+                );
                 effective_workspace_root = Some(runtime.workspace_root.clone());
                 effective_runtime_hint = effective_workspace_hint
                     .as_ref()
@@ -18316,8 +18410,12 @@ async fn open_session_result(
         let session = sessions.get_or_create(&params.session_id).await;
         (data_dir, session.messages.clone())
     };
-    let (context, context_state) =
-        appui_context_inspection_snapshot(&data_dir, &params.session_id, &history);
+    let (context, context_state) = appui_context_open_snapshot(
+        &data_dir,
+        &params.session_id,
+        &history,
+        open_context_provider.as_ref(),
+    );
     let (context, context_state) = if features.context_lifecycle_available() {
         (Some(context), Some(context_state))
     } else {

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -258,6 +258,131 @@ async fn compaction_started_precedes_completed_in_lifecycle_batch() {
     assert_eq!(started.trigger, "preflight");
 }
 
+/// Provider stub for the open-snapshot compaction tests. The window must be
+/// LARGE relative to the compaction floor (16 kept items + a ≤4096-token
+/// summary) so a successful pass actually lands under threshold — with a toy
+/// window the keep-floor dominates and the assertion would test nothing. 64K
+/// window → ~45K threshold; 60×4000-char messages ≈ 60K estimate. `chat` is
+/// unreachable because the deterministic summarizer never calls the model.
+struct OpenSnapshotTinyProvider;
+#[async_trait::async_trait]
+impl octos_llm::LlmProvider for OpenSnapshotTinyProvider {
+    async fn chat(
+        &self,
+        _messages: &[octos_core::Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &octos_llm::ChatConfig,
+    ) -> eyre::Result<octos_llm::ChatResponse> {
+        unreachable!("open-snapshot compaction never calls the provider")
+    }
+    fn model_id(&self) -> &str {
+        "tiny"
+    }
+    fn provider_name(&self) -> &str {
+        "tiny"
+    }
+    fn context_window(&self) -> u32 {
+        65_536
+    }
+}
+
+fn open_snapshot_padding_history(messages: usize) -> Vec<octos_core::Message> {
+    (0..messages)
+        .map(|i| octos_core::Message {
+            role: octos_core::MessageRole::User,
+            content: format!("padding message {i}: {}", "x".repeat(4000)),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: None,
+            timestamp: chrono::Utc::now(),
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn session_open_snapshot_compacts_oversized_context() {
+    // Field report 2026-08-07: a session whose ledger is REBUILT from a long
+    // raw history at `session/open` (legacy/stale/missing snapshot) published
+    // and persisted an over-window estimate — the TUI gauge sat at
+    // `ctx 1.2M/1M` from open until the next turn's pre-turn pass finally
+    // compacted. Open must run the SAME threshold compaction the pre-turn
+    // path would run, so the published state is never over the window the
+    // session's own provider reports.
+    let dir = tempfile::tempdir().unwrap();
+    let session: SessionKey = SessionKey("full:api:open-compact".to_string());
+    let history = open_snapshot_padding_history(60);
+    let provider: Arc<dyn octos_llm::LlmProvider> = Arc::new(OpenSnapshotTinyProvider);
+    let threshold = appui_context_compact_threshold_tokens(provider.as_ref());
+
+    let (_value, context_state) =
+        appui_context_open_snapshot(dir.path(), &session, &history, Some(&provider));
+
+    assert!(
+        context_state.token_estimate <= threshold,
+        "open snapshot must compact an over-threshold context before publishing \
+         (estimate {} > threshold {threshold})",
+        context_state.token_estimate,
+    );
+    assert!(
+        context_state.last_compaction_id.is_some(),
+        "the open-time pass must be recorded as a real compaction"
+    );
+
+    // The compacted manager — not the oversized rebuild — must be what
+    // persisted: a reload sees the small estimate and a LOADED ledger.
+    let (reloaded, status) = crate::context_manager::load_or_rebuild_context_manager(
+        dir.path(),
+        session.to_string(),
+        None,
+        &history,
+    );
+    assert_eq!(
+        status,
+        crate::context_manager::ContextLedgerLoadStatus::Loaded,
+        "the persisted open snapshot must cover the history it was built from"
+    );
+    assert!(reloaded.state().token_estimate <= threshold);
+}
+
+#[tokio::test]
+async fn session_open_snapshot_leaves_small_context_untouched() {
+    // Under-threshold sessions must open exactly as before: no compaction
+    // record, estimate untouched.
+    let dir = tempfile::tempdir().unwrap();
+    let session: SessionKey = SessionKey("full:api:open-small".to_string());
+    let history = open_snapshot_padding_history(1);
+    let provider: Arc<dyn octos_llm::LlmProvider> = Arc::new(OpenSnapshotTinyProvider);
+
+    let (_value, context_state) =
+        appui_context_open_snapshot(dir.path(), &session, &history, Some(&provider));
+
+    assert!(
+        context_state.last_compaction_id.is_none(),
+        "an under-threshold open must not compact"
+    );
+}
+
+#[tokio::test]
+async fn session_open_snapshot_without_provider_never_compacts() {
+    // No provider (no materialized session runtime — e.g. a profile-less
+    // open) means no window to derive a threshold from. Compacting against a
+    // guessed default could DESTRUCTIVELY over-compact a long-window session,
+    // so the open snapshot must fail open: publish as-is, like today.
+    let dir = tempfile::tempdir().unwrap();
+    let session: SessionKey = SessionKey("full:api:open-noprov".to_string());
+    let history = open_snapshot_padding_history(60);
+
+    let (_value, context_state) = appui_context_open_snapshot(dir.path(), &session, &history, None);
+
+    assert!(
+        context_state.last_compaction_id.is_none(),
+        "without a provider the open snapshot must not compact"
+    );
+}
+
 #[test]
 fn post_terminal_drain_skips_late_tokens_but_keeps_background_progress() {
     // Regression for the "queued N messages after active turn" wedge: the


### PR DESCRIPTION
## Field report

Booted serve hydrated a 3,170-message session into a rebuilt ledger: 4,145 items, **token_estimate 1,168,156** on a 1M-window model, `compactions: []`, published to the client — the TUI gauge read **`ctx 1.2M/1M ~100%`** on an idle session. The estimate stays there until the next turn, because the threshold compaction only ran on the pre-turn/in-loop paths.

Forensics: `recovery_state: 'rebuilt'`, every item's `recorded_at_ms` == boot time, ledger 7.2MB. The healthy sibling session (loaded snapshot, mid-turn compactions 821k→6.5k / 734k→6.4k) confirms the machinery works when a turn drives it — open just never did.

## Fix

- Extract the threshold-gated compaction body (started event → summary → `compact_context` → completed event) into `appui_compact_context_if_over_threshold`; the pre-turn path now calls it (behavior-identical, guarded by the existing `compaction_started_precedes_completed_in_lifecycle_batch`).
- `session/open` runs the same pass via the new `appui_context_open_snapshot` before publish/persist, with the threshold derived from the **same provider the session's turns resolve** (peer lane → profile primary).
- **Deterministic summarizer only at open** — an interactive RPC must not spend an LLM call per session at boot, even under `--llm-compaction`.
- **No runtime ⇒ fail open**: without a provider there is no window; compacting against a guessed default could destructively over-compact a long-window session. Publish as-is (today's behavior).
- New named CI step `Session-open context compaction` — the tests are `api`-gated, and an api test without a named step never runs in CI.

## Tests

- `session_open_snapshot_compacts_oversized_context` — over-threshold rebuild compacts before publish; persisted ledger reloads as `Loaded` with the small estimate
- `session_open_snapshot_leaves_small_context_untouched`
- `session_open_snapshot_without_provider_never_compacts`
- Suites: `--lib` 1019 ✓, `--lib --features api` 2732 ✓, fmt ✓, clippy(api) ✓

Client-side companion (unclamped >100% gauge label) lands in octoscode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)