### PR TITLE
feat(peers): enroll peers as supervised tasks + exclude them from master liveness

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -29377,8 +29377,41 @@ async fn run_standalone_turn(
         if peer_handoff_allowed_for_session(&session_id) {
             let peer_ws = ws.clone();
             let peer_ledger = ledger.clone();
+            // #1868 Phase 1 — enroll the peer as SUPERVISED work. Peers were
+            // never registered with the `TaskSupervisor` (`goal_tool.rs` had
+            // zero supervisor references), so the master's task count never
+            // showed a peer, peers had no cancel token, and the in-flight
+            // liveness rule (#2014) had to read `state.agents` directly rather
+            // than ask the supervisor.
+            //
+            // The task is registered against the MASTER's session, not the
+            // peer's: it represents "this master has a peer working for it",
+            // which is exactly the question liveness asks. Retired in the
+            // `emit_closed` hook below — NOT on turn terminal, because a peer
+            // runs many turns and would otherwise retire after its first.
+            let peer_supervisor = tool_registry.supervisor();
+            let peer_task_profile = session_runtime.profile.profile_id.clone();
             let emit_staged: Arc<dyn Fn(PeerStagedEvent) + Send + Sync> =
                 Arc::new(move |event: PeerStagedEvent| {
+                    let registry_key = peer_wire_key(&peer_task_profile, &event.slug);
+                    // `register` returns an EMPTY-STRING sentinel when the
+                    // per-session task cap rejects it. Binding that would make
+                    // the close path try to retire a task that never existed.
+                    let task_id = peer_supervisor.register(
+                        "peer_handoff",
+                        &registry_key,
+                        Some(&event.session_id.0),
+                    );
+                    if task_id.is_empty() {
+                        tracing::warn!(
+                            slug = %event.slug,
+                            master = %event.session_id,
+                            "peer task registration rejected by the supervisor cap; \
+                             peer runs UNSUPERVISED (no task row, no cancel token)"
+                        );
+                    } else {
+                        peer_task_registry().bind(registry_key, task_id);
+                    }
                     let _ = send_notification_durable(
                         &peer_ws,
                         &peer_ledger,
@@ -29563,8 +29596,19 @@ async fn run_standalone_turn(
             let close_ledger = ledger.clone();
             // Durable `peer/closed` — mirrors the `peer/staged` emit so a
             // briefly-disconnected client still tears down the peer on replay.
+            let close_supervisor = tool_registry.supervisor();
             let emit_closed: Arc<dyn Fn(PeerClosedEvent) + Send + Sync> =
                 Arc::new(move |event: PeerClosedEvent| {
+                    // #1868 Phase 1 — retire the supervised task bound at
+                    // staging. `take` removes the binding, so a second close is
+                    // a no-op rather than re-marking a terminal task (or, worse,
+                    // a task id later reused). A peer with no binding either
+                    // predates this wiring or was rejected by the task cap.
+                    if let Some(task_id) =
+                        peer_task_registry().take(&peer_wire_key(&event.profile_id, &event.slug))
+                    {
+                        close_supervisor.mark_completed(&task_id, Vec::new());
+                    }
                     let _ = send_notification_durable(
                         &close_ws,
                         &close_ledger,

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -8333,16 +8333,31 @@ fn in_flight_marker_is_live(
 /// already reaches the orchestrator through `upsert_background_task_agent` —
 /// so we ASK that state rather than infer liveness, and no plumbing is needed.
 ///
-/// Deliberately NOT covered: peers. They are sovereign sessions that are not
-/// registered as supervised tasks, and a master's own turn ENDS after staging
-/// them (holding no marker to protect). Bringing peers under the supervisor is
-/// tracked separately (#1868).
+/// Deliberately EXCLUDED: peers.
+///
+/// #1868 enrolled peers as supervised tasks on their MASTER's session, which
+/// silently invalidated the earlier version of this rule. A peer is not proof
+/// that the master's TURN is alive — it is a sovereign session doing its own
+/// work, and it stays non-terminal from staging until `peer_close`, often for
+/// hours. Counting it here would make a master that wedges WITH PEERS OPEN hold
+/// a marker that can never go stale, disarming #2004's rescue in precisely the
+/// case it exists for (the reported failure was a wedged master with five peers
+/// running). The marker protects the master's own in-flight work; peer liveness
+/// is answered by the fleet gate, not by this predicate.
 fn session_has_live_supervised_work(state: &AutonomyRuntimeState, session_id: &SessionKey) -> bool {
-    state
-        .agents
-        .values()
-        .any(|agent| agent.session_id == *session_id && !is_agent_terminal_status(&agent.status))
+    state.agents.values().any(|agent| {
+        agent.session_id == *session_id
+            && !is_agent_terminal_status(&agent.status)
+            && agent.backend_kind != PEER_HANDOFF_BACKEND_KIND
+    })
 }
+
+/// `backend_kind` stamped on a supervised PEER task, as built by
+/// [`background_task_backend_kind`] from the `peer_handoff` tool name. Peers
+/// are enrolled for observability and cancellation (#1868) but must not count
+/// as liveness for their master's in-flight marker — see
+/// [`session_has_live_supervised_work`].
+pub(crate) const PEER_HANDOFF_BACKEND_KIND: &str = "task_supervisor:peer_handoff";
 
 /// The full in-flight predicate: a marker counts as held while it is either
 /// FRESH or backed by live supervised work. Only a marker that is both stale
@@ -24845,6 +24860,69 @@ mod tests {
     /// session that is genuinely working. `TaskSupervisor` is the lifecycle
     /// authority for that work and its state reaches the orchestrator via
     /// `upsert_background_task_agent`, so we ask it instead of guessing.
+    /// #1868 — an open PEER must NOT keep a wedged master's marker alive.
+    ///
+    /// Peers are enrolled as supervised tasks on their MASTER's session, and
+    /// they stay non-terminal from staging until `peer_close` — often hours.
+    /// If they counted as liveness, a master that wedges with peers open would
+    /// hold a marker that can never age out, disarming #2004's rescue in
+    /// exactly the reported failure (a wedged master with five peers running).
+    #[test]
+    fn an_open_peer_does_not_keep_a_wedged_masters_marker_alive() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-peer-wedge");
+
+        orchestrator.mark_goal_dispatch_in_flight(&session_id);
+        orchestrator.force_in_flight_marked_at_for_test(
+            &session_id,
+            now_ms_u64().saturating_sub(IN_FLIGHT_STALE_AFTER_MS + 1_000),
+        );
+
+        // A staged peer, registered against the MASTER's session by #1868 and
+        // mirrored here through `upsert_background_task_agent`.
+        orchestrator.upsert_agent(AgentUpsert {
+            agent_id: "peer-reviewer".into(),
+            parent_agent_id: Some("master".into()),
+            session_id: session_id.clone(),
+            task_id: None,
+            path: "master/peer-reviewer".into(),
+            role: "peer".into(),
+            nickname: "reviewer".into(),
+            backend_kind: PEER_HANDOFF_BACKEND_KIND.into(),
+            status: "running".into(),
+            last_task: None,
+            cwd: None,
+            profile_id: "tenant-a".into(),
+        });
+
+        assert!(
+            !orchestrator.is_goal_dispatch_in_flight(&session_id),
+            "an open peer is NOT proof the master's own turn is alive; the aged \
+             marker must still be rescued or a wedged master with peers open can \
+             never be recovered",
+        );
+
+        // A genuine sub-agent on the same session still protects it.
+        orchestrator.upsert_agent(AgentUpsert {
+            agent_id: "child-running".into(),
+            parent_agent_id: Some("master".into()),
+            session_id: session_id.clone(),
+            task_id: None,
+            path: "master/child-running".into(),
+            role: "worker".into(),
+            nickname: "Ada".into(),
+            backend_kind: "native".into(),
+            status: "running".into(),
+            last_task: None,
+            cwd: None,
+            profile_id: "tenant-a".into(),
+        });
+        assert!(
+            orchestrator.is_goal_dispatch_in_flight(&session_id),
+            "a real sub-agent must still hold the marker",
+        );
+    }
+
     #[test]
     fn stale_marker_is_still_held_while_supervised_children_run() {
         let orchestrator = InProcessAgentOrchestrator::default();

--- a/crates/octos-cli/src/peers/mod.rs
+++ b/crates/octos-cli/src/peers/mod.rs
@@ -139,6 +139,61 @@ pub(crate) fn peer_wire_registry() -> &'static PeerWireRegistry {
     PEER_WIRE_REGISTRY.get_or_init(PeerWireRegistry::default)
 }
 
+/// #1868 Phase 1 — maps a staged peer to the `TaskSupervisor` task enrolled on
+/// its MASTER's session, so the peer's retirement can mark that task terminal.
+///
+/// Peers were never registered with the supervisor at all (`goal_tool.rs` had
+/// zero supervisor references), which is why the master's task count never
+/// showed a peer, why peers had no cancel token, and why the in-flight liveness
+/// rule added in #2014 had to read `state.agents` directly instead of asking
+/// the supervisor. Enrolling them puts all three kinds of supervised work —
+/// sub-agents, background tasks, peers — behind one source of truth.
+///
+/// Keyed by the same `"{profile}:peer:{slug}"` string as [`peer_wire_registry`]
+/// so both registries are addressed identically; the VALUE is the supervisor's
+/// task id. Process-global for the same reason the wire registry is: a peer is
+/// staged on one path and retired on another.
+#[derive(Default)]
+pub(crate) struct PeerTaskRegistry {
+    pub(crate) by_key: std::sync::Mutex<HashMap<String, String>>,
+}
+
+impl PeerTaskRegistry {
+    /// Bind `key` to a supervisor task id. A re-stage under the same key
+    /// overwrites, mirroring [`PeerWireRegistry::register`]'s latest-open-wins.
+    pub(crate) fn bind(&self, key: String, task_id: String) {
+        let mut map = self
+            .by_key
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if map.len() >= PEER_WIRE_REGISTRY_MAX && !map.contains_key(&key) {
+            tracing::warn!(
+                key = %key,
+                cap = PEER_WIRE_REGISTRY_MAX,
+                "peer task registry at capacity; peer will not be supervised"
+            );
+            return;
+        }
+        map.insert(key, task_id);
+    }
+
+    /// Take the task id for `key`, removing the binding. Retirement is
+    /// exactly-once: a second close finds nothing and must NOT re-mark a task
+    /// terminal (the supervisor's terminal guard would reject it anyway, but a
+    /// second `mark_completed` would also race a task id later reused).
+    pub(crate) fn take(&self, key: &str) -> Option<String> {
+        self.by_key
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .remove(key)
+    }
+}
+
+pub(crate) fn peer_task_registry() -> &'static PeerTaskRegistry {
+    static PEER_TASK_REGISTRY: OnceLock<PeerTaskRegistry> = OnceLock::new();
+    PEER_TASK_REGISTRY.get_or_init(PeerTaskRegistry::default)
+}
+
 /// Registry key for a peer session: `"{profile}:peer:{slug}"` (mirrors the
 /// gateway inbox registry's key construction in `session_actor`).
 pub(crate) fn peer_wire_key(profile_id: &str, slug: &str) -> String {

--- a/crates/octos-cli/src/peers/mod.rs
+++ b/crates/octos-cli/src/peers/mod.rs
@@ -2546,3 +2546,90 @@ pub(crate) fn build_peer_list_callback(
         ))
     })
 }
+
+#[cfg(test)]
+mod peer_task_registry_tests {
+    use super::*;
+
+    /// #1868 Phase 1 — retirement is EXACTLY ONCE.
+    ///
+    /// `emit_closed` can fire more than once for the same peer (a close racing
+    /// a replayed/durable notification). The binding must be consumed by the
+    /// first retirement so a second close cannot mark a task terminal again —
+    /// task ids are recycled, so a late second `mark_completed` could land on
+    /// an unrelated task rather than being a harmless no-op.
+    #[test]
+    fn taking_a_peer_task_binding_is_exactly_once() {
+        let reg = PeerTaskRegistry::default();
+        let key = peer_wire_key("tenant-a", "peer-one");
+        reg.bind(key.clone(), "task-1".to_owned());
+
+        assert_eq!(
+            reg.take(&key).as_deref(),
+            Some("task-1"),
+            "first close retires the task"
+        );
+        assert_eq!(
+            reg.take(&key),
+            None,
+            "second close must find nothing to retire"
+        );
+    }
+
+    /// A re-stage under the same slug rebinds to the NEW task, mirroring
+    /// `PeerWireRegistry::register`'s latest-open-wins. Otherwise the close
+    /// path would retire the dead task and leak the live one, leaving a
+    /// permanently-running row on the master's session.
+    #[test]
+    fn restaging_a_slug_rebinds_to_the_newer_task() {
+        let reg = PeerTaskRegistry::default();
+        let key = peer_wire_key("tenant-a", "peer-one");
+        reg.bind(key.clone(), "task-old".to_owned());
+        reg.bind(key.clone(), "task-new".to_owned());
+
+        assert_eq!(reg.take(&key).as_deref(), Some("task-new"));
+    }
+
+    /// Peers are keyed per PROFILE: the same slug under two profiles is two
+    /// distinct peers, and retiring one must not retire the other.
+    #[test]
+    fn the_same_slug_under_two_profiles_is_two_bindings() {
+        let reg = PeerTaskRegistry::default();
+        let a = peer_wire_key("tenant-a", "reviewer");
+        let b = peer_wire_key("tenant-b", "reviewer");
+        reg.bind(a.clone(), "task-a".to_owned());
+        reg.bind(b.clone(), "task-b".to_owned());
+
+        assert_eq!(reg.take(&a).as_deref(), Some("task-a"));
+        assert_eq!(
+            reg.take(&b).as_deref(),
+            Some("task-b"),
+            "other profile untouched"
+        );
+    }
+
+    /// At capacity a NEW key is dropped rather than evicting a live peer's
+    /// binding — an unsupervised peer is recoverable, silently retiring some
+    /// other peer's task is not. Existing keys still rebind past the cap.
+    #[test]
+    fn a_full_registry_drops_new_keys_but_still_rebinds_existing_ones() {
+        let reg = PeerTaskRegistry::default();
+        for i in 0..PEER_WIRE_REGISTRY_MAX {
+            reg.bind(
+                peer_wire_key("t", &format!("peer-{i}")),
+                format!("task-{i}"),
+            );
+        }
+        let overflow = peer_wire_key("t", "one-too-many");
+        reg.bind(overflow.clone(), "task-overflow".to_owned());
+        assert_eq!(reg.take(&overflow), None, "new key past the cap is dropped");
+
+        let existing = peer_wire_key("t", "peer-0");
+        reg.bind(existing.clone(), "task-rebound".to_owned());
+        assert_eq!(
+            reg.take(&existing).as_deref(),
+            Some("task-rebound"),
+            "an EXISTING key still rebinds at capacity"
+        );
+    }
+}


### PR DESCRIPTION
Two commits.

**1. Enroll peers as supervised tasks.** Peers are registered with `TaskSupervisor` against their **master's** session. Enrollment is terminal at `peer_close` rather than at turn end, because a peer runs many turns over its lifetime and turn-terminal semantics would retire it far too early.

**2. Follow-up fix: exclude peers from master liveness.** Peers must be excluded from `session_has_live_supervised_work`. An enrolled peer stays non-terminal for hours, so counting it as live supervised work would pin a wedged master's in-flight marker open indefinitely — disarming the 30-minute staleness rescue from #2004 in exactly the situation the rescue exists to handle.

Peers are excluded via `backend_kind` `task_supervisor:peer_handoff`. The exclusion is covered by a RED-proven test.

Local gates:
- 2882 passed / 0 failed (api lib run serialized)
- `clippy --all-targets` clean
- `fmt` clean

Refs #1868, #2004.
