### PR TITLE
refactor(llm): read every family's default model from the catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ In `--json` mode stdout carries exactly one object (everything else — logs, th
 status line, approval prompts — goes to stderr). On success:
 
 ```json
-{ "text": "…final answer…", "model": "glm-5.2", "input_tokens": 1234, "output_tokens": 567 }
+{ "text": "…final answer…", "model": "glm-5.3", "input_tokens": 1234, "output_tokens": 567 }
 ```
 
 `text` is the final assistant answer; `model` is the model that actually

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -756,7 +756,7 @@ async fn llm_select_promotes_fallback_and_lists_all_models() {
     let state = Arc::new(local_profile_state(dir.path()));
     for (family, model, set_primary) in [
         ("deepseek", "deepseek-v4-pro", true),
-        ("zai", "glm-5.2", false),
+        ("zai", "glm-5.3", false),
     ] {
         let request = RpcRequest::new(
             format!("u-{model}"),
@@ -791,7 +791,7 @@ async fn llm_select_promotes_fallback_and_lists_all_models() {
     assert_eq!(list.len(), 2, "primary + fallback both listed: {models}");
     assert_eq!(list[0]["model"], "deepseek-v4-pro");
     assert_eq!(list[0]["selected"], true);
-    assert_eq!(list[1]["model"], "glm-5.2");
+    assert_eq!(list[1]["model"], "glm-5.3");
     assert_eq!(list[1]["selected"], false);
 
     let request = RpcRequest::new(
@@ -800,7 +800,7 @@ async fn llm_select_promotes_fallback_and_lists_all_models() {
         json!({
             "profile_id": "dev",
             "family_id": "zai",
-            "model_id": "glm-5.2",
+            "model_id": "glm-5.3",
             "route_id": "official",
         }),
     );
@@ -808,7 +808,7 @@ async fn llm_select_promotes_fallback_and_lists_all_models() {
         .await
         .expect("select");
     assert_eq!(result["applied"], true);
-    assert_eq!(result["selected"]["model"], "glm-5.2");
+    assert_eq!(result["selected"]["model"], "glm-5.3");
     assert_eq!(result["selected"]["selected"], true);
 
     let profile = state
@@ -821,7 +821,7 @@ async fn llm_select_promotes_fallback_and_lists_all_models() {
     let llm = profile.config.llm.as_ref().unwrap();
     assert_eq!(
         llm.primary.as_ref().unwrap().model_id.as_deref(),
-        Some("glm-5.2"),
+        Some("glm-5.3"),
         "fallback promoted to primary"
     );
     assert_eq!(llm.fallbacks.len(), 1, "demoted primary kept as fallback");
@@ -833,7 +833,7 @@ async fn llm_select_promotes_fallback_and_lists_all_models() {
     let request = RpcRequest::new(
         "s2".to_string(),
         APPUI_METHOD_PROFILE_LLM_SELECT.to_string(),
-        json!({ "profile_id": "dev", "model_id": "glm-5.2" }),
+        json!({ "profile_id": "dev", "model_id": "glm-5.3" }),
     );
     let result = raw_profile_llm_select(&state, &request, None)
         .await
@@ -855,7 +855,7 @@ async fn llm_select_promotes_fallback_and_lists_all_models() {
 /// without persisting: the runtime re-ensure would fail silently (the
 /// live session keeps the old chain while the UI claims the switch), and
 /// the persisted keyless primary bricks the next `session/open` at
-/// bootstrap. Found live: a user selected zai/glm-5.2 with no
+/// bootstrap. Found live: a user selected zai/glm-5.3 with no
 /// ZAI_API_KEY — "Model selected" echoed, the footer snapped back, and
 /// the next launch failed to boot.
 #[tokio::test]
@@ -890,7 +890,7 @@ async fn llm_select_rejects_keyless_models_before_persisting() {
     raw_profile_llm_upsert(&state, &upsert("deepseek-chat", Some("dk"), true), None)
         .await
         .expect("seed keyed primary");
-    raw_profile_llm_upsert(&state, &upsert("glm-5.2", None, false), None)
+    raw_profile_llm_upsert(&state, &upsert("glm-5.3", None, false), None)
         .await
         .expect("seed keyless fallback");
 
@@ -898,7 +898,7 @@ async fn llm_select_rejects_keyless_models_before_persisting() {
         RpcRequest::new(
             id.to_string(),
             APPUI_METHOD_PROFILE_LLM_SELECT.to_string(),
-            json!({ "profile_id": "dev", "model_id": "glm-5.2" }),
+            json!({ "profile_id": "dev", "model_id": "glm-5.3" }),
         )
     };
     let error = raw_profile_llm_select(&state, &select("s-keyless"), None)
@@ -911,7 +911,7 @@ async fn llm_select_rejects_keyless_models_before_persisting() {
         "got {error:?}"
     );
     assert!(
-        error.message.contains("OCTOS_TEST_GLM_5_2_KEY"),
+        error.message.contains("OCTOS_TEST_GLM_5_3_KEY"),
         "message must name the missing variable: {}",
         error.message
     );
@@ -938,14 +938,14 @@ async fn llm_select_rejects_keyless_models_before_persisting() {
     );
 
     // Adding the key (the onboarding key step) makes the same select work.
-    raw_profile_llm_upsert(&state, &upsert("glm-5.2", Some("zk"), false), None)
+    raw_profile_llm_upsert(&state, &upsert("glm-5.3", Some("zk"), false), None)
         .await
         .expect("re-save with key");
     let result = raw_profile_llm_select(&state, &select("s-keyed"), None)
         .await
         .expect("keyed select applies");
     assert_eq!(result["applied"], true);
-    assert_eq!(result["selected"]["model"], "glm-5.2");
+    assert_eq!(result["selected"]["model"], "glm-5.3");
     assert_eq!(
         result.get("restart_required"),
         None,
@@ -981,7 +981,7 @@ async fn llm_select_does_not_abandon_running_skill_action_jobs() {
     )
     .await
     .expect("seed primary");
-    raw_profile_llm_upsert(&state, &upsert("fallback", "zai", "glm-5.2", false), None)
+    raw_profile_llm_upsert(&state, &upsert("fallback", "zai", "glm-5.3", false), None)
         .await
         .expect("seed fallback");
 
@@ -1025,7 +1025,7 @@ async fn llm_select_does_not_abandon_running_skill_action_jobs() {
             json!({
                 "profile_id": "job-owner",
                 "family_id": "zai",
-                "model_id": "glm-5.2",
+                "model_id": "glm-5.3",
                 "route_id": "official",
             }),
         ),
@@ -1229,7 +1229,7 @@ async fn llm_select_rejects_unactivatable_api_type_and_unknown_families() {
 async fn llm_upsert_set_primary_demotes_old_primary_instead_of_dropping_it() {
     let dir = tempfile::tempdir().unwrap();
     let state = Arc::new(local_profile_state(dir.path()));
-    for (family, model) in [("deepseek", "deepseek-v4-pro"), ("zai", "glm-5.2")] {
+    for (family, model) in [("deepseek", "deepseek-v4-pro"), ("zai", "glm-5.3")] {
         let request = RpcRequest::new(
             format!("u-{model}"),
             APPUI_METHOD_PROFILE_LLM_UPSERT.to_string(),
@@ -1258,7 +1258,7 @@ async fn llm_upsert_set_primary_demotes_old_primary_instead_of_dropping_it() {
     let llm = profile.config.llm.as_ref().unwrap();
     assert_eq!(
         llm.primary.as_ref().unwrap().model_id.as_deref(),
-        Some("glm-5.2")
+        Some("glm-5.3")
     );
     assert_eq!(
         llm.fallbacks.len(),
@@ -1306,7 +1306,7 @@ async fn llm_upsert_set_primary_demotes_old_primary_instead_of_dropping_it() {
             .iter()
             .map(|fb| fb.model_id.as_deref())
             .collect::<Vec<_>>(),
-        vec![Some("glm-5.2")],
+        vec![Some("glm-5.3")],
         "round-trip must neither duplicate the promoted model nor drop the demoted one"
     );
 }
@@ -1320,7 +1320,7 @@ async fn llm_upsert_set_primary_demotes_old_primary_instead_of_dropping_it() {
 async fn llm_delete_removes_entries_and_promotes_fallback() {
     let dir = tempfile::tempdir().unwrap();
     let state = Arc::new(local_profile_state(dir.path()));
-    for (family, model) in [("deepseek", "deepseek-v4-pro"), ("zai", "glm-5.2")] {
+    for (family, model) in [("deepseek", "deepseek-v4-pro"), ("zai", "glm-5.3")] {
         let request = RpcRequest::new(
             format!("u-{model}"),
             APPUI_METHOD_PROFILE_LLM_UPSERT.to_string(),
@@ -1365,7 +1365,7 @@ async fn llm_delete_removes_entries_and_promotes_fallback() {
     // (b) Delete the PRIMARY -> the fallback is promoted.
     let result = raw_profile_llm_delete(
         &state,
-        &delete("zai", "glm-5.2", "official", "d-primary"),
+        &delete("zai", "glm-5.3", "official", "d-primary"),
         None,
     )
     .expect("delete primary");
@@ -1718,7 +1718,7 @@ async fn llm_select_enforces_scope_and_route_discrimination() {
                 "profile_id": "dev",
                 "selection": {
                     "family_id": "zai",
-                    "model_id": "glm-5.2",
+                    "model_id": "glm-5.3",
                     "route": { "route_id": route },
                 },
                 // Key present so the exact-route select below tests
@@ -1736,7 +1736,7 @@ async fn llm_select_enforces_scope_and_route_discrimination() {
         APPUI_METHOD_PROFILE_LLM_SELECT.to_string(),
         json!({
             "profile_id": "dev",
-            "model_id": "glm-5.2",
+            "model_id": "glm-5.3",
             "route_id": "official",
         }),
     );
@@ -1750,7 +1750,7 @@ async fn llm_select_enforces_scope_and_route_discrimination() {
         APPUI_METHOD_PROFILE_LLM_SELECT.to_string(),
         json!({
             "profile_id": "dev",
-            "model_id": "glm-5.2",
+            "model_id": "glm-5.3",
             "route_id": "proxy",
         }),
     );
@@ -1816,7 +1816,7 @@ fn catalog_result_ignores_runtime_qos_not_in_canonical() {
     let zai_models = families["zai"]["models"].as_array().unwrap();
     // Canonical lineup is present …
     assert!(
-        zai_models.iter().any(|model| model["id"] == "glm-5.2"),
+        zai_models.iter().any(|model| model["id"] == "glm-5.3"),
         "canonical zai lineup present: {zai_models:?}"
     );
     // … but the runtime-QoS-only model does NOT leak into onboarding: the
@@ -1852,9 +1852,9 @@ fn catalog_result_sourced_from_registry_and_canonical_catalog() {
 
     // Key-env comes from the registry, not a hand-maintained env map.
     assert_eq!(families["zai"]["env"], "ZAI_API_KEY");
-    // Curation: glm-5.2 + kimi-k2.6 + kimi-k3 present; deepseek-chat removed.
+    // Curation: glm-5.3 + kimi-k2.6 + kimi-k3 present; deepseek-chat removed.
     assert!(
-        ids("zai").contains(&"glm-5.2".to_owned()),
+        ids("zai").contains(&"glm-5.3".to_owned()),
         "{:?}",
         ids("zai")
     );
@@ -1891,7 +1891,7 @@ fn catalog_result_sourced_from_registry_and_canonical_catalog() {
         .as_array()
         .unwrap()
         .iter()
-        .find(|m| m["id"] == "glm-5.2")
+        .find(|m| m["id"] == "glm-5.3")
         .unwrap();
     assert_eq!(glm52["context_window"], 1_000_000);
 

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -3612,12 +3612,14 @@ pub fn create_provider_with_api_type(
     // This allows any provider to use the Anthropic Messages API protocol.
     if api_type == Some("anthropic") {
         let key = api_key.ok_or_else(|| eyre::eyre!("API key required for anthropic api_type"))?;
-        let m = model.unwrap_or_else(|| {
-            entry
-                .default_model
-                .unwrap_or("claude-sonnet-4-20250514")
-                .into()
-        });
+        let m = model
+            .or_else(|| entry.default_model().map(str::to_string))
+            .ok_or_else(|| {
+                eyre::eyre!(
+                    "{}: no model given and the catalog declares no default for this family",
+                    entry.name
+                )
+            })?;
         let url = base_url.unwrap_or_else(|| {
             entry
                 .default_base_url
@@ -3637,7 +3639,14 @@ pub fn create_provider_with_api_type(
     // This forces the Responses API even for models not auto-detected.
     if api_type == Some("responses") {
         let key = api_key.ok_or_else(|| eyre::eyre!("API key required for responses api_type"))?;
-        let m = model.unwrap_or_else(|| entry.default_model.unwrap_or("gpt-4o").into());
+        let m = model
+            .or_else(|| entry.default_model().map(str::to_string))
+            .ok_or_else(|| {
+                eyre::eyre!(
+                    "{}: no model given and the catalog declares no default for this family",
+                    entry.name
+                )
+            })?;
         let mut provider = octos_llm::openai_responses::OpenAIResponsesProvider::new(&key, &m);
         if let Some(url) = base_url {
             provider = provider.with_base_url(&url);

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -548,7 +548,7 @@ pub(crate) fn build_synthesis_config(
         .clone()
         .or_else(|| {
             octos_llm::registry::lookup(provider_name)
-                .and_then(|e| e.default_model)
+                .and_then(|e| e.default_model())
                 .map(String::from)
         })
         .unwrap_or_else(|| match provider_name {

--- a/crates/octos-cli/src/qos_catalog.rs
+++ b/crates/octos-cli/src/qos_catalog.rs
@@ -104,13 +104,25 @@ pub(crate) fn merge_qos_catalog(base: &QosCatalog, overlay: &QosCatalog) -> QosC
                     b.context_window,
                     b.max_output,
                     b.ds_output,
+                    b.is_family_default,
                 )
             });
         let merged = match base_static {
-            Some((model_type, cost_in, cost_out, context_window, max_output, ds_output)) => {
+            Some((
+                model_type,
+                cost_in,
+                cost_out,
+                context_window,
+                max_output,
+                ds_output,
+                is_family_default,
+            )) => {
                 ModelCatalogEntry {
                     provider: entry.provider.clone(),
-                    // Static — canonical base wins (SSOT convergence).
+                    // Static — canonical base wins (SSOT convergence). The
+                    // family-default flag is canonical-only: a live QoS row must
+                    // never be able to elect a different default model.
+                    is_family_default,
                     model_type,
                     cost_in,
                     cost_out,
@@ -515,6 +527,7 @@ mod tests {
                 ModelCatalogEntry {
                     provider: "zai/glm-5-turbo".to_string(),
                     model_type: ModelType::Fast,
+                    is_family_default: false,
                     stability: 0.97,
                     tool_avg_ms: 900,
                     p95_ms: 1500,
@@ -528,6 +541,7 @@ mod tests {
                 ModelCatalogEntry {
                     provider: "dashscope/qwen3.5-plus".to_string(),
                     model_type: ModelType::Strong,
+                    is_family_default: false,
                     stability: 0.92,
                     tool_avg_ms: 1400,
                     p95_ms: 2400,
@@ -561,6 +575,7 @@ mod tests {
         ModelCatalogEntry {
             provider: provider.to_string(),
             model_type: ModelType::Strong,
+            is_family_default: false,
             stability: 1.0,
             tool_avg_ms: 0,
             p95_ms: 0,
@@ -582,20 +597,20 @@ mod tests {
     #[test]
     fn merge_qos_catalog_preserves_base_and_overlays_live() {
         // Base deepseek carries an EVALUATED canonical deep-search quality (>0);
-        // the overlay's is stale, so the canonical value wins. Base glm-5.2 leaves
+        // the overlay's is stale, so the canonical value wins. Base glm-5.3 leaves
         // ds_output at the `0` "not evaluated" sentinel (via `scored_entry`), so an
         // evaluated overlay value there must be PRESERVED, not clobbered by 0.
         let mut base_deepseek = scored_entry("deepseek/deepseek-v4-pro", 0.0, 1_048_576);
         base_deepseek.ds_output = 1500;
         let base = QosCatalog {
             updated_at: "SEED".to_string(),
-            models: vec![scored_entry("zai/glm-5.2", 0.0, 1_000_000), base_deepseek],
+            models: vec![scored_entry("zai/glm-5.3", 0.0, 1_000_000), base_deepseek],
         };
         let mut overlay_deepseek = scored_entry("deepseek/deepseek-v4-pro", 0.87, 999);
         overlay_deepseek.ds_output = 1; // stale seed re-exported by the router
-        // Host-tagged lane whose bare base (`zai/glm-5.2`) is unevaluated (0);
+        // Host-tagged lane whose bare base (`zai/glm-5.3`) is unevaluated (0);
         // this lane carries a real benchmarked ds_output the merge must keep.
-        let mut overlay_glm = scored_entry("zai@api/glm-5.2", 0.9, 111);
+        let mut overlay_glm = scored_entry("zai@api/glm-5.3", 0.9, 111);
         overlay_glm.ds_output = 2222;
         let overlay = QosCatalog {
             updated_at: "2026-07-12T00:00:00Z".to_string(),
@@ -605,7 +620,7 @@ mod tests {
                 // pre-upgrade catalog) — the canonical values must win.
                 overlay_deepseek,
                 // A host-tagged OpenAI-compatible lane whose bare form IS in the
-                // base — it must reconcile with `zai/glm-5.2` (stale ctx wins from
+                // base — it must reconcile with `zai/glm-5.3` (stale ctx wins from
                 // canonical, live score from overlay), not be treated as new.
                 overlay_glm,
                 // … plus a lane not in the base (custom base_url model).
@@ -623,13 +638,13 @@ mod tests {
         let merged = merge_qos_catalog(&base, &overlay);
         // Fresh export timestamp is carried onto the merged catalog.
         assert_eq!(merged.updated_at, "2026-07-12T00:00:00Z");
-        // base-only (zai/glm-5.2) + overlaid (deepseek) + host-tagged
-        // (zai@api/glm-5.2) + overlay-only (stub) + two custom lanes = 6.
+        // base-only (zai/glm-5.3) + overlaid (deepseek) + host-tagged
+        // (zai@api/glm-5.3) + overlay-only (stub) + two custom lanes = 6.
         assert_eq!(merged.models.len(), 6);
         let by = |p: &str| merged.models.iter().find(|m| m.provider == p).unwrap();
         // Base-only entry preserved (researched context window intact).
-        assert_eq!(by("zai/glm-5.2").context_window, 1_000_000);
-        assert_eq!(by("zai/glm-5.2").score, 0.0);
+        assert_eq!(by("zai/glm-5.3").context_window, 1_000_000);
+        assert_eq!(by("zai/glm-5.3").score, 0.0);
         // Overlapping provider: live score wins (DYNAMIC) …
         assert_eq!(by("deepseek/deepseek-v4-pro").score, 0.87);
         // … but the canonical static context window wins over the stale overlay.
@@ -648,16 +663,16 @@ mod tests {
         // Host-tagged lane reconciled with the bare canonical base: canonical
         // static context window, live overlay score.
         assert_eq!(
-            by("zai@api/glm-5.2").context_window,
+            by("zai@api/glm-5.3").context_window,
             1_000_000,
             "host-tagged lane converges to canonical static via key normalization"
         );
-        assert_eq!(by("zai@api/glm-5.2").score, 0.9);
-        // …but the canonical ds_output for glm-5.2 is the `0` "not evaluated"
+        assert_eq!(by("zai@api/glm-5.3").score, 0.9);
+        // …but the canonical ds_output for glm-5.3 is the `0` "not evaluated"
         // sentinel, so the overlay's benchmarked value must be PRESERVED, not
         // erased to 0.
         assert_eq!(
-            by("zai@api/glm-5.2").ds_output,
+            by("zai@api/glm-5.3").ds_output,
             2222,
             "an evaluated overlay ds_output survives when the canonical value is the 0 sentinel"
         );
@@ -680,13 +695,13 @@ mod tests {
     }
 
     /// The compiled-in canonical catalog (the seed floor for fresh installs) is
-    /// well-formed and reflects curation: glm-5.2 + kimi-k2.6 + kimi-k3
+    /// well-formed and reflects curation: glm-5.3 + kimi-k2.6 + kimi-k3
     /// present, deepseek-chat removed.
     #[test]
     fn embedded_qos_catalog_is_curated_ssot() {
         let catalog = embedded_qos_catalog().expect("embedded canonical catalog must parse");
         let has = |p: &str| catalog.models.iter().any(|m| m.provider == p);
-        assert!(has("zai/glm-5.2"), "glm-5.2 present");
+        assert!(has("zai/glm-5.3"), "glm-5.3 present");
         assert!(has("moonshot/kimi-k2.6"), "kimi-k2.6 present");
         assert!(has("moonshot/kimi-k3"), "kimi-k3 present");
         assert!(
@@ -697,7 +712,7 @@ mod tests {
         let glm52 = catalog
             .models
             .iter()
-            .find(|m| m.provider == "zai/glm-5.2")
+            .find(|m| m.provider == "zai/glm-5.3")
             .unwrap();
         assert_eq!(glm52.context_window, 1_000_000);
         // kimi-k3 researched values: 1M window, 131072 (default max
@@ -894,6 +909,7 @@ mod tests {
                 ModelCatalogEntry {
                     provider: stub_key.clone(),
                     model_type: ModelType::Fast,
+                    is_family_default: false,
                     stability: 0.95,
                     tool_avg_ms: 700,
                     p95_ms: 1100,
@@ -907,6 +923,7 @@ mod tests {
                 ModelCatalogEntry {
                     provider: ollama_key.clone(),
                     model_type: ModelType::Strong,
+                    is_family_default: false,
                     stability: 0.88,
                     tool_avg_ms: 1800,
                     p95_ms: 3200,

--- a/crates/octos-cli/src/tools/switch_model.rs
+++ b/crates/octos-cli/src/tools/switch_model.rs
@@ -165,7 +165,7 @@ impl SwitchModelTool {
             };
 
             let default = entry
-                .default_model
+                .default_model()
                 .map(|m| format!(" (default: {m})"))
                 .unwrap_or_default();
 

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -425,6 +425,10 @@ impl std::fmt::Display for ModelType {
 
 /// Unified model catalog entry — single source of truth for model metadata + live QoS.
 ///
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 /// Static fields (type, cost, ds_output) are loaded from `model_catalog.json`.
 /// Dynamic fields (stability, tool_avg_ms, p95_ms, score) are updated by the QoS scanner.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -434,6 +438,14 @@ pub struct ModelCatalogEntry {
     /// Model capability type.
     #[serde(rename = "type")]
     pub model_type: ModelType,
+    /// Whether this row is its provider family's default model — the model a
+    /// family resolves to when a profile names no model. Exactly one row per
+    /// family carries it; `registry::catalog_default_model` reads it.
+    ///
+    /// Skipped when false so the per-profile catalogs that `qos_catalog`
+    /// rewrites do not sprout `"default": false` on all 150-odd rows.
+    #[serde(default, rename = "default", skip_serializing_if = "is_false")]
+    pub is_family_default: bool,
     /// Tool call stability (0.0 to 1.0). Updated by QoS scanner.
     pub stability: f64,
     /// Average tool call latency in ms. Updated by QoS scanner.
@@ -1542,6 +1554,10 @@ impl AdaptiveRouter {
                 ModelCatalogEntry {
                     provider: format!("{}/{}", s.provider.provider_name(), s.provider.model_id()),
                     model_type: ModelType::from_u8(s.model_type.load(Ordering::Relaxed)),
+                    // A live QoS row describes observed behaviour, never which
+                    // model a family defaults to — that fact belongs only to
+                    // the canonical catalog.
+                    is_family_default: false,
                     stability,
                     tool_avg_ms,
                     p95_ms,

--- a/crates/octos-llm/src/adaptive_tests.rs
+++ b/crates/octos-llm/src/adaptive_tests.rs
@@ -879,6 +879,7 @@ async fn test_qos_ranking_changes_lane_selection() {
         ModelCatalogEntry {
             provider: "priority-primary/m1".into(),
             model_type: ModelType::Strong,
+            is_family_default: false,
             stability: 1.0,
             tool_avg_ms: 200,
             p95_ms: 300,
@@ -892,6 +893,7 @@ async fn test_qos_ranking_changes_lane_selection() {
         ModelCatalogEntry {
             provider: "quality-fallback/m2".into(),
             model_type: ModelType::Strong,
+            is_family_default: false,
             stability: 1.0,
             tool_avg_ms: 200,
             p95_ms: 300,
@@ -939,6 +941,7 @@ fn seed_catalog_matches_host_tagged_lane_to_bare_catalog_key() {
     router.seed_catalog(&[ModelCatalogEntry {
         provider: "moonshot/kimi-k2.5".into(),
         model_type: ModelType::Strong,
+        is_family_default: false,
         stability: 1.0,
         tool_avg_ms: 200,
         p95_ms: 300,
@@ -968,6 +971,7 @@ fn test_derive_cold_start_catalog_assigns_non_zero_scores() {
             ModelCatalogEntry {
                 provider: "moonshot/kimi-k2.5".into(),
                 model_type: ModelType::Strong,
+                is_family_default: false,
                 stability: 0.93,
                 tool_avg_ms: 1200,
                 p95_ms: 2200,
@@ -981,6 +985,7 @@ fn test_derive_cold_start_catalog_assigns_non_zero_scores() {
             ModelCatalogEntry {
                 provider: "deepseek/deepseek-chat".into(),
                 model_type: ModelType::Fast,
+                is_family_default: false,
                 stability: 1.0,
                 tool_avg_ms: 1400,
                 p95_ms: 2600,

--- a/crates/octos-llm/src/registry/anthropic.rs
+++ b/crates/octos-llm/src/registry/anthropic.rs
@@ -10,7 +10,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "anthropic",
     aliases: &[],
-    default_model: Some("claude-sonnet-4-20250514"),
     api_key_env: Some("ANTHROPIC_API_KEY"),
     key_env_aliases: &[],
     default_base_url: Some("https://api.anthropic.com"),
@@ -26,7 +25,15 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     let key = p
         .api_key
         .ok_or_else(|| eyre::eyre!("ANTHROPIC_API_KEY not set"))?;
-    let model = p.model.unwrap_or_else(|| "claude-sonnet-4-20250514".into());
+    let model = p
+        .model
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
     let mut provider = AnthropicProvider::new(&key, &model);
     if let Some(url) = p.base_url {
         provider = provider.with_base_url(&url);

--- a/crates/octos-llm/src/registry/dashscope.rs
+++ b/crates/octos-llm/src/registry/dashscope.rs
@@ -10,7 +10,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "dashscope",
     aliases: &["qwen"],
-    default_model: Some("qwen-max"),
     api_key_env: Some("DASHSCOPE_API_KEY"),
     key_env_aliases: &[],
     default_base_url: Some("https://dashscope.aliyuncs.com/compatible-mode/v1"),
@@ -26,7 +25,15 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     let key = p
         .api_key
         .ok_or_else(|| eyre::eyre!("DASHSCOPE_API_KEY not set"))?;
-    let model = p.model.unwrap_or_else(|| "qwen-max".into());
+    let model = p
+        .model
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
     let url = p
         .base_url
         .unwrap_or_else(|| "https://dashscope.aliyuncs.com/compatible-mode/v1".into());

--- a/crates/octos-llm/src/registry/deepseek.rs
+++ b/crates/octos-llm/src/registry/deepseek.rs
@@ -10,7 +10,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "deepseek",
     aliases: &[],
-    default_model: Some("deepseek-chat"),
     api_key_env: Some("DEEPSEEK_API_KEY"),
     key_env_aliases: &[],
     default_base_url: Some("https://api.deepseek.com/v1"),
@@ -26,7 +25,15 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     let key = p
         .api_key
         .ok_or_else(|| eyre::eyre!("DEEPSEEK_API_KEY not set"))?;
-    let model = p.model.unwrap_or_else(|| "deepseek-chat".into());
+    let model = p
+        .model
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
     let url = p
         .base_url
         .unwrap_or_else(|| "https://api.deepseek.com/v1".into());

--- a/crates/octos-llm/src/registry/gemini.rs
+++ b/crates/octos-llm/src/registry/gemini.rs
@@ -10,7 +10,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "gemini",
     aliases: &["google"],
-    default_model: Some("gemini-2.5-flash"),
     api_key_env: Some("GEMINI_API_KEY"),
     key_env_aliases: &[],
     default_base_url: Some("https://generativelanguage.googleapis.com/v1beta"),
@@ -26,7 +25,15 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     let key = p
         .api_key
         .ok_or_else(|| eyre::eyre!("GEMINI_API_KEY not set"))?;
-    let model = p.model.unwrap_or_else(|| "gemini-2.5-flash".into());
+    let model = p
+        .model
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
     let mut provider = GeminiProvider::new(&key, &model);
     if let Some(url) = p.base_url {
         provider = provider.with_base_url(&url);

--- a/crates/octos-llm/src/registry/groq.rs
+++ b/crates/octos-llm/src/registry/groq.rs
@@ -10,7 +10,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "groq",
     aliases: &[],
-    default_model: Some("llama-3.3-70b-versatile"),
     api_key_env: Some("GROQ_API_KEY"),
     key_env_aliases: &[],
     default_base_url: Some("https://api.groq.com/openai/v1"),
@@ -27,7 +26,15 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     let key = p
         .api_key
         .ok_or_else(|| eyre::eyre!("GROQ_API_KEY not set"))?;
-    let model = p.model.unwrap_or_else(|| "llama-3.3-70b-versatile".into());
+    let model = p
+        .model
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
     let url = p
         .base_url
         .unwrap_or_else(|| "https://api.groq.com/openai/v1".into());

--- a/crates/octos-llm/src/registry/minimax.rs
+++ b/crates/octos-llm/src/registry/minimax.rs
@@ -10,7 +10,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "minimax",
     aliases: &[],
-    default_model: Some("MiniMax-Text-01"),
     api_key_env: Some("MINIMAX_API_KEY"),
     key_env_aliases: &[],
     default_base_url: Some("https://api.minimax.io/v1"),
@@ -26,7 +25,15 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     let key = p
         .api_key
         .ok_or_else(|| eyre::eyre!("MINIMAX_API_KEY not set"))?;
-    let model = p.model.unwrap_or_else(|| "MiniMax-Text-01".into());
+    let model = p
+        .model
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
     let url = p
         .base_url
         .unwrap_or_else(|| "https://api.minimax.io/v1".into());

--- a/crates/octos-llm/src/registry/mod.rs
+++ b/crates/octos-llm/src/registry/mod.rs
@@ -3,12 +3,67 @@
 //! Each sub-module exports a `pub const ENTRY: ProviderEntry` and a `create()`
 //! factory.  Adding a new provider = add a file + one line in `ALL`.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
 
 use eyre::Result;
 
 use crate::openai::ModelHints;
 use crate::provider::LlmProvider;
+
+// ── Family defaults, from the catalog ───────────────────────────────────────
+
+/// The canonical `model_catalog.json`, compiled in — the same SSOT the CLI
+/// serves for onboarding. It is the single place a model NAME is written down;
+/// no provider module hardcodes one.
+const CANONICAL_MODEL_CATALOG: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../model_catalog.json"
+));
+
+/// `family -> default model`, built once from the rows flagged `"default": true`.
+///
+/// A family's default used to be a `&'static str` on each `ProviderEntry`, which
+/// meant the same fact lived in two places and drifted: four families (deepseek,
+/// minimax, openrouter, vertex) had hardcoded defaults that no catalog row even
+/// mentioned. Reading it from the catalog makes drift impossible by construction.
+fn family_defaults() -> &'static HashMap<String, String> {
+    static DEFAULTS: OnceLock<HashMap<String, String>> = OnceLock::new();
+    DEFAULTS.get_or_init(|| {
+        let catalog: crate::adaptive::QosCatalog =
+            match serde_json::from_str(CANONICAL_MODEL_CATALOG) {
+                Ok(catalog) => catalog,
+                Err(error) => {
+                    // The catalog is compiled in, so this is a build-time-shaped
+                    // failure surfacing at runtime. Degrade to "no defaults" rather
+                    // than panicking a live process: every caller already handles
+                    // `None` by demanding an explicit model.
+                    tracing::error!(%error, "canonical model catalog failed to parse; \
+                     provider families will report no default model");
+                    return HashMap::new();
+                }
+            };
+        catalog
+            .models
+            .iter()
+            .filter(|entry| entry.is_family_default)
+            .filter_map(|entry| {
+                // `provider` is `"<family>/<model>"`, and the model half may
+                // itself contain slashes (`openrouter/anthropic/claude-...`),
+                // so split ONCE.
+                let (family, model) = entry.provider.split_once('/')?;
+                Some((family.to_string(), model.to_string()))
+            })
+            .collect()
+    })
+}
+
+/// The catalog-declared default model for a provider family, if it has one.
+///
+/// `None` means the family requires an explicit model.
+pub fn catalog_default_model(family: &str) -> Option<&'static str> {
+    family_defaults().get(family).map(String::as_str)
+}
 
 // ── Provider sub-modules ────────────────────────────────────────────────────
 
@@ -67,8 +122,6 @@ pub struct ProviderEntry {
     pub name: &'static str,
     /// Alternative names that also resolve to this provider.
     pub aliases: &'static [&'static str],
-    /// Default model when none is specified. `None` = must be provided by user.
-    pub default_model: Option<&'static str>,
     /// Environment variable holding the API key. `None` = no key required.
     pub api_key_env: Option<&'static str>,
     /// Additional accepted API-key env var names for this provider, beyond
@@ -92,6 +145,15 @@ pub struct ProviderEntry {
 }
 
 impl ProviderEntry {
+    /// The model this family uses when a profile names none, read from the
+    /// catalog row flagged `"default": true`. `None` = the user must supply one.
+    ///
+    /// Was a `&'static str` const on every entry until the catalog became the
+    /// single place a model name is written down.
+    pub fn default_model(&self) -> Option<&'static str> {
+        catalog_default_model(self.name)
+    }
+
     /// Every API-key env var name this provider accepts: the primary
     /// `api_key_env` plus any declared `key_env_aliases`.
     pub fn key_env_names(&self) -> impl Iterator<Item = &'static str> {
@@ -188,6 +250,84 @@ pub fn detect_provider(model: &str) -> Option<&'static str> {
 mod tests {
     use super::*;
 
+    /// The catalog is the only place a default model is written down, so every
+    /// family that claims one must actually find it there. A family silently
+    /// losing its default would make `octos chat -p <family>` start demanding an
+    /// explicit `--model`.
+    #[test]
+    fn every_family_with_a_default_resolves_it_from_the_catalog() {
+        // Families that must have one, with the value the catalog declares.
+        for (family, expected) in [
+            ("anthropic", "claude-sonnet-4-20250514"),
+            ("deepseek", "deepseek-v4-flash"),
+            ("gemini", "gemini-2.5-flash"),
+            ("minimax", "MiniMax-M3"),
+            ("moonshot-coding", "k3"),
+            ("openai", "gpt-4o"),
+            ("openrouter", "anthropic/claude-sonnet-4-6"),
+            ("vertex", "gemini-2.5-flash"),
+            ("zai", "glm-5-turbo"),
+            ("zai-coding", "glm-5.3"),
+        ] {
+            let entry = lookup(family).unwrap_or_else(|| panic!("{family} registered"));
+            assert_eq!(
+                entry.default_model(),
+                Some(expected),
+                "{family} must resolve its default from the catalog"
+            );
+        }
+    }
+
+    /// A family's default model must be unambiguous: two rows flagged `default`
+    /// under one family would make the resolved value depend on catalog order,
+    /// which is exactly the fragility this replaced.
+    #[test]
+    fn the_catalog_declares_at_most_one_default_per_family() {
+        let catalog: crate::adaptive::QosCatalog =
+            serde_json::from_str(CANONICAL_MODEL_CATALOG).expect("canonical catalog parses");
+
+        let mut by_family: HashMap<&str, Vec<&str>> = HashMap::new();
+        for entry in catalog.models.iter().filter(|e| e.is_family_default) {
+            let (family, _) = entry
+                .provider
+                .split_once('/')
+                .unwrap_or((entry.provider.as_str(), ""));
+            by_family.entry(family).or_default().push(&entry.provider);
+        }
+
+        let duplicated: Vec<_> = by_family.iter().filter(|(_, v)| v.len() > 1).collect();
+        assert!(
+            duplicated.is_empty(),
+            "each family may flag at most one default: {duplicated:?}"
+        );
+        assert!(
+            !by_family.is_empty(),
+            "the catalog must declare family defaults at all"
+        );
+    }
+
+    /// `openrouter` and `nvidia` models carry a slash of their own
+    /// (`anthropic/claude-sonnet-4-6`), so the family split must take the FIRST
+    /// separator only — splitting on the last would yield family `anthropic`
+    /// and silently give OpenRouter no default.
+    #[test]
+    fn a_model_id_containing_a_slash_still_resolves_to_its_family() {
+        assert_eq!(
+            catalog_default_model("openrouter"),
+            Some("anthropic/claude-sonnet-4-6")
+        );
+        assert_eq!(
+            catalog_default_model("nvidia"),
+            Some("meta/llama-3.3-70b-instruct")
+        );
+    }
+
+    /// An unregistered family has no default rather than a wrong one.
+    #[test]
+    fn an_unknown_family_has_no_default() {
+        assert_eq!(catalog_default_model("not-a-provider"), None);
+    }
+
     #[test]
     fn lookup_by_name() {
         assert!(lookup("anthropic").is_some());
@@ -246,7 +386,7 @@ mod tests {
     fn coding_plan_families_resolve_to_coding_endpoints() {
         // Kimi coding plan: OpenAI-compat, api.kimi.com/coding/v1, default k3.
         let mc = lookup("moonshot-coding").expect("moonshot-coding registered");
-        assert_eq!(mc.default_model, Some("k3"));
+        assert_eq!(mc.default_model(), Some("k3"));
         assert_eq!(mc.default_base_url, Some("https://api.kimi.com/coding/v1"));
         assert!(mc.is_known_key_env("KIMI_API_KEY"));
         assert_eq!(

--- a/crates/octos-llm/src/registry/moonshot.rs
+++ b/crates/octos-llm/src/registry/moonshot.rs
@@ -10,7 +10,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "moonshot",
     aliases: &["kimi"],
-    default_model: Some("kimi-k2.5"),
     api_key_env: Some("MOONSHOT_API_KEY"),
     key_env_aliases: &["KIMI_API_KEY"],
     default_base_url: Some("https://api.moonshot.ai/v1"),
@@ -26,7 +25,15 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     let key = p
         .api_key
         .ok_or_else(|| eyre::eyre!("MOONSHOT_API_KEY not set"))?;
-    let model = p.model.unwrap_or_else(|| "kimi-k2.5".into());
+    let model = p
+        .model
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
     let url = p
         .base_url
         .unwrap_or_else(|| "https://api.moonshot.ai/v1".into());

--- a/crates/octos-llm/src/registry/moonshot_coding.rs
+++ b/crates/octos-llm/src/registry/moonshot_coding.rs
@@ -16,7 +16,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "moonshot-coding",
     aliases: &["kimi-coding"],
-    default_model: Some("k3"),
     api_key_env: Some("KIMI_CODING_API_KEY"),
     key_env_aliases: &["KIMI_API_KEY", "MOONSHOT_API_KEY"],
     default_base_url: Some("https://api.kimi.com/coding/v1"),
@@ -35,7 +34,15 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     let key = p
         .api_key
         .ok_or_else(|| eyre::eyre!("KIMI_CODING_API_KEY (Kimi coding plan) not set"))?;
-    let model = p.model.unwrap_or_else(|| "k3".into());
+    let model = p
+        .model
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
     let url = p
         .base_url
         .unwrap_or_else(|| "https://api.kimi.com/coding/v1".into());

--- a/crates/octos-llm/src/registry/nvidia.rs
+++ b/crates/octos-llm/src/registry/nvidia.rs
@@ -10,7 +10,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "nvidia",
     aliases: &["nim"],
-    default_model: Some("meta/llama-3.3-70b-instruct"),
     api_key_env: Some("NVIDIA_API_KEY"),
     key_env_aliases: &[],
     default_base_url: Some("https://integrate.api.nvidia.com/v1"),
@@ -29,7 +28,13 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
         .ok_or_else(|| eyre::eyre!("NVIDIA_API_KEY not set"))?;
     let model = p
         .model
-        .unwrap_or_else(|| "meta/llama-3.3-70b-instruct".into());
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
     let url = p
         .base_url
         .unwrap_or_else(|| "https://integrate.api.nvidia.com/v1".into());

--- a/crates/octos-llm/src/registry/ollama.rs
+++ b/crates/octos-llm/src/registry/ollama.rs
@@ -10,7 +10,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "ollama",
     aliases: &[],
-    default_model: Some("llama3.2"),
     api_key_env: None,
     key_env_aliases: &[],
     default_base_url: Some("http://localhost:11434/v1"),
@@ -24,7 +23,15 @@ pub const ENTRY: ProviderEntry = ProviderEntry {
 
 fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     let http_timeout = p.http_timeout();
-    let model = p.model.unwrap_or_else(|| "llama3.2".into());
+    let model = p
+        .model
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
     let url = p
         .base_url
         .unwrap_or_else(|| "http://localhost:11434/v1".into());

--- a/crates/octos-llm/src/registry/openai.rs
+++ b/crates/octos-llm/src/registry/openai.rs
@@ -11,7 +11,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "openai",
     aliases: &[],
-    default_model: Some("gpt-4o"),
     api_key_env: Some("OPENAI_API_KEY"),
     key_env_aliases: &[],
     default_base_url: Some("https://api.openai.com/v1"),
@@ -27,7 +26,15 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     let key = p
         .api_key
         .ok_or_else(|| eyre::eyre!("OPENAI_API_KEY not set"))?;
-    let model = p.model.unwrap_or_else(|| "gpt-4o".into());
+    let model = p
+        .model
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
 
     // Auto-detect: use Responses API for capable models when talking to OpenAI directly
     // (no custom base_url set, which would indicate a compatible provider).

--- a/crates/octos-llm/src/registry/openrouter.rs
+++ b/crates/octos-llm/src/registry/openrouter.rs
@@ -10,7 +10,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "openrouter",
     aliases: &[],
-    default_model: Some("anthropic/claude-sonnet-4-20250514"),
     api_key_env: Some("OPENROUTER_API_KEY"),
     key_env_aliases: &[],
     default_base_url: Some("https://openrouter.ai/api/v1"),
@@ -29,7 +28,13 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
         .ok_or_else(|| eyre::eyre!("OPENROUTER_API_KEY not set"))?;
     let model = p
         .model
-        .unwrap_or_else(|| "anthropic/claude-sonnet-4-20250514".into());
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
     let mut provider = OpenRouterProvider::new(&key, &model);
     if let Some(url) = p.base_url {
         provider = provider.with_base_url(&url);

--- a/crates/octos-llm/src/registry/r9s.rs
+++ b/crates/octos-llm/src/registry/r9s.rs
@@ -11,7 +11,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "r9s",
     aliases: &["r9s.ai"],
-    default_model: Some("claude-sonnet-4-6"),
     api_key_env: Some("R9S_API_KEY"),
     key_env_aliases: &[],
     default_base_url: Some("https://api.r9s.ai/v1"),
@@ -28,7 +27,15 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     let key = p
         .api_key
         .ok_or_else(|| eyre::eyre!("R9S_API_KEY not set"))?;
-    let model = p.model.unwrap_or_else(|| "claude-sonnet-4-6".into());
+    let model = p
+        .model
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
     let url = p.base_url.unwrap_or_else(|| "https://api.r9s.ai/v1".into());
 
     // Auto-detect protocol: Anthropic Messages API for claude-* models,

--- a/crates/octos-llm/src/registry/vertex.rs
+++ b/crates/octos-llm/src/registry/vertex.rs
@@ -21,7 +21,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "vertex",
     aliases: &["vertex-ai", "vertexai"],
-    default_model: Some("gemini-2.5-flash"),
     api_key_env: Some("VERTEX_SA_JSON"),
     key_env_aliases: &[],
     default_base_url: None,
@@ -42,7 +41,15 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     })?;
     let sa = ServiceAccount::from_json(&json)
         .wrap_err("failed to parse Vertex service-account JSON credential")?;
-    let model = p.model.unwrap_or_else(|| "gemini-2.5-flash".into());
+    let model = p
+        .model
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
     // Thread the timeout into both the chat client (`with_http_timeout`) and the
     // OAuth token-exchange client (the `_with_timeout` constructor).
     let mut provider =

--- a/crates/octos-llm/src/registry/vllm.rs
+++ b/crates/octos-llm/src/registry/vllm.rs
@@ -10,7 +10,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "vllm",
     aliases: &[],
-    default_model: None,
     api_key_env: Some("VLLM_API_KEY"),
     key_env_aliases: &[],
     default_base_url: None,

--- a/crates/octos-llm/src/registry/zai.rs
+++ b/crates/octos-llm/src/registry/zai.rs
@@ -11,7 +11,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "zai",
     aliases: &["z.ai"],
-    default_model: Some("glm-5-turbo"),
     api_key_env: Some("ZAI_API_KEY"),
     key_env_aliases: &[],
     default_base_url: Some("https://api.z.ai/api/anthropic"),
@@ -28,7 +27,15 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     let key = p
         .api_key
         .ok_or_else(|| eyre::eyre!("ZAI_API_KEY not set"))?;
-    let model = p.model.unwrap_or_else(|| "glm-5-turbo".into());
+    let model = p
+        .model
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
     let url = p
         .base_url
         .unwrap_or_else(|| "https://api.z.ai/api/anthropic".into());

--- a/crates/octos-llm/src/registry/zai_coding.rs
+++ b/crates/octos-llm/src/registry/zai_coding.rs
@@ -17,7 +17,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "zai-coding",
     aliases: &["z.ai-coding", "glm-coding"],
-    default_model: Some("glm-5.2"),
     api_key_env: Some("ZAI_CODING_API_KEY"),
     key_env_aliases: &["ZAI_API_KEY"],
     default_base_url: Some("https://api.z.ai/api/anthropic"),
@@ -35,7 +34,15 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     let key = p
         .api_key
         .ok_or_else(|| eyre::eyre!("ZAI_CODING_API_KEY (Z.AI GLM coding plan) not set"))?;
-    let model = p.model.unwrap_or_else(|| "glm-5.2".into());
+    let model = p
+        .model
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
     let url = p
         .base_url
         .unwrap_or_else(|| "https://api.z.ai/api/anthropic".into());

--- a/crates/octos-llm/src/registry/zhipu.rs
+++ b/crates/octos-llm/src/registry/zhipu.rs
@@ -10,7 +10,6 @@ use super::{CreateParams, ProviderEntry};
 pub const ENTRY: ProviderEntry = ProviderEntry {
     name: "zhipu",
     aliases: &["glm"],
-    default_model: Some("glm-4-plus"),
     api_key_env: Some("ZHIPU_API_KEY"),
     key_env_aliases: &[],
     default_base_url: Some("https://open.bigmodel.cn/api/paas/v4"),
@@ -26,7 +25,15 @@ fn create(p: CreateParams) -> Result<Arc<dyn LlmProvider>> {
     let key = p
         .api_key
         .ok_or_else(|| eyre::eyre!("ZHIPU_API_KEY not set"))?;
-    let model = p.model.unwrap_or_else(|| "glm-4-plus".into());
+    let model = p
+        .model
+        .or_else(|| ENTRY.default_model().map(str::to_string))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "{}: no model given and the catalog declares no default for this family",
+                ENTRY.name
+            )
+        })?;
     let url = p
         .base_url
         .unwrap_or_else(|| "https://open.bigmodel.cn/api/paas/v4".into());

--- a/dashboard/src/providers.json
+++ b/dashboard/src/providers.json
@@ -189,7 +189,7 @@
   "zai-coding": {
     "env": "ZAI_CODING_API_KEY",
     "models": [
-      { "id": "glm-5.2", "input": 0.0, "output": 0.0, "max_output": 131072, "endpoints": [
+      { "id": "glm-5.3", "input": 0.0, "output": 0.0, "max_output": 131072, "endpoints": [
         { "id": "zai-coding", "label": "GLM Coding Plan", "base_url": "https://api.z.ai/api/anthropic", "api_key_env": "ZAI_API_KEY" }
       ] }
     ]
@@ -208,7 +208,7 @@
   "zai": {
     "env": "ZAI_API_KEY",
     "models": [
-      { "id": "glm-5.2", "input": 1.0, "output": 4.0, "max_output": 131072 },
+      { "id": "glm-5.3", "input": 1.0, "output": 4.0, "max_output": 131072 },
       { "id": "glm-5-turbo", "input": 1.0, "output": 0.4, "max_output": 131072 },
       { "id": "glm-5.1", "input": 0.5, "output": 2.0, "max_output": 131072 },
       { "id": "glm-4.7", "input": 0.3, "output": 1.2, "max_output": 8192 },

--- a/dashboard/src/providers.json
+++ b/dashboard/src/providers.json
@@ -46,6 +46,13 @@
       { "id": "gemini-2.0-flash-001", "input": 0.1, "output": 0.4, "max_output": 8192 }
     ]
   },
+  "vertex": {
+    "env": "VERTEX_SA_JSON",
+    "models": [
+      { "id": "gemini-2.5-flash", "input": 0.15, "output": 2.5, "max_output": 65536 },
+      { "id": "gemini-2.5-pro", "input": 1.25, "output": 10.0, "max_output": 65536 }
+    ]
+  },
   "r9s": {
     "env": "R9S_API_KEY",
     "models": [

--- a/model_catalog.json
+++ b/model_catalog.json
@@ -95,6 +95,7 @@
     {
       "provider": "anthropic/claude-sonnet-4-20250514",
       "type": "strong",
+      "default": true,
       "stability": 1.0,
       "tool_avg_ms": 0,
       "p95_ms": 0,
@@ -147,6 +148,7 @@
     {
       "provider": "dashscope/qwen-max",
       "type": "strong",
+      "default": true,
       "stability": 1.0,
       "tool_avg_ms": 0,
       "p95_ms": 0,
@@ -251,6 +253,7 @@
     {
       "provider": "deepseek/deepseek-v4-flash",
       "type": "fast",
+      "default": true,
       "stability": 1.0,
       "tool_avg_ms": 0,
       "p95_ms": 0,
@@ -314,6 +317,7 @@
     {
       "provider": "gemini/gemini-2.5-flash",
       "type": "fast",
+      "default": true,
       "stability": 1.0,
       "tool_avg_ms": 0,
       "p95_ms": 0,
@@ -390,6 +394,33 @@
       "max_output": 65536
     },
     {
+      "provider": "vertex/gemini-2.5-flash",
+      "type": "fast",
+      "default": true,
+      "stability": 1.0,
+      "tool_avg_ms": 0,
+      "p95_ms": 0,
+      "score": 0.0,
+      "ds_output": 0,
+      "cost_in": 0.15,
+      "cost_out": 2.5,
+      "context_window": 1048576,
+      "max_output": 65536
+    },
+    {
+      "provider": "vertex/gemini-2.5-pro",
+      "type": "fast",
+      "stability": 1.0,
+      "tool_avg_ms": 0,
+      "p95_ms": 0,
+      "score": 0.0,
+      "ds_output": 0,
+      "cost_in": 1.25,
+      "cost_out": 10.0,
+      "context_window": 1048576,
+      "max_output": 65536
+    },
+    {
       "provider": "groq/gemma2-9b-it",
       "type": "strong",
       "stability": 1.0,
@@ -418,6 +449,7 @@
     {
       "provider": "groq/llama-3.3-70b-versatile",
       "type": "strong",
+      "default": true,
       "stability": 1.0,
       "tool_avg_ms": 0,
       "p95_ms": 0,
@@ -547,6 +579,7 @@
     {
       "provider": "minimax/MiniMax-M3",
       "type": "strong",
+      "default": true,
       "stability": 1.0,
       "tool_avg_ms": 0,
       "p95_ms": 0,
@@ -560,6 +593,7 @@
     {
       "provider": "moonshot/kimi-k2.5",
       "type": "fast",
+      "default": true,
       "stability": 1.0,
       "tool_avg_ms": 0,
       "p95_ms": 0,
@@ -650,6 +684,7 @@
     {
       "provider": "nvidia/meta/llama-3.3-70b-instruct",
       "type": "strong",
+      "default": true,
       "stability": 1.0,
       "tool_avg_ms": 0,
       "p95_ms": 0,
@@ -806,6 +841,7 @@
     {
       "provider": "ollama/llama3.2",
       "type": "strong",
+      "default": true,
       "stability": 1.0,
       "tool_avg_ms": 0,
       "p95_ms": 0,
@@ -897,6 +933,7 @@
     {
       "provider": "openai/gpt-4o",
       "type": "strong",
+      "default": true,
       "stability": 1.0,
       "tool_avg_ms": 0,
       "p95_ms": 0,
@@ -1079,6 +1116,7 @@
     {
       "provider": "openrouter/anthropic/claude-sonnet-4-6",
       "type": "strong",
+      "default": true,
       "stability": 1.0,
       "tool_avg_ms": 0,
       "p95_ms": 0,
@@ -1560,6 +1598,7 @@
     {
       "provider": "r9s/claude-sonnet-4-6",
       "type": "strong",
+      "default": true,
       "stability": 1.0,
       "tool_avg_ms": 0,
       "p95_ms": 0,
@@ -1872,6 +1911,7 @@
     {
       "provider": "zai/glm-5-turbo",
       "type": "fast",
+      "default": true,
       "cost_in": 1.0,
       "cost_out": 0.4,
       "context_window": 200000,
@@ -1896,7 +1936,7 @@
       "max_output": 131072
     },
     {
-      "provider": "zai/glm-5.2",
+      "provider": "zai/glm-5.3",
       "type": "strong",
       "cost_in": 1.0,
       "cost_out": 4.0,
@@ -1963,6 +2003,7 @@
     {
       "provider": "zhipu/glm-4-plus",
       "type": "strong",
+      "default": true,
       "stability": 1.0,
       "tool_avg_ms": 0,
       "p95_ms": 0,
@@ -1989,6 +2030,7 @@
     {
       "provider": "moonshot-coding/k3",
       "type": "strong",
+      "default": true,
       "stability": 1.0,
       "tool_avg_ms": 0,
       "p95_ms": 0,
@@ -2029,8 +2071,9 @@
       ]
     },
     {
-      "provider": "zai-coding/glm-5.2",
+      "provider": "zai-coding/glm-5.3",
       "type": "strong",
+      "default": true,
       "stability": 1.0,
       "tool_avg_ms": 0,
       "p95_ms": 0,


### PR DESCRIPTION
Started as "rename glm-5.2 to glm-5.3 in the model catalog". The rename immediately disagreed with `zai_coding.rs`, which still hardcoded `default_model: Some("glm-5.2")` — so the fix is to stop writing model names in Rust at all.

## The drift this surfaced

A family's default model lived in two places: a `&'static str` on each `ProviderEntry`, and a literal inside each `create()` fallback. Four families named a model the catalog does not contain:

| family | hardcoded default | catalog actually has |
|---|---|---|
| `deepseek` | `deepseek-chat` | `deepseek-v4-flash`, `deepseek-v4-pro` |
| `minimax` | `MiniMax-Text-01` | `MiniMax-M2` … `MiniMax-M3` |
| `openrouter` | `anthropic/claude-sonnet-4-20250514` | `anthropic/claude-sonnet-4-6` |
| `vertex` | `gemini-2.5-flash` | **no `vertex/` rows at all** |

`deepseek-chat` is the sharpest: `qos_catalog` has a test asserting it was *deliberately curated out* of the catalog, while `deepseek.rs` went on defaulting to it. Nothing could catch that while the two lived apart.

## The change

`model_catalog.json` gains `"default": true` on exactly one row per family. `octos-llm` compiles the catalog in and resolves `family -> model` once into a `OnceLock` map; `ProviderEntry::default_model` becomes a method over it.

Removed: 17 `default_model` consts, 17 `create()` fallbacks, and the two last-resort literals in `chat.rs` (`"claude-sonnet-4-20250514"`, `"gpt-4o"`). **No model name is written in Rust any more** — only base URLs. A family with no catalog default now returns a clear error instead of quietly using a baked-in string.

The four drifted families move to their catalog successors, and `vertex` gains rows mirroring the native `gemini` figures (it serves the same models). `zai/glm-5.2` and `zai-coding/glm-5.2` become `glm-5.3`, with `dashboard/src/providers.json` and the README example following.

The flag is canonical-only. `merge_qos_catalog` takes it from the base entry so a live QoS row can never elect a different default, and it is `skip_serializing_if` false so the per-profile catalogs `qos_catalog` rewrites do not sprout `"default": false` on all 150-odd rows.

## Tests

Written against the invariant rather than the values, so they keep working as models turn over:

- `every_family_with_a_default_resolves_it_from_the_catalog` — a family silently losing its default would make `octos chat -p <family>` start demanding `--model`
- `the_catalog_declares_at_most_one_default_per_family` — two flagged rows would make the answer depend on file order, which is the fragility this replaced
- `a_model_id_containing_a_slash_still_resolves_to_its_family` — `openrouter`/`nvidia` model ids carry their own slash, so the family split must take the first separator only
- `an_unknown_family_has_no_default`

Mutation-checked: removing a single `"default": true` flag fails the resolution test.

## Gates

`cargo test -p octos-llm --lib` — 505 pass. `cargo test -p octos-cli --features api --lib -- --test-threads=1` — 2921 pass. fmt clean; clippy clean on `octos-llm --all-targets` and the CI-exact `octos-cli` feature set.

One unrelated pre-existing failure: `global_drain_spawns_before_the_stdio_early_return` fails identically on pristine `main` — its source-scan needle went stale in the #1728 rename and CI's filters never run it. Diagnosed on #2029.

Three catalog-reading tests needed updating for the rename (they pin `zai/glm-5.2` by id), as did one test's derived env-var name (`OCTOS_TEST_GLM_5_2_KEY`).
