### PR TITLE
fix(serve): stop sysinfo from holding /proc/*/stat handles for the server's lifetime

### DIFF
--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -1851,7 +1851,9 @@ pub async fn system_metrics(
     let include_procs = params.get("procs").map(|v| v == "1").unwrap_or(false);
 
     let mut sys = state.sysinfo.lock().await;
-    sys.refresh_all();
+    // task-sysinfo-proc-stat-fd-budget: refresh only what this endpoint
+    // renders; processes (without per-thread tasks) only when asked for.
+    crate::sysinfo_budget::refresh_metrics(&mut sys, include_procs);
 
     // CPU info
     let cpu_count = sys.cpus().len();

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -490,7 +490,7 @@ impl AppState {
             config_path: None,
             watchdog_enabled: None,
             alerts_enabled: None,
-            sysinfo: tokio::sync::Mutex::new(sysinfo::System::new()),
+            sysinfo: tokio::sync::Mutex::new(crate::sysinfo_budget::new_metrics_system()),
             tenant_store: None,
             run_id_cache: Arc::new(RunIdCache::new()),
             tunnel_domain: None,

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -1413,7 +1413,9 @@ impl ServeCommand {
             config_path: resolved_config_path.or_else(|| Some(ctx.config_home.join("config.json"))),
             watchdog_enabled: watchdog_flag.clone(),
             alerts_enabled: alerts_flag.clone(),
-            sysinfo: tokio::sync::Mutex::new(sysinfo::System::new_all()),
+            // task-sysinfo-proc-stat-fd-budget: no startup process snapshot,
+            // no retained /proc handles (see sysinfo_budget).
+            sysinfo: tokio::sync::Mutex::new(crate::sysinfo_budget::new_metrics_system()),
             tenant_store: crate::tenant::TenantStore::open(&data_dir)
                 .ok()
                 .map(Arc::new),

--- a/crates/octos-cli/src/lib.rs
+++ b/crates/octos-cli/src/lib.rs
@@ -25,6 +25,9 @@ pub mod auth;
 // full `dead_code` enforcement.
 #[cfg_attr(not(feature = "api"), allow(dead_code))]
 pub(crate) mod autonomy;
+/// task-sysinfo-proc-stat-fd-budget: the one place the metrics `sysinfo::System`
+/// is constructed (handle cache off, no startup process snapshot).
+pub(crate) mod sysinfo_budget;
 pub use octos_services::cli_agent_adapter;
 pub mod commands;
 pub use octos_services::compaction;

--- a/crates/octos-cli/src/sysinfo_budget.rs
+++ b/crates/octos-cli/src/sysinfo_budget.rs
@@ -1,0 +1,153 @@
+//! task-sysinfo-proc-stat-fd-budget: keep `sysinfo` from holding `/proc`
+//! handles open for the lifetime of the server.
+//!
+//! On Linux `sysinfo` caches an open `/proc/<pid>/stat` (and per-task
+//! `/proc/<pid>/task/<tid>/stat`) file for every process it indexes — up to
+//! HALF of `RLIMIT_NOFILE`, and it raises the soft limit to the hard limit to
+//! get there. `octos serve` used to build its metrics `System` with
+//! `System::new_all()`, which indexes every process and thread on the host at
+//! startup and keeps those files open; nothing closes them until an admin
+//! `system_metrics` poll happens to `refresh_all()` again. A 26-hour
+//! `--stdio --solo` server was found holding ~1200 such handles, many for
+//! long-dead pids (incident 2026-08-17).
+//!
+//! Policy here: no handle cache at all (`set_open_files_limit(0)` — every
+//! refresh is open→read→close), no process snapshot at construction, and the
+//! metrics endpoint refreshes only what it renders.
+
+/// Build the metrics `System` for `AppState`: handle cache disabled, no
+/// process snapshot. CPU usage becomes meaningful from the second refresh,
+/// exactly as before (a fresh `new_all()` also needed two samples).
+#[cfg(feature = "api")]
+pub(crate) fn new_metrics_system() -> sysinfo::System {
+    // Idempotent process-wide setting; must precede the first process
+    // refresh. Returns false on non-Linux, where nothing is cached anyway.
+    let _ = sysinfo::set_open_files_limit(0);
+    sysinfo::System::new()
+}
+
+/// Refresh exactly what `system_metrics` renders. Processes are refreshed
+/// only on request, without per-thread tasks, dropping dead entries.
+#[cfg(feature = "api")]
+pub(crate) fn refresh_metrics(sys: &mut sysinfo::System, include_procs: bool) {
+    use sysinfo::{ProcessRefreshKind, ProcessesToUpdate};
+    sys.refresh_cpu_usage();
+    sys.refresh_memory();
+    if include_procs {
+        sys.refresh_processes_specifics(
+            ProcessesToUpdate::All,
+            true,
+            ProcessRefreshKind::nothing().with_cpu().with_memory(),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Structural guard, feature-independent: `System` is constructed in
+    /// exactly one place (here) and never via the all-snapshotting
+    /// `System::new_all()`.
+    #[test]
+    fn sysinfo_budget_module_owns_all_system_constructions() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut offenders = Vec::new();
+        let mut stack = vec![root.clone()];
+        while let Some(dir) = stack.pop() {
+            for entry in std::fs::read_dir(&dir).expect("read src dir") {
+                let path = entry.expect("dir entry").path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                    continue;
+                }
+                let text = std::fs::read_to_string(&path).expect("read source");
+                let rel = path
+                    .strip_prefix(&root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string();
+                let is_budget_module = rel == "sysinfo_budget.rs";
+                for (i, line) in text.lines().enumerate() {
+                    let l = line.trim_start();
+                    if l.starts_with("//") {
+                        continue;
+                    }
+                    // The budget module itself only mentions the pattern in
+                    // docs/tests; every real construction site is elsewhere.
+                    if !is_budget_module && l.contains("System::new_all()") {
+                        offenders.push(format!("{rel}:{}: System::new_all()", i + 1));
+                    }
+                    if !is_budget_module && l.contains("sysinfo::System::new") {
+                        offenders.push(format!(
+                            "{rel}:{}: direct sysinfo::System construction",
+                            i + 1
+                        ));
+                    }
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "construct the metrics System only via sysinfo_budget::new_metrics_system():\n{}",
+            offenders.join("\n")
+        );
+    }
+
+    #[cfg(all(feature = "api", target_os = "linux"))]
+    fn retained_proc_stat_fds() -> Vec<String> {
+        let mut out = Vec::new();
+        for entry in std::fs::read_dir("/proc/self/fd").expect("read /proc/self/fd") {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            let Ok(target) = std::fs::read_link(entry.path()) else {
+                continue;
+            };
+            let t = target.to_string_lossy();
+            let is_stat = t.starts_with("/proc/")
+                && t.ends_with("/stat")
+                && t.split('/')
+                    .nth(2)
+                    .is_some_and(|pid| pid.chars().all(|c| c.is_ascii_digit()));
+            if is_stat {
+                out.push(t.to_string());
+            }
+        }
+        out
+    }
+
+    #[cfg(all(feature = "api", target_os = "linux"))]
+    #[test]
+    fn metrics_refresh_retains_no_proc_stat_fds() {
+        let mut sys = super::new_metrics_system();
+        super::refresh_metrics(&mut sys, true);
+        super::refresh_metrics(&mut sys, true);
+        assert!(!sys.processes().is_empty(), "processes were refreshed");
+        let retained = retained_proc_stat_fds();
+        assert!(
+            retained.is_empty(),
+            "sysinfo must not keep /proc stat handles open: {retained:?}"
+        );
+    }
+
+    #[cfg(all(feature = "api", target_os = "linux"))]
+    #[test]
+    fn metrics_system_does_not_snapshot_processes_at_startup() {
+        let sys = super::new_metrics_system();
+        assert!(sys.processes().is_empty());
+        assert!(retained_proc_stat_fds().is_empty());
+    }
+
+    #[cfg(feature = "api")]
+    #[test]
+    fn metrics_refresh_without_procs_leaves_process_table_empty() {
+        let mut sys = super::new_metrics_system();
+        super::refresh_metrics(&mut sys, false);
+        assert!(sys.processes().is_empty());
+        assert!(!sys.cpus().is_empty());
+        assert!(sys.total_memory() > 0);
+    }
+}

--- a/specs/task-sysinfo-proc-stat-fd-budget.spec.md
+++ b/specs/task-sysinfo-proc-stat-fd-budget.spec.md
@@ -1,0 +1,95 @@
+spec: task
+name: "octos serve 不再长期持有 /proc/*/stat 句柄"
+tags: [octos-cli, sysinfo, resources, admin-metrics]
+estimate: 0.5d
+---
+
+## Intent
+
+事故排查时发现运行 26 小时的 `octos serve --stdio --solo` 持有约 1200 个
+`/proc/<pid>/stat` 与 `/proc/<pid>/task/<tid>/stat` 句柄，其中不少指向早已退出
+的进程。根因是 `sysinfo` 在 Linux 上为每个索引过的进程/线程缓存一个打开的
+`stat` 文件（预算为 `RLIMIT_NOFILE` 的一半，且会把软限制抬到硬限制）；
+`serve` 启动时用 `System::new_all()` 把全机进程快照进内存并持有句柄，之后只有
+admin dashboard 轮询 `system_metrics` 时才 `refresh_all()` 清理死进程——stdio
+模式下没人轮询，句柄就永久开着。本任务把 `sysinfo` 的句柄缓存关掉、启动时不再
+快照进程、`system_metrics` 只刷新它真正渲染的数据。
+
+## Decisions
+
+<!-- lint-ack: verification-metadata-suggestion — fd 计数场景读的是本进程 /proc/self/fd，属进程内自检，非外部 I/O -->
+
+- 在构造 `AppState.sysinfo` 之前调用一次 `sysinfo::set_open_files_limit(0)`（封装为
+  `octos_cli::sysinfo_budget::new_metrics_system()`——模块位于 crate 顶层，sysinfo 相关函数
+  以 `#[cfg(feature = "api")]` 门控，结构检查测试不门控；`serve.rs` 与 `api/mod.rs`
+  两处构造均改用它），
+  使 `sysinfo` 每次刷新都是打开→读取→关闭，不保留任何 `/proc` 句柄。
+- 启动构造用 `System::new()`（不快照进程），不再使用 `System::new_all()`。
+- `system_metrics` 改为按需刷新：`refresh_cpu_usage()` + `refresh_memory()`；仅当
+  `procs=1` 时以 `ProcessesToUpdate::All`、`remove_dead_processes = true`、
+  `ProcessRefreshKind::nothing().with_cpu().with_memory()`（不含 tasks/线程）刷新进程；
+  封装为 `sysinfo_budget::refresh_metrics(sys, include_procs)`。
+- 语义不变：端点输出的字段集与数值来源不变（CPU 平均、内存、磁盘、可选 top 进程）。
+- Linux 专属行为：fd 断言测试仅在 `target_os = "linux"` 编译。
+
+## Boundaries
+
+### Allowed Changes
+- crates/octos-cli/src/lib.rs
+- crates/octos-cli/src/sysinfo_budget.rs
+- crates/octos-cli/src/api/mod.rs
+- crates/octos-cli/src/api/admin.rs
+- crates/octos-cli/src/commands/serve.rs
+- specs/task-sysinfo-proc-stat-fd-budget.spec.md
+
+### Forbidden
+- 不改变 `system_metrics` 响应的字段名或含义。
+- 不新增 crate 依赖，不升级 `sysinfo` 版本。
+- 不引入周期性后台刷新任务来"清理"句柄（治标）。
+
+## Completion Criteria
+
+### Rule: no-retained-proc-handles — 刷新后不保留 /proc 句柄
+Scenario: 进程刷新两轮后本进程没有任何 /proc/*/stat 句柄（critical；需 --features api）
+  Tags: critical
+  Review: human
+  Test:
+    Package: octos-cli
+    Filter: metrics_refresh_retains_no_proc_stat_fds
+  Given 通过 `new_metrics_system()`（内部已调用 `sysinfo::set_open_files_limit(0)`）构造的 `System`
+  When `refresh_metrics(sys, true)` 连续调用两次（进程刷新用 `ProcessRefreshKind::nothing().with_cpu().with_memory()`）
+  Then `/proc/self/fd` 中不存在指向 `/proc/<pid>/stat` 或 `/proc/<pid>/task/<tid>/stat` 的链接（`target_os = "linux"`）
+  And `sys.processes()` 非空（进程数据确实被刷新了）
+
+Scenario: 启动构造不快照进程（需 --features api）
+  Review: human
+  Test:
+    Package: octos-cli
+    Filter: metrics_system_does_not_snapshot_processes_at_startup
+  When 调用 `new_metrics_system()`
+  Then `sys.processes()` 为空
+  And `/proc/self/fd` 中不存在指向 `/proc/<pid>/stat` 的链接
+
+Scenario: 不请求 procs 时不刷新进程表（需 --features api）
+  Review: human
+  Test:
+    Package: octos-cli
+    Filter: metrics_refresh_without_procs_leaves_process_table_empty
+  Given 通过 `new_metrics_system()` 构造的 `System`
+  When `refresh_metrics(sys, false)` 被调用（只走 `refresh_cpu_usage()` + `refresh_memory()`）
+  Then `sys.processes()` 仍为空
+  And CPU 数量与总内存已被填充（大于 0）
+
+### Rule: no-new-all — 代码中不再有启动期全量快照
+Scenario: serve 与 api 状态构造不再调用 System::new_all（结构检查）
+  Test:
+    Package: octos-cli
+    Filter: sysinfo_budget_module_owns_all_system_constructions
+  When 扫描 `crates/octos-cli/src` 中的 `sysinfo::System::new` 调用
+  Then 只有 `sysinfo_budget.rs` 直接构造 `System`
+  And 源码中不出现 `System::new_all()`
+
+## Out of Scope
+
+- 把 dashboard 的进程列表改为分页/流式。
+- 其他 `/proc` 读取路径（tool sandbox、bwrap 探测）——本次事故的句柄全部来自 `sysinfo`。


### PR DESCRIPTION
## Summary

Resource follow-up to the 2026-08-17 incident. A 26-hour `octos serve --stdio --solo` was holding ~1200 open `/proc/<pid>/stat` / `/proc/<pid>/task/<tid>/stat` handles, many for long-dead pids.

**Cause.** On Linux `sysinfo` caches an open stat file for every process/thread it indexes — budgeted at half of `RLIMIT_NOFILE` (it even raises the soft limit to the hard limit). `serve` built its metrics `System` with `System::new_all()`, indexing the whole host at startup and keeping those files open. Only an admin `system_metrics` poll would `refresh_all()` and drop dead entries; in stdio mode nothing polls, so the handles lived forever.

**Fix.**
- `octos_cli::sysinfo_budget::new_metrics_system()`: `sysinfo::set_open_files_limit(0)` (every refresh is open→read→close, nothing retained) + `System::new()` (no startup snapshot). Both `AppState` construction sites use it.
- `system_metrics` refreshes only what it renders (`refresh_metrics`): CPU usage + memory; processes — without per-thread tasks, dead entries removed — only when `?procs=1`. Response shape unchanged.
- Feature-independent structural test keeps `System` construction in the budget module and bans `System::new_all()`.

**Evidence** (sysinfo 0.34.2, standalone probe on this host): `System::new_all()` → **1879** retained `/proc/*/stat` fds; `new_metrics_system()` + `refresh_metrics` → **1880 processes indexed, 0 retained**.

Contract: `specs/task-sysinfo-proc-stat-fd-budget.spec.md` (agent-spec, lint 100%; force-added because the repo `.gitignore` has a global `*.md`).

## Verification

- `cargo test -p octos-cli --lib -- sysinfo_budget` → 1/1 (structural, no feature)
- `cargo test -p octos-cli --features api --lib -- sysinfo_budget` → 4/4 (fd count after two process refreshes = 0; no snapshot at startup; `procs` off leaves the table empty while CPU/memory are populated)
- clippy clean on `octos-cli` (`--features api --lib --tests`)
- agent-spec lifecycle (default runner) 1/4 + 3 skipped: the fd/behaviour scenarios sit behind `--features api` (sysinfo is an optional dep); resolved via `--ai-mode caller` + `resolve-ai` with the recorded `--features api` run (merged 4/4, 3 inferential). Reviewers may prefer to run the `--features api` command directly.

Independent of #2049 / #2050 (based on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
