### PR TITLE
chore(release): v2.0.3-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4531,7 +4531,7 @@ dependencies = [
 
 [[package]]
 name = "octos-agent"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -4592,7 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "octos-bus"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "aes",
  "async-imap",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "octos-cli"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "agent-client-protocol",
  "argon2",
@@ -4715,7 +4715,7 @@ dependencies = [
 
 [[package]]
 name = "octos-core"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "chrono",
  "eyre",
@@ -4730,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "octos-diagnostics"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4742,14 +4742,14 @@ dependencies = [
 
 [[package]]
 name = "octos-dora-mcp"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "octos-agent",
 ]
 
 [[package]]
 name = "octos-embed-llama"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4763,7 +4763,7 @@ dependencies = [
 
 [[package]]
 name = "octos-ffi"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "libc",
  "octos-agent",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet-worker"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4812,7 +4812,7 @@ dependencies = [
 
 [[package]]
 name = "octos-llm"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "octos-memory"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "bincode",
  "chrono",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pipeline"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4880,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "octos-plugin"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "eyre",
  "metrics",
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pyo3"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "octos-ffi",
  "pyo3",
@@ -4917,7 +4917,7 @@ dependencies = [
 
 [[package]]
 name = "octos-server"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -4954,7 +4954,7 @@ dependencies = [
 
 [[package]]
 name = "octos-services"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "octos-store"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "base64",
  "chrono",
@@ -4995,7 +4995,7 @@ dependencies = [
 
 [[package]]
 name = "octos-swarm"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5015,7 +5015,7 @@ dependencies = [
 
 [[package]]
 name = "octos-uniffi"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "octos-ffi",
  "uniffi",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "octos-wasm"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "octos-workflows"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "chrono",
  "eyre",
@@ -8473,7 +8473,7 @@ dependencies = [
 
 [[package]]
 name = "wechat-bridge"
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 dependencies = [
  "clap",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.3-rc.2"
+version = "2.0.3-rc.3"
 edition = "2024"
 rust-version = "1.85.0"
 authors = ["octos team"]


### PR DESCRIPTION
Version bump only — 23 commits since `v2.0.3-rc.2`.

## What's in this RC

**Peer-agent goal — correctness (the bulk of it)**
- Completion verifier can now see the durable ledger, so a genuinely-complete peer goal actually converges instead of looping until its budget drains (#1990)
- Errored / rate-limited / stalled turns carry their partial token spend instead of charging the goal 0 (#1992), and interrupted turns do too (#1994)
- A user replacing a `complete` goal mints a fresh `goal_id` with reset counters instead of resurrecting the finished record (#1991)
- The durable ledger is reconciled after a mid-turn completion, so it stops under-counting the goal's true cost (#1993)
- A closed peer can no longer re-park invisibly (#1998)

**Goals in the core CLI (new)**
- `octos chat --goals` — a durable objective + token budget that survives across invocations (#1997), on top of the Phase 0 refactor that lifted the goal state engine out of the api-gated tree (#1996)

**Other**
- `fix(llm)`: support disabled reasoning effort (#1985)
- `ci`: install Playwright browsers before the e2e suite, which had become a runner-cache coin flip (#1995)
- `test`: gate two supervisor-store concurrency tests to non-Windows — they expose a real Windows limitation tracked in #1999 (#2000)

## Verification

Every change above landed with its CI green (test-octos-cli, check, check-matrix, check-windows, test-octos-agent). The peer-goal work was additionally live-soaked: 10 concurrent peers under one goal (10 findings, ledger integrity, convergence), a backend restart with goal rehydration, and budget exhaustion flipping to `budget_limited`.

**Not included:** peers in `octos chat` (built and live-proven, but not yet merged), and the autonomous continuation loop / fleet in chat.