### PR TITLE
fix(peers): keep a live peer out of the per-turn orphan sweep, and cover the wiring

### DIFF
--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -188,8 +188,9 @@ pub use swarm::{
 };
 pub use task_supervisor::{
     BackgroundTask, RelaunchOpts, RelaunchRequest, SpawnOnlyFailureSignal, TaskCancelError,
-    TaskCancelToken, TaskLifecycleState, TaskRelaunchError, TaskRuntimeState, TaskStatus,
-    TaskSupervisor, TaskTerminalGuard, TerminalEvent, TerminalOutcome, parse_alternatives,
+    TaskCancelToken, TaskLifecycleState, TaskLivenessLease, TaskRelaunchError, TaskRuntimeState,
+    TaskStatus, TaskSupervisor, TaskTerminalGuard, TerminalEvent, TerminalOutcome,
+    parse_alternatives, task_is_live,
 };
 pub use tools::{
     AskUserQuestionTool, BackgroundResultKind, BackgroundResultPayload, BrowserTool,

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -3689,6 +3689,62 @@ impl Drop for TaskTerminalGuard {
     }
 }
 
+/// Whether `task_id` currently holds a liveness claim in this process — either
+/// a detached worker's [`TaskTerminalGuard`] or a [`TaskLivenessLease`].
+///
+/// This is what the orphan sweep consults, so it is also the honest way for a
+/// caller outside this crate to assert that it has (or has released) liveness
+/// for work it owns.
+pub fn task_is_live(task_id: &str) -> bool {
+    is_task_live(task_id)
+}
+
+/// A liveness lease for work that is genuinely in flight but is NOT driven by
+/// a detached `tokio` worker in this process — a peer session the CLIENT
+/// boots and drives being the motivating case (#2035).
+///
+/// The orphan sweep in [`TaskSupervisor::enable_persistence`] reaps every
+/// non-terminal row that is absent from the process-global live-set, on the
+/// premise that "non-terminal ⇒ no live worker". [`TaskTerminalGuard`] is what
+/// makes that premise true for detached workers, but it is the wrong tool
+/// here: it holds an `Arc<TaskSupervisor>` (which would pin a per-turn
+/// supervisor for the whole life of the peer and defeat the `Weak`-based
+/// pruning in `SessionTaskQueryStore`), and its `Drop` fires a terminal
+/// transition — whereas a peer is retired by `peer_close`, not by a worker
+/// future ending.
+///
+/// So this type carries the liveness half alone: mark on construction, clear
+/// on `Drop`, no supervisor reference and no terminal side effect. Hold it for
+/// exactly as long as the client-driven work is live.
+///
+/// It does not weaken the sweep. Membership is process-global and starts EMPTY
+/// in a new process, so a row left behind by a genuine cross-process restart
+/// has no lease and is still correctly reaped.
+pub struct TaskLivenessLease {
+    task_id: String,
+}
+
+impl TaskLivenessLease {
+    /// Mark `task_id` live until the returned lease is dropped. Idempotent —
+    /// re-leasing an already-live id is a no-op insert.
+    pub fn new(task_id: impl Into<String>) -> Self {
+        let task_id = task_id.into();
+        mark_task_live(&task_id);
+        Self { task_id }
+    }
+
+    /// The task this lease keeps live.
+    pub fn task_id(&self) -> &str {
+        &self.task_id
+    }
+}
+
+impl Drop for TaskLivenessLease {
+    fn drop(&mut self) {
+        clear_task_live(&self.task_id);
+    }
+}
+
 #[cfg(test)]
 #[path = "task_supervisor_tests.rs"]
 mod tests;

--- a/crates/octos-agent/src/task_supervisor_tests.rs
+++ b/crates/octos-agent/src/task_supervisor_tests.rs
@@ -3962,6 +3962,89 @@ async fn foreground_armed_guard_survives_sweep_before_worker_polls() {
     );
 }
 
+// ── issue #2035: liveness for CLIENT-DRIVEN work (peers) ──────────────
+
+/// Reproduction of #2035. A `peer_handoff` row is the shape the sweep was
+/// never designed for: it is non-terminal for the peer's whole life (it is
+/// retired on `peer_close`, not on turn terminal) and its worker is a
+/// sovereign session the CLIENT drives, so no `TaskTerminalGuard` is ever
+/// armed for it. The next turn's `enable_persistence` therefore reaps a peer
+/// that is perfectly healthy — observed live on mini5, where both peers were
+/// stamped `failed` six seconds after staging and then ran to completion.
+#[test]
+fn a_client_driven_task_with_no_lease_is_reaped_by_the_next_sweep() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let ledger_path = dir.path().join("tasks.jsonl");
+
+    let staging_turn = TaskSupervisor::new();
+    staging_turn.enable_persistence(&ledger_path).unwrap();
+    let peer = staging_turn.register("peer_handoff", "profile:peer:auditor", Some("api:master"));
+
+    // The very next turn rebuilds a fresh supervisor over the SAME ledger.
+    let next_turn = TaskSupervisor::new();
+    next_turn.enable_persistence(&ledger_path).unwrap();
+
+    assert_eq!(
+        next_turn.get_task(&peer).expect("peer row restored").error,
+        Some("orphaned across restart".to_string()),
+        "documents the #2035 defect: without a lease the peer is reaped",
+    );
+}
+
+/// The fix. A liveness lease marks the task live for as long as the CLIENT's
+/// work is in flight, so the per-turn sweep skips it — the same exemption a
+/// detached tokio worker gets from `TaskTerminalGuard`, minus the terminal
+/// side effect (a peer is retired by `peer_close`, not by a worker future).
+#[test]
+fn a_liveness_lease_keeps_a_client_driven_task_out_of_the_sweep() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let ledger_path = dir.path().join("tasks.jsonl");
+
+    let staging_turn = TaskSupervisor::new();
+    staging_turn.enable_persistence(&ledger_path).unwrap();
+    let peer = staging_turn.register("peer_handoff", "profile:peer:auditor", Some("api:master"));
+    let _lease = TaskLivenessLease::new(peer.clone());
+
+    // Several turns pass while the peer works; every one of them sweeps.
+    for _ in 0..3 {
+        let turn = TaskSupervisor::new();
+        turn.enable_persistence(&ledger_path).unwrap();
+        assert_ne!(
+            turn.get_task(&peer).expect("peer row restored").error,
+            Some("orphaned across restart".to_string()),
+            "a leased peer must survive every per-turn sweep",
+        );
+    }
+}
+
+/// The lease must not defeat the sweep's real purpose. Membership is
+/// process-global and starts empty in a new process, so a peer left behind by
+/// a genuine cross-process restart is still reaped — modelled here by dropping
+/// the lease (what process death does to the whole set) and sweeping again.
+#[test]
+fn dropping_the_liveness_lease_makes_the_task_reapable_again() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let ledger_path = dir.path().join("tasks.jsonl");
+
+    let staging_turn = TaskSupervisor::new();
+    staging_turn.enable_persistence(&ledger_path).unwrap();
+    let peer = staging_turn.register("peer_handoff", "profile:peer:auditor", Some("api:master"));
+
+    {
+        let _lease = TaskLivenessLease::new(peer.clone());
+        assert!(is_task_live(&peer), "lease marks the task live");
+    }
+    assert!(!is_task_live(&peer), "drop clears the live-set entry");
+
+    let after_restart = TaskSupervisor::new();
+    after_restart.enable_persistence(&ledger_path).unwrap();
+    assert_eq!(
+        after_restart.get_task(&peer).expect("peer row").error,
+        Some("orphaned across restart".to_string()),
+        "an unleased peer row is still a genuine orphan",
+    );
+}
+
 // ── issue #1920: heartbeat-based in-flight orphan reaper ──────────────
 
 /// A live worker whose heartbeat (`updated_at`) has been silent for longer

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -29739,22 +29739,22 @@ async fn run_standalone_turn(
                 Arc::new(move |event: PeerStagedEvent| {
                     let registry_key = peer_wire_key(&peer_task_profile, &event.slug);
                     // `register` returns an EMPTY-STRING sentinel when the
-                    // per-session task cap rejects it. Binding that would make
-                    // the close path try to retire a task that never existed.
-                    let task_id = peer_supervisor.register(
-                        "peer_handoff",
-                        &registry_key,
-                        Some(&event.session_id.0),
-                    );
-                    if task_id.is_empty() {
+                    // supervisor refuses. Binding that would make the close path
+                    // try to retire a task that never existed. See
+                    // `bind_peer_supervised_task` for the binding contract.
+                    if bind_peer_supervised_task(
+                        &peer_supervisor,
+                        registry_key,
+                        &event.session_id.0,
+                    )
+                    .is_none()
+                    {
                         tracing::warn!(
                             slug = %event.slug,
                             master = %event.session_id,
-                            "peer task registration rejected by the supervisor cap; \
+                            "peer task registration refused by the supervisor; \
                              peer runs UNSUPERVISED (no task row, no cancel token)"
                         );
-                    } else {
-                        peer_task_registry().bind(registry_key, task_id);
                     }
                     let _ = send_notification_durable(
                         &peer_ws,
@@ -29960,11 +29960,7 @@ async fn run_standalone_turn(
                     // a no-op rather than re-marking a terminal task (or, worse,
                     // a task id later reused). A peer with no binding either
                     // predates this wiring or was rejected by the task cap.
-                    if let Some(task_id) =
-                        peer_task_registry().take(&peer_wire_key(&event.profile_id, &event.slug))
-                    {
-                        close_supervisor.mark_completed(&task_id, Vec::new());
-                    }
+                    retire_peer_supervised_task(&close_supervisor, &event.profile_id, &event.slug);
                     let _ = send_notification_durable(
                         &close_ws,
                         &close_ledger,

--- a/crates/octos-cli/src/peers/mod.rs
+++ b/crates/octos-cli/src/peers/mod.rs
@@ -194,6 +194,48 @@ pub(crate) fn peer_task_registry() -> &'static PeerTaskRegistry {
     PEER_TASK_REGISTRY.get_or_init(PeerTaskRegistry::default)
 }
 
+/// #1868 Phase 1 — bind a staged peer to a supervised task.
+///
+/// The task is registered against the MASTER's session, not the peer's: it
+/// represents "this master has a peer working for it", which is exactly the
+/// question liveness asks.
+///
+/// Returns `None` when the supervisor refuses the registration — `register`
+/// signals that with an EMPTY-STRING sentinel, and binding it would make the
+/// close path try to retire a task that never existed. The peer then runs
+/// UNSUPERVISED (no task row, no cancel token); callers should say so loudly.
+pub(crate) fn bind_peer_supervised_task(
+    supervisor: &octos_agent::TaskSupervisor,
+    registry_key: String,
+    master_session: &str,
+) -> Option<String> {
+    let task_id = supervisor.register("peer_handoff", &registry_key, Some(master_session));
+    if task_id.is_empty() {
+        return None;
+    }
+    peer_task_registry().bind(registry_key, task_id.clone());
+    Some(task_id)
+}
+
+/// #1868 Phase 1 — retire the task bound at staging, on the CLOSE path only.
+///
+/// Deliberately not called on turn terminal: a peer runs many turns and would
+/// otherwise retire after its first, leaving every later turn unsupervised
+/// while the master still believed a peer was working for it.
+///
+/// Retirement is exactly-once — `take` removes the binding, so a second close
+/// finds nothing rather than re-marking a terminal task (or, worse, a task id
+/// later reused). Returns the retired task id.
+pub(crate) fn retire_peer_supervised_task(
+    supervisor: &octos_agent::TaskSupervisor,
+    profile_id: &str,
+    slug: &str,
+) -> Option<String> {
+    let task_id = peer_task_registry().take(&peer_wire_key(profile_id, slug))?;
+    supervisor.mark_completed(&task_id, Vec::new());
+    Some(task_id)
+}
+
 /// Registry key for a peer session: `"{profile}:peer:{slug}"` (mirrors the
 /// gateway inbox registry's key construction in `session_actor`).
 pub(crate) fn peer_wire_key(profile_id: &str, slug: &str) -> String {
@@ -2706,6 +2748,103 @@ pub(crate) fn build_peer_list_callback(
 #[cfg(test)]
 mod peer_task_registry_tests {
     use super::*;
+
+    /// #1868 Phase 1 — staging a peer must REGISTER it with the supervisor,
+    /// keyed to the MASTER's session.
+    ///
+    /// Before this wiring, peers were never registered at all: the master's
+    /// task count never showed a peer, peers had no cancel token, and the
+    /// in-flight liveness rule (#2014) had to read `state.agents` directly
+    /// instead of asking the supervisor. The registry's own bind/take was
+    /// covered; the call site that fills it was not.
+    #[test]
+    fn peer_staging_binds_a_supervised_task_keyed_to_the_master_session() {
+        let supervisor = octos_agent::TaskSupervisor::new();
+        let master = "wiring-a:local:tui";
+        let key = peer_wire_key("wiring-a", "auditor");
+
+        let task_id = bind_peer_supervised_task(&supervisor, key, master)
+            .expect("staging a peer must bind a supervised task");
+
+        assert!(!task_id.is_empty(), "an empty sentinel must never be bound");
+        let active = supervisor.get_active_tasks();
+        assert!(
+            active.iter().any(|task| task.id == task_id),
+            "the bound task must be ACTIVE on the supervisor — that is what \
+             liveness queries; got {active:?}"
+        );
+        assert_eq!(
+            retire_peer_supervised_task(&supervisor, "wiring-a", "auditor").as_deref(),
+            Some(task_id.as_str()),
+            "the binding must be addressable by (profile, slug) on the close path"
+        );
+    }
+
+    /// #1868 Phase 1 — the close path retires the task, exactly once.
+    ///
+    /// `emit_closed` can fire more than once for one peer (a close racing a
+    /// replayed durable notification). The second retirement must find nothing
+    /// rather than mark a terminal task again — task ids are recycled, so a
+    /// late second `mark_completed` could land on an unrelated task.
+    #[test]
+    fn peer_close_retires_the_supervised_task_exactly_once() {
+        let supervisor = octos_agent::TaskSupervisor::new();
+        let key = peer_wire_key("wiring-b", "auditor");
+        let task_id = bind_peer_supervised_task(&supervisor, key, "wiring-b:local:tui")
+            .expect("staging must bind");
+
+        assert_eq!(
+            retire_peer_supervised_task(&supervisor, "wiring-b", "auditor").as_deref(),
+            Some(task_id.as_str()),
+            "the first close retires the bound task"
+        );
+        assert_eq!(
+            retire_peer_supervised_task(&supervisor, "wiring-b", "auditor"),
+            None,
+            "a second close must be a no-op, not a second mark_completed"
+        );
+        assert!(
+            !supervisor
+                .get_active_tasks()
+                .iter()
+                .any(|task| task.id == task_id),
+            "the retired task must no longer be active"
+        );
+    }
+
+    /// #1868 Phase 1 — retirement belongs to CLOSE, not to turn terminal.
+    ///
+    /// A peer runs many turns. Retiring on turn terminal would drop the task
+    /// after its first turn, so every later turn would run unsupervised while
+    /// the master still believed a peer was working for it — the master would
+    /// look idle to liveness with a peer mid-turn. This pins the lifetime:
+    /// the task stays active across turns and dies only on close.
+    #[test]
+    fn a_peer_supervised_task_survives_many_turns_and_dies_only_on_close() {
+        let supervisor = octos_agent::TaskSupervisor::new();
+        let key = peer_wire_key("wiring-c", "auditor");
+        let task_id = bind_peer_supervised_task(&supervisor, key, "wiring-c:local:tui")
+            .expect("staging must bind");
+
+        // Three peer turns come and go. None of them touches the binding —
+        // if a future refactor retires on turn terminal, this loop is where it
+        // shows up.
+        for turn in 1..=3 {
+            assert!(
+                supervisor
+                    .get_active_tasks()
+                    .iter()
+                    .any(|task| task.id == task_id),
+                "peer task must still be supervised after turn {turn}"
+            );
+        }
+
+        assert_eq!(
+            retire_peer_supervised_task(&supervisor, "wiring-c", "auditor").as_deref(),
+            Some(task_id.as_str()),
+            "close — and only close — retires the task"
+        );
+    }
 
     /// #1868 Phase 1 — retirement is EXACTLY ONCE.
     ///

--- a/crates/octos-cli/src/peers/mod.rs
+++ b/crates/octos-cli/src/peers/mod.rs
@@ -153,14 +153,27 @@ pub(crate) fn peer_wire_registry() -> &'static PeerWireRegistry {
 /// so both registries are addressed identically; the VALUE is the supervisor's
 /// task id. Process-global for the same reason the wire registry is: a peer is
 /// staged on one path and retired on another.
+/// What the registry holds for one staged peer: the supervisor task id, plus
+/// the liveness lease that keeps the per-turn orphan sweep off it (#2035).
+///
+/// The lease lives HERE, for exactly the peer's supervised lifetime — bound at
+/// staging, dropped by `take` on the close path. Holding it anywhere shorter
+/// (the staging closure, the turn's supervisor) would put it out of scope
+/// while the peer is still working, which is the defect.
+pub(crate) struct PeerTaskBinding {
+    task_id: String,
+    _liveness: octos_agent::TaskLivenessLease,
+}
+
 #[derive(Default)]
 pub(crate) struct PeerTaskRegistry {
-    pub(crate) by_key: std::sync::Mutex<HashMap<String, String>>,
+    pub(crate) by_key: std::sync::Mutex<HashMap<String, PeerTaskBinding>>,
 }
 
 impl PeerTaskRegistry {
-    /// Bind `key` to a supervisor task id. A re-stage under the same key
-    /// overwrites, mirroring [`PeerWireRegistry::register`]'s latest-open-wins.
+    /// Bind `key` to a supervisor task id and take a liveness lease on it. A
+    /// re-stage under the same key overwrites, mirroring
+    /// [`PeerWireRegistry::register`]'s latest-open-wins.
     pub(crate) fn bind(&self, key: String, task_id: String) {
         let mut map = self
             .by_key
@@ -174,18 +187,32 @@ impl PeerTaskRegistry {
             );
             return;
         }
-        map.insert(key, task_id);
+        // A re-stage that resolves to the SAME task id must keep the existing
+        // lease: replacing it would drop the old one AFTER the new insert, and
+        // `Drop` clears the live-set entry unconditionally — briefly unleasing
+        // a task that is still live. Different id ⇒ the old peer is superseded
+        // and its lease should indeed be released.
+        if map.get(&key).is_some_and(|bound| bound.task_id == task_id) {
+            return;
+        }
+        let binding = PeerTaskBinding {
+            _liveness: octos_agent::TaskLivenessLease::new(task_id.clone()),
+            task_id,
+        };
+        map.insert(key, binding);
     }
 
-    /// Take the task id for `key`, removing the binding. Retirement is
-    /// exactly-once: a second close finds nothing and must NOT re-mark a task
-    /// terminal (the supervisor's terminal guard would reject it anyway, but a
-    /// second `mark_completed` would also race a task id later reused).
+    /// Take the task id for `key`, removing the binding and releasing its
+    /// liveness lease. Retirement is exactly-once: a second close finds nothing
+    /// and must NOT re-mark a task terminal (the supervisor's terminal guard
+    /// would reject it anyway, but a second `mark_completed` would also race a
+    /// task id later reused).
     pub(crate) fn take(&self, key: &str) -> Option<String> {
         self.by_key
             .lock()
             .unwrap_or_else(|error| error.into_inner())
             .remove(key)
+            .map(|bound| bound.task_id)
     }
 }
 
@@ -2777,6 +2804,74 @@ mod peer_task_registry_tests {
             retire_peer_supervised_task(&supervisor, "wiring-a", "auditor").as_deref(),
             Some(task_id.as_str()),
             "the binding must be addressable by (profile, slug) on the close path"
+        );
+    }
+
+    /// #2035 — a staged peer must survive the per-turn orphan sweep.
+    ///
+    /// Enrolling a peer is worthless if the next turn immediately un-enrols it.
+    /// The WS turn path builds a fresh `TaskSupervisor` every turn and calls
+    /// `enable_persistence` over the SHARED per-session ledger; its orphan
+    /// sweep reaps every non-terminal row that is not in the process-global
+    /// live-set. A peer row is non-terminal for its whole life (it retires on
+    /// `peer_close`, not on turn terminal) and its worker is a sovereign
+    /// session the CLIENT drives, so nothing arms a `TaskTerminalGuard` for it.
+    ///
+    /// Observed live on mini5 (`80cec9254`): both peers were stamped
+    /// `failed / "orphaned across restart"` six seconds after staging, then ran
+    /// to completion and wrote real findings. `agent/list` showed them dead the
+    /// whole time, and each bogus terminal queued a master continuation.
+    ///
+    /// The pre-existing wiring tests missed this because they build a bare
+    /// supervisor with no persistence, so no sweep ever runs.
+    #[test]
+    fn a_staged_peer_survives_the_per_turn_orphan_sweep() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let ledger = dir.path().join("tasks.jsonl");
+
+        let staging_turn = octos_agent::TaskSupervisor::new();
+        staging_turn.enable_persistence(&ledger).unwrap();
+        let key = peer_wire_key("sweep-a", "auditor");
+        let task_id = bind_peer_supervised_task(&staging_turn, key, "sweep-a:local:tui")
+            .expect("staging must bind");
+
+        // The master takes further turns while the peer works. Each one
+        // rebuilds a supervisor over the same ledger and sweeps.
+        for _ in 0..3 {
+            let next_turn = octos_agent::TaskSupervisor::new();
+            next_turn.enable_persistence(&ledger).unwrap();
+            let row = next_turn.get_task(&task_id).expect("peer row restored");
+            assert_ne!(
+                row.error.as_deref(),
+                Some("orphaned across restart"),
+                "a working peer must not be reaped by the per-turn sweep"
+            );
+        }
+
+        retire_peer_supervised_task(&staging_turn, "sweep-a", "auditor");
+    }
+
+    /// #2035 — retirement must release the liveness lease.
+    ///
+    /// The live-set is process-global and never garbage-collected, so a lease
+    /// that outlives its peer both leaks and, worse, would protect a task id
+    /// from a sweep it should no longer be exempt from.
+    #[test]
+    fn peer_retirement_releases_the_liveness_lease() {
+        let supervisor = octos_agent::TaskSupervisor::new();
+        let key = peer_wire_key("sweep-b", "auditor");
+        let task_id = bind_peer_supervised_task(&supervisor, key, "sweep-b:local:tui")
+            .expect("staging must bind");
+        assert!(
+            octos_agent::task_is_live(&task_id),
+            "a staged peer holds a liveness lease"
+        );
+
+        retire_peer_supervised_task(&supervisor, "sweep-b", "auditor");
+
+        assert!(
+            !octos_agent::task_is_live(&task_id),
+            "closing a peer must release its lease, not leak it"
         );
     }
 


### PR DESCRIPTION
Started as tests for the peer↔supervisor wiring. The live soak that followed showed the wiring was itself broken, so this now carries the fix as well.

## The defect (#2035)

A peer staged by `peer_handoff` was marked `Failed("orphaned across restart")` one turn after enrolment, while the peer ran normally for minutes.

From the run on mini5 (`80cec9254` = `main`), the supervisor's own persisted ledger:

```
04:23:50.289  peer_handoff aud-auth  status: spawned
04:23:56.935  peer_handoff aud-auth  status: failed   error: "orphaned across restart"
04:24:5x      …peer completes successfully and writes a real goal-ledger finding
```

`agent/list` reported both peers `failed` for their whole working life, and each bogus terminal queued a master continuation — the master spent a turn reasoning about "a supervised child … reported failed — orphaned across restart".

## Why

The orphan sweep in `TaskSupervisor::enable_persistence` reaps every non-terminal row absent from the process-global live-set. That set is populated only by `TaskTerminalGuard`, which wraps a detached `tokio` worker. A peer has no such worker — it is a sovereign session the client boots — and by design its row stays non-terminal until `peer_close`. Structurally reap-eligible.

## The fix

`TaskLivenessLease` — the liveness half of `TaskTerminalGuard`, with neither of the parts that make the guard wrong here:

- no `Arc<TaskSupervisor>`, which would pin a per-turn supervisor for the peer's whole life and defeat the `Weak`-based pruning in `SessionTaskQueryStore`
- no terminal transition on `Drop`, because a peer is retired by `peer_close`, not by a worker future ending

The peer task registry holds the lease for exactly the peer's supervised lifetime; `take` releases it on the close path. A re-stage resolving to the same task id keeps the existing lease rather than replacing it, so the live-set entry is never briefly cleared for a task that is still live.

It does not weaken the sweep. Membership is process-global and starts empty in a new process, so a peer left behind by a genuine cross-process restart still has no lease and is still reaped — covered by a test.

## Tests

The three original wiring tests stay: they cover bind/retire at the call site, which the pre-existing registry tests did not.

Two more cover the defect, and they had to be shaped differently — the reason this was invisible is that every existing peer test builds a bare `TaskSupervisor` with no persistence, so no sweep ever runs. The new ones drive the real per-turn shape: a second supervisor over the same ledger.

- `a_staged_peer_survives_the_per_turn_orphan_sweep`
- `peer_retirement_releases_the_liveness_lease`
- plus three in `octos-agent` for the primitive, including the restart case

Mutation-checked twice. Removing the `bind` call fails all three original tests while the four pre-existing registry tests pass. Removing the liveness claim fails exactly the two new peer tests and leaves the seven others green.

## Gates

`cargo test -p octos-agent --lib` — 2565 pass. `cargo test -p octos-cli --features api --lib` — 2926 pass single-threaded. fmt clean; clippy clean on `octos-agent --all-targets` and on the CI-exact `octos-cli` feature set.

Two failures in the full `octos-cli` suite are pre-existing and unrelated, both reported on #2029: `global_drain_spawns_before_the_stdio_early_return` fails on pristine `main` (its source-scan needle went stale in the #1728 rename and CI's filters never run it), and `closed_peer_park_produces_neither_wake_nor_escalation_row` is the known parallel-contention flake that passes with `--test-threads=1`.

Closes #2035.
