### PR TITLE
fix(ci): make the e2e gate actually run, and stop it reporting green when it doesn't

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -931,13 +931,18 @@ jobs:
           path: octos-bundle-x86_64-pc-windows-msvc.zip
           retention-days: 7
 
-  e2e-tool-regression:
-    runs-on: macos-14
-    needs: [check, test-octos-agent, test-octos-cli]
-    # Run on pushes to main and on every PR. The file-level detection below is
-    # the only filter — PR-title keyword matching used to gate this job, so a
-    # PR that changed tools without saying so in the title skipped e2e entirely.
+  # Change detection lives in its OWN job so that "nothing relevant changed"
+  # surfaces as a SKIPPED e2e check rather than a green one. Previously the
+  # filter set a step-level flag and every step carried
+  # `if: steps.changes.outputs.run == 'true'` — a job whose steps all skip
+  # still concludes SUCCESS, so `e2e-tool-regression: SUCCESS` was
+  # indistinguishable from "the suite ran and passed". It had not actually
+  # executed in any of the last 14 CI runs (#2015).
+  e2e-changes:
+    runs-on: ubuntu-latest
     if: github.event_name != 'schedule'
+    outputs:
+      run: ${{ steps.changes.outputs.run }}
     steps:
       # fetch-depth: 0 is load-bearing: the diff below needs HEAD~1 (push) and
       # the PR base sha (pull_request). The default depth-1 checkout has
@@ -946,14 +951,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
 
       - name: Check for relevant changes
         id: changes
@@ -966,22 +963,53 @@ jobs:
           fi
           echo "Changed files:"
           echo "$FILES"
-          if echo "$FILES" | grep -qE '(activate_tools|sandbox|shell\.rs|tools/mod|session_actor|exec_env)'; then
+          # `.github/workflows/ci.yml` is in the list so that changes to THIS
+          # job are self-testing. Without it a PR that repairs the e2e gate
+          # cannot observe its own repair — the gate skips itself.
+          if echo "$FILES" | grep -qE '(activate_tools|sandbox|shell\.rs|tools/mod|session_actor|exec_env|\.github/workflows/ci\.yml)'; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
 
+  e2e-tool-regression:
+    runs-on: macos-14
+    needs: [check, test-octos-agent, test-octos-cli, e2e-changes]
+    # Run on pushes to main and on every PR whose diff touches the paths in
+    # `e2e-changes`. PR-title keyword matching used to gate this job, so a PR
+    # that changed tools without saying so in the title skipped e2e entirely.
+    if: github.event_name != 'schedule' && needs.e2e-changes.outputs.run == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      # MUST precede the cargo build: the admin SPA is embedded into the
+      # binary at COMPILE time via `rust_embed::Embed` (api/static_files.rs),
+      # not read from disk at runtime, so building it afterwards has no
+      # effect. `crates/octos-cli/static/admin/` is gitignored by the
+      # ephemeral-bundle policy and `scripts/build-dashboard.sh` runs in the
+      # separate `dashboard` job, whose filesystem this job never sees.
+      # Without this, `/admin/login` answers 503 (static_files.rs:169), the
+      # setup-wizard readiness probe never gets its 2xx, and the whole suite
+      # fails on a six-minute timeout that has nothing to do with the diff
+      # under test (#2015).
+      - name: Build dashboard bundle (embedded at compile time)
+        run: ./scripts/build-dashboard.sh
+
       - name: Build octos with all features
-        if: steps.changes.outputs.run == 'true'
         run: cargo build --release -p octos-cli --features "octos-cli/api,octos-cli/telegram"
 
       - name: Install Homebrew ffmpeg (macOS)
-        if: steps.changes.outputs.run == 'true'
         run: brew install ffmpeg
 
       - name: Start octos serve
-        if: steps.changes.outputs.run == 'true'
         run: |
           OCTOS_AUTH_TOKEN=ci-test-token ./target/release/octos serve --port 3000 &
           # Wait for server to be ready
@@ -994,7 +1022,6 @@ jobs:
           done
 
       - name: Install e2e deps
-        if: steps.changes.outputs.run == 'true'
         working-directory: e2e
         run: npm ci
 
@@ -1008,12 +1035,10 @@ jobs:
       # coin flip decided by runner assignment, not by the diff under test.
       # `install chromium` also fetches the headless shell.
       - name: Install Playwright browsers
-        if: steps.changes.outputs.run == 'true'
         working-directory: e2e
         run: npx playwright install chromium
 
       - name: Run e2e tool regression tests
-        if: steps.changes.outputs.run == 'true'
         working-directory: e2e
         run: OCTOS_TEST_URL=http://localhost:3000 OCTOS_AUTH_TOKEN=ci-test-token npx playwright test --reporter=line
 


### PR DESCRIPTION
Fixes #2015.

`e2e-tool-regression` reported **SUCCESS without running a single test** on essentially every PR, and failed structurally whenever it did run. The two defects hid each other — the skip kept the check green, so the structural failure was never observed.

The step `Run e2e tool regression tests` across the last 14 CI runs: **6 skipped** (job still SUCCESS), **7 job-absent**, **1 actually ran** — #2014, which failed. #2009 shipped peer-agents-in-chat with e2e "passing" having executed nothing.

## 1. Build the dashboard bundle before the cargo build

Every failure cascaded from one line: `octos serve did not become ready`. Serve starts fine (`Listening:` and `Dashboard:` both logged). The readiness probe wants a 2xx on `/admin/login` (`admin-setup-wizard.spec.ts:132`), and that route answers **503** because the admin SPA bundle is absent — `static_files.rs:169` documents exactly this.

`crates/octos-cli/static/admin/` is gitignored by the ephemeral-bundle policy, and `scripts/build-dashboard.sh` runs in the separate `dashboard` job whose filesystem this job never sees. So the probe could never pass; it burned the full 6-minute `SERVER_READY_TIMEOUT_MS` and took ~40 downstream tests with it.

**The step must precede the cargo build**, not merely the serve start — the SPA is embedded at **compile time** via `rust_embed::Embed`, not read from disk at runtime.

Verified locally with the harness's exact args:

| state | `/admin/login` |
|---|---|
| bundle missing `index.html` (as in CI) | **503** |
| after `./scripts/build-dashboard.sh` | **200** |

The same probe returns 503 on `b0dc4e619` (v2.0.3-rc.4) built identically — so this was never a #2014 regression.

## 2. Gate at the job level so a skip reads as SKIPPED

The filter set a step-level flag and every step carried `if: steps.changes.outputs.run == 'true'`. A job whose steps all skip still concludes **SUCCESS**, indistinguishable from a real pass. Change detection moves into its own `e2e-changes` job whose output gates the whole e2e job.

`e2e-tool-regression` is **not** a required status check (verified against the active ruleset), so a skipped conclusion blocks nothing.

Also adds `.github/workflows/ci.yml` to the filter so changes to this job are **self-testing** — without it, a PR repairing the gate cannot observe its own repair. **This PR therefore runs the suite on itself**, which is the real acceptance test.

## Scope

The `security` job has the identical step-level false-green pattern — its "Security sandbox tests" skip and report green the same way. Left alone here to keep this reviewable; noted on #2015 as a follow-up.

If the suite still shows failures beyond the bundle (the ffmpeg PATH assertions are the likely candidates), those are pre-existing and get triaged on #2015 rather than folded in here.