### PR TITLE
fix(goal): reconcile the durable ledger tokens after a mid-turn goal completion

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -2894,21 +2894,31 @@ impl InProcessAgentOrchestrator {
         true
     }
 
+    /// Charge a completed turn's tokens to the session's goal.
+    ///
+    /// #1982 — returns the goal snapshot ONLY when the goal is TERMINAL
+    /// (`complete`/`blocked`) after the charge. A goal completed/blocked
+    /// mid-turn had its ledger goals-row frozen at the pre-completion total by
+    /// the mid-turn transition, and this post-turn charge persists only to the
+    /// supervisor store — so the durable ledger under-counts the goal's true
+    /// final cost and no later transition re-syncs it. The caller (which holds
+    /// the profile data dir) reconciles the ledger via
+    /// [`Self::reconcile_terminal_goal_ledger`]. Non-terminal goals return
+    /// `None`: their next transition re-syncs the ledger, so a per-turn ledger
+    /// write would be wasteful.
     pub(crate) fn record_goal_turn(
         &self,
         session_id: &SessionKey,
         profile_id: &str,
         tokens_consumed: u64,
         elapsed_seconds: u64,
-    ) {
+    ) -> Option<AutonomyGoalRecord> {
         let now = now_ms();
         let now_system = SystemTime::now();
         let mut state = self.state();
-        let Some(goal) = state.goals.get_mut(session_id) else {
-            return;
-        };
+        let goal = state.goals.get_mut(session_id)?;
         if goal.profile_id != profile_id {
-            return;
+            return None;
         }
         let wrap_up = record_goal_turn_internal(goal, tokens_consumed, elapsed_seconds, now);
         let goal_snapshot = goal.clone();
@@ -2923,6 +2933,47 @@ impl InProcessAgentOrchestrator {
             // key shape.
             enqueue_goal_wrap_up(&mut state, session_id, &goal_snapshot, prompt, now_system);
         }
+        if matches!(goal_snapshot.status.as_str(), "complete" | "blocked") {
+            Some(goal_snapshot)
+        } else {
+            None
+        }
+    }
+
+    /// #1982 — reconcile the durable goal-ledger `tokens_used` with the live
+    /// total after a goal completed/blocked MID-TURN (see
+    /// [`Self::record_goal_turn`]). `status_changed == false` runs the guarded
+    /// `upsert_goal` (which admits the higher tokens on a complete==complete /
+    /// blocked==blocked row) and appends NO decision row. A no-op when the goal
+    /// has no existing ledger under `ledger_data_dir` — this only corrects an
+    /// under-count, it never creates a ledger for a goal that never had one.
+    pub(crate) fn reconcile_terminal_goal_ledger(
+        &self,
+        decided_by: &SessionKey,
+        snapshot: &AutonomyGoalRecord,
+        ledger_data_dir: &std::path::Path,
+    ) {
+        // No-op if the goal never had a ledger: this only CORRECTS an
+        // under-count, it never creates a fresh ledger for a goal that never
+        // synced one (which would change existing non-peer-goal behavior).
+        let ledger_path = Self::goal_ledger_dir(ledger_data_dir).join(format!(
+            "{}.db",
+            sanitize_filename_for_ledger(&snapshot.goal_id)
+        ));
+        if !ledger_path.is_file() {
+            return;
+        }
+        // `status_changed == false` → the guarded `upsert_goal` admits the higher
+        // tokens (complete==complete / blocked==blocked passes the guard clauses)
+        // and returns before appending any decision row.
+        self.sync_transition_to_ledger_blocking(
+            ledger_data_dir,
+            snapshot,
+            "post-turn token reconcile",
+            decided_by,
+            false,
+            false,
+        );
     }
 
     /// #1650 — the `goal_id` of the session's active goal for
@@ -8803,7 +8854,7 @@ struct AutonomyAgentRecord {
 }
 
 #[derive(Debug, Clone)]
-struct AutonomyGoalRecord {
+pub(crate) struct AutonomyGoalRecord {
     profile_id: String,
     goal_id: String,
     objective: String,
@@ -14142,6 +14193,62 @@ mod tests {
                 .len(),
             1,
             "blocked → blocked re-transition must append NO duplicate decision",
+        );
+    }
+
+    /// #1982 — a goal COMPLETED mid-turn freezes its durable ledger
+    /// `tokens_used` at the pre-completion total, and the post-turn
+    /// `record_goal_turn` charges the full turn but persists only to the
+    /// supervisor store — so the ledger under-counts the goal's true final cost
+    /// (soak: 266K live vs 129K ledger). `record_goal_turn` hands back the
+    /// terminal snapshot; `reconcile_terminal_goal_ledger` re-syncs the ledger.
+    #[tokio::test]
+    async fn record_goal_turn_reconciles_ledger_tokens_when_goal_completed_mid_turn() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let wire = SessionKey::new("api", "goal-token-reconcile");
+
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: wire.clone(),
+                profile_id: "tenant-a".to_owned(),
+                objective: "reconcile tokens".to_owned(),
+                status: Some("active".to_owned()),
+                token_budget: Some(2_000_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        let goal_id = orchestrator.goal_id_for_test(&wire).expect("goal_id");
+
+        // Complete mid-turn via the tool-supplied data dir → ledger row synced at
+        // the pre-turn total (0 spent so far).
+        orchestrator
+            .model_transition_goal(&wire, "tenant-a", "complete", "done", Some(data_dir.path()))
+            .await
+            .expect("complete");
+
+        // The full turn's spend is charged to the now-complete goal post-turn.
+        let terminal = orchestrator.record_goal_turn(&wire, "tenant-a", 191_064, 30);
+
+        let live = orchestrator.model_goal_snapshot(&wire, "tenant-a")["tokens_used"]
+            .as_u64()
+            .expect("tokens_used");
+        assert_eq!(live, 191_064, "live goal reflects the full turn spend");
+
+        // record_goal_turn hands back the terminal snapshot; the caller reconciles.
+        let snapshot = terminal.expect("terminal goal snapshot returned for reconcile");
+        orchestrator.reconcile_terminal_goal_ledger(&wire, &snapshot, data_dir.path());
+
+        let ledger_path = InProcessAgentOrchestrator::goal_ledger_dir(data_dir.path())
+            .join(format!("{}.db", sanitize_filename_for_ledger(&goal_id)));
+        let ledger = octos_fleet::GoalLedger::open(&ledger_path).expect("open ledger");
+        let row = ledger
+            .get_goal(&goal_id)
+            .expect("query ledger")
+            .expect("goals row present");
+        assert_eq!(
+            row.tokens_used, live,
+            "durable ledger must reflect the goal's true final cost after a mid-turn completion",
         );
     }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -34623,12 +34623,17 @@ async fn run_standalone_turn(
             .map(|start| start.elapsed().as_secs())
             .unwrap_or(0);
         let orchestrator = default_agent_orchestrator();
-        orchestrator.record_goal_turn(
+        if let Some(snapshot) = orchestrator.record_goal_turn(
             goal_key,
             &goal_ctx.profile_id,
             final_tokens_consumed,
             elapsed_seconds,
-        );
+        ) {
+            // #1982 — a goal completed/blocked mid-turn froze its ledger tokens
+            // at the pre-completion total; reconcile the durable record with the
+            // full turn's spend now.
+            orchestrator.reconcile_terminal_goal_ledger(goal_key, &snapshot, &goal_ledger_data_dir);
+        }
         if let Some(reply) = assistant_reply {
             // Loop-engineering completion gate: only spend the INDEPENDENT
             // verifier LLM call when the agent actually CLAIMS completion —

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -5101,12 +5101,20 @@ impl SessionActor {
         let elapsed_seconds = goal_turn_start.elapsed().as_secs();
         let tokens_consumed = self.last_turn_total_tokens;
         let orchestrator = default_agent_orchestrator();
-        orchestrator.record_goal_turn(
+        if let Some(snapshot) = orchestrator.record_goal_turn(
             &self.session_key,
             profile_id,
             tokens_consumed,
             elapsed_seconds,
-        );
+        ) {
+            // #1982 — reconcile the durable ledger after a mid-turn completion so
+            // its `tokens_used` reflects the goal's true final cost.
+            orchestrator.reconcile_terminal_goal_ledger(
+                &self.session_key,
+                &snapshot,
+                &self.data_dir,
+            );
+        }
         // Capture the most recent assistant turn's text content to feed
         // the completion-sentinel detector. Reading from the durable
         // session handle keeps the wiring narrow — `process_inbound`


### PR DESCRIPTION
## Problem

A goal's `tokens_used` diverges between the live record and the durable SQLite ledger when the goal is **completed/blocked mid-turn**. Caught live in the multi-peer restart soak: chip/`goal_get` showed **266K** while the goal's ledger row read **~129K**.

Mechanism (a **missing** write, not a rejected re-sync — correcting #1982's original wording):
1. Mid-turn, `goal_update(complete)` syncs the ledger row at the *running* (low) total.
2. The turn keeps spending.
3. Post-turn, `record_goal_turn` charges the full turn to the now-terminal goal but persists **only to the supervisor store** — never re-syncs the ledger. Because the goal is terminal, no later transition syncs it either. A re-sync carrying the higher value *would* pass `upsert_goal`'s guards; nothing attempts it.

The durable ledger is the fleet's authoritative multi-process cost record, so under the accepted "full turn counts" scope the ledger is the wrong side (an ~8.5× under-count on mid-turn-completed goals).

## Fix (reconcile, not cap)

- `record_goal_turn` now returns the goal snapshot **only when the goal is terminal** (`complete`/`blocked`) after the charge — `None` otherwise (non-terminal goals are re-synced by their next transition, so no per-turn ledger write).
- New `reconcile_terminal_goal_ledger` calls `sync_transition_to_ledger_blocking(..., status_changed = false)`: the guarded `upsert_goal` admits the higher tokens (complete==complete / blocked==blocked) and appends **no decision row**. Gated on the ledger already existing — it only corrects an under-count, never creates a ledger for a goal that never synced one.
- Both post-turn callers (`ui_protocol` AppUI driver, `session_actor` gateway) reconcile on the terminal snapshot. NOT a status-gate on the charge — that would make both layers agree at the *wrong* low value.

The return-value design keeps the fix to 2 production call sites; the 27 test call sites ignore the new `Option` return unchanged.

## Tests (RED → GREEN)

`record_goal_turn_reconciles_ledger_tokens_when_goal_completed_mid_turn` — complete a goal mid-turn (ledger synced at 0), charge 191,064 post-turn, reconcile, assert the ledger row == the live total. RED: ledger stayed `0` vs live `191064`. GREEN after the reconcile. Full serialized `octos-cli --features api --lib`; clippy clean.

Fixes #1982.
