### PR TITLE
feat(fleet): add Finding store with append_finding and list_findings

### DIFF
--- a/crates/octos-fleet/src/records.rs
+++ b/crates/octos-fleet/src/records.rs
@@ -9,6 +9,7 @@
 
 use octos_core::SessionKey;
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::grant::WorkerGrant;
 
@@ -402,6 +403,103 @@ pub enum DecisionKind {
     Replan,
     Cancel,
     Note,
+}
+
+// ---------------------------------------------------------------------------
+// Findings
+// ---------------------------------------------------------------------------
+
+/// What a [`Finding`] asserts about its claim.
+///
+/// `RuledOut` is a first-class result, not an absence. A proven dead end and a
+/// failed attempt are different facts — the first is knowledge that stops a
+/// repeat, the second is noise — and [`ChildResultSnapshot`] cannot tell them
+/// apart, because `success: false` is both. That is why a finding is its own
+/// record rather than a field on an attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FindingStatus {
+    /// Demonstrated, with evidence, under the stated `config`.
+    Confirmed,
+    /// Asserted from analysis before confirmation. A legitimate starting
+    /// state, and one a dependency plan cannot express: a predicted wall can
+    /// dissolve without ever being worked.
+    Predicted,
+    /// Demonstrated NOT to hold. The expensive kind, and most of why the
+    /// record is worth keeping.
+    RuledOut,
+}
+
+/// A durable unit of learning: one falsifiable claim, its evidence, and the
+/// build state under which it holds.
+///
+/// Distinct from [`DecisionEntry`], which is a closed set of *kernel-emitted*
+/// lifecycle events. A finding is a claim about the **problem domain**, made
+/// by a worker, and the two must not share a table: "the kernel launched a
+/// child" and "the second `eglCreateWindowSurface` returns `EGL_NO_SURFACE`"
+/// are not the same kind of fact.
+///
+/// Findings are **append-only and never mutated**. Supersession is derived
+/// from the `supersedes` edges of *later* findings (see [`superseded_ids`]),
+/// so history stays reconstructable and no write ever contends with another —
+/// which is what lets this table skip the CAS machinery the child/attempt
+/// tables need.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Finding {
+    pub schema_version: u32,
+    /// `f-{seq}`. Assigned by the store; `supersedes` references it.
+    pub id: String,
+    pub seq: u64,
+    pub fleet_id: String,
+    /// The task whose exploration produced it, when there is one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+
+    /// One falsifiable sentence. The test of a good claim: another worker can
+    /// attempt to disprove it without first asking anyone a question.
+    pub claim: String,
+    pub status: FindingStatus,
+    /// What the claim is *about* — the clustering key. Two paths whose recent
+    /// findings cite one component is a mechanically computable hint that they
+    /// share a root cause. That hint is most of what makes the synthesis
+    /// available to a controller who never reads a transcript.
+    pub component: String,
+
+    /// Reused unchanged from the acceptance path: content-addressed, so a
+    /// claim cannot drift from what was actually observed.
+    #[serde(default)]
+    pub evidence: Vec<EvidenceRef>,
+    /// Component → version under which the claim holds. A finding without
+    /// this is not a weaker finding, it is an untrustworthy one: the next
+    /// reader cannot tell whether it still applies. It is also the
+    /// invalidation rule — when a version moves, findings scoped to the old
+    /// one become STALE, which is a third state distinct from wrong.
+    #[serde(default)]
+    pub config: BTreeMap<String, String>,
+
+    /// Findings this one overturns, by `id`. Validated to exist at append
+    /// time: a dangling overturn edge is how a knowledge base rots into
+    /// contradictions its readers learn to distrust.
+    #[serde(default)]
+    pub supersedes: Vec<String>,
+    /// What it cost to learn. Feeds cost-against-yield per path, which is the
+    /// input to abandoning one.
+    #[serde(default)]
+    pub cost_tokens: u64,
+
+    pub by: String,
+    pub at_ms: u64,
+}
+
+/// Ids overturned by some later finding in `findings`.
+///
+/// Derived rather than stored: marking the old record would be a mutation,
+/// and mutation is the only thing that would force this table to carry the
+/// revision fencing the rest of the kernel needs.
+pub fn superseded_ids(findings: &[Finding]) -> BTreeSet<String> {
+    findings
+        .iter()
+        .flat_map(|f| f.supersedes.iter().cloned())
+        .collect()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/octos-fleet/src/store.rs
+++ b/crates/octos-fleet/src/store.rs
@@ -31,7 +31,7 @@
 //! the decoded record's own ids against the requested ones (defense in
 //! depth).
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -48,6 +48,7 @@ const FLEET_CHILDREN: TableDefinition<&str, &str> = TableDefinition::new("fleet_
 const ATTEMPTS: TableDefinition<&str, &str> = TableDefinition::new("attempts");
 const PLANS: TableDefinition<&str, &str> = TableDefinition::new("plans");
 const DECISION_LOG: TableDefinition<&str, &str> = TableDefinition::new("decision_log");
+const FINDINGS: TableDefinition<&str, &str> = TableDefinition::new("findings");
 const OUTBOX: TableDefinition<&str, &str> = TableDefinition::new("outbox");
 
 const DB_FILENAME: &str = "fleet-kernel.redb";
@@ -205,6 +206,7 @@ impl FleetKernelStore {
                 wtx.open_table(ATTEMPTS)?;
                 wtx.open_table(PLANS)?;
                 wtx.open_table(DECISION_LOG)?;
+                wtx.open_table(FINDINGS)?;
                 wtx.open_table(OUTBOX)?;
             }
             wtx.commit().wrap_err("commit fleet-kernel init")?;
@@ -2470,6 +2472,126 @@ impl FleetKernelStore {
         .await
         .wrap_err("join list_decisions")?
     }
+
+    /// Append a finding to a fleet's durable learning log, assigning the next
+    /// per-fleet sequence. Validates that all `supersedes` edges reference
+    /// existing findings in this fleet.
+    pub async fn append_finding(
+        &self,
+        fleet_id: &str,
+        task_id: Option<&str>,
+        claim: &str,
+        status: FindingStatus,
+        component: &str,
+        evidence: Vec<EvidenceRef>,
+        config: BTreeMap<String, String>,
+        supersedes: Vec<String>,
+        cost_tokens: u64,
+        by: &str,
+        now_ms: u64,
+    ) -> Result<Finding> {
+        ensure_key_safe(&[fleet_id])?;
+        if let Some(t) = task_id {
+            ensure_key_safe(&[t])?;
+        }
+        if claim.trim().is_empty() {
+            bail!("a finding must carry a claim");
+        }
+        if component.trim().is_empty() {
+            // The clustering key is what makes cross-path root-cause hints
+            // computable rather than something a reader has to notice.
+            bail!("a finding must name the component it is about");
+        }
+
+        let db = self.db.clone();
+        let fleet_id = fleet_id.to_string();
+        let task_id = task_id.map(str::to_string);
+        let claim = claim.to_string();
+        let component = component.to_string();
+        let by = by.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<Finding> {
+            let _held = held;
+            let wtx = db.begin_write()?;
+            let stored = {
+                let mut table = wtx.open_table(FINDINGS)?;
+
+                // One pass: highest sequence for this fleet, and the id set the
+                // supersedes edges must resolve against.
+                let mut max = 0u64;
+                let mut known: BTreeSet<String> = BTreeSet::new();
+                for item in table.iter()? {
+                    let (k, v) = item?;
+                    if let Some(s) = fleet_seq(k.value(), &fleet_id) {
+                        max = max.max(s);
+                        if let Some(f) = decode_row::<Finding>(v.value())? {
+                            known.insert(f.id);
+                        }
+                    }
+                }
+                let dangling: Vec<&String> = supersedes
+                    .iter()
+                    .filter(|id| !known.contains(*id))
+                    .collect();
+                if !dangling.is_empty() {
+                    bail!("supersedes references unknown finding(s): {dangling:?}");
+                }
+
+                let next = max
+                    .checked_add(1)
+                    .ok_or_else(|| eyre::eyre!("finding sequence overflow for {fleet_id}"))?;
+                let finding = Finding {
+                    schema_version: SCHEMA_VERSION,
+                    id: format!("f-{next}"),
+                    seq: next,
+                    fleet_id: fleet_id.clone(),
+                    task_id,
+                    claim,
+                    status,
+                    component,
+                    evidence,
+                    config,
+                    supersedes,
+                    cost_tokens,
+                    by,
+                    at_ms: now_ms,
+                };
+                let key = fleet_seq_key(&fleet_id, next);
+                table.insert(key.as_str(), serde_json::to_string(&finding)?.as_str())?;
+                finding
+            };
+            wtx.commit()?;
+            Ok(stored)
+        })
+        .await
+        .wrap_err("join append_finding")?
+    }
+
+    /// List all findings for a fleet, sorted by sequence (oldest first).
+    pub async fn list_findings(&self, fleet_id: &str) -> Result<Vec<Finding>> {
+        ensure_key_safe(&[fleet_id])?;
+        let db = self.db.clone();
+        let fleet_id = fleet_id.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<Vec<Finding>> {
+            let _held = held;
+            let rtx = db.begin_read()?;
+            let table = rtx.open_table(FINDINGS)?;
+            let mut out = Vec::new();
+            for item in table.iter()? {
+                let (k, v) = item?;
+                if fleet_seq(k.value(), &fleet_id).is_some() {
+                    if let Some(f) = decode_row::<Finding>(v.value())? {
+                        out.push(f);
+                    }
+                }
+            }
+            out.sort_by_key(|f| f.seq);
+            Ok(out)
+        })
+        .await
+        .wrap_err("join list_findings")?
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2508,6 +2630,10 @@ fn decision_key(fleet_id: &str, seq: u64) -> String {
     format!("{fleet_id}\0{seq:020}")
 }
 
+fn fleet_seq_key(fleet_id: &str, seq: u64) -> String {
+    format!("{fleet_id}\0{seq:020}")
+}
+
 fn outbox_key(seq: u64) -> String {
     format!("{seq:020}")
 }
@@ -2515,6 +2641,13 @@ fn outbox_key(seq: u64) -> String {
 /// Parse the per-fleet sequence out of a `decision_log` key, if it
 /// belongs to `fleet_id`.
 fn decision_seq(key: &str, fleet_id: &str) -> Option<u64> {
+    let prefix = format!("{fleet_id}\0");
+    key.strip_prefix(&prefix)?.parse::<u64>().ok()
+}
+
+/// Parse the per-fleet sequence out of a `findings` key, if it belongs to
+/// `fleet_id`.
+fn fleet_seq(key: &str, fleet_id: &str) -> Option<u64> {
     let prefix = format!("{fleet_id}\0");
     key.strip_prefix(&prefix)?.parse::<u64>().ok()
 }


### PR DESCRIPTION
## Summary

Implements the **durable Finding ledger** (store layer) that PR #1934's digest reads from.

## What's New

- **FINDINGS redb table** — per-fleet sequences (same pattern as decision_log)
- **append_finding** — validates supersedes edges, assigns next seq, atomic write
- **list_findings** — reads all findings for a fleet, sorted by seq
- **fleet_seq_key/fleet_seq** helpers (mirrors decision_key/decision_seq)
- **Finding/FindingStatus** types in records.rs

## Implementation Details

**append_finding** validates:
- fleet_id and task_id are key-safe
- claim is non-empty
- component is non-empty (required for clustering)
- all supersedes edges reference existing findings in this fleet

**Atomic write:**
- One pass to find max seq + validate supersedes
- Insert with next seq
- Single write transaction

**list_findings:**
- Reads all findings for a fleet
- Sorted by seq (oldest first)
- Returns Vec<Finding>

## Testing

✅ **98/98 tests pass**

## Relationship to Other PRs

- **PR #1934** (digest) — reads from this store
- **feat/fleet-finding-record** (original branch) — this is a reimplementation on latest main

## Next Steps

After this merges, the Finding ledger will be fully functional:
1. Workers append findings via append_finding
2. Controller reads bounded digest via digest() (PR #1934)
3. Goal completion verified by independent verifier (PR #1937)