### PR TITLE
fix(peer-goal): escalation lifecycle — read APIs, goal_get surface, resolve-on-close, timeout sweep (#1967)

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -3982,6 +3982,166 @@ impl InProcessAgentOrchestrator {
             .map_err(|e| format!("failed to resolve peer escalation: {e}"))
     }
 
+    /// #1967 — the READ surface for peer escalations: list this goal's OPEN
+    /// escalation rows for `goal_get`. The write half
+    /// ([`Self::model_goal_record_peer_escalation`]) has run since #1961 but
+    /// no production SELECT existed — an open escalation was invisible to the
+    /// master model unless it happened to catch the park-time wake. Mirrors
+    /// [`Self::model_goal_ledger_findings`]: no binding check here because
+    /// `goal_get` already authorized the goal_id it passes, and a missing /
+    /// unopenable ledger is an empty list, never an error. Question text is
+    /// re-capped at ≤300 chars INCLUDING the truncation ellipsis (the
+    /// producer caps at 500) to keep the goal_get snapshot compact.
+    pub(crate) fn model_goal_ledger_open_escalations(
+        &self,
+        profile_data_dir: &std::path::Path,
+        goal_id: &str,
+    ) -> Vec<Value> {
+        let ledger_dir = Self::goal_ledger_dir(profile_data_dir);
+        let ledger_path = ledger_dir.join(format!("{}.db", sanitize_filename_for_ledger(goal_id)));
+        if !ledger_path.is_file() {
+            return Vec::new();
+        }
+        let Ok(ledger) = octos_fleet::GoalLedger::open(&ledger_path) else {
+            return Vec::new();
+        };
+        let now_ms = now_ms_u64();
+        ledger
+            .list_open_escalations(goal_id)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|e| {
+                // #1967 codex round — the cap INCLUDES the ellipsis: a
+                // >300-char question renders as 299 chars + '…' (exactly
+                // 300), never 301, so the surface's ≤300 contract holds for
+                // the whole rendered string. An exactly-300-char question
+                // passes through untouched (`nth(300)` = a 301st char
+                // exists). The producer caps at 500, so this re-cap only
+                // bites on long questions.
+                let question = if e.question.chars().nth(300).is_some() {
+                    let capped: String = e.question.chars().take(299).collect();
+                    format!("{capped}…")
+                } else {
+                    e.question
+                };
+                json!({
+                    "escalation_id": e.escalation_id,
+                    "peer_id": e.peer_id,
+                    "task_id": e.task_id,
+                    "question": question,
+                    "created_at_ms": e.created_at_ms,
+                    "age_seconds": now_ms.saturating_sub(e.created_at_ms) / 1000,
+                    "default_action": e.default_action,
+                    "default_after_secs": e.default_after_secs,
+                })
+            })
+            .collect()
+    }
+
+    /// #1967 — resolve every OPEN escalation whose producer-declared default
+    /// timer has elapsed (`created_at_ms + default_after_secs*1000 < now`),
+    /// across ALL of this profile's goal ledgers. Returns the number of rows
+    /// resolved. Wired into the global master-continuation drain
+    /// (`spawn_global_master_continuation_drain`), throttled THERE to once
+    /// per minute. DORMANT until a producer sets defaults: the only writer
+    /// ([`Self::model_goal_record_peer_escalation`]) records
+    /// `default_action`/`default_after_secs` as `None` today, so no row
+    /// qualifies until escalations start declaring them.
+    ///
+    /// IMPORTANT LIMIT (v1): resolving the ledger row does NOT un-park a live
+    /// peer. The parked approval/question oneshot lives in the process-global
+    /// pending stores keyed by the peer's wire session, and honouring
+    /// `default_action` there would need the full `peer_respond` delivery
+    /// path (approve/deny/answer routing + decided events) — a hard cancel
+    /// would DENY an escalation whose default says "proceed". v1 timeout is
+    /// ledger-truth + master-visibility only: `goal_get` stops surfacing the
+    /// row; the peer stays parked until answered (`peer_respond`), closed
+    /// (`peer_close`), or its pending entry is cancelled.
+    ///
+    /// ORDERING HAZARD (#1967 codex round, dormant today): `peer_respond`
+    /// DELIVERS the answer to the parked peer BEFORE it resolves the ledger
+    /// row. A sweep firing inside that gap flips the row to `[timeout] …`
+    /// first; the answer's bulk resolve then matches no `open` row (benign
+    /// `Ok(0)`) and records nothing — the ledger attributes a timeout to an
+    /// escalation that was actually ANSWERED. The answer itself is never
+    /// lost (delivery already happened); only the ledger's resolution text
+    /// is wrong. Unreachable while every producer writes
+    /// `default_after_secs = None`; if defaults ever ship, revisit with an
+    /// answered-wins amend step — deliberately NOT an amend API today.
+    ///
+    /// NOTE: `serve --stdio` returns before the global drain is spawned
+    /// (serve.rs spawns it only on the ws/http path), so this sweep never
+    /// runs under `--stdio` — a pre-existing drain gap tracked separately;
+    /// the drain spawn is deliberately not moved in this change.
+    pub(crate) fn sweep_escalation_timeouts(&self, profile_data_dir: &std::path::Path) -> usize {
+        let ledger_dir = Self::goal_ledger_dir(profile_data_dir);
+        let Ok(entries) = std::fs::read_dir(&ledger_dir) else {
+            // No goal-ledgers dir — this profile never recorded an escalation.
+            return 0;
+        };
+        let now_ms = now_ms();
+        let mut resolved = 0usize;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            // Real ledger files only — skips the WAL/SHM sidecars (`.db-wal`,
+            // `.db-shm`) SQLite keeps beside each ledger.
+            if path.extension().and_then(|e| e.to_str()) != Some("db") {
+                continue;
+            }
+            // #1967 codex round — `GoalLedger::open` MUTATES its target (WAL
+            // pragma switch + DDL), so never follow a symlinked entry out of
+            // `goal-ledgers/`: a planted link would let this scan
+            // initialize/flip tables in an arbitrary sqlite file. Fail closed
+            // on an unstat-able entry too (same posture as `staged_peer_dir`).
+            let is_symlink = std::fs::symlink_metadata(&path)
+                .map(|meta| meta.file_type().is_symlink())
+                .unwrap_or(true);
+            if is_symlink {
+                tracing::warn!(
+                    path = %path.display(),
+                    "escalation sweep skipping symlinked/unstatable goal-ledger entry"
+                );
+                continue;
+            }
+            let Ok(ledger) = octos_fleet::GoalLedger::open(&path) else {
+                continue;
+            };
+            let Ok(candidates) = ledger.list_expired_open_escalations(now_ms) else {
+                continue;
+            };
+            for esc in candidates {
+                let resolution = escalation_timeout_resolution(esc.default_action.as_deref());
+                match ledger.resolve_escalation_by_id(
+                    &esc.escalation_id,
+                    &resolution,
+                    "system:escalation-timeout",
+                ) {
+                    Ok(true) => {
+                        resolved += 1;
+                        tracing::info!(
+                            escalation_id = %esc.escalation_id,
+                            goal_id = %esc.goal_id,
+                            peer_id = %esc.peer_id,
+                            resolution = %resolution,
+                            "escalation timeout sweep resolved an expired escalation"
+                        );
+                    }
+                    // Raced a concurrent answer/close between SELECT and
+                    // UPDATE — the real resolution wins, nothing to count.
+                    Ok(false) => {}
+                    Err(err) => {
+                        tracing::warn!(
+                            escalation_id = %esc.escalation_id,
+                            error = %err,
+                            "escalation timeout sweep failed to resolve a row"
+                        );
+                    }
+                }
+            }
+        }
+        resolved
+    }
+
     /// Directory holding this profile's per-goal ledgers. Resolved under the
     /// profile's persistent `data_dir` so ledgers (a) survive restarts and
     /// `/tmp` cleanup, (b) are profile-isolated (a peer on profile A cannot
@@ -6814,6 +6974,15 @@ fn sanitize_filename_for_ledger(goal_id: &str) -> String {
             }
         })
         .collect()
+}
+
+/// #1967 — the resolution text a timed-out escalation records: `[timeout]
+/// <default_action>` when the producer declared what the peer would do,
+/// `[timeout] expired` otherwise — so an audit can tell an answered row
+/// (`[answer]`/`[approval]`), an abandoned one (`[closed]`) and an expired
+/// one apart at a glance.
+fn escalation_timeout_resolution(default_action: Option<&str>) -> String {
+    format!("[timeout] {}", default_action.unwrap_or("expired"))
 }
 
 /// Symlink-safe `staged_peer_dir` for the ledger aggregation path: a peer
@@ -14415,6 +14584,293 @@ mod tests {
             "the durable ledger must reflect the final `complete` status"
         );
         assert_eq!(row.objective, "prove the ledger reflects completion");
+    }
+
+    /// #1967 test helper — seed a goal ledger at
+    /// `<data_dir>/goal-ledgers/<goal_id>.db` with its goals row, returning
+    /// the opened ledger for direct escalation writes.
+    fn seed_goal_ledger(data_dir: &std::path::Path, goal_id: &str) -> octos_fleet::GoalLedger {
+        let ledger_dir = InProcessAgentOrchestrator::goal_ledger_dir(data_dir);
+        std::fs::create_dir_all(&ledger_dir).unwrap();
+        let ledger = octos_fleet::GoalLedger::open(
+            ledger_dir.join(format!("{}.db", sanitize_filename_for_ledger(goal_id))),
+        )
+        .expect("open ledger");
+        ledger
+            .upsert_goal(&octos_fleet::Goal {
+                goal_id: goal_id.to_owned(),
+                objective: "escalation lifecycle".to_owned(),
+                status: "active".to_owned(),
+                tokens_used: 0,
+                token_budget: 1_000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1_000,
+                updated_at_ms: 1_000,
+            })
+            .expect("goals row");
+        ledger
+    }
+
+    /// #1967 test helper — an OPEN escalation row for the sweeps/surfaces.
+    fn open_escalation_row(
+        escalation_id: &str,
+        goal_id: &str,
+        peer_id: &str,
+        question: &str,
+        created_at_ms: u64,
+        default_action: Option<&str>,
+        default_after_secs: Option<i64>,
+    ) -> octos_fleet::Escalation {
+        octos_fleet::Escalation {
+            escalation_id: escalation_id.to_owned(),
+            goal_id: goal_id.to_owned(),
+            task_id: None,
+            peer_id: peer_id.to_owned(),
+            question: question.to_owned(),
+            context: None,
+            status: "open".to_owned(),
+            default_action: default_action.map(str::to_owned),
+            default_after_secs,
+            created_at_ms,
+            resolved_at_ms: None,
+            resolved_by: None,
+            resolution: None,
+        }
+    }
+
+    /// #1967 — `goal_get`'s escalation surface: open rows come back in the
+    /// compact shape the tool folds in (escalation_id, peer_id, task_id,
+    /// question capped at 300 chars, created_at_ms, age_seconds,
+    /// default_action, default_after_secs), oldest first; resolved rows and
+    /// a missing ledger yield nothing.
+    #[test]
+    fn model_goal_ledger_open_escalations_shape_and_truncation() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let data_dir = tempfile::TempDir::new().unwrap();
+        // No ledger file yet → empty, not an error.
+        assert!(
+            orchestrator
+                .model_goal_ledger_open_escalations(data_dir.path(), "g-esc")
+                .is_empty()
+        );
+        let ledger = seed_goal_ledger(data_dir.path(), "g-esc");
+        let now_ms = now_ms_u64();
+        ledger
+            .append_escalation(&open_escalation_row(
+                "esc-newer",
+                "g-esc",
+                "peer-b",
+                &"q".repeat(400),
+                now_ms.saturating_sub(5_000),
+                Some("proceed"),
+                Some(300),
+            ))
+            .unwrap();
+        ledger
+            .append_escalation(&open_escalation_row(
+                "esc-older",
+                "g-esc",
+                "peer-a",
+                "[question] which port?",
+                now_ms.saturating_sub(60_000),
+                None,
+                None,
+            ))
+            .unwrap();
+        // A resolved row must never surface.
+        ledger
+            .append_escalation(&open_escalation_row(
+                "esc-done", "g-esc", "peer-c", "answered", 1_000, None, None,
+            ))
+            .unwrap();
+        ledger
+            .resolve_escalation("peer-c", "[answer] yes", "master", 2_000)
+            .unwrap();
+
+        let rows = orchestrator.model_goal_ledger_open_escalations(data_dir.path(), "g-esc");
+        assert_eq!(rows.len(), 2, "open rows only");
+        assert_eq!(rows[0]["escalation_id"], json!("esc-older"), "oldest first");
+        assert_eq!(rows[0]["peer_id"], json!("peer-a"));
+        assert_eq!(rows[0]["question"], json!("[question] which port?"));
+        assert_eq!(rows[0]["task_id"], Value::Null);
+        assert_eq!(rows[0]["default_action"], Value::Null);
+        assert_eq!(rows[0]["default_after_secs"], Value::Null);
+        let age = rows[0]["age_seconds"].as_u64().expect("age_seconds");
+        assert!((30..=600).contains(&age), "age ≈ 60s, got {age}");
+        // #1967 codex round — the 400-char question is capped at 300 chars
+        // INCLUDING the ellipsis (299 + '…'), never 301: the surface's ≤300
+        // contract holds for the whole rendered string.
+        let question = rows[1]["question"].as_str().expect("question");
+        assert_eq!(
+            question.chars().count(),
+            300,
+            "cap is ≤300 INCLUDING the ellipsis"
+        );
+        assert_eq!(question, format!("{}…", "q".repeat(299)));
+        assert_eq!(rows[1]["default_action"], json!("proceed"));
+        assert_eq!(rows[1]["default_after_secs"], json!(300));
+        assert_eq!(
+            rows[1]["created_at_ms"],
+            json!(now_ms.saturating_sub(5_000))
+        );
+        // Boundary: an EXACTLY-300-char question passes through untruncated —
+        // no ellipsis burned on a question already within the cap.
+        ledger
+            .append_escalation(&open_escalation_row(
+                "esc-exact",
+                "g-esc",
+                "peer-d",
+                &"e".repeat(300),
+                now_ms,
+                None,
+                None,
+            ))
+            .unwrap();
+        let rows = orchestrator.model_goal_ledger_open_escalations(data_dir.path(), "g-esc");
+        let exact = rows
+            .iter()
+            .find(|r| r["escalation_id"] == json!("esc-exact"))
+            .expect("esc-exact listed");
+        assert_eq!(exact["question"], json!("e".repeat(300)));
+    }
+
+    /// #1967 — the timeout resolution string carries the producer's declared
+    /// default (or the "expired" placeholder) so the master can tell WHAT the
+    /// timeout committed the peer to.
+    #[test]
+    fn escalation_timeout_resolution_names_default_or_expired() {
+        assert_eq!(
+            escalation_timeout_resolution(Some("proceed with plan A")),
+            "[timeout] proceed with plan A"
+        );
+        assert_eq!(escalation_timeout_resolution(None), "[timeout] expired");
+    }
+
+    /// #1967 — `sweep_escalation_timeouts` resolves ONLY open escalations
+    /// whose `default_after_secs` has elapsed; unexpired and no-default rows
+    /// stay open, and a second pass is a no-op (idempotent).
+    #[test]
+    fn sweep_escalation_timeouts_resolves_only_elapsed_defaults() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let data_dir = tempfile::TempDir::new().unwrap();
+        // No goal-ledgers dir at all → nothing to sweep.
+        assert_eq!(orchestrator.sweep_escalation_timeouts(data_dir.path()), 0);
+        let ledger = seed_goal_ledger(data_dir.path(), "g-sweep");
+        let now_ms = now_ms_u64();
+        // Expired: created 10s ago with a 1s default.
+        ledger
+            .append_escalation(&open_escalation_row(
+                "esc-expired",
+                "g-sweep",
+                "p1",
+                "waited too long",
+                now_ms.saturating_sub(10_000),
+                Some("proceed"),
+                Some(1),
+            ))
+            .unwrap();
+        // Unexpired: created now with a 1h default.
+        ledger
+            .append_escalation(&open_escalation_row(
+                "esc-later",
+                "g-sweep",
+                "p2",
+                "still fresh",
+                now_ms,
+                None,
+                Some(3_600),
+            ))
+            .unwrap();
+        // No default → the sweep must never touch it.
+        ledger
+            .append_escalation(&open_escalation_row(
+                "esc-forever",
+                "g-sweep",
+                "p3",
+                "needs a human",
+                now_ms.saturating_sub(10_000),
+                None,
+                None,
+            ))
+            .unwrap();
+
+        assert_eq!(
+            orchestrator.sweep_escalation_timeouts(data_dir.path()),
+            1,
+            "exactly the elapsed default resolves"
+        );
+        let still_open = ledger.list_open_escalations("g-sweep").unwrap();
+        assert_eq!(
+            still_open
+                .iter()
+                .map(|e| e.escalation_id.as_str())
+                .collect::<Vec<_>>(),
+            // Oldest first: esc-forever (now-10s) precedes esc-later (now).
+            vec!["esc-forever", "esc-later"],
+            "unexpired + no-default rows stay open"
+        );
+        assert_eq!(
+            orchestrator.sweep_escalation_timeouts(data_dir.path()),
+            0,
+            "second pass is a no-op"
+        );
+    }
+
+    /// #1967 codex round — `GoalLedger::open` MUTATES its target (WAL pragma
+    /// switch + DDL), so the sweep must never follow a symlinked entry out of
+    /// `goal-ledgers/`: a planted link would let the scan initialize/flip
+    /// tables in an arbitrary sqlite file. Same fail-closed posture as
+    /// `staged_peer_dir`.
+    #[cfg(unix)]
+    #[test]
+    fn sweep_escalation_timeouts_skips_symlinked_ledgers() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let data_dir = tempfile::TempDir::new().unwrap();
+        // A REAL ledger with an expired-default row lives OUTSIDE the
+        // goal-ledgers dir; only a symlink points at it from inside.
+        let outside = data_dir.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        let target_db = outside.join("foreign.db");
+        let foreign = octos_fleet::GoalLedger::open(&target_db).expect("open foreign ledger");
+        foreign
+            .upsert_goal(&octos_fleet::Goal {
+                goal_id: "g-foreign".to_owned(),
+                objective: "not ours".to_owned(),
+                status: "active".to_owned(),
+                tokens_used: 0,
+                token_budget: 1_000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1_000,
+                updated_at_ms: 1_000,
+            })
+            .unwrap();
+        foreign
+            .append_escalation(&open_escalation_row(
+                "esc-foreign",
+                "g-foreign",
+                "p1",
+                "expired elsewhere",
+                now_ms_u64().saturating_sub(10_000),
+                Some("proceed"),
+                Some(1),
+            ))
+            .unwrap();
+        let ledger_dir = InProcessAgentOrchestrator::goal_ledger_dir(data_dir.path());
+        std::fs::create_dir_all(&ledger_dir).unwrap();
+        std::os::unix::fs::symlink(&target_db, ledger_dir.join("linked.db")).unwrap();
+
+        assert_eq!(
+            orchestrator.sweep_escalation_timeouts(data_dir.path()),
+            0,
+            "a symlinked ledger entry must be skipped, not opened"
+        );
+        assert_eq!(
+            foreign.list_open_escalations("g-foreign").unwrap().len(),
+            1,
+            "the link target's row must remain untouched"
+        );
     }
 
     /// #1696 — `goal_get` snapshot: stable shape with remaining budget;

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -14344,12 +14344,39 @@ fn enqueue_peer_awaiting_input_wake(
     }
 }
 
-/// Resolve the peer's `peers_root` from `state.profiles` and enqueue the
-/// awaiting-input wake on its originator. The thin `AppState` seam over
-/// [`enqueue_peer_awaiting_input_wake`] that the park-point requesters call.
-/// No-op for a non-peer session or an unregistered profile.
+/// Resolve the peer's profile `data_dir` from `state.profiles` and delegate.
+/// The thin `AppState` seam over [`wake_master_and_record_park_escalation`]
+/// that the park-point requesters call. No-op for a non-peer session or an
+/// unregistered profile.
 fn wake_master_on_peer_awaiting_input(
     state: &AppState,
+    peer_session: &SessionKey,
+    pending_id: &str,
+    park_kind: PeerPendingKind,
+    prompt: &str,
+) {
+    let Some((profile_id, _slug)) = peer_slug_and_profile(peer_session) else {
+        return;
+    };
+    let Some(runtime) = state.profiles.get(profile_id) else {
+        return;
+    };
+    wake_master_and_record_park_escalation(
+        &runtime.data_dir,
+        peer_session,
+        pending_id,
+        park_kind,
+        prompt,
+    );
+}
+
+/// The `AppState`-free body of [`wake_master_on_peer_awaiting_input`] (split
+/// out in the #1967 codex round so the park-time effects are unit-testable
+/// with a tempdir `data_dir`): enqueue the awaiting-input wake on the peer's
+/// originator, then persist the park as a durable `Escalation` row when the
+/// peer carries a goal context.
+fn wake_master_and_record_park_escalation(
+    data_dir: &Path,
     peer_session: &SessionKey,
     pending_id: &str,
     park_kind: PeerPendingKind,
@@ -14358,10 +14385,24 @@ fn wake_master_on_peer_awaiting_input(
     let Some((profile_id, slug)) = peer_slug_and_profile(peer_session) else {
         return;
     };
-    let Some(runtime) = state.profiles.get(profile_id) else {
+    let peers_root = data_dir.join("peers");
+    // #1967 codex round — a park can land in the documented close race (the
+    // #P1-2 residual: between peer_close's pending-cancel sweep and its wire
+    // eviction). By then the `closed` marker is durable, `peer_respond`
+    // refuses the peer, and peer_close's ledger resolve has ALREADY run — so
+    // a wake would point the master at an unanswerable peer, and a fresh
+    // escalation row would sit orphaned `open` forever. A closed peer's park
+    // must produce NEITHER. The requester's live oneshot itself remains
+    // #1842 (close-while-parked) — out of scope here.
+    if peer_is_closed(&peers_root, slug) {
+        tracing::debug!(
+            slug,
+            profile = profile_id,
+            kind = park_kind.as_str(),
+            "peer parked after close — suppressing master wake and escalation row"
+        );
         return;
-    };
-    let peers_root = runtime.data_dir.join("peers");
+    }
     let _ =
         enqueue_peer_awaiting_input_wake(&peers_root, peer_session, pending_id, park_kind, prompt);
 
@@ -14402,7 +14443,7 @@ fn wake_master_on_peer_awaiting_input(
         PeerPendingKind::Question => "question",
     };
     if let Err(err) = default_agent_orchestrator().model_goal_record_peer_escalation(
-        &runtime.data_dir,
+        data_dir,
         goal_id,
         profile_id,
         &originator,
@@ -14448,6 +14489,104 @@ mod peer_awaiting_wake_tests {
 
     fn peer_session(profile: &str, chat: &str, slug: &str) -> SessionKey {
         SessionKey::with_profile_topic(profile, "api", chat, &format!("peer-{slug}"))
+    }
+
+    /// #1967 codex round — a peer that parks AFTER `peer_close` (the
+    /// documented #P1-2 close-race residual: a park landing between the
+    /// pending-cancel sweep and the wire eviction) must produce NEITHER a
+    /// master wake NOR a fresh escalation row. The close already cancelled
+    /// its pendings and resolved its ledger rows; `peer_respond` refuses a
+    /// closed peer, so a row written now would be orphaned `open` forever.
+    /// An identically-staged OPEN peer is the positive control: same goal,
+    /// same originator — wake + row both land.
+    #[test]
+    fn closed_peer_park_produces_neither_wake_nor_escalation_row() {
+        use crate::api::agent_orchestrator::{AgentOrchestrator as _, GoalSetRequest};
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+        let peers_root = data_dir.join("peers");
+        let profile = "tenant-wake-closed-esc";
+        let master = "tenant-wake-closed-esc:api:master";
+        // A goal OWNED by the originator, so the escalation write would
+        // succeed if (wrongly) attempted for the closed peer — the test must
+        // prove the GUARD suppresses it, not a binding failure.
+        let orchestrator = default_agent_orchestrator();
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: SessionKey(master.to_owned()),
+                profile_id: profile.to_owned(),
+                objective: "close-race escalation guard".to_owned(),
+                status: Some("active".to_owned()),
+                token_budget: Some(1_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        let goal_id = orchestrator
+            .goal_id_for_session(&SessionKey(master.to_owned()))
+            .expect("goal id");
+        let ledger_path = data_dir.join("goal-ledgers").join(format!("{goal_id}.db"));
+        // `set_goal` enqueues the initial GoalContinue on the master, so the
+        // wake assertions below are DELTAS against this baseline.
+        let baseline = orchestrator.pending_continuation_count_for_session_for_test(
+            &SessionKey(master.to_owned()),
+            profile,
+        );
+
+        // The CLOSED peer: staged + goal-bound, with the durable marker.
+        stage_peer_with_originator(&peers_root, "retired", Some(master));
+        std::fs::write(
+            peers_root.join("retired").join("goal"),
+            format!("{goal_id}\n"),
+        )
+        .unwrap();
+        std::fs::write(peers_root.join("retired").join("closed"), "closer\n1\n").unwrap();
+        wake_master_and_record_park_escalation(
+            data_dir,
+            &peer_session(profile, "retired-wire", "retired"),
+            "approval-closed-1",
+            PeerPendingKind::Approval,
+            "run the migration?",
+        );
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_session_for_test(
+                &SessionKey(master.to_owned()),
+                profile,
+            ),
+            baseline,
+            "a closed peer's park must not wake the master"
+        );
+        assert!(
+            !ledger_path.exists(),
+            "a closed peer's park must not write an escalation row (ledger created at {})",
+            ledger_path.display()
+        );
+
+        // Positive control: the SAME staging without the marker → both land.
+        stage_peer_with_originator(&peers_root, "active", Some(master));
+        std::fs::write(
+            peers_root.join("active").join("goal"),
+            format!("{goal_id}\n"),
+        )
+        .unwrap();
+        wake_master_and_record_park_escalation(
+            data_dir,
+            &peer_session(profile, "active-wire", "active"),
+            "approval-open-1",
+            PeerPendingKind::Approval,
+            "run the migration?",
+        );
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_session_for_test(
+                &SessionKey(master.to_owned()),
+                profile,
+            ),
+            baseline + 1,
+            "an open peer's park wakes the master"
+        );
+        let ledger = octos_fleet::GoalLedger::open(&ledger_path).expect("ledger exists");
+        let open = ledger.list_open_escalations(&goal_id).unwrap();
+        assert_eq!(open.len(), 1, "exactly the open peer's row was written");
+        assert_eq!(open[0].peer_id, "active");
     }
 
     /// A peer parking on an APPROVAL wakes its originator (master) with a
@@ -14964,6 +15103,14 @@ fn peer_respond_resolve(
     // stops showing it as open. Best-effort: a goal-less peer, a missing
     // ledger, or no open escalation is a benign no-op, and a ledger write
     // failure must NOT fail the resume the caller already committed to.
+    //
+    // #1967 codex round — ordering: because delivery happens BEFORE this
+    // resolve, a timeout sweep (`sweep_escalation_timeouts`) firing in the
+    // gap can flip the row to `[timeout] …` first, making this bulk resolve
+    // a no-op — the ledger then shows a timeout for an escalation that was
+    // actually answered (the delivered answer itself is unaffected). Dormant
+    // while producers write `default_after_secs = None`; the hazard and the
+    // deliberate no-amend-API decision are documented on the sweep.
     if let Some(peer_dir) = staged_peer_dir(peers_root, &slug) {
         let goal_id = peer_io::read_peer_file(&peer_dir, "goal", peer_io::PEER_FILE_READ_CAP_SMALL)
             .and_then(|body| body.lines().next().map(|l| l.trim().to_owned()))
@@ -16165,6 +16312,35 @@ fn build_peer_close_callback(
         cancel_peer_pending_on_close(&contracts, &profile_id, &slug, &|event| {
             emit_cancelled(event)
         });
+        // #1967 — the cancel above released the live oneshot, but the
+        // escalation row written at park time
+        // (`model_goal_record_peer_escalation`) is DURABLE: with the peer now
+        // closed, `peer_respond` refuses it, so nothing would ever flip the
+        // row off `open` — a permanent phantom on the master's goal_get
+        // escalation surface. Resolve it bulk-by-peer (the depth-1 peer has
+        // at most one open escalation, and every open row of a closed peer is
+        // by definition abandoned). Best-effort: a goal-less peer / missing
+        // ledger is a benign Ok(0), and a ledger failure must never fail the
+        // close (the marker is already durable).
+        let goal_id = peer_io::read_peer_file(&peer_dir, "goal", peer_io::PEER_FILE_READ_CAP_SMALL)
+            .and_then(|body| body.lines().next().map(|l| l.trim().to_owned()))
+            .filter(|s| !s.is_empty());
+        if let (Some(goal_id), Some(data_dir)) = (goal_id, peers_root.parent()) {
+            if let Err(err) = default_agent_orchestrator().model_goal_resolve_peer_escalation(
+                data_dir,
+                &goal_id,
+                &slug,
+                "[closed] peer closed before answering",
+                &origin_session,
+            ) {
+                tracing::warn!(
+                    slug = %slug,
+                    goal_id = %goal_id,
+                    error = %err,
+                    "peer-goal: failed to resolve open escalation on peer close (close proceeds)"
+                );
+            }
+        }
         // Peer-fleet auto-synthesis RESET — the close marker now excludes this
         // peer from the master's owned fleet. If it was the LAST owned peer, the
         // fleet is fully retired: drop the `.synthesized` marker so a genuinely
@@ -21498,8 +21674,52 @@ pub(crate) fn spawn_global_master_continuation_drain(state: Arc<AppState>) {
             interval_secs = GLOBAL_MASTER_CONTINUATION_DRAIN_INTERVAL_SECS,
             "global master-continuation drain loop started (connection-independent)"
         );
+        // #1967 — escalation timeout sweep cadence: this loop ticks every 5s,
+        // but the sweep opens every goal-ledger db under every profile, so it
+        // runs at most once per minute. Loop-local throttle state on purpose
+        // (NOT in the orchestrator): the cadence belongs to this driver, and
+        // tests driving `sweep_escalation_timeouts` directly must never be
+        // throttled. `None` start = first in-loop tick sweeps immediately, so
+        // rows that expired while the serve was down resolve promptly.
+        const ESCALATION_SWEEP_MIN_INTERVAL: Duration = Duration::from_secs(60);
+        let mut last_escalation_sweep: Option<std::time::Instant> = None;
         loop {
             tick.tick().await;
+
+            // #1967 — resolve expired open escalations across every profile's
+            // goal ledgers. Ledger-truth + master-visibility only: a live
+            // parked peer is NOT un-parked (see `sweep_escalation_timeouts`
+            // for why a hard cancel would be wrong). Dormant until producers
+            // set `default_after_secs`.
+            if last_escalation_sweep.is_none_or(|at| at.elapsed() >= ESCALATION_SWEEP_MIN_INTERVAL)
+            {
+                last_escalation_sweep = Some(std::time::Instant::now());
+                // #1967 codex round — the sweep is synchronous rusqlite I/O
+                // (opens every goal-ledger db), so run it on the blocking
+                // pool: it must never stall this drain tick. Detached on
+                // purpose (handle dropped): the 60s throttle above bounds
+                // re-entry, and a pathological >60s sweep overlapping the
+                // next is harmless — `resolve_escalation_by_id` only ever
+                // flips rows still `open`.
+                let profile_dirs: Vec<(String, PathBuf)> = state
+                    .profiles
+                    .iter()
+                    .map(|(id, runtime)| (id.clone(), runtime.data_dir.clone()))
+                    .collect();
+                tokio::task::spawn_blocking(move || {
+                    for (profile_id, data_dir) in profile_dirs {
+                        let swept =
+                            default_agent_orchestrator().sweep_escalation_timeouts(&data_dir);
+                        if swept > 0 {
+                            info!(
+                                profile = %profile_id,
+                                swept,
+                                "escalation timeout sweep resolved expired escalations"
+                            );
+                        }
+                    }
+                });
+            }
 
             // codex P2 (reap): this loop never closes, so the per-connection
             // cleanup path (`abort_connection_turns` on socket close) never runs

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -28051,6 +28051,77 @@ fn peer_close_callback_emits_closed_event_on_success_only() {
     assert_eq!(event.profile_id, "tenant-a");
 }
 
+/// #1967 — closing a goal-scoped peer must RESOLVE its open escalation row in
+/// the goal ledger. The close cancels the parked oneshot
+/// (`cancel_peer_pending_on_close`) and `peer_respond` refuses closed peers,
+/// so before this fix the row written at park time stayed `open` forever — a
+/// permanent phantom on the master's `goal_get` escalation surface.
+#[test]
+fn peer_close_resolves_open_goal_escalations_in_ledger() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path().join("peers");
+    let slug = "close-esc";
+    std::fs::create_dir_all(peers_root.join(slug)).unwrap();
+    std::fs::write(peers_root.join(slug).join("brief.md"), "work").unwrap();
+    let owner = "tenant-a:api:master";
+    std::fs::write(peers_root.join(slug).join("originator"), owner).unwrap();
+    // Goal binding: first line goal_id, second (optional) task_id — the same
+    // layout `wake_master_on_peer_awaiting_input` reads when it WRITES the row.
+    std::fs::write(peers_root.join(slug).join("goal"), "g-close\ntask-9\n").unwrap();
+
+    // Seed the OPEN escalation the peer parked on (written at park time by
+    // `model_goal_record_peer_escalation`; seeded directly here).
+    let ledger_dir = tmp.path().join("goal-ledgers");
+    std::fs::create_dir_all(&ledger_dir).unwrap();
+    let ledger = octos_fleet::GoalLedger::open(ledger_dir.join("g-close.db")).unwrap();
+    ledger
+        .upsert_goal(&octos_fleet::Goal {
+            goal_id: "g-close".to_owned(),
+            objective: "test".to_owned(),
+            status: "active".to_owned(),
+            tokens_used: 0,
+            token_budget: 1_000,
+            continuations_used: 0,
+            revision: 0,
+            created_at_ms: 1_000,
+            updated_at_ms: 1_000,
+        })
+        .unwrap();
+    ledger
+        .append_escalation(&octos_fleet::Escalation {
+            escalation_id: "esc-close-1".to_owned(),
+            goal_id: "g-close".to_owned(),
+            task_id: None,
+            peer_id: slug.to_owned(),
+            question: "[approval] run the migration?".to_owned(),
+            context: None,
+            status: "open".to_owned(),
+            default_action: None,
+            default_after_secs: None,
+            created_at_ms: 1_000,
+            resolved_at_ms: None,
+            resolved_by: None,
+            resolution: None,
+        })
+        .unwrap();
+
+    let close = build_peer_close_callback(
+        peers_root.clone(),
+        owner.to_owned(),
+        "tenant-a".to_owned(),
+        Arc::new(UiProtocolContractStores::default()),
+        Arc::new(|_event: PeerClosedEvent| {}),
+        Arc::new(|_event: ApprovalCancelledEvent| {}),
+    );
+    close(slug.to_owned()).expect("owner closes");
+
+    let open = ledger.list_open_escalations("g-close").unwrap();
+    assert!(
+        open.is_empty(),
+        "peer_close must resolve the orphaned escalation, still open: {open:?}"
+    );
+}
+
 /// PART C — a NAMED peer reserves the exact name-derived slug, stores the
 /// display name, and REJECTS a duplicate name (case-insensitive) or a name
 /// that derives an already-taken slug (no auto-suffix).

--- a/crates/octos-cli/src/goal_tool.rs
+++ b/crates/octos-cli/src/goal_tool.rs
@@ -268,10 +268,12 @@ pub struct GoalGetTool {
     /// Peer-agent-based goal: the profile's persistent `data_dir`. When set,
     /// `goal_get` aggregates the latest `result.md` from every staged peer
     /// whose `goal` file points at the queried goal (under
-    /// `<data_dir>/peers/<slug>/goal`), AND the durable findings from the
-    /// goal's sqlite ledger (under `<data_dir>/goal-ledgers/<goal_id>.db`),
-    /// surfacing them as `peer_findings` and `ledger_findings` in the
-    /// snapshot. `None` preserves pre-peer-goal behaviour (no aggregation).
+    /// `<data_dir>/peers/<slug>/goal`), AND the durable findings + open
+    /// escalations from the goal's sqlite ledger (under
+    /// `<data_dir>/goal-ledgers/<goal_id>.db`), surfacing them as
+    /// `peer_findings`, `ledger_findings` and `open_escalations` (#1967) in
+    /// the snapshot. `None` preserves pre-peer-goal behaviour (no
+    /// aggregation).
     data_dir: Option<std::path::PathBuf>,
 }
 
@@ -425,6 +427,22 @@ impl Tool for GoalGetTool {
             if !ledger_findings.is_empty() {
                 if let Value::Object(map) = &mut snapshot {
                     map.insert("ledger_findings".to_owned(), Value::Array(ledger_findings));
+                }
+            }
+            // #1967 — fold in the goal's OPEN escalations (rows written when a
+            // goal-scoped peer parks on an approval/question). Until this read
+            // the escalations table was write-only: a master that missed the
+            // park-time wake could never rediscover a blocked peer from
+            // goal_get. Open rows only, compact shape (question ≤300 chars),
+            // omitted entirely when none are open.
+            let open_escalations =
+                orchestrator.model_goal_ledger_open_escalations(data_dir, &goal_id);
+            if !open_escalations.is_empty() {
+                if let Value::Object(map) = &mut snapshot {
+                    map.insert(
+                        "open_escalations".to_owned(),
+                        Value::Array(open_escalations),
+                    );
                 }
             }
         }
@@ -1305,6 +1323,92 @@ impl Tool for GoalCreateTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #1967 — `goal_get` must SURFACE open escalations: the rows are written
+    /// when a goal-scoped peer parks (`model_goal_record_peer_escalation`) but
+    /// until this fold no production read existed, so the master model could
+    /// never see them. Same data_dir gate as `ledger_findings`.
+    #[tokio::test]
+    async fn goal_get_includes_open_escalations_when_data_dir_set() {
+        use crate::api::agent_orchestrator::{AgentOrchestrator as _, GoalSetRequest};
+        // The tool reads the PROCESS-GLOBAL orchestrator: use a unique
+        // session/profile and never clear the shared state (sibling tests own
+        // their own keys — same idiom as the ui_protocol continuation tests).
+        let orchestrator = default_agent_orchestrator();
+        let session = SessionKey("esc-tenant:api:goal-get-open-escalations".to_owned());
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session.clone(),
+                profile_id: "esc-tenant".to_owned(),
+                objective: "surface open escalations".to_owned(),
+                status: Some("active".to_owned()),
+                token_budget: Some(1_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        let goal_id = orchestrator
+            .goal_id_for_session(&session)
+            .expect("goal id minted");
+
+        // Seed the goal's ledger with ONE open escalation (goal ids are
+        // `goal_NN` — already filename-safe).
+        let data_dir = tempfile::tempdir().unwrap();
+        let ledger_dir = data_dir.path().join("goal-ledgers");
+        std::fs::create_dir_all(&ledger_dir).unwrap();
+        let ledger =
+            octos_fleet::GoalLedger::open(ledger_dir.join(format!("{goal_id}.db"))).unwrap();
+        ledger
+            .upsert_goal(&octos_fleet::Goal {
+                goal_id: goal_id.clone(),
+                objective: "surface open escalations".to_owned(),
+                status: "active".to_owned(),
+                tokens_used: 0,
+                token_budget: 1_000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1_000,
+                updated_at_ms: 1_000,
+            })
+            .unwrap();
+        ledger
+            .append_escalation(&octos_fleet::Escalation {
+                escalation_id: "esc-helper-1".to_owned(),
+                goal_id: goal_id.clone(),
+                task_id: None,
+                peer_id: "helper".to_owned(),
+                question: "[question] which port?".to_owned(),
+                context: None,
+                status: "open".to_owned(),
+                default_action: None,
+                default_after_secs: None,
+                created_at_ms: 1_000,
+                resolved_at_ms: None,
+                resolved_by: None,
+                resolution: None,
+            })
+            .unwrap();
+
+        let tool = GoalGetTool::new("esc-tenant").with_data_dir(data_dir.path().to_path_buf());
+        let mut ctx = ToolContext::zero();
+        ctx.parent_session_key = Some(session.0.clone());
+        let result = tool
+            .execute_with_context(&ctx, &json!({}))
+            .await
+            .expect("goal_get runs");
+        assert!(result.success, "goal_get succeeds: {}", result.output);
+        let snapshot: Value = serde_json::from_str(&result.output).expect("json snapshot");
+        let escalations = snapshot["open_escalations"]
+            .as_array()
+            .unwrap_or_else(|| panic!("open_escalations folded in, got: {snapshot}"));
+        assert_eq!(escalations.len(), 1);
+        assert_eq!(escalations[0]["escalation_id"], json!("esc-helper-1"));
+        assert_eq!(escalations[0]["peer_id"], json!("helper"));
+        assert_eq!(escalations[0]["question"], json!("[question] which port?"));
+        assert!(
+            escalations[0]["age_seconds"].as_u64().is_some(),
+            "age_seconds present"
+        );
+    }
 
     #[test]
     fn goal_plan_absent_grant_is_minimal() {

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -88,6 +88,12 @@ pub struct Escalation {
     pub resolution: Option<String>,
 }
 
+/// #1967 — the one column list every escalation SELECT shares; order is the
+/// contract [`GoalLedger::escalation_from_row`] maps by index.
+const ESCALATION_SELECT_COLUMNS: &str = "escalation_id, goal_id, task_id, peer_id, question, \
+     context, status, default_action, default_after_secs, created_at_ms, resolved_at_ms, \
+     resolved_by, resolution";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Decision {
     pub decision_id: String,
@@ -552,6 +558,11 @@ impl GoalLedger {
     /// `open` status resolves exactly the escalation just answered. Returns the
     /// number of rows updated (0 when there was no open escalation — e.g. an
     /// approval on a goal-less peer, or a double-resolve).
+    ///
+    /// #1967 — this bulk-by-peer form stays the right call for the ANSWER and
+    /// CLOSE paths ("everything open for this peer" IS the one escalation the
+    /// depth-1 peer parked on / abandoned). The timeout sweep instead addresses
+    /// individual rows via [`Self::resolve_escalation_by_id`].
     pub fn resolve_escalation(
         &self,
         peer_id: &str,
@@ -567,6 +578,93 @@ impl GoalLedger {
             params![resolution, resolved_by, resolved_at_ms, peer_id],
         )?;
         Ok(updated)
+    }
+
+    /// #1967 — shared row → [`Escalation`] mapper for the SELECT paths below.
+    /// Column order must match [`ESCALATION_SELECT_COLUMNS`].
+    fn escalation_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Escalation> {
+        Ok(Escalation {
+            escalation_id: row.get(0)?,
+            goal_id: row.get(1)?,
+            task_id: row.get(2)?,
+            peer_id: row.get(3)?,
+            question: row.get(4)?,
+            context: row.get(5)?,
+            status: row.get(6)?,
+            default_action: row.get(7)?,
+            default_after_secs: row.get(8)?,
+            created_at_ms: row.get(9)?,
+            resolved_at_ms: row.get(10)?,
+            resolved_by: row.get(11)?,
+            resolution: row.get(12)?,
+        })
+    }
+
+    /// #1967 — the READ half of the escalation lifecycle. Producers wrote rows
+    /// (`append_escalation`) and the answer path flipped them
+    /// (`resolve_escalation`), but no production SELECT existed — an open
+    /// escalation was invisible to the master model. `goal_get` folds these in
+    /// via `model_goal_ledger_open_escalations`; oldest first so the master
+    /// answers in park order.
+    pub fn list_open_escalations(&self, goal_id: &str) -> Result<Vec<Escalation>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(&format!(
+            "SELECT {ESCALATION_SELECT_COLUMNS} FROM escalations
+             WHERE goal_id = ?1 AND status = 'open'
+             ORDER BY created_at_ms ASC"
+        ))?;
+        let rows = stmt
+            .query_map(params![goal_id], Self::escalation_from_row)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// #1967 — TARGETED resolve: flip ONE escalation by primary key, provided
+    /// it is still `open`. Returns whether a row flipped (`false` = unknown id
+    /// or already resolved — a recorded resolution is never clobbered). Used
+    /// by the timeout sweep, which addresses each expired row individually;
+    /// the answer/close paths use the peer_id-bulk
+    /// [`Self::resolve_escalation`] instead (see its doc).
+    pub fn resolve_escalation_by_id(
+        &self,
+        escalation_id: &str,
+        resolution: &str,
+        resolved_by: &str,
+    ) -> Result<bool> {
+        let resolved_at_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+        let conn = self.conn.lock().unwrap();
+        let updated = conn.execute(
+            "UPDATE escalations
+             SET status = 'resolved', resolution = ?1, resolved_by = ?2, resolved_at_ms = ?3
+             WHERE escalation_id = ?4 AND status = 'open'",
+            params![resolution, resolved_by, resolved_at_ms, escalation_id],
+        )?;
+        Ok(updated > 0)
+    }
+
+    /// #1967 — timeout candidates for the escalation sweep: OPEN rows whose
+    /// `default_after_secs` timer has ELAPSED (`created_at_ms +
+    /// default_after_secs*1000 < now_ms`, strict). Deliberately NO goal
+    /// filter: the sweep addresses one per-goal ledger FILE, and the filename
+    /// is a lossy `sanitize_filename_for_ledger` mapping so the goal_id cannot
+    /// be recovered from the path — the rows carry it. Rows without a default
+    /// never qualify (the master must answer them via peer_respond, or
+    /// peer_close resolves them).
+    pub fn list_expired_open_escalations(&self, now_ms: i64) -> Result<Vec<Escalation>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(&format!(
+            "SELECT {ESCALATION_SELECT_COLUMNS} FROM escalations
+             WHERE status = 'open' AND default_after_secs IS NOT NULL
+               AND created_at_ms + default_after_secs * 1000 < ?1
+             ORDER BY created_at_ms ASC"
+        ))?;
+        let rows = stmt
+            .query_map(params![now_ms], Self::escalation_from_row)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
     }
 
     /// Append a decision to the ledger.
@@ -1732,6 +1830,220 @@ mod digest_integration_tests {
             ledger.get_goal("g2").unwrap().unwrap().status,
             "active",
             "a newer resume of a `blocked` goal must be allowed"
+        );
+    }
+
+    /// #1967 test helper — a minimal OPEN escalation row. The lifecycle tests
+    /// below vary only id/peer/timing/defaults, so keep the noise here.
+    fn open_escalation(
+        escalation_id: &str,
+        goal_id: &str,
+        peer_id: &str,
+        created_at_ms: u64,
+        default_action: Option<&str>,
+        default_after_secs: Option<i64>,
+    ) -> Escalation {
+        Escalation {
+            escalation_id: escalation_id.to_string(),
+            goal_id: goal_id.to_string(),
+            task_id: None,
+            peer_id: peer_id.to_string(),
+            question: format!("question from {peer_id}"),
+            context: None,
+            status: "open".to_string(),
+            default_action: default_action.map(str::to_string),
+            default_after_secs,
+            created_at_ms,
+            resolved_at_ms: None,
+            resolved_by: None,
+            resolution: None,
+        }
+    }
+
+    fn goal_row(goal_id: &str) -> Goal {
+        Goal {
+            goal_id: goal_id.to_string(),
+            objective: "test".to_string(),
+            status: "active".to_string(),
+            tokens_used: 0,
+            token_budget: 10000,
+            continuations_used: 0,
+            revision: 0,
+            created_at_ms: 1000,
+            updated_at_ms: 1000,
+        }
+    }
+
+    /// #1967 — the READ half of the escalation lifecycle. `append_escalation`
+    /// wrote rows and the resolve paths flipped them, but no production SELECT
+    /// existed: an open escalation was invisible. `list_open_escalations`
+    /// returns only this goal's OPEN rows, oldest first.
+    #[test]
+    fn list_open_escalations_returns_open_rows_oldest_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
+        ledger.create_goal(&goal_row("g1")).unwrap();
+        ledger.create_goal(&goal_row("g2")).unwrap();
+        // Insert out of created order to prove the ORDER BY.
+        ledger
+            .append_escalation(&open_escalation("esc-b", "g1", "peer-b", 3000, None, None))
+            .unwrap();
+        ledger
+            .append_escalation(&open_escalation("esc-a", "g1", "peer-a", 1000, None, None))
+            .unwrap();
+        ledger
+            .append_escalation(&open_escalation("esc-c", "g1", "peer-c", 2000, None, None))
+            .unwrap();
+        // A different goal's row must not leak into g1's listing.
+        ledger
+            .append_escalation(&open_escalation("esc-x", "g2", "peer-x", 500, None, None))
+            .unwrap();
+        // A resolved row must not be listed as open.
+        ledger
+            .resolve_escalation("peer-c", "[answer] done", "master", 4000)
+            .unwrap();
+
+        let open = ledger.list_open_escalations("g1").unwrap();
+        assert_eq!(
+            open.iter()
+                .map(|e| e.escalation_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["esc-a", "esc-b"],
+            "open-only, this goal only, oldest first"
+        );
+        assert_eq!(open[0].peer_id, "peer-a");
+        assert_eq!(open[0].question, "question from peer-a");
+    }
+
+    /// #1967 — `resolve_escalation_by_id` flips exactly the addressed row
+    /// (the peer_id-bulk `resolve_escalation` cannot target one of several
+    /// rows) and refuses an already-resolved or unknown id with `Ok(false)`.
+    #[test]
+    fn resolve_escalation_by_id_targets_one_row_and_refuses_resolved() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
+        ledger.create_goal(&goal_row("g1")).unwrap();
+        // TWO open rows for the SAME peer — bulk resolve would flip both.
+        ledger
+            .append_escalation(&open_escalation("esc-1", "g1", "picker", 1000, None, None))
+            .unwrap();
+        ledger
+            .append_escalation(&open_escalation("esc-2", "g1", "picker", 2000, None, None))
+            .unwrap();
+
+        let flipped = ledger
+            .resolve_escalation_by_id("esc-1", "[timeout] expired", "system:escalation-timeout")
+            .unwrap();
+        assert!(flipped, "an open row must resolve");
+        let open = ledger.list_open_escalations("g1").unwrap();
+        assert_eq!(open.len(), 1, "only the addressed row was flipped");
+        assert_eq!(open[0].escalation_id, "esc-2");
+
+        // Already resolved → refused (no clobber of the recorded resolution).
+        let again = ledger
+            .resolve_escalation_by_id("esc-1", "[answer] late", "master")
+            .unwrap();
+        assert!(!again, "a resolved row must not re-resolve");
+        // Unknown id → refused, not an error.
+        assert!(
+            !ledger
+                .resolve_escalation_by_id("esc-nope", "[timeout] expired", "system")
+                .unwrap()
+        );
+
+        // The FIRST resolve's text landed verbatim and survived the refused
+        // re-resolve (same raw-row check idiom as the #1961 test above).
+        let conn = ledger.conn.lock().unwrap();
+        let (status, resolution, resolved_by): (String, Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT status, resolution, resolved_by FROM escalations WHERE escalation_id = 'esc-1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "resolved");
+        assert_eq!(resolution.as_deref(), Some("[timeout] expired"));
+        assert_eq!(resolved_by.as_deref(), Some("system:escalation-timeout"));
+    }
+
+    /// #1967 — timeout candidates: only OPEN rows whose `default_after_secs`
+    /// has ELAPSED (`created_at_ms + s*1000 < now_ms`) qualify. Unexpired,
+    /// no-default, and already-resolved rows never surface.
+    #[test]
+    fn list_expired_open_escalations_filters_elapsed_defaults_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
+        ledger.create_goal(&goal_row("g1")).unwrap();
+        // created 1000 + 10s → expires at 11_000: EXPIRED at now=60_000.
+        ledger
+            .append_escalation(&open_escalation(
+                "esc-expired",
+                "g1",
+                "p1",
+                1000,
+                Some("proceed"),
+                Some(10),
+            ))
+            .unwrap();
+        // created 1000 + 100s → expires at 101_000: NOT expired at now=60_000.
+        ledger
+            .append_escalation(&open_escalation(
+                "esc-later",
+                "g1",
+                "p2",
+                1000,
+                None,
+                Some(100),
+            ))
+            .unwrap();
+        // No default timer → never a candidate.
+        ledger
+            .append_escalation(&open_escalation(
+                "esc-forever",
+                "g1",
+                "p3",
+                1000,
+                None,
+                None,
+            ))
+            .unwrap();
+        // Expired timer but already resolved → never a candidate.
+        ledger
+            .append_escalation(&open_escalation(
+                "esc-done",
+                "g1",
+                "p4",
+                1000,
+                None,
+                Some(1),
+            ))
+            .unwrap();
+        ledger
+            .resolve_escalation("p4", "[answer] handled", "master", 5000)
+            .unwrap();
+
+        let candidates = ledger.list_expired_open_escalations(60_000).unwrap();
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|e| e.escalation_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["esc-expired"],
+            "only the elapsed open default is a timeout candidate"
+        );
+        assert_eq!(candidates[0].default_action.as_deref(), Some("proceed"));
+        // At the exact boundary (created + s*1000 == now) the row is NOT yet
+        // expired — strict `<` matches the sweep's contract.
+        assert!(
+            ledger
+                .list_expired_open_escalations(11_000)
+                .unwrap()
+                .is_empty(),
+            "boundary instant is not yet expired"
+        );
+        assert_eq!(
+            ledger.list_expired_open_escalations(11_001).unwrap().len(),
+            1
         );
     }
 }


### PR DESCRIPTION
Fixes #1967. Found by the 2026-08-11 deep review: peer escalations were write-only rows — no reader anywhere, no timeout, `goal_get` never surfaced them, and closing a parked peer orphaned its `open` row forever.

## Fix
- **Read + targeted-resolve APIs** (`sqlite_ledger`): `list_open_escalations(goal_id)` (open-only, oldest-first), `resolve_escalation_by_id(...) -> bool` (first-write-wins), `list_expired_open_escalations(now_ms)` (strict, NULL-safe); bulk `resolve_escalation` kept for the answer/close paths.
- **`goal_get` surfaces `open_escalations`** ({escalation_id, peer_id, task_id, question ≤300 incl. ellipsis, created_at_ms, age_seconds, default_action, default_after_secs}) behind the same data_dir gate as `ledger_findings`; missing ledger → absent, never a tool failure.
- **`peer_close` resolves** the peer's open rows as `[closed] peer closed before answering` — best-effort, after the durable closed marker.
- **Timeout sweep** `sweep_escalation_timeouts`: resolves expired rows (`[timeout] <default_action|expired>`, `system:escalation-timeout`), wired once in the global master-continuation drain with a 60s throttle. Dormant today (producers write NULL defaults).

## Codex adversarial round (all findings addressed)
- Cap contract: >300-char questions now render as exactly 300 INCLUDING the ellipsis (was 301); boundary case tested.
- Orphan-after-close race: the park writer now checks `peer_is_closed` BEFORE both the master wake and the escalation row — a closed peer's park produces neither (seam-tested with a positive open-peer control). The in-process oneshot residual remains #1842.
- Sweep hardening: symlinked `*.db` entries skipped fail-closed (unit-tested with a planted symlink); the sync rusqlite scan runs in `tokio::task::spawn_blocking` off the drain task; the answered-vs-timeout ordering hazard and the `serve --stdio` no-global-drain gap are documented in place (both pre-existing classes, tracked separately).

## Validation
octos-fleet 127 · goal 98 · escalation 15 · peer 103 (all green post-rebase onto #1970, no count drops; every fix runtime-RED first) · no-api build · fmt · clippy clean.