### PR TITLE
feat(goal): per-path write grants — fs write allowlist + create_only, kernel-enforced (#1976)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4564,6 +4564,7 @@ dependencies = [
  "reqwest 0.12.28",
  "reqwest 0.13.2",
  "rmcp",
+ "rustix",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,11 @@ symphonia = { version = "0.5", default-features = false, features = ["mp3"] }
 
 # Unix-specific (O_NOFOLLOW for symlink-safe file I/O)
 libc = "0.2"
+# Safe openat/mkdirat for the #1976 write-grant component-wise confined walk
+# (closes the ancestor-symlink TOCTOU under the workspace-wide deny(unsafe_code)
+# lint — rustix wraps the raw syscalls in a safe API). Already vendored
+# transitively; pinned here as a direct dep of octos-agent.
+rustix = { version = "1", features = ["fs"] }
 
 # LRU cache
 lru = "0.16"

--- a/crates/octos-agent/Cargo.toml
+++ b/crates/octos-agent/Cargo.toml
@@ -107,6 +107,13 @@ keyring = { workspace = true, features = ["linux-native"] }
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { workspace = true, features = ["windows-native"] }
 
+# #1976 — safe openat/mkdirat for the write-grant component-wise confined walk
+# (closes the ancestor-symlink TOCTOU under the workspace-wide
+# deny(unsafe_code) lint). Unix only; the Windows path uses the symlink-check
+# fallback documented in `tools::write_grant`.
+[target.'cfg(unix)'.dependencies]
+rustix = { workspace = true }
+
 [features]
 # `browser` is ON by default: it gates the headless-Chrome (CDP) search
 # provider that `web_search` uses as a last-resort fallback (after every HTTP

--- a/crates/octos-agent/src/sandbox/macos.rs
+++ b/crates/octos-agent/src/sandbox/macos.rs
@@ -93,6 +93,41 @@ fn canonicalize_lexical(path: &Path) -> std::path::PathBuf {
     }
 }
 
+/// #1976 — translate ONE v1 write-grant glob into an anchored SBPL regex
+/// under the (canonical) workspace root. The translation is the EXACT mirror
+/// of the tool-layer matcher (`globset` with `literal_separator`): `*` →
+/// `[^/]*`, `?` → `[^/]`, everything else a regex-escaped literal. v1 grant
+/// validation already rejected `**`/classes/alternations, so the two layers
+/// provably grant the same path set.
+pub(crate) fn glob_to_sbpl_regex(real_cwd: &str, glob: &str) -> String {
+    let mut pattern = String::with_capacity(real_cwd.len() + glob.len() + 8);
+    pattern.push('^');
+    for ch in real_cwd.chars() {
+        push_regex_escaped(&mut pattern, ch);
+    }
+    pattern.push('/');
+    for ch in glob.chars() {
+        match ch {
+            '*' => pattern.push_str("[^/]*"),
+            '?' => pattern.push_str("[^/]"),
+            other => push_regex_escaped(&mut pattern, other),
+        }
+    }
+    pattern.push('$');
+    pattern
+}
+
+/// Escape a literal char for a POSIX-ERE SBPL regex.
+fn push_regex_escaped(out: &mut String, ch: char) {
+    if matches!(
+        ch,
+        '.' | '+' | '*' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '^' | '$' | '|' | '\\'
+    ) {
+        out.push('\\');
+    }
+    out.push(ch);
+}
+
 /// macOS sandbox using sandbox-exec.
 pub struct MacosSandbox {
     pub(crate) allow_network: bool,
@@ -115,6 +150,20 @@ pub struct MacosSandbox {
     /// gate (`supports_repo_git_write`) enforces that. Default `None` = today's
     /// cwd-only writable behaviour. The operator's explicit grant, NOT a fence.
     pub(crate) repo_git_write: Option<PathBuf>,
+    /// #1976 — per-path WRITE fence: workspace-relative globs (`*`/`?` within
+    /// one segment) naming the ONLY workspace paths the shell may write.
+    /// `Some(globs)` REPLACES the broad cwd `file-write*` subpath grant with
+    /// one `(allow file-write* (regex ...))` per glob (see
+    /// [`glob_to_sbpl_regex`] — the translation mirrors the tool-layer
+    /// globset semantics exactly), moves TMPDIR outside the workspace (the
+    /// `<cwd>/tmp` scratch is no longer writable), and — deny-wins — narrows
+    /// even `workspace_write=true`. An incoherent pairing with
+    /// `repo_git_write` (validated impossible upstream: a fence excludes
+    /// `FsGrant::Host`) resolves to the FENCE. macOS is the one backend that
+    /// expresses the fence at the OS; what it CANNOT express is
+    /// create-vs-overwrite, so `create_only`'s no-overwrite half remains
+    /// tool-layer enforced (documented on `SandboxConfig::write_allow_globs`).
+    pub(crate) write_allow_globs: Option<Vec<String>>,
 }
 
 impl Sandbox for MacosSandbox {
@@ -210,7 +259,16 @@ impl Sandbox for MacosSandbox {
             rules.join("\n")
         };
 
-        // Workspace write rule. Three cases:
+        // Workspace write rule. Four cases:
+        // - #1976 `write_allow_globs` (a per-path write fence): one
+        //   `(allow file-write* (regex ...))` per granted glob REPLACES the
+        //   broad cwd subpath grant — the shell can create/write ONLY the
+        //   allowlisted paths, `(deny default)` refuses everything else in
+        //   the workspace. Deny-wins over `workspace_write` AND over
+        //   `repo_git_write` (that pairing is validated impossible upstream —
+        //   a fence excludes `FsGrant::Host` — but if constructed anyway the
+        //   FENCE is emitted). A glob with SBPL metacharacters (unreachable
+        //   via a validated grant) is SKIPPED fail-closed, never injected.
         // - `repo_git_write` (a fleet worktree worker granted `FsGrant::Host`):
         //   grant `file-write*` to the cwd checkout AND a `(subpath "<repo>/.git")`
         //   so `git commit` can reach objects/refs/worktree-admin OUTSIDE the cwd.
@@ -226,7 +284,32 @@ impl Sandbox for MacosSandbox {
         //   denies the write. `/dev/null` stays writable regardless so shell
         //   redirections and git internals still function.
         let cwd_write_rule = format!("(allow file-write* (subpath \"{cwd}\"))\n", cwd = real_cwd);
-        let workspace_write_rule = if let Some(git_dir) = &self.repo_git_write {
+        let workspace_write_rule = if let Some(globs) = &self.write_allow_globs {
+            let mut rules = String::new();
+            for glob in globs {
+                if glob.bytes().any(|b| {
+                    b < 0x20 || b == 0x7F || b == b'(' || b == b')' || b == b'\\' || b == b'"'
+                }) {
+                    tracing::error!(
+                        glob = %glob,
+                        "write_allow_globs entry contains SBPL metacharacters, skipping \
+                         (the path is simply not writable — fail closed)"
+                    );
+                    continue;
+                }
+                rules.push_str(&format!(
+                    "(allow file-write* (regex #\"{}\"))\n",
+                    glob_to_sbpl_regex(&real_cwd, glob)
+                ));
+            }
+            if self.repo_git_write.is_some() {
+                tracing::error!(
+                    "write_allow_globs and repo_git_write are mutually exclusive (a fence \
+                     excludes FsGrant::Host); emitting the FENCE only (deny-wins)"
+                );
+            }
+            rules
+        } else if let Some(git_dir) = &self.repo_git_write {
             let real_git = std::fs::canonicalize(git_dir)
                 .map(|p| p.to_string_lossy().to_string())
                 .unwrap_or_else(|_| git_dir.to_string_lossy().to_string());
@@ -247,17 +330,22 @@ impl Sandbox for MacosSandbox {
             String::new()
         };
 
+        // #1976: a fenced workspace is read-only OUTSIDE the granted globs, so
+        // `<cwd>/tmp` is not writable — scratch must live outside, exactly
+        // like the read-only profile.
+        let workspace_scratch_writable = self.workspace_write && self.write_allow_globs.is_none();
+
         // Choose a scratch temp dir for TMPDIR/TEMP/TMP.
         //
         // - Writable workspace: keep the historical `<cwd>/tmp` (covered by the
         //   cwd file-write* grant above).
-        // - Read-only workspace (P2, codex): NEVER create or point TMPDIR under
-        //   the workspace — that would mutate it BEFORE sandbox-exec even runs.
-        //   Use a private dir OUTSIDE the workspace and grant SBPL write to
-        //   THAT instead, so read-only truly means no workspace mutation while
-        //   tools that need scratch space (Python tempfile, compilers) still
-        //   work.
-        let user_tmp = if self.workspace_write {
+        // - Read-only OR fenced workspace (P2, codex; #1976): NEVER create or
+        //   point TMPDIR under the workspace — that would mutate it BEFORE
+        //   sandbox-exec even runs. Use a private dir OUTSIDE the workspace and
+        //   grant SBPL write to THAT instead, so read-only truly means no
+        //   workspace mutation while tools that need scratch space (Python
+        //   tempfile, compilers) still work.
+        let user_tmp = if workspace_scratch_writable {
             cwd.join("tmp")
         } else {
             // `std::env::temp_dir()` honours `$TMPDIR`, which a hostile parent
@@ -273,12 +361,12 @@ impl Sandbox for MacosSandbox {
         // (writable) workspace; for the read-only case it is outside it.
         let _ = std::fs::create_dir_all(&user_tmp);
 
-        // For the read-only case, grant SBPL file-write* to the external temp
-        // dir's real path so scratch writes succeed there (not in the
-        // workspace). The path is validated for SBPL metacharacters; if it is
-        // unexpectedly unsafe we simply omit the grant (fail-closed: scratch
-        // writes fail rather than the profile being injectable).
-        let external_tmp_write_rule = if self.workspace_write {
+        // For the read-only / fenced case, grant SBPL file-write* to the
+        // external temp dir's real path so scratch writes succeed there (not
+        // in the workspace). The path is validated for SBPL metacharacters;
+        // if it is unexpectedly unsafe we simply omit the grant (fail-closed:
+        // scratch writes fail rather than the profile being injectable).
+        let external_tmp_write_rule = if workspace_scratch_writable {
             String::new()
         } else {
             let real_tmp_path =
@@ -361,6 +449,7 @@ mod tests {
             read_allow_paths: Vec::new(),
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let cmd = sb.wrap_command("echo hi", Path::new("/tmp/test"));
         let prog = cmd.as_std().get_program().to_string_lossy().to_string();
@@ -405,6 +494,7 @@ mod tests {
             read_allow_paths: Vec::new(),
             workspace_write: true,
             repo_git_write: Some(PathBuf::from("/tmp/controller-repo/.git")),
+            write_allow_globs: None,
         };
         let cmd = sb.wrap_command("git commit -am wip", Path::new("/tmp/ws"));
         let args: Vec<_> = cmd
@@ -446,6 +536,7 @@ mod tests {
             read_allow_paths: Vec::new(),
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let cmd = plain.wrap_command("echo hi", Path::new("/tmp/ws"));
         let args: Vec<_> = cmd
@@ -473,6 +564,7 @@ mod tests {
             read_allow_paths: vec!["/opt/custom".to_string()],
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         assert!(
             !sb.supports_repo_git_write(),
@@ -488,6 +580,7 @@ mod tests {
             read_allow_paths: Vec::new(),
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let cmd = sb.wrap_command("ls", Path::new("/tmp/\x01bad"));
         let prog = cmd.as_std().get_program().to_string_lossy().to_string();
@@ -510,6 +603,7 @@ mod tests {
             read_allow_paths: Vec::new(),
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         // Parentheses, backslash, and quote should all be rejected
         for path in &[
@@ -540,6 +634,7 @@ mod tests {
             read_allow_paths: Vec::new(),
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let cmd = sb.wrap_command("echo hi", Path::new("/tmp/test"));
         let args: Vec<_> = cmd
@@ -561,6 +656,7 @@ mod tests {
             read_allow_paths: Vec::new(),
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let cmd = sb.wrap_command("echo ok", Path::new("/Users/test/project"));
         let prog = cmd.as_std().get_program().to_string_lossy().to_string();
@@ -575,6 +671,7 @@ mod tests {
             read_allow_paths: Vec::new(),
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let cmd = sb.wrap_command("ls", Path::new("/tmp/evil\x7Fpath"));
         let prog = cmd.as_std().get_program().to_string_lossy().to_string();
@@ -591,6 +688,7 @@ mod tests {
             read_allow_paths: Vec::new(),
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let cmd = sb.wrap_command("echo hi", Path::new("/tmp/test"));
         let args: Vec<_> = cmd
@@ -620,6 +718,7 @@ mod tests {
             read_allow_paths: vec!["/custom/path".to_string()],
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let cmd = sb.wrap_command("echo hi", cwd);
         let args: Vec<_> = cmd
@@ -669,6 +768,7 @@ mod tests {
             ],
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let cmd = sb.wrap_command("echo hi", Path::new("/tmp/test"));
         let args: Vec<_> = cmd
@@ -706,6 +806,7 @@ mod tests {
             read_allow_paths: vec!["/path/with(parens)".to_string()],
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let cmd = sb.wrap_command("echo hi", Path::new("/tmp/test"));
         let args: Vec<_> = cmd
@@ -735,6 +836,7 @@ mod tests {
             ],
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let cmd = sb.wrap_command("echo hi", Path::new("/tmp/test"));
         let args: Vec<_> = cmd
@@ -773,6 +875,7 @@ mod tests {
             read_allow_paths: vec![],
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let mut cmd = sb.wrap_command(
             "touch /tmp/sandbox_escape_test_file 2>&1; echo exit=$?",
@@ -799,6 +902,7 @@ mod tests {
             read_allow_paths: vec![],
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let mut cmd = sb.wrap_command("touch test_file && echo ok", cwd);
         let output = cmd.output().await.expect("sandbox-exec should run");
@@ -832,6 +936,7 @@ mod tests {
             read_allow_paths: Vec::new(),
             workspace_write: false,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let cmd = sb.wrap_command("touch newfile", cwd);
         let args: Vec<_> = cmd
@@ -869,6 +974,7 @@ mod tests {
             read_allow_paths: Vec::new(),
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let cmd = sb.wrap_command("touch newfile", cwd);
         let args: Vec<_> = cmd
@@ -901,6 +1007,7 @@ mod tests {
             read_allow_paths: Vec::new(),
             workspace_write: false,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let cmd = sb.wrap_command("echo hi", cwd);
 
@@ -945,6 +1052,7 @@ mod tests {
             read_allow_paths: Vec::new(),
             workspace_write: false,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let cmd = sb.wrap_command("echo hi", cwd);
         let args: Vec<_> = cmd
@@ -1119,6 +1227,7 @@ mod tests {
             read_allow_paths: Vec::new(),
             workspace_write: false,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let cmd = sb.wrap_command("echo hi", cwd);
 
@@ -1165,6 +1274,7 @@ mod tests {
             read_allow_paths: vec![],
             workspace_write: false,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let mut cmd = sb.wrap_command("echo hello; :", cwd);
         let output = cmd.output().await.expect("sandbox-exec should run");
@@ -1190,6 +1300,7 @@ mod tests {
             read_allow_paths: vec![],
             workspace_write: false,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let mut cmd = sb.wrap_command("touch newfile 2>&1; echo exit=$?", cwd);
         let output = cmd.output().await.expect("sandbox-exec should run");
@@ -1218,6 +1329,7 @@ mod tests {
             read_allow_paths: vec!["/nonexistent/path".to_string()],
             workspace_write: true,
             repo_git_write: None,
+            write_allow_globs: None,
         };
         let real_secret =
             std::fs::canonicalize(&secret_file).unwrap_or_else(|_| secret_file.clone());
@@ -1231,6 +1343,217 @@ mod tests {
         assert!(
             !stdout.contains("top-secret-data"),
             "sandbox should block reading files outside allowed paths, got: {stdout}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #1976: per-path write fence (write_allow_globs → SBPL regex rules).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn glob_translation_matches_tool_layer_semantics() {
+        // The SBPL regex must express EXACTLY the tool-layer globset contract:
+        // `*` → [^/]* and `?` → [^/] (never crossing `/`), everything else a
+        // regex-escaped literal, anchored under the canonical cwd.
+        assert_eq!(
+            glob_to_sbpl_regex("/ws/dir", "cards/*.card"),
+            r"^/ws/dir/cards/[^/]*\.card$",
+        );
+        assert_eq!(
+            glob_to_sbpl_regex("/ws/dir", "notes-?.md"),
+            r"^/ws/dir/notes-[^/]\.md$",
+        );
+        // Regex specials in the CWD (dots, pluses) are escaped so a
+        // `/ws/v1.2` cwd cannot accidentally match `/ws/v1x2`.
+        assert_eq!(
+            glob_to_sbpl_regex("/ws/v1.2+a", "out.txt"),
+            r"^/ws/v1\.2\+a/out\.txt$",
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn write_fence_emits_regex_rules_not_cwd_subpath() {
+        // A fenced profile grants file-write* per GLOB (regex), NEVER the
+        // broad cwd subpath — the fence narrows workspace_write=true.
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let cwd = tmp.path();
+        let real_cwd = std::fs::canonicalize(cwd)
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+
+        let sb = MacosSandbox {
+            allow_network: false,
+            read_allow_paths: Vec::new(),
+            workspace_write: true,
+            repo_git_write: None,
+            write_allow_globs: Some(vec![
+                "exemplar.card".to_string(),
+                "cards/*.card".to_string(),
+            ]),
+        };
+        let cmd = sb.wrap_command("echo hi", cwd);
+        let args: Vec<_> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        let profile = args
+            .iter()
+            .find(|a| a.contains("deny default"))
+            .expect("should have SBPL profile");
+        assert!(
+            !profile.contains(&format!(r#"(allow file-write* (subpath "{real_cwd}"))"#)),
+            "a fenced profile must NOT grant the broad cwd write, profile:\n{profile}"
+        );
+        assert_eq!(
+            profile.matches("(allow file-write* (regex #\"").count(),
+            2,
+            "one regex write rule per granted glob, profile:\n{profile}"
+        );
+        assert!(
+            !profile.contains("(allow file-write*)"),
+            "never a global write grant, profile:\n{profile}"
+        );
+        // Reads stay workspace-wide (non-goal: no per-path READ fence) and
+        // /dev/null stays writable.
+        assert!(profile.contains("(allow file-read*)"));
+        assert!(profile.contains(r#"(allow file-write* (literal "/dev/null"))"#));
+
+        // TMPDIR must live OUTSIDE the fenced workspace — `<cwd>/tmp` is not
+        // granted, so pointing scratch there would break every tool needing
+        // temp space (mirrors the read-only workspace behaviour).
+        let envs: std::collections::HashMap<String, Option<String>> = cmd
+            .as_std()
+            .get_envs()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().to_string(),
+                    v.map(|v| v.to_string_lossy().to_string()),
+                )
+            })
+            .collect();
+        let tmpdir = envs
+            .get("TMPDIR")
+            .and_then(|v| v.clone())
+            .expect("TMPDIR must be set");
+        assert!(
+            !std::path::Path::new(&tmpdir).starts_with(cwd),
+            "TMPDIR must not point inside the fenced workspace, got {tmpdir}"
+        );
+        assert!(
+            !cwd.join("tmp").exists(),
+            "fenced wrapper must not create <cwd>/tmp"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn write_fence_skips_unsafe_globs_fail_closed() {
+        // A glob with SBPL metacharacters (unreachable via a validated grant,
+        // but this layer fails closed on its own): the rule is OMITTED — the
+        // path is simply not writable — and no injected rule appears.
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let sb = MacosSandbox {
+            allow_network: false,
+            read_allow_paths: Vec::new(),
+            workspace_write: true,
+            repo_git_write: None,
+            write_allow_globs: Some(vec![
+                "ok.txt".to_string(),
+                "evil\")\n(allow file-write* (subpath \"/".to_string(),
+            ]),
+        };
+        let cmd = sb.wrap_command("echo hi", tmp.path());
+        let args: Vec<_> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        let profile = args
+            .iter()
+            .find(|a| a.contains("deny default"))
+            .expect("should have SBPL profile");
+        assert_eq!(
+            profile.matches("(allow file-write* (regex #\"").count(),
+            1,
+            "only the safe glob is granted, profile:\n{profile}"
+        );
+        assert!(
+            !profile.contains(r#"(allow file-write* (subpath "/"))"#),
+            "injected root write must not appear, profile:\n{profile}"
+        );
+    }
+
+    /// LIVE acceptance for #1976 (macOS only — sandbox-exec ships with the
+    /// OS, so this runs on any mac; Linux CI skips via cfg, which is the
+    /// honest platform boundary: bwrap cannot express the fence at all).
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn write_fence_enforced_by_sandbox_exec_live() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let cwd = tmp.path();
+        // Parent dirs of granted paths must exist (or be granted themselves)
+        // for SHELL writes — the sandbox cannot create `cards/` since the
+        // directory path is not in the allowlist. Documented degradation.
+        std::fs::create_dir(cwd.join("cards")).expect("pre-create cards/");
+
+        let sb = MacosSandbox {
+            allow_network: false,
+            read_allow_paths: Vec::new(),
+            workspace_write: true,
+            repo_git_write: None,
+            write_allow_globs: Some(vec![
+                "exemplar.card".to_string(),
+                "cards/*.card".to_string(),
+            ]),
+        };
+
+        // CAN create an allowlisted file via shell redirect (the fence is a
+        // grant, not a lockout).
+        let mut ok = sb.wrap_command("echo v1 > exemplar.card && echo created=$?", cwd);
+        let out = ok.output().await.expect("sandbox-exec should run");
+        assert!(
+            cwd.join("exemplar.card").exists(),
+            "granted shell redirect must succeed, stdout={} stderr={}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+        let mut ok2 = sb.wrap_command("echo a > cards/a.card", cwd);
+        let _ = ok2.output().await.expect("sandbox-exec should run");
+        assert!(
+            cwd.join("cards/a.card").exists(),
+            "granted glob shell redirect must succeed"
+        );
+
+        // CANNOT write a non-allowlisted path via shell (OS-enforced fence).
+        let mut denied = sb.wrap_command("echo nope > app.md 2>/dev/null; echo exit=$?", cwd);
+        let out = denied.output().await.expect("sandbox-exec should run");
+        assert!(
+            !cwd.join("app.md").exists(),
+            "the OS fence must deny app.md, stdout={}",
+            String::from_utf8_lossy(&out.stdout),
+        );
+
+        // CANNOT bypass via rename/mv: the target path is not granted, so
+        // rename fails and the source survives.
+        let mut mv = sb.wrap_command("mv exemplar.card app.md 2>/dev/null; echo exit=$?", cwd);
+        let _ = mv.output().await.expect("sandbox-exec should run");
+        assert!(
+            cwd.join("exemplar.card").exists() && !cwd.join("app.md").exists(),
+            "mv to a non-granted path must fail"
+        );
+
+        // Documented degradation: the OS layer CANNOT distinguish create from
+        // overwrite, so a shell append/overwrite of a GRANTED path succeeds —
+        // create_only's no-overwrite half is tool-layer-enforced only.
+        let mut append = sb.wrap_command("echo v2 >> exemplar.card; echo exit=$?", cwd);
+        let out = append.output().await.expect("sandbox-exec should run");
+        assert!(
+            String::from_utf8_lossy(&out.stdout).contains("exit=0"),
+            "shell append to a granted path is OS-allowed (documented) — create_only \
+             overwrite protection lives at the file-tool layer"
         );
     }
 }

--- a/crates/octos-agent/src/sandbox/mod.rs
+++ b/crates/octos-agent/src/sandbox/mod.rs
@@ -87,6 +87,29 @@ pub struct SandboxConfig {
     #[serde(default)]
     pub read_allow_paths: Vec<String>,
 
+    /// #1976 — per-path WRITE fence for the shell: workspace-relative globs
+    /// (`*` / `?` within one segment — the same v1 syntax as
+    /// `WorkerGrant::write_paths`, whose grant this projects) naming the ONLY
+    /// paths shell commands may write inside the workspace. `None` (default,
+    /// every pre-#1976 config) = `workspace_write` alone governs writes.
+    ///
+    /// Backend coverage (deny-wins everywhere — no backend widens the fence):
+    /// - **macOS (sandbox-exec)** expresses it exactly: one
+    ///   `(allow file-write* (regex ...))` per glob replaces the broad cwd
+    ///   subpath grant; TMPDIR moves outside the workspace like the
+    ///   read-only profile. The OS cannot distinguish create-vs-overwrite,
+    ///   so `create_only`'s no-overwrite half stays TOOL-layer enforced.
+    /// - **bwrap / Landlock / AppContainer** cannot bind/grant a glob (or a
+    ///   create-target that does not exist yet): the workspace degrades to
+    ///   READ-ONLY for the shell (fail closed; granted paths stay writable
+    ///   via the fenced file tools), warned at sandbox construction.
+    /// - **Docker** mounts the workspace `:ro` under a fence (same honest
+    ///   degradation).
+    /// - **NoSandbox** enforces nothing — construction warns that the shell
+    ///   fence is UNENFORCED (tool-layer enforcement still applies).
+    #[serde(default)]
+    pub write_allow_globs: Option<Vec<String>>,
+
     /// Profile name for sandbox isolation (used as AppContainer profile ID on Windows).
     #[serde(default)]
     pub profile_name: Option<String>,
@@ -131,6 +154,7 @@ impl Default for SandboxConfig {
             repo_git_write: None,
             docker: DockerConfig::default(),
             read_allow_paths: Vec::new(),
+            write_allow_globs: None,
             profile_name: None,
         }
     }
@@ -290,18 +314,67 @@ impl Sandbox for NoSandbox {
     }
 }
 
+/// #1976 — the effective `workspace_write` for a backend that CANNOT express
+/// a per-path write fence (bwrap/Landlock/AppContainer binds and grants are
+/// concrete paths; a glob — or a create-target that does not exist yet —
+/// cannot be bound). Deny-wins: under a fence the workspace degrades to
+/// READ-ONLY for the shell (granted paths stay writable via the fenced file
+/// tools), warned once per sandbox construction (≈ once per spawned attempt).
+fn fence_degraded_workspace_write(config: &SandboxConfig, backend: &str) -> bool {
+    if config.write_allow_globs.is_some() {
+        tracing::warn!(
+            backend,
+            "per-path write grant: {backend} cannot express per-path shell writes; \
+             the workspace is READ-ONLY for the shell on this backend (granted paths \
+             remain writable via the fenced file tools only)",
+        );
+        return false;
+    }
+    config.workspace_write
+}
+
+/// #1976 — Docker's projection of the same degradation: a fenced workspace
+/// mounts `:ro` (mount targets are concrete paths, same limitation as bwrap).
+fn fence_degraded_docker(config: &SandboxConfig) -> DockerConfig {
+    let mut docker = config.docker.clone();
+    if config.write_allow_globs.is_some() && docker.mount_mode == MountMode::ReadWrite {
+        tracing::warn!(
+            "per-path write grant: docker cannot express per-path shell writes; \
+             the workspace mounts READ-ONLY (granted paths remain writable via the \
+             fenced file tools only)",
+        );
+        docker.mount_mode = MountMode::ReadOnly;
+    }
+    docker
+}
+
+/// #1976 — a fenced config resolving to NO sandbox leaves the shell fence
+/// unenforced entirely; never let that pass silently.
+fn warn_fence_unenforced(config: &SandboxConfig) {
+    if config.write_allow_globs.is_some() {
+        tracing::warn!(
+            "per-path write grant: no sandbox backend — the SHELL write fence is \
+             UNENFORCED (file-tool enforcement still applies)",
+        );
+    }
+}
+
 /// Create a sandbox from config.
 pub fn create_sandbox(config: &SandboxConfig) -> Box<dyn Sandbox> {
     if !config.enabled {
         tracing::info!("sandbox disabled, shell commands run without isolation");
+        warn_fence_unenforced(config);
         return Box::new(NoSandbox);
     }
 
     match &config.mode {
-        SandboxMode::None => Box::new(NoSandbox),
+        SandboxMode::None => {
+            warn_fence_unenforced(config);
+            Box::new(NoSandbox)
+        }
         SandboxMode::Bwrap => Box::new(BwrapSandbox {
             allow_network: config.allow_network,
-            workspace_write: config.workspace_write,
+            workspace_write: fence_degraded_workspace_write(config, "bwrap"),
             repo_git_write: config.repo_git_write.clone(),
         }),
         SandboxMode::Landlock => {
@@ -311,7 +384,7 @@ pub fn create_sandbox(config: &SandboxConfig) -> Box<dyn Sandbox> {
                     allow_network: config.allow_network,
                     read_allow_paths: config.read_allow_paths.clone(),
                     profile_name: config.profile_name.clone(),
-                    workspace_write: config.workspace_write,
+                    workspace_write: fence_degraded_workspace_write(config, "landlock"),
                 })
             }
             #[cfg(not(target_os = "linux"))]
@@ -319,6 +392,7 @@ pub fn create_sandbox(config: &SandboxConfig) -> Box<dyn Sandbox> {
                 tracing::warn!(
                     "Landlock/seccomp is only available on Linux, falling back to NoSandbox"
                 );
+                warn_fence_unenforced(config);
                 Box::new(NoSandbox)
             }
         }
@@ -327,9 +401,11 @@ pub fn create_sandbox(config: &SandboxConfig) -> Box<dyn Sandbox> {
             read_allow_paths: config.read_allow_paths.clone(),
             workspace_write: config.workspace_write,
             repo_git_write: config.repo_git_write.clone(),
+            // #1976: macOS EXPRESSES the fence (per-glob SBPL regex rules).
+            write_allow_globs: config.write_allow_globs.clone(),
         }),
         SandboxMode::Docker => Box::new(DockerSandbox {
-            config: config.docker.clone(),
+            config: fence_degraded_docker(config),
             allow_network: config.allow_network,
         }),
         SandboxMode::AppContainer => {
@@ -339,7 +415,7 @@ pub fn create_sandbox(config: &SandboxConfig) -> Box<dyn Sandbox> {
                     allow_network: config.allow_network,
                     read_allow_paths: config.read_allow_paths.clone(),
                     profile_name: config.profile_name.clone(),
-                    workspace_write: config.workspace_write,
+                    workspace_write: fence_degraded_workspace_write(config, "appcontainer"),
                 })
             }
             #[cfg(not(windows))]
@@ -347,6 +423,7 @@ pub fn create_sandbox(config: &SandboxConfig) -> Box<dyn Sandbox> {
                 tracing::warn!(
                     "AppContainer is only available on Windows, falling back to NoSandbox"
                 );
+                warn_fence_unenforced(config);
                 Box::new(NoSandbox)
             }
         }
@@ -400,6 +477,8 @@ fn create_auto_sandbox(config: &SandboxConfig) -> Box<dyn Sandbox> {
                 read_allow_paths: config.read_allow_paths.clone(),
                 workspace_write: config.workspace_write,
                 repo_git_write: config.repo_git_write.clone(),
+                // #1976: macOS EXPRESSES the fence (per-glob regex rules).
+                write_allow_globs: config.write_allow_globs.clone(),
             });
         }
     }
@@ -409,7 +488,7 @@ fn create_auto_sandbox(config: &SandboxConfig) -> Box<dyn Sandbox> {
         if bwrap_works() {
             return Box::new(BwrapSandbox {
                 allow_network: config.allow_network,
-                workspace_write: config.workspace_write,
+                workspace_write: fence_degraded_workspace_write(config, "bwrap"),
                 repo_git_write: config.repo_git_write.clone(),
             });
         }
@@ -418,7 +497,7 @@ fn create_auto_sandbox(config: &SandboxConfig) -> Box<dyn Sandbox> {
                 allow_network: config.allow_network,
                 read_allow_paths: config.read_allow_paths.clone(),
                 profile_name: config.profile_name.clone(),
-                workspace_write: config.workspace_write,
+                workspace_write: fence_degraded_workspace_write(config, "landlock"),
             });
         }
     }
@@ -430,14 +509,14 @@ fn create_auto_sandbox(config: &SandboxConfig) -> Box<dyn Sandbox> {
                 allow_network: config.allow_network,
                 read_allow_paths: config.read_allow_paths.clone(),
                 profile_name: config.profile_name.clone(),
-                workspace_write: config.workspace_write,
+                workspace_write: fence_degraded_workspace_write(config, "appcontainer"),
             });
         }
     }
 
     if which_exists("docker") {
         Box::new(DockerSandbox {
-            config: config.docker.clone(),
+            config: fence_degraded_docker(config),
             allow_network: config.allow_network,
         })
     } else {
@@ -446,6 +525,7 @@ fn create_auto_sandbox(config: &SandboxConfig) -> Box<dyn Sandbox> {
              Shell commands will run WITHOUT isolation. \
              Install a sandbox backend or set sandbox.enabled = false to silence this warning."
         );
+        warn_fence_unenforced(config);
         Box::new(NoSandbox)
     }
 }
@@ -711,6 +791,7 @@ mod tests {
             repo_git_write: None,
             docker: DockerConfig::default(),
             read_allow_paths: Vec::new(),
+            write_allow_globs: None,
             profile_name: None,
         };
         let sb = create_sandbox(&config);
@@ -721,6 +802,100 @@ mod tests {
         assert_eq!(prog, "cmd");
         #[cfg(not(windows))]
         assert_eq!(prog, "sh");
+    }
+
+    // --- #1976: per-path write fence (write_allow_globs) ---
+
+    #[test]
+    fn sandbox_config_write_allow_globs_defaults_none() {
+        // Back-compat: configs written before #1976 carry no fence.
+        let config: SandboxConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(config.write_allow_globs, None);
+        assert_eq!(SandboxConfig::default().write_allow_globs, None);
+    }
+
+    #[test]
+    fn fence_degrades_bwrap_to_ro_workspace() {
+        // #1976 honest degradation: bwrap binds are CONCRETE paths — a glob
+        // (or a create-target that does not exist yet) cannot be bind-mounted,
+        // so a fenced workspace is bound READ-ONLY for the shell (fail
+        // closed; granted paths stay writable via the fenced file tools).
+        let config = SandboxConfig {
+            mode: SandboxMode::Bwrap,
+            workspace_write: true,
+            write_allow_globs: Some(vec!["exemplar.card".to_string()]),
+            ..SandboxConfig::default()
+        };
+        let sb = create_sandbox(&config);
+        let dir = tempfile::tempdir().unwrap();
+        let cmd = sb.wrap_command("echo hi", dir.path());
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        let cwd_str = dir.path().to_string_lossy().to_string();
+        // The workspace is bound with `--ro-bind` (read-only), not the
+        // read-write `--bind`. (`--chdir <cwd>` also names cwd_str, so match
+        // the bind flags specifically, not merely "cwd appears as w[1]".)
+        let bound_ro = args
+            .windows(2)
+            .any(|w| w[0] == "--ro-bind" && w[1] == cwd_str);
+        let bound_rw = args.windows(2).any(|w| w[0] == "--bind" && w[1] == cwd_str);
+        assert!(
+            bound_ro && !bound_rw,
+            "a fenced workspace must be read-only (--ro-bind) under bwrap, args: {args:?}"
+        );
+    }
+
+    #[test]
+    fn fence_degrades_docker_mount_to_ro() {
+        // #1976 honest degradation: Docker mounts are concrete too — a
+        // fenced workspace mounts `:ro` (fail closed for the shell).
+        let config = SandboxConfig {
+            mode: SandboxMode::Docker,
+            write_allow_globs: Some(vec!["exemplar.card".to_string()]),
+            ..SandboxConfig::default()
+        };
+        let sb = create_sandbox(&config);
+        let dir = tempfile::tempdir().unwrap();
+        let cmd = sb.wrap_command("echo hi", dir.path());
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert!(
+            args.iter().any(|a| a.ends_with(":/workspace:ro")),
+            "a fenced workspace must mount read-only under docker, args: {args:?}"
+        );
+    }
+
+    #[test]
+    fn fence_reaches_macos_backend_as_globs() {
+        // macOS is the one backend that EXPRESSES the fence (SBPL regex);
+        // create_sandbox must thread the globs through, not degrade them.
+        let config = SandboxConfig {
+            mode: SandboxMode::Macos,
+            write_allow_globs: Some(vec!["exemplar.card".to_string()]),
+            ..SandboxConfig::default()
+        };
+        let sb = create_sandbox(&config);
+        let dir = tempfile::tempdir().unwrap();
+        let cmd = sb.wrap_command("echo hi", dir.path());
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        let profile = args
+            .iter()
+            .find(|a| a.contains("deny default"))
+            .expect("SBPL profile present");
+        assert!(
+            profile.contains("(allow file-write* (regex #\""),
+            "macOS must emit per-glob regex write rules, profile: {profile}"
+        );
     }
 
     // --- is_noop contract (fail-closed callers depend on this) ---

--- a/crates/octos-agent/src/tools/edit_file.rs
+++ b/crates/octos-agent/src/tools/edit_file.rs
@@ -7,6 +7,7 @@ use eyre::Result;
 use serde::Deserialize;
 use tracing::warn;
 
+use super::write_grant::WritePathGrant;
 use super::{ConcurrencyClass, Tool, ToolContext, ToolResult};
 use crate::policy::{FileAccessMode, FilesystemScope};
 
@@ -18,6 +19,10 @@ pub struct EditFileTool {
     filesystem_scope: FilesystemScope,
     /// Whether writes are permitted.
     file_access: FileAccessMode,
+    /// #1976 — optional per-path write fence. Under `create_only` EVERY edit
+    /// is refused (allowlisted paths may only be created); otherwise edits
+    /// follow the allowlist. `None` = pre-#1976 behaviour.
+    write_grant: Option<WritePathGrant>,
 }
 
 impl EditFileTool {
@@ -27,6 +32,7 @@ impl EditFileTool {
             base_dir: base_dir.into(),
             filesystem_scope: FilesystemScope::Workspace,
             file_access: FileAccessMode::ReadWrite,
+            write_grant: None,
         }
     }
 
@@ -39,6 +45,13 @@ impl EditFileTool {
     /// Set the effective file access mode.
     pub fn with_file_access(mut self, file_access: FileAccessMode) -> Self {
         self.file_access = file_access;
+        self
+    }
+
+    /// #1976 — bind a per-path write fence (see
+    /// [`WriteFileTool::with_write_grant`](super::WriteFileTool::with_write_grant)).
+    pub fn with_write_grant(mut self, write_grant: WritePathGrant) -> Self {
+        self.write_grant = Some(write_grant);
         self
     }
 }
@@ -157,10 +170,57 @@ impl Tool for EditFileTool {
             },
         };
 
-        // Read current content (O_NOFOLLOW atomically rejects symlinks)
-        let content = match super::read_no_follow(&path).await {
-            Ok(c) => c,
-            Err(e) => return Ok(super::file_io_error(e, &input.path)),
+        // #1976 — per-path write fence, BEFORE any file I/O. SECURITY ROUND
+        // (codex): a fenced edit must read AND write through ONE confined
+        // handle so an ancestor swapped between the read and the write cannot
+        // redirect the edit. Under create_only every edit is refused ("created,
+        // never modified"); otherwise `check_edit` returns the workspace-
+        // relative path and `confined_open_rdwr` opens the leaf `O_RDWR` via a
+        // component-wise `O_NOFOLLOW` `openat` walk (symlinked ancestor →
+        // refused). The returned handle is reused for the write-back below, so
+        // read and write bind to the same walked object. Unfenced edits keep
+        // the historical `read_no_follow` + `write_no_follow`.
+        let mut fenced: Option<(std::fs::File, std::path::PathBuf)> = None;
+        let content = if let Some(grant) = &self.write_grant {
+            let workspace_root = ctx
+                .session_scope
+                .as_ref()
+                .map(|scope| scope.workspace().to_path_buf())
+                .unwrap_or_else(|| self.base_dir.clone());
+            let rel = match grant.check_edit(&workspace_root, &path, &input.path, self.name()) {
+                Ok(rel) => rel,
+                Err(denied) => {
+                    return Ok(ToolResult {
+                        output: denied,
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            };
+            match super::write_grant::confined_open_rdwr(workspace_root.clone(), rel).await {
+                Ok((file, content)) => {
+                    fenced = Some((file, workspace_root));
+                    content
+                }
+                Err(e) => {
+                    return Ok(ToolResult {
+                        output: grant.map_confined_error(
+                            &e,
+                            &workspace_root,
+                            &input.path,
+                            self.name(),
+                        ),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            }
+        } else {
+            // Read current content (O_NOFOLLOW atomically rejects symlinks)
+            match super::read_no_follow(&path).await {
+                Ok(c) => c,
+                Err(e) => return Ok(super::file_io_error(e, &input.path)),
+            }
         };
 
         if input.old_string.is_empty() {
@@ -248,15 +308,44 @@ impl Tool for EditFileTool {
         new_content.push_str(&splice_new);
         new_content.push_str(&content[range.end..]);
 
-        // Write back (O_NOFOLLOW)
-        if let Err(e) = super::write_no_follow(&path, new_content.as_bytes()).await {
+        // Write back. A fenced edit rewrites the SAME confined handle opened
+        // above (truncate + write from offset 0) — no re-open, so no
+        // ancestor-swap window between read and write. Unfenced edits keep the
+        // historical lexical `write_no_follow`.
+        if let Some((file, workspace_root)) = fenced.take() {
+            if let Err(e) =
+                super::write_grant::confined_rewrite(file, new_content.as_bytes().to_vec()).await
+            {
+                // `map_confined_error` records the typed `[denied]`/[io] to the
+                // sink; a rewrite failure is not create_only-relevant.
+                let grant = self.write_grant.as_ref().expect("fenced implies a grant");
+                return Ok(ToolResult {
+                    output: grant.map_confined_error(&e, &workspace_root, &input.path, self.name()),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+        } else if let Err(e) = super::write_no_follow(&path, new_content.as_bytes()).await {
             return Ok(super::file_io_error(e, &input.path));
         }
+
+        // #1976 SECURITY ROUND 2 (codex): under a per-path write fence the
+        // post-write processors that re-resolve the LEXICAL path are SKIPPED —
+        // a fenced edit is a leaf-file operation, not a project mutation.
+        // Formatting would run an external tool on a lexical filename, and
+        // `snapshot_workspace_change` lexically derives a repo root and
+        // unconditionally creates dirs/`.git`/objects/commits at NON-granted
+        // sibling paths (reopening the ancestor-swap window the confined edit
+        // just closed). `write_grant` Some at this point means the edit went
+        // through the confined path above. Cache invalidation stays (pure
+        // in-memory, path-keyed).
+        let fence_active = self.write_grant.is_some();
 
         // #1774: opt-in post-edit formatting. Runs BEFORE cache invalidation
         // and the git snapshot so both observe the final on-disk content.
         // Best-effort by contract — a formatter failure never fails the edit.
-        let format_note = if ctx.format_after_edit {
+        // Never runs under a fence (see above).
+        let format_note = if ctx.format_after_edit && !fence_active {
             crate::format::post_edit_format_note(&path, &new_content).await
         } else {
             None
@@ -268,14 +357,16 @@ impl Tool for EditFileTool {
             cache.invalidate(&path);
         }
 
-        if let Err(error) =
-            crate::workspace_git::snapshot_workspace_change(&self.base_dir, &path, "edit_file")
-        {
-            warn!(
-                path = %input.path,
-                error = %error,
-                "workspace git snapshot failed after edit_file"
-            );
+        if !fence_active {
+            if let Err(error) =
+                crate::workspace_git::snapshot_workspace_change(&self.base_dir, &path, "edit_file")
+            {
+                warn!(
+                    path = %input.path,
+                    error = %error,
+                    "workspace git snapshot failed after edit_file"
+                );
+            }
         }
 
         // Report which replacer produced the match. The exact-match wording
@@ -1294,6 +1385,92 @@ mod tests {
             std::fs::read_to_string(dir.path().join("broken.rs")).unwrap(),
             "fn main( { let a=2 \n",
             "the edit must be kept exactly as written when formatting fails"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #1976: per-path write-grant enforcement.
+    // -----------------------------------------------------------------------
+
+    fn fenced_tool(dir: &std::path::Path, patterns: &[&str], create_only: bool) -> EditFileTool {
+        let owned: Vec<String> = patterns.iter().map(|s| s.to_string()).collect();
+        EditFileTool::new(dir).with_write_grant(
+            crate::tools::write_grant::WritePathGrant::new(&owned, create_only)
+                .expect("test grant compiles"),
+        )
+    }
+
+    #[tokio::test]
+    async fn write_grant_create_only_refuses_edit_even_on_allowlisted_path() {
+        // Acceptance (#1976): under create_only, edit_file is refused on ANY
+        // path — allowlisted or not ("created, never modified").
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("exemplar.card"), "v1\n").unwrap();
+        let tool = fenced_tool(dir.path(), &["exemplar.card"], true);
+
+        let result = tool
+            .execute(&serde_json::json!({
+                "path": "exemplar.card",
+                "old_string": "v1",
+                "new_string": "v2",
+            }))
+            .await
+            .unwrap();
+        assert!(!result.success, "create_only must refuse edits");
+        assert!(
+            result
+                .output
+                .contains(crate::tools::write_grant::DENIED_MARKER),
+            "typed refusal: {}",
+            result.output
+        );
+        assert!(result.output.contains("create-only"), "{}", result.output);
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("exemplar.card")).unwrap(),
+            "v1\n",
+            "refused edit must leave the file untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_grant_edit_follows_allowlist_without_create_only() {
+        // Without create_only: edits inside the allowlist pass, outside are
+        // refused with the typed `[denied]` class.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("exemplar.card"), "v1\n").unwrap();
+        std::fs::write(dir.path().join("app.md"), "keep\n").unwrap();
+        let tool = fenced_tool(dir.path(), &["exemplar.card"], false);
+
+        let ok = tool
+            .execute(&serde_json::json!({
+                "path": "exemplar.card",
+                "old_string": "v1",
+                "new_string": "v2",
+            }))
+            .await
+            .unwrap();
+        assert!(ok.success, "allowlisted edit must pass: {}", ok.output);
+
+        let denied = tool
+            .execute(&serde_json::json!({
+                "path": "app.md",
+                "old_string": "keep",
+                "new_string": "gone",
+            }))
+            .await
+            .unwrap();
+        assert!(!denied.success);
+        assert!(
+            denied
+                .output
+                .contains(crate::tools::write_grant::DENIED_MARKER),
+            "typed refusal: {}",
+            denied.output
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("app.md")).unwrap(),
+            "keep\n",
+            "refused edit must leave the file untouched"
         );
     }
 }

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -793,6 +793,7 @@ pub mod synthesize_research;
 pub mod web_fetch;
 pub mod web_search;
 pub mod write_file;
+pub mod write_grant;
 
 pub mod admin;
 pub mod browser;
@@ -860,6 +861,9 @@ pub use synthesize_research::SynthesizeResearchTool;
 pub use web_fetch::WebFetchTool;
 pub use web_search::WebSearchTool;
 pub use write_file::WriteFileTool;
+pub use write_grant::{
+    DENIED_MARKER, WriteGrantViolation, WriteGrantViolationSink, WritePathGrant,
+};
 
 pub use browser::BrowserTool;
 pub use check::CheckTool;
@@ -1334,6 +1338,12 @@ pub async fn write_no_follow(path: &Path, content: &[u8]) -> std::io::Result<()>
     .await
     .unwrap_or_else(|e| Err(std::io::Error::other(e)))
 }
+
+// #1976 note: `create_only` (`O_CREAT|O_EXCL`) enforcement moved into the
+// component-wise confined `openat` walk in `tools::write_grant::open_confined`
+// (which also closes the ancestor-symlink TOCTOU a whole-path lexical open
+// cannot). A standalone leaf-only exclusive writer would re-introduce that
+// divergence, so it is intentionally absent here.
 
 /// Convert a file I/O error to a ToolResult, handling symlink and not-found cases.
 pub fn file_io_error(e: std::io::Error, display_path: &str) -> ToolResult {

--- a/crates/octos-agent/src/tools/write_file.rs
+++ b/crates/octos-agent/src/tools/write_file.rs
@@ -7,6 +7,7 @@ use eyre::{Result, WrapErr};
 use serde::Deserialize;
 use tracing::warn;
 
+use super::write_grant::WritePathGrant;
 use super::{ConcurrencyClass, Tool, ToolContext, ToolResult};
 use crate::policy::{FileAccessMode, FilesystemScope};
 
@@ -18,6 +19,9 @@ pub struct WriteFileTool {
     filesystem_scope: FilesystemScope,
     /// Whether writes are permitted.
     file_access: FileAccessMode,
+    /// #1976 — optional per-path write fence. `None` (default, every
+    /// pre-#1976 construction) = writes governed by scope/access alone.
+    write_grant: Option<WritePathGrant>,
 }
 
 impl WriteFileTool {
@@ -27,6 +31,7 @@ impl WriteFileTool {
             base_dir: base_dir.into(),
             filesystem_scope: FilesystemScope::Workspace,
             file_access: FileAccessMode::ReadWrite,
+            write_grant: None,
         }
     }
 
@@ -39,6 +44,15 @@ impl WriteFileTool {
     /// Set the effective file access mode.
     pub fn with_file_access(mut self, file_access: FileAccessMode) -> Self {
         self.file_access = file_access;
+        self
+    }
+
+    /// #1976 — bind a per-path write fence: only allowlisted
+    /// workspace-relative paths are writable (canonical match, deny-wins on
+    /// top of scope/access); under `create_only` they may be CREATED but
+    /// never overwritten (`O_CREAT|O_EXCL`).
+    pub fn with_write_grant(mut self, write_grant: WritePathGrant) -> Self {
+        self.write_grant = Some(write_grant);
         self
     }
 }
@@ -154,22 +168,84 @@ impl Tool for WriteFileTool {
             },
         };
 
-        // Create parent directories if needed
-        if let Some(parent) = path.parent() {
-            tokio::fs::create_dir_all(parent)
-                .await
-                .wrap_err_with(|| format!("failed to create directories: {}", parent.display()))?;
+        // #1976 — per-path write fence. SECURITY ROUND (codex): the allowlist
+        // decision and the actual open must target the SAME resolved object,
+        // or an attacker who swaps a checked ancestor dir for a symlink
+        // between check and open escapes (leaf `O_NOFOLLOW` guards only the
+        // leaf). So a fenced write does NOT reuse the generic lexical
+        // `write_no_follow` below: `check_write` returns the workspace-relative
+        // path, and `confined_write` re-opens it via a component-wise
+        // `O_NOFOLLOW` `openat` walk — a symlinked (or swapped-to-symlink)
+        // ancestor fails `ELOOP`/`ENOTDIR` at its own component. `create_only`
+        // becomes `O_CREAT|O_EXCL` on that same walked leaf.
+        let fenced = if let Some(grant) = &self.write_grant {
+            let workspace_root = ctx
+                .session_scope
+                .as_ref()
+                .map(|scope| scope.workspace().to_path_buf())
+                .unwrap_or_else(|| self.base_dir.clone());
+            let rel = match grant.check_write(&workspace_root, &path, &input.path, self.name()) {
+                Ok(rel) => rel,
+                Err(denied) => {
+                    return Ok(ToolResult {
+                        output: denied,
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            };
+            if let Err(e) = super::write_grant::confined_write(
+                workspace_root.clone(),
+                rel,
+                input.content.as_bytes().to_vec(),
+                grant.create_only(),
+            )
+            .await
+            {
+                return Ok(ToolResult {
+                    output: grant.map_confined_error(&e, &workspace_root, &input.path, self.name()),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+            true
+        } else {
+            false
+        };
+
+        if !fenced {
+            // Create parent directories if needed (generic, unfenced path).
+            if let Some(parent) = path.parent() {
+                tokio::fs::create_dir_all(parent).await.wrap_err_with(|| {
+                    format!("failed to create directories: {}", parent.display())
+                })?;
+            }
+            // Write file (O_NOFOLLOW atomically rejects symlinks, no TOCTOU race).
+            if let Err(e) = super::write_no_follow(&path, input.content.as_bytes()).await {
+                return Ok(super::file_io_error(e, &input.path));
+            }
         }
 
-        // Write file (O_NOFOLLOW atomically rejects symlinks, no TOCTOU race)
-        if let Err(e) = super::write_no_follow(&path, input.content.as_bytes()).await {
-            return Ok(super::file_io_error(e, &input.path));
-        }
+        // #1976 SECURITY ROUND 2 (codex): a per-path write fence makes this a
+        // LEAF-FILE operation, not a project mutation — so the post-write
+        // processors that re-resolve the LEXICAL path are SKIPPED under a
+        // fence. Both would breach the fence: the formatter would run an
+        // external tool on a lexical filename, and `snapshot_workspace_change`
+        // lexically derives a repo root and unconditionally creates
+        // dirs/`.gitignore`/`.git`/objects/commits at NON-granted sibling
+        // paths (and an ancestor swap before it re-opens the very TOCTOU the
+        // confined write just closed). A fenced worker is allowlisted to
+        // specific files; it must not trigger repo snapshotting of
+        // lexically-derived siblings. Cache invalidation stays — it is a pure
+        // in-memory, path-keyed operation with no filesystem re-resolution.
+        // `fenced` (set on the confined-write path above) is true iff a fence
+        // is bound: reaching here with `write_grant` Some implies `fenced`.
 
         // #1774: opt-in post-edit formatting. Runs BEFORE cache invalidation
         // and the git snapshot so both observe the final on-disk content.
         // Best-effort by contract — a formatter failure never fails the write.
-        let format_note = if ctx.format_after_edit {
+        // Never runs under a fence (see above).
+        let format_note = if ctx.format_after_edit && !fenced {
             crate::format::post_edit_format_note(&path, &input.content).await
         } else {
             None
@@ -182,14 +258,16 @@ impl Tool for WriteFileTool {
             cache.invalidate(&path);
         }
 
-        if let Err(error) =
-            crate::workspace_git::snapshot_workspace_change(&self.base_dir, &path, "write_file")
-        {
-            warn!(
-                path = %input.path,
-                error = %error,
-                "workspace git snapshot failed after write_file"
-            );
+        if !fenced {
+            if let Err(error) =
+                crate::workspace_git::snapshot_workspace_change(&self.base_dir, &path, "write_file")
+            {
+                warn!(
+                    path = %input.path,
+                    error = %error,
+                    "workspace git snapshot failed after write_file"
+                );
+            }
         }
 
         let line_count = input.content.lines().count();
@@ -607,6 +685,220 @@ mod tests {
         assert!(
             on_disk.contains("fn main() {"),
             "file must be rustfmt-formatted on disk: {on_disk}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #1976: per-path write-grant enforcement.
+    // -----------------------------------------------------------------------
+
+    fn fenced_tool(dir: &std::path::Path, patterns: &[&str], create_only: bool) -> WriteFileTool {
+        let owned: Vec<String> = patterns.iter().map(|s| s.to_string()).collect();
+        WriteFileTool::new(dir).with_write_grant(
+            crate::tools::write_grant::WritePathGrant::new(&owned, create_only)
+                .expect("test grant compiles"),
+        )
+    }
+
+    #[tokio::test]
+    async fn write_grant_allows_creating_allowlisted_file() {
+        // Acceptance (#1976): a worker granted write:["exemplar.card"],
+        // create_only CAN create exemplar.card via write_file.
+        let dir = tempfile::tempdir().unwrap();
+        let tool = fenced_tool(dir.path(), &["exemplar.card"], true);
+
+        let result = tool
+            .execute(&serde_json::json!({"path": "exemplar.card", "content": "v1\n"}))
+            .await
+            .unwrap();
+        assert!(
+            result.success,
+            "granted create must pass: {}",
+            result.output
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("exemplar.card")).unwrap(),
+            "v1\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_grant_denies_non_allowlisted_path() {
+        // Acceptance (#1976): the same worker CANNOT write app.md — typed
+        // `[denied]` refusal, file never created, violation never silent.
+        let dir = tempfile::tempdir().unwrap();
+        let tool = fenced_tool(dir.path(), &["exemplar.card"], true);
+
+        let result = tool
+            .execute(&serde_json::json!({"path": "app.md", "content": "nope\n"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result
+                .output
+                .contains(crate::tools::write_grant::DENIED_MARKER),
+            "refusal must carry the [denied] class: {}",
+            result.output
+        );
+        assert!(
+            !dir.path().join("app.md").exists(),
+            "refused write must not create the file"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_grant_create_only_refuses_overwrite() {
+        // Acceptance (#1976): create_only = O_CREAT|O_EXCL semantics — the
+        // first create passes, the second write to the SAME allowlisted path
+        // is refused and the content is untouched.
+        let dir = tempfile::tempdir().unwrap();
+        let tool = fenced_tool(dir.path(), &["exemplar.card"], true);
+
+        let first = tool
+            .execute(&serde_json::json!({"path": "exemplar.card", "content": "v1\n"}))
+            .await
+            .unwrap();
+        assert!(first.success, "{}", first.output);
+
+        let second = tool
+            .execute(&serde_json::json!({"path": "exemplar.card", "content": "v2\n"}))
+            .await
+            .unwrap();
+        assert!(!second.success, "overwrite must be refused");
+        assert!(
+            second.output.contains("already exists"),
+            "typed create-only refusal: {}",
+            second.output
+        );
+        assert!(
+            second
+                .output
+                .contains(crate::tools::write_grant::DENIED_MARKER)
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("exemplar.card")).unwrap(),
+            "v1\n",
+            "refused overwrite must leave the original bytes"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_grant_without_create_only_allows_overwrite_of_allowlisted() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = fenced_tool(dir.path(), &["exemplar.card"], false);
+        for content in ["v1\n", "v2\n"] {
+            let result = tool
+                .execute(&serde_json::json!({"path": "exemplar.card", "content": content}))
+                .await
+                .unwrap();
+            assert!(result.success, "{}", result.output);
+        }
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("exemplar.card")).unwrap(),
+            "v2\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_grant_symlinked_ancestor_cannot_reach_allowlisted_name() {
+        // Acceptance (#1976): CANNOT bypass via symlink — `cards` symlinked
+        // outside the workspace makes `cards/a.card` (lexically allowlisted)
+        // resolve outside; the canonical match denies it.
+        use std::os::unix::fs::symlink;
+        let ws = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), ws.path().join("cards")).unwrap();
+
+        let tool = fenced_tool(ws.path(), &["cards/*.card"], false);
+        let result = tool
+            .execute(&serde_json::json!({"path": "cards/a.card", "content": "leak\n"}))
+            .await
+            .unwrap();
+        assert!(!result.success, "symlink bypass must be refused");
+        assert!(
+            !outside.path().join("a.card").exists(),
+            "nothing may land at the symlink target"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_grant_skips_workspace_git_snapshot() {
+        // #1976 security round 2 (codex): a fenced write to an allowlisted
+        // sites/<slug>/index.html must NOT trigger workspace-git snapshotting,
+        // which lexically derives repo root sites/<slug>/ and creates
+        // .gitignore/.git there — NON-granted paths (and reopens the
+        // ancestor-swap window). Assert the snapshot was skipped.
+        let dir = tempfile::tempdir().unwrap();
+        let tool = fenced_tool(dir.path(), &["sites/demo/index.html"], false);
+        let result = tool
+            .execute(&serde_json::json!({
+                "path": "sites/demo/index.html",
+                "content": "<h1>hi</h1>\n",
+            }))
+            .await
+            .unwrap();
+        assert!(
+            result.success,
+            "granted create must pass: {}",
+            result.output
+        );
+        assert!(dir.path().join("sites/demo/index.html").exists());
+        assert!(
+            !dir.path().join("sites/demo/.git").exists(),
+            "fence must skip git init",
+        );
+        assert!(
+            !dir.path().join("sites/demo/.gitignore").exists(),
+            "fence must skip .gitignore creation",
+        );
+
+        // Control: the SAME shape WITHOUT a fence DOES snapshot (writes
+        // .gitignore at the derived repo root before git init), so the skip
+        // assertion above is not vacuous.
+        let unfenced = WriteFileTool::new(dir.path());
+        let ctrl = unfenced
+            .execute(&serde_json::json!({
+                "path": "sites/other/index.html",
+                "content": "<h1>c</h1>\n",
+            }))
+            .await
+            .unwrap();
+        assert!(ctrl.success, "{}", ctrl.output);
+        assert!(
+            dir.path().join("sites/other/.gitignore").exists(),
+            "unfenced write must snapshot (control) — else the skip is vacuous",
+        );
+    }
+
+    #[tokio::test]
+    async fn write_grant_skips_post_edit_formatting() {
+        // #1976 security round 2: format-under-fence is a no-op — the external
+        // formatter (which re-resolves the lexical path) is skipped even with
+        // format_after_edit ON, and the bytes stay exactly as written.
+        let dir = tempfile::tempdir().unwrap();
+        let tool = fenced_tool(dir.path(), &["gen.rs"], false);
+        let mut ctx = ToolContext::zero();
+        ctx.format_after_edit = true;
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "gen.rs", "content": "fn main(){let x=1;}\n"}),
+            )
+            .await
+            .unwrap();
+        assert!(result.success, "{}", result.output);
+        assert!(
+            !result.output.contains("reformatted") && !result.output.contains("Note:"),
+            "no formatter must run under a fence: {}",
+            result.output,
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("gen.rs")).unwrap(),
+            "fn main(){let x=1;}\n",
+            "fenced write must leave the bytes unformatted",
         );
     }
 

--- a/crates/octos-agent/src/tools/write_grant.rs
+++ b/crates/octos-agent/src/tools/write_grant.rs
@@ -1,0 +1,911 @@
+//! #1976 — per-path WRITE-grant enforcement for the native file tools.
+//!
+//! A [`WritePathGrant`] is the octos-agent realisation of a fleet task's
+//! `fs: { write: [...], create_only }` grant (`octos_fleet::WorkerGrant::
+//! write_paths` — this crate deliberately has no `octos-fleet` dependency, so
+//! the host-side mapping lives in `octos-fleet-worker::closed_registry`,
+//! mirroring how `FsGrant` maps to `EffectivePermissions`). Bound to
+//! `write_file` / `edit_file` via their `with_write_grant` builders, it makes
+//! the fence kernel-side: a write outside the allowlist is a typed refusal,
+//! not a polite request the model may ignore.
+//!
+//! # Matching contract (must stay aligned with the sandbox translation)
+//!
+//! Patterns are workspace-relative with `*` / `?` wildcards confined to ONE
+//! path segment (`literal_separator`); `**`, `[...]`, `{...}` are rejected —
+//! the v1 syntax is deliberately the intersection that this globset matcher
+//! and the macOS SBPL regex translation
+//! (`crate::sandbox::macos` `write_allow_globs`) express IDENTICALLY, so the
+//! tool layer and the shell sandbox can never disagree about what is granted.
+//! The same rules are validated fleet-side at plan time
+//! (`octos_fleet::validate_write_path_pattern`); re-validating here is
+//! defense-in-depth for programmatic constructions.
+//!
+//! # Symlink safety (security round — ancestor-swap TOCTOU)
+//!
+//! The allowlist decision and the actual open MUST target the same resolved
+//! object. An earlier design canonicalized the path for the CHECK but the
+//! tools then opened the LEXICAL path — so an attacker who swapped a checked
+//! real directory (`cards/`) for a symlink between check and open escaped
+//! (leaf `O_NOFOLLOW` guards only the leaf, never ancestors). The fix:
+//! [`check_write`](WritePathGrant::check_write) does a purely LEXICAL
+//! allowlist match and returns the workspace-relative path, and the write goes
+//! through [`open_confined`] — a component-wise `O_NOFOLLOW` `openat` walk from
+//! the workspace-root dirfd. A symlinked (or swapped-to-symlink) ancestor
+//! fails `ELOOP`/`ENOTDIR` at its OWN component, so the opened object is
+//! provably the one the allowlist matched. `create_only` is `O_CREAT|O_EXCL`
+//! on that same walked leaf; a fenced edit reads and rewrites ONE handle.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
+
+/// The marker every write-grant refusal (and ledger finding derived from one)
+/// carries — the `[denied]` class from issue #1976. Violations must never be
+/// silent: the model sees this in the tool error, the host can sink it into
+/// the goal ledger.
+pub const DENIED_MARKER: &str = "[denied]";
+
+/// One recorded write-grant violation, as handed to a
+/// [`WriteGrantViolationSink`].
+#[derive(Debug, Clone)]
+pub struct WriteGrantViolation {
+    /// The workspace root the fenced tool was bound to (for fleet workers
+    /// this is the attempt cwd `<workspace_root>/<fleet>/<task>`, which is
+    /// how the host maps a violation back to its task).
+    pub workspace: PathBuf,
+    /// The refusing tool (`write_file` / `edit_file`).
+    pub tool: String,
+    /// The full `[denied] ...` refusal message returned to the model.
+    pub detail: String,
+}
+
+/// Host-supplied sink invoked ONCE per violation, at refusal time (not
+/// post-hoc), so a violation is durable even if the attempt later times out.
+/// Must be cheap/non-blocking — the fleet host wraps its ledger write in a
+/// detached task.
+pub type WriteGrantViolationSink = Arc<dyn Fn(WriteGrantViolation) + Send + Sync>;
+
+/// A compiled per-path write fence. See the module docs for the contract.
+#[derive(Clone)]
+pub struct WritePathGrant {
+    /// The original patterns, for refusal messages (what IS writable).
+    patterns: Vec<String>,
+    /// Compiled matcher (`literal_separator`: `*`/`?` never cross `/`).
+    matcher: GlobSet,
+    /// Allowlisted paths may be CREATED but never overwritten/edited.
+    create_only: bool,
+    /// Optional host sink for the `[denied]` audit trail.
+    sink: Option<WriteGrantViolationSink>,
+}
+
+impl std::fmt::Debug for WritePathGrant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WritePathGrant")
+            .field("patterns", &self.patterns)
+            .field("create_only", &self.create_only)
+            .field("sink", &self.sink.as_ref().map(|_| "..."))
+            .finish()
+    }
+}
+
+impl WritePathGrant {
+    /// Compile a fence from workspace-relative patterns. Fails (so the caller
+    /// can fail CLOSED — no registry, no worker) on any pattern outside the
+    /// v1 syntax: absolute, `.`/`..` segments, empty segments, `**`, glob
+    /// classes/alternations, profile metacharacters, control bytes, `:`.
+    pub fn new(patterns: &[String], create_only: bool) -> eyre::Result<Self> {
+        let mut builder = GlobSetBuilder::new();
+        let mut kept = Vec::with_capacity(patterns.len());
+        for pattern in patterns {
+            let pattern = pattern.trim();
+            validate_pattern(pattern)?;
+            let glob = GlobBuilder::new(pattern)
+                // `*` / `?` stay within one path segment — the property the
+                // SBPL regex translation mirrors ([^/]* / [^/]).
+                .literal_separator(true)
+                .build()
+                .map_err(|e| {
+                    eyre::eyre!("write grant pattern `{pattern}` failed to compile: {e}")
+                })?;
+            builder.add(glob);
+            kept.push(pattern.to_owned());
+        }
+        let matcher = builder
+            .build()
+            .map_err(|e| eyre::eyre!("write grant failed to compile: {e}"))?;
+        Ok(Self {
+            patterns: kept,
+            matcher,
+            create_only,
+            sink: None,
+        })
+    }
+
+    /// Attach the host's violation sink (`[denied]` audit trail).
+    pub fn with_violation_sink(mut self, sink: WriteGrantViolationSink) -> Self {
+        self.sink = Some(sink);
+        self
+    }
+
+    /// Whether allowlisted paths may only be CREATED (never overwritten /
+    /// edited / deleted).
+    pub fn create_only(&self) -> bool {
+        self.create_only
+    }
+
+    /// The original allowlist patterns (for messages / profile generation).
+    pub fn patterns(&self) -> &[String] {
+        &self.patterns
+    }
+
+    /// Decide `write_file` against the allowlist and return the
+    /// workspace-RELATIVE path to write (the input for the confined openat
+    /// walk). `Ok(rel)` = allowed → the caller MUST open it via
+    /// [`confined_write`] (which re-derives the SAME object symlink-safely,
+    /// so the allowlist decision and the actual open never diverge — the
+    /// security-round TOCTOU fix). `Err(msg)` = typed `[denied]` refusal,
+    /// already recorded to the sink.
+    ///
+    /// The match is purely LEXICAL here (no canonicalization): ancestor
+    /// symlink safety is enforced at OPEN time by the component-wise
+    /// `O_NOFOLLOW` walk, not by a check-time canonicalize that a later open
+    /// could contradict.
+    pub fn check_write(
+        &self,
+        workspace_root: &Path,
+        resolved: &Path,
+        display_path: &str,
+        tool: &str,
+    ) -> Result<PathBuf, String> {
+        let Some(rel) = workspace_relative(workspace_root, resolved) else {
+            return Err(self.record(
+                workspace_root,
+                tool,
+                format!("`{display_path}` is not inside the workspace."),
+            ));
+        };
+        if self.matcher.is_match(&rel) {
+            Ok(rel)
+        } else {
+            Err(self.record(
+                workspace_root,
+                tool,
+                format!(
+                    "`{display_path}` is outside this task's write grant \
+                     (writable: {}). Everything else is read-only.",
+                    self.patterns_for_message(),
+                ),
+            ))
+        }
+    }
+
+    /// Decide `edit_file`. Under `create_only` EVERY edit is refused —
+    /// allowlisted or not (issue #1976: created, never modified); otherwise
+    /// the allowlist applies exactly as for writes, returning the
+    /// workspace-relative path the caller opens via [`confined_open_rdwr`].
+    pub fn check_edit(
+        &self,
+        workspace_root: &Path,
+        resolved: &Path,
+        display_path: &str,
+        tool: &str,
+    ) -> Result<PathBuf, String> {
+        if self.create_only {
+            return Err(self.record(
+                workspace_root,
+                tool,
+                format!(
+                    "this task's write grant is create-only — `{display_path}` (and every \
+                     other file) may not be edited; allowlisted paths may only be CREATED \
+                     (writable: {}).",
+                    self.patterns_for_message(),
+                ),
+            ));
+        }
+        self.check_write(workspace_root, resolved, display_path, tool)
+    }
+
+    /// The typed refusal for a create-only overwrite (`O_CREAT|O_EXCL` came
+    /// back `AlreadyExists`), recorded to the sink like every violation.
+    pub fn deny_overwrite(&self, workspace_root: &Path, display_path: &str, tool: &str) -> String {
+        self.record(
+            workspace_root,
+            tool,
+            format!(
+                "create-only write grant — `{display_path}` already exists and may not be \
+                 overwritten."
+            ),
+        )
+    }
+
+    /// Map a confined-open/rewrite `io::Error` into a typed `[denied]` (or a
+    /// plain I/O failure), recording the security-relevant cases to the sink.
+    /// `ELOOP` / `ENOTDIR` from the `O_NOFOLLOW` walk means a symlinked
+    /// ancestor (the ancestor-swap TOCTOU) — refuse loudly. `AlreadyExists`
+    /// under `create_only` is the overwrite refusal.
+    pub fn map_confined_error(
+        &self,
+        e: &std::io::Error,
+        workspace_root: &Path,
+        display_path: &str,
+        tool: &str,
+    ) -> String {
+        use std::io::ErrorKind;
+        if self.create_only && e.kind() == ErrorKind::AlreadyExists {
+            return self.deny_overwrite(workspace_root, display_path, tool);
+        }
+        // ELOOP (symlink with O_NOFOLLOW) and ENOTDIR (a non-dir where a dir
+        // component was required) are the ancestor-swap signatures. (`raw` is
+        // scoped to the unix branch so the non-unix build has no unused var.)
+        #[cfg(unix)]
+        let is_symlink_ancestor = {
+            let raw = e.raw_os_error();
+            raw == Some(libc::ELOOP) || raw == Some(libc::ENOTDIR) || raw == Some(libc::EMLINK)
+        };
+        #[cfg(not(unix))]
+        let is_symlink_ancestor = e.kind() == ErrorKind::PermissionDenied;
+        if is_symlink_ancestor {
+            return self.record(
+                workspace_root,
+                tool,
+                format!(
+                    "`{display_path}` traverses a symlinked directory — symlinked ancestors \
+                     are not followed for granted writes (no escape via symlink/rename)."
+                ),
+            );
+        }
+        // A non-security failure (e.g. ENOENT parent for an edit of a missing
+        // file): surface plainly, still sink-recorded so the audit is complete.
+        self.record(
+            workspace_root,
+            tool,
+            format!("`{display_path}` could not be written: {e}"),
+        )
+    }
+
+    fn patterns_for_message(&self) -> String {
+        if self.patterns.is_empty() {
+            "nothing — this grant is read-only".to_string()
+        } else {
+            self.patterns.join(", ")
+        }
+    }
+
+    /// Format the `[denied]` message, push it to the sink, return it.
+    fn record(&self, workspace_root: &Path, tool: &str, detail: String) -> String {
+        let message = format!("{DENIED_MARKER} {tool}: {detail}");
+        if let Some(sink) = &self.sink {
+            sink(WriteGrantViolation {
+                workspace: workspace_root.to_path_buf(),
+                tool: tool.to_owned(),
+                detail: message.clone(),
+            });
+        }
+        tracing::warn!(
+            tool,
+            workspace = %workspace_root.display(),
+            %message,
+            "write grant violation refused",
+        );
+        message
+    }
+}
+
+/// The workspace-RELATIVE form of `resolved` (an absolute path the tool's
+/// scope machinery already confined), or `None` if it is not under the
+/// workspace. Purely lexical `strip_prefix` (the symlink safety is the
+/// confined open's job); falls back to a canonicalized root prefix so a
+/// symlinked workspace root (e.g. cwd under `/tmp` → `/private/tmp`) still
+/// relativizes. A `..`/`.` component (there should be none post-normalize)
+/// makes the confined walk reject it — deny-wins.
+fn workspace_relative(workspace_root: &Path, resolved: &Path) -> Option<PathBuf> {
+    if let Ok(rel) = resolved.strip_prefix(workspace_root) {
+        return Some(rel.to_path_buf());
+    }
+    if let Ok(root_c) = std::fs::canonicalize(workspace_root) {
+        if let Ok(rel) = resolved.strip_prefix(&root_c) {
+            return Some(rel.to_path_buf());
+        }
+    }
+    None
+}
+
+/// The leaf open discipline for the confined walk.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConfinedLeaf {
+    /// `O_CREAT|O_EXCL` — create, refuse if it already exists (`create_only`).
+    CreateNew,
+    /// `O_CREAT|O_TRUNC` — create or overwrite (fenced write, not create_only).
+    CreateOrTruncate,
+    /// `O_RDWR`, no create — the leaf must already exist (fenced edit).
+    OpenExistingRw,
+}
+
+/// #1976 security round — open `workspace_root`/`rel` for writing via a
+/// component-wise `O_NOFOLLOW` `openat` walk, so the opened object is THE SAME
+/// one the allowlist matched (no check-vs-open divergence). Each intermediate
+/// component is opened from the parent dir's fd with `O_NOFOLLOW|O_DIRECTORY`,
+/// so a symlinked — or swapped-to-symlink — ancestor fails `ELOOP`/`ENOTDIR`
+/// at its own component, closing the ancestor-swap TOCTOU. The leaf is opened
+/// `O_NOFOLLOW` with the [`ConfinedLeaf`] discipline. `rustix` wraps the raw
+/// `openat`/`mkdirat` syscalls in a safe API (no `unsafe` under the
+/// workspace-wide `deny(unsafe_code)`).
+#[cfg(unix)]
+pub fn open_confined(
+    workspace_root: &Path,
+    rel: &Path,
+    leaf_mode: ConfinedLeaf,
+) -> std::io::Result<std::fs::File> {
+    use rustix::fs::{Mode, OFlags, RawMode, mkdirat, openat};
+    use std::ffi::OsStr;
+    use std::io;
+    use std::os::fd::OwnedFd;
+
+    // Only Normal components survive (the grant validator + `workspace_relative`
+    // already reject `..`; re-check fail-closed so a `.`/`..`/root can never
+    // re-point the walk).
+    let mut names: Vec<&OsStr> = Vec::new();
+    for comp in rel.components() {
+        match comp {
+            std::path::Component::Normal(name) => names.push(name),
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "write grant: non-normal path component",
+                ));
+            }
+        }
+    }
+    let Some((leaf, ancestors)) = names.split_last() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "write grant: empty relative path",
+        ));
+    };
+
+    // Anchor at the CANONICAL workspace root: resolving the trusted root's OWN
+    // symlinks is intended; the fence guards components UNDER it. The canonical
+    // root has no symlink components, so a plain `O_DIRECTORY` open is safe.
+    let root_real = std::fs::canonicalize(workspace_root)?;
+    let dir_flags = OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC;
+    let mut dir: OwnedFd = openat(
+        rustix::fs::CWD,
+        root_real.as_path(),
+        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+        Mode::empty(),
+    )?;
+
+    let create_parents = matches!(
+        leaf_mode,
+        ConfinedLeaf::CreateNew | ConfinedLeaf::CreateOrTruncate
+    );
+    let dir_mode = Mode::from_raw_mode(0o755 as RawMode);
+    for name in ancestors {
+        dir = match openat(&dir, *name, dir_flags, Mode::empty()) {
+            Ok(fd) => fd,
+            Err(rustix::io::Errno::NOENT) if create_parents => {
+                // Create the missing intermediate FROM this dirfd (never
+                // through a symlink), then reopen it `O_NOFOLLOW`.
+                mkdirat(&dir, *name, dir_mode)?;
+                openat(&dir, *name, dir_flags, Mode::empty())?
+            }
+            Err(e) => return Err(io::Error::from(e)),
+        };
+    }
+
+    let leaf_flags = OFlags::NOFOLLOW
+        | OFlags::CLOEXEC
+        | match leaf_mode {
+            ConfinedLeaf::CreateNew => OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL,
+            ConfinedLeaf::CreateOrTruncate => OFlags::WRONLY | OFlags::CREATE | OFlags::TRUNC,
+            ConfinedLeaf::OpenExistingRw => OFlags::RDWR,
+        };
+    let leaf_fd = openat(
+        &dir,
+        *leaf,
+        leaf_flags,
+        Mode::from_raw_mode(0o644 as RawMode),
+    )?;
+    Ok(std::fs::File::from(leaf_fd))
+}
+
+/// Non-Unix fallback for [`open_confined`].
+///
+/// **KNOWN LIMITATION (non-Unix only; fleet workers run on Unix).** Without
+/// `openat`, this cannot walk the path component-by-component race-free, so it
+/// approximates: an ancestor `symlink_metadata` scan up to the root, then a
+/// leaf open at the lexically-joined path. Precisely:
+/// - [`ConfinedLeaf::CreateNew`] is race-free at the LEAF — `create_new(true)`
+///   is `O_CREAT|O_EXCL`, which atomically refuses a pre-existing file OR
+///   symlink at the leaf; parents are created first (parity with Unix).
+/// - [`ConfinedLeaf::CreateOrTruncate`] / [`ConfinedLeaf::OpenExistingRw`] use
+///   a check-then-open leaf symlink test that is inherently TOCTOU-racy, and
+///   the ANCESTOR `lstat` scan is likewise racy against a concurrent swap.
+///
+/// This path is therefore a best-effort DEGRADED fallback, NOT the race-free
+/// security boundary the Unix `openat` walk provides. The tool-layer allowlist
+/// still applies on every platform; only the OS-level ancestor-swap defense is
+/// weaker here.
+#[cfg(not(unix))]
+pub fn open_confined(
+    workspace_root: &Path,
+    rel: &Path,
+    leaf_mode: ConfinedLeaf,
+) -> std::io::Result<std::fs::File> {
+    use std::io;
+    let full = workspace_root.join(rel);
+    // Best-effort: reject if any ancestor up to the root is a symlink (racy —
+    // see the KNOWN LIMITATION above).
+    let mut cur = full.parent();
+    while let Some(dir) = cur {
+        if dir == workspace_root {
+            break;
+        }
+        if dir.symlink_metadata().is_ok_and(|m| m.is_symlink()) {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "symlinked ancestor",
+            ));
+        }
+        cur = dir.parent();
+    }
+    // Create missing parents for BOTH create modes (parity with the Unix walk's
+    // `mkdirat`), so a fenced create of `dir/leaf` behaves the same per-OS.
+    if matches!(
+        leaf_mode,
+        ConfinedLeaf::CreateNew | ConfinedLeaf::CreateOrTruncate
+    ) {
+        if let Some(parent) = full.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let mut opts = std::fs::OpenOptions::new();
+    match leaf_mode {
+        // `create_new` == O_CREAT|O_EXCL: atomically refuses an existing file
+        // or symlink at the leaf, so no separate (racy) leaf check is needed.
+        ConfinedLeaf::CreateNew => {
+            opts.write(true).create_new(true);
+            return opts.open(&full);
+        }
+        ConfinedLeaf::CreateOrTruncate => {
+            opts.write(true).create(true).truncate(true);
+        }
+        ConfinedLeaf::OpenExistingRw => {
+            opts.read(true).write(true);
+        }
+    }
+    // Racy leaf symlink test for the non-exclusive modes (documented residual).
+    if full.symlink_metadata().is_ok_and(|m| m.is_symlink()) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "symlink leaf",
+        ));
+    }
+    opts.open(&full)
+}
+
+/// Confined create/overwrite: open `rel` via [`open_confined`] and write
+/// `content` to it, off the reactor (`spawn_blocking`). Returns the raw
+/// `io::Error` for the caller to map through
+/// [`WritePathGrant::map_confined_error`].
+pub async fn confined_write(
+    workspace_root: PathBuf,
+    rel: PathBuf,
+    content: Vec<u8>,
+    create_only: bool,
+) -> std::io::Result<()> {
+    tokio::task::spawn_blocking(move || {
+        use std::io::Write;
+        let leaf_mode = if create_only {
+            ConfinedLeaf::CreateNew
+        } else {
+            ConfinedLeaf::CreateOrTruncate
+        };
+        let mut file = open_confined(&workspace_root, &rel, leaf_mode)?;
+        file.write_all(&content)?;
+        Ok(())
+    })
+    .await
+    .unwrap_or_else(|e| Err(std::io::Error::other(e)))
+}
+
+/// Confined edit — phase 1: open the existing leaf `O_RDWR` via
+/// [`open_confined`] and read its contents, returning BOTH the open handle and
+/// the bytes. The SAME handle is handed to [`confined_rewrite`] for the
+/// write-back, so read and write bind to one walked object (no re-open, no
+/// ancestor-swap window between them).
+pub async fn confined_open_rdwr(
+    workspace_root: PathBuf,
+    rel: PathBuf,
+) -> std::io::Result<(std::fs::File, String)> {
+    tokio::task::spawn_blocking(move || {
+        use std::io::Read;
+        let mut file = open_confined(&workspace_root, &rel, ConfinedLeaf::OpenExistingRw)?;
+        let mut content = String::new();
+        file.read_to_string(&mut content)?;
+        Ok((file, content))
+    })
+    .await
+    .unwrap_or_else(|e| Err(std::io::Error::other(e)))
+}
+
+/// Confined edit — phase 2: rewrite the file handle from [`confined_open_rdwr`]
+/// with `new_content` (truncate + write from offset 0), off the reactor. The
+/// handle is the same object phase 1 opened, so the edit never re-resolves the
+/// path (closing the read-vs-write TOCTOU an ancestor swap would exploit).
+pub async fn confined_rewrite(
+    mut file: std::fs::File,
+    new_content: Vec<u8>,
+) -> std::io::Result<()> {
+    tokio::task::spawn_blocking(move || {
+        use std::io::{Seek, SeekFrom, Write};
+        file.seek(SeekFrom::Start(0))?;
+        file.set_len(0)?;
+        file.write_all(&new_content)?;
+        Ok(())
+    })
+    .await
+    .unwrap_or_else(|e| Err(std::io::Error::other(e)))
+}
+
+/// v1 pattern validation — the octos-agent twin of
+/// `octos_fleet::validate_write_path_pattern` (kept textually close on
+/// purpose; this crate has no octos-fleet dependency). Plan-time validation
+/// already rejected these for fleet grants; re-checking here fails closed for
+/// any programmatic caller.
+fn validate_pattern(pattern: &str) -> eyre::Result<()> {
+    let bail = |reason: &str| eyre::bail!("write grant pattern `{pattern}` is invalid: {reason}");
+    if pattern.is_empty() {
+        return bail("pattern is empty");
+    }
+    if Path::new(pattern).is_absolute() || pattern.starts_with('/') {
+        return bail("pattern must be workspace-relative");
+    }
+    if pattern.bytes().any(|b| b < 0x20 || b == 0x7F) {
+        return bail("pattern contains control characters");
+    }
+    if pattern.contains("**") {
+        return bail("recursive `**` globs are not supported in v1");
+    }
+    for ch in ['(', ')', '\\', '"', ':', '[', ']', '{', '}'] {
+        if pattern.contains(ch) {
+            return bail("pattern contains unsupported metacharacters");
+        }
+    }
+    for segment in pattern.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return bail("`.`/`..`/empty path segments are not allowed");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    fn grant(patterns: &[&str], create_only: bool) -> WritePathGrant {
+        let owned: Vec<String> = patterns.iter().map(|s| s.to_string()).collect();
+        WritePathGrant::new(&owned, create_only).expect("test grant compiles")
+    }
+
+    #[test]
+    fn write_grant_matches_workspace_relative_globs() {
+        let dir = tempfile::tempdir().unwrap();
+        let g = grant(&["exemplar.card", "cards/*.card"], false);
+
+        let ok = |rel: &str| {
+            g.check_write(dir.path(), &dir.path().join(rel), rel, "write_file")
+                .is_ok()
+        };
+        assert!(ok("exemplar.card"));
+        assert!(ok("cards/a.card"));
+        // Exact-name glob does not match extensions of it.
+        assert!(!ok("exemplar.card.bak"));
+        // `*` must not cross `/` (literal_separator).
+        assert!(!ok("cards/nested/b.card"));
+        assert!(!ok("app.md"));
+    }
+
+    #[test]
+    fn write_grant_rejects_invalid_patterns_at_construction() {
+        for bad in ["../up", "/abs", "a/**", "a[b]", "a{b}", "a:b", "", "a//b"] {
+            assert!(
+                WritePathGrant::new(&[bad.to_string()], false).is_err(),
+                "pattern {bad:?} must fail to compile",
+            );
+        }
+    }
+
+    #[test]
+    fn write_grant_denial_records_to_sink_with_denied_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let seen: Arc<Mutex<Vec<WriteGrantViolation>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_seen = seen.clone();
+        let g = grant(&["exemplar.card"], true).with_violation_sink(Arc::new(move |v| {
+            sink_seen.lock().unwrap().push(v);
+        }));
+
+        let denied = g
+            .check_write(
+                dir.path(),
+                &dir.path().join("app.md"),
+                "app.md",
+                "write_file",
+            )
+            .expect_err("app.md is outside the grant");
+        assert!(denied.contains(DENIED_MARKER), "typed refusal: {denied}");
+        assert!(denied.contains("app.md"));
+        assert!(denied.contains("exemplar.card"), "message lists the grant");
+
+        let overwrite = g.deny_overwrite(dir.path(), "exemplar.card", "write_file");
+        assert!(overwrite.contains(DENIED_MARKER));
+        assert!(overwrite.contains("already exists"));
+
+        let events = seen.lock().unwrap();
+        assert_eq!(events.len(), 2, "both violations recorded");
+        assert_eq!(events[0].tool, "write_file");
+        assert_eq!(events[0].workspace, dir.path());
+        assert!(events[0].detail.contains(DENIED_MARKER));
+    }
+
+    #[test]
+    fn write_grant_create_only_refuses_every_edit() {
+        let dir = tempfile::tempdir().unwrap();
+        let g = grant(&["exemplar.card"], true);
+        // Even the ALLOWLISTED path may not be edited under create_only.
+        let denied = g
+            .check_edit(
+                dir.path(),
+                &dir.path().join("exemplar.card"),
+                "exemplar.card",
+                "edit_file",
+            )
+            .expect_err("create_only refuses edits");
+        assert!(denied.contains("create-only"), "{denied}");
+
+        // Without create_only, edits follow the allowlist.
+        let g = grant(&["exemplar.card"], false);
+        assert!(
+            g.check_edit(
+                dir.path(),
+                &dir.path().join("exemplar.card"),
+                "exemplar.card",
+                "edit_file",
+            )
+            .is_ok()
+        );
+        assert!(
+            g.check_edit(
+                dir.path(),
+                &dir.path().join("app.md"),
+                "app.md",
+                "edit_file"
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn write_grant_empty_allowlist_denies_all_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let g = grant(&[], false);
+        let denied = g
+            .check_write(dir.path(), &dir.path().join("x.txt"), "x.txt", "write_file")
+            .expect_err("empty allowlist = read-only");
+        assert!(denied.contains("read-only"), "{denied}");
+    }
+
+    #[test]
+    fn check_write_is_lexical_symlink_safety_is_the_open() {
+        // Security round: `check_write` is now a PURELY LEXICAL allowlist
+        // decision returning the relative path — it does NOT touch the
+        // filesystem (the confined open enforces symlink safety). A matching
+        // path returns Ok(rel) regardless of on-disk symlinks; a symlinked
+        // ancestor is refused later, at `open_confined`.
+        let dir = tempfile::tempdir().unwrap();
+        let g = grant(&["cards/*.card"], false);
+        let rel = g
+            .check_write(
+                dir.path(),
+                &dir.path().join("cards/a.card"),
+                "cards/a.card",
+                "write_file",
+            )
+            .expect("lexical match returns the relative path");
+        assert_eq!(rel, std::path::Path::new("cards/a.card"));
+    }
+
+    // ------------------------------------------------------------------
+    // Security round (codex): the component-wise O_NOFOLLOW confined walk
+    // is what makes the checked path and the opened object THE SAME, closing
+    // the ancestor-swap TOCTOU. These exercise `open_confined` directly.
+    // ------------------------------------------------------------------
+
+    #[cfg(unix)]
+    #[test]
+    fn write_no_follow_follows_ancestor_symlink_the_gap_confined_open_closes() {
+        // RED/motivation: the OLD fenced write used `write_no_follow(lexical)`,
+        // whose leaf-only O_NOFOLLOW FOLLOWS a symlinked ANCESTOR — the exact
+        // escape. Prove the gap concretely so the confined-open fix is
+        // grounded, not theoretical.
+        use std::os::unix::fs::symlink;
+        let ws = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), ws.path().join("cards")).unwrap();
+
+        // Leaf-only O_NOFOLLOW open of `<ws>/cards/x.card` follows `cards`.
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let res = rt.block_on(crate::tools::write_no_follow(
+            &ws.path().join("cards/x.card"),
+            b"escaped\n",
+        ));
+        assert!(
+            res.is_ok(),
+            "the OLD primitive follows the ancestor symlink"
+        );
+        assert!(
+            outside.path().join("x.card").exists(),
+            "demonstrates the escape the confined walk must close",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_confined_refuses_symlinked_ancestor() {
+        // The fix: a symlinked ancestor fails at its own component (ELOOP /
+        // ENOTDIR), so nothing is created at the symlink target.
+        use std::os::unix::fs::symlink;
+        let ws = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), ws.path().join("cards")).unwrap();
+
+        let err = open_confined(
+            ws.path(),
+            std::path::Path::new("cards/x.card"),
+            ConfinedLeaf::CreateOrTruncate,
+        )
+        .expect_err("symlinked ancestor must be refused");
+        assert!(
+            matches!(err.raw_os_error(), Some(libc::ELOOP) | Some(libc::ENOTDIR)),
+            "expected ELOOP/ENOTDIR, got {err:?}",
+        );
+        assert!(
+            !outside.path().join("x.card").exists(),
+            "nothing may land at the symlink target",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_confined_toctou_ancestor_swap_after_stage_is_refused() {
+        // The coordinator's scenario, deterministic: a REAL `cards/` exists
+        // (an allowlist check would pass), THEN `cards` is swapped for a
+        // symlink to outside; the confined open refuses at the `cards`
+        // component. This is the TOCTOU the fix eliminates — check and open are
+        // one walked object.
+        use std::os::unix::fs::symlink;
+        let ws = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::create_dir(ws.path().join("cards")).unwrap();
+
+        // ... time passes; attacker swaps the checked dir for a symlink ...
+        std::fs::remove_dir(ws.path().join("cards")).unwrap();
+        symlink(outside.path(), ws.path().join("cards")).unwrap();
+
+        let err = open_confined(
+            ws.path(),
+            std::path::Path::new("cards/loot.card"),
+            ConfinedLeaf::CreateOrTruncate,
+        )
+        .expect_err("swapped ancestor must be refused at open");
+        assert!(matches!(
+            err.raw_os_error(),
+            Some(libc::ELOOP) | Some(libc::ENOTDIR)
+        ));
+        assert!(!outside.path().join("loot.card").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_confined_creates_inside_real_dirs_and_mkdir_parents() {
+        let ws = tempfile::tempdir().unwrap();
+        // Missing intermediate dir is created safely (mkdirat in the walk).
+        let file = open_confined(
+            ws.path(),
+            std::path::Path::new("cards/a.card"),
+            ConfinedLeaf::CreateOrTruncate,
+        )
+        .expect("create inside real dirs");
+        drop(file);
+        assert!(ws.path().join("cards/a.card").exists());
+        // Overwrite (CreateOrTruncate) succeeds; content truncated.
+        std::fs::write(ws.path().join("cards/a.card"), "old-and-long").unwrap();
+        let mut f = open_confined(
+            ws.path(),
+            std::path::Path::new("cards/a.card"),
+            ConfinedLeaf::CreateOrTruncate,
+        )
+        .expect("overwrite ok");
+        use std::io::Write;
+        f.write_all(b"new").unwrap();
+        drop(f);
+        assert_eq!(
+            std::fs::read_to_string(ws.path().join("cards/a.card")).unwrap(),
+            "new"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_confined_create_new_refuses_existing() {
+        let ws = tempfile::tempdir().unwrap();
+        open_confined(
+            ws.path(),
+            std::path::Path::new("x.card"),
+            ConfinedLeaf::CreateNew,
+        )
+        .expect("first create ok");
+        let err = open_confined(
+            ws.path(),
+            std::path::Path::new("x.card"),
+            ConfinedLeaf::CreateNew,
+        )
+        .expect_err("O_EXCL refuses the second create");
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_confined_rdwr_requires_existing() {
+        let ws = tempfile::tempdir().unwrap();
+        assert!(
+            open_confined(
+                ws.path(),
+                std::path::Path::new("missing.card"),
+                ConfinedLeaf::OpenExistingRw,
+            )
+            .is_err(),
+            "rdwr does not create",
+        );
+        std::fs::write(ws.path().join("here.card"), "v1").unwrap();
+        assert!(
+            open_confined(
+                ws.path(),
+                std::path::Path::new("here.card"),
+                ConfinedLeaf::OpenExistingRw,
+            )
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn confined_write_and_rewrite_round_trip() {
+        let ws = tempfile::tempdir().unwrap();
+        confined_write(
+            ws.path().to_path_buf(),
+            std::path::PathBuf::from("note.txt"),
+            b"hello\n".to_vec(),
+            false,
+        )
+        .await
+        .expect("confined write");
+        let (file, content) = confined_open_rdwr(
+            ws.path().to_path_buf(),
+            std::path::PathBuf::from("note.txt"),
+        )
+        .await
+        .expect("confined open rdwr");
+        assert_eq!(content, "hello\n");
+        confined_rewrite(file, b"world\n".to_vec())
+            .await
+            .expect("confined rewrite");
+        assert_eq!(
+            std::fs::read_to_string(ws.path().join("note.txt")).unwrap(),
+            "world\n"
+        );
+    }
+}

--- a/crates/octos-agent/tests/security_sandbox.rs
+++ b/crates/octos-agent/tests/security_sandbox.rs
@@ -451,6 +451,7 @@ fn should_restrict_reads_when_configured() {
         repo_git_write: None,
         docker: octos_agent::sandbox::DockerConfig::default(),
         read_allow_paths: vec!["/usr".into(), "/opt/custom".into()],
+        write_allow_globs: None,
         profile_name: None,
     };
     let sandbox = octos_agent::create_sandbox(&config);
@@ -678,6 +679,7 @@ fn should_block_dangerous_docker_cwd() {
         repo_git_write: None,
         docker: DockerConfig::default(),
         read_allow_paths: Vec::new(),
+        write_allow_globs: None,
         profile_name: None,
     });
 

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -4804,6 +4804,128 @@ impl InProcessAgentOrchestrator {
         Ok((finding_id, goal_row.status == "active"))
     }
 
+    /// #1976 — record a fleet worker's per-path WRITE-grant violation as a
+    /// `[denied]`-class finding in the offending task's goal ledger. The wire
+    /// for the file tools' `WriteGrantViolationSink`: the tool already
+    /// returned the refusal to the model (never silent); THIS makes it
+    /// DURABLE audit alongside the peer/verifier findings the master lists.
+    ///
+    /// Unlike [`Self::model_goal_record_peer_finding`] this is HOST-generated
+    /// (not a model call), so there is no token charge and no originator
+    /// auth: the grant itself is the authority. The violation carries the
+    /// worker's `workspace` (`<fleet-work>/<fleet_id>/<task_id>`), from which
+    /// we recover `fleet_id`/`task_id` and resolve the goal that binds the
+    /// fleet under `profile_id`. Best-effort by contract — a resolution miss
+    /// or ledger error is logged and dropped (the tool refusal already
+    /// bounded the worker); it never blocks the worker.
+    pub(crate) fn record_fleet_write_grant_denial(
+        &self,
+        profile_data_dir: &std::path::Path,
+        profile_id: &str,
+        workspace: &std::path::Path,
+        detail: &str,
+    ) {
+        // `<...>/fleet-work/<fleet_id>/<task_id>` — the pool's per-attempt cwd.
+        let mut components = workspace.components().rev();
+        let task_id = components
+            .next()
+            .map(|c| c.as_os_str().to_string_lossy().into_owned());
+        let fleet_id = components
+            .next()
+            .map(|c| c.as_os_str().to_string_lossy().into_owned());
+        let (Some(task_id), Some(fleet_id)) = (task_id, fleet_id) else {
+            tracing::warn!(
+                workspace = %workspace.display(),
+                "write-grant denial: could not recover fleet/task from workspace path; dropping finding"
+            );
+            return;
+        };
+        // Resolve the goal that binds THIS fleet under this profile (the
+        // reverse of `goal_bound_fleet_id`). Capture the authoritative goal
+        // row so the ledger's goals FK row is real, mirroring the peer path.
+        let goal_row = {
+            let state = self.state();
+            state
+                .goals
+                .values()
+                .find(|goal| {
+                    goal.fleet_id.as_deref() == Some(fleet_id.as_str())
+                        && goal.profile_id == profile_id
+                })
+                .map(|goal| octos_fleet::Goal {
+                    goal_id: goal.goal_id.clone(),
+                    objective: goal.objective.clone(),
+                    status: goal.status.clone(),
+                    tokens_used: goal.tokens_used,
+                    token_budget: goal.token_budget,
+                    continuations_used: goal.continuations_used,
+                    revision: 0, // preserved on conflict by upsert_goal
+                    created_at_ms: goal.created_at_ms.max(0) as u64,
+                    updated_at_ms: goal.updated_at_ms.max(0) as u64,
+                })
+        };
+        let Some(goal_row) = goal_row else {
+            tracing::warn!(
+                %fleet_id,
+                %profile_id,
+                "write-grant denial: no goal binds this fleet; dropping finding (tool already refused)"
+            );
+            return;
+        };
+        let goal_id = goal_row.goal_id.clone();
+        let ledger_dir = Self::goal_ledger_dir(profile_data_dir);
+        if let Err(e) = std::fs::create_dir_all(&ledger_dir) {
+            tracing::warn!(error = %e, "write-grant denial: cannot create ledger dir; dropping finding");
+            return;
+        }
+        let ledger_path = ledger_dir.join(format!("{}.db", sanitize_filename_for_ledger(&goal_id)));
+        let Ok(ledger) = octos_fleet::GoalLedger::open(&ledger_path) else {
+            tracing::warn!(path = %ledger_path.display(), "write-grant denial: cannot open ledger; dropping finding");
+            return;
+        };
+        // FK: goals row before findings; task stub before a task-scoped finding.
+        let _ = ledger.upsert_goal(&goal_row);
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let task_stub = octos_fleet::Task {
+            task_id: task_id.clone(),
+            goal_id: goal_id.clone(),
+            title: String::new(),
+            detail: String::new(),
+            status: "running".to_owned(),
+            assigned_peer: None,
+            created_at_ms: now_ms,
+            updated_at_ms: now_ms,
+        };
+        let _ = ledger.create_task(&task_stub);
+        let finding = octos_fleet::Finding {
+            rowid: None,
+            finding_id: format!("denied-{fleet_id}-{}", uuid::Uuid::now_v7()),
+            seq: 0,
+            task_id: Some(task_id),
+            goal_id,
+            // A denied write is a hard, evidenced CONSTRAINT the worker hit —
+            // high confidence (it is a fact: the write was refused).
+            kind: "constraint".to_owned(),
+            lifecycle: "observed".to_owned(),
+            confidence: "high".to_owned(),
+            review_state: "unreviewed".to_owned(),
+            assertion: detail.chars().take(500).collect(),
+            evidence: None,
+            config_version: None,
+            derived_from: None,
+            supersedes: Vec::new(),
+            cost_tokens: 0,
+            created_at_ms: now_ms,
+            created_by: "host:write-grant".to_owned(),
+        };
+        if let Err(e) = ledger.append_finding(&finding) {
+            tracing::warn!(error = %e, "write-grant denial: append_finding failed; dropping");
+        }
+    }
+
     /// Peer-agent-based goal: record a peer escalation into the goal's
     /// durable ledger. This is the WIRE for `append_escalation` — called
     /// when a goal-scoped peer parks on `awaiting_input` (approval /

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -995,16 +995,56 @@ impl ServeCommand {
                                 let mut cfg = sandbox_cfg.clone();
                                 cfg.allow_network = grant.allow_network;
                                 cfg.repo_git_write = grant.repo_git_dir;
+                                // #1976 — fold the per-path SHELL write fence
+                                // onto the base config. macOS enforces it as
+                                // SBPL regex rules; bwrap/docker degrade the
+                                // workspace to read-only for the shell (warned
+                                // in create_sandbox). Deny-wins with the file
+                                // tools' own fence.
+                                cfg.write_allow_globs = grant.write_allow_globs;
                                 Arc::<dyn octos_agent::sandbox::Sandbox>::from(
                                     octos_agent::sandbox::create_sandbox(&cfg),
                                 )
                             },
                         );
-                        let factory = Arc::new(octos_fleet_worker::AgentFactory::new(
-                            rt.llm.clone(),
-                            rt.memory.clone(),
-                            sandbox_factory,
-                        ));
+                        // #1976 — the `[denied]` write-grant violation sink:
+                        // a fenced worker's refused write is returned to the
+                        // model by the tool AND recorded here as a durable
+                        // `[denied]`-class finding on the offending task's
+                        // goal ledger. Detached to the blocking pool (sqlite
+                        // I/O) so a rare violation never stalls the worker's
+                        // async turn. Best-effort — the tool refusal already
+                        // bounded the write.
+                        let denial_data_dir = rt.data_dir.clone();
+                        let denial_profile_id = rt.profile_id.clone();
+                        let violation_sink: octos_agent::tools::write_grant::WriteGrantViolationSink =
+                            Arc::new(move |v: octos_agent::tools::write_grant::WriteGrantViolation| {
+                                let data_dir = denial_data_dir.clone();
+                                let profile_id = denial_profile_id.clone();
+                                let record = move || {
+                                    crate::api::agent_orchestrator::default_agent_orchestrator()
+                                        .record_fleet_write_grant_denial(
+                                            &data_dir,
+                                            &profile_id,
+                                            &v.workspace,
+                                            &v.detail,
+                                        );
+                                };
+                                match tokio::runtime::Handle::try_current() {
+                                    Ok(handle) => {
+                                        handle.spawn_blocking(record);
+                                    }
+                                    Err(_) => record(),
+                                }
+                            });
+                        let factory = Arc::new(
+                            octos_fleet_worker::AgentFactory::new(
+                                rt.llm.clone(),
+                                rt.memory.clone(),
+                                sandbox_factory,
+                            )
+                            .with_violation_sink(violation_sink),
+                        );
                         let cfg = octos_fleet_worker::PoolConfig {
                             global_concurrency: FLEET_POOL_GLOBAL_CONCURRENCY,
                             per_fleet_concurrency: FLEET_POOL_PER_FLEET_CONCURRENCY,

--- a/crates/octos-cli/src/goal_tool.rs
+++ b/crates/octos-cli/src/goal_tool.rs
@@ -143,10 +143,15 @@ fn parse_task_specs(args: &Value) -> Result<Vec<TaskSpec>, String> {
 /// Wire shape:
 /// `{ "network": { "mode": "none"|"hosts"|"full", "hosts": ["example.com"] },
 ///    "tools": ["read_file", ..., "web_fetch"],
-///    "fs": "workspace"|"host" }`
+///    "fs": "workspace"|"host"
+///        | { "write": ["exemplar.card", "cards/*.card"], "create_only": true } }`
 ///
-/// `fs` is the coarse binary scope (v1 has no per-path allowlist — see
-/// [`parse_fs`]), NOT a `{read, write}` path object.
+/// `fs` is the coarse binary scope as a STRING, or (#1976) the per-path WRITE
+/// fence as an OBJECT: a workspace-relative allowlist of writable paths
+/// (`*`/`?` globs) with optional `create_only` (allowlisted paths may be
+/// created but never overwritten/edited). The object form always implies the
+/// workspace scope — reads stay workspace-wide, writes narrow to the list.
+/// See [`parse_fs`].
 fn parse_grant(value: Option<&Value>, task_id: &str) -> Result<WorkerGrant, String> {
     let value = match value {
         None | Some(Value::Null) => return Ok(WorkerGrant::minimal()),
@@ -181,11 +186,17 @@ fn parse_grant(value: Option<&Value>, task_id: &str) -> Result<WorkerGrant, Stri
     };
 
     let fs = match obj.get("fs") {
-        None | Some(Value::Null) => FsGrant::Workspace,
+        None | Some(Value::Null) => ParsedFs::default(),
         Some(fs) => parse_fs(fs, task_id)?,
     };
 
-    let grant = WorkerGrant { network, tools, fs };
+    let grant = WorkerGrant {
+        network,
+        tools,
+        fs: fs.scope,
+        write_paths: fs.write_paths,
+        create_only: fs.create_only,
+    };
     grant
         .validate()
         .map_err(|e| format!("task `{task_id}`: {e}"))?;
@@ -233,17 +244,83 @@ fn parse_network(value: &Value, task_id: &str) -> Result<NetworkGrant, String> {
     }
 }
 
-/// Parse the coarse `fs` scope — the string `"workspace"` (cwd-only, the
-/// default) or `"host"` (full daemon-user read+write). v1 is deliberately
-/// binary: the native tools have no per-path allowlist, so a narrow-paths grant
-/// is not offered here (it would falsely promise narrow but deliver host-wide).
-fn parse_fs(value: &Value, task_id: &str) -> Result<FsGrant, String> {
+/// The parsed `fs` lane of a grant: the coarse scope plus (#1976) the
+/// optional per-path write fence. Default = workspace scope, no fence —
+/// exactly the pre-#1976 behaviour for an absent `fs`.
+#[derive(Default)]
+struct ParsedFs {
+    scope: FsGrant,
+    write_paths: Option<Vec<String>>,
+    create_only: bool,
+}
+
+/// Parse the `fs` lane — either the coarse binary scope as a STRING
+/// (`"workspace"` cwd-only, the default; `"host"` full daemon-user
+/// read+write) or (#1976) the per-path WRITE fence as an OBJECT:
+/// `{ "write": ["exemplar.card", "cards/*.card"], "create_only": true }`.
+/// The object form always implies the workspace scope (a fence under `host`
+/// is incoherent — `WorkerGrant::validate` also rejects the programmatic
+/// combination); pattern syntax is validated there too (`*`/`?` globs,
+/// relative, no `..`). `write` is REQUIRED in the object form so `fs: {}`
+/// cannot silently mean "no fence".
+fn parse_fs(value: &Value, task_id: &str) -> Result<ParsedFs, String> {
+    if let Some(obj) = value.as_object() {
+        for key in obj.keys() {
+            if key != "write" && key != "create_only" {
+                return Err(format!(
+                    "task `{task_id}`: unknown `grant.fs` key `{key}` (use `write` and \
+                     `create_only`)"
+                ));
+            }
+        }
+        let write_paths = match obj.get("write") {
+            Some(Value::Array(items)) => {
+                let mut paths = Vec::with_capacity(items.len());
+                for item in items {
+                    let pattern = item.as_str().map(str::trim).ok_or_else(|| {
+                        format!(
+                            "task `{task_id}`: each `grant.fs.write` entry must be a \
+                             workspace-relative path pattern"
+                        )
+                    })?;
+                    paths.push(pattern.to_owned());
+                }
+                paths
+            }
+            _ => {
+                return Err(format!(
+                    "task `{task_id}`: `grant.fs.write` (array of workspace-relative path \
+                     patterns) is required in the object form of `grant.fs`"
+                ));
+            }
+        };
+        let create_only = match obj.get("create_only") {
+            None | Some(Value::Null) => false,
+            Some(Value::Bool(flag)) => *flag,
+            Some(_) => {
+                return Err(format!(
+                    "task `{task_id}`: `grant.fs.create_only` must be a boolean"
+                ));
+            }
+        };
+        return Ok(ParsedFs {
+            scope: FsGrant::Workspace,
+            write_paths: Some(write_paths),
+            create_only,
+        });
+    }
     let mode = value.as_str().map(str::trim).ok_or_else(|| {
-        format!("task `{task_id}`: `grant.fs` must be the string \"workspace\" or \"host\"")
+        format!(
+            "task `{task_id}`: `grant.fs` must be the string \"workspace\" or \"host\", or \
+             the per-path object {{\"write\": [...], \"create_only\": bool}}"
+        )
     })?;
     match mode.to_ascii_lowercase().as_str() {
-        "workspace" => Ok(FsGrant::Workspace),
-        "host" => Ok(FsGrant::Host),
+        "workspace" => Ok(ParsedFs::default()),
+        "host" => Ok(ParsedFs {
+            scope: FsGrant::Host,
+            ..ParsedFs::default()
+        }),
         other => Err(format!(
             "task `{task_id}`: unknown fs scope `{other}` (use \"workspace\" or \"host\")"
         )),
@@ -584,9 +661,26 @@ impl Tool for GoalPlanTool {
                                         "description": "The tools the worker may hold. Omit = the base file tools (read_file/write_file/edit_file/glob/grep/list_dir/shell). Add web_fetch/web_search (each REQUIRES a network grant)."
                                     },
                                     "fs": {
-                                        "type": "string",
-                                        "enum": ["workspace", "host"],
-                                        "description": "Filesystem reach. Omit = workspace (the worker's own scratch dir only, read+write). host = FULL daemon-user filesystem read+write (broad — grant only when a task genuinely needs host access). v1 is binary: narrow per-path grants are not yet supported."
+                                        "description": "Filesystem reach. Omit = workspace (the worker's own scratch dir only, read+write). String \"host\" = FULL daemon-user filesystem read+write (broad — grant only when a task genuinely needs host access). OBJECT = per-path WRITE fence (#1976): {\"write\": [\"exemplar.card\", \"cards/*.card\"], \"create_only\": true} — the worker may WRITE only the listed workspace-relative paths (globs: * and ? within one path segment; no **), everything else is read-only, kernel-enforced (file tools + shell sandbox). create_only additionally means listed paths may be CREATED but never overwritten/edited.",
+                                        "oneOf": [
+                                            { "type": "string", "enum": ["workspace", "host"] },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "write": {
+                                                        "type": "array",
+                                                        "items": { "type": "string" },
+                                                        "description": "Workspace-relative writable path patterns (* and ? globs). Everything else is read-only."
+                                                    },
+                                                    "create_only": {
+                                                        "type": "boolean",
+                                                        "description": "Listed paths may be created but never overwritten, edited, or deleted."
+                                                    }
+                                                },
+                                                "required": ["write"],
+                                                "additionalProperties": false
+                                            }
+                                        ]
                                     }
                                 },
                                 "additionalProperties": false
@@ -816,7 +910,21 @@ impl Tool for GoalGrantTool {
                             "additionalProperties": false
                         },
                         "tools": { "type": "array", "items": { "type": "string" } },
-                        "fs": { "type": "string", "enum": ["workspace", "host"] }
+                        "fs": {
+                            "description": "\"workspace\" | \"host\", or the #1976 per-path write fence object {\"write\": [globs], \"create_only\": bool} (same shape as goal_plan's task grant).",
+                            "oneOf": [
+                                { "type": "string", "enum": ["workspace", "host"] },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "write": { "type": "array", "items": { "type": "string" } },
+                                        "create_only": { "type": "boolean" }
+                                    },
+                                    "required": ["write"],
+                                    "additionalProperties": false
+                                }
+                            ]
+                        }
                     },
                     "additionalProperties": false
                 }
@@ -1928,6 +2036,102 @@ mod tests {
         let specs = parse_task_specs(&full).expect("parses");
         assert_eq!(specs[0].grant.network, NetworkGrant::Full);
         assert_eq!(specs[0].grant.fs, FsGrant::Workspace);
+    }
+
+    #[test]
+    fn goal_plan_parses_per_path_write_grant() {
+        // #1976 — the object form of `fs` expresses a per-path WRITE fence:
+        // `{ "write": [globs], "create_only": bool }`. The fs scope stays
+        // Workspace (a fence is only coherent there) and the allowlist +
+        // create_only land on the grant verbatim.
+        let args = json!({
+            "tasks": [ {
+                "task_id": "refine",
+                "title": "refine the exemplar",
+                "grant": {
+                    "fs": { "write": ["exemplar.card", "cards/*.card"], "create_only": true }
+                }
+            } ]
+        });
+        let specs = parse_task_specs(&args).expect("parses");
+        let grant = &specs[0].grant;
+        assert_eq!(grant.fs, FsGrant::Workspace);
+        assert_eq!(
+            grant.write_paths,
+            Some(vec![
+                "exemplar.card".to_string(),
+                "cards/*.card".to_string()
+            ]),
+        );
+        assert!(grant.create_only);
+        // Omitted create_only defaults false; entries are trimmed.
+        let plain = json!({
+            "tasks": [ {
+                "task_id": "t",
+                "title": "t",
+                "grant": { "fs": { "write": ["  out.txt  "] } }
+            } ]
+        });
+        let specs = parse_task_specs(&plain).expect("parses");
+        assert_eq!(
+            specs[0].grant.write_paths,
+            Some(vec!["out.txt".to_string()])
+        );
+        assert!(!specs[0].grant.create_only);
+    }
+
+    #[test]
+    fn goal_plan_rejects_malformed_per_path_write_grant() {
+        // #1976 — parse/validation failures surface as plan-time errors, so
+        // an inexpressible fence can never reach the store: traversal,
+        // absolute paths, create_only-with-nothing, unknown keys, and
+        // non-boolean create_only are all named in the error.
+        let cases: [(Value, &str); 6] = [
+            (json!({ "write": ["../escape"] }), "fs.write"),
+            (json!({ "write": ["/etc/passwd"] }), "fs.write"),
+            (json!({ "write": [], "create_only": true }), "create_only"),
+            (json!({ "create_only": true }), "write"),
+            (json!({ "write": ["ok.txt"], "surprise": 1 }), "surprise"),
+            (
+                json!({ "write": ["ok.txt"], "create_only": "yes" }),
+                "create_only",
+            ),
+        ];
+        for (fs, needle) in cases {
+            let args = json!({
+                "tasks": [ {
+                    "task_id": "t1",
+                    "title": "do it",
+                    "grant": { "fs": fs }
+                } ]
+            });
+            let err = parse_task_specs(&args).expect_err("malformed fence rejected");
+            assert!(
+                err.contains(needle),
+                "error for fs={} must mention `{needle}`: {err}",
+                args["tasks"][0]["grant"]["fs"],
+            );
+        }
+    }
+
+    #[test]
+    fn goal_plan_rejects_per_path_write_grant_with_host_fs() {
+        // #1976 — the object form always implies workspace scope; a fence
+        // cannot be combined with `host` (there is no syntax for it: `fs` is
+        // ONE field), and the fleet-side validate() also rejects the
+        // programmatic combination. Assert the parse-level story: `host`
+        // still parses as the binary grant with NO fence.
+        let args = json!({
+            "tasks": [ {
+                "task_id": "t1",
+                "title": "do it",
+                "grant": { "fs": "host" }
+            } ]
+        });
+        let specs = parse_task_specs(&args).expect("binary host grant parses");
+        assert_eq!(specs[0].grant.fs, FsGrant::Host);
+        assert_eq!(specs[0].grant.write_paths, None);
+        assert!(!specs[0].grant.create_only);
     }
 
     #[test]

--- a/crates/octos-fleet-worker/src/closed_registry.rs
+++ b/crates/octos-fleet-worker/src/closed_registry.rs
@@ -26,6 +26,7 @@ use eyre::{Result, eyre};
 use octos_agent::policy::{ApprovalPolicy, EffectivePermissions, FilesystemScope};
 use octos_agent::sandbox::Sandbox;
 use octos_agent::tools::policy::ToolPolicy;
+use octos_agent::tools::write_grant::{WriteGrantViolationSink, WritePathGrant};
 use octos_agent::tools::{
     EditFileTool, GlobTool, GrepTool, ListDirTool, ReadFileTool, ShellTool, ToolRegistry,
     WebFetchTool, WebSearchTool, WriteFileTool,
@@ -94,13 +95,38 @@ pub fn build_fleet_worker_registry(
     max_shell_timeout_secs: u64,
     grant: &WorkerGrant,
     escalation: EscalationSlot,
+    // #1976 — optional `[denied]`-violation audit sink. `Some` on the AGENT
+    // path (the fleet host wires it to the goal ledger); `None` on the
+    // acceptance-validator path (validators never call file tools) and in the
+    // pure unit tests. The tool refusal is returned to the model regardless;
+    // the sink is the DURABLE audit trail on top of it.
+    violation_sink: Option<WriteGrantViolationSink>,
 ) -> Result<ToolRegistry> {
     // Reject an incoherent grant up front (unknown tool / web tool with no
-    // network) — validated at parse time too, so this is defense-in-depth: an
-    // unknown tool can never reach a live worker.
+    // network, or an incoherent per-path write fence — #1976) — validated at
+    // parse time too, so this is defense-in-depth: an unknown tool or an
+    // inexpressible fence can never reach a live worker.
     grant
         .validate()
         .map_err(|e| eyre!("fleet worker: invalid grant: {e}"))?;
+
+    // #1976 — build the per-path write fence from the grant's `write_paths`
+    // (`None` = no fence, byte-for-byte the pre-#1976 worker). Compiled ONCE
+    // here and cloned onto write_file + edit_file so both enforce the same
+    // allowlist. A pattern the fleet-side `validate()` already accepted must
+    // compile here too; a mismatch fails the build (fail closed) rather than
+    // silently dropping the fence.
+    let write_fence: Option<WritePathGrant> = match &grant.write_paths {
+        Some(paths) => {
+            let mut fence = WritePathGrant::new(paths, grant.create_only)
+                .map_err(|e| eyre!("fleet worker: invalid write grant: {e}"))?;
+            if let Some(sink) = violation_sink.clone() {
+                fence = fence.with_violation_sink(sink);
+            }
+            Some(fence)
+        }
+        None => None,
+    };
 
     // P1-3-enforce (document, don't type-enforce): the API cannot police
     // sandbox quality, but a no-op sandbox leaves the shell's network reach and
@@ -148,16 +174,28 @@ pub fn build_fleet_worker_registry(
                     .with_max_timeout_secs(max_shell_timeout_secs),
             ),
             "read_file" => r.register(ReadFileTool::new(cwd).with_filesystem_scope(scope)),
-            "write_file" => r.register(
-                WriteFileTool::new(cwd)
+            // #1976 — write_file / edit_file carry the per-path write fence
+            // when granted (deny-wins on top of the fs scope). Under
+            // `create_only` write_file opens `O_CREAT|O_EXCL` and edit_file
+            // is refused outright — enforced inside the tools.
+            "write_file" => {
+                let mut tool = WriteFileTool::new(cwd)
                     .with_filesystem_scope(scope)
-                    .with_file_access(access),
-            ),
-            "edit_file" => r.register(
-                EditFileTool::new(cwd)
+                    .with_file_access(access);
+                if let Some(fence) = &write_fence {
+                    tool = tool.with_write_grant(fence.clone());
+                }
+                r.register(tool);
+            }
+            "edit_file" => {
+                let mut tool = EditFileTool::new(cwd)
                     .with_filesystem_scope(scope)
-                    .with_file_access(access),
-            ),
+                    .with_file_access(access);
+                if let Some(fence) = &write_fence {
+                    tool = tool.with_write_grant(fence.clone());
+                }
+                r.register(tool);
+            }
             "glob" => r.register(GlobTool::new(cwd).with_filesystem_scope(scope)),
             "grep" => r.register(GrepTool::new(cwd).with_filesystem_scope(scope)),
             "list_dir" => r.register(ListDirTool::new(cwd).with_filesystem_scope(scope)),
@@ -309,6 +347,7 @@ mod tests {
             30,
             &grant,
             slot(),
+            None,
         )
         .expect("minimal grant builds");
 
@@ -393,6 +432,7 @@ mod tests {
                 30,
                 &grant,
                 slot(),
+                None,
             )
             .expect("grant builds");
             assert!(
@@ -427,8 +467,10 @@ mod tests {
                 t
             },
             fs: FsGrant::Host,
+            write_paths: None,
+            create_only: false,
         };
-        let reg = build_fleet_worker_registry(cwd, Arc::new(NoSandbox), 30, &grant, slot())
+        let reg = build_fleet_worker_registry(cwd, Arc::new(NoSandbox), 30, &grant, slot(), None)
             .expect("expanded grant builds");
 
         assert!(reg.get("web_fetch").is_some(), "granted web_fetch present");
@@ -470,6 +512,7 @@ mod tests {
             30,
             &grant,
             slot(),
+            None,
         )
         .expect("hosts grant builds");
         assert!(reg.get("web_fetch").is_some());
@@ -499,6 +542,7 @@ mod tests {
             30,
             &grant,
             slot(),
+            None,
         )
         .expect("full grant builds");
         assert!(reg.get("web_fetch").is_some());
@@ -526,6 +570,7 @@ mod tests {
             30,
             &grant,
             slot(),
+            None,
         );
         let err = result
             .err()
@@ -549,6 +594,7 @@ mod tests {
             30,
             &WorkerGrant::minimal(),
             slot(),
+            None,
         )
         .expect("minimal grant builds");
         let shell = reg.get("shell").expect("shell tool present");
@@ -572,6 +618,69 @@ mod tests {
             "trailing-& background must be refused, got: {}",
             ampersand.output
         );
+    }
+
+    /// #1976 — a `write_paths` grant BINDS into the built registry: the
+    /// worker's write_file enforces the allowlist (create allowed inside,
+    /// refused outside) and the factory's violation sink records the
+    /// `[denied]` audit. This is the worker-side wiring acceptance (the
+    /// enforcement mechanics themselves are proved in octos-agent).
+    #[tokio::test]
+    async fn write_grant_binds_into_worker_registry_and_records_denials() {
+        use octos_agent::tools::write_grant::{DENIED_MARKER, WriteGrantViolation};
+        use std::sync::Mutex;
+
+        let cwd = tempfile::tempdir().unwrap();
+        let grant = WorkerGrant {
+            write_paths: Some(vec!["exemplar.card".into()]),
+            create_only: true,
+            ..WorkerGrant::minimal()
+        };
+        let seen: Arc<Mutex<Vec<WriteGrantViolation>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_seen = seen.clone();
+        let reg = build_fleet_worker_registry(
+            cwd.path(),
+            Arc::new(NoSandbox),
+            30,
+            &grant,
+            slot(),
+            Some(Arc::new(move |v| sink_seen.lock().unwrap().push(v))),
+        )
+        .expect("fenced grant builds");
+
+        let write_file = reg.get("write_file").expect("write_file present");
+        // Allowlisted create passes.
+        let ok = write_file
+            .execute(&serde_json::json!({"path": "exemplar.card", "content": "v1\n"}))
+            .await
+            .unwrap();
+        assert!(ok.success, "granted create must pass: {}", ok.output);
+        // Non-allowlisted write is refused + recorded.
+        let denied = write_file
+            .execute(&serde_json::json!({"path": "app.md", "content": "no\n"}))
+            .await
+            .unwrap();
+        assert!(!denied.success);
+        assert!(denied.output.contains(DENIED_MARKER), "{}", denied.output);
+        assert!(!cwd.path().join("app.md").exists());
+        // create_only edit_file is refused outright.
+        let edit = reg.get("edit_file").expect("edit_file present");
+        let edit_denied = edit
+            .execute(&serde_json::json!({
+                "path": "exemplar.card", "old_string": "v1", "new_string": "v2",
+            }))
+            .await
+            .unwrap();
+        assert!(!edit_denied.success, "create_only refuses edit");
+
+        let events = seen.lock().unwrap();
+        assert!(
+            events.len() >= 2,
+            "each refusal records to the sink, got {}",
+            events.len()
+        );
+        assert!(events.iter().all(|v| v.detail.contains(DENIED_MARKER)));
+        assert_eq!(events[0].workspace, cwd.path());
     }
 
     /// Discriminator: proves the audit above is not vacuous — the FULL

--- a/crates/octos-fleet-worker/src/escalate.rs
+++ b/crates/octos-fleet-worker/src/escalate.rs
@@ -208,7 +208,17 @@ fn parse_requested_grant(value: Option<&Value>) -> WorkerGrant {
         _ => FsGrant::Workspace,
     };
 
-    WorkerGrant { network, tools, fs }
+    WorkerGrant {
+        network,
+        tools,
+        fs,
+        // #1976 — the escalate valve's REQUESTED grant stays binary in v1: a
+        // fenced worker asking for more asks for the coarse scopes; only the
+        // keeper's `goal_grant` (which parses the full object form) can set a
+        // per-path fence. The request is advisory anyway — the keeper decides.
+        write_paths: None,
+        create_only: false,
+    }
 }
 
 #[cfg(test)]

--- a/crates/octos-fleet-worker/src/lib.rs
+++ b/crates/octos-fleet-worker/src/lib.rs
@@ -56,6 +56,7 @@ use std::time::Duration;
 
 use eyre::Result;
 use octos_agent::sandbox::Sandbox;
+use octos_agent::tools::write_grant::WriteGrantViolationSink;
 use octos_agent::{Agent, AgentConfig, ToolRegistry};
 use octos_core::AgentId;
 use octos_fleet::WorkerGrant;
@@ -91,6 +92,13 @@ pub struct SandboxGrant {
     /// The repo `.git` common dir to rw-bind beyond the cwd (operator
     /// `FsGrant::Host` worktree worker), or `None` for a cwd-only worker.
     pub repo_git_dir: Option<PathBuf>,
+    /// #1976 — the per-path SHELL write fence: the grant's `write_paths`
+    /// (workspace-relative globs), or `None` for an unfenced worker. The host
+    /// factory folds this onto `SandboxConfig::write_allow_globs`; macOS
+    /// expresses it as SBPL regex rules, other backends degrade the workspace
+    /// to read-only for the shell (documented on the config field). Mutually
+    /// exclusive with `repo_git_dir` (a fence excludes `FsGrant::Host`).
+    pub write_allow_globs: Option<Vec<String>>,
 }
 
 /// A per-attempt sandbox factory: given a working directory AND the
@@ -120,6 +128,11 @@ pub struct AgentFactory {
     sandbox_factory: SandboxFactory,
     max_iterations: u32,
     max_tokens: Option<u32>,
+    /// #1976 — optional `[denied]` write-grant violation sink, threaded onto
+    /// every AGENT registry this factory builds. The host (serve.rs) wires it
+    /// to the goal ledger so a fenced worker's refusal is durable, not just a
+    /// transcript line. `None` (default) = tool-error + tracing only.
+    violation_sink: Option<WriteGrantViolationSink>,
 }
 
 impl AgentFactory {
@@ -142,6 +155,7 @@ impl AgentFactory {
             sandbox_factory,
             max_iterations: DEFAULT_MAX_ITERATIONS,
             max_tokens: None,
+            violation_sink: None,
         }
     }
 
@@ -169,6 +183,15 @@ impl AgentFactory {
     /// Override the per-attempt total-token ceiling (`None` = unlimited).
     pub fn with_max_tokens(mut self, max_tokens: Option<u32>) -> Self {
         self.max_tokens = max_tokens;
+        self
+    }
+
+    /// #1976 — set the `[denied]` write-grant violation sink threaded onto
+    /// every AGENT registry (fenced write_file / edit_file record here on a
+    /// refusal). The host builds one that appends a `[denied]`-class finding
+    /// to the offending task's goal ledger.
+    pub fn with_violation_sink(mut self, sink: WriteGrantViolationSink) -> Self {
+        self.violation_sink = Some(sink);
         self
     }
 
@@ -207,7 +230,18 @@ impl AgentFactory {
         grant: &WorkerGrant,
         escalation: EscalationSlot,
     ) -> Result<ToolRegistry> {
-        build_fleet_worker_registry(cwd, sandbox, max_shell_timeout_secs, grant, escalation)
+        // #1976 — thread the factory's violation sink onto the granted
+        // registry. Harmless on the acceptance-validator registry (validators
+        // run `CommandExit` shells, never file tools, so the fence never
+        // fires there); load-bearing on the agent registry.
+        build_fleet_worker_registry(
+            cwd,
+            sandbox,
+            max_shell_timeout_secs,
+            grant,
+            escalation,
+            self.violation_sink.clone(),
+        )
     }
 
     /// The [`AgentConfig`] for an attempt bounded by `deadline`. The per-tool

--- a/crates/octos-fleet-worker/src/worker.rs
+++ b/crates/octos-fleet-worker/src/worker.rs
@@ -279,6 +279,14 @@ pub async fn run_attempt(
     let grant = SandboxGrant {
         allow_network: task_view.grant.network.allows_raw_egress(),
         repo_git_dir: worktree.map(|w| w.git_dir.clone()),
+        // #1976 — project the per-path write fence into the sandbox scope so
+        // the SHELL is bounded to the same allowlist as the file tools (macOS
+        // OS-enforced; other backends degrade to read-only workspace). A
+        // fence and a worktree (`FsGrant::Host`) are mutually exclusive by
+        // construction — `validate()` rejects `write_paths` under `Host`, and
+        // the pool only allocates a worktree for a full-trust Host grant — so
+        // `write_allow_globs` and `repo_git_dir` are never both `Some`.
+        write_allow_globs: task_view.grant.write_paths.clone(),
     };
 
     // P1-3-fix: ONE sandbox instance for the whole attempt, shared by the
@@ -1423,6 +1431,7 @@ mod tests {
             grants.contains(&SandboxGrant {
                 allow_network: false,
                 repo_git_dir: None,
+                write_allow_globs: None,
             }),
             "a minimal scratch worker gets the base sandbox (no network, cwd-only): {grants:?}",
         );
@@ -1430,6 +1439,7 @@ mod tests {
             grants.contains(&SandboxGrant {
                 allow_network: true,
                 repo_git_dir: None,
+                write_allow_globs: None,
             }),
             "a Full-network SCRATCH worker gets network but NOT the .git write: {grants:?}",
         );
@@ -1437,6 +1447,7 @@ mod tests {
             grants.contains(&SandboxGrant {
                 allow_network: true,
                 repo_git_dir: Some(std::path::PathBuf::from("/nonexistent-repo/.git")),
+                write_allow_globs: None,
             }),
             "a WORKTREE attempt gets repo_git_dir = <repo>/.git: {grants:?}",
         );

--- a/crates/octos-fleet/src/fleet.rs
+++ b/crates/octos-fleet/src/fleet.rs
@@ -2105,6 +2105,8 @@ mod tests {
             network: crate::grant::NetworkGrant::Hosts(vec!["example.com".into()]),
             tools: vec!["read_file".into(), "write_file".into(), "web_fetch".into()],
             fs: crate::grant::FsGrant::default(),
+            write_paths: None,
+            create_only: false,
         };
         let task = TaskSpec {
             task_id: "a".into(),

--- a/crates/octos-fleet/src/grant.rs
+++ b/crates/octos-fleet/src/grant.rs
@@ -158,6 +158,35 @@ pub struct WorkerGrant {
     /// Filesystem reach. Default [`FsGrant::Workspace`] (cwd-only).
     #[serde(default)]
     pub fs: FsGrant,
+    /// #1976 — per-path WRITE fence: a workspace-relative path allowlist the
+    /// worker may write; everything else in the workspace is read-only.
+    /// `None` (the default, and every pre-#1976 record) = no fence — the
+    /// binary `fs` scope alone governs writes, byte-for-byte the old worker.
+    /// `Some(vec![])` is a coherent READ-ONLY fence (write nothing).
+    ///
+    /// v1 pattern syntax (validated by [`WorkerGrant::validate`], enforced by
+    /// [`validate_write_path_pattern`]): relative paths with `/` separators,
+    /// `*` (any within one segment) and `?` (one char within a segment)
+    /// wildcards, literal everything else. NO `**`, `[...]`, `{...}` — the
+    /// syntax is deliberately the intersection the tool-layer matcher
+    /// (globset, `literal_separator`) and the sandbox translation (SBPL
+    /// regex) express IDENTICALLY, so the two layers can never disagree
+    /// about what is granted. Only coherent with [`FsGrant::Workspace`].
+    ///
+    /// `skip_serializing_if`: an unfenced grant serializes in the exact
+    /// pre-#1976 shape, so old readers of new records see no new keys.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub write_paths: Option<Vec<String>>,
+    /// #1976 — `create_only`: allowlisted paths may be CREATED but never
+    /// overwritten / edited / deleted (`O_CREAT|O_EXCL` semantics at the file
+    /// tools; `edit_file` is refused outright, allowlisted or not). Only
+    /// meaningful with a non-empty `write_paths` (validated). The sandbox
+    /// layer enforces the PATH fence only — no OS backend can distinguish
+    /// create-vs-overwrite, so the no-overwrite half of `create_only` is
+    /// tool-layer enforced (documented degradation, see
+    /// `octos_agent::sandbox::SandboxConfig::write_allow_globs`).
+    #[serde(default, skip_serializing_if = "core::ops::Not::not")]
+    pub create_only: bool,
 }
 
 fn base_tools_vec() -> Vec<String> {
@@ -180,7 +209,17 @@ impl WorkerGrant {
             network: NetworkGrant::None,
             tools: base_tools_vec(),
             fs: FsGrant::default(),
+            // #1976: no per-path fence — the binary fs scope governs writes.
+            write_paths: None,
+            create_only: false,
         }
+    }
+
+    /// #1976 — whether this grant carries a per-path write fence.
+    /// `Some(_)` (even the empty read-only list) is a fence; `None` is the
+    /// pre-#1976 binary behaviour.
+    pub fn has_write_fence(&self) -> bool {
+        self.write_paths.is_some()
     }
 
     /// The granted tool names, deduplicated + sorted — the closed-worker audit
@@ -223,8 +262,96 @@ impl WorkerGrant {
                 }
             }
         }
+        // #1976 — per-path write fence coherence:
+        // - a fence under `fs: Host` is incoherent (Host lets the shell reach
+        //   everything the fence forbids; deny-wins → reject),
+        // - `create_only` without a fence has nothing to apply to,
+        // - `create_only` over an EMPTY allowlist grants the ability to
+        //   create nothing (issue: "empty list-with-create_only"),
+        // - every pattern must pass the v1 syntax (see
+        //   [`validate_write_path_pattern`]).
+        match &self.write_paths {
+            Some(paths) => {
+                if self.fs.is_host() {
+                    return Err(GrantError::WritePathsWithHostFs);
+                }
+                let all_blank = paths.iter().all(|p| p.trim().is_empty());
+                if self.create_only && all_blank {
+                    return Err(GrantError::EmptyWritePathsWithCreateOnly);
+                }
+                // An empty list without create_only is a valid read-only
+                // fence; blank ENTRIES in a non-empty list are still invalid
+                // patterns (caught below).
+                for pattern in paths {
+                    validate_write_path_pattern(pattern)?;
+                }
+            }
+            None => {
+                if self.create_only {
+                    return Err(GrantError::CreateOnlyWithoutWritePaths);
+                }
+            }
+        }
         Ok(())
     }
+}
+
+/// #1976 — validate ONE `fs.write` allowlist pattern against the v1 syntax:
+/// a workspace-RELATIVE `/`-separated path whose segments may use `*` / `?`
+/// wildcards. Rejects anything that could escape the workspace (`..`,
+/// absolute), inject into a sandbox profile (SBPL metacharacters, control
+/// bytes, `:` — the Docker mount-spec separator / Windows drive marker), or
+/// silently mean different things to the tool-layer matcher vs the sandbox
+/// regex translation (`**`, `[...]`, `{...}` are v1-unsupported for exactly
+/// that reason — the two layers must be provably aligned).
+pub fn validate_write_path_pattern(pattern: &str) -> Result<(), GrantError> {
+    let reject = |reason: &'static str| {
+        Err(GrantError::InvalidWritePath {
+            pattern: pattern.to_owned(),
+            reason,
+        })
+    };
+    if pattern.trim().is_empty() {
+        return reject("pattern is empty");
+    }
+    if pattern.starts_with('/') {
+        return reject("pattern must be workspace-relative, not absolute");
+    }
+    for byte in pattern.bytes() {
+        if byte < 0x20 || byte == 0x7F {
+            return reject("pattern contains control characters");
+        }
+    }
+    for ch in ['(', ')', '\\', '"'] {
+        if pattern.contains(ch) {
+            return reject("pattern contains sandbox-profile metacharacters ( ) \\ \"");
+        }
+    }
+    if pattern.contains(':') {
+        return reject("pattern must not contain `:` (mount-spec / drive separator)");
+    }
+    for ch in ['[', ']', '{', '}'] {
+        if pattern.contains(ch) {
+            return reject(
+                "glob classes/alternations are not supported in fs.write v1 (use * and ?)",
+            );
+        }
+    }
+    if pattern.contains("**") {
+        return reject("recursive `**` globs are not supported in fs.write v1");
+    }
+    for segment in pattern.split('/') {
+        match segment {
+            "" => return reject("empty path segment (`//` or trailing `/`)"),
+            "." | ".." => {
+                return reject(
+                    "`.` / `..` path segments are not allowed (write the plain relative path)",
+                );
+            }
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 /// A typed rejection of an incoherent [`WorkerGrant`].
@@ -236,6 +363,19 @@ pub enum GrantError {
     WebToolWithoutNetwork(String),
     /// A [`NetworkGrant::Hosts`] grant with an empty allowlist (fail-open trap).
     EmptyHostAllowlist,
+    /// #1976 — a per-path write fence combined with `fs: Host` (incoherent:
+    /// Host lets the shell reach everything the fence forbids).
+    WritePathsWithHostFs,
+    /// #1976 — `create_only` with no `write_paths` allowlist to apply to.
+    CreateOnlyWithoutWritePaths,
+    /// #1976 — `create_only` over an EMPTY allowlist (nothing creatable).
+    EmptyWritePathsWithCreateOnly,
+    /// #1976 — an `fs.write` pattern outside the v1 syntax (absolute, `..`,
+    /// `**`, glob classes, profile metacharacters, ...).
+    InvalidWritePath {
+        pattern: String,
+        reason: &'static str,
+    },
 }
 
 impl std::fmt::Display for GrantError {
@@ -255,6 +395,25 @@ impl std::fmt::Display for GrantError {
                 f,
                 "network mode `hosts` needs a non-empty allowlist — an empty list denies \
                  everything; use `none` for no network"
+            ),
+            GrantError::WritePathsWithHostFs => write!(
+                f,
+                "fs.write per-path grants require the workspace fs scope — `host` grants \
+                 full filesystem write, which contradicts a narrow write allowlist"
+            ),
+            GrantError::CreateOnlyWithoutWritePaths => write!(
+                f,
+                "fs.create_only requires an fs.write allowlist to apply to"
+            ),
+            GrantError::EmptyWritePathsWithCreateOnly => write!(
+                f,
+                "fs.create_only over an empty fs.write allowlist grants the ability to \
+                 create nothing — list the creatable paths or drop create_only"
+            ),
+            GrantError::InvalidWritePath { pattern, reason } => write!(
+                f,
+                "fs.write pattern `{pattern}` is invalid: {reason} (v1 patterns are \
+                 workspace-relative paths with `*` / `?` wildcards)"
             ),
         }
     }
@@ -370,6 +529,8 @@ mod tests {
             network: NetworkGrant::Hosts(vec!["example.com".into()]),
             tools: vec!["read_file".into(), "shell".into(), "web_fetch".into()],
             fs: FsGrant::Host,
+            write_paths: None,
+            create_only: false,
         };
         let json = serde_json::to_string(&g).unwrap();
         let back: WorkerGrant = serde_json::from_str(&json).unwrap();
@@ -386,5 +547,168 @@ mod tests {
             g.sorted_tools(),
             vec!["read_file".to_string(), "shell".to_string()]
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // #1976 — per-path write grants (fs.write allowlist + create_only).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn write_paths_default_absent_and_back_compat() {
+        // #1976 back-compat: the minimal grant, `{}`, and a FULL old-shape
+        // grant JSON (written before per-path grants existed) all load with
+        // NO write fence — `write_paths: None`, `create_only: false` — i.e.
+        // byte-for-byte today's binary-fs worker.
+        let g = WorkerGrant::minimal();
+        assert_eq!(g.write_paths, None);
+        assert!(!g.create_only);
+        g.validate().expect("minimal stays valid");
+
+        let g: WorkerGrant = serde_json::from_str("{}").unwrap();
+        assert_eq!(g.write_paths, None);
+        assert!(!g.create_only);
+
+        let old = r#"{"network":"None","tools":["read_file"],"fs":"Workspace"}"#;
+        let g: WorkerGrant = serde_json::from_str(old).unwrap();
+        assert_eq!(g.write_paths, None);
+        assert!(!g.create_only);
+
+        // A grant WITHOUT a fence serializes WITHOUT the new keys, so an
+        // OLD reader of a NEW record sees exactly the old shape.
+        let json = serde_json::to_string(&WorkerGrant::minimal()).unwrap();
+        assert!(
+            !json.contains("write_paths") && !json.contains("create_only"),
+            "unfenced grant must serialize without #1976 keys: {json}"
+        );
+    }
+
+    #[test]
+    fn write_paths_round_trips_through_json() {
+        let g = WorkerGrant {
+            write_paths: Some(vec!["exemplar.card".into(), "cards/*.card".into()]),
+            create_only: true,
+            ..WorkerGrant::minimal()
+        };
+        g.validate().expect("a well-formed fence validates");
+        let json = serde_json::to_string(&g).unwrap();
+        let back: WorkerGrant = serde_json::from_str(&json).unwrap();
+        assert_eq!(g, back);
+        assert!(g.has_write_fence(), "Some(write_paths) is a fence");
+        assert!(
+            !WorkerGrant::minimal().has_write_fence(),
+            "None is no fence"
+        );
+    }
+
+    #[test]
+    fn write_paths_with_host_fs_is_rejected() {
+        // A narrow per-path WRITE fence combined with full-host fs is
+        // incoherent — `Host` would let the shell reach everything the
+        // fence forbids. Deny-wins: reject at validation.
+        let g = WorkerGrant {
+            fs: FsGrant::Host,
+            write_paths: Some(vec!["exemplar.card".into()]),
+            ..WorkerGrant::minimal()
+        };
+        assert_eq!(g.validate(), Err(GrantError::WritePathsWithHostFs));
+    }
+
+    #[test]
+    fn create_only_without_write_paths_is_rejected() {
+        // `create_only` modifies the allowlist; with no allowlist there is
+        // nothing it could apply to — an operator typo, not a policy.
+        let g = WorkerGrant {
+            create_only: true,
+            ..WorkerGrant::minimal()
+        };
+        assert_eq!(g.validate(), Err(GrantError::CreateOnlyWithoutWritePaths));
+    }
+
+    #[test]
+    fn empty_write_paths_with_create_only_is_rejected() {
+        // An EMPTY allowlist under create_only grants the ability to create
+        // nothing — incoherent (issue #1976: "empty list-with-create_only").
+        for paths in [vec![], vec!["  ".to_string()]] {
+            let g = WorkerGrant {
+                write_paths: Some(paths.clone()),
+                create_only: true,
+                ..WorkerGrant::minimal()
+            };
+            assert_eq!(
+                g.validate(),
+                Err(GrantError::EmptyWritePathsWithCreateOnly),
+                "paths {paths:?} + create_only must be rejected",
+            );
+        }
+    }
+
+    #[test]
+    fn empty_write_paths_without_create_only_is_readonly_and_valid() {
+        // `write: []` (no create_only) is a coherent grant: the worker may
+        // read the workspace but write NOTHING via file tools or shell —
+        // previously inexpressible. Fail-closed, so it is allowed.
+        let g = WorkerGrant {
+            write_paths: Some(vec![]),
+            ..WorkerGrant::minimal()
+        };
+        g.validate().expect("write:[] is a valid read-only fence");
+        assert!(g.has_write_fence());
+    }
+
+    #[test]
+    fn write_path_patterns_are_validated() {
+        // v1 pattern syntax (#1976): workspace-RELATIVE, `*`/`?` wildcards
+        // only. Everything that could escape the workspace, inject into a
+        // sandbox profile (SBPL/Docker), or silently diverge between the
+        // tool-layer matcher and the sandbox translation is rejected at
+        // parse time.
+        let rejected = [
+            "/etc/passwd", // absolute
+            "../escape",   // parent traversal
+            "a/../b",      // inner traversal
+            "./x",         // `.` component (write the plain relative form)
+            "",            // empty
+            "   ",         // blank
+            "a(b",         // SBPL metacharacter
+            "a)b",         // SBPL metacharacter
+            "a\\b",        // SBPL metacharacter / Windows separator
+            "a\"b",        // SBPL metacharacter
+            "a[b]",        // glob class — unsupported in v1 (divergence risk)
+            "a{b}",        // glob alternation — unsupported in v1
+            "a:b",         // Docker mount-spec separator / Windows drive
+            "a\nb",        // control character (profile injection)
+            "cards/**",    // recursive glob — unsupported in v1
+            "**/x.card",   // recursive glob — unsupported in v1
+            "a//b",        // empty component
+            "trailing/",   // empty trailing component
+        ];
+        for pattern in rejected {
+            let g = WorkerGrant {
+                write_paths: Some(vec![pattern.to_string()]),
+                ..WorkerGrant::minimal()
+            };
+            assert!(
+                matches!(g.validate(), Err(GrantError::InvalidWritePath { .. })),
+                "pattern {pattern:?} must be rejected, got {:?}",
+                g.validate(),
+            );
+        }
+
+        let accepted = [
+            "exemplar.card",
+            "cards/*.card",
+            "a/b/c.txt",
+            "notes-?.md",
+            "*.card",
+            "out/*",
+        ];
+        for pattern in accepted {
+            let g = WorkerGrant {
+                write_paths: Some(vec![pattern.to_string()]),
+                ..WorkerGrant::minimal()
+            };
+            g.validate()
+                .unwrap_or_else(|e| panic!("pattern {pattern:?} must be accepted: {e}"));
+        }
     }
 }

--- a/crates/octos-fleet/src/records.rs
+++ b/crates/octos-fleet/src/records.rs
@@ -720,6 +720,8 @@ mod tests {
                 network: NetworkGrant::Hosts(vec!["example.com".into()]),
                 tools: vec!["read_file".into(), "write_file".into(), "web_fetch".into()],
                 fs: FsGrant::Host,
+                write_paths: None,
+                create_only: false,
             },
         };
         // PlanTask is nested inside DurablePlan (which carries schema_version);


### PR DESCRIPTION
Fixes #1976. A goal-driven refiner/worker can now be granted `fs: {write: ["exemplar.card","cards/*.card"], create_only: true}` — writes outside the allowlist are refused, allowlisted paths are create-only (no overwrite/edit/delete), and the fence is enforced at the OS/file-descriptor layer, not by model cooperation. The primary consumer is the octos-one on-device refinement loop ("may write exemplar.card, never app.md").

## Enforcement
- **Grant model** (octos-fleet `grant.rs`, goal_tool `parse_grant`): `WorkerGrant.write_paths` + `create_only`; `validate()` rejects absolute/`..`/`**`/glob-classes/SBPL-metachars; persists on the ledger task row; binary grants unchanged (back-compat).
- **File tools** — the confinement core is `open_confined`: a **component-wise `openat` walk** from the canonicalized workspace-root dirfd, each ancestor opened `O_DIRECTORY|O_NOFOLLOW` (a symlinked/swapped ancestor fails `ELOOP` at its own component), the leaf opened from the final dirfd; `create_only` = `O_CREAT|O_EXCL` on that leaf. Check and open target ONE walked object — no check-canonical/open-lexical divergence. Implemented with `rustix` under the workspace `deny(unsafe_code)` lint.
- **Sandbox** (macOS SBPL): one anchored `(allow file-write* (regex ^<root>/…$))` per glob (`*`→`[^/]*`, metachars escaped) — OS-enforces the shell-redirect fence; non-macOS backends fail-closed to a read-only workspace (granted paths stay writable via the fenced file tools); NoSandbox posture documented, not silent.
- **Wiring**: `build_fleet_worker_registry` binds the fence + records violations as `[denied]`-class ledger findings.

## Security review — three codex rounds (final verdict MERGE)
- **Regex translation** (SBPL): confirmed anchored + escaped + `/`-bounded — no bypass (`exemplar.card.bak`, `cards/sub/evil`, `cards/../app.card`, absolute paths all rejected).
- **TOCTOU (FIX-FIRST, round 2)**: the original code checked the canonical path but opened the *lexical* path — an ancestor-directory swap escaped. Fixed by the `openat` walk above so the checked and opened object are identical (codex round-3: CORRECT, confinement holds).
- **Post-write escapes (FIX-FIRST, round 3)**: under a fence, the optional formatter and the workspace-git snapshot re-resolved the lexical path (the snapshot created `.git`/commits at non-granted sibling paths, reopening the swap window). Both are now skipped when a write fence is active — a grant-restricted write is a leaf-file op, not a project mutation. Non-vacuous test: a fenced write to `sites/demo/index.html` creates no `.git`/`.gitignore`; the unfenced control does.

## Deferred (documented residuals)
- **Peer binding** — the primitive is ready but peer sessions use the full interactive registry; threading the grant through `stage_peer` is a follow-up.
- **create_only-no-overwrite via shell on macOS** — the SBPL grants `file-write*` on the glob, so a shell `>` to a granted path is OS-allowed; the file tools refuse it. Documented boundary.
- **Non-Unix fallback** retains the ancestor-swap race (workers run on Unix, where the `openat` walk is race-free).

## Validation
octos-agent 2560 · octos-fleet 146 · octos-fleet-worker 63 · grant 13 · no-api build · fmt · clippy `--all-targets -D warnings` clean (4 crates). Windows-target clippy is inspection-only here (aws-lc-sys cross-build) — the two cfg-only fixes are Unix-scoped.