### PR TITLE
fix(test): repair the serve wiring guard and actually run it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,6 +443,15 @@ jobs:
       - name: Peer staging + worktree fencing (octos-cli)
         run: cargo test -p octos-cli --features api peer
 
+      # `commands::serve::tests` matched NONE of the filters on this list, so
+      # its guards had not executed in CI since #1728 — long enough for
+      # `global_drain_spawns_before_the_stdio_early_return` to go red on main
+      # unnoticed (its source-scan needle carried the pre-rename module path).
+      # A filter that matches nothing reports `ok`, so absent coverage is
+      # indistinguishable from passing coverage; see #2029 for the general fix.
+      - name: serve wiring guards (octos-cli)
+        run: cargo test -p octos-cli --features api commands::serve::tests
+
       # The goal-completion verifier's ledger-evidence fold lives in the
       # `api`-gated goal_tool module, so the unfeatured runs above never compile
       # it. Guards the peer-goal convergence fix (#1989): a genuinely-complete

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -1972,13 +1972,25 @@ mod tests {
             "spawn_global_master_continuation_drain{}",
             "(state.clone());"
         );
-        let stdio_needle = format!("ui_protocol::stdio_connection{}", "(state)");
+        // Anchor on the CALL, not on the module path that reaches it. The
+        // original needle was `ui_protocol::stdio_connection(state)`; #1728
+        // renamed the module to `ui_protocol_transport`, so the needle stopped
+        // matching, `find` returned `None`, and this guard has been failing
+        // ever since — unnoticed, because CI's api-feature steps are a list of
+        // hand-written name filters and `commands::serve::tests::*` matches
+        // none of them (#2029). Dropping the module prefix makes the anchor
+        // survive a rename while still pinning the one call that matters.
+        let stdio_needle = format!("::stdio_connection{}", "(state)");
         let spawn_at = src
             .find(&spawn_needle)
             .expect("the global drain spawn call must exist in serve.rs");
-        let stdio_at = src
-            .find(&stdio_needle)
-            .expect("the stdio connection call must exist in serve.rs");
+        let stdio_at = src.find(&stdio_needle).unwrap_or_else(|| {
+            panic!(
+                "the stdio connection call must exist in serve.rs — if it was \
+                 renamed, update `stdio_needle` rather than deleting this guard: \
+                 it is the only thing pinning the drain BEFORE the early return"
+            )
+        });
         assert!(
             spawn_at < stdio_at,
             "the global master-continuation drain must be spawned BEFORE the stdio \


### PR DESCRIPTION
See the commit message for the full account. Found while validating the peer-goal fixes with a real-world soak on merged main.