### PR TITLE
ci(e2e): install Playwright browsers before running the e2e suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -998,6 +998,20 @@ jobs:
         working-directory: e2e
         run: npm ci
 
+      # `npm ci` installs the @playwright/test PACKAGE but NOT the browser
+      # binaries. Several specs in this suite (dashboard/harness/swarm-gate)
+      # launch chrome-headless-shell, so without this step the job only passed
+      # when the runner happened to have a warm ~/Library/Caches/ms-playwright
+      # from an earlier run. Once that cache aged out, every run failed with
+      # `browserType.launch: Executable doesn't exist at
+      # .../chromium_headless_shell-*/chrome-headless-shell` — a green-vs-red
+      # coin flip decided by runner assignment, not by the diff under test.
+      # `install chromium` also fetches the headless shell.
+      - name: Install Playwright browsers
+        if: steps.changes.outputs.run == 'true'
+        working-directory: e2e
+        run: npx playwright install chromium
+
       - name: Run e2e tool regression tests
         if: steps.changes.outputs.run == 'true'
         working-directory: e2e


### PR DESCRIPTION
## Problem

`e2e-tool-regression` runs `npm ci` and then `npx playwright test` — but **never installs the browser binaries**. `npm ci` installs the `@playwright/test` *package* only.

Several specs in that suite (coding-loop dashboard, operator harness dashboard, swarm dispatch gate) launch `chrome-headless-shell`. So the job only passed when the assigned `macos-14` runner happened to have a warm `~/Library/Caches/ms-playwright` from an earlier run.

Once that cache aged out, every run began failing with:

```
Error: browserType.launch: Executable doesn't exist at
  ~/Library/Caches/ms-playwright/chromium_headless_shell-1208/.../chrome-headless-shell
```

That makes the gate a **green-vs-red coin flip decided by runner assignment**, not by the diff under test. Observed: 4 consecutive failures across two PRs (#1993 ×3 attempts, #1994) whose changes were pure-Rust goal token accounting — with **zero failing subtests in the changed area**, the identical failure signature each time, and the same job green on `main` days earlier.

## Fix

Add the missing install step (matching the sibling steps' `if:` gate and `working-directory`):

```yaml
- name: Install Playwright browsers
  if: steps.changes.outputs.run == 'true'
  working-directory: e2e
  run: npx playwright install chromium
```

`install chromium` also fetches the headless shell.

## Note

This addresses the **browser-provisioning** cause specifically. The same failed job also showed two unrelated environmental errors (`ENOENT .../workstreams/M15-agent-goal-loop-autonomy.md` — a gitignored doc — and `ECONNREFUSED 127.0.0.1:56831` from the m9 ephemeral server); those are separate and not addressed here.