### PR TITLE
feat(activity): give background events a human sink, not just a model wake (#2019)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,6 +451,15 @@ jobs:
       - name: Goal completion verifier ledger evidence (octos-cli)
         run: cargo test -p octos-cli --features api -- completion_evidence goal_update_folds_ledger --nocapture
 
+      # #2019 human sink: the `background/activity` capability gate and the
+      # durable per-session replay both live in the `api`-gated ui_protocol
+      # module, so the unfeatured runs above never compile them — same reason
+      # as the §6 guard. The routing assertion itself is deliberately in
+      # non-gated `crate::autonomy` and DOES run in the unfeatured lib step;
+      # this covers the two halves that cannot.
+      - name: Background activity human sink (octos-cli)
+        run: cargo test -p octos-cli --features api background_activity -- --nocapture
+
   # Lightweight check that exercises the `matrix` feature gate. The default
   # `FEATURES` env above intentionally omits `matrix` to keep the main `check`
   # job lean, but the Dockerfile and several release configurations enable it.

--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -623,6 +623,21 @@ Peer staging (#1801 v3, ungated):
   `slug`, and `profile_id`. Durable: reconnect replay redelivers it, so
   clients dedup by the already-closed peer for the topic.
 
+Background activity — the human sink (#2019, gate `event.background_activity.v1`):
+
+- `background/activity` — one background event that woke the model, surfaced
+  to the HUMAN. Monitor event lines (#1977) and claimed fleet outbox events
+  already exist, are already durable, and already have producers; their only
+  consumer is the model, so a monitor that fires forty times during a loop is
+  invisible to the user. `params` carry the REQUIRED `session_id` of the
+  session that owns the emitter (the routing key), `origin_kind`
+  (`monitor` | `fleet`), `origin_id`, optional `origin_label`, the observed
+  `text`, `emitted_at_ms`, plus `dropped_count?` / `suppressed` for the
+  per-origin cap's visible drop marker. Durable: a client disconnected
+  mid-loop replays the stream by cursor rather than losing its middle.
+  Purely additive — the model is woken exactly as before, and this stream is
+  never routed back into model context.
+
 ## 7. Command Semantics
 
 ### `session/open`

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -51,24 +51,25 @@ use octos_core::ui_protocol::{
     TurnInterruptResult, TurnLifecycleState, TurnSessionResult, TurnStartParams,
     TurnStateGetParams, TurnStateGetResult, TurnTerminalError, TurnTerminalOutcome,
     UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1, UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1,
-    UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1, UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1,
-    UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1, UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1,
-    UI_PROTOCOL_FEATURE_CODING_MONITOR_RUNTIME_V1, UI_PROTOCOL_FEATURE_CONTEXT_LIFECYCLE_V1,
-    UI_PROTOCOL_FEATURE_FILE_ATTACHED_V1, UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1,
-    UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1, UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
-    UI_PROTOCOL_FEATURE_PLAN_TODOS_V1, UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1,
-    UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V2, UI_PROTOCOL_FEATURE_REVIEW_START_V1,
-    UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1, UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1,
-    UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1, UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1,
-    UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1, UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1,
-    UI_PROTOCOL_FEATURE_USER_QUESTION_V1, UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1, UiAgentRecord,
-    UiArtifactPaneItem, UiArtifactPaneSnapshot, UiCommand, UiContextCompactionRecord,
-    UiContextNormalizationReport, UiContextState, UiCursor, UiFileMutationNotice, UiGitHistoryItem,
-    UiGitPaneSnapshot, UiGitStatusItem, UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation,
-    UiProgressEvent, UiProgressMetadata, UiProtocolCapabilities, UiRpcResult, UiWorkspacePaneEntry,
-    UiWorkspacePaneSnapshot, UnsupportedCapabilityReport, UserQuestionRequestedEvent,
-    UserQuestionRespondParams, VoiceAudioChunkEvent, approval_cancelled_reasons, approval_kinds,
-    hydrate_sections, progress_kinds, thread_status,
+    UI_PROTOCOL_FEATURE_BACKGROUND_ACTIVITY_V1, UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1,
+    UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1, UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1,
+    UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1, UI_PROTOCOL_FEATURE_CODING_MONITOR_RUNTIME_V1,
+    UI_PROTOCOL_FEATURE_CONTEXT_LIFECYCLE_V1, UI_PROTOCOL_FEATURE_FILE_ATTACHED_V1,
+    UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1, UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
+    UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1, UI_PROTOCOL_FEATURE_PLAN_TODOS_V1,
+    UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1, UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V2,
+    UI_PROTOCOL_FEATURE_REVIEW_START_V1, UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1,
+    UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1, UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
+    UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1, UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1,
+    UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1, UI_PROTOCOL_FEATURE_USER_QUESTION_V1,
+    UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1, UiAgentRecord, UiArtifactPaneItem, UiArtifactPaneSnapshot,
+    UiCommand, UiContextCompactionRecord, UiContextNormalizationReport, UiContextState, UiCursor,
+    UiFileMutationNotice, UiGitHistoryItem, UiGitPaneSnapshot, UiGitStatusItem, UiNotification,
+    UiPaneSnapshot, UiPaneSnapshotLimitation, UiProgressEvent, UiProgressMetadata,
+    UiProtocolCapabilities, UiRpcResult, UiWorkspacePaneEntry, UiWorkspacePaneSnapshot,
+    UnsupportedCapabilityReport, UserQuestionRequestedEvent, UserQuestionRespondParams,
+    VoiceAudioChunkEvent, approval_cancelled_reasons, approval_kinds, hydrate_sections,
+    progress_kinds, thread_status,
 };
 use octos_core::{
     AgentId, InboundMessage, MAIN_PROFILE_ID, Message, MessageOrigin, MessageRole, SessionKey,
@@ -1762,6 +1763,12 @@ struct ConnectionUiFeatures {
     /// replays the latest snapshot on `session/open`. Otherwise the plan rides
     /// out only on the legacy `tool/completed` `structured_metadata` path.
     plan_todos: bool,
+    /// #2019 `event.background_activity.v1`: the HUMAN sink over background
+    /// events that today only wake the model (monitor event lines, claimed
+    /// fleet outbox events). Not negotiated → the connection never receives
+    /// `background/activity`, so a client that cannot render it never sees an
+    /// "unknown notification" (the ui-protocol v2 migration trap).
+    background_activity: bool,
     /// UPCR-2026-014 M9-γ `projection.envelope.v1` negotiated. When set,
     /// the client opts in to the historical v1 envelope shape (spec
     /// § 14) for projected events. γ-1 wires capability negotiation
@@ -1860,6 +1867,11 @@ impl ConnectionUiFeatures {
             file_attached: has_ui_feature(headers, query, UI_PROTOCOL_FEATURE_FILE_ATTACHED_V1),
             voice_audio: has_ui_feature(headers, query, UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1),
             plan_todos: has_ui_feature(headers, query, UI_PROTOCOL_FEATURE_PLAN_TODOS_V1),
+            background_activity: has_ui_feature(
+                headers,
+                query,
+                UI_PROTOCOL_FEATURE_BACKGROUND_ACTIVITY_V1,
+            ),
             projection_envelope: has_ui_feature(
                 headers,
                 query,
@@ -1933,6 +1945,7 @@ impl ConnectionUiFeatures {
             file_attached: true,
             voice_audio: true,
             plan_todos: true,
+            background_activity: true,
             // Do NOT auto-enable `projection.envelope.v1` for stdio
             // connections. Legacy `turn/completed` is the turn-lifecycle
             // source for clients that do not consume `projection/envelope`
@@ -1990,6 +2003,7 @@ impl ConnectionUiFeatures {
             file_attached: has(UI_PROTOCOL_FEATURE_FILE_ATTACHED_V1),
             voice_audio: has(UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1),
             plan_todos: has(UI_PROTOCOL_FEATURE_PLAN_TODOS_V1),
+            background_activity: has(UI_PROTOCOL_FEATURE_BACKGROUND_ACTIVITY_V1),
             projection_envelope: has(UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1),
             projection_envelope_v2: has(UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V2),
             auxiliary_rest_to_ws_v1: has(UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1),
@@ -2060,6 +2074,9 @@ impl ConnectionUiFeatures {
         }
         if self.plan_todos {
             requested.push(UI_PROTOCOL_FEATURE_PLAN_TODOS_V1);
+        }
+        if self.background_activity {
+            requested.push(UI_PROTOCOL_FEATURE_BACKGROUND_ACTIVITY_V1);
         }
         if self.projection_envelope {
             requested.push(UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1);
@@ -16932,6 +16949,16 @@ fn live_event_passes_capability_filter(
             return false;
         }
     }
+    // #2019 `event.background_activity.v1` gate. The human sink is a NEW
+    // notification shape; a client that did not negotiate it cannot render it
+    // and would report "unknown UI protocol notification" — the exact
+    // ui-protocol-v2-migration trap this pairing exists to avoid. Applies on
+    // both the live broadcast and reconnect replay (both call this filter).
+    if !features.background_activity {
+        if let UiProtocolLedgerEvent::Notification(UiNotification::BackgroundActivity(_)) = event {
+            return false;
+        }
+    }
     // UPCR-2026-023 `user_question.v1` gate. A client that did not negotiate
     // the structured-question capability never installed a
     // `SessionUserQuestionRequester` and has no `user_question/respond` path,
@@ -19712,6 +19739,69 @@ async fn emit_session_orchestration_updates(
         }
     }
     *last = current;
+}
+
+/// #2019 — bound on the human-sink queue. Producers (`try_send`) never block:
+/// a full queue drops the event, bumps a metric, and logs. Generous enough
+/// that only a genuinely pathological burst reaches it, and the per-origin cap
+/// in `autonomy::human_events` already emits a VISIBLE marker long before.
+const BACKGROUND_ACTIVITY_QUEUE_CAPACITY: usize = 512;
+
+/// #2019 — install the process-global HUMAN sink for background events that
+/// today only wake the model, and spawn its drain task.
+///
+/// Monitor event lines (#1977) and claimed fleet outbox events already exist,
+/// are already durable, and already have producers — with exactly ONE
+/// consumer, the model. This adds the second consumer, the user, WITHOUT
+/// touching how or when the model is woken.
+///
+/// Shape:
+/// - Producers call the sync, non-blocking
+///   [`crate::autonomy::human_events::emit_background_activity`], which caps
+///   per origin and hands the event to the installed sink.
+/// - The sink is a bounded-channel `try_send`. A full queue DROPS and logs; it
+///   must never stall a watcher task or the outbox consumer.
+/// - The drain task appends each event to the durable per-session ledger via
+///   [`send_notification_durable`] over a DETACHED connection, mirroring
+///   `PeerStaged`. The append (ring + disk + `publish_live`) is
+///   connection-independent, so a client disconnected mid-loop replays the
+///   stream by cursor on reconnect instead of losing its middle; connected
+///   clients receive it on their session's live forwarder, which applies their
+///   own `event.background_activity.v1` capability filter.
+///
+/// Nothing here is routed back into model context.
+pub(crate) fn spawn_background_activity_sink(state: Arc<AppState>) {
+    let (tx, mut rx) = mpsc::channel::<octos_core::ui_protocol::BackgroundActivityEvent>(
+        BACKGROUND_ACTIVITY_QUEUE_CAPACITY,
+    );
+    // Best-effort, non-blocking producer side. `try_send` is the whole
+    // contract: a producer must never await, block, or fail on the human sink.
+    crate::autonomy::human_events::set_background_activity_sink(std::sync::Arc::new(
+        move |event: octos_core::ui_protocol::BackgroundActivityEvent| {
+            if let Err(err) = tx.try_send(event) {
+                metrics::counter!("ws.background_activity.drop").increment(1);
+                tracing::debug!(
+                    target: "octos::ui_protocol::ws",
+                    reason = %err,
+                    "background activity dropped: human sink queue full or closed"
+                );
+            }
+        },
+    ));
+    tokio::spawn(async move {
+        // Detached connection: there is no live peer. Outbound frames are
+        // discarded by a drain task (the durable record is the ledger); keep
+        // the receiver alive so sends never backpressure-fail.
+        let (writer_tx, mut writer_rx) = mpsc::channel::<WsMessage>(WS_WRITER_CHANNEL_CAPACITY);
+        tokio::spawn(async move { while writer_rx.recv().await.is_some() {} });
+        let ws = WsConnection::new(writer_tx);
+        let ledger = event_ledger(&state).await;
+        info!("background activity human sink started (#2019)");
+        while let Some(event) = rx.recv().await {
+            let _ =
+                send_notification_durable(&ws, &ledger, UiNotification::BackgroundActivity(event));
+        }
+    });
 }
 
 /// Cadence for the server-level (connection-independent) master-continuation
@@ -36023,6 +36113,10 @@ fn ledger_event_cursor(event: &UiProtocolLedgerEvent) -> Option<UiCursor> {
             // peer/closed likewise carries only teardown facts (slug / topic),
             // not a replay cursor — same authoritative-ledger-cursor rule.
             | UiNotification::PeerClosed(_)
+            // #2019: the human sink carries an origin + text + timestamp, not
+            // a replay cursor; the surrounding ledger event's cursor is what
+            // a reconnecting client resumes from.
+            | UiNotification::BackgroundActivity(_)
             // UPCR-2026-014 M9-γ: envelopes carry their OWN per-thread
             // `seq` allocated by `ThreadSeqAllocator`, not the per-session
             // `UiCursor` the legacy ledger replay uses. The durable

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -2895,6 +2895,10 @@ fn notification_session_id(notification: &UiNotification) -> &SessionKey {
         UiNotification::SessionOrchestration(event) => &event.session_id,
         UiNotification::PeerStaged(event) => &event.session_id,
         UiNotification::PeerClosed(event) => &event.session_id,
+        // #2019 — the human sink routes on the OWNING session, like everything
+        // else here. This is the ledger's routing key, so a wrong answer would
+        // land the event on whichever session the client has focused.
+        UiNotification::BackgroundActivity(event) => &event.session_id,
         UiNotification::UserQuestionRequested(event) => &event.session_id,
         UiNotification::Envelope(event) => &event.session_id,
         UiNotification::EnvelopeV2(event) => &event.session_id,

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -10475,6 +10475,7 @@ fn shell_approval_event_is_typed_only_after_negotiation() {
             file_attached: false,
             voice_audio: false,
             plan_todos: false,
+            background_activity: false,
             projection_envelope: false,
             projection_envelope_v2: false,
             auxiliary_rest_to_ws_v1: false,
@@ -10543,6 +10544,7 @@ fn risk_default_is_unspecified_when_manifest_silent() {
             file_attached: false,
             voice_audio: false,
             plan_todos: false,
+            background_activity: false,
             projection_envelope: false,
             projection_envelope_v2: false,
             auxiliary_rest_to_ws_v1: false,
@@ -10656,6 +10658,7 @@ fn plugin_high_risk_approval_emits_risk_field_on_wire() {
             file_attached: false,
             voice_audio: false,
             plan_todos: false,
+            background_activity: false,
             projection_envelope: false,
             projection_envelope_v2: false,
             auxiliary_rest_to_ws_v1: false,
@@ -10724,6 +10727,7 @@ fn plugin_critical_risk_approval_emits_risk_critical() {
             file_attached: false,
             voice_audio: false,
             plan_todos: false,
+            background_activity: false,
             projection_envelope: false,
             projection_envelope_v2: false,
             auxiliary_rest_to_ws_v1: false,
@@ -10785,6 +10789,7 @@ fn shell_approval_still_emits_risk_field() {
             file_attached: false,
             voice_audio: false,
             plan_todos: false,
+            background_activity: false,
             projection_envelope: false,
             projection_envelope_v2: false,
             auxiliary_rest_to_ws_v1: false,
@@ -10889,6 +10894,7 @@ fn approval_cwd_is_sanitized_against_path_spoof() {
             file_attached: false,
             voice_audio: false,
             plan_todos: false,
+            background_activity: false,
             projection_envelope: false,
             projection_envelope_v2: false,
             auxiliary_rest_to_ws_v1: false,
@@ -12978,6 +12984,130 @@ fn plan_updated_gated_by_plan_todos_capability() {
     assert!(live_event_passes_capability_filter(&event, negotiated));
 }
 
+/// #2019 — build a human-sink event for the tests below.
+fn background_activity_for(
+    session_id: &SessionKey,
+    origin_id: &str,
+    text: &str,
+) -> octos_core::ui_protocol::BackgroundActivityEvent {
+    octos_core::ui_protocol::BackgroundActivityEvent {
+        session_id: session_id.clone(),
+        profile_id: Some("main".into()),
+        origin_kind: "monitor".into(),
+        origin_id: origin_id.into(),
+        origin_label: Some("ci-tail".into()),
+        text: text.into(),
+        emitted_at_ms: 1_760_000_000_000,
+        dropped_count: None,
+        suppressed: false,
+    }
+}
+
+/// #2019 — `background/activity` is a NEW notification shape. A client that
+/// did not negotiate `event.background_activity.v1` cannot render it and would
+/// report "unknown UI protocol notification" — the ui-protocol-v2-migration
+/// trap. Gate it on both the live broadcast and reconnect replay (both routes
+/// call this filter), mirroring the `plan.todos.v1` discipline.
+#[test]
+fn should_gate_background_activity_when_the_capability_was_not_negotiated() {
+    let event = UiProtocolLedgerEvent::Notification(UiNotification::BackgroundActivity(
+        background_activity_for(&SessionKey("local:test".into()), "monitor_01", "boom"),
+    ));
+    assert!(
+        !live_event_passes_capability_filter(&event, ConnectionUiFeatures::default()),
+        "a connection without event.background_activity.v1 must never receive it"
+    );
+    let negotiated = ConnectionUiFeatures {
+        background_activity: true,
+        ..Default::default()
+    };
+    assert!(live_event_passes_capability_filter(&event, negotiated));
+}
+
+/// #2019 acceptance — ten monitor fires land on the OWNING session's durable
+/// stream and are replayable by cursor after a client disconnects mid-run.
+///
+/// Two properties in one test, because they are the same property: the ledger
+/// append is the routing decision AND the disconnect-survival mechanism.
+/// Asserts ROUTING (the sibling session's stream stays empty), not merely that
+/// events were emitted — activity on the wrong stream renders in whichever
+/// session happens to be focused (octos-tui#461, #466, #483).
+#[tokio::test]
+async fn should_replay_background_activity_on_the_owning_session_when_a_client_reconnects() {
+    let (ws, _rx) = ws_connection_for_test(64);
+    let ledger = UiProtocolLedger::new(256);
+    let owner = SessionKey("local:owner".into());
+    let sibling = SessionKey("local:sibling".into());
+
+    // A client connected at the start of the run captures the cursor it would
+    // resume from, then "disconnects" (we simply stop reading the socket).
+    let resume_from = UiCursor {
+        stream: owner.0.clone(),
+        seq: 0,
+    };
+    for i in 0..10 {
+        let _ = send_notification_durable(
+            &ws,
+            &ledger,
+            UiNotification::BackgroundActivity(background_activity_for(
+                &owner,
+                "monitor_01",
+                &format!("line {i}"),
+            )),
+        );
+    }
+    // One event from a DIFFERENT origin on the SAME session: grouping is a
+    // client concern, so both must be on the one session stream.
+    let _ = send_notification_durable(
+        &ws,
+        &ledger,
+        UiNotification::BackgroundActivity(background_activity_for(
+            &owner,
+            "monitor_02",
+            "other origin",
+        )),
+    );
+
+    let replay = ledger
+        .replay_after(&owner, Some(&resume_from))
+        .expect("reconnecting client replays the owning session");
+    let replayed: Vec<(String, String)> = replay
+        .iter()
+        .filter_map(|entry| match &entry.event {
+            UiProtocolLedgerEvent::Notification(UiNotification::BackgroundActivity(event)) => {
+                Some((event.origin_id.clone(), event.text.clone()))
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        replayed.len(),
+        11,
+        "the whole run replays after a mid-run disconnect, not just its tail"
+    );
+    assert_eq!(replayed[0], ("monitor_01".into(), "line 0".into()));
+    assert_eq!(replayed[9], ("monitor_01".into(), "line 9".into()));
+    assert_eq!(replayed[10], ("monitor_02".into(), "other origin".into()));
+
+    // ROUTING: the sibling session's stream never saw any of it.
+    let sibling_replay = ledger
+        .replay_after(
+            &sibling,
+            Some(&UiCursor {
+                stream: sibling.0.clone(),
+                seq: 0,
+            }),
+        )
+        .unwrap_or_default();
+    assert!(
+        !sibling_replay.iter().any(|entry| matches!(
+            &entry.event,
+            UiProtocolLedgerEvent::Notification(UiNotification::BackgroundActivity(_))
+        )),
+        "background activity must never land on a session that did not own the emitter"
+    );
+}
+
 /// #1977 blocker 6 — `monitor/*` notifications are gated by
 /// `coding.monitor_runtime.v1`. A connection that sent a feature header but did
 /// NOT negotiate monitor runtime must never receive a `monitor/updated` (or
@@ -13415,6 +13545,7 @@ async fn session_open_includes_pane_snapshot_after_negotiation() {
             file_attached: false,
             voice_audio: false,
             plan_todos: false,
+            background_activity: false,
             projection_envelope: false,
             projection_envelope_v2: false,
             auxiliary_rest_to_ws_v1: false,

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -8716,6 +8716,24 @@ impl InProcessAgentOrchestrator {
                 &session_id,
                 &format!("[{name}] {line}"),
             );
+            // #2019 — SECOND consumer: the human. The wake above is untouched
+            // (same continuation, same dedupe key, same ordering); this is a
+            // purely additive, best-effort tap so the user can SEE what the
+            // model was woken by instead of watching a silent session. Routed
+            // on the monitor's OWNING session — never the client's focused one
+            // — and attributed to the monitor. Never fed back into model
+            // context: the model's view is the note above plus the
+            // continuation metadata, exactly as before.
+            crate::autonomy::human_events::emit_background_activity(
+                crate::autonomy::human_events::background_activity(
+                    &session_id,
+                    Some(profile_id.as_str()),
+                    crate::autonomy::human_events::ORIGIN_KIND_MONITOR,
+                    monitor_id,
+                    Some(name.as_str()),
+                    line.clone(),
+                ),
+            );
         }
         MonitorBatchOutcome::Fired { queued }
     }
@@ -25419,6 +25437,136 @@ mod tests {
         assert_eq!(
             orchestrator.handle_monitor_batch(id, &["status: done".into()], 1),
             MonitorBatchOutcome::DedupedUnchanged
+        );
+        assert_eq!(pending_wakes(&orchestrator, &session, "tenant-a"), 1);
+    }
+
+    /// #2019 acceptance — a monitor that fires produces HUMAN-visible,
+    /// origin-attributed lines on the session that OWNS the monitor, and the
+    /// model's wake is untouched.
+    ///
+    /// This asserts ROUTING, not merely emission: two monitors on two
+    /// different sessions fire in an interleaved order, and each event must
+    /// land on ITS OWN session. Activity without a correct routing key renders
+    /// in whichever session happens to be focused (octos-tui#461, #466, #483)
+    /// — the exact bug class this event must not re-ship.
+    #[test]
+    fn should_emit_attributed_human_activity_on_the_owning_session_when_a_monitor_fires() {
+        use crate::autonomy::human_events::{
+            BackgroundActivitySink, ORIGIN_KIND_MONITOR, clear_background_activity_sink,
+            set_background_activity_sink,
+        };
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorder = seen.clone();
+        let sink: BackgroundActivitySink = std::sync::Arc::new(move |event| {
+            recorder.lock().unwrap().push(event);
+        });
+        set_background_activity_sink(sink);
+
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_a = SessionKey::new("api", "mon-human-a");
+        let session_b = SessionKey::new("api", "mon-human-b");
+        create_monitor_for_test(
+            &orchestrator,
+            &session_a,
+            "tenant-a",
+            monitor_spec("ci-tail", MonitorMode::Stream),
+            None,
+        );
+        create_monitor_for_test(
+            &orchestrator,
+            &session_b,
+            "tenant-b",
+            monitor_spec("deploy-tail", MonitorMode::Stream),
+            None,
+        );
+        let (id_a, id_b) = ("monitor_01", "monitor_02");
+
+        // Interleave so a "last writer wins" / ambient-session implementation
+        // could not accidentally pass.
+        assert_eq!(
+            orchestrator.handle_monitor_batch(id_a, &["a1".into()], 1),
+            MonitorBatchOutcome::Fired { queued: true }
+        );
+        assert_eq!(
+            orchestrator.handle_monitor_batch(id_b, &["b1".into()], 1),
+            MonitorBatchOutcome::Fired { queued: true }
+        );
+        assert_eq!(
+            orchestrator.handle_monitor_batch(id_a, &["a2".into(), "a3".into()], 2),
+            MonitorBatchOutcome::Fired { queued: true }
+        );
+
+        let events = seen.lock().unwrap().clone();
+        clear_background_activity_sink();
+
+        // One human-visible line per observed event line.
+        assert_eq!(events.len(), 4, "one event per observed line: {events:?}");
+
+        // ROUTING: every event names the session that OWNS its monitor.
+        let a_texts: Vec<&str> = events
+            .iter()
+            .filter(|event| event.session_id == session_a)
+            .map(|event| event.text.as_str())
+            .collect();
+        let b_texts: Vec<&str> = events
+            .iter()
+            .filter(|event| event.session_id == session_b)
+            .map(|event| event.text.as_str())
+            .collect();
+        assert_eq!(a_texts, vec!["a1", "a2", "a3"]);
+        assert_eq!(b_texts, vec!["b1"]);
+        assert!(
+            events.iter().all(|event| !event.session_id.0.is_empty()),
+            "every event carries a routing key"
+        );
+
+        // ATTRIBUTION: an unattributed line reads as the master speaking.
+        for event in &events {
+            assert_eq!(event.origin_kind, ORIGIN_KIND_MONITOR);
+            assert!(!event.origin_id.is_empty());
+            assert!(event.emitted_at_ms > 0);
+            assert!(!event.suppressed);
+        }
+        let a_event = events
+            .iter()
+            .find(|event| event.session_id == session_a)
+            .expect("session A event");
+        assert_eq!(a_event.origin_id, id_a);
+        assert_eq!(a_event.origin_label.as_deref(), Some("ci-tail"));
+        assert_eq!(a_event.profile_id.as_deref(), Some("tenant-a"));
+        let b_event = events
+            .iter()
+            .find(|event| event.session_id == session_b)
+            .expect("session B event");
+        assert_eq!(b_event.origin_id, id_b);
+        assert_eq!(b_event.origin_label.as_deref(), Some("deploy-tail"));
+
+        // WAKE BEHAVIOUR IS UNCHANGED: the human sink is purely additive —
+        // still exactly one master continuation per fired batch, on the
+        // owning session, as before #2019.
+        assert_eq!(pending_wakes(&orchestrator, &session_a, "tenant-a"), 2);
+        assert_eq!(pending_wakes(&orchestrator, &session_b, "tenant-b"), 1);
+    }
+
+    /// #2019 — a producer must never be blocked or failed by the human sink.
+    /// With NO sink installed (the production "queue closed" degradation), the
+    /// monitor's wake path is byte-for-byte the same.
+    #[test]
+    fn should_leave_the_wake_path_intact_when_no_human_sink_is_installed() {
+        crate::autonomy::human_events::clear_background_activity_sink();
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session = SessionKey::new("api", "mon-human-nosink");
+        create_monitor_for_test(
+            &orchestrator,
+            &session,
+            "tenant-a",
+            monitor_spec("ci-tail", MonitorMode::Stream),
+            None,
+        );
+        assert_eq!(
+            orchestrator.handle_monitor_batch("monitor_01", &["x".into()], 1),
+            MonitorBatchOutcome::Fired { queued: true }
         );
         assert_eq!(pending_wakes(&orchestrator, &session, "tenant-a"), 1);
     }

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -25453,9 +25453,13 @@ mod tests {
     #[test]
     fn should_emit_attributed_human_activity_on_the_owning_session_when_a_monitor_fires() {
         use crate::autonomy::human_events::{
-            BackgroundActivitySink, ORIGIN_KIND_MONITOR, clear_background_activity_sink,
-            set_background_activity_sink,
+            BackgroundActivitySink, ORIGIN_KIND_MONITOR, background_activity_test_guard,
+            clear_background_activity_sink, set_background_activity_sink,
         };
+        // The sink is process-global; hold the guard so a sibling case's
+        // teardown cannot wipe the sink this test installs (libtest runs cases
+        // in parallel by default, and CI does NOT pass --test-threads=1).
+        let _guard = background_activity_test_guard();
         let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let recorder = seen.clone();
         let sink: BackgroundActivitySink = std::sync::Arc::new(move |event| {
@@ -25554,7 +25558,9 @@ mod tests {
     /// monitor's wake path is byte-for-byte the same.
     #[test]
     fn should_leave_the_wake_path_intact_when_no_human_sink_is_installed() {
-        crate::autonomy::human_events::clear_background_activity_sink();
+        // Serialize + reset: "no sink installed" must be true for the whole
+        // body, not just at its first line.
+        let _guard = crate::autonomy::human_events::background_activity_test_guard();
         let orchestrator = InProcessAgentOrchestrator::default();
         let session = SessionKey::new("api", "mon-human-nosink");
         create_monitor_for_test(

--- a/crates/octos-cli/src/autonomy/fleet_wake.rs
+++ b/crates/octos-cli/src/autonomy/fleet_wake.rs
@@ -190,6 +190,32 @@ pub(crate) fn fleet_keeper_continuation_request(
     req
 }
 
+/// #2019 — the human-facing label for a fleet origin: the plan objective when
+/// the snapshot read succeeded, else `None` (the client falls back to the
+/// fleet id). Never a raw verdict reason — the snapshot only carries the
+/// objective, task lines, and ready ids.
+fn snapshot_label(snap: &FleetKeeperSnapshot) -> Option<&str> {
+    let objective = snap.objective.trim();
+    (!objective.is_empty()).then_some(objective)
+}
+
+/// #2019 — the human-facing one-liner for a claimed fleet outbox event. Says
+/// WHAT happened and what is dispatchable now; the model's keeper prompt
+/// (which carries the full task table) is unchanged and unrelated.
+fn fleet_activity_text(kind: FleetEventKind, snap: &FleetKeeperSnapshot) -> String {
+    let what = match kind {
+        FleetEventKind::ChildDone => "a child task finished",
+        FleetEventKind::FleetDrained => "the fleet drained (no runnable work left)",
+        _ => "fleet event",
+    };
+    let ready = snap.ready.trim();
+    if ready.is_empty() {
+        what.to_owned()
+    } else {
+        format!("{what}; ready now: {ready}")
+    }
+}
+
 /// Drain the fleet outbox once: claim up to `max_batch` currently-claimable
 /// events, wake the controller for each `ChildDone` / `FleetDrained`, and ack
 /// **only after the wake is durably committed**.
@@ -258,7 +284,27 @@ where
                         rec.controller_workspace_root.as_deref(),
                         rec.controller_workspace_has_runtime_hint,
                     );
-                    matches!(commit_wake(req), WakeCommit::Durable)
+                    let durable = matches!(commit_wake(req), WakeCommit::Durable);
+                    // #2019 — SECOND consumer: the human. The keeper wake above
+                    // is untouched; this is a purely additive, best-effort tap
+                    // so the user can SEE the fleet event that woke the
+                    // controller. Emitted only once the wake is DURABLE, so a
+                    // redelivered (not-yet-acked) event does not double-report.
+                    // Routed on the CONTROLLER's session — the session that
+                    // owns the keeper — and attributed to the fleet.
+                    if durable {
+                        crate::autonomy::human_events::emit_background_activity(
+                            crate::autonomy::human_events::background_activity(
+                                &rec.controller_session_key,
+                                Some(rec.profile_id.as_str()),
+                                crate::autonomy::human_events::ORIGIN_KIND_FLEET,
+                                &ev.fleet_id,
+                                snapshot_label(&snap),
+                                fleet_activity_text(ev.kind, &snap),
+                            ),
+                        );
+                    }
+                    durable
                 }
                 // A vanished fleet has no wake to persist; ack so the outbox
                 // advances rather than wedging on a missing record.

--- a/crates/octos-cli/src/autonomy/human_events.rs
+++ b/crates/octos-cli/src/autonomy/human_events.rs
@@ -1,0 +1,399 @@
+//! #2019 — the HUMAN sink over background events that today only wake the model.
+//!
+//! Background events already exist, are already durable, and already have
+//! producers: [`super::monitor_runtime`] (#1977) turns a child probe's filtered
+//! stdout lines into `External("monitor_fired")` master continuations, and
+//! [`super::fleet_wake`] claims `ChildDone` / `FleetDrained` off the durable
+//! fleet outbox into keeper continuations. Every one of them has exactly ONE
+//! consumer: the model. A monitor can fire forty times during a self-critic
+//! loop and the user sees nothing, because the only effect of an event is that
+//! the master gets woken — whether any of it reaches the transcript depends on
+//! whether the model volunteers it.
+//!
+//! This module is the SECOND consumer: the human. It is a process-global,
+//! best-effort tap that producers call in addition to (never instead of) the
+//! wake they already perform.
+//!
+//! ## Invariants
+//!
+//! - **Additive only.** Nothing here changes how or when the model is woken.
+//!   Producers call [`emit_background_activity`] AFTER their durable wake work.
+//! - **Never blocks or fails the producer.** The installed sink is expected to
+//!   be non-blocking (the `api` surface installs a bounded-channel `try_send`);
+//!   a missing sink, a full queue, or a poisoned lock all degrade to a dropped
+//!   event plus a log line. No producer path can stall or error on this.
+//! - **Routing is by owning session.** Every emitted event carries the
+//!   `session_id` of the session that OWNS the emitter. Activity without one
+//!   renders in whichever session happens to be focused (octos-tui#461, #466,
+//!   #483); an event with a blank key is refused here rather than shipped.
+//! - **Capped, with a VISIBLE drop marker.** Unbounded emission is a client
+//!   DoS. The per-origin budget below caps admissions per window and emits ONE
+//!   explicit marker row when it starts dropping — silent truncation reads as
+//!   "nothing more happened" (#2015).
+//! - **Never fed back into model context.** This stream exists so the human can
+//!   see what the model was woken by. Routing it back would be a compaction and
+//!   cost problem, and would make the loop observe itself. The model's view is
+//!   unchanged: it still gets the continuation metadata + the monitor notes.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use octos_core::ui_protocol::BackgroundActivityEvent;
+
+/// The installed human sink. Sync + `Send + Sync` so any producer (a watcher
+/// task, the outbox consumer, a blocking-pool sweep) can call it directly.
+/// Implementations MUST NOT block.
+pub(crate) type BackgroundActivitySink = Arc<dyn Fn(BackgroundActivityEvent) + Send + Sync>;
+
+/// Rolling window for the per-origin admission budget.
+pub(crate) const BACKGROUND_ACTIVITY_WINDOW: Duration = Duration::from_secs(60);
+/// Max events admitted per origin per [`BACKGROUND_ACTIVITY_WINDOW`]. A monitor
+/// is already flood-capped at the durable seam (`max_events_per_hour`); this is
+/// the independent CLIENT-side bound, so a pathological or multi-origin burst
+/// can never turn the transcript into a DoS.
+pub(crate) const BACKGROUND_ACTIVITY_MAX_PER_WINDOW: u32 = 40;
+/// Per-event text cap. Monitor lines are already clipped upstream; this is the
+/// backstop for any other origin.
+pub(crate) const BACKGROUND_ACTIVITY_TEXT_CAP: usize = 2_000;
+/// Bound on the budget map. There is no origin-close hook, so cap growth: a
+/// reset only re-admits one extra window's worth per origin.
+const MAX_TRACKED_ORIGINS: usize = 4_096;
+
+fn sink_slot() -> &'static StdMutex<Option<BackgroundActivitySink>> {
+    static SLOT: OnceLock<StdMutex<Option<BackgroundActivitySink>>> = OnceLock::new();
+    SLOT.get_or_init(|| StdMutex::new(None))
+}
+
+fn budget_slot() -> &'static StdMutex<HashMap<String, OriginBudget>> {
+    static SLOT: OnceLock<StdMutex<HashMap<String, OriginBudget>>> = OnceLock::new();
+    SLOT.get_or_init(|| StdMutex::new(HashMap::new()))
+}
+
+/// Install the process-global human sink. Called once by the `api` surface at
+/// serve boot; a second call replaces the first (the ledger is a process
+/// singleton, so re-installing is idempotent in practice).
+pub(crate) fn set_background_activity_sink(sink: BackgroundActivitySink) {
+    let mut slot = sink_slot()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *slot = Some(sink);
+}
+
+/// Remove the sink (and reset the budgets). Test-only: the slot is a `static`
+/// that cannot otherwise be reset between cases.
+#[cfg(test)]
+pub(crate) fn clear_background_activity_sink() {
+    let mut slot = sink_slot()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    *slot = None;
+    budget_slot()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clear();
+}
+
+/// What the per-origin cap decided for one candidate event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CapDecision {
+    /// Emit the event. `dropped` is the suppression backlog this event
+    /// accounts for (0 when nothing was dropped).
+    Admit { dropped: u64 },
+    /// The budget just ran out. Emit ONE marker row instead of the event, so
+    /// the user is told the stream is being truncated. `dropped` is the
+    /// backlog the marker accounts for.
+    Marker { dropped: u64 },
+    /// Already marked this window: drop silently (the marker already said so).
+    Drop,
+}
+
+#[derive(Debug)]
+struct OriginBudget {
+    window_start: Instant,
+    emitted: u32,
+    /// Suppressed events not yet reported to the human.
+    suppressed: u64,
+    /// Whether the drop marker was already emitted for the current window.
+    marked: bool,
+}
+
+/// Pure cap core (extracted so tests can drive it with a synthetic clock — the
+/// outer `static` map cannot be reset per case).
+fn cap_admit(
+    budgets: &mut HashMap<String, OriginBudget>,
+    key: &str,
+    now: Instant,
+    window: Duration,
+    max_per_window: u32,
+) -> CapDecision {
+    if budgets.len() >= MAX_TRACKED_ORIGINS && !budgets.contains_key(key) {
+        budgets.clear();
+    }
+    let budget = budgets.entry(key.to_owned()).or_insert(OriginBudget {
+        window_start: now,
+        emitted: 0,
+        suppressed: 0,
+        marked: false,
+    });
+    if now.duration_since(budget.window_start) >= window {
+        budget.window_start = now;
+        budget.emitted = 0;
+        budget.marked = false;
+    }
+    if budget.emitted < max_per_window {
+        budget.emitted = budget.emitted.saturating_add(1);
+        return CapDecision::Admit {
+            dropped: std::mem::take(&mut budget.suppressed),
+        };
+    }
+    budget.suppressed = budget.suppressed.saturating_add(1);
+    if budget.marked {
+        return CapDecision::Drop;
+    }
+    budget.marked = true;
+    CapDecision::Marker {
+        dropped: std::mem::take(&mut budget.suppressed),
+    }
+}
+
+/// The cap key. Per (session, origin) so one noisy monitor cannot starve a
+/// sibling origin in the same session, and two sessions never share a budget.
+fn cap_key(event: &BackgroundActivityEvent) -> String {
+    format!(
+        "{}\u{0}{}\u{0}{}",
+        event.session_id.0, event.origin_kind, event.origin_id
+    )
+}
+
+/// Emit one background event to the HUMAN sink. Best-effort in every failure
+/// mode; the caller's wake path is never blocked, delayed, or failed by this.
+pub(crate) fn emit_background_activity(mut event: BackgroundActivityEvent) {
+    // An event without a routing key would render in whichever session the
+    // client happens to have focused. Refuse it here rather than ship the bug.
+    if event.session_id.0.trim().is_empty() {
+        tracing::warn!(
+            origin_kind = %event.origin_kind,
+            origin_id = %event.origin_id,
+            "background activity dropped: empty session_id (would misroute)"
+        );
+        return;
+    }
+    // Cheap early-out: with no sink installed (unfeatured build, `octos chat`,
+    // unit tests) do not even touch the budget map.
+    let sink = {
+        let slot = sink_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match slot.as_ref() {
+            Some(sink) => sink.clone(),
+            None => return,
+        }
+    };
+    octos_core::truncate_utf8(&mut event.text, BACKGROUND_ACTIVITY_TEXT_CAP, " [...]");
+    let decision = {
+        let key = cap_key(&event);
+        let mut budgets = budget_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        cap_admit(
+            &mut budgets,
+            &key,
+            Instant::now(),
+            BACKGROUND_ACTIVITY_WINDOW,
+            BACKGROUND_ACTIVITY_MAX_PER_WINDOW,
+        )
+    };
+    match decision {
+        CapDecision::Admit { dropped } => {
+            event.dropped_count = (dropped > 0).then_some(dropped);
+        }
+        CapDecision::Marker { dropped } => {
+            event.suppressed = true;
+            event.dropped_count = Some(dropped);
+            event.text = format!(
+                "further events from this origin are suppressed \
+                 (more than {BACKGROUND_ACTIVITY_MAX_PER_WINDOW} in \
+                 {}s); the model is still being woken by every one of them",
+                BACKGROUND_ACTIVITY_WINDOW.as_secs()
+            );
+        }
+        CapDecision::Drop => {
+            tracing::debug!(
+                session = %event.session_id,
+                origin_kind = %event.origin_kind,
+                origin_id = %event.origin_id,
+                "background activity suppressed by the per-origin cap"
+            );
+            return;
+        }
+    }
+    sink(event);
+}
+
+/// Current wall clock in ms since the Unix epoch, for `emitted_at_ms`.
+pub(crate) fn now_ms_for_activity() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .and_then(|d| i64::try_from(d.as_millis()).ok())
+        .unwrap_or_default()
+}
+
+/// Build a background-activity event with the required routing key + origin
+/// attribution already in place. Keeping construction here means no producer
+/// can forget `session_id` or ship an unattributed line.
+pub(crate) fn background_activity(
+    session_id: &octos_core::SessionKey,
+    profile_id: Option<&str>,
+    origin_kind: &str,
+    origin_id: &str,
+    origin_label: Option<&str>,
+    text: impl Into<String>,
+) -> BackgroundActivityEvent {
+    BackgroundActivityEvent {
+        session_id: session_id.clone(),
+        profile_id: profile_id.map(ToOwned::to_owned),
+        origin_kind: origin_kind.to_owned(),
+        origin_id: origin_id.to_owned(),
+        origin_label: origin_label
+            .map(str::trim)
+            .filter(|label| !label.is_empty())
+            .map(ToOwned::to_owned),
+        text: text.into(),
+        emitted_at_ms: now_ms_for_activity(),
+        dropped_count: None,
+        suppressed: false,
+    }
+}
+
+/// Origin class for monitor event lines (#1977).
+pub(crate) const ORIGIN_KIND_MONITOR: &str = "monitor";
+/// Origin class for claimed fleet outbox events.
+pub(crate) const ORIGIN_KIND_FLEET: &str = "fleet";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use octos_core::SessionKey;
+
+    fn event_for(session: &str, origin: &str) -> BackgroundActivityEvent {
+        background_activity(
+            &SessionKey(session.to_owned()),
+            Some("dev"),
+            ORIGIN_KIND_MONITOR,
+            origin,
+            Some("ci-tail"),
+            "line",
+        )
+    }
+
+    /// The cap admits a bounded number per window, then emits exactly ONE
+    /// visible marker, then goes quiet — and the backlog is reconciled onto
+    /// the next admitted event when the window rolls.
+    #[test]
+    fn should_emit_one_visible_marker_when_the_origin_cap_is_crossed() {
+        let mut budgets = HashMap::new();
+        let start = Instant::now();
+        let window = Duration::from_secs(60);
+        for i in 0..3 {
+            assert_eq!(
+                cap_admit(&mut budgets, "k", start, window, 3),
+                CapDecision::Admit { dropped: 0 },
+                "event {i} is within the budget"
+            );
+        }
+        // First over-budget event is the MARKER, not a silent drop.
+        assert_eq!(
+            cap_admit(&mut budgets, "k", start, window, 3),
+            CapDecision::Marker { dropped: 1 }
+        );
+        // Subsequent over-budget events are silent (the marker already said so).
+        for _ in 0..5 {
+            assert_eq!(
+                cap_admit(&mut budgets, "k", start, window, 3),
+                CapDecision::Drop
+            );
+        }
+        // The next window admits again and REPORTS the accumulated backlog, so
+        // the drop total is never lost.
+        let rolled = start + window;
+        assert_eq!(
+            cap_admit(&mut budgets, "k", rolled, window, 3),
+            CapDecision::Admit { dropped: 5 }
+        );
+        // ...and once reported it is not double-counted.
+        assert_eq!(
+            cap_admit(&mut budgets, "k", rolled, window, 3),
+            CapDecision::Admit { dropped: 0 }
+        );
+    }
+
+    /// Budgets are per (session, origin): a noisy monitor must not starve a
+    /// sibling origin, and two sessions never share one budget.
+    #[test]
+    fn should_budget_independently_when_origins_or_sessions_differ() {
+        let mut budgets = HashMap::new();
+        let now = Instant::now();
+        let window = Duration::from_secs(60);
+        let noisy = cap_key(&event_for("s-a", "mon-1"));
+        let quiet = cap_key(&event_for("s-a", "mon-2"));
+        let other_session = cap_key(&event_for("s-b", "mon-1"));
+        assert_ne!(noisy, quiet);
+        assert_ne!(noisy, other_session);
+
+        for _ in 0..2 {
+            assert!(matches!(
+                cap_admit(&mut budgets, &noisy, now, window, 2),
+                CapDecision::Admit { .. }
+            ));
+        }
+        assert!(matches!(
+            cap_admit(&mut budgets, &noisy, now, window, 2),
+            CapDecision::Marker { .. }
+        ));
+        // The sibling origin and the other session are untouched.
+        assert_eq!(
+            cap_admit(&mut budgets, &quiet, now, window, 2),
+            CapDecision::Admit { dropped: 0 }
+        );
+        assert_eq!(
+            cap_admit(&mut budgets, &other_session, now, window, 2),
+            CapDecision::Admit { dropped: 0 }
+        );
+    }
+
+    /// An event with no routing key must never reach the sink — it would
+    /// render in whichever session the client happens to have focused.
+    #[test]
+    fn should_refuse_to_emit_when_the_session_key_is_empty() {
+        let seen = Arc::new(StdMutex::new(Vec::new()));
+        let recorder = seen.clone();
+        set_background_activity_sink(Arc::new(move |event: BackgroundActivityEvent| {
+            recorder.lock().unwrap().push(event);
+        }));
+        emit_background_activity(event_for("   ", "mon-1"));
+        emit_background_activity(event_for("dev:local:tui", "mon-1"));
+        let captured = seen.lock().unwrap().clone();
+        clear_background_activity_sink();
+        assert_eq!(captured.len(), 1, "only the routable event is emitted");
+        assert_eq!(captured[0].session_id.0, "dev:local:tui");
+    }
+
+    /// A producer must never be blocked or failed by the sink: emitting with
+    /// NO sink installed is a silent no-op, and a panicking-free best-effort
+    /// call is all the producer ever sees.
+    #[test]
+    fn should_no_op_when_no_sink_is_installed() {
+        clear_background_activity_sink();
+        emit_background_activity(event_for("dev:local:tui", "mon-1"));
+        // Reaching here without panicking IS the assertion; also prove the
+        // budget map was never touched (early-out before the lock).
+        assert!(
+            budget_slot()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .is_empty()
+        );
+    }
+}

--- a/crates/octos-cli/src/autonomy/human_events.rs
+++ b/crates/octos-cli/src/autonomy/human_events.rs
@@ -80,6 +80,34 @@ pub(crate) fn set_background_activity_sink(sink: BackgroundActivitySink) {
     *slot = Some(sink);
 }
 
+/// Serializes every test that touches the process-global sink or budget map,
+/// and resets both on acquisition.
+///
+/// The sink is deliberately process-global in production (a watcher task deep
+/// in the runtime has no handle to thread down, same rationale as
+/// `default_agent_orchestrator()`), so tests that install or clear it are
+/// mutually destructive: libtest runs them in PARALLEL by default, and one
+/// case's teardown wipes the sink another case just installed. That is a test
+/// harness race, not a production one — a single serve process installs the
+/// sink exactly once at boot — but it makes the routing assertion flap, which
+/// is unacceptable for the one property that has regressed three times
+/// (octos-tui#461 / #466 / #483).
+///
+/// Hold the returned guard for the WHOLE test body. Poison-safe: a failing
+/// test panics while holding it, and the next test must still be able to run
+/// (it resets the state it cares about anyway).
+#[cfg(test)]
+#[must_use = "hold the guard for the whole test body, or the sink races again"]
+pub(crate) fn background_activity_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<StdMutex<()>> = OnceLock::new();
+    let guard = LOCK
+        .get_or_init(|| StdMutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    clear_background_activity_sink();
+    guard
+}
+
 /// Remove the sink (and reset the budgets). Test-only: the slot is a `static`
 /// that cannot otherwise be reset between cases.
 #[cfg(test)]
@@ -367,6 +395,7 @@ mod tests {
     /// render in whichever session the client happens to have focused.
     #[test]
     fn should_refuse_to_emit_when_the_session_key_is_empty() {
+        let _guard = background_activity_test_guard();
         let seen = Arc::new(StdMutex::new(Vec::new()));
         let recorder = seen.clone();
         set_background_activity_sink(Arc::new(move |event: BackgroundActivityEvent| {
@@ -385,7 +414,9 @@ mod tests {
     /// call is all the producer ever sees.
     #[test]
     fn should_no_op_when_no_sink_is_installed() {
-        clear_background_activity_sink();
+        // The guard both serializes against the sink-installing cases and
+        // resets the sink + budgets, so "no sink" is a fact, not a hope.
+        let _guard = background_activity_test_guard();
         emit_background_activity(event_for("dev:local:tui", "mon-1"));
         // Reaching here without panicking IS the assertion; also prove the
         // budget map was never touched (early-out before the lock).

--- a/crates/octos-cli/src/autonomy/mod.rs
+++ b/crates/octos-cli/src/autonomy/mod.rs
@@ -14,6 +14,7 @@
 pub(crate) mod agent_orchestrator;
 pub(crate) mod fleet_wake;
 pub(crate) mod goal_loop_runtime;
+pub(crate) mod human_events;
 pub(crate) mod master_continuation_scheduler;
 pub(crate) mod monitor_runtime;
 pub(crate) mod specialist_runner;

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -1491,6 +1491,15 @@ impl ServeCommand {
         // Everything the drain needs (the full AppState) is constructed above.
         crate::api::ui_protocol::spawn_global_master_continuation_drain(state.clone());
 
+        // #2019 — install the HUMAN sink over background events that today
+        // only wake the model (monitor event lines, claimed fleet outbox
+        // events). Spawned here, next to (and before) the global drain, so
+        // both `serve --stdio` and the HTTP serve get it: the producers are
+        // the connection-independent watcher tasks and the outbox consumer,
+        // so the sink must not be per-connection either. Purely additive —
+        // it changes nothing about how or when the model is woken.
+        crate::api::ui_protocol::spawn_background_activity_sink(state.clone());
+
         if self.stdio {
             crate::api::ui_protocol::stdio_connection(state).await?;
             tracing::info!("stopping all gateway child processes");

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -257,6 +257,16 @@ pub const UI_PROTOCOL_FEATURE_USER_QUESTION_V1: &str = "user_question.v1";
 /// turn keeps emitting whole-file `file/attached` audio.
 pub const UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1: &str = "event.voice_audio.v1";
 
+/// #2019 — feature flag for the HUMAN sink over background events that
+/// otherwise only wake the model. Monitor event lines (#1977) and claimed
+/// fleet outbox events already exist, are already durable, and already have
+/// producers — but their sole consumer is the model, so a monitor that fires
+/// forty times during a loop is invisible to the user. When negotiated, the
+/// server additionally pushes `background/activity` notifications carrying the
+/// origin-attributed event text. Purely additive: the model is woken exactly
+/// as before, and this stream is NEVER fed back into model context.
+pub const UI_PROTOCOL_FEATURE_BACKGROUND_ACTIVITY_V1: &str = "event.background_activity.v1";
+
 /// Feature flag for the model-authored plan/todo checklist. When negotiated,
 /// the server pushes `plan/updated` notifications carrying the agent's current
 /// ordered checklist (the `update_plan` tool's live state), and replays the
@@ -304,6 +314,7 @@ pub const UI_PROTOCOL_KNOWN_FEATURES: &[&str] = &[
     UI_PROTOCOL_FEATURE_USER_QUESTION_V1,
     UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1,
     UI_PROTOCOL_FEATURE_PLAN_TODOS_V1,
+    UI_PROTOCOL_FEATURE_BACKGROUND_ACTIVITY_V1,
     UI_PROTOCOL_FEATURE_SMART_HOME_V1,
 ];
 
@@ -1261,6 +1272,12 @@ pub mod methods {
     pub const CONTEXT_NORMALIZATION_REPORTED: &str = "context/normalization_reported";
     /// Session-level whole-job orchestration status notification.
     pub const SESSION_ORCHESTRATION: &str = "session/orchestration";
+    /// #2019 `background/activity` — the HUMAN sink over background events
+    /// that today only wake the model (monitor event lines, claimed fleet
+    /// outbox events). Origin-attributed, durable, capped, and NEVER routed
+    /// back into model context. Gated on
+    /// [`super::UI_PROTOCOL_FEATURE_BACKGROUND_ACTIVITY_V1`].
+    pub const BACKGROUND_ACTIVITY: &str = "background/activity";
     /// #1801 v3 `peer/staged` — agent-initiated peer staging. The model's
     /// `peer_handoff` tool staged a sovereign peer session server-side
     /// (durable brief + optional fenced worktree); sessions are
@@ -1425,6 +1442,7 @@ pub const UI_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &[
     methods::CONTEXT_NORMALIZATION_REPORTED,
     methods::PEER_STAGED,
     methods::PEER_CLOSED,
+    methods::BACKGROUND_ACTIVITY,
 ];
 
 /// Request methods currently handled by the first server/runtime slice.
@@ -6495,6 +6513,59 @@ pub struct PeerClosedEvent {
     pub profile_id: String,
 }
 
+/// #2019 — one background event surfaced to the HUMAN.
+///
+/// Background events (a monitor's filtered stdout line, a claimed fleet outbox
+/// event) already exist and are already durable, but their only consumer is
+/// the model: the sole effect of an event is that the master gets woken, and
+/// whether any of it reaches the transcript depends on whether the model
+/// volunteers it. This is the second consumer — the user — so a monitor that
+/// fires forty times during a self-critic loop is visible rather than a silent
+/// session.
+///
+/// Contract:
+/// - `session_id` is **required** and is the routing key. Activity without one
+///   renders in whichever session happens to be focused (octos-tui#461, #466,
+///   #483) — the exact bug class this event must not re-ship.
+/// - `origin_kind` + `origin_id` (+ optional `origin_label`) attribute the
+///   line. An unattributed monitor/peer line reads as the master speaking.
+/// - The stream is CAPPED per origin. `dropped_count` reports events the cap
+///   suppressed and that this event accounts for; `suppressed` marks the
+///   explicit drop MARKER row (silent truncation reads as "nothing more
+///   happened").
+/// - Durable (ledger-appended) so a client disconnected mid-loop replays the
+///   stream instead of losing its middle.
+/// - This payload is NEVER routed back into model context. It exists so the
+///   human can see what the model was woken by; feeding it back would be a
+///   compaction/cost problem and would make the loop observe itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BackgroundActivityEvent {
+    /// REQUIRED routing key — the session whose master this event woke.
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+    /// Emitter class. Open registry; today `"monitor"` or `"fleet"`.
+    pub origin_kind: String,
+    /// Stable id of the emitter within its class (monitor id / fleet id).
+    pub origin_id: String,
+    /// Human label for the emitter (monitor name, peer slug, …). Clients fall
+    /// back to `origin_id` when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin_label: Option<String>,
+    /// The observed event text (one monitor line, or one fleet event summary).
+    pub text: String,
+    /// Wall-clock emission time, ms since the Unix epoch.
+    pub emitted_at_ms: i64,
+    /// Events this origin's cap suppressed, accounted for by THIS event.
+    /// `None`/`0` when nothing was dropped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dropped_count: Option<u64>,
+    /// `true` when this row IS the cap's visible drop marker rather than an
+    /// observed event line.
+    #[serde(default)]
+    pub suppressed: bool,
+}
+
 /// Draft notification payloads for UI protocol v1.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
@@ -6596,6 +6667,9 @@ pub enum UiNotification {
     /// The model's `peer_close` tool tore down a staged peer session; the
     /// client closes the peer pane it opened. See [`PeerClosedEvent`].
     PeerClosed(PeerClosedEvent),
+    /// #2019: a background event that woke the model, surfaced to the HUMAN.
+    /// See [`BackgroundActivityEvent`].
+    BackgroundActivity(BackgroundActivityEvent),
     /// UPCR-2026-014 (M9-γ) canonical projection envelope (`projection/envelope`).
     /// Spec § 14. Capability-gated on `projection.envelope.v1`; the
     /// per-connection live filter keeps legacy and envelope deliveries
@@ -6674,6 +6748,7 @@ impl UiNotification {
             Self::SessionOrchestration(_) => methods::SESSION_ORCHESTRATION,
             Self::PeerStaged(_) => methods::PEER_STAGED,
             Self::PeerClosed(_) => methods::PEER_CLOSED,
+            Self::BackgroundActivity(_) => methods::BACKGROUND_ACTIVITY,
             Self::Envelope(_) => methods::PROJECTION_ENVELOPE,
             Self::EnvelopeV2(_) => methods::PROJECTION_ENVELOPE,
         }
@@ -6730,6 +6805,7 @@ impl UiNotification {
             Self::SessionOrchestration(event) => &event.session_id,
             Self::PeerStaged(event) => &event.session_id,
             Self::PeerClosed(event) => &event.session_id,
+            Self::BackgroundActivity(event) => &event.session_id,
             Self::Envelope(event) => &event.session_id,
             Self::EnvelopeV2(event) => &event.session_id,
         }
@@ -6895,6 +6971,9 @@ impl UiNotification {
             // and routing keys off `session_id` (the originating session).
             Self::PeerStaged(params) => serde_json::to_value(params),
             Self::PeerClosed(params) => serde_json::to_value(params),
+            // #2019: routing keys off `session_id` like every other
+            // session-scoped notification; the origin fields are payload.
+            Self::BackgroundActivity(params) => serde_json::to_value(params),
             // UPCR-2026-014 (M9-γ) + feat(envelope-wire-routing): the wire
             // shape per spec § 14.1 is the bare `Envelope` fields FLATTENED
             // with the routing keys `session_id` (the bare base key) +
@@ -7046,6 +7125,9 @@ impl UiNotification {
             }
             methods::PEER_STAGED => Ok(Self::PeerStaged(decode_params(method, params)?)),
             methods::PEER_CLOSED => Ok(Self::PeerClosed(decode_params(method, params)?)),
+            methods::BACKGROUND_ACTIVITY => {
+                Ok(Self::BackgroundActivity(decode_params(method, params)?))
+            }
             // UPCR-2026-014 (M9-γ) + feat(envelope-wire-routing): decode
             // the FLATTENED wire frame — bare Envelope keys plus the
             // routing keys `session_id` + `topic`. Backward-compatible:

--- a/crates/octos-core/src/ui_protocol_tests.rs
+++ b/crates/octos-core/src/ui_protocol_tests.rs
@@ -869,6 +869,7 @@ fn ui_protocol_v1_wire_contract_is_golden() {
             "context/normalization_reported",
             "peer/staged",
             "peer/closed",
+            "background/activity",
         ]
     );
     assert_eq!(
@@ -1083,7 +1084,8 @@ fn ui_protocol_v1_representative_wire_payloads_are_golden() {
                 "context/compaction_started",
                 "context/normalization_reported",
                 "peer/staged",
-                "peer/closed"
+                "peer/closed",
+                "background/activity"
             ],
             "supported_features": [
                 "approval.typed.v1",
@@ -1110,6 +1112,7 @@ fn ui_protocol_v1_representative_wire_payloads_are_golden() {
                 "user_question.v1",
                 "event.voice_audio.v1",
                 "plan.todos.v1",
+                "event.background_activity.v1",
                 "smart_home.v1"
             ]
         })
@@ -3037,6 +3040,83 @@ fn peer_staged_notification_roundtrips_and_keeps_peer_topic() {
     .into_rpc_notification()
     .expect("serialize plain peer/staged");
     assert!(plain.params.get("worktree_branch").is_none());
+}
+
+/// #2019 — `background/activity` is the HUMAN sink over events that today
+/// only wake the model. The routing key is the session that OWNS the emitter,
+/// and it must survive the wire boundary intact: an event that loses (or never
+/// carries) `session_id` renders in whichever session happens to be focused
+/// (octos-tui#461/#466/#483). Attribution and the visible drop marker must
+/// survive too.
+#[test]
+fn should_route_on_owning_session_when_background_activity_crosses_the_wire() {
+    let owner = SessionKey("dev:local:tui#coding".into());
+    let other = SessionKey("dev:local:tui#review".into());
+    let event = BackgroundActivityEvent {
+        session_id: owner.clone(),
+        profile_id: Some("dev".into()),
+        origin_kind: "monitor".into(),
+        origin_id: "mon-7".into(),
+        origin_label: Some("ci-tail".into()),
+        text: "ERROR bus test flaked".into(),
+        emitted_at_ms: 1_760_000_000_000,
+        dropped_count: None,
+        suppressed: false,
+    };
+    let notification = UiNotification::BackgroundActivity(event.clone());
+
+    assert_eq!(notification.method(), methods::BACKGROUND_ACTIVITY);
+    assert!(UI_PROTOCOL_NOTIFICATION_METHODS.contains(&methods::BACKGROUND_ACTIVITY));
+    assert!(UI_PROTOCOL_KNOWN_FEATURES.contains(&UI_PROTOCOL_FEATURE_BACKGROUND_ACTIVITY_V1));
+
+    let rpc = notification
+        .clone()
+        .into_rpc_notification()
+        .expect("serialize background/activity");
+    assert_eq!(rpc.method, methods::BACKGROUND_ACTIVITY);
+    // ROUTING, not merely emission: the wire frame names the OWNING session,
+    // never the sibling a client might happen to have focused.
+    assert_eq!(rpc.params["session_id"], owner.0);
+    assert_ne!(rpc.params["session_id"], other.0);
+    // Attribution rides along — an unattributed line reads as the master.
+    assert_eq!(rpc.params["origin_kind"], "monitor");
+    assert_eq!(rpc.params["origin_id"], "mon-7");
+    assert_eq!(rpc.params["origin_label"], "ci-tail");
+
+    let decoded = UiNotification::from_rpc_notification(rpc).expect("decode background/activity");
+    assert_eq!(decoded, notification);
+    assert_eq!(decoded.session_id(), &owner);
+    assert_eq!(decoded.topic(), Some("coding"));
+}
+
+/// #2019 — the cap's drop marker must be explicitly representable on the wire:
+/// silent truncation reads as "nothing more happened".
+#[test]
+fn should_carry_a_visible_drop_marker_when_background_activity_is_capped() {
+    let marker = UiNotification::BackgroundActivity(BackgroundActivityEvent {
+        session_id: SessionKey("dev:local:tui".into()),
+        profile_id: None,
+        origin_kind: "monitor".into(),
+        origin_id: "mon-7".into(),
+        origin_label: None,
+        text: "further events from this monitor suppressed".into(),
+        emitted_at_ms: 1_760_000_000_001,
+        dropped_count: Some(9),
+        suppressed: true,
+    });
+    let rpc = marker
+        .clone()
+        .into_rpc_notification()
+        .expect("serialize drop marker");
+    assert_eq!(rpc.params["suppressed"], true);
+    assert_eq!(rpc.params["dropped_count"], 9);
+    // Absent optionals stay off the wire.
+    assert!(rpc.params.get("origin_label").is_none());
+    assert!(rpc.params.get("profile_id").is_none());
+    assert_eq!(
+        UiNotification::from_rpc_notification(rpc).expect("decode drop marker"),
+        marker
+    );
 }
 
 /// `peer/closed` round-trips through the wire boundary with the originating


### PR DESCRIPTION
Closes #2019.

Follows the correction comment on the issue: **no new emit API.** `monitor_create` is already the producer API. Monitor event lines (#1977) and claimed fleet outbox events already exist, are already durable, and already have producers. Every one of them has exactly one consumer: **the model**. A monitor can fire forty times during a self-critic loop and the user sees nothing, because the only effect of an event is that the master gets woken — whether any of it reaches the transcript depends on whether the model volunteers it.

This adds the **second consumer: the human**, without touching how or when the model is woken.

## What landed

**Protocol** — `background/activity` (`UiNotification::BackgroundActivity`) carries the REQUIRED `session_id` of the session that OWNS the emitter, the origin (`origin_kind` / `origin_id` / `origin_label`), the observed `text`, `emitted_at_ms`, and the cap's `dropped_count` / `suppressed` marker. Gated on the new `event.background_activity.v1` capability, so a client that cannot render it never receives it.

**Sink** — `crates/octos-cli/src/autonomy/human_events.rs` is the process-global tap. Producers call a sync, non-blocking `emit_background_activity`; the `api` surface installs a bounded-channel `try_send` sink whose drain task appends to the durable per-session ledger via `send_notification_durable` (mirroring `PeerStaged`), so a client disconnected mid-loop replays the stream by cursor instead of losing its middle.

**Producers (existing paths, untouched semantics)** — `handle_monitor_batch` emits one event per observed line **after** its durable wake; the fleet outbox consumer emits one per claimed `ChildDone` / `FleetDrained` **once the keeper wake is durable**, so a redelivery does not double-report.

## Against each hard requirement

- **Every event carries `session_id`, and routing is asserted.** `should_emit_attributed_human_activity_on_the_owning_session_when_a_monitor_fires` fires two monitors on two different sessions interleaved and asserts each event lands on ITS OWN session; the ledger test asserts the sibling session's stream stays **empty**. Both were proven RED first: stamping a fixed "focused" session makes the routing assertion fail (`left: []`, `right: ["a1","a2","a3"]`). An event with a blank key is refused at the emit boundary rather than shipped.
- **Attribution is mandatory.** Construction goes through one helper that requires the origin, and the tests pin `origin_kind` / `origin_id` / `origin_label` on every row.
- **Capped with a VISIBLE drop marker.** Per `(session, origin)` budget (40 / 60s). The first over-budget event becomes an explicit marker row (`suppressed: true` + `dropped_count`); the backlog is reconciled onto the next admitted event when the window rolls, so no drop is ever silent or double-counted.
- **Never blocks or fails the producer.** No sink installed, a full queue, or a poisoned lock all degrade to a dropped event plus a log line. `should_leave_the_wake_path_intact_when_no_human_sink_is_installed` pins that the monitor's wake path is unchanged with no sink.
- **Never fed back into model context.** Nothing reads this stream server-side. The model's view is exactly what it was: the same monitor notes and the same continuation metadata.
- **Wake behaviour unchanged.** Same continuation, same dedupe key, same ordering, same persist-before-accounting sequence. The routing test asserts the pending-continuation counts are the pre-#2019 values.

## Gates (local)

- `cargo test -p octos-cli --features api --lib -- --test-threads=1` → **2891 passed, 0 failed**
- `cargo clippy -p octos-cli --features api --all-targets` → clean
- `cargo fmt --all -- --check` → clean
- `cargo test -p octos-core --lib ui_protocol` → 158 passed

## Pairing

Paired with **octos-org/octos-tui#534** — a notification variant the client cannot render is invisible (the "unknown notification" trap from the ui-protocol v2 migration). Both must land together.

