### PR TITLE
feat(ui-protocol): return unconsumed turn/steer inputs as turn/steer_dropped

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -2921,6 +2921,7 @@ fn notification_session_id(notification: &UiNotification) -> &SessionKey {
         UiNotification::Warning(event) => &event.session_id,
         UiNotification::TurnCompleted(event) => &event.session_id,
         UiNotification::TurnError(event) => &event.session_id,
+        UiNotification::TurnSteerDropped(event) => &event.session_id,
         UiNotification::ReplayLossy(event) => &event.session_id,
         UiNotification::TurnSpawnComplete(event) => &event.session_id,
         UiNotification::FileAttached(event) => &event.session_id,

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -33393,3 +33393,149 @@ async fn interactive_sentinel_skips_verifier_without_completion_claim() {
         .expect("goal exists");
     assert_eq!(tokens_used, 0, "nothing charged without a claim");
 }
+
+// ---- task-return-unconsumed-steer-inputs: accepted-but-undrained steers are
+// returned to the client as `turn/steer_dropped` at turn end ----
+
+fn steer_dropped_frame(writer_rx: &std::sync::mpsc::Receiver<WsMessage>) -> Value {
+    let message = writer_rx
+        .recv_timeout(Duration::from_millis(500))
+        .expect("a frame reaches the stdio writer");
+    let WsMessage::Text(text) = message else {
+        panic!("expected a text frame");
+    };
+    serde_json::from_str::<Value>(text.as_ref()).expect("valid JSON frame")
+}
+
+fn ledgered_steer_dropped(
+    ledger: &UiProtocolLedger,
+    session_id: &SessionKey,
+) -> Vec<octos_core::ui_protocol::TurnSteerDroppedEvent> {
+    let baseline = UiCursor {
+        stream: session_id.0.clone(),
+        seq: 0,
+    };
+    ledger
+        .replay_after(session_id, Some(&baseline))
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|e| match &e.event {
+            UiProtocolLedgerEvent::Notification(UiNotification::TurnSteerDropped(event)) => {
+                Some(event.clone())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn leftover_steers_at_turn_end_are_returned_as_turn_steer_dropped() {
+    let (writer_tx, writer_rx) = std::sync::mpsc::sync_channel(4);
+    let ws = WsConnection::new_stdio(writer_tx);
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:steer-dropped".into());
+    let turn_id = TurnId::new();
+    let buffer: octos_agent::SharedSteerBuffer = Arc::new(octos_agent::SteerBuffer::default());
+    buffer.push("first steer".into());
+    buffer.push("second steer".into());
+
+    let returned = settle_leftover_steers(&buffer, &ws, &ledger, &session_id, &turn_id, true);
+
+    assert_eq!(returned, 2);
+    assert!(buffer.is_empty(), "the buffer is drained");
+    let frame = steer_dropped_frame(&writer_rx);
+    assert_eq!(frame["method"], json!("turn/steer_dropped"));
+    assert_eq!(frame["params"]["session_id"], json!("local:steer-dropped"));
+    assert_eq!(frame["params"]["turn_id"], json!(turn_id));
+    assert_eq!(
+        frame["params"]["inputs"],
+        json!(["first steer", "second steer"]),
+        "buffer order is preserved"
+    );
+    assert_eq!(frame["params"]["reason"], json!("interrupted"));
+
+    let ledgered = ledgered_steer_dropped(&ledger, &session_id);
+    assert_eq!(
+        ledgered.len(),
+        1,
+        "the return is durable for reconnect replay"
+    );
+    assert_eq!(ledgered[0].inputs, vec!["first steer", "second steer"]);
+    assert_eq!(ledgered[0].reason, "interrupted");
+}
+
+#[test]
+fn leftover_steers_after_normal_end_are_labelled_turn_ended() {
+    let (writer_tx, writer_rx) = std::sync::mpsc::sync_channel(4);
+    let ws = WsConnection::new_stdio(writer_tx);
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:steer-dropped-ended".into());
+    let turn_id = TurnId::new();
+    let buffer: octos_agent::SharedSteerBuffer = Arc::new(octos_agent::SteerBuffer::default());
+    buffer.push("late steer".into());
+
+    let returned = settle_leftover_steers(&buffer, &ws, &ledger, &session_id, &turn_id, false);
+
+    assert_eq!(returned, 1);
+    let frame = steer_dropped_frame(&writer_rx);
+    assert_eq!(frame["params"]["reason"], json!("turn_ended"));
+    assert_eq!(frame["params"]["inputs"], json!(["late steer"]));
+}
+
+#[test]
+fn no_leftover_steers_emits_nothing() {
+    let (writer_tx, writer_rx) = std::sync::mpsc::sync_channel(4);
+    let ws = WsConnection::new_stdio(writer_tx);
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:steer-none".into());
+    let turn_id = TurnId::new();
+    let buffer: octos_agent::SharedSteerBuffer = Arc::new(octos_agent::SteerBuffer::default());
+
+    let returned = settle_leftover_steers(&buffer, &ws, &ledger, &session_id, &turn_id, true);
+
+    assert_eq!(returned, 0);
+    assert!(
+        writer_rx.recv_timeout(Duration::from_millis(100)).is_err(),
+        "an empty buffer must not produce an empty return frame"
+    );
+    assert!(ledgered_steer_dropped(&ledger, &session_id).is_empty());
+    // Terminal payload shapes are untouched by this task: the legacy
+    // `turn/error` frame still carries exactly its four fields.
+    let error = UiNotification::TurnError(TurnErrorEvent {
+        session_id: session_id.clone(),
+        topic: None,
+        turn_id: turn_id.clone(),
+        code: "interrupted".into(),
+        message: "turn interrupted by client".into(),
+    })
+    .into_rpc_notification()
+    .expect("serialize turn/error");
+    let keys: Vec<&str> = error
+        .params
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(keys, vec!["session_id", "turn_id", "code", "message"]);
+}
+
+#[test]
+fn leftover_steers_are_ledgered_even_when_connection_write_fails() {
+    let (writer_tx, writer_rx) = std::sync::mpsc::sync_channel::<WsMessage>(1);
+    let ws = WsConnection::new_stdio(writer_tx);
+    // Simulate a dead stdio peer: the receiver is gone, so every send fails.
+    drop(writer_rx);
+    let ledger = Arc::new(UiProtocolLedger::new(16));
+    let session_id = SessionKey("local:steer-dead-peer".into());
+    let turn_id = TurnId::new();
+    let buffer: octos_agent::SharedSteerBuffer = Arc::new(octos_agent::SteerBuffer::default());
+    buffer.push("orphaned steer".into());
+
+    let returned = settle_leftover_steers(&buffer, &ws, &ledger, &session_id, &turn_id, true);
+
+    assert_eq!(returned, 1);
+    let ledgered = ledgered_steer_dropped(&ledger, &session_id);
+    assert_eq!(ledgered.len(), 1, "text survives in the ledger for replay");
+    assert_eq!(ledgered[0].inputs, vec!["orphaned steer"]);
+}

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -8639,6 +8639,7 @@ async fn try_emit_terminal_populates_turn_completed_tokens_and_session_result() 
         &turn_id,
         None,
         Some(details.clone()),
+        None,
     )
     .await;
 
@@ -8699,6 +8700,7 @@ async fn try_emit_terminal_with_no_details_omits_token_fields() {
         &ledger,
         &session_id,
         &turn_id,
+        None,
         None,
         None,
     )
@@ -11014,6 +11016,7 @@ fn shell_approval_event_is_typed_only_after_negotiation() {
             user_question_v1: false,
             skill_actions_v1: false,
             skill_action_jobs_v1: false,
+            turn_steer_dropped_v1: false,
             header_present: true,
             stdio_transport: false,
         },
@@ -11083,6 +11086,7 @@ fn risk_default_is_unspecified_when_manifest_silent() {
             user_question_v1: false,
             skill_actions_v1: false,
             skill_action_jobs_v1: false,
+            turn_steer_dropped_v1: false,
             header_present: true,
             stdio_transport: false,
         },
@@ -11197,6 +11201,7 @@ fn plugin_high_risk_approval_emits_risk_field_on_wire() {
             user_question_v1: false,
             skill_actions_v1: false,
             skill_action_jobs_v1: false,
+            turn_steer_dropped_v1: false,
             header_present: true,
             stdio_transport: false,
         },
@@ -11266,6 +11271,7 @@ fn plugin_critical_risk_approval_emits_risk_critical() {
             user_question_v1: false,
             skill_actions_v1: false,
             skill_action_jobs_v1: false,
+            turn_steer_dropped_v1: false,
             header_present: true,
             stdio_transport: false,
         },
@@ -11328,6 +11334,7 @@ fn shell_approval_still_emits_risk_field() {
             user_question_v1: false,
             skill_actions_v1: false,
             skill_action_jobs_v1: false,
+            turn_steer_dropped_v1: false,
             header_present: true,
             stdio_transport: false,
         },
@@ -11433,6 +11440,7 @@ fn approval_cwd_is_sanitized_against_path_spoof() {
             user_question_v1: false,
             skill_actions_v1: false,
             skill_action_jobs_v1: false,
+            turn_steer_dropped_v1: false,
             header_present: true,
             stdio_transport: false,
         },
@@ -14084,6 +14092,7 @@ async fn session_open_includes_pane_snapshot_after_negotiation() {
             user_question_v1: false,
             skill_actions_v1: false,
             skill_action_jobs_v1: false,
+            turn_steer_dropped_v1: false,
             header_present: true,
             stdio_transport: false,
         },
@@ -33538,4 +33547,134 @@ fn leftover_steers_are_ledgered_even_when_connection_write_fails() {
     let ledgered = ledgered_steer_dropped(&ledger, &session_id);
     assert_eq!(ledgered.len(), 1, "text survives in the ledger for replay");
     assert_eq!(ledgered[0].inputs, vec!["orphaned steer"]);
+}
+
+/// task-return-unconsumed-steer-inputs (v2 ordering): once the turn flips to
+/// Terminal, its accepted-but-undrained steers are returned as ONE
+/// `turn/steer_dropped` BEFORE the terminal frame, on the same connection —
+/// so a client may treat "terminal without a preceding steer_dropped naming
+/// my steer" as "consumed". Drives `try_emit_terminal` directly (the wire-side
+/// closure), like the #1332 test above.
+#[tokio::test]
+async fn steer_dropped_is_emitted_before_the_terminal_frame() {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<axum::extract::ws::Message>(8);
+    let ws = WsConnection::new(tx);
+    let ledger = UiProtocolLedger::new(32);
+    let session_id = SessionKey("local:steer-order".into());
+    let turn_id = TurnId::new();
+    let turn_state = TokioMutex::new(TurnState::Active);
+    let buffer: octos_agent::SharedSteerBuffer = Arc::new(octos_agent::SteerBuffer::default());
+    buffer.push("accepted but never drained".into());
+
+    try_emit_terminal(
+        &turn_state,
+        TerminalReason::Interrupted,
+        &ws,
+        &ledger,
+        &session_id,
+        &turn_id,
+        Some(("interrupted", "turn interrupted by client")),
+        None,
+        Some(&buffer),
+    )
+    .await;
+
+    let mut methods = Vec::new();
+    while let Ok(msg) = rx.try_recv() {
+        if let axum::extract::ws::Message::Text(text) = msg {
+            let frame: Value = serde_json::from_str(text.as_ref()).expect("json frame");
+            if let Some(method) = frame.get("method").and_then(Value::as_str) {
+                methods.push(method.to_string());
+                if method == "turn/steer_dropped" {
+                    assert_eq!(
+                        frame["params"]["inputs"],
+                        json!(["accepted but never drained"])
+                    );
+                    assert_eq!(frame["params"]["reason"], json!("interrupted"));
+                }
+            }
+        }
+    }
+    let dropped_at = methods.iter().position(|m| m == "turn/steer_dropped");
+    let terminal_at = methods.iter().position(|m| m == "turn/error");
+    assert!(dropped_at.is_some(), "steer_dropped emitted: {methods:?}");
+    assert!(terminal_at.is_some(), "terminal emitted: {methods:?}");
+    assert!(
+        dropped_at < terminal_at,
+        "steer_dropped must precede the terminal: {methods:?}"
+    );
+    assert!(buffer.is_empty());
+    assert!(matches!(
+        *turn_state.lock().await,
+        TurnState::Terminal(TerminalReason::Interrupted)
+    ));
+
+    // A second terminal attempt is a no-op (idempotent) and returns nothing more.
+    try_emit_terminal(
+        &turn_state,
+        TerminalReason::Interrupted,
+        &ws,
+        &ledger,
+        &session_id,
+        &turn_id,
+        Some(("interrupted", "turn interrupted by client")),
+        None,
+        Some(&buffer),
+    )
+    .await;
+    assert!(
+        rx.try_recv().is_err(),
+        "no duplicate frames after the terminal"
+    );
+}
+
+/// Once the state is Terminal, `turn/steer` can no longer be accepted for the
+/// turn — the settlement above therefore saw the complete set of inputs.
+#[tokio::test]
+async fn steer_is_not_accepted_after_terminal_transition() {
+    let turn_state = Arc::new(TokioMutex::new(TurnState::Active));
+    let transition = transition_to_terminal(&turn_state, TerminalReason::Completed).await;
+    assert!(transition.is_some());
+    // The steer admission check reads the same state: Terminal → NoActiveTurn.
+    let terminal = matches!(*turn_state.lock().await, TurnState::Terminal(_));
+    assert!(terminal, "post-terminal steers fall back to a fresh turn");
+}
+
+/// The dropped-before-terminal guarantee is advertised as
+/// `event.turn_steer_dropped.v1` — on by default for stdio, and honoured when
+/// a ws client requests it — so a client can decide whether "terminal without
+/// steer_dropped" means "consumed" (new server) or "unknown" (old server).
+#[test]
+fn turn_steer_dropped_feature_is_advertised_when_requested_and_by_stdio_default() {
+    let stdio = ConnectionUiFeatures::stdio_defaults().negotiated_capabilities();
+    assert!(
+        stdio
+            .supported_features
+            .iter()
+            .any(|f| f == UI_PROTOCOL_FEATURE_TURN_STEER_DROPPED_V1),
+        "{:?}",
+        stdio.supported_features
+    );
+    let ws = ConnectionUiFeatures::from_requested_feature_tokens(
+        [UI_PROTOCOL_FEATURE_TURN_STEER_DROPPED_V1],
+        false,
+    )
+    .negotiated_capabilities();
+    assert!(
+        ws.supported_features
+            .iter()
+            .any(|f| f == UI_PROTOCOL_FEATURE_TURN_STEER_DROPPED_V1)
+    );
+    let legacy = ConnectionUiFeatures::from_requested_feature_tokens(
+        [UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1],
+        false,
+    )
+    .negotiated_capabilities();
+    assert!(
+        !legacy
+            .supported_features
+            .iter()
+            .any(|f| f == UI_PROTOCOL_FEATURE_TURN_STEER_DROPPED_V1),
+        "not advertised unless requested"
+    );
 }

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -33448,7 +33448,16 @@ fn leftover_steers_at_turn_end_are_returned_as_turn_steer_dropped() {
     buffer.push("first steer".into());
     buffer.push("second steer".into());
 
-    let returned = settle_leftover_steers(&buffer, &ws, &ledger, &session_id, &turn_id, true);
+    let returned = settle_leftover_steers(
+        &buffer,
+        SteerReturnSink::Live {
+            ws: &ws,
+            ledger: &ledger,
+        },
+        &session_id,
+        &turn_id,
+        true,
+    );
 
     assert_eq!(returned, 2);
     assert!(buffer.is_empty(), "the buffer is drained");
@@ -33483,7 +33492,16 @@ fn leftover_steers_after_normal_end_are_labelled_turn_ended() {
     let buffer: octos_agent::SharedSteerBuffer = Arc::new(octos_agent::SteerBuffer::default());
     buffer.push("late steer".into());
 
-    let returned = settle_leftover_steers(&buffer, &ws, &ledger, &session_id, &turn_id, false);
+    let returned = settle_leftover_steers(
+        &buffer,
+        SteerReturnSink::Live {
+            ws: &ws,
+            ledger: &ledger,
+        },
+        &session_id,
+        &turn_id,
+        false,
+    );
 
     assert_eq!(returned, 1);
     let frame = steer_dropped_frame(&writer_rx);
@@ -33500,7 +33518,16 @@ fn no_leftover_steers_emits_nothing() {
     let turn_id = TurnId::new();
     let buffer: octos_agent::SharedSteerBuffer = Arc::new(octos_agent::SteerBuffer::default());
 
-    let returned = settle_leftover_steers(&buffer, &ws, &ledger, &session_id, &turn_id, true);
+    let returned = settle_leftover_steers(
+        &buffer,
+        SteerReturnSink::Live {
+            ws: &ws,
+            ledger: &ledger,
+        },
+        &session_id,
+        &turn_id,
+        true,
+    );
 
     assert_eq!(returned, 0);
     assert!(
@@ -33541,7 +33568,16 @@ fn leftover_steers_are_ledgered_even_when_connection_write_fails() {
     let buffer: octos_agent::SharedSteerBuffer = Arc::new(octos_agent::SteerBuffer::default());
     buffer.push("orphaned steer".into());
 
-    let returned = settle_leftover_steers(&buffer, &ws, &ledger, &session_id, &turn_id, true);
+    let returned = settle_leftover_steers(
+        &buffer,
+        SteerReturnSink::Live {
+            ws: &ws,
+            ledger: &ledger,
+        },
+        &session_id,
+        &turn_id,
+        true,
+    );
 
     assert_eq!(returned, 1);
     let ledgered = ledgered_steer_dropped(&ledger, &session_id);
@@ -33677,4 +33713,74 @@ fn turn_steer_dropped_feature_is_advertised_when_requested_and_by_stdio_default(
             .any(|f| f == UI_PROTOCOL_FEATURE_TURN_STEER_DROPPED_V1),
         "not advertised unless requested"
     );
+}
+
+/// task-return-unconsumed-steer-inputs (review round 3, P0): the connection-
+/// close abort path is a terminal outlet too. It must go through the same
+/// gate, so the ledger a reconnecting client replays reads
+/// `turn/steer_dropped` strictly BEFORE `turn/error(connection_closed)`.
+#[tokio::test]
+async fn connection_close_settles_steers_before_connection_closed_terminal() {
+    let session_id = SessionKey("api:profile/local:closing".into());
+    let turn_id = TurnId::new();
+    let active_turns: SharedActiveTurns = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let connection_turns: SharedConnectionTurns = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let handle = tokio::spawn(async { std::future::pending::<()>().await });
+    let buffer: octos_agent::SharedSteerBuffer = Arc::new(octos_agent::SteerBuffer::default());
+    buffer.push("typed just before the socket died".into());
+    let mut entry = test_active_turn(turn_id.clone(), handle.abort_handle());
+    entry.steer = Some(buffer.clone());
+    active_turns.lock().await.insert(session_id.clone(), entry);
+    connection_turns
+        .lock()
+        .await
+        .insert(session_id.clone(), turn_id.clone());
+
+    let scopes = ScopePolicy::default();
+    let ledger = UiProtocolLedger::new(16);
+    let approvals = PendingApprovalStore::default();
+    let user_questions = PendingQuestionStore::default();
+    abort_connection_turns(
+        &active_turns,
+        &connection_turns,
+        &scopes,
+        &ledger,
+        &approvals,
+        &user_questions,
+    )
+    .await;
+
+    let baseline = UiCursor {
+        stream: session_id.0.clone(),
+        seq: 0,
+    };
+    let replay = ledger.replay_after(&session_id, Some(&baseline)).unwrap();
+    let kinds: Vec<String> = replay
+        .iter()
+        .filter_map(|e| match &e.event {
+            UiProtocolLedgerEvent::Notification(UiNotification::TurnSteerDropped(d)) => {
+                assert_eq!(d.inputs, vec!["typed just before the socket died"]);
+                assert_eq!(d.reason, "interrupted");
+                Some("turn/steer_dropped".to_string())
+            }
+            UiProtocolLedgerEvent::Notification(UiNotification::TurnError(err)) => {
+                Some(format!("turn/error:{}", err.code))
+            }
+            _ => None,
+        })
+        .collect();
+    let dropped_at = kinds.iter().position(|k| k == "turn/steer_dropped");
+    let terminal_at = kinds
+        .iter()
+        .position(|k| k == "turn/error:connection_closed");
+    assert!(dropped_at.is_some() && terminal_at.is_some(), "{kinds:?}");
+    assert!(
+        dropped_at < terminal_at,
+        "replay order must be steer_dropped → terminal: {kinds:?}"
+    );
+    assert!(
+        buffer.is_empty(),
+        "the aborted turn's later safety-net drain finds nothing"
+    );
+    handle.abort();
 }

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -32663,23 +32663,24 @@ async fn run_standalone_turn(
 
     let _ = agent_task.await;
 
-    // `turn/steer` turn-end race residual (codex §5 parity): the loop keeps
-    // the turn alive for steers that land BEFORE its final EndTurn check,
-    // but a steer accepted in the narrow window between that check and this
-    // point never drains. Make the drop observable rather than silent — the
+    // `turn/steer` turn-end residual: the loop keeps the turn alive for
+    // steers that land BEFORE its final EndTurn check, but a steer accepted
+    // after that check — or, far more commonly, one accepted while a tool
+    // was running when the client then INTERRUPTED the turn (incident
+    // 2026-08-17: 32 s between accept and abort) — never drains. The
     // registry entry is still keyed to this turn, so no later turn can
-    // consume the leftovers.
+    // consume the leftovers. task-return-unconsumed-steer-inputs: hand them
+    // back to the client as `turn/steer_dropped` (durable + ledgered) so it
+    // can re-queue them deterministically instead of inferring the loss.
     if let Some(buffer) = steer_buffer.as_ref() {
-        let leftovers = buffer.drain();
-        if !leftovers.is_empty() {
-            warn!(
-                session = %session_id.0,
-                turn = %turn_id.0,
-                dropped = leftovers.len(),
-                "turn/steer input(s) arrived as the turn ended and were dropped; \
-                 the client should re-send (a fresh call now falls back to a new turn)"
-            );
-        }
+        settle_leftover_steers(
+            buffer,
+            &ws,
+            &ledger,
+            &session_id,
+            &turn_id,
+            interrupt_observed,
+        );
     }
 
     // NEW-16 codex round-3 P1+P2: GC moved from here to the
@@ -35913,6 +35914,44 @@ fn send_raw_notification_ephemeral(
     ws.send_ephemeral(frame, method)
 }
 
+/// task-return-unconsumed-steer-inputs: drain whatever `turn/steer` inputs the
+/// server accepted (`steered:true`) but never fed to the loop, and return
+/// them to the client as ONE `turn/steer_dropped` notification (buffer
+/// order preserved). Sent durable — the payload is user text, so it must not
+/// be lost to backpressure — and appended to the ledger so a reconnecting
+/// client replays it. Emits nothing for an empty buffer. Returns the number
+/// of inputs returned. Called after the turn's terminal event; the client
+/// treats it as "re-queue these as new input".
+pub(crate) fn settle_leftover_steers(
+    buffer: &octos_agent::SharedSteerBuffer,
+    ws: &WsConnection,
+    ledger: &UiProtocolLedger,
+    session_id: &SessionKey,
+    turn_id: &TurnId,
+    interrupt_observed: bool,
+) -> usize {
+    let leftovers = buffer.drain();
+    let count = leftovers.len();
+    let Some(notification) = crate::steer_return::leftover_steer_notification(
+        session_id,
+        turn_id,
+        leftovers,
+        interrupt_observed,
+    ) else {
+        return 0;
+    };
+    warn!(
+        session = %session_id.0,
+        turn = %turn_id.0,
+        dropped = count,
+        interrupted = interrupt_observed,
+        "turn/steer input(s) were still pending when the turn ended; returning them \
+         to the client as turn/steer_dropped"
+    );
+    let _ = send_notification_durable(ws, ledger, notification);
+    count
+}
+
 fn send_turn_error(
     ws: &WsConnection,
     ledger: &UiProtocolLedger,
@@ -36630,6 +36669,7 @@ fn ledger_event_cursor(event: &UiProtocolLedgerEvent) -> Option<UiCursor> {
             | UiNotification::ProgressUpdated(_)
             | UiNotification::Warning(_)
             | UiNotification::TurnError(_)
+            | UiNotification::TurnSteerDropped(_)
             // ReplayLossy references a `last_durable_cursor` belonging to
             // the events it summarises, not its own — surfacing it here
             // would re-loop the replay flag onto itself.

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -61,15 +61,15 @@ use octos_core::ui_protocol::{
     UI_PROTOCOL_FEATURE_REVIEW_START_V1, UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1,
     UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1, UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
     UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1, UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1,
-    UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1, UI_PROTOCOL_FEATURE_USER_QUESTION_V1,
-    UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1, UiAgentRecord, UiArtifactPaneItem, UiArtifactPaneSnapshot,
-    UiCommand, UiContextCompactionRecord, UiContextNormalizationReport, UiContextState, UiCursor,
-    UiFileMutationNotice, UiGitHistoryItem, UiGitPaneSnapshot, UiGitStatusItem, UiNotification,
-    UiPaneSnapshot, UiPaneSnapshotLimitation, UiProgressEvent, UiProgressMetadata,
-    UiProtocolCapabilities, UiRpcResult, UiWorkspacePaneEntry, UiWorkspacePaneSnapshot,
-    UnsupportedCapabilityReport, UserQuestionRequestedEvent, UserQuestionRespondParams,
-    VoiceAudioChunkEvent, approval_cancelled_reasons, approval_kinds, hydrate_sections,
-    progress_kinds, thread_status,
+    UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1, UI_PROTOCOL_FEATURE_TURN_STEER_DROPPED_V1,
+    UI_PROTOCOL_FEATURE_USER_QUESTION_V1, UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1, UiAgentRecord,
+    UiArtifactPaneItem, UiArtifactPaneSnapshot, UiCommand, UiContextCompactionRecord,
+    UiContextNormalizationReport, UiContextState, UiCursor, UiFileMutationNotice, UiGitHistoryItem,
+    UiGitPaneSnapshot, UiGitStatusItem, UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation,
+    UiProgressEvent, UiProgressMetadata, UiProtocolCapabilities, UiRpcResult, UiWorkspacePaneEntry,
+    UiWorkspacePaneSnapshot, UnsupportedCapabilityReport, UserQuestionRequestedEvent,
+    UserQuestionRespondParams, VoiceAudioChunkEvent, approval_cancelled_reasons, approval_kinds,
+    hydrate_sections, progress_kinds, thread_status,
 };
 use octos_core::{
     AgentId, InboundMessage, MAIN_PROFILE_ID, Message, MessageOrigin, MessageRole, SessionKey,
@@ -1896,6 +1896,9 @@ struct ConnectionUiFeatures {
     skill_actions_v1: bool,
     /// Persisted background skill action jobs and their update events.
     skill_action_jobs_v1: bool,
+    /// task-return-unconsumed-steer-inputs: client asked for the
+    /// dropped-before-terminal steer settlement guarantee.
+    turn_steer_dropped_v1: bool,
     /// `true` when the client sent at least one feature token via the
     /// `X-Octos-Ui-Features` header or the `ui_feature` / `ui_features`
     /// query parameter (UPCR-2026-007). Distinguishes "no header at all"
@@ -1995,6 +1998,11 @@ impl ConnectionUiFeatures {
                 query,
                 APPUI_FEATURE_SKILL_ACTION_JOBS_V1,
             ),
+            turn_steer_dropped_v1: has_ui_feature(
+                headers,
+                query,
+                UI_PROTOCOL_FEATURE_TURN_STEER_DROPPED_V1,
+            ),
             header_present: has_any_ui_feature_token(headers, query),
             stdio_transport: false,
         }
@@ -2043,6 +2051,7 @@ impl ConnectionUiFeatures {
             user_question_v1: true,
             skill_actions_v1: true,
             skill_action_jobs_v1: true,
+            turn_steer_dropped_v1: true,
             header_present: true,
             stdio_transport: true,
         }
@@ -2087,6 +2096,7 @@ impl ConnectionUiFeatures {
             user_question_v1: has(UI_PROTOCOL_FEATURE_USER_QUESTION_V1),
             skill_actions_v1: has(APPUI_FEATURE_SKILL_ACTIONS_V1),
             skill_action_jobs_v1: has(APPUI_FEATURE_SKILL_ACTION_JOBS_V1),
+            turn_steer_dropped_v1: has(UI_PROTOCOL_FEATURE_TURN_STEER_DROPPED_V1),
             header_present: true,
             stdio_transport,
         }
@@ -2186,6 +2196,9 @@ impl ConnectionUiFeatures {
         }
         if self.skill_action_jobs_v1 {
             requested.push(APPUI_FEATURE_SKILL_ACTION_JOBS_V1);
+        }
+        if self.turn_steer_dropped_v1 {
+            requested.push(UI_PROTOCOL_FEATURE_TURN_STEER_DROPPED_V1);
         }
         UiProtocolCapabilities::for_negotiated_features(requested)
     }
@@ -19632,7 +19645,15 @@ async fn handle_turn_steer(
                 // counts as live: the client asked to stop, and a raced
                 // steer behaves like the codex loop-exit race (buffered,
                 // possibly dropped at turn end — logged, never mis-routed).
-                let terminal = matches!(*existing.state.lock().await, TurnState::Terminal(_));
+                // task-return-unconsumed-steer-inputs: hold the turn-state
+                // guard across check AND push. `try_emit_terminal` settles
+                // the steer buffer right after it flips the state to
+                // `Terminal` (under this same lock) and BEFORE the terminal
+                // frame — so any input accepted here is either drained by
+                // the loop, or returned by that settlement; nothing can slip
+                // in between the settlement and the terminal frame.
+                let state = existing.state.lock().await;
+                let terminal = matches!(*state, TurnState::Terminal(_));
                 if terminal {
                     TurnSteerDecision::NoActiveTurn
                 } else if params
@@ -26206,6 +26227,7 @@ async fn run_m9_fixture_turn(
                     None,
                     // M9 fixtures replay canned events; no live LLM token data.
                     None,
+                    None,
                 )
                 .await;
             }
@@ -26219,6 +26241,7 @@ async fn run_m9_fixture_turn(
                 &session_id,
                 &turn_id,
                 Some((code, message.as_str())),
+                None,
                 None,
             )
             .await;
@@ -26251,6 +26274,7 @@ async fn run_m9_fixture_turn(
                     "interrupted",
                     captured_interrupt_origin(&turn_state).await.message(),
                 )),
+                None,
                 None,
             )
             .await;
@@ -27054,6 +27078,7 @@ async fn run_native_code_review_turn(
                     &turn_id,
                     Some(("runtime_unavailable", message.as_str())),
                     None,
+                    None,
                 )
                 .await;
                 contracts.scopes.evict_turn(&session_id, &turn_id);
@@ -27069,6 +27094,7 @@ async fn run_native_code_review_turn(
                     &session_id,
                     &turn_id,
                     Some(("runtime_unavailable", message.as_str())),
+                    None,
                     None,
                 )
                 .await;
@@ -27091,6 +27117,7 @@ async fn run_native_code_review_turn(
                 &session_id,
                 &turn_id,
                 Some(("permission_denied", message.as_str())),
+                None,
                 None,
             )
             .await;
@@ -27119,6 +27146,7 @@ async fn run_native_code_review_turn(
                 &session_id,
                 &turn_id,
                 Some(("runtime_unavailable", &error.to_string())),
+                None,
                 None,
             )
             .await;
@@ -27352,6 +27380,7 @@ async fn run_native_code_review_turn(
                     &turn_id,
                     Some(("interrupted", "review/start interrupted by client")),
                     None,
+                    None,
                 )
                 .await;
                 contracts.scopes.evict_turn(&session_id, &turn_id);
@@ -27474,6 +27503,7 @@ async fn run_native_code_review_turn(
         // review/start scatter-join does not run a single LLM turn end
         // to end; the summary message is emitted ad-hoc. No aggregated
         // token data is in scope here.
+        None,
         None,
     )
     .await;
@@ -28971,6 +29001,7 @@ async fn run_standalone_turn(
             &turn_id,
             Some(("runtime_unavailable", error.as_str())),
             None,
+            steer_buffer.as_ref(),
         )
         .await;
         contracts.scopes.evict_turn(&session_id, &turn_id);
@@ -29020,6 +29051,7 @@ async fn run_standalone_turn(
                 &turn_id,
                 Some(("permission_denied", message.as_str())),
                 None,
+                steer_buffer.as_ref(),
             )
             .await;
             contracts.scopes.evict_turn(&session_id, &turn_id);
@@ -29048,6 +29080,7 @@ async fn run_standalone_turn(
                 &turn_id,
                 Some(("runtime_unavailable", &error.to_string())),
                 None,
+                steer_buffer.as_ref(),
             )
             .await;
             contracts.scopes.evict_turn(&session_id, &turn_id);
@@ -29337,7 +29370,7 @@ async fn run_standalone_turn(
     // forward `FailoverEvent`s as `router/failover` notifications for
     // the duration of this turn. The abort handle ends the forwarder
     // when the turn ends — see the `.abort()` call near
-    // `try_emit_terminal()` below.
+    // `try_emit_terminal(, steer_buffer.as_ref())` below.
     let failover_forwarder = spawn_router_failover_forwarder(
         ws.clone(),
         ledger.clone(),
@@ -29386,6 +29419,7 @@ async fn run_standalone_turn(
             // Slash-command shortcut bypasses the LLM entirely; the
             // reply is canned and no token meter ran.
             None,
+            steer_buffer.as_ref(),
         )
         .await;
         contracts.scopes.evict_turn(&session_id, &turn_id);
@@ -30986,6 +31020,7 @@ async fn run_standalone_turn(
                     &turn_id,
                     Some(("profile_config_unavailable", &error.to_string())),
                     None,
+                    steer_buffer.as_ref(),
                 )
                 .await;
                 contracts.scopes.evict_turn(&session_id, &turn_id);
@@ -31040,6 +31075,7 @@ async fn run_standalone_turn(
             &turn_id,
             None,
             None,
+            steer_buffer.as_ref(),
         )
         .await;
         contracts.scopes.evict_turn(&session_id, &turn_id);
@@ -32179,6 +32215,7 @@ async fn run_standalone_turn(
                     &turn_id,
                     None,
                     Some(details),
+                    steer_buffer.as_ref(),
                 )
                 .await;
                 break;
@@ -32279,6 +32316,7 @@ async fn run_standalone_turn(
                     &turn_id,
                     Some((code, wire_msg.as_str())),
                     None,
+                    steer_buffer.as_ref(),
                 )
                 .await;
                 break;
@@ -32645,6 +32683,7 @@ async fn run_standalone_turn(
                 captured_interrupt_origin(&turn_state).await.message(),
             )),
             None,
+            steer_buffer.as_ref(),
         )
         .await;
         // codex #2 residual — a client-interrupted peer takes THIS branch, not
@@ -33601,12 +33640,33 @@ async fn try_emit_terminal(
     turn_id: &TurnId,
     error_payload: Option<(&str, &str)>,
     completion_details: Option<TurnCompletionDetails>,
+    // task-return-unconsumed-steer-inputs: the turn's `turn/steer` buffer, if
+    // it has one. Settled (returned as `turn/steer_dropped`) after the state
+    // flips to Terminal and BEFORE the terminal frame below — see
+    // `settle_leftover_steers`.
+    steer_buffer: Option<&octos_agent::SharedSteerBuffer>,
 ) {
     let Some(TerminalTransition { reason, ack }) =
         transition_to_terminal(turn_state, expected_reason).await
     else {
         return;
     };
+    // The state is Terminal now: `handle_turn_steer` (which holds the same
+    // state lock across check-and-push) can no longer accept input for this
+    // turn, so whatever is in the buffer is the complete set of accepted-but-
+    // undrained steers. Return them FIRST, so a client that sees the
+    // terminal without a preceding `turn/steer_dropped` naming its steer may
+    // conclude the steer was consumed (`event.turn_steer_dropped.v1`).
+    if let Some(buffer) = steer_buffer {
+        settle_leftover_steers(
+            buffer,
+            ws,
+            ledger,
+            session_id,
+            turn_id,
+            matches!(reason, TerminalReason::Interrupted),
+        );
+    }
 
     // Terminal events are lifecycle: failure to deliver does not change the
     // state-machine outcome (the entry stays terminal for replay/idempotency)

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -25880,7 +25880,18 @@ async fn run_m9_fixture_turn(
         topic: None,
     });
     if send_notification_lifecycle(&ws, &ledger, started).is_err() {
-        let _ = transition_to_terminal(&turn_state, TerminalReason::Errored).await;
+        let _ = transition_to_terminal_settling_steers(
+            &turn_state,
+            TerminalReason::Errored,
+            None,
+            SteerReturnSink::Live {
+                ws: &ws,
+                ledger: &ledger,
+            },
+            &session_id,
+            &turn_id,
+        )
+        .await;
         contracts.scopes.evict_turn(&session_id, &turn_id);
         return;
     }
@@ -27052,7 +27063,18 @@ async fn run_native_code_review_turn(
         topic: None,
     });
     if send_notification_lifecycle(&ws, &ledger, started).is_err() {
-        let _ = transition_to_terminal(&turn_state, TerminalReason::Errored).await;
+        let _ = transition_to_terminal_settling_steers(
+            &turn_state,
+            TerminalReason::Errored,
+            None,
+            SteerReturnSink::Live {
+                ws: &ws,
+                ledger: &ledger,
+            },
+            &session_id,
+            &turn_id,
+        )
+        .await;
         contracts.scopes.evict_turn(&session_id, &turn_id);
         return;
     }
@@ -28935,7 +28957,18 @@ async fn run_standalone_turn(
     // transition the turn to a terminal state so the registry doesn't keep
     // an orphaned `Active` entry.
     if send_notification_lifecycle(&ws, &ledger, started).is_err() {
-        let _ = transition_to_terminal(&turn_state, TerminalReason::Errored).await;
+        let _ = transition_to_terminal_settling_steers(
+            &turn_state,
+            TerminalReason::Errored,
+            steer_buffer.as_ref(),
+            SteerReturnSink::Live {
+                ws: &ws,
+                ledger: &ledger,
+            },
+            &session_id,
+            &turn_id,
+        )
+        .await;
         contracts.scopes.evict_turn(&session_id, &turn_id);
         return;
     }
@@ -32706,20 +32739,32 @@ async fn run_standalone_turn(
     // steers that land BEFORE its final EndTurn check, but a steer accepted
     // after that check — or, far more commonly, one accepted while a tool
     // was running when the client then INTERRUPTED the turn (incident
-    // 2026-08-17: 32 s between accept and abort) — never drains. The
-    // registry entry is still keyed to this turn, so no later turn can
-    // consume the leftovers. task-return-unconsumed-steer-inputs: hand them
-    // back to the client as `turn/steer_dropped` (durable + ledgered) so it
-    // can re-queue them deterministically instead of inferring the loss.
+    // 2026-08-17: 32 s between accept and abort) — never drains.
+    // task-return-unconsumed-steer-inputs: the terminal gate
+    // (`transition_to_terminal_settling_steers`) already returned every
+    // leftover BEFORE the terminal frame, and the state lock in
+    // `handle_turn_steer` guarantees nothing was accepted after the flip —
+    // so this is a safety net that should find an empty buffer. If it ever
+    // does not, returning late is still better than dropping the text.
     if let Some(buffer) = steer_buffer.as_ref() {
-        settle_leftover_steers(
+        let late = settle_leftover_steers(
             buffer,
-            &ws,
-            &ledger,
+            SteerReturnSink::Live {
+                ws: &ws,
+                ledger: &ledger,
+            },
             &session_id,
             &turn_id,
             interrupt_observed,
         );
+        if late > 0 {
+            warn!(
+                session = %session_id.0,
+                turn = %turn_id.0,
+                late,
+                "turn/steer leftovers found AFTER the terminal gate — ordering invariant violated"
+            );
+        }
     }
 
     // NEW-16 codex round-3 P1+P2: GC moved from here to the
@@ -33646,27 +33691,20 @@ async fn try_emit_terminal(
     // `settle_leftover_steers`.
     steer_buffer: Option<&octos_agent::SharedSteerBuffer>,
 ) {
-    let Some(TerminalTransition { reason, ack }) =
-        transition_to_terminal(turn_state, expected_reason).await
+    // Single terminal gate: state → Terminal, then the steer settlement
+    // (`turn/steer_dropped`), then — below — the terminal frame.
+    let Some(TerminalTransition { reason, ack }) = transition_to_terminal_settling_steers(
+        turn_state,
+        expected_reason,
+        steer_buffer,
+        SteerReturnSink::Live { ws, ledger },
+        session_id,
+        turn_id,
+    )
+    .await
     else {
         return;
     };
-    // The state is Terminal now: `handle_turn_steer` (which holds the same
-    // state lock across check-and-push) can no longer accept input for this
-    // turn, so whatever is in the buffer is the complete set of accepted-but-
-    // undrained steers. Return them FIRST, so a client that sees the
-    // terminal without a preceding `turn/steer_dropped` naming its steer may
-    // conclude the steer was consumed (`event.turn_steer_dropped.v1`).
-    if let Some(buffer) = steer_buffer {
-        settle_leftover_steers(
-            buffer,
-            ws,
-            ledger,
-            session_id,
-            turn_id,
-            matches!(reason, TerminalReason::Interrupted),
-        );
-    }
 
     // Terminal events are lifecycle: failure to deliver does not change the
     // state-machine outcome (the entry stays terminal for replay/idempotency)
@@ -33887,8 +33925,15 @@ async fn try_emit_completed_terminal_with_forced_backpressure(
     session_id: &SessionKey,
     turn_id: &TurnId,
 ) {
-    let Some(TerminalTransition { ack, .. }) =
-        transition_to_terminal(turn_state, TerminalReason::Completed).await
+    let Some(TerminalTransition { ack, .. }) = transition_to_terminal_settling_steers(
+        turn_state,
+        TerminalReason::Completed,
+        None,
+        SteerReturnSink::Live { ws, ledger },
+        session_id,
+        turn_id,
+    )
+    .await
     else {
         return;
     };
@@ -34551,12 +34596,14 @@ async fn abort_connection_turns(
     let mut active = active_turns.lock().await;
     for (session_id, turn_id) in turns {
         let mut aborted_state: Option<Arc<TokioMutex<TurnState>>> = None;
+        let mut aborted_steer: Option<octos_agent::SharedSteerBuffer> = None;
         let should_abort = active
             .get(&session_id)
             .is_some_and(|active| active.turn_id == turn_id);
         if should_abort {
             if let Some(active) = active.remove(&session_id) {
                 aborted_state = Some(active.state.clone());
+                aborted_steer = active.steer.clone();
                 active.abort.abort();
             }
         }
@@ -34568,8 +34615,21 @@ async fn abort_connection_turns(
         // with a natural completion / interrupt that may already have
         // flipped state to Terminal.
         if let Some(state) = aborted_state {
-            if let Some(transition) =
-                transition_to_terminal(state.as_ref(), TerminalReason::Interrupted).await
+            // task-return-unconsumed-steer-inputs: same terminal gate as the
+            // live path — state Terminal → `turn/steer_dropped` (ledger-only:
+            // the connection is gone, the reconnecting client replays it) →
+            // terminal. Without this the aborted turn task's safety-net drain
+            // would land AFTER this terminal and a same-process reconnect
+            // would lose the steer.
+            if let Some(transition) = transition_to_terminal_settling_steers(
+                state.as_ref(),
+                TerminalReason::Interrupted,
+                aborted_steer.as_ref(),
+                SteerReturnSink::LedgerOnly { ledger },
+                &session_id,
+                &turn_id,
+            )
+            .await
             {
                 let _ = ledger.append_notification(UiNotification::TurnError(TurnErrorEvent {
                     session_id: session_id.clone(),
@@ -35974,18 +36034,37 @@ fn send_raw_notification_ephemeral(
     ws.send_ephemeral(frame, method)
 }
 
+/// task-return-unconsumed-steer-inputs: where a `turn/steer_dropped` return
+/// goes. The live connection sends durably AND ledgers; a closed connection
+/// (see `abort_connection_turns`) can only ledger — the reconnecting client
+/// replays it, still ahead of the terminal.
+pub(crate) enum SteerReturnSink<'a> {
+    Live {
+        ws: &'a WsConnection,
+        ledger: &'a UiProtocolLedger,
+    },
+    LedgerOnly {
+        ledger: &'a UiProtocolLedger,
+    },
+}
+
 /// task-return-unconsumed-steer-inputs: drain whatever `turn/steer` inputs the
 /// server accepted (`steered:true`) but never fed to the loop, and return
 /// them to the client as ONE `turn/steer_dropped` notification (buffer
 /// order preserved). Sent durable — the payload is user text, so it must not
 /// be lost to backpressure — and appended to the ledger so a reconnecting
 /// client replays it. Emits nothing for an empty buffer. Returns the number
-/// of inputs returned. Called after the turn's terminal event; the client
-/// treats it as "re-queue these as new input".
+/// of inputs returned.
+///
+/// ORDER CONTRACT (`event.turn_steer_dropped.v1`): this runs after the turn
+/// state flipped to Terminal (no more steers can be accepted) and BEFORE the
+/// terminal frame — see `transition_to_terminal_settling_steers`, the single
+/// gate every terminal outlet goes through. A client that sees the terminal
+/// without a preceding `turn/steer_dropped` naming its steer may conclude the
+/// steer was consumed.
 pub(crate) fn settle_leftover_steers(
     buffer: &octos_agent::SharedSteerBuffer,
-    ws: &WsConnection,
-    ledger: &UiProtocolLedger,
+    sink: SteerReturnSink<'_>,
     session_id: &SessionKey,
     turn_id: &TurnId,
     interrupt_observed: bool,
@@ -36006,10 +36085,44 @@ pub(crate) fn settle_leftover_steers(
         dropped = count,
         interrupted = interrupt_observed,
         "turn/steer input(s) were still pending when the turn ended; returning them \
-         to the client as turn/steer_dropped"
+         to the client as turn/steer_dropped ahead of the terminal"
     );
-    let _ = send_notification_durable(ws, ledger, notification);
+    match sink {
+        SteerReturnSink::Live { ws, ledger } => {
+            let _ = send_notification_durable(ws, ledger, notification);
+        }
+        SteerReturnSink::LedgerOnly { ledger } => {
+            let _ = ledger.append_notification(notification);
+        }
+    }
     count
+}
+
+/// task-return-unconsumed-steer-inputs: THE terminal gate. Every terminal
+/// outlet (live `try_emit_terminal`, the connection-close abort path, the
+/// early `turn/started`-failed bail-outs) flips the state through here so the
+/// `event.turn_steer_dropped.v1` order — state Terminal → steers settled →
+/// terminal frame — cannot be bypassed. Returns the transition for the caller
+/// to emit its terminal frame, or `None` if the turn was already terminal.
+async fn transition_to_terminal_settling_steers(
+    turn_state: &TokioMutex<TurnState>,
+    expected_reason: TerminalReason,
+    steer_buffer: Option<&octos_agent::SharedSteerBuffer>,
+    sink: SteerReturnSink<'_>,
+    session_id: &SessionKey,
+    turn_id: &TurnId,
+) -> Option<TerminalTransition> {
+    let transition = transition_to_terminal(turn_state, expected_reason).await?;
+    if let Some(buffer) = steer_buffer {
+        settle_leftover_steers(
+            buffer,
+            sink,
+            session_id,
+            turn_id,
+            matches!(transition.reason, TerminalReason::Interrupted),
+        );
+    }
+    Some(transition)
 }
 
 fn send_turn_error(

--- a/crates/octos-cli/src/lib.rs
+++ b/crates/octos-cli/src/lib.rs
@@ -25,6 +25,10 @@ pub mod auth;
 // full `dead_code` enforcement.
 #[cfg_attr(not(feature = "api"), allow(dead_code))]
 pub(crate) mod autonomy;
+/// task-return-unconsumed-steer-inputs: feature-independent shape of the
+/// `turn/steer_dropped` return (the `api` module does the sending).
+#[cfg_attr(not(feature = "api"), allow(dead_code))]
+pub(crate) mod steer_return;
 pub use octos_services::cli_agent_adapter;
 pub mod commands;
 pub use octos_services::compaction;

--- a/crates/octos-cli/src/steer_return.rs
+++ b/crates/octos-cli/src/steer_return.rs
@@ -1,0 +1,130 @@
+//! task-return-unconsumed-steer-inputs: build the `turn/steer_dropped`
+//! notification that hands accepted-but-undrained `turn/steer` inputs back to
+//! the client at turn end. Kept outside the `api` feature so its shape is
+//! verifiable with a plain `cargo test -p octos-cli`; the `api` side
+//! (`settle_leftover_steers`) drains the buffer, calls this and sends durably.
+
+use octos_core::SessionKey;
+use octos_core::ui_protocol::{TurnId, TurnSteerDroppedEvent, UiNotification};
+
+/// `reason` when the turn was interrupted by the client.
+pub(crate) const REASON_INTERRUPTED: &str = "interrupted";
+/// `reason` when the turn ended on its own (EndTurn / error) with input pending.
+pub(crate) const REASON_TURN_ENDED: &str = "turn_ended";
+
+/// One `turn/steer_dropped` for the given leftovers, in buffer order. `None`
+/// when there is nothing to return — an empty return frame is never emitted.
+pub(crate) fn leftover_steer_notification(
+    session_id: &SessionKey,
+    turn_id: &TurnId,
+    leftovers: Vec<String>,
+    interrupt_observed: bool,
+) -> Option<UiNotification> {
+    if leftovers.is_empty() {
+        return None;
+    }
+    let reason = if interrupt_observed {
+        REASON_INTERRUPTED
+    } else {
+        REASON_TURN_ENDED
+    };
+    Some(UiNotification::TurnSteerDropped(TurnSteerDroppedEvent {
+        session_id: session_id.clone(),
+        topic: None,
+        turn_id: turn_id.clone(),
+        inputs: leftovers,
+        reason: reason.to_owned(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use octos_core::ui_protocol::{TurnCompletedEvent, TurnErrorEvent, methods};
+
+    fn ids() -> (SessionKey, TurnId) {
+        (SessionKey("local:steer".into()), TurnId::new())
+    }
+
+    #[test]
+    fn leftover_steer_notification_preserves_order_and_labels_interrupted() {
+        let (session_id, turn_id) = ids();
+        let notification = leftover_steer_notification(
+            &session_id,
+            &turn_id,
+            vec!["first steer".into(), "second steer".into()],
+            true,
+        )
+        .expect("two leftovers produce one notification");
+        assert_eq!(notification.method(), methods::TURN_STEER_DROPPED);
+        assert_eq!(notification.method(), "turn/steer_dropped");
+        let UiNotification::TurnSteerDropped(event) = notification else {
+            panic!("expected TurnSteerDropped");
+        };
+        assert_eq!(event.session_id, session_id);
+        assert_eq!(event.turn_id, turn_id);
+        assert_eq!(event.inputs, vec!["first steer", "second steer"]);
+        assert_eq!(event.reason, REASON_INTERRUPTED);
+        assert_eq!(event.reason, "interrupted");
+    }
+
+    #[test]
+    fn leftover_steer_notification_labels_turn_ended_without_interrupt() {
+        let (session_id, turn_id) = ids();
+        let UiNotification::TurnSteerDropped(event) =
+            leftover_steer_notification(&session_id, &turn_id, vec!["late".into()], false)
+                .expect("one leftover produces one notification")
+        else {
+            panic!("expected TurnSteerDropped");
+        };
+        assert_eq!(event.reason, "turn_ended");
+        assert_eq!(event.inputs, vec!["late"]);
+    }
+
+    #[test]
+    fn no_leftover_steers_produce_no_notification() {
+        let (session_id, turn_id) = ids();
+        assert!(leftover_steer_notification(&session_id, &turn_id, vec![], true).is_none());
+        assert!(leftover_steer_notification(&session_id, &turn_id, vec![], false).is_none());
+
+        // The terminal payloads keep their exact field sets — the return is a
+        // separate frame, never folded into turn/error or turn/completed.
+        let error = UiNotification::TurnError(TurnErrorEvent {
+            session_id: session_id.clone(),
+            topic: None,
+            turn_id: turn_id.clone(),
+            code: "interrupted".into(),
+            message: "turn interrupted by client".into(),
+        })
+        .into_rpc_notification()
+        .expect("serialize turn/error");
+        let error_keys: Vec<&str> = error
+            .params
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(error_keys, vec!["session_id", "turn_id", "code", "message"]);
+
+        let completed = UiNotification::TurnCompleted(TurnCompletedEvent {
+            session_id,
+            topic: None,
+            turn_id,
+            cursor: None,
+            tokens_in: None,
+            tokens_out: None,
+            session_result: None,
+        })
+        .into_rpc_notification()
+        .expect("serialize turn/completed");
+        let completed_keys: Vec<&str> = completed
+            .params
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(completed_keys, vec!["session_id", "turn_id"]);
+    }
+}

--- a/crates/octos-cli/src/steer_return.rs
+++ b/crates/octos-cli/src/steer_return.rs
@@ -2,7 +2,9 @@
 //! notification that hands accepted-but-undrained `turn/steer` inputs back to
 //! the client at turn end. Kept outside the `api` feature so its shape is
 //! verifiable with a plain `cargo test -p octos-cli`; the `api` side
-//! (`settle_leftover_steers`) drains the buffer, calls this and sends durably.
+//! (`settle_leftover_steers`, invoked from the single terminal gate
+//! `transition_to_terminal_settling_steers`) drains the buffer, calls this
+//! and sends it — always BEFORE the terminal frame (`event.turn_steer_dropped.v1`).
 
 use octos_core::SessionKey;
 use octos_core::ui_protocol::{TurnId, TurnSteerDroppedEvent, UiNotification};
@@ -126,5 +128,45 @@ mod tests {
             .map(String::as_str)
             .collect();
         assert_eq!(completed_keys, vec!["session_id", "turn_id"]);
+    }
+}
+
+#[cfg(test)]
+mod gate_tests {
+    /// Structural guard, feature-independent: `transition_to_terminal(` is
+    /// invoked ONLY inside `transition_to_terminal_settling_steers` — every
+    /// terminal outlet (live emit, connection-close abort, early bail-outs,
+    /// fixtures) must go through the settling gate, or the
+    /// `event.turn_steer_dropped.v1` order promise breaks silently.
+    #[test]
+    fn every_terminal_outlet_goes_through_the_settling_gate() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/api/ui_protocol.rs");
+        let text = std::fs::read_to_string(&path).expect("read ui_protocol.rs");
+        let mut current_fn = String::new();
+        let mut offenders = Vec::new();
+        for (i, line) in text.lines().enumerate() {
+            let t = line.trim_start();
+            if t.starts_with("async fn ")
+                || t.starts_with("fn ")
+                || t.starts_with("pub(crate) async fn ")
+                || t.starts_with("pub(crate) fn ")
+            {
+                current_fn = t.to_string();
+            }
+            if t.starts_with("//") {
+                continue;
+            }
+            if t.contains("transition_to_terminal(")
+                && !t.contains("fn transition_to_terminal(")
+                && !current_fn.contains("fn transition_to_terminal_settling_steers(")
+            {
+                offenders.push(format!("{}: {}", i + 1, t));
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "call transition_to_terminal_settling_steers instead:\n{}",
+            offenders.join("\n")
+        );
     }
 }

--- a/crates/octos-cli/src/steer_return.rs
+++ b/crates/octos-cli/src/steer_return.rs
@@ -140,8 +140,9 @@ mod gate_tests {
     /// `event.turn_steer_dropped.v1` order promise breaks silently.
     #[test]
     fn every_terminal_outlet_goes_through_the_settling_gate() {
-        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/api/ui_protocol.rs");
-        let text = std::fs::read_to_string(&path).expect("read ui_protocol.rs");
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/api/ui_protocol_transport.rs");
+        let text = std::fs::read_to_string(&path).expect("read ui_protocol_transport.rs");
         let mut current_fn = String::new();
         let mut offenders = Vec::new();
         for (i, line) in text.lines().enumerate() {

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -1090,6 +1090,13 @@ pub mod methods {
     pub const TURN_STARTED: &str = "turn/started";
     pub const TURN_COMPLETED: &str = "turn/completed";
     pub const TURN_ERROR: &str = "turn/error";
+    /// task-return-unconsumed-steer-inputs: emitted AFTER a turn's terminal
+    /// when `turn/steer` inputs the server had accepted (`steered:true`) were
+    /// still sitting in the pending-input buffer at turn end — i.e. never
+    /// drained into the conversation. Carries the texts back, in order, so the
+    /// client can re-queue them deterministically instead of inferring the
+    /// loss from a missing echo.
+    pub const TURN_STEER_DROPPED: &str = "turn/steer_dropped";
     pub const MESSAGE_DELTA: &str = "message/delta";
     pub const MESSAGE_REASONING_DELTA: &str = "message/reasoning_delta";
     pub const TOOL_STARTED: &str = "tool/started";
@@ -6312,6 +6319,20 @@ pub struct TurnErrorEvent {
     pub message: String,
 }
 
+/// task-return-unconsumed-steer-inputs: `turn/steer_dropped` payload. See
+/// [`methods::TURN_STEER_DROPPED`]. `inputs` preserves the buffer order;
+/// `reason` is `"interrupted"` when the turn was interrupted by the client and
+/// `"turn_ended"` otherwise. Sent after the turn's terminal event.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TurnSteerDroppedEvent {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+    pub turn_id: TurnId,
+    pub inputs: Vec<String>,
+    pub reason: String,
+}
+
 /// Wire signal that one or more durable notifications were dropped due to
 /// per-connection backpressure. Clients should diverge from their cursor and
 /// rehydrate via REST snapshot or `session/open` replay.
@@ -6604,6 +6625,9 @@ pub enum UiNotification {
     Warning(WarningEvent),
     TurnCompleted(TurnCompletedEvent),
     TurnError(TurnErrorEvent),
+    /// task-return-unconsumed-steer-inputs: accepted-but-undrained steer
+    /// inputs returned at turn end.
+    TurnSteerDropped(TurnSteerDroppedEvent),
     ReplayLossy(ReplayLossyEvent),
     /// Legacy completion event for durable records written before the v2-only
     /// background-child projection migration. New writes use `EnvelopeV2`.
@@ -6723,6 +6747,7 @@ impl UiNotification {
             Self::Warning(_) => methods::WARNING,
             Self::TurnCompleted(_) => methods::TURN_COMPLETED,
             Self::TurnError(_) => methods::TURN_ERROR,
+            Self::TurnSteerDropped(_) => methods::TURN_STEER_DROPPED,
             Self::ReplayLossy(_) => methods::REPLAY_LOSSY,
             Self::TurnSpawnComplete(_) => methods::TURN_SPAWN_COMPLETE,
             Self::FileAttached(_) => methods::FILE_ATTACHED,
@@ -6780,6 +6805,7 @@ impl UiNotification {
             Self::Warning(event) => &event.session_id,
             Self::TurnCompleted(event) => &event.session_id,
             Self::TurnError(event) => &event.session_id,
+            Self::TurnSteerDropped(event) => &event.session_id,
             Self::ReplayLossy(event) => &event.session_id,
             Self::TurnSpawnComplete(event) => &event.session_id,
             Self::FileAttached(event) => &event.session_id,
@@ -6861,6 +6887,9 @@ impl UiNotification {
                 event.topic.as_deref().or_else(|| event.session_id.topic())
             }
             Self::TurnError(event) => event.topic.as_deref().or_else(|| event.session_id.topic()),
+            Self::TurnSteerDropped(event) => {
+                event.topic.as_deref().or_else(|| event.session_id.topic())
+            }
             Self::TurnSpawnComplete(event) => {
                 event.topic.as_deref().or_else(|| event.session_id.topic())
             }
@@ -6904,6 +6933,7 @@ impl UiNotification {
             Self::TaskOutputDelta(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::TurnCompleted(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::TurnError(event) => set_topic_if_absent(&mut event.topic, &topic),
+            Self::TurnSteerDropped(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::TurnSpawnComplete(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::FileAttached(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::VoiceAudioChunk(event) => set_topic_if_absent(&mut event.topic, &topic),
@@ -6942,6 +6972,7 @@ impl UiNotification {
             Self::Warning(params) => serde_json::to_value(params),
             Self::TurnCompleted(params) => serde_json::to_value(params),
             Self::TurnError(params) => serde_json::to_value(params),
+            Self::TurnSteerDropped(params) => serde_json::to_value(params),
             Self::ReplayLossy(params) => serde_json::to_value(params),
             Self::TurnSpawnComplete(params) => serde_json::to_value(params),
             Self::FileAttached(params) => serde_json::to_value(params),
@@ -7082,6 +7113,9 @@ impl UiNotification {
             methods::WARNING => Ok(Self::Warning(decode_params(method, params)?)),
             methods::TURN_COMPLETED => Ok(Self::TurnCompleted(decode_params(method, params)?)),
             methods::TURN_ERROR => Ok(Self::TurnError(decode_params(method, params)?)),
+            methods::TURN_STEER_DROPPED => {
+                Ok(Self::TurnSteerDropped(decode_params(method, params)?))
+            }
             methods::REPLAY_LOSSY => Ok(Self::ReplayLossy(decode_params(method, params)?)),
             methods::TURN_SPAWN_COMPLETE => {
                 Ok(Self::TurnSpawnComplete(decode_params(method, params)?))

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -1101,12 +1101,14 @@ pub mod methods {
     pub const TURN_STARTED: &str = "turn/started";
     pub const TURN_COMPLETED: &str = "turn/completed";
     pub const TURN_ERROR: &str = "turn/error";
-    /// task-return-unconsumed-steer-inputs: emitted AFTER a turn's terminal
-    /// when `turn/steer` inputs the server had accepted (`steered:true`) were
-    /// still sitting in the pending-input buffer at turn end — i.e. never
-    /// drained into the conversation. Carries the texts back, in order, so the
-    /// client can re-queue them deterministically instead of inferring the
-    /// loss from a missing echo.
+    /// task-return-unconsumed-steer-inputs: emitted at turn end — after the
+    /// turn can no longer accept steers and BEFORE its terminal frame
+    /// (`event.turn_steer_dropped.v1`) — when `turn/steer` inputs the server
+    /// had accepted (`steered:true`) were still sitting in the pending-input
+    /// buffer, i.e. never drained into the conversation. Carries the texts
+    /// back, in order, so the client can re-queue them deterministically; a
+    /// terminal without a preceding `turn/steer_dropped` naming a steer means
+    /// the server consumed it.
     pub const TURN_STEER_DROPPED: &str = "turn/steer_dropped";
     pub const MESSAGE_DELTA: &str = "message/delta";
     pub const MESSAGE_REASONING_DELTA: &str = "message/reasoning_delta";
@@ -6333,7 +6335,8 @@ pub struct TurnErrorEvent {
 /// task-return-unconsumed-steer-inputs: `turn/steer_dropped` payload. See
 /// [`methods::TURN_STEER_DROPPED`]. `inputs` preserves the buffer order;
 /// `reason` is `"interrupted"` when the turn was interrupted by the client and
-/// `"turn_ended"` otherwise. Sent after the turn's terminal event.
+/// `"turn_ended"` otherwise. Sent BEFORE the turn's terminal event on the same
+/// stream (`event.turn_steer_dropped.v1`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TurnSteerDroppedEvent {
     pub session_id: SessionKey,

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -267,6 +267,16 @@ pub const UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1: &str = "event.voice_audio.v1";
 /// as before, and this stream is NEVER fed back into model context.
 pub const UI_PROTOCOL_FEATURE_BACKGROUND_ACTIVITY_V1: &str = "event.background_activity.v1";
 
+/// task-return-unconsumed-steer-inputs: the server settles `turn/steer` input
+/// at turn end — after the turn can no longer accept steers and BEFORE the
+/// terminal frame it emits one `turn/steer_dropped` carrying every accepted
+/// input that was never drained into the conversation. A client that sees
+/// this feature may treat "terminal without a preceding `turn/steer_dropped`
+/// naming my steer" as "the server consumed it" (no client-side re-stage
+/// needed); without it, the client must fall back to its own terminal
+/// re-stage heuristics.
+pub const UI_PROTOCOL_FEATURE_TURN_STEER_DROPPED_V1: &str = "event.turn_steer_dropped.v1";
+
 /// Feature flag for the model-authored plan/todo checklist. When negotiated,
 /// the server pushes `plan/updated` notifications carrying the agent's current
 /// ordered checklist (the `update_plan` tool's live state), and replays the
@@ -315,6 +325,7 @@ pub const UI_PROTOCOL_KNOWN_FEATURES: &[&str] = &[
     UI_PROTOCOL_FEATURE_VOICE_AUDIO_V1,
     UI_PROTOCOL_FEATURE_PLAN_TODOS_V1,
     UI_PROTOCOL_FEATURE_BACKGROUND_ACTIVITY_V1,
+    UI_PROTOCOL_FEATURE_TURN_STEER_DROPPED_V1,
     UI_PROTOCOL_FEATURE_SMART_HOME_V1,
 ];
 

--- a/crates/octos-core/src/ui_protocol_tests.rs
+++ b/crates/octos-core/src/ui_protocol_tests.rs
@@ -1113,6 +1113,7 @@ fn ui_protocol_v1_representative_wire_payloads_are_golden() {
                 "event.voice_audio.v1",
                 "plan.todos.v1",
                 "event.background_activity.v1",
+                "event.turn_steer_dropped.v1",
                 "smart_home.v1"
             ]
         })

--- a/crates/octos-core/src/ui_protocol_tests.rs
+++ b/crates/octos-core/src/ui_protocol_tests.rs
@@ -7242,3 +7242,63 @@ fn monitor_notifications_roundtrip_as_ui_notifications() {
     let decoded = UiNotification::from_rpc_notification(rpc).expect("decode monitor/expired");
     assert_eq!(decoded, expired);
 }
+
+// ---- task-return-unconsumed-steer-inputs: `turn/steer_dropped` shape ----
+
+#[test]
+fn turn_steer_dropped_round_trips_through_method_and_params() {
+    let event = TurnSteerDroppedEvent {
+        session_id: SessionKey("local:demo".into()),
+        topic: None,
+        turn_id: TurnId(Uuid::from_u128(7)),
+        inputs: vec!["first steer".into(), "second steer".into()],
+        reason: "interrupted".into(),
+    };
+    let notification = UiNotification::TurnSteerDropped(event.clone());
+    assert_eq!(notification.method(), methods::TURN_STEER_DROPPED);
+    assert_eq!(methods::TURN_STEER_DROPPED, "turn/steer_dropped");
+
+    let rpc = notification
+        .into_rpc_notification()
+        .expect("serialize turn/steer_dropped");
+    assert_eq!(rpc.method, "turn/steer_dropped");
+    assert_eq!(
+        rpc.params,
+        json!({
+            "session_id": "local:demo",
+            "turn_id": TurnId(Uuid::from_u128(7)),
+            "inputs": ["first steer", "second steer"],
+            "reason": "interrupted"
+        })
+    );
+
+    let decoded = UiNotification::from_method_and_params("turn/steer_dropped", rpc.params)
+        .expect("decode turn/steer_dropped");
+    assert_eq!(decoded, UiNotification::TurnSteerDropped(event));
+}
+
+#[test]
+fn turn_steer_dropped_topic_routing_matches_other_turn_events() {
+    let mut notification = UiNotification::TurnSteerDropped(TurnSteerDroppedEvent {
+        session_id: SessionKey("local:demo#coding".into()),
+        topic: None,
+        turn_id: TurnId(Uuid::from_u128(8)),
+        inputs: vec!["late steer".into()],
+        reason: "turn_ended".into(),
+    });
+    // Absent topic falls back to the session key's topic suffix, like TurnError.
+    assert_eq!(notification.topic(), Some("coding"));
+    assert_eq!(
+        notification.session_id(),
+        &SessionKey("local:demo#coding".into())
+    );
+
+    // An explicit topic is never overwritten by the routing stamp.
+    if let UiNotification::TurnSteerDropped(event) = &mut notification {
+        event.topic = Some("explicit".into());
+    }
+    let rpc = notification
+        .into_rpc_notification()
+        .expect("serialize with explicit topic");
+    assert_eq!(rpc.params["topic"], json!("explicit"));
+}

--- a/specs/task-return-unconsumed-steer-inputs.spec.md
+++ b/specs/task-return-unconsumed-steer-inputs.spec.md
@@ -15,6 +15,7 @@ ledger（可 replay），使客户端能确定性地重新入队，而不是靠"
 
 ## Decisions
 
+<!-- lint-ack: decision-coverage — "恢复边界"是范围声明（same-process reconnect only），无对应可执行场景；跨进程恢复列入 Out of Scope -->
 <!-- lint-ack: verification-metadata-suggestion — 两个错误路径场景使用进程内 stdio WsConnection + 内存 ledger fixture，无真实外部 I/O -->
 
 - 新增 `octos-core` 通知 `UiNotification::TurnSteerDropped(TurnSteerDroppedEvent)`，
@@ -35,10 +36,22 @@ ledger（可 replay），使客户端能确定性地重新入队，而不是靠"
   顺序/reason/空残留由纯函数测试机械验证，发送与 ledger 行为由 `--features api`
   下的测试验证并以 `Review: human` 场景登记。
 - 发送方式：`send_notification_durable`（等待容量、写 ledger），因为载荷是用户
-  文本，不允许因背压丢帧；该通知在 turn 终态事件之后发出，客户端应把它当作
-  "终态后需重新入队的输入"处理。
+  文本，不允许因背压丢帧。
+- 时序（v2，审查 P0）：`try_emit_terminal` 在 `transition_to_terminal` 把状态置为
+  Terminal 之后、终态帧之前调用 `settle_leftover_steers`，因此同一连接上
+  `turn/steer_dropped` **严格先于** `turn/error`/`turn/completed`；`handle_turn_steer`
+  在持有 turn 状态锁期间完成 check-and-push，状态转 Terminal 后不再受理，故结算看到
+  的是完整的残留集合。`agent_task.await` 之后的旧 drain 仅作安全网保留。
+- capability：新增 `UI_PROTOCOL_FEATURE_TURN_STEER_DROPPED_V1 = "event.turn_steer_dropped.v1"`
+  加入 `UI_PROTOCOL_KNOWN_FEATURES`，`ConnectionUiFeatures` 增加 `turn_steer_dropped_v1`
+  （stdio 默认开、ws 按请求）。客户端见到该 feature 即可把"终态前没有 dropped 点名
+  我的 steer"解释为"服务端已消费"，不再做终态兜底重排。
+- 恢复边界（审查 P1）：本任务的 durable/ledger 只支持**同一客户端进程内的断线重连
+  replay**（客户端凭内存中的 retained 记录匹配）；客户端进程重启后 `/resume` 无法
+  恢复未消费 steer——那需要稳定的 steer 回执 id 与持久化的提交/消费状态，列为后续
+  工作，不在本任务范围内声称。
 - 服务端在 `Interrupting` 状态下继续受理 steer 的行为不变——被受理的输入现在保证
-  要么被 drain 进对话，要么通过 `turn/steer_dropped` 返还。
+  要么被 drain 进对话，要么在终态帧之前通过 `turn/steer_dropped` 返还。
 - 不修改 `TurnErrorEvent`/`TurnCompletedEvent` 的字段，保持既有客户端兼容（由
   "没有残留时不发任何帧"场景与既有终态测试共同约束：终态帧形状不变）。
 
@@ -81,6 +94,34 @@ Scenario: 正常结束时的残留标为 turn_ended
   Given 一条残留输入
   When `leftover_steer_notification` 以 `interrupt_observed = false` 被调用
   Then 事件的 `reason` 为 `"turn_ended"`
+
+Scenario: steer_dropped 严格先于终态帧且状态已 Terminal（critical；需 --features api）
+  Tags: critical
+  Review: human
+  Test:
+    Package: octos-cli
+    Filter: steer_dropped_is_emitted_before_the_terminal_frame
+  Given 一个 Active 的 turn 状态与含一条残留的 `SteerBuffer`
+  When `try_emit_terminal(Interrupted, …, Some(buffer))` 被调用
+  Then 连接上 `turn/steer_dropped` 帧的位置在 `turn/error` 之前
+  And 状态为 `Terminal(Interrupted)`、buffer 为空
+  And 第二次调用不再产生任何帧
+
+Scenario: 状态 Terminal 后不再受理 steer（需 --features api）
+  Review: human
+  Test:
+    Package: octos-cli
+    Filter: steer_is_not_accepted_after_terminal_transition
+  When `transition_to_terminal` 成功
+  Then steer 受理检查读到 `Terminal` 并走 `NoActiveTurn`
+
+Scenario: capability 广告（需 --features api）
+  Review: human
+  Test:
+    Package: octos-cli
+    Filter: turn_steer_dropped_feature_is_advertised_when_requested_and_by_stdio_default
+  When stdio 默认能力或 ws 请求含 `UI_PROTOCOL_FEATURE_TURN_STEER_DROPPED_V1`（`event.turn_steer_dropped.v1`）
+  Then `supported_features` 含该 feature；未请求则不含
 
 Scenario: 没有残留时不生成事件（错误路径：不能产生空返还）
   Test:
@@ -131,6 +172,7 @@ Scenario: 事件的 topic 路由与其他 turn 事件一致
 
 ## Out of Scope
 
-- 客户端（octoscode）消费 `turn/steer_dropped` 并重新入队（需先把 octos-core 重新 pin 到本改动之后的 rev）。
+- 客户端（octoscode）消费 `turn/steer_dropped`（task-consume-turn-steer-dropped）。
+- 跨客户端进程重启的 durable 恢复（需要 steer 回执 id 与持久化状态；本任务明确为 same-process reconnect only）。
 - interrupt/steer 的 INFO 级关联日志（F7）、`octos serve` fd 累积（F8）。
 - 把残留输入合并进 `turn/error`/`turn/completed` 载荷。

--- a/specs/task-return-unconsumed-steer-inputs.spec.md
+++ b/specs/task-return-unconsumed-steer-inputs.spec.md
@@ -68,7 +68,7 @@ ledger（可 replay），使客户端能确定性地重新入队，而不是靠"
 - crates/octos-core/src/ui_protocol_tests.rs
 - crates/octos-cli/src/lib.rs
 - crates/octos-cli/src/steer_return.rs
-- crates/octos-cli/src/api/ui_protocol.rs
+- crates/octos-cli/src/api/ui_protocol_transport.rs
 - crates/octos-cli/src/api/ui_protocol_ledger.rs
 - crates/octos-cli/src/api/ui_protocol_tests.rs
 - specs/task-return-unconsumed-steer-inputs.spec.md
@@ -128,7 +128,7 @@ Scenario: 所有终态出口都经过结算闸门（结构检查）
   Test:
     Package: octos-cli
     Filter: every_terminal_outlet_goes_through_the_settling_gate
-  When 扫描 `crates/octos-cli/src/api/ui_protocol.rs`
+  When 扫描 `crates/octos-cli/src/api/ui_protocol_transport.rs`
   Then `transition_to_terminal(` 只在 `transition_to_terminal_settling_steers` 内被调用
 
 Scenario: 状态 Terminal 后不再受理 steer（需 --features api）

--- a/specs/task-return-unconsumed-steer-inputs.spec.md
+++ b/specs/task-return-unconsumed-steer-inputs.spec.md
@@ -37,17 +37,23 @@ ledger（可 replay），使客户端能确定性地重新入队，而不是靠"
   下的测试验证并以 `Review: human` 场景登记。
 - 发送方式：`send_notification_durable`（等待容量、写 ledger），因为载荷是用户
   文本，不允许因背压丢帧。
-- 时序（v2，审查 P0）：`try_emit_terminal` 在 `transition_to_terminal` 把状态置为
-  Terminal 之后、终态帧之前调用 `settle_leftover_steers`，因此同一连接上
-  `turn/steer_dropped` **严格先于** `turn/error`/`turn/completed`；`handle_turn_steer`
-  在持有 turn 状态锁期间完成 check-and-push，状态转 Terminal 后不再受理，故结算看到
-  的是完整的残留集合。`agent_task.await` 之后的旧 drain 仅作安全网保留。
+- 时序（v2，审查 P0）：唯一的终态闸门 `transition_to_terminal_settling_steers`
+  = `transition_to_terminal`（状态置 Terminal）→ `settle_leftover_steers`（发/写
+  `turn/steer_dropped`）→ 调用方发终态帧。**所有**终态出口——live 的
+  `try_emit_terminal`、连接关闭的 `abort_connection_turns`（v3：连接已断，只写 ledger，
+  `SteerReturnSink::LedgerOnly`）、`turn/started` 发送失败的早退、测试夹具——都经此闸门；
+  `transition_to_terminal` 不得在闸门之外调用（结构测试守卫）。因此同一连接/ledger 流上
+  `turn/steer_dropped` **严格先于** `turn/error`/`turn/completed`（含 `connection_closed`）；
+  `handle_turn_steer` 在持有 turn 状态锁期间完成 check-and-push，状态转 Terminal 后不再受理，
+  故结算看到的是完整的残留集合。`agent_task.await` 之后的旧 drain 仅作安全网（找到残留即
+  WARN 违反不变量）。
 - capability：新增 `UI_PROTOCOL_FEATURE_TURN_STEER_DROPPED_V1 = "event.turn_steer_dropped.v1"`
   加入 `UI_PROTOCOL_KNOWN_FEATURES`，`ConnectionUiFeatures` 增加 `turn_steer_dropped_v1`
   （stdio 默认开、ws 按请求）。客户端见到该 feature 即可把"终态前没有 dropped 点名
   我的 steer"解释为"服务端已消费"，不再做终态兜底重排。
 - 恢复边界（审查 P1）：本任务的 durable/ledger 只支持**同一客户端进程内的断线重连
-  replay**（客户端凭内存中的 retained 记录匹配）；客户端进程重启后 `/resume` 无法
+  replay**（客户端凭内存中的 retained 记录匹配；连接关闭路径的返还也在 ledger 中先于
+  `connection_closed` 终态，重连 replay 时顺序成立）；客户端进程重启后 `/resume` 无法
   恢复未消费 steer——那需要稳定的 steer 回执 id 与持久化的提交/消费状态，列为后续
   工作，不在本任务范围内声称。
 - 服务端在 `Interrupting` 状态下继续受理 steer 的行为不变——被受理的输入现在保证
@@ -106,6 +112,24 @@ Scenario: steer_dropped 严格先于终态帧且状态已 Terminal（critical；
   Then 连接上 `turn/steer_dropped` 帧的位置在 `turn/error` 之前
   And 状态为 `Terminal(Interrupted)`、buffer 为空
   And 第二次调用不再产生任何帧
+
+Scenario: 连接关闭路径同样先返还再终态（critical；需 --features api）
+  Tags: critical
+  Review: human
+  Test:
+    Package: octos-cli
+    Filter: connection_close_settles_steers_before_connection_closed_terminal
+  Given 注册表中一个 Active turn 的 `SteerBuffer` 有一条残留，连接随后关闭
+  When `abort_connection_turns` 处理该连接
+  Then ledger replay 中 `turn/steer_dropped` 严格早于 `turn/error(connection_closed)`
+  And buffer 为空
+
+Scenario: 所有终态出口都经过结算闸门（结构检查）
+  Test:
+    Package: octos-cli
+    Filter: every_terminal_outlet_goes_through_the_settling_gate
+  When 扫描 `crates/octos-cli/src/api/ui_protocol.rs`
+  Then `transition_to_terminal(` 只在 `transition_to_terminal_settling_steers` 内被调用
 
 Scenario: 状态 Terminal 后不再受理 steer（需 --features api）
   Review: human

--- a/specs/task-return-unconsumed-steer-inputs.spec.md
+++ b/specs/task-return-unconsumed-steer-inputs.spec.md
@@ -1,0 +1,136 @@
+spec: task
+name: "turn 退出时把未消费的 steer 输入返还客户端"
+tags: [ui-protocol, steer, turn-lifecycle, octos-cli, octos-core]
+estimate: 1d
+---
+
+## Intent
+
+`turn/steer` 返回 `steered:true` 只表示输入进入了 pending-input buffer；如果 turn
+在下一次 drain 之前被中断（事故 2026-08-17：steer 受理 32 秒后用户按 Esc，agent
+被 abort），`run_standalone_turn` 在 `agent_task.await` 之后只把残留 drain 出来打一条
+WARN，客户端因 RPC 已成功而认为文本"已发送"，文本静默丢失。本任务把这次 drop
+变成协议事件：残留输入以新的 `turn/steer_dropped` 通知按原顺序返还客户端并写入
+ledger（可 replay），使客户端能确定性地重新入队，而不是靠"没收到 echo"推断。
+
+## Decisions
+
+<!-- lint-ack: verification-metadata-suggestion — 两个错误路径场景使用进程内 stdio WsConnection + 内存 ledger fixture，无真实外部 I/O -->
+
+- 新增 `octos-core` 通知 `UiNotification::TurnSteerDropped(TurnSteerDroppedEvent)`，
+  method 常量 `methods::TURN_STEER_DROPPED = "turn/steer_dropped"`；事件字段
+  `session_id`、`topic`（可选，与其他 turn 事件同样走 `set_topic_if_absent`）、
+  `turn_id`、`inputs: Vec<String>`（保持 buffer 顺序）、`reason: String`。
+- `reason` 取值：turn 被中断（`interrupt_observed`）时为 `"interrupted"`，其余为
+  `"turn_ended"`。
+- 分层：不依赖 `api` feature 的纯函数
+  `steer_return::leftover_steer_notification(session_id, turn_id, leftovers,
+  interrupt_observed) -> Option<UiNotification>`（空残留返回 `None`）负责事件形状；
+  `api` 侧的 `settle_leftover_steers(buffer, ws, ledger, session_id, turn_id,
+  interrupt_observed) -> usize` 在 `run_standalone_turn` 中 `agent_task.await`
+  之后的现有残留 drain 处调用它并发送；有残留才发送，返回返还条数；原 WARN
+  日志保留。
+- 验证边界说明：`octos-cli` 的 `api` 模块（`WsConnection`、ledger）在 `api`
+  feature 后面，`agent-spec` 的默认 `cargo test -p octos-cli` 不启用它；因此形状/
+  顺序/reason/空残留由纯函数测试机械验证，发送与 ledger 行为由 `--features api`
+  下的测试验证并以 `Review: human` 场景登记。
+- 发送方式：`send_notification_durable`（等待容量、写 ledger），因为载荷是用户
+  文本，不允许因背压丢帧；该通知在 turn 终态事件之后发出，客户端应把它当作
+  "终态后需重新入队的输入"处理。
+- 服务端在 `Interrupting` 状态下继续受理 steer 的行为不变——被受理的输入现在保证
+  要么被 drain 进对话，要么通过 `turn/steer_dropped` 返还。
+- 不修改 `TurnErrorEvent`/`TurnCompletedEvent` 的字段，保持既有客户端兼容（由
+  "没有残留时不发任何帧"场景与既有终态测试共同约束：终态帧形状不变）。
+
+## Boundaries
+
+### Allowed Changes
+- crates/octos-core/src/ui_protocol.rs
+- crates/octos-core/src/ui_protocol_tests.rs
+- crates/octos-cli/src/lib.rs
+- crates/octos-cli/src/steer_return.rs
+- crates/octos-cli/src/api/ui_protocol.rs
+- crates/octos-cli/src/api/ui_protocol_ledger.rs
+- crates/octos-cli/src/api/ui_protocol_tests.rs
+- specs/task-return-unconsumed-steer-inputs.spec.md
+
+### Forbidden
+- 不改变 `turn/steer` 的受理判定（`TurnSteerDecision`）与返回值。
+- 不改变 turn 终态事件（`turn/error`、`turn/completed`）的载荷。
+- 不在残留 drain 处直接把输入重新注入新的 turn（是否重发由客户端决定）。
+- 不新增 crate 依赖。
+
+## Completion Criteria
+
+### Rule: leftover-steers-returned — 残留 steer 以协议事件返还
+Scenario: 中断后残留的 steer 按顺序生成 turn/steer_dropped 事件（critical）
+  Tags: critical
+  Test:
+    Package: octos-cli
+    Filter: leftover_steer_notification_preserves_order_and_labels_interrupted
+  Given 两条已受理但未 drain 的输入
+  When `leftover_steer_notification` 以 `interrupt_observed = true` 被调用
+  Then 返回 `TurnSteerDropped` 事件，`inputs` 与输入顺序一致
+  And `reason` 为 `"interrupted"` 且 `session_id`/`turn_id` 正确
+  And 事件的 method 为 `turn/steer_dropped`
+
+Scenario: 正常结束时的残留标为 turn_ended
+  Test:
+    Package: octos-cli
+    Filter: leftover_steer_notification_labels_turn_ended_without_interrupt
+  Given 一条残留输入
+  When `leftover_steer_notification` 以 `interrupt_observed = false` 被调用
+  Then 事件的 `reason` 为 `"turn_ended"`
+
+Scenario: 没有残留时不生成事件（错误路径：不能产生空返还）
+  Test:
+    Package: octos-cli
+    Filter: no_leftover_steers_produce_no_notification
+  Given 空的残留列表
+  When `leftover_steer_notification` 被调用
+  Then 返回 `None`
+  And `TurnErrorEvent`/`TurnCompletedEvent` 的字段集不因本任务改变
+
+Scenario: api 侧把事件 durable 发送并写入 ledger、buffer 被清空（需 --features api）
+  Review: human
+  Test:
+    Package: octos-cli
+    Filter: leftover_steers_at_turn_end_are_returned_as_turn_steer_dropped
+  Given 一个 `SteerBuffer` 里有两条残留输入与一个 stdio `WsConnection`
+  When `settle_leftover_steers` 以 `interrupt_observed = true` 被调用
+  Then 连接上收到一帧 `turn/steer_dropped` 且 ledger 追加了同一条通知
+  And 返回值为 2 且 buffer 之后为空
+
+Scenario: 连接已失效时残留仍写入 ledger（错误路径：断连不丢文本；需 --features api）
+  Review: human
+  Test:
+    Package: octos-cli
+    Filter: leftover_steers_are_ledgered_even_when_connection_write_fails
+  Given 连接的 stdio writer 已经关闭
+  When `settle_leftover_steers` 处理一条残留输入
+  Then ledger 仍追加了 `turn/steer_dropped` 通知以供 reconnect replay
+  And 返回值为 1
+
+### Rule: protocol-shape — 事件形状与路由
+Scenario: 事件通过 method 与 params 往返编码
+  Test:
+    Package: octos-core
+    Filter: turn_steer_dropped_round_trips_through_method_and_params
+  Given 一个 `TurnSteerDroppedEvent`
+  When 以 `method_name()` + `to_params()` 编码再用 `from_method_params` 解码
+  Then method 为 `turn/steer_dropped` 且解码结果与原事件相等
+
+Scenario: 事件的 topic 路由与其他 turn 事件一致
+  Test:
+    Package: octos-core
+    Filter: turn_steer_dropped_topic_routing_matches_other_turn_events
+  Given 一个 `session_id` 带 topic 后缀而 `topic` 字段为空的事件
+  When 读取 `topic()` 并调用 `set_topic_if_absent`
+  Then `topic()` 返回 session key 的 topic
+  And 已有 topic 不会被覆盖
+
+## Out of Scope
+
+- 客户端（octoscode）消费 `turn/steer_dropped` 并重新入队（需先把 octos-core 重新 pin 到本改动之后的 rev）。
+- interrupt/steer 的 INFO 级关联日志（F7）、`octos serve` fd 累积（F8）。
+- 把残留输入合并进 `turn/error`/`turn/completed` 载荷。


### PR DESCRIPTION
## Summary

`turn/steer` answering `steered:true` only means the text entered the pending-input buffer. When the loop is aborted before its next drain (incident 2026-08-17: the client interrupted 32 s after a steer was accepted while a tool was running), `run_standalone_turn` drained the leftovers after `agent_task.await` and merely logged a WARN — the client, whose RPC had succeeded, showed the text as sent and it was lost.

This PR makes the drop a protocol event:

- **octos-core**: new `UiNotification::TurnSteerDropped` / `methods::TURN_STEER_DROPPED = "turn/steer_dropped"` with `{session_id, topic?, turn_id, inputs: Vec<String>, reason}`; wired through method/session_id/topic/set_topic/params/decode. `turn/error` / `turn/completed` payloads unchanged; steer acceptance semantics unchanged.
- **octos-cli**: `settle_leftover_steers` returns the undrained inputs in buffer order with `reason` = `interrupted` | `turn_ended`, sent **durably** (user text; ledgered). Empty buffer → no frame. The feature-independent shape lives in `octos_cli::steer_return` so it is verifiable with a plain `cargo test -p octos-cli`.
- **Ordering (v2, review P0)**: one terminal gate, `transition_to_terminal_settling_steers` = state → Terminal → `settle_leftover_steers` (`turn/steer_dropped`) → caller emits its terminal frame. **Every** terminal outlet goes through it (round 3): live `try_emit_terminal`, the connection-close `abort_connection_turns` (ledger-only sink — the socket is gone, the reconnecting client replays it), the early turn/started-failed bail-outs, fixtures; a feature-independent structural test asserts `transition_to_terminal` is called nowhere else. So on one connection *and* in the replayed ledger, `turn/steer_dropped` strictly precedes `turn/error`/`turn/completed` (incl. `connection_closed`). `handle_turn_steer` holds the turn-state lock across check-and-push, so nothing can be accepted between the settlement and the frame; the post-await drain stays as a safety net and WARNs if it ever finds leftovers. Advertised as **`event.turn_steer_dropped.v1`** (`UI_PROTOCOL_KNOWN_FEATURES`; stdio default on, ws by request): a client that sees it may treat "terminal without a preceding steer_dropped naming my steer" as *consumed* and skip its own re-stage.
- **Scope (review P1)**: ledger replay of the return is **same-process reconnect only** — the client matches by its in-memory retained record. Recovery across a client restart needs steer receipt ids and persisted commit/consume state and is explicitly out of scope here (follow-up).

Client consumer (octoscode) is in a companion PR; the notification is additive, so older clients are unaffected.

Contract: `specs/task-return-unconsumed-steer-inputs.spec.md` (agent-spec, lint 100%).

## Verification

- `cargo test -p octos-core --lib -- turn_steer_dropped` → 2/2
- `cargo test -p octos-cli --lib -- steer_return` → 3/3
- `cargo test -p octos-cli --features api --lib -- leftover_steers no_leftover_steers steer_dropped_is_emitted steer_is_not_accepted turn_steer_dropped_feature connection_close_settles` → 9/9 (wire ordering `steer_dropped_is_emitted_before_the_terminal_frame`; **ledger ordering on connection close** `connection_close_settles_steers_before_connection_closed_terminal`; post-terminal admission; capability advertisement)
- `cargo test -p octos-cli --lib -- steer_return` → 4/4 incl. structural `every_terminal_outlet_goes_through_the_settling_gate` (no feature needed)
- `cargo check --workspace --all-targets` clean; clippy clean on touched crates
- `agent-spec lifecycle` (default runner): 7/13 passed, 6 skipped — the `--features api` scenarios cannot be executed by the default runner (`cargo test -p octos-cli` without features); they were resolved via `--ai-mode caller` + `resolve-ai` with the recorded `--features api` run as evidence (merged report 12/12, 6 inferential). Reviewers may prefer to run the `--features api` command above directly.

## Rebase note

Rebased onto `main` 24d00f32 (which renamed `ui_protocol.rs` → `ui_protocol_transport.rs`); the structural gate test and the Contract now name the new path. All gates re-run green after the rebase.

## Notes for reviewers

- The spec file is force-added: the repo's `.gitignore` has a global `*.md` that also ignores `specs/` (existing specs were added the same way). Consider `!specs/*.md`.
- Follow-up (not in this PR): INFO-level correlation logging for interrupt/steer accept/consume/return (F7 in the incident report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
