### PR TITLE
fix(ci): enable the admin shell endpoint so the e2e ffmpeg specs can run (#2031)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1032,21 +1032,26 @@ jobs:
       - name: Install Homebrew ffmpeg (macOS)
         run: brew install ffmpeg
 
+      # #2031 — the four ffmpeg/PATH specs in `tool-use-regression.spec.ts`
+      # drive `POST /api/admin/shell`, and that route is registered ONLY when
+      # `allow_admin_shell` is true (api/router.rs). It defaults to false and
+      # nothing in CI ever set it, so every one of those requests answered
+      # 404 `{"error":"not_found"}`. `res.json()` on that body has no
+      # `exit_code` field, which is why the failures read
+      # `expect(result.exit_code).toBe(0) // Received: undefined` — an absent
+      # route, not a missing binary and not a PATH problem.
+      #
+      # This is a full-RCE endpoint, so it is enabled here and nowhere else:
+      # an ephemeral runner, bound to loopback, behind an admin token. Do not
+      # copy this config to anything long-lived.
+      - name: Write CI serve config (enables the admin shell endpoint)
+        run: |
+          echo '{"allow_admin_shell": true}' > /tmp/octos-ci-serve.json
+
       - name: Start octos serve
         run: |
-          # #2031 — the suite asserts the AGENT's shell tool can reach Homebrew
-          # binaries (`ffmpeg version N`, and `/opt/homebrew/bin` present on
-          # PATH). The agent inherits its environment from THIS process, so the
-          # install step passing proves only that the RUNNER has ffmpeg — not
-          # that serve, and therefore the agent, can see it. Set the prefix
-          # explicitly rather than trusting the image's default PATH.
-          export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
-          # Recorded so a future failure shows what serve actually inherited,
-          # instead of leaving the next reader to infer it from a green install
-          # step — which is exactly how this stayed misdiagnosed.
-          echo "serve PATH: $PATH"
-          command -v ffmpeg || echo "WARNING: ffmpeg not on serve's PATH"
-          OCTOS_AUTH_TOKEN=ci-test-token ./target/release/octos serve --port 3000 &
+          OCTOS_AUTH_TOKEN=ci-test-token ./target/release/octos serve --port 3000 \
+            --config /tmp/octos-ci-serve.json &
           # Wait for server to be ready
           for i in $(seq 1 30); do
             if curl -sf http://localhost:3000/api/status -H "Authorization: Bearer ci-test-token" > /dev/null 2>&1; then
@@ -1055,6 +1060,23 @@ jobs:
             fi
             sleep 1
           done
+
+      # Fail loudly at the precondition rather than inside four assertions that
+      # each report it as `undefined`. If this step ever 404s again, the config
+      # above stopped taking effect — that is a different bug from ffmpeg being
+      # absent, and the two were conflated for long enough to be worth naming.
+      - name: Verify the admin shell endpoint is live
+        run: |
+          body=$(curl -s -w '\n%{http_code}' -X POST http://localhost:3000/api/admin/shell \
+            -H "Authorization: Bearer ci-test-token" \
+            -H 'Content-Type: application/json' \
+            -d '{"command":"command -v ffmpeg"}')
+          code=$(echo "$body" | tail -1)
+          echo "$body" | sed '$d'
+          if [ "$code" != "200" ]; then
+            echo "::error::/api/admin/shell answered HTTP $code — expected 200."
+            exit 1
+          fi
 
       - name: Install e2e deps
         working-directory: e2e
@@ -1132,14 +1154,16 @@ jobs:
       - name: Install Homebrew ffmpeg (macOS)
         run: brew install ffmpeg
 
+      # Same `allow_admin_shell` config as the required job (#2031) — this job
+      # runs the full tree, which includes the admin-shell specs.
+      - name: Write CI serve config (enables the admin shell endpoint)
+        run: |
+          echo '{"allow_admin_shell": true}' > /tmp/octos-ci-serve.json
+
       - name: Start octos serve
         run: |
-          # Same environment fix as the required job (#2031): the agent inherits
-          # its PATH from serve, so the install step alone is not enough.
-          export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
-          echo "serve PATH: $PATH"
-          command -v ffmpeg || echo "WARNING: ffmpeg not on serve's PATH"
-          OCTOS_AUTH_TOKEN=ci-test-token ./target/release/octos serve --port 3000 &
+          OCTOS_AUTH_TOKEN=ci-test-token ./target/release/octos serve --port 3000 \
+            --config /tmp/octos-ci-serve.json &
           for i in $(seq 1 30); do
             if curl -sf http://localhost:3000/api/status -H "Authorization: Bearer ci-test-token" > /dev/null 2>&1; then
               echo "Server ready after ${i}s"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1034,6 +1034,18 @@ jobs:
 
       - name: Start octos serve
         run: |
+          # #2031 — the suite asserts the AGENT's shell tool can reach Homebrew
+          # binaries (`ffmpeg version N`, and `/opt/homebrew/bin` present on
+          # PATH). The agent inherits its environment from THIS process, so the
+          # install step passing proves only that the RUNNER has ffmpeg — not
+          # that serve, and therefore the agent, can see it. Set the prefix
+          # explicitly rather than trusting the image's default PATH.
+          export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+          # Recorded so a future failure shows what serve actually inherited,
+          # instead of leaving the next reader to infer it from a green install
+          # step — which is exactly how this stayed misdiagnosed.
+          echo "serve PATH: $PATH"
+          command -v ffmpeg || echo "WARNING: ffmpeg not on serve's PATH"
           OCTOS_AUTH_TOKEN=ci-test-token ./target/release/octos serve --port 3000 &
           # Wait for server to be ready
           for i in $(seq 1 30); do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1073,7 +1073,90 @@ jobs:
         working-directory: e2e
         run: npx playwright install chromium
 
+      # #1923 — run THIS job's namesake, not all 52 specs.
+      #
+      # `npx playwright test` with no filter swept in the whole e2e tree,
+      # including specs that ask a live model for specific words
+      # (`toContain('OK')`, `toContain('ALPHA')`, "answer in Chinese"). Those
+      # fail when a model phrases an answer differently or when CI has no
+      # provider credential — failures nobody can act on. A required check that
+      # fails for unactionable reasons gets routed around, which is exactly what
+      # happened: this job was narrowed to a path filter, went red on main, and
+      # reported SUCCESS by simply not running.
+      #
+      # Required checks stay deterministic. The model-dependent specs run in
+      # `e2e-live-nightly` below, where a flake costs a notification instead of
+      # a merge.
       - name: Run e2e tool regression tests
+        working-directory: e2e
+        run: OCTOS_TEST_URL=http://localhost:3000 OCTOS_AUTH_TOKEN=ci-test-token npx playwright test --reporter=line tests/tool-use-regression.spec.ts
+
+      - name: Stop octos serve
+        if: always()
+        run: pkill -f "octos serve" || true
+
+  # #1923 — the model-dependent half of the e2e tree, nightly and NON-BLOCKING.
+  #
+  # These specs ask a live model to produce particular words and then assert on
+  # them exactly (`toContain('OK')`, `toContain('ALPHA')`, CJK output, event
+  # counts). They catch real regressions, but they can also fail because a model
+  # phrased an answer differently or because no provider credential is present —
+  # neither of which is a reason to block a merge.
+  #
+  # `continue-on-error` keeps a red run visible without gating anything. If these
+  # are ever promoted back to required, the assertions need to be semantic rather
+  # than exact-match first.
+  e2e-live-nightly:
+    runs-on: macos-14
+    if: github.event_name == 'schedule'
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: e2e/package-lock.json
+
+      - name: Build dashboard bundle (embedded at compile time)
+        run: ./scripts/build-dashboard.sh
+
+      - name: Build octos with all features
+        run: cargo build --release -p octos-cli --features "$FEATURES"
+
+      - name: Install Homebrew ffmpeg (macOS)
+        run: brew install ffmpeg
+
+      - name: Start octos serve
+        run: |
+          # Same environment fix as the required job (#2031): the agent inherits
+          # its PATH from serve, so the install step alone is not enough.
+          export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+          echo "serve PATH: $PATH"
+          command -v ffmpeg || echo "WARNING: ffmpeg not on serve's PATH"
+          OCTOS_AUTH_TOKEN=ci-test-token ./target/release/octos serve --port 3000 &
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000/api/status -H "Authorization: Bearer ci-test-token" > /dev/null 2>&1; then
+              echo "Server ready after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Install e2e deps
+        working-directory: e2e
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: e2e
+        run: npx playwright install chromium
+
+      - name: Run model-dependent e2e specs
         working-directory: e2e
         run: OCTOS_TEST_URL=http://localhost:3000 OCTOS_AUTH_TOKEN=ci-test-token npx playwright test --reporter=line
 


### PR DESCRIPTION
Makes `e2e-tool-regression` a check that can actually pass, and scopes it to the specs it is named for.

## Root cause

The four ffmpeg/PATH specs in `tool-use-regression.spec.ts` drive `POST /api/admin/shell`. That route is registered **only when `allow_admin_shell` is true** (`api/router.rs:825`). It defaults to false and nothing in CI ever set it, so every request answered:

```
HTTP 404 {"error":"not_found","path":"/api/admin/shell"}
```

`res.json()` on that body has no `exit_code`, which is precisely what the failures said:

```
expect(result.exit_code).toBe(0)
Received: undefined
```

`undefined`, not a non-zero exit code — an absent field from an absent route. These four specs could never have passed in CI as written.

## Correcting this PR's first commit

The first commit exported the Homebrew prefix into serve's environment, on the theory that the agent's sandboxed shell tool could not reach ffmpeg. **That was wrong, and the diagnostic it added disproved it in its own run** — serve's PATH already contained `/opt/homebrew/bin`, no warning fired, and the specs still failed.

The handler is also not sandboxed and does not filter PATH: it spawns `sh -c` in serve's own environment with only `BLOCKED_ENV_VARS` removed (`api/admin.rs:4107`), and `PATH` is explicitly retained by the sanitizer (`subprocess_env.rs:57`). The export is reverted here; it fixed nothing.

## Verification

Measured against a release binary, not inferred:

| invocation | result |
|---|---|
| `--config '{"allow_admin_shell": true}'` → `which ffmpeg` | `{"stdout":"/opt/homebrew/bin/ffmpeg","exit_code":0}` |
| … → `echo $PATH` | contains `/opt/homebrew/bin` |
| … → the concat script | `{"stdout":"CONCAT_OK","exit_code":0}` |
| no config (CI's current invocation) | `HTTP 404 {"error":"not_found"}` |

All four specs pass with the config; the 404 reproduces the exact CI symptom without it.

## Changes

1. **Write a CI serve config enabling `allow_admin_shell`** and pass `--config`. Full-RCE endpoint, so it is enabled here and nowhere else — ephemeral runner, loopback bind, admin token — and the comment says not to copy it.
2. **A precondition step** asserting the endpoint answers 200 before the suite runs, so a regression names itself instead of surfacing as four `undefined` assertions. Both branches exercised locally: 200 passes, 404 exits 1.
3. **Scope the required job to `tests/tool-use-regression.spec.ts`** (unchanged from the first commit). The unfiltered run swept in the whole tree — 44 failed / 14 passed.
4. **Move model-dependent specs to a nightly `continue-on-error` job** (unchanged). They assert exact model wording (`toContain('ALPHA')`, CJK output); a merge should not hinge on phrasing.

## Why this matters beyond the four specs

The spec named `PATH includes /opt/homebrew/bin` is exactly the assertion that would have caught the original #1923 regression — and it was structurally incapable of running. Same family as #2029, where a name filter matching nothing prints `ok`.

Unblocks #2048 and #2041, both currently parked behind this job.

Refs #2031, #1923
