### PR TITLE
fix(test): diff-edit format timeout must not assume the file is unformatted

### DIFF
--- a/crates/octos-agent/src/tools/diff_edit.rs
+++ b/crates/octos-agent/src/tools/diff_edit.rs
@@ -503,8 +503,16 @@ mod tests {
         if result.output.contains("timed out") {
             eprintln!("skipping formatter assertions: rustfmt exceeded FORMAT_TIMEOUT");
             let on_disk = std::fs::read_to_string(dir.path().join("lib.rs")).unwrap();
+            // Accept EITHER spelling. A timeout means the tool stopped WAITING
+            // for rustfmt, not that rustfmt stopped running: the process can
+            // still finish and write the formatted file before this read. So
+            // `timed out` does NOT imply the on-disk text is unformatted, and
+            // asserting the unformatted spelling made this test fail whenever
+            // it lost that race (`check-windows` on ce1818258 read
+            // `let x = 2;` here and panicked). What this branch actually needs
+            // to prove is that the EDIT SURVIVED formatting either way.
             assert!(
-                on_disk.contains("let x=2"),
+                on_disk.contains("let x=2") || on_disk.contains("let x = 2"),
                 "the edit must survive even when formatting times out: {on_disk}"
             );
             return;


### PR DESCRIPTION
`should_format_after_diff_edit_when_enabled` is currently making main red.

The timeout branch of the test asserted the **unformatted** spelling (`let x=2`), but the file it read back contained `let x = 2;`.

That assumption is wrong. A timeout means the **tool** stopped waiting for rustfmt — not that rustfmt stopped running. The formatter process can still finish and write the formatted file before the test reads it, so on a slow or loaded machine the timeout branch legitimately observes formatted content.

The assertion's real intent is that the **edit survived** the formatting attempt, and that holds under either spelling. The timeout branch now checks for that instead of pinning one particular formatting outcome.

Refs #2011.
