### PR TITLE
chore(release): v2.0.3-rc.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4531,7 +4531,7 @@ dependencies = [
 
 [[package]]
 name = "octos-agent"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -4592,7 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "octos-bus"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "aes",
  "async-imap",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "octos-cli"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "agent-client-protocol",
  "argon2",
@@ -4715,7 +4715,7 @@ dependencies = [
 
 [[package]]
 name = "octos-core"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "chrono",
  "eyre",
@@ -4730,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "octos-diagnostics"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4742,14 +4742,14 @@ dependencies = [
 
 [[package]]
 name = "octos-dora-mcp"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "octos-agent",
 ]
 
 [[package]]
 name = "octos-embed-llama"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4763,7 +4763,7 @@ dependencies = [
 
 [[package]]
 name = "octos-ffi"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "libc",
  "octos-agent",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet-worker"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4812,7 +4812,7 @@ dependencies = [
 
 [[package]]
 name = "octos-llm"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "octos-memory"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "bincode",
  "chrono",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pipeline"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4880,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "octos-plugin"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "eyre",
  "metrics",
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pyo3"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "octos-ffi",
  "pyo3",
@@ -4917,7 +4917,7 @@ dependencies = [
 
 [[package]]
 name = "octos-server"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -4954,7 +4954,7 @@ dependencies = [
 
 [[package]]
 name = "octos-services"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "chrono",
  "dirs",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "octos-store"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "base64",
  "chrono",
@@ -4995,7 +4995,7 @@ dependencies = [
 
 [[package]]
 name = "octos-swarm"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5015,7 +5015,7 @@ dependencies = [
 
 [[package]]
 name = "octos-uniffi"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "octos-ffi",
  "uniffi",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "octos-wasm"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "octos-workflows"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "chrono",
  "eyre",
@@ -8473,7 +8473,7 @@ dependencies = [
 
 [[package]]
 name = "wechat-bridge"
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 dependencies = [
  "clap",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.3-rc.4"
+version = "2.0.3-rc.5"
 edition = "2024"
 rust-version = "1.85.0"
 authors = ["octos team"]


### PR DESCRIPTION
Version bump only — `Cargo.toml` + `Cargo.lock`, no code changes. **Not tagged yet.**

Ships the five commits on main since `v2.0.3-rc.4`:

| commit | what |
|---|---|
| `fa9f70eba` | **#2014** in-flight staleness rescue made safe + progress-aware |
| `af9514baa` | **#2009** peer agents in `octos chat --peers` (Phase 3) |
| `1c69e911b` | **#2010** default goal token budget 2M → 100M |
| `6d2cd3d51` | **#2007** corrupt `cron.json` quarantined instead of wiping schedules |
| `a2cf258e6` | **#2012** gitignore `/scratchpad/` |

## Why this one matters for anyone on rc.4

rc.4 shipped #2004's 30-minute staleness rescue **without** the generation stamping that makes it safe. On rc.4:

- a turn that unwinds after being evicted for staleness clears whatever marker is present — including a **newer** turn's — re-opening the #1529 double-dispatch the marker exists to prevent;
- nothing re-stamps a running turn, so the horizon can fire on healthy long-running work, not just wedged work.

Both are fixed in #2014. Paired with #2010, a peer fleet no longer exhausts its budget five times over on the old 2M default.

## Not included

**#2016** (e2e CI gate repair) is deliberately out — it changes no shipped code, and its own self-test run is still in flight.