### PR TITLE
fix(agent): expose session workspace to plugins

### DIFF
--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -2716,6 +2716,19 @@ impl Tool for PluginTool {
             cmd.env("OCTOS_WORK_DIR", dir);
         }
 
+        // The plugin output directory and the session workspace are different
+        // roots in a normal session (`<workspace>/skill-output` versus
+        // `<workspace>`). Inputs materialized by the host are relative to the
+        // latter, so expose it explicitly instead of making plugins infer it
+        // by walking to the parent of `OCTOS_WORK_DIR`.
+        if let Some(workspace) = ctx
+            .as_ref()
+            .and_then(|ctx| ctx.session_scope.as_deref())
+            .map(SessionScope::workspace)
+        {
+            cmd.env("OCTOS_SESSION_WORKSPACE", workspace);
+        }
+
         // Codex round-3 BLOCKER fix (PR #1186 review): when
         // `prepare_effective_args` -> `rewrite_workspace_file_args` ->
         // `resolve_plugin_input_path` rejects a path with `..`

--- a/crates/octos-agent/src/plugins/tool_tests.rs
+++ b/crates/octos-agent/src/plugins/tool_tests.rs
@@ -3077,6 +3077,49 @@ async fn plugin_uses_scope_workspace_when_present() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[cfg(unix)]
+async fn plugin_exposes_session_workspace_separately_from_output_work_dir() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let skill_output = workspace.path().join("skill-output");
+    std::fs::create_dir_all(&skill_output).expect("skill output");
+
+    let bin_dir = tempfile::tempdir().expect("bin dir");
+    let script_path = bin_dir.path().join("script.sh");
+    write_test_script(
+        &script_path,
+        "#!/bin/sh\nprintf '{\"output\":\"%s|%s\",\"success\":true}' \"$OCTOS_WORK_DIR\" \"$OCTOS_SESSION_WORKSPACE\"\n",
+    );
+
+    let tool = PluginTool::new(
+        "plug".into(),
+        make_tool_def("session_roots", "echo session roots"),
+        script_path,
+    )
+    .with_work_dir(skill_output.clone())
+    .with_timeout(TEST_PLUGIN_TIMEOUT);
+    let ctx = ctx_with_scope(solo_scope_at(workspace.path()));
+    let result = crate::tools::TOOL_CTX
+        .scope(ctx, tool.execute(&json!({})))
+        .await
+        .expect("execute should succeed");
+
+    assert!(result.success);
+    let (actual_output, actual_workspace) = result
+        .output
+        .trim()
+        .split_once('|')
+        .expect("plugin should echo both roots");
+    assert_eq!(
+        std::fs::canonicalize(actual_output).unwrap(),
+        std::fs::canonicalize(skill_output).unwrap(),
+    );
+    assert_eq!(
+        std::fs::canonicalize(actual_workspace).unwrap(),
+        std::fs::canonicalize(workspace.path()).unwrap(),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(unix)]
 async fn high_risk_plugin_approval_cwd_reflects_scope_workspace() {
     // Codex P3 pin (Phase 2-B): the approval prompt's `cwd` field
     // must reflect the directory the plugin will ACTUALLY run in,


### PR DESCRIPTION
## Summary

- expose the session workspace to plugin tools as `OCTOS_SESSION_WORKSPACE`
- keep `OCTOS_WORK_DIR` unchanged as the skill output directory
- cover the two roots with a Unix plugin execution regression test

## Why

Manifest file bindings materialize uploaded inputs relative to the session workspace, while plugin outputs live under a separate skill-output directory. A plugin must not guess the input root by walking to the parent of its output directory.

This allows learning-coach to read the exact saved whiteboard selection image while retaining its existing output location and path-containment checks.

## Validation

- `cargo test -p octos-agent plugin_exposes_session_workspace_separately_from_output_work_dir`
- `cargo fmt --all -- --check`
