### PR TITLE
fix(agent): charge interrupted goal turns their partial spend (#1969 interrupt leg)

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -825,10 +825,16 @@ impl Agent {
         history: &[Message],
         media: Vec<String>,
         attachments: TurnAttachmentContext,
-        tracker: &TokenTracker,
+        tracker: std::sync::Arc<TokenTracker>,
     ) -> Result<ConversationResponse> {
-        self.process_message_inner(user_content, history, media, attachments, Some(tracker))
-            .await
+        self.process_message_inner(
+            user_content,
+            history,
+            media,
+            attachments,
+            Some(tracker.as_ref()),
+        )
+        .await
     }
 
     async fn process_message_inner(

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -30292,6 +30292,33 @@ async fn run_interactive_sentinel_completion(
     )
 }
 
+/// #1969 — resolve the token charge for a turn that may have been INTERRUPTED.
+/// The AppUI drain loop breaks on interrupt before the done/error arm folds the
+/// turn's usage into `folded`, so an interrupted goal/peer turn would charge 0.
+/// When interrupted with nothing folded, fall back to the live `tracker` (which
+/// accumulated usage as the turn ran) so the partial spend still charges. A
+/// non-interrupted turn — or one that already folded a nonzero total — is
+/// unchanged. The tracker mirrors input/output tokens only (no cache).
+fn interrupted_goal_charge(
+    interrupt_observed: bool,
+    folded: u64,
+    tracker: &octos_agent::TokenTracker,
+) -> u64 {
+    if interrupt_observed && folded == 0 {
+        u64::from(
+            tracker
+                .input_tokens
+                .load(std::sync::atomic::Ordering::Relaxed),
+        ) + u64::from(
+            tracker
+                .output_tokens
+                .load(std::sync::atomic::Ordering::Relaxed),
+        )
+    } else {
+        folded
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_standalone_turn(
     ws: WsConnection,
@@ -32603,6 +32630,12 @@ async fn run_standalone_turn(
     if let Some(flag) = turn_dispatched.as_ref() {
         flag.store(true, std::sync::atomic::Ordering::Release);
     }
+    // #1969 — shared token tracker: `token_tracker_task` is moved into the
+    // spawned agent task below; the original `token_tracker` stays in THIS scope
+    // so the drain loop can read an interrupted turn's partial spend after the
+    // task future is dropped.
+    let token_tracker = std::sync::Arc::new(octos_agent::TokenTracker::new());
+    let token_tracker_task = std::sync::Arc::clone(&token_tracker);
     let agent_task = tokio::spawn(async move {
         let start = std::time::Instant::now();
         // RFC-3 (#1292): wrap the agent.process_message future in the
@@ -32626,11 +32659,16 @@ async fn run_standalone_turn(
             live_video: params.live_video,
             ..Default::default()
         };
-        let message_future = request_agent.process_message_with_attachments(
+        // #1969 — feed the shared token tracker (its clone `token_tracker_task`
+        // was moved into this spawned agent task; the original stays in the
+        // outer scope) so an INTERRUPTED turn's partial spend is readable after
+        // the drain loop. Mirrors the pattern `session_actor` already uses.
+        let message_future = request_agent.process_message_tracked_with_attachments(
             &prompt,
             &history,
             turn_media_paths,
             turn_attachments,
+            token_tracker_task,
         );
         let scoped_message_future: std::pin::Pin<
             Box<
@@ -33730,6 +33768,15 @@ async fn run_standalone_turn(
             }
         }
     }
+
+    // #1969 — an interrupt breaks the drain loop above before the done/error
+    // arm folds the turn's token usage, so `final_tokens_consumed` is still 0.
+    // Read the live tracker so an INTERRUPTED master/peer goal turn charges its
+    // real partial spend via `record_goal_turn` below instead of 0. The
+    // interactive accountant that follows is gated on a Completed terminal, so
+    // it stays unaffected.
+    final_tokens_consumed =
+        interrupted_goal_charge(interrupt_observed, final_tokens_consumed, &token_tracker);
 
     // #1650 — interactive goal accountant. Placed HERE — immediately
     // after the turn loop and BEFORE the voice-TTS / spawn_only

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -17744,6 +17744,27 @@ fn ws_connection_for_test(
     (WsConnection::new(tx), rx)
 }
 
+/// #1969 — an interrupted goal/peer turn must charge its partial spend from the
+/// live tracker (the drain loop breaks before the done/error arm folds usage),
+/// while a completed/errored turn keeps the folded total.
+#[test]
+fn interrupted_goal_charge_falls_back_to_tracker_only_when_interrupted_with_zero_folded() {
+    let tracker = octos_agent::TokenTracker::new();
+    tracker
+        .input_tokens
+        .store(1_000, std::sync::atomic::Ordering::Relaxed);
+    tracker
+        .output_tokens
+        .store(500, std::sync::atomic::Ordering::Relaxed);
+
+    // interrupted + nothing folded → charge the tracker's accumulated spend
+    assert_eq!(interrupted_goal_charge(true, 0, &tracker), 1_500);
+    // NOT interrupted → keep the folded value (0 here), never read the tracker
+    assert_eq!(interrupted_goal_charge(false, 0, &tracker), 0);
+    // interrupted but a real total was already folded → never override it
+    assert_eq!(interrupted_goal_charge(true, 42, &tracker), 42);
+}
+
 #[tokio::test]
 async fn slow_fixture_checks_pending_interrupt_before_emitting_delta() {
     let (ws, mut rx) = ws_connection_for_test(32);

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -7648,7 +7648,7 @@ impl SessionActor {
                             &history_for_agent,
                             media,
                             attachments,
-                            &tracker,
+                            std::sync::Arc::clone(&tracker),
                         ),
                     ),
                 ),
@@ -9382,7 +9382,7 @@ impl SessionActor {
                         attachment_prompt,
                         Self::inbound_live_video(&inbound),
                     ),
-                    &token_tracker,
+                    std::sync::Arc::clone(&token_tracker),
                 ),
             ),
         )


### PR DESCRIPTION
## Problem (the residual half of #1969)

#1992 fixed the **error / rate-limit / stall** paths. The remaining leg: a **user interrupt mid-turn**. The AppUI turn runs in a spawned task and feeds a drain loop; on interrupt the drain loop breaks (`ui_protocol.rs`) **before** the done/error arm folds the turn's token usage, so `final_tokens_consumed` stays 0 and `record_goal_turn` charges the goal **0** — a peer/master turn that burned tokens then got interrupted is free against the budget.

## Fix

Track live usage for the AppUI turn and read it on interrupt — the pattern `session_actor` already uses:
- Create a shared `TokenTracker` in the turn scope; move a clone into the spawned agent task and switch it to `process_message_tracked_with_attachments` (which feeds the tracker live via `record_usage`). The original stays in the outer scope, readable after the task future is dropped.
- After the drain loop, `interrupted_goal_charge(interrupt_observed, final_tokens_consumed, &tracker)` falls back to the tracker's accumulated spend **only** when interrupted with nothing folded; a completed/errored turn keeps its folded total. That feeds `record_goal_turn` below.
- The interactive accountant is gated on a `Completed` terminal, so it stays unaffected (interrupted interactive turns still don't charge — unchanged). This targets the master/peer `record_goal_turn` path, which is #1969's subject.

`process_message_tracked_with_attachments` now takes `Arc<TokenTracker>` by value (the AppUI boxes the turn future as `'static`, so a per-turn borrow won't fit); `session_actor`'s two call sites pass an owned clone.

## Tests

`interrupted_goal_charge_falls_back_to_tracker_only_when_interrupted_with_zero_folded` — the extracted charge-resolution helper: interrupted+0-folded → tracker sum; not-interrupted → folded unchanged; interrupted+nonzero-folded → folded unchanged. The tracker *population* is already exercised by `session_actor`'s tracked path; a full interrupt-mid-turn integration test would need a bespoke goal+interrupt harness (the existing interrupt harness only drives protocol fixtures) — noted.

octos-agent 2562/0; full serialized octos-cli suite; clippy clean.

Closes #1969.
