### PR TITLE
fix(ui-protocol): break the standalone-turn loop the moment an interrupt lands

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -32119,26 +32119,35 @@ async fn run_standalone_turn(
         // can wake us out of `progress_rx.recv()` even if the agent task is
         // mid-await. The state mutex is the actual race winner; this select
         // is a notification, not a guard.
-        let event = tokio::select! {
-            biased;
-            _ = interrupt_rx.recv(), if !interrupt_observed => {
+        //
+        // task-interrupt-breaks-progress-wait: on `Interrupted` we BREAK
+        // right here. The old shape (`continue`, then a post-select check)
+        // re-entered the select with the interrupt arm disabled and waited
+        // for the NEXT progress event — a silent long tool (`bash sleep …`)
+        // held the terminal back until the ~8 s status_word heartbeat and the
+        // client's 5 s turn/interrupt ack timed out.
+        let event = match crate::turn_loop::next_turn_loop_step(
+            &mut interrupt_rx,
+            &mut progress_rx,
+            interrupt_observed,
+        )
+        .await
+        {
+            crate::turn_loop::TurnLoopStep::Interrupted => {
+                // The handler transitioned state to `Interrupting`. Drop any
+                // remaining progress events on the floor; they are no longer
+                // observable to the client.
                 interrupt_observed = true;
-                continue;
+                break;
             }
-            recv = progress_rx.recv() => match recv {
-                Some(data) => match serde_json::from_str::<Value>(&data) {
+            crate::turn_loop::TurnLoopStep::Closed => break,
+            crate::turn_loop::TurnLoopStep::Progress(data) => {
+                match serde_json::from_str::<Value>(&data) {
                     Ok(event) => event,
                     Err(_) => continue,
-                },
-                None => break,
+                }
             }
         };
-        if interrupt_observed {
-            // The handler transitioned state to `Interrupting`. Drop any
-            // remaining progress events on the floor; they are no longer
-            // observable to the client.
-            break;
-        }
         match event.get("type").and_then(Value::as_str) {
             Some("done") => {
                 if !saw_delta {

--- a/crates/octos-cli/src/lib.rs
+++ b/crates/octos-cli/src/lib.rs
@@ -32,6 +32,10 @@ pub(crate) mod steer_return;
 /// task-sysinfo-proc-stat-fd-budget: the one place the metrics `sysinfo::System`
 /// is constructed (handle cache off, no startup process snapshot).
 pub(crate) mod sysinfo_budget;
+/// task-interrupt-breaks-progress-wait: the standalone-turn loop's next-step
+/// race (interrupt vs progress), kept feature-independent so it is testable.
+#[cfg_attr(not(feature = "api"), allow(dead_code))]
+pub(crate) mod turn_loop;
 pub use octos_services::cli_agent_adapter;
 pub mod commands;
 pub use octos_services::compaction;

--- a/crates/octos-cli/src/turn_loop.rs
+++ b/crates/octos-cli/src/turn_loop.rs
@@ -1,0 +1,127 @@
+//! task-interrupt-breaks-progress-wait: the one place the standalone-turn
+//! event loop decides what to do next. Extracted so the interrupt-vs-progress
+//! race is unit-testable: an interrupt must be reported the moment it lands,
+//! never "after the next progress event" — a long tool with no output
+//! (`bash sleep …`) used to hold the terminal back until the ~8 s status_word
+//! heartbeat, so the client's 5 s `turn/interrupt` ack timed out.
+
+use tokio::sync::mpsc;
+
+/// What the turn loop should do next.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum TurnLoopStep {
+    /// The interrupt signal arrived (reported once — the caller flips its
+    /// `interrupt_observed` flag and breaks out of the loop immediately).
+    Interrupted,
+    /// A progress event payload from the agent task.
+    Progress(String),
+    /// The progress channel closed: the agent task is gone.
+    Closed,
+}
+
+/// Race the interrupt signal against the next progress event, interrupt
+/// first (`biased`). Once `interrupt_observed` is set the interrupt arm is
+/// disabled, mirroring the loop's original guard, so a caller that keeps
+/// draining after an interrupt only ever sees progress/closed.
+pub(crate) async fn next_turn_loop_step(
+    interrupt_rx: &mut mpsc::Receiver<()>,
+    progress_rx: &mut mpsc::Receiver<String>,
+    interrupt_observed: bool,
+) -> TurnLoopStep {
+    tokio::select! {
+        biased;
+        _ = interrupt_rx.recv(), if !interrupt_observed => TurnLoopStep::Interrupted,
+        recv = progress_rx.recv() => match recv {
+            Some(data) => TurnLoopStep::Progress(data),
+            None => TurnLoopStep::Closed,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn interrupt_returns_immediately_without_progress_events() {
+        let (interrupt_tx, mut interrupt_rx) = mpsc::channel::<()>(1);
+        let (_progress_tx, mut progress_rx) = mpsc::channel::<String>(8);
+        // A "long tool with no output": nothing ever lands on progress_rx.
+        interrupt_tx.send(()).await.unwrap();
+        let step = tokio::time::timeout(
+            Duration::from_millis(100),
+            next_turn_loop_step(&mut interrupt_rx, &mut progress_rx, false),
+        )
+        .await
+        .expect("interrupt must wake the loop without any progress event");
+        assert_eq!(step, TurnLoopStep::Interrupted);
+    }
+
+    #[tokio::test]
+    async fn progress_events_flow_when_no_interrupt() {
+        let (_interrupt_tx, mut interrupt_rx) = mpsc::channel::<()>(1);
+        let (progress_tx, mut progress_rx) = mpsc::channel::<String>(8);
+        progress_tx
+            .send("{\"type\":\"delta\"}".into())
+            .await
+            .unwrap();
+        let step = next_turn_loop_step(&mut interrupt_rx, &mut progress_rx, false).await;
+        assert_eq!(step, TurnLoopStep::Progress("{\"type\":\"delta\"}".into()));
+    }
+
+    #[tokio::test]
+    async fn interrupt_wins_over_ready_progress() {
+        let (interrupt_tx, mut interrupt_rx) = mpsc::channel::<()>(1);
+        let (progress_tx, mut progress_rx) = mpsc::channel::<String>(8);
+        progress_tx
+            .send("{\"type\":\"delta\"}".into())
+            .await
+            .unwrap();
+        interrupt_tx.send(()).await.unwrap();
+        let step = next_turn_loop_step(&mut interrupt_rx, &mut progress_rx, false).await;
+        assert_eq!(step, TurnLoopStep::Interrupted, "biased: interrupt first");
+    }
+
+    #[tokio::test]
+    async fn observed_interrupt_is_not_reported_twice_and_closed_channel_ends_loop() {
+        let (interrupt_tx, mut interrupt_rx) = mpsc::channel::<()>(1);
+        let (progress_tx, mut progress_rx) = mpsc::channel::<String>(8);
+        interrupt_tx.send(()).await.unwrap();
+        drop(progress_tx);
+        // Already observed: the interrupt arm is disabled; the closed progress
+        // channel ends the loop instead.
+        let step = next_turn_loop_step(&mut interrupt_rx, &mut progress_rx, true).await;
+        assert_eq!(step, TurnLoopStep::Closed);
+    }
+
+    /// Structural guard: the production loop takes its next step from this
+    /// helper and breaks on `Interrupted` — the `continue`-then-wait shape
+    /// that caused the latency must not come back.
+    #[test]
+    fn standalone_turn_loop_breaks_on_interrupt_step() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/api/ui_protocol_transport.rs");
+        let text = std::fs::read_to_string(&path).expect("read ui_protocol_transport.rs");
+        let start = text
+            .find("async fn run_standalone_turn")
+            .expect("run_standalone_turn exists");
+        let body = &text[start..];
+        assert!(
+            body.contains("crate::turn_loop::next_turn_loop_step("),
+            "run_standalone_turn must take its next step from turn_loop::next_turn_loop_step"
+        );
+        let mut lines = body.lines().peekable();
+        while let Some(line) = lines.next() {
+            if line.trim() == "interrupt_observed = true;" {
+                if let Some(next) = lines.peek() {
+                    assert_ne!(
+                        next.trim(),
+                        "continue;",
+                        "interrupt observation must break out of the loop, not continue into another progress wait"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/specs/task-interrupt-breaks-progress-wait.spec.md
+++ b/specs/task-interrupt-breaks-progress-wait.spec.md
@@ -1,0 +1,95 @@
+spec: task
+name: "turn/interrupt 立即跳出 progress 等待，不依赖下一条 progress 事件"
+tags: [ui-protocol, interrupt, latency, octos-cli]
+estimate: 0.5d
+---
+
+## Intent
+
+真机验证（2026-08-18）发现：`run_standalone_turn` 的事件循环在
+`tokio::select!` 的 interrupt 分支里 `interrupt_observed = true; continue;`，随后
+再次进入 select 时该分支已被 `if !interrupt_observed` 禁用，只能等
+`progress_rx.recv()` 返回下一条 progress 事件才走到 `if interrupt_observed { break }`。
+当 agent 正在执行没有进度输出的工具（如 `bash sleep`）时，终态要等到 ~8 秒一次的
+`status_word` 心跳才发出：客户端 `turn/interrupt` 的 ack 在 5 秒超时
+（`ack=ack_timed_out`），用户以为 Esc 无效而连按，多余的 Esc 又打断了随后自动
+提交的下一回合。本任务让中断在被观察到的那一刻就跳出循环，与 progress 节奏无关。
+
+## Decisions
+
+<!-- lint-ack: verification-metadata-suggestion — 场景为进程内 tokio channel 单元测试，无外部 I/O -->
+<!-- lint-ack: decision-coverage — "不改变中断之后的处理顺序"是不变项声明，由结构检查场景（循环体只替换取事件方式）间接约束 -->
+<!-- lint-ack: observable-decision-coverage — 同上，处理顺序不变由既有 interrupt 测试与结构检查共同覆盖 -->
+
+- 把循环里的 select 抽成可测的 `next_turn_loop_step(interrupt_rx, progress_rx,
+  interrupt_observed) -> TurnLoopStep`（`Interrupted | Progress(String) |
+  Closed`），保持 `biased` 且 interrupt 优先；循环里 `Interrupted => { interrupt_observed
+  = true; break; }`——不再 `continue`。
+- 行为不变项：interrupt 未到时 progress 事件照常返回；progress 通道关闭返回
+  `Closed`；interrupt 已观察过后不再重复报告（与原 `if !interrupt_observed` 门等价）。
+- 不改变中断之后的处理顺序（abort agent → 取消后台任务 → 终态闸门），只改"何时
+  开始处理"。
+
+## Boundaries
+
+### Allowed Changes
+- crates/octos-cli/src/api/ui_protocol_transport.rs
+- crates/octos-cli/src/api/ui_protocol_tests.rs
+- crates/octos-cli/src/turn_loop.rs
+- crates/octos-cli/src/lib.rs
+- specs/task-interrupt-breaks-progress-wait.spec.md
+
+### Forbidden
+- 不改变 `turn/interrupt` 的 RPC 结果形状或 5 秒 ack 超时。
+- 不改变 progress 事件的解析与转发逻辑。
+- 不新增 crate 依赖。
+
+## Completion Criteria
+
+### Rule: interrupt-wakes-immediately — 中断不等 progress
+Scenario: 没有任何 progress 事件时，interrupt 立即返回 Interrupted（critical）
+  Tags: critical
+  Test:
+    Package: octos-cli
+    Filter: interrupt_returns_immediately_without_progress_events
+  Given progress 通道空闲（模拟无输出的长工具）
+  When 发送 interrupt 信号
+  Then `next_turn_loop_step(interrupt_rx, progress_rx, interrupt_observed)` 在 100ms 内返回 `TurnLoopStep::Interrupted`
+  And 不需要任何 progress 事件
+
+Scenario: 无 interrupt 时 progress 事件正常返回
+  Test:
+    Package: octos-cli
+    Filter: progress_events_flow_when_no_interrupt
+  Given 一条 progress 事件已入队
+  When 调用 `next_turn_loop_step`
+  Then 返回 `Progress` 且载荷原样
+
+Scenario: interrupt 与 progress 同时就绪时 interrupt 优先（biased）
+  Test:
+    Package: octos-cli
+    Filter: interrupt_wins_over_ready_progress
+  Given interrupt 与一条 progress 都已就绪
+  When 调用 `next_turn_loop_step`
+  Then 返回 `Interrupted`
+
+Scenario: interrupt 已观察后不再重复报告，progress 关闭返回 Closed（错误路径）
+  Test:
+    Package: octos-cli
+    Filter: observed_interrupt_is_not_reported_twice_and_closed_channel_ends_loop
+  Given `interrupt_observed = true` 且 progress 通道已关闭
+  When 调用 `next_turn_loop_step`
+  Then 返回 `Closed` 而不是 `Interrupted`
+
+Scenario: 生产循环使用 helper 且 interrupt 分支直接 break（结构检查）
+  Test:
+    Package: octos-cli
+    Filter: standalone_turn_loop_breaks_on_interrupt_step
+  When 扫描 `crates/octos-cli/src/api/ui_protocol_transport.rs`
+  Then `run_standalone_turn` 的循环通过 `next_turn_loop_step` 取事件
+  And 不再存在 `interrupt_observed = true;` 后接 `continue;` 的写法
+
+## Out of Scope
+
+- stdio 请求分发在等待 interrupt ack 期间的队头阻塞（另立任务）。
+- 客户端对 `ack_timed_out` 的展示。


### PR DESCRIPTION
## Summary

Found on the first live run of the fixed client + server (companion to #2049/#2050/#540): pressing Esc while a silent `bash` tool was running gave `turn/interrupt … ack=ack_timed_out` after 5 s and only then the terminal; the user, seeing nothing happen, pressed Esc repeatedly and one late press interrupted the *next* turn.

**Cause.** The standalone-turn loop's select arm did `interrupt_observed = true; continue;`, re-entered the select with the interrupt arm now disabled (`if !interrupt_observed`), and waited for the **next progress event** before reaching the post-select `break`. With a tool that emits no progress, that meant waiting for the ~8 s `status_word` heartbeat — interrupt latency was a function of progress cadence.

**Fix.** New feature-independent `octos_cli::turn_loop::next_turn_loop_step` (biased, interrupt first; `Interrupted | Progress | Closed`); the loop breaks on `Interrupted` immediately. Everything after the break (abort agent, cancel background tasks, terminal gate) is unchanged.

**Tests** (all run with plain `cargo test -p octos-cli --lib -- turn_loop`, no feature): interrupt returns within 100 ms with an idle progress channel; progress flows without interrupt; interrupt wins over ready progress; an observed interrupt is not reported twice / closed channel ends the loop; structural guard that the production loop uses the helper and never `continue`s after observing an interrupt. `--features api -- interrupt turn_loop steer` 32/32; clippy clean.

Contract: `specs/task-interrupt-breaks-progress-wait.spec.md` (agent-spec, lint 100%, lifecycle 6/6 mechanical; force-added because of the repo's global `*.md` ignore).

Independent of the other PRs (based on `main`).

**Noted, not in this PR:** while `handle_turn_interrupt` awaits the ack (up to 5 s), the stdio request loop processes nothing else — ~60 queued `turn/interrupt` frames were dispatched in one millisecond once the ack timed out. With this fix the ack normally returns in milliseconds, but the head-of-line block itself deserves its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
