### PR TITLE
fix(goal): resolve peer escalations in the ledger on peer_respond (#1961)

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -3735,6 +3735,37 @@ impl InProcessAgentOrchestrator {
         Ok(escalation_id)
     }
 
+    /// #1961 — the resolution half of [`Self::model_goal_record_peer_escalation`].
+    /// When `peer_respond` answers a peer's parked question/approval, mark the
+    /// peer's OPEN escalation resolved in the goal ledger. Best-effort: returns
+    /// the number of rows updated, and a missing ledger / no-open-escalation is
+    /// a benign `Ok(0)` (a goal-less peer never recorded one). The ledger is
+    /// opened, not created — if the goal never recorded an escalation there is
+    /// nothing to resolve.
+    pub(crate) fn model_goal_resolve_peer_escalation(
+        &self,
+        profile_data_dir: &std::path::Path,
+        goal_id: &str,
+        peer_slug: &str,
+        resolution: &str,
+        resolved_by: &str,
+    ) -> Result<usize, String> {
+        let ledger_path = Self::goal_ledger_dir(profile_data_dir)
+            .join(format!("{}.db", sanitize_filename_for_ledger(goal_id)));
+        if !ledger_path.exists() {
+            return Ok(0);
+        }
+        let ledger = octos_fleet::GoalLedger::open(&ledger_path)
+            .map_err(|e| format!("failed to open goal ledger {}: {e}", ledger_path.display()))?;
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+        ledger
+            .resolve_escalation(peer_slug, resolution, resolved_by, now_ms)
+            .map_err(|e| format!("failed to resolve peer escalation: {e}"))
+    }
+
     /// Directory holding this profile's per-goal ledgers. Resolved under the
     /// profile's persistent `data_dir` so ledgers (a) survive restarts and
     /// `/tmp` cleanup, (b) are profile-isolated (a peer on profile A cannot

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -14868,6 +14868,9 @@ fn peer_respond_resolve(
         }
     };
 
+    // #1961 — the human-readable resolution to stamp on the goal-ledger
+    // escalation once the answer/decision is delivered below.
+    let escalation_resolution: String;
     match target.kind {
         PeerPendingKind::Approval => {
             let Some(decision) = req.decision.as_deref() else {
@@ -14877,6 +14880,7 @@ fn peer_respond_resolve(
                     id = target.id
                 ));
             };
+            escalation_resolution = format!("[approval] {decision}");
             let approval_id: ApprovalId =
                 serde_json::from_value(serde_json::Value::String(target.id.clone()))
                     .map_err(|_| format!("peer '{slug}' pending id is malformed"))?;
@@ -14914,6 +14918,18 @@ fn peer_respond_resolve(
                     id = target.id
                 ));
             };
+            escalation_resolution = format!(
+                "[answer] {}",
+                req_answers
+                    .iter()
+                    .map(|a| if a.selected_labels.is_empty() {
+                        a.free_text.clone().unwrap_or_default()
+                    } else {
+                        a.selected_labels.join("/")
+                    })
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            );
             let question_id: octos_core::ui_protocol::QuestionId =
                 serde_json::from_value(serde_json::Value::String(target.id.clone()))
                     .map_err(|_| format!("peer '{slug}' pending id is malformed"))?;
@@ -14941,6 +14957,32 @@ fn peer_respond_resolve(
                 .map_err(|err| {
                     format!("could not resolve peer '{slug}' question: {}", err.message)
                 })?;
+        }
+    }
+    // #1961 — the answer/decision was delivered above; mark this peer's OPEN
+    // escalation resolved in the goal ledger so its durable escalation history
+    // stops showing it as open. Best-effort: a goal-less peer, a missing
+    // ledger, or no open escalation is a benign no-op, and a ledger write
+    // failure must NOT fail the resume the caller already committed to.
+    if let Some(peer_dir) = staged_peer_dir(peers_root, &slug) {
+        let goal_id = peer_io::read_peer_file(&peer_dir, "goal", peer_io::PEER_FILE_READ_CAP_SMALL)
+            .and_then(|body| body.lines().next().map(|l| l.trim().to_owned()))
+            .filter(|s| !s.is_empty());
+        if let (Some(goal_id), Some(data_dir)) = (goal_id, peers_root.parent()) {
+            if let Err(err) = default_agent_orchestrator().model_goal_resolve_peer_escalation(
+                data_dir,
+                &goal_id,
+                &slug,
+                &escalation_resolution,
+                origin_session,
+            ) {
+                tracing::warn!(
+                    slug = %slug,
+                    goal_id = %goal_id,
+                    error = %err,
+                    "peer-goal: failed to resolve escalation in goal ledger (answer already delivered)"
+                );
+            }
         }
     }
     Ok(())

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -486,6 +486,30 @@ impl GoalLedger {
         Ok(rowid)
     }
 
+    /// #1961 — mark this peer's OPEN escalation resolved. `append_escalation`
+    /// only ever wrote the `open` row; without this the ledger's escalation
+    /// history showed every answered escalation as perpetually open. A peer
+    /// parks one prompt at a time (depth-1), so matching `peer_id` + the
+    /// `open` status resolves exactly the escalation just answered. Returns the
+    /// number of rows updated (0 when there was no open escalation — e.g. an
+    /// approval on a goal-less peer, or a double-resolve).
+    pub fn resolve_escalation(
+        &self,
+        peer_id: &str,
+        resolution: &str,
+        resolved_by: &str,
+        resolved_at_ms: i64,
+    ) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE escalations
+             SET status = 'resolved', resolution = ?1, resolved_by = ?2, resolved_at_ms = ?3
+             WHERE peer_id = ?4 AND status = 'open'",
+            params![resolution, resolved_by, resolved_at_ms, peer_id],
+        )?;
+        Ok(updated)
+    }
+
     /// Append a decision to the ledger.
     pub fn append_decision(&self, decision: &Decision) -> Result<i64> {
         let mut conn = self.conn.lock().unwrap();
@@ -1348,5 +1372,64 @@ mod digest_integration_tests {
                 lifecycle, expected_status
             );
         }
+    }
+
+    // #1961 — an answered escalation must become `resolved` in the ledger.
+    #[test]
+    fn resolve_escalation_marks_the_open_row_resolved() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ledger.db");
+        let ledger = GoalLedger::open(&path).unwrap();
+        let goal = Goal {
+            goal_id: "g1".to_string(),
+            objective: "test".to_string(),
+            status: "active".to_string(),
+            tokens_used: 0,
+            token_budget: 10000,
+            continuations_used: 0,
+            revision: 0,
+            created_at_ms: 1000,
+            updated_at_ms: 1000,
+        };
+        ledger.create_goal(&goal).unwrap();
+        let esc = Escalation {
+            escalation_id: "esc-picker-1".to_string(),
+            goal_id: "g1".to_string(),
+            task_id: None,
+            peer_id: "picker".to_string(),
+            question: "7 or 8?".to_string(),
+            context: None,
+            status: "open".to_string(),
+            default_action: None,
+            default_after_secs: None,
+            created_at_ms: 1000,
+            resolved_at_ms: None,
+            resolved_by: None,
+            resolution: None,
+        };
+        ledger.append_escalation(&esc).unwrap();
+
+        let updated = ledger
+            .resolve_escalation("picker", "[answer] 7", "master-session", 2000)
+            .unwrap();
+        assert_eq!(updated, 1, "the one open escalation must be resolved");
+
+        // A second resolve is a no-op (no open rows left) — idempotent.
+        let again = ledger
+            .resolve_escalation("picker", "[answer] 7", "master-session", 2001)
+            .unwrap();
+        assert_eq!(again, 0, "double-resolve must not update anything");
+
+        let conn = ledger.conn.lock().unwrap();
+        let (status, resolution, resolved_by): (String, Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT status, resolution, resolved_by FROM escalations WHERE escalation_id = 'esc-picker-1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "resolved");
+        assert_eq!(resolution.as_deref(), Some("[answer] 7"));
+        assert_eq!(resolved_by.as_deref(), Some("master-session"));
     }
 }


### PR DESCRIPTION
Found by soaking the shipped peer-goal loop (post-#1956).

## Bug (#1961)
The goal ledger's `escalations` were **write-once**: `append_escalation` wrote the `open` row when a peer parked, but nothing ever marked it resolved. A peer whose parked question was answered via `peer_respond` — after which it resumed, wrote its file, and the goal **completed** — still showed `status=open`, `resolution=NULL`, `resolved_by=NULL` forever in the durable escalation history. `grep 'UPDATE escalations'` returned nothing: there was no resolve path at all.

## Fix
- `GoalLedger::resolve_escalation(peer_id, resolution, resolved_by, resolved_at_ms)` — `UPDATE escalations SET status='resolved', … WHERE peer_id=? AND status='open'`. A peer parks one prompt at a time (depth-1), so `(peer_id, open)` targets exactly the escalation just answered. Returns the row count (0 = benign no-op: goal-less peer / double-resolve).
- `model_goal_resolve_peer_escalation` opens the goal ledger (not creates) and calls it.
- `peer_respond_resolve` calls it after the answer/decision is delivered, reading the peer's goal binding. Best-effort: a missing ledger / no open row / write failure never fails the resume.

## Validation
- Unit test `resolve_escalation_marks_the_open_row_resolved` (append → resolve → assert `resolved` + resolution + resolver; double-resolve is a 0-row no-op).
- **Live soak:** peer parks on a question → `peer_respond blue` → ledger row transitions `open → resolved`, `resolution=[answer] blue`, `resolved_by=dev:local:tui#coding` (was `open` forever before).

## Also from the same soak (not in this PR)
- #1962 (budget not enforced for interactive) — **re-verified and closed as a misdiagnosis**: `active_goal_id` filters `active`, so post-`budget_limited` peers auto-bind goal-less and don't charge the frozen goal (verified tokens_used froze).
- #1957 extended: the ledger persists no token data (`goals.tokens_used=0`, `findings.cost_tokens=0`) — a broader ledger-completeness change, tracked there.