### PR TITLE
fix(goal): sync real goal state + decisions into the durable ledger (#1957)

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -3126,6 +3126,13 @@ impl InProcessAgentOrchestrator {
         assistant_content: &str,
         verdict: &GoalCompletionVerdict,
         expected_goal_id: Option<&str>,
+        // #1957 (codex #1) — profile data dir. The sentinel-driven completion
+        // path used to flip `status = "complete"` in memory only, leaving the
+        // durable ledger showing the goal still `active`. When `Some`, sync the
+        // completion into the ledger (guarded upsert + a decision row) using the
+        // snapshot we just flipped — same treatment as the `goal_update` tool
+        // path in `model_transition_goal`. `None` skips the sync (tests).
+        ledger_data_dir: Option<&std::path::Path>,
     ) -> bool {
         if !detect_goal_complete_sentinel(assistant_content) {
             return false;
@@ -3169,6 +3176,20 @@ impl InProcessAgentOrchestrator {
         goal.updated_at_ms = now_ms();
         let snapshot = goal.clone();
         persist_goal_state(&state, session_id, &snapshot, false);
+        // Drop the state lock before any ledger file I/O.
+        drop(state);
+        // #1957 (codex #1) — sync the sentinel completion into the durable
+        // ledger. `status_changed` is always true here: we returned early above
+        // if the goal was already `complete`, so this is a genuine transition.
+        if let Some(data_dir) = ledger_data_dir {
+            self.sync_transition_to_ledger(
+                data_dir,
+                &snapshot,
+                "goal completion sentinel confirmed by verifier",
+                session_id,
+                true,
+            );
+        }
         true
     }
 
@@ -3450,6 +3471,12 @@ impl InProcessAgentOrchestrator {
         profile_id: &str,
         status: &str,
         reason: &str,
+        // #1957 — profile data dir. When `Some`, this transition is synced into
+        // the goal ledger (goals-row status + a decision) using the in-hand
+        // snapshot below — NO re-resolution of the scope, so it cannot attach a
+        // decision to a different folder's goal (codex #3). `None` for callers
+        // that have no data dir (fleet/tests); those just skip the sync.
+        ledger_data_dir: Option<&std::path::Path>,
     ) -> Result<Value, String> {
         if !matches!(status, "complete" | "blocked") {
             return Err(format!(
@@ -3458,20 +3485,26 @@ impl InProcessAgentOrchestrator {
         }
         // #1666 residue — the `goal_update` tool addresses THIS folder's goal.
         let key = self.scoped_goal_key(session_id);
-        let mut state = self.state();
-        let Some(goal) = state.goals.get_mut(&key) else {
-            return Err("no goal is set for this session".to_owned());
+        // Do the mutation + persist under the lock, then DROP it before any
+        // ledger file I/O below.
+        let (snapshot, status_changed) = {
+            let mut state = self.state();
+            let Some(goal) = state.goals.get_mut(&key) else {
+                return Err("no goal is set for this session".to_owned());
+            };
+            if goal.profile_id != profile_id {
+                return Err("goal is outside this profile's scope".to_owned());
+            }
+            if goal.status == "complete" {
+                return Err("goal is already complete".to_owned());
+            }
+            let status_changed = goal.status != status;
+            goal.status = status.to_owned();
+            goal.updated_at_ms = now_ms();
+            let snapshot = goal.clone();
+            persist_goal_state(&state, &key, &snapshot, false);
+            (snapshot, status_changed)
         };
-        if goal.profile_id != profile_id {
-            return Err("goal is outside this profile's scope".to_owned());
-        }
-        if goal.status == "complete" {
-            return Err("goal is already complete".to_owned());
-        }
-        goal.status = status.to_owned();
-        goal.updated_at_ms = now_ms();
-        let snapshot = goal.clone();
-        persist_goal_state(&state, &key, &snapshot, false);
         tracing::info!(
             session = %session_id,
             goal_id = %snapshot.goal_id,
@@ -3479,71 +3512,78 @@ impl InProcessAgentOrchestrator {
             reason = %reason,
             "model transitioned goal via goal_update tool"
         );
+        // #1957 — sync the transition into the durable ledger using the snapshot
+        // we JUST transitioned (no re-fetch → codex #3). Best-effort. The
+        // guarded `upsert_goal` makes this newer state win over a stale
+        // finding-path upsert (codex #2), and a decision is appended only on a
+        // real status change (codex #5 — `blocked → blocked` retries add none).
+        if let Some(data_dir) = ledger_data_dir {
+            self.sync_transition_to_ledger(data_dir, &snapshot, reason, session_id, status_changed);
+        }
         Ok(autonomy_goal_json(&snapshot))
     }
 
-    /// #1957 — sync a goal transition into the durable ledger: upsert the goal
-    /// row with its now-current status/tokens AND append a `decisions` row
-    /// recording the transition. Without this the ledger goals-row showed the
-    /// status as of the last peer finding (usually `active`, since completing a
-    /// goal records no finding) and the `decisions` table was never written at
-    /// all. Best-effort — a ledger failure never affects the in-memory
-    /// transition the caller already committed. Opens (creates) the ledger,
-    /// since a transition can be the FIRST ledger write for a finding-less goal.
-    pub(crate) fn model_goal_record_transition_to_ledger(
+    /// #1957 — sync a JUST-transitioned goal snapshot into the durable ledger:
+    /// upsert the goals-row (guarded, so a stale finding upsert can't undo it)
+    /// AND — only when the status actually changed — append a `decisions` row.
+    /// Takes the caller's IN-HAND snapshot, never a re-fetch, so it always
+    /// targets the goal the transition mutated even if another folder re-bound
+    /// the same wire session concurrently (codex #3). Best-effort: a ledger
+    /// failure never affects the in-memory transition. Opens (creates) the
+    /// ledger, since a transition can be the FIRST ledger write for a
+    /// finding-less goal.
+    fn sync_transition_to_ledger(
         &self,
         profile_data_dir: &std::path::Path,
-        session_id: &SessionKey,
-        profile_id: &str,
-        status: &str,
+        snapshot: &AutonomyGoalRecord,
         reason: &str,
+        decided_by: &SessionKey,
+        status_changed: bool,
     ) {
-        let key = self.scoped_goal_key(session_id);
-        let goal_row = {
-            let state = self.state();
-            match state.goals.get(&key) {
-                Some(goal) if goal.profile_id == profile_id => octos_fleet::Goal {
-                    goal_id: goal.goal_id.clone(),
-                    objective: goal.objective.clone(),
-                    status: goal.status.clone(),
-                    tokens_used: goal.tokens_used,
-                    token_budget: goal.token_budget,
-                    continuations_used: goal.continuations_used,
-                    revision: 0,
-                    created_at_ms: goal.created_at_ms.max(0) as u64,
-                    updated_at_ms: goal.updated_at_ms.max(0) as u64,
-                },
-                _ => return,
-            }
-        };
         let ledger_dir = Self::goal_ledger_dir(profile_data_dir);
         if std::fs::create_dir_all(&ledger_dir).is_err() {
             return;
         }
         let ledger_path = ledger_dir.join(format!(
             "{}.db",
-            sanitize_filename_for_ledger(&goal_row.goal_id)
+            sanitize_filename_for_ledger(&snapshot.goal_id)
         ));
         let Ok(ledger) = octos_fleet::GoalLedger::open(&ledger_path) else {
             return;
         };
-        let _ = ledger.upsert_goal(&goal_row);
+        let _ = ledger.upsert_goal(&octos_fleet::Goal {
+            goal_id: snapshot.goal_id.clone(),
+            objective: snapshot.objective.clone(),
+            status: snapshot.status.clone(),
+            tokens_used: snapshot.tokens_used,
+            token_budget: snapshot.token_budget,
+            continuations_used: snapshot.continuations_used,
+            revision: 0,
+            created_at_ms: snapshot.created_at_ms.max(0) as u64,
+            updated_at_ms: snapshot.updated_at_ms.max(0) as u64,
+        });
+        // codex #5 — no decision row for a no-op (e.g. `blocked → blocked`
+        // retry after a lost response), so the audit trail can't fill with
+        // indistinguishable duplicates.
+        if !status_changed {
+            return;
+        }
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0);
         let decision = octos_fleet::Decision {
-            decision_id: format!("dec-{}-{}", goal_row.goal_id, uuid::Uuid::now_v7()),
-            goal_id: goal_row.goal_id.clone(),
+            decision_id: format!("dec-{}-{}", snapshot.goal_id, uuid::Uuid::now_v7()),
+            goal_id: snapshot.goal_id.clone(),
             task_id: None,
-            question: format!("transition goal to `{status}`"),
+            question: format!("transition goal to `{}`", snapshot.status),
             options_considered: None,
-            choice: status.to_owned(),
+            choice: snapshot.status.clone(),
             rationale: reason.chars().take(1000).collect(),
             based_on_findings: None,
             based_on_rev: 0,
             decided_at_ms: now_ms,
-            decided_by: session_id.to_string(),
+            decided_by: decided_by.to_string(),
         };
         let _ = ledger.append_decision(&decision);
     }
@@ -4451,6 +4491,9 @@ impl InProcessAgentOrchestrator {
                 // the goal even if a later read would fail. (The `goal_get` snapshot
                 // stays as a backstop for the non-deny paths.)
                 if fleet_un_completable {
+                    // Fleet-completion path: no profile data dir in scope, so the
+                    // ledger sync is skipped here (`None`). The interactive
+                    // goal_update path carries the data dir and syncs (#1957).
                     let _ = self.model_transition_goal(
                         session_id,
                         profile_id,
@@ -4459,6 +4502,7 @@ impl InProcessAgentOrchestrator {
                             "fleet cannot complete — task `{task_id}` was denied and will not \
                              re-run without a replan",
                         ),
+                        None,
                     );
                 }
                 Ok(json!({
@@ -4507,11 +4551,14 @@ impl InProcessAgentOrchestrator {
     ) -> bool {
         let un_completable = !complete && !failed_tasks.is_empty();
         if complete {
+            // Fleet-completion path: no data dir in scope → ledger sync skipped
+            // (`None`). Interactive goal_update carries the data dir (#1957).
             let _ = self.model_transition_goal(
                 session_id,
                 profile_id,
                 "complete",
                 "all fleet tasks accepted",
+                None,
             );
         } else if un_completable {
             let _ = self.model_transition_goal(
@@ -4523,6 +4570,7 @@ impl InProcessAgentOrchestrator {
                      replan: {}",
                     failed_tasks.join(", ")
                 ),
+                None,
             );
         }
         un_completable
@@ -14134,7 +14182,7 @@ mod tests {
 
         // Once COMPLETE, the model may replace it with a fresh active goal.
         orchestrator
-            .model_transition_goal(&session_id, "tenant-a", "complete", "done")
+            .model_transition_goal(&session_id, "tenant-a", "complete", "done", None)
             .expect("complete the goal");
         let replaced = orchestrator
             .model_create_goal(&session_id, "tenant-a", "next objective", None)
@@ -14178,7 +14226,7 @@ mod tests {
         for status in ["paused", "active", "budget_limited", "cleared"] {
             assert!(
                 orchestrator
-                    .model_transition_goal(&session_id, "tenant-a", status, "nope")
+                    .model_transition_goal(&session_id, "tenant-a", status, "nope", None)
                     .is_err(),
                 "{status} must not be a model-allowed transition"
             );
@@ -14186,13 +14234,13 @@ mod tests {
         // Wrong profile is rejected.
         assert!(
             orchestrator
-                .model_transition_goal(&session_id, "tenant-b", "complete", "scope")
+                .model_transition_goal(&session_id, "tenant-b", "complete", "scope", None)
                 .is_err()
         );
 
         // complete works and returns the goal snapshot.
         let goal = orchestrator
-            .model_transition_goal(&session_id, "tenant-a", "complete", "haiku written")
+            .model_transition_goal(&session_id, "tenant-a", "complete", "haiku written", None)
             .expect("model completes");
         assert_eq!(goal["status"], json!("complete"));
         assert_eq!(
@@ -14202,7 +14250,7 @@ mod tests {
         // Double-complete refused.
         assert!(
             orchestrator
-                .model_transition_goal(&session_id, "tenant-a", "complete", "again")
+                .model_transition_goal(&session_id, "tenant-a", "complete", "again", None)
                 .is_err()
         );
 
@@ -14216,6 +14264,57 @@ mod tests {
             Some("complete"),
             "budget flip must not clobber a model-set terminal status"
         );
+    }
+
+    /// #1957 — a model `goal_update` completion must land in the DURABLE goal
+    /// ledger, not just the in-memory record. Before this fix a goal that
+    /// completed without ever recording a peer finding left the ledger's goals
+    /// row stuck at `active`; `model_transition_goal` now syncs the transition
+    /// straight from the snapshot it just flipped (no re-fetch → codex #3).
+    #[test]
+    fn model_transition_goal_syncs_final_status_into_the_ledger() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-ledger-sync");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "prove the ledger reflects completion".into(),
+                status: Some("active".into()),
+                token_budget: Some(1_000),
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let goal_id = orchestrator
+            .goal_id_for_session(&session_id)
+            .expect("goal_id");
+
+        // Complete via the model path WITH the profile data dir → must sync.
+        // Note: no peer finding was ever recorded for this goal, so the ledger
+        // row is created for the FIRST time by the transition sync itself.
+        orchestrator
+            .model_transition_goal(
+                &session_id,
+                "tenant-a",
+                "complete",
+                "objective met",
+                Some(data_dir.path()),
+            )
+            .expect("model completes");
+
+        let ledger_path = InProcessAgentOrchestrator::goal_ledger_dir(data_dir.path())
+            .join(format!("{}.db", sanitize_filename_for_ledger(&goal_id)));
+        let ledger = octos_fleet::GoalLedger::open(&ledger_path).expect("open ledger");
+        let row = ledger
+            .get_goal(&goal_id)
+            .expect("query ledger")
+            .expect("goal row present in ledger");
+        assert_eq!(
+            row.status, "complete",
+            "the durable ledger must reflect the final `complete` status"
+        );
+        assert_eq!(row.objective, "prove the ledger reflects completion");
     }
 
     /// #1696 — `goal_get` snapshot: stable shape with remaining budget;
@@ -16091,6 +16190,7 @@ mod tests {
             "still working on it",
             &GoalCompletionVerdict::Done,
             None,
+            None,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
@@ -16103,6 +16203,7 @@ mod tests {
             "tenant-a",
             "All done. <goal:complete>",
             &GoalCompletionVerdict::Done,
+            None,
             None,
         ));
         assert_eq!(
@@ -16149,6 +16250,7 @@ mod tests {
                 reason: "evidence insufficient".to_string(),
             },
             None,
+            None,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
@@ -16183,6 +16285,7 @@ mod tests {
             "Done. <goal:complete>",
             &GoalCompletionVerdict::Done,
             Some("wrong-goal-id"), // Stale/incorrect ID
+            None,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
@@ -16197,6 +16300,7 @@ mod tests {
             "Done. <goal:complete>",
             &GoalCompletionVerdict::Done,
             goal_a_id.as_deref(), // Correct ID
+            None,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
@@ -17997,6 +18101,7 @@ mod tests {
             "I am about to write <goal:complete> shortly, but step 2 first.",
             &GoalCompletionVerdict::Done,
             None,
+            None,
         ));
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
@@ -18009,6 +18114,7 @@ mod tests {
             "tenant-a",
             "All requested checks finished.\n\n<goal:complete>",
             &GoalCompletionVerdict::Done,
+            None,
             None,
         ));
         assert_eq!(

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -3482,6 +3482,72 @@ impl InProcessAgentOrchestrator {
         Ok(autonomy_goal_json(&snapshot))
     }
 
+    /// #1957 — sync a goal transition into the durable ledger: upsert the goal
+    /// row with its now-current status/tokens AND append a `decisions` row
+    /// recording the transition. Without this the ledger goals-row showed the
+    /// status as of the last peer finding (usually `active`, since completing a
+    /// goal records no finding) and the `decisions` table was never written at
+    /// all. Best-effort — a ledger failure never affects the in-memory
+    /// transition the caller already committed. Opens (creates) the ledger,
+    /// since a transition can be the FIRST ledger write for a finding-less goal.
+    pub(crate) fn model_goal_record_transition_to_ledger(
+        &self,
+        profile_data_dir: &std::path::Path,
+        session_id: &SessionKey,
+        profile_id: &str,
+        status: &str,
+        reason: &str,
+    ) {
+        let key = self.scoped_goal_key(session_id);
+        let goal_row = {
+            let state = self.state();
+            match state.goals.get(&key) {
+                Some(goal) if goal.profile_id == profile_id => octos_fleet::Goal {
+                    goal_id: goal.goal_id.clone(),
+                    objective: goal.objective.clone(),
+                    status: goal.status.clone(),
+                    tokens_used: goal.tokens_used,
+                    token_budget: goal.token_budget,
+                    continuations_used: goal.continuations_used,
+                    revision: 0,
+                    created_at_ms: goal.created_at_ms.max(0) as u64,
+                    updated_at_ms: goal.updated_at_ms.max(0) as u64,
+                },
+                _ => return,
+            }
+        };
+        let ledger_dir = Self::goal_ledger_dir(profile_data_dir);
+        if std::fs::create_dir_all(&ledger_dir).is_err() {
+            return;
+        }
+        let ledger_path = ledger_dir.join(format!(
+            "{}.db",
+            sanitize_filename_for_ledger(&goal_row.goal_id)
+        ));
+        let Ok(ledger) = octos_fleet::GoalLedger::open(&ledger_path) else {
+            return;
+        };
+        let _ = ledger.upsert_goal(&goal_row);
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let decision = octos_fleet::Decision {
+            decision_id: format!("dec-{}-{}", goal_row.goal_id, uuid::Uuid::now_v7()),
+            goal_id: goal_row.goal_id.clone(),
+            task_id: None,
+            question: format!("transition goal to `{status}`"),
+            options_considered: None,
+            choice: status.to_owned(),
+            rationale: reason.chars().take(1000).collect(),
+            based_on_findings: None,
+            based_on_rev: 0,
+            decided_at_ms: now_ms,
+            decided_by: session_id.to_string(),
+        };
+        let _ = ledger.append_decision(&decision);
+    }
+
     /// Peer-agent-based goal: record a peer finding into the goal's durable
     /// ledger. This is the persistence half of `model_goal_peer_findings`
     /// (which scans live `result.md` files): once a peer completes, its
@@ -3527,22 +3593,41 @@ impl InProcessAgentOrchestrator {
         // — it equals the goal's stored key (the same resolution `active_goal_id`
         // used to auto-bind the peer here in the first place).
         let originator_scoped = self.scoped_goal_key(&SessionKey(originator_session.to_owned()));
-        let state = self.state();
-        let goal_owner_matches = state.goals.iter().any(|(key, goal)| {
-            goal.goal_id == goal_id
-                && goal.profile_id == profile_id
-                && (*key == originator_scoped
-                    || key.to_string() == originator_session
-                    || key.base_key() == originator_session)
-        });
-        drop(state);
-        if !goal_owner_matches {
+        // #1957 — capture the REAL goal record (not just verify ownership) so we
+        // can sync its authoritative objective/status/tokens into the ledger
+        // instead of the old placeholder stub. `.find` yields `&(&K,&V)`, hence
+        // `**key` for the scoped-key compare.
+        let goal_row = {
+            let state = self.state();
+            state
+                .goals
+                .iter()
+                .find(|(key, goal)| {
+                    goal.goal_id == goal_id
+                        && goal.profile_id == profile_id
+                        && (**key == originator_scoped
+                            || key.to_string() == originator_session
+                            || key.base_key() == originator_session)
+                })
+                .map(|(_, goal)| octos_fleet::Goal {
+                    goal_id: goal_id.to_owned(),
+                    objective: goal.objective.clone(),
+                    status: goal.status.clone(),
+                    tokens_used: goal.tokens_used,
+                    token_budget: goal.token_budget,
+                    continuations_used: goal.continuations_used,
+                    revision: 0, // preserved on conflict by upsert_goal
+                    created_at_ms: goal.created_at_ms.max(0) as u64,
+                    updated_at_ms: goal.updated_at_ms.max(0) as u64,
+                })
+        };
+        let Some(goal_row) = goal_row else {
             return Err(format!(
                 "goal `{goal_id}` is not owned by originator session `{originator_session}` \
                  under profile `{profile_id}` — refusing to record peer finding into a \
                  foreign goal's ledger"
             ));
-        }
+        };
         // The ledger is keyed by goal_id; open (creating on first use) the
         // per-profile goal ledger under the orchestrator's data dir. We use
         // a stable path so all peers of the same goal land in the same file.
@@ -3556,29 +3641,15 @@ impl InProcessAgentOrchestrator {
         let ledger_path = ledger_dir.join(format!("{}.db", sanitize_filename_for_ledger(goal_id)));
         let ledger = octos_fleet::GoalLedger::open(&ledger_path)
             .map_err(|e| format!("failed to open goal ledger {}: {e}", ledger_path.display()))?;
-        // FK constraint: findings reference goals(goal_id), so we must
-        // upsert the goal row BEFORE appending a finding. Without this,
-        // a fresh ledger would reject the append (codex PR review #3).
-        // We use a minimal goal stub (objective/status unknown at this
-        // layer; the master owns the authoritative record in the goal
-        // store). If the goal already exists, this is a no-op.
+        // FK constraint: findings reference goals(goal_id), so we must upsert
+        // the goal row BEFORE appending a finding. #1957 — write the goal's REAL
+        // objective/status/tokens/budget (captured above) so the ledger reflects
+        // the authoritative state, and keep it fresh on every finding.
+        let _ = ledger.upsert_goal(&goal_row);
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0);
-        let goal_stub = octos_fleet::Goal {
-            goal_id: goal_id.to_owned(),
-            objective: String::new(), // unknown at this layer; master owns it
-            status: "active".to_owned(),
-            tokens_used: 0,
-            token_budget: 0,
-            continuations_used: 0,
-            revision: 0, // assigned by store on update
-            created_at_ms: now_ms,
-            updated_at_ms: now_ms,
-        };
-        // Ignore "already exists" errors (goal row already present).
-        let _ = ledger.create_goal(&goal_stub);
         // FK constraint: findings with task_id reference tasks(task_id), so
         // we must ALSO upsert a task stub when task_id is Some (codex PR
         // review merge blocker). Same minimal-stub pattern as goals above.
@@ -3649,22 +3720,39 @@ impl InProcessAgentOrchestrator {
         // the #1666 scoped-key match): the goal record's owning session must
         // match the peer's originator.
         let originator_scoped = self.scoped_goal_key(&SessionKey(originator_session.to_owned()));
-        let state = self.state();
-        let goal_owner_matches = state.goals.iter().any(|(key, goal)| {
-            goal.goal_id == goal_id
-                && goal.profile_id == profile_id
-                && (*key == originator_scoped
-                    || key.to_string() == originator_session
-                    || key.base_key() == originator_session)
-        });
-        drop(state);
-        if !goal_owner_matches {
+        // #1957 — capture the REAL goal so the ledger row carries its
+        // authoritative objective/status/tokens (see the finding path).
+        let goal_row = {
+            let state = self.state();
+            state
+                .goals
+                .iter()
+                .find(|(key, goal)| {
+                    goal.goal_id == goal_id
+                        && goal.profile_id == profile_id
+                        && (**key == originator_scoped
+                            || key.to_string() == originator_session
+                            || key.base_key() == originator_session)
+                })
+                .map(|(_, goal)| octos_fleet::Goal {
+                    goal_id: goal_id.to_owned(),
+                    objective: goal.objective.clone(),
+                    status: goal.status.clone(),
+                    tokens_used: goal.tokens_used,
+                    token_budget: goal.token_budget,
+                    continuations_used: goal.continuations_used,
+                    revision: 0,
+                    created_at_ms: goal.created_at_ms.max(0) as u64,
+                    updated_at_ms: goal.updated_at_ms.max(0) as u64,
+                })
+        };
+        let Some(goal_row) = goal_row else {
             return Err(format!(
                 "goal `{goal_id}` is not owned by originator session `{originator_session}` \
                  under profile `{profile_id}` — refusing to record peer escalation into a \
                  foreign goal's ledger"
             ));
-        }
+        };
         let ledger_dir = Self::goal_ledger_dir(profile_data_dir);
         std::fs::create_dir_all(&ledger_dir).map_err(|e| {
             format!(
@@ -3675,25 +3763,13 @@ impl InProcessAgentOrchestrator {
         let ledger_path = ledger_dir.join(format!("{}.db", sanitize_filename_for_ledger(goal_id)));
         let ledger = octos_fleet::GoalLedger::open(&ledger_path)
             .map_err(|e| format!("failed to open goal ledger {}: {e}", ledger_path.display()))?;
-        // FK constraint: escalations reference goals(goal_id), so we must
-        // upsert the goal row BEFORE appending an escalation (codex PR
-        // review #3). Same minimal-stub pattern as findings above.
+        // FK constraint: escalations reference goals(goal_id) — upsert the goal
+        // row (with REAL fields, #1957) BEFORE appending an escalation.
+        let _ = ledger.upsert_goal(&goal_row);
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0);
-        let goal_stub = octos_fleet::Goal {
-            goal_id: goal_id.to_owned(),
-            objective: String::new(),
-            status: "active".to_owned(),
-            tokens_used: 0,
-            token_budget: 0,
-            continuations_used: 0,
-            revision: 0, // assigned by store on update
-            created_at_ms: now_ms,
-            updated_at_ms: now_ms,
-        };
-        let _ = ledger.create_goal(&goal_stub);
         // FK constraint: escalations with task_id reference tasks(task_id),
         // so we must ALSO upsert a task stub when task_id is Some (codex PR
         // review merge blocker). Same minimal-stub pattern as findings above.

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -33814,23 +33814,27 @@ async fn run_standalone_turn(
         default_agent_orchestrator()
             .record_goal_dispatch_timestamp_only(goal_key, &goal_ctx.profile_id);
         let pre = pre_assistant_count_for_post_turn.unwrap_or(0);
-        // #1957 (codex #1) — capture the session's data dir under the same lock
-        // so a sentinel completion below can sync to the goal ledger.
-        let (assistant_reply, goal_ledger_data_dir): (Option<String>, std::path::PathBuf) = {
+        let assistant_reply: Option<String> = {
             let mut guard = sessions_for_reschedule.lock().await;
-            let data_dir = guard.data_dir();
             let session = guard.get_or_create(&session_id).await;
             let history = session.get_history(usize::MAX);
-            let reply = history
+            history
                 .iter()
                 .filter(|message| matches!(message.role, MessageRole::Assistant))
                 .enumerate()
                 .filter(|(idx, _)| *idx >= pre)
                 .filter(|(_, message)| !message.content.is_empty())
                 .last()
-                .map(|(_, message)| message.content.clone());
-            (reply, data_dir)
+                .map(|(_, message)| message.content.clone())
         };
+        // #1957 (codex #1) — the goal ledger lives under the PROFILE data dir
+        // (`goal_get`, the peer-finding sync, and `GoalUpdateTool` all key off
+        // `profile.data_dir`), NOT the session store root. Under
+        // `appui.sessions_in_cwd` the two diverge (`sessions_root` relocates to
+        // `<cwd>/.octos`), so resolving the ledger dir from the sessions manager
+        // would write a sentinel completion into a SPLIT ledger the master
+        // never reads. Pin it to the profile data dir.
+        let goal_ledger_data_dir = session_runtime.profile.data_dir.clone();
         let elapsed_seconds = goal_turn_start
             .map(|start| start.elapsed().as_secs())
             .unwrap_or(0);

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -33814,18 +33814,22 @@ async fn run_standalone_turn(
         default_agent_orchestrator()
             .record_goal_dispatch_timestamp_only(goal_key, &goal_ctx.profile_id);
         let pre = pre_assistant_count_for_post_turn.unwrap_or(0);
-        let assistant_reply: Option<String> = {
+        // #1957 (codex #1) — capture the session's data dir under the same lock
+        // so a sentinel completion below can sync to the goal ledger.
+        let (assistant_reply, goal_ledger_data_dir): (Option<String>, std::path::PathBuf) = {
             let mut guard = sessions_for_reschedule.lock().await;
+            let data_dir = guard.data_dir();
             let session = guard.get_or_create(&session_id).await;
             let history = session.get_history(usize::MAX);
-            history
+            let reply = history
                 .iter()
                 .filter(|message| matches!(message.role, MessageRole::Assistant))
                 .enumerate()
                 .filter(|(idx, _)| *idx >= pre)
                 .filter(|(_, message)| !message.content.is_empty())
                 .last()
-                .map(|(_, message)| message.content.clone())
+                .map(|(_, message)| message.content.clone());
+            (reply, data_dir)
         };
         let elapsed_seconds = goal_turn_start
             .map(|start| start.elapsed().as_secs())
@@ -33883,6 +33887,8 @@ async fn run_standalone_turn(
                 &reply,
                 &verdict,
                 expected_goal_id.as_deref(),
+                // #1957 (codex #1) — sync a sentinel completion into the ledger.
+                Some(goal_ledger_data_dir.as_path()),
             );
         }
         // #1696/#1698 — push the post-turn goal snapshot to the OWNING

--- a/crates/octos-cli/src/goal_tool.rs
+++ b/crates/octos-cli/src/goal_tool.rs
@@ -961,13 +961,24 @@ impl Tool for GoalDenyTool {
 /// `goal_update` — model-owned terminal transitions ONLY.
 pub struct GoalUpdateTool {
     profile_id: String,
+    /// #1957 — profile's persistent data dir, so a transition can sync the
+    /// goal-row status + a `decisions` row into `<data_dir>/goal-ledgers/`.
+    /// `None` on paths that never wired it (the sync is then skipped).
+    data_dir: Option<std::path::PathBuf>,
 }
 
 impl GoalUpdateTool {
     pub fn new(profile_id: impl Into<String>) -> Self {
         Self {
             profile_id: profile_id.into(),
+            data_dir: None,
         }
+    }
+
+    /// #1957 — set the profile data dir used to sync a transition to the ledger.
+    pub fn with_data_dir(mut self, data_dir: std::path::PathBuf) -> Self {
+        self.data_dir = Some(data_dir);
+        self
     }
 }
 
@@ -1144,15 +1155,30 @@ impl Tool for GoalUpdateTool {
             status,
             reason,
         ) {
-            Ok(goal) => Ok(ToolResult {
-                output: format!(
-                    "goal transitioned to `{status}`:\n{}",
-                    serde_json::to_string_pretty(&goal).unwrap_or_else(|_| goal.to_string())
-                ),
-                success: true,
-                tokens_used: verifier_usage.clone(),
-                ..Default::default()
-            }),
+            Ok(goal) => {
+                // #1957 — sync the transition into the durable ledger (goal-row
+                // status + a decisions row), so the ledger reflects the FINAL
+                // status even when the completing turn recorded no new finding.
+                // Best-effort; only when this tool carries the profile data dir.
+                if let Some(data_dir) = self.data_dir.as_ref() {
+                    default_agent_orchestrator().model_goal_record_transition_to_ledger(
+                        data_dir,
+                        &session_id,
+                        &self.profile_id,
+                        status,
+                        reason,
+                    );
+                }
+                Ok(ToolResult {
+                    output: format!(
+                        "goal transitioned to `{status}`:\n{}",
+                        serde_json::to_string_pretty(&goal).unwrap_or_else(|_| goal.to_string())
+                    ),
+                    success: true,
+                    tokens_used: verifier_usage.clone(),
+                    ..Default::default()
+                })
+            }
             Err(message) => Ok(ToolResult {
                 output: format!("goal_update: {message}"),
                 success: false,

--- a/crates/octos-cli/src/goal_tool.rs
+++ b/crates/octos-cli/src/goal_tool.rs
@@ -1149,36 +1149,26 @@ impl Tool for GoalUpdateTool {
             }
         }
 
+        // #1957 — pass the profile data dir so model_transition_goal syncs the
+        // transition into the ledger (goals-row status + a decision) using the
+        // snapshot it just transitioned. Done INSIDE model_transition_goal (not
+        // here) so it uses the correct goal without a racy re-fetch (codex #3).
         match default_agent_orchestrator().model_transition_goal(
             &session_id,
             &self.profile_id,
             status,
             reason,
+            self.data_dir.as_deref(),
         ) {
-            Ok(goal) => {
-                // #1957 — sync the transition into the durable ledger (goal-row
-                // status + a decisions row), so the ledger reflects the FINAL
-                // status even when the completing turn recorded no new finding.
-                // Best-effort; only when this tool carries the profile data dir.
-                if let Some(data_dir) = self.data_dir.as_ref() {
-                    default_agent_orchestrator().model_goal_record_transition_to_ledger(
-                        data_dir,
-                        &session_id,
-                        &self.profile_id,
-                        status,
-                        reason,
-                    );
-                }
-                Ok(ToolResult {
-                    output: format!(
-                        "goal transitioned to `{status}`:\n{}",
-                        serde_json::to_string_pretty(&goal).unwrap_or_else(|_| goal.to_string())
-                    ),
-                    success: true,
-                    tokens_used: verifier_usage.clone(),
-                    ..Default::default()
-                })
-            }
+            Ok(goal) => Ok(ToolResult {
+                output: format!(
+                    "goal transitioned to `{status}`:\n{}",
+                    serde_json::to_string_pretty(&goal).unwrap_or_else(|_| goal.to_string())
+                ),
+                success: true,
+                tokens_used: verifier_usage.clone(),
+                ..Default::default()
+            }),
             Err(message) => Ok(ToolResult {
                 output: format!("goal_update: {message}"),
                 success: false,

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -1196,7 +1196,10 @@ impl ProfileRuntime {
                     .with_data_dir(data_dir.to_path_buf()),
             );
             tools.register(crate::goal_tool::GoalCreateTool::new(profile.id.clone()));
-            tools.register(crate::goal_tool::GoalUpdateTool::new(profile.id.clone()));
+            tools.register(
+                crate::goal_tool::GoalUpdateTool::new(profile.id.clone())
+                    .with_data_dir(data_dir.to_path_buf()),
+            );
             // #1857 PR 5a — the goal keeper's fleet controls: decompose the
             // objective onto a durable fleet (`goal_plan`) and launch its ready
             // tasks onto the live worker pool (`goal_dispatch`). `goal_get`

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -5148,6 +5148,9 @@ impl SessionActor {
             &assistant_tail,
             &verdict,
             expected_goal_id.as_deref(),
+            // #1957 (codex #1) — this interactive-chat goal path carries the
+            // profile data dir, so a sentinel completion syncs to the ledger.
+            Some(self.data_dir.as_path()),
         ) {
             return;
         }

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -233,8 +233,14 @@ impl GoalLedger {
     /// stale, tokens 0) purely to satisfy the findings/escalations FK, so an
     /// audit of the ledger saw no real goal state. This writes the authoritative
     /// objective/status/tokens/budget on first use AND keeps them fresh on every
-    /// later call. `created_at_ms` and `revision` are preserved on conflict
-    /// (a sync is not a CAS update); everything mutable is overwritten.
+    /// later call. `created_at_ms` and `revision` are preserved on conflict.
+    ///
+    /// #1957 codex #2 — the UPDATE is GUARDED on `updated_at_ms`: it only
+    /// overwrites when the incoming snapshot is at least as new as the stored
+    /// row. Without this, a finding/escalation path that snapshotted an older
+    /// `active` state (then did file I/O before writing) could clobber a
+    /// concurrently-written `complete` back to `active`. A `>=` (not `>`) keeps
+    /// same-instant writers idempotent.
     pub fn upsert_goal(&self, goal: &Goal) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
@@ -246,7 +252,8 @@ impl GoalLedger {
                  tokens_used = excluded.tokens_used,
                  token_budget = excluded.token_budget,
                  continuations_used = excluded.continuations_used,
-                 updated_at_ms = excluded.updated_at_ms",
+                 updated_at_ms = excluded.updated_at_ms
+             WHERE excluded.updated_at_ms >= goals.updated_at_ms",
             params![
                 goal.goal_id,
                 goal.objective,
@@ -1512,6 +1519,39 @@ mod digest_integration_tests {
         assert_eq!(
             got.created_at_ms, 1000,
             "created_at must be preserved on conflict"
+        );
+
+        // Guard (issue #1957 codex #2): a STALE upsert — one whose
+        // `updated_at_ms` is OLDER than the row's — must NOT clobber the newer
+        // state. This is the finding-path-after-completion race: a peer finding
+        // lands and re-upserts the goal row with the goal's pre-completion
+        // status; without the `updated_at_ms >=` guard it would flip a
+        // `complete` goal back to `active` in the durable ledger.
+        ledger
+            .upsert_goal(&Goal {
+                goal_id: "g1".to_string(),
+                objective: "compute 6x7".to_string(),
+                status: "active".to_string(), // stale pre-completion status
+                tokens_used: 120,             // stale, lower spend
+                token_budget: 2000,
+                continuations_used: 1,
+                revision: 0,
+                created_at_ms: 1000,
+                updated_at_ms: 1500, // OLDER than the row's 2000 → must be dropped
+            })
+            .unwrap();
+        let got = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!(
+            got.status, "complete",
+            "a stale (older updated_at_ms) upsert must not downgrade the status"
+        );
+        assert_eq!(
+            got.tokens_used, 550,
+            "a stale upsert must not roll the token counter backwards"
+        );
+        assert_eq!(
+            got.continuations_used, 3,
+            "stale continuations rejected too"
         );
     }
 }

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -235,12 +235,21 @@ impl GoalLedger {
     /// objective/status/tokens/budget on first use AND keeps them fresh on every
     /// later call. `created_at_ms` and `revision` are preserved on conflict.
     ///
-    /// #1957 codex #2 — the UPDATE is GUARDED on `updated_at_ms`: it only
-    /// overwrites when the incoming snapshot is at least as new as the stored
-    /// row. Without this, a finding/escalation path that snapshotted an older
-    /// `active` state (then did file I/O before writing) could clobber a
-    /// concurrently-written `complete` back to `active`. A `>=` (not `>`) keeps
-    /// same-instant writers idempotent.
+    /// #1957 codex #2 — the UPDATE is GUARDED so a stale snapshot cannot undo a
+    /// newer one. Two clauses:
+    ///  1. `updated_at_ms >=`: only overwrite when the incoming snapshot is at
+    ///     least as new as the stored row. Both producers (the transition sync
+    ///     and the finding/escalation path) capture `status` and `updated_at_ms`
+    ///     together under the orchestrator state lock, so a stale status always
+    ///     carries a stale timestamp and this clause rejects it. `>=` (not `>`)
+    ///     keeps same-instant re-writes of the SAME state idempotent.
+    ///  2. never downgrade a `complete` row to a non-`complete` status. This is
+    ///     defence-in-depth against the millisecond-resolution tie the `>=`
+    ///     clause alone cannot break: `complete` is terminal for a given
+    ///     `goal_id` (re-activation mints a FRESH goal_id), so no legitimate
+    ///     writer ever moves an existing `complete` row back to active/blocked.
+    ///     `blocked` is deliberately NOT protected — a blocked goal is
+    ///     user-resumable to `active` under the same id.
     pub fn upsert_goal(&self, goal: &Goal) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
@@ -253,7 +262,8 @@ impl GoalLedger {
                  token_budget = excluded.token_budget,
                  continuations_used = excluded.continuations_used,
                  updated_at_ms = excluded.updated_at_ms
-             WHERE excluded.updated_at_ms >= goals.updated_at_ms",
+             WHERE excluded.updated_at_ms >= goals.updated_at_ms
+               AND NOT (goals.status = 'complete' AND excluded.status <> 'complete')",
             params![
                 goal.goal_id,
                 goal.objective,
@@ -1552,6 +1562,126 @@ mod digest_integration_tests {
         assert_eq!(
             got.continuations_used, 3,
             "stale continuations rejected too"
+        );
+    }
+
+    #[test]
+    fn upsert_goal_never_downgrades_a_complete_goal() {
+        // Issue #1957 codex #2, defence-in-depth: the `updated_at_ms >=` guard
+        // alone cannot break a millisecond tie, and timestamps are only
+        // millisecond-resolution. A `complete` row is terminal for a goal_id
+        // (re-activation mints a fresh id), so a non-`complete` write must NEVER
+        // win against it — not even one carrying an equal or NEWER timestamp.
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("l.db")).unwrap();
+        ledger
+            .upsert_goal(&Goal {
+                goal_id: "g1".to_string(),
+                objective: "obj".to_string(),
+                status: "complete".to_string(),
+                tokens_used: 500,
+                token_budget: 2000,
+                continuations_used: 2,
+                revision: 0,
+                created_at_ms: 1000,
+                updated_at_ms: 2000,
+            })
+            .unwrap();
+
+        // EQUAL-ms stale `active` write (the tie the `>=` clause would admit):
+        // must be rejected by the complete-protection clause.
+        ledger
+            .upsert_goal(&Goal {
+                goal_id: "g1".to_string(),
+                objective: "obj".to_string(),
+                status: "active".to_string(),
+                tokens_used: 10,
+                token_budget: 2000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1000,
+                updated_at_ms: 2000, // EQUAL to the stored row
+            })
+            .unwrap();
+        assert_eq!(
+            ledger.get_goal("g1").unwrap().unwrap().status,
+            "complete",
+            "an equal-ms `active` write must not downgrade a `complete` goal"
+        );
+
+        // Even a strictly NEWER `active` write must not undo completion.
+        ledger
+            .upsert_goal(&Goal {
+                goal_id: "g1".to_string(),
+                objective: "obj".to_string(),
+                status: "active".to_string(),
+                tokens_used: 10,
+                token_budget: 2000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1000,
+                updated_at_ms: 9999, // strictly newer
+            })
+            .unwrap();
+        let g1 = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!(
+            g1.status, "complete",
+            "even a newer `active` write must not downgrade a terminal `complete` goal"
+        );
+        assert_eq!(g1.tokens_used, 500, "counters stay at the completed values");
+
+        // A `complete → complete` refresh with a newer ts IS allowed.
+        ledger
+            .upsert_goal(&Goal {
+                goal_id: "g1".to_string(),
+                objective: "obj".to_string(),
+                status: "complete".to_string(),
+                tokens_used: 600,
+                token_budget: 2000,
+                continuations_used: 3,
+                revision: 0,
+                created_at_ms: 1000,
+                updated_at_ms: 10_000,
+            })
+            .unwrap();
+        assert_eq!(
+            ledger.get_goal("g1").unwrap().unwrap().tokens_used,
+            600,
+            "a complete→complete refresh with a newer ts still updates"
+        );
+
+        // `blocked` is NOT protected: a blocked goal is user-resumable to active
+        // under the same id, so a newer `active` write MUST win.
+        ledger
+            .upsert_goal(&Goal {
+                goal_id: "g2".to_string(),
+                objective: "obj2".to_string(),
+                status: "blocked".to_string(),
+                tokens_used: 100,
+                token_budget: 2000,
+                continuations_used: 1,
+                revision: 0,
+                created_at_ms: 1000,
+                updated_at_ms: 1000,
+            })
+            .unwrap();
+        ledger
+            .upsert_goal(&Goal {
+                goal_id: "g2".to_string(),
+                objective: "obj2".to_string(),
+                status: "active".to_string(),
+                tokens_used: 100,
+                token_budget: 2000,
+                continuations_used: 1,
+                revision: 0,
+                created_at_ms: 1000,
+                updated_at_ms: 2000, // newer → resume must win
+            })
+            .unwrap();
+        assert_eq!(
+            ledger.get_goal("g2").unwrap().unwrap().status,
+            "active",
+            "a newer resume of a `blocked` goal must be allowed"
         );
     }
 }

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -228,6 +228,40 @@ impl GoalLedger {
         Ok(())
     }
 
+    /// #1957 — upsert the goal row with its REAL fields. `create_goal` was the
+    /// only writer and callers used a placeholder (objective empty, status
+    /// stale, tokens 0) purely to satisfy the findings/escalations FK, so an
+    /// audit of the ledger saw no real goal state. This writes the authoritative
+    /// objective/status/tokens/budget on first use AND keeps them fresh on every
+    /// later call. `created_at_ms` and `revision` are preserved on conflict
+    /// (a sync is not a CAS update); everything mutable is overwritten.
+    pub fn upsert_goal(&self, goal: &Goal) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO goals (goal_id, objective, status, tokens_used, token_budget, continuations_used, revision, created_at_ms, updated_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+             ON CONFLICT(goal_id) DO UPDATE SET
+                 objective = excluded.objective,
+                 status = excluded.status,
+                 tokens_used = excluded.tokens_used,
+                 token_budget = excluded.token_budget,
+                 continuations_used = excluded.continuations_used,
+                 updated_at_ms = excluded.updated_at_ms",
+            params![
+                goal.goal_id,
+                goal.objective,
+                goal.status,
+                goal.tokens_used,
+                goal.token_budget,
+                goal.continuations_used,
+                goal.revision,
+                goal.created_at_ms,
+                goal.updated_at_ms,
+            ],
+        )?;
+        Ok(())
+    }
+
     /// Get a goal by ID.
     pub fn get_goal(&self, goal_id: &str) -> Result<Option<Goal>> {
         let conn = self.conn.lock().unwrap();
@@ -1431,5 +1465,53 @@ mod digest_integration_tests {
         assert_eq!(status, "resolved");
         assert_eq!(resolution.as_deref(), Some("[answer] 7"));
         assert_eq!(resolved_by.as_deref(), Some("master-session"));
+    }
+
+    // #1957 — upsert_goal writes REAL fields on insert and refreshes the mutable
+    // ones on conflict, so the ledger goals-row is no longer a stale placeholder.
+    #[test]
+    fn upsert_goal_writes_real_fields_and_refreshes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ledger.db");
+        let ledger = GoalLedger::open(&path).unwrap();
+        ledger
+            .upsert_goal(&Goal {
+                goal_id: "g1".to_string(),
+                objective: "compute 6x7".to_string(),
+                status: "active".to_string(),
+                tokens_used: 100,
+                token_budget: 2000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1000,
+                updated_at_ms: 1000,
+            })
+            .unwrap();
+        let got = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!(got.objective, "compute 6x7");
+        assert_eq!(got.tokens_used, 100);
+        // Second upsert refreshes status/tokens; created_at is preserved.
+        ledger
+            .upsert_goal(&Goal {
+                goal_id: "g1".to_string(),
+                objective: "compute 6x7".to_string(),
+                status: "complete".to_string(),
+                tokens_used: 550,
+                token_budget: 2000,
+                continuations_used: 3,
+                revision: 0,
+                created_at_ms: 9999, // must be IGNORED on conflict
+                updated_at_ms: 2000,
+            })
+            .unwrap();
+        let got = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!(got.status, "complete", "status must refresh");
+        assert_eq!(got.tokens_used, 550, "tokens must refresh");
+        assert_eq!(got.continuations_used, 3);
+        assert_eq!(got.objective, "compute 6x7");
+        assert_eq!(
+            got.created_at_ms, 1000,
+            "created_at must be preserved on conflict"
+        );
     }
 }


### PR DESCRIPTION
Found by soaking (2026-08-11). The SQLite goal ledger's `goals` row was a minimal **FK placeholder** (objective empty, status stale `active`, tokens 0) and the `decisions` table was **never written** — so an audit of `goal-ledgers/<goal>.db` saw no real goal state or decision history.

## Fix

- **`GoalLedger::upsert_goal`** — `INSERT … ON CONFLICT(goal_id) DO UPDATE` writes the REAL objective/status/tokens/budget and refreshes the mutable fields (created_at + revision preserved).
- **`model_goal_record_peer_finding` / `_escalation`** capture the authoritative goal from orchestrator state and `upsert_goal` it (instead of the empty stub) before appending.
- **Transition sync moved *inside* `model_transition_goal`** — it takes the profile data dir (`Option<&Path>`) and, using the snapshot it JUST transitioned, upserts the goals-row status and appends a `decisions` row. Wired from the `goal_update` tool (`GoalUpdateTool::with_data_dir`) and from the **sentinel completion path** (`maybe_complete_goal_from_model`, both real callers). Best-effort everywhere — a ledger failure never affects the in-memory goal.

## Codex review — two adversarial passes, all findings addressed

Round 1 reshaped the design; round 2 confirmed 3/5 fixed and surfaced the two below.

1. **Sentinel completion bypassed the ledger** — `maybe_complete_goal_from_model` flipped `status=complete` in memory only. Now syncs via the same path. **Self-caught + codex-confirmed sub-bug:** my first wiring resolved the ledger dir from the sessions manager (`sessions_root`), which under `appui.sessions_in_cwd` relocates to `<cwd>/.octos` and would write a **split ledger** the master never reads. Fixed to pin `session_runtime.profile.data_dir` (the same root `goal_get` / peer-findings / `GoalUpdateTool` use). The interactive `SessionActor` path is already correct — `ActorFactory.data_dir` *is* that profile data dir.
2. **Stale write could roll back a completed goal** — `upsert_goal` is guarded `WHERE excluded.updated_at_ms >= goals.updated_at_ms` (both producers capture status+ts atomically under the state lock, so a stale status carries a stale ts). Defence-in-depth added on top: the UPDATE also refuses to move an existing `complete` row to a non-`complete` status regardless of timestamp, closing the millisecond-tie edge. Safe because the ledger is one-file-per-goal_id and `complete` is terminal for an id (re-activation mints a fresh id); `blocked→active` resume stays allowed.
3. **Re-fetch could target the wrong folder's goal** — the sync now uses the in-hand transition snapshot; no scope re-resolution. `model_transition_goal` drops the state lock before ledger I/O.
4. **Counters can omit the final turn** *(accurately disclosed, non-blocking)* — the ledger gets `snapshot.tokens_used`; a structured `goal_update` syncs mid-turn before the post-turn `record_goal_turn`, so the last charge may not be reflected. `findings.cost_tokens` stays `0` (see Deferred).
5. **Duplicate decision rows on no-op retries** — a `decisions` row is appended only when the status actually changed (`blocked→blocked` retries add none).

## Validation

- **octos-fleet lib: 124 pass**, incl. `upsert_goal_writes_real_fields_and_refreshes` (real fields + refresh + stale-write rejection) and `upsert_goal_never_downgrades_a_complete_goal` (equal-ms and newer `active` both rejected; complete→complete refresh and blocked→active resume both allowed).
- **octos-cli goal suite: 92 pass**, incl. new `model_transition_goal_syncs_final_status_into_the_ledger` (a finding-less completion reaches the durable ledger — the exact gap this PR closes).
- fmt + clippy clean; non-`api` build green.
- **Live soak** (complete a peer-goal): the ledger `goals` row shows the real objective, `status=complete`, real budget; `decisions` has `choice=complete` with the real rationale + `decided_by`. All were empty/stale before.

## Deferred (honest, tracked in #1957)

- **Fleet-completion / deny transitions** (`drive_goal_terminal_transition`, `model_deny_escalation`) still pass `None` and skip the ledger sync — those orchestrator-internal paths have no profile data dir in scope, and threading one reaches deeper through multiple tools + async signatures than this PR should. They were never synced before, so no regression; the user-driven `goal_update` and sentinel paths ARE covered.
- **Decision audit-backfill:** because a decision is written only on a status *change*, if the (best-effort) append errors once, a later retry sees the same status and won't backfill it. The goal-row **status** — the load-bearing datum — is always synced; only the secondary audit row can be missed on a rare write error.
- **`findings.cost_tokens` stays `0`:** needs the peer's per-turn token usage threaded into the finding-record path (not available there today).
