### PR TITLE
feat(voice): support dedicated external ASR services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8157,7 +8157,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voice"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "base64",
  "reqwest 0.12.28",

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Most agentic systems are single-tenant chat assistants — one user, one model, 
 - **Autonomy — goals & loops**: `/goal <objective>` keeps the agent working across turns via checkpointed continuations (under a token budget); `/loop` runs a task on a fixed interval or self-paced. The agent keeps going between your messages — see [Autonomy: goals & loops](#autonomy-goals--loops).
 - **Session time-travel**: `session/rollback` RPC with resume/rewind checkpoint pickers in both clients; every session can be rolled back to any prior user turn.
 - **Live reasoning**: streams the model's thinking as it happens, with per-session `/thinking` effort control.
-- **Voice**: per-profile cloud TTS voices, rich HTML/image voice output, and an OMiniX runtime provider for local ASR/TTS.
+- **Voice**: per-profile cloud TTS voices, rich HTML/image voice output, dedicated batch-ASR routing via `ASR_API_URL`, and an OMiniX fallback for local ASR/TTS.
 - **Native office suite**: PPTX/DOCX/XLSX via pure Rust (zip + quick-xml).
 - **Sandbox isolation**: bwrap + Landlock/seccomp + sandbox-exec + Docker + Windows AppContainer. `deny(unsafe_code)` workspace-wide. 67 prompt injection tests.
 

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -1508,6 +1508,15 @@ pub struct VoiceLeg {
     pub detail: String,
 }
 
+/// Readiness of the ASR leg, including which route the host resolves to.
+#[derive(Serialize)]
+pub struct VoiceAsrLeg {
+    pub ready: bool,
+    /// Effective route: `"external"` (`ASR_API_URL`) or `"ominix"`.
+    pub mode: String,
+    pub detail: String,
+}
+
 /// Readiness of the TTS leg, including which route the profile resolves to.
 #[derive(Serialize)]
 pub struct VoiceTtsLeg {
@@ -1522,9 +1531,62 @@ pub struct VoiceTtsLeg {
 pub struct VoiceReadiness {
     /// All legs ready → a voice turn can complete end to end.
     pub ready: bool,
-    pub asr: VoiceLeg,
+    pub asr: VoiceAsrLeg,
     pub llm: VoiceLeg,
     pub tts: VoiceTtsLeg,
+}
+
+async fn external_asr_readiness(client: &reqwest::Client, base_url: &str) -> VoiceAsrLeg {
+    let response = client
+        .get(format!("{}/health", base_url.trim_end_matches('/')))
+        .timeout(std::time::Duration::from_secs(3))
+        .send()
+        .await;
+
+    match response {
+        Ok(response) if response.status().is_success() => VoiceAsrLeg {
+            ready: true,
+            mode: "external".into(),
+            detail: "External ASR ready".into(),
+        },
+        Ok(response)
+            if matches!(
+                response.status(),
+                StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
+            ) =>
+        {
+            VoiceAsrLeg {
+                ready: true,
+                mode: "external".into(),
+                detail: "External ASR configured (health endpoint not provided)".into(),
+            }
+        }
+        Ok(response) => VoiceAsrLeg {
+            ready: false,
+            mode: "external".into(),
+            detail: format!(
+                "External ASR health check returned HTTP {}",
+                response.status()
+            ),
+        },
+        Err(error) => VoiceAsrLeg {
+            ready: false,
+            mode: "external".into(),
+            detail: if error.is_timeout() {
+                "External ASR health check timed out".into()
+            } else {
+                "External ASR is unreachable".into()
+            },
+        },
+    }
+}
+
+fn voice_readiness_needs_ominix(
+    asr_route: &crate::skills_scope::AsrRoute,
+    tts_route: crate::api::voice_turn::TtsRoute,
+) -> bool {
+    matches!(asr_route, crate::skills_scope::AsrRoute::Ominix(_))
+        || tts_route == crate::api::voice_turn::TtsRoute::Local
 }
 
 const MAX_SPEECH_SYNTHESIS_CHARS: usize = 4_000;
@@ -1764,8 +1826,8 @@ pub(crate) async fn synthesize_speech(
 /// GET /api/voice/readiness — per-tenant pre-flight for the voice assistant.
 ///
 /// Confirms the whole pipeline can run under THIS profile's current config:
-/// - **ASR**: on-device model ready. Always required — there is no cloud ASR
-///   route (only TTS has a cloud option), so ASR is on-device in every mode.
+/// - **ASR**: `ASR_API_URL` health when explicitly configured; otherwise the
+///   OMiniX ASR model.
 /// - **LLM**: the profile's provider chain is constructed (running runtime with
 ///   a named provider).
 /// - **TTS**: the *chosen* route is actually usable — cloud credentials resolve
@@ -1785,21 +1847,6 @@ pub async fn voice_readiness(
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
     let profile = resolve_my_profile(&identity, ps, &state, &headers)?;
     let profile_id = profile.id.clone();
-
-    // ── ASR leg (always on-device) ──
-    let runtime = crate::api::ominix_runtime::runtime_status(&state.http_client).await;
-    let health_healthy = runtime.health.healthy;
-    let asr_ok = crate::api::ominix_runtime::asr_ready(health_healthy, &runtime.voice_models);
-    let asr = VoiceLeg {
-        ready: asr_ok,
-        detail: if asr_ok {
-            "On-device ASR ready".into()
-        } else if !health_healthy {
-            "Voice engine unavailable".into()
-        } else {
-            "On-device ASR model not ready".into()
-        },
-    };
 
     // ── LLM leg ──
     // The provider chain is built at bootstrap; a running runtime with a named
@@ -1827,7 +1874,42 @@ pub async fn voice_readiness(
         .map(|r| (r.voice.tts_provider.clone(), r.voice.cloud.clone()))
         .unwrap_or_else(|| ("auto".to_string(), None));
     let cloud_configured = crate::api::voice_turn::cloud_tts_configured(cloud.as_ref());
-    let tts = match crate::api::voice_turn::classify_tts_route(&provider, cloud_configured) {
+    let tts_route = crate::api::voice_turn::classify_tts_route(&provider, cloud_configured);
+    let asr_route = crate::skills_scope::discover_asr_route();
+    let ominix_runtime = if voice_readiness_needs_ominix(&asr_route, tts_route) {
+        Some(crate::api::ominix_runtime::runtime_status(&state.http_client).await)
+    } else {
+        None
+    };
+
+    // ── ASR leg (route-aware) ──
+    let asr = match &asr_route {
+        crate::skills_scope::AsrRoute::External(url) => {
+            external_asr_readiness(&state.http_client, url).await
+        }
+        crate::skills_scope::AsrRoute::Ominix(_) => {
+            let runtime = ominix_runtime
+                .as_ref()
+                .expect("OMiniX ASR route requires an OMiniX runtime probe");
+            let health_healthy = runtime.health.healthy;
+            let ready =
+                crate::api::ominix_runtime::asr_ready(health_healthy, &runtime.voice_models);
+            VoiceAsrLeg {
+                ready,
+                mode: "ominix".into(),
+                detail: if ready {
+                    "OMiniX ASR ready".into()
+                } else if !health_healthy {
+                    "OMiniX voice engine unavailable".into()
+                } else {
+                    "OMiniX ASR model not ready".into()
+                },
+            }
+        }
+    };
+
+    // ── TTS leg (route-aware) ──
+    let tts = match tts_route {
         crate::api::voice_turn::TtsRoute::Cloud => VoiceTtsLeg {
             ready: cloud_configured,
             mode: "cloud".into(),
@@ -1838,6 +1920,10 @@ pub async fn voice_readiness(
             },
         },
         crate::api::voice_turn::TtsRoute::Local => {
+            let runtime = ominix_runtime
+                .as_ref()
+                .expect("local TTS route requires an OMiniX runtime probe");
+            let health_healthy = runtime.health.healthy;
             // The on-device leg needs the TTS MODEL itself: a ready ASR plus
             // a present voice with a missing GPT-SoVITS model would report
             // ready here and then fail inside `synthesize_reply`.
@@ -4234,6 +4320,71 @@ pub async fn my_wechat_qr_poll(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn should_require_ominix_only_for_local_voice_legs() {
+        use crate::api::voice_turn::TtsRoute;
+        use crate::skills_scope::AsrRoute;
+
+        let external = AsrRoute::External("http://127.0.0.1:8093".to_string());
+        let ominix = AsrRoute::Ominix(Some("http://127.0.0.1:8081".to_string()));
+
+        assert!(!voice_readiness_needs_ominix(&external, TtsRoute::Cloud));
+        assert!(voice_readiness_needs_ominix(&external, TtsRoute::Local));
+        assert!(voice_readiness_needs_ominix(&ominix, TtsRoute::Cloud));
+        assert!(voice_readiness_needs_ominix(&ominix, TtsRoute::Local));
+    }
+
+    async fn external_asr_health_server(status: &str) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let status = status.to_string();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let read = socket.read(&mut request).await.unwrap();
+            assert!(
+                String::from_utf8_lossy(&request[..read]).starts_with("GET /health "),
+                "readiness must probe the external ASR health path"
+            );
+            let response =
+                format!("HTTP/1.1 {status}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+        format!("http://{address}")
+    }
+
+    #[tokio::test]
+    async fn should_accept_external_asr_when_health_check_succeeds() {
+        let url = external_asr_health_server("200 OK").await;
+        let leg = external_asr_readiness(&reqwest::Client::new(), &url).await;
+
+        assert!(leg.ready);
+        assert_eq!(leg.mode, "external");
+        assert_eq!(leg.detail, "External ASR ready");
+    }
+
+    #[tokio::test]
+    async fn should_accept_external_asr_when_health_endpoint_is_not_implemented() {
+        let url = external_asr_health_server("404 Not Found").await;
+        let leg = external_asr_readiness(&reqwest::Client::new(), &url).await;
+
+        assert!(leg.ready);
+        assert_eq!(leg.mode, "external");
+        assert!(leg.detail.contains("health endpoint not provided"));
+    }
+
+    #[tokio::test]
+    async fn should_reject_external_asr_when_health_endpoint_reports_unavailable() {
+        let url = external_asr_health_server("503 Service Unavailable").await;
+        let leg = external_asr_readiness(&reqwest::Client::new(), &url).await;
+
+        assert!(!leg.ready);
+        assert_eq!(leg.mode, "external");
+        assert!(leg.detail.contains("HTTP 503"));
+    }
 
     #[test]
     fn speech_synthesis_rejects_blank_and_oversized_text() {

--- a/crates/octos-cli/src/api/ominix_runtime.rs
+++ b/crates/octos-cli/src/api/ominix_runtime.rs
@@ -297,12 +297,11 @@ pub(crate) async fn runtime_status(client: &reqwest::Client) -> OminixRuntimeSta
     runtime_status_with_config(&config, client).await
 }
 
-/// Whether the on-device ASR model is ready in the probed runtime.
+/// Whether the OMiniX ASR model is ready in the probed runtime.
 ///
-/// ASR is always on-device (there is no cloud ASR route — only TTS has a cloud
-/// option), so the voice pipeline requires this regardless of the chosen TTS
-/// mode. Pure over the probed inputs so it can be unit-tested without a live
-/// runtime.
+/// This is the local fallback check when no dedicated `ASR_API_URL` is
+/// configured. Pure over the probed inputs so it can be unit-tested without a
+/// live runtime.
 pub(crate) fn asr_ready(health_healthy: bool, voice_models: &[OminixVoiceModelStatus]) -> bool {
     health_healthy
         && voice_models

--- a/crates/octos-cli/src/api/voice_turn.rs
+++ b/crates/octos-cli/src/api/voice_turn.rs
@@ -11,10 +11,15 @@ use octos_llm::ominix::OminixClient;
 
 use crate::config::CloudTtsConfig;
 
-/// 解析 OminiX 服务基址（平台级，env 优先）。与 `api/admin.rs` 的同名 helper 等价；
-/// 抽到此处避免跨模块可见性问题。
+/// 解析批量 ASR 服务基址。`ASR_API_URL` 指向独立 ASR 时优先；未设置时回退到
+/// OminiX，保留既有部署行为。
 // TODO(later-tasks): remove dead_code allow once callers are wired up.
 #[allow(dead_code)]
+fn asr_base_url() -> String {
+    crate::skills_scope::discover_asr_url().unwrap_or_else(|| "http://127.0.0.1:8081".to_string())
+}
+
+/// TTS remains on OminiX even when ASR is redirected to a separate service.
 fn ominix_base_url() -> String {
     crate::skills_scope::discover_ominix_url()
         .unwrap_or_else(|| "http://127.0.0.1:8081".to_string())
@@ -39,7 +44,7 @@ pub(crate) async fn transcribe_audio_media(
     media: &[String],
     language: Option<&str>,
 ) -> Vec<String> {
-    transcribe_audio_media_with_base_url(media, language, &ominix_base_url()).await
+    transcribe_audio_media_with_base_url(media, language, &asr_base_url()).await
 }
 
 async fn transcribe_audio_media_with_base_url(
@@ -1504,7 +1509,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_send_reloaded_profile_asr_language_to_ominix_request() {
+    async fn should_send_reloaded_profile_asr_language_to_asr_request() {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1523,6 +1528,7 @@ mod tests {
                 }
             };
             let headers = String::from_utf8_lossy(&request[..body_start]);
+            let request_line = headers.lines().next().unwrap().to_string();
             let content_length = headers
                 .lines()
                 .find_map(|line| {
@@ -1541,7 +1547,7 @@ mod tests {
             }
             let body: serde_json::Value =
                 serde_json::from_slice(&request[body_start..body_start + content_length]).unwrap();
-            request_tx.send(body).unwrap();
+            request_tx.send((request_line, body)).unwrap();
             let response_body = r#"{"text":"bonjour"}"#;
             let response = format!(
                 "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
@@ -1587,7 +1593,8 @@ mod tests {
         .await;
 
         assert_eq!(transcripts, vec!["bonjour"]);
-        let request = request_rx.await.unwrap();
+        let (request_line, request) = request_rx.await.unwrap();
+        assert_eq!(request_line, "POST /v1/audio/transcriptions HTTP/1.1");
         assert_eq!(request["language"], "French");
     }
 

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -132,7 +132,7 @@ async fn next_gateway_loop_event(
 
 // `discover_ominix_url` and `push_runtime_plugin_env` live in
 // `crate::skills_scope` so the `serve` plugin loader can reuse them.
-use crate::skills_scope::{discover_ominix_url, push_runtime_plugin_env};
+use crate::skills_scope::{discover_asr_url, discover_ominix_url, push_runtime_plugin_env};
 
 async fn apply_profile_runtime_contracts(
     profile: &UserProfile,
@@ -594,8 +594,9 @@ impl GatewayRuntime {
             .join("voice")
             .join("main");
         let ominix_url = discover_ominix_url();
+        let asr_url = discover_asr_url();
         let asr_binary =
-            if let Some(url) = ominix_url.as_deref().filter(|_| voice_binary_path.exists()) {
+            if let Some(url) = asr_url.as_deref().filter(|_| voice_binary_path.exists()) {
                 println!("{}: voice platform skill ({})", "Transcriber".green(), url);
                 println!("{}: {} ({})", "Voice".green(), "enabled".green(), url);
                 Some(voice_binary_path)
@@ -1951,6 +1952,14 @@ impl GatewayRuntime {
                 &self.channel_mgr,
             )
             .await;
+            if media_result.rejected_audio_only {
+                info!(
+                    channel = %inbound.channel,
+                    chat_id = %inbound.chat_id,
+                    "ASR rejected audio-only inbound message; skipping agent dispatch"
+                );
+                continue;
+            }
             let image_media = media_result.image_media;
             let attachment_media = media_result.attachment_media;
             let attachment_prompt = media_result.attachment_prompt;

--- a/crates/octos-cli/src/commands/gateway/message_preprocessing.rs
+++ b/crates/octos-cli/src/commands/gateway/message_preprocessing.rs
@@ -26,6 +26,9 @@ pub struct MediaResult {
     /// Whether any audio attachment was detected (for auto-TTS downstream).
     #[allow(dead_code)]
     pub is_voice_message: bool,
+    /// All audio inputs returned a successful empty transcript, with no typed
+    /// prompt or non-audio attachment to process. This is a normal ASR reject.
+    pub rejected_audio_only: bool,
 }
 
 /// Transcribe audio, separate images, and tag voice metadata on an inbound message.
@@ -44,11 +47,14 @@ pub async fn process_media(
     let mut audio_filenames = Vec::new();
     let mut attachment_filenames = Vec::new();
     let mut attachment_notes = Vec::new();
+    let mut saw_audio = false;
+    let mut all_audio_transcripts_rejected = asr_binary.is_some();
 
     if let Some(asr_bin) = asr_binary {
         for path in &inbound.media {
             let resolved_path = resolve_media_reference(path);
             if octos_bus::media::is_audio(path) {
+                saw_audio = true;
                 is_voice_message = true;
                 attachment_media.push(resolved_path.clone());
                 audio_filenames.push(attachment_display_name(path));
@@ -61,7 +67,11 @@ pub async fn process_media(
                     input["language"] = serde_json::Value::String(lang.to_string());
                 }
                 match transcribe_via_skill(asr_bin, &input.to_string()).await {
+                    Ok(text) if text.trim().is_empty() => {
+                        tracing::info!(audio = %resolved_path, "ASR rejected audio without speech");
+                    }
                     Ok(text) => {
+                        all_audio_transcripts_rejected = false;
                         if let Some(obj) = inbound.metadata.as_object_mut() {
                             obj.insert(
                                 "voice_transcript".into(),
@@ -70,7 +80,10 @@ pub async fn process_media(
                         }
                         inbound.content = merge_transcript_into_content(&inbound.content, &text);
                     }
-                    Err(e) => warn!("transcription failed: {e}"),
+                    Err(e) => {
+                        all_audio_transcripts_rejected = false;
+                        warn!("transcription failed: {e}");
+                    }
                 }
             } else {
                 route_non_audio_attachment(
@@ -126,6 +139,12 @@ pub async fn process_media(
         }
     }
 
+    let rejected_audio_only = should_skip_rejected_audio_only_turn(
+        saw_audio && all_audio_transcripts_rejected,
+        &inbound.content,
+        !image_media.is_empty() || !attachment_filenames.is_empty(),
+    );
+
     MediaResult {
         image_media,
         attachment_media,
@@ -135,7 +154,18 @@ pub async fn process_media(
             Some(attachment_prompt)
         },
         is_voice_message,
+        rejected_audio_only,
     }
+}
+
+/// A successful empty ASR result is only terminal when this message contains
+/// no other user input. Mixed text/audio and attachment turns must proceed.
+fn should_skip_rejected_audio_only_turn(
+    all_audio_rejected: bool,
+    content: &str,
+    has_non_audio_media: bool,
+) -> bool {
+    all_audio_rejected && content.trim().is_empty() && !has_non_audio_media
 }
 
 async fn route_non_audio_attachment(
@@ -671,5 +701,17 @@ mod tests {
             merge_transcript_into_content("", "hello world"),
             "hello world"
         );
+    }
+
+    #[test]
+    fn should_skip_agent_when_audio_only_turn_is_rejected() {
+        assert!(should_skip_rejected_audio_only_turn(true, "", false));
+        assert!(!should_skip_rejected_audio_only_turn(false, "", false));
+        assert!(!should_skip_rejected_audio_only_turn(
+            true,
+            "typed prompt",
+            false
+        ));
+        assert!(!should_skip_rejected_audio_only_turn(true, "", true));
     }
 }

--- a/crates/octos-cli/src/skills_scope.rs
+++ b/crates/octos-cli/src/skills_scope.rs
@@ -144,6 +144,46 @@ pub(crate) fn discover_ominix_url() -> Option<String> {
         })
 }
 
+/// Resolve the ASR endpoint independently from OminiX. `ASR_API_URL` is an
+/// explicit Octos/OMiniX JSON batch-transcription override at
+/// `/v1/audio/transcriptions`; without it, ASR continues to use OminiX for
+/// backward compatibility.
+pub(crate) fn discover_asr_url() -> Option<String> {
+    discover_asr_route().into_url()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AsrRoute {
+    External(String),
+    Ominix(Option<String>),
+}
+
+impl AsrRoute {
+    fn into_url(self) -> Option<String> {
+        match self {
+            Self::External(url) => Some(url),
+            Self::Ominix(url) => url,
+        }
+    }
+}
+
+pub(crate) fn discover_asr_route() -> AsrRoute {
+    resolve_asr_route(std::env::var("ASR_API_URL").ok(), discover_ominix_url)
+}
+
+fn resolve_asr_route<F>(explicit: Option<String>, discover_ominix: F) -> AsrRoute
+where
+    F: FnOnce() -> Option<String>,
+{
+    let explicit = explicit
+        .map(|s| s.trim().trim_end_matches('/').to_string())
+        .filter(|s| !s.is_empty());
+    match explicit {
+        Some(url) => AsrRoute::External(url),
+        None => AsrRoute::Ominix(discover_ominix()),
+    }
+}
+
 /// Append the standard per-profile runtime env vars onto a plugin-env
 /// vector. Mirrors the gateway path's call site at
 /// `gateway_runtime.rs:435` so the `serve` plugin loader can spawn
@@ -342,6 +382,61 @@ mod tests {
 
         let dirs = build_account_plugin_dirs(&data_dir);
         assert_eq!(dirs, vec![skills_dir]);
+    }
+
+    #[test]
+    fn should_prefer_explicit_asr_url_over_ominix_fallback() {
+        assert_eq!(
+            resolve_asr_route(Some(" http://127.0.0.1:8093/ ".to_string()), || Some(
+                "http://127.0.0.1:8081".to_string()
+            ),)
+            .into_url()
+            .as_deref(),
+            Some("http://127.0.0.1:8093")
+        );
+    }
+
+    #[test]
+    fn should_fall_back_to_ominix_when_asr_url_is_blank_or_missing() {
+        let fallback = Some("http://127.0.0.1:8081".to_string());
+        assert_eq!(
+            resolve_asr_route(Some("  ".to_string()), || fallback.clone()).into_url(),
+            fallback
+        );
+        assert_eq!(
+            resolve_asr_route(None, || fallback.clone()).into_url(),
+            fallback
+        );
+    }
+
+    #[test]
+    fn should_classify_explicit_asr_url_as_external_route() {
+        assert_eq!(
+            resolve_asr_route(Some(" http://127.0.0.1:8093/ ".to_string()), || Some(
+                "http://127.0.0.1:8081".to_string()
+            ),),
+            AsrRoute::External("http://127.0.0.1:8093".to_string())
+        );
+    }
+
+    #[test]
+    fn should_not_discover_ominix_when_dedicated_asr_url_is_set() {
+        let route = resolve_asr_route(Some("http://127.0.0.1:8093".to_string()), || {
+            panic!("OMiniX discovery must be lazy when ASR_API_URL is set")
+        });
+
+        assert_eq!(
+            route,
+            AsrRoute::External("http://127.0.0.1:8093".to_string())
+        );
+    }
+
+    #[test]
+    fn should_classify_missing_asr_url_as_ominix_route() {
+        assert_eq!(
+            resolve_asr_route(None, || Some("http://127.0.0.1:8081".to_string())),
+            AsrRoute::Ominix(Some("http://127.0.0.1:8081".to_string()))
+        );
     }
 
     #[test]

--- a/crates/octos-llm/src/ominix.rs
+++ b/crates/octos-llm/src/ominix.rs
@@ -354,10 +354,10 @@ impl VoicesRegistry {
 }
 
 // ---------------------------------------------------------------------------
-// OminixClient — async HTTP client for ominix-api
+// OminixClient — async HTTP client for OMiniX and compatible ASR services
 // ---------------------------------------------------------------------------
 
-/// Async client for ominix-api ASR/TTS endpoints.
+/// Async client for OMiniX TTS endpoints and the shared JSON ASR contract.
 pub struct OminixClient {
     client: Client,
     base_url: String,
@@ -457,12 +457,12 @@ impl OminixClient {
             .timeout(std::time::Duration::from_secs(120))
             .send()
             .await
-            .wrap_err("failed to call ominix-api transcription")?;
+            .wrap_err("failed to call ASR transcription service")?;
 
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            eyre::bail!("ominix-api transcription failed: {status} - {body}");
+            eyre::bail!("ASR service transcription failed: {status} - {body}");
         }
 
         let json: serde_json::Value = resp
@@ -475,7 +475,7 @@ impl OminixClient {
             .and_then(|v| v.as_str())
             .ok_or_else(|| eyre::eyre!("no text field in transcription response"))?;
 
-        debug!(chars = text.len(), "audio transcribed via ominix-api");
+        debug!(chars = text.len(), "audio transcribed via ASR service");
         Ok(text.to_string())
     }
 
@@ -557,7 +557,7 @@ impl OminixClient {
 
 #[cfg(test)]
 mod tests {
-    use super::tts_endpoint;
+    use super::{OminixClient, tts_endpoint};
 
     #[test]
     fn sovits_is_the_default_endpoint() {
@@ -572,6 +572,40 @@ mod tests {
     #[test]
     fn unknown_engine_falls_back_to_sovits() {
         assert_eq!(tts_endpoint("nonsense"), "/v1/audio/tts/sovits");
+    }
+
+    #[tokio::test]
+    async fn should_name_generic_asr_service_when_transcription_fails() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 4096];
+            let _ = socket.read(&mut request).await.unwrap();
+            socket
+                .write_all(
+                    b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 4\r\nConnection: close\r\n\r\ndown",
+                )
+                .await
+                .unwrap();
+        });
+
+        let dir = tempfile::tempdir().unwrap();
+        let audio = dir.path().join("utterance.wav");
+        std::fs::write(&audio, b"RIFF-test-audio").unwrap();
+        let error = OminixClient::new(&format!("http://{address}"))
+            .transcribe(&audio)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            error.contains("ASR service transcription failed"),
+            "{error}"
+        );
+        assert!(!error.contains("ominix-api"), "{error}");
     }
 }
 

--- a/crates/platform-skills/voice/Cargo.toml
+++ b/crates/platform-skills/voice/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "voice"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
-description = "Voice skill binary (ASR/TTS/model management) using ominix-api on Apple Silicon"
+description = "Voice skill binary with external ASR routing and OMiniX TTS/model management"
 authors = ["octos"]
 
 [[bin]]

--- a/crates/platform-skills/voice/SKILL.md
+++ b/crates/platform-skills/voice/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: voice
-description: OminiX ASR (speech-to-text), preset-voice TTS with emotion/speed control, and model management via Qwen3 models on Apple Silicon. For voice cloning and custom voice profiles, use mofa-fm. Triggers: voice, transcribe audio, text to speech, speak this, read aloud, model management, download model, 语音识别, 语音合成, 模型管理.
-version: 1.1.2
+description: Batch ASR (via dedicated ASR_API_URL or OminiX fallback), preset-voice TTS with emotion/speed control, and model management via Qwen3 models on Apple Silicon. For voice cloning and custom voice profiles, use mofa-fm. Triggers: voice, transcribe audio, text to speech, speak this, read aloud, model management, download model, 语音识别, 语音合成, 模型管理.
+version: 1.2.0
 author: octos
 always: true
 ---
 
-# OminiX ASR / TTS / Model Management
+# Batch ASR / OminiX TTS / Model Management
 
-On-device speech-to-text and preset-voice text-to-speech with emotion control
-plus model lifecycle management, backed by Qwen3 ASR/TTS models running on the
-local ominix-api server (Apple Silicon).
+Speech-to-text uses `ASR_API_URL` when configured (the Octos/OMiniX JSON +
+base64 batch-transcription contract at `POST /v1/audio/transcriptions`, such as
+the local Whisper or Nemotron adapter); otherwise it falls back to Qwen3 ASR
+through local OminiX. Preset-voice text-to-speech with emotion control and model
+lifecycle management remain backed by local OminiX (Apple Silicon).
+
+An empty ASR result is a successful no-speech rejection, not an error.
 
 ## Boundary — when NOT to use this skill
 

--- a/crates/platform-skills/voice/manifest.json
+++ b/crates/platform-skills/voice/manifest.json
@@ -1,14 +1,14 @@
 {
   "name": "voice",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "author": "octos",
-  "description": "OminiX voice skill: ASR, preset-voice TTS with emotion/speed control, and model management via local Qwen3 models on Apple Silicon. For voice cloning and custom voice profiles, use mofa-fm instead.",
+  "description": "Batch ASR via ASR_API_URL or OminiX fallback, preset-voice TTS with emotion/speed control, and OminiX model management on Apple Silicon. For voice cloning and custom voice profiles, use mofa-fm instead.",
   "timeout_secs": 600,
   "requires_network": true,
   "tools": [
     {
       "name": "voice_transcribe",
-      "description": "Transcribe an audio file to text using Qwen3-ASR (POST /v1/audio/asr/qwen3). Supports WAV, OGG, MP3, FLAC, M4A. Use this when you receive a voice message or need to extract text from audio. Returns the transcribed text.",
+      "description": "Transcribe an audio file to text. By default uses Qwen3-ASR through OminiX; when ASR_API_URL is set, sends the Octos/OMiniX JSON + base64 contract to POST /v1/audio/transcriptions (for example a local Whisper or Nemotron adapter). Supports WAV, OGG, MP3, FLAC, M4A. Empty text is a successful no-speech rejection.",
       "input_schema": {
         "type": "object",
         "properties": {

--- a/crates/platform-skills/voice/src/main.rs
+++ b/crates/platform-skills/voice/src/main.rs
@@ -1,8 +1,10 @@
-//! Voice platform skill binary (ASR, preset-voice TTS, model management) via ominix-api.
+//! Voice platform skill binary (ASR, preset-voice TTS, model management).
 //!
 //! Protocol: `./main <tool_name>` with JSON on stdin, JSON on stdout.
-//! Auto-discovers ominix-api via OMINIX_API_URL, ~/.ominix/api_url, or by
-//! probing common default ports (9090, 8080, 8081).
+//! ASR may use an independent Octos/OMiniX-compatible JSON endpoint via
+//! ASR_API_URL.
+//! TTS and model management use OminiX via OMINIX_API_URL, ~/.ominix/api_url,
+//! or the default ports (9090, 8080, 8081).
 //!
 //! NOTE: Voice cloning and custom voice profiles are handled by mofa-fm.
 //! This skill only supports preset voices for TTS.
@@ -61,6 +63,22 @@ const DEFAULT_CANDIDATE_URLS: &[&str] = &[
     "http://localhost:8081",
 ];
 
+const QWEN3_ASR_PATH: &str = "/v1/audio/asr/qwen3";
+const STANDARD_TRANSCRIPTION_PATH: &str = "/v1/audio/transcriptions";
+
+/// ASR route and base URL. `ASR_API_URL` selects the standard transcription
+/// path with Octos' JSON + base64 request contract; omitting it preserves the
+/// existing Qwen3 route.
+#[derive(Debug, PartialEq, Eq)]
+struct AsrEndpoint {
+    base_url: String,
+    path: &'static str,
+    /// OMiniX keeps its existing preflight health check. A dedicated ASR is
+    /// validated by the transcription request itself because
+    /// `/health` is not part of the external-ASR contract.
+    requires_health_check: bool,
+}
+
 /// Normalize a base URL: trim trailing slash, reject empty.
 fn normalize_base_url(url: &str) -> Option<String> {
     let trimmed = url.trim().trim_end_matches('/');
@@ -76,6 +94,35 @@ fn env_base_url() -> Option<String> {
     std::env::var("OMINIX_API_URL")
         .ok()
         .and_then(|v| normalize_base_url(&v))
+}
+
+/// Read the optional dedicated ASR endpoint. It intentionally has no
+/// discovery-file fallback: the file identifies OminiX, whereas this URL may
+/// point to a separate batch ASR service such as local Whisper.
+fn env_asr_base_url() -> Option<String> {
+    std::env::var("ASR_API_URL")
+        .ok()
+        .and_then(|v| normalize_base_url(&v))
+}
+
+fn resolve_asr_endpoint<F>(asr_url: Option<String>, discover_ominix_url: F) -> Option<AsrEndpoint>
+where
+    F: FnOnce() -> Option<String>,
+{
+    if let Some(base_url) = asr_url.and_then(|url| normalize_base_url(&url)) {
+        return Some(AsrEndpoint {
+            base_url,
+            path: STANDARD_TRANSCRIPTION_PATH,
+            requires_health_check: false,
+        });
+    }
+    discover_ominix_url()
+        .and_then(|url| normalize_base_url(&url))
+        .map(|base_url| AsrEndpoint {
+            base_url,
+            path: QWEN3_ASR_PATH,
+            requires_health_check: true,
+        })
 }
 
 /// Read discovery file `~/.ominix/api_url`, normalized.
@@ -145,6 +192,12 @@ fn discover_api_base_url() -> Option<String> {
         DEFAULT_CANDIDATE_URLS,
         |url| probe_candidate(&client, url),
     )
+}
+
+/// Resolve ASR independently from OminiX. A dedicated service has priority;
+/// retaining the OminiX fallback leaves existing Qwen3 deployments unchanged.
+fn discover_asr_endpoint() -> Option<AsrEndpoint> {
+    resolve_asr_endpoint(env_asr_base_url(), discover_api_base_url)
 }
 
 /// Resolve the API base URL for tools that *require* ominix-api (list_models,
@@ -352,17 +405,19 @@ fn handle_transcribe(input_json: &str) {
         }
     }
 
-    let base_url = match discover_api_base_url() {
-        Some(url) => url,
+    let endpoint = match discover_asr_endpoint() {
+        Some(endpoint) => endpoint,
         None => fail(
-            "ominix-api not reachable at OMINIX_API_URL, ~/.ominix/api_url, or default \
-             ports (9090/8080/8081). Start it with: ominix-api --port 8080",
+            "ASR service not configured. Set ASR_API_URL for an Octos-compatible \
+             JSON transcription endpoint, or start ominix-api and configure OMINIX_API_URL.",
         ),
     };
     let client = http_client();
-    eprintln!("Checking ominix-api health at {base_url}...");
-    if let Err(e) = check_health(&client, &base_url) {
-        fail(&e);
+    if endpoint.requires_health_check {
+        eprintln!("Checking OminiX health at {}...", endpoint.base_url);
+        if let Err(e) = check_health(&client, &endpoint.base_url) {
+            fail(&e);
+        }
     }
 
     let language = input.language.unwrap_or_else(|| "Chinese".to_string());
@@ -385,9 +440,10 @@ fn handle_transcribe(input_json: &str) {
         "response_format": "verbose_json"
     });
 
-    // Use model-specific ASR endpoint (Qwen3-ASR)
+    // A dedicated ASR service uses the standard transcription path with the
+    // Octos JSON contract; otherwise retain OminiX's model-specific Qwen3 path.
     let resp = match client
-        .post(format!("{base_url}/v1/audio/asr/qwen3"))
+        .post(format!("{}{}", endpoint.base_url, endpoint.path))
         .json(&body)
         .send()
     {
@@ -412,7 +468,10 @@ fn handle_transcribe(input_json: &str) {
 
     let text = result["text"].as_str().unwrap_or("").trim();
     if text.is_empty() {
-        fail("ASR returned empty transcription (silence or unsupported format)");
+        // Empty text is a successful ASR rejection (for example Whisper's
+        // no-speech decision), not an invocation failure. Gateway and serve
+        // paths use the successful empty result to end an audio-only turn.
+        succeed("");
     }
 
     let mut output = text.to_string();
@@ -816,6 +875,28 @@ mod tests {
         );
         assert_eq!(normalize_base_url("").as_deref(), None);
         assert_eq!(normalize_base_url("   ").as_deref(), None);
+    }
+
+    #[test]
+    fn should_skip_ominix_discovery_when_dedicated_asr_url_is_set() {
+        let endpoint = resolve_asr_endpoint(Some(" http://127.0.0.1:8091/ ".to_string()), || {
+            panic!("OminiX discovery must be lazy when ASR_API_URL is set")
+        })
+        .expect("dedicated ASR URL resolves");
+
+        assert_eq!(endpoint.base_url, "http://127.0.0.1:8091");
+        assert_eq!(endpoint.path, "/v1/audio/transcriptions");
+        assert!(!endpoint.requires_health_check);
+    }
+
+    #[test]
+    fn should_keep_qwen_endpoint_when_dedicated_asr_url_is_unset() {
+        let endpoint = resolve_asr_endpoint(None, || Some("http://127.0.0.1:8090".to_string()))
+            .expect("OminiX fallback resolves");
+
+        assert_eq!(endpoint.base_url, "http://127.0.0.1:8090");
+        assert_eq!(endpoint.path, "/v1/audio/asr/qwen3");
+        assert!(endpoint.requires_health_check);
     }
 
     // ── validate_synthesized_audio ────────────────────────────────────

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -335,7 +335,8 @@ Sub-agent multi-model routing. Routes different sub-agent tasks to different pro
 
 ### OminixClient (`ominix.rs`)
 
-Client for local ASR/TTS via Ominix runtime.
+Client for OminiX TTS and the shared JSON batch-ASR contract. Voice input uses
+`ASR_API_URL` when configured and otherwise falls back to OminiX.
 
 ### Token Estimation
 
@@ -611,7 +612,7 @@ Triggered when estimated tokens exceed 80% of context window / 1.2 safety margin
 | `smart-home` | `smart_home` | List/control smart-home devices via profile bridge |
 | `skill-evolve` | `skill-evolve` | Patch-management for skill SKILL.md drift |
 
-`PLATFORM_SKILLS` adds one more entry — `voice` — bootstrapped once by `octos serve` at admin-bot startup, shared across all gateway profiles, only installed when its OminiX-API backend is reachable. Voice cloning is **not** part of the platform voice skill — it is handled by the separate `mofa-fm` skill (`fm_tts`).
+`PLATFORM_SKILLS` adds one more entry — `voice` — bootstrapped once by `octos serve` at admin-bot startup and shared across all gateway profiles. Its ASR leg uses `ASR_API_URL` when configured or OminiX otherwise; TTS and model-management operations remain on OminiX. Voice cloning is **not** part of the platform voice skill — it is handled by the separate `mofa-fm` skill (`fm_tts`).
 
 The other workspace `app-skills/*` crates (`harness-starter-{audio,coding,generic,report}`, `wechat-bridge`) are **not** in `BUNDLED_APP_SKILLS`. They build as part of `cargo build --workspace` but are not auto-installed by the gateway; harness-starters are templates new skill authors copy, and `wechat-bridge` is a WebSocket transport helper rather than a tool-providing skill.
 
@@ -1573,8 +1574,9 @@ crates/
 │                    Workspace-only (not bundled):
 │                      harness-starter-{audio, coding, generic, report},
 │                      wechat-bridge)
-└── platform-skills/voice/   (preset-voice TTS + ASR via OminiX-API.
-                              Cloning lives in mofa-fm / fm_tts, not here.)
+└── platform-skills/voice/   (batch ASR via ASR_API_URL or OminiX fallback;
+                              preset-voice TTS via OminiX. Cloning lives in
+                              mofa-fm / fm_tts, not here.)
 ```
 
 ---

--- a/docs/user-guide-zh.md
+++ b/docs/user-guide-zh.md
@@ -1531,13 +1531,17 @@ export LARK_FROM_ADDRESS="your-feishu-email@company.com"
 
 ## 13. 平台技能 (ASR/TTS)
 
-平台技能是服务器级别的技能，需要在 Apple Silicon 上运行 OminiX 后端。它们提供设备端语音转录和合成 — 无需云端 API。
+平台技能是服务器级别的语音工具。语音转录可通过 `ASR_API_URL` 使用独立的批量
+ASR 服务；未配置时保持原有 OminiX 回退。预设音色合成和模型管理仍由 Apple
+Silicon 上的 OminiX 提供。
 
 ### 13.1 前提条件
 
-- Apple Silicon Mac（M1/M2/M3/M4）
-- OminiX API 服务器运行中（通过 `octos serve` 管理）
-- 已下载模型：`Qwen3-ASR-1.7B-8bit`、`Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit`
+- 使用 OminiX ASR 或本地 TTS 时需要 Apple Silicon Mac
+- ASR：配置了 `ASR_API_URL` 的兼容服务，或者运行 OminiX API 并下载
+  `Qwen3-ASR-1.7B-8bit`
+- 本地 TTS：运行 OminiX API 并下载
+  `Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit`
 
 ### 13.2 通过仪表盘管理 OminiX
 
@@ -1568,6 +1572,19 @@ curl http://localhost:50080/api/admin/platform-skills/ominix-api/logs?lines=100
 ### 13.3 语音转录 (`voice_transcribe`)
 
 将音频文件转录为文本。
+
+在启动 `octos serve` 或 `octos gateway` 前，把 `ASR_API_URL` 设置为服务基址，
+即可让 AppUI 语音轮、Gateway 语音消息和 `voice_transcribe` 工具统一走独立 ASR：
+
+```bash
+ASR_API_URL=http://127.0.0.1:8091 octos serve --port 50080
+```
+
+服务必须接受 `POST /v1/audio/transcriptions`，JSON 请求字段为 `file`（base64
+音频）、可选的 `language` 和 `response_format`，并返回包含字符串 `text` 的
+JSON。成功但为空的 `text` 会被视为“未检测到人声”，不会发送给智能体。
+Octos 会通过 `GET /health` 检查 readiness；没有该路由的服务可返回 `404` 或
+`405`。如果 `ASR_API_URL` 未设置或为空，Octos 会继续使用 OminiX ASR。
 
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
@@ -2099,6 +2116,7 @@ chmod +x .octos/skills/translator/main
 | `LARK_APP_SECRET` | 飞书邮件应用密钥 |
 | `LARK_FROM_ADDRESS` | 飞书邮件发件人地址 |
 | **语音** | |
+| `ASR_API_URL` | 独立批量 ASR 服务基址；设置后转录不再走 OMiniX |
 | `OMINIX_API_URL` | OminiX ASR/TTS API 地址 |
 | **系统** | |
 | `RUST_LOG` | 日志级别（error/warn/info/debug/trace） |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1610,13 +1610,18 @@ These are intended as templates — the `SKILL.md` for each says "Replace with a
 
 ## 13. Platform Skills (ASR/TTS)
 
-Platform skills are server-level skills that require the OminiX backend running on Apple Silicon. They provide on-device voice transcription and synthesis — no cloud APIs needed.
+Platform skills are server-level voice tools. Transcription can use a dedicated
+batch-ASR service through `ASR_API_URL`, with OMiniX as the backward-compatible
+fallback. Preset-voice synthesis and model management continue to use OMiniX on
+Apple Silicon.
 
 ### 13.1 Prerequisites
 
-- Apple Silicon Mac (M1/M2/M3/M4)
-- OminiX API server running (managed via `octos serve`)
-- Models downloaded: `Qwen3-ASR-1.7B-8bit`, `Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit`
+- Apple Silicon Mac when using OMiniX-backed ASR or local TTS
+- For ASR, either a compatible service configured with `ASR_API_URL`, or an
+  OMiniX API server with `Qwen3-ASR-1.7B-8bit`
+- For local TTS, an OMiniX API server with
+  `Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit`
 
 ### 13.2 Managing OminiX via Dashboard
 
@@ -1647,6 +1652,21 @@ curl http://localhost:50080/api/admin/platform-skills/ominix-api/logs?lines=100
 ### 13.3 Voice Transcription (`voice_transcribe`)
 
 Transcribes audio files to text.
+
+Set `ASR_API_URL` to the service base URL before starting `octos serve` or
+`octos gateway` to route AppUI voice turns, gateway voice messages, and the
+`voice_transcribe` tool to a dedicated ASR service:
+
+```bash
+ASR_API_URL=http://127.0.0.1:8091 octos serve --port 50080
+```
+
+The service must accept `POST /v1/audio/transcriptions` with JSON fields
+`file` (base64 audio), optional `language`, and `response_format`. It must
+return JSON containing a string `text` field. A successful empty `text` is
+treated as a no-speech rejection. Octos probes `GET /health` for readiness;
+services without that route may return `404` or `405`. If `ASR_API_URL` is
+unset or blank, Octos uses the existing OMiniX ASR route.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -2186,6 +2206,7 @@ Bot: [uses translate tool with text="Hello world", target_lang="JA"]
 | `LARK_APP_SECRET` | Feishu mail app secret |
 | `LARK_FROM_ADDRESS` | Feishu mail from address |
 | **Voice** | |
+| `ASR_API_URL` | Dedicated batch-ASR service base URL; overrides OMiniX for transcription |
 | `OMINIX_API_URL` | OminiX ASR/TTS API URL |
 | **System** | |
 | `RUST_LOG` | Log level (error/warn/info/debug/trace) |


### PR DESCRIPTION
## What

- Add `ASR_API_URL` as a dedicated batch-ASR route for AppUI voice turns, gateway voice messages, and the bundled `voice_transcribe` tool.
- Keep the existing OMiniX ASR path as the backward-compatible fallback; OMiniX remains responsible for local TTS and model management.
- Make `/api/voice/readiness` probe the effective ASR route and avoid requiring OMiniX when external ASR plus cloud TTS can complete the pipeline.
- Treat a successful empty transcript as no speech, and skip agent dispatch only for an otherwise empty audio-only gateway turn.
- Document the external contract and report ASR failures with provider-neutral errors.

## Why

Voice transcription was coupled to OMiniX discovery and readiness even when an independent Whisper or Nemotron service was available. That made the UI report voice as unavailable and prevented gateway transcription unless the OMiniX runtime was also present.

The external service contract is `POST /v1/audio/transcriptions` with JSON/base64 audio (`file`, optional `language`, and `response_format`) and a JSON response containing `text`. Readiness probes `GET /health`; `404` and `405` mean the optional health route is not implemented.

## Review fixes

- Added route/path contract coverage and external readiness coverage.
- Made OMiniX fallback discovery lazy when `ASR_API_URL` is set.
- Reworded shared-client transcription diagnostics so external ASR failures are not mislabeled as OMiniX failures.
- Updated README, architecture, English guide, and Chinese guide to match the implementation.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p voice --all-targets -- -D warnings`
- `cargo clippy -p octos-llm --all-targets -- -D warnings`
- `cargo clippy -p octos-cli --features api --all-targets -- -D warnings`
- `cargo test -p octos-cli --features api --lib` — 2742 passed, 6 ignored
- `cargo test -p voice` — 14 passed
- `cargo test --workspace -- --skip tools::ssrf::tests::test_with_addrs_fails_closed_on_nonexistent_domain --skip tools::web_fetch::tests::test_ssrf_dns_failure_blocks_request`

The unfiltered workspace run reaches two DNS-failure assertion mismatches because this machine resolves the intentionally nonexistent test hostname to a private address. Both failures reproduce unchanged on `origin/main`; the workspace run excluding those two environment-dependent baseline cases passes.
