### PR TITLE
test(session-actor): give the continuation-tick test a unique agent id (#2029)

### DIFF
--- a/crates/octos-cli/src/session_actor_tests.rs
+++ b/crates/octos-cli/src/session_actor_tests.rs
@@ -2442,13 +2442,31 @@ async fn master_continuation_tick_reenters_actor_loop() {
         setup_actor_with_mode(provider.clone(), QueueMode::Followup, None, false, &dir).await;
     let session_id = test_session_key(dir.path());
 
+    // #2029: the orchestrator's agent registry is process-global and keyed by
+    // `agent_id` ALONE — the session is a field on the record, not part of the
+    // key. Eighteen tests hardcode `child-a`, so a sibling running concurrently
+    // overwrites this record's session_id/status, the tick finds no completed
+    // child for THIS session, and the assertion below fails. It passed under
+    // `--test-threads=1` and under the narrow CI filters, and failed in roughly
+    // one full parallel run in three.
+    //
+    // Uniqueness is unilateral: a unique id cannot be clobbered no matter what
+    // the other seventeen do. Derived from the TempDir name, which is already
+    // what makes `session_id` unique here.
+    let agent_id = format!(
+        "child-a-{}",
+        dir.path()
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default()
+    );
     crate::autonomy::agent_orchestrator::default_agent_orchestrator().upsert_agent(
         crate::autonomy::agent_orchestrator::AgentUpsert {
-            agent_id: "child-a".into(),
+            agent_id: agent_id.clone(),
             parent_agent_id: Some("master".into()),
             session_id: session_id.clone(),
             task_id: None,
-            path: "master/child-a".into(),
+            path: format!("master/{agent_id}"),
             role: "worker".into(),
             nickname: "Ada".into(),
             backend_kind: "native".into(),


### PR DESCRIPTION
Part of #2029. One of the two flaky tests identified there.

## The failure

`master_continuation_tick_reenters_actor_loop` failed in **roughly one full parallel run in three**, while passing alone, passing under every CI filter, and passing under `--test-threads=1`. A failure that only appears in a wide parallel run — and moves between runs — is interference, not logic.

## The cause

The orchestrator's agent registry is process-global and keyed by `agent_id` **alone**. The session is a field on the record, not part of the key:

```rust
let entry = state
    .agents
    .entry(upsert.agent_id.clone())     // session NOT in the key
    .or_insert_with(|| AutonomyAgentRecord { .. });
```

**18 test sites hardcode `agent_id: "child-a"`.** A sibling upserting it with a different `session_id` replaces this test's record. The periodic tick then finds no completed child for *this* session, nothing drains, and the assertion fails:

```rust
assert!(provider.call_count.load(Ordering::Relaxed) > 0,
    "periodic actor tick must drain queued child completion into process_inbound");
```

Everything else about the test was already unique — the session key is derived from its `TempDir`. Only the agent id wasn't, and that's the part that keys the map.

## The fix

Derive the agent id from the same `TempDir` name.

Uniqueness is **unilateral**: a unique id cannot be clobbered no matter what the other seventeen sites do. So this needs no coordinated change and no churn across all 18.

## Verification

| | failures |
|---|---|
| before (recorded on #2029) | 3 of 8 full parallel runs |
| after | **0 of 4** |

Plus clippy (CI-exact, all features) and fmt clean.

## Scope

Deliberately does **not** fix the other two known flakes — `closed_peer_park_produces_neither_wake_nor_escalation_row` and `second_serve_on_same_data_dir_is_refused_with_a_greppable_marker`. Those are different globals and still reproduce; one of them appeared in run 1 of the verification above.

The class-level fix — putting the session in the registry key, so two sessions each having a `child-a` is normal rather than a conflict — is tracked on #2029. It changes production keying and shouldn't ride along with a test cleanup.