### PR TITLE
fix(llm): support disabled reasoning effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ fan-out non-blocking.
 | `--config <path>` | — | explicit flat config file — **wins over** `--profile` |
 | `--cwd <dir>` | current dir | workspace root the agent reads/writes |
 | `--data-dir <dir>` | `$OCTOS_HOME` / `~/.octos` | episodes / memory / sessions store |
-| `--effort <e>` | provider default | `low` \| `medium` \| `high` \| `max` (thinking models; others ignore it) |
+| `--effort <e>` | provider default | `none` \| `low` \| `medium` \| `high` \| `max` (`none` disables reasoning where supported) |
 | `--no-session-persistence` | off | ephemeral run (no episode saved); also **enables parallel agents** on one `--data-dir` |
 | `--max-iterations <n>` | `20` | per-turn tool-call cap |
 | `--no-retry` | off | disable automatic retry on transient LLM errors |

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -137,8 +137,9 @@ pub struct ChatCommand {
     #[arg(long, value_enum)]
     pub ask_for_approval: Option<ChatApprovalMode>,
 
-    /// Reasoning effort for thinking models: `low`, `medium`, `high`, or
-    /// `max` (claude/codex parity). Overrides the config
+    /// Reasoning effort for thinking models: `none`, `low`, `medium`, `high`,
+    /// or `max` (claude/codex parity). `none` disables reasoning where
+    /// supported. Overrides the config
     /// `gateway.reasoning_effort`; non-thinking models ignore it, and
     /// providers without a distinct `max` tier clamp it to `high`.
     #[arg(long, value_enum)]
@@ -237,11 +238,12 @@ pub enum ChatApprovalMode {
 /// `--effort` choices, mirroring claude/codex reasoning-effort tiers. Maps
 /// 1:1 to [`octos_llm::ReasoningEffort`]. For these single-word variants
 /// clap's default `ValueEnum` naming and serde's `kebab-case` agree
-/// (`low`/`medium`/`high`/`max`), so a `config.cli.chat.effort` round-trips
+/// (`none`/`low`/`medium`/`high`/`max`), so a `config.cli.chat.effort` round-trips
 /// losslessly — matching [`ChatSandboxMode`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ChatEffort {
+    None,
     Low,
     Medium,
     High,
@@ -251,6 +253,7 @@ pub enum ChatEffort {
 impl From<ChatEffort> for octos_llm::ReasoningEffort {
     fn from(effort: ChatEffort) -> Self {
         match effort {
+            ChatEffort::None => octos_llm::ReasoningEffort::Disabled,
             ChatEffort::Low => octos_llm::ReasoningEffort::Low,
             ChatEffort::Medium => octos_llm::ReasoningEffort::Medium,
             ChatEffort::High => octos_llm::ReasoningEffort::High,
@@ -2336,6 +2339,10 @@ mod tests {
     #[test]
     fn should_map_chat_effort_to_reasoning_effort() {
         use octos_llm::ReasoningEffort;
+        assert_eq!(
+            ReasoningEffort::from(ChatEffort::None),
+            ReasoningEffort::Disabled
+        );
         assert_eq!(ReasoningEffort::from(ChatEffort::Low), ReasoningEffort::Low);
         assert_eq!(
             ReasoningEffort::from(ChatEffort::Medium),
@@ -2397,6 +2404,7 @@ mod tests {
 
         // Every effort tier parses (clap's default kebab/lower naming).
         for (arg, want) in [
+            ("none", ChatEffort::None),
             ("low", ChatEffort::Low),
             ("medium", ChatEffort::Medium),
             ("high", ChatEffort::High),
@@ -2411,6 +2419,26 @@ mod tests {
         assert_eq!(bare.effort, None);
         assert!(!bare.no_session_persistence);
         assert_eq!(bare.prompt, None);
+    }
+
+    #[test]
+    fn should_parse_none_when_reasoning_is_disabled() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Wrap {
+            #[command(flatten)]
+            chat: ChatCommand,
+        }
+
+        let chat = Wrap::try_parse_from(["prog", "--effort", "none"])
+            .expect("none should be a valid effort")
+            .chat;
+        let effort = octos_llm::ReasoningEffort::from(chat.effort.unwrap());
+        assert_eq!(
+            serde_json::to_value(effort).unwrap(),
+            serde_json::json!("none")
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -2332,6 +2332,20 @@ mod tests {
     }
 
     #[test]
+    fn should_parse_none_when_gateway_reasoning_is_disabled() {
+        let json = r#"{
+            "channels": [{"type": "cli"}],
+            "reasoning_effort": "none"
+        }"#;
+        let gw: GatewayConfig =
+            serde_json::from_str(json).expect("none should disable gateway reasoning");
+        assert_eq!(
+            serde_json::to_value(gw.reasoning_effort.unwrap()).unwrap(),
+            serde_json::json!("none")
+        );
+    }
+
+    #[test]
     fn test_gateway_config_defaults() {
         let json = r#"{"provider": "anthropic"}"#;
         let config: Config = serde_json::from_str(json).unwrap();

--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -395,6 +395,7 @@ fn build_anthropic_thinking(effort: ReasoningEffort, max_tokens: u32) -> Option<
 
 fn anthropic_thinking_budget_tokens(effort: ReasoningEffort) -> u32 {
     match effort {
+        ReasoningEffort::Disabled => 0,
         ReasoningEffort::Low => 1_024,
         ReasoningEffort::Medium => 4_096,
         ReasoningEffort::High => 8_192,
@@ -1342,6 +1343,21 @@ mod tests {
         let body = serde_json::to_value(&request).unwrap();
         assert_eq!(body["thinking"]["type"], "enabled");
         assert_eq!(body["thinking"]["budget_tokens"], 8_192);
+    }
+
+    #[test]
+    fn should_omit_thinking_when_reasoning_is_disabled() {
+        let provider = AnthropicProvider::new("test-key", "claude-test");
+        let messages = vec![msg(MessageRole::User, "hi")];
+        let effort = serde_json::from_value(serde_json::json!("none"))
+            .expect("none should disable reasoning");
+        let config = ChatConfig {
+            reasoning_effort: Some(effort),
+            ..Default::default()
+        };
+
+        let body = serde_json::to_value(provider.build_request(&messages, &[], &config)).unwrap();
+        assert!(body.get("thinking").is_none());
     }
 
     #[test]

--- a/crates/octos-llm/src/config.rs
+++ b/crates/octos-llm/src/config.rs
@@ -17,7 +17,7 @@ pub struct ChatConfig {
     /// Stop sequences.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub stop_sequences: Vec<String>,
-    /// Reasoning effort for thinking models (low/medium/high).
+    /// Reasoning effort for thinking models (none/low/medium/high/max).
     /// Maps to provider-specific parameters (OpenAI reasoning.effort,
     /// Anthropic thinking budget, Gemini thinkingConfig).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -63,6 +63,9 @@ fn default_strict() -> bool {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReasoningEffort {
+    /// Disable reasoning where the provider supports it.
+    #[serde(rename = "none")]
+    Disabled,
     Low,
     Medium,
     High,
@@ -104,6 +107,16 @@ pub enum ToolChoice {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn should_deserialize_disabled_reasoning_effort_from_none() {
+        let effort: ReasoningEffort = serde_json::from_value(serde_json::json!("none"))
+            .expect("none should disable reasoning");
+        assert_eq!(
+            serde_json::to_value(effort).unwrap(),
+            serde_json::json!("none")
+        );
+    }
 
     #[test]
     fn test_chat_config_defaults() {

--- a/crates/octos-llm/src/gemini.rs
+++ b/crates/octos-llm/src/gemini.rs
@@ -434,6 +434,7 @@ fn build_gemini_generation_config(
 
     let thinking_config = config.reasoning_effort.map(|effort| {
         let budget = match effort {
+            ReasoningEffort::Disabled => Some(0),
             ReasoningEffort::Low => Some(1024),
             ReasoningEffort::Medium => Some(8192),
             // High and Max both let the model decide (unbounded thinking budget).
@@ -1814,6 +1815,19 @@ mod tests {
         let gen_config = build_gemini_generation_config(&config, "gemini/test").unwrap();
         let tc = gen_config.thinking_config.unwrap();
         assert!(tc.thinking_budget.is_none());
+    }
+
+    #[test]
+    fn should_set_zero_thinking_budget_when_reasoning_is_disabled() {
+        let effort = serde_json::from_value(serde_json::json!("none"))
+            .expect("none should disable reasoning");
+        let config = ChatConfig {
+            reasoning_effort: Some(effort),
+            ..Default::default()
+        };
+        let gen_config = build_gemini_generation_config(&config, "gemini/test").unwrap();
+        let tc = gen_config.thinking_config.unwrap();
+        assert_eq!(tc.thinking_budget, Some(0));
     }
 
     #[test]

--- a/crates/octos-llm/src/openai.rs
+++ b/crates/octos-llm/src/openai.rs
@@ -43,8 +43,9 @@ pub struct ModelHints {
     pub merge_system_messages: bool,
 
     /// How this model accepts a reasoning/thinking control on the chat path.
-    /// Translates `ChatConfig::reasoning_effort` into request fields; `None`
-    /// (default) emits nothing, so it is a no-op for non-thinking models.
+    /// Translates `ChatConfig::reasoning_effort` into request fields. The
+    /// default style ignores enabled effort, while an explicit disabled effort
+    /// uses the generic OpenAI-compatible control.
     #[serde(default)]
     pub reasoning_style: ReasoningStyle,
 }
@@ -126,7 +127,8 @@ impl ModelHints {
         // because the same `deepseek-v4` name fronts endpoints that differ
         // (api.deepseek.com accepts it; nvidia/vllm may not), same caveat as
         // `lacks_vision`. `grok` is narrowed to `grok-4` since older Grok
-        // families can reject `reasoning_effort`.
+        // families can reject enabled `reasoning_effort` values. An operator
+        // may still explicitly request `none` for a compatible endpoint.
         let reasoning_style = if m.contains("deepseek-v4") || m.contains("deepseek-reasoner") {
             ReasoningStyle::EffortAndThinkingToggle
         } else if m.contains("kimi-k3")
@@ -182,7 +184,8 @@ impl ModelHints {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum ReasoningStyle {
-    /// No reasoning control emitted on the chat path (default — backward compatible).
+    /// No enabled reasoning control emitted on the chat path. Explicitly disabled
+    /// reasoning uses the generic `reasoning_effort: "none"` control.
     #[default]
     None,
     /// Top-level `reasoning_effort: "low"|"medium"|"high"` — OpenAI chat-completions
@@ -523,21 +526,42 @@ impl OpenAIProvider {
         });
 
         // Translate the provider-agnostic `reasoning_effort` into the chat-path
-        // request fields the model's ReasoningStyle expects. Emitted only when
-        // an effort is configured AND the model declares a non-None style, so
-        // it stays a no-op for models/endpoints that don't accept it.
+        // request fields the model's ReasoningStyle expects. Enabled effort is
+        // emitted only for a declared style. Explicitly disabled reasoning is
+        // also forwarded to generic OpenAI-compatible endpoints because local
+        // servers such as Ollama accept the standard `reasoning_effort: "none"`.
         let (reasoning_effort, thinking): (Option<&str>, Option<serde_json::Value>) =
             match (config.reasoning_effort, self.hints.reasoning_style) {
-                (Some(effort), style) if style != ReasoningStyle::None => {
+                (Some(effort), style) => {
                     use crate::config::ReasoningEffort as RE;
                     let enabled = || serde_json::json!({ "type": "enabled" });
-                    match style {
+                    let disabled = || serde_json::json!({ "type": "disabled" });
+                    match (effort, style) {
+                        // Toggle-based providers disable thinking through their
+                        // native binary control and reject reasoning_effort.
+                        (
+                            RE::Disabled,
+                            ReasoningStyle::ThinkingToggle
+                            | ReasoningStyle::EffortAndThinkingToggle,
+                        ) => (None, Some(disabled())),
+                        // Kimi K3 has no documented off value. Omitting the
+                        // control preserves the provider default.
+                        (
+                            RE::Disabled,
+                            ReasoningStyle::EffortLowHighMax | ReasoningStyle::EffortMaxOnly,
+                        ) => (None, None),
+                        // Standard and generic OpenAI-compatible endpoints use
+                        // reasoning_effort:"none" to disable reasoning.
+                        (RE::Disabled, ReasoningStyle::Effort | ReasoningStyle::None) => {
+                            (Some("none"), None)
+                        }
                         // GLM-4.5+/5.x: binary thinking toggle, NO reasoning_effort.
-                        ReasoningStyle::ThinkingToggle => (None, Some(enabled())),
+                        (_, ReasoningStyle::ThinkingToggle) => (None, Some(enabled())),
                         // Kimi K3: low|high|max (no medium tier → clamp up to high;
                         // Max stays "max", NOT clamped to "high"). Thinking always on.
-                        ReasoningStyle::EffortLowHighMax => {
+                        (_, ReasoningStyle::EffortLowHighMax) => {
                             let e = match effort {
+                                RE::Disabled => unreachable!(),
                                 RE::Low => "low",
                                 RE::Medium | RE::High => "high",
                                 RE::Max => "max",
@@ -545,10 +569,11 @@ impl OpenAIProvider {
                             (Some(e), None)
                         }
                         // Legacy manual-override: everything → "max".
-                        ReasoningStyle::EffortMaxOnly => (Some("max"), None),
+                        (_, ReasoningStyle::EffortMaxOnly) => (Some("max"), None),
                         // DeepSeek V4: reasoning_effort + `thinking` toggle.
-                        ReasoningStyle::EffortAndThinkingToggle => {
+                        (_, ReasoningStyle::EffortAndThinkingToggle) => {
                             let e = match effort {
+                                RE::Disabled => unreachable!(),
                                 RE::Low => "low",
                                 RE::Medium => "medium",
                                 RE::High => "high",
@@ -557,8 +582,9 @@ impl OpenAIProvider {
                             (Some(e), Some(enabled()))
                         }
                         // OpenAI/Grok: low|medium|high, no max tier → clamp to high.
-                        ReasoningStyle::Effort => {
+                        (_, ReasoningStyle::Effort) => {
                             let e = match effort {
+                                RE::Disabled => unreachable!(),
                                 RE::Low => "low",
                                 RE::Medium => "medium",
                                 RE::High => "high",
@@ -566,7 +592,7 @@ impl OpenAIProvider {
                             };
                             (Some(e), None)
                         }
-                        ReasoningStyle::None => (None, None),
+                        (_, ReasoningStyle::None) => (None, None),
                     }
                 }
                 _ => (None, None),
@@ -1585,6 +1611,54 @@ mod tests {
         let v2 = serde_json::to_value(p2.build_request(&msgs, &[], &cfg2, false)).unwrap();
         assert!(v2.get("reasoning_effort").is_none());
         assert!(v2.get("thinking").is_none());
+    }
+
+    #[test]
+    fn should_emit_none_when_reasoning_is_disabled_for_openai_compatible_endpoint() {
+        let effort = serde_json::from_value(serde_json::json!("none"))
+            .expect("none should disable reasoning");
+        let provider =
+            OpenAIProvider::new("key", "qwen3.5:9b").with_base_url("http://localhost:11434/v1");
+        let config = ChatConfig {
+            reasoning_effort: Some(effort),
+            ..Default::default()
+        };
+
+        let request = serde_json::to_value(provider.build_request(
+            &[msg("return JSON")],
+            &[],
+            &config,
+            false,
+        ))
+        .unwrap();
+
+        assert_eq!(request["reasoning_effort"], "none");
+        assert!(request.get("thinking").is_none());
+    }
+
+    #[test]
+    fn should_disable_thinking_toggle_when_reasoning_is_disabled() {
+        let effort = serde_json::from_value(serde_json::json!("none"))
+            .expect("none should disable reasoning");
+        let provider = OpenAIProvider::new("key", "glm-5.2");
+        let config = ChatConfig {
+            reasoning_effort: Some(effort),
+            ..Default::default()
+        };
+
+        let request = serde_json::to_value(provider.build_request(
+            &[msg("return JSON")],
+            &[],
+            &config,
+            false,
+        ))
+        .unwrap();
+
+        assert_eq!(
+            request["thinking"],
+            serde_json::json!({ "type": "disabled" })
+        );
+        assert!(request.get("reasoning_effort").is_none());
     }
 
     #[test]

--- a/crates/octos-llm/src/openai_responses.rs
+++ b/crates/octos-llm/src/openai_responses.rs
@@ -85,6 +85,7 @@ impl OpenAIResponsesProvider {
         // Reasoning effort maps to the reasoning object
         if let Some(effort) = &config.reasoning_effort {
             let effort_str = match effort {
+                crate::config::ReasoningEffort::Disabled => "none",
                 crate::config::ReasoningEffort::Low => "low",
                 crate::config::ReasoningEffort::Medium => "medium",
                 crate::config::ReasoningEffort::High => "high",
@@ -761,6 +762,21 @@ mod tests {
         let request = provider.build_request(&messages, &[], &config);
 
         assert_eq!(request["reasoning"]["effort"].as_str(), Some("high"));
+    }
+
+    #[test]
+    fn should_emit_none_when_reasoning_is_disabled() {
+        let provider = OpenAIResponsesProvider::new("test-key", "gpt-5");
+        let messages = vec![msg(MessageRole::User, "answer directly")];
+        let effort = serde_json::from_value(serde_json::json!("none"))
+            .expect("none should disable reasoning");
+        let config = ChatConfig {
+            reasoning_effort: Some(effort),
+            ..Default::default()
+        };
+        let request = provider.build_request(&messages, &[], &config);
+
+        assert_eq!(request["reasoning"]["effort"].as_str(), Some("none"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- accept `none` in `octos chat --effort` and `gateway.reasoning_effort`
- map disabled reasoning to provider-specific controls, including `reasoning_effort: "none"` for OpenAI-compatible endpoints
- add provider, CLI, config, and documentation coverage

Fixes #1984

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p octos-llm`
- `cargo test -p octos-cli --lib -- --skip bootstrap_with_dangerous_solo_permissions_disables_sandbox_and_uses_host_scope`
- `cargo clippy -p octos-llm --all-targets -- -D warnings`
- `cargo clippy -p octos-cli --lib`

The skipped CLI test is an existing Windows-only failure: it invokes the Unix `printf` command through `cmd.exe`. The remaining CLI library tests pass (1010 passed, 3 ignored).