### PR TITLE
fix(peers): re-evaluate fleet synthesis on the master-idle edge

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -14551,15 +14551,79 @@ async fn maybe_enqueue_peer_fleet_synthesis(state: &Arc<AppState>, peer_session:
     if master.is_empty() {
         return;
     }
-    let master_key = SessionKey(master.clone());
+    evaluate_and_enqueue_fleet_synthesis(profile_id, &peers_root, &master, peer_session).await;
+}
 
-    // One lock: sessions with a live (non-terminal) turn. Exclude THIS peer —
-    // its turn is still marked Active at this hook (the terminal transition
-    // runs just after), yet its result is already on the blackboard, so it
-    // counts as DONE, not mid-turn.
+/// #2003 — the MASTER-idle edge.
+///
+/// The fleet gate used to be evaluated ONLY when a peer's turn terminated, and
+/// a `Hold` was discarded with nothing rescheduled. So a fleet whose LAST peer
+/// landed while the master happened to be busy (live turn or pending approval)
+/// was never synthesized: every peer was terminal, so no further peer event
+/// could ever fire, and no other trigger recomputed the decision. That is the
+/// "master just stopped" report — five peers all wrote `result.md` and the
+/// master sat idle forever.
+///
+/// Clearing a wedged in-flight marker (#2004/#2014) does NOT fix it, because
+/// clearing the wedge does not re-run the gate. The lost `Fire` has to be
+/// recomputed, and the master finishing a turn is exactly the edge on which the
+/// input that forced `Hold` (`master_idle == false`) becomes true.
+///
+/// Safe to call on every turn terminal: the decision is pure over
+/// `(peers, stamp_exists, master_idle)` and exactly-once via the
+/// `.synthesized-<master>` stamp, so a redundant evaluation is a no-op.
+async fn maybe_enqueue_peer_fleet_synthesis_for_master(
+    state: &Arc<AppState>,
+    master_session: &SessionKey,
+) {
+    // Peer terminals are already handled by the peer-terminal path above;
+    // this hook is only for a session acting as a MASTER.
+    if peer_slug_and_profile(master_session).is_some() {
+        return;
+    }
+    let Some(profile_id) = master_session.profile_id() else {
+        return;
+    };
+    let Some(runtime) = state.profiles.get(profile_id) else {
+        return;
+    };
+    let peers_root = runtime.data_dir.join("peers");
+    // Cheap early-out so an ordinary session with no fleet does not pay for a
+    // `peers/` scan on every single turn terminal.
+    if !peers_root.is_dir() {
+        return;
+    }
+    evaluate_and_enqueue_fleet_synthesis(
+        profile_id,
+        &peers_root,
+        &master_session.0,
+        master_session,
+    )
+    .await;
+}
+
+/// Shared fleet-readiness evaluation, reached from BOTH the peer-terminal edge
+/// and the master-idle edge. `exclude_session` is the session whose turn is
+/// terminating right now: its turn is still marked Active at this hook (the
+/// terminal transition runs just after), so it must not count against
+/// idle/settled or the gate can never fire on its own edge.
+async fn evaluate_and_enqueue_fleet_synthesis(
+    profile_id: &str,
+    peers_root: &Path,
+    master: &str,
+    exclude_session: &SessionKey,
+) {
+    let master_key = SessionKey(master.to_owned());
+
+    // One lock: sessions with a live (non-terminal) turn. Exclude the session
+    // whose turn is terminating right now — it is still marked Active at this
+    // hook (the terminal transition runs just after). On the peer edge its
+    // result is already on the blackboard, so it counts as DONE, not mid-turn;
+    // on the master edge (#2003) excluding it is what lets `master_idle` become
+    // true on the very edge the master goes idle.
     let active_turns = active_turns_registry();
     let mut running = active_turn_sessions(&active_turns).await;
-    running.remove(peer_session);
+    running.remove(exclude_session);
 
     // Master idle-eligibility, mirroring the drain's gate inputs: no in-flight
     // turn AND no pending approval. (The drain re-checks this before firing.)
@@ -14577,7 +14641,7 @@ async fn maybe_enqueue_peer_fleet_synthesis(state: &Arc<AppState>, peer_session:
     // this pass (no fire, no reset) rather than mistake an unreadable dir for a
     // cleared fleet.
     let orchestrator = default_agent_orchestrator();
-    let Some(owned) = collect_owned_peer_results(&peers_root, &master) else {
+    let Some(owned) = collect_owned_peer_results(peers_root, master) else {
         return;
     };
     let mut owned_slugs: Vec<String> = Vec::with_capacity(owned.len());
@@ -14604,7 +14668,7 @@ async fn maybe_enqueue_peer_fleet_synthesis(state: &Arc<AppState>, peer_session:
         })
         .collect();
 
-    let stamp_exists = peer_fleet_synthesized_stamp_exists(&peers_root, &master);
+    let stamp_exists = peer_fleet_synthesized_stamp_exists(peers_root, master);
     match evaluate_peer_fleet_synthesis(&peers, stamp_exists, master_idle) {
         FleetSynthesisDecision::Hold => {}
         // Defensive: a peer-terminal eval always includes the just-terminated
@@ -14612,7 +14676,7 @@ async fn maybe_enqueue_peer_fleet_synthesis(state: &Arc<AppState>, peer_session:
         // `peer_close`. Handle it anyway so the decision contract is honored —
         // drop the disk marker AND the recent-claim guard together (Bug 1).
         FleetSynthesisDecision::ClearStamp => {
-            remove_peer_fleet_synthesized_stamp(&peers_root, &master);
+            remove_peer_fleet_synthesized_stamp(peers_root, master);
             orchestrator.clear_peer_fleet_synthesis_claim(&master_key);
         }
         FleetSynthesisDecision::Fire => {
@@ -14626,7 +14690,7 @@ async fn maybe_enqueue_peer_fleet_synthesis(state: &Arc<AppState>, peer_session:
                 .map(|elapsed| elapsed.as_secs())
                 .unwrap_or(0);
             if let Err(err) = crate::memory_consolidate::apply::atomic_write(
-                &peer_fleet_synthesized_stamp_path(&peers_root, &master),
+                &peer_fleet_synthesized_stamp_path(peers_root, master),
                 &now_unix.to_string(),
             ) {
                 tracing::warn!(
@@ -31406,6 +31470,9 @@ async fn run_standalone_turn(
                 // result still counts toward readiness (it does not block) but
                 // does not itself kick off a synthesis.
                 maybe_enqueue_peer_fleet_synthesis(&state, &session_id).await;
+                // #2003 — also evaluate on the MASTER-idle edge. No-ops for a peer
+                // session (handled just above) and for a session with no fleet.
+                maybe_enqueue_peer_fleet_synthesis_for_master(&state, &session_id).await;
                 // FIX-04: flush any accumulated drops before the lifecycle
                 // terminal so the client knows the cursor is incomplete.
                 flush_replay_lossy(&ws, &ledger, &session_id, &progress_dropped);
@@ -31505,6 +31572,9 @@ async fn run_standalone_turn(
                 // body is part of what the master consolidates). Same fleet
                 // gate as the completed arm; no-op for non-peer sessions.
                 maybe_enqueue_peer_fleet_synthesis(&state, &session_id).await;
+                // #2003 — also evaluate on the MASTER-idle edge. No-ops for a peer
+                // session (handled just above) and for a session with no fleet.
+                maybe_enqueue_peer_fleet_synthesis_for_master(&state, &session_id).await;
                 flush_replay_lossy(&ws, &ledger, &session_id, &progress_dropped);
                 try_emit_terminal(
                     &turn_state,
@@ -31889,6 +31959,9 @@ async fn run_standalone_turn(
         // point is to not SKIP evaluation on the interrupt path. No-op for
         // non-peer sessions.
         maybe_enqueue_peer_fleet_synthesis(&state, &session_id).await;
+        // #2003 — also evaluate on the MASTER-idle edge. No-ops for a peer
+        // session (handled just above) and for a session with no fleet.
+        maybe_enqueue_peer_fleet_synthesis_for_master(&state, &session_id).await;
     }
 
     let _ = agent_task.await;

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -9702,6 +9702,69 @@ fn reset_removes_marker_only_when_fleet_fully_cleared() {
     );
 }
 
+/// #2003 — a fleet whose LAST peer lands while the master is BUSY must still
+/// synthesize once the master goes idle.
+///
+/// This is the case that produced "the master just stopped". The gate used to
+/// be evaluated only on a peer's terminal edge, and `Hold` was discarded with
+/// nothing rescheduled — so once every peer was terminal there was no event
+/// left to re-trigger it, and the `Fire` was lost forever. Clearing a wedged
+/// in-flight marker (#2004/#2014) does not help: it does not re-run the gate.
+///
+/// Drives the shared evaluation the way the MASTER edge does, and asserts the
+/// observable effect — the `.synthesized-<master>` stamp — rather than the
+/// decision value, so it fails if the master edge stops being reachable.
+#[tokio::test]
+async fn fleet_that_landed_while_master_was_busy_synthesizes_on_the_master_idle_edge() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path();
+    let master = "tenant-a:api:master-rearm";
+    let master_key = SessionKey(master.to_owned());
+
+    let stage = |slug: &str| {
+        let dir = peers_root.join(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("brief.md"), "brief").unwrap();
+        std::fs::write(dir.join("originator"), master).unwrap();
+        // Landed: has a result and no live turn.
+        std::fs::write(dir.join("result.md"), "findings").unwrap();
+    };
+    stage("peer-one");
+    stage("peer-two");
+
+    // The master is BUSY: a live (non-terminal) turn is registered for it.
+    let abort = tokio::spawn(async {}).abort_handle();
+    let busy_turn = test_active_turn(TurnId::new(), abort);
+    active_turns_registry()
+        .lock()
+        .await
+        .insert(master_key.clone(), busy_turn);
+
+    // 1. The PEER edge, with the master busy. This is the moment the last peer
+    //    lands. `master_idle` is false, so the gate Holds — and the old code
+    //    dropped that decision with nothing rescheduled.
+    let landing_peer = SessionKey(format!("{MAIN_PROFILE_ID}:api:peer-two"));
+    evaluate_and_enqueue_fleet_synthesis(MAIN_PROFILE_ID, peers_root, master, &landing_peer).await;
+    assert!(
+        !peer_fleet_synthesized_stamp_exists(peers_root, master),
+        "precondition: a busy master must NOT synthesize on the peer edge"
+    );
+
+    // 2. The MASTER-idle edge (#2003): the master's own turn is the one
+    //    terminating, so it is excluded from the active-turn set — which is
+    //    precisely what flips `master_idle` true and recovers the lost Fire.
+    //    Every peer is already terminal here, so without this edge NOTHING
+    //    would ever re-evaluate the gate and the master would wait forever.
+    evaluate_and_enqueue_fleet_synthesis(MAIN_PROFILE_ID, peers_root, master, &master_key).await;
+    assert!(
+        peer_fleet_synthesized_stamp_exists(peers_root, master),
+        "a complete fleet must synthesize once the master goes idle; without \
+         the re-arm the Fire is lost when the last peer lands on a busy master"
+    );
+
+    active_turns_registry().lock().await.remove(&master_key);
+}
+
 /// Bug 2 (reset edge) — `collect_owned_peer_results` distinguishes a
 /// genuinely-EMPTY readable directory (`Some(vec![])`) from a `peers/` scan
 /// FAILURE (`None`), so a transient read error is never mistaken for a cleared


### PR DESCRIPTION
Root cause of #2003 ("the master just stopped"). **Not a leak.**

## The bug

The fleet-synthesis gate was evaluated **only when a peer's turn terminated**, and a negative decision was discarded (`ui_protocol.rs:14608`):

```rust
match evaluate_peer_fleet_synthesis(&peers, stamp_exists, master_idle) {
    FleetSynthesisDecision::Hold => {}   // nothing rescheduled
```

`master_idle` is false while the master has a live turn or a pending approval, and all three call sites (`:31408` completed, `:31507` errored, `:31891` interrupted) are on the peer-terminal path. So:

1. the last peer of a fleet lands → the gate is evaluated
2. the master is busy at that instant → **Hold**
3. every peer is now terminal, so **no further peer event can ever fire**
4. nothing recomputes the decision → the master waits forever

That is the observed report: five peers each wrote `result.md` and the master sat idle.

## Why #2004 and #2014 did not fix it

A wedged in-flight marker made `master_idle` false at the decisive moment. Those changes bounded the wedge and made the rescue safe and progress-aware — but **clearing a wedge does not re-run the gate**. The `Fire` was already lost at step 2. Searching for a marker leak found nothing because the marker was a *trigger* of the bug, not the bug.

## Fix

Evaluate on the master-idle edge as well. The shared evaluation is split out of `maybe_enqueue_peer_fleet_synthesis` so both edges reach it, and `maybe_enqueue_peer_fleet_synthesis_for_master` is wired into the same three terminal sites — it no-ops for a peer session (handled by the existing path) and for a session with no `peers/` dir, so an ordinary turn does not pay for a scan.

The session whose turn is terminating is excluded from the active-turn set on **both** edges. On the peer edge that is the pre-existing behaviour (its result is already on the blackboard); on the master edge it is exactly what flips `master_idle` true on the edge the master goes idle.

Re-evaluating more often is safe by construction: the decision is pure over `(peers, stamp_exists, master_idle)` and exactly-once via the `.synthesized-<master>` stamp.

## Test

`fleet_that_landed_while_master_was_busy_synthesizes_on_the_master_idle_edge` registers a **live turn for the master**, asserts the peer edge holds, then asserts the master edge fires.

**RED-proven**: disabling the exclusion makes it fail on the second assertion.

Worth flagging — my first version of this test passed unconditionally, because an empty active-turns registry makes `master_idle` true regardless. It could not have caught the bug. The committed version drives the registry so the busy-master precondition is real.

## Gates

- `octos-cli --features api --lib` (serialized): **2878 passed, 0 failed**
- `octos-cli --lib` (unfeatured): **1433 passed, 0 failed**
- `clippy --all-targets`: clean · `fmt --all --check`: clean

Closes #2003.