### PR TITLE
fix(peer-goal): stop truncating peer results into unverifiable evidence

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -176,6 +176,41 @@ const INTERRUPT_ACK_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 /// callers from the actual socket so a slow client cannot wedge unrelated
 /// traffic. Tunable per session size.
 const WS_WRITER_CHANNEL_CAPACITY: usize = 1024;
+/// #2036 — how much of a peer's result survives into the DURABLE goal-ledger
+/// finding. Since #1990 that finding is what the completion verifier reads, so
+/// this budget decides whether a multi-peer goal can ever be verified: the
+/// previous 400 was a notification-sized cut that destroyed real audit reports
+/// before the verifier ever saw them. Sized to hold an ordinary multi-finding
+/// peer report whole; the verifier's own input stays bounded by
+/// `MAX_LEDGER_EVIDENCE_ASSERTION_CHARS` at the assembly site.
+const MAX_PEER_FINDING_RECORD_CHARS: usize = 4_000;
+/// The peer-progress WAKE is a notification — the master reads the durable
+/// finding for detail — so it keeps the short budget.
+const MAX_PEER_WAKE_SUMMARY_CHARS: usize = 400;
+// The wake is a pointer to the durable finding, never a copy of it. Widening it
+// past the record budget would paste a whole audit report into a system message
+// on the master's next turn. Enforced at compile time so it cannot drift.
+const _: () = assert!(MAX_PEER_WAKE_SUMMARY_CHARS < MAX_PEER_FINDING_RECORD_CHARS);
+
+/// #2036 — build the DURABLE goal-ledger assertion for a peer's result.
+///
+/// Since #1990 this string is what the completion verifier judges, so it must
+/// not be cut to the size of a notification. At the previous 400-char bare
+/// `take` a real multi-defect peer report lost every finding — one observed
+/// live stopped inside its findings-table header row — and the verifier
+/// rejected completion on exactly that basis until the goal was abandoned as
+/// `blocked`.
+///
+/// Two properties matter and neither held before: the budget is large enough
+/// for an ordinary peer report to arrive whole, and when it does bite the
+/// abridgement is MARKED — an unmarked mid-token cut reads to a verifier as
+/// corrupt evidence rather than as an abridged report. The verifier's own
+/// input stays bounded independently, by `MAX_LEDGER_EVIDENCE_ASSERTION_CHARS`
+/// at the assembly site in `goal_tool`.
+fn peer_finding_assertion(outcome: &str, body: &str) -> String {
+    let content = octos_core::truncated_utf8(body, MAX_PEER_FINDING_RECORD_CHARS, " …[truncated]");
+    format!("[{outcome}] {content}")
+}
 const APPROVAL_CANCELLED_REASON_REQUEST_SEND_FAILED: &str = "request_send_failed";
 /// Reason recorded when a pending APPROVAL entry is cancelled because the
 /// approval-requesting tool's waiting future was dropped (turn interrupt/abort,
@@ -12838,6 +12873,73 @@ fn wake_master_and_record_park_escalation(
 }
 
 #[cfg(test)]
+mod peer_finding_evidence_tests {
+    use super::*;
+
+    /// #2036 — an ordinary peer report reaches the ledger WHOLE.
+    ///
+    /// The durable finding is the completion verifier's evidence, so anything
+    /// the recorder drops here is lost to verification permanently. Live, a
+    /// four-defect audit was cut at 400 chars inside its findings-table header
+    /// row; the verifier could see none of the defects and refused completion
+    /// until the goal was abandoned as `blocked`.
+    #[test]
+    fn a_multi_defect_peer_report_is_recorded_whole() {
+        let mut body = String::from("Audit of auth.py — 4 defects found:\n");
+        for i in 0..4 {
+            body.push_str(&format!(
+                "| CRITICAL | defect number {i} with a full explanation of the \
+                 failure mode and the remediation that follows from it |\n"
+            ));
+        }
+        body.push_str("Totals: 4 defects.");
+        assert!(
+            body.chars().count() > 400,
+            "the fixture must exceed the OLD budget or it proves nothing"
+        );
+
+        let assertion = peer_finding_assertion("completed", &body);
+
+        assert!(
+            assertion.starts_with("[completed] "),
+            "the outcome prefix is preserved: {assertion}"
+        );
+        assert!(
+            assertion.contains("defect number 0") && assertion.contains("defect number 3"),
+            "every defect must survive, first to last: {assertion}"
+        );
+        assert!(
+            assertion.contains("Totals: 4 defects."),
+            "the report's own summary must survive: {assertion}"
+        );
+        assert!(
+            !assertion.contains("…[truncated]"),
+            "an ordinary report must not be abridged at all: {assertion}"
+        );
+    }
+
+    /// The bound still exists — a runaway peer cannot write an unbounded row —
+    /// but when it bites it says so, so a verifier reads "abridged" rather than
+    /// "corrupt".
+    #[test]
+    fn an_oversized_peer_report_is_bounded_and_marked() {
+        let body = "Z".repeat(MAX_PEER_FINDING_RECORD_CHARS * 4);
+
+        let assertion = peer_finding_assertion("completed", &body);
+
+        assert!(
+            assertion.chars().count() < MAX_PEER_FINDING_RECORD_CHARS + 100,
+            "the row stays bounded: {} chars",
+            assertion.chars().count()
+        );
+        assert!(
+            assertion.contains("…[truncated]"),
+            "abridgement must be marked: {assertion}"
+        );
+    }
+}
+
+#[cfg(test)]
 mod peer_awaiting_wake_tests {
     use super::*;
     use crate::autonomy::agent_orchestrator::PEER_AWAITING_INPUT_EXTERNAL_KIND;
@@ -13421,7 +13523,7 @@ fn write_peer_result_if_peer_session(
             // The returned `goal_still_active` is the POST-charge status:
             // it gates the goal-progress wake below so a budget-crossing
             // peer cannot queue one more uncharged master turn past the cap.
-            let content_summary: String = body.chars().take(400).collect();
+            let content_summary = peer_finding_assertion(outcome_str, body);
             let goal_still_active = match default_agent_orchestrator()
                 .model_goal_record_peer_finding(
                     &runtime.data_dir,
@@ -13430,7 +13532,7 @@ fn write_peer_result_if_peer_session(
                     &originator,
                     slug,
                     task_id,
-                    &format!("[{outcome_str}] {content_summary}"),
+                    &content_summary,
                     tokens_consumed,
                 ) {
                 Err(err) => {
@@ -13489,7 +13591,12 @@ fn write_peer_result_if_peer_session(
                 // session. This is the same mechanism used for peer parking /
                 // approval wakes — it surfaces as a system message on the
                 // master's next turn.
-                let content_summary: String = body.chars().take(400).collect();
+                // The WAKE is a notification, not evidence — the master reads
+                // the durable finding for detail — so a short bound is right
+                // here. Marked all the same, so the master can tell a complete
+                // short report from an abridged long one.
+                let content_summary =
+                    octos_core::truncated_utf8(body, MAX_PEER_WAKE_SUMMARY_CHARS, " …[truncated]");
                 if let Err(err) = enqueue_goal_progress_wake(
                     &runtime.data_dir,
                     &originator,

--- a/crates/octos-cli/src/goal_tool.rs
+++ b/crates/octos-cli/src/goal_tool.rs
@@ -1203,7 +1203,12 @@ impl GoalUpdateTool {
 /// Max ledger findings folded into the completion evidence, and the per-finding
 /// assertion budget, so a large ledger cannot blow the verifier's input context.
 const MAX_LEDGER_EVIDENCE_FINDINGS: usize = 24;
-const MAX_LEDGER_EVIDENCE_ASSERTION_CHARS: usize = 600;
+/// #2036 — raised from 600. A peer-recorded finding is a whole report, not one
+/// sentence, and at 600 the verifier was shown a fragment of every multi-defect
+/// audit and rejected completion on exactly that basis. Worst case is still
+/// bounded: 24 × 2000 ≈ 48K chars of evidence, and abridgement stays explicitly
+/// marked so the verifier can tell "abridged" from "corrupt".
+const MAX_LEDGER_EVIDENCE_ASSERTION_CHARS: usize = 2_000;
 
 /// Assemble the completion evidence the INDEPENDENT verifier judges.
 ///
@@ -2106,13 +2111,89 @@ mod tests {
 
     #[test]
     fn completion_evidence_truncates_a_giant_assertion() {
-        let big = "Z".repeat(5000);
+        let big = "Z".repeat(50_000);
         let findings = vec![json!({"created_by":"peer:x","kind":"observation","assertion":big})];
         let evidence = completion_evidence_with_ledger("done", &findings);
         assert!(
-            evidence.len() < 2000,
+            evidence.len() < MAX_LEDGER_EVIDENCE_ASSERTION_CHARS + 500,
             "a giant assertion is bounded: len={}",
             evidence.len()
+        );
+        assert!(
+            evidence.contains("…[truncated]"),
+            "abridgement must be MARKED, so the verifier reads it as abridged \
+             rather than as corrupt evidence: {evidence}"
+        );
+    }
+
+    /// #2036 — a peer's multi-finding report must reach the verifier WHOLE.
+    ///
+    /// This is the shape that failed live: two peers audited a file each and
+    /// reported a table of defects. At the old 600-char budget the verifier saw
+    /// the first row and a cut-off second, and rejected completion six times on
+    /// exactly that basis ("only ~2 of the 7 claimed findings are actually
+    /// verifiable") until the master gave up and marked the goal `blocked` —
+    /// even though every finding was real and correctly recorded.
+    #[test]
+    fn completion_evidence_keeps_a_realistic_peer_report_intact() {
+        let mut report = String::from("[completed] Audit of auth.py — 4 defects found:\n");
+        for (severity, defect, remediation) in [
+            (
+                "CRITICAL",
+                "hardcoded live admin token in source (line 3): ADMIN_TOKEN is a \
+                 real credential committed to the repository and readable by \
+                 anyone with source access",
+                "rotate the token immediately and load it from the environment",
+            ),
+            (
+                "CRITICAL",
+                "check_pin off-by-one (lines 8-11): the loop bound is \
+                 len(expected) - 1, so the final digit is never compared and \
+                 \"123X\" authenticates against \"1234\" for any X",
+                "iterate the full range and compare with a constant-time helper",
+            ),
+            (
+                "HIGH",
+                "no length check (lines 6-11): a short entry raises IndexError \
+                 out of the comparison loop, and a longer-than-expected entry is \
+                 silently accepted because only the shared prefix is examined",
+                "reject a mismatched length before comparing",
+            ),
+            (
+                "MEDIUM",
+                "non-constant-time comparison (lines 9-10, 15): both the PIN loop \
+                 and the token equality short-circuit on first mismatch, leaking \
+                 the shared prefix length through timing",
+                "use hmac.compare_digest for both",
+            ),
+        ] {
+            report.push_str(&format!("| {severity} | {defect} | fix: {remediation} |\n"));
+        }
+        report.push_str("Totals: 2 critical, 1 high, 1 medium.");
+        assert!(
+            report.chars().count() > 600,
+            "the fixture must exceed the OLD budget or it proves nothing"
+        );
+
+        let findings =
+            vec![json!({"created_by":"peer:aud-auth","kind":"observation","assertion":report})];
+        let evidence = completion_evidence_with_ledger("both peers reported", &findings);
+
+        assert!(
+            evidence.contains("hardcoded live admin token"),
+            "the first defect must survive: {evidence}"
+        );
+        assert!(
+            evidence.contains("hmac.compare_digest"),
+            "the LAST defect must survive too — truncation used to drop it: {evidence}"
+        );
+        assert!(
+            evidence.contains("Totals: 2 critical"),
+            "the report's own summary must survive: {evidence}"
+        );
+        assert!(
+            !evidence.contains("…[truncated]"),
+            "an ordinary peer report must not be abridged at all: {evidence}"
         );
     }
 


### PR DESCRIPTION
A peer's result was cut to 400 characters before it became a goal-ledger finding. Since #1990 that finding is what the completion verifier reads, so on a multi-peer goal the verifier was handed fragments that stop mid-token and — correctly — refused to verify. The goal could not reach `complete` no matter how good the work was.

Found in a live two-peer goal soak on `80cec9254`. Full evidence in #2036.

## What it looked like

Both peers did genuinely good work — seven real defects between them, every planted one found. Both stored findings were exactly 412 chars (400 plus the `[completed] ` prefix), and both ended mid-token:

```
seq 1  by peer:aud-auth   len 412
   tail: '…efect |\n|---|----------|----------|--------|\n| 1 | 🔴 Critica'
```

`aud-auth`'s finding stops inside its findings-table **header row** — not one of its four defects reached the ledger. The verifier answered:

```
NOT_DONE: The ledger evidence is truncated — finding #1 cuts off mid-word ("🔴 Critica")
and findings 3–7 are not shown at all, so only ~2 of the 7 claimed findings are
actually verifiable
```

Six attempts, ~608K tokens, then `blocked`. There was no escape hatch: the goal tools are create/get/plan/update and nothing appends a finding, so the master could not route around it — it tried a complete `goal-ledger.md` in the workspace and even shelling rows into `goal_01.db`, neither of which is what the verifier reads.

## The fix

Two budgets were squeezing the same evidence, and the tighter one was also the cruder:

| | before | after |
|---|---|---|
| record time (`peer_finding_assertion`) | 400, bare `chars().take()`, unmarked | 4000, `truncated_utf8`, marked |
| assembly (`MAX_LEDGER_EVIDENCE_ASSERTION_CHARS`) | 600, marked | 2000, marked |

An unmarked mid-token cut is what made this read as *corrupt* rather than *abridged*, which is what the verifier was actually penalising — so every path now marks. The verifier's input stays bounded: 24 findings × 2000 ≈ 48K chars worst case.

The peer-progress **wake** keeps its 400-char notification budget — it is a pointer to the durable finding, not a copy of it — and a `const` assertion pins it below the record budget so the two cannot drift back together.

## Tests

`peer_finding_assertion` is extracted for this. The record-time behaviour previously lived inline in a closure, which is why nothing caught the defect — same shape of blind spot as #2035.

- `a_multi_defect_peer_report_is_recorded_whole` — first defect through last, plus the report's own totals line, with no abridgement marker
- `an_oversized_peer_report_is_bounded_and_marked` — the bound still exists and announces itself
- `completion_evidence_keeps_a_realistic_peer_report_intact` — the same report survives the assembly hop
- `completion_evidence_truncates_a_giant_assertion` — updated to assert the marker rather than a magic length

Both new tests carry a guard asserting the fixture actually exceeds the old budget, so they cannot silently stop proving anything. That guard earned its place — it caught my first fixture being too small.

Mutation-checked: restoring the 600-char assembly budget fails `completion_evidence_keeps_a_realistic_peer_report_intact` and leaves the four pre-existing evidence tests green.

## Gates

`cargo test -p octos-cli --features api --lib -- --test-threads=1` — 2924 pass. fmt clean; clippy clean on the CI-exact feature set.

One unrelated pre-existing failure: `global_drain_spawns_before_the_stdio_early_return` fails on pristine `main` too — its source-scan needle went stale in the #1728 rename and CI's filters never run it. Diagnosed on #2029; deliberately not fixed here to keep this PR to one concern.

Closes #2036.
