### PR TITLE
feat(goal): raise the default goal token budget 2M → 100M for peer fleets

### DIFF
--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -51,7 +51,24 @@ const AUTONOMY_POLICY_ID: &str = "coding-autonomy-v1";
 /// as "the goal stopped counting". Users can override per-goal up to
 /// [`GOAL_MAX_TOKEN_BUDGET`]. `pub(crate)` so the capability advertisement
 /// (`ui_protocol`) reports the real value instead of a drifting literal.
-pub(crate) const GOAL_DEFAULT_TOKEN_BUDGET: u64 = 2_000_000;
+///
+/// Raised 2M -> 100M for PEER FLEETS. A goal that fans out to peers charges
+/// every peer's turns to the MASTER's budget (#1965/#1970), so the old 2M
+/// default was exhausted by a single realistic fleet: a 5-peer deep-review
+/// goal spent 10.65M and flipped to `budget_limited` with all five peers
+/// still doing useful work. Enforcement is at the TURN BOUNDARY (mid-turn
+/// limiting was deliberately dropped), so the overshoot is unbounded within
+/// a turn and a budget only ever acts as a tripwire noticed afterwards —
+/// which made 2M a guard that fired on correct behaviour rather than runaway
+/// behaviour.
+///
+/// TRADE-OFF, stated plainly: this is the ceiling on what an UNSPECIFIED
+/// goal may spend autonomously. At the ~$1/M-token rate observed in soaks,
+/// 100M is on the order of $100 per goal before anything stops it. Set a
+/// smaller explicit `--budget` for anything cost-sensitive; the default now
+/// optimises for "a legitimate fleet finishes" over "an unattended goal
+/// cannot spend much".
+pub(crate) const GOAL_DEFAULT_TOKEN_BUDGET: u64 = 100_000_000;
 /// Hard ceiling on a caller-supplied goal budget — a sanity limit against
 /// typos / overflow, NOT a practical cap (at ~175K tokens/turn this still
 /// allows thousands of continuations). The user owns whatever value they


### PR DESCRIPTION
## Why

Peer turns charge to the **master's** goal budget (#1965/#1970), and budget enforcement is at the **turn boundary** only — mid-turn limiting was deliberately dropped. So the old 2M default was exhausted by a single realistic fleet:

> A 5-peer deep-review goal spent **10.65M against a 2M budget** and flipped to `budget_limited` while all five peers were still doing useful work. The user saw the master go silent.

At fleet scale, 2M was a guard that fired on **correct** behaviour rather than runaway behaviour. Because enforcement is turn-boundary, a budget is a tripwire noticed afterwards, not a cap — so setting it below one fleet's real cost just produces a confusing halt.

## The trade-off, stated plainly

This is the ceiling on what an **unspecified** goal may spend autonomously. At the ~$1/M-token rate observed in soaks, **100M is on the order of $100 per goal** before anything stops it (that 5-peer fleet was ~$10). The default now optimises for *"a legitimate fleet finishes"* over *"an unattended goal cannot spend much"*.

Recorded in the constant's doc comment so the next reader sees the reasoning, not just the number. Set a smaller explicit `--budget` for cost-sensitive work; still far below `GOAL_MAX_TOKEN_BUDGET` (1B).

If $100 of unattended exposure is too much, **20M** (~2× the worst observed real fleet) is a reasonable middle ground — one-line change.

## Verification

`cargo test -p octos-cli --features api --lib -- --test-threads=1` → 2862 passed, 1 failed: `session_actor::tests::master_continuation_tick_reenters_actor_loop`. **Pre-existing load-sensitive flake, not caused by this change** — a one-constant diff cannot affect it, and over 12 consecutive runs it fails **3/12 on unmodified main** as well (machine was at load average ~300). Filed separately.

Tests that pin an explicit `token_budget: Some(2_000_000)` are unaffected — they set their own budget. The capability advertisement in `ui_protocol` reads the constant, so it reports the new value automatically.