### PR TITLE
chore(release): v2.0.3-rc.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4531,7 +4531,7 @@ dependencies = [
 
 [[package]]
 name = "octos-agent"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -4592,7 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "octos-bus"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "aes",
  "async-imap",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "octos-cli"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "agent-client-protocol",
  "argon2",
@@ -4715,7 +4715,7 @@ dependencies = [
 
 [[package]]
 name = "octos-core"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "chrono",
  "eyre",
@@ -4730,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "octos-diagnostics"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4742,14 +4742,14 @@ dependencies = [
 
 [[package]]
 name = "octos-dora-mcp"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "octos-agent",
 ]
 
 [[package]]
 name = "octos-embed-llama"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4763,7 +4763,7 @@ dependencies = [
 
 [[package]]
 name = "octos-ffi"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "libc",
  "octos-agent",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet-worker"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4812,7 +4812,7 @@ dependencies = [
 
 [[package]]
 name = "octos-llm"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "octos-memory"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "bincode",
  "chrono",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pipeline"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4880,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "octos-plugin"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "eyre",
  "metrics",
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pyo3"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "octos-ffi",
  "pyo3",
@@ -4917,7 +4917,7 @@ dependencies = [
 
 [[package]]
 name = "octos-server"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "async-trait",
  "axum",
@@ -4954,7 +4954,7 @@ dependencies = [
 
 [[package]]
 name = "octos-services"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "chrono",
  "dirs",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "octos-store"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "base64",
  "chrono",
@@ -4995,7 +4995,7 @@ dependencies = [
 
 [[package]]
 name = "octos-swarm"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5015,7 +5015,7 @@ dependencies = [
 
 [[package]]
 name = "octos-uniffi"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "octos-ffi",
  "uniffi",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "octos-wasm"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "octos-workflows"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "chrono",
  "eyre",
@@ -8473,7 +8473,7 @@ dependencies = [
 
 [[package]]
 name = "wechat-bridge"
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 dependencies = [
  "clap",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.3-rc.3"
+version = "2.0.3-rc.4"
 edition = "2024"
 rust-version = "1.85.0"
 authors = ["octos team"]


### PR DESCRIPTION
Version bump only. Cuts a release containing **#2004** — the stale in-flight marker fix — which missed the rc.3 tag by minutes (rc.3 was tagged while #2004 was still in CI, so the shipped rc.3 has no mitigation for the 'master silently stops' wedge).

Since v2.0.3-rc.3:
- **fix(goal): stop a stale in-flight marker from wedging a session forever (#2004)** — a leaked `GoalDispatchInFlightGuard` could stall every continuation kind for a session indefinitely; the marker is now timestamped and self-heals after 30 minutes. Mitigation, not root cause — #2003 stays open for the leak audit.