### PR TITLE
feat(ui-protocol): session/turn-correlated logs for turn/interrupt and turn/steer

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -81,7 +81,7 @@ use serde_json::{Value, json};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufWriter};
 use tokio::sync::{Mutex as TokioMutex, mpsc, oneshot};
 use tokio::task::AbortHandle;
-use tracing::{debug, info, warn};
+use tracing::{Instrument, debug, info, warn};
 
 use super::AppState;
 use super::metrics::MetricsReporter;
@@ -19577,8 +19577,11 @@ async fn handle_turn_start_with_accept(
 /// Outcome of the `turn/steer` registry decision (computed under the
 /// active-turns registry lock — see [`handle_turn_steer`]).
 enum TurnSteerDecision {
-    /// Input pushed into the ACTIVE turn's pending buffer.
-    Steered(TurnId),
+    /// Input pushed into the ACTIVE turn's pending buffer. `interrupting`
+    /// records that the turn was already winding down at acceptance
+    /// (task-turn-interrupt-steer-correlation-logs) — such input is likely
+    /// to be returned as `turn/steer_dropped` rather than drained.
+    Steered { turn_id: TurnId, interrupting: bool },
     /// `expected_turn_id` was present and does not name the active turn
     /// (codex `ExpectedTurnMismatch`). Carries the actual active id for the
     /// error message.
@@ -19654,6 +19657,10 @@ async fn handle_turn_steer(
                 // in between the settlement and the terminal frame.
                 let state = existing.state.lock().await;
                 let terminal = matches!(*state, TurnState::Terminal(_));
+                // task-turn-interrupt-steer-correlation-logs: input accepted
+                // while the turn is already winding down is the case that
+                // ends up returned as turn/steer_dropped.
+                let interrupting = matches!(*state, TurnState::Interrupting { .. });
                 if terminal {
                     TurnSteerDecision::NoActiveTurn
                 } else if params
@@ -19669,7 +19676,10 @@ async fn handle_turn_steer(
                             // the accept below can never name a turn that a
                             // concurrent admission already replaced.
                             buffer.push(prompt.clone());
-                            TurnSteerDecision::Steered(existing.turn_id.clone())
+                            TurnSteerDecision::Steered {
+                                turn_id: existing.turn_id.clone(),
+                                interrupting,
+                            }
                         }
                         None => TurnSteerDecision::NotSteerable,
                     }
@@ -19680,12 +19690,11 @@ async fn handle_turn_steer(
     };
 
     match decision {
-        TurnSteerDecision::Steered(turn_id) => {
-            info!(
-                session = %params.session_id.0,
-                turn = %turn_id.0,
-                "turn/steer accepted into the active turn's pending-input buffer"
-            );
+        TurnSteerDecision::Steered {
+            turn_id,
+            interrupting,
+        } => {
+            crate::turn_trace::log_steer_accepted(&params.session_id, &turn_id, interrupting);
             let _ = send_rpc_result(ws, id, json!({ "turn_id": turn_id, "steered": true }));
         }
         TurnSteerDecision::Mismatch(active_turn_id) => {
@@ -20656,7 +20665,20 @@ async fn handle_turn_interrupt(
     id: String,
     params: TurnInterruptParams,
 ) {
+    // task-turn-interrupt-steer-correlation-logs: make the interrupt's
+    // receipt, decision and ack reconstructible from the log alone.
+    crate::turn_trace::log_interrupt_received(&params.session_id, &params.turn_id);
     let outcome = decide_interrupt(active_turns, &params).await;
+    let outcome_label: String = match &outcome {
+        InterruptOutcome::Unknown => "unknown".into(),
+        InterruptOutcome::Mismatch => "mismatch".into(),
+        InterruptOutcome::AlreadyTerminal(reason) => {
+            format!("already_terminal:{}", reason.as_str())
+        }
+        InterruptOutcome::AlreadyInterrupting => "already_interrupting".into(),
+        InterruptOutcome::Captured { .. } => "captured".into(),
+    };
+    crate::turn_trace::log_interrupt_outcome(&params.session_id, &params.turn_id, &outcome_label);
     match outcome {
         InterruptOutcome::Unknown => {
             let _ = send_rpc_error(ws, Some(id), unknown_turn_error(&params.turn_id));
@@ -20694,6 +20716,15 @@ async fn handle_turn_interrupt(
             // outer turn future here — that would race with the terminal
             // emission and could lose the wire-side event.
             let result = tokio::time::timeout(INTERRUPT_ACK_TIMEOUT, ack_rx).await;
+            crate::turn_trace::log_interrupt_ack(
+                &params.session_id,
+                &params.turn_id,
+                if matches!(result, Ok(Ok(()))) {
+                    "interrupted"
+                } else {
+                    "ack_timed_out"
+                },
+            );
             let payload = match result {
                 Ok(Ok(())) => TurnInterruptResult::interrupted_ok(),
                 Ok(Err(_)) => {
@@ -31268,6 +31299,11 @@ async fn run_standalone_turn(
     // task future is dropped.
     let token_tracker = std::sync::Arc::new(octos_agent::TokenTracker::new());
     let token_tracker_task = std::sync::Arc::clone(&token_tracker);
+    // task-turn-interrupt-steer-correlation-logs: every agent-side log line
+    // (LLM calls, tool batches, steer drains, EndTurn rounds) inherits
+    // `session`/`turn` from this span (postfix `.instrument` keeps the block
+    // itself untouched).
+    let turn_span = crate::turn_trace::turn_span(&session_id, &turn_id);
     let agent_task = tokio::spawn(async move {
         let start = std::time::Instant::now();
         // RFC-3 (#1292): wrap the agent.process_message future in the
@@ -31983,7 +32019,7 @@ async fn run_standalone_turn(
                 let _ = progress_tx_for_result.send(error.to_string()).await;
             }
         }
-    });
+    }.instrument(turn_span));
     let _abort_guard = AbortOnDrop {
         abort: agent_task.abort_handle(),
     };

--- a/crates/octos-cli/src/lib.rs
+++ b/crates/octos-cli/src/lib.rs
@@ -32,6 +32,11 @@ pub(crate) mod steer_return;
 /// task-sysinfo-proc-stat-fd-budget: the one place the metrics `sysinfo::System`
 /// is constructed (handle cache off, no startup process snapshot).
 pub(crate) mod sysinfo_budget;
+/// task-turn-interrupt-steer-correlation-logs: session/turn-correlated
+/// lifecycle logging for turn/interrupt and turn/steer (the `api` module
+/// calls these; kept feature-independent so the shape is testable).
+#[cfg_attr(not(feature = "api"), allow(dead_code))]
+pub(crate) mod turn_trace;
 pub use octos_services::cli_agent_adapter;
 pub mod commands;
 pub use octos_services::compaction;

--- a/crates/octos-cli/src/turn_trace.rs
+++ b/crates/octos-cli/src/turn_trace.rs
@@ -1,0 +1,183 @@
+//! task-turn-interrupt-steer-correlation-logs: session/turn-correlated
+//! lifecycle logging for `turn/interrupt` and `turn/steer`.
+//!
+//! The 2026-08-17 incident had to be reconstructed from the ledger because
+//! the server log carried no INFO record of the interrupt and the agent-side
+//! lines (`calling LLM`, `executing tool batch`, `draining mid-turn steer
+//! input`) named neither session nor turn. Everything here logs ids, counts
+//! and states only — never user text.
+
+use octos_core::SessionKey;
+use octos_core::ui_protocol::TurnId;
+use tracing::{Span, info, info_span};
+
+/// The span the spawned agent future runs under, so every log line it emits
+/// (LLM calls, tool batches, steer drains, EndTurn rounds) carries
+/// `session` and `turn` without each call site naming them.
+pub(crate) fn turn_span(session_id: &SessionKey, turn_id: &TurnId) -> Span {
+    info_span!("turn", session = %session_id.0, turn = %turn_id.0)
+}
+
+/// `turn/interrupt` reached the server for this session/turn.
+pub(crate) fn log_interrupt_received(session_id: &SessionKey, turn_id: &TurnId) {
+    info!(session = %session_id.0, turn = %turn_id.0, "turn/interrupt received");
+}
+
+/// How the interrupt was decided: `captured`, `already_interrupting`,
+/// `already_terminal:<reason>`, `mismatch` or `unknown`.
+pub(crate) fn log_interrupt_outcome(session_id: &SessionKey, turn_id: &TurnId, outcome: &str) {
+    info!(session = %session_id.0, turn = %turn_id.0, %outcome, "turn/interrupt decided");
+}
+
+/// The captured interrupt's ack result: `interrupted` or `ack_timed_out`.
+pub(crate) fn log_interrupt_ack(session_id: &SessionKey, turn_id: &TurnId, ack: &str) {
+    info!(session = %session_id.0, turn = %turn_id.0, %ack, "turn/interrupt acknowledged");
+}
+
+/// `turn/steer` accepted into the turn's pending-input buffer.
+/// `interrupting = true` means the turn was already winding down when the
+/// input was accepted — it will most likely be returned as
+/// `turn/steer_dropped` rather than drained.
+pub(crate) fn log_steer_accepted(session_id: &SessionKey, turn_id: &TurnId, interrupting: bool) {
+    info!(
+        session = %session_id.0,
+        turn = %turn_id.0,
+        interrupting,
+        "turn/steer accepted into the active turn's pending-input buffer"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Default)]
+    struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for CapturedLogs {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn capture(run: impl FnOnce()) -> String {
+        let captured = CapturedLogs::default();
+        let writer = captured.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_target(false)
+            .with_max_level(tracing::Level::INFO)
+            .with_writer(move || writer.clone())
+            .finish();
+        tracing::subscriber::with_default(subscriber, run);
+        String::from_utf8(captured.0.lock().unwrap().clone()).unwrap()
+    }
+
+    fn ids() -> (SessionKey, TurnId) {
+        (SessionKey("local:tui#coding".into()), TurnId::new())
+    }
+
+    #[test]
+    fn interrupt_lifecycle_logs_carry_session_and_turn() {
+        let (session, turn) = ids();
+        let logs = capture(|| {
+            log_interrupt_received(&session, &turn);
+            log_interrupt_outcome(&session, &turn, "captured");
+            log_interrupt_ack(&session, &turn, "interrupted");
+        });
+        let lines: Vec<&str> = logs.lines().collect();
+        assert_eq!(lines.len(), 3, "{logs}");
+        for line in &lines {
+            assert!(line.contains("session=local:tui#coding"), "{line}");
+            assert!(line.contains(&format!("turn={}", turn.0)), "{line}");
+            assert!(
+                line.starts_with(" INFO") || line.starts_with("INFO"),
+                "{line}"
+            );
+        }
+        assert!(lines[0].contains("turn/interrupt received"));
+        assert!(lines[1].contains("outcome=captured"), "{:?}", lines[1]);
+        assert!(
+            !lines[1].contains("outcome=\"captured\""),
+            "Display, not Debug: {:?}",
+            lines[1]
+        );
+        assert!(lines[2].contains("ack=interrupted"));
+    }
+
+    #[test]
+    fn agent_logs_inside_turn_span_carry_session_and_turn() {
+        let (session, turn) = ids();
+        let logs = capture(|| {
+            let span = turn_span(&session, &turn);
+            let _guard = span.enter();
+            tracing::info!("calling LLM iteration=6");
+        });
+        assert!(logs.contains("turn{"), "span name is printed: {logs}");
+        assert!(logs.contains("session=local:tui#coding"), "{logs}");
+        assert!(logs.contains(&format!("turn={}", turn.0)), "{logs}");
+        assert!(logs.contains("calling LLM iteration=6"));
+    }
+
+    #[test]
+    fn steer_accepted_log_marks_interrupting_turns() {
+        let (session, turn) = ids();
+        let logs = capture(|| {
+            log_steer_accepted(&session, &turn, false);
+            log_steer_accepted(&session, &turn, true);
+        });
+        let lines: Vec<&str> = logs.lines().collect();
+        assert_eq!(lines.len(), 2, "{logs}");
+        assert!(
+            lines[0].contains("interrupting=false")
+                && lines[0].contains("session=")
+                && lines[0].contains("turn=")
+        );
+        assert!(
+            lines[1].contains("interrupting=true")
+                && lines[1].contains("session=")
+                && lines[1].contains("turn=")
+        );
+    }
+
+    #[test]
+    fn correlation_logs_never_contain_user_text() {
+        let (session, turn) = ids();
+        let steer_text = "SECRET-MARKER-please-rm-rf-nothing";
+        let logs = capture(|| {
+            // The text lives with the caller; none of the log fns take it.
+            let _pending = [steer_text.to_string()];
+            log_interrupt_received(&session, &turn);
+            log_interrupt_outcome(&session, &turn, "captured");
+            log_interrupt_ack(&session, &turn, "interrupted");
+            log_steer_accepted(&session, &turn, true);
+        });
+        assert!(!logs.contains(steer_text), "{logs}");
+        assert!(!logs.contains("SECRET-MARKER"));
+    }
+
+    #[test]
+    fn interrupt_outcome_logs_cover_rejections_at_info() {
+        let (session, turn) = ids();
+        let logs = capture(|| {
+            log_interrupt_outcome(&session, &turn, "unknown");
+            log_interrupt_outcome(&session, &turn, "mismatch");
+            log_interrupt_outcome(&session, &turn, "already_terminal:interrupted");
+        });
+        let lines: Vec<&str> = logs.lines().collect();
+        assert_eq!(lines.len(), 3, "{logs}");
+        assert!(lines[0].contains("outcome=unknown") && lines[0].contains("INFO"));
+        assert!(lines[1].contains("outcome=mismatch") && lines[1].contains("INFO"));
+        assert!(
+            lines[2].contains("outcome=already_terminal:interrupted") && lines[2].contains("INFO")
+        );
+        assert!(!logs.contains("WARN") && !logs.contains("ERROR"));
+    }
+}

--- a/specs/task-turn-interrupt-steer-correlation-logs.spec.md
+++ b/specs/task-turn-interrupt-steer-correlation-logs.spec.md
@@ -1,0 +1,99 @@
+spec: task
+name: "interrupt/steer 生命周期的 session/turn 关联日志"
+tags: [ui-protocol, observability, interrupt, steer, octos-cli]
+estimate: 0.5d
+---
+
+## Intent
+
+事故（2026-08-17）排查时，服务端日志里 `turn/interrupt` 的收到/裁决/ack 没有任何
+INFO 记录，agent 侧的 `calling LLM`、`executing tool batch`、`draining mid-turn
+steer input` 等行也不带 session/turn，只能靠 ledger 反推中断时刻与 steer 命运。
+本任务补齐关联：把 agent 任务包进带 `session`/`turn` 字段的 tracing span，让
+agent 侧所有日志自动携带二者；并在 interrupt 收到/裁决/ack 与 steer 受理（含
+"turn 正在 Interrupting 时仍受理"）处输出 INFO 级结构化日志。日志只记 id、计数与
+状态，绝不记录用户文本。
+
+## Decisions
+
+<!-- lint-ack: verification-metadata-suggestion — 日志场景以进程内 tracing 订阅器捕获文本断言，无外部 I/O -->
+
+- 新增不依赖 `api` feature 的模块 `octos_cli::turn_trace`：
+  `turn_span(session_id, turn_id) -> tracing::Span`（`info_span!("turn", session, turn)`），
+  以及 `log_interrupt_received`、`log_interrupt_outcome(outcome)`、
+  `log_interrupt_ack(ack)`、`log_steer_accepted(interrupting)`；全部 INFO 级、字段
+  名固定为 `session`/`turn`/`outcome`/`ack`/`interrupting`。
+- `run_standalone_turn` 中 `tokio::spawn` 的 agent future 用 `turn_span` 包裹
+  （`tracing::Instrument`），使 agent 侧既有日志继承 `session`/`turn`。
+- `handle_turn_interrupt`：进入时 `log_interrupt_received`；按 `InterruptOutcome`
+  分支记录 `outcome` ∈ {`captured`,`already_interrupting`,`already_terminal:<reason>`,
+  `mismatch`,`unknown`}；`Captured` 分支等待 ack 后记录 `ack` ∈
+  {`interrupted`,`ack_timed_out`}。
+- `turn/steer` 受理日志改为 `log_steer_accepted(interrupting)`，`interrupting` 表示
+  受理时 turn 已处于 `Interrupting`（这类输入大概率会在 turn 退出时被返还）。
+- 日志内容边界：不记录 steer 文本、prompt 或工具参数。
+
+## Boundaries
+
+### Allowed Changes
+- crates/octos-cli/src/lib.rs
+- crates/octos-cli/src/turn_trace.rs
+- crates/octos-cli/src/api/ui_protocol_transport.rs
+- specs/task-turn-interrupt-steer-correlation-logs.spec.md
+
+### Forbidden
+- 不改变 interrupt/steer 的任何行为、返回值或时序（只加日志与 span）。
+- 不在日志中输出用户文本、prompt、工具参数或 token 内容。
+- 不把日志级别提高到 WARN/ERROR（正常生命周期为 INFO）。
+- 不新增 crate 依赖。
+
+## Completion Criteria
+
+### Rule: correlated-lifecycle-logs — 生命周期日志携带 session/turn
+Scenario: interrupt 收到/裁决/ack 三条日志都带 session 与 turn（critical）
+  Tags: critical
+  Test:
+    Package: octos-cli
+    Filter: interrupt_lifecycle_logs_carry_session_and_turn
+  Given 一个捕获输出的 tracing 订阅器与 `octos_cli::turn_trace` 模块
+  When 依次调用 `log_interrupt_received`、`log_interrupt_outcome("captured")`、`log_interrupt_ack("interrupted")`
+  Then 三行日志都包含 `session=<id>` 与 `turn=<id>`
+  And 分别包含 `outcome=captured` 与 `ack=interrupted`
+  And 级别均为 INFO
+
+Scenario: agent 侧日志在 turn span 内自动携带 session/turn
+  Test:
+    Package: octos-cli
+    Filter: agent_logs_inside_turn_span_carry_session_and_turn
+  Given `turn_span(session, turn)` 已进入作用域
+  When 记录一条不带任何字段的 `tracing::info!`
+  Then 捕获输出的该行包含 span 名 `turn` 及 `session=<id>`、`turn=<id>`
+
+Scenario: steer 受理日志标明 turn 是否正在 Interrupting
+  Test:
+    Package: octos-cli
+    Filter: steer_accepted_log_marks_interrupting_turns
+  When 分别以 `interrupting = false` 与 `true` 调用 `log_steer_accepted`
+  Then 两行都包含 `session=`、`turn=` 且分别包含 `interrupting=false`、`interrupting=true`
+
+### Rule: no-user-text — 日志不泄露用户内容
+Scenario: 日志函数不接收也不输出用户文本（错误路径）
+  Test:
+    Package: octos-cli
+    Filter: correlation_logs_never_contain_user_text
+  Given 一个含唯一标记的 steer 文本存在于调用方
+  When 调用全部 `turn_trace` 日志函数
+  Then 捕获输出不包含该标记
+
+Scenario: 未知/不匹配裁决同样记录且不升级级别（错误路径）
+  Test:
+    Package: octos-cli
+    Filter: interrupt_outcome_logs_cover_rejections_at_info
+  When 以 `unknown`、`mismatch`、`already_terminal:interrupted` 调用 `log_interrupt_outcome`
+  Then 三行都以 INFO 记录并包含各自的 `outcome=` 值
+
+## Out of Scope
+
+- 把 span 传播到 octos-agent crate 内部的更细粒度（LLM provider、tool 执行）日志。
+- 日志格式/JSON 输出配置。
+- F8：`octos serve` 的 fd 累积。


### PR DESCRIPTION
## Summary

Observability follow-up to the 2026-08-17 incident (companion to #2049). Reconstructing that incident needed the ledger because the server log had no INFO record of the `turn/interrupt` (receipt / decision / ack), and agent-side lines (`calling LLM`, `executing tool batch`, `draining mid-turn steer input`, the EndTurn steer round) named neither session nor turn.

- **`octos_cli::turn_trace`** (feature-independent): `turn_span(session, turn)` + INFO helpers `log_interrupt_received / _outcome / _ack`, `log_steer_accepted(interrupting)`. Ids, counts and states only — never user text (tested).
- **Agent task runs under `turn_span`** (`.instrument`, block untouched) → every agent-side log line inherits `session=… turn=…`.
- **`handle_turn_interrupt`** logs receipt, the outcome (`captured | already_interrupting | already_terminal:<reason> | mismatch | unknown`) and, for captured interrupts, the ack (`interrupted | ack_timed_out`).
- **`turn/steer` acceptance** records `interrupting=true|false` — the `true` case is exactly the input that #2049 returns as `turn/steer_dropped`.

No behavioural change to interrupt/steer; log level stays INFO. **Stacked on #2049** (rebased onto its head `9b6cd916` (itself rebased on main 24d00f32) because both touch the `turn/steer` admission block; merge #2049 first — this PR then reduces to one commit).

Contract: `specs/task-turn-interrupt-steer-correlation-logs.spec.md` (agent-spec, lint 100%, lifecycle 6/6 incl. boundaries; force-added because the repo `.gitignore` has a global `*.md`).

## Verification

- `cargo test -p octos-cli --lib -- turn_trace` → 5/5 (captured-subscriber tests, same pattern as `router.rs`)
- `cargo test -p octos-cli --features api --lib -- interrupt steer turn_trace` → 32/32
- clippy clean on `octos-cli` (`--features api --lib --tests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
