### PR TITLE
fix(goal): charge peer turn tokens to the master goal budget (#1965)

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -3609,9 +3609,25 @@ impl InProcessAgentOrchestrator {
     /// result is frozen as a `Finding` row so the master can list findings
     /// across restarts even if the peer's `result.md` is later overwritten.
     ///
-    /// Returns the new finding's `finding_id`. Errors when the goal is not
-    /// found under this profile (a peer whose master is on a different
-    /// profile must not write into its ledger).
+    /// #1965 — `cost_tokens` is the peer turn's accumulated token spend. It
+    /// charges the master goal's `tokens_used` (one shared budget pool with
+    /// master turns) under the state lock, right on the ownership-checked
+    /// record this function already resolves, and lands verbatim on the
+    /// `Finding` row so cost-against-yield per path stays truthful. Honesty
+    /// note (codex round): today only a COMPLETED turn delivers real usage —
+    /// the agent loop bails with a bare `Err` that carries no usage, so
+    /// errored/rate-limited turns arrive here with 0 and interrupted turns
+    /// never reach the turn-terminal writer at all; those turns UNDER-charge.
+    /// Partial-usage preservation on failure is a tracked follow-up.
+    ///
+    /// Returns the new finding's `finding_id` plus `goal_still_active` — the
+    /// goal's POST-charge scheduling eligibility (`status == "active"`), so
+    /// the caller can skip the goal-progress master wake once the charge has
+    /// flipped the goal to `budget_limited` (a post-budget wake would queue
+    /// an uncharged, unaccounted master turn past the cap; the wrap-up
+    /// continuation the flip enqueued carries the reorientation instead).
+    /// Errors when the goal is not found under this profile (a peer whose
+    /// master is on a different profile must not write into its ledger).
     ///
     /// # Goal-binding check
     ///
@@ -3633,7 +3649,8 @@ impl InProcessAgentOrchestrator {
         peer_slug: &str,
         task_id: Option<&str>,
         content: &str,
-    ) -> Result<String, String> {
+        cost_tokens: u64,
+    ) -> Result<(String, bool), String> {
         // Verify the goal exists under this profile AND that its owning
         // session matches the peer's originator (the goal-binding check).
         //
@@ -3650,13 +3667,33 @@ impl InProcessAgentOrchestrator {
         let originator_scoped = self.scoped_goal_key(&SessionKey(originator_session.to_owned()));
         // #1957 — capture the REAL goal record (not just verify ownership) so we
         // can sync its authoritative objective/status/tokens into the ledger
-        // instead of the old placeholder stub. `.find` yields `&(&K,&V)`, hence
-        // `**key` for the scoped-key compare.
+        // instead of the old placeholder stub.
+        //
+        // #1965 — the capture is now a CHARGE-then-capture: peer turns draw on
+        // the SAME budget pool as master turns, so before snapshotting we add
+        // the peer turn's `cost_tokens` to the ownership-checked goal, all
+        // under the state lock. Mirrors `charge_active_goal_tokens` (budget
+        // flip + one-shot wrap-up) MINUS the continuation / rate-window /
+        // elapsed-time bumps: a peer finding is not a continuation, and peer
+        // wall-clock overlaps the master's, so charging elapsed time here
+        // would double-count it. The flip is gated on `status == "active"`
+        // (#1696 parity) — a goal the model completed or the user paused
+        // mid-flight must not be yanked to `budget_limited` by a straggler
+        // peer, while the straggler's REAL spend still lands on `tokens_used`
+        // (the budget bounds TOTAL goal spend; overshoot is real). v1
+        // non-goals: no cross-session live chip event to the master's
+        // connection (no such transport exists — the flip still gates
+        // scheduling immediately and the master's next turn repaints the
+        // chip), and in-flight peers are not halted on exhaustion.
         let goal_row = {
-            let state = self.state();
-            state
+            let mut state = self.state();
+            let now = now_ms();
+            let now_system = SystemTime::now();
+            // `.find` yields `&(&K,&mut V)`, hence `**key` for the scoped-key
+            // compare.
+            let charged = state
                 .goals
-                .iter()
+                .iter_mut()
                 .find(|(key, goal)| {
                     goal.goal_id == goal_id
                         && goal.profile_id == profile_id
@@ -3664,17 +3701,55 @@ impl InProcessAgentOrchestrator {
                             || key.to_string() == originator_session
                             || key.base_key() == originator_session)
                 })
-                .map(|(_, goal)| octos_fleet::Goal {
+                .map(|(key, goal)| {
+                    goal.tokens_used = goal.tokens_used.saturating_add(cost_tokens);
+                    goal.updated_at_ms = now;
+                    let exhausted = goal.status == "active"
+                        && goal.token_budget > 0
+                        && goal.tokens_used >= goal.token_budget
+                        && !goal.wrap_up_emitted;
+                    let wrap_up_prompt = if exhausted {
+                        goal.status = "budget_limited".to_owned();
+                        goal.wrap_up_emitted = true;
+                        Some(goal_budget_wrap_up_prompt(
+                            &goal.goal_id,
+                            goal.tokens_used,
+                            goal.token_budget,
+                        ))
+                    } else {
+                        None
+                    };
+                    (key.clone(), goal.clone(), wrap_up_prompt)
+                });
+            charged.map(|(owning_key, snapshot, wrap_up_prompt)| {
+                persist_goal_state(&state, &owning_key, &snapshot, false);
+                if let Some(prompt) = wrap_up_prompt {
+                    enqueue_goal_wrap_up(
+                        &mut state,
+                        &owning_key,
+                        &snapshot.profile_id,
+                        &snapshot.goal_id,
+                        &snapshot.objective,
+                        prompt,
+                        now_system,
+                    );
+                }
+                // The FRESH snapshot (post-charge, post-flip) feeds the ledger
+                // upsert below, so the goals row finally carries real numbers.
+                octos_fleet::Goal {
                     goal_id: goal_id.to_owned(),
-                    objective: goal.objective.clone(),
-                    status: goal.status.clone(),
-                    tokens_used: goal.tokens_used,
-                    token_budget: goal.token_budget,
-                    continuations_used: goal.continuations_used,
+                    objective: snapshot.objective.clone(),
+                    status: snapshot.status.clone(),
+                    tokens_used: snapshot.tokens_used,
+                    token_budget: snapshot.token_budget,
+                    continuations_used: snapshot.continuations_used,
                     revision: 0, // preserved on conflict by upsert_goal
-                    created_at_ms: goal.created_at_ms.max(0) as u64,
-                    updated_at_ms: goal.updated_at_ms.max(0) as u64,
-                })
+                    created_at_ms: snapshot.created_at_ms.max(0) as u64,
+                    updated_at_ms: snapshot.updated_at_ms.max(0) as u64,
+                }
+            })
+            // The state lock drops here — all ledger file I/O below runs
+            // unlocked (mirrors `charge_active_goal_tokens`).
         };
         let Some(goal_row) = goal_row else {
             return Err(format!(
@@ -3737,7 +3812,9 @@ impl InProcessAgentOrchestrator {
             config_version: None,
             derived_from: None,
             supersedes: Vec::new(),
-            cost_tokens: 0,
+            // #1965 — the peer turn's REAL spend (already charged to the
+            // master goal above), not a hardcoded 0.
+            cost_tokens,
             created_at_ms: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_millis() as u64)
@@ -3747,7 +3824,10 @@ impl InProcessAgentOrchestrator {
         ledger
             .append_finding(&finding)
             .map_err(|e| format!("failed to append peer finding: {e}"))?;
-        Ok(finding_id)
+        // #1965 codex round — report the POST-charge scheduling eligibility
+        // from the same fresh snapshot the ledger row was built from, so the
+        // caller's wake gate and the durable row can never disagree.
+        Ok((finding_id, goal_row.status == "active"))
     }
 
     /// Peer-agent-based goal: record a peer escalation into the goal's
@@ -3758,6 +3838,11 @@ impl InProcessAgentOrchestrator {
     /// `originator_session` under `profile_id`, otherwise the write is
     /// refused (a peer whose master is on a different goal must not inject
     /// escalations into a foreign goal's ledger).
+    ///
+    /// #1965 — deliberately NO `cost_tokens` / budget charge here: an
+    /// escalation parks MID-turn, and the whole turn's spend is charged
+    /// exactly once by the turn-terminal finding write. Charging here too
+    /// would double-count the parked turn.
     ///
     /// Returns the new escalation's `escalation_id`.
     #[allow(clippy::too_many_arguments)]
@@ -15340,6 +15425,228 @@ mod tests {
         // not enqueue a duplicate wrap-up.
         let _ = orchestrator.charge_active_goal_tokens(&session_id, "tenant-a", &goal_id, 100, 1);
         assert_eq!(orchestrator.pending_continuation_count_for_test(), 0);
+    }
+
+    /// #1965 — a peer turn's token spend must charge the SAME shared budget
+    /// pool as master turns: recording the peer finding with `cost_tokens=N`
+    /// increments the master goal's `tokens_used` by N, keeps the fresh total
+    /// on the ledger goals row, and stamps the REAL cost on the Finding row.
+    /// The goal is registered under a cwd-SCOPED store key (#1666) while the
+    /// peer's originator is the plain wire id, so the charge must ride the
+    /// same three-way ownership match the finding write already uses.
+    #[test]
+    fn peer_finding_charges_master_goal_budget_under_scoped_key() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let data_dir = tempfile::tempdir().expect("tempdir");
+        let wire = SessionKey("octos:local:tui#coding".into());
+        orchestrator.set_goal_scope(&wire, Some("aaaa111122223333".into()));
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: wire.clone(),
+                profile_id: "octos".into(),
+                objective: "peer-charged goal".into(),
+                status: Some("active".into()),
+                token_budget: Some(1_000_000),
+                transition_actor: None,
+            })
+            .expect("set scoped active goal");
+        let goal_id = orchestrator
+            .active_goal_id(&wire, "octos")
+            .expect("active goal id resolves through the registered scope");
+
+        let (finding_id, goal_still_active) = orchestrator
+            .model_goal_record_peer_finding(
+                data_dir.path(),
+                &goal_id,
+                "octos",
+                &wire.0, // originator = plain wire id, matched via scoped-key resolution
+                "researcher",
+                None,
+                "[completed] found the thing",
+                12_345,
+            )
+            .expect("record peer finding");
+        assert!(
+            goal_still_active,
+            "a charge far below the budget reports the goal still active \
+             (the caller keeps enqueueing the goal-progress wake)",
+        );
+
+        // The master goal absorbed the peer turn's spend — one shared pool —
+        // WITHOUT any continuation/rate-window side effects (a peer finding
+        // is not a continuation).
+        let scoped = SessionKey(format!("{}\u{0}~cwd-aaaa111122223333", wire.0));
+        let (tokens_used, continuations_used, rate_window_count) = orchestrator
+            .goal_counters_for_test(&scoped)
+            .expect("scoped goal exists");
+        assert_eq!(tokens_used, 12_345, "peer turn charges the master goal");
+        assert_eq!(
+            continuations_used, 0,
+            "a peer finding is NOT a continuation — must not bump continuations_used",
+        );
+        assert_eq!(
+            rate_window_count, 0,
+            "peer charge must not touch the autonomous rate window",
+        );
+
+        // The ledger goals row was upserted AFTER the charge, so it carries
+        // the fresh post-charge total, and the Finding row carries the real
+        // cost (pre-#1965 both were stuck at 0).
+        let ledger_path = data_dir
+            .path()
+            .join("goal-ledgers")
+            .join(format!("{}.db", sanitize_filename_for_ledger(&goal_id)));
+        let ledger = octos_fleet::GoalLedger::open(&ledger_path).expect("open goal ledger");
+        let goal_row = ledger
+            .get_goal(&goal_id)
+            .expect("read goals row")
+            .expect("goals row exists");
+        assert_eq!(
+            goal_row.tokens_used, 12_345,
+            "ledger goals row reflects the fresh post-charge total",
+        );
+        let findings = ledger
+            .list_findings_since(&goal_id, 0)
+            .expect("list findings");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].finding_id, finding_id);
+        assert_eq!(
+            findings[0].cost_tokens, 12_345,
+            "Finding row must carry the peer turn's REAL cost_tokens",
+        );
+
+        // A second finding accumulates on the same pool.
+        orchestrator
+            .model_goal_record_peer_finding(
+                data_dir.path(),
+                &goal_id,
+                "octos",
+                &wire.0,
+                "researcher",
+                None,
+                "[completed] more work",
+                655,
+            )
+            .expect("record second peer finding");
+        let (tokens_used, _, _) = orchestrator
+            .goal_counters_for_test(&scoped)
+            .expect("scoped goal exists");
+        assert_eq!(tokens_used, 13_000, "peer charges accumulate");
+    }
+
+    /// #1965 — crossing `token_budget` via a peer finding flips the goal to
+    /// `budget_limited`, sets `wrap_up_emitted`, and enqueues exactly ONE
+    /// wrap-up (mirroring `charge_active_goal_tokens`); a second finding
+    /// still charges (the overshoot is real spend) but must not enqueue a
+    /// duplicate wrap-up.
+    #[test]
+    fn peer_finding_crossing_budget_flips_goal_and_enqueues_one_wrap_up() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let data_dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-peer-budget");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "exhaust via peers".into(),
+                status: Some("active".into()),
+                token_budget: Some(1_000),
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        let goal_id = orchestrator
+            .active_goal_id(&session_id, "tenant-a")
+            .expect("active goal id");
+        // Drain the initial GoalContinue set_goal enqueues so the only
+        // continuation left after the crossing below is the wrap-up.
+        let _ = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        assert_eq!(orchestrator.pending_continuation_count_for_test(), 0);
+
+        orchestrator.force_goal_tokens_used_for_test(&session_id, 900);
+        // 900 + 200 >= 1_000 → the peer turn crosses the budget.
+        let (_, goal_still_active) = orchestrator
+            .model_goal_record_peer_finding(
+                data_dir.path(),
+                &goal_id,
+                "tenant-a",
+                &session_id.0,
+                "worker",
+                None,
+                "[completed] burned the budget",
+                200,
+            )
+            .expect("record crossing peer finding");
+        assert!(
+            !goal_still_active,
+            "the crossing call itself reports the flip so the caller can \
+             skip the post-budget goal-progress wake",
+        );
+
+        assert_eq!(
+            orchestrator.goal_status_for_test(&session_id).as_deref(),
+            Some("budget_limited"),
+            "peer crossing flips the goal to budget_limited",
+        );
+        assert!(
+            orchestrator
+                .state()
+                .goals
+                .get(&session_id)
+                .map(|goal| goal.wrap_up_emitted)
+                .unwrap_or(false),
+            "crossing sets wrap_up_emitted so later charges cannot re-emit",
+        );
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_test(),
+            1,
+            "exactly one wrap-up enqueued by the crossing finding",
+        );
+
+        // A straggler peer finishing after exhaustion still charges (its
+        // tokens were really consumed) but must not enqueue another wrap-up.
+        orchestrator
+            .model_goal_record_peer_finding(
+                data_dir.path(),
+                &goal_id,
+                "tenant-a",
+                &session_id.0,
+                "worker",
+                None,
+                "[completed] straggler",
+                50,
+            )
+            .expect("record straggler peer finding");
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_test(),
+            1,
+            "no duplicate wrap-up on a post-exhaustion finding",
+        );
+        let (tokens_used, _, _) = orchestrator
+            .goal_counters_for_test(&session_id)
+            .expect("goal exists");
+        assert_eq!(
+            tokens_used, 1_150,
+            "post-exhaustion peer spend still counts — the pool tracks REAL total spend",
+        );
+
+        // The one queued continuation is the wrap-up, on its dedicated reason.
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].reason, MasterContinuationReason::GoalWrapUp);
+        assert_eq!(
+            drained[0].metadata.get("wrap_up").map(String::as_str),
+            Some("true"),
+        );
     }
 
     /// #1141 — when an AppUI goal turn exhausts `token_budget`,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -15001,11 +15001,22 @@ fn peer_respond_resolve(
 /// no per-turn auto-close. The TUI keeps the session alive across multiple
 /// turns; this function is called at every turn terminal to update the
 /// blackboard with the latest result (and a versioned historical copy).
+///
+/// #1965 — `tokens_consumed` is the turn's accumulated token spend (the same
+/// `final_tokens_consumed` total the master goal accountants charge from).
+/// When the peer is goal-bound, the finding write below charges it against
+/// the master goal's shared budget pool. Honesty (codex round): only a
+/// COMPLETED turn carries real usage — the agent loop bails with a bare
+/// `Err` that discards the turn's accumulated usage, so the errored /
+/// rate-limited arm threads 0, and an interrupted turn never reaches this
+/// writer at all. Those turns currently UNDER-charge the goal; preserving
+/// partial usage across the loop's error path is a tracked follow-up.
 fn write_peer_result_if_peer_session(
     state: &Arc<AppState>,
     session_id: &SessionKey,
     outcome: TurnTerminalOutcome,
     content: &str,
+    tokens_consumed: u64,
 ) {
     let Some(slug) = session_id
         .topic()
@@ -15135,31 +15146,48 @@ fn write_peer_result_if_peer_session(
             // Best-effort: a ledger write failure must NOT fail the peer's
             // turn (the result.md is already written above and is the
             // authoritative output). We log and continue.
+            //
+            // #1965 — `tokens_consumed` charges the master goal's budget
+            // inside the recorder (it already holds the ownership-checked
+            // goal record) and lands as the Finding row's real `cost_tokens`.
+            // The returned `goal_still_active` is the POST-charge status:
+            // it gates the goal-progress wake below so a budget-crossing
+            // peer cannot queue one more uncharged master turn past the cap.
             let content_summary: String = body.chars().take(400).collect();
-            if let Err(err) = default_agent_orchestrator().model_goal_record_peer_finding(
-                &runtime.data_dir,
-                goal_id,
-                profile_id,
-                &originator,
-                slug,
-                task_id,
-                &format!("[{outcome_str}] {content_summary}"),
-            ) {
-                tracing::warn!(
-                    ?err,
-                    slug,
+            let goal_still_active = match default_agent_orchestrator()
+                .model_goal_record_peer_finding(
+                    &runtime.data_dir,
                     goal_id,
-                    "peer-goal: failed to record peer finding to goal ledger"
-                );
-            } else {
-                tracing::info!(
+                    profile_id,
+                    &originator,
                     slug,
-                    goal_id,
                     task_id,
-                    outcome = outcome_str,
-                    "peer-goal: recorded finding to goal ledger"
-                );
-            }
+                    &format!("[{outcome_str}] {content_summary}"),
+                    tokens_consumed,
+                ) {
+                Err(err) => {
+                    tracing::warn!(
+                        ?err,
+                        slug,
+                        goal_id,
+                        "peer-goal: failed to record peer finding to goal ledger"
+                    );
+                    // Recording failed → the post-charge status is unknown;
+                    // keep the wake (pre-#1965 behaviour) so the master still
+                    // learns of the peer result.
+                    true
+                }
+                Ok((_, goal_still_active)) => {
+                    tracing::info!(
+                        slug,
+                        goal_id,
+                        task_id,
+                        outcome = outcome_str,
+                        "peer-goal: recorded finding to goal ledger"
+                    );
+                    goal_still_active
+                }
+            };
 
             // Peer-agent-based goal: wake the master session so it sees the
             // new finding on its next turn WITHOUT having to poll `goal_get`.
@@ -15171,35 +15199,55 @@ fn write_peer_result_if_peer_session(
             // Best-effort: if the wake channel is unavailable (e.g. master
             // session is offline), the ledger row above is still durable —
             // the master will see the finding on its next `goal_get`.
-            tracing::info!(
-                slug,
-                goal_id,
-                task_id,
-                originator,
-                outcome = outcome_str,
-                "peer-goal: waking master session"
-            );
-            // Enqueue the wake as an awaiting-input note on the master
-            // session. This is the same mechanism used for peer parking /
-            // approval wakes — it surfaces as a system message on the
-            // master's next turn.
-            let content_summary: String = body.chars().take(400).collect();
-            if let Err(err) = enqueue_goal_progress_wake(
-                &runtime.data_dir,
-                &originator,
-                goal_id,
-                slug,
-                turn_count,
-                outcome_str,
-                &content_summary,
-                profile_id,
-            ) {
-                tracing::warn!(
-                    ?err,
+            //
+            // #1965 codex round — gated on the goal still being ACTIVE after
+            // the charge above. This External "goal_progress" wake bypasses
+            // goal-status scheduling and is not goal-accounted, so an ungated
+            // wake right after the charge flipped the goal to
+            // `budget_limited` would queue exactly the post-budget master
+            // turn the flip exists to stop. The wrap-up continuation the flip
+            // enqueued carries the reorientation instead; still-active goals
+            // wake exactly as before.
+            if goal_still_active {
+                tracing::info!(
+                    slug,
+                    goal_id,
+                    task_id,
+                    originator,
+                    outcome = outcome_str,
+                    "peer-goal: waking master session"
+                );
+                // Enqueue the wake as an awaiting-input note on the master
+                // session. This is the same mechanism used for peer parking /
+                // approval wakes — it surfaces as a system message on the
+                // master's next turn.
+                let content_summary: String = body.chars().take(400).collect();
+                if let Err(err) = enqueue_goal_progress_wake(
+                    &runtime.data_dir,
+                    &originator,
+                    goal_id,
+                    slug,
+                    turn_count,
+                    outcome_str,
+                    &content_summary,
+                    profile_id,
+                ) {
+                    tracing::warn!(
+                        ?err,
+                        slug,
+                        goal_id,
+                        originator,
+                        "peer-goal: failed to enqueue master wake (ledger row is still durable)"
+                    );
+                }
+            } else {
+                tracing::info!(
                     slug,
                     goal_id,
                     originator,
-                    "peer-goal: failed to enqueue master wake (ledger row is still durable)"
+                    "peer-goal: goal no longer active after charge; skipping \
+                     goal-progress wake (the wrap-up continuation reorients \
+                     the master)"
                 );
             }
         }
@@ -32847,12 +32895,16 @@ async fn run_standalone_turn(
                     outcome: Some(TurnTerminalOutcome::Completed),
                 };
                 // #1801 v2: a peer session's terminal leaves its result on
-                // the blackboard (result.md beside the brief).
+                // the blackboard (result.md beside the brief). #1965 — the
+                // turn's accumulated spend (folded from this `done` event
+                // just above) rides along so a goal-bound peer charges the
+                // master goal's budget.
                 write_peer_result_if_peer_session(
                     &state,
                     &session_id,
                     TurnTerminalOutcome::Completed,
                     event.get("content").and_then(Value::as_str).unwrap_or(""),
+                    final_tokens_consumed,
                 );
                 // Peer-fleet auto-synthesis: a peer COMPLETING may be the last
                 // of its master's fleet — evaluate the fleet and, when every
@@ -32927,7 +32979,22 @@ async fn run_standalone_turn(
                 } else {
                     TurnTerminalOutcome::Errored
                 };
-                write_peer_result_if_peer_session(&state, &session_id, turn_outcome, &wire_msg);
+                // #1965 — thread the turn total here too so the wiring is
+                // outcome-independent, but be honest: on this arm it is
+                // ALWAYS 0 today. The agent loop bails with a bare `Err`
+                // that discards the turn's accumulated usage, and
+                // `final_tokens_consumed` only folds from `done` — so an
+                // errored/rate-limited peer turn UNDER-charges the goal (it
+                // burned real tokens before failing). Preserving partial
+                // usage across the loop's error path is a tracked follow-up;
+                // the master accountant shares the same gap.
+                write_peer_result_if_peer_session(
+                    &state,
+                    &session_id,
+                    turn_outcome,
+                    &wire_msg,
+                    final_tokens_consumed,
+                );
                 // codex #2 — an ERRORED/interrupted/rate-limited peer still
                 // wrote a result.md; evaluate the fleet here too so a fleet
                 // whose LAST peer errors still triggers synthesis (the error

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -30548,6 +30548,7 @@ async fn peer_fleet_result_writer_and_gather_roundtrip() {
         &peer_key,
         TurnTerminalOutcome::Completed,
         "All three lenses agree.",
+        0,
     );
     let written =
         std::fs::read_to_string(peers_root.join("lens-review-2").join("result.md")).unwrap();
@@ -30570,7 +30571,13 @@ async fn peer_fleet_result_writer_and_gather_roundtrip() {
     );
     let ghost_key =
         octos_core::SessionKey::with_profile_topic("dev", "local", "tui", "peer-never-staged");
-    write_peer_result_if_peer_session(&state, &ghost_key, TurnTerminalOutcome::Completed, "ghost");
+    write_peer_result_if_peer_session(
+        &state,
+        &ghost_key,
+        TurnTerminalOutcome::Completed,
+        "ghost",
+        0,
+    );
     assert!(
         !peers_root.join("never-staged").exists(),
         "an unstaged peer topic must not create directories"
@@ -30582,6 +30589,7 @@ async fn peer_fleet_result_writer_and_gather_roundtrip() {
         &coding_key,
         TurnTerminalOutcome::Completed,
         "not a peer",
+        0,
     );
 
     // Overwrite = latest state on result.md, versioned file for turn 2.
@@ -30590,6 +30598,7 @@ async fn peer_fleet_result_writer_and_gather_roundtrip() {
         &peer_key,
         TurnTerminalOutcome::Errored,
         "second turn failed",
+        0,
     );
     let rewritten =
         std::fs::read_to_string(peers_root.join("lens-review-2").join("result.md")).unwrap();

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -236,14 +236,21 @@ impl GoalLedger {
     /// later call. `created_at_ms` and `revision` are preserved on conflict.
     ///
     /// #1957 codex #2 — the UPDATE is GUARDED so a stale snapshot cannot undo a
-    /// newer one. Two clauses:
+    /// newer one. Three clauses:
     ///  1. `updated_at_ms >=`: only overwrite when the incoming snapshot is at
     ///     least as new as the stored row. Both producers (the transition sync
     ///     and the finding/escalation path) capture `status` and `updated_at_ms`
     ///     together under the orchestrator state lock, so a stale status always
     ///     carries a stale timestamp and this clause rejects it. `>=` (not `>`)
     ///     keeps same-instant re-writes of the SAME state idempotent.
-    ///  2. never downgrade a `complete` row to a non-`complete` status. This is
+    ///  2. `tokens_used >=` (#1965 codex round): the counter is MONOTONIC per
+    ///     `goal_id` — every in-memory writer only ever `saturating_add`s, a
+    ///     replacement goal mints a FRESH goal_id (different ledger file), and
+    ///     re-activation never resets counters. Two peers finishing in the
+    ///     SAME millisecond tie on clause 1, so without this clause the
+    ///     smaller charge upserting second would roll the durable counter
+    ///     backwards while memory holds the higher total.
+    ///  3. never downgrade a `complete` row to a non-`complete` status. This is
     ///     defence-in-depth against the millisecond-resolution tie the `>=`
     ///     clause alone cannot break: `complete` is terminal for a given
     ///     `goal_id` (re-activation mints a FRESH goal_id), so no legitimate
@@ -263,6 +270,7 @@ impl GoalLedger {
                  continuations_used = excluded.continuations_used,
                  updated_at_ms = excluded.updated_at_ms
              WHERE excluded.updated_at_ms >= goals.updated_at_ms
+               AND excluded.tokens_used >= goals.tokens_used
                AND NOT (goals.status = 'complete' AND excluded.status <> 'complete')",
             params![
                 goal.goal_id,
@@ -781,7 +789,9 @@ mod tests {
             config_version: None,
             derived_from: None,
             supersedes: Vec::new(),
-            cost_tokens: 0,
+            // #1965 — a REAL cost, so the round-trip below proves the row
+            // persists the caller's spend instead of a hardcoded 0.
+            cost_tokens: 4_321,
             created_at_ms: 2000,
             created_by: "peer-a".to_string(),
         };
@@ -790,6 +800,10 @@ mod tests {
         let findings = ledger.list_findings_since("g1", 0).unwrap();
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].assertion, "test assertion");
+        assert_eq!(
+            findings[0].cost_tokens, 4_321,
+            "Finding row must persist the real cost_tokens (#1965)"
+        );
     }
 
     #[test]
@@ -1562,6 +1576,42 @@ mod digest_integration_tests {
         assert_eq!(
             got.continuations_used, 3,
             "stale continuations rejected too"
+        );
+
+        // #1965 codex round — the monotonic-counter clause, isolated from the
+        // complete-protection clause (fresh ACTIVE goal): two peers can finish
+        // in the SAME millisecond, so `updated_at_ms >=` alone admits the
+        // smaller charge upserting second and rolls the durable counter back
+        // while memory holds the higher total. tokens_used is MONOTONIC per
+        // goal_id (a replacement goal mints a fresh goal_id → different ledger
+        // file; re-activation never resets counters), so an equal-ms write
+        // carrying a LOWER tokens_used must be rejected...
+        let seed = |tokens_used: u64| Goal {
+            goal_id: "g2".to_string(),
+            objective: "concurrent peers".to_string(),
+            status: "active".to_string(),
+            tokens_used,
+            token_budget: 2000,
+            continuations_used: 0,
+            revision: 0,
+            created_at_ms: 5000,
+            updated_at_ms: 5000, // every write in this block ties on ms
+        };
+        ledger.upsert_goal(&seed(300)).unwrap();
+        ledger.upsert_goal(&seed(100)).unwrap(); // equal-ms, LOWER → rejected
+        assert_eq!(
+            ledger.get_goal("g2").unwrap().unwrap().tokens_used,
+            300,
+            "an equal-ms upsert with a lower tokens_used must not roll the \
+             counter backwards"
+        );
+        // ...while an equal-ms write carrying a HIGHER tokens_used (the other
+        // peer's larger charge landing second) must still be accepted.
+        ledger.upsert_goal(&seed(450)).unwrap();
+        assert_eq!(
+            ledger.get_goal("g2").unwrap().unwrap().tokens_used,
+            450,
+            "an equal-ms upsert with a higher tokens_used must be accepted"
         );
     }
 


### PR DESCRIPTION
Fixes #1965. Found by the 2026-08-11 deep review: the goal's `token_budget` — the design's central economic invariant — only counted MASTER turns. Peers (the agents doing the actual work) burned unbounded tokens invisibly: `budget_limited` never fired on peer spend and `findings.cost_tokens` was hardcoded 0.

## Fix
- Peer turn-terminal arms thread the turn's real token usage into `write_peer_result_if_peer_session` → `model_goal_record_peer_finding` (new `cost_tokens` param).
- Inside the same ownership-checked block (state lock, scoped-key originator match): master goal `tokens_used` increments, budget exhaustion flips `budget_limited` + latches exactly one wrap-up (mirroring `charge_active_goal_tokens`, minus continuation/rate-window side effects). Ledger goals-row upsert uses the FRESH snapshot; Finding rows carry real `cost_tokens`.
- Escalation path does not charge (the terminal arm charges the whole turn).

## Codex adversarial round (all findings addressed)
- **Equal-ms concurrent-peer rollback (new bug, fixed):** two peers finishing in the same millisecond could roll the durable goals-row counters backward. `upsert_goal` gains a third guard clause `AND excluded.tokens_used >= goals.tokens_used` (tokens are monotonic per goal_id — replacements mint fresh ids). Runtime RED reproduced the rollback (100 clobbered 300) before the fix.
- **Post-budget uncharged wakes (fixed):** `model_goal_record_peer_finding` now returns `goal_still_active`; the goal-progress master wake is skipped once the goal leaves `active` (the wrap-up continuation reorients the master instead).
- **Under-charge honesty (documented, tracked #1969):** only Completed turns deliver real usage — the agent loop discards accumulated usage on `Err` and Interrupted never reaches the writer, so those turns charge 0. Partial-usage preservation is deliberately NOT rushed into this PR.
- **Pre-existing residuals noted:** cwd-rebind ownership-match drop (#1953 scope-registry class); state lock held across the supervisor-store append (shared pattern, tracked separately).

## Validation
octos-fleet 124 · goal filter 95 · peer filter 101 (all green, no count drops) · no-api build · fmt · clippy clean. Rebased onto #1968.