### PR TITLE
refactor(agent): retire the RecoveryHint inbox — one re-entry path for background-task terminals

### DIFF
--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -2305,7 +2305,7 @@ async fn run_task_with_m8_9_recovery(
 
 /// Build the synthetic `[system-internal]` instruction the spawn-task
 /// recovery wrapper sends after a first-pass failure. The shape mirrors
-/// `session_actor::build_recovery_prompt` but operates on the
+/// `session_actor::build_recovery_prompt_body` but operates on the
 /// pre-LLM task description (we don't have a tool_input here).
 fn build_spawn_recovery_prompt(task_desc: &str, error_message: &str) -> String {
     format!(

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -20014,12 +20014,10 @@ async fn unified_terminal_sink_failure_with_ack_queues_recovery_under_profile() 
     crate::autonomy::agent_orchestrator::route_terminal_event_to_continuation_queue(
         &event,
         Some(profile_id),
-        crate::autonomy::agent_orchestrator::TerminalFailureRouting::Queue,
     );
     crate::autonomy::agent_orchestrator::route_terminal_event_to_continuation_queue(
         &event,
         Some(profile_id),
-        crate::autonomy::agent_orchestrator::TerminalFailureRouting::Queue,
     );
 
     assert_eq!(
@@ -20088,7 +20086,6 @@ async fn unified_terminal_sink_failure_without_ack_suppresses_recovery() {
     crate::autonomy::agent_orchestrator::route_terminal_event_to_continuation_queue(
         &event,
         Some(profile_id),
-        crate::autonomy::agent_orchestrator::TerminalFailureRouting::Queue,
     );
 
     assert_eq!(
@@ -20130,12 +20127,10 @@ async fn unified_terminal_sink_success_queues_child_completed_under_profile() {
     crate::autonomy::agent_orchestrator::route_terminal_event_to_continuation_queue(
         &event,
         Some(profile_id),
-        crate::autonomy::agent_orchestrator::TerminalFailureRouting::Queue,
     );
     crate::autonomy::agent_orchestrator::route_terminal_event_to_continuation_queue(
         &event,
         Some(profile_id),
-        crate::autonomy::agent_orchestrator::TerminalFailureRouting::Queue,
     );
 
     let drained = default_agent_orchestrator().drain_ready_continuations_for_session(

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -29344,17 +29344,19 @@ async fn run_standalone_turn(
         // post-spawn failure signal BEFORE `enable_persistence` so the
         // orphan-task sweep at `task_supervisor.rs:1164-1166` —
         // which can `mark_failed` resurrected tasks — does NOT
-        // silently drop the recovery turn. The gateway path drives
-        // recovery through `ActorMessage::RecoveryHint` directly into
-        // the session actor's inbox; the WS turn handler has no
-        // actor, so we re-inject the failure into the global master
-        // continuation queue (drained on every
+        // silently drop the recovery turn. We re-inject the failure
+        // into the global master continuation queue (drained on every
         // `appui_continuation_tick`). `default_agent_orchestrator()`
         // is a process-wide singleton, so the callback survives both
         // the per-turn `tool_registry` drop AND a closed WS
         // connection — on next subscribe, the queued
         // `External("spawn_only_failure")` continuation fires and
         // `master_continuation_prompt` renders the recovery body.
+        //
+        // #2020: the gateway now enqueues onto this same queue from its own
+        // `set_on_failure_signal` (it used to own a separate
+        // `ActorMessage::RecoveryHint` inbox), so both runtime modes
+        // re-enter through one transport.
         //
         // The per-connection drain filter
         // (`maybe_spawn_appui_master_continuation_runner`) takes
@@ -29443,11 +29445,12 @@ async fn run_standalone_turn(
         // (ChildCompleted) AND failure (recovery) re-entry through ONE
         // profile-resolving call into the master continuation queue. Runs
         // alongside the legacy `set_on_change` (success) and
-        // `set_on_failure_signal` (failure) wiring during the strangler
-        // migration — shared dedupe keys collapse the double delivery to one
-        // continuation. The threaded `terminal_profile_id` (mirrors
-        // `change_profile_id` / `failure_profile_id`) kills the `_main`
-        // failure-stranding by construction.
+        // `set_on_failure_signal` (failure, which still owns the deferred
+        // fail-before-ack re-emit) wiring — shared dedupe keys collapse the
+        // double delivery to one continuation. The threaded
+        // `terminal_profile_id` (mirrors `change_profile_id` /
+        // `failure_profile_id`) kills the `_main` failure-stranding by
+        // construction.
         let terminal_profile_id = active_profile_id
             .clone()
             .or_else(|| routed_profile_id.clone())
@@ -29456,10 +29459,6 @@ async fn run_standalone_turn(
             crate::autonomy::agent_orchestrator::route_terminal_event_to_continuation_queue(
                 event,
                 Some(terminal_profile_id.as_str()),
-                // WS / standalone-turn path: the queue IS the only failure
-                // channel here (the legacy `set_on_failure_signal` enqueues
-                // the SAME dedupe key), so route both outcomes.
-                crate::autonomy::agent_orchestrator::TerminalFailureRouting::Queue,
             );
         });
         if let Err(error) = task_supervisor.enable_persistence(task_state_path.clone()) {

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -155,17 +155,22 @@ const NATIVE_SPECIALIST_ARTIFACT_CONTENT_MAX_BYTES: usize = 256 * 1024;
 
 /// #1324 follow-up — kind label for the `External(_)` master continuation
 /// reason used to re-inject a `SpawnOnlyFailureSignal` as a synthetic
-/// recovery turn on the WS / standalone-turn path. The gateway path drives
-/// recovery through `ActorMessage::RecoveryHint` directly into the actor
-/// inbox; on the WS path the closest equivalent is the global master
-/// continuation queue (drained on the connection's tick).
+/// recovery turn.
+///
+/// #2020 (Gap-1 step 4): this is now the ONLY failure re-entry transport.
+/// Both runtime modes enqueue here — the WS / standalone-turn path (drained
+/// on the connection's tick and by the connection-independent global drain)
+/// and the gateway path (drained by
+/// `SessionActor::drain_master_continuations`). The gateway's former
+/// `ActorMessage::RecoveryHint` inbox — a SECOND, parallel re-entry channel
+/// — is retired.
 pub(crate) const SPAWN_ONLY_FAILURE_EXTERNAL_KIND: &str = "spawn_only_failure";
-const SPAWN_ONLY_FAILURE_META_TASK_ID: &str = "task_id";
-const SPAWN_ONLY_FAILURE_META_TOOL_NAME: &str = "tool_name";
+pub(crate) const SPAWN_ONLY_FAILURE_META_TASK_ID: &str = "task_id";
+pub(crate) const SPAWN_ONLY_FAILURE_META_TOOL_NAME: &str = "tool_name";
 const SPAWN_ONLY_FAILURE_META_ERROR_MESSAGE: &str = "error_message";
 const SPAWN_ONLY_FAILURE_META_TOOL_INPUT: &str = "tool_input";
 const SPAWN_ONLY_FAILURE_META_ALTERNATIVES: &str = "suggested_alternatives";
-const SPAWN_ONLY_FAILURE_META_ORIGINATING_CMID: &str = "originating_client_message_id";
+pub(crate) const SPAWN_ONLY_FAILURE_META_ORIGINATING_CMID: &str = "originating_client_message_id";
 /// Synthetic "group" id stamped onto spawn_only failure continuations so
 /// the `External` enqueue path passes the scheduler's required field.
 /// Distinct from `coding-autonomy` (loops/goals) so operators can filter
@@ -922,31 +927,6 @@ pub(crate) fn upsert_background_task_agent(
     Some((session_id, agent))
 }
 
-/// Gap-1 unification: how a runtime mode wants the unified terminal sink to
-/// route the FAILURE outcome.
-///
-/// Success always routes through the queue (`ChildCompleted`); the question
-/// is only whether the failure outcome also enqueues a recovery
-/// continuation HERE, or stays on the mode's legacy failure delivery during
-/// the strangler migration.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum TerminalFailureRouting {
-    /// Route the failure outcome through the queue
-    /// (`External("spawn_only_failure")`). Used by the WS / standalone-turn
-    /// path, whose only failure channel IS the queue (the legacy
-    /// `set_on_failure_signal` enqueues the SAME dedupe key, so the two
-    /// collapse to one continuation).
-    Queue,
-    /// Skip the failure outcome — the mode still drives failure recovery
-    /// through its OWN channel (the gateway `ActorMessage::RecoveryHint`
-    /// inbox, which carries the consecutive-recovery cap + per-task claim +
-    /// exhaustion banner the queue drain does not yet replicate). Routing
-    /// failure here too would DOUBLE-deliver across the two distinct
-    /// channels (no shared dedupe key between the inbox and the queue).
-    /// Retiring `RecoveryHint` (Gap-1 step 4) flips this to `Queue`.
-    LegacyChannel,
-}
-
 /// Gap-1 unification: the SINGLE sink that routes terminal background
 /// transitions through the master continuation queue. Wired via
 /// `TaskSupervisor::set_on_terminal` in every runtime mode (gateway, WS,
@@ -959,8 +939,7 @@ pub(crate) enum TerminalFailureRouting {
 ///   exactly the success path the legacy `on_change` callback already
 ///   drives — the explicit `child/...` dedupe key (step 3) keeps the
 ///   strangler double-delivery collapsed to one continuation.
-/// - **Failure** (`TerminalOutcome::Failed`) → when `failure_routing` is
-///   [`TerminalFailureRouting::Queue`], enqueue an
+/// - **Failure** (`TerminalOutcome::Failed`) → enqueue an
 ///   `External("spawn_only_failure")` recovery continuation under the SAME
 ///   profile-resolving rule (killing `_main` stranding for failures by
 ///   construction). The synth-ack gate moves to PROMPT SELECTION here: a
@@ -968,12 +947,16 @@ pub(crate) enum TerminalFailureRouting {
 ///   short-circuit) is SUPPRESSED — matching the documented skip cases —
 ///   while the recovery body is rendered only when the LLM was previously
 ///   told the work started. The failure dedupe key
-///   (`external/<kind>/<session>/<task_id>`) is shared with the legacy WS
-///   `enqueue_spawn_only_failure_continuation`, so double-delivery on the WS
-///   path collapses to one continuation. The gateway passes
-///   [`TerminalFailureRouting::LegacyChannel`] so its `RecoveryHint` inbox
-///   (which owns the runaway-recovery caps) remains the single failure
-///   channel until step 4 retires it.
+///   (`external/<kind>/<session>/<task_id>`) is shared with
+///   [`InProcessAgentOrchestrator::enqueue_spawn_only_failure_continuation`],
+///   which the deferred synth-ack stash still fires through `on_failure`, so
+///   the two producers collapse to one continuation.
+///
+/// #2020 (Gap-1 step 4): failure now routes here for EVERY runtime mode.
+/// The gateway used to opt out (its `ActorMessage::RecoveryHint` inbox was a
+/// second, parallel re-entry channel that owned the recovery caps); that
+/// inbox is retired and the caps moved onto the queue drain, so there is one
+/// re-entry path for both outcomes.
 ///
 /// `runtime_profile_id` is the turn's resolved profile (mirrors the
 /// `active_profile_id.or(routed_profile_id)` resolution the call sites use);
@@ -982,7 +965,6 @@ pub(crate) enum TerminalFailureRouting {
 pub(crate) fn route_terminal_event_to_continuation_queue(
     event: &octos_agent::TerminalEvent,
     runtime_profile_id: Option<&str>,
-    failure_routing: TerminalFailureRouting,
 ) {
     match &event.outcome {
         octos_agent::TerminalOutcome::Completed => {
@@ -990,13 +972,6 @@ pub(crate) fn route_terminal_event_to_continuation_queue(
             // transition enqueues the autonomous ChildCompleted re-entry
             // under the resolved profile.
             let _ = upsert_background_task_agent(&event.task, runtime_profile_id);
-        }
-        octos_agent::TerminalOutcome::Failed(_)
-            if failure_routing == TerminalFailureRouting::LegacyChannel =>
-        {
-            // The mode drives failure recovery through its own channel
-            // (gateway RecoveryHint inbox). Routing it here too would
-            // double-deliver across two channels with no shared dedupe key.
         }
         octos_agent::TerminalOutcome::Failed(signal) => {
             // Synth-ack-as-prompt-selection: only the ack-emitted failures
@@ -3356,19 +3331,25 @@ impl InProcessAgentOrchestrator {
     /// PR #1324 follow-up — enqueue a synthetic recovery continuation for a
     /// failed `spawn_only` task.
     ///
-    /// The gateway path drives recovery through
-    /// [`ActorMessage::RecoveryHint`] directly into the session actor's
-    /// inbox (see `session_actor.rs::SessionActor::spawn` for the wiring).
-    /// The WS / `run_standalone_turn` path has no equivalent inbox: the
-    /// per-turn registry's `TaskSupervisor` outlives the turn (background
-    /// tokio::spawn tasks may fail AFTER the turn terminates), and the
-    /// WS connection itself may have closed before the failure surfaces.
-    /// The closest survivor is the in-process master continuation queue
-    /// (drained on every `appui_continuation_tick`), so we enqueue an
-    /// `External("spawn_only_failure")` request carrying the recovery
-    /// fields in metadata. `master_continuation_prompt` recognises the
-    /// kind and renders the same `[system-internal] Your previous ...`
-    /// body that `build_recovery_prompt` produces on the gateway path.
+    /// The per-turn registry's `TaskSupervisor` outlives the turn (background
+    /// tokio::spawn tasks may fail AFTER the turn terminates), and on the WS
+    /// path the connection itself may have closed before the failure
+    /// surfaces. The survivor in every runtime mode is the in-process master
+    /// continuation queue, so we enqueue an
+    /// `External("spawn_only_failure")` request carrying the recovery fields
+    /// in metadata. `master_continuation_prompt` recognises the kind and
+    /// renders the `[system-internal] Your previous ...` body via the shared
+    /// [`crate::session_actor::build_recovery_prompt_body`] formatter.
+    ///
+    /// #2020: BOTH runtime modes now call this. It is reached two ways —
+    /// directly from `on_failure` (which is what re-delivers a
+    /// *fail-before-ack* failure once the deferred synth-ack stash drains,
+    /// the case the unified `on_terminal` sink prompt-suppresses because the
+    /// ack had not been recorded when its event was built), and from
+    /// [`route_terminal_event_to_continuation_queue`] for an already-acked
+    /// failure. Both carry the SAME dedupe key, so the pair collapses to one
+    /// continuation; the scheduler's recently-claimed guard closes the drain
+    /// race between them.
     ///
     /// The dedupe key is keyed on `task_id` so repeated `mark_failed`
     /// calls (live + cascade-fail, idempotent re-marks) collapse onto a
@@ -12074,53 +12055,85 @@ pub(crate) fn render_fleet_keeper_prompt(continuation: &QueuedMasterContinuation
 }
 
 /// PR #1324 follow-up — render the spawn_only post-spawn failure recovery
-/// prompt from a queued continuation's metadata. Mirrors the
-/// `build_recovery_prompt` helper in `session_actor.rs` that the gateway
-/// path uses on the `ActorMessage::RecoveryHint` inbox, so the LLM sees
-/// the same `[system-internal] Your previous ...` body regardless of
-/// which path delivered the recovery turn.
+/// prompt from a queued continuation's metadata.
+///
+/// #2020: delegates to [`crate::session_actor::build_recovery_prompt_body`],
+/// the single formatter for this body. It used to carry its own copy of the
+/// format string "mirroring" `build_recovery_prompt` on the retired
+/// `RecoveryHint` inbox — two renderers that had to be kept in sync by hand.
+/// With the inbox gone there is one delivery path, so there is one renderer.
 fn render_spawn_only_failure_recovery_prompt(continuation: &QueuedMasterContinuation) -> String {
-    let tool_name = continuation
-        .metadata
-        .get(SPAWN_ONLY_FAILURE_META_TOOL_NAME)
-        .map(String::as_str)
-        .unwrap_or("unknown");
-    let error_message = continuation
-        .metadata
-        .get(SPAWN_ONLY_FAILURE_META_ERROR_MESSAGE)
-        .map(String::as_str)
-        .unwrap_or("");
-    let input_block = continuation
-        .metadata
-        .get(SPAWN_ONLY_FAILURE_META_TOOL_INPUT)
-        .map(|input| format!("\nOriginal input: {input}"))
-        .unwrap_or_default();
-    let alternatives_block = continuation
+    let alternatives = continuation
         .metadata
         .get(SPAWN_ONLY_FAILURE_META_ALTERNATIVES)
         .map(|joined| {
-            let list = joined
+            joined
                 .split('\u{001f}')
                 .filter(|alt| !alt.is_empty())
-                .map(|alt| format!("- {alt}"))
                 .collect::<Vec<_>>()
-                .join("\n");
-            if list.is_empty() {
-                String::new()
-            } else {
-                format!("\nDetected alternatives:\n{list}\n")
-            }
         })
         .unwrap_or_default();
-    format!(
-        "[system-internal] Your previous `{tool}` call failed.\n\
-         Error: {err}{input}{alts}\n\
-         Respond to the user with a path forward — offer the alternatives, or try the safest one yourself if appropriate. Do not just report failure.",
-        tool = tool_name,
-        err = error_message,
-        input = input_block,
-        alts = alternatives_block,
+    crate::session_actor::build_recovery_prompt_body(
+        continuation
+            .metadata
+            .get(SPAWN_ONLY_FAILURE_META_TOOL_NAME)
+            .map(String::as_str)
+            .unwrap_or("unknown"),
+        continuation
+            .metadata
+            .get(SPAWN_ONLY_FAILURE_META_ERROR_MESSAGE)
+            .map(String::as_str)
+            .unwrap_or(""),
+        continuation
+            .metadata
+            .get(SPAWN_ONLY_FAILURE_META_TOOL_INPUT)
+            .map(String::as_str),
+        &alternatives,
     )
+}
+
+/// #2020 — the recovery-policy fields a drain needs off a queued
+/// `External("spawn_only_failure")` continuation, so the metadata key names
+/// stay owned by this module.
+///
+/// Returns `None` for any other continuation reason, which is the drain's
+/// signal that the recovery gate (per-task claim + consecutive cap +
+/// exhaustion banner) does not apply to it.
+pub(crate) struct SpawnOnlyFailureRecoveryFields<'a> {
+    pub(crate) task_id: &'a str,
+    pub(crate) tool_name: &'a str,
+    pub(crate) originating_client_message_id: Option<&'a str>,
+}
+
+pub(crate) fn spawn_only_failure_recovery_fields(
+    continuation: &QueuedMasterContinuation,
+) -> Option<SpawnOnlyFailureRecoveryFields<'_>> {
+    match &continuation.reason {
+        MasterContinuationReason::External(kind) if kind == SPAWN_ONLY_FAILURE_EXTERNAL_KIND => {
+            Some(SpawnOnlyFailureRecoveryFields {
+                // A continuation with no `task_id` metadata (legacy persisted
+                // row) still gets a claim slot — keyed on the dedupe key,
+                // which is task-scoped by construction — so the cap and the
+                // claim can never be bypassed by a missing field.
+                task_id: continuation
+                    .metadata
+                    .get(SPAWN_ONLY_FAILURE_META_TASK_ID)
+                    .map(String::as_str)
+                    .unwrap_or_else(|| continuation.dedupe_key.as_str()),
+                tool_name: continuation
+                    .metadata
+                    .get(SPAWN_ONLY_FAILURE_META_TOOL_NAME)
+                    .map(String::as_str)
+                    .unwrap_or("unknown"),
+                originating_client_message_id: continuation
+                    .metadata
+                    .get(SPAWN_ONLY_FAILURE_META_ORIGINATING_CMID)
+                    .map(String::as_str)
+                    .filter(|cmid| !cmid.is_empty()),
+            })
+        }
+        _ => None,
+    }
 }
 
 fn master_continuation_reason_wire_name(reason: &MasterContinuationReason) -> String {
@@ -16698,15 +16711,21 @@ mod tests {
         );
     }
 
-    /// Gap-1 step 2/4 boundary: the gateway wires the unified sink with
-    /// `TerminalFailureRouting::LegacyChannel` so failure recovery stays on
-    /// the `RecoveryHint` inbox (which owns the runaway-recovery caps).
-    /// Routing failure through the queue here too would DOUBLE-deliver
-    /// across two channels with no shared dedupe key. This pins that a
-    /// failure event under `LegacyChannel` enqueues NOTHING, while the same
-    /// event under `Queue` (WS path) enqueues exactly one recovery.
+    /// Gap-1 step 4 (#2020): the unified sink routes the FAILURE outcome
+    /// through the queue for EVERY runtime mode. The gateway used to opt out
+    /// (`TerminalFailureRouting::LegacyChannel`) because its
+    /// `ActorMessage::RecoveryHint` inbox was a second, parallel re-entry
+    /// channel that owned the runaway-recovery caps; with the inbox retired
+    /// and the caps moved onto the queue drain, the opt-out is gone.
+    ///
+    /// This pins the post-flip contract: a gateway-shaped failure (no
+    /// threaded runtime profile — the profile resolves off the session key)
+    /// and a WS-shaped failure (explicit runtime profile) each enqueue
+    /// EXACTLY ONE recovery continuation, under the profile the turn ran as.
+    /// A regression to zero would silently drop failure recovery on the
+    /// gateway; a regression to two would double-deliver.
     #[test]
-    fn legacy_channel_failure_routing_does_not_double_enqueue() {
+    fn failure_routing_enqueues_exactly_one_recovery_for_every_runtime_mode() {
         let session_legacy = SessionKey::with_profile("tenant-legacy", "api", "fail-legacy");
         let session_queue = SessionKey::with_profile("tenant-queue", "api", "fail-queue");
         let now = Utc::now();
@@ -16759,30 +16778,32 @@ mod tests {
             }
         };
 
-        // Gateway: LegacyChannel — failure must NOT reach the queue.
+        // Gateway shape: no threaded runtime profile — the profile resolves
+        // off the (profile-bearing) session key inside the router. Pre-#2020
+        // this enqueued NOTHING, because failure stayed on the RecoveryHint
+        // inbox.
         route_terminal_event_to_continuation_queue(
             &make_event(&session_legacy, "task-legacy"),
-            Some("tenant-legacy"),
-            TerminalFailureRouting::LegacyChannel,
+            None,
         );
         assert_eq!(
             default_agent_orchestrator()
                 .pending_continuation_count_for_session_for_test(&session_legacy, "tenant-legacy"),
-            0,
-            "LegacyChannel failure routing must not enqueue (recovery stays on RecoveryHint)",
+            1,
+            "gateway failure routing must enqueue exactly one recovery continuation \
+             under the key-derived profile",
         );
 
-        // WS: Queue — same shaped failure enqueues exactly one recovery.
+        // WS shape: explicit runtime profile — same single enqueue.
         route_terminal_event_to_continuation_queue(
             &make_event(&session_queue, "task-queue"),
             Some("tenant-queue"),
-            TerminalFailureRouting::Queue,
         );
         assert_eq!(
             default_agent_orchestrator()
                 .pending_continuation_count_for_session_for_test(&session_queue, "tenant-queue"),
             1,
-            "Queue failure routing must enqueue exactly one recovery continuation",
+            "WS failure routing must enqueue exactly one recovery continuation",
         );
     }
 
@@ -17299,11 +17320,7 @@ mod tests {
         // 3. Unified `on_terminal` WS enqueue (route_terminal_event...Queue) —
         //    same transition, microseconds later. Must be collapsed by the
         //    recently-claimed guard, NOT produce a second recovery.
-        route_terminal_event_to_continuation_queue(
-            &event,
-            Some(profile),
-            TerminalFailureRouting::Queue,
-        );
+        route_terminal_event_to_continuation_queue(&event, Some(profile));
         assert_eq!(
             orchestrator.pending_continuation_count_for_session_for_test(&session_id, profile),
             0,
@@ -17377,11 +17394,7 @@ mod tests {
 
         // 1. Unified `notify_terminal` fires first on the failed transition but
         //    PROMPT-SUPPRESSES (ack never emitted at fire time) → enqueues nothing.
-        route_terminal_event_to_continuation_queue(
-            &unified_event,
-            Some(profile),
-            TerminalFailureRouting::Queue,
-        );
+        route_terminal_event_to_continuation_queue(&unified_event, Some(profile));
         assert_eq!(
             orchestrator.pending_continuation_count_for_session_for_test(&session_id, profile),
             0,

--- a/crates/octos-cli/src/autonomy/master_continuation_scheduler.rs
+++ b/crates/octos-cli/src/autonomy/master_continuation_scheduler.rs
@@ -7,13 +7,20 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, BinaryHeap, HashMap};
 use std::time::{Duration, SystemTime};
 
-/// codex DO-NOT-SHIP TOCTOU window: the WS spawn_only-failure recovery fires
-/// the legacy `on_failure` enqueue and the unified `on_terminal` enqueue
-/// SEQUENTIALLY inside one `mark_failed` (microseconds apart). Both carry the
-/// identical `external/spawn_only_failure/<session>/<task>` dedupe key. If the
-/// AppUI continuation tick drains the first enqueue before the second runs,
-/// the key has already left `pending_by_key` so the existing dedupe misses and
-/// one terminal transition would produce TWO recovery turns.
+/// codex DO-NOT-SHIP TOCTOU window: spawn_only-failure recovery fires the
+/// `on_failure` enqueue and the unified `on_terminal` enqueue SEQUENTIALLY
+/// inside one `mark_failed` (microseconds apart). Both carry the identical
+/// `external/spawn_only_failure/<session>/<task>` dedupe key. If the
+/// continuation tick drains the first enqueue before the second runs, the key
+/// has already left `pending_by_key` so the existing dedupe misses and one
+/// terminal transition would produce TWO recovery turns.
+///
+/// #2020 widened the blast radius rather than closing it: retiring the
+/// gateway's `ActorMessage::RecoveryHint` inbox put the GATEWAY on this same
+/// two-producer queue, so this guard is now load-bearing for both runtime
+/// modes, not just the WS path it was written for. `on_failure` cannot simply
+/// be deleted in favour of `on_terminal` alone — it is the ONLY delivery for a
+/// fail-before-ack failure, which `on_terminal` prompt-suppresses.
 ///
 /// The recently-claimed guard records the moment an `External` continuation is
 /// claimed (drained/popped) and rejects a re-enqueue of the SAME key inside
@@ -1192,15 +1199,20 @@ mod tests {
         assert!(scheduler.is_empty());
     }
 
-    /// codex DO-NOT-SHIP TOCTOU: the WS spawn_only-failure recovery fires
-    /// the legacy `on_failure` enqueue and the unified `on_terminal` enqueue
+    /// codex DO-NOT-SHIP TOCTOU: spawn_only-failure recovery fires the
+    /// `on_failure` enqueue and the unified `on_terminal` enqueue
     /// SEQUENTIALLY (not atomically) inside one `mark_failed`. Both use the
     /// IDENTICAL `external/spawn_only_failure/<session>/<task>` dedupe key.
-    /// If the AppUI continuation tick DRAINS the first enqueue before the
+    /// If the continuation tick DRAINS the first enqueue before the
     /// second one runs, the pending-map dedupe misses (the key already left
     /// `pending_by_key`) and ONE terminal transition produces TWO recovery
     /// turns. The recently-claimed guard rejects the re-enqueue of a key that
     /// was claimed moments ago within the same transition window.
+    ///
+    /// #2020 note: this property is unchanged by retiring the gateway's
+    /// `RecoveryHint` inbox — that migration puts the gateway on this SAME
+    /// two-producer queue, so the interleaving pinned below now describes
+    /// both runtime modes.
     #[test]
     fn recent_claim_guard_collapses_drain_between_two_spawn_only_failure_enqueues() {
         let mut scheduler = MasterContinuationScheduler::new();

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -196,6 +196,11 @@ const DEFAULT_CONTEXT_COMPACT_KEEP_ITEMS: usize = 16;
 /// distinct task failures (LLM retries the same broken approach with new
 /// tool_call_ids and they all fail). Reset to 0 on a user-initiated turn.
 ///
+/// #2020: both caps are applied by
+/// [`SessionActor::admit_spawn_only_failure_recovery`] on the continuation
+/// queue drain — the single re-entry path — rather than by the retired
+/// `ActorMessage::RecoveryHint` handler.
+///
 /// Default 2 = the LLM gets up to two corrective rounds before the actor
 /// gives up and emits a final UI banner ("Background failure could not be
 /// recovered after N attempts"). Higher values risk runaway loops on
@@ -1000,7 +1005,31 @@ fn inbound_bool_metadata(inbound: &InboundMessage, key: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// #2020 — a drained `External("spawn_only_failure")` continuation is
+/// stamped `_recovery_turn` by
+/// [`SessionActor::synthetic_master_continuation_inbound`].
+fn inbound_is_recovery_turn(inbound: &InboundMessage) -> bool {
+    inbound_bool_metadata(inbound, "_recovery_turn")
+}
+
+/// Inbounds the runtime synthesised for itself, whose prompt is a directive
+/// rather than a turn the user took — so no durable user row and no session
+/// summary derived from it.
+///
+/// #2020 — a spawn_only-failure RECOVERY continuation is deliberately
+/// excluded. Unlike a goal/loop/child continuation it is not a bare
+/// directive: the recovery prompt is the only record of WHY the assistant
+/// suddenly re-engaged, and the M8.9 "Design A" constraint requires the model
+/// to see it on its next turn. The retired `ActorMessage::RecoveryHint`
+/// inbound carried no `_master_continuation` marker and so persisted by
+/// default; without this exclusion, moving recovery onto the continuation
+/// queue would have silently stopped persisting it — the turn would still
+/// run, but the transcript would show an assistant reply with no visible
+/// cause and the next turn would lose the failure context entirely.
 fn runtime_internal_inbound(inbound: &InboundMessage) -> bool {
+    if inbound_is_recovery_turn(inbound) {
+        return false;
+    }
     inbound_is_master_continuation(inbound) || inbound_is_approval_continuation(inbound)
 }
 
@@ -2130,35 +2159,45 @@ async fn dispatch_background_result_to_actor(
     }
 }
 
-/// Build the synthetic `[system-internal]` recovery prompt that the
-/// session actor enqueues when a `spawn_only` task transitions to
-/// `Failed` (M8.9). The prompt frames the failure for the LLM and asks
-/// it to offer a path forward — alternatives parsed from the error, or
-/// a safer fallback the model can attempt itself.
-pub(crate) fn build_recovery_prompt(signal: &octos_agent::SpawnOnlyFailureSignal) -> String {
-    let alternatives_block = if signal.suggested_alternatives.is_empty() {
+/// Build the synthetic `[system-internal]` recovery prompt body for a
+/// `spawn_only` task that transitioned to `Failed` (M8.9). The prompt
+/// frames the failure for the LLM and asks it to offer a path forward —
+/// alternatives parsed from the error, or a safer fallback the model can
+/// attempt itself.
+///
+/// #2020: the SINGLE formatter for this body. There used to be two — this
+/// one, fed a live `SpawnOnlyFailureSignal` on the `ActorMessage::
+/// RecoveryHint` inbox, and a hand-synchronised copy of the same format
+/// string in `agent_orchestrator::render_spawn_only_failure_recovery_prompt`
+/// fed a queued continuation's metadata. The duplicate existed only because
+/// the two re-entry paths rendered independently. With the inbox retired
+/// there is one delivery path, so the signal is flattened into metadata by
+/// `enqueue_spawn_only_failure_continuation` and rendered here, once.
+pub(crate) fn build_recovery_prompt_body(
+    tool_name: &str,
+    error_message: &str,
+    tool_input_json: Option<&str>,
+    suggested_alternatives: &[&str],
+) -> String {
+    let alternatives_block = if suggested_alternatives.is_empty() {
         String::new()
     } else {
-        let list = signal
-            .suggested_alternatives
+        let list = suggested_alternatives
             .iter()
             .map(|alt| format!("- {alt}"))
             .collect::<Vec<_>>()
             .join("\n");
         format!("\nDetected alternatives:\n{list}\n")
     };
-    let input_block = if signal.tool_input.is_null() {
-        String::new()
-    } else {
-        let pretty = serde_json::to_string(&signal.tool_input).unwrap_or_else(|_| "{}".into());
-        format!("\nOriginal input: {pretty}")
-    };
+    let input_block = tool_input_json
+        .map(|input| format!("\nOriginal input: {input}"))
+        .unwrap_or_default();
     format!(
         "[system-internal] Your previous `{tool}` call failed.\n\
          Error: {err}{input}{alts}\n\
          Respond to the user with a path forward — offer the alternatives, or try the safest one yourself if appropriate. Do not just report failure.",
-        tool = signal.tool_name,
-        err = signal.error_message,
+        tool = tool_name,
+        err = error_message,
         input = input_block,
         alts = alternatives_block,
     )
@@ -2443,25 +2482,6 @@ pub enum ActorMessage {
     /// A pending human-approval request reached its expiry deadline
     /// (Phase 4, docs/ROBRIX-PHASE4-APPROVAL-FLOW-ADR.md).
     ApprovalExpired { request_id: String },
-    /// Synthetic recovery turn enqueued by the spawn_only failure-signal
-    /// callback (M8.9). Drives the LLM to re-engage on a failed background
-    /// task with the actionable error and (optionally parsed) alternatives.
-    RecoveryHint {
-        /// Task ID that triggered the recovery (used for de-duplication).
-        task_id: String,
-        /// Tool that failed — surfaced verbatim in the synthetic prompt.
-        tool_name: String,
-        /// Best-effort prompt body. Already framed as `[system-internal]` so
-        /// the LLM treats it as runtime guidance, not a user turn.
-        prompt: String,
-        /// Issue #738 fix: the originating user turn's `client_message_id`,
-        /// captured when the spawn_only task was registered. Stamped onto
-        /// the synthetic recovery `InboundMessage`'s metadata so
-        /// `process_inbound` reuses it as the cmid for the recovery turn
-        /// instead of minting a fresh server UUIDv7. `None` for legacy
-        /// callers / tests that pre-date the fix.
-        originating_client_message_id: Option<String>,
-    },
     /// Cancel the current operation.
     Cancel,
 }
@@ -3328,21 +3348,49 @@ impl ActorFactory {
         // reorder both this gateway path and the WS `run_standalone_turn`
         // path to wire the callbacks first so every terminal path —
         // orphan-sweep, live `mark_failed`/`mark_completed`, cascade-fail —
-        // reaches the recovery inbox and the SSE/WS task-status consumers.
-        let recovery_tx = tx.clone();
+        // reaches the recovery queue and the SSE/WS task-status consumers.
+        //
+        // #2020 — this used to push `ActorMessage::RecoveryHint` onto the
+        // actor inbox: a SECOND re-entry channel running in parallel with the
+        // continuation queue. It now enqueues onto the queue, exactly like the
+        // WS path, so failure and success re-enter through one transport.
+        //
+        // The callback is still wired (rather than deleted in favour of the
+        // unified `on_terminal` sink alone) because `on_failure` is the ONLY
+        // delivery for a fail-BEFORE-ack failure: `notify_terminal` samples
+        // `synth_ack_emitted = false` at `mark_failed` time and the consumer
+        // prompt-suppresses it, while the supervisor's two-phase stash
+        // re-emits the deferred signal here once `mark_synth_ack_emitted`
+        // lands. Both producers share the `external/<kind>/<session>/<task>`
+        // dedupe key, so an acked failure (where both fire) still yields
+        // exactly one continuation.
+        let failure_session_key = session_key.clone();
+        let failure_profile_id = session_key
+            .profile_id()
+            .unwrap_or(MAIN_PROFILE_ID)
+            .to_owned();
         supervisor.set_on_failure_signal(move |signal| {
-            let prompt = build_recovery_prompt(signal);
-            let _ = recovery_tx.try_send(ActorMessage::RecoveryHint {
-                task_id: signal.task_id.clone(),
-                tool_name: signal.tool_name.clone(),
-                prompt,
-                // Issue #738 fix: forward the originating user turn's
-                // cmid into the recovery hint so the synthetic
-                // InboundMessage stamps `client_message_id` into its
-                // metadata and `process_inbound` reuses it instead of
-                // minting an orphan UUIDv7.
-                originating_client_message_id: signal.originating_client_message_id.clone(),
-            });
+            let outcome = crate::autonomy::agent_orchestrator::default_agent_orchestrator()
+                .enqueue_spawn_only_failure_continuation(
+                    &failure_session_key,
+                    &failure_profile_id,
+                    signal,
+                );
+            if outcome.is_duplicate() {
+                debug!(
+                    session = %failure_session_key,
+                    task_id = %signal.task_id,
+                    tool = %signal.tool_name,
+                    "spawn_only failure recovery continuation suppressed (duplicate dedupe key)"
+                );
+            } else {
+                info!(
+                    session = %failure_session_key,
+                    task_id = %signal.task_id,
+                    tool = %signal.tool_name,
+                    "spawn_only failure recovery continuation queued (gateway path)"
+                );
+            }
         });
         // Wire supervisor on_change callback to push task status via SSE,
         // ALSO before `enable_persistence` (see the combined ordering note
@@ -3359,26 +3407,15 @@ impl ActorFactory {
         // `enable_persistence` (see the combined ordering note above). Routes
         // BOTH success (ChildCompleted) AND failure (recovery) re-entry
         // through ONE profile-resolving call into the master continuation
-        // queue. Runs alongside the legacy gateway wiring (the `on_change` →
-        // `upsert_background_task_agent` success path and the
-        // `set_on_failure_signal` → `RecoveryHint` failure path) during the
-        // strangler migration; shared dedupe keys collapse double delivery.
-        // Gateway session keys carry the profile (`profile:channel:chat`), so
-        // `None` lets the key-derived profile resolve inside the router —
-        // matching `forward_task_status_to_actor_inbox`'s `None` call.
+        // queue. Runs alongside the legacy `on_change` →
+        // `upsert_background_task_agent` success path; shared dedupe keys
+        // collapse double delivery. Gateway session keys carry the profile
+        // (`profile:channel:chat`), so `None` lets the key-derived profile
+        // resolve inside the router — matching
+        // `forward_task_status_to_actor_inbox`'s `None` call.
         supervisor.set_on_terminal(move |event| {
             crate::autonomy::agent_orchestrator::route_terminal_event_to_continuation_queue(
-                event,
-                None,
-                // Gateway: failure recovery stays on the `RecoveryHint` inbox
-                // (which owns the consecutive-recovery cap + per-task claim +
-                // exhaustion banner). Routing failure through the queue too
-                // would double-deliver across two distinct channels. Only the
-                // SUCCESS outcome routes through the queue here (and it
-                // collapses against the legacy on_change ChildCompleted via
-                // the step-3 dedupe key). Step 4 retires RecoveryHint and
-                // flips this to `Queue`.
-                crate::autonomy::agent_orchestrator::TerminalFailureRouting::LegacyChannel,
+                event, None,
             );
         });
         if let Err(error) = supervisor.enable_persistence(&task_state_path) {
@@ -4486,8 +4523,9 @@ struct SessionActor {
     /// Counter of CONSECUTIVE recovery turns the actor has dispatched in
     /// response to spawn_only post-spawn failures (PR
     /// feat/spawn-only-failure-feedback-loop). Reset to 0 on a
-    /// user-initiated turn; incremented every time a `RecoveryHint` drives
-    /// an inbound. When the counter reaches
+    /// user-initiated turn; incremented every time a drained
+    /// `External("spawn_only_failure")` continuation drives an inbound (see
+    /// [`Self::admit_spawn_only_failure_recovery`]). When the counter reaches
     /// [`MAX_CONSECUTIVE_RECOVERY_TURNS`] the actor emits a final UI
     /// banner instead of dispatching another recovery so the loop cannot
     /// run away on pathological LLM retries with new tool_call_ids.
@@ -4737,6 +4775,76 @@ impl SessionActor {
         true
     }
 
+    /// #2020 — the runaway-recovery gate, applied to a drained continuation
+    /// before it is dispatched as a turn.
+    ///
+    /// This is the policy the retired `ActorMessage::RecoveryHint` handler
+    /// owned, moved onto the queue drain so it guards the SINGLE re-entry
+    /// path instead of one of two. Returns `true` when the continuation may
+    /// proceed. Non-recovery continuations (goal, loop, child, peer …) are
+    /// always admitted — the gate is scoped to
+    /// `External("spawn_only_failure")`.
+    ///
+    /// Three rejections, all preserved verbatim from the inbox handler:
+    ///
+    /// 1. **Per-task claim** — one recovery per task id, so a recovery turn
+    ///    that itself fails cannot ignite a runaway loop. The queue's
+    ///    task-scoped dedupe key collapses repeated `mark_failed` calls while
+    ///    a continuation is still pending, but says nothing once it has been
+    ///    drained; this claim is what survives the drain.
+    /// 2. **Consecutive-recovery cap** — bounds the chain of DISTINCT failing
+    ///    tasks (the LLM retrying its broken approach under new
+    ///    tool_call_ids), which no per-task key can catch. Reset on a
+    ///    user-initiated turn by `process_inbound`.
+    /// 3. **Exhaustion banner** — when the cap trips the user is TOLD. A
+    ///    silent stop is indistinguishable from the task having succeeded.
+    async fn admit_spawn_only_failure_recovery(
+        &mut self,
+        continuation: &QueuedMasterContinuation,
+    ) -> bool {
+        let Some(fields) =
+            crate::autonomy::agent_orchestrator::spawn_only_failure_recovery_fields(continuation)
+        else {
+            return true;
+        };
+        let task_id = fields.task_id.to_owned();
+        let tool_name = fields.tool_name.to_owned();
+        if !self.claim_recovery_slot(&task_id) {
+            debug!(
+                session = %self.session_key,
+                task_id,
+                tool_name,
+                "skipping duplicate spawn_only failure recovery continuation"
+            );
+            return false;
+        }
+        if !self.try_begin_recovery_turn() {
+            let max = self.max_consecutive_recovery_turns();
+            warn!(
+                session = %self.session_key,
+                task_id,
+                tool_name,
+                max,
+                "consecutive recovery cap exceeded — emitting final banner instead of dispatching another LLM turn"
+            );
+            let banner = format!(
+                "Background failure could not be recovered after {max} attempts. The last failure was on `{tool_name}`. Please review the error and try a different approach.",
+            );
+            self.deliver_background_notification(banner, Vec::new(), None)
+                .await;
+            return false;
+        }
+        debug!(
+            session = %self.session_key,
+            task_id,
+            tool_name,
+            originating_client_message_id =
+                fields.originating_client_message_id.unwrap_or("<none>"),
+            "dispatching synthetic recovery turn from the continuation queue"
+        );
+        true
+    }
+
     /// Reset the consecutive-recovery counter to 0. Called when a
     /// user-initiated inbound is about to be processed — once the user
     /// re-engages we no longer count the prior chain as "consecutive".
@@ -4835,47 +4943,7 @@ impl SessionActor {
         frame.messages
     }
 
-    /// Build a synthetic `InboundMessage` carrying the recovery prompt so
-    /// the existing inbound pipeline (history persistence, agent loop)
-    /// runs unchanged.
-    ///
-    /// Issue #738 fix: when `originating_client_message_id` is supplied,
-    /// stamp it into `metadata.client_message_id` so `process_inbound`'s
-    /// `inbound_client_message_id` helper reads it back and the recovery
-    /// turn inherits the originating user turn's thread_id instead of
-    /// `process_inbound` minting a fresh server UUIDv7. The eventual
-    /// successful retry's deliverables (e.g. `_report.md`) then land
-    /// under the original SPA bubble rather than an orphan thread_id.
-    fn synthetic_recovery_inbound(
-        &self,
-        prompt: String,
-        originating_client_message_id: Option<String>,
-    ) -> InboundMessage {
-        let mut metadata = serde_json::Map::new();
-        metadata.insert("_recovery_turn".to_string(), serde_json::json!(true));
-        if let Some(cmid) = originating_client_message_id {
-            if !cmid.is_empty() {
-                metadata.insert(
-                    "client_message_id".to_string(),
-                    serde_json::Value::String(cmid),
-                );
-            }
-        }
-        InboundMessage {
-            channel: self.channel.clone(),
-            sender_id: "octos-runtime".to_string(),
-            chat_id: self.chat_id.clone(),
-            content: prompt,
-            timestamp: chrono::Utc::now(),
-            media: vec![],
-            metadata: serde_json::Value::Object(metadata),
-            message_id: None,
-            origin: octos_core::MessageOrigin::Synthetic,
-        }
-    }
-
-    /// Synthetic `InboundMessage` for the completion-review turn — the
-    /// success-path sibling of [`Self::synthetic_recovery_inbound`]. Stamped
+    /// Synthetic `InboundMessage` for the completion-review turn. Stamped
     /// `_completion_review` so `process_inbound` does NOT reset the
     /// consecutive-auto-turn cap (the review is server-driven, not user
     /// re-engagement); the optional originating id threads the review under
@@ -4922,6 +4990,33 @@ impl SessionActor {
             "continuation_reason".to_string(),
             serde_json::json!(master_continuation_reason_name(&continuation.reason)),
         );
+        // #2020 — a spawn_only failure recovery continuation IS the recovery
+        // turn that `ActorMessage::RecoveryHint` used to build, so it must
+        // carry the same two markers the retired inbox stamped:
+        //
+        //  * `_recovery_turn` — load-bearing in TWO places. It tells
+        //    `process_inbound` not to reset the consecutive-recovery counter
+        //    (which `_master_continuation` would also do), and it tells
+        //    `runtime_internal_inbound` this prompt IS durable user history —
+        //    which `_master_continuation` alone would suppress, silently
+        //    dropping the recovery prompt from the transcript.
+        //  * `client_message_id` (#738) — the originating user turn's cmid,
+        //    threaded through the continuation's metadata by
+        //    `enqueue_spawn_only_failure_continuation`. Without it
+        //    `process_inbound` mints a fresh server UUIDv7 and the eventual
+        //    successful retry's deliverables land under an orphan thread_id
+        //    with no DOM bubble in the SPA.
+        if let Some(fields) =
+            crate::autonomy::agent_orchestrator::spawn_only_failure_recovery_fields(continuation)
+        {
+            metadata.insert("_recovery_turn".to_string(), serde_json::json!(true));
+            if let Some(cmid) = fields.originating_client_message_id {
+                metadata.insert(
+                    "client_message_id".to_string(),
+                    serde_json::Value::String(cmid.to_owned()),
+                );
+            }
+        }
 
         InboundMessage {
             channel: self.channel.clone(),
@@ -4975,6 +5070,19 @@ impl SessionActor {
                 reason = master_continuation_reason_name(&continuation.reason),
                 "draining queued master continuation into session actor"
             );
+            // #2020 — runaway-recovery policy, applied on the ONE re-entry
+            // path. A rejected continuation is marked completed (not
+            // re-queued) so the queue does not redeliver it forever.
+            // Deliberately NO matching `mark_continuation_started`: no turn
+            // ran, so the ledger records a resolution with an explicit
+            // suppression reason rather than a phantom start.
+            if !self.admit_spawn_only_failure_recovery(&continuation).await {
+                default_agent_orchestrator().mark_continuation_completed(
+                    &continuation,
+                    Some("suppressed_by_recovery_policy".to_owned()),
+                );
+                continue;
+            }
             // #1131 — `GoalWrapUp` is the final goal turn under
             // budget exhaustion. Treat it as a goal turn for runtime
             // accounting so per-turn elapsed time is still recorded;
@@ -5768,7 +5876,7 @@ impl SessionActor {
                             // hit, since a missed review is harmless.
                             //
                             // SUCCESS ONLY (codex P2): a FAILED spawn_only task already
-                            // drives the dedicated RecoveryHint path AND emits a failure
+                            // drives the queued recovery continuation AND emits a failure
                             // BackgroundResult — reviewing that would (a) summarize a
                             // failure the recovery turn is already handling and (b) burn
                             // a shared recovery-cap slot a real recovery needs.
@@ -5831,77 +5939,6 @@ impl SessionActor {
                                     "_task_status": task_json
                                 }),
                             }).await;
-                        }
-                        Some(ActorMessage::RecoveryHint {
-                            task_id,
-                            tool_name,
-                            prompt,
-                            originating_client_message_id,
-                        }) => {
-                            idle_sleep.as_mut().reset(tokio::time::Instant::now() + self.idle_timeout);
-                            // Cap recovery at one attempt per task to avoid
-                            // runaway loops if the recovery turn itself
-                            // fails. Subsequent failures from the same task
-                            // ID are silently dropped here.
-                            if !self.claim_recovery_slot(&task_id) {
-                                debug!(
-                                    session = %self.session_key,
-                                    task_id,
-                                    tool_name,
-                                    "skipping duplicate recovery hint"
-                                );
-                                continue;
-                            }
-                            // Consecutive-recovery cap
-                            // (feat/spawn-only-failure-feedback-loop): a
-                            // distinct, second-or-later task failing AGAIN
-                            // (the LLM retried its broken approach with a
-                            // new tool_call_id) is still bounded by
-                            // MAX_CONSECUTIVE_RECOVERY_TURNS. Above the
-                            // cap, emit a final user-visible banner via
-                            // the same persisted-notification path the
-                            // background-result consumer uses, then bail
-                            // out instead of dispatching another LLM
-                            // turn. The counter resets on every user-
-                            // initiated turn (see `process_inbound`).
-                            if !self.try_begin_recovery_turn() {
-                                let max = self.max_consecutive_recovery_turns();
-                                warn!(
-                                    session = %self.session_key,
-                                    task_id,
-                                    tool_name,
-                                    max,
-                                    "consecutive recovery cap exceeded — emitting final banner instead of dispatching another LLM turn"
-                                );
-                                let banner = format!(
-                                    "Background failure could not be recovered after {max} attempts. The last failure was on `{tool_name}`. Please review the error and try a different approach.",
-                                );
-                                self.deliver_background_notification(banner, Vec::new(), None)
-                                    .await;
-                                continue;
-                            }
-                            debug!(
-                                session = %self.session_key,
-                                task_id,
-                                tool_name,
-                                originating_client_message_id =
-                                    originating_client_message_id.as_deref().unwrap_or("<none>"),
-                                "enqueueing synthetic recovery turn"
-                            );
-                            let synthetic = self.synthetic_recovery_inbound(
-                                prompt,
-                                originating_client_message_id,
-                            );
-                            let final_attachment_media = self
-                                .copy_media_to_workspace(Vec::new());
-                            self.process_inbound(
-                                synthetic,
-                                Vec::new(),
-                                final_attachment_media,
-                                None,
-                            )
-                            .await;
-                            let _ = self.drain_master_continuations().await;
                         }
                         Some(ActorMessage::Cancel) => {
                             idle_sleep.as_mut().reset(tokio::time::Instant::now() + self.idle_timeout);
@@ -6643,21 +6680,6 @@ impl SessionActor {
                         Ok(ActorMessage::TaskStatusChanged { .. }) => {
                             // Ignore in drain — status is pushed via the main loop
                         }
-                        Ok(ActorMessage::RecoveryHint {
-                            task_id, tool_name, ..
-                        }) => {
-                            // Drain context: a turn is already running. The
-                            // claim guarantees we won't try to recover this
-                            // task again later. Trace and drop — the LLM
-                            // will see the failure via TaskStatusChanged.
-                            debug!(
-                                session = %self.session_key,
-                                task_id,
-                                tool_name,
-                                "dropping recovery hint received during drain"
-                            );
-                            self.claim_recovery_slot(&task_id);
-                        }
                         Ok(ActorMessage::Cancel) => {
                             self.cancelled.store(true, Ordering::Release);
                             break;
@@ -6736,21 +6758,6 @@ impl SessionActor {
                         }
                         Ok(ActorMessage::TaskStatusChanged { .. }) => {
                             // Ignore in drain — status is pushed via the main loop
-                        }
-                        Ok(ActorMessage::RecoveryHint {
-                            task_id, tool_name, ..
-                        }) => {
-                            // Drain context: a turn is already running. The
-                            // claim guarantees we won't try to recover this
-                            // task again later. Trace and drop — the LLM
-                            // will see the failure via TaskStatusChanged.
-                            debug!(
-                                session = %self.session_key,
-                                task_id,
-                                tool_name,
-                                "dropping recovery hint received during drain"
-                            );
-                            self.claim_recovery_slot(&task_id);
                         }
                         Ok(ActorMessage::Cancel) => {
                             self.cancelled.store(true, Ordering::Release);
@@ -7786,20 +7793,6 @@ impl SessionActor {
                                     "_task_status": task_json
                                 }),
                             }).await;
-                        }
-                        Some(ActorMessage::RecoveryHint { task_id, tool_name, .. }) => {
-                            // Speculative-overflow context: the primary
-                            // turn is already running. Reserve the slot
-                            // (so we don't try again later) and drop the
-                            // hint — the failure will be visible via
-                            // TaskStatusChanged.
-                            debug!(
-                                session = %self.session_key,
-                                task_id,
-                                tool_name,
-                                "dropping recovery hint during speculative overflow"
-                            );
-                            self.claim_recovery_slot(&task_id);
                         }
                         Some(ActorMessage::Cancel) => {
                             self.cancelled.store(true, Ordering::Release);
@@ -9136,15 +9129,11 @@ impl SessionActor {
         // break the "recovery chain" — once the user re-engages we no
         // longer count the prior auto-recoveries against the cap. Master
         // continuations are server-driven and don't represent user
-        // re-engagement, so they're excluded too. The recovery hint
-        // path stamps `_recovery_turn = true` in metadata via
-        // `synthetic_recovery_inbound`; any inbound without that flag
-        // counts as user-initiated for this reset.
-        let is_recovery_turn = inbound
-            .metadata
-            .get("_recovery_turn")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
+        // re-engagement, so they're excluded too. The recovery path stamps
+        // `_recovery_turn = true` in metadata via
+        // `synthetic_master_continuation_inbound`; any inbound without that
+        // flag counts as user-initiated for this reset.
+        let is_recovery_turn = inbound_is_recovery_turn(&inbound);
         // A completion-review turn (event-driven background acknowledgment) is
         // server-driven too — it must NOT reset the consecutive-auto-turn cap,
         // otherwise a review that spawns more background work could review its

--- a/crates/octos-cli/src/session_actor_tests.rs
+++ b/crates/octos-cli/src/session_actor_tests.rs
@@ -6672,20 +6672,16 @@ async fn should_return_immediately_when_assistant_already_landed() {
     assert_eq!(snapshot.len(), 2);
 }
 
-// ── M8.9: Runtime failure recovery ─────────────────────────────────────
+// ── M8.9: Runtime failure recovery ─────────────────────────────────
 
 #[test]
 fn recovery_prompt_includes_tool_name_and_error() {
-    let signal = octos_agent::SpawnOnlyFailureSignal {
-        task_id: "task-1".into(),
-        tool_name: "fm_tts".into(),
-        tool_input: serde_json::json!({"voice": "yangmi"}),
-        error_message: "voice 'yangmi' not registered".into(),
-        suggested_alternatives: vec![],
-        parent_session_key: Some("api:test".into()),
-        originating_client_message_id: None,
-    };
-    let prompt = build_recovery_prompt(&signal);
+    let prompt = build_recovery_prompt_body(
+        "fm_tts",
+        "voice 'yangmi' not registered",
+        Some(r#"{"voice":"yangmi"}"#),
+        &[],
+    );
     assert!(prompt.starts_with("[system-internal]"));
     assert!(prompt.contains("fm_tts"));
     assert!(prompt.contains("voice 'yangmi' not registered"));
@@ -6694,16 +6690,12 @@ fn recovery_prompt_includes_tool_name_and_error() {
 
 #[test]
 fn recovery_prompt_includes_alternatives_block_when_present() {
-    let signal = octos_agent::SpawnOnlyFailureSignal {
-        task_id: "task-2".into(),
-        tool_name: "fm_tts".into(),
-        tool_input: serde_json::Value::Null,
-        error_message: "voice missing".into(),
-        suggested_alternatives: vec!["vivian".into(), "serena".into(), "longxiang".into()],
-        parent_session_key: None,
-        originating_client_message_id: None,
-    };
-    let prompt = build_recovery_prompt(&signal);
+    let prompt = build_recovery_prompt_body(
+        "fm_tts",
+        "voice missing",
+        None,
+        &["vivian", "serena", "longxiang"],
+    );
     assert!(prompt.contains("Detected alternatives"));
     assert!(prompt.contains("- vivian"));
     assert!(prompt.contains("- serena"));
@@ -6712,40 +6704,68 @@ fn recovery_prompt_includes_alternatives_block_when_present() {
 
 #[test]
 fn recovery_prompt_omits_alternatives_block_when_empty() {
-    let signal = octos_agent::SpawnOnlyFailureSignal {
-        task_id: "task-3".into(),
-        tool_name: "fm_tts".into(),
-        tool_input: serde_json::Value::Null,
-        error_message: "internal error".into(),
-        suggested_alternatives: vec![],
-        parent_session_key: None,
-        originating_client_message_id: None,
-    };
-    let prompt = build_recovery_prompt(&signal);
+    let prompt = build_recovery_prompt_body("fm_tts", "internal error", None, &[]);
     assert!(!prompt.contains("Detected alternatives"));
+    assert!(!prompt.contains("Original input"));
 }
 
 #[test]
 fn recovery_prompt_includes_tool_input_when_set() {
-    let signal = octos_agent::SpawnOnlyFailureSignal {
-        task_id: "task-4".into(),
-        tool_name: "fm_tts".into(),
-        tool_input: serde_json::json!({"voice": "yangmi", "text": "hello"}),
-        error_message: "voice missing".into(),
-        suggested_alternatives: vec![],
-        parent_session_key: None,
-        originating_client_message_id: None,
-    };
-    let prompt = build_recovery_prompt(&signal);
+    let prompt = build_recovery_prompt_body(
+        "fm_tts",
+        "voice missing",
+        Some(r#"{"text":"hello","voice":"yangmi"}"#),
+        &[],
+    );
     assert!(prompt.contains("Original input"));
     assert!(prompt.contains("yangmi"));
 }
 
+/// #2020 — enqueue a spawn_only failure recovery continuation onto the ONE
+/// re-entry path (the master continuation queue) for `session_key`, the way
+/// production does from `set_on_failure_signal` / the unified terminal sink.
+fn enqueue_recovery_continuation(
+    session_key: &SessionKey,
+    signal: &octos_agent::SpawnOnlyFailureSignal,
+) {
+    default_agent_orchestrator().enqueue_spawn_only_failure_continuation(
+        session_key,
+        session_key.profile_id().unwrap_or(MAIN_PROFILE_ID),
+        signal,
+    );
+}
+
+fn recovery_signal(
+    task_id: &str,
+    tool_name: &str,
+    error: &str,
+) -> octos_agent::SpawnOnlyFailureSignal {
+    octos_agent::SpawnOnlyFailureSignal {
+        task_id: task_id.into(),
+        tool_name: tool_name.into(),
+        tool_input: serde_json::json!({"voice": "yangmi"}),
+        error_message: error.into(),
+        suggested_alternatives: vec![],
+        parent_session_key: None,
+        originating_client_message_id: None,
+    }
+}
+
+/// A queued recovery continuation is drained on the actor's continuation
+/// tick (2s), so recovery-turn assertions need more headroom than an
+/// inbox-delivered message did.
+const RECOVERY_DRAIN_DEADLINE: Duration = Duration::from_secs(20);
+
 #[tokio::test]
 async fn should_enqueue_synthetic_recovery_turn_with_error_message() {
-    // End-to-end: a RecoveryHint pushed onto the inbox should drive a
-    // primary turn whose user/system content includes the recovery
-    // prompt, so the LLM (mock here) sees and responds to it.
+    // End-to-end: a queued spawn_only-failure continuation drives a primary
+    // turn whose user/system content includes the recovery prompt, so the
+    // LLM (mock here) sees and responds to it.
+    //
+    // #2020: this used to push `ActorMessage::RecoveryHint` onto the actor
+    // inbox — a second re-entry channel alongside the continuation queue.
+    // The inbox is retired; the queue is the single path, and the rendered
+    // body is unchanged (same `build_recovery_prompt_body` formatter).
     let dir = tempfile::TempDir::new().unwrap();
     let agent_llm = Arc::new(DelayedMockProvider::new(
         "agent",
@@ -6757,31 +6777,29 @@ async fn should_enqueue_synthetic_recovery_turn_with_error_message() {
     let (tx, mut rx, handle, _session_mgr) =
         setup_actor_with_mode(agent_llm.clone(), QueueMode::Followup, None, false, &dir).await;
 
-    let prompt = build_recovery_prompt(&octos_agent::SpawnOnlyFailureSignal {
-        task_id: "task-rh-1".into(),
-        tool_name: "fm_tts".into(),
-        tool_input: serde_json::json!({"voice": "yangmi"}),
-        error_message: "voice 'yangmi' not registered. available: vivian, serena.".into(),
-        suggested_alternatives: vec!["vivian".into(), "serena".into()],
-        parent_session_key: Some("cli:test".into()),
-        originating_client_message_id: None,
-    });
-    tx.send(ActorMessage::RecoveryHint {
-        task_id: "task-rh-1".into(),
-        tool_name: "fm_tts".into(),
-        prompt,
-        originating_client_message_id: None,
-    })
-    .await
-    .unwrap();
+    enqueue_recovery_continuation(
+        &test_session_key(dir.path()),
+        &octos_agent::SpawnOnlyFailureSignal {
+            task_id: "task-rh-1".into(),
+            tool_name: "fm_tts".into(),
+            tool_input: serde_json::json!({"voice": "yangmi"}),
+            error_message: "voice 'yangmi' not registered. available: vivian, serena.".into(),
+            suggested_alternatives: vec!["vivian".into(), "serena".into()],
+            parent_session_key: Some("cli:test".into()),
+            originating_client_message_id: None,
+        },
+    );
 
     let mut responses = Vec::new();
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let deadline = tokio::time::Instant::now() + RECOVERY_DRAIN_DEADLINE;
     while let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await {
         if !msg.content.is_empty() {
             responses.push(msg.content);
         }
-        if !responses.is_empty() {
+        if responses
+            .iter()
+            .any(|c| c.contains("acknowledging recovery"))
+        {
             break;
         }
     }
@@ -6904,9 +6922,12 @@ async fn background_result_does_not_auto_review_when_gate_disabled() {
 
 #[tokio::test]
 async fn should_not_enqueue_second_recovery_for_same_task_id() {
-    // Two RecoveryHints for the same task_id — only the first should
-    // produce a recovery turn. The second is silently dropped via the
-    // recovered_tasks claim slot.
+    // Two terminal failure reports for the SAME task must produce exactly
+    // ONE recovery turn. #2020 moved the per-task claim from the retired
+    // `RecoveryHint` handler onto the queue drain
+    // (`admit_spawn_only_failure_recovery`), so this pins the property
+    // end-to-end through the one re-entry path rather than through the
+    // inbox that used to own it.
     let dir = tempfile::TempDir::new().unwrap();
     let agent_llm = Arc::new(DelayedMockProvider::new(
         "agent",
@@ -6918,45 +6939,132 @@ async fn should_not_enqueue_second_recovery_for_same_task_id() {
     let (tx, mut rx, handle, _session_mgr) =
         setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
 
-    let prompt1 = "[system-internal] first recovery prompt".to_string();
-    let prompt2 = "[system-internal] second recovery prompt".to_string();
-    tx.send(ActorMessage::RecoveryHint {
-        task_id: "task-dup".into(),
-        tool_name: "fm_tts".into(),
-        prompt: prompt1,
-        originating_client_message_id: None,
-    })
-    .await
-    .unwrap();
-    tokio::time::sleep(Duration::from_millis(200)).await;
-    tx.send(ActorMessage::RecoveryHint {
-        task_id: "task-dup".into(),
-        tool_name: "fm_tts".into(),
-        prompt: prompt2,
-        originating_client_message_id: None,
-    })
-    .await
-    .unwrap();
+    let session_key = test_session_key(dir.path());
+    let signal = recovery_signal("task-dup", "fm_tts", "first failure report");
+    enqueue_recovery_continuation(&session_key, &signal);
+    // A second report of the same task — the queue's task-scoped dedupe key
+    // collapses it while the first is pending, and the actor's per-task
+    // claim collapses it after the first has been drained.
+    enqueue_recovery_continuation(&session_key, &signal);
 
     let mut responses = Vec::new();
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    let deadline = tokio::time::Instant::now() + RECOVERY_DRAIN_DEADLINE;
     while let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await {
         if !msg.content.is_empty() {
             responses.push(msg.content);
         }
+        if responses.iter().any(|c| c.contains("second recovery")) {
+            break;
+        }
     }
-    // Only the first recovery should have driven an LLM turn.
-    let first_seen = responses.iter().any(|c| c.contains("first recovery"));
-    let second_seen = responses.iter().any(|c| c.contains("second recovery"));
     assert!(
-        first_seen,
-        "first recovery should have run: {:?}",
-        responses
+        responses.iter().any(|c| c.contains("first recovery")),
+        "first recovery should have run: {responses:?}",
     );
     assert!(
-        !second_seen,
-        "second recovery should have been suppressed: {:?}",
+        !responses.iter().any(|c| c.contains("second recovery")),
+        "second recovery should have been suppressed: {responses:?}",
+    );
+
+    // Exactly one recovery prompt in durable history — the decisive check,
+    // since a suppressed turn must leave no transcript trace either.
+    let session_handle = SessionHandle::open(dir.path(), &test_session_key(dir.path()));
+    let session = session_handle.session();
+    let recovery_prompts = session
+        .messages
+        .iter()
+        .filter(|m| m.role == MessageRole::User && m.content.contains("[system-internal]"))
+        .count();
+    assert_eq!(
+        recovery_prompts, 1,
+        "one terminal transition must yield one recovery turn: {:?}",
+        session.messages
+    );
+
+    drop(tx);
+    let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+}
+
+/// #2020 RED-shaped guard for the highest-risk regression the migration
+/// could introduce: the consecutive-recovery cap must still BITE, and must
+/// still tell the user when it does.
+///
+/// The cap bounds a chain of DISTINCT failing tasks (the LLM retrying its
+/// broken approach under fresh tool_call_ids) — something no per-task dedupe
+/// key can catch, which is precisely why moving the policy had to move this
+/// with it. Above the cap the actor must emit the exhaustion banner instead
+/// of dispatching another LLM turn: stopping silently is indistinguishable
+/// from the task having succeeded.
+#[tokio::test]
+async fn consecutive_recovery_cap_trips_and_emits_banner_instead_of_a_turn() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let agent_llm = Arc::new(DelayedMockProvider::new(
+        "agent",
+        vec![
+            (Duration::from_millis(50), make_response("recovery-turn-1")),
+            (Duration::from_millis(50), make_response("recovery-turn-2")),
+            (Duration::from_millis(50), make_response("recovery-turn-3")),
+        ],
+    ));
+    let (tx, mut rx, handle, _session_mgr) =
+        setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
+
+    // MAX_CONSECUTIVE_RECOVERY_TURNS distinct tasks are admitted; the next
+    // one must trip the cap. Enqueued up-front — the drain takes one per
+    // tick, so they are processed in order.
+    let session_key = test_session_key(dir.path());
+    let over_cap = MAX_CONSECUTIVE_RECOVERY_TURNS + 1;
+    for index in 0..over_cap {
+        enqueue_recovery_continuation(
+            &session_key,
+            &recovery_signal(
+                &format!("task-cap-{index}"),
+                "mofa_slides",
+                "Gemini API: 429 quota exceeded",
+            ),
+        );
+    }
+
+    let mut responses = Vec::new();
+    let deadline = tokio::time::Instant::now() + RECOVERY_DRAIN_DEADLINE;
+    while let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await {
+        if !msg.content.is_empty() {
+            responses.push(msg.content);
+        }
+        if responses
+            .iter()
+            .any(|c| c.contains("could not be recovered after"))
+        {
+            break;
+        }
+    }
+
+    assert!(
         responses
+            .iter()
+            .any(|c| c.contains("could not be recovered after")),
+        "cap exhaustion must emit the user-visible banner, got: {responses:?}",
+    );
+    assert!(
+        responses
+            .iter()
+            .any(|c| c.contains("could not be recovered after") && c.contains("mofa_slides")),
+        "the banner must name the tool that last failed: {responses:?}",
+    );
+
+    // The cap BITES: only MAX_CONSECUTIVE_RECOVERY_TURNS recovery prompts
+    // reach the transcript, no matter how many failures were queued.
+    let session_handle = SessionHandle::open(dir.path(), &test_session_key(dir.path()));
+    let session = session_handle.session();
+    let recovery_prompts = session
+        .messages
+        .iter()
+        .filter(|m| m.role == MessageRole::User && m.content.contains("[system-internal]"))
+        .count();
+    assert_eq!(
+        recovery_prompts as u32, MAX_CONSECUTIVE_RECOVERY_TURNS,
+        "recovery turns must be bounded by the cap: {:?}",
+        session.messages
     );
 
     drop(tx);
@@ -6964,12 +7072,10 @@ async fn should_not_enqueue_second_recovery_for_same_task_id() {
 }
 
 #[tokio::test]
-async fn supervisor_failure_signal_generates_recovery_actor_message_end_to_end() {
-    // Full integration: install the failure-signal callback we set up
-    // in spawn(), trigger mark_failed, and assert the actor enqueues
-    // and processes a RecoveryHint.
-    use octos_agent::TaskSupervisor;
-
+async fn supervisor_failure_signal_generates_recovery_continuation_end_to_end() {
+    // Full integration: install the failure-signal callback the gateway
+    // wires in `spawn()`, trigger mark_failed, and assert the actor drains
+    // the resulting continuation and runs the recovery turn.
     let dir = tempfile::TempDir::new().unwrap();
     let agent_llm = Arc::new(DelayedMockProvider::new(
         "agent",
@@ -6978,23 +7084,12 @@ async fn supervisor_failure_signal_generates_recovery_actor_message_end_to_end()
     let (tx, mut rx, handle, _session_mgr) =
         setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
 
-    // Mirror the spawn() wiring: a TaskSupervisor whose failure signal
-    // dispatches a RecoveryHint into the actor inbox.
-    let supervisor = TaskSupervisor::new();
-    let recovery_tx = tx.clone();
-    supervisor.set_on_failure_signal(move |signal| {
-        let prompt = build_recovery_prompt(signal);
-        let _ = recovery_tx.try_send(ActorMessage::RecoveryHint {
-            task_id: signal.task_id.clone(),
-            tool_name: signal.tool_name.clone(),
-            prompt,
-            originating_client_message_id: signal.originating_client_message_id.clone(),
-        });
-    });
+    let session_key = test_session_key(dir.path());
+    let supervisor = wire_supervisor_to_continuation_queue(&session_key);
     let task_id = supervisor.register_with_input(
         "fm_tts",
         "call-int-1",
-        Some(test_session_key(dir.path()).to_string().as_str()),
+        Some(session_key.to_string().as_str()),
         Some(serde_json::json!({"voice": "yangmi", "text": "hi"})),
     );
     // Synth-ack gate (feat/spawn-only-failure-feedback-loop): mark
@@ -7008,7 +7103,7 @@ async fn supervisor_failure_signal_generates_recovery_actor_message_end_to_end()
     );
 
     let mut responses = Vec::new();
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let deadline = tokio::time::Instant::now() + RECOVERY_DRAIN_DEADLINE;
     while let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await {
         if !msg.content.is_empty() {
             responses.push(msg.content);
@@ -7043,17 +7138,19 @@ async fn supervisor_failure_signal_generates_recovery_actor_message_end_to_end()
 
 #[tokio::test]
 async fn recovery_turn_preserves_originating_client_message_id_from_failure_signal() {
-    // Issue #738 RED test: when the supervisor emits a
-    // `SpawnOnlyFailureSignal` with `originating_client_message_id`,
-    // the synthetic recovery turn the actor enqueues MUST persist a
-    // user message whose `client_message_id` matches the originating
-    // turn's cmid. Pre-fix, `synthetic_recovery_inbound` stamped only
-    // `_recovery_turn = true` into the InboundMessage metadata, so
-    // `inbound_client_message_id` returned None and `process_inbound`
-    // minted a fresh server UUIDv7 — leaving the eventual successful
-    // retry's deliverables stranded under an orphan thread_id with no
-    // DOM bubble in the SPA.
-    use octos_agent::TaskSupervisor;
+    // Issue #738: when the supervisor emits a `SpawnOnlyFailureSignal` with
+    // `originating_client_message_id`, the synthetic recovery turn MUST
+    // persist a user message whose `client_message_id` matches the
+    // originating turn's cmid. Pre-#738 the recovery inbound stamped no
+    // cmid, so `process_inbound` minted a fresh server UUIDv7 — leaving the
+    // eventual successful retry's deliverables stranded under an orphan
+    // thread_id with no DOM bubble in the SPA.
+    //
+    // #2020 re-homes this: the cmid now travels as continuation metadata
+    // (`originating_client_message_id`) and is stamped back onto the inbound
+    // by `synthetic_master_continuation_inbound`. Dropping that thread on
+    // the way to the queue would silently reintroduce #738, so this test
+    // guards the migrated path, not the retired one.
     const ORIGINATING_CMID: &str = "45756a8f-1234-4abc-8def-cafebabe0001";
 
     let dir = tempfile::TempDir::new().unwrap();
@@ -7067,21 +7164,8 @@ async fn recovery_turn_preserves_originating_client_message_id_from_failure_sign
     let (tx, mut rx, handle, _session_mgr) =
         setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
 
-    // Mirror the production wiring: the failure-signal callback
-    // forwards `signal.originating_client_message_id` onto
-    // `ActorMessage::RecoveryHint` so the actor's
-    // `synthetic_recovery_inbound` builder can stamp it into metadata.
-    let supervisor = TaskSupervisor::new();
-    let recovery_tx = tx.clone();
-    supervisor.set_on_failure_signal(move |signal| {
-        let prompt = build_recovery_prompt(signal);
-        let _ = recovery_tx.try_send(ActorMessage::RecoveryHint {
-            task_id: signal.task_id.clone(),
-            tool_name: signal.tool_name.clone(),
-            prompt,
-            originating_client_message_id: signal.originating_client_message_id.clone(),
-        });
-    });
+    let session_key = test_session_key(dir.path());
+    let supervisor = wire_supervisor_to_continuation_queue(&session_key);
 
     // Register the failed task with the originating user turn's
     // cmid. The supervisor must thread it through to the failure
@@ -7089,7 +7173,7 @@ async fn recovery_turn_preserves_originating_client_message_id_from_failure_sign
     let task_id = supervisor.register_with_input_and_cmid(
         "deep_research",
         "call-738",
-        Some(test_session_key(dir.path()).to_string().as_str()),
+        Some(session_key.to_string().as_str()),
         Some(serde_json::json!({"query": "rust news"})),
         Some(ORIGINATING_CMID.to_string()),
     );
@@ -7097,7 +7181,7 @@ async fn recovery_turn_preserves_originating_client_message_id_from_failure_sign
     supervisor.mark_failed(&task_id, "MiniMax 429 rate limited".into());
 
     let mut responses = Vec::new();
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let deadline = tokio::time::Instant::now() + RECOVERY_DRAIN_DEADLINE;
     while let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await {
         if !msg.content.is_empty() {
             responses.push(msg.content);
@@ -7113,9 +7197,7 @@ async fn recovery_turn_preserves_originating_client_message_id_from_failure_sign
 
     // The decisive assertion: the persisted user message for the
     // recovery turn must carry the originating cmid, NOT a freshly
-    // minted server UUIDv7. Pre-fix this was None or a fresh UUID
-    // because synthetic_recovery_inbound only stamped
-    // `_recovery_turn` and `process_inbound` had nothing to read.
+    // minted server UUIDv7.
     let session_handle = SessionHandle::open(dir.path(), &test_session_key(dir.path()));
     let session = session_handle.session();
     let recovery_msg = session
@@ -7912,23 +7994,18 @@ async fn router_failover_filters_to_originating_session() {
 // `task_supervisor::tests`; these are end-to-end against the running
 // actor.
 
-/// Wire a TaskSupervisor to the actor's RecoveryHint inbox exactly the
-/// way `SessionActor::spawn` does in production. Returns the
-/// supervisor so tests can drive `mark_synth_ack_emitted` +
-/// `mark_failed`.
-fn wire_supervisor_to_actor_inbox(
-    tx: &mpsc::Sender<ActorMessage>,
+/// Wire a TaskSupervisor to the master continuation queue exactly the way
+/// `SessionActor::spawn` does in production (#2020 — the gateway's
+/// `set_on_failure_signal` used to push `ActorMessage::RecoveryHint` onto
+/// the actor inbox instead). Returns the supervisor so tests can drive
+/// `mark_synth_ack_emitted` + `mark_failed`.
+fn wire_supervisor_to_continuation_queue(
+    session_key: &SessionKey,
 ) -> Arc<octos_agent::TaskSupervisor> {
     let supervisor = Arc::new(octos_agent::TaskSupervisor::new());
-    let recovery_tx = tx.clone();
+    let failure_session_key = session_key.clone();
     supervisor.set_on_failure_signal(move |signal| {
-        let prompt = build_recovery_prompt(signal);
-        let _ = recovery_tx.try_send(ActorMessage::RecoveryHint {
-            task_id: signal.task_id.clone(),
-            tool_name: signal.tool_name.clone(),
-            prompt,
-            originating_client_message_id: signal.originating_client_message_id.clone(),
-        });
+        enqueue_recovery_continuation(&failure_session_key, signal);
     });
     supervisor
 }
@@ -7948,7 +8025,7 @@ async fn background_failure_with_synth_ack_triggers_recovery_turn() {
     let (tx, mut rx, handle, _session_mgr) =
         setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
 
-    let supervisor = wire_supervisor_to_actor_inbox(&tx);
+    let supervisor = wire_supervisor_to_continuation_queue(&test_session_key(dir.path()));
     let task_id = supervisor.register_with_input(
         "mofa_slides",
         "call-spawn-fb-1",
@@ -7960,7 +8037,7 @@ async fn background_failure_with_synth_ack_triggers_recovery_turn() {
     supervisor.mark_failed(&task_id, "Gemini API: 429 quota exceeded".to_string());
 
     let mut responses = Vec::new();
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let deadline = tokio::time::Instant::now() + RECOVERY_DRAIN_DEADLINE;
     while let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await {
         if !msg.content.is_empty() {
             responses.push(msg.content);
@@ -8013,7 +8090,7 @@ async fn background_failure_without_synth_ack_no_op() {
     let (tx, mut rx, handle, _session_mgr) =
         setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
 
-    let supervisor = wire_supervisor_to_actor_inbox(&tx);
+    let supervisor = wire_supervisor_to_continuation_queue(&test_session_key(dir.path()));
     let task_id = supervisor.register_with_input(
         "mofa_slides",
         "call-spawn-fb-2",
@@ -8025,8 +8102,10 @@ async fn background_failure_without_synth_ack_no_op() {
     supervisor.mark_running(&task_id);
     supervisor.mark_failed(&task_id, "plugin crash".to_string());
 
-    // Give the inbox a window to deliver a hypothetical RecoveryHint.
-    let push = tokio::time::timeout(Duration::from_millis(500), rx.recv()).await;
+    // #2020: recovery now arrives on the continuation queue, drained on the
+    // actor's 2s tick — so the negative window must span at least one full
+    // tick, or the test would pass simply by not having looked yet.
+    let push = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await;
     assert!(
         push.is_err()
             || push
@@ -8068,7 +8147,7 @@ async fn background_success_path_unchanged() {
     let (tx, mut rx, handle, _session_mgr) =
         setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
 
-    let supervisor = wire_supervisor_to_actor_inbox(&tx);
+    let supervisor = wire_supervisor_to_continuation_queue(&test_session_key(dir.path()));
     let task_id = supervisor.register(
         "mofa_slides",
         "call-spawn-fb-3",
@@ -8114,7 +8193,7 @@ async fn background_failure_dedup_on_repeated_payloads() {
     let (tx, mut rx, handle, _session_mgr) =
         setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
 
-    let supervisor = wire_supervisor_to_actor_inbox(&tx);
+    let supervisor = wire_supervisor_to_continuation_queue(&test_session_key(dir.path()));
     let task_id = supervisor.register(
         "mofa_slides",
         "call-spawn-fb-4",
@@ -8171,7 +8250,7 @@ async fn background_failure_recovery_capped_at_max_retries() {
     let (tx, mut rx, handle, _session_mgr) =
         setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
 
-    let supervisor = wire_supervisor_to_actor_inbox(&tx);
+    let supervisor = wire_supervisor_to_continuation_queue(&test_session_key(dir.path()));
 
     // Drain `rx`, accumulating every non-empty message into `seen`, until
     // one containing `needle` arrives. Deterministic sequencing: each
@@ -8279,7 +8358,7 @@ async fn user_turn_resets_consecutive_recovery_counter() {
     let (tx, mut rx, handle, _session_mgr) =
         setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
 
-    let supervisor = wire_supervisor_to_actor_inbox(&tx);
+    let supervisor = wire_supervisor_to_continuation_queue(&test_session_key(dir.path()));
     let task_id = supervisor.register(
         "mofa_slides",
         "call-reset-1",


### PR DESCRIPTION
Completes the Gap-1 strangler. Phases 1-3 landed in #2023 and #2034; this is the last step.

## The problem

A background task reaching a terminal state re-entered the agent loop through **two** channels, split by outcome:

| outcome | path |
|---|---|
| success | `set_on_terminal` → `route_terminal_event_to_continuation_queue` |
| failure | `set_on_failure_signal` → `ActorMessage::RecoveryHint` inbox |

Two channels for one lifecycle event is not merely untidy:

- **The channels had no shared dedupe key**, so the unified sink had to be told to *skip* failures on the gateway (`TerminalFailureRouting::LegacyChannel`) purely to stop the two paths colliding. A routing flag whose only job was to keep the strangler's two halves apart.
- **Policy that must hold for every recovery lived on one of the two paths.** The per-task claim, the consecutive-recovery cap and the exhaustion banner were owned by the inbox handler, so they applied to the gateway and were structurally unavailable to the WS path.
- **"What happens when a background task ends" could not be answered by reading one path** — the answer depended on which outcome you meant and which runtime mode you were in.

## What changed

The gateway flips onto the queue; the inbox variant, its handler, and the three drain-path arms that swallowed it mid-turn are deleted.

**Policy moved before routing flipped.** The caps now live on the queue drain (`SessionActor::admit_spawn_only_failure_recovery`), guarding the single re-entry path rather than one of two. All three behaviours preserved:

1. **Per-task claim** — this is what survives a drain. The queue's task-scoped dedupe key only collapses while an item is still *pending*; it says nothing once drained.
2. **Consecutive cap** over *distinct* failing tasks — the LLM retrying its broken approach under fresh `tool_call_id`s, which no per-task key can catch.
3. **Exhaustion banner** — stopping silently is indistinguishable from the task having succeeded.

## Two things a mechanical deletion would have dropped silently

**#738 cmid propagation.** The originating turn's `client_message_id` now travels as continuation metadata and is stamped back onto the synthetic inbound. Losing it re-orphans the recovery turn under a fresh UUIDv7 and strands the eventual retry's deliverables with no DOM bubble.

**Durable user-row persistence.** Master continuations deliberately skip the user-row persist — they are runtime directives, not user turns. But the recovery prompt is not a bare directive: it is the only record of *why* the assistant re-engaged, and the M8.9 "Design A" constraint requires the model to see it on its next turn. `runtime_internal_inbound` now excludes it.

This one is worth calling out because of how it failed. The turn still ran, the LLM still replied, and a test asserting "a recovery response was produced" still passed — the transcript just showed an assistant reply with no visible cause, and the next turn lost the failure context. It was caught only because the migrated tests assert the *prompt lands in durable history*, not merely that a turn happened.

## What is NOT deleted, and why

`set_on_failure_signal` is **retargeted onto the queue, not removed**. It is the only delivery for a **fail-before-ack** failure: `notify_terminal` samples `synth_ack_emitted = false` at `mark_failed` time and the consumer prompt-suppresses, while the supervisor's two-phase stash re-emits the deferred signal once `mark_synth_ack_emitted` lands. Deleting it in favour of the unified sink alone would deliver **zero** recovery for that race — the case `fail_before_ack_spawn_only_failure_yields_exactly_one` pins.

Both producers now share the `external/<kind>/<session>/<task>` dedupe key, so an acked failure (where both fire) still yields exactly one continuation.

## The double-enqueue invariant holds

`master_continuation_scheduler.rs` is **doc-prose only** — the recently-claimed guard implementation and both invariant test bodies are byte-identical. Verify with `git diff origin/main -- crates/octos-cli/src/autonomy/master_continuation_scheduler.rs`.

The guard is now load-bearing for **both** runtime modes rather than just the WS path it was written for, since the gateway joins the same two-producer queue. The migration widened its blast radius rather than removing its reason to exist.

## Also

The prompt-renderer duplication goes: `build_recovery_prompt_body` is the single formatter. The hand-synchronised copy in the orchestrator existed only because the two re-entry paths rendered independently.

## Tests

- **New:** `consecutive_recovery_cap_trips_and_emits_banner_instead_of_a_turn` — the highest-risk regression. This is the error path: it runs when something has already gone wrong, which is when it is least likely to be exercised by a happy-path soak and most likely to be noticed by a user. Asserts both that the cap bites (bounded recovery prompts) and that the banner names the failing tool.
- **Migrated onto the queue:** the recovery e2e tests, the per-task-claim test (now driven through the real transport), and the #738 cmid test.
- **Inverted:** `legacy_channel_failure_routing_does_not_double_enqueue` → `failure_routing_enqueues_exactly_one_recovery_for_every_runtime_mode`. It used to pin that the gateway enqueued *nothing*; it now pins that gateway-shaped and WS-shaped failures each enqueue exactly one. A regression to zero would silently drop gateway failure recovery; a regression to two would double-deliver.

## Scoping note

`octos_agent::RecoveryHint` in `harness_errors.rs` is an unrelated error-**classification** enum (`BackoffRetry` / `SwitchProvider` / `CompactContext` / `FailFast` / `Bug`) that happens to share the name. It is not a re-entry path. It and its consumers (`loop_state.rs`, the `lib.rs` re-export) are untouched — those files do not appear in this diff.

## Gates

| gate | result |
|---|---|
| `cargo test -p octos-agent --lib` | 2565 passed |
| `cargo test -p octos-cli --features api --lib -- --test-threads=1` | see below |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p octos-agent --all-targets -- -D warnings` | clean |
| `cargo clippy -p octos-cli --all-targets --no-default-features --features api,telegram,... -- -D warnings` | clean |

`2931 passed / 3 failed`. All three are pre-existing or environmental, none in a file this branch touches (`git diff --name-only origin/main` covers 7 files; none of `commands/serve.rs`, `process_manager.rs`, or the continuation-tick test's production path):

- `commands::serve::tests::global_drain_spawns_before_the_stdio_early_return` — fails on pristine `main` (stale source-scan needle, reported on #2029).
- `process_manager::tests::should_allocate_bridge_ports_as_consecutive_pair` — environment-dependent: it hardcodes `BRIDGE_BASE_WS_PORT` (3101), and an unrelated `ssh` tunnel held that port on the test host (`lsof -iTCP:3101`), so allocation skipped to 3103.
- `session_actor::tests::master_continuation_tick_reenters_actor_loop` — **pre-existing flake, measured on both sides.** Run alone, 10×: `origin/main` 1/10 fail, this branch 2/10 fail. Same assertion each time (`:2505`, "should persist the model-generated progress summary: `[]`"), and the *first* assertion — that the tick drained and reached `process_inbound` — always passes. The race is test-side: it is `#[tokio::test(flavor = "current_thread", start_paused = true)]` and gives the durable write a **fixed budget of 10 `advance`+`yield_now` iterations**, while `SessionHandle::open` does real blocking file I/O on the same single thread. Under load the write misses the budget. It is a `ChildCompleted` continuation, so it does not traverse the recovery gate this PR adds — and that gate is a non-`await`ing early return for every non-recovery reason, contributing zero executor turns. Left alone deliberately: retiming an unrelated flaky test inside a strangler PR would muddy the diff.

Closes #2020.
