### PR TITLE
fix(peers): evaluate owed peer-fleet synthesis at boot (#2033)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -10145,6 +10145,151 @@ async fn a_second_peer_round_is_not_recorded_as_summarized_unless_a_turn_actuall
     );
 }
 
+/// #2033 — a synthesis that was OWED when the process died must be evaluated at
+/// BOOT, not left waiting for the next unrelated turn.
+///
+/// The gate is EDGE-triggered: `evaluate_and_enqueue_fleet_synthesis` is reached
+/// from exactly two edges, a PEER turn terminal and a MASTER turn terminal.
+/// Normally that is enough — a deduped enqueue deliberately leaves the marks
+/// behind (#2024) and the in-flight synthesis continuation's OWN terminal is the
+/// retry edge. What has no edge at all is a process restart: if the owed round's
+/// retry edge was still in the future when the process died, nothing on the new
+/// process ever recomputes the gate.
+///
+/// Observed live (mini5 soak): a peer's round-2 terminal landed while a round-1
+/// synthesis was in flight, so the enqueue deduped and the marks stayed at
+/// `1 auditor`; the serve was then killed before that continuation reached its
+/// terminal. On restart the master session was opened and sat for 220s with the
+/// marks still at round 1 — one trivial master turn advanced them in 3s. The
+/// peer's last round is only ever written up if the user happens to type again.
+///
+/// Reconstructs exactly that on-disk state — peer delivered round 2, marks
+/// recorded at round 1, nothing in flight — and asserts the BOOT sweep fires it
+/// with NO turn edge whatsoever. The already-current fleet in the same
+/// `peers/` root must NOT be evaluated: the sweep is bounded to owed fleets.
+#[tokio::test]
+async fn boot_sweep_synthesizes_a_peer_fleet_round_left_owed_when_the_process_died() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path();
+    // Unique masters/slugs: the continuation dedupe key, its recent-claim
+    // guard, and the peer wire registry are all process-global, so shared names
+    // would collide with sibling tests in a parallel run (#2029).
+    let owed_master = "tenant-a:api:master-2033-owed";
+    let current_master = "tenant-a:api:master-2033-current";
+
+    let stage = |slug: &str, master: &str, rounds: u32| {
+        let dir = peers_root.join(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("brief.md"), "brief").unwrap();
+        std::fs::write(dir.join("originator"), master).unwrap();
+        std::fs::write(dir.join("result.md"), "findings").unwrap();
+        for round in 1..=rounds {
+            std::fs::write(dir.join(format!("result-{round}.md")), "findings").unwrap();
+        }
+    };
+    // OWED: delivered round 2, only round 1 recorded as summarized.
+    stage("auditor-2033", owed_master, 2);
+    write_peer_fleet_synthesis_marks(peers_root, owed_master, &[("auditor-2033".to_owned(), 1)])
+        .unwrap();
+    // CURRENT: delivered round 1, round 1 already summarized. Nothing owed.
+    stage("scribe-2033", current_master, 1);
+    write_peer_fleet_synthesis_marks(peers_root, current_master, &[("scribe-2033".to_owned(), 1)])
+        .unwrap();
+
+    // Precondition: the owed fleet's record is genuinely behind its delivery.
+    assert_eq!(
+        synthesized_round_for(
+            &read_peer_fleet_synthesis_marks(peers_root, owed_master),
+            "auditor-2033",
+            2
+        ),
+        1,
+        "precondition: the round-2 delivery is recorded as summarized only through round 1",
+    );
+
+    // The BOOT sweep — no peer terminal, no master terminal, no client.
+    let evaluated = enqueue_boot_owed_peer_fleet_synthesis(MAIN_PROFILE_ID, peers_root).await;
+
+    assert_eq!(
+        synthesized_round_for(
+            &read_peer_fleet_synthesis_marks(peers_root, owed_master),
+            "auditor-2033",
+            2
+        ),
+        2,
+        "boot must enqueue the owed synthesis and advance the marks; without a \
+         boot-time evaluation the round waits for an unrelated turn, forever on \
+         a quiet fleet",
+    );
+    assert_eq!(
+        evaluated, 1,
+        "exactly the OWED fleet is evaluated; a fleet with nothing new must not \
+         be re-evaluated (the sweep is bounded to owed fleets, not a full scan)",
+    );
+    assert_eq!(
+        synthesized_round_for(
+            &read_peer_fleet_synthesis_marks(peers_root, current_master),
+            "scribe-2033",
+            1
+        ),
+        1,
+        "an already-summarized fleet is untouched by the boot sweep",
+    );
+}
+
+/// #2033 — the boot sweep only decides WHICH fleets to look at; whether one
+/// fires stays with the shared gate.
+///
+/// "Owed" (a delivered round past the recorded mark) is a strictly weaker
+/// condition than "ready": it says nothing about the other peers in the fleet.
+/// A sweep that wrote the marks itself — or that treated owed as fire — would
+/// summarize a fleet mid-flight and, because the marks advance, never write up
+/// the sibling's work at all. Here one peer is owed at round 2 while a sibling
+/// has not delivered anything, so the fleet must be selected and then HELD.
+#[tokio::test]
+async fn boot_sweep_selects_an_owed_peer_fleet_but_leaves_the_fire_decision_to_the_gate() {
+    let tmp = tempfile::tempdir().unwrap();
+    let peers_root = tmp.path();
+    let master = "tenant-a:api:master-2033-unfinished";
+
+    // Owed: delivered round 2, recorded at round 1.
+    let delivered = peers_root.join("auditor-2033-unfinished");
+    std::fs::create_dir_all(&delivered).unwrap();
+    std::fs::write(delivered.join("brief.md"), "brief").unwrap();
+    std::fs::write(delivered.join("originator"), master).unwrap();
+    std::fs::write(delivered.join("result.md"), "findings").unwrap();
+    std::fs::write(delivered.join("result-1.md"), "findings").unwrap();
+    std::fs::write(delivered.join("result-2.md"), "findings").unwrap();
+    // Sibling in the SAME fleet with no result at all — the fleet is not done.
+    let pending = peers_root.join("scribe-2033-unfinished");
+    std::fs::create_dir_all(&pending).unwrap();
+    std::fs::write(pending.join("brief.md"), "brief").unwrap();
+    std::fs::write(pending.join("originator"), master).unwrap();
+    write_peer_fleet_synthesis_marks(
+        peers_root,
+        master,
+        &[("auditor-2033-unfinished".to_owned(), 1)],
+    )
+    .unwrap();
+
+    let evaluated = enqueue_boot_owed_peer_fleet_synthesis(MAIN_PROFILE_ID, peers_root).await;
+
+    assert_eq!(
+        evaluated, 1,
+        "the fleet IS owed, so the sweep must hand it to the gate",
+    );
+    assert_eq!(
+        synthesized_round_for(
+            &read_peer_fleet_synthesis_marks(peers_root, master),
+            "auditor-2033-unfinished",
+            2
+        ),
+        1,
+        "the gate holds an unfinished fleet, so the boot sweep must not advance \
+         the marks — advancing them here would lose the sibling's round entirely",
+    );
+}
+
 /// Bug 2 (reset edge) — `collect_owned_peer_results` distinguishes a
 /// genuinely-EMPTY readable directory (`Some(vec![])`) from a `peers/` scan
 /// FAILURE (`None`), so a transient read error is never mistaken for a cleared

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -14827,44 +14827,83 @@ fn collect_owned_peer_results(peers_root: &Path, master: &str) -> Option<Vec<Own
     let mut owned = Vec::new();
     for entry in read_dir.flatten() {
         let slug = entry.file_name().to_string_lossy().into_owned();
-        // Route through `staged_peer_dir`: a symlinked / unsafe slug is never
-        // followed, and the `.synthesized-*` stamp files (not dirs) are skipped.
-        let Some(dir) = staged_peer_dir(peers_root, &slug) else {
+        let Some((originator, peer)) = read_owned_peer_entry(peers_root, slug) else {
             continue;
         };
-        // Retired peer: neither blocks nor keeps the fleet alive.
-        if peer_io::peer_regular_file_exists(&dir, "closed") {
+        // Originator gate — only peers THIS master staged.
+        if originator != master {
             continue;
         }
-        // Originator gate — only peers THIS master staged. After the atomic
-        // owner-before-brief write in `stage_peer`, a visible (brief.md) member
-        // always has a readable originator, so a member of THIS master is never
-        // silently dropped from the ownership scan.
-        let Some(originator) =
-            peer_io::read_peer_file(&dir, "originator", peer_io::PEER_FILE_READ_CAP_SMALL)
-        else {
-            continue;
-        };
-        if originator.trim() != master {
-            continue;
-        }
-        let has_result = peer_io::peer_regular_file_exists(&dir, "result.md");
-        // #2024: how many rounds this peer has DELIVERED. Versioned results
-        // (`result-<n>.md`) have existed since #435, but a peer whose result
-        // predates them has only the bare `result.md` — floor it at 1 so it
-        // can still exceed a mark of 0 and synthesize at all.
-        let round = if has_result {
-            crate::peers::count_peer_result_versions(&dir).max(1)
-        } else {
-            0
-        };
-        owned.push(OwnedPeer {
+        owned.push(peer);
+    }
+    Some(owned)
+}
+
+/// Read ONE `peers/<slug>` entry as `(originating master, fleet inputs)`, or
+/// `None` when it is not a live owned peer.
+///
+/// Single definition of "owned", shared by the per-master scan
+/// ([`collect_owned_peer_results`]) and the boot-time all-fleets scan
+/// ([`collect_peer_fleets_by_master`]) so the two can never disagree about
+/// which peers a fleet has — a divergence would let the boot sweep judge a
+/// fleet against a different membership than the turn-terminal edges do.
+fn read_owned_peer_entry(peers_root: &Path, slug: String) -> Option<(String, OwnedPeer)> {
+    // Route through `staged_peer_dir`: a symlinked / unsafe slug is never
+    // followed, and the `.synthesized-*` stamp files (not dirs) are skipped.
+    let dir = staged_peer_dir(peers_root, &slug)?;
+    // Retired peer: neither blocks nor keeps the fleet alive.
+    if peer_io::peer_regular_file_exists(&dir, "closed") {
+        return None;
+    }
+    // After the atomic owner-before-brief write in `stage_peer`, a visible
+    // (brief.md) member always has a readable originator, so a member of a
+    // master's fleet is never silently dropped from the ownership scan.
+    let originator =
+        peer_io::read_peer_file(&dir, "originator", peer_io::PEER_FILE_READ_CAP_SMALL)?;
+    let has_result = peer_io::peer_regular_file_exists(&dir, "result.md");
+    // #2024: how many rounds this peer has DELIVERED. Versioned results
+    // (`result-<n>.md`) have existed since #435, but a peer whose result
+    // predates them has only the bare `result.md` — floor it at 1 so it
+    // can still exceed a mark of 0 and synthesize at all.
+    let round = if has_result {
+        crate::peers::count_peer_result_versions(&dir).max(1)
+    } else {
+        0
+    };
+    Some((
+        originator.trim().to_owned(),
+        OwnedPeer {
             slug,
             has_result,
             round,
-        });
+        },
+    ))
+}
+
+/// Every live peer under `peers_root`, grouped by the master that staged it.
+///
+/// The inverse of [`collect_owned_peer_results`], which needs the master up
+/// front. The boot sweep (#2033) has no master to start from — nothing is
+/// terminating, there is no session in hand — so it discovers the fleets from
+/// the directory itself, in ONE scan rather than one scan per candidate master.
+///
+/// Same fail-closed contract: `None` when `peers/` cannot be READ, so a
+/// transient scan error is never mistaken for "no fleets".
+fn collect_peer_fleets_by_master(peers_root: &Path) -> Option<HashMap<String, Vec<OwnedPeer>>> {
+    let read_dir = std::fs::read_dir(peers_root).ok()?;
+    let mut fleets: HashMap<String, Vec<OwnedPeer>> = HashMap::new();
+    for entry in read_dir.flatten() {
+        let slug = entry.file_name().to_string_lossy().into_owned();
+        let Some((originator, peer)) = read_owned_peer_entry(peers_root, slug) else {
+            continue;
+        };
+        // An empty originator names no master; it can never be evaluated.
+        if originator.is_empty() {
+            continue;
+        }
+        fleets.entry(originator).or_default().push(peer);
     }
-    Some(owned)
+    Some(fleets)
 }
 
 /// Peer-fleet auto-synthesis hook. Called at a PEER session's turn terminal
@@ -15120,6 +15159,110 @@ async fn evaluate_and_enqueue_fleet_synthesis(
             );
         }
     }
+}
+
+/// True when `master`'s fleet has a peer whose DELIVERED round is past what the
+/// stamp records as summarized — i.e. a synthesis is OWED for this fleet.
+///
+/// Deliberately the freshness half of [`evaluate_peer_fleet_synthesis`] and
+/// nothing else: it is a cheap pre-filter, not a second gate. Idle/settled/done
+/// are re-decided by the real evaluation, which is the only thing allowed to
+/// fire. A [`Legacy`](FleetSynthesisMarks::Legacy) record reads every peer as
+/// covered at its current round, so an unparseable stamp is never owed — the
+/// same fail-closed posture the gate takes.
+fn peer_fleet_synthesis_is_owed(marks: &FleetSynthesisMarks, peers: &[OwnedPeer]) -> bool {
+    peers
+        .iter()
+        .any(|peer| peer.round > synthesized_round_for(marks, &peer.slug, peer.round))
+}
+
+/// The `exclude_session` the BOOT sweep passes to the shared evaluation.
+///
+/// Every other caller is a session whose turn is terminating right now and so
+/// must not count against idle/settled. At boot NOTHING is terminating, so
+/// nothing may be excluded. A session key is always `<profile>:<channel>:<id>`,
+/// so the empty key can never name a real session and removing it from the
+/// live-turn set is a guaranteed no-op — which is exactly the intent.
+fn boot_sweep_exclude_session() -> SessionKey {
+    SessionKey(String::new())
+}
+
+/// #2033 — BOOT-TIME evaluation of owed peer-fleet synthesis, for one profile.
+/// Returns how many fleets were evaluated (i.e. how many were owed).
+///
+/// The synthesis gate is EDGE-triggered: [`evaluate_and_enqueue_fleet_synthesis`]
+/// is reached from exactly two edges, a PEER turn terminal and a MASTER turn
+/// terminal. That is sound *within* a process — a deduped enqueue deliberately
+/// holds the marks back (#2024) and the in-flight continuation's own terminal is
+/// the guaranteed retry edge. A process restart is what has no edge at all: when
+/// the owed round's retry edge was still in the future at the moment the process
+/// died, the new process has nothing that recomputes the gate.
+///
+/// Observed live (mini5 soak, #2033): a peer's round-2 terminal landed while a
+/// round-1 synthesis was in flight, so the enqueue deduped and the marks stayed
+/// at round 1; the serve was killed before that continuation reached terminal.
+/// After the restart the master session sat for 220s with the round still
+/// unsynthesized, and one trivial master turn advanced it in 3s. The peer's last
+/// round of work is written up only if the user happens to type again — on a
+/// quiet fleet, never.
+///
+/// This is the missing boot edge, and it is the boot-resume precedent already
+/// applied to restart-stranded fleet-kernel fleets
+/// ([`crate::autonomy::fleet_wake::enqueue_fleet_boot_resume_wakes`]) and to
+/// persisted monitors: recompute at startup what only an event would otherwise
+/// recompute.
+///
+/// BOUNDED, not a poll. One `peers/` scan per profile at startup, then the real
+/// evaluation ONLY for fleets whose delivered round is past their recorded mark.
+/// Fleets with nothing new pay a mark read and no more, and the turn-terminal
+/// edges are untouched — no tick, no re-arm-on-dedupe, no per-tick scan.
+///
+/// Enqueue-only: the continuation is drained by the same
+/// `spawn_global_master_continuation_drain` / per-connection tick as any other,
+/// under the same workspace-known gate. So a master session that has not been
+/// opened this process run defers until it is — which is the observed case
+/// (the user opens the master, then waits), and it fires on the next drain tick
+/// instead of never.
+pub(crate) async fn enqueue_boot_owed_peer_fleet_synthesis(
+    profile_id: &str,
+    peers_root: &Path,
+) -> usize {
+    // Cheap early-out: a profile that has never staged a peer has no fleets.
+    if !peers_root.is_dir() {
+        return 0;
+    }
+    // FAIL-CLOSED, as everywhere else on this path: an unreadable `peers/` is
+    // "can't determine", not "no fleets".
+    let Some(fleets) = collect_peer_fleets_by_master(peers_root) else {
+        tracing::warn!(
+            profile = profile_id,
+            peers_root = %peers_root.display(),
+            "boot peer-fleet synthesis sweep: peers/ unreadable; skipping this profile"
+        );
+        return 0;
+    };
+    let exclude = boot_sweep_exclude_session();
+    let mut evaluated = 0usize;
+    for (master, peers) in fleets {
+        let marks = read_peer_fleet_synthesis_marks(peers_root, &master);
+        if !peer_fleet_synthesis_is_owed(&marks, &peers) {
+            continue;
+        }
+        evaluated += 1;
+        // Hand off to the SAME evaluation the two turn-terminal edges use — it
+        // re-reads the fleet, re-checks master-idle/settled, and owns the
+        // exactly-once marks write. The boot sweep only decides WHO to look at.
+        evaluate_and_enqueue_fleet_synthesis(profile_id, peers_root, &master, &exclude).await;
+    }
+    if evaluated > 0 {
+        tracing::info!(
+            profile = profile_id,
+            fleets = evaluated,
+            "boot peer-fleet synthesis sweep: re-evaluated fleets whose last round was \
+             left unsynthesized when the previous process exited"
+        );
+    }
+    evaluated
 }
 
 /// Serializes profile `sub_providers` read-modify-write across concurrent

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -1133,6 +1133,26 @@ impl ServeCommand {
             }
         }
 
+        // #2033 — the PEER-fleet half of boot-resume. The peer-fleet synthesis
+        // gate is edge-triggered (a peer turn terminal / a master turn
+        // terminal), which is sound inside a process but leaves a restart with
+        // no edge at all: a synthesis that was owed when the previous process
+        // exited is recovered only by the next unrelated turn — never, on a
+        // fleet whose master is idle and whose peers are done. Recompute it here
+        // for every profile, bounded to fleets whose delivered round is past
+        // their recorded mark. Enqueue-only; the global continuation drain
+        // spawned below turns it into a turn under the usual gates.
+        //
+        // Peers live under the PROFILE data dir (not the serve `data_dir`), so
+        // this walks the profile runtimes rather than a single root.
+        for (profile_id, rt) in &profile_runtimes {
+            crate::api::ui_protocol_transport::enqueue_boot_owed_peer_fleet_synthesis(
+                profile_id,
+                &rt.data_dir.join("peers"),
+            )
+            .await;
+        }
+
         let session_cache = Arc::new(
             crate::runtime::SessionRuntimeCache::new(64, std::time::Duration::from_secs(1800))
                 // Per-project session storage (opt-in, default off). When set,


### PR DESCRIPTION
Closes #2033.

## The defect

The peer-fleet synthesis gate is **edge-triggered**: `evaluate_and_enqueue_fleet_synthesis` is reached from exactly two edges — a peer turn terminal and a master turn terminal.

Inside one process that is sound. When `enqueue_peer_fleet_synthesis_continuation` dedupes against an in-flight synthesis it deliberately leaves the marks un-advanced (#2024) so "the next terminal retries", and the in-flight continuation's **own** terminal is that retry edge — guaranteed to arrive.

**What has no edge at all is a process restart.**

## Evidence

From the mini5 multi-round peer-collaboration soak (`2.0.3-rc.5` @ 80cec9254):

1. a peer finished round 2 with a complete `result-2.md` and `turns.txt` reading `2 completed`, while a round-1 synthesis was still in flight → its terminal deduped, marks correctly stayed at `1 auditor`
2. the serve was killed **before** that continuation reached terminal → the retry edge never arrived
3. fresh process, master session opened, **220s** — nothing
4. one trivial master turn (`Reply with exactly: OK`) → marks advanced to `2 auditor` in **3s**

Step 3 is the gap. The peer's last round of work is written up only if the user happens to type again — on a quiet fleet whose master is idle and whose peers are all done, never. There is no error, no chip and no log line; the only symptom is an absence.

## The fix

Add the missing boot edge, next to the fleet-kernel boot-resume sweep (`enqueue_fleet_boot_resume_wakes`) that already recomputes at startup what only an event would otherwise recompute.

Per profile, scan `peers/` **once**, group live peers by originating master, and hand to the existing shared evaluation only those fleets whose delivered round is past their recorded mark. A fleet with nothing new pays one marks read. The two turn-terminal edges are untouched — no tick, no polling, no re-arm-on-dedupe.

The sweep chooses **which** fleets to look at and nothing else. Firing stays with `evaluate_peer_fleet_synthesis`, which re-checks master-idle / settled / done and owns the exactly-once marks write. "Owed" is strictly weaker than "ready", so a sweep that advanced the marks itself would summarize a fleet mid-flight and lose a sibling's round entirely.

Enqueue-only, so the continuation drains under the usual workspace-known gate: a master session not yet opened this process run defers until it is (exactly the observed case) and then fires on the next drain tick, instead of never.

`read_owned_peer_entry` is extracted so the per-master scan and the new all-fleets scan share one definition of "owned" — a divergence would let the boot sweep judge a fleet against a different membership than the turn-terminal edges do.

## Scope correction

The issue **title** over-states the defect, and the description's suggested fix (1) solves a problem that isn't there. `maybe_enqueue_peer_fleet_synthesis_for_master` runs on every master turn terminal and the synthesis continuation *is* a master turn, so a deduped continuation's own terminal re-runs the gate — that path already self-heals. Re-arm-on-dedupe is not needed. Boot-time evaluation is the whole gap, and the only thing this changes. (This matches the correction comment on the issue.)

## Tests

Both new tests are named to contain `peer` so CI's `cargo test -p octos-cli --features api peer` job actually runs them.

- `boot_sweep_synthesizes_a_peer_fleet_round_left_owed_when_the_process_died` — reconstructs the soak's on-disk state (peer delivered round 2, marks recorded at round 1, nothing in flight) and asserts the boot sweep advances the marks with **no turn edge whatsoever**, while an already-current fleet in the same `peers/` root is not evaluated (the sweep is bounded to owed fleets).
- `boot_sweep_selects_an_owed_peer_fleet_but_leaves_the_fire_decision_to_the_gate` — one peer owed at round 2 with a sibling that has delivered nothing: the fleet is selected and then **held**, so the sweep can never advance the marks on its own.

**Mutation check** — with the sweep body stubbed to `return 0` (the pre-fix behaviour), both new tests fail on their primary assertions (`marks: 1, expected 2`; `evaluated: 0, expected 1`) and all 13 pre-existing peer-fleet-synthesis tests still pass.

## Gates

- `cargo test -p octos-cli --features api peer` — 146 passed, 0 failed
- `cargo test -p octos-cli --features api --lib -- --test-threads=1` — 2933 passed, 2 failed
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p octos-cli --all-targets --no-default-features --features api,telegram,discord,dingtalk,slack,whatsapp,feishu,email,matrix,audio_mp3 -- -D warnings` — clean

The 2 full-suite failures are **pre-existing on `origin/main`** and unrelated — verified by reverting all three files to `origin/main` in the same worktree and re-running them:

- `commands::serve::tests::global_drain_spawns_before_the_stdio_early_return` — its source-order needle is `"ui_protocol::stdio_connection" + "(state)"`, which stopped matching when `ui_protocol.rs` was renamed to `ui_protocol_transport.rs`. The test never runs in CI (`commands::serve` is `#[cfg(feature = "api")]` and CI's `cargo test -p octos-cli --lib` job has no `api` feature), so the tripwire has been silently dead since the rename. Left alone here as out of scope — worth its own issue.
- `process_manager::tests::should_allocate_bridge_ports_as_consecutive_pair` — environment-dependent port allocation (got 3103, wanted 3101 on this host).