### PR TITLE
fix(format): scale the formatter timeout on Windows (#2053)

### DIFF
--- a/crates/octos-agent/src/format.rs
+++ b/crates/octos-agent/src/format.rs
@@ -41,7 +41,36 @@ use crate::subprocess_env::{EnvAllowlist, sanitize_command_env};
 
 /// Hard wall-clock limit for a single formatter run. The child is killed when
 /// the limit elapses (`kill_on_drop` — dropping the wait future SIGKILLs).
+///
+/// #2053 — the budget is platform-scaled because it bounds a *hung* formatter,
+/// not a slow one, and "slow" means something very different on Windows. A
+/// cold `rustfmt` there pays for process creation plus on-access AV scanning of
+/// the binary and its inputs, and routinely exceeds five seconds on CI: the
+/// same test (`edit_file::should_return_formatted_content_when_format_after_edit_enabled`)
+/// tripped this limit five times across four unrelated PRs in one day, twice
+/// consecutively on the same PR, always with
+///
+/// ```text
+/// Note: post-edit formatting with rustfmt timed out after 5s and was killed;
+///       the edit itself was applied unchanged.
+/// ```
+///
+/// This is not only a CI artifact. The timeout is a real code path: when it
+/// fires, the edit lands unformatted and the user is merely told so. A budget
+/// that a healthy formatter cannot meet therefore degrades Windows users'
+/// output silently and at random, which is a worse failure than waiting a few
+/// more seconds for the answer they asked for. Raising the ceiling does not
+/// weaken the guarantee it exists for — a genuinely hung formatter is still
+/// killed, just later.
+///
+/// Unix keeps 5s, where rustfmt returns in well under a second.
+#[cfg(not(windows))]
 pub const FORMAT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Windows counterpart of [`FORMAT_TIMEOUT`] — see that constant for why the
+/// budget differs by platform.
+#[cfg(windows)]
+pub const FORMAT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Byte cap for the formatted-content echo appended to the tool output.
 /// Larger files are truncated at a UTF-8 boundary with a marker; the LLM can


### PR DESCRIPTION
Fixes the flake that has become the dominant cost of merging anything on this repo today.

## Evidence

`FORMAT_TIMEOUT` is a flat 5s. The same test tripped it **five times across four unrelated PRs in one day**, twice consecutively on #2049:

| PR | what it changed | could it affect formatting? |
|---|---|---|
| #2043 | `.github/workflows/ci.yml` only | no |
| #2052 | ui-protocol turn loop | no |
| #2049 (attempt 1) | ui-protocol steer handling | no |
| #2049 (attempt 2, re-run) | same | no |

Always the same message:

```
Note: post-edit formatting with rustfmt timed out after 5s and was killed;
      the edit itself was applied unchanged.
```

On Windows a cold rustfmt pays for process creation plus on-access AV scanning of the binary and its inputs. 5s sits right at that noise floor, so it fails at random on runner load rather than on anything under test.

## Why production code and not the test

The tempting fix is to relax the assertion. I don't think that's right here.

The timeout is a **live path**: when it fires, the edit lands **unformatted** and the user is merely told so afterwards. A budget that a healthy formatter cannot meet therefore degrades real Windows users' output — silently, and at random. The test is not being unreasonable; it is reporting a genuine Windows defect that happens to be cheapest to observe in CI.

Raising the ceiling does not weaken what the timeout exists for. A genuinely hung formatter is still killed, just later. Unix keeps 5s, where rustfmt returns in well under a second.

## Why it matters beyond the wall-clock

Each occurrence costs a ~45 minute re-run, and it has now delayed four PRs. The larger cost is that it trains everyone to read a red `check-windows` as noise — which is exactly the reflex that let #1923 stay hidden for as long as it did, just paid in wall-clock instead of silence.

## No test

Deliberately. A test asserting a constant equals a constant is noise, and the real property — *a healthy Windows rustfmt fits the budget* — is only observable on a Windows runner. Verification is empirical: the flake stops recurring on `check-windows`. Happy to add a scaling-invariant assertion if reviewers would rather have one.

## Deliberately not changed

- `BACKGROUND_DEADLINE` — already 60s, and already raised once from 5s for this same reason, with the prior incident documented in its comment.
- `session_actor::test_speculative_overflow_concurrent`.

Each failed once. Neither justifies a change yet; #2053 keeps tracking them.

Refs #2053. Unblocks #2049 → #2050 → #2052 → octoscode #540.
