### PR TITLE
fix(goal): restart durability — scopes, cleared fleets, solo park, wake retry, stdio drain (#1973)

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -477,6 +477,22 @@ pub(crate) trait AgentOrchestrator: Send + Sync {
     fn get_goal(&self, request: GoalSessionRequest) -> Result<Value, RpcError>;
     fn set_goal(&self, request: GoalSetRequest) -> Result<Value, RpcError>;
     fn clear_goal(&self, request: GoalSessionRequest) -> Result<Value, RpcError>;
+
+    /// #1973 fix B — [`Self::clear_goal`] plus a best-effort sync of the
+    /// cleared status into the durable per-goal SQLite ledger under
+    /// `ledger_data_dir` (the PROFILE data dir), so the goals-row stops
+    /// claiming `active` after a user clear. The RPC dispatch resolves the
+    /// dir from the profile store and calls this; a `None` dir (or this
+    /// default impl, kept so test mocks stay untouched) is a plain clear.
+    fn clear_goal_with_ledger_sync(
+        &self,
+        request: GoalSessionRequest,
+        ledger_data_dir: Option<&Path>,
+    ) -> Result<Value, RpcError> {
+        let _ = ledger_data_dir;
+        self.clear_goal(request)
+    }
+
     fn create_loop(&self, request: LoopCreateRequest) -> Result<Value, RpcError>;
     fn list_loops(&self, request: LoopListRequest) -> Result<Value, RpcError>;
     fn control_loop(&self, request: LoopControlRequest) -> Result<Value, RpcError>;
@@ -589,6 +605,32 @@ struct OrchestratorShared {
     /// the legacy behavior and to the gateway/session-actor path (which never
     /// registers a scope).
     goal_scopes: StdMutex<HashMap<String, String>>,
+    /// #1973 fix A — where `goal_scopes` persists across restarts:
+    /// `<data_dir>/goal-scopes.json`, written atomically (write-tmp-then-
+    /// rename) on every scope mutation and loaded by
+    /// [`Self::configure_goal_scopes_sidecar`] BEFORE the supervisor store
+    /// restores goals. Unset (the default — unit tests, chat/gateway boots)
+    /// means the registry stays in-memory-only, byte-identical to the
+    /// pre-sidecar behavior. Same last-writer-wins single-scope-per-wire-key
+    /// semantics as the in-memory map (and as the ledger's documented
+    /// residual): the file records the MOST RECENTLY registered folder per
+    /// wire key, so a restart resumes the last-active folder's goals.
+    /// GC (#1973 fix-round 4b): mutation-driven saves prune FILE entries with
+    /// no goal under their scoped key and no live registration this process —
+    /// see [`Self::persist_goal_scopes_locked`] for the policy.
+    goal_scopes_sidecar: OnceLock<PathBuf>,
+    /// #1973 fix-round 4b — wires registered LIVE this process (by
+    /// `set_goal_scope(Some)` / `set_goal_scope_if_absent`), exempt from the
+    /// sidecar GC even before a goal exists under them. Only ever accessed
+    /// while the caller holds the `goal_scopes` lock (mutators + the persist
+    /// helper), which serializes it; it is never locked together with `state`.
+    live_goal_scope_wires: StdMutex<std::collections::HashSet<String>>,
+    /// #1973 fix D — fleet keeper wakes whose durable persist FAILED (and was
+    /// rolled back) during the boot-resume pass, awaiting their ONE bounded
+    /// retry. Stashed by `fleet_wake::enqueue_fleet_boot_resume_wakes` and
+    /// consumed — never re-queued — by [`Self::retry_stashed_fleet_wakes`] at
+    /// the start of the next fleet-outbox drain tick.
+    fleet_wake_retry: StdMutex<Vec<MasterContinuationRequest>>,
 }
 
 /// The plain WIRE session id underlying a (possibly cwd-scoped) goal-store
@@ -912,6 +954,12 @@ impl InProcessAgentOrchestrator {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clear();
+        // #1973 fix D — a stashed retry must not leak across singleton tests.
+        self.shared
+            .fleet_wake_retry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
     }
 
     /// #1666 residue — register (or clear) the per-project goal-store scope
@@ -921,18 +969,29 @@ impl InProcessAgentOrchestrator {
     /// each session's cwd scope. Mirrors
     /// [`UiProtocolLedger::set_session_scope`].
     pub(crate) fn set_goal_scope(&self, session_id: &SessionKey, scope: Option<String>) {
+        // #1973 fix-round 4b — GC snapshot: the scoped-goal keys currently in
+        // the store, taken (and the state lock RELEASED) BEFORE the
+        // goal_scopes lock — the two locks must never nest in that order
+        // anywhere else, and this way they never nest at all.
+        let gc_live_goal_keys = self.goal_key_snapshot_for_scope_gc();
         let mut scopes = self
             .shared
             .goal_scopes
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        match scope {
+        let changed = match scope {
             Some(scope) => {
-                scopes.insert(session_id.0.clone(), scope);
+                self.mark_scope_wire_live(session_id);
+                scopes.insert(session_id.0.clone(), scope.clone()) != Some(scope)
             }
-            None => {
-                scopes.remove(session_id.0.as_str());
-            }
+            None => scopes.remove(session_id.0.as_str()).is_some(),
+        };
+        // #1973 fix A — persist the mutation so a restart still resolves the
+        // scope. Skipped when nothing changed: `session/open` re-registers the
+        // SAME scope on every open, and rewriting an identical file each time
+        // is pure churn.
+        if changed {
+            self.persist_goal_scopes_locked(&scopes, Some(&gc_live_goal_keys));
         }
     }
 
@@ -946,18 +1005,154 @@ impl InProcessAgentOrchestrator {
     /// `set_goal_scope` would race that authoritative live write).
     pub(crate) fn set_goal_scope_if_absent(&self, session_id: &SessionKey, scope: &str) -> bool {
         use std::collections::hash_map::Entry;
-        match self
+        // #1973 fix-round 4b — GC snapshot BEFORE the goal_scopes lock (see
+        // `set_goal_scope`).
+        let gc_live_goal_keys = self.goal_key_snapshot_for_scope_gc();
+        let mut scopes = self
             .shared
             .goal_scopes
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .entry(session_id.0.clone())
-        {
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let registered = match scopes.entry(session_id.0.clone()) {
             Entry::Occupied(_) => false,
             Entry::Vacant(slot) => {
                 slot.insert(scope.to_owned());
                 true
             }
+        };
+        // #1973 fix A — a genuine registration is a mutation; persist it.
+        if registered {
+            self.mark_scope_wire_live(session_id);
+            self.persist_goal_scopes_locked(&scopes, Some(&gc_live_goal_keys));
+        }
+        registered
+    }
+
+    /// #1973 fix-round 4b — record that `session_id`'s wire was registered
+    /// LIVE this process (by `session/open` or the Gate-D re-seed), so the
+    /// sidecar GC keeps its entry even before a goal exists under it. Only
+    /// ever called while the caller holds the `goal_scopes` lock, which is
+    /// what serializes access to this set (it is never locked together with
+    /// anything else).
+    fn mark_scope_wire_live(&self, session_id: &SessionKey) {
+        self.shared
+            .live_goal_scope_wires
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(session_id.0.clone());
+    }
+
+    /// #1973 fix-round 4b — the scoped-goal keys currently in the store, for
+    /// the sidecar GC's keep-if-goal-exists filter. Takes and RELEASES the
+    /// state lock; callers must invoke it BEFORE taking the `goal_scopes`
+    /// lock so the two never nest.
+    fn goal_key_snapshot_for_scope_gc(&self) -> std::collections::HashSet<String> {
+        self.state().goals.keys().map(|key| key.0.clone()).collect()
+    }
+
+    /// #1973 fix A — install the `goal-scopes.json` sidecar path (first call
+    /// wins) and load its persisted scopes into the registry. Called from
+    /// serve boot right BEFORE [`Self::configure_supervisor_store`], so
+    /// restored SCOPED goals (stored under `<wire>\u{0}~cwd-<scope>`) resolve
+    /// through [`Self::scoped_goal_key`] immediately — and their persisted
+    /// continuations pass [`Self::goal_target_is_dispatchable`] — without
+    /// waiting for a client to reopen the session.
+    ///
+    /// The load fills VACANT keys only: a live `session/open` registration
+    /// that raced boot is authoritative and must never be clobbered by the
+    /// file (same rule as `set_goal_scope_if_absent`). A missing file is a
+    /// clean first boot; an unreadable/unparsable file is an error the caller
+    /// logs — the registry then simply starts empty (the pre-fix behavior).
+    ///
+    /// #1973 fix-round 4a — the MERGED map is written back to the file under
+    /// the same lock. A registration that raced in BEFORE this configure had
+    /// no sidecar path to persist to, so without the write-back it survives
+    /// this boot (occupied entry beats the load) but is silently lost on the
+    /// NEXT restart. The write-back is verbatim — no GC: goals are restored
+    /// AFTER this call (`configure_supervisor_store`), so the
+    /// keep-if-goal-exists filter would wipe every loaded entry here.
+    pub(crate) fn configure_goal_scopes_sidecar(&self, path: PathBuf) -> std::io::Result<()> {
+        let path = self.shared.goal_scopes_sidecar.get_or_init(|| path);
+        // File read BEFORE the lock (I/O stays off the mutex where possible)…
+        let loaded: HashMap<String, String> = match std::fs::read(path) {
+            Ok(bytes) => serde_json::from_slice(&bytes)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+            Err(error) => return Err(error),
+        };
+        // …merge + write-back UNDER it, so no registration can interleave
+        // between the merge and the flush.
+        let mut scopes = self
+            .shared
+            .goal_scopes
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        for (wire, scope) in loaded {
+            scopes.entry(wire).or_insert(scope);
+        }
+        self.persist_goal_scopes_locked(&scopes, None);
+        Ok(())
+    }
+
+    /// #1973 fix A — write the CURRENT scope map to the sidecar, atomically
+    /// (write `.tmp`, then rename), while the caller still holds the
+    /// `goal_scopes` lock — that lock is what serializes concurrent mutators
+    /// so a slow writer can never overwrite a newer map with a stale one. The
+    /// write is a few hundred bytes of JSON on the rare `session/open` scope
+    /// mutation path, so holding the (sync, never-awaited) mutex across it is
+    /// cheap. Best-effort: persistence failure must never break session open —
+    /// it is logged, and the in-memory registry stays correct for THIS boot.
+    ///
+    /// #1973 fix-round 4b — **GC policy**: when the caller supplies the
+    /// scoped-goal-key snapshot (`gc_live_goal_keys`, mutation-driven saves),
+    /// the FILE keeps only entries that are (a) backed by a goal under their
+    /// scoped key, or (b) registered live this process (`session/open` /
+    /// Gate-D re-seed — tracked in `live_goal_scope_wires`). Everything else
+    /// is a goalless leftover from a prior boot that nothing can resolve to
+    /// work at restart, so it is pruned — this is what bounds the sidecar's
+    /// growth. `None` (the boot write-back, before goals restore) writes the
+    /// map verbatim. The GC never touches the in-memory registry.
+    fn persist_goal_scopes_locked(
+        &self,
+        scopes: &HashMap<String, String>,
+        gc_live_goal_keys: Option<&std::collections::HashSet<String>>,
+    ) {
+        let Some(path) = self.shared.goal_scopes_sidecar.get() else {
+            return;
+        };
+        let to_write: HashMap<&String, &String> = match gc_live_goal_keys {
+            None => scopes.iter().collect(),
+            Some(goal_keys) => {
+                let live = self
+                    .shared
+                    .live_goal_scope_wires
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                scopes
+                    .iter()
+                    .filter(|(wire, scope)| {
+                        live.contains(wire.as_str())
+                            || goal_keys.contains(&format!("{wire}\u{0}~cwd-{scope}"))
+                    })
+                    .collect()
+            }
+        };
+        let payload = match serde_json::to_vec_pretty(&to_write) {
+            Ok(payload) => payload,
+            Err(error) => {
+                tracing::warn!(%error, "goal-scopes sidecar: failed to serialize scope map");
+                return;
+            }
+        };
+        let tmp = path.with_extension("json.tmp");
+        let written = std::fs::write(&tmp, &payload).and_then(|()| std::fs::rename(&tmp, path));
+        if let Err(error) = written {
+            tracing::warn!(
+                %error,
+                path = %path.display(),
+                "goal-scopes sidecar: failed to persist scope map; scoped goals may be \
+                 invisible after a restart until their session reopens"
+            );
         }
     }
 
@@ -1098,6 +1293,9 @@ impl InProcessAgentOrchestrator {
     /// redelivery rather than acking a wake that a crash could lose. Returns the
     /// number of outbox events acked.
     pub(crate) async fn drain_fleet_outbox(&self, store: &FleetKernelStore) -> eyre::Result<usize> {
+        // #1973 fix D — consume any boot-resume wakes whose durable persist
+        // failed: this tick IS their one bounded retry.
+        self.retry_stashed_fleet_wakes();
         super::fleet_wake::drain_fleet_outbox_once(
             store,
             now_ms_u64,
@@ -1105,6 +1303,63 @@ impl InProcessAgentOrchestrator {
             |req| self.commit_fleet_keeper_wake(req),
         )
         .await
+    }
+
+    /// #1973 fix D — stash a boot-resume keeper wake whose durable persist
+    /// failed (and was rolled back), for ONE bounded retry on the next
+    /// fleet-outbox drain tick. Before this, such a wake was dropped with no
+    /// retry at all: the fleet stayed `Ready` with no keeper wake for the
+    /// whole boot even when the persist failure was transient.
+    pub(crate) fn stash_fleet_wake_retry(&self, request: MasterContinuationRequest) {
+        self.shared
+            .fleet_wake_retry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(request);
+    }
+
+    /// #1973 fix D — re-attempt every stashed boot-resume wake ONCE through
+    /// the same durable-commit gate ([`Self::commit_fleet_keeper_wake`]),
+    /// returning how many committed durably. The stash is drained up front and
+    /// a failed re-attempt is NEVER re-queued — one retry, bounded and honest:
+    /// a wake whose persist fails twice is lost for THIS boot (loud warn
+    /// below; the fleet stays Ready with no keeper wake until the next fleet
+    /// event or a restart re-runs the boot-resume pass, which re-derives the
+    /// wake from the store). The ~3s gap to the next drain tick is the
+    /// backoff — long enough for a transient I/O condition (fsync pressure,
+    /// disk-full-then-freed) to clear, with no sleep on the boot path.
+    pub(crate) fn retry_stashed_fleet_wakes(&self) -> usize {
+        let stashed: Vec<MasterContinuationRequest> = {
+            let mut retry = self
+                .shared
+                .fleet_wake_retry
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            std::mem::take(&mut *retry)
+        };
+        if stashed.is_empty() {
+            return 0;
+        }
+        let mut committed = 0usize;
+        for request in stashed {
+            let dedupe_key = request.dedupe_key.clone();
+            match self.commit_fleet_keeper_wake(request) {
+                super::fleet_wake::WakeCommit::Durable => {
+                    committed += 1;
+                    tracing::info!(
+                        dedupe_key = ?dedupe_key,
+                        "fleet boot-resume wake retry committed durably"
+                    );
+                }
+                super::fleet_wake::WakeCommit::NotDurable => tracing::warn!(
+                    dedupe_key = ?dedupe_key,
+                    "fleet boot-resume wake retry FAILED to persist; dropping it for this boot \
+                     — the fleet stays Ready with no keeper wake until the next fleet event or \
+                     a restart re-runs boot-resume"
+                ),
+            }
+        }
+        committed
     }
 
     /// The durable-commit half of [`Self::drain_fleet_outbox`]: enqueue the
@@ -1254,49 +1509,98 @@ impl InProcessAgentOrchestrator {
     /// the boot log. Wrap-ups are untouched: a `budget_limited` goal is
     /// not active, so it is never parked and its one-shot wrap-up still
     /// drains.
+    ///
+    /// #1973 fix C — production (serve boot) now always calls
+    /// [`Self::pause_restored_goals_for_solo_boot_with_ledger_sync`] with a
+    /// real profile-dir resolver; this no-resolver wrapper remains as the
+    /// test seam for the park mechanics alone.
+    #[cfg(test)]
     pub(crate) fn pause_restored_goals_for_solo_boot(&self) -> Vec<(String, SessionKey)> {
-        let mut state = self.state();
-        let state = &mut *state;
-        let supervisor_store = state.supervisor_store.as_ref();
-        let now = now_ms();
-        let mut paused = Vec::new();
-        for (session_id, goal) in state.goals.iter_mut() {
-            if goal.status != "active" {
-                continue;
+        self.pause_restored_goals_for_solo_boot_with_ledger_sync(&|_| None)
+    }
+
+    /// #1973 fix C — the full solo-boot goal park, plus a sync of each parked
+    /// goal's durable SQLite ledger row. The park used to flip the in-memory +
+    /// supervisor state to `paused` while the goals-row kept saying `active` —
+    /// a durable lie that outlived the boot (and every audit read of the
+    /// ledger). `profile_data_dir_for` maps a parked goal's `profile_id` to
+    /// its PROFILE data dir (serve boot resolves through the profile
+    /// registry); `None` for a profile skips its sync (no registry entry, or
+    /// the no-op resolver the plain [`Self::pause_restored_goals_for_solo_boot`]
+    /// passes). The sync reuses [`Self::sync_transition_to_ledger`] — a park is
+    /// a genuine `active → paused` status change, so it upserts the row AND
+    /// appends a decision — and runs strictly AFTER the state lock drops
+    /// (ledger writes are file I/O).
+    pub(crate) fn pause_restored_goals_for_solo_boot_with_ledger_sync(
+        &self,
+        profile_data_dir_for: &dyn Fn(&str) -> Option<PathBuf>,
+    ) -> Vec<(String, SessionKey)> {
+        let mut parked_snapshots: Vec<(AutonomyGoalRecord, SessionKey)> = Vec::new();
+        let paused = {
+            let mut state = self.state();
+            let state = &mut *state;
+            let supervisor_store = state.supervisor_store.as_ref();
+            let now = now_ms();
+            let mut paused = Vec::new();
+            for (session_id, goal) in state.goals.iter_mut() {
+                if goal.status != "active" {
+                    continue;
+                }
+                goal.status = "paused".to_owned();
+                goal.updated_at_ms = now;
+                persist_goal_state_with_store(supervisor_store, session_id, goal, false);
+                paused.push((goal.goal_id.clone(), session_id.clone()));
+                parked_snapshots.push((goal.clone(), session_id.clone()));
             }
-            goal.status = "paused".to_owned();
-            goal.updated_at_ms = now;
-            persist_goal_state_with_store(supervisor_store, session_id, goal, false);
-            paused.push((goal.goal_id.clone(), session_id.clone()));
-        }
-        let parked: std::collections::HashSet<&str> =
-            paused.iter().map(|(goal_id, _)| goal_id.as_str()).collect();
-        let orphaned: Vec<_> = state
-            .continuations
-            .pending_items()
-            .filter(|item| {
-                item.reason == MasterContinuationReason::GoalContinue
-                    && item
-                        .goal_id
-                        .as_ref()
-                        .is_some_and(|goal_id| parked.contains(goal_id.as_str()))
-            })
-            .map(|item| (item.group_id.clone(), item.dedupe_key.clone()))
-            .collect();
-        for (group_id, dedupe_key) in orphaned {
-            state.continuations.cancel(&dedupe_key);
-            if let Some(store) = supervisor_store {
-                let _ = store.record_continuation_completed(
-                    group_id.as_str(),
-                    dedupe_key.as_str(),
-                    now_ms_u64(),
-                    Some("discarded:solo_boot_parked_goal".into()),
+            let parked: std::collections::HashSet<&str> =
+                paused.iter().map(|(goal_id, _)| goal_id.as_str()).collect();
+            let orphaned: Vec<_> = state
+                .continuations
+                .pending_items()
+                .filter(|item| {
+                    item.reason == MasterContinuationReason::GoalContinue
+                        && item
+                            .goal_id
+                            .as_ref()
+                            .is_some_and(|goal_id| parked.contains(goal_id.as_str()))
+                })
+                .map(|item| (item.group_id.clone(), item.dedupe_key.clone()))
+                .collect();
+            for (group_id, dedupe_key) in orphaned {
+                state.continuations.cancel(&dedupe_key);
+                if let Some(store) = supervisor_store {
+                    let _ = store.record_continuation_completed(
+                        group_id.as_str(),
+                        dedupe_key.as_str(),
+                        now_ms_u64(),
+                        Some("discarded:solo_boot_parked_goal".into()),
+                    );
+                }
+                tracing::info!(
+                    dedupe_key = %dedupe_key.as_str(),
+                    "solo boot: retired queued goal continuation alongside its parked goal"
                 );
             }
-            tracing::info!(
-                dedupe_key = %dedupe_key.as_str(),
-                "solo boot: retired queued goal continuation alongside its parked goal"
-            );
+            paused
+        };
+        // #1973 fix C — ledger sync outside the state lock. Best-effort per
+        // goal (the sync helper swallows ledger I/O errors); a missing profile
+        // dir skips that goal's sync, matching the pre-fix behavior. This is a
+        // SYNC boot-time caller, so it uses the blocking core directly with
+        // the plain open profile (`retry_contended_open: false` — the bounded
+        // retry stays exclusive to the #1865 `spawn_blocking` facade); boot
+        // runs once before serving, so inline ledger I/O here is fine.
+        for (snapshot, session_id) in parked_snapshots {
+            if let Some(profile_dir) = profile_data_dir_for(&snapshot.profile_id) {
+                self.sync_transition_to_ledger_blocking(
+                    &profile_dir,
+                    &snapshot,
+                    "solo boot: goal parked paused (resume with /goal resume)",
+                    &session_id,
+                    true,
+                    false,
+                );
+            }
         }
         paused
     }
@@ -3765,6 +4069,25 @@ impl InProcessAgentOrchestrator {
     ///   default busy handling — the EXACT pre-#1865 blocking profile for
     ///   that path (call sites untouched; this restores the core's behavior
     ///   for them after this branch briefly routed them through the retry).
+    ///
+    /// #1973 fix-round — the #1970 monotonic-token clause used to silently
+    /// reject an ADMINISTRATIVE status sync (park/clear) whose snapshot
+    /// carries stale LOWER counters (a peer charge pushed the row ahead of
+    /// the in-memory record), while the decision was appended
+    /// unconditionally: row said `active`, decision said `cleared`. Now: when
+    /// the guarded upsert reports the write was NOT admitted and this is a
+    /// status transition, re-read the row and retry ONCE via a targeted
+    /// status-CAS ([`octos_fleet::GoalLedger::cas_goal_status`]) — the status
+    /// lands with the row's counters untouched (they are authoritative). The
+    /// retry is ORDERING-GATED: it runs only when the snapshot is at least as
+    /// new as the row (`snapshot.updated_at_ms >= row.updated_at_ms`), so an
+    /// OLDER transition's retry can never overwrite a newer status change
+    /// (the fix-round-2 max'd-timestamp re-upsert could: a late `blocked`
+    /// sync forged the row's own T2 and overwrote `cleared`). Complete stays
+    /// terminal on both layers (the gate skips a `complete` row; the CAS
+    /// refuses one). The decision is appended ONLY when the row's status now
+    /// reflects the transition, so the audit trail can never claim a status
+    /// the goals-row rejected.
     fn sync_transition_to_ledger_blocking(
         &self,
         profile_data_dir: &std::path::Path,
@@ -3795,7 +4118,8 @@ impl InProcessAgentOrchestrator {
                 return;
             }
         };
-        let _ = ledger.upsert_goal(&octos_fleet::Goal {
+        let snapshot_ts = snapshot.updated_at_ms.max(0) as u64;
+        let row = octos_fleet::Goal {
             goal_id: snapshot.goal_id.clone(),
             objective: snapshot.objective.clone(),
             status: snapshot.status.clone(),
@@ -3804,12 +4128,66 @@ impl InProcessAgentOrchestrator {
             continuations_used: snapshot.continuations_used,
             revision: 0,
             created_at_ms: snapshot.created_at_ms.max(0) as u64,
-            updated_at_ms: snapshot.updated_at_ms.max(0) as u64,
-        });
+            updated_at_ms: snapshot_ts,
+        };
+        let admitted = ledger.upsert_goal(&row).unwrap_or(false);
+        if !admitted && status_changed {
+            // Guarded rejection of a genuine status transition. Retry ONCE via
+            // the targeted status-CAS, but ONLY when the rejection was solely
+            // the monotonic-token clause — i.e. this transition is still at
+            // least as new as the row (ordering gate) and the row is not
+            // terminal (complete gate) and actually differs. An older
+            // transition, or one racing a terminal row, is dropped here and
+            // the decision gate below keeps the audit trail consistent.
+            if let Ok(Some(current)) = ledger.get_goal(&snapshot.goal_id) {
+                let retry_admissible = snapshot_ts >= current.updated_at_ms
+                    && current.status != "complete"
+                    && current.status != snapshot.status;
+                if retry_admissible {
+                    // True CAS on the exact (status, updated_at_ms) pair just
+                    // read: any interleaved write defeats it and the newer
+                    // state wins (one shot, never re-attempted). Combined
+                    // with the `snapshot_ts >= current.updated_at_ms` gate
+                    // above, the stamp written can never regress the row's
+                    // clock.
+                    let _ = ledger.cas_goal_status(
+                        &snapshot.goal_id,
+                        &snapshot.status,
+                        &current.status,
+                        current.updated_at_ms,
+                        snapshot_ts,
+                    );
+                }
+            }
+        }
         // codex #5 — no decision row for a no-op (e.g. `blocked → blocked`
         // retry after a lost response), so the audit trail can't fill with
         // indistinguishable duplicates.
         if !status_changed {
+            return;
+        }
+        // #1973 fix-round — append the decision ONLY when the row actually
+        // reflects the transition, so the audit trail can never claim a
+        // status the goals-row rejected.
+        //
+        // DOCUMENTED RESIDUAL (codex-acknowledged): this re-read and the
+        // append below are NOT atomic with the write above. A writer racing
+        // into the gap can flip the row after our status landed, suppressing
+        // a decision for a transition that DID happen — an UNDER-REPORT of
+        // the audit trail, never a contradiction (a decision is only ever
+        // appended while the row was observed carrying that very status).
+        let row_reflects_transition = ledger
+            .get_goal(&snapshot.goal_id)
+            .ok()
+            .flatten()
+            .is_some_and(|current| current.status == snapshot.status);
+        if !row_reflects_transition {
+            tracing::warn!(
+                goal_id = %snapshot.goal_id,
+                intended_status = %snapshot.status,
+                "goal ledger sync: the guarded goals-row did not admit this status \
+                 transition (terminal row wins); no decision appended"
+            );
             return;
         }
         let now_ms = std::time::SystemTime::now()
@@ -3830,6 +4208,127 @@ impl InProcessAgentOrchestrator {
             decided_by: decided_by.to_string(),
         };
         let _ = ledger.append_decision(&decision);
+    }
+
+    /// #1973 fix B — the shared body behind both `clear_goal` trait entry
+    /// points. On top of the original remove + `persist_goal_cleared`, a clear
+    /// now also:
+    ///
+    /// 1. **Terminalizes the bound fleet.** The cleared record's `fleet_id`
+    ///    (when set, with a fleet store installed) is cancelled in the kernel
+    ///    store via [`FleetKernelStore::cancel_fleet`] on a SPAWNED task —
+    ///    best-effort by contract: a store error (or a missing tokio runtime)
+    ///    must never block or fail the clear, so the in-memory/goal-store
+    ///    outcome is identical whether or not the cancel lands. Before this,
+    ///    the orphan stayed `Active` in redb forever and every boot-resume
+    ///    pass re-scanned it just to skip it as orphaned.
+    /// 2. **Syncs the durable ledger goals-row** (when the caller resolved a
+    ///    profile data dir): upsert the row as `cleared` + append a decision,
+    ///    via the same guarded [`Self::sync_transition_to_ledger`] the other
+    ///    transitions use — so the row stops claiming `active`. The guard's
+    ///    complete-is-terminal clause still wins: clearing an already-complete
+    ///    goal keeps the row `complete` (only the decision row records the
+    ///    clear), which is the honest audit shape.
+    ///
+    /// Lock discipline matches `model_transition_goal`: mutation + persist +
+    /// generation stamp under the state lock, fleet spawn + ledger file I/O
+    /// strictly after it drops.
+    fn clear_goal_impl(
+        &self,
+        request: GoalSessionRequest,
+        ledger_data_dir: Option<&Path>,
+    ) -> Result<Value, RpcError> {
+        // #1666 residue — clear the cwd-scoped goal for this wire session id so
+        // `goal_clear` in folder B never removes folder A's goal.
+        let key = self.scoped_goal_key(&request.session_id);
+        let (removed, generation, fleet_store) = {
+            let mut state = self.state();
+            let removed = match state.goals.get(&key) {
+                Some(goal) if goal.profile_id == request.profile_id => state.goals.remove(&key),
+                Some(_) => {
+                    return Err(autonomy_error(
+                        kinds::GOAL_UNAVAILABLE,
+                        "goal is outside the requested profile scope",
+                        Some(&request.session_id),
+                        Some(&request.profile_id),
+                        None,
+                        true,
+                    ));
+                }
+                None => None,
+            };
+            if removed.is_some() {
+                persist_goal_cleared(&state, &key, &request.profile_id);
+            }
+            // #1959 — stamp the same monotonic generation as
+            // `SessionGoalUpdated` so the client can order a clear against a
+            // racing stale update. A stale update always bumps before this
+            // clear (its goal read preceded the removal above), so
+            // `update.generation < clear.generation`.
+            let generation = next_goal_event_generation(&mut state);
+            let fleet_store = state.fleet_store.clone();
+            (removed, generation, fleet_store)
+        };
+        let cleared = removed.is_some();
+        if let Some(goal) = removed {
+            if let (Some(fleet_id), Some(store)) = (goal.fleet_id.clone(), fleet_store) {
+                match tokio::runtime::Handle::try_current() {
+                    Ok(handle) => {
+                        let goal_id = goal.goal_id.clone();
+                        handle.spawn(async move {
+                            match store.cancel_fleet(&fleet_id, now_ms_u64()).await {
+                                Ok(true) => tracing::info!(
+                                    fleet_id = %fleet_id,
+                                    goal_id = %goal_id,
+                                    "goal_clear: terminalized the cleared goal's fleet (Cancelled)"
+                                ),
+                                Ok(false) => {}
+                                Err(error) => tracing::warn!(
+                                    fleet_id = %fleet_id,
+                                    goal_id = %goal_id,
+                                    %error,
+                                    "goal_clear: failed to terminalize the cleared goal's fleet; \
+                                     it stays live in the kernel store (boot-resume will skip it \
+                                     as orphaned)"
+                                ),
+                            }
+                        });
+                    }
+                    // No async runtime (sync test/tool context): the clear
+                    // stands; the fleet stays live and boot-resume's orphan
+                    // guard keeps skipping it — exactly the pre-fix shape.
+                    Err(_) => tracing::warn!(
+                        fleet_id = %fleet_id,
+                        "goal_clear: no async runtime to terminalize the cleared goal's fleet"
+                    ),
+                }
+            }
+            if let Some(data_dir) = ledger_data_dir {
+                let mut snapshot = goal;
+                snapshot.status = "cleared".to_owned();
+                snapshot.updated_at_ms = now_ms();
+                // SYNC caller (the clear RPC arm): blocking core, plain open
+                // profile — same inline best-effort class as the pre-existing
+                // finding/escalation writers (#1865 keeps the bounded retry
+                // exclusive to the spawn_blocking facade).
+                self.sync_transition_to_ledger_blocking(
+                    data_dir,
+                    &snapshot,
+                    "goal cleared by user",
+                    &request.session_id,
+                    true,
+                    false,
+                );
+            }
+        }
+        Ok(json!({
+            "session_id": request.session_id,
+            "profile_id": request.profile_id,
+            "cleared": cleared,
+            "goal": Value::Null,
+            "generation": generation,
+            "transition_actor": "user"
+        }))
     }
 
     /// Peer-agent-based goal: record a peer finding into the goal's durable
@@ -6496,42 +6995,16 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
     }
 
     fn clear_goal(&self, request: GoalSessionRequest) -> Result<Value, RpcError> {
-        // #1666 residue — clear the cwd-scoped goal for this wire session id so
-        // `goal_clear` in folder B never removes folder A's goal.
-        let key = self.scoped_goal_key(&request.session_id);
-        let mut state = self.state();
-        let cleared = match state.goals.get(&key) {
-            Some(goal) if goal.profile_id == request.profile_id => {
-                state.goals.remove(&key).is_some()
-            }
-            Some(_) => {
-                return Err(autonomy_error(
-                    kinds::GOAL_UNAVAILABLE,
-                    "goal is outside the requested profile scope",
-                    Some(&request.session_id),
-                    Some(&request.profile_id),
-                    None,
-                    true,
-                ));
-            }
-            None => false,
-        };
-        if cleared {
-            persist_goal_cleared(&state, &key, &request.profile_id);
-        }
-        // #1959 — stamp the same monotonic generation as `SessionGoalUpdated`
-        // so the client can order a clear against a racing stale update. A
-        // stale update always bumps before this clear (its goal read preceded
-        // the removal above), so `update.generation < clear.generation`.
-        let generation = next_goal_event_generation(&mut state);
-        Ok(json!({
-            "session_id": request.session_id,
-            "profile_id": request.profile_id,
-            "cleared": cleared,
-            "goal": Value::Null,
-            "generation": generation,
-            "transition_actor": "user"
-        }))
+        // #1973 fix B — shared body; no ledger dir on this legacy entry point.
+        self.clear_goal_impl(request, None)
+    }
+
+    fn clear_goal_with_ledger_sync(
+        &self,
+        request: GoalSessionRequest,
+        ledger_data_dir: Option<&Path>,
+    ) -> Result<Value, RpcError> {
+        self.clear_goal_impl(request, ledger_data_dir)
     }
 
     fn create_loop(&self, request: LoopCreateRequest) -> Result<Value, RpcError> {
@@ -20257,6 +20730,666 @@ mod tests {
         assert_eq!(
             continuations_after, 1,
             "one recorded turn charges the scoped goal exactly once",
+        );
+    }
+
+    /// #1973 fix A — the cwd-scope registry survives a restart via the
+    /// `goal-scopes.json` sidecar. Without it a restored SCOPED goal (stored
+    /// under `<wire>\0~cwd-<scope>`) is invisible to every scoped lookup and
+    /// its restored continuation is NOT dispatchable until a client happens to
+    /// reopen the session. The restart seam: register scope + set goal on
+    /// orchestrator A; a FRESH orchestrator loading sidecar-then-store resolves
+    /// the scoped key immediately and the restored target is dispatchable.
+    #[test]
+    fn goal_scope_sidecar_restores_scoped_goals_dispatchable_after_restart() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let sidecar = dir.path().join("goal-scopes.json");
+        let wire = SessionKey::with_profile("tenant-a", "api", "scope-sidecar");
+
+        let orchestrator = InProcessAgentOrchestrator::default();
+        orchestrator
+            .configure_goal_scopes_sidecar(sidecar.clone())
+            .expect("configure sidecar");
+        orchestrator
+            .configure_supervisor_store(dir.path().join("supervisor"))
+            .expect("configure store");
+        orchestrator.set_goal_scope(&wire, Some("aaaa111122223333".into()));
+        let scoped = orchestrator.scoped_goal_key(&wire);
+        assert_ne!(scoped, wire);
+        seed_goal(&orchestrator, &wire, "tenant-a");
+        assert!(sidecar.is_file(), "the scope mutation writes the sidecar");
+
+        // The PRE-FIX gap, pinned: a restart that reloads only the supervisor
+        // store restores the goal under its scoped key but resolves the wire to
+        // ITSELF, so nothing scoped is visible or dispatchable.
+        let amnesiac = InProcessAgentOrchestrator::default();
+        amnesiac
+            .configure_supervisor_store(dir.path().join("supervisor"))
+            .expect("reload store");
+        assert!(amnesiac.state().goals.contains_key(&scoped));
+        assert_eq!(amnesiac.scoped_goal_key(&wire), wire);
+        assert!(!amnesiac.goal_target_is_dispatchable(&scoped));
+
+        // With the sidecar loaded BEFORE the goals restore, the scoped goal
+        // resolves immediately and its restored continuation target is
+        // dispatchable — no session/open required.
+        let restored = InProcessAgentOrchestrator::default();
+        restored
+            .configure_goal_scopes_sidecar(sidecar)
+            .expect("load sidecar");
+        restored
+            .configure_supervisor_store(dir.path().join("supervisor"))
+            .expect("reload store");
+        assert_eq!(
+            restored.scoped_goal_key(&wire),
+            scoped,
+            "the sidecar restores the wire's cwd scope",
+        );
+        assert!(
+            restored.state().goals.contains_key(&scoped),
+            "the goal restores under its scoped key",
+        );
+        assert!(
+            restored.goal_target_is_dispatchable(&scoped),
+            "the restored scoped continuation target must be dispatchable at boot",
+        );
+        assert_eq!(
+            restored.goal_objective_for_test(&wire).as_deref(),
+            Some("ship the thing"),
+            "scoped lookups through the wire key resolve the restored goal",
+        );
+    }
+
+    /// #1973 fix A — `set_goal_scope_if_absent` (the fleet-keeper Gate-D
+    /// re-seed) persists too, and clearing a scope (`set_goal_scope(None)`)
+    /// removes it from the sidecar rather than resurrecting it on reload.
+    #[test]
+    fn goal_scope_sidecar_persists_if_absent_and_clears_removed_scopes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let sidecar = dir.path().join("goal-scopes.json");
+        let seeded = SessionKey::new("api", "scope-seeded");
+        let cleared = SessionKey::new("api", "scope-cleared");
+
+        let orchestrator = InProcessAgentOrchestrator::default();
+        orchestrator
+            .configure_goal_scopes_sidecar(sidecar.clone())
+            .expect("configure sidecar");
+        assert!(orchestrator.set_goal_scope_if_absent(&seeded, "1111222233334444"));
+        orchestrator.set_goal_scope(&cleared, Some("5555666677778888".into()));
+        orchestrator.set_goal_scope(&cleared, None);
+
+        let restored = InProcessAgentOrchestrator::default();
+        restored
+            .configure_goal_scopes_sidecar(sidecar)
+            .expect("load sidecar");
+        assert_eq!(
+            restored.goal_scope(&seeded).as_deref(),
+            Some("1111222233334444"),
+            "an if-absent registration persists",
+        );
+        assert_eq!(
+            restored.goal_scope(&cleared),
+            None,
+            "a cleared scope must not resurrect on reload",
+        );
+    }
+
+    /// #1973 fix A — last-writer-wins: the sidecar mirrors the in-memory
+    /// registry's single-scope-per-wire-key semantics (the most recently
+    /// opened folder owns the wire), same as the ledger's documented residual.
+    /// And a live registration always beats a later sidecar load (the load
+    /// only fills vacant keys — it can never clobber a `session/open` write);
+    /// with the 4a write-back, that surviving live registration ALSO becomes
+    /// the file's entry, staying last-writer-wins across the boot boundary.
+    #[test]
+    fn goal_scope_sidecar_is_last_writer_wins_and_never_clobbers_live_scopes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let sidecar = dir.path().join("goal-scopes.json");
+        let wire = SessionKey::new("api", "scope-lww");
+
+        let writer = InProcessAgentOrchestrator::default();
+        writer
+            .configure_goal_scopes_sidecar(sidecar.clone())
+            .expect("configure sidecar");
+        writer.set_goal_scope(&wire, Some("aaaa111122223333".into()));
+        writer.set_goal_scope(&wire, Some("bbbb444455556666".into()));
+        // Within one boot: the file holds only the LAST registered scope.
+        let file: HashMap<String, String> =
+            serde_json::from_slice(&std::fs::read(&sidecar).unwrap()).unwrap();
+        assert_eq!(
+            file.get(wire.0.as_str()).map(String::as_str),
+            Some("bbbb444455556666"),
+            "the sidecar keeps the LAST registered scope per wire key",
+        );
+
+        let restored = InProcessAgentOrchestrator::default();
+        // A live registration lands BEFORE the sidecar load (a client raced
+        // boot): the load must leave it untouched.
+        restored.set_goal_scope(&wire, Some("cccc777788889999".into()));
+        restored
+            .configure_goal_scopes_sidecar(sidecar)
+            .expect("load sidecar");
+        assert_eq!(
+            restored.goal_scope(&wire).as_deref(),
+            Some("cccc777788889999"),
+            "a live scope must never be clobbered by the sidecar load",
+        );
+
+        // #1973 fix-round 4a — the boot write-back flushes the merged map, so
+        // the NEXT restart resumes the surviving (live) registration: LWW
+        // holds across boots too.
+        let fresh = InProcessAgentOrchestrator::default();
+        fresh
+            .configure_goal_scopes_sidecar(dir.path().join("goal-scopes.json"))
+            .expect("load sidecar");
+        assert_eq!(
+            fresh.goal_scope(&wire).as_deref(),
+            Some("cccc777788889999"),
+            "the write-back makes the surviving live registration the file's entry",
+        );
+    }
+
+    /// #1973 fix-round 4a — the configure-time load WRITES BACK the merged
+    /// map. A registration that raced in BEFORE the sidecar was configured
+    /// had no path to persist to; without the write-back it survives THIS
+    /// boot (occupied entry beats the load) but is lost on the NEXT restart.
+    #[test]
+    fn goal_scope_sidecar_boot_load_writes_back_pre_configure_registrations() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let sidecar = dir.path().join("goal-scopes.json");
+        // The file carries an entry from a prior boot.
+        std::fs::write(&sidecar, r#"{"api:scope-from-file":"1111222233334444"}"#).unwrap();
+
+        let orchestrator = InProcessAgentOrchestrator::default();
+        // A live registration landing BEFORE configure (nothing persists it —
+        // there is no sidecar path yet).
+        let early = SessionKey::new("api", "scope-early");
+        orchestrator.set_goal_scope(&early, Some("aaaa111122223333".into()));
+        orchestrator
+            .configure_goal_scopes_sidecar(sidecar.clone())
+            .expect("configure sidecar");
+
+        // NEXT restart: both the loaded entry and the pre-configure live
+        // registration must come back from the file.
+        let restored = InProcessAgentOrchestrator::default();
+        restored
+            .configure_goal_scopes_sidecar(sidecar)
+            .expect("reload sidecar");
+        assert_eq!(
+            restored.goal_scope(&early).as_deref(),
+            Some("aaaa111122223333"),
+            "a pre-configure registration must survive the next restart",
+        );
+        assert_eq!(
+            restored
+                .goal_scope(&SessionKey("api:scope-from-file".into()))
+                .as_deref(),
+            Some("1111222233334444"),
+            "the loaded entry is preserved by the write-back",
+        );
+    }
+
+    /// #1973 fix-round 4b — sidecar GC: a mutation-driven save prunes FILE
+    /// entries whose wire key has no goal under its scoped key AND was never
+    /// registered live this process (the keep-if-goal-exists policy), so the
+    /// file cannot grow unboundedly across restarts. The in-memory registry
+    /// keeps everything for this boot.
+    #[test]
+    fn goal_scope_sidecar_gc_prunes_goalless_unregistered_entries_on_save() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let sidecar = dir.path().join("goal-scopes.json");
+        let wired = SessionKey::new("api", "scope-gc-goal");
+        let stale = SessionKey::new("api", "scope-gc-stale");
+        let seeded: HashMap<String, String> = HashMap::from([
+            (wired.0.clone(), "aaaa111122223333".to_owned()),
+            (stale.0.clone(), "bbbb444455556666".to_owned()),
+        ]);
+        std::fs::write(&sidecar, serde_json::to_vec(&seeded).unwrap()).unwrap();
+
+        let orchestrator = InProcessAgentOrchestrator::default();
+        orchestrator
+            .configure_goal_scopes_sidecar(sidecar.clone())
+            .expect("configure sidecar");
+        // Restore-equivalent: a goal exists under `wired`'s SCOPED key
+        // (bind_goal_fleet_for_test inserts at scoped_goal_key(wired)).
+        orchestrator.bind_goal_fleet_for_test(&wired, "tenant-a", "fleet-gc");
+        // A live this-boot registration (kept even though no goal exists yet)
+        // — and the mutation that triggers the GC'd save.
+        let live = SessionKey::new("api", "scope-gc-live");
+        orchestrator.set_goal_scope(&live, Some("cccc777788889999".into()));
+
+        let file: HashMap<String, String> =
+            serde_json::from_slice(&std::fs::read(&sidecar).unwrap()).unwrap();
+        assert_eq!(
+            file.get(wired.0.as_str()).map(String::as_str),
+            Some("aaaa111122223333"),
+            "an entry backing a restored goal is kept",
+        );
+        assert_eq!(
+            file.get(live.0.as_str()).map(String::as_str),
+            Some("cccc777788889999"),
+            "a this-boot live registration is kept even before its goal exists",
+        );
+        assert!(
+            !file.contains_key(stale.0.as_str()),
+            "a goalless, never-registered leftover is pruned from the FILE",
+        );
+        // The in-memory registry still resolves the pruned entry this boot.
+        assert_eq!(
+            orchestrator.goal_scope(&stale).as_deref(),
+            Some("bbbb444455556666"),
+            "GC affects only the file, never the live registry",
+        );
+    }
+
+    /// #1973 fix B — `goal_clear` terminalizes the goal's bound fleet in the
+    /// kernel store (best-effort, spawned). Before this, the cleared goal's
+    /// fleet stayed `Active` in redb forever: boot-resume skipped it as
+    /// orphaned every boot, but nothing ever retired it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clear_goal_terminalizes_the_bound_fleet_in_the_kernel_store() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let (_sd, store) = fleet_test_store().await;
+        orchestrator.set_fleet_store(store.clone());
+        let wire = SessionKey::new("api", "keeper-clear-fleet");
+        seed_goal(&orchestrator, &wire, "tenant-a");
+        orchestrator.set_goal_workspace_root(
+            &orchestrator.scoped_goal_key(&wire),
+            Some("/repos/app".into()),
+        );
+        let plan = orchestrator
+            .model_create_fleet_plan(&wire, "tenant-a", plan_tasks(), 1_000)
+            .await
+            .expect("plan");
+        let fleet_id = plan["fleet_id"].as_str().expect("fleet id").to_owned();
+        assert_eq!(
+            store.get_fleet(&fleet_id).await.unwrap().unwrap().status,
+            octos_fleet::FleetStatus::Active,
+        );
+
+        let cleared = orchestrator
+            .clear_goal(GoalSessionRequest {
+                session_id: wire.clone(),
+                profile_id: "tenant-a".into(),
+            })
+            .expect("clear goal");
+        assert_eq!(cleared["cleared"], json!(true));
+        assert_eq!(orchestrator.goal_fleet_id_for_test(&wire), None);
+
+        // The terminalization is spawned (best-effort, never blocks the
+        // clear), so poll briefly for it to land.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let status = store.get_fleet(&fleet_id).await.unwrap().unwrap().status;
+            if status == octos_fleet::FleetStatus::Cancelled {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "cleared goal's fleet must become Cancelled within 5s (last: {status:?})",
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        // The boot-resume sweep no longer sees the fleet as resumable.
+        assert!(
+            store
+                .fleets_with_ready_children(2_000)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a cancelled fleet must not be boot-resumable",
+        );
+    }
+
+    /// #1973 fix B — a goal with NO bound fleet clears exactly as before
+    /// (no spawn, no store interaction), and clearing with no fleet store
+    /// installed stays a plain clear. Guards the best-effort contract: fleet
+    /// terminalization must never block or fail the clear.
+    #[tokio::test]
+    async fn clear_goal_without_fleet_binding_or_store_still_clears() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let wire = SessionKey::new("api", "keeper-clear-nofleet");
+        seed_goal(&orchestrator, &wire, "tenant-a");
+        let cleared = orchestrator
+            .clear_goal(GoalSessionRequest {
+                session_id: wire.clone(),
+                profile_id: "tenant-a".into(),
+            })
+            .expect("clear goal");
+        assert_eq!(cleared["cleared"], json!(true));
+        assert!(orchestrator.goal_objective_for_test(&wire).is_none());
+    }
+
+    /// #1973 fix C — the solo-boot goal park syncs `paused` into the durable
+    /// per-goal SQLite ledger. Before this, `pause_restored_goals_for_solo_boot`
+    /// flipped the in-memory + supervisor state to `paused` but the goals-row
+    /// kept saying `active` — a durable lie that outlived the boot.
+    #[test]
+    fn solo_boot_park_syncs_paused_goal_status_into_the_ledger() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let orchestrator = InProcessAgentOrchestrator::default();
+        orchestrator
+            .configure_supervisor_store(dir.path().join("supervisor"))
+            .expect("configure store");
+        let wire = SessionKey::new("api", "solo-park-ledger");
+        seed_goal(&orchestrator, &wire, "tenant-a");
+        let goal_id = orchestrator.goal_id_for_test(&wire).expect("goal id");
+
+        // Seed the durable goals-row as `active` (what a live goal turn leaves).
+        let profile_dir = dir.path().join("profile-data");
+        let ledger_dir = InProcessAgentOrchestrator::goal_ledger_dir(&profile_dir);
+        std::fs::create_dir_all(&ledger_dir).unwrap();
+        let ledger_path = ledger_dir.join(format!("{}.db", sanitize_filename_for_ledger(&goal_id)));
+        let ledger = octos_fleet::GoalLedger::open(&ledger_path).expect("open ledger");
+        ledger
+            .upsert_goal(&octos_fleet::Goal {
+                goal_id: goal_id.clone(),
+                objective: "ship the thing".into(),
+                status: "active".into(),
+                tokens_used: 0,
+                token_budget: 1_000_000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1,
+                updated_at_ms: 1,
+            })
+            .expect("seed active row");
+
+        let parked =
+            orchestrator.pause_restored_goals_for_solo_boot_with_ledger_sync(&|profile_id| {
+                (profile_id == "tenant-a").then(|| profile_dir.clone())
+            });
+        assert_eq!(parked.len(), 1, "the active goal is parked");
+        assert_eq!(
+            orchestrator
+                .state()
+                .goals
+                .get(&orchestrator.scoped_goal_key(&wire))
+                .map(|goal| goal.status.clone())
+                .as_deref(),
+            Some("paused"),
+        );
+        let row = ledger
+            .get_goal(&goal_id)
+            .expect("read row")
+            .expect("row exists");
+        assert_eq!(
+            row.status, "paused",
+            "the durable goals-row must read `paused` after a solo-boot park",
+        );
+    }
+
+    /// #1973 fix C — a resolver that finds no profile dir (no registry entry,
+    /// gateway boot) parks exactly as before: in-memory + supervisor state
+    /// only, no ledger write, no error.
+    #[test]
+    fn solo_boot_park_without_a_profile_dir_still_parks_goals() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let wire = SessionKey::new("api", "solo-park-nodir");
+        seed_goal(&orchestrator, &wire, "tenant-a");
+        let parked = orchestrator.pause_restored_goals_for_solo_boot_with_ledger_sync(&|_| None);
+        assert_eq!(parked.len(), 1);
+        assert_eq!(
+            orchestrator
+                .state()
+                .goals
+                .get(&orchestrator.scoped_goal_key(&wire))
+                .map(|goal| goal.status.clone())
+                .as_deref(),
+            Some("paused"),
+        );
+    }
+
+    /// #1973 fix B — the RPC path syncs the cleared status into the durable
+    /// per-goal SQLite ledger when a profile data dir is in scope, so the
+    /// goals-row stops claiming `active` after a user clear.
+    #[test]
+    fn clear_goal_with_ledger_sync_marks_the_goals_row_cleared() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let wire = SessionKey::new("api", "keeper-clear-ledger");
+        seed_goal(&orchestrator, &wire, "tenant-a");
+        let goal_id = orchestrator.goal_id_for_test(&wire).expect("goal id");
+
+        // Seed the durable goals-row as `active` (what a live goal turn leaves).
+        let ledger_dir = InProcessAgentOrchestrator::goal_ledger_dir(dir.path());
+        std::fs::create_dir_all(&ledger_dir).unwrap();
+        let ledger_path = ledger_dir.join(format!("{}.db", sanitize_filename_for_ledger(&goal_id)));
+        let ledger = octos_fleet::GoalLedger::open(&ledger_path).expect("open ledger");
+        ledger
+            .upsert_goal(&octos_fleet::Goal {
+                goal_id: goal_id.clone(),
+                objective: "ship the thing".into(),
+                status: "active".into(),
+                tokens_used: 0,
+                token_budget: 1_000_000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1,
+                updated_at_ms: 1,
+            })
+            .expect("seed active row");
+
+        let cleared = orchestrator
+            .clear_goal_with_ledger_sync(
+                GoalSessionRequest {
+                    session_id: wire.clone(),
+                    profile_id: "tenant-a".into(),
+                },
+                Some(dir.path()),
+            )
+            .expect("clear goal");
+        assert_eq!(cleared["cleared"], json!(true));
+
+        let row = ledger
+            .get_goal(&goal_id)
+            .expect("read row")
+            .expect("row exists");
+        assert_eq!(
+            row.status, "cleared",
+            "the durable goals-row must stop claiming `active` after a clear",
+        );
+    }
+
+    /// #1973 fix-round — an ADMINISTRATIVE status sync (park/clear) whose
+    /// snapshot carries STALE lower token counters (a peer charge pushed the
+    /// ledger row ahead of the in-memory record) must still land the STATUS:
+    /// the #1970 monotonic guard rejects the first upsert, the sync detects
+    /// it and retries once with max'd counters, and the decision is appended
+    /// only once the row actually reflects the transition. Before, the row
+    /// silently stayed `active` while a decision claimed `cleared`.
+    #[test]
+    fn goal_status_sync_beats_stale_token_counter_guard() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let wire = SessionKey::new("api", "keeper-stale-sync");
+        seed_goal(&orchestrator, &wire, "tenant-a");
+        let goal_id = orchestrator.goal_id_for_test(&wire).expect("goal id");
+
+        // The ledger row is AHEAD on tokens (a peer finding charged 500) while
+        // the in-memory goal still says 0 — exactly the divergence the guard
+        // exists for.
+        let ledger_dir = InProcessAgentOrchestrator::goal_ledger_dir(dir.path());
+        std::fs::create_dir_all(&ledger_dir).unwrap();
+        let ledger_path = ledger_dir.join(format!("{}.db", sanitize_filename_for_ledger(&goal_id)));
+        let ledger = octos_fleet::GoalLedger::open(&ledger_path).expect("open ledger");
+        ledger
+            .upsert_goal(&octos_fleet::Goal {
+                goal_id: goal_id.clone(),
+                objective: "ship the thing".into(),
+                status: "active".into(),
+                tokens_used: 500,
+                token_budget: 1_000_000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1,
+                updated_at_ms: 1,
+            })
+            .expect("seed charged row");
+
+        orchestrator
+            .clear_goal_with_ledger_sync(
+                GoalSessionRequest {
+                    session_id: wire.clone(),
+                    profile_id: "tenant-a".into(),
+                },
+                Some(dir.path()),
+            )
+            .expect("clear goal");
+
+        let row = ledger
+            .get_goal(&goal_id)
+            .expect("read row")
+            .expect("row exists");
+        assert_eq!(
+            row.status, "cleared",
+            "the status transition must land despite the stale token counter",
+        );
+        assert_eq!(
+            row.tokens_used, 500,
+            "the retry must NOT roll the monotonic counter back",
+        );
+        assert_eq!(
+            ledger.count_decisions(&goal_id).expect("count decisions"),
+            1,
+            "exactly one decision, appended only once the row reflects it",
+        );
+    }
+
+    /// #1973 fix-round 3 — codex regression: an OLDER transition whose sync
+    /// retries against a row that already carries a NEWER status change must
+    /// NOT overwrite it. The previous retry forged `updated_at_ms` up to the
+    /// row's own timestamp, so a late `blocked` sync could overwrite
+    /// `cleared` (both syncs run post-lock; the interleaving is reachable).
+    /// The status-CAS retry is ordering-gated: `cleared` stays, the newer
+    /// timestamp stays, and zero `blocked` decisions are appended.
+    #[test]
+    fn goal_stale_transition_retry_must_not_overwrite_a_newer_status() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let wire = SessionKey::new("api", "keeper-stale-retry");
+
+        // Ledger row: `cleared` at T2=2_000 with tokens 500 (a later
+        // transition + a peer charge already landed).
+        let ledger_dir = InProcessAgentOrchestrator::goal_ledger_dir(dir.path());
+        std::fs::create_dir_all(&ledger_dir).unwrap();
+        let ledger_path =
+            ledger_dir.join(format!("{}.db", sanitize_filename_for_ledger("goal_stale")));
+        let ledger = octos_fleet::GoalLedger::open(&ledger_path).expect("open ledger");
+        ledger
+            .upsert_goal(&octos_fleet::Goal {
+                goal_id: "goal_stale".into(),
+                objective: "obj".into(),
+                status: "cleared".into(),
+                tokens_used: 500,
+                token_budget: 1_000_000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1,
+                updated_at_ms: 2_000,
+            })
+            .expect("seed cleared row");
+
+        // The OLDER `blocked` transition (T1=1_000 < T2) with stale-low
+        // tokens: its upsert is rejected, and the retry must not land either.
+        let snapshot = AutonomyGoalRecord {
+            profile_id: "tenant-a".into(),
+            goal_id: "goal_stale".into(),
+            objective: "obj".into(),
+            status: "blocked".into(),
+            token_budget: 1_000_000,
+            tokens_used: 0,
+            time_used_seconds: 0,
+            created_at_ms: 1,
+            updated_at_ms: 1_000,
+            continuations_used: 0,
+            last_continued_at_ms: 0,
+            rate_window_start_ms: 0,
+            rate_window_count: 0,
+            wrap_up_emitted: false,
+            consecutive_failed_turns: 0,
+            fleet_id: None,
+            controller_workspace_root: None,
+            controller_workspace_has_runtime_hint: None,
+        };
+        orchestrator.sync_transition_to_ledger_blocking(
+            dir.path(),
+            &snapshot,
+            "late blocked",
+            &wire,
+            true,
+            false,
+        );
+
+        let row = ledger
+            .get_goal("goal_stale")
+            .expect("read row")
+            .expect("row exists");
+        assert_eq!(
+            row.status, "cleared",
+            "an older transition's retry must never overwrite a newer status",
+        );
+        assert_eq!(
+            row.updated_at_ms, 2_000,
+            "the newer row's timestamp must not be forged over",
+        );
+        assert_eq!(
+            ledger.count_decisions("goal_stale").expect("count"),
+            0,
+            "zero blocked decisions against a row that stayed cleared",
+        );
+    }
+
+    /// #1973 fix-round — the complete-is-terminal guard still wins: clearing
+    /// a goal whose ledger row is already `complete` leaves the row complete
+    /// AND appends NO decision (a decision claiming `cleared` against a row
+    /// saying `complete` would be exactly the divergence this fix removes).
+    #[test]
+    fn goal_clear_sync_on_complete_row_appends_no_decision() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let wire = SessionKey::new("api", "keeper-complete-clear");
+        seed_goal(&orchestrator, &wire, "tenant-a");
+        let goal_id = orchestrator.goal_id_for_test(&wire).expect("goal id");
+
+        let ledger_dir = InProcessAgentOrchestrator::goal_ledger_dir(dir.path());
+        std::fs::create_dir_all(&ledger_dir).unwrap();
+        let ledger_path = ledger_dir.join(format!("{}.db", sanitize_filename_for_ledger(&goal_id)));
+        let ledger = octos_fleet::GoalLedger::open(&ledger_path).expect("open ledger");
+        ledger
+            .upsert_goal(&octos_fleet::Goal {
+                goal_id: goal_id.clone(),
+                objective: "ship the thing".into(),
+                status: "complete".into(),
+                tokens_used: 0,
+                token_budget: 1_000_000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1,
+                updated_at_ms: 1,
+            })
+            .expect("seed complete row");
+
+        orchestrator
+            .clear_goal_with_ledger_sync(
+                GoalSessionRequest {
+                    session_id: wire.clone(),
+                    profile_id: "tenant-a".into(),
+                },
+                Some(dir.path()),
+            )
+            .expect("clear goal");
+
+        let row = ledger
+            .get_goal(&goal_id)
+            .expect("read row")
+            .expect("row exists");
+        assert_eq!(row.status, "complete", "complete is terminal per goal_id");
+        assert_eq!(
+            ledger.count_decisions(&goal_id).expect("count decisions"),
+            0,
+            "no decision may claim a transition the row does not reflect",
         );
     }
 

--- a/crates/octos-cli/src/api/fleet_wake.rs
+++ b/crates/octos-cli/src/api/fleet_wake.rs
@@ -39,7 +39,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use octos_core::SessionKey;
-use octos_fleet::{AckOutcome, Fleet, FleetEventKind, FleetKernelStore};
+use octos_fleet::{AckOutcome, Fleet, FleetEventKind, FleetKernelStore, FleetStatus};
 use tokio::time::MissedTickBehavior;
 
 use super::agent_orchestrator::{
@@ -231,6 +231,22 @@ where
             FleetEventKind::ChildDone | FleetEventKind::FleetDrained
         ) {
             match store.get_fleet(&ev.fleet_id).await? {
+                // #1973 fix-round — a CANCELLED fleet's `ChildDone` (a
+                // completion/escalation that raced `goal_clear` in before the
+                // store's terminal-fleet fence) has no keeper to wake: the
+                // goal that owned it is gone, and a wake would re-animate a
+                // dead controller with stale metadata. Ack without a wake.
+                // Scoped to `Cancelled` only — a `Complete`/`Failed` fleet's
+                // late events still wake the keeper, which legitimately
+                // self-detects completion from them.
+                Some(rec) if rec.status == FleetStatus::Cancelled => {
+                    tracing::debug!(
+                        sequence = ev.sequence,
+                        fleet_id = %ev.fleet_id,
+                        "fleet outbox: dropping wake for a cancelled fleet (goal cleared)"
+                    );
+                    true
+                }
                 Some(rec) => {
                     let snap = render_fleet_snapshot(store, &ev.fleet_id, now_ms).await;
                     let req = fleet_keeper_continuation_request(
@@ -401,6 +417,9 @@ pub(crate) async fn enqueue_fleet_boot_resume_wakes(
             &rec.controller_session_key,
             &rec.fleet_id,
         ));
+        // #1973 fix D — cloned up front so a failed persist can stash the
+        // request for its one bounded retry (the commit consumes `req`).
+        let retry_req = req.clone();
         match orchestrator.commit_fleet_keeper_wake(req) {
             // Persisted to the durable store — survives a further restart.
             WakeCommit::Durable => enqueued += 1,
@@ -410,17 +429,24 @@ pub(crate) async fn enqueue_fleet_boot_resume_wakes(
             WakeCommit::NotDurable if !has_store => enqueued += 1,
             // A supervisor store IS configured yet the commit is NotDurable —
             // the ONLY cause is a persistence error that ROLLED BACK the
-            // in-memory enqueue. There is now NO wake and NO retry, and
-            // reconcile emitted no outbox event either, so this fleet will NOT
-            // auto-resume this boot. Surface it honestly; do NOT count it as a
+            // in-memory enqueue. There is now NO wake, and reconcile emitted no
+            // outbox event either. Surface it honestly; do NOT count it as a
             // success (never report false progress that masks a stall).
-            WakeCommit::NotDurable => tracing::warn!(
-                fleet_id = %rec.fleet_id,
-                controller = %rec.controller_session_key,
-                "fleet boot-resume wake FAILED to persist and was rolled back; this fleet will \
-                 NOT auto-resume this boot — it stays Ready with no keeper wake until the next \
-                 fleet event or a restart"
-            ),
+            // #1973 fix D — stash the request for ONE bounded retry on the next
+            // fleet-outbox drain tick (~3s), so a transient persist failure no
+            // longer strands the fleet for the whole boot. If the retry fails
+            // too, the wake is dropped for this boot (the retry path warns).
+            WakeCommit::NotDurable => {
+                orchestrator.stash_fleet_wake_retry(retry_req);
+                tracing::warn!(
+                    fleet_id = %rec.fleet_id,
+                    controller = %rec.controller_session_key,
+                    "fleet boot-resume wake FAILED to persist and was rolled back; stashed for \
+                     ONE retry on the next drain tick — if that also fails, this fleet will NOT \
+                     auto-resume this boot (it stays Ready with no keeper wake until the next \
+                     fleet event or a restart)"
+                );
+            }
         }
     }
     if enqueued > 0 {
@@ -881,6 +907,41 @@ mod tests {
                 .await
                 .expect("probe")
                 .is_none()
+        );
+    }
+
+    /// #1973 fix-round — a `ChildDone` for a CANCELLED fleet (a completion or
+    /// escalation that raced `goal_clear` in before the store fence) must be
+    /// acked WITHOUT a keeper wake: the goal that owned the keeper is gone, so
+    /// a wake would re-animate a dead controller with stale metadata.
+    #[tokio::test]
+    async fn consumer_drops_child_done_wakes_for_cancelled_fleets() {
+        let (_dir, store) = test_store().await;
+        let controller = SessionKey::new("api", "keeper-cancelled-drop");
+        make_fleet(&store, "fleet-cx", &controller, "obj").await;
+        store
+            .append_event(event("fleet-cx", "ev-cx", FleetEventKind::ChildDone))
+            .await
+            .expect("append");
+        assert!(store.cancel_fleet("fleet-cx", 50).await.expect("cancel"));
+
+        let processed = drain_fleet_outbox_once(
+            &store,
+            || 100,
+            FLEET_WAKE_MAX_BATCH,
+            |_req| panic!("a cancelled fleet's ChildDone must not enqueue a wake"),
+        )
+        .await
+        .expect("drain");
+
+        assert_eq!(processed, 1, "acked (dropped), so the outbox advances");
+        assert!(
+            store
+                .claim_next("probe", 200, FLEET_WAKE_TTL_MS)
+                .await
+                .expect("probe")
+                .is_none(),
+            "nothing left to redeliver",
         );
     }
 
@@ -1436,6 +1497,60 @@ mod tests {
         );
     }
 
+    /// #1973 fix B end-to-end — `goal_clear` terminalizes its bound fleet, so
+    /// the boot-resume query EXCLUDES it outright (before, the fleet stayed
+    /// `Active` in redb forever and was merely re-skipped as orphaned on
+    /// every boot).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn boot_resume_no_longer_scans_a_fleet_terminalized_by_goal_clear() {
+        use crate::api::agent_orchestrator::{AgentOrchestrator, GoalSessionRequest};
+
+        let (dir, store) = test_store().await;
+        let controller = SessionKey::new("api", "keeper-goalclear");
+        let root = dir.path().to_string_lossy().into_owned();
+        make_fleet_with_root(&store, "fleet-cleared", &controller, "obj", Some(&root)).await;
+
+        let orch = InProcessAgentOrchestrator::default();
+        orch.set_fleet_store(store.clone());
+        bind_goal(&orch, &controller, "fleet-cleared");
+
+        // Sanity: before the clear, the fleet IS a boot-resume candidate.
+        assert_eq!(
+            store.fleets_with_ready_children(500).await.unwrap().len(),
+            1,
+        );
+
+        orch.clear_goal(GoalSessionRequest {
+            session_id: controller.clone(),
+            profile_id: "profile-x".into(),
+        })
+        .expect("clear goal");
+
+        // The terminalization is spawned (best-effort); wait for it to land.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let status = store
+                .get_fleet("fleet-cleared")
+                .await
+                .unwrap()
+                .unwrap()
+                .status;
+            if status == octos_fleet::FleetStatus::Cancelled {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "cleared goal's fleet must cancel within 5s (last: {status:?})",
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        let enqueued = enqueue_fleet_boot_resume_wakes(&store, &orch, 1_000)
+            .await
+            .expect("boot resume");
+        assert_eq!(enqueued, 0, "a terminalized fleet is not resumable");
+    }
+
     #[tokio::test]
     async fn boot_resume_skips_an_orphaned_fleet_not_bound_to_the_current_goal() {
         // HIGH fix (b) + the collision scenario: a controller whose goal G1 was
@@ -1543,6 +1658,104 @@ mod tests {
             orch.pending_continuation_count_for_session_for_test(&controller, "profile-x"),
             0,
             "the failed wake was rolled back → no pending continuation lingers"
+        );
+    }
+
+    /// #1973 fix D — a boot-resume wake whose durable persist failed is
+    /// retried ONCE on the next fleet-outbox drain tick instead of being
+    /// dropped forever. Simulates the persist failure (directory planted at
+    /// the event-ledger path), repairs the store, then drives one drain tick:
+    /// the stashed wake commits durably.
+    #[tokio::test]
+    async fn boot_resume_persist_failure_is_retried_once_on_the_next_drain_tick() {
+        let (dir, store) = test_store().await;
+        let controller = SessionKey::new("api", "keeper-retry");
+        let root = dir.path().to_string_lossy().into_owned();
+        make_fleet_with_root(&store, "fleet-retry", &controller, "obj", Some(&root)).await;
+
+        let orch = InProcessAgentOrchestrator::default();
+        let sup = dir.path().join("supervisor");
+        orch.configure_supervisor_store(&sup)
+            .expect("configure supervisor store");
+        bind_goal(&orch, &controller, "fleet-retry");
+
+        // Sabotage the durable write (same trick as the persist-failure test):
+        // a DIRECTORY where the event-ledger FILE must be.
+        std::fs::create_dir_all(&sup).expect("sup dir");
+        let events = sup.join("supervisor-events.jsonl");
+        let _ = std::fs::remove_file(&events);
+        std::fs::create_dir_all(&events).expect("plant ledger-path directory");
+
+        let enqueued = enqueue_fleet_boot_resume_wakes(&store, &orch, 1_000)
+            .await
+            .expect("boot resume");
+        assert_eq!(enqueued, 0, "the failed wake is not counted");
+        assert_eq!(
+            orch.pending_continuation_count_for_session_for_test(&controller, "profile-x"),
+            0,
+            "the failed wake was rolled back",
+        );
+
+        // Repair the store, then drive the next outbox drain tick — the code
+        // path that consumes the retry stash.
+        std::fs::remove_dir_all(&events).expect("repair ledger path");
+        orch.drain_fleet_outbox(&store).await.expect("drain tick");
+        assert_eq!(
+            orch.pending_continuation_count_for_session_for_test(&controller, "profile-x"),
+            1,
+            "the retried wake commits durably on the next drain tick",
+        );
+
+        // The stash was consumed: another tick must not double-enqueue.
+        orch.drain_fleet_outbox(&store).await.expect("drain tick 2");
+        assert_eq!(
+            orch.pending_continuation_count_for_session_for_test(&controller, "profile-x"),
+            1,
+            "exactly one retry attempt — the stash is one-shot",
+        );
+    }
+
+    /// #1973 fix D residual, pinned honestly — the retry is BOUNDED: if the
+    /// re-attempt's persist ALSO fails, the wake is dropped for this boot
+    /// (loud warn; the fleet stays Ready with no keeper wake until the next
+    /// fleet event or restart, when boot-resume runs again).
+    #[tokio::test]
+    async fn boot_resume_retry_that_fails_again_is_dropped_for_this_boot() {
+        let (dir, store) = test_store().await;
+        let controller = SessionKey::new("api", "keeper-retry-fail");
+        let root = dir.path().to_string_lossy().into_owned();
+        make_fleet_with_root(&store, "fleet-retry-fail", &controller, "obj", Some(&root)).await;
+
+        let orch = InProcessAgentOrchestrator::default();
+        let sup = dir.path().join("supervisor");
+        orch.configure_supervisor_store(&sup)
+            .expect("configure supervisor store");
+        bind_goal(&orch, &controller, "fleet-retry-fail");
+
+        std::fs::create_dir_all(&sup).expect("sup dir");
+        let events = sup.join("supervisor-events.jsonl");
+        let _ = std::fs::remove_file(&events);
+        std::fs::create_dir_all(&events).expect("plant ledger-path directory");
+
+        enqueue_fleet_boot_resume_wakes(&store, &orch, 1_000)
+            .await
+            .expect("boot resume");
+
+        // The sabotage stays in place: the one retry fails too → dropped.
+        orch.drain_fleet_outbox(&store).await.expect("drain tick");
+        assert_eq!(
+            orch.pending_continuation_count_for_session_for_test(&controller, "profile-x"),
+            0,
+            "a twice-failed wake is dropped (bounded retry, documented loss)",
+        );
+
+        // Even after repair, no ghost retry lingers.
+        std::fs::remove_dir_all(&events).expect("repair ledger path");
+        orch.drain_fleet_outbox(&store).await.expect("drain tick 2");
+        assert_eq!(
+            orch.pending_continuation_count_for_session_for_test(&controller, "profile-x"),
+            0,
+            "the retry stash never re-queues a failed re-attempt",
         );
     }
 }

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -5066,40 +5066,72 @@ pub(super) async fn event_ledger(state: &AppState) -> Arc<UiProtocolLedger> {
     if let Some(existing) = EVENT_LEDGER.get() {
         return existing.clone();
     }
+    // The data_dir read is the only async step; it runs OUTSIDE the once-init
+    // (two racers both computing it is benign — the loser's value is dropped).
     let data_dir = match &state.sessions {
         Some(sessions) => Some(sessions.lock().await.data_dir()),
         None => None,
     };
-    let config = match data_dir {
-        Some(dir) => LedgerConfig::durable(dir),
-        None => LedgerConfig::ephemeral(EVENT_LEDGER_RETAINED_PER_SESSION),
-    };
-    let ledger = if config.data_dir.is_some() {
-        let outcome = UiProtocolLedger::recover(config);
-        info!(
-            target = "octos::ledger",
-            sessions_recovered = outcome.sessions_recovered,
-            events_recovered = outcome.events_recovered,
-            "ui protocol ledger initialized with durable backing"
-        );
-        outcome.ledger
-    } else {
-        Arc::new(UiProtocolLedger::with_config(config))
-    };
-    let installed = EVENT_LEDGER.get_or_init(|| ledger.clone()).clone();
-    // Only spawn the sweep task on the install path. If two connections
-    // race here, only one wins the get_or_init and only that one starts
-    // the sweep.
-    if Arc::ptr_eq(&installed, &ledger) {
+    let (installed, installed_now) = event_ledger_init_once(&EVENT_LEDGER, data_dir);
+    // Only the caller whose closure actually ran spawns the sweep + observer,
+    // so a process never has two eviction tasks or competing observers.
+    if installed_now {
         let _handle = spawn_eviction_task(installed.clone());
         // Install the post-fsync observer that converts every successful
         // `add_message_with_seq` commit into a canonical v2 projection
-        // envelope. We install on the same
-        // path that wins the ledger get_or_init so a process never has
-        // two competing observers.
+        // envelope. Installed on the same path that won the once-init so a
+        // process never has two competing observers.
         install_message_commit_observer(installed.clone());
     }
     installed
+}
+
+/// #1973 fix-round — the once-init core of [`event_ledger`]: build the ledger
+/// (running DISK RECOVERY for a durable config) strictly INSIDE the
+/// `OnceLock::get_or_init` closure, which runs at most once per lock.
+///
+/// Before, recovery ran BEFORE `get_or_init`: two callers racing the first
+/// initialization (the global master-continuation drain and the stdio
+/// connection both call [`event_ledger`] at serve boot) could BOTH replay the
+/// same on-disk JSONL and BOTH synthesize orphan-terminal records —
+/// interleaving appends into the live log before one loser's ledger was
+/// discarded. `get_or_init` blocks the losing racer until the winner's
+/// closure returns; recovery is fast boot-time disk replay and runs once per
+/// process, so briefly parking a second initializer is the correct trade
+/// (and the pre-existing behavior already ran this same blocking I/O on the
+/// async path).
+///
+/// Returns the installed ledger plus whether THIS call ran the init closure —
+/// the caller uses that to spawn the eviction sweep / commit observer exactly
+/// once. Extracted (with the `OnceLock` injected) so a test can race N
+/// threads against a fresh lock and pin the exactly-once guarantee.
+fn event_ledger_init_once(
+    once: &'static OnceLock<Arc<UiProtocolLedger>>,
+    data_dir: Option<PathBuf>,
+) -> (Arc<UiProtocolLedger>, bool) {
+    let mut installed_now = false;
+    let installed = once
+        .get_or_init(|| {
+            installed_now = true;
+            let config = match data_dir {
+                Some(dir) => LedgerConfig::durable(dir),
+                None => LedgerConfig::ephemeral(EVENT_LEDGER_RETAINED_PER_SESSION),
+            };
+            if config.data_dir.is_some() {
+                let outcome = UiProtocolLedger::recover(config);
+                info!(
+                    target = "octos::ledger",
+                    sessions_recovered = outcome.sessions_recovered,
+                    events_recovered = outcome.events_recovered,
+                    "ui protocol ledger initialized with durable backing"
+                );
+                outcome.ledger
+            } else {
+                Arc::new(UiProtocolLedger::with_config(config))
+            }
+        })
+        .clone();
+    (installed, installed_now)
 }
 
 /// Install the durable-commit observer that records every successful
@@ -17064,24 +17096,60 @@ fn resolve_autonomy_profile_id(
         .unwrap_or_else(|| MAIN_PROFILE_ID.to_owned()))
 }
 
+/// #1973 fix B — how the autonomy RPC surface resolves a profile's data dir
+/// (for the `goal_clear` durable-ledger sync). `None` (unit tests, callers
+/// with no profile store) skips the sync — byte-identical legacy behavior.
+type ProfileDataDirResolver<'a> = &'a dyn Fn(&str) -> Option<PathBuf>;
+
+/// Legacy 3-arg entry point (test seam): no ledger resolver → `goal_clear`
+/// skips the durable-ledger sync, everything else is unchanged.
+#[cfg(test)]
 fn raw_autonomy_rpc(
     request: &RpcRequest<Value>,
     features: ConnectionUiFeatures,
     connection_profile_id: Option<&str>,
 ) -> Result<Value, RpcError> {
-    raw_autonomy_rpc_with_orchestrator(
+    raw_autonomy_rpc_with_ledger(request, features, connection_profile_id, None)
+}
+
+fn raw_autonomy_rpc_with_ledger(
+    request: &RpcRequest<Value>,
+    features: ConnectionUiFeatures,
+    connection_profile_id: Option<&str>,
+    profile_data_dir_for: Option<ProfileDataDirResolver<'_>>,
+) -> Result<Value, RpcError> {
+    raw_autonomy_rpc_with_orchestrator_and_ledger(
         request,
         features,
         connection_profile_id,
         default_agent_orchestrator(),
+        profile_data_dir_for,
     )
 }
 
+/// Test seam kept signature-stable: the ledger resolver defaults to `None`.
+#[cfg(test)]
 fn raw_autonomy_rpc_with_orchestrator(
     request: &RpcRequest<Value>,
     features: ConnectionUiFeatures,
     connection_profile_id: Option<&str>,
     orchestrator: &dyn AgentOrchestrator,
+) -> Result<Value, RpcError> {
+    raw_autonomy_rpc_with_orchestrator_and_ledger(
+        request,
+        features,
+        connection_profile_id,
+        orchestrator,
+        None,
+    )
+}
+
+fn raw_autonomy_rpc_with_orchestrator_and_ledger(
+    request: &RpcRequest<Value>,
+    features: ConnectionUiFeatures,
+    connection_profile_id: Option<&str>,
+    orchestrator: &dyn AgentOrchestrator,
+    profile_data_dir_for: Option<ProfileDataDirResolver<'_>>,
 ) -> Result<Value, RpcError> {
     use octos_core::ui_protocol::methods;
 
@@ -17249,10 +17317,18 @@ fn raw_autonomy_rpc_with_orchestrator(
                 params.profile_id.as_deref(),
                 connection_profile_id,
             )?;
-            orchestrator.clear_goal(GoalSessionRequest {
-                session_id: params.session_id,
-                profile_id,
-            })
+            // #1973 fix B — resolve the profile data dir so the clear also
+            // syncs the durable per-goal ledger row to `cleared` (best-effort;
+            // `None` — no store / unresolvable profile — is a plain clear).
+            let ledger_data_dir =
+                profile_data_dir_for.and_then(|resolve| resolve(profile_id.as_str()));
+            orchestrator.clear_goal_with_ledger_sync(
+                GoalSessionRequest {
+                    session_id: params.session_id,
+                    profile_id,
+                },
+                ledger_data_dir.as_deref(),
+            )
         }
         methods::LOOP_CREATE => {
             let params: RawLoopCreateParams = parse_raw_params(request)?;
@@ -17379,7 +17455,20 @@ async fn handle_raw_appui_rpc(
 
     let result = match request.method.as_str() {
         method if is_autonomy_method(method) => {
-            raw_autonomy_rpc(request, features, connection_profile_id)
+            // #1973 fix B — profile data-dir resolver for the `goal_clear`
+            // durable-ledger sync (honors per-profile `data_dir` overrides via
+            // the store's own resolution).
+            let profile_data_dir_for = |profile_id: &str| -> Option<PathBuf> {
+                let store = state.profile_store.as_ref()?;
+                let profile = store.get(profile_id).ok().flatten()?;
+                Some(store.resolve_data_dir(&profile))
+            };
+            raw_autonomy_rpc_with_ledger(
+                request,
+                features,
+                connection_profile_id,
+                Some(&profile_data_dir_for),
+            )
         }
         APPUI_METHOD_CONFIG_CAPABILITIES_LIST => {
             Ok(json!({ "capabilities": features.advertised_capabilities(state) }))

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -31635,3 +31635,80 @@ fn goal_event_generation_admits_should_be_per_session_and_pass_legacy_zero() {
     assert!(!goal_event_generation_admits(&mut last, "sessionA", 50));
     assert!(goal_event_generation_admits(&mut last, "sessionA", 101));
 }
+
+/// #1973 fix-round — the process-global event ledger's INIT (including disk
+/// recovery) runs exactly once even when N callers race the first
+/// `event_ledger()` call (global drain vs stdio connection at serve boot).
+/// Before, recovery ran BEFORE the `get_or_init` install: two racers could
+/// both replay the same JSONL and both synthesize orphan-terminal records,
+/// interleaving appends before one loser's ledger was discarded.
+///
+/// Drives the extracted once-init core (`event_ledger_init_once`) with its
+/// own `OnceLock` + 8 threads: exactly one runs the init closure (recovery
+/// is inside it), every caller gets the same `Arc`, and the seeded orphan is
+/// swept by exactly ONE synthesized terminal.
+#[test]
+fn event_ledger_recovery_runs_exactly_once_across_concurrent_initializers() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let session_id = SessionKey("local:init-race-orphan".into());
+    // Seed a durable dir with a session whose last task row is NON-terminal,
+    // so the recovery has a real orphan sweep to perform.
+    {
+        let ledger = UiProtocolLedger::with_config(LedgerConfig::durable(temp.path().into()));
+        let task: octos_core::ui_protocol::TaskUpdatedEvent = serde_json::from_value(json!({
+            "session_id": session_id.0.clone(),
+            "task_id": octos_core::TaskId::new().to_string(),
+            "title": "ghost task",
+            "state": "running",
+        }))
+        .expect("task event");
+        ledger.append_notification(UiNotification::TaskUpdated(task));
+    } // process "dies" — no terminal event
+
+    static ONCE: OnceLock<Arc<UiProtocolLedger>> = OnceLock::new();
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let dir: PathBuf = temp.path().into();
+        handles.push(std::thread::spawn(move || {
+            event_ledger_init_once(&ONCE, Some(dir))
+        }));
+    }
+    let results: Vec<(Arc<UiProtocolLedger>, bool)> = handles
+        .into_iter()
+        .map(|handle| handle.join().expect("join init thread"))
+        .collect();
+
+    let installs = results
+        .iter()
+        .filter(|(_, installed_now)| *installed_now)
+        .count();
+    assert_eq!(
+        installs, 1,
+        "exactly one caller may run the init closure (and thus the recovery)"
+    );
+    for (ledger, _) in &results {
+        assert!(
+            Arc::ptr_eq(ledger, &results[0].0),
+            "every racer must get the same installed ledger"
+        );
+    }
+
+    // The single recovery swept the orphan exactly once.
+    let (events, _) = results[0]
+        .0
+        .snapshot_with_cursor(&session_id, None)
+        .expect("snapshot");
+    let synthesized = events
+        .iter()
+        .filter(|event| match &event.event {
+            UiProtocolLedgerEvent::Notification(UiNotification::TaskUpdated(task)) => {
+                task.runtime_detail.as_deref() == Some("orphaned_by_restart")
+            }
+            _ => false,
+        })
+        .count();
+    assert_eq!(
+        synthesized, 1,
+        "one recovery → one synthesized orphan terminal, never N interleaved sets"
+    );
+}

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -614,6 +614,21 @@ impl ServeCommand {
             }
         };
 
+        // #1973 fix A — load the persisted cwd-scope registry BEFORE the
+        // supervisor store restores goals, so a goal stored under a scoped key
+        // (`<wire>\0~cwd-<scope>`) resolves — and its restored continuation is
+        // dispatchable — immediately at boot instead of only after a client
+        // reopens the session. Failure is non-fatal: the registry starts empty
+        // (the pre-sidecar behavior) and repopulates on session/open.
+        if let Err(error) = crate::api::agent_orchestrator::default_agent_orchestrator()
+            .configure_goal_scopes_sidecar(data_dir.join("goal-scopes.json"))
+        {
+            tracing::warn!(
+                %error,
+                "failed to load goal-scopes sidecar; restored cwd-scoped goals stay \
+                 invisible until their session reopens"
+            );
+        }
         if let Err(error) = crate::api::agent_orchestrator::default_agent_orchestrator()
             .configure_supervisor_store(data_dir.join("supervisor"))
         {
@@ -641,9 +656,22 @@ impl ServeCommand {
             // for. Park paused; `/goal resume` re-arms,
             // OCTOS_SOLO_RESUME_GOALS=1 opts out.
             if std::env::var("OCTOS_SOLO_RESUME_GOALS").ok().as_deref() != Some("1") {
+                // #1973 fix C — resolve each parked goal's PROFILE data dir so
+                // the park also flips the durable per-goal SQLite ledger row to
+                // `paused` (it used to keep saying `active` forever). A
+                // short-lived registry handle: the long-lived `profile_store`
+                // is built later in boot, and opening the store twice is just
+                // idempotent path math + create_dir_all.
+                let park_profile_registry =
+                    crate::profiles::ProfileStore::open(&state_home, &data_dir).ok();
+                let park_profile_data_dir = |profile_id: &str| -> Option<PathBuf> {
+                    let registry = park_profile_registry.as_ref()?;
+                    let profile = registry.get(profile_id).ok().flatten()?;
+                    Some(registry.resolve_data_dir(&profile))
+                };
                 for (goal_id, session_id) in
                     crate::api::agent_orchestrator::default_agent_orchestrator()
-                        .pause_restored_goals_for_solo_boot()
+                        .pause_restored_goals_for_solo_boot_with_ledger_sync(&park_profile_data_dir)
                 {
                     tracing::info!(
                         goal_id = %goal_id,
@@ -1404,6 +1432,24 @@ impl ServeCommand {
             preview_sweeper: Some(preview_sweeper),
         });
 
+        // mini5 soak gap #1 / #1973 fix E: drain queued master continuations
+        // (ChildCompleted / ScatterJoinComplete / GoalContinue / LoopFire)
+        // even when NO ws/stdio client is connected. The per-connection
+        // `appui_continuation_tick` only runs inside a live handler loop, so a
+        // sub-agent finishing while the TUI is disconnected (or a continuation
+        // re-loaded after a serve restart) would otherwise sit undrained until
+        // a client reconnects. Shares the process-global active-turns registry
+        // with the per-connection ticks, so there is no double-run.
+        //
+        // #1973 fix E — spawned BEFORE the stdio early-return below, so
+        // `serve --stdio` (headless stdio deployments) gets the same
+        // continuation safety net and escalation-timeout sweep the HTTP serve
+        // always had. This is a deliberate behavior change for stdio serves:
+        // restored goal/loop continuations now drain even while the stdio
+        // client is idle or detached, instead of waiting for connection ticks.
+        // Everything the drain needs (the full AppState) is constructed above.
+        crate::api::ui_protocol::spawn_global_master_continuation_drain(state.clone());
+
         if self.stdio {
             crate::api::ui_protocol::stdio_connection(state).await?;
             tracing::info!("stopping all gateway child processes");
@@ -1638,16 +1684,9 @@ impl ServeCommand {
             }
         }
 
-        // mini5 soak gap #1: drain queued master continuations
-        // (ChildCompleted / ScatterJoinComplete / GoalContinue / LoopFire)
-        // even when NO ws/stdio client is connected. The per-connection
-        // `appui_continuation_tick` only runs inside a live handler loop, so a
-        // sub-agent finishing while the TUI is disconnected (or a continuation
-        // re-loaded after a serve restart) would otherwise sit undrained until
-        // a client reconnects. Shares the process-global active-turns registry
-        // with the per-connection ticks, so there is no double-run.
-        crate::api::ui_protocol::spawn_global_master_continuation_drain(state.clone());
-
+        // (#1973 fix E — the global master-continuation drain used to be
+        // spawned HERE, after the stdio early-return; it now spawns right
+        // before that branch so stdio serves share the safety net.)
         let app = build_router(state);
         let listener =
             http_listener.expect("non-stdio serve must bind its HTTP listener before AppState");
@@ -1861,6 +1900,44 @@ mod tests {
         assert!(
             stdio_task_query_store(true).is_some(),
             "stdio serve must wire a task_query_store"
+        );
+    }
+
+    /// #1973 fix E — a SOURCE-ORDER tripwire, stated plainly for what it is:
+    /// no unit-level harness can boot a real `octos serve --stdio` (the run()
+    /// method is a monolith that binds sockets, opens redb stores, and holds a
+    /// data-dir lock), so this test asserts the one thing the fix changed — in
+    /// `run()`, `spawn_global_master_continuation_drain` is called BEFORE the
+    /// stdio early-return (`stdio_connection`) — by scanning this file's own
+    /// source. It proves wiring ORDER at the call-site level, not runtime
+    /// behavior; a refactor that reorders the two lines trips it immediately.
+    #[test]
+    fn global_drain_spawns_before_the_stdio_early_return() {
+        let src = include_str!("serve.rs");
+        // Needles assembled at runtime so this test's own string literals
+        // cannot satisfy (or double-count) the search.
+        let spawn_needle = format!(
+            "spawn_global_master_continuation_drain{}",
+            "(state.clone());"
+        );
+        let stdio_needle = format!("ui_protocol::stdio_connection{}", "(state)");
+        let spawn_at = src
+            .find(&spawn_needle)
+            .expect("the global drain spawn call must exist in serve.rs");
+        let stdio_at = src
+            .find(&stdio_needle)
+            .expect("the stdio connection call must exist in serve.rs");
+        assert!(
+            spawn_at < stdio_at,
+            "the global master-continuation drain must be spawned BEFORE the stdio \
+             early-return, or headless `serve --stdio` loses its goal-continuation \
+             safety net and escalation-timeout sweep"
+        );
+        assert_eq!(
+            src.matches(&spawn_needle).count(),
+            1,
+            "exactly one drain spawn call site (the pre-#1973 post-stdio site was \
+             MOVED, not duplicated — two loops would burn duplicate sweep I/O)"
         );
     }
 

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -18,7 +18,9 @@ pub struct GoalLedger {
 pub struct Goal {
     pub goal_id: String,
     pub objective: String,
-    pub status: String, // active | complete | blocked | budget_limited | paused
+    // `cleared` (#1973 fix B) is the terminal a user `goal_clear` stamps; the
+    // upsert guard still refuses to downgrade a `complete` row to it.
+    pub status: String, // active | complete | blocked | budget_limited | paused | cleared
     pub tokens_used: u64,
     pub token_budget: u64,
     pub continuations_used: u32,
@@ -352,9 +354,17 @@ impl GoalLedger {
     ///     writer ever moves an existing `complete` row back to active/blocked.
     ///     `blocked` is deliberately NOT protected — a blocked goal is
     ///     user-resumable to `active` under the same id.
-    pub fn upsert_goal(&self, goal: &Goal) -> Result<()> {
+    ///
+    /// #1973 fix-round — returns whether the write was ADMITTED (`true`: the
+    /// row was inserted, or the guarded update fired), via SQLite's
+    /// rows-changed count. A guarded rejection returns `false`, so an
+    /// administrative STATUS sync (park/clear) whose snapshot carries stale
+    /// lower counters can detect the loss and retry once with max'd monotonic
+    /// fields — instead of silently leaving the row on its old status while a
+    /// decision row claims the transition happened.
+    pub fn upsert_goal(&self, goal: &Goal) -> Result<bool> {
         let conn = self.conn.lock().unwrap();
-        conn.execute(
+        let admitted = conn.execute(
             "INSERT INTO goals (goal_id, objective, status, tokens_used, token_budget, continuations_used, revision, created_at_ms, updated_at_ms)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
              ON CONFLICT(goal_id) DO UPDATE SET
@@ -379,7 +389,72 @@ impl GoalLedger {
                 goal.updated_at_ms,
             ],
         )?;
-        Ok(())
+        Ok(admitted > 0)
+    }
+
+    /// #1973 fix-round 3/4 — targeted STATUS compare-and-swap for an
+    /// administrative transition (park/clear) whose guarded [`Self::upsert_goal`]
+    /// was rejected by the monotonic-token clause. Flips ONLY the status (+
+    /// `updated_at_ms`); the row's counters are authoritative and untouched.
+    ///
+    /// A TRUE CAS (round-4 codex): the predicate requires the row to still
+    /// carry the EXACT `(expected_status, expected_updated_at_ms)` pair the
+    /// caller just read — so ANY interleaved write, including a same-status
+    /// counters refresh with a newer timestamp, changes the pair and defeats
+    /// the CAS (a status-only predicate admitted that interleave and could
+    /// stamp an older `updated_at_ms` over a newer row: a clock REGRESSION
+    /// that then let a delayed older transition pass the caller's ordering
+    /// gate). `status <> 'complete'` stays as belt-and-suspenders (complete
+    /// is terminal per goal_id; the caller never reads `complete` as its
+    /// expectation anyway). Returns whether a row changed — the caller's
+    /// decision-append gate; a defeated CAS is NOT re-attempted (one shot —
+    /// the newer state wins).
+    ///
+    /// Clock invariant: the caller gates the CAS on
+    /// `snapshot.updated_at_ms >= expected_updated_at_ms` (the row value it
+    /// read), and the CAS fires only while the row STILL carries exactly that
+    /// value — so the stamp written here is always `>=` the timestamp it
+    /// replaces. `updated_at_ms` never regresses. The one interleave the pair
+    /// cannot detect — an equal-timestamp, same-status write (counters-only,
+    /// same millisecond) — is safe by construction: the CAS writes only
+    /// status + timestamp, so the interleaved counters survive untouched.
+    pub fn cas_goal_status(
+        &self,
+        goal_id: &str,
+        new_status: &str,
+        expected_status: &str,
+        expected_updated_at_ms: u64,
+        updated_at_ms: u64,
+    ) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let changed = conn.execute(
+            "UPDATE goals SET status = ?1, updated_at_ms = ?2
+             WHERE goal_id = ?3 AND status = ?4 AND updated_at_ms = ?5
+               AND status <> 'complete'",
+            params![
+                new_status,
+                updated_at_ms,
+                goal_id,
+                expected_status,
+                expected_updated_at_ms
+            ],
+        )?;
+        Ok(changed > 0)
+    }
+
+    /// #1973 fix-round — number of decision rows recorded for `goal_id`. The
+    /// audit-side counterpart to [`Self::append_decision`]: the transition
+    /// sync appends a decision ONLY when the goals-row actually reflects the
+    /// transition, and this reader lets callers (and tests) verify the two
+    /// never diverge.
+    pub fn count_decisions(&self, goal_id: &str) -> Result<u64> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM decisions WHERE goal_id = ?1",
+            params![goal_id],
+            |row| row.get(0),
+        )?;
+        Ok(count.max(0) as u64)
     }
 
     /// Get a goal by ID.
@@ -2337,8 +2412,17 @@ mod digest_integration_tests {
             created_at_ms: 5000,
             updated_at_ms: 5000, // every write in this block ties on ms
         };
-        ledger.upsert_goal(&seed(300)).unwrap();
-        ledger.upsert_goal(&seed(100)).unwrap(); // equal-ms, LOWER → rejected
+        assert!(
+            ledger.upsert_goal(&seed(300)).unwrap(),
+            "the seeding insert is admitted"
+        );
+        // equal-ms, LOWER → rejected; #1973 fix-round: the rejection is now
+        // REPORTED (`false`) so an administrative status sync can detect the
+        // loss and retry with max'd counters instead of silently diverging.
+        assert!(
+            !ledger.upsert_goal(&seed(100)).unwrap(),
+            "a guarded rejection must report false"
+        );
         assert_eq!(
             ledger.get_goal("g2").unwrap().unwrap().tokens_used,
             300,
@@ -2347,12 +2431,142 @@ mod digest_integration_tests {
         );
         // ...while an equal-ms write carrying a HIGHER tokens_used (the other
         // peer's larger charge landing second) must still be accepted.
-        ledger.upsert_goal(&seed(450)).unwrap();
+        assert!(
+            ledger.upsert_goal(&seed(450)).unwrap(),
+            "an admitted refresh must report true"
+        );
         assert_eq!(
             ledger.get_goal("g2").unwrap().unwrap().tokens_used,
             450,
             "an equal-ms upsert with a higher tokens_used must be accepted"
         );
+    }
+
+    /// #1973 fix-round 3 — `cas_goal_status` flips ONLY the status of a row
+    /// still carrying the expected status; counters untouched; a mismatched
+    /// expectation or a `complete` row is a `false` no-op.
+    #[test]
+    fn cas_goal_status_updates_only_on_matching_expected_status() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("l.db")).unwrap();
+        ledger
+            .upsert_goal(&Goal {
+                goal_id: "g1".to_string(),
+                objective: "obj".to_string(),
+                status: "active".to_string(),
+                tokens_used: 300,
+                token_budget: 2000,
+                continuations_used: 1,
+                revision: 0,
+                created_at_ms: 1000,
+                updated_at_ms: 1000,
+            })
+            .unwrap();
+
+        // Matching (status, updated_at_ms) pair → status lands, counters
+        // untouched.
+        assert!(
+            ledger
+                .cas_goal_status("g1", "paused", "active", 1000, 2000)
+                .unwrap()
+        );
+        let row = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!(row.status, "paused");
+        assert_eq!(row.updated_at_ms, 2000);
+        assert_eq!(row.tokens_used, 300, "the CAS never touches counters");
+        assert_eq!(row.continuations_used, 1);
+
+        // Stale status expectation (row moved on) → no-op.
+        assert!(
+            !ledger
+                .cas_goal_status("g1", "cleared", "active", 2000, 3000)
+                .unwrap()
+        );
+        let row = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!(row.status, "paused", "a lost CAS changes nothing");
+        assert_eq!(row.updated_at_ms, 2000);
+
+        // Stale TIMESTAMP expectation with a matching status: an interleaved
+        // write bumped the row after the read → the CAS must fail (round-4
+        // codex: predicating on status alone admitted this and could regress
+        // the row's clock).
+        assert!(
+            !ledger
+                .cas_goal_status("g1", "cleared", "paused", 1234, 4000)
+                .unwrap()
+        );
+        assert_eq!(ledger.get_goal("g1").unwrap().unwrap().status, "paused");
+
+        // Missing goal → no-op.
+        assert!(
+            !ledger
+                .cas_goal_status("ghost", "paused", "active", 1000, 3000)
+                .unwrap()
+        );
+
+        // Complete is terminal: even a MATCHING expectation pair is refused.
+        ledger
+            .upsert_goal(&Goal {
+                goal_id: "g2".to_string(),
+                objective: "obj".to_string(),
+                status: "complete".to_string(),
+                tokens_used: 10,
+                token_budget: 2000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1000,
+                updated_at_ms: 1000,
+            })
+            .unwrap();
+        assert!(
+            !ledger
+                .cas_goal_status("g2", "cleared", "complete", 1000, 5000)
+                .unwrap()
+        );
+        assert_eq!(ledger.get_goal("g2").unwrap().unwrap().status, "complete");
+    }
+
+    /// #1973 fix-round 4 — codex: an INTERVENING SAME-STATUS write between
+    /// the caller's read and its CAS must defeat the CAS. With a status-only
+    /// predicate, `active@1000` read → concurrent `active@3000/tok600` upsert
+    /// → CAS(expected active) still matched and stamped `cleared@2000`,
+    /// REGRESSING the row's clock (which then let a delayed `blocked@2500`
+    /// pass the ordering gate and flip cleared→blocked). Predicating on the
+    /// exact `(status, updated_at_ms)` pair read makes any interleaved write
+    /// change the pair → CAS fails → the newer state wins (one shot, no
+    /// re-attempt).
+    #[test]
+    fn cas_goal_status_is_defeated_by_an_intervening_same_status_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("l.db")).unwrap();
+        let seed = |tokens_used: u64, updated_at_ms: u64| Goal {
+            goal_id: "g1".to_string(),
+            objective: "obj".to_string(),
+            status: "active".to_string(),
+            tokens_used,
+            token_budget: 2000,
+            continuations_used: 0,
+            revision: 0,
+            created_at_ms: 1000,
+            updated_at_ms,
+        };
+        ledger.upsert_goal(&seed(300, 1000)).unwrap();
+        // The caller reads (active, 1000)…
+        let read = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!((read.status.as_str(), read.updated_at_ms), ("active", 1000));
+        // …then a concurrent upsert lands the SAME status with newer fields.
+        assert!(ledger.upsert_goal(&seed(600, 3000)).unwrap());
+        // The CAS against the stale read must fail — and the newer row wins.
+        assert!(
+            !ledger
+                .cas_goal_status("g1", "cleared", "active", 1000, 2000)
+                .unwrap(),
+            "an interleaved write must defeat the CAS",
+        );
+        let row = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!(row.status, "active");
+        assert_eq!(row.updated_at_ms, 3000, "no clock regression");
+        assert_eq!(row.tokens_used, 600, "the newer counters survive");
     }
 
     #[test]

--- a/crates/octos-fleet/src/store.rs
+++ b/crates/octos-fleet/src/store.rs
@@ -56,14 +56,20 @@ const DB_FILENAME: &str = "fleet-kernel.redb";
 // Outcome / report types
 // ---------------------------------------------------------------------------
 
-/// Result of a launch CAS. The three rejections are *values*, not
+/// Result of a launch CAS. The rejections are *values*, not
 /// errors: they are ordinary control flow the keeper reasons over.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LaunchOutcome {
-    Launched { attempt_id: String },
+    Launched {
+        attempt_id: String,
+    },
     RejectedNotReady,
     RejectedDoubleLaunch,
     RejectedBudgetExceeded,
+    /// #1973 fix-round — the parent fleet is terminal
+    /// (`Complete`/`Failed`/`Cancelled`): `goal_clear` cancels the fleet, and
+    /// a keeper/pool racing that cancel must not launch new work onto it.
+    RejectedFleetTerminal,
 }
 
 /// Result of a complete CAS. `Superseded` means the four-part predicate
@@ -115,6 +121,11 @@ pub enum PlanMutateOutcome {
     RevisionMismatch {
         actual: u64,
     },
+    /// #1973 fix-round — the parent FLEET is terminal
+    /// (`Complete`/`Failed`/`Cancelled`, e.g. `goal_clear` cancelled it):
+    /// plan/grant mutations are refused with zero mutation, same in-txn fence
+    /// as the child CAS ops.
+    RejectedFleetTerminal,
     /// A `RetargetDeps`-style edit tried to change the dependency set of a
     /// task that is terminal (`Succeeded`/`Failed`) — detected **inside**
     /// the `replan` write-txn, so a task that completes between a caller's
@@ -284,7 +295,17 @@ impl FleetKernelStore {
     /// refuses to overwrite an existing plan (use [`FleetKernelStore::replan`]
     /// for edits) — a blind overwrite would silently drop tasks without
     /// advancing the generation fence.
-    pub async fn create_plan(&self, mut plan: DurablePlan) -> Result<()> {
+    ///
+    /// #1973 fix-round 4 — terminal-fleet fenced, same typed rejection as
+    /// `replan`/`set_task_grant`: `create_fleet → cancel_fleet → create_plan`
+    /// used to seed a plan onto the cancelled fleet (this fn opened only the
+    /// PLANS table). Now the fleet row is read in the SAME write txn: a
+    /// terminal fleet returns [`PlanMutateOutcome::RejectedFleetTerminal`]
+    /// with zero mutation, a MISSING/newer-schema fleet is a `bail!` (this
+    /// fn's native misuse idiom, like the duplicate-plan reject — a plan must
+    /// never exist without its fleet), and success is
+    /// [`PlanMutateOutcome::Mutated`] carrying the plan's initial revision.
+    pub async fn create_plan(&self, mut plan: DurablePlan) -> Result<PlanMutateOutcome> {
         ensure_key_safe(&[plan.fleet_id.as_str()])?;
         for t in &plan.tasks {
             ensure_key_safe(&[t.task_id.as_str()])?;
@@ -295,24 +316,46 @@ impl FleetKernelStore {
         plan.schema_version = SCHEMA_VERSION;
         let db = self.db.clone();
         let held = self.io_gate.clone().lock_owned().await;
-        tokio::task::spawn_blocking(move || -> Result<()> {
+        tokio::task::spawn_blocking(move || -> Result<PlanMutateOutcome> {
             let _held = held;
             let wtx = db.begin_write()?;
-            {
+            let outcome = {
+                let fleets = wtx.open_table(FLEETS)?;
                 let mut plans = wtx.open_table(PLANS)?;
+
+                let Some(fj) = fleets
+                    .get(plan.fleet_id.as_str())?
+                    .map(|g| g.value().to_string())
+                else {
+                    bail!("cannot create plan for unknown fleet {}", plan.fleet_id);
+                };
+                let Some(fleet) = decode_row::<FleetRecord>(&fj)? else {
+                    bail!("fleet {} is a newer schema", plan.fleet_id);
+                };
+                if fleet.fleet_id != plan.fleet_id {
+                    bail!("create_plan: fleet identity mismatch for {}", plan.fleet_id);
+                }
+                if !fleet_is_live(&fleet) {
+                    return Ok(PlanMutateOutcome::RejectedFleetTerminal);
+                }
+
                 if plans.get(plan.fleet_id.as_str())?.is_some() {
                     bail!(
                         "plan for fleet {} already exists; use replan",
                         plan.fleet_id
                     );
                 }
+                let revision = plan.revision;
                 plans.insert(
                     plan.fleet_id.as_str(),
                     serde_json::to_string(&plan)?.as_str(),
                 )?;
+                PlanMutateOutcome::Mutated { revision }
+            };
+            if matches!(outcome, PlanMutateOutcome::Mutated { .. }) {
+                wtx.commit()?;
             }
-            wtx.commit()?;
-            Ok(())
+            Ok(outcome)
         })
         .await
         .wrap_err("join create_plan")?
@@ -488,6 +531,13 @@ impl FleetKernelStore {
                 let Some(fleet) = decode_row::<FleetRecord>(&fj)? else {
                     bail!("fleet {fleet_id} is a newer schema");
                 };
+                // #1973 fix-round — terminal-fleet fence: no new children on a
+                // fleet `goal_clear` cancelled. `bail!` is this fn's native
+                // rejection idiom (it already errors on unknown fleet /
+                // duplicate child), so misuse stays an error, not a value.
+                if !fleet_is_live(&fleet) {
+                    bail!("cannot add child to terminal fleet {fleet_id}");
+                }
 
                 let ckey = child_key(&fleet_id, &child_id);
                 if children.get(ckey.as_str())?.is_some() {
@@ -537,7 +587,24 @@ impl FleetKernelStore {
             let _held = held;
             let wtx = db.begin_write()?;
             let promoted = {
+                let fleets = wtx.open_table(FLEETS)?;
                 let mut children = wtx.open_table(FLEET_CHILDREN)?;
+                // #1973 fix-round — terminal-fleet fence: a cancelled fleet's
+                // Planned children must not promote to Ready (they would look
+                // launchable to any direct reader). A missing/newer-schema/
+                // mismatched fleet row counts as not-live — promotion requires
+                // a live owner; a real decode error still propagates.
+                let fleet_live = match fleets
+                    .get(fleet_id.as_str())?
+                    .map(|g| g.value().to_string())
+                {
+                    Some(fj) => decode_row::<FleetRecord>(&fj)?
+                        .is_some_and(|fleet| fleet.fleet_id == fleet_id && fleet_is_live(&fleet)),
+                    None => false,
+                };
+                if !fleet_live {
+                    return Ok(false);
+                }
                 let ckey = child_key(&fleet_id, &child_id);
                 let Some(cj) = children.get(ckey.as_str())?.map(|g| g.value().to_string()) else {
                     bail!("mark_ready: unknown child {child_id} in fleet {fleet_id}");
@@ -620,7 +687,24 @@ impl FleetKernelStore {
             let wtx = db.begin_write()?;
             let mut ready = Vec::new();
             {
+                let fleets = wtx.open_table(FLEETS)?;
                 let mut children = wtx.open_table(FLEET_CHILDREN)?;
+
+                // #1973 fix-round — terminal-fleet fence: a cancelled fleet has
+                // no launchable set — no promotions, empty result. Missing/
+                // newer-schema/mismatched fleet rows count as not-live; a real
+                // decode error still propagates.
+                let fleet_live = match fleets
+                    .get(fleet_id.as_str())?
+                    .map(|g| g.value().to_string())
+                {
+                    Some(fj) => decode_row::<FleetRecord>(&fj)?
+                        .is_some_and(|fleet| fleet.fleet_id == fleet_id && fleet_is_live(&fleet)),
+                    None => false,
+                };
+                if !fleet_live {
+                    return Ok(Vec::new());
+                }
 
                 // Collect this fleet's children (owned, identity-checked) so
                 // the iterator's borrow is released before we mutate.
@@ -705,9 +789,7 @@ impl FleetKernelStore {
                         // Identity check (defense in depth, mirrors get_fleet):
                         // the row must own the key it lives under. Filter to the
                         // two live states — terminal fleets never re-dispatch.
-                        if rec.fleet_id == k.value()
-                            && matches!(rec.status, FleetStatus::Active | FleetStatus::Draining)
-                        {
+                        if rec.fleet_id == k.value() && fleet_is_live(&rec) {
                             out.push(rec);
                         }
                     }
@@ -732,6 +814,67 @@ impl FleetKernelStore {
             }
         }
         Ok(out)
+    }
+
+    /// Terminalize a fleet as `Cancelled` (#1973 fix B — the `goal_clear`
+    /// half of goal↔fleet lifecycle symmetry). `goal_clear` used to remove
+    /// the goal WITHOUT terminalizing its bound fleet, so the orphan stayed
+    /// `Active` in this store forever: every boot-resume pass re-scanned it
+    /// (and only the orchestrator-side orphan guard kept it from being woken).
+    ///
+    /// One write-txn: a **live** (`Active`/`Draining`) fleet becomes
+    /// `Cancelled` with `updated_at_ms = now_ms` and the call returns `true`.
+    /// A missing fleet, a newer-schema row, or an already-terminal fleet
+    /// (`Complete`/`Failed`/`Cancelled`) is a `false` no-op — cancellation
+    /// never resurrects or rewrites terminal history. Children and attempts
+    /// are deliberately left as-is HERE: the terminal status is itself the
+    /// fence (`launch_child`/`mark_running`/`complete_child`/
+    /// `record_escalation` all refuse under a terminal fleet, and
+    /// [`Self::fleets_with_ready_children`] filters on live status), and
+    /// [`Self::reconcile`] settles any still-live attempt + its reservation
+    /// on the next boot. No outbox event is appended — the goal that owned
+    /// the keeper is gone, so there is nobody to wake (and the outbox
+    /// consumer drops `ChildDone` wakes for `Cancelled` fleets anyway).
+    pub async fn cancel_fleet(&self, fleet_id: &str, now_ms: u64) -> Result<bool> {
+        ensure_key_safe(&[fleet_id])?;
+        let db = self.db.clone();
+        let fleet_id = fleet_id.to_string();
+        let held = self.io_gate.clone().lock_owned().await;
+        tokio::task::spawn_blocking(move || -> Result<bool> {
+            let _held = held;
+            let wtx = db.begin_write()?;
+            let cancelled = {
+                let mut fleets = wtx.open_table(FLEETS)?;
+                let Some(fj) = fleets
+                    .get(fleet_id.as_str())?
+                    .map(|g| g.value().to_string())
+                else {
+                    return Ok(false);
+                };
+                let Some(mut fleet) = decode_row::<FleetRecord>(&fj)? else {
+                    // Newer-schema row: leave it for the newer binary.
+                    return Ok(false);
+                };
+                // Identity check (defense in depth, mirrors get_fleet).
+                if fleet.fleet_id != fleet_id {
+                    bail!("cancel_fleet: fleet identity mismatch");
+                }
+                if !fleet_is_live(&fleet) {
+                    false
+                } else {
+                    fleet.status = FleetStatus::Cancelled;
+                    fleet.updated_at_ms = now_ms;
+                    fleets.insert(fleet_id.as_str(), serde_json::to_string(&fleet)?.as_str())?;
+                    true
+                }
+            };
+            if cancelled {
+                wtx.commit()?;
+            }
+            Ok(cancelled)
+        })
+        .await
+        .wrap_err("join cancel_fleet")?
     }
 
     // ---- CAS state transitions -------------------------------------------
@@ -806,6 +949,13 @@ impl FleetKernelStore {
                 };
                 if fleet.fleet_id != fleet_id {
                     return Ok(LaunchOutcome::RejectedNotReady);
+                }
+
+                // #1973 fix-round — terminal-fleet fence, checked in the SAME
+                // txn as every other predicate: a fleet `goal_clear` cancelled
+                // must not accept new launches from a racing keeper/pool.
+                if !fleet_is_live(&fleet) {
+                    return Ok(LaunchOutcome::RejectedFleetTerminal);
                 }
 
                 // Budget predicate — checked *before* any write, so a
@@ -958,6 +1108,12 @@ impl FleetKernelStore {
                     return Ok(MarkRunningOutcome::Superseded);
                 }
 
+                // #1973 fix-round — terminal-fleet fence (see `launch_child`):
+                // a child of a cancelled fleet must not advance to Running.
+                if !fleet_is_live(&fleet) {
+                    return Ok(MarkRunningOutcome::Superseded);
+                }
+
                 // Validate EVERYTHING before writing either row (P2-6). Each is
                 // a CAS-predicate fence — a miss is a lost race (`Superseded`).
                 if child.current_attempt_id.as_deref() != Some(attempt_id.as_str())
@@ -1059,6 +1215,16 @@ impl FleetKernelStore {
                     || attempt.attempt_id != attempt_id
                     || fleet.fleet_id != fleet_id
                 {
+                    return Ok(CompleteOutcome::Superseded);
+                }
+
+                // #1973 fix-round — terminal-fleet fence: a worker completing
+                // AFTER `goal_clear` cancelled the fleet must not mutate
+                // terminal history, settle budget, or append a `ChildDone`
+                // wake (the goal that owned the keeper is gone). The still-
+                // live attempt + its reservation are settled by `reconcile`'s
+                // terminal-fleet release at the next boot.
+                if !fleet_is_live(&fleet) {
                     return Ok(CompleteOutcome::Superseded);
                 }
 
@@ -1228,6 +1394,14 @@ impl FleetKernelStore {
                     return Ok(CompleteOutcome::Superseded);
                 }
 
+                // #1973 fix-round — terminal-fleet fence, same as
+                // `complete_child`: an escalation yielded after `goal_clear`
+                // cancelled the fleet must not mutate its rows or append a
+                // `ChildDone` wake (no keeper exists to decide it).
+                if !fleet_is_live(&fleet) {
+                    return Ok(CompleteOutcome::Superseded);
+                }
+
                 // Same four-part predicate as `complete_child` — a stale / late
                 // / superseded attempt cannot escalate.
                 let is_current = child.current_attempt_id.as_deref() == Some(attempt_id.as_str());
@@ -1389,6 +1563,14 @@ impl FleetKernelStore {
                 };
                 if fleet.fleet_id != fleet_id {
                     bail!("replan: fleet identity mismatch for {fleet_id}");
+                }
+                // #1973 fix-round — terminal-fleet fence: a replan interrupts
+                // attempts, releases budget, and RESURRECTS children — none of
+                // which may happen on a fleet `goal_clear` cancelled. Zero
+                // mutation. (`PlanEdit::RetargetDeps` routes through here, so
+                // it is fenced too.)
+                if !fleet_is_live(&fleet) {
+                    return Ok(PlanMutateOutcome::RejectedFleetTerminal);
                 }
                 let new_gen = fleet
                     .generation
@@ -1640,7 +1822,22 @@ impl FleetKernelStore {
             let _held = held;
             let wtx = db.begin_write()?;
             let outcome = {
+                let fleets = wtx.open_table(FLEETS)?;
                 let mut plans = wtx.open_table(PLANS)?;
+                // #1973 fix-round — terminal-fleet fence. Beyond the six ops
+                // the review listed, this keeps the invariant total: NO plan
+                // mutator (even a title-only edit) touches a terminal fleet.
+                let fleet_live = match fleets
+                    .get(fleet_id.as_str())?
+                    .map(|g| g.value().to_string())
+                {
+                    Some(fj) => decode_row::<FleetRecord>(&fj)?
+                        .is_some_and(|fleet| fleet.fleet_id == fleet_id && fleet_is_live(&fleet)),
+                    None => false,
+                };
+                if !fleet_live {
+                    return Ok(PlanMutateOutcome::RejectedFleetTerminal);
+                }
                 let Some(pj) = plans.get(fleet_id.as_str())?.map(|g| g.value().to_string()) else {
                     bail!("retitle_task: no plan for fleet {fleet_id}");
                 };
@@ -1715,8 +1912,23 @@ impl FleetKernelStore {
             let _held = held;
             let wtx = db.begin_write()?;
             let outcome = {
+                let fleets = wtx.open_table(FLEETS)?;
                 let mut plans = wtx.open_table(PLANS)?;
                 let mut children = wtx.open_table(FLEET_CHILDREN)?;
+
+                // #1973 fix-round — terminal-fleet fence: a grant must not
+                // resurrect a cancelled fleet's Blocked child to Ready.
+                let fleet_live = match fleets
+                    .get(fleet_id.as_str())?
+                    .map(|g| g.value().to_string())
+                {
+                    Some(fj) => decode_row::<FleetRecord>(&fj)?
+                        .is_some_and(|fleet| fleet.fleet_id == fleet_id && fleet_is_live(&fleet)),
+                    None => false,
+                };
+                if !fleet_live {
+                    return Ok(PlanMutateOutcome::RejectedFleetTerminal);
+                }
 
                 let Some(pj) = plans.get(fleet_id.as_str())?.map(|g| g.value().to_string()) else {
                     bail!("set_task_grant: no plan for fleet {fleet_id}");
@@ -1833,9 +2045,27 @@ impl FleetKernelStore {
             };
             let wtx = db.begin_write()?;
             let outcome = {
+                let fleets = wtx.open_table(FLEETS)?;
                 let mut children = wtx.open_table(FLEET_CHILDREN)?;
                 let mut plans = wtx.open_table(PLANS)?;
                 let mut outbox = wtx.open_table(OUTBOX)?;
+
+                // #1973 fix-round — terminal-fleet fence: a deny on a fleet
+                // `goal_clear` cancelled must not flip its Blocked child to
+                // Failed, bump the plan, or append a ChildDone wake. Same
+                // no-op shape as a not-Blocked deny.
+                let fleet_live = match fleets
+                    .get(fleet_id.as_str())?
+                    .map(|g| g.value().to_string())
+                {
+                    Some(fj) => decode_row::<FleetRecord>(&fj)?
+                        .is_some_and(|fleet| fleet.fleet_id == fleet_id && fleet_is_live(&fleet)),
+                    None => false,
+                };
+                if !fleet_live {
+                    return Ok(superseded);
+                }
+
                 let ckey = child_key(&fleet_id, &child_id);
                 let Some(cj) = children.get(ckey.as_str())?.map(|g| g.value().to_string()) else {
                     return Ok(superseded);
@@ -1952,9 +2182,12 @@ impl FleetKernelStore {
     /// **or** expired at `now_ms`), atomically mark the attempt
     /// `Interrupted`, **release its reservation** from the fleet budget
     /// (P1-1), clear `current_attempt_id`, and return the child to
-    /// `Ready`. Children of a `Cancelled` fleet are left terminal, never
-    /// resurrected (P2-7). The old attempt is never resurrected; all
-    /// reclamations commit together.
+    /// `Ready`. A **terminal** fleet's live attempts are settled the same
+    /// way but UNCONDITIONALLY (#1973 fix-round — before, `Cancelled`
+    /// fleets were skipped wholesale, pinning the attempt + reservation
+    /// forever), and their children are retired `Cancelled` instead of
+    /// `Ready` — never resurrected (P2-7). The old attempt is never
+    /// resurrected; all reclamations commit together.
     pub async fn reconcile(&self, now_ms: u64, owner_epoch: u64) -> Result<ReconcileReport> {
         let db = self.db.clone();
         let held = self.io_gate.clone().lock_owned().await;
@@ -2008,9 +2241,7 @@ impl FleetKernelStore {
                     if fleet.fleet_id != child.fleet_id {
                         continue;
                     }
-                    if fleet.status == FleetStatus::Cancelled {
-                        continue;
-                    }
+                    let fleet_live = fleet_is_live(&fleet);
 
                     let akey = attempt_key(&child.child_id, &aid);
                     let Some(aj) = attempts.get(akey.as_str())?.map(|g| g.value().to_string())
@@ -2034,10 +2265,19 @@ impl FleetKernelStore {
                     ) {
                         continue;
                     }
-                    let stale = attempt.lease.owner_epoch != owner_epoch
-                        || attempt.lease.expires_at_ms < now_ms;
-                    if !stale {
-                        continue;
+                    // A LIVE fleet's attempt is only reclaimed when its lease is
+                    // stale (foreign epoch or expired). A TERMINAL fleet's live
+                    // attempt is settled UNCONDITIONALLY (#1973 fix-round):
+                    // before, `Cancelled` fleets were skipped wholesale (P2-7),
+                    // permanently pinning the attempt + its reservation — and
+                    // the completion path can no longer settle it either, since
+                    // `complete_child` is now fenced on terminal fleets.
+                    if fleet_live {
+                        let stale = attempt.lease.owner_epoch != owner_epoch
+                            || attempt.lease.expires_at_ms < now_ms;
+                        if !stale {
+                            continue;
+                        }
                     }
 
                     let reserved = attempt.reserved_tokens;
@@ -2065,7 +2305,15 @@ impl FleetKernelStore {
                     )?;
 
                     let ckey = child_key(&child.fleet_id, &child.child_id);
-                    child.status = ChildStatus::Ready;
+                    // P2-7 still holds: a terminal fleet's child is NEVER
+                    // resurrected to `Ready` — it is retired terminal
+                    // (`Cancelled`) alongside its settled attempt. Only a live
+                    // fleet's child returns to `Ready` for this boot to relaunch.
+                    child.status = if fleet_live {
+                        ChildStatus::Ready
+                    } else {
+                        ChildStatus::Cancelled
+                    };
                     child.current_attempt_id = None;
                     child.updated_at_ms = now_ms;
                     children.insert(ckey.as_str(), serde_json::to_string(&child)?.as_str())?;
@@ -2496,6 +2744,15 @@ fn ensure_key_safe(components: &[&str]) -> Result<()> {
     Ok(())
 }
 
+/// #1973 fix-round — the ONE liveness predicate behind every terminal-fleet
+/// fence: only an `Active`/`Draining` fleet accepts mutations of its plan,
+/// children, attempts, or budget. `goal_clear` cancels the fleet, and every
+/// racing keeper/pool/worker op must refuse against the terminal record
+/// inside its own write txn.
+fn fleet_is_live(fleet: &FleetRecord) -> bool {
+    matches!(fleet.status, FleetStatus::Active | FleetStatus::Draining)
+}
+
 fn child_key(fleet_id: &str, child_id: &str) -> String {
     format!("{fleet_id}\0{child_id}")
 }
@@ -2673,6 +2930,454 @@ mod tests {
         assert_eq!(fleet.budget.token_budget, 500);
         assert_eq!(fleet.status, FleetStatus::Active);
         assert_eq!(fleet.generation, 0);
+    }
+
+    /// #1973 fix B — `goal_clear` must be able to terminalize the cleared
+    /// goal's fleet so the boot-resume sweep stops treating it as resumable.
+    /// `cancel_fleet` is that terminal op: live → `Cancelled` (true); already
+    /// terminal or missing → no-op (false, never resurrects/overwrites).
+    #[tokio::test]
+    async fn cancel_fleet_terminalizes_a_live_fleet_and_is_idempotent() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+
+        // The live fleet has a launchable child → visible to boot-resume.
+        assert_eq!(
+            store
+                .fleets_with_ready_children(500)
+                .await
+                .unwrap()
+                .iter()
+                .map(|f| f.fleet_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["f1"],
+        );
+
+        assert!(store.cancel_fleet("f1", 700).await.unwrap(), "live → true");
+        let fleet = store.get_fleet("f1").await.unwrap().unwrap();
+        assert_eq!(fleet.status, FleetStatus::Cancelled);
+        assert_eq!(fleet.updated_at_ms, 700);
+
+        // The boot-resume sweep no longer sees it as resumable.
+        assert!(
+            store
+                .fleets_with_ready_children(800)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a cancelled fleet must not be boot-resumable",
+        );
+
+        // Idempotent: cancelling again is a no-op that keeps the terminal state.
+        assert!(!store.cancel_fleet("f1", 900).await.unwrap());
+        let fleet = store.get_fleet("f1").await.unwrap().unwrap();
+        assert_eq!(fleet.status, FleetStatus::Cancelled);
+        assert_eq!(fleet.updated_at_ms, 700, "no-op must not touch the record");
+
+        // Missing fleet: no-op, not an error (goal_clear is best-effort).
+        assert!(!store.cancel_fleet("ghost", 950).await.unwrap());
+    }
+
+    /// `cancel_fleet` never rewrites another terminal status (`Complete` stays
+    /// `Complete` — a finished fleet's history must not read as cancelled).
+    #[tokio::test]
+    async fn cancel_fleet_leaves_other_terminal_statuses_untouched() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let mut fleet = store.get_fleet("f1").await.unwrap().unwrap();
+        fleet.status = FleetStatus::Complete;
+        store
+            .write_raw_fleet("f1", &serde_json::to_string(&fleet).unwrap())
+            .await
+            .unwrap();
+
+        assert!(!store.cancel_fleet("f1", 900).await.unwrap());
+        assert_eq!(
+            store.get_fleet("f1").await.unwrap().unwrap().status,
+            FleetStatus::Complete,
+        );
+    }
+
+    /// #1973 fix-round — the terminal-fleet FENCE, swept across EVERY
+    /// mutating op. `cancel_fleet` alone was not a fence: none of these ops
+    /// consulted the parent fleet's status, so keeper/pool/worker calls racing
+    /// `goal_clear` could keep mutating children/attempts/plan/budget — and
+    /// `complete_child`/`record_escalation`/`deny_escalation` would append
+    /// `ChildDone` wakes for a keeper whose goal is gone. Every op now refuses
+    /// (via its own typed rejection value; `add_child` via its native `bail!`)
+    /// inside the SAME write txn as its other predicates, with ZERO mutation:
+    /// launch_child, mark_running, complete_child, record_escalation,
+    /// deny_escalation, set_task_grant, replan (RetargetDeps routes through
+    /// it), retitle_task, create_plan (round 4: `create_fleet → cancel_fleet
+    /// → create_plan` used to seed a plan onto the corpse), add_child,
+    /// mark_ready, resolve_and_collect_ready.
+    ///
+    /// INTENTIONALLY EXEMPT from the fence:
+    /// - `reconcile` — the one sanctioned mutator of a terminal fleet: it is
+    ///   the CLEANUP path, settling stranded live attempts + reservations
+    ///   in-txn (and retiring the children terminal, never `Ready`);
+    /// - `append_event` / `append_decision` — outbox/decision-LOG appends
+    ///   only, no fleet/child/attempt/plan/budget state;
+    /// - `claim_next` / `ack` — outbox claim bookkeeping only.
+    ///
+    /// Zero-mutation is proven by FULL-record comparison: every child,
+    /// every staged attempt, and the fleet record itself are snapshotted
+    /// right after the cancel and must be byte-identical (PartialEq) after
+    /// the sweep — plus an empty outbox probe.
+    #[tokio::test]
+    async fn terminal_fleet_fences_child_operations() {
+        let (_d, store) = fresh().await;
+        store
+            .create_fleet("f1", controller(), None, "default", 10_000, false, 0)
+            .await
+            .unwrap();
+        // f2: a cancelled fleet WITHOUT a plan — the create_plan fence target
+        // (with a plan present, the insert-only duplicate bail would mask it).
+        store
+            .create_fleet("f2", controller(), None, "default", 1_000, false, 0)
+            .await
+            .unwrap();
+        assert!(store.cancel_fleet("f2", 50).await.unwrap());
+        store
+            .create_plan(plan(
+                "f1",
+                0,
+                vec![
+                    plan_task("c1", &[]),
+                    plan_task("c2", &[]),
+                    plan_task("c3", &[]),
+                    plan_task("c4", &[]),
+                    plan_task("c5", &["c6"]),
+                    plan_task("c6", &[]),
+                ],
+            ))
+            .await
+            .unwrap();
+        for (cid, deps) in [
+            ("c1", vec![]),
+            ("c2", vec![]),
+            ("c3", vec![]),
+            ("c4", vec![]),
+            ("c5", vec!["c6".to_string()]),
+            ("c6", vec![]),
+        ] {
+            store.add_child("f1", cid, deps, 0).await.unwrap();
+        }
+
+        // Helper: launch (+ optionally mark running) a child pre-cancel.
+        async fn launch(store: &FleetKernelStore, cid: &str, run: bool) -> String {
+            let id = match store
+                .launch_child("f1", cid, 100, 100, EPOCH, TTL)
+                .await
+                .unwrap()
+            {
+                LaunchOutcome::Launched { attempt_id } => attempt_id,
+                other => panic!("{other:?}"),
+            };
+            if run {
+                assert_eq!(
+                    store.mark_running(cid, &id).await.unwrap(),
+                    MarkRunningOutcome::Running
+                );
+            }
+            id
+        }
+        // Pre-cancel shapes: c1 Running (a1), c2 Launching/Leased (a2),
+        // c3 Ready, c4 Blocked with a pending escalation, c5 Planned with its
+        // dep met (c6 Succeeded).
+        let a1 = launch(&store, "c1", true).await;
+        let a2 = launch(&store, "c2", false).await;
+        let a4 = launch(&store, "c4", true).await;
+        assert_eq!(
+            store
+                .record_escalation(
+                    "f1",
+                    "c4",
+                    &a4,
+                    EscalationRequest {
+                        requested_grant: crate::grant::WorkerGrant::minimal(),
+                        reason: "need more".into(),
+                    },
+                    50,
+                    EPOCH,
+                    150,
+                )
+                .await
+                .unwrap(),
+            CompleteOutcome::Completed,
+        );
+        let a6 = launch(&store, "c6", true).await;
+        assert_eq!(
+            store
+                .complete_child("f1", "c6", &a6, accepted(), snapshot(), 80, EPOCH, 160)
+                .await
+                .unwrap(),
+            CompleteOutcome::Completed,
+        );
+
+        // Drain the pre-cancel outbox so "no new events" is a clean probe.
+        while let Some(ev) = store.claim_next("probe", 10_000, TTL).await.unwrap() {
+            let token = ev.claim_token.as_deref().unwrap_or_default().to_owned();
+            store.ack(ev.sequence, "probe", &token).await.unwrap();
+        }
+
+        assert!(store.cancel_fleet("f1", 200).await.unwrap());
+        let fleet_at_cancel = store.get_fleet("f1").await.unwrap().unwrap();
+        let reserved_at_cancel = fleet_at_cancel.budget.tokens_reserved;
+        assert_eq!(reserved_at_cancel, 200, "c1 + c2 reservations held");
+
+        // FULL-record snapshots (round-4 codex: attempts were never re-read
+        // and only selected fields compared). Everything below must be
+        // byte-identical after the sweep.
+        let staged_attempts = [
+            ("c1", a1.clone()),
+            ("c2", a2.clone()),
+            ("c4", a4.clone()),
+            ("c6", a6.clone()),
+        ];
+        let mut attempts_at_cancel = Vec::new();
+        for (cid, aid) in &staged_attempts {
+            attempts_at_cancel.push(store.get_attempt(cid, aid).await.unwrap().unwrap());
+        }
+        let child_ids = ["c1", "c2", "c3", "c4", "c5", "c6"];
+        let mut children_at_cancel = Vec::new();
+        for cid in &child_ids {
+            children_at_cancel.push(store.get_child("f1", cid).await.unwrap().unwrap());
+        }
+        let plan_at_cancel = store.get_plan("f1").await.unwrap().unwrap();
+
+        // launch: a Ready child of a cancelled fleet must not launch.
+        assert_eq!(
+            store
+                .launch_child("f1", "c3", 100, 300, EPOCH, TTL)
+                .await
+                .unwrap(),
+            LaunchOutcome::RejectedFleetTerminal,
+        );
+        assert_eq!(
+            store.get_child("f1", "c3").await.unwrap().unwrap().status,
+            ChildStatus::Ready,
+            "the rejected child is left untouched",
+        );
+
+        // mark_running: a Leased attempt must not advance.
+        assert_eq!(
+            store.mark_running("c2", &a2).await.unwrap(),
+            MarkRunningOutcome::Superseded,
+        );
+        assert_eq!(
+            store.get_child("f1", "c2").await.unwrap().unwrap().status,
+            ChildStatus::Launching,
+            "no mutation on the fenced mark_running",
+        );
+
+        // complete: the racing worker's result is dropped with ZERO mutation.
+        assert_eq!(
+            store
+                .complete_child("f1", "c1", &a1, accepted(), snapshot(), 80, EPOCH, 400)
+                .await
+                .unwrap(),
+            CompleteOutcome::Superseded,
+        );
+        let c1 = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(c1.status, ChildStatus::Running, "child state untouched");
+        assert_eq!(c1.tokens_committed, 0, "no tokens committed");
+
+        // record_escalation: a racing escalation yield is dropped too.
+        assert_eq!(
+            store
+                .record_escalation(
+                    "f1",
+                    "c1",
+                    &a1,
+                    EscalationRequest {
+                        requested_grant: crate::grant::WorkerGrant::minimal(),
+                        reason: "late yield".into(),
+                    },
+                    40,
+                    EPOCH,
+                    410,
+                )
+                .await
+                .unwrap(),
+            CompleteOutcome::Superseded,
+        );
+        let c1 = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(c1.status, ChildStatus::Running);
+        assert!(c1.pending_escalation.is_none());
+
+        // deny_escalation: must not flip Blocked→Failed or bump the plan.
+        let deny = store
+            .deny_escalation("f1", "c4", "refused", 420)
+            .await
+            .unwrap();
+        assert_eq!(deny.settled, CompleteOutcome::Superseded);
+        assert!(!deny.fleet_un_completable);
+        let c4 = store.get_child("f1", "c4").await.unwrap().unwrap();
+        assert_eq!(c4.status, ChildStatus::Blocked, "deny fenced");
+        assert!(c4.pending_escalation.is_some(), "request left in place");
+
+        // set_task_grant: must not resurrect the Blocked child to Ready.
+        assert_eq!(
+            store
+                .set_task_grant("f1", 0, "c4", crate::grant::WorkerGrant::minimal(), 430)
+                .await
+                .unwrap(),
+            PlanMutateOutcome::RejectedFleetTerminal,
+        );
+        assert_eq!(
+            store.get_child("f1", "c4").await.unwrap().unwrap().status,
+            ChildStatus::Blocked,
+        );
+
+        // replan (RetargetDeps routes through it): must not interrupt
+        // attempts, release budget, or resurrect children.
+        assert_eq!(
+            store
+                .replan("f1", 0, plan("f1", 0, vec![plan_task("c1", &[])]), 440)
+                .await
+                .unwrap(),
+            PlanMutateOutcome::RejectedFleetTerminal,
+        );
+        // retitle_task: even a title-only plan edit is refused.
+        assert_eq!(
+            store
+                .retitle_task("f1", 0, "c3", "t", "d", 450)
+                .await
+                .unwrap(),
+            PlanMutateOutcome::RejectedFleetTerminal,
+        );
+        let plan_row = store.get_plan("f1").await.unwrap().unwrap();
+        assert_eq!(plan_row.revision, 0, "plan revision untouched");
+        assert_eq!(plan_row.tasks.len(), 6, "plan tasks untouched");
+
+        // add_child: refused via this fn's native error idiom.
+        assert!(
+            store
+                .add_child("f1", "c7", vec![], 460)
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("terminal fleet"),
+        );
+        assert!(store.get_child("f1", "c7").await.unwrap().is_none());
+
+        // mark_ready: c5's dep (c6) Succeeded pre-cancel, but no promotion.
+        assert!(!store.mark_ready("f1", "c5", 470).await.unwrap());
+        assert_eq!(
+            store.get_child("f1", "c5").await.unwrap().unwrap().status,
+            ChildStatus::Planned,
+        );
+
+        // resolve_and_collect_ready: no promotions, empty launchable set.
+        assert!(
+            store
+                .resolve_and_collect_ready("f1", 480)
+                .await
+                .unwrap()
+                .is_empty(),
+        );
+        assert_eq!(
+            store.get_child("f1", "c5").await.unwrap().unwrap().status,
+            ChildStatus::Planned,
+            "the fenced resolve must not promote",
+        );
+
+        // create_plan (round 4): a cancelled fleet with NO plan yet must not
+        // have one seeded onto it — the exact create_fleet → cancel_fleet →
+        // create_plan sequence.
+        assert_eq!(
+            store
+                .create_plan(plan("f2", 0, vec![plan_task("x1", &[])]))
+                .await
+                .unwrap(),
+            PlanMutateOutcome::RejectedFleetTerminal,
+        );
+        assert!(
+            store.get_plan("f2").await.unwrap().is_none(),
+            "no plan may be seeded onto a terminal fleet",
+        );
+
+        // Nothing settled, nothing bumped, nothing woken — proven by FULL
+        // record equality against the at-cancel snapshots.
+        assert_eq!(
+            store.get_fleet("f1").await.unwrap().unwrap(),
+            fleet_at_cancel,
+            "the fleet record (budget, generation, timestamps) is untouched",
+        );
+        for (i, (cid, aid)) in staged_attempts.iter().enumerate() {
+            assert_eq!(
+                store.get_attempt(cid, aid).await.unwrap().unwrap(),
+                attempts_at_cancel[i],
+                "attempt {aid} of {cid} must be byte-identical after the sweep",
+            );
+        }
+        for (i, cid) in child_ids.iter().enumerate() {
+            assert_eq!(
+                store.get_child("f1", cid).await.unwrap().unwrap(),
+                children_at_cancel[i],
+                "child {cid} must be byte-identical after the sweep",
+            );
+        }
+        assert_eq!(
+            store.get_plan("f1").await.unwrap().unwrap(),
+            plan_at_cancel,
+            "the plan is untouched",
+        );
+        assert!(
+            store
+                .claim_next("probe", 20_000, TTL)
+                .await
+                .unwrap()
+                .is_none(),
+            "no fenced op may append an outbox event",
+        );
+    }
+
+    /// #1973 fix-round — reconcile SETTLES the stranded live attempts of a
+    /// terminal fleet (release the reservation, mark the attempt Interrupted,
+    /// clear `current_attempt_id`) while still never resurrecting the child to
+    /// `Ready`. Before, a Cancelled fleet was skipped wholesale, permanently
+    /// pinning its live attempt and `tokens_reserved`.
+    #[tokio::test]
+    async fn reconcile_releases_reservations_of_terminal_fleets() {
+        let (_d, store) = fresh().await;
+        fleet_with_ready_child(&store, 1_000).await;
+        let attempt_id = launch_running(&store).await;
+        assert!(store.cancel_fleet("f1", 500).await.unwrap());
+        assert_eq!(
+            store
+                .get_fleet("f1")
+                .await
+                .unwrap()
+                .unwrap()
+                .budget
+                .tokens_reserved,
+            100,
+            "the launch reservation is held at cancel time",
+        );
+
+        let report = store.reconcile(9_999, EPOCH + 999).await.unwrap();
+        assert_eq!(
+            report.interrupted.len(),
+            1,
+            "the terminal fleet's stranded attempt is settled (and reported)",
+        );
+
+        let fleet = store.get_fleet("f1").await.unwrap().unwrap();
+        assert_eq!(
+            fleet.budget.tokens_reserved, 0,
+            "the stranded reservation is released",
+        );
+        let attempt = store.get_attempt("c1", &attempt_id).await.unwrap().unwrap();
+        assert_eq!(attempt.status, AttemptStatus::Interrupted);
+        let child = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(
+            child.status,
+            ChildStatus::Cancelled,
+            "the child is retired terminal, NEVER resurrected to Ready (P2-7)",
+        );
+        assert_eq!(child.current_attempt_id, None);
     }
 
     #[tokio::test]
@@ -3300,7 +4005,10 @@ mod tests {
         );
     }
 
-    /// P2-7: a Cancelled fleet's stranded child must not be resurrected.
+    /// P2-7 (updated by the #1973 fix-round): a Cancelled fleet's stranded
+    /// child must not be RESURRECTED — but its live attempt IS settled now
+    /// (Interrupted + reservation released + attempt-id cleared) instead of
+    /// being skipped wholesale, which pinned the reservation forever.
     #[tokio::test]
     async fn reconcile_skips_children_of_cancelled_fleet() {
         let (_d, store) = fresh().await;
@@ -3316,12 +4024,15 @@ mod tests {
             .unwrap();
 
         let report = store.reconcile(9_999, EPOCH + 999).await.unwrap();
-        assert!(report.interrupted.is_empty(), "cancelled fleet is skipped");
-        // Child + attempt left as they were (not reset to Ready).
         assert_eq!(
-            store.get_child("f1", "c1").await.unwrap().unwrap().status,
-            ChildStatus::Running
+            report.interrupted.len(),
+            1,
+            "the terminal fleet's stranded attempt is settled",
         );
+        // Never resurrected to Ready — retired terminal instead.
+        let child = store.get_child("f1", "c1").await.unwrap().unwrap();
+        assert_eq!(child.status, ChildStatus::Cancelled);
+        assert_eq!(child.current_attempt_id, None);
         assert_eq!(
             store
                 .get_attempt("c1", &attempt_id)
@@ -3329,7 +4040,18 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .status,
-            AttemptStatus::Running
+            AttemptStatus::Interrupted
+        );
+        assert_eq!(
+            store
+                .get_fleet("f1")
+                .await
+                .unwrap()
+                .unwrap()
+                .budget
+                .tokens_reserved,
+            0,
+            "the reservation is released, not pinned forever",
         );
     }
 


### PR DESCRIPTION
Fixes #1973. Five restart-durability gaps from the 2026-08-11 deep review, hardened through four codex adversarial rounds (final verdict: MERGE).

## The five gaps
1. **cwd-scope registry persisted** (`goal-scopes.json`, atomic, vacant-keys-only boot load + merged write-back + GC) — restored scoped goals are dispatchable at boot; previously invisible until a client reopened the session.
2. **`clear_goal` terminalizes its fleet** (`cancel_fleet`, one txn) + ledger row → `cleared`. The terminal-fleet **fence now covers every store mutator** in-txn (12 ops, typed rejections — codex found the last one, `create_plan`, in round 3); the outbox consumer drops a Cancelled fleet's ChildDone; reconcile releases terminal fleets' reservations.
3. **Solo-boot park syncs the ledger** (active→paused + decision) — the durable row no longer lies about parked goals.
4. **NotDurable boot wakes get one bounded retry** on the outbox drain tick.
5. **`serve --stdio` spawns the global drain** — headless stdio gets goal continuations + the escalation-timeout sweep.

## Codex-driven ledger consistency work
- `upsert_goal` → rows-changed; rejected status transitions retry ONCE via a **true CAS on the exact (status, updated_at_ms) pair read** — codex killed two earlier designs (a forged-timestamp re-upsert that could roll `cleared`→`blocked`, then a status-only CAS defeated by an intervening same-status write with the clock-regression exploit spelled out). The final CAS: any interleaved write defeats it, newer state wins, complete stays terminal on both layers.
- Decision rows append only when the goals-row reflects the transition (under-report-only residual, documented).
- OnceLock event-ledger recovery runs exactly once inside `get_or_init` (8-racer test).

## Merge-train integration (rebased over #1978 + #1979)
F's CAS body now forms the #1865 blocking core behind E's awaited `spawn_blocking` facade — both lanes' invariants hold: the bounded-retry open profile stays exclusive to the facade; F's sync callers (solo park, clear RPC, tests) use the plain open profile inline (same best-effort class as the pre-existing finding/escalation writers).

## Validation
fleet 139 (parameterized fence sweep with full-record `PartialEq`; CAS races incl. intervening same-status write) · goal 120 · fleet_wake 29 · scope 130 · no-api build · fmt · clippy `--all-targets -D warnings` ×3 crates. TDD RED-first throughout (the CAS regression reproduced codex's exact exploit before the fix).

Residuals (documented): fence closes post-commit races only (consumer-drop + reconcile absorb the pre-commit instant); decision-append read-after-write can under-report; sidecar is last-writer-wins per wire key across boots.