### PR TITLE
chore(release): v2.0.3-rc.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4531,7 +4531,7 @@ dependencies = [
 
 [[package]]
 name = "octos-agent"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "async-trait",
  "base64",
@@ -4592,7 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "octos-bus"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "aes",
  "async-imap",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "octos-cli"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "agent-client-protocol",
  "argon2",
@@ -4715,7 +4715,7 @@ dependencies = [
 
 [[package]]
 name = "octos-core"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "chrono",
  "eyre",
@@ -4730,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "octos-diagnostics"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4742,14 +4742,14 @@ dependencies = [
 
 [[package]]
 name = "octos-dora-mcp"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "octos-agent",
 ]
 
 [[package]]
 name = "octos-embed-llama"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4763,7 +4763,7 @@ dependencies = [
 
 [[package]]
 name = "octos-ffi"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "libc",
  "octos-agent",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet-worker"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4812,7 +4812,7 @@ dependencies = [
 
 [[package]]
 name = "octos-llm"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "async-trait",
  "base64",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "octos-memory"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "bincode",
  "chrono",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pipeline"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4880,7 +4880,7 @@ dependencies = [
 
 [[package]]
 name = "octos-plugin"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "eyre",
  "metrics",
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pyo3"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "octos-ffi",
  "pyo3",
@@ -4917,7 +4917,7 @@ dependencies = [
 
 [[package]]
 name = "octos-server"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -4954,7 +4954,7 @@ dependencies = [
 
 [[package]]
 name = "octos-services"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "chrono",
  "dirs",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "octos-store"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "base64",
  "chrono",
@@ -4995,7 +4995,7 @@ dependencies = [
 
 [[package]]
 name = "octos-swarm"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5015,7 +5015,7 @@ dependencies = [
 
 [[package]]
 name = "octos-uniffi"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "octos-ffi",
  "uniffi",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "octos-wasm"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "octos-workflows"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "chrono",
  "eyre",
@@ -8474,7 +8474,7 @@ dependencies = [
 
 [[package]]
 name = "wechat-bridge"
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 dependencies = [
  "clap",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.3-rc.5"
+version = "2.0.3-rc.6"
 edition = "2024"
 rust-version = "1.85.0"
 authors = ["octos team"]


### PR DESCRIPTION
Version bump only — `2.0.3-rc.5` → `2.0.3-rc.6` across the workspace, plus the lock.

Cuts an RC over today's merges:

| | |
|---|---|
| #2034 | keep a live peer out of the per-turn orphan sweep |
| #2037 | stop truncating peer results into unverifiable evidence |
| #2039 | raise the ledger-row assertion cap that still truncated reviews |
| #2042 | report `peer_close` as the interrupt cause, not the client |
| #2038 | read every family's default model from the catalog |

Validated end to end rather than by unit tests alone: a real-world peer-goal soak on merged main, two peers reviewing genuine production modules (`ssrf.rs`, `policy.rs`) under one goal. The goal reached **`complete`**, and the recorded findings measured **3956 / 2833 / 3945** characters where the pre-fix caps produced exactly **412**, then exactly **500**.

That soak is also what found #2039 — #2037 fixed the outer cap and left an inner `take(500)` behind, which only a real workload exposed.

Not included: #2041 (parked behind #1923) and #2043 (CI-only, in flight).