### PR TITLE
chore: gitignore /scratchpad/ so an accidental `git add -A` cannot sweep it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,10 @@ tsconfig.tsbuildinfo
 
 # Local audit artifacts (personal, not tracked)
 /audit/
+
+# Agent/dev scratch space — soak runs, driver scripts, issue drafts, captured
+# transcripts. Local only, and large (a single peer-goal soak leaves tens of MB
+# of session ledgers and server logs). Ignored because an accidental
+# `git add -A` here otherwise sweeps hundreds of artifact files — and any
+# workspace dirs the soaks `git init` — into a commit.
+/scratchpad/


### PR DESCRIPTION
`/scratchpad/` is the agent/dev scratch space — soak runs, driver scripts, issue drafts, captured transcripts. It is local-only and **large**: a single peer-goal soak leaves tens of MB of session ledgers and server logs, and the soak harness `git init`s its own workspace dirs, so a stray `git add -A` pulls in hundreds of artifact files **and embedded git repositories**.

Not hypothetical — it happened while preparing #2007: **316 files / 42,744 insertions** of soak logs and session transcripts went into a commit and were force-pushed before I caught it by reading the commit stat and rebuilt the branch. The remote is clean now, but the trap is still armed for anyone else working in this tree.

Ignoring the directory removes the trap instead of relying on everyone remembering to stage explicitly.

Currently 64M / 545 files locally. Note there are other untracked dirs in this repo (`.codex/`, `Splash/`, `robrix2/`) that are also embedded git repos and would be swept the same way — I have deliberately NOT added those, since they are not mine to decide on. Worth a look if the same protection is wanted.