### PR TITLE
chore(release): v2.0.3-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4531,7 +4531,7 @@ dependencies = [
 
 [[package]]
 name = "octos-agent"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -4591,7 +4591,7 @@ dependencies = [
 
 [[package]]
 name = "octos-bus"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "aes",
  "async-imap",
@@ -4633,7 +4633,7 @@ dependencies = [
 
 [[package]]
 name = "octos-cli"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "agent-client-protocol",
  "argon2",
@@ -4714,7 +4714,7 @@ dependencies = [
 
 [[package]]
 name = "octos-core"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "chrono",
  "eyre",
@@ -4729,7 +4729,7 @@ dependencies = [
 
 [[package]]
 name = "octos-diagnostics"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4741,14 +4741,14 @@ dependencies = [
 
 [[package]]
 name = "octos-dora-mcp"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "octos-agent",
 ]
 
 [[package]]
 name = "octos-embed-llama"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4762,7 +4762,7 @@ dependencies = [
 
 [[package]]
 name = "octos-ffi"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "libc",
  "octos-agent",
@@ -4778,7 +4778,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet-worker"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "octos-llm"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -4835,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "octos-memory"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "bincode",
  "chrono",
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pipeline"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "octos-plugin"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "eyre",
  "metrics",
@@ -4895,7 +4895,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pyo3"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "octos-ffi",
  "pyo3",
@@ -4916,7 +4916,7 @@ dependencies = [
 
 [[package]]
 name = "octos-server"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -4953,7 +4953,7 @@ dependencies = [
 
 [[package]]
 name = "octos-services"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -4974,7 +4974,7 @@ dependencies = [
 
 [[package]]
 name = "octos-store"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "base64",
  "chrono",
@@ -4994,7 +4994,7 @@ dependencies = [
 
 [[package]]
 name = "octos-swarm"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "octos-uniffi"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "octos-ffi",
  "uniffi",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "octos-wasm"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -5038,7 +5038,7 @@ dependencies = [
 
 [[package]]
 name = "octos-workflows"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "chrono",
  "eyre",
@@ -8472,7 +8472,7 @@ dependencies = [
 
 [[package]]
 name = "wechat-bridge"
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 dependencies = [
  "clap",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.3-rc.1"
+version = "2.0.3-rc.2"
 edition = "2024"
 rust-version = "1.85.0"
 authors = ["octos team"]


### PR DESCRIPTION
Version bump to cut **v2.0.3-rc.2** from main (`97fef110a`), which carries the #1959 goal-event `generation` field merged in #1956. Unblocks octos-org/octoscode#521 (the airtight client-honor), whose release-pin gate requires a released backend that speaks the new protocol. After merge: tag `v2.0.3-rc.2` → `release.yml` publishes.