### PR TITLE
fix(agent): carry partial turn usage out of errored turns so goals are charged

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -16,7 +16,7 @@ use super::budget::BudgetStop;
 use super::loop_compaction::{prepare_conversation_messages, prepare_task_messages};
 use super::loop_state::{LoopDecision, LoopRetryState, SHELL_SPIRAL_VARIANT};
 use super::message_repair::sanitize_tool_call_id;
-use super::turn_state::{LoopRetryReason, LoopTurnState};
+use super::turn_state::{LoopRetryReason, LoopTurnState, attach_partial_usage};
 use super::verifier::{TurnLedger, ledger_entry_from_tool_result};
 use super::{Agent, ConversationResponse, TASK_REPORTER, TokenTracker};
 use crate::harness_errors::HarnessError;
@@ -1163,7 +1163,11 @@ impl Agent {
                     // with a typed error if the controller reports stalled.
                     // A None controller / disabled config is a no-op so the
                     // 830+ existing tests see identical behavior.
-                    self.beat_heartbeat(iteration)?;
+                    // #1969: a heartbeat interrupt/stall is an error EXIT too —
+                    // carry the turn's accumulated usage out with it.
+                    if let Err(e) = self.beat_heartbeat(iteration) {
+                        return Err(attach_partial_usage(e, turn.total_usage().clone()));
+                    }
                     self.reporter()
                         .report(ProgressEvent::Thinking { iteration });
 
@@ -1259,7 +1263,7 @@ impl Agent {
                                 if let Some(sink) = &self.voice_failure_sink {
                                     let _ = sink.send(crate::TurnFailure::EmptyResponse);
                                 }
-                                return Err(e);
+                                return Err(attach_partial_usage(e, turn.total_usage().clone()));
                             }
                             // Empty response after retries -- try once more (adaptive router
                             // may select a different provider on this second attempt).
@@ -1285,7 +1289,7 @@ impl Agent {
                                 Ok(r) => r,
                                 Err(e) => {
                                     if self.failfast_llm_bail(&e) {
-                                        return Err(e);
+                                        return Err(attach_partial_usage(e, turn.total_usage().clone()));
                                     }
                                     match self.handle_loop_error_with_dispatch(
                                         &e,
@@ -1294,14 +1298,14 @@ impl Agent {
                                         &mut messages,
                                     ) {
                                         LoopErrorAction::Retry => continue,
-                                        LoopErrorAction::Bail => return Err(e),
+                                        LoopErrorAction::Bail => return Err(attach_partial_usage(e, turn.total_usage().clone())),
                                     }
                                 }
                             }
                         }
                         Err(e) => {
                             if self.failfast_llm_bail(&e) {
-                                return Err(e);
+                                return Err(attach_partial_usage(e, turn.total_usage().clone()));
                             }
                             match self.handle_loop_error_with_dispatch(
                                 &e,
@@ -1310,7 +1314,7 @@ impl Agent {
                                 &mut messages,
                             ) {
                                 LoopErrorAction::Retry => continue,
-                                LoopErrorAction::Bail => return Err(e),
+                                LoopErrorAction::Bail => return Err(attach_partial_usage(e, turn.total_usage().clone())),
                             }
                         }
                     };
@@ -1695,7 +1699,7 @@ impl Agent {
                                         &mut messages,
                                     ) {
                                         LoopErrorAction::Retry => continue,
-                                        LoopErrorAction::Bail => return Err(e),
+                                        LoopErrorAction::Bail => return Err(attach_partial_usage(e, turn.total_usage().clone())),
                                     }
                                 }
                             };
@@ -1746,7 +1750,7 @@ impl Agent {
                                     &mut messages,
                                 ) {
                                     LoopErrorAction::Retry => continue,
-                                    LoopErrorAction::Bail => return Err(e),
+                                    LoopErrorAction::Bail => return Err(attach_partial_usage(e, turn.total_usage().clone())),
                                 }
                             }
 
@@ -2147,7 +2151,10 @@ impl Agent {
                 let iter_start = Instant::now();
                 // Realtime heartbeat beat + stall check (no-op when realtime
                 // is disabled or unattached).
-                self.beat_heartbeat(iteration)?;
+                // #1969: carry accumulated usage out on an interrupt/stall exit.
+                if let Err(e) = self.beat_heartbeat(iteration) {
+                    return Err(attach_partial_usage(e, turn.total_usage().clone()));
+                }
                 self.reporter()
                     .report(ProgressEvent::Thinking { iteration });
 
@@ -2186,7 +2193,7 @@ impl Agent {
                     Ok(pair) => pair,
                     Err(e) => {
                         if self.failfast_llm_bail(&e) {
-                            return Err(e);
+                            return Err(attach_partial_usage(e, turn.total_usage().clone()));
                         }
                         match self.handle_loop_error_with_dispatch(
                             &e,
@@ -2195,7 +2202,7 @@ impl Agent {
                             &mut messages,
                         ) {
                             LoopErrorAction::Retry => continue,
-                            LoopErrorAction::Bail => return Err(e),
+                            LoopErrorAction::Bail => return Err(attach_partial_usage(e, turn.total_usage().clone())),
                         }
                     }
                 };
@@ -2422,7 +2429,7 @@ impl Agent {
                                 &mut messages,
                             ) {
                                 LoopErrorAction::Retry => continue,
-                                LoopErrorAction::Bail => return Err(e),
+                                LoopErrorAction::Bail => return Err(attach_partial_usage(e, turn.total_usage().clone())),
                             }
                         }
                         if let Err(e) = self
@@ -2442,7 +2449,7 @@ impl Agent {
                                 &mut messages,
                             ) {
                                 LoopErrorAction::Retry => continue,
-                                LoopErrorAction::Bail => return Err(e),
+                                LoopErrorAction::Bail => return Err(attach_partial_usage(e, turn.total_usage().clone())),
                             }
                         }
                     }

--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -3611,6 +3611,103 @@ async fn doom_loop_aborts_turn_when_third_identical_call_arrives() {
     );
 }
 
+/// #1969 mock: call 1 returns a tool_use that burns real tokens
+/// (input=1000, output=500); call 2 rate-limits. Under FailFast the loop
+/// bails on call 2 — and the accumulated usage from call 1 must ride out on
+/// the error instead of being dropped by the bare `return Err(report)`.
+struct UsageThenRateLimitProvider {
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl LlmProvider for UsageThenRateLimitProvider {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &octos_llm::ChatConfig,
+    ) -> Result<ChatResponse> {
+        let n = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+        if n == 0 {
+            Ok(tool_use(
+                vec![ToolCall {
+                    id: "call_0".to_string(),
+                    name: "noop_tool".to_string(),
+                    arguments: serde_json::json!({}),
+                    metadata: None,
+                }],
+                1000,
+                500,
+            ))
+        } else {
+            // Typed provider rate-limit; under FailFast the loop bails here.
+            Err(LlmError::rate_limited(Some(2)).into())
+        }
+    }
+
+    fn model_id(&self) -> &str {
+        "mock"
+    }
+
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+#[tokio::test]
+async fn should_surface_accumulated_usage_when_llm_errors_after_prior_iteration() {
+    // #1969: the turn accumulates usage in `LoopTurnState.total_usage` and the
+    // happy path returns it via `ConversationResponse.token_usage`. Every error
+    // exit was a bare `return Err(report)`, dropping that usage — so an
+    // errored/rate-limited peer or goal turn charged 0 tokens despite having
+    // burned real tokens on earlier iterations. The bailed error must now carry
+    // the accumulated usage, WITHOUT hiding the underlying `LlmError` that
+    // retry/breaker classification depends on.
+    let dir = tempfile::tempdir().unwrap();
+    let provider = Arc::new(UsageThenRateLimitProvider {
+        calls: AtomicUsize::new(0),
+    });
+    let provider_arc: Arc<dyn LlmProvider> = provider.clone();
+    let mut tools = ToolRegistry::new();
+    tools.register(StaticResultTool::new(
+        "noop_tool",
+        "ok",
+        true,
+        Arc::new(AtomicUsize::new(0)),
+    ));
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let agent = Agent::new(AgentId::new("usage-error"), provider_arc, tools, memory);
+
+    // FailFast makes call 2's rate-limit terminal (no retry/failover), so the
+    // loop bails deterministically after recording call 1's usage.
+    let err = octos_llm::with_llm_call_policy(
+        octos_llm::LlmCallPolicy::FailFast,
+        agent.process_message("please work", &[], vec![]),
+    )
+    .await
+    .expect_err("rate-limit under FailFast must bail the turn");
+
+    // Constraint: the underlying LlmError must remain downcastable so
+    // `classify_report` / retry-breaker logic still sees the rate limit.
+    assert!(
+        err.downcast_ref::<octos_llm::LlmError>().is_some(),
+        "underlying LlmError must stay downcastable through the usage carrier"
+    );
+
+    // The bailed error carries call 1's accumulated usage.
+    let partial = err
+        .downcast_ref::<crate::PartialTurnUsage>()
+        .expect("bailed error must carry the turn's accumulated usage");
+    assert_eq!(
+        partial.total.input_tokens, 1000,
+        "accumulated input tokens from iteration 1 must survive the error exit"
+    );
+    assert_eq!(
+        partial.total.output_tokens, 500,
+        "accumulated output tokens from iteration 1 must survive the error exit"
+    );
+}
+
 /// LLM mock that alternates between two different argument sets for the
 /// same tool. The doom guard (consecutive identical) must never fire;
 /// the cycle detector (`LoopDetector::record`) owns alternating

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -39,6 +39,7 @@ use verifier::AgentVerifierConfig;
 
 pub use message_repair::normalize_tool_call_id;
 pub use realtime::RealtimeController;
+pub use turn_state::PartialTurnUsage;
 
 tokio::task_local! {
     /// Task-local reporter override.  When set (via `TASK_REPORTER.scope()`),

--- a/crates/octos-agent/src/agent/turn_state.rs
+++ b/crates/octos-agent/src/agent/turn_state.rs
@@ -191,6 +191,13 @@ impl LoopTurnState {
         });
     }
 
+    // NOTE: `attach_partial_usage` / `PartialTurnUsage` (below) is how an
+    // error EXIT of the loop carries this `total_usage` out. The happy path
+    // returns it via `ConversationResponse.token_usage` / `TaskResult`, but a
+    // bare `return Err(report)` on an error/interrupt would otherwise drop it
+    // (`eyre::Report` has no usage channel), so an errored/rate-limited peer
+    // or goal turn charges 0 tokens (issue #1969).
+
     // NOTE: `new_messages` / `new_output_start` were removed in NEW-16
     // (fix/persist-from-append-only-turn-log-not-mutated-buffer).
     //
@@ -209,9 +216,88 @@ impl LoopTurnState {
     // shift OLD rows into it.
 }
 
+/// Downcastable carrier for a turn's accumulated token usage, attached to the
+/// eyre error when the agent loop bails on an error/interrupt (issue #1969).
+///
+/// The happy path surfaces per-turn usage via `ConversationResponse.token_usage`
+/// / `TaskResult.token_usage`. Every error exit, though, was a bare
+/// `return Err(report)` and `eyre::Report` has no usage channel — so the
+/// turn's real spend was dropped and a downstream peer/goal accountant charged
+/// 0 tokens for a turn that had already burned real tokens before failing.
+///
+/// Attach via [`attach_partial_usage`]. It uses eyre's `wrap_err`, which is the
+/// ONE attachment mechanism that keeps the wrapped report downcastable to BOTH
+/// this carrier AND the original error (e.g. `LlmError`). That dual-downcast is
+/// load-bearing: `HarnessError::classify_report` and the CLI's
+/// `classify_runtime_error_message` reach the underlying `LlmError` (via
+/// `Report::downcast_ref` and via `chain()` + std downcast respectively) to
+/// drive retry/breaker classification, and must keep working through the
+/// wrapper.
+#[derive(Debug, Clone)]
+pub struct PartialTurnUsage {
+    /// The turn's accumulated usage at the moment it bailed.
+    pub total: TokenUsage,
+    /// The wrapped error's outer `Display`, captured at attach time. Because
+    /// `wrap_err` makes THIS carrier the outermost layer, reproducing the
+    /// original message here keeps `report.to_string()` (and the
+    /// `classify_runtime_error_message` fallback) reporting the real error
+    /// instead of a usage note.
+    display: String,
+}
+
+impl std::fmt::Display for PartialTurnUsage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.display)
+    }
+}
+
+/// Attach a turn's accumulated `total` usage to an outgoing error WITHOUT
+/// hiding the original error (issue #1969).
+///
+/// `wrap_err` layers a [`PartialTurnUsage`] context over `err`; the inner
+/// error stays reachable through both eyre's `Report::downcast_ref` and
+/// `chain()` + std downcast, so classification/retry logic is unchanged. The
+/// captured display string keeps the wrapper's own `Display` equal to the
+/// original error's outer message.
+pub(crate) fn attach_partial_usage(err: eyre::Report, total: TokenUsage) -> eyre::Report {
+    let display = err.to_string();
+    err.wrap_err(PartialTurnUsage { total, display })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn should_carry_usage_and_preserve_inner_error_when_attached() {
+        use octos_llm::LlmError;
+        // A Report built FROM an LlmError, mirroring the loop's LLM bail.
+        let report: eyre::Report = LlmError::rate_limited(Some(2)).into();
+        let original = report.to_string();
+        let usage = TokenUsage {
+            input_tokens: 1_000,
+            output_tokens: 500,
+            ..Default::default()
+        };
+
+        let wrapped = attach_partial_usage(report, usage);
+
+        // Carrier is extractable with the accumulated totals.
+        let carried = wrapped
+            .downcast_ref::<PartialTurnUsage>()
+            .expect("carrier attached");
+        assert_eq!(carried.total.input_tokens, 1_000);
+        assert_eq!(carried.total.output_tokens, 500);
+        // Inner LlmError still reachable (classification/retry logic).
+        assert!(wrapped.downcast_ref::<LlmError>().is_some());
+        assert!(
+            wrapped
+                .chain()
+                .any(|c| c.downcast_ref::<LlmError>().is_some())
+        );
+        // Outer Display unchanged (no usage note buried the real message).
+        assert_eq!(wrapped.to_string(), original);
+    }
 
     #[test]
     fn records_explicit_budget_terminal_reason() {

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -79,8 +79,8 @@ pub use abi_schema::{
 };
 pub use agent::{
     Agent, AgentConfig, ConversationResponse, DEFAULT_SESSION_TIMEOUT_SECS,
-    DEFAULT_TOOL_TIMEOUT_SECS, DEFAULT_WORKER_PROMPT, MAX_TOOL_TIMEOUT_SECS, PromptSegmentProvider,
-    RealtimeController, TASK_REPORTER, TokenTracker,
+    DEFAULT_TOOL_TIMEOUT_SECS, DEFAULT_WORKER_PROMPT, MAX_TOOL_TIMEOUT_SECS, PartialTurnUsage,
+    PromptSegmentProvider, RealtimeController, TASK_REPORTER, TokenTracker,
     loop_state::{
         LoopDecision, LoopRetryCounters, LoopRetryLimits, LoopRetryState, OCTOS_LOOP_RETRY_TOTAL,
         SHELL_SPIRAL_VARIANT,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -15236,12 +15236,14 @@ fn peer_respond_resolve(
 /// #1965 — `tokens_consumed` is the turn's accumulated token spend (the same
 /// `final_tokens_consumed` total the master goal accountants charge from).
 /// When the peer is goal-bound, the finding write below charges it against
-/// the master goal's shared budget pool. Honesty (codex round): only a
-/// COMPLETED turn carries real usage — the agent loop bails with a bare
-/// `Err` that discards the turn's accumulated usage, so the errored /
-/// rate-limited arm threads 0, and an interrupted turn never reaches this
-/// writer at all. Those turns currently UNDER-charge the goal; preserving
-/// partial usage across the loop's error path is a tracked follow-up.
+/// the master goal's shared budget pool. #1969 — both COMPLETED and
+/// ERRORED/rate-limited turns now carry real usage: the agent loop attaches
+/// the turn total to the bailed error (`PartialTurnUsage`) and the `error`
+/// arm folds it into `final_tokens_consumed`, so a peer that burned tokens
+/// before failing charges its real spend. Residual gap: an INTERRUPTED turn
+/// aborts the agent task before it can report usage (and this path has no
+/// shared token tracker to read post-abort), so it still threads 0 and never
+/// reaches this writer — tracked as a follow-up.
 fn write_peer_result_if_peer_session(
     state: &Arc<AppState>,
     session_id: &SessionKey,
@@ -33277,9 +33279,36 @@ async fn run_standalone_turn(
                 // — HTTP 403 ..."` instead. Downcast and re-classify
                 // so the SPA sees the actionable text.
                 let wire_message = classify_runtime_error_message(&error);
+                // #1969 — the agent loop now attaches the turn's accumulated
+                // usage to the bailed error (`PartialTurnUsage`, via
+                // `attach_partial_usage`). Surface it on the error event —
+                // mirroring the `done` event's `tokens_in`/`tokens_out`/
+                // `tokens_cache` — so the drain loop can fold it into
+                // `final_tokens_consumed`. Without this an errored/rate-limited
+                // peer or goal turn that burned real tokens before failing
+                // under-charges the goal by 0. `downcast_ref` still sees the
+                // carrier through the `LlmError` classification above (both stay
+                // reachable: `wrap_err` layers the carrier without hiding the
+                // inner error). Absent carrier (non-loop error) → zeros, the
+                // pre-#1969 behaviour.
+                let (err_tokens_in, err_tokens_out, err_tokens_cache) = error
+                    .downcast_ref::<octos_agent::PartialTurnUsage>()
+                    .map(|partial| {
+                        let usage = &partial.total;
+                        (
+                            u64::from(usage.input_tokens),
+                            u64::from(usage.output_tokens),
+                            u64::from(usage.cache_read_tokens)
+                                + u64::from(usage.cache_write_tokens),
+                        )
+                    })
+                    .unwrap_or((0, 0, 0));
                 let error = json!({
                     "type": "error",
                     "message": wire_message,
+                    "tokens_in": err_tokens_in,
+                    "tokens_out": err_tokens_out,
+                    "tokens_cache": err_tokens_cache,
                 });
                 let _ = progress_tx_for_result.send(error.to_string()).await;
             }
@@ -33555,6 +33584,24 @@ async fn run_standalone_turn(
                     .and_then(Value::as_str)
                     .unwrap_or("turn failed")
                     .to_string();
+                // #1969 — fold the errored turn's accumulated usage into
+                // `final_tokens_consumed` BEFORE the peer-result write and the
+                // post-turn `record_goal_turn`, mirroring the `done` arm. The
+                // agent loop now attaches the turn total to the bailed error
+                // and the agent task surfaces it on this event, so a peer/goal
+                // turn that burned tokens before failing charges its real spend
+                // instead of under-charging 0. Absent (older/malformed payload,
+                // or a non-loop error with no carrier) → 0, as before.
+                let tokens_in = event.get("tokens_in").and_then(Value::as_u64).unwrap_or(0);
+                let tokens_out = event.get("tokens_out").and_then(Value::as_u64).unwrap_or(0);
+                let tokens_cache = event
+                    .get("tokens_cache")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0);
+                final_tokens_consumed = final_tokens_consumed
+                    .saturating_add(tokens_in)
+                    .saturating_add(tokens_out)
+                    .saturating_add(tokens_cache);
                 // Voice fail-fast: a classified `TurnFailure` rode the side
                 // channel. Speak a short apology through the SAME TTS worker as
                 // a normal reply, and DRAIN the worker before the terminal so
@@ -33597,15 +33644,10 @@ async fn run_standalone_turn(
                 } else {
                     TurnTerminalOutcome::Errored
                 };
-                // #1965 — thread the turn total here too so the wiring is
-                // outcome-independent, but be honest: on this arm it is
-                // ALWAYS 0 today. The agent loop bails with a bare `Err`
-                // that discards the turn's accumulated usage, and
-                // `final_tokens_consumed` only folds from `done` — so an
-                // errored/rate-limited peer turn UNDER-charges the goal (it
-                // burned real tokens before failing). Preserving partial
-                // usage across the loop's error path is a tracked follow-up;
-                // the master accountant shares the same gap.
+                // #1965/#1969 — `final_tokens_consumed` now carries the errored
+                // turn's real accumulated spend (folded from this event's token
+                // fields just above), so a goal-bound peer that rate-limited
+                // mid-run charges the master goal instead of 0.
                 write_peer_result_if_peer_session(
                     &state,
                     &session_id,
@@ -34523,10 +34565,15 @@ async fn run_standalone_turn(
     //      stops recurrence.
     //
     // Token usage comes from `final_tokens_consumed` — populated when the
-    // agent_task's `done` JSON event traversed the main `select!` loop
-    // (`tokens_in + tokens_out`). On interrupt / agent error the value
-    // remains zero, which is the correct conservative behaviour: an
-    // interrupted turn should not exhaust the goal's token budget.
+    // agent_task's `done` OR `error` JSON event traversed the main `select!`
+    // loop (`tokens_in + tokens_out + tokens_cache`). #1969: an ERRORED /
+    // rate-limited turn now charges its real accumulated spend (the loop
+    // attaches the turn total to the bailed error and the `error` arm folds
+    // it), closing the under-charge where a goal turn burned tokens then
+    // failed. On INTERRUPT the value remains zero: the agent task is aborted
+    // before it can report usage and this path holds no shared token tracker
+    // to read post-abort — an interrupted turn simply does not exhaust the
+    // goal's budget (tracked follow-up).
     if let Some(goal_ctx) = goal_context.as_ref() {
         // #1140 codex P2 re-review #2: the turn-start dispatch stamp
         // can go stale on long goal turns (model + tool work > 30s


### PR DESCRIPTION
## Problem

The agent loop accumulates per-turn token usage in `LoopTurnState.total_usage`, but surfaced it **only** through the `Ok(ConversationResponse)` happy path. Every error / rate-limit / stall exit was a bare `return Err(report)` / `?`, which drops the turn and its accumulated usage (`eyre::Report` has no usage channel). Downstream, an errored peer/goal turn charged **0** tokens to the goal — a peer that burns 100k tokens then rate-limits was *free* against the goal budget. This was deliberately deferred in #1965 ("partial-usage preservation is a tracked follow-up, deliberately not fixed here"); this PR is that follow-up.

## Fix

- **octos-agent** — a typed carrier `PartialTurnUsage { total: TokenUsage }` (`turn_state.rs`), attached to the bailed error via `attach_partial_usage(e, turn.total_usage().clone())` at every bail site in `process_message_inner` / `run_task_inner` (14 sites) **and** the heartbeat-interrupt/stall sites (`if let Err(e) = self.beat_heartbeat(..)`). It uses eyre `wrap_err`, so the inner `LlmError` stays reachable through `downcast_ref` + `chain()` — **error classification / retry logic is unchanged** (verified: all `classify_report_downcasts_*` tests still pass).
- **octos-cli (`api`)** — the AppUI driver downcasts the errored task's `PartialTurnUsage`, surfaces `tokens_in/out/cache` on the `error` event (mirroring `done`), and folds them into `final_tokens_consumed` **before** the peer-result write and the post-turn `record_goal_turn`. So an errored peer's real spend now charges the goal.

## Tests (RED → GREEN)

- `should_surface_accumulated_usage_when_llm_errors_after_prior_iteration` (loop_runner) — scripts iteration 1 with 1000/500 usage, iteration 2 `Err(RateLimit)` under FailFast; asserts the bail error carries the accumulated usage. RED before the carrier, GREEN after.
- `should_carry_usage_and_preserve_inner_error_when_attached` — proves the carrier is extractable AND the inner `LlmError` stays downcastable (both `downcast_ref` and `chain()`).
- Full `octos-agent --lib` (2562/0) incl. all classification tests; full serialized `octos-cli --features api --lib`.

## Scope / residual

Covers the **error / rate-limit / stall** bail paths (the common under-charge). The caller-side **external-interrupt leg** — a user interrupt via `interrupt_rx` breaks the drain loop before any terminal arm, so its charge isn't folded — needs separate `TokenTracker` plumbing and remains a tracked follow-up (noted on #1969). This PR does not close #1969.

Addresses #1969 (error/stall path).
