### PR TITLE
fix(goal): mint a fresh goal_id + reset counters when a user replaces a complete goal

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -7397,6 +7397,26 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
         // stage the wrap-up prompt here and enqueue it AFTER the mutable
         // `goal` borrow ends (the wrap-up enqueue needs `&mut state`).
         let mut pending_wrap_up: Option<String> = None;
+        // #1975 — a USER/backend replace of a COMPLETE goal must mint a FRESH
+        // goal_id with zeroed counters, exactly as `model_create_goal`'s Fix B
+        // does for the model path. Reusing the finished record carries its old
+        // goal_id + spent `tokens_used` into the new budget (a fresh 300K budget
+        // "born 85% spent") and lands new activity in the OLD goal's ledger file,
+        // whose complete-protection then rejects the active-state refreshes.
+        // Dropping the terminal record here forces the create branch below.
+        // `clear_goal` already removes its record, so `complete` is the only
+        // terminal state that can reach the update branch; a requested `complete`
+        // status keeps an idempotent re-complete in place; the profile match
+        // preserves the update branch's cross-profile guard (which still fires
+        // for a mismatched profile because we only remove on a match).
+        if requested_status != Some("complete")
+            && state
+                .goals
+                .get(&key)
+                .is_some_and(|g| g.status == "complete" && g.profile_id == request.profile_id)
+        {
+            state.goals.remove(&key);
+        }
         let goal = if let Some(goal) = state.goals.get_mut(&key) {
             if goal.profile_id != request.profile_id {
                 return Err(autonomy_error(
@@ -17740,6 +17760,71 @@ mod tests {
         );
         assert_eq!(
             replaced["objective"],
+            json!("next objective"),
+            "the replacement carries the new objective"
+        );
+    }
+
+    /// #1975 — the USER path (`set_goal` with the default "user" actor, i.e. the
+    /// `/goal` command) must mint a FRESH goal_id with zeroed counters when it
+    /// replaces a COMPLETE goal — exactly like the model path (Fix B). The bug:
+    /// `set_goal`'s update branch resurrected the finished record, carrying its
+    /// goal_id and spent `tokens_used` into the new budget (a fresh 300K budget
+    /// "born 85% spent") and landing new activity in the old goal's ledger file,
+    /// whose complete-protection then rejects the active-state refreshes.
+    #[tokio::test]
+    async fn should_mint_fresh_goal_id_and_reset_tokens_when_user_replaces_complete_goal() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-user-reuse", "api", "goal-set");
+
+        // USER create (transition_actor defaults to "user").
+        let first = orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-user-reuse".to_owned(),
+                objective: "first objective".to_owned(),
+                status: Some("active".to_owned()),
+                token_budget: Some(2_000),
+                transition_actor: None,
+            })
+            .expect("user create when none exists");
+        let first_goal_id = first["goal"]["goal_id"]
+            .as_str()
+            .expect("goal_id")
+            .to_owned();
+
+        // Spend tokens, then complete it so the carried-over spend is observable.
+        orchestrator.force_goal_tokens_used_for_test(&session_id, 1_500);
+        orchestrator
+            .model_transition_goal(&session_id, "tenant-user-reuse", "complete", "done", None)
+            .await
+            .expect("complete the goal");
+
+        // USER replace of the COMPLETE goal — must mint a fresh identity.
+        let replaced = orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-user-reuse".to_owned(),
+                objective: "next objective".to_owned(),
+                status: Some("active".to_owned()),
+                token_budget: Some(300_000),
+                transition_actor: None,
+            })
+            .expect("user replace of a complete goal");
+
+        assert_ne!(
+            replaced["goal"]["goal_id"].as_str().expect("goal_id"),
+            first_goal_id,
+            "a user replace of a complete goal must mint a fresh goal_id, not reuse the finished one"
+        );
+        assert_eq!(
+            replaced["goal"]["tokens_used"],
+            json!(0),
+            "the replacement goal's token counter must reset to zero, not carry the finished goal's spend"
+        );
+        assert_eq!(replaced["goal"]["status"], json!("active"));
+        assert_eq!(
+            replaced["goal"]["objective"],
             json!("next objective"),
             "the replacement carries the new objective"
         );


### PR DESCRIPTION
## Problem

The USER path (`/goal` → `session/goal/set` → `set_goal` with the default `"user"` actor) **replaces a `complete` goal in place**, reusing its `goal_id` and carrying `tokens_used`. So a fresh 300K-budget goal is "born 85% spent," and new activity lands in the *old* goal's ledger file — whose complete-protection then rejects the active-state refreshes. The MODEL path (`goal_create`) doesn't have this bug: `model_create_goal` drops the completed record first (Fix B), forcing `set_goal`'s create branch (fresh id + zeroed counters).

Filed as #1975.

## Root cause

`set_goal`'s update branch (`agent_orchestrator.rs`) mutates only `revision`/`objective`/`status`/`token_budget`/`updated_at_ms` and returns the existing record — it never reassigns `goal_id` or resets `tokens_used`. Only the *create* branch mints a fresh `goal_{NN}` id with `tokens_used: 0`. `clear_goal` already removes its record, so `complete` is the only terminal state that can reach the update branch.

## Fix

In `set_goal`, before the update/create branch, drop a terminal `complete` record on the user/backend path so it falls into the create branch — mirroring the model path's Fix B, now for both paths:

```rust
if requested_status != Some("complete")
    && state.goals.get(&key).is_some_and(|g| g.status == "complete" && g.profile_id == request.profile_id)
{
    state.goals.remove(&key);
}
```

- `requested_status != Some("complete")` keeps an idempotent re-complete in place.
- The profile match preserves the update branch's cross-profile guard (a mismatched profile still errors).
- The model path is unaffected (its record is already removed upstream → no-op). Re-activation of a *paused*/*budget_limited* goal still updates in place (only `complete` is dropped).

## Tests (RED → GREEN)

`should_mint_fresh_goal_id_and_reset_tokens_when_user_replaces_complete_goal` — the user-path analogue of the existing model-path `model_create_goal_gates_on_unfinished_goal` assertions. RED: the replace returned `goal_01` with `tokens_used == 1500`. GREEN after the fix (fresh id, `tokens_used == 0`). `model_create_goal_gates`, `budget_limited`, and `reactivating_goal` regressions all still pass.

Fixes #1975.
