### PR TITLE
fix(peers): re-arm fleet synthesis when a peer delivers a new round (#2024)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -14868,33 +14868,58 @@ async fn evaluate_and_enqueue_fleet_synthesis(
             orchestrator.clear_peer_fleet_synthesis_claim(&master_key);
         }
         FleetSynthesisDecision::Fire => {
-            // Advance the per-peer marks FIRST (durably, atomically). If the
-            // write fails, do NOT enqueue: a fire without a persisted mark would
-            // re-fire the same rounds on the next terminal. Concurrent terminals
-            // writing the same marks are safe (same observed rounds, atomic
-            // replace), and the per-master dedupe key collapses the paired
-            // enqueue.
-            if let Err(err) = write_peer_fleet_synthesis_marks(peers_root, master, &fired_marks) {
-                tracing::warn!(
-                    ?err,
-                    "peer fleet synthesis: .synthesized marks write failed; not enqueuing"
-                );
-                return;
-            }
+            // ENQUEUE FIRST, advance the marks only if it actually queued.
+            //
+            // The synthesis continuation's dedupe key is STABLE PER MASTER
+            // (`external/<kind>/<master>`), so a second synthesis lands as a
+            // duplicate whenever the first is still pending or was claimed
+            // inside `RECENT_CLAIM_GUARD_WINDOW`. Advancing the marks before
+            // knowing that would record "round N summarized" for a turn that
+            // never ran, and nothing would ever retry it — the #2024 gate fix
+            // alone would then still lose the second synthesis, silently.
+            //
+            // Holding the marks back makes it self-healing instead: the gate
+            // still reads Fire on the next edge, and the round-1 synthesis
+            // turn's OWN terminal is that edge (the master-idle re-evaluation
+            // added in #2018), by which point the guard window has moved on.
+            //
+            // The inverted order is safe here precisely because the queue is
+            // in-memory: a crash between enqueue and mark-write loses the
+            // continuation too, so re-firing on restart is correct, not double
+            // work. Concurrent terminals are safe as well — the dedupe key
+            // collapses the paired enqueue, and the marks write is an atomic
+            // whole-record replace of the same observed rounds.
             let outcome = orchestrator.enqueue_peer_fleet_synthesis_continuation(
                 &master_key,
                 profile_id,
                 &owned_slugs,
                 peers.len(),
             );
-            if outcome.queued().is_some() {
+            if outcome.queued().is_none() {
                 tracing::debug!(
                     master = %master_key,
                     profile = profile_id,
-                    peers = peers.len(),
-                    "peer fleet complete — enqueued ONE autonomous synthesis turn on master"
+                    "peer fleet synthesis deduped against an in-flight synthesis; \
+                     marks NOT advanced so the next terminal retries"
+                );
+                return;
+            }
+            if let Err(err) = write_peer_fleet_synthesis_marks(peers_root, master, &fired_marks) {
+                // The turn IS queued; only the record failed. Log loudly — the
+                // cost is a repeated synthesis, not a lost one.
+                tracing::warn!(
+                    ?err,
+                    master = %master_key,
+                    "peer fleet synthesis: marks write failed AFTER enqueuing; \
+                     this fleet may synthesize again"
                 );
             }
+            tracing::debug!(
+                master = %master_key,
+                profile = profile_id,
+                peers = peers.len(),
+                "peer fleet complete — enqueued ONE autonomous synthesis turn on master"
+            );
         }
     }
 }

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -14334,6 +14334,21 @@ fn peer_results_ready_note(peers_root: &Path, session_id: &SessionKey) -> Option
     ))
 }
 
+/// One peer of a master's fleet, as read off the blackboard by
+/// [`collect_owned_peer_results`]. A named struct rather than a tuple so the
+/// compiler enumerates every call site when a field is added.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct OwnedPeer {
+    slug: String,
+    /// True when this peer has a `result.md` on the blackboard.
+    has_result: bool,
+    /// Which round of work this peer has DELIVERED: its count of versioned
+    /// `result-<n>.md` files, floored at 1 whenever a bare `result.md` exists
+    /// (pre-#435 peers wrote no versioned file and would otherwise read as
+    /// round 0 forever, and so never synthesize). `0` means no result yet.
+    round: u32,
+}
+
 /// Peer-fleet auto-synthesis — one owned peer's readiness inputs for the
 /// [`evaluate_peer_fleet_synthesis`] decision.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -14346,6 +14361,12 @@ struct OwnedPeerState {
     /// run yet. Either BLOCKS synthesis so a stale result isn't synthesized
     /// while a fresher one is (about to be) produced.
     mid_turn: bool,
+    /// Which round of work this peer has DELIVERED — see [`OwnedPeer::round`].
+    round: u32,
+    /// The highest round of this peer the master has ALREADY summarized, read
+    /// from the per-master stamp (#2024). `0` when this peer has never been
+    /// summarized. A peer whose `round` exceeds this has fresh work.
+    synthesized_round: u32,
 }
 
 /// Peer-fleet auto-synthesis — the decision for one evaluation of a master's
@@ -14364,19 +14385,28 @@ enum FleetSynthesisDecision {
 }
 
 /// Peer-fleet auto-synthesis — decide whether a master's peer fleet warrants an
-/// AUTONOMOUS synthesis turn. The `.synthesized` stamp is an EXISTENCE marker:
-/// a fleet fires EXACTLY ONCE and never re-fires while any owned peer lives (a
-/// newer result or an added-and-completed peer must NOT re-synthesize). The
-/// stamp is cleared only when the fleet is fully retired (zero owned peers), so
-/// a genuinely fresh fleet later fires once.
+/// AUTONOMOUS synthesis turn.
+///
+/// #2024: the stamp used to be a bare EXISTENCE marker, so once a fleet had
+/// been summarized it could never synthesize again while any owned peer lived —
+/// a master that put its fleet through a second round of work got no second
+/// write-up unless every peer was closed first. The stamp now records WHICH
+/// round of each peer was summarized, so "exactly once" is per ROUND rather
+/// than per fleet: a peer that delivers work past its recorded mark re-arms the
+/// gate, and a fleet with nothing new still holds.
 ///
 /// Decision:
 /// - zero owned peers → [`ClearStamp`](FleetSynthesisDecision::ClearStamp) when
-///   the marker exists (reset for a future fresh fleet), else `Hold`.
-/// - marker already exists (this fleet was synthesized) → `Hold` — never
-///   re-fire while any owned peer remains.
+///   a stamp exists (tidy-up for a future fresh fleet), else `Hold`.
 /// - master busy, or any owned peer not settled / not done → `Hold`.
-/// - otherwise (≥1 owned peer, idle, all settled + done, no marker) → `Fire`.
+/// - no owned peer has a round past its recorded mark → `Hold` (nothing new to
+///   write up).
+/// - otherwise (≥1 owned peer, idle, all settled + done, ≥1 fresh round)
+///   → `Fire`.
+///
+/// Note the ordering: the settled/done preconditions are checked BEFORE the
+/// freshness test, so one peer's fresh round never fires a synthesis while a
+/// sibling is still mid-turn.
 ///
 /// Pure + input-driven so the whole fire/reset/idle/settled matrix is
 /// unit-testable without the filesystem, the wire registry, or a live turn.
@@ -14385,7 +14415,7 @@ fn evaluate_peer_fleet_synthesis(
     stamp_exists: bool,
     master_idle: bool,
 ) -> FleetSynthesisDecision {
-    // Fleet fully cleared → drop the marker so a fresh fleet can fire once.
+    // Fleet fully cleared → drop the marker so a fresh fleet starts clean.
     // Checked FIRST and independent of idle: a retired fleet resets regardless.
     if peers.is_empty() {
         return if stamp_exists {
@@ -14394,14 +14424,9 @@ fn evaluate_peer_fleet_synthesis(
             FleetSynthesisDecision::Hold
         };
     }
-    // Already synthesized this fleet → EXACTLY ONCE: never re-fire while any
-    // owned peer exists (added peers / newer results do not re-arm).
-    if stamp_exists {
-        return FleetSynthesisDecision::Hold;
-    }
     // Never fire onto a busy master. The continuation drain re-checks
     // idle-eligibility before firing; gating here keeps the decision
-    // self-contained and avoids creating the marker for an unfired wave.
+    // self-contained and avoids advancing the marks for an unfired wave.
     if !master_idle {
         return FleetSynthesisDecision::Hold;
     }
@@ -14411,7 +14436,14 @@ fn evaluate_peer_fleet_synthesis(
             return FleetSynthesisDecision::Hold;
         }
     }
-    FleetSynthesisDecision::Fire
+    // #2024: fire only when there is something NEW to write up. A peer with no
+    // recorded mark reads as `synthesized_round == 0`, so a fresh fleet's first
+    // completed round fires exactly as before.
+    if peers.iter().any(|peer| peer.round > peer.synthesized_round) {
+        FleetSynthesisDecision::Fire
+    } else {
+        FleetSynthesisDecision::Hold
+    }
 }
 
 /// Per-master `.synthesized` stamp path under `peers/`. Keyed by a
@@ -14427,11 +14459,115 @@ fn peer_fleet_synthesized_stamp_path(peers_root: &Path, master: &str) -> PathBuf
     ))
 }
 
-/// True when the per-master `.synthesized` EXISTENCE marker is present. Only
-/// existence gates synthesis; the file's content (a debug timestamp) is never
-/// read.
+/// True when the per-master `.synthesized` stamp file is present, in EITHER
+/// format. Only used for the `ClearStamp` tidy-up decision; the fire decision
+/// reads the marks (see [`read_peer_fleet_synthesis_marks`]).
 fn peer_fleet_synthesized_stamp_exists(peers_root: &Path, master: &str) -> bool {
     peer_fleet_synthesized_stamp_path(peers_root, master).exists()
+}
+
+/// First line of a #2024-format stamp. Its presence is what distinguishes the
+/// new per-round record from the pre-#2024 bare-timestamp existence marker, so
+/// it must never change without a version bump.
+const PEER_FLEET_MARKS_HEADER: &str = "octos-peer-fleet-marks v1";
+
+/// Refuse to parse an implausibly large stamp rather than read it into memory.
+/// A stamp holds one short line per owned peer, and the fleet scan itself is
+/// capped, so anything past this is corruption or a hostile write.
+const PEER_FLEET_MARKS_READ_CAP: u64 = 256 * 1024;
+
+/// What the per-master `.synthesized` stamp says about work already written up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FleetSynthesisMarks {
+    /// No stamp on disk — nothing has been summarized.
+    None,
+    /// A pre-#2024 stamp: a bare unix timestamp with no per-peer rounds. It
+    /// proves the fleet WAS summarized but not at which rounds, so every
+    /// currently-owned peer is read as already covered AT ITS CURRENT ROUND.
+    /// That makes the upgrade silent — an already-summarized fleet does not
+    /// re-fire — while a genuinely new round still re-arms the gate.
+    Legacy,
+    /// Per-slug highest round already summarized.
+    Rounds(HashMap<String, u32>),
+}
+
+/// The highest round of `slug` already summarized, given `marks`.
+///
+/// `current_round` is only consulted for [`FleetSynthesisMarks::Legacy`], where
+/// it IS the answer (see the variant's docs). For `Rounds`, a slug absent from
+/// the record reads as `0` — an unrecorded peer is unsummarized, NOT
+/// covered-at-current — so a peer added after the last synthesis fires.
+fn synthesized_round_for(marks: &FleetSynthesisMarks, slug: &str, current_round: u32) -> u32 {
+    match marks {
+        FleetSynthesisMarks::None => 0,
+        FleetSynthesisMarks::Legacy => current_round,
+        FleetSynthesisMarks::Rounds(rounds) => rounds.get(slug).copied().unwrap_or(0),
+    }
+}
+
+/// Read the per-master stamp. Any unreadable / oversized / header-less file is
+/// treated as [`Legacy`](FleetSynthesisMarks::Legacy) rather than `None`:
+/// fail-closed, because mistaking a real stamp for "nothing summarized" would
+/// re-synthesize a fleet that was already written up.
+fn read_peer_fleet_synthesis_marks(peers_root: &Path, master: &str) -> FleetSynthesisMarks {
+    let path = peer_fleet_synthesized_stamp_path(peers_root, master);
+    let Ok(meta) = std::fs::metadata(&path) else {
+        return FleetSynthesisMarks::None;
+    };
+    if !meta.is_file() || meta.len() > PEER_FLEET_MARKS_READ_CAP {
+        return FleetSynthesisMarks::Legacy;
+    }
+    let Ok(body) = std::fs::read_to_string(&path) else {
+        return FleetSynthesisMarks::Legacy;
+    };
+    let mut lines = body.lines();
+    if lines.next().map(str::trim) != Some(PEER_FLEET_MARKS_HEADER) {
+        return FleetSynthesisMarks::Legacy;
+    }
+    let mut rounds = HashMap::new();
+    for line in lines {
+        // `<round> <slug>` — round FIRST so a slug containing spaces (peer dir
+        // names are not guaranteed space-free) survives the split intact.
+        let Some((round, slug)) = line.trim_end_matches(['\r', '\n']).split_once(' ') else {
+            continue;
+        };
+        let (Ok(round), false) = (round.parse::<u32>(), slug.is_empty()) else {
+            continue;
+        };
+        // Keep the HIGHEST on a duplicated slug: a lower mark would re-fire
+        // work that was already summarized.
+        rounds
+            .entry(slug.to_owned())
+            .and_modify(|existing: &mut u32| *existing = (*existing).max(round))
+            .or_insert(round);
+    }
+    FleetSynthesisMarks::Rounds(rounds)
+}
+
+/// Write the per-master stamp, replacing any previous record wholesale so a
+/// peer dropped from the fleet does not linger. Atomic — a torn stamp would
+/// read as `Legacy` and silently freeze the gate.
+fn write_peer_fleet_synthesis_marks(
+    peers_root: &Path,
+    master: &str,
+    marks: &[(String, u32)],
+) -> std::io::Result<()> {
+    let mut body = String::with_capacity(PEER_FLEET_MARKS_HEADER.len() + 1 + marks.len() * 24);
+    body.push_str(PEER_FLEET_MARKS_HEADER);
+    body.push('\n');
+    for (slug, round) in marks {
+        // A newline in a slug would forge extra records. Peer slugs come from
+        // directory names via `staged_peer_dir`, so this is belt-and-braces.
+        if slug.is_empty() || slug.contains(['\n', '\r']) {
+            continue;
+        }
+        body.push_str(&format!("{round} {slug}\n"));
+    }
+    crate::memory_consolidate::apply::atomic_write(
+        &peer_fleet_synthesized_stamp_path(peers_root, master),
+        &body,
+    )
+    .map_err(|err| std::io::Error::other(err.to_string()))
 }
 
 /// Remove the per-master `.synthesized` marker (best-effort). Absent is not an
@@ -14488,7 +14624,7 @@ fn reset_peer_fleet_synthesis_if_cleared(peers_root: &Path, master: &str) {
 /// The caller MUST treat `None` as "can't determine this pass" and fail closed
 /// (never reset the marker, never fire), so a transient scan error is never
 /// mistaken for a cleared fleet.
-fn collect_owned_peer_results(peers_root: &Path, master: &str) -> Option<Vec<(String, bool)>> {
+fn collect_owned_peer_results(peers_root: &Path, master: &str) -> Option<Vec<OwnedPeer>> {
     let read_dir = std::fs::read_dir(peers_root).ok()?;
     let mut owned = Vec::new();
     for entry in read_dir.flatten() {
@@ -14514,7 +14650,21 @@ fn collect_owned_peer_results(peers_root: &Path, master: &str) -> Option<Vec<(St
         if originator.trim() != master {
             continue;
         }
-        owned.push((slug, peer_io::peer_regular_file_exists(&dir, "result.md")));
+        let has_result = peer_io::peer_regular_file_exists(&dir, "result.md");
+        // #2024: how many rounds this peer has DELIVERED. Versioned results
+        // (`result-<n>.md`) have existed since #435, but a peer whose result
+        // predates them has only the bare `result.md` — floor it at 1 so it
+        // can still exceed a mark of 0 and synthesize at all.
+        let round = if has_result {
+            crate::peers::count_peer_result_versions(&dir).max(1)
+        } else {
+            0
+        };
+        owned.push(OwnedPeer {
+            slug,
+            has_result,
+            round,
+        });
     }
     Some(owned)
 }
@@ -14529,13 +14679,18 @@ fn collect_owned_peer_results(peers_root: &Path, master: &str) -> Option<Vec<(St
 /// pending-continuation sweep surfaces the master even without an active
 /// goal/loop.
 ///
-/// EXACTLY ONCE: the per-master `.synthesized` marker is an existence gate. On
-/// fire the marker is CREATED FIRST (atomically); the continuation is enqueued
-/// ONLY if that write succeeds, so no synthesis fires without a durable marker.
-/// While the marker exists the fleet never re-fires — a newer result or an
-/// added peer does NOT re-synthesize. The marker is cleared only when the fleet
-/// is fully retired (see [`reset_peer_fleet_synthesis_if_cleared`], called from
-/// `peer_close`), letting a later fresh fleet fire once.
+/// EXACTLY ONCE PER ROUND (#2024): the per-master `.synthesized` stamp records
+/// the highest round of each peer already summarized. On fire the marks are
+/// ADVANCED FIRST (atomically); the continuation is enqueued ONLY if that write
+/// succeeds, so no synthesis fires without a durable record. A peer that
+/// delivers a round past its mark — or a peer with no mark at all — re-arms the
+/// gate; a fleet with nothing new holds. The stamp is dropped when the fleet is
+/// fully retired (see [`reset_peer_fleet_synthesis_if_cleared`], called from
+/// `peer_close`), so a later fresh fleet starts from a clean record.
+///
+/// Before #2024 the stamp was a bare existence marker, which made the unit
+/// "once per FLEET": a master that put its peers through a second round got no
+/// second write-up unless every peer was closed first.
 ///
 /// LOOP SAFETY: this fires ONLY on a `peer-<slug>` session's terminal. The
 /// synthesis turn runs on the MASTER session (not a peer), and `peer_gather`
@@ -14661,10 +14816,22 @@ async fn evaluate_and_enqueue_fleet_synthesis(
     let Some(owned) = collect_owned_peer_results(peers_root, master) else {
         return;
     };
+    // #2024: what this master has already written up, per peer. Read ONCE for
+    // the whole fleet so every peer is judged against the same snapshot.
+    let marks = read_peer_fleet_synthesis_marks(peers_root, master);
     let mut owned_slugs: Vec<String> = Vec::with_capacity(owned.len());
+    // The marks to persist if this evaluation fires: each peer AT THE ROUND
+    // this pass observed, so the write can never claim a round the synthesis
+    // did not actually cover.
+    let mut fired_marks: Vec<(String, u32)> = Vec::with_capacity(owned.len());
     let peers: Vec<OwnedPeerState> = owned
         .into_iter()
-        .map(|(slug, has_result)| {
+        .map(|peer| {
+            let OwnedPeer {
+                slug,
+                has_result,
+                round,
+            } = peer;
             // Resolve the wire session ONCE; reuse it for both the active-turn
             // check and the in-flight-injection check.
             let wire_session = peer_wire_registry().resolve(&peer_wire_key(profile_id, &slug));
@@ -14677,10 +14844,14 @@ async fn evaluate_and_enqueue_fleet_synthesis(
             // reads; the recent-claim check closes the pop-vs-snapshot window.
             let inflight_injection =
                 orchestrator.peer_has_inflight_send_input(profile_id, &slug, wire_session.as_ref());
+            let synthesized_round = synthesized_round_for(&marks, &slug, round);
+            fired_marks.push((slug.clone(), round.max(synthesized_round)));
             owned_slugs.push(slug);
             OwnedPeerState {
                 has_result,
                 mid_turn: active_mid_turn || inflight_injection,
+                round,
+                synthesized_round,
             }
         })
         .collect();
@@ -14697,22 +14868,16 @@ async fn evaluate_and_enqueue_fleet_synthesis(
             orchestrator.clear_peer_fleet_synthesis_claim(&master_key);
         }
         FleetSynthesisDecision::Fire => {
-            // Write the `.synthesized` marker FIRST (durably, atomically). If it
-            // fails, do NOT enqueue: no fire without a persisted marker. The
-            // content is a debug timestamp; only existence gates. Concurrent
-            // terminals writing the same marker are safe (idempotent), and the
-            // per-master dedupe key collapses the paired enqueue.
-            let now_unix = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|elapsed| elapsed.as_secs())
-                .unwrap_or(0);
-            if let Err(err) = crate::memory_consolidate::apply::atomic_write(
-                &peer_fleet_synthesized_stamp_path(peers_root, master),
-                &now_unix.to_string(),
-            ) {
+            // Advance the per-peer marks FIRST (durably, atomically). If the
+            // write fails, do NOT enqueue: a fire without a persisted mark would
+            // re-fire the same rounds on the next terminal. Concurrent terminals
+            // writing the same marks are safe (same observed rounds, atomic
+            // replace), and the per-master dedupe key collapses the paired
+            // enqueue.
+            if let Err(err) = write_peer_fleet_synthesis_marks(peers_root, master, &fired_marks) {
                 tracing::warn!(
                     ?err,
-                    "peer fleet synthesis: .synthesized marker write failed; not enqueuing"
+                    "peer fleet synthesis: .synthesized marks write failed; not enqueuing"
                 );
                 return;
             }

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -9474,19 +9474,29 @@ fn peer_send_input_authorized_only_for_recorded_originator() {
     assert!(err3.contains("not a staged peer"), "reason: {err3}");
 }
 
-/// Peer-fleet auto-synthesis fire policy — EXACTLY ONCE per fleet, on the pure
-/// decision. FIRES when every owned peer is done + the master is idle + no
-/// marker yet; HOLDS while any peer is mid-turn (or has queued input), while the
-/// master is busy, when a peer has no result, and — crucially — when the marker
-/// ALREADY EXISTS (no re-fire while any owned peer lives, even if all are done).
-/// A cleared fleet (zero owned peers) yields ClearStamp when a marker exists (so
-/// a fresh fleet can fire), else Hold.
+/// Peer-fleet auto-synthesis fire policy — EXACTLY ONCE PER ROUND, on the pure
+/// decision. FIRES when every owned peer is done + the master is idle + at least
+/// one peer has a round past its recorded mark; HOLDS while any peer is mid-turn
+/// (or has queued input), while the master is busy, when a peer has no result,
+/// and when every peer's delivered round has already been summarized. A cleared
+/// fleet (zero owned peers) yields ClearStamp when a stamp exists (tidy-up), else
+/// Hold.
+///
+/// #2024 changed the exactly-once unit from FLEET to ROUND: the old gate keyed
+/// on stamp existence alone, so a fleet that did more work after being
+/// summarized could never synthesize again until every peer was closed. The
+/// re-arm behaviour is covered by
+/// `a_new_peer_round_re_arms_fleet_synthesis`.
 #[test]
 fn evaluate_peer_fleet_synthesis_fires_once_and_resets_on_clear() {
     use FleetSynthesisDecision::{ClearStamp, Fire, Hold};
+    // A peer on round 1 with nothing summarized yet — the shape every
+    // assertion below except the exactly-once one uses.
     let peer = |has_result: bool, mid_turn: bool| OwnedPeerState {
         has_result,
         mid_turn,
+        round: u32::from(has_result),
+        synthesized_round: 0,
     };
     let done_a = peer(true, false);
     let done_b = peer(true, false);
@@ -9515,11 +9525,18 @@ fn evaluate_peer_fleet_synthesis_fires_once_and_resets_on_clear() {
         Hold,
     );
 
-    // EXACTLY ONCE: the marker already exists → NEVER re-fire while any owned
-    // peer remains, even with MORE peers all done (added-and-completed peers and
-    // newer results do NOT re-synthesize).
+    // EXACTLY ONCE PER ROUND: every peer's delivered round is already recorded
+    // as summarized → HOLD, however many peers, and regardless of the stamp
+    // flag. This is the guarantee the old existence marker provided; #2024 only
+    // changed WHAT is compared, not that a summarized round stays summarized.
+    let summarized = |round: u32| OwnedPeerState {
+        has_result: true,
+        mid_turn: false,
+        round,
+        synthesized_round: round,
+    };
     assert_eq!(
-        evaluate_peer_fleet_synthesis(&[done_a, done_b, peer(true, false)], true, true),
+        evaluate_peer_fleet_synthesis(&[summarized(1), summarized(2), summarized(1)], true, true),
         Hold,
     );
 
@@ -9545,6 +9562,8 @@ fn evaluate_holds_for_resultless_interrupt_and_fires_with_prior_result() {
     let peer = |has_result: bool| OwnedPeerState {
         has_result,
         mid_turn: false,
+        round: u32::from(has_result),
+        synthesized_round: 0,
     };
     let sibling_done = peer(true);
 
@@ -9562,6 +9581,252 @@ fn evaluate_holds_for_resultless_interrupt_and_fires_with_prior_result() {
         Fire,
         "an interrupted peer with a prior result still lets the fleet synthesize",
     );
+}
+
+/// #2024 — a SECOND round of peer work RE-ARMS the gate.
+///
+/// The pre-#2024 stamp was an existence marker: once written it held forever
+/// while any owned peer lived, so a master that put its fleet through another
+/// round never got a second write-up unless every peer was closed first. That
+/// is the stall behind #2024. The stamp now records WHICH round of each peer
+/// was summarized, and a peer that delivers a round past its mark re-arms.
+#[test]
+fn a_new_peer_round_re_arms_fleet_synthesis() {
+    use FleetSynthesisDecision::{Fire, Hold};
+    let peer = |round: u32, synthesized_round: u32| OwnedPeerState {
+        has_result: true,
+        mid_turn: false,
+        round,
+        synthesized_round,
+    };
+
+    // Round 1 delivered, nothing summarized yet → FIRE (unchanged).
+    assert_eq!(
+        evaluate_peer_fleet_synthesis(&[peer(1, 0)], true, true),
+        Fire
+    );
+
+    // Round 1 delivered AND summarized → HOLD. This is the exactly-once
+    // guarantee the old existence stamp gave, and it is preserved.
+    assert_eq!(
+        evaluate_peer_fleet_synthesis(&[peer(1, 1)], true, true),
+        Hold
+    );
+
+    // THE BUG: the peer did another round. The old gate held here forever;
+    // now the unsummarized round 2 re-arms.
+    assert_eq!(
+        evaluate_peer_fleet_synthesis(&[peer(2, 1)], true, true),
+        Fire
+    );
+
+    // ONE peer with fresh work is enough — the others being caught up does
+    // not suppress it.
+    assert_eq!(
+        evaluate_peer_fleet_synthesis(&[peer(3, 3), peer(2, 1), peer(1, 1)], true, true),
+        Fire,
+    );
+
+    // Whole fleet caught up → HOLD, however many peers.
+    assert_eq!(
+        evaluate_peer_fleet_synthesis(&[peer(3, 3), peer(2, 2), peer(1, 1)], true, true),
+        Hold,
+    );
+
+    // A newly-added peer has no mark at all (synthesized_round 0) → FIRE.
+    assert_eq!(
+        evaluate_peer_fleet_synthesis(&[peer(2, 2), peer(1, 0)], true, true),
+        Fire,
+    );
+
+    // Fresh work still does NOT override the settled/done/idle preconditions:
+    // a busy master, a mid-turn peer, or a resultless peer all still HOLD.
+    assert_eq!(
+        evaluate_peer_fleet_synthesis(&[peer(2, 1)], true, false),
+        Hold,
+        "a busy master holds even with an unsummarized round",
+    );
+    assert_eq!(
+        evaluate_peer_fleet_synthesis(
+            &[
+                peer(2, 1),
+                OwnedPeerState {
+                    has_result: true,
+                    mid_turn: true,
+                    round: 1,
+                    synthesized_round: 1,
+                },
+            ],
+            true,
+            true,
+        ),
+        Hold,
+        "a mid-turn sibling holds even with an unsummarized round elsewhere",
+    );
+    assert_eq!(
+        evaluate_peer_fleet_synthesis(
+            &[
+                peer(2, 1),
+                OwnedPeerState {
+                    has_result: false,
+                    mid_turn: false,
+                    round: 0,
+                    synthesized_round: 0,
+                },
+            ],
+            true,
+            true,
+        ),
+        Hold,
+        "a resultless sibling holds even with an unsummarized round elsewhere",
+    );
+}
+
+/// #2024 back-compat — a stamp written before this change is a bare unix
+/// timestamp with no per-peer rounds. It proves the fleet WAS summarized but
+/// not at which rounds, so every currently-owned peer reads as already covered
+/// at its CURRENT round. An upgrade therefore never re-fires a fleet that was
+/// already written up, while a genuinely new round still re-arms.
+#[test]
+fn a_legacy_peer_fleet_stamp_reads_as_every_current_round_summarized() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path();
+    let master = "tenant-a:api:master-1";
+
+    // Exactly what the old code wrote: seconds-since-epoch, nothing else.
+    std::fs::write(
+        peer_fleet_synthesized_stamp_path(peers_root, master),
+        "1755200000",
+    )
+    .unwrap();
+
+    let marks = read_peer_fleet_synthesis_marks(peers_root, master);
+    assert_eq!(marks, FleetSynthesisMarks::Legacy);
+
+    // A legacy mark covers whatever round the peer is on right now...
+    assert_eq!(synthesized_round_for(&marks, "any-slug", 4), 4);
+    assert_eq!(synthesized_round_for(&marks, "other-slug", 1), 1);
+
+    // ...so the fleet holds on upgrade rather than re-firing.
+    assert_eq!(
+        evaluate_peer_fleet_synthesis(
+            &[OwnedPeerState {
+                has_result: true,
+                mid_turn: false,
+                round: 4,
+                synthesized_round: synthesized_round_for(&marks, "any-slug", 4),
+            }],
+            true,
+            true,
+        ),
+        FleetSynthesisDecision::Hold,
+        "upgrading must not re-synthesize an already-summarized fleet",
+    );
+}
+
+/// #2024 — the stamp round-trips per-peer marks, and an absent stamp reads as
+/// `None` (nothing summarized) rather than as a legacy marker.
+#[test]
+fn peer_fleet_synthesis_marks_round_trip_through_the_stamp_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path();
+    let master = "tenant-a:api:master-1";
+
+    // No stamp at all → None, and every peer reads as unsummarized.
+    let absent = read_peer_fleet_synthesis_marks(peers_root, master);
+    assert_eq!(absent, FleetSynthesisMarks::None);
+    assert_eq!(synthesized_round_for(&absent, "whatever", 3), 0);
+
+    write_peer_fleet_synthesis_marks(
+        peers_root,
+        master,
+        &[("alpha".to_owned(), 2), ("beta".to_owned(), 1)],
+    )
+    .expect("stamp write");
+
+    let marks = read_peer_fleet_synthesis_marks(peers_root, master);
+    assert_eq!(synthesized_round_for(&marks, "alpha", 2), 2);
+    assert_eq!(synthesized_round_for(&marks, "beta", 1), 1);
+    // A slug absent from the record is unsummarized — NOT covered-at-current
+    // the way a legacy stamp would be.
+    assert_eq!(synthesized_round_for(&marks, "gamma", 5), 0);
+
+    // Rewriting replaces the record wholesale — a peer dropped from the fleet
+    // does not linger in the stamp.
+    write_peer_fleet_synthesis_marks(peers_root, master, &[("alpha".to_owned(), 3)])
+        .expect("stamp rewrite");
+    let rewritten = read_peer_fleet_synthesis_marks(peers_root, master);
+    assert_eq!(synthesized_round_for(&rewritten, "alpha", 3), 3);
+    assert_eq!(synthesized_round_for(&rewritten, "beta", 1), 0);
+}
+
+/// #2024 — a slug containing whitespace (the field separator) round-trips. The
+/// stamp is keyed by slug, and slugs come from peer directory names, so the
+/// encoding must not be defeated by one.
+#[test]
+fn peer_fleet_synthesis_marks_survive_a_slug_with_a_space() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path();
+    let master = "tenant-a:api:master-1";
+
+    write_peer_fleet_synthesis_marks(
+        peers_root,
+        master,
+        &[("two words".to_owned(), 2), ("plain".to_owned(), 1)],
+    )
+    .expect("stamp write");
+
+    let marks = read_peer_fleet_synthesis_marks(peers_root, master);
+    assert_eq!(synthesized_round_for(&marks, "two words", 2), 2);
+    assert_eq!(
+        synthesized_round_for(&marks, "plain", 1),
+        1,
+        "a space in one slug must not corrupt the rest of the record"
+    );
+}
+
+/// #2024 — the round a peer is on is its count of versioned `result-<n>.md`
+/// files, with one back-compat rule: a peer whose result predates versioning
+/// (bare `result.md`, no `result-1.md`) still counts as round 1. Without that
+/// floor such a peer would read as round 0, never exceed its mark, and never
+/// synthesize at all.
+#[test]
+fn peer_result_round_counts_versions_and_floors_a_legacy_result_at_one() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path();
+    let master = "tenant-a:api:master-1";
+
+    let stage = |slug: &str| {
+        let dir = peers_root.join(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("brief.md"), "brief").unwrap();
+        std::fs::write(dir.join("originator"), master).unwrap();
+        dir
+    };
+
+    // No result at all → round 0.
+    stage("pending");
+    // Legacy: bare result.md, no versioned files → floored to round 1.
+    let legacy = stage("legacy");
+    std::fs::write(legacy.join("result.md"), "res").unwrap();
+    // Versioned: three rounds delivered.
+    let versioned = stage("versioned");
+    std::fs::write(versioned.join("result.md"), "res").unwrap();
+    for n in 1..=3 {
+        std::fs::write(versioned.join(format!("result-{n}.md")), "res").unwrap();
+    }
+
+    let owned = collect_owned_peer_results(peers_root, master).expect("peers dir readable");
+    let round_of = |slug: &str| {
+        owned
+            .iter()
+            .find(|peer| peer.slug == slug)
+            .unwrap_or_else(|| panic!("{slug} owned"))
+            .round
+    };
+    assert_eq!(round_of("pending"), 0, "no result → round 0");
+    assert_eq!(round_of("legacy"), 1, "bare result.md floors to round 1");
+    assert_eq!(round_of("versioned"), 3, "three result-<n>.md → round 3");
 }
 
 /// Peer-fleet auto-synthesis — `collect_owned_peer_results` returns exactly the
@@ -9603,32 +9868,43 @@ fn collect_owned_peer_results_filters_by_originator_and_excludes_closed() {
 
     let mut owned = collect_owned_peer_results(peers_root, master).expect("peers dir readable");
     owned.sort();
-    let slugs: Vec<&str> = owned.iter().map(|(slug, _)| slug.as_str()).collect();
+    let slugs: Vec<&str> = owned.iter().map(|peer| peer.slug.as_str()).collect();
     assert_eq!(
         slugs,
         vec!["done-peer", "errored-peer", "pending-peer"],
         "only this master's non-closed peers are owned"
     );
+    let has_result = |slug: &str| {
+        owned
+            .iter()
+            .find(|peer| peer.slug == slug)
+            .unwrap_or_else(|| panic!("{slug} owned"))
+            .has_result
+    };
     assert!(
-        owned.iter().find(|(s, _)| s == "done-peer").unwrap().1,
+        has_result("done-peer"),
         "a written result → has_result true"
     );
     assert!(
-        owned.iter().find(|(s, _)| s == "errored-peer").unwrap().1,
+        has_result("errored-peer"),
         "an errored peer's result.md still counts as present"
     );
     assert!(
-        !owned.iter().find(|(s, _)| s == "pending-peer").unwrap().1,
+        !has_result("pending-peer"),
         "a peer with no result.md → has_result false"
     );
 }
 
-/// Peer-fleet auto-synthesis — the per-master `.synthesized` stamp is an
-/// EXISTENCE marker: create/exists/remove round-trips, distinct masters are
-/// independent (`safe_filename`), removing an absent marker is a no-op, and the
-/// colocated marker file is never mistaken for a staged peer.
+/// Peer-fleet auto-synthesis — the per-master `.synthesized` stamp FILE's
+/// lifecycle: create/exists/remove round-trips, distinct masters are independent
+/// (`safe_filename`), removing an absent stamp is a no-op, and the colocated
+/// stamp file is never mistaken for a staged peer.
+///
+/// This covers the file only. What the stamp SAYS — per-peer summarized rounds
+/// since #2024 — is covered by
+/// `peer_fleet_synthesis_marks_round_trip_through_the_stamp_file`.
 #[test]
-fn peer_fleet_synthesized_stamp_is_an_existence_marker() {
+fn peer_fleet_synthesized_stamp_file_lifecycle() {
     let tmp = tempfile::tempdir().unwrap();
     let peers_root = tmp.path();
     let master_a = "tenant-a:api:master-1";
@@ -9636,7 +9912,8 @@ fn peer_fleet_synthesized_stamp_is_an_existence_marker() {
 
     assert!(!peer_fleet_synthesized_stamp_exists(peers_root, master_a));
 
-    // Create (content is a debug timestamp; only existence gates).
+    // Create. Content is irrelevant here — `..._exists` gates only the
+    // ClearStamp tidy-up, which does not read the record.
     crate::memory_consolidate::apply::atomic_write(
         &peer_fleet_synthesized_stamp_path(peers_root, master_a),
         "1721900000",
@@ -9894,7 +10171,7 @@ fn stage_peer_records_originator_for_ownership_scan() {
     let owned_slugs: Vec<String> = collect_owned_peer_results(&peers_root, master)
         .expect("peers dir readable")
         .into_iter()
-        .map(|(slug, _)| slug)
+        .map(|peer| peer.slug)
         .collect();
     assert_eq!(
         owned_slugs,

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -10096,9 +10096,22 @@ async fn a_second_peer_round_is_not_recorded_as_summarized_unless_a_turn_actuall
     );
 
     // ROUND 2: the master sent a follow-up and the peer delivered again. The
-    // gate re-arms — but round 1's continuation is still pending, so this
-    // enqueue DEDUPES. The mark must therefore stay at 1, leaving the gate
+    // gate re-arms — but a synthesis for this master is already in flight, so
+    // the enqueue DEDUPES. The mark must therefore stay at 1, leaving the gate
     // armed for the next edge instead of recording a synthesis that never ran.
+    //
+    // Establish that precondition EXPLICITLY rather than relying on round 1's
+    // continuation still sitting in the process-global queue: sibling tests
+    // share that queue, and depending on its state made this test flaky in a
+    // full parallel run (the #2029 disease — do not add another instance of
+    // it). A redundant enqueue on the same per-master key is a no-op if one is
+    // already pending, so this is safe either way.
+    default_agent_orchestrator().enqueue_peer_fleet_synthesis_continuation(
+        &master_key,
+        MAIN_PROFILE_ID,
+        &["worker".to_owned()],
+        1,
+    );
     std::fs::write(dir.join("result.md"), "round two").unwrap();
     std::fs::write(dir.join("result-2.md"), "round two").unwrap();
     evaluate_and_enqueue_fleet_synthesis(MAIN_PROFILE_ID, peers_root, master, &master_key).await;

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -10042,6 +10042,96 @@ async fn fleet_that_landed_while_master_was_busy_synthesizes_on_the_master_idle_
     active_turns_registry().lock().await.remove(&master_key);
 }
 
+/// #2024 END-TO-END — a peer's SECOND round produces a SECOND synthesis, driven
+/// through the real `evaluate_and_enqueue_fleet_synthesis` rather than the pure
+/// decision.
+///
+/// This is the case the pure-function tests cannot reach and that the fix
+/// initially got wrong. The synthesis continuation's dedupe key is stable per
+/// master, so round 2's enqueue lands as a DUPLICATE while round 1's is still
+/// pending. With the marks advanced before the enqueue, round 2 would be
+/// recorded as summarized by a turn that never ran, and nothing would retry —
+/// the gate fix alone would have lost the second synthesis silently while every
+/// unit test passed.
+///
+/// Asserts the marks on disk, because they are what the gate reads next time.
+#[tokio::test]
+async fn a_second_peer_round_is_not_recorded_as_summarized_unless_a_turn_actually_queued() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path();
+    // Unique master: the dedupe key and its recent-claim guard are
+    // process-global, so a shared name would collide with sibling tests.
+    let master = "tenant-a:api:master-2024-e2e";
+    let master_key = SessionKey(master.to_owned());
+
+    let dir = peers_root.join("worker");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("brief.md"), "brief").unwrap();
+    std::fs::write(dir.join("originator"), master).unwrap();
+
+    // ROUND 1: the peer delivers. Master-idle edge → fires, records round 1.
+    std::fs::write(dir.join("result.md"), "round one").unwrap();
+    std::fs::write(dir.join("result-1.md"), "round one").unwrap();
+    evaluate_and_enqueue_fleet_synthesis(MAIN_PROFILE_ID, peers_root, master, &master_key).await;
+    assert_eq!(
+        synthesized_round_for(
+            &read_peer_fleet_synthesis_marks(peers_root, master),
+            "worker",
+            1
+        ),
+        1,
+        "round 1 queued a synthesis, so it must be recorded as summarized",
+    );
+
+    // Re-evaluating with NOTHING new must not disturb the record.
+    evaluate_and_enqueue_fleet_synthesis(MAIN_PROFILE_ID, peers_root, master, &master_key).await;
+    assert_eq!(
+        synthesized_round_for(
+            &read_peer_fleet_synthesis_marks(peers_root, master),
+            "worker",
+            1
+        ),
+        1,
+        "an evaluation with no new round is a no-op",
+    );
+
+    // ROUND 2: the master sent a follow-up and the peer delivered again. The
+    // gate re-arms — but round 1's continuation is still pending, so this
+    // enqueue DEDUPES. The mark must therefore stay at 1, leaving the gate
+    // armed for the next edge instead of recording a synthesis that never ran.
+    std::fs::write(dir.join("result.md"), "round two").unwrap();
+    std::fs::write(dir.join("result-2.md"), "round two").unwrap();
+    evaluate_and_enqueue_fleet_synthesis(MAIN_PROFILE_ID, peers_root, master, &master_key).await;
+    assert_eq!(
+        synthesized_round_for(
+            &read_peer_fleet_synthesis_marks(peers_root, master),
+            "worker",
+            2
+        ),
+        1,
+        "a deduped enqueue must NOT record round 2 as summarized — otherwise \
+         the second synthesis is lost with nothing left to retry it",
+    );
+
+    // And the gate is still armed: round 2 > recorded 1.
+    let owned = collect_owned_peer_results(peers_root, master).expect("peers dir readable");
+    let marks = read_peer_fleet_synthesis_marks(peers_root, master);
+    let states: Vec<OwnedPeerState> = owned
+        .iter()
+        .map(|peer| OwnedPeerState {
+            has_result: peer.has_result,
+            mid_turn: false,
+            round: peer.round,
+            synthesized_round: synthesized_round_for(&marks, &peer.slug, peer.round),
+        })
+        .collect();
+    assert_eq!(
+        evaluate_peer_fleet_synthesis(&states, true, true),
+        FleetSynthesisDecision::Fire,
+        "round 2 stays armed so the next terminal retries the synthesis",
+    );
+}
+
 /// Bug 2 (reset edge) — `collect_owned_peer_results` distinguishes a
 /// genuinely-EMPTY readable directory (`Some(vec![])`) from a `peers/` scan
 /// FAILURE (`None`), so a transient read error is never mistaken for a cleared


### PR DESCRIPTION
Closes #2024.

## The bug

The per-master `.synthesized` stamp was a bare existence marker. Once a master had written up its peers, `evaluate_peer_fleet_synthesis` returned `Hold` for as long as any owned peer existed:

```rust
if stamp_exists {
    return FleetSynthesisDecision::Hold;   // forever
}
```

So the exactly-once unit was the **fleet**. A master that put the same peers through a second round of work got no second write-up unless every peer was closed first. That is the stall behind #2024: a live fleet did more work, and the synthesis that was supposed to summarize it never fired.

## The fix

The stamp now records the highest round of each peer already summarized, which makes the unit the **round**:

| peer state | recorded | delivered | decision |
|---|---|---|---|
| new peer, first result | — | 1 | Fire |
| peer did another round | 1 | 2 | Fire |
| nothing new | 2 | 2 | Hold |

One peer with fresh work is enough; a fleet with nothing new holds. The settled / done / idle preconditions are still checked **before** the freshness test, so one peer's new round never fires a synthesis while a sibling is mid-turn.

A peer's round is its count of versioned `result-<n>.md` files (which have existed since #435), floored at 1 whenever a bare `result.md` is present — otherwise a peer whose result predates versioning would read as round 0, never exceed a mark of 0, and never synthesize at all.

## Back-compat

A stamp written before this change is a bare unix timestamp. It proves the fleet *was* summarized but not at which rounds, so it reads as **"every currently-owned peer is covered at its current round"**. Upgrading therefore never re-fires an already-summarized fleet, while a genuinely new round still re-arms.

Any unreadable, oversized, or header-less stamp is read the same way — fail-closed, because mistaking a real stamp for "nothing summarized" would re-synthesize work already written up.

## Format

```
octos-peer-fleet-marks v1
2 alpha
1 two words
```

Round first, so a slug containing spaces survives the split. Written atomically and wholesale, so a peer dropped from the fleet does not linger in the record. Reads are size-capped.

`collect_owned_peer_results` now returns a named `OwnedPeer` instead of a `(String, bool)` tuple, so the compiler enumerates every call site when a field is added.

## Tests

Five added (553 → 558 `#[test]` in the file; no deletions):

- `a_new_peer_round_re_arms_fleet_synthesis` — the bug, plus proof the busy-master / mid-turn / resultless holds still win over freshness
- `a_legacy_peer_fleet_stamp_reads_as_every_current_round_summarized` — upgrade does not re-fire
- `peer_fleet_synthesis_marks_round_trip_through_the_stamp_file` — absent ≠ legacy; rewrite drops stale slugs
- `peer_fleet_synthesis_marks_survive_a_slug_with_a_space`
- `peer_result_round_counts_versions_and_floors_a_legacy_result_at_one`

Every name contains `peer` so CI's existing `cargo test -p octos-cli --features api peer` step actually selects them. Three of them did not, as first written — they would have compiled and never run, which is the same failure class as #2025 and the reason for the CI-coverage follow-up.

One existing assertion changed rather than being added to: the case that asserted "marker exists → Hold even with more peers all done" documented the bug. It is replaced by the same guarantee expressed per-round (all peers at their summarized round → Hold), and `peer_fleet_synthesized_stamp_is_an_existence_marker` is renamed to `peer_fleet_synthesized_stamp_file_lifecycle` since it only ever covered the file, not what the file says.

## Gates

- `cargo test -p octos-cli --lib` — 1448 passed
- `cargo test -p octos-cli --features api peer` — 132 passed
- `cargo clippy -p octos-cli --all-targets --no-default-features --features api,...` — clean
- `cargo fmt --all -- --check` — clean

Not yet live-soaked against a real multi-round fleet.