### PR TITLE
feat(goal): create ledger task rows at registration and settle them at terminal (#2055, #2054)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,14 @@ jobs:
       - name: Test octos-pipeline
         run: cargo test -p octos-pipeline
 
+      # #2055 — octos-fleet was missing from this list entirely (the #2029
+      # failure mode at crate granularity: absent coverage prints nothing and
+      # looks like passing coverage), so the goal-ledger suite — including the
+      # #2054/#2057 task-status writer and the #2055 idempotent task-row
+      # upsert — never ran in CI.
+      - name: Test octos-fleet
+        run: cargo test -p octos-fleet
+
       - name: Test octos-plugin
         run: cargo test -p octos-plugin
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,6 +4684,7 @@ dependencies = [
  "redb",
  "regex",
  "reqwest 0.12.28",
+ "rusqlite",
  "rust-embed",
  "rustix",
  "rustls 0.23.36",

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -372,6 +372,15 @@ impl BackgroundTask {
 /// Callback invoked when a task's status changes.
 type OnChangeCallback = Arc<dyn Fn(&BackgroundTask) + Send + Sync>;
 
+/// #2055 — callback invoked once per SUCCESSFUL registration, with the
+/// freshly inserted task snapshot. The registration-side twin of
+/// [`OnTerminalCallback`]: octos-agent cannot see octos-fleet, so the
+/// goal-ledger task-row creation lives in octos-cli and is wired through
+/// this observer next to `set_on_terminal`. `Arc` (not `Box`) so
+/// `notify_register` can clone it out of its mutex and invoke it with no
+/// supervisor locks held, exactly like `notify_change`.
+type OnRegisterCallback = Arc<dyn Fn(&BackgroundTask) + Send + Sync>;
+
 /// Payload emitted when a `spawn_only` background task transitions to
 /// `Failed`. Consumers (e.g. the session actor) use this to schedule a
 /// synthetic recovery turn so the LLM can re-engage with an actionable
@@ -851,6 +860,7 @@ impl std::fmt::Debug for TaskSupervisor {
             .field("on_change", &"<callback>")
             .field("on_failure", &"<callback>")
             .field("on_terminal", &"<callback>")
+            .field("on_register", &"<callback>")
             .field("on_relaunch", &"<callback>")
             .field("progress_reporter", &progress_reporter_attached)
             .field(
@@ -904,6 +914,10 @@ pub struct TaskSupervisor {
     /// callbacks (strangler — both live during migration; shared dedupe
     /// keys collapse double-delivery to one continuation).
     on_terminal: Arc<Mutex<Option<OnTerminalCallback>>>,
+    /// #2055 — registration observer, fired once from `register_full`'s
+    /// single success path (covers every `register*` entry point). The
+    /// octos-cli runtime wires the goal-ledger task-row creation here.
+    on_register: Arc<Mutex<Option<OnRegisterCallback>>>,
     on_relaunch: Arc<Mutex<Option<OnRelaunchCallback>>>,
     persistence_path: Arc<Mutex<Option<PathBuf>>>,
     /// Optional reporter that receives a [`ProgressEvent::ToolProgress`]
@@ -1243,6 +1257,7 @@ impl TaskSupervisor {
             on_change_listeners: Arc::new(Mutex::new(HashMap::new())),
             on_failure: Arc::new(Mutex::new(None)),
             on_terminal: Arc::new(Mutex::new(None)),
+            on_register: Arc::new(Mutex::new(None)),
             on_relaunch: Arc::new(Mutex::new(None)),
             persistence_path: Arc::new(Mutex::new(None)),
             progress_reporter: Arc::new(Mutex::new(None)),
@@ -1584,6 +1599,19 @@ impl TaskSupervisor {
     pub fn set_on_terminal(&self, cb: impl Fn(&TerminalEvent) + Send + Sync + 'static) {
         let mut guard = self.on_terminal.lock().unwrap_or_else(|e| e.into_inner());
         *guard = Some(Box::new(cb));
+    }
+
+    /// #2055 — set the registration observer, fired once per SUCCESSFUL
+    /// registration with the freshly inserted task snapshot. Fired from
+    /// `register_full`'s single success return, AFTER the task is inserted
+    /// and its snapshot persisted, so ONE call site covers every
+    /// registration kind (background/spawn_only, sub-agents, MCP sessions,
+    /// peers). Refused registrations (terminal parent, fan-out cap) never
+    /// fire it. The latest observer wins — runtimes re-wire it per turn /
+    /// per actor next to [`Self::set_on_terminal`].
+    pub fn set_on_register(&self, cb: impl Fn(&BackgroundTask) + Send + Sync + 'static) {
+        let mut guard = self.on_register.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = Some(Arc::new(cb));
     }
 
     /// Attach a [`ProgressReporter`] that receives a
@@ -2296,6 +2324,10 @@ impl TaskSupervisor {
                 "detached"
             },
         );
+        // #2055 — the single success path every `register*` entry point
+        // funnels through: fire the registration observer AFTER the insert
+        // and snapshot persist, with no locks held (see `notify_register`).
+        self.notify_register(&id);
         Ok(id)
     }
 
@@ -3364,6 +3396,38 @@ impl TaskSupervisor {
         for cb in listeners {
             cb(task);
         }
+    }
+
+    /// #2055 — fire the registration observer (if set) with a snapshot of
+    /// the just-registered task. Mirrors `notify_change`'s locking
+    /// discipline exactly: the callback is cloned out of its own mutex and
+    /// invoked with NO supervisor locks held — it is user code that may
+    /// take other locks (the octos-cli closure opens the goal ledger and
+    /// re-enters orchestrator state) and may re-enter the supervisor.
+    ///
+    /// Cheap early-out mirroring `notify_terminal`: an unwired supervisor
+    /// returns before the map lookup and before cloning the task snapshot,
+    /// so registration-hot unwired builds pay one mutex probe and nothing
+    /// else.
+    fn notify_register(&self, task_id: &str) {
+        let callback = {
+            let guard = self.on_register.lock().unwrap_or_else(|e| e.into_inner());
+            match guard.as_ref() {
+                Some(callback) => Arc::clone(callback),
+                None => return,
+            }
+        };
+        // Snapshot under the `tasks` mutex, invoke after releasing it. The
+        // lookup is by id rather than a pre-insert clone so the observer
+        // sees the task exactly as the map holds it post-insert.
+        let snapshot = {
+            let tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
+            match tasks.get(task_id) {
+                Some(task) => task.clone(),
+                None => return,
+            }
+        };
+        callback(&snapshot);
     }
 
     /// Gap-1 unification: fire the unified `on_terminal` callback (if set)

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -1614,6 +1614,49 @@ impl TaskSupervisor {
         *guard = Some(Arc::new(cb));
     }
 
+    /// #2055 review round 2 — copy the REGISTRATION observers from `parent`
+    /// onto this (freshly created) supervisor: the `on_register` callback
+    /// and the NAMED `on_change_listeners` map. Called wherever a child /
+    /// nested supervisor is minted (`ToolRegistry::snapshot_excluding`, the
+    /// nested-spawn child registry), so goal-ledger task rows cover nested
+    /// subagent registrations instead of silently stopping at the first
+    /// fresh supervisor.
+    ///
+    /// Deliberately NOT copied: the primary `on_change`, `on_failure`,
+    /// `on_terminal`, and `on_relaunch` callbacks — their wake/continuation
+    /// semantics are per-instance by design (a child's terminal event must
+    /// not double-drive the parent's re-entry wiring). Existing entries
+    /// under the same listener key are replaced; entries only the child has
+    /// are kept. Both copies are `Arc` clones — cheap, and later re-wiring
+    /// on either side does not affect the other.
+    pub fn inherit_registration_observers(&self, parent: &TaskSupervisor) {
+        let parent_register = parent
+            .on_register
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        if let Some(callback) = parent_register {
+            let mut guard = self.on_register.lock().unwrap_or_else(|e| e.into_inner());
+            *guard = Some(callback);
+        }
+        let parent_listeners: Vec<(String, OnChangeCallback)> = parent
+            .on_change_listeners
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+            .map(|(key, callback)| (key.clone(), Arc::clone(callback)))
+            .collect();
+        if !parent_listeners.is_empty() {
+            let mut guard = self
+                .on_change_listeners
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            for (key, callback) in parent_listeners {
+                guard.insert(key, callback);
+            }
+        }
+    }
+
     /// Attach a [`ProgressReporter`] that receives a
     /// [`ProgressEvent::ToolProgress`] for every supervised runtime-state
     /// transition. The emitted event carries the originating `tool_call_id`

--- a/crates/octos-agent/src/task_supervisor_tests.rs
+++ b/crates/octos-agent/src/task_supervisor_tests.rs
@@ -4400,3 +4400,110 @@ fn unwired_on_register_leaves_registration_untouched() {
         TaskStatus::Spawned
     );
 }
+
+/// #2055 review round 2 — child/nested supervisors must inherit the
+/// REGISTRATION observers (`on_register` + the NAMED `on_change_listeners`
+/// map) so goal-ledger task rows cover nested subagent registries — and
+/// must NOT inherit the primary `on_change` / `on_failure` / `on_terminal`
+/// callbacks, whose wake semantics are deliberately per-instance.
+#[test]
+fn inherit_registration_observers_copies_observer_pair_but_not_wake_callbacks() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let parent = TaskSupervisor::new();
+    let register_calls = Arc::new(AtomicUsize::new(0));
+    let named_calls = Arc::new(AtomicUsize::new(0));
+    let primary_calls = Arc::new(AtomicUsize::new(0));
+    let terminal_calls = Arc::new(AtomicUsize::new(0));
+
+    let register_c = register_calls.clone();
+    parent.set_on_register(move |_| {
+        register_c.fetch_add(1, Ordering::SeqCst);
+    });
+    let named_c = named_calls.clone();
+    parent.set_on_change_listener("settle", move |_| {
+        named_c.fetch_add(1, Ordering::SeqCst);
+    });
+    let primary_c = primary_calls.clone();
+    parent.set_on_change(move |_| {
+        primary_c.fetch_add(1, Ordering::SeqCst);
+    });
+    let terminal_c = terminal_calls.clone();
+    parent.set_on_terminal(move |_| {
+        terminal_c.fetch_add(1, Ordering::SeqCst);
+    });
+
+    let child = TaskSupervisor::new();
+    child.inherit_registration_observers(&parent);
+
+    let id = child.register("web_probe", "call-inherit-1", Some("api:sess-inherit"));
+    child.mark_running(&id);
+    child.mark_completed(&id, vec![]);
+
+    assert_eq!(
+        register_calls.load(Ordering::SeqCst),
+        1,
+        "the child inherits on_register"
+    );
+    assert!(
+        named_calls.load(Ordering::SeqCst) >= 1,
+        "the child inherits the NAMED change listeners"
+    );
+    assert_eq!(
+        primary_calls.load(Ordering::SeqCst),
+        0,
+        "the primary on_change is per-instance and must NOT be inherited"
+    );
+    assert_eq!(
+        terminal_calls.load(Ordering::SeqCst),
+        0,
+        "on_terminal is per-instance and must NOT be inherited"
+    );
+}
+
+/// #2055 review round 2 — the production nesting path: a registry snapshot
+/// (`ToolRegistry::snapshot_excluding`) mints a FRESH supervisor (the
+/// deliberate per-subtree isolation), which used to drop the registration
+/// observers entirely — nested subagent registrations were invisible to the
+/// goal ledger. The fresh supervisor now inherits the observer pair while
+/// the task maps stay isolated.
+#[test]
+fn snapshot_excluding_child_supervisor_inherits_registration_observers() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let parent_registry = crate::ToolRegistry::new();
+    let register_calls = Arc::new(AtomicUsize::new(0));
+    let named_calls = Arc::new(AtomicUsize::new(0));
+    let register_c = register_calls.clone();
+    parent_registry.supervisor().set_on_register(move |_| {
+        register_c.fetch_add(1, Ordering::SeqCst);
+    });
+    let named_c = named_calls.clone();
+    parent_registry
+        .supervisor()
+        .set_on_change_listener("settle", move |_| {
+            named_c.fetch_add(1, Ordering::SeqCst);
+        });
+
+    let child_registry = parent_registry.snapshot_excluding(&[]);
+    let child = child_registry.supervisor();
+    let id = child.register("nested_tool", "call-snap-1", Some("api:sess-snap"));
+    child.mark_running(&id);
+
+    assert_eq!(
+        register_calls.load(Ordering::SeqCst),
+        1,
+        "a registration on the snapshot's fresh supervisor reaches the parent's observer"
+    );
+    assert!(
+        named_calls.load(Ordering::SeqCst) >= 1,
+        "the named change listeners ride along onto the snapshot"
+    );
+    // The isolation contract is untouched: the child's task lives in the
+    // child's map only.
+    assert!(
+        parent_registry.supervisor().get_task(&id).is_none(),
+        "task maps stay per-subtree"
+    );
+    assert!(child.get_task(&id).is_some());
+}

--- a/crates/octos-agent/src/task_supervisor_tests.rs
+++ b/crates/octos-agent/src/task_supervisor_tests.rs
@@ -4217,3 +4217,186 @@ async fn start_reaper_loop_reaps_stuck_task_on_interval() {
     );
     assert!(supervisor.cancel_token(&id).is_cancelled());
 }
+
+// ---------------------------------------------------------------------------
+// #2055 — registration observer (`set_on_register`).
+//
+// The goal-ledger task-row creation lives in octos-cli (octos-agent cannot
+// see octos-fleet), so the supervisor exposes a registration callback the
+// runtime wires next to `set_on_terminal`. Fired from `register_full`'s
+// single success path, so ONE call site covers every registration kind
+// (background/spawn_only, sub-agents, MCP, peers).
+// ---------------------------------------------------------------------------
+
+/// The observer fires exactly once per successful registration, with the
+/// freshly inserted task snapshot.
+#[test]
+fn on_register_fires_exactly_once_per_successful_registration() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let supervisor = TaskSupervisor::new();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let seen = Arc::new(std::sync::Mutex::new(Vec::<BackgroundTask>::new()));
+    let calls_c = calls.clone();
+    let seen_c = seen.clone();
+    supervisor.set_on_register(move |task| {
+        calls_c.fetch_add(1, Ordering::SeqCst);
+        seen_c.lock().unwrap().push(task.clone());
+    });
+
+    let id = supervisor.register("web_probe", "call-reg-1", Some("api:sess-reg"));
+
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "one successful registration fires the observer exactly once"
+    );
+    let snapshots = seen.lock().unwrap();
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0].id, id);
+    assert_eq!(snapshots[0].tool_name, "web_probe");
+    assert_eq!(snapshots[0].tool_call_id, "call-reg-1");
+    assert_eq!(
+        snapshots[0].parent_session_key.as_deref(),
+        Some("api:sess-reg")
+    );
+
+    // Subsequent lifecycle transitions must NOT re-fire the observer.
+    supervisor.mark_running(&id);
+    supervisor.mark_completed(&id, vec![]);
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "on_register is a registration observer, not a change feed"
+    );
+}
+
+/// Every `register*` entry point funnels through `register_full`, so the
+/// observer covers all of them without per-entry-point wiring.
+#[test]
+fn on_register_fires_for_every_register_entry_point() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let supervisor = TaskSupervisor::new();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_c = calls.clone();
+    supervisor.set_on_register(move |_| {
+        calls_c.fetch_add(1, Ordering::SeqCst);
+    });
+
+    supervisor.register("t1", "call-ep-1", Some("api:sess-ep"));
+    supervisor.register_with_lineage("t2", "call-ep-2", Some("api:sess-ep"), None);
+    supervisor.register_with_input(
+        "t3",
+        "call-ep-3",
+        Some("api:sess-ep"),
+        Some(serde_json::json!({"a": 1})),
+    );
+    supervisor.register_with_input_and_cmid("t4", "call-ep-4", Some("api:sess-ep"), None, None);
+    supervisor
+        .try_register_with_input("t5", "call-ep-5", Some("api:sess-ep"), None)
+        .expect("strict registration succeeds");
+
+    assert_eq!(calls.load(Ordering::SeqCst), 5);
+}
+
+/// The callback is invoked with NO supervisor locks held (cloned out of its
+/// own mutex first, like `notify_change`), so user code that re-enters the
+/// supervisor — the octos-cli closure resolves goal bindings and may read
+/// task state — cannot deadlock.
+#[test]
+fn on_register_callback_may_reenter_the_supervisor_without_deadlock() {
+    let supervisor = Arc::new(TaskSupervisor::new());
+    let reentrant = Arc::clone(&supervisor);
+    let observed = Arc::new(std::sync::Mutex::new(Option::<usize>::None));
+    let observed_c = observed.clone();
+    supervisor.set_on_register(move |task| {
+        // Re-enter through read paths that take the `tasks` mutex.
+        let all = reentrant.get_all_tasks();
+        assert!(reentrant.get_task(&task.id).is_some());
+        *observed_c.lock().unwrap() = Some(all.len());
+    });
+
+    supervisor.register("web_probe", "call-reenter", Some("api:sess-re"));
+
+    assert_eq!(
+        *observed.lock().unwrap(),
+        Some(1),
+        "the re-entrant read observed the freshly inserted task"
+    );
+}
+
+/// A REFUSED registration (terminal parent / fan-out cap) never fires the
+/// observer — there is no task to create a ledger row for.
+#[test]
+fn on_register_does_not_fire_for_refused_registrations() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // Terminal-parent refusal.
+    let supervisor = TaskSupervisor::new();
+    let parent_tcid = "call-onreg-parent";
+    let parent = supervisor.register("run_pipeline", parent_tcid, Some("sess-onreg"));
+    supervisor.mark_running(&parent);
+    supervisor.mark_failed(&parent, "orphaned across restart".to_string());
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_c = calls.clone();
+    supervisor.set_on_register(move |_| {
+        calls_c.fetch_add(1, Ordering::SeqCst);
+    });
+    supervisor
+        .try_register_node_task("pipeline:analyze", parent_tcid, Some("sess-onreg"))
+        .expect_err("terminal parent refuses the child registration");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "a ParentTerminal refusal must not fire on_register"
+    );
+
+    // Fan-out-cap refusal. The cap reader caches once per process
+    // (`OnceLock`), so exercise the production cap: fill it with the
+    // observer UNWIRED, wire the observer, then assert the refused
+    // overflow attempt fires nothing.
+    let cap_calls = Arc::new(AtomicUsize::new(0));
+    let cap_calls_c = cap_calls.clone();
+    let capped = TaskSupervisor::new();
+    for i in 0..MAX_CHILDREN_PER_PARENT {
+        capped
+            .try_register_with_input(
+                "tts",
+                &format!("call-cap-onreg-{i}"),
+                Some("sess-cap-onreg"),
+                None,
+            )
+            .unwrap_or_else(|err| panic!("register #{i} should succeed; got {err}"));
+    }
+    capped.set_on_register(move |_| {
+        cap_calls_c.fetch_add(1, Ordering::SeqCst);
+    });
+    capped
+        .try_register_with_input(
+            "tts",
+            "call-cap-onreg-overflow",
+            Some("sess-cap-onreg"),
+            None,
+        )
+        .expect_err("overflow child exceeds the cap");
+    assert_eq!(
+        cap_calls.load(Ordering::SeqCst),
+        0,
+        "a ChildFanoutExceeded refusal must not fire on_register"
+    );
+}
+
+/// An unwired supervisor registers exactly as before — the observer hook is
+/// a no-op (the guard early-outs before taking any task snapshot).
+#[test]
+fn unwired_on_register_leaves_registration_untouched() {
+    let supervisor = TaskSupervisor::new();
+    let id = supervisor.register("web_probe", "call-unwired", Some("api:sess-unwired"));
+    assert!(!id.is_empty());
+    assert_eq!(
+        supervisor.get_task(&id).unwrap().status,
+        TaskStatus::Spawned
+    );
+}

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -1015,6 +1015,11 @@ impl ToolRegistry {
             spawn_only: self.spawn_only.clone(),
             spawn_only_messages: self.spawn_only_messages.clone(),
             background_result_sender: None,
+            // Fresh per-snapshot supervisor (deliberate per-subtree
+            // isolation of task maps); #2055 review round 2 — the
+            // REGISTRATION observers are inherited right below so a nested
+            // registration still reaches the goal-ledger recorder/settle
+            // wiring installed on the parent.
             supervisor: Arc::new(TaskSupervisor::new()),
             spawn_only_invoked: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             live_catalog: Arc::new(std::sync::Mutex::new(Vec::new())),
@@ -1048,6 +1053,14 @@ impl ToolRegistry {
             let cell = snapshot.live_catalog_handle();
             snapshot.register(ToolSuggestTool::new(cell));
         }
+        // #2055 review round 2 — the fresh supervisor keeps its task map
+        // isolated per-subtree, but the REGISTRATION observers (`on_register`
+        // + the named `on_change_listeners`) ride along so goal-ledger task
+        // rows cover registrations on the snapshot. Wake callbacks
+        // (`on_change`/`on_failure`/`on_terminal`) stay per-instance.
+        snapshot
+            .supervisor
+            .inherit_registration_observers(&self.supervisor);
         snapshot.refresh_live_catalog();
         snapshot
     }

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -3892,6 +3892,21 @@ impl Tool for SpawnTool {
             // fan-out cap is per-subtree, not global. The grandchild's RESULT
             // still flows back via the inherited result sender / inline
             // output; only its task-tracking row stays subtree-local.
+            // #2055 review round 2 — the child registry above was built from
+            // scratch (`with_builtins_and_sandbox`), so its private
+            // supervisor has NO observers: nested subagent registrations
+            // were invisible to the goal-ledger recorder. Inherit the
+            // REGISTRATION observer pair (`on_register` + named
+            // `on_change_listeners`) from this delegate's own supervisor —
+            // the session/turn one the runtime wired — while the task map
+            // stays subtree-private (the isolation rationale above is about
+            // task-tracking rows, not observers). Wake callbacks are
+            // deliberately not inherited.
+            if let Some(parent_supervisor) = self.task_supervisor.as_ref() {
+                tools
+                    .supervisor()
+                    .inherit_registration_observers(parent_supervisor);
+            }
             let mut child_spawn = self.child_spawn_clone(child_working_dir.clone(), &worker_id);
             child_spawn.task_supervisor = Some(tools.supervisor());
             tools.register(child_spawn);

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -4508,6 +4508,20 @@ impl Tool for SpawnTool {
                 for factory in &child_tool_factories {
                     tools.register_arc(factory());
                 }
+                // #2055 review round 3 — this DETACHED (background-mode,
+                // the default) branch builds its child registry from scratch
+                // exactly like the sync branch, so its private supervisor
+                // starts with no observers. Inherit the REGISTRATION
+                // observer pair from the parent supervisor here too —
+                // without this, a nested spawn under the DEFAULT mode
+                // registered its grandchild invisibly to the goal ledger
+                // while the (non-default) sync branch was covered. Task maps
+                // stay subtree-private; wake callbacks are not inherited.
+                if let Some(parent_supervisor) = task_supervisor.as_ref() {
+                    tools
+                        .supervisor()
+                        .inherit_registration_observers(parent_supervisor);
+                }
                 // Bind the detached child's OWN native `spawn` delegate (see
                 // the foreground `child_spawn_template` build). Mirrors the
                 // sync path: bind the template to THIS child registry's own

--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -194,6 +194,11 @@ octos-store = { workspace = true, features = ["test-util"] }
 octos-services = { workspace = true, features = ["test-util"] }
 tokio-tungstenite.workspace = true
 wiremock = { workspace = true }
+# #2055 round 3 — the goal-task-row contention tests hold a real SQLite
+# write transaction against the goal ledger while asserting the executor
+# stays responsive and the settle retry converges. Test-only; production
+# SQLite access stays behind octos-fleet.
+rusqlite = { workspace = true }
 
 [[test]]
 name = "build_output_dir_validation"

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -10617,6 +10617,42 @@ async fn invoke_skill_action_tool_binding(
     Ok(Value::Object(response))
 }
 
+/// #2055 review round 2 (coverage holes c + d) — wire the goal-task-row
+/// observer pair onto a CACHED session supervisor (`session_runtime.tools`),
+/// which outlives goals coming and going, so the goal binding resolves at
+/// CALLBACK time via `active_goal_id` — the gateway idiom, not the per-turn
+/// dispatch snapshot. Installed idempotently at each point of use, the same
+/// pattern as [`install_skill_action_job_projection_listener`] below (the
+/// SessionRuntime constructor is deliberately left out of the loop: the
+/// session-cache layer has no autonomy coupling today, and point-of-use
+/// wiring keeps it that way). Snapshots taken from this registry
+/// (`snapshot_excluding` — e.g. the native-review specialist swarm) inherit
+/// the pair onto their fresh supervisors.
+fn wire_goal_task_row_observers_for_cached_supervisor(
+    supervisor: &octos_agent::TaskSupervisor,
+    session_id: &SessionKey,
+    profile_id: &str,
+    profile_data_dir: &std::path::Path,
+) {
+    let register_session = session_id.clone();
+    let register_profile = profile_id.to_owned();
+    let register_data_dir = profile_data_dir.to_path_buf();
+    supervisor.set_on_register(move |task| {
+        let orchestrator = default_agent_orchestrator();
+        let Some(goal_id) = orchestrator.active_goal_id(&register_session, &register_profile)
+        else {
+            return;
+        };
+        orchestrator.record_goal_task_registration(
+            &register_data_dir,
+            &register_profile,
+            &goal_id,
+            task,
+        );
+    });
+    crate::autonomy::agent_orchestrator::install_goal_task_row_settle_listener(supervisor);
+}
+
 fn install_skill_action_job_projection_listener(
     supervisor: &octos_agent::TaskSupervisor,
     profile_id: &str,
@@ -11021,6 +11057,16 @@ async fn raw_skill_action_invoke(
             let batch_permit = reserve_skill_action_batch()?;
             let profile_id = session_runtime.profile.profile_id.clone();
             let supervisor = session_runtime.tools.supervisor();
+            // #2055 review round 2 (hole d) — background skill actions
+            // register on THIS cached supervisor, not the per-turn snapshot
+            // the turn path wires, so give it the goal-task-row observer
+            // pair here (resolve-at-callback; idempotent re-install).
+            wire_goal_task_row_observers_for_cached_supervisor(
+                &supervisor,
+                &params.session_id,
+                &profile_id,
+                &session_runtime.profile.data_dir,
+            );
             install_skill_action_job_projection_listener(
                 &supervisor,
                 &profile_id,
@@ -27227,6 +27273,17 @@ async fn run_native_code_review_turn(
     let workspace_root = session_runtime.workspace_root.clone();
     let llm_provider = session_runtime.profile.llm.clone();
     let memory_store = session_runtime.profile.memory.clone();
+    // #2055 review round 2 (hole c) — the review specialists run on a FRESH
+    // snapshot registry whose supervisor used to carry no observers, so
+    // their `native_agent` registrations were invisible to the goal ledger.
+    // Wire the cached supervisor first; the snapshot below inherits the
+    // observer pair (`snapshot_excluding` → `inherit_registration_observers`).
+    wire_goal_task_row_observers_for_cached_supervisor(
+        &session_runtime.tools.supervisor(),
+        &session_id,
+        &profile_id,
+        &session_runtime.profile.data_dir,
+    );
     let tools = Arc::new(session_runtime.tools.snapshot_excluding(&[]));
     let agent_config = session_runtime.agent.agent_config();
     // UPCR follow-up to #1561: refresh named prompt segments (memory) on
@@ -29721,6 +29778,14 @@ async fn run_standalone_turn(
                 task,
             );
         });
+        // #2054 (review round 2) — the settle half rides the change feed as
+        // a NAMED listener (not the `on_terminal` sink below): `cancel`
+        // emits only `notify_change`, and the sink's once-per-task dedupe
+        // would swallow the owner's failed→complete correction. Inherited
+        // by nested child supervisors together with `on_register`.
+        crate::autonomy::agent_orchestrator::install_goal_task_row_settle_listener(
+            &task_supervisor,
+        );
         // Gap-1 unification: the single terminal sink. Routes BOTH success
         // (ChildCompleted) AND failure (recovery) re-entry through ONE
         // profile-resolving call into the master continuation queue. Runs

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -29682,6 +29682,45 @@ async fn run_standalone_turn(
                 Some(change_profile_id.as_str()),
             );
         });
+        // #2055 — create the goal-ledger task row at registration time,
+        // wired next to the unified terminal sink below (whose settle half,
+        // #2054, flips the row at terminal). The turn's goal binding is
+        // snapshotted HERE at wiring time, mirroring the #1650
+        // dispatch-time `interactive_goal_binding` semantics: an autonomous
+        // continuation carries `goal_context` (its goal resolves under the
+        // already-scoped store key it was enqueued with, family-2 — never
+        // re-scoped), an interactive turn uses the #1935
+        // `interactive_goal_id` snapshot. This wiring is REPLACED every
+        // turn, so a goal-less turn overwrites a prior goal turn's closure
+        // with the no-op rather than leaking a stale binding. No binding ⇒
+        // no rows — correct behavior, not an error. The recorder swallows
+        // every ledger error (registration must never fail, block, or
+        // panic on ledger I/O). The ledger lives under the PROFILE data
+        // dir (#1957 rule — never the relocatable sessions root).
+        let register_goal_binding: Option<(String, String)> = goal_context
+            .as_ref()
+            .and_then(|goal_ctx| {
+                default_agent_orchestrator()
+                    .active_goal_id_under_goal_key(&goal_ctx.goal_session_key, &goal_ctx.profile_id)
+                    .map(|goal_id| (goal_id, goal_ctx.profile_id.clone()))
+            })
+            .or_else(|| {
+                interactive_goal_id
+                    .clone()
+                    .map(|goal_id| (goal_id, goal_charge_profile.clone()))
+            });
+        let register_ledger_data_dir = session_runtime.profile.data_dir.clone();
+        task_supervisor.set_on_register(move |task| {
+            let Some((goal_id, profile_id)) = register_goal_binding.as_ref() else {
+                return;
+            };
+            default_agent_orchestrator().record_goal_task_registration(
+                &register_ledger_data_dir,
+                profile_id,
+                goal_id,
+                task,
+            );
+        });
         // Gap-1 unification: the single terminal sink. Routes BOTH success
         // (ChildCompleted) AND failure (recovery) re-entry through ONE
         // profile-resolving call into the master continuation queue. Runs

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -10634,23 +10634,14 @@ fn wire_goal_task_row_observers_for_cached_supervisor(
     profile_id: &str,
     profile_data_dir: &std::path::Path,
 ) {
-    let register_session = session_id.clone();
-    let register_profile = profile_id.to_owned();
-    let register_data_dir = profile_data_dir.to_path_buf();
-    supervisor.set_on_register(move |task| {
-        let orchestrator = default_agent_orchestrator();
-        let Some(goal_id) = orchestrator.active_goal_id(&register_session, &register_profile)
-        else {
-            return;
-        };
-        orchestrator.record_goal_task_registration(
-            &register_data_dir,
-            &register_profile,
-            &goal_id,
-            task,
-        );
-    });
-    crate::autonomy::agent_orchestrator::install_goal_task_row_settle_listener(supervisor);
+    // Round 3 — thin adapter over the SHARED installer so this site cannot
+    // drift from the per-turn / gateway wiring or from the effect tests.
+    crate::autonomy::agent_orchestrator::install_goal_task_row_observers_resolving_at_callback(
+        supervisor,
+        session_id,
+        profile_id,
+        profile_data_dir,
+    );
 }
 
 fn install_skill_action_job_projection_listener(
@@ -29766,25 +29757,17 @@ async fn run_standalone_turn(
                     .clone()
                     .map(|goal_id| (goal_id, goal_charge_profile.clone()))
             });
-        let register_ledger_data_dir = session_runtime.profile.data_dir.clone();
-        task_supervisor.set_on_register(move |task| {
-            let Some((goal_id, profile_id)) = register_goal_binding.as_ref() else {
-                return;
-            };
-            default_agent_orchestrator().record_goal_task_registration(
-                &register_ledger_data_dir,
-                profile_id,
-                goal_id,
-                task,
-            );
-        });
-        // #2054 (review round 2) — the settle half rides the change feed as
-        // a NAMED listener (not the `on_terminal` sink below): `cancel`
-        // emits only `notify_change`, and the sink's once-per-task dedupe
-        // would swallow the owner's failed→complete correction. Inherited
-        // by nested child supervisors together with `on_register`.
-        crate::autonomy::agent_orchestrator::install_goal_task_row_settle_listener(
+        // Round 3 — the SHARED installer wires both halves (recorder +
+        // change-feed settle listener), with THIS turn's dispatch-time
+        // binding snapshot as the resolver. The settle rides the change
+        // feed as a NAMED listener (not the `on_terminal` sink below):
+        // `cancel` emits only `notify_change`, and the sink's once-per-task
+        // dedupe would swallow the owner's failed→complete correction.
+        // Inherited by nested child supervisors.
+        crate::autonomy::agent_orchestrator::install_goal_task_row_observers(
             &task_supervisor,
+            &session_runtime.profile.data_dir,
+            move || register_goal_binding.clone(),
         );
         // Gap-1 unification: the single terminal sink. Routes BOTH success
         // (ChildCompleted) AND failure (recovery) re-entry through ONE

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -830,6 +830,9 @@ pub(crate) fn goal_task_settle_attempts_for(task_id: &str) -> u64 {
 /// hold's release steal the new incarnation's live flight). Production task
 /// ids are fresh UUIDv7s today, but the monotonic counter also pre-covers
 /// the same-id restoration path #2056 tracks.
+///
+/// u64 wrap is a non-concern by arithmetic: at a million stashes per second
+/// the counter takes about 5.8 × 10^5 years (~585 millennia) to wrap.
 fn next_goal_task_binding_generation() -> u64 {
     static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
@@ -879,6 +882,28 @@ struct GoalTaskLedgerBinding {
 }
 
 impl GoalTaskLedgerBinding {
+    /// Build a binding that has NOT been stashed yet: `generation` and
+    /// `in_flight` carry placeholder values here (round 8 — the one place
+    /// they appear) because the single stash point,
+    /// [`InProcessAgentOrchestrator::stash_goal_task_binding`], assigns
+    /// both authoritatively when the binding enters the map.
+    fn new_unstashed(
+        goal_row: octos_fleet::Goal,
+        title: String,
+        assigned_peer: Option<String>,
+        profile_data_dir: PathBuf,
+    ) -> Self {
+        Self {
+            goal_row,
+            title,
+            assigned_peer,
+            profile_data_dir,
+            retained_since: None,
+            generation: 0,
+            in_flight: 0,
+        }
+    }
+
     fn ledger_path(&self) -> PathBuf {
         InProcessAgentOrchestrator::goal_ledger_dir(&self.profile_data_dir).join(format!(
             "{}.db",
@@ -887,13 +912,15 @@ impl GoalTaskLedgerBinding {
     }
 }
 
-/// #2055 review round 6 (V2b) — THE one release point for a settle-attempt
-/// flight hold. Constructed at blocking-core entry, it releases the hold the
-/// attempt was scheduled with (the enqueue's take for attempt 0, the
-/// previous attempt's re-arm take for every retry) on EVERY exit path via
-/// `Drop` — success, budget exhaustion, fence-kill, and panic-unwind alike —
-/// so no exit can skip the release and no exit can release twice. The
-/// release is generation-matched inside
+/// #2055 review round 6 (V2b), ownership reworked in round 7 — THE one
+/// release point for a settle-attempt flight hold. Constructed by whoever
+/// SCHEDULES the attempt (the enqueue for attempt 0, the previous attempt's
+/// re-arm for every retry) and HANDED THROUGH the timer future and the
+/// blocking closure into the core, it releases the hold on EVERY fate of
+/// the attempt via `Drop` — success, budget exhaustion, fence-kill,
+/// panic-unwind, and a future dropped before it ever ran — so no exit can
+/// skip the release and no exit can release twice. The release is
+/// generation-matched inside
 /// [`InProcessAgentOrchestrator::release_goal_task_settle_flight`], so a
 /// hold whose entry was removed or re-stashed (the fence-kill cases) is a
 /// harmless no-op: the hold physically died with the old entry, and the new
@@ -5833,15 +5860,12 @@ impl InProcessAgentOrchestrator {
         // is the agent id. Every other kind has no peer identity.
         let assigned_peer = (task.tool_name == "native_agent" && !task.tool_call_id.is_empty())
             .then(|| task.tool_call_id.clone());
-        let mut binding = GoalTaskLedgerBinding {
+        let mut binding = GoalTaskLedgerBinding::new_unstashed(
             goal_row,
-            title: task.tool_name.clone(),
+            task.tool_name.clone(),
             assigned_peer,
-            profile_data_dir: profile_data_dir.to_path_buf(),
-            retained_since: None,
-            generation: 0,
-            in_flight: 0,
-        };
+            profile_data_dir.to_path_buf(),
+        );
         // Stash BEFORE the offload so a terminal racing in can already
         // resolve the binding; the settle write sequence converges with the
         // creation in either order. A re-stash (same task id) carries a
@@ -18047,8 +18071,8 @@ mod tests {
         goal_id: &str,
         task_id: &str,
     ) -> GoalTaskLedgerBinding {
-        let mut binding = GoalTaskLedgerBinding {
-            goal_row: octos_fleet::Goal {
+        let mut binding = GoalTaskLedgerBinding::new_unstashed(
+            octos_fleet::Goal {
                 goal_id: goal_id.to_string(),
                 objective: "converge".to_string(),
                 status: "active".to_string(),
@@ -18059,32 +18083,30 @@ mod tests {
                 created_at_ms: 1,
                 updated_at_ms: 1,
             },
-            title: "web_probe".to_string(),
-            assigned_peer: None,
-            profile_data_dir: data_dir.to_path_buf(),
-            retained_since: None,
-            generation: 0,
-            in_flight: 0,
-        };
+            "web_probe".to_string(),
+            None,
+            data_dir.to_path_buf(),
+        );
         // Round 7 — stash through the PRODUCTION assignment path, so every
         // direct-core test runs under a real (globally monotonic) generation.
         binding.generation = orchestrator.stash_goal_task_binding(task_id, binding.clone());
         binding
     }
 
-    /// Construct the flight guard a scheduler would hand to an attempt for
-    /// `binding` — tests that drive the blocking core directly must supply
-    /// the hold the production enqueue/re-arm would have taken.
+    /// Take the flight hold a scheduler would hand to an attempt for
+    /// `binding` — round 8: through the REAL
+    /// `acquire_goal_task_settle_flight`, so test guards are
+    /// indistinguishable from production guards and every hold a test hands
+    /// to the core is BALANCED (a fabricated guard was an unbalanced
+    /// release that `saturating_sub` masked).
     fn test_flight_for(
         orchestrator: &InProcessAgentOrchestrator,
         task_id: &str,
         binding: &GoalTaskLedgerBinding,
     ) -> GoalTaskSettleFlightGuard {
-        GoalTaskSettleFlightGuard {
-            orchestrator: orchestrator.clone(),
-            task_id: task_id.to_owned(),
-            generation: binding.generation,
-        }
+        orchestrator
+            .acquire_goal_task_settle_flight(task_id, binding.generation)
+            .expect("the stashed entry admits the attempt's flight hold")
     }
 
     /// #2055 review round 2 (Additional-3): with the I/O offloaded, nothing
@@ -18209,17 +18231,12 @@ mod tests {
         let orchestrator = InProcessAgentOrchestrator::default();
         let binding = stashed_test_binding(&orchestrator, dir.path(), "goal-gen", "task-gen-stale");
 
-        // Re-stash with a bumped generation — the captured `binding`
-        // (generation 0) is now stale.
-        {
-            let mut bindings = orchestrator
-                .shared
-                .goal_task_ledger_bindings
-                .lock()
-                .unwrap();
-            let entry = bindings.get_mut("task-gen-stale").expect("entry");
-            entry.generation += 1;
-        }
+        // The chain's hold is taken while its incarnation is live (the
+        // production shape), THEN the entry is re-stashed through the REAL
+        // stash path (round 8 — fresh counter-assigned generation) — the
+        // captured `binding` and its hold are now stale.
+        let stale_flight = test_flight_for(&orchestrator, "task-gen-stale", &binding);
+        orchestrator.stash_goal_task_binding("task-gen-stale", binding.clone());
 
         orchestrator.settle_goal_task_row_blocking(
             &binding,
@@ -18227,7 +18244,7 @@ mod tests {
             octos_fleet::TaskSettleAuthority::FinalFailure,
             true,
             0,
-            test_flight_for(&orchestrator, "task-gen-stale", &binding),
+            stale_flight,
         );
 
         // The stale chain died BEFORE any write: no ledger file, no row.
@@ -18984,23 +19001,14 @@ mod tests {
 
         // (2) exhaustion: every attempt fails (the ledger dir path is a
         // FILE), driven inline so the whole bounded chain runs to
-        // exhaustion synchronously. The enqueue's hold is simulated
-        // directly, as the scheduler would take it.
+        // exhaustion synchronously. The attempt-0 hold comes from the real
+        // acquire inside `test_flight_for` (round 8), exactly as the
+        // enqueue would take it.
         let dir2 = tempfile::TempDir::new().unwrap();
         let orchestrator = InProcessAgentOrchestrator::default();
         let blocked = dir2.path().join("blocked");
         std::fs::write(&blocked, b"not a dir").unwrap();
         let binding = stashed_test_binding(&orchestrator, &blocked, "goal-exhaust", "task-exhaust");
-        {
-            // Simulate the enqueue's flight take for attempt 0 (the local
-            // clone's counter is irrelevant; the map entry is the ledger).
-            let mut bindings = orchestrator
-                .shared
-                .goal_task_ledger_bindings
-                .lock()
-                .unwrap();
-            bindings.get_mut("task-exhaust").expect("entry").in_flight = 1;
-        }
         orchestrator.settle_goal_task_row_blocking(
             &binding,
             "task-exhaust",
@@ -19023,7 +19031,10 @@ mod tests {
         );
 
         // (3) fence-killed stale chain: the live re-stashed entry keeps its
-        // own accounting (no stale release lands on it).
+        // own accounting (no stale release lands on it). Round 8 — the
+        // stale hold is taken while its incarnation is live, then the
+        // re-stash goes through the REAL stash path, and the new
+        // incarnation takes its own hold through the real acquire.
         let dir3 = tempfile::TempDir::new().unwrap();
         let orchestrator3 = InProcessAgentOrchestrator::default();
         let stale = stashed_test_binding(
@@ -19032,23 +19043,19 @@ mod tests {
             "goal-stale",
             "task-stale-flight",
         );
-        {
-            let mut bindings = orchestrator3
-                .shared
-                .goal_task_ledger_bindings
-                .lock()
-                .unwrap();
-            let entry = bindings.get_mut("task-stale-flight").expect("entry");
-            entry.generation += 1; // re-stash: new incarnation
-            entry.in_flight = 1; // the new incarnation's own hold
-        }
+        let stale_flight = test_flight_for(&orchestrator3, "task-stale-flight", &stale);
+        let live_generation =
+            orchestrator3.stash_goal_task_binding("task-stale-flight", stale.clone());
+        let _live_hold = orchestrator3
+            .acquire_goal_task_settle_flight("task-stale-flight", live_generation)
+            .expect("the new incarnation admits its own hold");
         orchestrator3.settle_goal_task_row_blocking(
             &stale,
             "task-stale-flight",
             octos_fleet::TaskSettleAuthority::FinalFailure,
             true,
             0,
-            test_flight_for(&orchestrator3, "task-stale-flight", &stale),
+            stale_flight,
         );
         let live_in_flight = orchestrator3
             .shared

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -869,6 +869,30 @@ impl GoalTaskLedgerBinding {
     }
 }
 
+/// #2055 review round 6 (V2b) — THE one release point for a settle-attempt
+/// flight hold. Constructed at blocking-core entry, it releases the hold the
+/// attempt was scheduled with (the enqueue's take for attempt 0, the
+/// previous attempt's re-arm take for every retry) on EVERY exit path via
+/// `Drop` — success, budget exhaustion, fence-kill, and panic-unwind alike —
+/// so no exit can skip the release and no exit can release twice. The
+/// release is generation-matched inside
+/// [`InProcessAgentOrchestrator::release_goal_task_settle_flight`], so a
+/// hold whose entry was removed or re-stashed (the fence-kill cases) is a
+/// harmless no-op: the hold physically died with the old entry, and the new
+/// incarnation's accounting is never touched.
+struct GoalTaskSettleFlightGuard {
+    orchestrator: InProcessAgentOrchestrator,
+    task_id: String,
+    generation: u64,
+}
+
+impl Drop for GoalTaskSettleFlightGuard {
+    fn drop(&mut self) {
+        self.orchestrator
+            .release_goal_task_settle_flight(&self.task_id, self.generation);
+    }
+}
+
 /// #2055 review round 2 (H9) — run goal-ledger I/O off the async executor.
 /// The registration/settle observers fire synchronously inside tokio-driven
 /// paths (SpawnTool's async execute, the session actor), and the I/O behind
@@ -5971,6 +5995,28 @@ impl InProcessAgentOrchestrator {
         }
     }
 
+    /// #2055 review round 6 (V2a) — take one settle-flight hold on
+    /// `task_id`, generation-matched. Used by the retry re-arm to take the
+    /// NEXT attempt's hold BEFORE the current attempt's guard releases its
+    /// own, so `in_flight` never touches zero across the backoff gap and
+    /// the purge cannot kill a chain between attempts. Returns whether the
+    /// hold was taken; a failed take (entry gone or re-stashed) means the
+    /// chain is already dead and the re-arm is pointless.
+    fn acquire_goal_task_settle_flight(&self, task_id: &str, generation: u64) -> bool {
+        let mut bindings = self
+            .shared
+            .goal_task_ledger_bindings
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match bindings.get_mut(task_id) {
+            Some(entry) if entry.generation == generation => {
+                entry.in_flight += 1;
+                true
+            }
+            _ => false,
+        }
+    }
+
     /// #2054 — the blocking half of the change-feed settle. SELF-SUFFICIENT:
     /// seeds the FK-parent goals row and the task row (as `running`) if the
     /// creation offload has not landed yet, then applies the
@@ -6017,6 +6063,17 @@ impl InProcessAgentOrchestrator {
                 .entry(task_id.to_owned())
                 .or_insert(0) += 1;
         }
+        // Round 6 (V2b) — this attempt's flight hold is released on EVERY
+        // exit path (success, exhaustion, fence-kill, panic-unwind) by this
+        // guard's Drop, and nowhere else: one release point, exactly once
+        // per attempt. The hold itself was taken by whoever SCHEDULED the
+        // attempt — the enqueue for attempt 0, the previous attempt's
+        // re-arm for a retry.
+        let _flight_guard = GoalTaskSettleFlightGuard {
+            orchestrator: self.clone(),
+            task_id: task_id.to_owned(),
+            generation: binding.generation,
+        };
         // Staleness fence — see the doc comment.
         {
             let bindings = self
@@ -6073,11 +6130,11 @@ impl InProcessAgentOrchestrator {
                             // Provisional failure settled: the binding stays
                             // purely as the correction window. Stamp the
                             // purge clock ONCE — a redelivery no-op must not
-                            // extend retention — and release this flight.
+                            // extend retention. The flight hold is released
+                            // by `_flight_guard`, like every other exit.
                             entry
                                 .retained_since
                                 .get_or_insert_with(std::time::Instant::now);
-                            entry.in_flight = entry.in_flight.saturating_sub(1);
                         }
                     }
                     _ => {}
@@ -6096,7 +6153,7 @@ impl InProcessAgentOrchestrator {
             Err(error) => {
                 let next_attempt = attempt + 1;
                 if next_attempt >= GOAL_TASK_SETTLE_ATTEMPTS {
-                    self.release_goal_task_settle_flight(task_id, binding.generation);
+                    // Chain end; `_flight_guard` releases the hold.
                     tracing::debug!(
                         task_id,
                         goal_id = %binding.goal_row.goal_id,
@@ -6104,6 +6161,21 @@ impl InProcessAgentOrchestrator {
                         attempt,
                         %error,
                         "goal task-row terminal settle failed; retry budget exhausted"
+                    );
+                    return;
+                }
+                // Round 6 (V2a) — take the NEXT attempt's hold BEFORE the
+                // timer is queued and before this attempt's guard releases
+                // its own, so `in_flight` stays above zero across the whole
+                // backoff gap and the purge cannot kill the chain between
+                // attempts. A failed take means the entry is gone or
+                // re-stashed — the chain is already dead, so don't re-arm.
+                if !self.acquire_goal_task_settle_flight(task_id, binding.generation) {
+                    tracing::debug!(
+                        task_id,
+                        goal_id = %binding.goal_row.goal_id,
+                        attempt,
+                        "goal task-row settle chain lost its binding at re-arm; dying"
                     );
                     return;
                 }
@@ -18491,25 +18563,22 @@ mod tests {
         )
         .await;
         assert_eq!(failed.as_deref(), Some("failed"));
-        // Wait for the provisional chain to fully finish (flight released),
-        // then force expiry. No liveness guard is armed for this task, so
-        // only the in-flight mark can protect the correction below.
+        // Wait for the provisional chain to fully finish (flight released,
+        // correction window stamped). No liveness guard is armed for this
+        // task, so later only the in-flight mark can protect the correction.
         {
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
             loop {
                 {
-                    let mut bindings = default_agent_orchestrator()
+                    let bindings = default_agent_orchestrator()
                         .shared
                         .goal_task_ledger_bindings
                         .lock()
                         .unwrap();
-                    if let Some(entry) = bindings.get_mut(&task_id)
+                    if let Some(entry) = bindings.get(&task_id)
                         && entry.in_flight == 0
                         && entry.retained_since.is_some()
                     {
-                        entry.retained_since = std::time::Instant::now().checked_sub(
-                            PROVISIONAL_CORRECTION_RETENTION + std::time::Duration::from_secs(1),
-                        );
                         break;
                     }
                 }
@@ -18536,14 +18605,59 @@ mod tests {
             );
             tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         }
+        // Force expiry only NOW, with the correction's flight hold already
+        // taken: an entry that is expired AND hold-free is legitimately
+        // purgeable (the accepted post-purge semantics), so expiring it
+        // before the enqueue would let any parallel test's purge — or the
+        // production-shaped hammer below — drop it in the setup gap and
+        // turn this into a test of its own scaffolding.
+        {
+            let mut bindings = default_agent_orchestrator()
+                .shared
+                .goal_task_ledger_bindings
+                .lock()
+                .unwrap();
+            bindings
+                .get_mut(&task_id)
+                .expect("held entry")
+                .retained_since = std::time::Instant::now()
+                .checked_sub(PROVISIONAL_CORRECTION_RETENTION + std::time::Duration::from_secs(1));
+        }
 
-        // Purge NOW: expired + liveness-cleared, but a flight is in
-        // progress — the entry must survive.
+        // Purge explicitly mid-attempt: expired + liveness-cleared, but a
+        // flight is in progress — the entry must survive.
         default_agent_orchestrator().purge_expired_goal_task_bindings();
         assert!(
             default_agent_orchestrator().goal_task_binding_exists_for_test(&task_id),
             "the purge must spare the in-flight correction's binding"
         );
+        // Round 6 (V2a) — and HAMMER the purge through the rest of the
+        // contention window, so it also lands inside the retry BACKOFF gap:
+        // the re-arm's hold hand-off keeps `in_flight` above zero between
+        // attempts, and without it (the mutation) some hammer hit lands at
+        // zero, drops the binding, and the correction never lands.
+        let hammer_stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let hammer = {
+            let stop = hammer_stop.clone();
+            tokio::spawn(async move {
+                while !stop.load(std::sync::atomic::Ordering::SeqCst) {
+                    default_agent_orchestrator().purge_expired_goal_task_bindings();
+                    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                }
+            })
+        };
+        // Keep the lock held until attempt 2 has verifiably ENTERED: that
+        // proves attempt 1 exhausted its busy budget, failed, and the chain
+        // crossed a real backoff gap while the hammer was pounding — the
+        // exact window the hand-off protects.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while goal_task_settle_attempts_for(&task_id) <= attempts_after_provisional + 1 {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the correction chain never crossed a backoff gap"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
 
         release.send(()).expect("release the held lock");
         holder.await.unwrap();
@@ -18556,6 +18670,8 @@ mod tests {
             std::time::Duration::from_secs(30),
         )
         .await;
+        hammer_stop.store(true, std::sync::atomic::Ordering::SeqCst);
+        hammer.await.unwrap();
         assert_eq!(
             status.as_deref(),
             Some("complete"),
@@ -18564,6 +18680,140 @@ mod tests {
         assert!(
             !default_agent_orchestrator().goal_task_binding_exists_for_test(&task_id),
             "the entry is removed by the settle, not the purge"
+        );
+    }
+
+    /// Read a binding entry's live flight count (test-side visibility for
+    /// the exactly-once release accounting).
+    fn in_flight_for(task_id: &str) -> Option<u32> {
+        default_agent_orchestrator()
+            .shared
+            .goal_task_ledger_bindings
+            .lock()
+            .unwrap()
+            .get(task_id)
+            .map(|entry| entry.in_flight)
+    }
+
+    /// #2055 review round 6 (V2b) — every chain exit releases its flight
+    /// hold EXACTLY ONCE (the drop-guard is the single release point):
+    ///
+    /// 1. a retained-success chain leaves `in_flight` at zero and the entry
+    ///    purgeable once expired;
+    /// 2. an EXHAUSTED chain (every attempt fails) leaves `in_flight` at
+    ///    zero and the entry purgeable;
+    /// 3. a fence-killed stale chain leaves the LIVE re-stashed entry's
+    ///    accounting untouched (its hold died with the replaced entry; the
+    ///    generation-matched release is a no-op, no underflow).
+    #[test]
+    fn settle_flight_hold_returns_to_zero_on_every_chain_exit() {
+        // (1) retained success, through the real inline flow.
+        let dir = tempfile::TempDir::new().unwrap();
+        let profile = "tenant-taskrows-flight";
+        let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-flight");
+        seed_goal(default_agent_orchestrator(), &wire, profile);
+        let supervisor = octos_agent::TaskSupervisor::new();
+        wire_supervisor_for_goal_task_rows(&supervisor, &wire, profile, dir.path());
+        let task_id = supervisor.register("web_probe", "call-flight-1", Some(&wire.to_string()));
+        supervisor.mark_running(&task_id);
+        supervisor.mark_failed_observed(&task_id, "flaky".to_string());
+        assert_eq!(
+            in_flight_for(&task_id),
+            Some(0),
+            "a completed retained settle must release its hold"
+        );
+        {
+            let mut bindings = default_agent_orchestrator()
+                .shared
+                .goal_task_ledger_bindings
+                .lock()
+                .unwrap();
+            bindings.get_mut(&task_id).expect("entry").retained_since = std::time::Instant::now()
+                .checked_sub(PROVISIONAL_CORRECTION_RETENTION + std::time::Duration::from_secs(1));
+        }
+        default_agent_orchestrator().purge_expired_goal_task_bindings();
+        assert!(
+            !default_agent_orchestrator().goal_task_binding_exists_for_test(&task_id),
+            "with the hold released, the expired window purges"
+        );
+
+        // (2) exhaustion: every attempt fails (the ledger dir path is a
+        // FILE), driven inline so the whole bounded chain runs to
+        // exhaustion synchronously. The enqueue's hold is simulated
+        // directly, as the scheduler would take it.
+        let dir2 = tempfile::TempDir::new().unwrap();
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let blocked = dir2.path().join("blocked");
+        std::fs::write(&blocked, b"not a dir").unwrap();
+        let binding = stashed_test_binding(&orchestrator, &blocked, "goal-exhaust", "task-exhaust");
+        {
+            // Simulate the enqueue's flight take for attempt 0 (the local
+            // clone's counter is irrelevant; the map entry is the ledger).
+            let mut bindings = orchestrator
+                .shared
+                .goal_task_ledger_bindings
+                .lock()
+                .unwrap();
+            bindings.get_mut("task-exhaust").expect("entry").in_flight = 1;
+        }
+        orchestrator.settle_goal_task_row_blocking(
+            &binding,
+            "task-exhaust",
+            octos_fleet::TaskSettleAuthority::FinalFailure,
+            true,
+            0,
+        );
+        let exhausted_in_flight = orchestrator
+            .shared
+            .goal_task_ledger_bindings
+            .lock()
+            .unwrap()
+            .get("task-exhaust")
+            .map(|entry| entry.in_flight);
+        assert_eq!(
+            exhausted_in_flight,
+            Some(0),
+            "an exhausted chain must release exactly its own hold"
+        );
+
+        // (3) fence-killed stale chain: the live re-stashed entry keeps its
+        // own accounting (no stale release lands on it).
+        let dir3 = tempfile::TempDir::new().unwrap();
+        let orchestrator3 = InProcessAgentOrchestrator::default();
+        let stale = stashed_test_binding(
+            &orchestrator3,
+            dir3.path(),
+            "goal-stale",
+            "task-stale-flight",
+        );
+        {
+            let mut bindings = orchestrator3
+                .shared
+                .goal_task_ledger_bindings
+                .lock()
+                .unwrap();
+            let entry = bindings.get_mut("task-stale-flight").expect("entry");
+            entry.generation += 1; // re-stash: new incarnation
+            entry.in_flight = 1; // the new incarnation's own hold
+        }
+        orchestrator3.settle_goal_task_row_blocking(
+            &stale,
+            "task-stale-flight",
+            octos_fleet::TaskSettleAuthority::FinalFailure,
+            true,
+            0,
+        );
+        let live_in_flight = orchestrator3
+            .shared
+            .goal_task_ledger_bindings
+            .lock()
+            .unwrap()
+            .get("task-stale-flight")
+            .map(|entry| entry.in_flight);
+        assert_eq!(
+            live_in_flight,
+            Some(1),
+            "a fence-killed stale chain must not touch the live incarnation's hold"
         );
     }
 

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -769,6 +769,35 @@ struct OrchestratorShared {
     goal_task_ledger_bindings: StdMutex<HashMap<String, GoalTaskLedgerBinding>>,
 }
 
+/// #2055 review round 3 — how long a settled OBSERVER-provisional failure
+/// keeps its binding open for the owner's correcting completion. The
+/// supervisor's correction (task_supervisor.rs:2527) fires when the owner
+/// watches its worker actually finish, which happens promptly after the
+/// observer's premature verdict or never — a correction arriving later than
+/// this is not a plausible owner signal, and the map is a process-global
+/// singleton that nothing else prunes (the supervisor task map never prunes,
+/// and detached registrations skip even the fan-out cap), so unbounded
+/// retention would grow with every provisionally-failed task for the
+/// process lifetime. A purged entry just drops the binding: the ledger row
+/// already reads `failed`, the honest final state when no correction came.
+const PROVISIONAL_CORRECTION_RETENTION: std::time::Duration =
+    std::time::Duration::from_secs(30 * 60);
+
+/// #2055 review round 3 — bounded retry budget for a settle whose ledger
+/// write failed (BUSY exhaustion, transient I/O). Cancellation emits exactly
+/// one change event, so without a retry a transient failure left the row
+/// `running` forever; five attempts with capped exponential backoff cover
+/// multi-second contention without unbounded queues.
+const GOAL_TASK_SETTLE_ATTEMPTS: u32 = 5;
+
+/// Capped exponential backoff for the settle retry chain: 100ms, 200ms,
+/// 400ms, 800ms — capped at 2s.
+fn goal_task_settle_backoff(attempt: u32) -> std::time::Duration {
+    let base = std::time::Duration::from_millis(100);
+    let capped = base.saturating_mul(1u32 << attempt.min(4));
+    capped.min(std::time::Duration::from_secs(2))
+}
+
 /// #2055/#2054 — everything the ledger I/O for one task's row needs, captured
 /// at registration-stash time so BOTH the offloaded row creation and any
 /// later settle can run without re-entering orchestrator state: the FK-parent
@@ -781,6 +810,12 @@ struct GoalTaskLedgerBinding {
     title: String,
     assigned_peer: Option<String>,
     profile_data_dir: PathBuf,
+    /// `None` while the task is live (or its settle is still retrying);
+    /// stamped when a provisional-failed settle SUCCEEDS and the binding is
+    /// retained purely as the correction window — the purge deadline
+    /// ([`PROVISIONAL_CORRECTION_RETENTION`]) applies only to that state, so
+    /// a legitimately long-running task can never be purged mid-flight.
+    retained_since: Option<std::time::Instant>,
 }
 
 impl GoalTaskLedgerBinding {
@@ -1101,6 +1136,56 @@ pub(crate) const GOAL_TASK_ROW_SETTLE_LISTENER_KEY: &str = "goal-task-row-settle
 pub(crate) fn install_goal_task_row_settle_listener(supervisor: &octos_agent::TaskSupervisor) {
     supervisor.set_on_change_listener(GOAL_TASK_ROW_SETTLE_LISTENER_KEY, |task| {
         default_agent_orchestrator().settle_goal_task_row_from_change(task);
+    });
+}
+
+/// #2055 review round 3 — THE one installer for the goal-task-row observer
+/// pair (`on_register` recorder + the named settle listener). Every
+/// production wiring site AND the effect tests go through this function, so
+/// test wiring cannot drift from production wiring: only the goal-binding
+/// RESOLVER differs per site (the per-turn WS path passes a dispatch-time
+/// snapshot; callback-time resolution uses
+/// [`install_goal_task_row_observers_resolving_at_callback`]).
+pub(crate) fn install_goal_task_row_observers(
+    supervisor: &octos_agent::TaskSupervisor,
+    profile_data_dir: &Path,
+    resolve_binding: impl Fn() -> Option<(String, String)> + Send + Sync + 'static,
+) {
+    let data_dir = profile_data_dir.to_path_buf();
+    supervisor.set_on_register(move |task| {
+        // (goal_id, profile_id); `None` ⇒ no goal bound ⇒ no row — correct
+        // behavior, not an error.
+        let Some((goal_id, profile_id)) = resolve_binding() else {
+            return;
+        };
+        default_agent_orchestrator().record_goal_task_registration(
+            &data_dir,
+            &profile_id,
+            &goal_id,
+            task,
+        );
+    });
+    install_goal_task_row_settle_listener(supervisor);
+}
+
+/// #2055 review round 3 — [`install_goal_task_row_observers`] with the
+/// callback-time resolver: the session's ACTIVE goal is looked up on every
+/// registration via [`InProcessAgentOrchestrator::active_goal_id`]. For
+/// supervisors that outlive goals coming and going — the gateway actor's,
+/// and the cached `session_runtime.tools` supervisor the out-of-turn WS
+/// paths use — where a dispatch-time snapshot would go stale.
+pub(crate) fn install_goal_task_row_observers_resolving_at_callback(
+    supervisor: &octos_agent::TaskSupervisor,
+    session_id: &SessionKey,
+    profile_id: &str,
+    profile_data_dir: &Path,
+) {
+    let session = session_id.clone();
+    let profile = profile_id.to_owned();
+    install_goal_task_row_observers(supervisor, profile_data_dir, move || {
+        default_agent_orchestrator()
+            .active_goal_id(&session, &profile)
+            .map(|goal_id| (goal_id, profile.clone()))
     });
 }
 
@@ -5620,9 +5705,12 @@ impl InProcessAgentOrchestrator {
         goal_id: &str,
         task: &octos_agent::BackgroundTask,
     ) {
+        // Round 3 — opportunistic retention purge on every map touch (no
+        // background sweeper): expired correction windows drop here.
+        self.purge_expired_goal_task_bindings();
         // Goal snapshot for the FK-parent goals row. Captured ONCE, at stash
         // time, and carried on the binding for both the creation offload and
-        // any later settle — it is only ever INSERTED-if-absent (H3: the
+        // any later settle — it is only ever inserted-if-absent (H3: the
         // registration path must never update a goals row; `upsert_goal`'s
         // monotonic guard admits equal millisecond timestamps, so a delayed
         // stale snapshot could regress an administrative transition). A goal
@@ -5666,6 +5754,7 @@ impl InProcessAgentOrchestrator {
             title: task.tool_name.clone(),
             assigned_peer,
             profile_data_dir: profile_data_dir.to_path_buf(),
+            retained_since: None,
         };
         // Stash BEFORE the offload so a terminal racing in can already
         // resolve the binding; the settle write sequence converges with the
@@ -5770,6 +5859,8 @@ impl InProcessAgentOrchestrator {
             octos_agent::TaskStatus::Failed => ("failed", !task.failed_by_observer),
             octos_agent::TaskStatus::Spawned | octos_agent::TaskStatus::Running => return,
         };
+        // Round 3 — opportunistic retention purge on every map touch.
+        self.purge_expired_goal_task_bindings();
         let binding = self
             .shared
             .goal_task_ledger_bindings
@@ -5783,23 +5874,39 @@ impl InProcessAgentOrchestrator {
         let this = self.clone();
         let task_id = task.id.clone();
         offload_goal_ledger_io(move || {
-            this.settle_goal_task_row_blocking(&binding, &task_id, status, remove_on_success);
+            this.settle_goal_task_row_blocking(&binding, &task_id, status, remove_on_success, 0);
         });
     }
 
-    /// #2054 (review round 2) — the blocking half of the change-feed settle.
-    /// SELF-SUFFICIENT: seeds the FK-parent goals row and the task row
-    /// (directly with the terminal status) if the creation offload has not
-    /// landed yet — creation-then-settle and settle-then-creation converge
-    /// on the same terminal row — then applies the guarded
-    /// [`octos_fleet::GoalLedger::update_task_status`], whose `Ok(false)` is
-    /// a normal no-op (row already carries this terminal).
+    /// #2054 (review round 2, retry in round 3) — the blocking half of the
+    /// change-feed settle. SELF-SUFFICIENT: seeds the FK-parent goals row
+    /// and the task row (as `running`) if the creation offload has not
+    /// landed yet, then applies the provenance-carrying
+    /// [`octos_fleet::GoalLedger::update_task_status_with_provenance`] —
+    /// creation-then-settle and settle-then-creation converge on the same
+    /// terminal row, and an observer-provisional failure stamps
+    /// `correctable = 1` so the owner's later completion is admitted. An
+    /// `Ok(false)` from the guarded update is a normal no-op (the row
+    /// already carries this terminal).
+    ///
+    /// Round 3 — bounded retry: `open_with_busy_retry` covers only the OPEN,
+    /// a write can still exhaust the busy handler, and cancellation emits
+    /// exactly ONE change event — so a transiently-failed settle would
+    /// otherwise leave the row `running` forever. On failure the SAME settle
+    /// is re-scheduled through an async `tokio::time::sleep` backoff and a
+    /// fresh `spawn_blocking` (never a sleep parked on the blocking pool;
+    /// without a runtime the bounded chain runs inline on the caller's
+    /// non-executor thread). At most [`GOAL_TASK_SETTLE_ATTEMPTS`] attempts,
+    /// deduplicated by the binding entry: a retry re-arms only while the
+    /// binding is still present, and a concurrent success removes it, which
+    /// cancels the chain naturally.
     fn settle_goal_task_row_blocking(
         &self,
         binding: &GoalTaskLedgerBinding,
         task_id: &str,
         status: &str,
         remove_on_success: bool,
+        attempt: u32,
     ) {
         let ledger_dir = Self::goal_ledger_dir(&binding.profile_data_dir);
         let now = now_ms_u64();
@@ -5808,49 +5915,128 @@ impl InProcessAgentOrchestrator {
             goal_id: binding.goal_row.goal_id.clone(),
             title: binding.title.clone(),
             detail: String::new(),
-            status: status.to_owned(),
+            status: "running".to_owned(),
             assigned_peer: binding.assigned_peer.clone(),
             created_at_ms: now,
             updated_at_ms: now,
         };
+        // Round 3 — provenance: `remove_on_success == false` is exactly the
+        // observer-provisional failure (see the status match above), the one
+        // verdict the owner may still correct; everything else is final.
+        let correctable = !remove_on_success;
         let written = std::fs::create_dir_all(&ledger_dir)
             .map_err(|error| eyre::eyre!("ledger dir unavailable: {error}"))
             .and_then(|()| octos_fleet::GoalLedger::open_with_busy_retry(binding.ledger_path()))
             .and_then(|ledger| {
                 ledger.create_goal_if_absent(&binding.goal_row)?;
                 ledger.create_task_if_absent(&seed_row)?;
-                ledger.update_task_status(task_id, status, now)
+                ledger.update_task_status_with_provenance(task_id, status, correctable, now)
             });
         match written {
             Ok(moved) => {
+                let mut bindings = self
+                    .shared
+                    .goal_task_ledger_bindings
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
                 if remove_on_success {
-                    self.shared
-                        .goal_task_ledger_bindings
-                        .lock()
-                        .unwrap_or_else(|poisoned| poisoned.into_inner())
-                        .remove(task_id);
+                    bindings.remove(task_id);
+                } else if let Some(entry) = bindings.get_mut(task_id) {
+                    // Provisional failure settled: the binding stays purely
+                    // as the correction window, now on the purge clock.
+                    entry.retained_since = Some(std::time::Instant::now());
                 }
+                drop(bindings);
                 tracing::debug!(
                     task_id,
                     goal_id = %binding.goal_row.goal_id,
                     status,
                     moved,
                     remove_on_success,
+                    attempt,
                     "goal task-row terminal settle"
                 );
             }
             Err(error) => {
-                // Binding deliberately left in place: a redelivered change
-                // event (the feed multi-fires for terminal tasks) retries.
+                let next_attempt = attempt + 1;
+                let binding_present = self
+                    .shared
+                    .goal_task_ledger_bindings
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .contains_key(task_id);
+                if next_attempt >= GOAL_TASK_SETTLE_ATTEMPTS || !binding_present {
+                    tracing::debug!(
+                        task_id,
+                        goal_id = %binding.goal_row.goal_id,
+                        status,
+                        attempt,
+                        %error,
+                        "goal task-row terminal settle failed; retry budget exhausted or binding gone"
+                    );
+                    return;
+                }
                 tracing::debug!(
                     task_id,
                     goal_id = %binding.goal_row.goal_id,
                     status,
+                    attempt,
                     %error,
-                    "goal task-row terminal settle failed; binding kept for retry"
+                    "goal task-row terminal settle failed; re-scheduling"
                 );
+                let this = self.clone();
+                let binding = binding.clone();
+                let task_id = task_id.to_owned();
+                let status = status.to_owned();
+                let backoff = goal_task_settle_backoff(attempt);
+                match tokio::runtime::Handle::try_current() {
+                    Ok(handle) => {
+                        let blocking_handle = handle.clone();
+                        handle.spawn(async move {
+                            tokio::time::sleep(backoff).await;
+                            blocking_handle.spawn_blocking(move || {
+                                this.settle_goal_task_row_blocking(
+                                    &binding,
+                                    &task_id,
+                                    &status,
+                                    remove_on_success,
+                                    next_attempt,
+                                );
+                            });
+                        });
+                    }
+                    Err(_) => {
+                        // Inline mode: the caller's plain (non-executor)
+                        // thread; the bounded chain may sleep here.
+                        std::thread::sleep(backoff);
+                        this.settle_goal_task_row_blocking(
+                            &binding,
+                            &task_id,
+                            &status,
+                            remove_on_success,
+                            next_attempt,
+                        );
+                    }
+                }
             }
         }
+    }
+
+    /// #2055 review round 3 — drop correction windows older than
+    /// [`PROVISIONAL_CORRECTION_RETENTION`]. Only entries whose settle
+    /// RETAINED them (`retained_since` stamped) are eligible — a live
+    /// task's binding carries `None` and is never purged, however long the
+    /// task runs. Called opportunistically from every registration and
+    /// settle map touch; no background sweeper.
+    fn purge_expired_goal_task_bindings(&self) {
+        self.shared
+            .goal_task_ledger_bindings
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .retain(|_, binding| match binding.retained_since {
+                Some(retained_since) => retained_since.elapsed() < PROVISIONAL_CORRECTION_RETENTION,
+                None => true,
+            });
     }
 
     /// #2055 review round 2 — test-only visibility into the binding map so
@@ -17186,37 +17372,24 @@ mod tests {
     // at terminal through the unified sink.
     // -----------------------------------------------------------------------
 
-    /// Wire a real `TaskSupervisor` exactly the way the runtime modes do:
-    /// `set_on_register` resolves the session's active goal and records the
-    /// row; the NAMED change listener settles terminal transitions; the
-    /// `on_terminal` sink stays wired for continuation routing (and must not
-    /// interfere with settling). These tests run WITHOUT a tokio runtime, so
-    /// `offload_goal_ledger_io` executes the ledger I/O inline and every
-    /// assertion below is deterministic; the offload branch has its own
-    /// `#[tokio::test]` coverage.
+    /// Wire a real `TaskSupervisor` through the SHARED production installer
+    /// (round 3, review R8): tests and every production site call the same
+    /// [`install_goal_task_row_observers_resolving_at_callback`], so test
+    /// wiring cannot drift from production wiring — deleting or gutting the
+    /// installer breaks these tests. The `on_terminal` sink stays wired for
+    /// continuation routing (and must not interfere with settling). Full
+    /// serve-boot integration coverage is out of scope here. Tests without
+    /// a tokio runtime run the ledger I/O inline (deterministic); the
+    /// offload branch has its own `#[tokio::test]` coverage.
     fn wire_supervisor_for_goal_task_rows(
         supervisor: &octos_agent::TaskSupervisor,
         session: &SessionKey,
         profile: &str,
         data_dir: &std::path::Path,
     ) {
-        let register_session = session.clone();
-        let register_profile = profile.to_owned();
-        let register_data_dir = data_dir.to_path_buf();
-        supervisor.set_on_register(move |task| {
-            let orchestrator = default_agent_orchestrator();
-            let Some(goal_id) = orchestrator.active_goal_id(&register_session, &register_profile)
-            else {
-                return;
-            };
-            orchestrator.record_goal_task_registration(
-                &register_data_dir,
-                &register_profile,
-                &goal_id,
-                task,
-            );
-        });
-        install_goal_task_row_settle_listener(supervisor);
+        install_goal_task_row_observers_resolving_at_callback(
+            supervisor, session, profile, data_dir,
+        );
         supervisor.set_on_terminal(move |event| {
             route_terminal_event_to_continuation_queue(event, None);
         });
@@ -17439,11 +17612,163 @@ mod tests {
         assert_eq!(row.status, "complete");
     }
 
+    /// #2055 review round 3 (P1): scripted provider for the REAL
+    /// default-mode nested spawn — the FIRST model turn (the outer
+    /// background child's) calls `spawn_agent`, every later turn (the
+    /// child's follow-up and the grandchild's whole run) ends immediately.
+    struct NestedSpawnScriptProvider {
+        spawned: std::sync::atomic::AtomicBool,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmProvider for NestedSpawnScriptProvider {
+        async fn chat(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            let first = !self.spawned.swap(true, std::sync::atomic::Ordering::SeqCst);
+            if first {
+                Ok(octos_llm::ChatResponse {
+                    content: None,
+                    reasoning_content: None,
+                    tool_calls: vec![octos_core::ToolCall {
+                        id: "call-nested-grandchild".to_string(),
+                        name: "spawn_agent".to_string(),
+                        arguments: serde_json::json!({
+                            "task": "reply with the word done",
+                            "label": "nested-grandchild",
+                        }),
+                        metadata: None,
+                    }],
+                    stop_reason: octos_llm::StopReason::ToolUse,
+                    usage: octos_llm::TokenUsage::default(),
+                    provider_index: None,
+                })
+            } else {
+                Ok(octos_llm::ChatResponse {
+                    content: Some("done".to_string()),
+                    reasoning_content: None,
+                    tool_calls: Vec::new(),
+                    stop_reason: octos_llm::StopReason::EndTurn,
+                    usage: octos_llm::TokenUsage::default(),
+                    provider_index: None,
+                })
+            }
+        }
+
+        fn model_id(&self) -> &str {
+            "nested-spawn-script"
+        }
+
+        fn provider_name(&self) -> &str {
+            "test"
+        }
+    }
+
+    /// #2055 review round 3 (P1): the DEFAULT-mode (background) nested
+    /// spawn, driven through the REAL spawn path end-to-end — no hand-built
+    /// child registry anywhere. The outer spawn omits `mode` (background is
+    /// the default), so the DETACHED branch builds the child registry; the
+    /// scripted child model then calls `spawn_agent`, whose registration
+    /// lands on that detached registry's private supervisor. Only the
+    /// detached-branch observer inheritance makes the grandchild's SQLite
+    /// row exist — this is exactly the hole class the deleted grep tests
+    /// hid (a hand-built registry would pass without the production path).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn default_mode_background_nested_spawn_lands_grandchild_row() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let profile = "tenant-taskrows-bgnest";
+        let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-bgnest");
+        seed_goal(default_agent_orchestrator(), &wire, profile);
+        let goal_id = default_agent_orchestrator()
+            .goal_id_for_test(&wire)
+            .expect("goal id");
+        let ledger_path = goal_task_ledger_path(dir.path(), &goal_id);
+
+        // The parent (session) supervisor, wired through the SHARED
+        // production installer.
+        let supervisor = Arc::new(octos_agent::TaskSupervisor::new());
+        wire_supervisor_for_goal_task_rows(&supervisor, &wire, profile, dir.path());
+
+        let memory = Arc::new(
+            octos_memory::EpisodeStore::open(dir.path().join("memory"))
+                .await
+                .expect("episode store"),
+        );
+        let (inbound_tx, _inbound_rx) = tokio::sync::mpsc::channel(16);
+        let spawn_tool = octos_agent::SpawnTool::new(
+            Arc::new(NestedSpawnScriptProvider {
+                spawned: std::sync::atomic::AtomicBool::new(false),
+            }),
+            memory,
+            dir.path().join("work"),
+            inbound_tx,
+        )
+        .with_task_supervisor(
+            Arc::clone(&supervisor),
+            wire.to_string(),
+            dir.path().join("tasks.jsonl"),
+        );
+        std::fs::create_dir_all(dir.path().join("work")).unwrap();
+
+        // No "mode" key: background IS the default, and the default is the
+        // branch under test.
+        let result = octos_agent::Tool::execute(
+            &spawn_tool,
+            &serde_json::json!({
+                "task": "spawn one nested helper, then finish",
+                "label": "outer-background-child",
+            }),
+        )
+        .await
+        .expect("outer spawn dispatch");
+        assert!(result.success, "outer background spawn must start");
+
+        // The grandchild's task id lives on the DETACHED child registry's
+        // private supervisor (invisible from here), so identify its row by
+        // title — registration records the tool label.
+        let mut titles = Vec::new();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        while std::time::Instant::now() < deadline {
+            let path = ledger_path.clone();
+            let gid = goal_id.clone();
+            titles = tokio::task::spawn_blocking(move || {
+                octos_fleet::GoalLedger::open(&path)
+                    .ok()
+                    .and_then(|ledger| ledger.tasks_for_goal(&gid).ok())
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|task| task.title)
+                    .collect::<Vec<_>>()
+            })
+            .await
+            .unwrap();
+            if titles.iter().any(|title| title == "nested-grandchild") {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        assert!(
+            titles.iter().any(|title| title == "outer-background-child"),
+            "the outer background child has a row (parent supervisor wiring); rows: {titles:?}"
+        );
+        assert!(
+            titles.iter().any(|title| title == "nested-grandchild"),
+            "the DEFAULT-mode nested grandchild must land a row via detached-branch \
+             observer inheritance; rows: {titles:?}"
+        );
+    }
+
     /// #2055 review round 2 (Additional-3): with the I/O offloaded, nothing
-    /// orders the creation write against the settle write. Drive the two
-    /// blocking cores directly in REVERSE order: the settle seeds the row
-    /// with its terminal status, and the late creation write preserves it —
-    /// both orders converge on the same terminal row.
+    /// orders the creation write against the settle write. This test
+    /// DELIBERATELY invokes the two PRIVATE blocking cores directly (review
+    /// round 3, R9-b): forcing the reverse order deterministically is only
+    /// possible below the offload layer, and pure write-ordering is exactly
+    /// what the cores own. The settle seeds the row and applies its
+    /// terminal; the late creation write preserves it — both orders
+    /// converge on the same terminal row.
     #[test]
     fn settle_before_create_ordering_converges() {
         let dir = tempfile::TempDir::new().unwrap();
@@ -17463,11 +17788,12 @@ mod tests {
             title: "web_probe".to_string(),
             assigned_peer: None,
             profile_data_dir: dir.path().to_path_buf(),
+            retained_since: None,
         };
 
         // Settle lands FIRST (fresh ledger file — the settle is
         // self-sufficient and seeds goal + task rows itself).
-        orchestrator.settle_goal_task_row_blocking(&binding, "task-order", "complete", true);
+        orchestrator.settle_goal_task_row_blocking(&binding, "task-order", "complete", true, 0);
         // The creation offload arrives LATE and must not resurrect it.
         InProcessAgentOrchestrator::record_goal_task_row_blocking(&binding, "task-order");
 
@@ -17482,11 +17808,70 @@ mod tests {
         );
     }
 
-    /// #2055 review round 2 (H9): inside a tokio runtime the observer
-    /// callbacks only stash and spawn — the SQLite I/O lands on the
-    /// blocking pool. Bounded poll for the offloaded row.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn offloaded_registration_write_lands_from_within_a_runtime() {
+    /// #2055 review round 3 (retention purge): a binding retained purely as
+    /// a correction window is dropped once it outlives the deadline; a LIVE
+    /// task's binding (no `retained_since`) is never purged.
+    #[test]
+    fn retention_purge_drops_only_expired_correction_windows() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let profile = "tenant-taskrows-purge";
+        let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-purge");
+        seed_goal(default_agent_orchestrator(), &wire, profile);
+
+        let supervisor = octos_agent::TaskSupervisor::new();
+        wire_supervisor_for_goal_task_rows(&supervisor, &wire, profile, dir.path());
+
+        let live_id = supervisor.register("web_probe", "call-purge-live", Some(&wire.to_string()));
+        let provisional_id =
+            supervisor.register("web_probe", "call-purge-prov", Some(&wire.to_string()));
+        supervisor.mark_running(&provisional_id);
+        supervisor.mark_failed_observed(&provisional_id, "flaky".to_string());
+        assert!(
+            default_agent_orchestrator().goal_task_binding_exists_for_test(&provisional_id),
+            "the settled provisional failure retains its correction window"
+        );
+
+        // Backdate the correction window past the deadline, then run the
+        // opportunistic purge directly (it also fires on every map touch).
+        {
+            let orchestrator = default_agent_orchestrator();
+            let mut bindings = orchestrator
+                .shared
+                .goal_task_ledger_bindings
+                .lock()
+                .unwrap();
+            let entry = bindings.get_mut(&provisional_id).expect("retained entry");
+            entry.retained_since = std::time::Instant::now()
+                .checked_sub(PROVISIONAL_CORRECTION_RETENTION + std::time::Duration::from_secs(1));
+            assert!(
+                entry.retained_since.is_some(),
+                "backdate must be representable"
+            );
+        }
+        default_agent_orchestrator().purge_expired_goal_task_bindings();
+
+        assert!(
+            !default_agent_orchestrator().goal_task_binding_exists_for_test(&provisional_id),
+            "an expired correction window is purged"
+        );
+        assert!(
+            default_agent_orchestrator().goal_task_binding_exists_for_test(&live_id),
+            "a live task's binding is never purged, however old"
+        );
+    }
+
+    /// #2055 review round 2 (H9), tightened in round 3 (R9-c/d): inside a
+    /// tokio runtime the observer callbacks only stash and spawn — the
+    /// SQLite I/O lands on the blocking pool. Proven under CONTENTION on a
+    /// SINGLE-worker runtime: while a real write transaction holds the
+    /// ledger, (1) the register call returns promptly, (2) a heartbeat task
+    /// keeps beating through the entire hold (inline I/O would starve the
+    /// only worker on the busy handler), and (3) the offloaded write lands
+    /// once the lock releases. All test-side ledger reads go through
+    /// `spawn_blocking` — the test must not itself commit the pattern this
+    /// PR removes.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn offloaded_registration_stays_off_the_executor_under_contention() {
         let dir = tempfile::TempDir::new().unwrap();
         let profile = "tenant-taskrows-offload";
         let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-offload");
@@ -17494,25 +17879,168 @@ mod tests {
         let goal_id = default_agent_orchestrator()
             .goal_id_for_test(&wire)
             .expect("goal id");
+        let ledger_path = goal_task_ledger_path(dir.path(), &goal_id);
+
+        // Materialize the ledger file, then take a REAL write transaction on
+        // it from the blocking pool so the registration's offloaded write
+        // must wait on the busy handler.
+        {
+            let path = ledger_path.clone();
+            tokio::task::spawn_blocking(move || {
+                std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+                octos_fleet::GoalLedger::open(&path).unwrap();
+            })
+            .await
+            .unwrap();
+        }
+        let contention_path = ledger_path.clone();
+        let contention = tokio::task::spawn_blocking(move || {
+            let conn = rusqlite::Connection::open(&contention_path).unwrap();
+            conn.execute_batch("BEGIN IMMEDIATE;").unwrap();
+            // Hold the write lock briefly — shorter than the 1s busy
+            // budget, so the blocked write completes right after release.
+            std::thread::sleep(std::time::Duration::from_millis(600));
+            conn.execute_batch("COMMIT;").unwrap();
+        });
+
+        let heartbeat = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let heartbeat_task = {
+            let heartbeat = heartbeat.clone();
+            tokio::spawn(async move {
+                loop {
+                    heartbeat.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+            })
+        };
 
         let supervisor = octos_agent::TaskSupervisor::new();
         wire_supervisor_for_goal_task_rows(&supervisor, &wire, profile, dir.path());
+        let register_started = std::time::Instant::now();
         let task_id =
             supervisor.register("web_probe", "call-rows-offload", Some(&wire.to_string()));
+        let register_elapsed = register_started.elapsed();
+        assert!(
+            register_elapsed < std::time::Duration::from_millis(250),
+            "registration must return promptly under ledger contention \
+             (took {register_elapsed:?} — inline I/O would ride the busy handler)"
+        );
 
-        let ledger_path = goal_task_ledger_path(dir.path(), &goal_id);
+        // The single worker must keep serving the heartbeat while the
+        // offloaded write waits out the held lock on the blocking pool.
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        let beats = heartbeat.load(std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            beats >= 20,
+            "the executor worker must keep beating under contention; got {beats} beats"
+        );
+        heartbeat_task.abort();
+        contention.await.unwrap();
+
         let mut row = None;
-        for _ in 0..100 {
-            if let Ok(ledger) = octos_fleet::GoalLedger::open(&ledger_path)
-                && let Ok(found @ Some(_)) = ledger.get_task(&task_id)
-            {
+        for _ in 0..200 {
+            let path = ledger_path.clone();
+            let id = task_id.clone();
+            let found = tokio::task::spawn_blocking(move || {
+                octos_fleet::GoalLedger::open(&path)
+                    .ok()
+                    .and_then(|ledger| ledger.get_task(&id).ok().flatten())
+            })
+            .await
+            .unwrap();
+            if found.is_some() {
                 row = found;
                 break;
             }
             tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         }
-        let row = row.expect("the offloaded creation write landed");
+        let row = row.expect("the offloaded creation write landed after the lock released");
         assert_eq!(row.status, "running");
+    }
+
+    /// #2055 review round 3 (bounded settle retry): a settle whose write
+    /// fails against held contention re-arms itself with backoff and
+    /// converges once the lock releases — cancellation emits exactly one
+    /// change event, so without the retry this row would stay `running`
+    /// forever.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn contended_settle_retries_until_the_row_converges() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let profile = "tenant-taskrows-retry";
+        let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-retry");
+        seed_goal(default_agent_orchestrator(), &wire, profile);
+        let goal_id = default_agent_orchestrator()
+            .goal_id_for_test(&wire)
+            .expect("goal id");
+        let ledger_path = goal_task_ledger_path(dir.path(), &goal_id);
+
+        let supervisor = octos_agent::TaskSupervisor::new();
+        wire_supervisor_for_goal_task_rows(&supervisor, &wire, profile, dir.path());
+        let task_id = supervisor.register("web_probe", "call-rows-retry", Some(&wire.to_string()));
+
+        // Wait for the registration write to land so the contention below
+        // targets the settle, not the creation.
+        for _ in 0..200 {
+            let path = ledger_path.clone();
+            let id = task_id.clone();
+            let found = tokio::task::spawn_blocking(move || {
+                octos_fleet::GoalLedger::open(&path)
+                    .ok()
+                    .and_then(|ledger| ledger.get_task(&id).ok().flatten())
+            })
+            .await
+            .unwrap();
+            if found.is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        // Hold a real write transaction PAST the settle's first busy budget
+        // (1s per lock acquisition on the retry-profile connection), so the
+        // first settle attempt genuinely fails and only the retry chain can
+        // converge the row.
+        let contention_path = ledger_path.clone();
+        let contention = tokio::task::spawn_blocking(move || {
+            let conn = rusqlite::Connection::open(&contention_path).unwrap();
+            conn.execute_batch("BEGIN IMMEDIATE;").unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(2_500));
+            conn.execute_batch("COMMIT;").unwrap();
+        });
+        // Give the lock holder a beat to actually acquire it.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        supervisor.mark_running(&task_id);
+        supervisor.mark_completed(&task_id, vec![]);
+        contention.await.unwrap();
+
+        let mut status = None;
+        for _ in 0..600 {
+            let path = ledger_path.clone();
+            let id = task_id.clone();
+            let found = tokio::task::spawn_blocking(move || {
+                octos_fleet::GoalLedger::open(&path)
+                    .ok()
+                    .and_then(|ledger| ledger.get_task(&id).ok().flatten())
+                    .map(|row| row.status)
+            })
+            .await
+            .unwrap();
+            if found.as_deref() == Some("complete") {
+                status = found;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert_eq!(
+            status.as_deref(),
+            Some("complete"),
+            "the settle retry chain must converge the row after the lock releases"
+        );
+        assert!(
+            !default_agent_orchestrator().goal_task_binding_exists_for_test(&task_id),
+            "the converged settle releases the binding"
+        );
     }
 
     /// A session with NO goal binding creates nothing — that is correct

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -823,6 +823,18 @@ pub(crate) fn goal_task_settle_attempts_for(task_id: &str) -> u64 {
         .unwrap_or(0)
 }
 
+/// #2055 review round 7 (W2) — the single source of binding generations: a
+/// process-wide monotonic counter, so a generation value can never repeat
+/// for any entry, ever — including a remove-then-re-stash of the SAME task
+/// id, which per-entry arithmetic restarted at zero (the ABA that let an old
+/// hold's release steal the new incarnation's live flight). Production task
+/// ids are fresh UUIDv7s today, but the monotonic counter also pre-covers
+/// the same-id restoration path #2056 tracks.
+fn next_goal_task_binding_generation() -> u64 {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
 /// #2055/#2054 — everything the ledger I/O for one task's row needs, captured
 /// at registration-stash time so BOTH the offloaded row creation and any
 /// later settle can run without re-entering orchestrator state: the FK-parent
@@ -845,9 +857,15 @@ struct GoalTaskLedgerBinding {
     /// #2055 review round 4 — chain-staleness fence. A settle chain captures
     /// the generation it was started under and re-checks presence AND
     /// generation immediately before EVERY write attempt; a re-registration
-    /// re-stashes with a bumped generation, and removal (success or purge)
+    /// re-stashes with a fresh generation, and removal (success or purge)
     /// deletes the entry, so a stale chain dies at its next check instead of
     /// writing after its sleep.
+    ///
+    /// Round 7 (W2) — generations come from ONE process-wide monotonic
+    /// counter ([`next_goal_task_binding_generation`]), never from per-entry
+    /// arithmetic: a remove-then-re-stash of the same task id used to
+    /// restart at zero, so an old generation-0 hold could match the new
+    /// incarnation (ABA) and its release could steal a live flight.
     generation: u64,
     /// #2055 review round 5 — settle flights currently holding this entry:
     /// incremented under the map lock at the moment settle work is enqueued,
@@ -5826,25 +5844,33 @@ impl InProcessAgentOrchestrator {
         };
         // Stash BEFORE the offload so a terminal racing in can already
         // resolve the binding; the settle write sequence converges with the
-        // creation in either order. A re-stash over an existing entry bumps
-        // the generation so any settle chain started under the old entry
-        // dies at its next pre-write check.
-        {
-            let mut bindings = self
-                .shared
-                .goal_task_ledger_bindings
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            binding.generation = bindings
-                .get(&task.id)
-                .map(|existing| existing.generation + 1)
-                .unwrap_or(0);
-            bindings.insert(task.id.clone(), binding.clone());
-        }
+        // creation in either order. A re-stash (same task id) carries a
+        // FRESH generation from the process-wide counter, so any settle
+        // chain started under a previous incarnation dies at its next
+        // pre-write check — and no removed incarnation's generation can
+        // ever be reused (round 7, W2).
+        binding.generation = self.stash_goal_task_binding(&task.id, binding.clone());
         let task_id = task.id.clone();
         offload_goal_ledger_io(move || {
             Self::record_goal_task_row_blocking(&binding, &task_id);
         });
+    }
+
+    /// #2055 review round 7 (W2) — THE one stash point: assigns the entry's
+    /// generation from the process-wide monotonic counter and inserts it
+    /// (replacing any previous incarnation, whose flight accounting dies
+    /// with it). Returns the assigned generation. Shared by production
+    /// registration and the ABA test, so the assignment rule cannot drift.
+    fn stash_goal_task_binding(&self, task_id: &str, mut binding: GoalTaskLedgerBinding) -> u64 {
+        let generation = next_goal_task_binding_generation();
+        binding.generation = generation;
+        binding.in_flight = 0;
+        self.shared
+            .goal_task_ledger_bindings
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(task_id.to_owned(), binding);
+        generation
     }
 
     /// #2055 — the blocking half of [`Self::record_goal_task_registration`]:
@@ -5952,8 +5978,11 @@ impl InProcessAgentOrchestrator {
             }
             octos_agent::TaskStatus::Spawned | octos_agent::TaskStatus::Running => return,
         };
-        // Fetch + flight-mark under ONE lock acquisition.
-        let binding = {
+        // Fetch + flight-mark under ONE lock acquisition. The attempt-0 hold
+        // is taken as an OWNING guard (round 7): it rides the offload
+        // closure into the blocking core, so even a closure that never runs
+        // (pool/runtime shutdown) releases it on drop.
+        let fetched = {
             let mut bindings = self
                 .shared
                 .goal_task_ledger_bindings
@@ -5962,20 +5991,32 @@ impl InProcessAgentOrchestrator {
             match bindings.get_mut(&task.id) {
                 Some(entry) => {
                     entry.in_flight += 1;
-                    Some(entry.clone())
+                    let flight = GoalTaskSettleFlightGuard {
+                        orchestrator: self.clone(),
+                        task_id: task.id.clone(),
+                        generation: entry.generation,
+                    };
+                    Some((entry.clone(), flight))
                 }
                 None => None,
             }
         };
         // Opportunistic retention purge AFTER the flight mark (see doc note).
         self.purge_expired_goal_task_bindings();
-        let Some(binding) = binding else {
+        let Some((binding, flight)) = fetched else {
             return;
         };
         let this = self.clone();
         let task_id = task.id.clone();
         offload_goal_ledger_io(move || {
-            this.settle_goal_task_row_blocking(&binding, &task_id, authority, remove_on_success, 0);
+            this.settle_goal_task_row_blocking(
+                &binding,
+                &task_id,
+                authority,
+                remove_on_success,
+                0,
+                flight,
+            );
         });
     }
 
@@ -5996,13 +6037,24 @@ impl InProcessAgentOrchestrator {
     }
 
     /// #2055 review round 6 (V2a) — take one settle-flight hold on
-    /// `task_id`, generation-matched. Used by the retry re-arm to take the
-    /// NEXT attempt's hold BEFORE the current attempt's guard releases its
-    /// own, so `in_flight` never touches zero across the backoff gap and
-    /// the purge cannot kill a chain between attempts. Returns whether the
-    /// hold was taken; a failed take (entry gone or re-stashed) means the
-    /// chain is already dead and the re-arm is pointless.
-    fn acquire_goal_task_settle_flight(&self, task_id: &str, generation: u64) -> bool {
+    /// `task_id`, generation-matched. Used at enqueue for attempt 0 and by
+    /// the retry re-arm to take the NEXT attempt's hold BEFORE the current
+    /// attempt's guard releases its own, so `in_flight` never touches zero
+    /// across the backoff gap and the purge cannot kill a chain between
+    /// attempts.
+    ///
+    /// Round 7 — returns the OWNING [`GoalTaskSettleFlightGuard`] rather
+    /// than a bare flag: the guard travels through the timer future and the
+    /// `spawn_blocking` closure into the blocking core, so the hold is
+    /// released on EVERY fate of the scheduled attempt — including a future
+    /// dropped before it ever runs (runtime shutdown) — closing the orphan
+    /// window between acquisition and core entry. `None` means the entry is
+    /// gone or re-stashed: the chain is already dead.
+    fn acquire_goal_task_settle_flight(
+        &self,
+        task_id: &str,
+        generation: u64,
+    ) -> Option<GoalTaskSettleFlightGuard> {
         let mut bindings = self
             .shared
             .goal_task_ledger_bindings
@@ -6011,9 +6063,13 @@ impl InProcessAgentOrchestrator {
         match bindings.get_mut(task_id) {
             Some(entry) if entry.generation == generation => {
                 entry.in_flight += 1;
-                true
+                Some(GoalTaskSettleFlightGuard {
+                    orchestrator: self.clone(),
+                    task_id: task_id.to_owned(),
+                    generation,
+                })
             }
-            _ => false,
+            _ => None,
         }
     }
 
@@ -6054,6 +6110,7 @@ impl InProcessAgentOrchestrator {
         authority: octos_fleet::TaskSettleAuthority,
         remove_on_success: bool,
         attempt: u32,
+        flight: GoalTaskSettleFlightGuard,
     ) {
         #[cfg(test)]
         {
@@ -6063,17 +6120,15 @@ impl InProcessAgentOrchestrator {
                 .entry(task_id.to_owned())
                 .or_insert(0) += 1;
         }
-        // Round 6 (V2b) — this attempt's flight hold is released on EVERY
-        // exit path (success, exhaustion, fence-kill, panic-unwind) by this
-        // guard's Drop, and nowhere else: one release point, exactly once
-        // per attempt. The hold itself was taken by whoever SCHEDULED the
-        // attempt — the enqueue for attempt 0, the previous attempt's
-        // re-arm for a retry.
-        let _flight_guard = GoalTaskSettleFlightGuard {
-            orchestrator: self.clone(),
-            task_id: task_id.to_owned(),
-            generation: binding.generation,
-        };
+        // Round 6 (V2b) / round 7 — this attempt's flight hold is released
+        // on EVERY exit path (success, exhaustion, fence-kill,
+        // panic-unwind) by the RECEIVED guard's Drop, and nowhere else: one
+        // release point, exactly once per attempt. The guard was
+        // constructed by whoever SCHEDULED the attempt — the enqueue for
+        // attempt 0, the previous attempt's re-arm for a retry — and rode
+        // the timer future / closure here, so an attempt that never runs
+        // (dropped future, pool shutdown) still releases on drop.
+        let _flight_guard = flight;
         // Staleness fence — see the doc comment.
         {
             let bindings = self
@@ -6170,7 +6225,9 @@ impl InProcessAgentOrchestrator {
                 // backoff gap and the purge cannot kill the chain between
                 // attempts. A failed take means the entry is gone or
                 // re-stashed — the chain is already dead, so don't re-arm.
-                if !self.acquire_goal_task_settle_flight(task_id, binding.generation) {
+                let Some(next_flight) =
+                    self.acquire_goal_task_settle_flight(task_id, binding.generation)
+                else {
                     tracing::debug!(
                         task_id,
                         goal_id = %binding.goal_row.goal_id,
@@ -6178,7 +6235,7 @@ impl InProcessAgentOrchestrator {
                         "goal task-row settle chain lost its binding at re-arm; dying"
                     );
                     return;
-                }
+                };
                 tracing::debug!(
                     task_id,
                     goal_id = %binding.goal_row.goal_id,
@@ -6203,6 +6260,7 @@ impl InProcessAgentOrchestrator {
                                     authority,
                                     remove_on_success,
                                     next_attempt,
+                                    next_flight,
                                 );
                             });
                         });
@@ -6217,6 +6275,7 @@ impl InProcessAgentOrchestrator {
                             authority,
                             remove_on_success,
                             next_attempt,
+                            next_flight,
                         );
                     }
                 }
@@ -17988,7 +18047,7 @@ mod tests {
         goal_id: &str,
         task_id: &str,
     ) -> GoalTaskLedgerBinding {
-        let binding = GoalTaskLedgerBinding {
+        let mut binding = GoalTaskLedgerBinding {
             goal_row: octos_fleet::Goal {
                 goal_id: goal_id.to_string(),
                 objective: "converge".to_string(),
@@ -18007,13 +18066,25 @@ mod tests {
             generation: 0,
             in_flight: 0,
         };
-        orchestrator
-            .shared
-            .goal_task_ledger_bindings
-            .lock()
-            .unwrap()
-            .insert(task_id.to_string(), binding.clone());
+        // Round 7 — stash through the PRODUCTION assignment path, so every
+        // direct-core test runs under a real (globally monotonic) generation.
+        binding.generation = orchestrator.stash_goal_task_binding(task_id, binding.clone());
         binding
+    }
+
+    /// Construct the flight guard a scheduler would hand to an attempt for
+    /// `binding` — tests that drive the blocking core directly must supply
+    /// the hold the production enqueue/re-arm would have taken.
+    fn test_flight_for(
+        orchestrator: &InProcessAgentOrchestrator,
+        task_id: &str,
+        binding: &GoalTaskLedgerBinding,
+    ) -> GoalTaskSettleFlightGuard {
+        GoalTaskSettleFlightGuard {
+            orchestrator: orchestrator.clone(),
+            task_id: task_id.to_owned(),
+            generation: binding.generation,
+        }
     }
 
     /// #2055 review round 2 (Additional-3): with the I/O offloaded, nothing
@@ -18038,6 +18109,7 @@ mod tests {
             octos_fleet::TaskSettleAuthority::Completion,
             true,
             0,
+            test_flight_for(&orchestrator, "task-order", &binding),
         );
         // The creation offload arrives LATE and must not resurrect it.
         InProcessAgentOrchestrator::record_goal_task_row_blocking(&binding, "task-order");
@@ -18080,8 +18152,14 @@ mod tests {
             let task_id = format!("task-order-{index}");
             let binding = stashed_test_binding(&orchestrator, dir.path(), "goal-order", &task_id);
             for authority in order {
-                orchestrator
-                    .settle_goal_task_row_blocking(&binding, &task_id, *authority, false, 0);
+                orchestrator.settle_goal_task_row_blocking(
+                    &binding,
+                    &task_id,
+                    *authority,
+                    false,
+                    0,
+                    test_flight_for(&orchestrator, &task_id, &binding),
+                );
             }
             let ledger = octos_fleet::GoalLedger::open(binding.ledger_path()).expect("open ledger");
             let row = ledger.get_task(&task_id).expect("read").expect("row");
@@ -18102,8 +18180,14 @@ mod tests {
             let task_id = format!("task-nod-{index}");
             let binding = stashed_test_binding(&orchestrator, dir.path(), "goal-order", &task_id);
             for authority in order {
-                orchestrator
-                    .settle_goal_task_row_blocking(&binding, &task_id, *authority, false, 0);
+                orchestrator.settle_goal_task_row_blocking(
+                    &binding,
+                    &task_id,
+                    *authority,
+                    false,
+                    0,
+                    test_flight_for(&orchestrator, &task_id, &binding),
+                );
             }
             let ledger = octos_fleet::GoalLedger::open(binding.ledger_path()).expect("open ledger");
             let row = ledger.get_task(&task_id).expect("read").expect("row");
@@ -18143,6 +18227,7 @@ mod tests {
             octos_fleet::TaskSettleAuthority::FinalFailure,
             true,
             0,
+            test_flight_for(&orchestrator, "task-gen-stale", &binding),
         );
 
         // The stale chain died BEFORE any write: no ledger file, no row.
@@ -18515,6 +18600,7 @@ mod tests {
             octos_fleet::TaskSettleAuthority::Completion,
             false,
             0,
+            test_flight_for(&orchestrator, "task-scoped-a", &binding),
         );
 
         assert!(
@@ -18683,6 +18769,165 @@ mod tests {
         );
     }
 
+    /// #2055 review round 7 (W2 ABA): a stale hold from a REMOVED
+    /// incarnation can never act on a re-stashed entry under the same task
+    /// id — generations come from one process-wide monotonic counter and
+    /// are never reused, so the old guard's release is generation-fenced
+    /// into a no-op and the new incarnation keeps its own live hold (and
+    /// with it, its purge protection). Production task ids are fresh
+    /// UUIDv7s today; this pre-covers the same-id restoration path #2056
+    /// tracks.
+    #[test]
+    fn rebound_task_id_cannot_be_stolen_by_a_stale_hold() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let first = stashed_test_binding(&orchestrator, dir.path(), "goal-aba", "task-aba");
+        let stale_hold = orchestrator
+            .acquire_goal_task_settle_flight("task-aba", first.generation)
+            .expect("hold on the first incarnation");
+
+        // The first incarnation is removed (the success-removal / purge
+        // shape), then the SAME task id is re-stashed — the ABA setup.
+        orchestrator
+            .shared
+            .goal_task_ledger_bindings
+            .lock()
+            .unwrap()
+            .remove("task-aba");
+        let second_generation = orchestrator.stash_goal_task_binding("task-aba", first.clone());
+        assert_ne!(
+            second_generation, first.generation,
+            "generations are globally monotonic and never reused"
+        );
+
+        // The new incarnation holds its own live flight...
+        let _live_hold = orchestrator
+            .acquire_goal_task_settle_flight("task-aba", second_generation)
+            .expect("hold on the new incarnation");
+        // ...and the stale hold's late release must not steal it.
+        drop(stale_hold);
+        let live = orchestrator
+            .shared
+            .goal_task_ledger_bindings
+            .lock()
+            .unwrap()
+            .get("task-aba")
+            .map(|entry| entry.in_flight);
+        assert_eq!(
+            live,
+            Some(1),
+            "the stale incarnation's release must not touch the live hold"
+        );
+        // Purge protection is intact under the live hold, even expired.
+        {
+            let mut bindings = orchestrator
+                .shared
+                .goal_task_ledger_bindings
+                .lock()
+                .unwrap();
+            bindings.get_mut("task-aba").expect("entry").retained_since = std::time::Instant::now()
+                .checked_sub(PROVISIONAL_CORRECTION_RETENTION + std::time::Duration::from_secs(1));
+        }
+        orchestrator.purge_expired_goal_task_bindings();
+        assert!(
+            orchestrator
+                .shared
+                .goal_task_ledger_bindings
+                .lock()
+                .unwrap()
+                .contains_key("task-aba"),
+            "the live hold keeps the re-stashed entry purge-protected"
+        );
+    }
+
+    /// #2055 review round 7 (blast-radius orphan): the hold taken for a
+    /// scheduled attempt is OWNED by the guard riding the timer future /
+    /// closure, so an attempt that never runs — here, the re-arm's timer
+    /// future dropped by a runtime shutdown before it fires — still
+    /// releases on drop, and the entry becomes purgeable again instead of
+    /// being orphaned unpurgeable forever.
+    #[test]
+    fn dropped_retry_future_releases_its_flight_hold() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let orchestrator = InProcessAgentOrchestrator::default();
+        // Every attempt fails instantly: the ledger dir path is a FILE.
+        let blocked = dir.path().join("blocked");
+        std::fs::write(&blocked, b"not a dir").unwrap();
+        let binding = stashed_test_binding(&orchestrator, &blocked, "goal-dropfut", "task-dropfut");
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_time()
+            .build()
+            .unwrap();
+        {
+            let orchestrator = orchestrator.clone();
+            let binding = binding.clone();
+            rt.block_on(async move {
+                let flight = orchestrator
+                    .acquire_goal_task_settle_flight("task-dropfut", binding.generation)
+                    .expect("attempt-0 hold");
+                // Attempt 0 fails fast and re-arms: the NEXT attempt's hold
+                // is taken and moved into the pending 100ms timer future.
+                orchestrator.settle_goal_task_row_blocking(
+                    &binding,
+                    "task-dropfut",
+                    octos_fleet::TaskSettleAuthority::FinalFailure,
+                    true,
+                    0,
+                    flight,
+                );
+            });
+        }
+        // Shut the runtime down BEFORE the timer fires: the pending future
+        // is dropped without ever running, and the hold it owns must die
+        // with it. (If the timer already fired, the chain runs on and every
+        // later scheduling inside a shutting-down runtime is equally
+        // dropped — either way the balance converges to zero.)
+        drop(rt);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let in_flight = orchestrator
+                .shared
+                .goal_task_ledger_bindings
+                .lock()
+                .unwrap()
+                .get("task-dropfut")
+                .map(|entry| entry.in_flight);
+            if in_flight == Some(0) {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the dropped future's hold must be released; still {in_flight:?}"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        // And the entry is purgeable again.
+        {
+            let mut bindings = orchestrator
+                .shared
+                .goal_task_ledger_bindings
+                .lock()
+                .unwrap();
+            bindings
+                .get_mut("task-dropfut")
+                .expect("entry")
+                .retained_since = std::time::Instant::now()
+                .checked_sub(PROVISIONAL_CORRECTION_RETENTION + std::time::Duration::from_secs(1));
+        }
+        orchestrator.purge_expired_goal_task_bindings();
+        assert!(
+            !orchestrator
+                .shared
+                .goal_task_ledger_bindings
+                .lock()
+                .unwrap()
+                .contains_key("task-dropfut"),
+            "with the hold released, the expired entry purges"
+        );
+    }
+
     /// Read a binding entry's live flight count (test-side visibility for
     /// the exactly-once release accounting).
     fn in_flight_for(task_id: &str) -> Option<u32> {
@@ -18762,6 +19007,7 @@ mod tests {
             octos_fleet::TaskSettleAuthority::FinalFailure,
             true,
             0,
+            test_flight_for(&orchestrator, "task-exhaust", &binding),
         );
         let exhausted_in_flight = orchestrator
             .shared
@@ -18802,6 +19048,7 @@ mod tests {
             octos_fleet::TaskSettleAuthority::FinalFailure,
             true,
             0,
+            test_flight_for(&orchestrator3, "task-stale-flight", &stale),
         );
         let live_in_flight = orchestrator3
             .shared

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -753,24 +753,61 @@ struct OrchestratorShared {
     /// the start of the next fleet-outbox drain tick.
     fleet_wake_retry: StdMutex<Vec<MasterContinuationRequest>>,
     /// #2055/#2054 — supervisor task id → the goal-ledger location its row
-    /// was created under at registration time. The terminal sink consumes
-    /// (removes) the entry to settle the SAME row — resolving afresh at
+    /// was created under at registration time. The change-feed settle
+    /// resolves the entry to settle the SAME row — resolving afresh at
     /// terminal time would chase whatever goal the session holds by then,
-    /// which can differ after a mid-flight clear/recreate. In-memory only:
-    /// entries are bounded by the supervisor's fan-out caps and removed at
-    /// terminal; a restart drops them, and the row a restored task left
-    /// behind stays `running` until re-registration/settle catches it —
-    /// delivery durability across restarts is #2056, out of scope here.
+    /// which can differ after a mid-flight clear/recreate. An entry is
+    /// removed only after a SUCCESSFUL settle write whose terminal is
+    /// final (`complete`, cancellation, owner-reported failure); an
+    /// observer-provisional failure keeps its entry so the owner's later
+    /// correcting completion (task_supervisor.rs:2527 semantics) can still
+    /// reach the ledger. In-memory only: entries are bounded by the
+    /// supervisor's fan-out caps (the retained-failure residue matches the
+    /// supervisor's own never-pruned task map); a restart drops them, and
+    /// the row a restored task left behind stays `running` — delivery
+    /// durability across restarts is #2056, out of scope here.
     goal_task_ledger_bindings: StdMutex<HashMap<String, GoalTaskLedgerBinding>>,
 }
 
-/// #2055/#2054 — where one supervisor task's goal-ledger row lives: enough
-/// to re-derive the per-goal ledger path (`<profile_data_dir>/goal-ledgers/
-/// <goal_id>.db`) at terminal time without re-resolving the session's goal.
+/// #2055/#2054 — everything the ledger I/O for one task's row needs, captured
+/// at registration-stash time so BOTH the offloaded row creation and any
+/// later settle can run without re-entering orchestrator state: the FK-parent
+/// goals-row snapshot (only ever inserted if absent — never an update), the
+/// task row seed, and the profile data dir the per-goal ledger path derives
+/// from (`<profile_data_dir>/goal-ledgers/<goal_id>.db`).
 #[derive(Debug, Clone)]
 struct GoalTaskLedgerBinding {
-    goal_id: String,
+    goal_row: octos_fleet::Goal,
+    title: String,
+    assigned_peer: Option<String>,
     profile_data_dir: PathBuf,
+}
+
+impl GoalTaskLedgerBinding {
+    fn ledger_path(&self) -> PathBuf {
+        InProcessAgentOrchestrator::goal_ledger_dir(&self.profile_data_dir).join(format!(
+            "{}.db",
+            sanitize_filename_for_ledger(&self.goal_row.goal_id)
+        ))
+    }
+}
+
+/// #2055 review round 2 (H9) — run goal-ledger I/O off the async executor.
+/// The registration/settle observers fire synchronously inside tokio-driven
+/// paths (SpawnTool's async execute, the session actor), and the I/O behind
+/// them is contended-open SQLite with multi-second busy budgets — so inside
+/// a runtime it goes to the blocking pool (detached: the observers are
+/// fire-and-forget by contract and must never stall registration), mirroring
+/// `sync_transition_to_ledger`'s `spawn_blocking` treatment. Without a
+/// runtime (plain threads, sync tests) the work runs inline — such a thread
+/// is not an executor worker, which is the only thing H9 protects.
+fn offload_goal_ledger_io(work: impl FnOnce() + Send + 'static) {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => {
+            handle.spawn_blocking(work);
+        }
+        Err(_) => work(),
+    }
 }
 
 /// The plain WIRE session id underlying a (possibly cwd-scoped) goal-store
@@ -985,13 +1022,11 @@ pub(crate) fn route_terminal_event_to_continuation_queue(
     event: &octos_agent::TerminalEvent,
     runtime_profile_id: Option<&str>,
 ) {
-    // #2054 — settle the goal-ledger task row FIRST, before any continuation
-    // routing (and before the failure arm's suppression early-returns: a
-    // synth-ack-suppressed failure still finished, and its row must flip).
-    // This writes one ledger cell and NOTHING else — no continuation, event,
-    // notification, or wake may originate here (completed → sink →
-    // ChildCompleted → wake is a cycle; fresh ids defeat dedupe).
-    default_agent_orchestrator().settle_goal_task_row(event);
+    // #2054 settling does NOT live here (review round 2): this sink never
+    // fires for `cancel` (which emits only `notify_change`) and its
+    // once-per-task dedupe would swallow the owner's failed→complete
+    // correction. The goal-ledger settle rides the change feed instead —
+    // see `install_goal_task_row_settle_listener`.
     match &event.outcome {
         octos_agent::TerminalOutcome::Completed => {
             // Mirror the terminal agent record; the upsert's terminal
@@ -1050,6 +1085,23 @@ pub(crate) fn route_terminal_event_to_continuation_queue(
             }
         }
     }
+}
+
+/// #2054 (review round 2) — stable key for the goal-task-row settle observer
+/// on `TaskSupervisor::on_change_listeners`. A NAMED listener (not the
+/// primary `on_change`, which every runtime mode already owns for its own
+/// wake wiring), re-installed idempotently wherever a supervisor is wired
+/// and inherited by child/nested supervisors alongside `on_register`.
+pub(crate) const GOAL_TASK_ROW_SETTLE_LISTENER_KEY: &str = "goal-task-row-settle";
+
+/// #2054 (review round 2) — install the change-feed settle observer on a
+/// supervisor. See [`InProcessAgentOrchestrator::settle_goal_task_row_from_change`]
+/// for why settling rides the change feed rather than the `on_terminal`
+/// sink (cancel coverage + the failed→complete owner correction).
+pub(crate) fn install_goal_task_row_settle_listener(supervisor: &octos_agent::TaskSupervisor) {
+    supervisor.set_on_change_listener(GOAL_TASK_ROW_SETTLE_LISTENER_KEY, |task| {
+        default_agent_orchestrator().settle_goal_task_row_from_change(task);
+    });
 }
 
 // "Workspace is known in-memory" predicate accepted by
@@ -5547,23 +5599,20 @@ impl InProcessAgentOrchestrator {
         (goal.profile_id == profile_id && goal.status == "active").then(|| goal.goal_id.clone())
     }
 
-    /// #2055 — create the goal-ledger `tasks` row for a task the
-    /// `TaskSupervisor` just registered, and remember where it lives so the
-    /// terminal sink can settle it (#2054). Called from the `on_register`
-    /// closures both runtime modes wire next to `set_on_terminal`.
+    /// #2055 — record a task the `TaskSupervisor` just registered: stash the
+    /// ledger binding (synchronously — this is all the `on_register`
+    /// callback pays on the caller's thread) and offload the row creation to
+    /// the blocking pool. Called from the `on_register` closures the runtime
+    /// modes wire next to their settle listener.
     ///
     /// Best-effort BY CONTRACT: registration must never fail, block, or
-    /// panic on ledger I/O, so every error is swallowed with a
-    /// `tracing::debug!`. Locates the ledger exactly like
-    /// [`Self::model_goal_record_peer_finding`]
-    /// (`<profile_data_dir>/goal-ledgers/<goal_id>.db`), and upserts the
-    /// goals row first for the same reason that path does — the bundled
-    /// SQLite enforces `FOREIGN KEY (goal_id)` (`foreign_keys=1` compile
-    /// default), and this row may be the ledger file's very first write.
-    /// Row creation is the idempotent [`octos_fleet::GoalLedger::
-    /// create_task_if_absent`], so re-registration across relaunch/restart
-    /// preserves an existing row and its status — including one that
-    /// already went terminal.
+    /// panic on ledger I/O — the synchronous part is one state read plus one
+    /// map insert, every I/O error in the offloaded part is swallowed with a
+    /// `tracing::debug!`, and a lost offload (process exit) is converged
+    /// later by the settle side, which is self-sufficient (it creates the
+    /// row with the terminal status when none exists). Locates the ledger
+    /// exactly like [`Self::model_goal_record_peer_finding`]
+    /// (`<profile_data_dir>/goal-ledgers/<goal_id>.db`).
     pub(crate) fn record_goal_task_registration(
         &self,
         profile_data_dir: &Path,
@@ -5571,10 +5620,15 @@ impl InProcessAgentOrchestrator {
         goal_id: &str,
         task: &octos_agent::BackgroundTask,
     ) {
-        // Fresh goal snapshot for the FK-parent goals row (mirrors the
-        // peer-finding recorder). A goal cleared between binding resolution
-        // and this callback simply skips the write — no goal, no row. The
-        // state lock drops before any file I/O below.
+        // Goal snapshot for the FK-parent goals row. Captured ONCE, at stash
+        // time, and carried on the binding for both the creation offload and
+        // any later settle — it is only ever INSERTED-if-absent (H3: the
+        // registration path must never update a goals row; `upsert_goal`'s
+        // monotonic guard admits equal millisecond timestamps, so a delayed
+        // stale snapshot could regress an administrative transition). A goal
+        // cleared between binding resolution and this callback simply skips
+        // the write — no goal, no row. The state lock drops before anything
+        // else.
         let goal_row = {
             let state = self.state();
             state
@@ -5588,7 +5642,7 @@ impl InProcessAgentOrchestrator {
                     tokens_used: goal.tokens_used,
                     token_budget: goal.token_budget,
                     continuations_used: goal.continuations_used,
-                    revision: 0, // preserved on conflict by upsert_goal
+                    revision: 0,
                     created_at_ms: goal.created_at_ms.max(0) as u64,
                     updated_at_ms: goal.updated_at_ms.max(0) as u64,
                 })
@@ -5602,125 +5656,213 @@ impl InProcessAgentOrchestrator {
             );
             return;
         };
-        let ledger_dir = Self::goal_ledger_dir(profile_data_dir);
+        // `assigned_peer` is derivable only for the native-specialist kind
+        // (peers and supervisor-spawned specialists), whose `tool_call_id`
+        // is the agent id. Every other kind has no peer identity.
+        let assigned_peer = (task.tool_name == "native_agent" && !task.tool_call_id.is_empty())
+            .then(|| task.tool_call_id.clone());
+        let binding = GoalTaskLedgerBinding {
+            goal_row,
+            title: task.tool_name.clone(),
+            assigned_peer,
+            profile_data_dir: profile_data_dir.to_path_buf(),
+        };
+        // Stash BEFORE the offload so a terminal racing in can already
+        // resolve the binding; the settle write sequence converges with the
+        // creation in either order.
+        self.shared
+            .goal_task_ledger_bindings
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(task.id.clone(), binding.clone());
+        let task_id = task.id.clone();
+        offload_goal_ledger_io(move || {
+            Self::record_goal_task_row_blocking(&binding, &task_id);
+        });
+    }
+
+    /// #2055 — the blocking half of [`Self::record_goal_task_registration`]:
+    /// FK-parent goals row via the never-updating
+    /// [`octos_fleet::GoalLedger::create_goal_if_absent`] (the bundled
+    /// SQLite enforces `foreign_keys=1`, and this can be the ledger file's
+    /// very first write), then the `running` task row via the idempotent
+    /// [`octos_fleet::GoalLedger::create_task_if_absent`] — so
+    /// re-registration across relaunch/restart preserves an existing row and
+    /// its status, including one the settle side already wrote terminal.
+    /// Runs on the blocking pool (or a non-executor thread), so the
+    /// contended-open profile (`open_with_busy_retry`) applies — the
+    /// fresh-WAL first-init race the plain `open` documents is exactly the
+    /// creation-vs-settle race this path can hit.
+    fn record_goal_task_row_blocking(binding: &GoalTaskLedgerBinding, task_id: &str) {
+        let ledger_dir = Self::goal_ledger_dir(&binding.profile_data_dir);
         if let Err(error) = std::fs::create_dir_all(&ledger_dir) {
             tracing::debug!(
-                goal_id,
-                task_id = %task.id,
+                goal_id = %binding.goal_row.goal_id,
+                task_id,
                 path = %ledger_dir.display(),
                 %error,
                 "goal task-row registration skipped: ledger dir unavailable"
             );
             return;
         }
-        let ledger_path = ledger_dir.join(format!("{}.db", sanitize_filename_for_ledger(goal_id)));
-        let ledger = match octos_fleet::GoalLedger::open(&ledger_path) {
-            Ok(ledger) => ledger,
-            Err(error) => {
-                tracing::debug!(
-                    goal_id,
-                    task_id = %task.id,
-                    path = %ledger_path.display(),
-                    %error,
-                    "goal task-row registration skipped: ledger open failed"
-                );
-                return;
-            }
-        };
-        // FK parent first (guarded upsert; a stale-snapshot rejection still
-        // leaves a valid parent row in place).
-        let _ = ledger.upsert_goal(&goal_row);
         let now = now_ms_u64();
-        // `assigned_peer` is derivable only for the native-specialist kind
-        // (peers and supervisor-spawned specialists), whose `tool_call_id`
-        // is the agent id. Every other kind has no peer identity.
-        let assigned_peer = (task.tool_name == "native_agent" && !task.tool_call_id.is_empty())
-            .then(|| task.tool_call_id.clone());
         let row = octos_fleet::Task {
-            task_id: task.id.clone(),
-            goal_id: goal_id.to_owned(),
-            title: task.tool_name.clone(),
+            task_id: task_id.to_owned(),
+            goal_id: binding.goal_row.goal_id.clone(),
+            title: binding.title.clone(),
             detail: String::new(),
             status: "running".to_owned(),
-            assigned_peer,
+            assigned_peer: binding.assigned_peer.clone(),
             created_at_ms: now,
             updated_at_ms: now,
         };
-        if let Err(error) = ledger.create_task_if_absent(&row) {
+        let written = octos_fleet::GoalLedger::open_with_busy_retry(binding.ledger_path())
+            .and_then(|ledger| {
+                ledger.create_goal_if_absent(&binding.goal_row)?;
+                ledger.create_task_if_absent(&row)
+            });
+        if let Err(error) = written {
             tracing::debug!(
-                goal_id,
-                task_id = %task.id,
+                goal_id = %binding.goal_row.goal_id,
+                task_id,
                 %error,
-                "goal task-row registration failed; continuing without a row"
+                "goal task-row registration write failed; settle will converge if the task finishes"
             );
-            return;
         }
-        // Remember where the row lives so the terminal sink can settle it
-        // even if the session's goal binding changes mid-flight.
-        self.shared
-            .goal_task_ledger_bindings
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(
-                task.id.clone(),
-                GoalTaskLedgerBinding {
-                    goal_id: goal_id.to_owned(),
-                    profile_data_dir: profile_data_dir.to_path_buf(),
-                },
-            );
     }
 
-    /// #2054 — settle the goal-ledger task row for a terminal transition.
-    /// Consumes the registration-time binding (`on_terminal` fires at most
-    /// once per task, so the entry is done after this) and writes ONE ledger
-    /// cell via the first-terminal-wins
-    /// [`octos_fleet::GoalLedger::update_task_status`]. `Ok(false)` is a
-    /// normal no-op (absent row / already terminal). Emits NO continuation,
-    /// event, notification, or wake — `completed → sink → ChildCompleted →
-    /// wake` is a cycle whose fresh ids defeat dedupe.
+    /// #2054 (review round 2) — the change-feed settle: fired for every task
+    /// status change through the NAMED `on_change_listeners` observer (see
+    /// [`install_goal_task_row_settle_listener`]), filtering to terminal
+    /// statuses. The change feed — not the `on_terminal` sink — because:
     ///
-    /// Fidelity note: `TerminalOutcome` collapses `Cancelled` into `Failed`
-    /// upstream, so a cancelled task settles as `"failed"`.
-    pub(crate) fn settle_goal_task_row(&self, event: &octos_agent::TerminalEvent) {
+    /// - `TaskSupervisor::cancel` emits ONLY `notify_change`; on the sink,
+    ///   every cancelled goal-bound task leaked its binding and a `running`
+    ///   row forever.
+    /// - the sink's once-per-task dedupe swallows the owner's correcting
+    ///   completion after an observer-provisional failure
+    ///   (task_supervisor.rs:2527); the change feed delivers it, and the
+    ///   ledger's one admitted terminal→terminal transition
+    ///   (`failed → complete`) receives it.
+    /// - the feed's multi-fire redelivery is absorbed by the ledger's
+    ///   first-terminal-wins idempotency.
+    ///
+    /// Emits NO continuation, event, notification, or wake — this writes
+    /// ledger cells and nothing else (`completed → sink → ChildCompleted →
+    /// wake` is a cycle whose fresh ids defeat dedupe). All I/O runs on the
+    /// blocking pool via [`offload_goal_ledger_io`].
+    ///
+    /// Binding lifecycle: the entry is removed only AFTER a successful write
+    /// (a BUSY/open failure keeps it so a redelivered change event retries),
+    /// and only for FINAL terminals — completion, cancellation, and
+    /// owner-reported failure. An observer-provisional failure
+    /// (`failed_by_observer`) keeps its entry so the correction can still
+    /// settle; the owner's authoritative re-mark or completion then closes
+    /// it.
+    ///
+    /// Fidelity note: cancellation settles as `"failed"` — the ledger keeps
+    /// the #2054 status vocabulary (`TerminalOutcome` collapses the two the
+    /// same way upstream).
+    pub(crate) fn settle_goal_task_row_from_change(&self, task: &octos_agent::BackgroundTask) {
+        let (status, remove_on_success) = match task.status {
+            octos_agent::TaskStatus::Completed => ("complete", true),
+            octos_agent::TaskStatus::Cancelled => ("failed", true),
+            octos_agent::TaskStatus::Failed => ("failed", !task.failed_by_observer),
+            octos_agent::TaskStatus::Spawned | octos_agent::TaskStatus::Running => return,
+        };
         let binding = self
             .shared
             .goal_task_ledger_bindings
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .remove(&event.task.id);
+            .get(&task.id)
+            .cloned();
         let Some(binding) = binding else {
             return;
         };
-        let status = match &event.outcome {
-            octos_agent::TerminalOutcome::Completed => "complete",
-            octos_agent::TerminalOutcome::Failed(_) => "failed",
+        let this = self.clone();
+        let task_id = task.id.clone();
+        offload_goal_ledger_io(move || {
+            this.settle_goal_task_row_blocking(&binding, &task_id, status, remove_on_success);
+        });
+    }
+
+    /// #2054 (review round 2) — the blocking half of the change-feed settle.
+    /// SELF-SUFFICIENT: seeds the FK-parent goals row and the task row
+    /// (directly with the terminal status) if the creation offload has not
+    /// landed yet — creation-then-settle and settle-then-creation converge
+    /// on the same terminal row — then applies the guarded
+    /// [`octos_fleet::GoalLedger::update_task_status`], whose `Ok(false)` is
+    /// a normal no-op (row already carries this terminal).
+    fn settle_goal_task_row_blocking(
+        &self,
+        binding: &GoalTaskLedgerBinding,
+        task_id: &str,
+        status: &str,
+        remove_on_success: bool,
+    ) {
+        let ledger_dir = Self::goal_ledger_dir(&binding.profile_data_dir);
+        let now = now_ms_u64();
+        let seed_row = octos_fleet::Task {
+            task_id: task_id.to_owned(),
+            goal_id: binding.goal_row.goal_id.clone(),
+            title: binding.title.clone(),
+            detail: String::new(),
+            status: status.to_owned(),
+            assigned_peer: binding.assigned_peer.clone(),
+            created_at_ms: now,
+            updated_at_ms: now,
         };
-        let ledger_path = Self::goal_ledger_dir(&binding.profile_data_dir).join(format!(
-            "{}.db",
-            sanitize_filename_for_ledger(&binding.goal_id)
-        ));
-        match octos_fleet::GoalLedger::open(&ledger_path)
-            .and_then(|ledger| ledger.update_task_status(&event.task.id, status, now_ms_u64()))
-        {
+        let written = std::fs::create_dir_all(&ledger_dir)
+            .map_err(|error| eyre::eyre!("ledger dir unavailable: {error}"))
+            .and_then(|()| octos_fleet::GoalLedger::open_with_busy_retry(binding.ledger_path()))
+            .and_then(|ledger| {
+                ledger.create_goal_if_absent(&binding.goal_row)?;
+                ledger.create_task_if_absent(&seed_row)?;
+                ledger.update_task_status(task_id, status, now)
+            });
+        match written {
             Ok(moved) => {
+                if remove_on_success {
+                    self.shared
+                        .goal_task_ledger_bindings
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .remove(task_id);
+                }
                 tracing::debug!(
-                    task_id = %event.task.id,
-                    goal_id = %binding.goal_id,
+                    task_id,
+                    goal_id = %binding.goal_row.goal_id,
                     status,
                     moved,
+                    remove_on_success,
                     "goal task-row terminal settle"
                 );
             }
             Err(error) => {
+                // Binding deliberately left in place: a redelivered change
+                // event (the feed multi-fires for terminal tasks) retries.
                 tracing::debug!(
-                    task_id = %event.task.id,
-                    goal_id = %binding.goal_id,
+                    task_id,
+                    goal_id = %binding.goal_row.goal_id,
                     status,
                     %error,
-                    "goal task-row terminal settle failed; row left as-is"
+                    "goal task-row terminal settle failed; binding kept for retry"
                 );
             }
         }
+    }
+
+    /// #2055 review round 2 — test-only visibility into the binding map so
+    /// effect tests can assert the lifecycle (kept across an observer-
+    /// provisional failure, removed after a final settle).
+    #[cfg(test)]
+    pub(crate) fn goal_task_binding_exists_for_test(&self, task_id: &str) -> bool {
+        self.shared
+            .goal_task_ledger_bindings
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .contains_key(task_id)
     }
 
     /// #1857 PR 5a — stash the controller workspace binding on the goal record
@@ -17046,8 +17188,12 @@ mod tests {
 
     /// Wire a real `TaskSupervisor` exactly the way the runtime modes do:
     /// `set_on_register` resolves the session's active goal and records the
-    /// row; `set_on_terminal` routes into the unified sink (which settles
-    /// the row before any continuation routing).
+    /// row; the NAMED change listener settles terminal transitions; the
+    /// `on_terminal` sink stays wired for continuation routing (and must not
+    /// interfere with settling). These tests run WITHOUT a tokio runtime, so
+    /// `offload_goal_ledger_io` executes the ledger I/O inline and every
+    /// assertion below is deterministic; the offload branch has its own
+    /// `#[tokio::test]` coverage.
     fn wire_supervisor_for_goal_task_rows(
         supervisor: &octos_agent::TaskSupervisor,
         session: &SessionKey,
@@ -17070,6 +17216,7 @@ mod tests {
                 task,
             );
         });
+        install_goal_task_row_settle_listener(supervisor);
         supervisor.set_on_terminal(move |event| {
             route_terminal_event_to_continuation_queue(event, None);
         });
@@ -17131,14 +17278,15 @@ mod tests {
         assert_eq!(counts.get("running"), None);
     }
 
-    /// #2054 failure side: a failed task flips its row to `failed` through
-    /// the sink — INCLUDING a failure whose synth-ack was never emitted
-    /// (the sink suppresses the recovery continuation for those, but the
-    /// ledger settle must still happen). `Cancelled` collapses into
-    /// `Failed` upstream in `TerminalOutcome`, so `failed` is also what a
-    /// cancelled task lands as.
+    /// #2054 failure side: an owner-reported failure flips its row to
+    /// `failed` through the change feed — INCLUDING a failure whose
+    /// synth-ack was never emitted (the terminal sink suppresses the
+    /// recovery continuation for those; settling rides `notify_change`, so
+    /// the ledger write is unaffected). An owner failure is FINAL
+    /// (`mark_completed` refuses to override it), so the binding is
+    /// released on settle.
     #[test]
-    fn goal_bound_registration_failure_settles_failed_row_through_the_sink() {
+    fn goal_bound_registration_failure_settles_failed_row_through_the_change_feed() {
         let dir = tempfile::TempDir::new().unwrap();
         let profile = "tenant-taskrows-fail";
         let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-fail");
@@ -17161,6 +17309,210 @@ mod tests {
             row.status, "failed",
             "a synth-ack-suppressed failure still settles its ledger row"
         );
+        assert!(
+            !default_agent_orchestrator().goal_task_binding_exists_for_test(&task_id),
+            "an owner failure is final — the binding is released"
+        );
+    }
+
+    /// #2055 review round 2 (hole a): `cancel` never fires `notify_terminal`
+    /// — settling rides the change feed precisely so a cancelled goal-bound
+    /// task neither leaks its binding nor leaves a `running` row. The
+    /// ledger keeps the #2054 vocabulary: cancellation lands as `failed`.
+    #[test]
+    fn cancelled_goal_bound_task_settles_failed_and_releases_binding() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let profile = "tenant-taskrows-cancel";
+        let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-cancel");
+        seed_goal(default_agent_orchestrator(), &wire, profile);
+        let goal_id = default_agent_orchestrator()
+            .goal_id_for_test(&wire)
+            .expect("goal id");
+
+        let supervisor = octos_agent::TaskSupervisor::new();
+        wire_supervisor_for_goal_task_rows(&supervisor, &wire, profile, dir.path());
+
+        let task_id = supervisor.register("web_probe", "call-rows-cancel", Some(&wire.to_string()));
+        supervisor.mark_running(&task_id);
+        supervisor.cancel(&task_id).expect("cancel");
+
+        let ledger = octos_fleet::GoalLedger::open(goal_task_ledger_path(dir.path(), &goal_id))
+            .expect("open ledger");
+        let row = ledger.get_task(&task_id).expect("read row").expect("row");
+        assert_eq!(
+            row.status, "failed",
+            "cancellation settles as `failed` (the #2054 vocabulary)"
+        );
+        assert!(
+            !default_agent_orchestrator().goal_task_binding_exists_for_test(&task_id),
+            "cancellation is final — the binding is released"
+        );
+    }
+
+    /// #2055 review round 2 (Additional-1): an OBSERVER-provisional failure
+    /// settles `failed` but keeps its binding, so the owner's later
+    /// completion (`mark_completed` overriding `failed_by_observer` —
+    /// task_supervisor.rs:2527) corrects the row to `complete` through the
+    /// change feed and the ledger's one admitted terminal→terminal
+    /// transition. The binding is released once the correction lands.
+    #[test]
+    fn observer_failure_then_owner_completion_corrects_row_to_complete() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let profile = "tenant-taskrows-correct";
+        let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-correct");
+        seed_goal(default_agent_orchestrator(), &wire, profile);
+        let goal_id = default_agent_orchestrator()
+            .goal_id_for_test(&wire)
+            .expect("goal id");
+
+        let supervisor = octos_agent::TaskSupervisor::new();
+        wire_supervisor_for_goal_task_rows(&supervisor, &wire, profile, dir.path());
+
+        let task_id = supervisor.register(
+            "review_worker",
+            "call-rows-correct",
+            Some(&wire.to_string()),
+        );
+        supervisor.mark_running(&task_id);
+        supervisor.mark_failed_observed(&task_id, "unknown tool: write_file".to_string());
+
+        let ledger = octos_fleet::GoalLedger::open(goal_task_ledger_path(dir.path(), &goal_id))
+            .expect("open ledger");
+        let row = ledger.get_task(&task_id).expect("read row").expect("row");
+        assert_eq!(row.status, "failed", "the provisional failure lands first");
+        assert!(
+            default_agent_orchestrator().goal_task_binding_exists_for_test(&task_id),
+            "a provisional failure keeps the binding open for the correction"
+        );
+
+        supervisor.mark_completed(&task_id, vec![]);
+
+        let row = ledger.get_task(&task_id).expect("read row").expect("row");
+        assert_eq!(
+            row.status, "complete",
+            "the owner's completion corrects the provisional failure in the ledger"
+        );
+        assert!(
+            !default_agent_orchestrator().goal_task_binding_exists_for_test(&task_id),
+            "the correction closes the binding"
+        );
+    }
+
+    /// #2055 review round 2 (H4/H6 ii): the production nesting path — a
+    /// snapshot registry's FRESH supervisor inherits the observer pair, so
+    /// a registration on the nested child still creates its ledger row.
+    #[test]
+    fn nested_snapshot_child_registration_creates_row() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let profile = "tenant-taskrows-nested";
+        let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-nested");
+        seed_goal(default_agent_orchestrator(), &wire, profile);
+        let goal_id = default_agent_orchestrator()
+            .goal_id_for_test(&wire)
+            .expect("goal id");
+
+        let parent_registry = octos_agent::ToolRegistry::new();
+        wire_supervisor_for_goal_task_rows(
+            &parent_registry.supervisor(),
+            &wire,
+            profile,
+            dir.path(),
+        );
+
+        let child_registry = parent_registry.snapshot_excluding(&[]);
+        let child = child_registry.supervisor();
+        let task_id = child.register("nested_probe", "call-rows-nested", Some(&wire.to_string()));
+
+        let ledger = octos_fleet::GoalLedger::open(goal_task_ledger_path(dir.path(), &goal_id))
+            .expect("open ledger");
+        let row = ledger
+            .get_task(&task_id)
+            .expect("read row")
+            .expect("the nested child's registration created a row");
+        assert_eq!(row.status, "running");
+        assert_eq!(row.title, "nested_probe");
+
+        // And the inherited settle listener flips it at terminal.
+        child.mark_running(&task_id);
+        child.mark_completed(&task_id, vec![]);
+        let row = ledger.get_task(&task_id).expect("read row").expect("row");
+        assert_eq!(row.status, "complete");
+    }
+
+    /// #2055 review round 2 (Additional-3): with the I/O offloaded, nothing
+    /// orders the creation write against the settle write. Drive the two
+    /// blocking cores directly in REVERSE order: the settle seeds the row
+    /// with its terminal status, and the late creation write preserves it —
+    /// both orders converge on the same terminal row.
+    #[test]
+    fn settle_before_create_ordering_converges() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let binding = GoalTaskLedgerBinding {
+            goal_row: octos_fleet::Goal {
+                goal_id: "goal-order".to_string(),
+                objective: "converge".to_string(),
+                status: "active".to_string(),
+                tokens_used: 0,
+                token_budget: 1_000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1,
+                updated_at_ms: 1,
+            },
+            title: "web_probe".to_string(),
+            assigned_peer: None,
+            profile_data_dir: dir.path().to_path_buf(),
+        };
+
+        // Settle lands FIRST (fresh ledger file — the settle is
+        // self-sufficient and seeds goal + task rows itself).
+        orchestrator.settle_goal_task_row_blocking(&binding, "task-order", "complete", true);
+        // The creation offload arrives LATE and must not resurrect it.
+        InProcessAgentOrchestrator::record_goal_task_row_blocking(&binding, "task-order");
+
+        let ledger = octos_fleet::GoalLedger::open(binding.ledger_path()).expect("open ledger");
+        let row = ledger
+            .get_task("task-order")
+            .expect("read row")
+            .expect("settle created the row");
+        assert_eq!(
+            row.status, "complete",
+            "a late creation write preserves the settled terminal"
+        );
+    }
+
+    /// #2055 review round 2 (H9): inside a tokio runtime the observer
+    /// callbacks only stash and spawn — the SQLite I/O lands on the
+    /// blocking pool. Bounded poll for the offloaded row.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn offloaded_registration_write_lands_from_within_a_runtime() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let profile = "tenant-taskrows-offload";
+        let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-offload");
+        seed_goal(default_agent_orchestrator(), &wire, profile);
+        let goal_id = default_agent_orchestrator()
+            .goal_id_for_test(&wire)
+            .expect("goal id");
+
+        let supervisor = octos_agent::TaskSupervisor::new();
+        wire_supervisor_for_goal_task_rows(&supervisor, &wire, profile, dir.path());
+        let task_id =
+            supervisor.register("web_probe", "call-rows-offload", Some(&wire.to_string()));
+
+        let ledger_path = goal_task_ledger_path(dir.path(), &goal_id);
+        let mut row = None;
+        for _ in 0..100 {
+            if let Ok(ledger) = octos_fleet::GoalLedger::open(&ledger_path)
+                && let Ok(found @ Some(_)) = ledger.get_task(&task_id)
+            {
+                row = found;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        let row = row.expect("the offloaded creation write landed");
+        assert_eq!(row.status, "running");
     }
 
     /// A session with NO goal binding creates nothing — that is correct
@@ -17249,25 +17601,6 @@ mod tests {
             .expect("open ledger");
         let row = ledger.get_task(&task_id).expect("read row").expect("row");
         assert_eq!(row.status, "complete");
-    }
-
-    /// #2055 wiring guard: BOTH runtime modes must wire the registration
-    /// observer next to their existing `set_on_terminal` call. Source-scan
-    /// needle in the `commands::serve::tests` tradition — the closures
-    /// themselves are exercised by the supervisor-driven tests above; this
-    /// pins that production actually installs them.
-    #[test]
-    fn runtime_modes_wire_the_registration_observer() {
-        let session_actor = include_str!("../session_actor.rs");
-        assert!(
-            session_actor.contains("set_on_register"),
-            "session_actor (gateway mode) must wire TaskSupervisor::set_on_register"
-        );
-        let ui_protocol_transport = include_str!("../api/ui_protocol_transport.rs");
-        assert!(
-            ui_protocol_transport.contains("set_on_register"),
-            "ui_protocol_transport (WS/serve mode) must wire TaskSupervisor::set_on_register"
-        );
     }
 
     /// Peer-fleet auto-synthesis — the synthesis continuation dedupes PER-MASTER:

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -786,17 +786,28 @@ const PROVISIONAL_CORRECTION_RETENTION: std::time::Duration =
 /// #2055 review round 3 — bounded retry budget for a settle whose ledger
 /// write failed (BUSY exhaustion, transient I/O). Cancellation emits exactly
 /// one change event, so without a retry a transient failure left the row
-/// `running` forever; five attempts with capped exponential backoff cover
+/// `running` forever; five attempts with exponential backoff cover
 /// multi-second contention without unbounded queues.
 const GOAL_TASK_SETTLE_ATTEMPTS: u32 = 5;
 
-/// Capped exponential backoff for the settle retry chain: 100ms, 200ms,
-/// 400ms, 800ms — capped at 2s.
+/// Exponential backoff for the settle retry chain. With
+/// [`GOAL_TASK_SETTLE_ATTEMPTS`] = 5 the reachable waits are 100ms, 200ms,
+/// 400ms, and 800ms (a failure at attempt N schedules attempt N+1 after
+/// `backoff(N)`; attempt 4's failure exhausts the budget, so the 2s cap
+/// below is reached only if the attempt budget is ever raised).
 fn goal_task_settle_backoff(attempt: u32) -> std::time::Duration {
     let base = std::time::Duration::from_millis(100);
     let capped = base.saturating_mul(1u32 << attempt.min(4));
     capped.min(std::time::Duration::from_secs(2))
 }
+
+/// #2055 review round 4 — settle blocking-core entries, visible to the
+/// contention tests so they can assert that the retry chain actually fired
+/// (the counter is process-global across parallel tests, so assertions are
+/// on DELTAS with `>=`).
+#[cfg(test)]
+pub(crate) static GOAL_TASK_SETTLE_ATTEMPT_COUNT: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
 
 /// #2055/#2054 — everything the ledger I/O for one task's row needs, captured
 /// at registration-stash time so BOTH the offloaded row creation and any
@@ -811,11 +822,19 @@ struct GoalTaskLedgerBinding {
     assigned_peer: Option<String>,
     profile_data_dir: PathBuf,
     /// `None` while the task is live (or its settle is still retrying);
-    /// stamped when a provisional-failed settle SUCCEEDS and the binding is
-    /// retained purely as the correction window — the purge deadline
-    /// ([`PROVISIONAL_CORRECTION_RETENTION`]) applies only to that state, so
-    /// a legitimately long-running task can never be purged mid-flight.
+    /// stamped ONCE when a provisional-failed settle first SUCCEEDS and the
+    /// binding is retained purely as the correction window — the purge
+    /// deadline ([`PROVISIONAL_CORRECTION_RETENTION`]) applies only to that
+    /// state, so a legitimately long-running task can never be purged
+    /// mid-flight, and a redelivery no-op never refreshes the clock.
     retained_since: Option<std::time::Instant>,
+    /// #2055 review round 4 — chain-staleness fence. A settle chain captures
+    /// the generation it was started under and re-checks presence AND
+    /// generation immediately before EVERY write attempt; a re-registration
+    /// re-stashes with a bumped generation, and removal (success or purge)
+    /// deletes the entry, so a stale chain dies at its next check instead of
+    /// writing after its sleep.
+    generation: u64,
 }
 
 impl GoalTaskLedgerBinding {
@@ -5749,21 +5768,31 @@ impl InProcessAgentOrchestrator {
         // is the agent id. Every other kind has no peer identity.
         let assigned_peer = (task.tool_name == "native_agent" && !task.tool_call_id.is_empty())
             .then(|| task.tool_call_id.clone());
-        let binding = GoalTaskLedgerBinding {
+        let mut binding = GoalTaskLedgerBinding {
             goal_row,
             title: task.tool_name.clone(),
             assigned_peer,
             profile_data_dir: profile_data_dir.to_path_buf(),
             retained_since: None,
+            generation: 0,
         };
         // Stash BEFORE the offload so a terminal racing in can already
         // resolve the binding; the settle write sequence converges with the
-        // creation in either order.
-        self.shared
-            .goal_task_ledger_bindings
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(task.id.clone(), binding.clone());
+        // creation in either order. A re-stash over an existing entry bumps
+        // the generation so any settle chain started under the old entry
+        // dies at its next pre-write check.
+        {
+            let mut bindings = self
+                .shared
+                .goal_task_ledger_bindings
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            binding.generation = bindings
+                .get(&task.id)
+                .map(|existing| existing.generation + 1)
+                .unwrap_or(0);
+            bindings.insert(task.id.clone(), binding.clone());
+        }
         let task_id = task.id.clone();
         offload_goal_ledger_io(move || {
             Self::record_goal_task_row_blocking(&binding, &task_id);
@@ -5831,10 +5860,10 @@ impl InProcessAgentOrchestrator {
     /// - the sink's once-per-task dedupe swallows the owner's correcting
     ///   completion after an observer-provisional failure
     ///   (task_supervisor.rs:2527); the change feed delivers it, and the
-    ///   ledger's one admitted terminal→terminal transition
-    ///   (`failed → complete`) receives it.
-    /// - the feed's multi-fire redelivery is absorbed by the ledger's
-    ///   first-terminal-wins idempotency.
+    ///   ledger's authority-ranked writer admits it over the provisional
+    ///   verdict.
+    /// - the feed's multi-fire redelivery is absorbed by the ranked
+    ///   writer's first-wins-within-a-rank idempotency.
     ///
     /// Emits NO continuation, event, notification, or wake — this writes
     /// ledger cells and nothing else (`completed → sink → ChildCompleted →
@@ -5850,17 +5879,28 @@ impl InProcessAgentOrchestrator {
     /// it.
     ///
     /// Fidelity note: cancellation settles as `"failed"` — the ledger keeps
-    /// the #2054 status vocabulary (`TerminalOutcome` collapses the two the
-    /// same way upstream).
+    /// the #2054 status vocabulary; the two are distinguishable only through
+    /// the persisted authority rank.
+    ///
+    /// Round 4 ordering note: the binding is fetched BEFORE the retention
+    /// purge runs — a live task finishing after the correction deadline must
+    /// not self-drop the very binding its own settle is about to use.
     pub(crate) fn settle_goal_task_row_from_change(&self, task: &octos_agent::BackgroundTask) {
-        let (status, remove_on_success) = match task.status {
-            octos_agent::TaskStatus::Completed => ("complete", true),
-            octos_agent::TaskStatus::Cancelled => ("failed", true),
-            octos_agent::TaskStatus::Failed => ("failed", !task.failed_by_observer),
+        let (authority, remove_on_success) = match task.status {
+            octos_agent::TaskStatus::Completed => {
+                (octos_fleet::TaskSettleAuthority::Completion, true)
+            }
+            octos_agent::TaskStatus::Cancelled => {
+                (octos_fleet::TaskSettleAuthority::FinalFailure, true)
+            }
+            octos_agent::TaskStatus::Failed if task.failed_by_observer => {
+                (octos_fleet::TaskSettleAuthority::ProvisionalFailure, false)
+            }
+            octos_agent::TaskStatus::Failed => {
+                (octos_fleet::TaskSettleAuthority::FinalFailure, true)
+            }
             octos_agent::TaskStatus::Spawned | octos_agent::TaskStatus::Running => return,
         };
-        // Round 3 — opportunistic retention purge on every map touch.
-        self.purge_expired_goal_task_bindings();
         let binding = self
             .shared
             .goal_task_ledger_bindings
@@ -5868,46 +5908,75 @@ impl InProcessAgentOrchestrator {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .get(&task.id)
             .cloned();
+        // Opportunistic retention purge AFTER the fetch (see doc note).
+        self.purge_expired_goal_task_bindings();
         let Some(binding) = binding else {
             return;
         };
         let this = self.clone();
         let task_id = task.id.clone();
         offload_goal_ledger_io(move || {
-            this.settle_goal_task_row_blocking(&binding, &task_id, status, remove_on_success, 0);
+            this.settle_goal_task_row_blocking(&binding, &task_id, authority, remove_on_success, 0);
         });
     }
 
-    /// #2054 (review round 2, retry in round 3) — the blocking half of the
-    /// change-feed settle. SELF-SUFFICIENT: seeds the FK-parent goals row
-    /// and the task row (as `running`) if the creation offload has not
-    /// landed yet, then applies the provenance-carrying
-    /// [`octos_fleet::GoalLedger::update_task_status_with_provenance`] —
-    /// creation-then-settle and settle-then-creation converge on the same
-    /// terminal row, and an observer-provisional failure stamps
-    /// `correctable = 1` so the owner's later completion is admitted. An
-    /// `Ok(false)` from the guarded update is a normal no-op (the row
-    /// already carries this terminal).
+    /// #2054 — the blocking half of the change-feed settle. SELF-SUFFICIENT:
+    /// seeds the FK-parent goals row and the task row (as `running`) if the
+    /// creation offload has not landed yet, then applies the
+    /// authority-ranked [`octos_fleet::GoalLedger::settle_task_status`] —
+    /// creation-then-settle and settle-then-creation converge, and the
+    /// persisted rank makes the outcome independent of write delivery order
+    /// (see [`octos_fleet::TaskSettleAuthority`]). An `Ok(false)` from the
+    /// ranked write is a normal no-op (redelivery or an outranked write).
     ///
-    /// Round 3 — bounded retry: `open_with_busy_retry` covers only the OPEN,
+    /// Staleness fence (round 4): before EVERY write attempt — the first and
+    /// each retry re-entry — the chain re-checks that the binding is still
+    /// present under the generation it captured; otherwise it dies. This
+    /// stops redundant work and duplicate chains (removal or a
+    /// re-registration bump kills survivors at their next check), not
+    /// corruption: the ranked write itself is order-safe, and a
+    /// completion-correction arriving after a purge would be a semantically
+    /// legitimate late correction that simply no longer has a binding to
+    /// route it.
+    ///
+    /// Bounded retry (round 3): `open_with_busy_retry` covers only the OPEN,
     /// a write can still exhaust the busy handler, and cancellation emits
     /// exactly ONE change event — so a transiently-failed settle would
     /// otherwise leave the row `running` forever. On failure the SAME settle
-    /// is re-scheduled through an async `tokio::time::sleep` backoff and a
-    /// fresh `spawn_blocking` (never a sleep parked on the blocking pool;
-    /// without a runtime the bounded chain runs inline on the caller's
-    /// non-executor thread). At most [`GOAL_TASK_SETTLE_ATTEMPTS`] attempts,
-    /// deduplicated by the binding entry: a retry re-arms only while the
-    /// binding is still present, and a concurrent success removes it, which
-    /// cancels the chain naturally.
+    /// re-arms through an async `tokio::time::sleep` backoff and a fresh
+    /// `spawn_blocking`. The retry chain itself parks no sleeps on the
+    /// blocking pool (the backoff rides the executor timer; without a
+    /// runtime the bounded chain runs inline on the caller's non-executor
+    /// thread) — `open_with_busy_retry`'s own 50ms inter-attempt sleeps DO
+    /// run on the blocking pool, by design: that is where sleeping is
+    /// allowed. At most [`GOAL_TASK_SETTLE_ATTEMPTS`] attempts.
     fn settle_goal_task_row_blocking(
         &self,
         binding: &GoalTaskLedgerBinding,
         task_id: &str,
-        status: &str,
+        authority: octos_fleet::TaskSettleAuthority,
         remove_on_success: bool,
         attempt: u32,
     ) {
+        #[cfg(test)]
+        GOAL_TASK_SETTLE_ATTEMPT_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        // Staleness fence — see the doc comment.
+        {
+            let bindings = self
+                .shared
+                .goal_task_ledger_bindings
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if bindings.get(task_id).map(|entry| entry.generation) != Some(binding.generation) {
+                tracing::debug!(
+                    task_id,
+                    goal_id = %binding.goal_row.goal_id,
+                    attempt,
+                    "goal task-row settle chain is stale (binding removed or re-stashed); dying"
+                );
+                return;
+            }
+        }
         let ledger_dir = Self::goal_ledger_dir(&binding.profile_data_dir);
         let now = now_ms_u64();
         let seed_row = octos_fleet::Task {
@@ -5920,17 +5989,13 @@ impl InProcessAgentOrchestrator {
             created_at_ms: now,
             updated_at_ms: now,
         };
-        // Round 3 — provenance: `remove_on_success == false` is exactly the
-        // observer-provisional failure (see the status match above), the one
-        // verdict the owner may still correct; everything else is final.
-        let correctable = !remove_on_success;
         let written = std::fs::create_dir_all(&ledger_dir)
             .map_err(|error| eyre::eyre!("ledger dir unavailable: {error}"))
             .and_then(|()| octos_fleet::GoalLedger::open_with_busy_retry(binding.ledger_path()))
             .and_then(|ledger| {
                 ledger.create_goal_if_absent(&binding.goal_row)?;
                 ledger.create_task_if_absent(&seed_row)?;
-                ledger.update_task_status_with_provenance(task_id, status, correctable, now)
+                ledger.settle_task_status(task_id, authority, now)
             });
         match written {
             Ok(moved) => {
@@ -5943,14 +6008,17 @@ impl InProcessAgentOrchestrator {
                     bindings.remove(task_id);
                 } else if let Some(entry) = bindings.get_mut(task_id) {
                     // Provisional failure settled: the binding stays purely
-                    // as the correction window, now on the purge clock.
-                    entry.retained_since = Some(std::time::Instant::now());
+                    // as the correction window. Stamp the purge clock ONCE —
+                    // a redelivery no-op must not extend retention.
+                    entry
+                        .retained_since
+                        .get_or_insert_with(std::time::Instant::now);
                 }
                 drop(bindings);
                 tracing::debug!(
                     task_id,
                     goal_id = %binding.goal_row.goal_id,
-                    status,
+                    authority = ?authority,
                     moved,
                     remove_on_success,
                     attempt,
@@ -5959,27 +6027,21 @@ impl InProcessAgentOrchestrator {
             }
             Err(error) => {
                 let next_attempt = attempt + 1;
-                let binding_present = self
-                    .shared
-                    .goal_task_ledger_bindings
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .contains_key(task_id);
-                if next_attempt >= GOAL_TASK_SETTLE_ATTEMPTS || !binding_present {
+                if next_attempt >= GOAL_TASK_SETTLE_ATTEMPTS {
                     tracing::debug!(
                         task_id,
                         goal_id = %binding.goal_row.goal_id,
-                        status,
+                        authority = ?authority,
                         attempt,
                         %error,
-                        "goal task-row terminal settle failed; retry budget exhausted or binding gone"
+                        "goal task-row terminal settle failed; retry budget exhausted"
                     );
                     return;
                 }
                 tracing::debug!(
                     task_id,
                     goal_id = %binding.goal_row.goal_id,
-                    status,
+                    authority = ?authority,
                     attempt,
                     %error,
                     "goal task-row terminal settle failed; re-scheduling"
@@ -5987,7 +6049,6 @@ impl InProcessAgentOrchestrator {
                 let this = self.clone();
                 let binding = binding.clone();
                 let task_id = task_id.to_owned();
-                let status = status.to_owned();
                 let backoff = goal_task_settle_backoff(attempt);
                 match tokio::runtime::Handle::try_current() {
                     Ok(handle) => {
@@ -5998,7 +6059,7 @@ impl InProcessAgentOrchestrator {
                                 this.settle_goal_task_row_blocking(
                                     &binding,
                                     &task_id,
-                                    &status,
+                                    authority,
                                     remove_on_success,
                                     next_attempt,
                                 );
@@ -6012,7 +6073,7 @@ impl InProcessAgentOrchestrator {
                         this.settle_goal_task_row_blocking(
                             &binding,
                             &task_id,
-                            &status,
+                            authority,
                             remove_on_success,
                             next_attempt,
                         );
@@ -6022,19 +6083,26 @@ impl InProcessAgentOrchestrator {
         }
     }
 
-    /// #2055 review round 3 — drop correction windows older than
-    /// [`PROVISIONAL_CORRECTION_RETENTION`]. Only entries whose settle
-    /// RETAINED them (`retained_since` stamped) are eligible — a live
-    /// task's binding carries `None` and is never purged, however long the
-    /// task runs. Called opportunistically from every registration and
-    /// settle map touch; no background sweeper.
+    /// #2055 review round 3 (liveness consult in round 4) — drop correction
+    /// windows older than [`PROVISIONAL_CORRECTION_RETENTION`], but NEVER a
+    /// live task's: eligibility requires BOTH an expired `retained_since`
+    /// stamp AND the process-global worker liveness
+    /// ([`octos_agent::task_is_live`]) reporting the worker gone — a
+    /// still-running provisionally-failed worker keeps its correction
+    /// window however long it runs. A binding with no stamp (task live or
+    /// settle still retrying) is never eligible at all. Called
+    /// opportunistically from registration and settle map touches; no
+    /// background sweeper.
     fn purge_expired_goal_task_bindings(&self) {
         self.shared
             .goal_task_ledger_bindings
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .retain(|_, binding| match binding.retained_since {
-                Some(retained_since) => retained_since.elapsed() < PROVISIONAL_CORRECTION_RETENTION,
+            .retain(|task_id, binding| match binding.retained_since {
+                Some(retained_since) => {
+                    retained_since.elapsed() < PROVISIONAL_CORRECTION_RETENTION
+                        || octos_agent::task_is_live(task_id)
+                }
                 None => true,
             });
     }
@@ -17761,6 +17829,42 @@ mod tests {
         );
     }
 
+    /// Build a binding AND stash it in the orchestrator's map (the settle
+    /// core's staleness fence requires a present, generation-matched entry),
+    /// for tests that drive the private blocking cores directly.
+    fn stashed_test_binding(
+        orchestrator: &InProcessAgentOrchestrator,
+        data_dir: &std::path::Path,
+        goal_id: &str,
+        task_id: &str,
+    ) -> GoalTaskLedgerBinding {
+        let binding = GoalTaskLedgerBinding {
+            goal_row: octos_fleet::Goal {
+                goal_id: goal_id.to_string(),
+                objective: "converge".to_string(),
+                status: "active".to_string(),
+                tokens_used: 0,
+                token_budget: 1_000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1,
+                updated_at_ms: 1,
+            },
+            title: "web_probe".to_string(),
+            assigned_peer: None,
+            profile_data_dir: data_dir.to_path_buf(),
+            retained_since: None,
+            generation: 0,
+        };
+        orchestrator
+            .shared
+            .goal_task_ledger_bindings
+            .lock()
+            .unwrap()
+            .insert(task_id.to_string(), binding.clone());
+        binding
+    }
+
     /// #2055 review round 2 (Additional-3): with the I/O offloaded, nothing
     /// orders the creation write against the settle write. This test
     /// DELIBERATELY invokes the two PRIVATE blocking cores directly (review
@@ -17773,27 +17877,17 @@ mod tests {
     fn settle_before_create_ordering_converges() {
         let dir = tempfile::TempDir::new().unwrap();
         let orchestrator = InProcessAgentOrchestrator::default();
-        let binding = GoalTaskLedgerBinding {
-            goal_row: octos_fleet::Goal {
-                goal_id: "goal-order".to_string(),
-                objective: "converge".to_string(),
-                status: "active".to_string(),
-                tokens_used: 0,
-                token_budget: 1_000,
-                continuations_used: 0,
-                revision: 0,
-                created_at_ms: 1,
-                updated_at_ms: 1,
-            },
-            title: "web_probe".to_string(),
-            assigned_peer: None,
-            profile_data_dir: dir.path().to_path_buf(),
-            retained_since: None,
-        };
+        let binding = stashed_test_binding(&orchestrator, dir.path(), "goal-order", "task-order");
 
         // Settle lands FIRST (fresh ledger file — the settle is
         // self-sufficient and seeds goal + task rows itself).
-        orchestrator.settle_goal_task_row_blocking(&binding, "task-order", "complete", true, 0);
+        orchestrator.settle_goal_task_row_blocking(
+            &binding,
+            "task-order",
+            octos_fleet::TaskSettleAuthority::Completion,
+            true,
+            0,
+        );
         // The creation offload arrives LATE and must not resurrect it.
         InProcessAgentOrchestrator::record_goal_task_row_blocking(&binding, "task-order");
 
@@ -17805,6 +17899,164 @@ mod tests {
         assert_eq!(
             row.status, "complete",
             "a late creation write preserves the settled terminal"
+        );
+    }
+
+    /// #2055 review round 4 (P1 terminal authority): every delivery order of
+    /// P = provisional failure, C = completion, D = final failure converges
+    /// through the REAL blocking cores — all six D-present orders end
+    /// `failed`; P/C alone end `complete` either way. `remove_on_success`
+    /// is passed as `false` throughout so the binding survives between
+    /// writes and the test isolates pure write-order convergence: in
+    /// production a D event after a final settle removed the binding cannot
+    /// be EMITTED by the owning supervisor at all (its terminal guard), and
+    /// cross-supervisor scrambles are #2060's problem — the ranked writer
+    /// below is what makes any of them harmless.
+    #[test]
+    fn every_authority_order_converges_through_the_blocking_cores() {
+        use octos_fleet::TaskSettleAuthority::{Completion, FinalFailure, ProvisionalFailure};
+        let three_event_orders: [[octos_fleet::TaskSettleAuthority; 3]; 6] = [
+            [ProvisionalFailure, Completion, FinalFailure],
+            [ProvisionalFailure, FinalFailure, Completion],
+            [Completion, ProvisionalFailure, FinalFailure],
+            [Completion, FinalFailure, ProvisionalFailure],
+            [FinalFailure, ProvisionalFailure, Completion],
+            [FinalFailure, Completion, ProvisionalFailure],
+        ];
+        for (index, order) in three_event_orders.iter().enumerate() {
+            let dir = tempfile::TempDir::new().unwrap();
+            let orchestrator = InProcessAgentOrchestrator::default();
+            let task_id = format!("task-order-{index}");
+            let binding = stashed_test_binding(&orchestrator, dir.path(), "goal-order", &task_id);
+            for authority in order {
+                orchestrator
+                    .settle_goal_task_row_blocking(&binding, &task_id, *authority, false, 0);
+            }
+            let ledger = octos_fleet::GoalLedger::open(binding.ledger_path()).expect("open ledger");
+            let row = ledger.get_task(&task_id).expect("read").expect("row");
+            assert_eq!(
+                row.status, "failed",
+                "order #{index} {order:?} contains a final failure and must end failed"
+            );
+        }
+        for (index, order) in [
+            [ProvisionalFailure, Completion],
+            [Completion, ProvisionalFailure],
+        ]
+        .iter()
+        .enumerate()
+        {
+            let dir = tempfile::TempDir::new().unwrap();
+            let orchestrator = InProcessAgentOrchestrator::default();
+            let task_id = format!("task-nod-{index}");
+            let binding = stashed_test_binding(&orchestrator, dir.path(), "goal-order", &task_id);
+            for authority in order {
+                orchestrator
+                    .settle_goal_task_row_blocking(&binding, &task_id, *authority, false, 0);
+            }
+            let ledger = octos_fleet::GoalLedger::open(binding.ledger_path()).expect("open ledger");
+            let row = ledger.get_task(&task_id).expect("read").expect("row");
+            assert_eq!(
+                row.status, "complete",
+                "{order:?} has no final failure and must end complete"
+            );
+        }
+    }
+
+    /// #2055 review round 4 (retry-chain lifecycle): a settle chain captures
+    /// its binding generation and re-checks presence + generation before
+    /// EVERY write attempt — a re-stash under a bumped generation kills the
+    /// stale chain even though an entry EXISTS under the same task id, so a
+    /// presence-only check cannot pass this test.
+    #[test]
+    fn stale_settle_chain_dies_on_generation_mismatch() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let binding = stashed_test_binding(&orchestrator, dir.path(), "goal-gen", "task-gen-stale");
+
+        // Re-stash with a bumped generation — the captured `binding`
+        // (generation 0) is now stale.
+        {
+            let mut bindings = orchestrator
+                .shared
+                .goal_task_ledger_bindings
+                .lock()
+                .unwrap();
+            let entry = bindings.get_mut("task-gen-stale").expect("entry");
+            entry.generation += 1;
+        }
+
+        orchestrator.settle_goal_task_row_blocking(
+            &binding,
+            "task-gen-stale",
+            octos_fleet::TaskSettleAuthority::FinalFailure,
+            true,
+            0,
+        );
+
+        // The stale chain died BEFORE any write: no ledger file, no row.
+        assert!(
+            octos_fleet::GoalLedger::open(binding.ledger_path())
+                .ok()
+                .and_then(|ledger| ledger.get_task("task-gen-stale").ok().flatten())
+                .is_none(),
+            "a generation-stale chain must not write"
+        );
+        // And the current-generation entry is untouched.
+        assert!(
+            orchestrator
+                .shared
+                .goal_task_ledger_bindings
+                .lock()
+                .unwrap()
+                .contains_key("task-gen-stale")
+        );
+    }
+
+    /// #2055 review round 4 (purge vs liveness): an expired correction
+    /// window is purged ONLY when the process-global worker liveness agrees
+    /// the worker is gone — a still-live provisionally-failed task keeps
+    /// its binding past the deadline.
+    #[test]
+    fn retention_purge_spares_live_workers_past_the_deadline() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let profile = "tenant-taskrows-purge-live";
+        let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-purge-live");
+        seed_goal(default_agent_orchestrator(), &wire, profile);
+
+        let supervisor = Arc::new(octos_agent::TaskSupervisor::new());
+        wire_supervisor_for_goal_task_rows(&supervisor, &wire, profile, dir.path());
+        let task_id = supervisor.register("web_probe", "call-purge-alive", Some(&wire.to_string()));
+        supervisor.mark_running(&task_id);
+        // Arm the process-global liveness for this worker (the guard is what
+        // real workers hold for their whole critical section).
+        let live_guard =
+            octos_agent::TaskTerminalGuard::new(Arc::clone(&supervisor), task_id.clone());
+        supervisor.mark_failed_observed(&task_id, "flaky".to_string());
+
+        // Backdate the correction window past the deadline.
+        {
+            let mut bindings = default_agent_orchestrator()
+                .shared
+                .goal_task_ledger_bindings
+                .lock()
+                .unwrap();
+            let entry = bindings.get_mut(&task_id).expect("retained entry");
+            entry.retained_since = std::time::Instant::now()
+                .checked_sub(PROVISIONAL_CORRECTION_RETENTION + std::time::Duration::from_secs(1));
+        }
+        default_agent_orchestrator().purge_expired_goal_task_bindings();
+        assert!(
+            default_agent_orchestrator().goal_task_binding_exists_for_test(&task_id),
+            "a LIVE worker's expired correction window must survive the purge"
+        );
+
+        // Once the worker is genuinely gone, the expired window purges.
+        drop(live_guard);
+        default_agent_orchestrator().purge_expired_goal_task_bindings();
+        assert!(
+            !default_agent_orchestrator().goal_task_binding_exists_for_test(&task_id),
+            "the same expired window purges once the worker liveness clears"
         );
     }
 
@@ -17860,16 +18112,70 @@ mod tests {
         );
     }
 
-    /// #2055 review round 2 (H9), tightened in round 3 (R9-c/d): inside a
-    /// tokio runtime the observer callbacks only stash and spawn — the
-    /// SQLite I/O lands on the blocking pool. Proven under CONTENTION on a
-    /// SINGLE-worker runtime: while a real write transaction holds the
-    /// ledger, (1) the register call returns promptly, (2) a heartbeat task
-    /// keeps beating through the entire hold (inline I/O would starve the
-    /// only worker on the busy handler), and (3) the offloaded write lands
-    /// once the lock releases. All test-side ledger reads go through
-    /// `spawn_blocking` — the test must not itself commit the pattern this
-    /// PR removes.
+    /// Poll a ledger row's status from the blocking pool (test-side reads
+    /// must not commit the runtime-thread SQLite pattern this PR removes).
+    async fn poll_row_status(
+        ledger_path: &std::path::Path,
+        task_id: &str,
+        want: &str,
+        deadline: std::time::Duration,
+    ) -> Option<String> {
+        let started = std::time::Instant::now();
+        while started.elapsed() < deadline {
+            let path = ledger_path.to_path_buf();
+            let id = task_id.to_owned();
+            let found = tokio::task::spawn_blocking(move || {
+                octos_fleet::GoalLedger::open(&path)
+                    .ok()
+                    .and_then(|ledger| ledger.get_task(&id).ok().flatten())
+                    .map(|row| row.status)
+            })
+            .await
+            .unwrap();
+            if found.as_deref() == Some(want) {
+                return found;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        None
+    }
+
+    /// Hold `BEGIN IMMEDIATE` on the ledger from the blocking pool. The
+    /// returned oneshot resolves AFTER the transaction actually began (the
+    /// lock-acquired handshake), and the returned sender releases it — no
+    /// fixed sleeps anywhere, so scheduler delays cannot invert the test's
+    /// phases.
+    fn hold_ledger_write_lock(
+        ledger_path: &std::path::Path,
+    ) -> (
+        tokio::sync::oneshot::Receiver<()>,
+        std::sync::mpsc::Sender<()>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let (held_tx, held_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let path = ledger_path.to_path_buf();
+        let holder = tokio::task::spawn_blocking(move || {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute_batch("BEGIN IMMEDIATE;").unwrap();
+            let _ = held_tx.send(());
+            // Held until the test says otherwise (or it dropped the sender).
+            let _ = release_rx.recv();
+            conn.execute_batch("COMMIT;").unwrap();
+        });
+        (held_rx, release_tx, holder)
+    }
+
+    /// #2055 review round 2 (H9), tightened in rounds 3-4: inside a tokio
+    /// runtime the observer callbacks only stash and spawn — the SQLite I/O
+    /// lands on the blocking pool. Proven under handshaked CONTENTION on a
+    /// SINGLE-worker runtime: with a real write transaction verifiably held,
+    /// (1) the register call returns promptly, (2) a verifiably-started
+    /// heartbeat keeps beating through a two-second window (inline I/O
+    /// would park the only worker on the busy handler and starve it), and
+    /// (3) the task's row genuinely lands — the post-release completion
+    /// settles it through the self-sufficient settle path, so no assertion
+    /// depends on the lock releasing before any internal busy budget.
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn offloaded_registration_stays_off_the_executor_under_contention() {
         let dir = tempfile::TempDir::new().unwrap();
@@ -17881,9 +18187,7 @@ mod tests {
             .expect("goal id");
         let ledger_path = goal_task_ledger_path(dir.path(), &goal_id);
 
-        // Materialize the ledger file, then take a REAL write transaction on
-        // it from the blocking pool so the registration's offloaded write
-        // must wait on the busy handler.
+        // Materialize the ledger file so the holder has something to lock.
         {
             let path = ledger_path.clone();
             tokio::task::spawn_blocking(move || {
@@ -17893,16 +18197,11 @@ mod tests {
             .await
             .unwrap();
         }
-        let contention_path = ledger_path.clone();
-        let contention = tokio::task::spawn_blocking(move || {
-            let conn = rusqlite::Connection::open(&contention_path).unwrap();
-            conn.execute_batch("BEGIN IMMEDIATE;").unwrap();
-            // Hold the write lock briefly — shorter than the 1s busy
-            // budget, so the blocked write completes right after release.
-            std::thread::sleep(std::time::Duration::from_millis(600));
-            conn.execute_batch("COMMIT;").unwrap();
-        });
+        let (held, release, holder) = hold_ledger_write_lock(&ledger_path);
+        held.await.expect("lock-acquired handshake");
 
+        // Heartbeat with a started-handshake: the measured window opens only
+        // after the first beat has demonstrably run.
         let heartbeat = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let heartbeat_task = {
             let heartbeat = heartbeat.clone();
@@ -17913,6 +18212,9 @@ mod tests {
                 }
             })
         };
+        while heartbeat.load(std::sync::atomic::Ordering::SeqCst) == 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
 
         let supervisor = octos_agent::TaskSupervisor::new();
         wire_supervisor_for_goal_task_rows(&supervisor, &wire, profile, dir.path());
@@ -17921,48 +18223,55 @@ mod tests {
             supervisor.register("web_probe", "call-rows-offload", Some(&wire.to_string()));
         let register_elapsed = register_started.elapsed();
         assert!(
-            register_elapsed < std::time::Duration::from_millis(250),
-            "registration must return promptly under ledger contention \
+            register_elapsed < std::time::Duration::from_millis(1_500),
+            "registration must return promptly under held ledger contention \
              (took {register_elapsed:?} — inline I/O would ride the busy handler)"
         );
 
         // The single worker must keep serving the heartbeat while the
-        // offloaded write waits out the held lock on the blocking pool.
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-        let beats = heartbeat.load(std::sync::atomic::Ordering::SeqCst);
+        // offloaded write busy-waits on the blocking pool behind the held
+        // lock. Two full seconds, wide tolerance (nominal ~200 beats).
+        let beats_before = heartbeat.load(std::sync::atomic::Ordering::SeqCst);
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        let beats = heartbeat.load(std::sync::atomic::Ordering::SeqCst) - beats_before;
         assert!(
-            beats >= 20,
+            beats >= 40,
             "the executor worker must keep beating under contention; got {beats} beats"
         );
         heartbeat_task.abort();
-        contention.await.unwrap();
+        release.send(()).expect("release the held lock");
+        holder.await.unwrap();
 
-        let mut row = None;
-        for _ in 0..200 {
-            let path = ledger_path.clone();
-            let id = task_id.clone();
-            let found = tokio::task::spawn_blocking(move || {
-                octos_fleet::GoalLedger::open(&path)
-                    .ok()
-                    .and_then(|ledger| ledger.get_task(&id).ok().flatten())
-            })
-            .await
-            .unwrap();
-            if found.is_some() {
-                row = found;
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-        }
-        let row = row.expect("the offloaded creation write landed after the lock released");
-        assert_eq!(row.status, "running");
+        // The row genuinely lands: the completion settle is self-sufficient
+        // (it seeds the row if the contended creation write lost its busy
+        // window), so this holds regardless of how long the lock was held.
+        supervisor.mark_running(&task_id);
+        supervisor.mark_completed(&task_id, vec![]);
+        let status = poll_row_status(
+            &ledger_path,
+            &task_id,
+            "complete",
+            std::time::Duration::from_secs(30),
+        )
+        .await;
+        assert_eq!(
+            status.as_deref(),
+            Some("complete"),
+            "the registered task's row must land in the ledger"
+        );
+        assert!(
+            !default_agent_orchestrator().goal_task_binding_exists_for_test(&task_id),
+            "the settled completion releases the binding"
+        );
     }
 
-    /// #2055 review round 3 (bounded settle retry): a settle whose write
-    /// fails against held contention re-arms itself with backoff and
-    /// converges once the lock releases — cancellation emits exactly one
-    /// change event, so without the retry this row would stay `running`
-    /// forever.
+    /// #2055 review rounds 3-4 (bounded settle retry): with the lock
+    /// verifiably held past the first attempt's busy budget, the settle
+    /// re-arms — the release is triggered by the ATTEMPT COUNTER observing a
+    /// retry entry, not by a fixed sleep, so scheduler delays cannot invert
+    /// the phases — and the chain converges the row once the lock releases.
+    /// Cancellation emits exactly one change event, so without the retry
+    /// this row would stay `running` forever.
     #[tokio::test(flavor = "multi_thread")]
     async fn contended_settle_retries_until_the_row_converges() {
         let dir = tempfile::TempDir::new().unwrap();
@@ -17980,62 +18289,58 @@ mod tests {
 
         // Wait for the registration write to land so the contention below
         // targets the settle, not the creation.
-        for _ in 0..200 {
-            let path = ledger_path.clone();
-            let id = task_id.clone();
-            let found = tokio::task::spawn_blocking(move || {
-                octos_fleet::GoalLedger::open(&path)
-                    .ok()
-                    .and_then(|ledger| ledger.get_task(&id).ok().flatten())
-            })
-            .await
-            .unwrap();
-            if found.is_some() {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-        }
+        let created = poll_row_status(
+            &ledger_path,
+            &task_id,
+            "running",
+            std::time::Duration::from_secs(30),
+        )
+        .await;
+        assert_eq!(created.as_deref(), Some("running"), "creation landed");
 
-        // Hold a real write transaction PAST the settle's first busy budget
-        // (1s per lock acquisition on the retry-profile connection), so the
-        // first settle attempt genuinely fails and only the retry chain can
-        // converge the row.
-        let contention_path = ledger_path.clone();
-        let contention = tokio::task::spawn_blocking(move || {
-            let conn = rusqlite::Connection::open(&contention_path).unwrap();
-            conn.execute_batch("BEGIN IMMEDIATE;").unwrap();
-            std::thread::sleep(std::time::Duration::from_millis(2_500));
-            conn.execute_batch("COMMIT;").unwrap();
-        });
-        // Give the lock holder a beat to actually acquire it.
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        let attempts_before =
+            GOAL_TASK_SETTLE_ATTEMPT_COUNT.load(std::sync::atomic::Ordering::SeqCst);
+        let (held, release, holder) = hold_ledger_write_lock(&ledger_path);
+        held.await.expect("lock-acquired handshake");
 
         supervisor.mark_running(&task_id);
         supervisor.mark_completed(&task_id, vec![]);
-        contention.await.unwrap();
 
-        let mut status = None;
-        for _ in 0..600 {
-            let path = ledger_path.clone();
-            let id = task_id.clone();
-            let found = tokio::task::spawn_blocking(move || {
-                octos_fleet::GoalLedger::open(&path)
-                    .ok()
-                    .and_then(|ledger| ledger.get_task(&id).ok().flatten())
-                    .map(|row| row.status)
-            })
-            .await
-            .unwrap();
-            if found.as_deref() == Some("complete") {
-                status = found;
+        // Hold until the counter proves a RETRY attempt entered (first
+        // attempt + at least one re-arm), then release. Counter is global
+        // across parallel tests, so the check is on the delta with `>=`.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            let attempts = GOAL_TASK_SETTLE_ATTEMPT_COUNT.load(std::sync::atomic::Ordering::SeqCst);
+            if attempts >= attempts_before + 2 {
                 break;
             }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "no settle retry entered within the deadline (attempts delta {})",
+                attempts - attempts_before
+            );
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;
         }
+        release.send(()).expect("release the held lock");
+        holder.await.unwrap();
+
+        let status = poll_row_status(
+            &ledger_path,
+            &task_id,
+            "complete",
+            std::time::Duration::from_secs(30),
+        )
+        .await;
         assert_eq!(
             status.as_deref(),
             Some("complete"),
             "the settle retry chain must converge the row after the lock releases"
+        );
+        assert!(
+            GOAL_TASK_SETTLE_ATTEMPT_COUNT.load(std::sync::atomic::Ordering::SeqCst)
+                >= attempts_before + 2,
+            "at least one outer retry fired"
         );
         assert!(
             !default_agent_orchestrator().goal_task_binding_exists_for_test(&task_id),

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -801,13 +801,27 @@ fn goal_task_settle_backoff(attempt: u32) -> std::time::Duration {
     capped.min(std::time::Duration::from_secs(2))
 }
 
-/// #2055 review round 4 — settle blocking-core entries, visible to the
-/// contention tests so they can assert that the retry chain actually fired
-/// (the counter is process-global across parallel tests, so assertions are
-/// on DELTAS with `>=`).
+/// #2055 review round 5 — settle blocking-core entries, keyed PER TASK so a
+/// contention test's release gate observes exactly ITS chain's attempts:
+/// the earlier process-global counter could be satisfied by parallel tests'
+/// attempts before this task's retry ever entered (a false pass).
 #[cfg(test)]
-pub(crate) static GOAL_TASK_SETTLE_ATTEMPT_COUNT: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(0);
+fn goal_task_settle_attempt_counts() -> &'static StdMutex<HashMap<String, u64>> {
+    static COUNTS: OnceLock<StdMutex<HashMap<String, u64>>> = OnceLock::new();
+    COUNTS.get_or_init(|| StdMutex::new(HashMap::new()))
+}
+
+/// #2055 review round 5 — how many settle blocking-core attempts have
+/// entered for exactly `task_id`.
+#[cfg(test)]
+pub(crate) fn goal_task_settle_attempts_for(task_id: &str) -> u64 {
+    goal_task_settle_attempt_counts()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(task_id)
+        .copied()
+        .unwrap_or(0)
+}
 
 /// #2055/#2054 — everything the ledger I/O for one task's row needs, captured
 /// at registration-stash time so BOTH the offloaded row creation and any
@@ -835,6 +849,15 @@ struct GoalTaskLedgerBinding {
     /// deletes the entry, so a stale chain dies at its next check instead of
     /// writing after its sleep.
     generation: u64,
+    /// #2055 review round 5 — settle flights currently holding this entry:
+    /// incremented under the map lock at the moment settle work is enqueued,
+    /// decremented (generation-matched) when the chain ends in success or
+    /// budget exhaustion. The purge NEVER drops an entry with a flight in
+    /// progress, however expired — the staleness fence would otherwise kill
+    /// a queued/backing-off correction whose window expired mid-flight
+    /// (`TaskTerminalGuard` clears liveness BEFORE the final transition, so
+    /// liveness alone cannot protect it).
+    in_flight: u32,
 }
 
 impl GoalTaskLedgerBinding {
@@ -5775,6 +5798,7 @@ impl InProcessAgentOrchestrator {
             profile_data_dir: profile_data_dir.to_path_buf(),
             retained_since: None,
             generation: 0,
+            in_flight: 0,
         };
         // Stash BEFORE the offload so a terminal racing in can already
         // resolve the binding; the settle write sequence converges with the
@@ -5882,9 +5906,12 @@ impl InProcessAgentOrchestrator {
     /// the #2054 status vocabulary; the two are distinguishable only through
     /// the persisted authority rank.
     ///
-    /// Round 4 ordering note: the binding is fetched BEFORE the retention
-    /// purge runs — a live task finishing after the correction deadline must
-    /// not self-drop the very binding its own settle is about to use.
+    /// Round 5 ordering note: the flight mark is taken ATOMICALLY with the
+    /// binding fetch, BEFORE the retention purge runs — an expired
+    /// correction whose settle is being enqueued right now must not be
+    /// purged out from under its own chain (`TaskTerminalGuard` clears
+    /// liveness before the final transition, so the liveness consult alone
+    /// cannot protect it).
     pub(crate) fn settle_goal_task_row_from_change(&self, task: &octos_agent::BackgroundTask) {
         let (authority, remove_on_success) = match task.status {
             octos_agent::TaskStatus::Completed => {
@@ -5901,14 +5928,22 @@ impl InProcessAgentOrchestrator {
             }
             octos_agent::TaskStatus::Spawned | octos_agent::TaskStatus::Running => return,
         };
-        let binding = self
-            .shared
-            .goal_task_ledger_bindings
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .get(&task.id)
-            .cloned();
-        // Opportunistic retention purge AFTER the fetch (see doc note).
+        // Fetch + flight-mark under ONE lock acquisition.
+        let binding = {
+            let mut bindings = self
+                .shared
+                .goal_task_ledger_bindings
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            match bindings.get_mut(&task.id) {
+                Some(entry) => {
+                    entry.in_flight += 1;
+                    Some(entry.clone())
+                }
+                None => None,
+            }
+        };
+        // Opportunistic retention purge AFTER the flight mark (see doc note).
         self.purge_expired_goal_task_bindings();
         let Some(binding) = binding else {
             return;
@@ -5918,6 +5953,22 @@ impl InProcessAgentOrchestrator {
         offload_goal_ledger_io(move || {
             this.settle_goal_task_row_blocking(&binding, &task_id, authority, remove_on_success, 0);
         });
+    }
+
+    /// #2055 review round 5 — release one settle flight on `task_id`,
+    /// generation-matched: a re-stashed entry (bumped generation) starts its
+    /// own flight accounting, and a stale chain's release must not touch it.
+    fn release_goal_task_settle_flight(&self, task_id: &str, generation: u64) {
+        let mut bindings = self
+            .shared
+            .goal_task_ledger_bindings
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(entry) = bindings.get_mut(task_id)
+            && entry.generation == generation
+        {
+            entry.in_flight = entry.in_flight.saturating_sub(1);
+        }
     }
 
     /// #2054 — the blocking half of the change-feed settle. SELF-SUFFICIENT:
@@ -5959,7 +6010,13 @@ impl InProcessAgentOrchestrator {
         attempt: u32,
     ) {
         #[cfg(test)]
-        GOAL_TASK_SETTLE_ATTEMPT_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        {
+            *goal_task_settle_attempt_counts()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .entry(task_id.to_owned())
+                .or_insert(0) += 1;
+        }
         // Staleness fence — see the doc comment.
         {
             let bindings = self
@@ -6004,15 +6061,26 @@ impl InProcessAgentOrchestrator {
                     .goal_task_ledger_bindings
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner());
-                if remove_on_success {
-                    bindings.remove(task_id);
-                } else if let Some(entry) = bindings.get_mut(task_id) {
-                    // Provisional failure settled: the binding stays purely
-                    // as the correction window. Stamp the purge clock ONCE —
-                    // a redelivery no-op must not extend retention.
-                    entry
-                        .retained_since
-                        .get_or_insert_with(std::time::Instant::now);
+                // Every map mutation below is generation-gated (round 5): a
+                // re-stash between this chain's fence and its success means
+                // the entry — and its flight accounting — belongs to the new
+                // incarnation, which this chain must not touch.
+                match bindings.get_mut(task_id) {
+                    Some(entry) if entry.generation == binding.generation => {
+                        if remove_on_success {
+                            bindings.remove(task_id);
+                        } else {
+                            // Provisional failure settled: the binding stays
+                            // purely as the correction window. Stamp the
+                            // purge clock ONCE — a redelivery no-op must not
+                            // extend retention — and release this flight.
+                            entry
+                                .retained_since
+                                .get_or_insert_with(std::time::Instant::now);
+                            entry.in_flight = entry.in_flight.saturating_sub(1);
+                        }
+                    }
+                    _ => {}
                 }
                 drop(bindings);
                 tracing::debug!(
@@ -6028,6 +6096,7 @@ impl InProcessAgentOrchestrator {
             Err(error) => {
                 let next_attempt = attempt + 1;
                 if next_attempt >= GOAL_TASK_SETTLE_ATTEMPTS {
+                    self.release_goal_task_settle_flight(task_id, binding.generation);
                     tracing::debug!(
                         task_id,
                         goal_id = %binding.goal_row.goal_id,
@@ -6098,12 +6167,21 @@ impl InProcessAgentOrchestrator {
             .goal_task_ledger_bindings
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .retain(|task_id, binding| match binding.retained_since {
-                Some(retained_since) => {
-                    retained_since.elapsed() < PROVISIONAL_CORRECTION_RETENTION
-                        || octos_agent::task_is_live(task_id)
+            .retain(|task_id, binding| {
+                // Round 5 — an entry with a settle flight in progress is
+                // NEVER purged, however expired: dropping it would make the
+                // chain's staleness fence kill a queued/backing-off
+                // correction (right fence, wrong victim).
+                if binding.in_flight > 0 {
+                    return true;
                 }
-                None => true,
+                match binding.retained_since {
+                    Some(retained_since) => {
+                        retained_since.elapsed() < PROVISIONAL_CORRECTION_RETENTION
+                            || octos_agent::task_is_live(task_id)
+                    }
+                    None => true,
+                }
             });
     }
 
@@ -17855,6 +17933,7 @@ mod tests {
             profile_data_dir: data_dir.to_path_buf(),
             retained_since: None,
             generation: 0,
+            in_flight: 0,
         };
         orchestrator
             .shared
@@ -18298,27 +18377,26 @@ mod tests {
         .await;
         assert_eq!(created.as_deref(), Some("running"), "creation landed");
 
-        let attempts_before =
-            GOAL_TASK_SETTLE_ATTEMPT_COUNT.load(std::sync::atomic::Ordering::SeqCst);
         let (held, release, holder) = hold_ledger_write_lock(&ledger_path);
         held.await.expect("lock-acquired handshake");
 
         supervisor.mark_running(&task_id);
         supervisor.mark_completed(&task_id, vec![]);
 
-        // Hold until the counter proves a RETRY attempt entered (first
-        // attempt + at least one re-arm), then release. Counter is global
-        // across parallel tests, so the check is on the delta with `>=`.
+        // Hold until THIS task's per-task attempt count proves a RETRY
+        // entered (first attempt + at least one re-arm), then release. The
+        // round-5 counter is keyed by task id, so parallel tests' attempts
+        // cannot satisfy this gate (the earlier global delta could release
+        // before this task's retry ever entered — a false pass).
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         loop {
-            let attempts = GOAL_TASK_SETTLE_ATTEMPT_COUNT.load(std::sync::atomic::Ordering::SeqCst);
-            if attempts >= attempts_before + 2 {
+            let attempts = goal_task_settle_attempts_for(&task_id);
+            if attempts >= 2 {
                 break;
             }
             assert!(
                 std::time::Instant::now() < deadline,
-                "no settle retry entered within the deadline (attempts delta {})",
-                attempts - attempts_before
+                "no settle retry entered within the deadline (this task's attempts: {attempts})"
             );
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;
         }
@@ -18338,13 +18416,154 @@ mod tests {
             "the settle retry chain must converge the row after the lock releases"
         );
         assert!(
-            GOAL_TASK_SETTLE_ATTEMPT_COUNT.load(std::sync::atomic::Ordering::SeqCst)
-                >= attempts_before + 2,
-            "at least one outer retry fired"
+            goal_task_settle_attempts_for(&task_id) >= 2,
+            "at least one outer retry fired for exactly this task"
         );
         assert!(
             !default_agent_orchestrator().goal_task_binding_exists_for_test(&task_id),
             "the converged settle releases the binding"
+        );
+    }
+
+    /// #2055 review round 5 (retry-proof isolation): the attempt counter is
+    /// keyed per task — attempts recorded for one task are invisible to
+    /// another task's gate, so a parallel test can never satisfy this
+    /// test's release condition.
+    #[test]
+    fn settle_attempt_counter_is_scoped_per_task() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let binding =
+            stashed_test_binding(&orchestrator, dir.path(), "goal-scoped", "task-scoped-a");
+        assert_eq!(goal_task_settle_attempts_for("task-scoped-b"), 0);
+
+        orchestrator.settle_goal_task_row_blocking(
+            &binding,
+            "task-scoped-a",
+            octos_fleet::TaskSettleAuthority::Completion,
+            false,
+            0,
+        );
+
+        assert!(
+            goal_task_settle_attempts_for("task-scoped-a") >= 1,
+            "the driven task's attempts are recorded under its own key"
+        );
+        assert_eq!(
+            goal_task_settle_attempts_for("task-scoped-b"),
+            0,
+            "another task's gate observes NONE of them"
+        );
+    }
+
+    /// #2055 review round 5 (purge vs in-flight correction): an expired,
+    /// liveness-cleared correction whose settle is queued/backing off must
+    /// NOT be purged out from under its own chain — the write fence would
+    /// kill it permanently. The flight mark protects it; the entry is then
+    /// removed by the SETTLE, not the purge.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn purge_spares_in_flight_correction_and_the_settle_lands_it() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let profile = "tenant-taskrows-inflight";
+        let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-inflight");
+        seed_goal(default_agent_orchestrator(), &wire, profile);
+        let goal_id = default_agent_orchestrator()
+            .goal_id_for_test(&wire)
+            .expect("goal id");
+        let ledger_path = goal_task_ledger_path(dir.path(), &goal_id);
+
+        let supervisor = octos_agent::TaskSupervisor::new();
+        wire_supervisor_for_goal_task_rows(&supervisor, &wire, profile, dir.path());
+        let task_id = supervisor.register(
+            "review_worker",
+            "call-rows-inflight",
+            Some(&wire.to_string()),
+        );
+        supervisor.mark_running(&task_id);
+
+        // Provisional failure settles and retains the correction window.
+        supervisor.mark_failed_observed(&task_id, "flaky verdict".to_string());
+        let failed = poll_row_status(
+            &ledger_path,
+            &task_id,
+            "failed",
+            std::time::Duration::from_secs(30),
+        )
+        .await;
+        assert_eq!(failed.as_deref(), Some("failed"));
+        // Wait for the provisional chain to fully finish (flight released),
+        // then force expiry. No liveness guard is armed for this task, so
+        // only the in-flight mark can protect the correction below.
+        {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+            loop {
+                {
+                    let mut bindings = default_agent_orchestrator()
+                        .shared
+                        .goal_task_ledger_bindings
+                        .lock()
+                        .unwrap();
+                    if let Some(entry) = bindings.get_mut(&task_id)
+                        && entry.in_flight == 0
+                        && entry.retained_since.is_some()
+                    {
+                        entry.retained_since = std::time::Instant::now().checked_sub(
+                            PROVISIONAL_CORRECTION_RETENTION + std::time::Duration::from_secs(1),
+                        );
+                        break;
+                    }
+                }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "provisional settle did not retain the binding in time"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        }
+        let attempts_after_provisional = goal_task_settle_attempts_for(&task_id);
+
+        // Hold the ledger, fire the owner's correction, and wait until its
+        // chain has verifiably ENTERED (scoped attempt counter) — it is now
+        // queued/backing off against the held lock.
+        let (held, release, holder) = hold_ledger_write_lock(&ledger_path);
+        held.await.expect("lock-acquired handshake");
+        supervisor.mark_completed(&task_id, vec![]);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while goal_task_settle_attempts_for(&task_id) <= attempts_after_provisional {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the correction chain never entered"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        // Purge NOW: expired + liveness-cleared, but a flight is in
+        // progress — the entry must survive.
+        default_agent_orchestrator().purge_expired_goal_task_bindings();
+        assert!(
+            default_agent_orchestrator().goal_task_binding_exists_for_test(&task_id),
+            "the purge must spare the in-flight correction's binding"
+        );
+
+        release.send(()).expect("release the held lock");
+        holder.await.unwrap();
+
+        // The correction lands, and the SETTLE removes the entry.
+        let status = poll_row_status(
+            &ledger_path,
+            &task_id,
+            "complete",
+            std::time::Duration::from_secs(30),
+        )
+        .await;
+        assert_eq!(
+            status.as_deref(),
+            Some("complete"),
+            "the spared correction must still land"
+        );
+        assert!(
+            !default_agent_orchestrator().goal_task_binding_exists_for_test(&task_id),
+            "the entry is removed by the settle, not the purge"
         );
     }
 

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -752,6 +752,25 @@ struct OrchestratorShared {
     /// consumed — never re-queued — by [`Self::retry_stashed_fleet_wakes`] at
     /// the start of the next fleet-outbox drain tick.
     fleet_wake_retry: StdMutex<Vec<MasterContinuationRequest>>,
+    /// #2055/#2054 — supervisor task id → the goal-ledger location its row
+    /// was created under at registration time. The terminal sink consumes
+    /// (removes) the entry to settle the SAME row — resolving afresh at
+    /// terminal time would chase whatever goal the session holds by then,
+    /// which can differ after a mid-flight clear/recreate. In-memory only:
+    /// entries are bounded by the supervisor's fan-out caps and removed at
+    /// terminal; a restart drops them, and the row a restored task left
+    /// behind stays `running` until re-registration/settle catches it —
+    /// delivery durability across restarts is #2056, out of scope here.
+    goal_task_ledger_bindings: StdMutex<HashMap<String, GoalTaskLedgerBinding>>,
+}
+
+/// #2055/#2054 — where one supervisor task's goal-ledger row lives: enough
+/// to re-derive the per-goal ledger path (`<profile_data_dir>/goal-ledgers/
+/// <goal_id>.db`) at terminal time without re-resolving the session's goal.
+#[derive(Debug, Clone)]
+struct GoalTaskLedgerBinding {
+    goal_id: String,
+    profile_data_dir: PathBuf,
 }
 
 /// The plain WIRE session id underlying a (possibly cwd-scoped) goal-store
@@ -966,6 +985,13 @@ pub(crate) fn route_terminal_event_to_continuation_queue(
     event: &octos_agent::TerminalEvent,
     runtime_profile_id: Option<&str>,
 ) {
+    // #2054 — settle the goal-ledger task row FIRST, before any continuation
+    // routing (and before the failure arm's suppression early-returns: a
+    // synth-ack-suppressed failure still finished, and its row must flip).
+    // This writes one ledger cell and NOTHING else — no continuation, event,
+    // notification, or wake may originate here (completed → sink →
+    // ChildCompleted → wake is a cycle; fresh ids defeat dedupe).
+    default_agent_orchestrator().settle_goal_task_row(event);
     match &event.outcome {
         octos_agent::TerminalOutcome::Completed => {
             // Mirror the terminal agent record; the upsert's terminal
@@ -1103,6 +1129,12 @@ impl InProcessAgentOrchestrator {
         // #1973 fix D — a stashed retry must not leak across singleton tests.
         self.shared
             .fleet_wake_retry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
+        // #2055 — registration-time ledger bindings are equally per-test state.
+        self.shared
+            .goal_task_ledger_bindings
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clear();
@@ -4996,6 +5028,10 @@ impl InProcessAgentOrchestrator {
         // FK constraint: findings with task_id reference tasks(task_id), so
         // we must ALSO upsert a task stub when task_id is Some (codex PR
         // review merge blocker). Same minimal-stub pattern as goals above.
+        // #2055 — explicit if-absent upsert: registration usually created
+        // the real row first (possibly already settled terminal by #2054),
+        // and this stub must PRESERVE it rather than rely on a swallowed
+        // UNIQUE violation.
         if let Some(task_id_str) = task_id {
             let task_stub = octos_fleet::Task {
                 task_id: task_id_str.to_owned(),
@@ -5007,7 +5043,7 @@ impl InProcessAgentOrchestrator {
                 created_at_ms: now_ms,
                 updated_at_ms: now_ms,
             };
-            let _ = ledger.create_task(&task_stub);
+            let _ = ledger.create_task_if_absent(&task_stub);
         }
         let finding_id = format!("peer-{}-{}", peer_slug, uuid::Uuid::now_v7());
         let finding = octos_fleet::Finding {
@@ -5132,6 +5168,8 @@ impl InProcessAgentOrchestrator {
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0);
+        // #2055 — if-absent upsert preserves a registration-created (and
+        // possibly already-settled) row; see model_goal_record_peer_finding.
         let task_stub = octos_fleet::Task {
             task_id: task_id.clone(),
             goal_id: goal_id.clone(),
@@ -5142,7 +5180,7 @@ impl InProcessAgentOrchestrator {
             created_at_ms: now_ms,
             updated_at_ms: now_ms,
         };
-        let _ = ledger.create_task(&task_stub);
+        let _ = ledger.create_task_if_absent(&task_stub);
         let finding = octos_fleet::Finding {
             rowid: None,
             finding_id: format!("denied-{fleet_id}-{}", uuid::Uuid::now_v7()),
@@ -5252,6 +5290,8 @@ impl InProcessAgentOrchestrator {
         // FK constraint: escalations with task_id reference tasks(task_id),
         // so we must ALSO upsert a task stub when task_id is Some (codex PR
         // review merge blocker). Same minimal-stub pattern as findings above.
+        // #2055 — if-absent upsert preserves a registration-created (and
+        // possibly already-settled) row.
         if let Some(task_id_str) = task_id {
             let task_stub = octos_fleet::Task {
                 task_id: task_id_str.to_owned(),
@@ -5263,7 +5303,7 @@ impl InProcessAgentOrchestrator {
                 created_at_ms: now_ms,
                 updated_at_ms: now_ms,
             };
-            let _ = ledger.create_task(&task_stub);
+            let _ = ledger.create_task_if_absent(&task_stub);
         }
         let escalation_id = format!("esc-{}-{}", peer_slug, uuid::Uuid::now_v7());
         let escalation = octos_fleet::Escalation {
@@ -5489,6 +5529,198 @@ impl InProcessAgentOrchestrator {
     /// permissions (0755) by `model_goal_record_peer_finding`.
     fn goal_ledger_dir(profile_data_dir: &std::path::Path) -> std::path::PathBuf {
         profile_data_dir.join("goal-ledgers")
+    }
+
+    /// #2055 — goal binding for ledger task-row creation on an autonomous
+    /// goal-continuation turn, keyed DIRECTLY by the already-scoped goal
+    /// store key the continuation carries (family-2, like `record_goal_turn`
+    /// / `set_goal_workspace_binding` — never re-scoped). Interactive turns
+    /// use [`Self::active_goal_id`] instead (wire key + re-scope), matching
+    /// how their #1935 `interactive_goal_binding` snapshot was resolved.
+    pub(crate) fn active_goal_id_under_goal_key(
+        &self,
+        goal_session_key: &SessionKey,
+        profile_id: &str,
+    ) -> Option<String> {
+        let state = self.state();
+        let goal = state.goals.get(goal_session_key)?;
+        (goal.profile_id == profile_id && goal.status == "active").then(|| goal.goal_id.clone())
+    }
+
+    /// #2055 — create the goal-ledger `tasks` row for a task the
+    /// `TaskSupervisor` just registered, and remember where it lives so the
+    /// terminal sink can settle it (#2054). Called from the `on_register`
+    /// closures both runtime modes wire next to `set_on_terminal`.
+    ///
+    /// Best-effort BY CONTRACT: registration must never fail, block, or
+    /// panic on ledger I/O, so every error is swallowed with a
+    /// `tracing::debug!`. Locates the ledger exactly like
+    /// [`Self::model_goal_record_peer_finding`]
+    /// (`<profile_data_dir>/goal-ledgers/<goal_id>.db`), and upserts the
+    /// goals row first for the same reason that path does — the bundled
+    /// SQLite enforces `FOREIGN KEY (goal_id)` (`foreign_keys=1` compile
+    /// default), and this row may be the ledger file's very first write.
+    /// Row creation is the idempotent [`octos_fleet::GoalLedger::
+    /// create_task_if_absent`], so re-registration across relaunch/restart
+    /// preserves an existing row and its status — including one that
+    /// already went terminal.
+    pub(crate) fn record_goal_task_registration(
+        &self,
+        profile_data_dir: &Path,
+        profile_id: &str,
+        goal_id: &str,
+        task: &octos_agent::BackgroundTask,
+    ) {
+        // Fresh goal snapshot for the FK-parent goals row (mirrors the
+        // peer-finding recorder). A goal cleared between binding resolution
+        // and this callback simply skips the write — no goal, no row. The
+        // state lock drops before any file I/O below.
+        let goal_row = {
+            let state = self.state();
+            state
+                .goals
+                .values()
+                .find(|goal| goal.goal_id == goal_id && goal.profile_id == profile_id)
+                .map(|goal| octos_fleet::Goal {
+                    goal_id: goal.goal_id.clone(),
+                    objective: goal.objective.clone(),
+                    status: goal.status.clone(),
+                    tokens_used: goal.tokens_used,
+                    token_budget: goal.token_budget,
+                    continuations_used: goal.continuations_used,
+                    revision: 0, // preserved on conflict by upsert_goal
+                    created_at_ms: goal.created_at_ms.max(0) as u64,
+                    updated_at_ms: goal.updated_at_ms.max(0) as u64,
+                })
+        };
+        let Some(goal_row) = goal_row else {
+            tracing::debug!(
+                goal_id,
+                profile_id,
+                task_id = %task.id,
+                "goal task-row registration skipped: goal record no longer present"
+            );
+            return;
+        };
+        let ledger_dir = Self::goal_ledger_dir(profile_data_dir);
+        if let Err(error) = std::fs::create_dir_all(&ledger_dir) {
+            tracing::debug!(
+                goal_id,
+                task_id = %task.id,
+                path = %ledger_dir.display(),
+                %error,
+                "goal task-row registration skipped: ledger dir unavailable"
+            );
+            return;
+        }
+        let ledger_path = ledger_dir.join(format!("{}.db", sanitize_filename_for_ledger(goal_id)));
+        let ledger = match octos_fleet::GoalLedger::open(&ledger_path) {
+            Ok(ledger) => ledger,
+            Err(error) => {
+                tracing::debug!(
+                    goal_id,
+                    task_id = %task.id,
+                    path = %ledger_path.display(),
+                    %error,
+                    "goal task-row registration skipped: ledger open failed"
+                );
+                return;
+            }
+        };
+        // FK parent first (guarded upsert; a stale-snapshot rejection still
+        // leaves a valid parent row in place).
+        let _ = ledger.upsert_goal(&goal_row);
+        let now = now_ms_u64();
+        // `assigned_peer` is derivable only for the native-specialist kind
+        // (peers and supervisor-spawned specialists), whose `tool_call_id`
+        // is the agent id. Every other kind has no peer identity.
+        let assigned_peer = (task.tool_name == "native_agent" && !task.tool_call_id.is_empty())
+            .then(|| task.tool_call_id.clone());
+        let row = octos_fleet::Task {
+            task_id: task.id.clone(),
+            goal_id: goal_id.to_owned(),
+            title: task.tool_name.clone(),
+            detail: String::new(),
+            status: "running".to_owned(),
+            assigned_peer,
+            created_at_ms: now,
+            updated_at_ms: now,
+        };
+        if let Err(error) = ledger.create_task_if_absent(&row) {
+            tracing::debug!(
+                goal_id,
+                task_id = %task.id,
+                %error,
+                "goal task-row registration failed; continuing without a row"
+            );
+            return;
+        }
+        // Remember where the row lives so the terminal sink can settle it
+        // even if the session's goal binding changes mid-flight.
+        self.shared
+            .goal_task_ledger_bindings
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(
+                task.id.clone(),
+                GoalTaskLedgerBinding {
+                    goal_id: goal_id.to_owned(),
+                    profile_data_dir: profile_data_dir.to_path_buf(),
+                },
+            );
+    }
+
+    /// #2054 — settle the goal-ledger task row for a terminal transition.
+    /// Consumes the registration-time binding (`on_terminal` fires at most
+    /// once per task, so the entry is done after this) and writes ONE ledger
+    /// cell via the first-terminal-wins
+    /// [`octos_fleet::GoalLedger::update_task_status`]. `Ok(false)` is a
+    /// normal no-op (absent row / already terminal). Emits NO continuation,
+    /// event, notification, or wake — `completed → sink → ChildCompleted →
+    /// wake` is a cycle whose fresh ids defeat dedupe.
+    ///
+    /// Fidelity note: `TerminalOutcome` collapses `Cancelled` into `Failed`
+    /// upstream, so a cancelled task settles as `"failed"`.
+    pub(crate) fn settle_goal_task_row(&self, event: &octos_agent::TerminalEvent) {
+        let binding = self
+            .shared
+            .goal_task_ledger_bindings
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&event.task.id);
+        let Some(binding) = binding else {
+            return;
+        };
+        let status = match &event.outcome {
+            octos_agent::TerminalOutcome::Completed => "complete",
+            octos_agent::TerminalOutcome::Failed(_) => "failed",
+        };
+        let ledger_path = Self::goal_ledger_dir(&binding.profile_data_dir).join(format!(
+            "{}.db",
+            sanitize_filename_for_ledger(&binding.goal_id)
+        ));
+        match octos_fleet::GoalLedger::open(&ledger_path)
+            .and_then(|ledger| ledger.update_task_status(&event.task.id, status, now_ms_u64()))
+        {
+            Ok(moved) => {
+                tracing::debug!(
+                    task_id = %event.task.id,
+                    goal_id = %binding.goal_id,
+                    status,
+                    moved,
+                    "goal task-row terminal settle"
+                );
+            }
+            Err(error) => {
+                tracing::debug!(
+                    task_id = %event.task.id,
+                    goal_id = %binding.goal_id,
+                    status,
+                    %error,
+                    "goal task-row terminal settle failed; row left as-is"
+                );
+            }
+        }
     }
 
     /// #1857 PR 5a — stash the controller workspace binding on the goal record
@@ -16804,6 +17036,237 @@ mod tests {
                 .pending_continuation_count_for_session_for_test(&session_queue, "tenant-queue"),
             1,
             "WS failure routing must enqueue exactly one recovery continuation",
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #2055 / #2054 — goal-ledger task rows: created at registration, settled
+    // at terminal through the unified sink.
+    // -----------------------------------------------------------------------
+
+    /// Wire a real `TaskSupervisor` exactly the way the runtime modes do:
+    /// `set_on_register` resolves the session's active goal and records the
+    /// row; `set_on_terminal` routes into the unified sink (which settles
+    /// the row before any continuation routing).
+    fn wire_supervisor_for_goal_task_rows(
+        supervisor: &octos_agent::TaskSupervisor,
+        session: &SessionKey,
+        profile: &str,
+        data_dir: &std::path::Path,
+    ) {
+        let register_session = session.clone();
+        let register_profile = profile.to_owned();
+        let register_data_dir = data_dir.to_path_buf();
+        supervisor.set_on_register(move |task| {
+            let orchestrator = default_agent_orchestrator();
+            let Some(goal_id) = orchestrator.active_goal_id(&register_session, &register_profile)
+            else {
+                return;
+            };
+            orchestrator.record_goal_task_registration(
+                &register_data_dir,
+                &register_profile,
+                &goal_id,
+                task,
+            );
+        });
+        supervisor.set_on_terminal(move |event| {
+            route_terminal_event_to_continuation_queue(event, None);
+        });
+    }
+
+    fn goal_task_ledger_path(data_dir: &std::path::Path, goal_id: &str) -> std::path::PathBuf {
+        InProcessAgentOrchestrator::goal_ledger_dir(data_dir)
+            .join(format!("{}.db", sanitize_filename_for_ledger(goal_id)))
+    }
+
+    /// #2055 (creation) + #2054 (settlement, success side): a goal-bound
+    /// session registering a background task creates a `running` row, and
+    /// the task completing flips it to `complete` THROUGH THE SINK — no
+    /// direct settle call anywhere in this test.
+    #[test]
+    fn goal_bound_registration_creates_running_row_and_completion_settles_it() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let profile = "tenant-taskrows-ok";
+        let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-ok");
+        seed_goal(default_agent_orchestrator(), &wire, profile);
+        let goal_id = default_agent_orchestrator()
+            .goal_id_for_test(&wire)
+            .expect("goal id");
+
+        let supervisor = octos_agent::TaskSupervisor::new();
+        wire_supervisor_for_goal_task_rows(&supervisor, &wire, profile, dir.path());
+
+        let task_id = supervisor.register("web_probe", "call-rows-1", Some(&wire.to_string()));
+        assert!(!task_id.is_empty(), "registration succeeds");
+
+        let ledger = octos_fleet::GoalLedger::open(goal_task_ledger_path(dir.path(), &goal_id))
+            .expect("ledger exists after registration");
+        let row = ledger
+            .get_task(&task_id)
+            .expect("read row")
+            .expect("registration created a task row");
+        assert_eq!(row.status, "running");
+        assert_eq!(row.goal_id, goal_id);
+        assert_eq!(row.title, "web_probe", "title carries the tool name");
+
+        supervisor.mark_running(&task_id);
+        supervisor.mark_completed(&task_id, vec![]);
+
+        let row = ledger.get_task(&task_id).expect("read row").expect("row");
+        assert_eq!(
+            row.status, "complete",
+            "the unified terminal sink settles the row on completion"
+        );
+        let counts: std::collections::BTreeMap<String, u64> = ledger
+            .task_status_counts(&goal_id)
+            .expect("counts")
+            .into_iter()
+            .collect();
+        assert_eq!(
+            counts.get("complete"),
+            Some(&1),
+            "task_status_counts observes the completion"
+        );
+        assert_eq!(counts.get("running"), None);
+    }
+
+    /// #2054 failure side: a failed task flips its row to `failed` through
+    /// the sink — INCLUDING a failure whose synth-ack was never emitted
+    /// (the sink suppresses the recovery continuation for those, but the
+    /// ledger settle must still happen). `Cancelled` collapses into
+    /// `Failed` upstream in `TerminalOutcome`, so `failed` is also what a
+    /// cancelled task lands as.
+    #[test]
+    fn goal_bound_registration_failure_settles_failed_row_through_the_sink() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let profile = "tenant-taskrows-fail";
+        let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-fail");
+        seed_goal(default_agent_orchestrator(), &wire, profile);
+        let goal_id = default_agent_orchestrator()
+            .goal_id_for_test(&wire)
+            .expect("goal id");
+
+        let supervisor = octos_agent::TaskSupervisor::new();
+        wire_supervisor_for_goal_task_rows(&supervisor, &wire, profile, dir.path());
+
+        let task_id = supervisor.register("web_probe", "call-rows-2", Some(&wire.to_string()));
+        supervisor.mark_running(&task_id);
+        supervisor.mark_failed(&task_id, "probe exited 1".to_string());
+
+        let ledger = octos_fleet::GoalLedger::open(goal_task_ledger_path(dir.path(), &goal_id))
+            .expect("open ledger");
+        let row = ledger.get_task(&task_id).expect("read row").expect("row");
+        assert_eq!(
+            row.status, "failed",
+            "a synth-ack-suppressed failure still settles its ledger row"
+        );
+    }
+
+    /// A session with NO goal binding creates nothing — that is correct
+    /// behavior, not an error. No ledger directory, no row, and the
+    /// registration itself is untouched.
+    #[test]
+    fn registration_without_goal_binding_creates_no_ledger_row() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let profile = "tenant-taskrows-nogoal";
+        let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-nogoal");
+        // Deliberately NO seed_goal.
+
+        let supervisor = octos_agent::TaskSupervisor::new();
+        wire_supervisor_for_goal_task_rows(&supervisor, &wire, profile, dir.path());
+
+        let task_id = supervisor.register("web_probe", "call-rows-3", Some(&wire.to_string()));
+        assert!(!task_id.is_empty(), "registration is unaffected");
+        assert!(
+            !InProcessAgentOrchestrator::goal_ledger_dir(dir.path()).exists(),
+            "no goal binding ⇒ no ledger write of any kind"
+        );
+    }
+
+    /// Ledger I/O failure must never fail, block, or panic registration.
+    /// Force `create_dir_all` to fail by pre-creating `goal-ledgers` as a
+    /// FILE; the recorder swallows the error and the register call still
+    /// returns a live task id.
+    #[test]
+    fn ledger_error_does_not_break_registration() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let profile = "tenant-taskrows-err";
+        let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-err");
+        seed_goal(default_agent_orchestrator(), &wire, profile);
+        // A FILE where the ledger DIRECTORY should be.
+        std::fs::write(
+            InProcessAgentOrchestrator::goal_ledger_dir(dir.path()),
+            b"not a directory",
+        )
+        .unwrap();
+
+        let supervisor = octos_agent::TaskSupervisor::new();
+        wire_supervisor_for_goal_task_rows(&supervisor, &wire, profile, dir.path());
+
+        let task_id = supervisor.register("web_probe", "call-rows-4", Some(&wire.to_string()));
+        assert!(
+            !task_id.is_empty(),
+            "a ledger I/O failure must not break registration"
+        );
+        assert_eq!(
+            supervisor.get_task(&task_id).unwrap().status,
+            octos_agent::TaskStatus::Spawned
+        );
+    }
+
+    /// A goal-bound task whose goal record disappears between registration
+    /// and terminal still settles: the binding captured at registration
+    /// addresses the ORIGINAL ledger, not whatever goal the session holds
+    /// at terminal time.
+    #[test]
+    fn settle_uses_the_binding_captured_at_registration() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let profile = "tenant-taskrows-rebind";
+        let wire = SessionKey::with_profile(profile, "api", "goal-task-rows-rebind");
+        seed_goal(default_agent_orchestrator(), &wire, profile);
+        let goal_id = default_agent_orchestrator()
+            .goal_id_for_test(&wire)
+            .expect("goal id");
+
+        let supervisor = octos_agent::TaskSupervisor::new();
+        wire_supervisor_for_goal_task_rows(&supervisor, &wire, profile, dir.path());
+        let task_id = supervisor.register("web_probe", "call-rows-5", Some(&wire.to_string()));
+
+        // The goal is cleared mid-flight; the terminal must still settle
+        // the row created above.
+        default_agent_orchestrator()
+            .clear_goal(GoalSessionRequest {
+                session_id: wire.clone(),
+                profile_id: profile.into(),
+            })
+            .expect("clear goal");
+
+        supervisor.mark_running(&task_id);
+        supervisor.mark_completed(&task_id, vec![]);
+
+        let ledger = octos_fleet::GoalLedger::open(goal_task_ledger_path(dir.path(), &goal_id))
+            .expect("open ledger");
+        let row = ledger.get_task(&task_id).expect("read row").expect("row");
+        assert_eq!(row.status, "complete");
+    }
+
+    /// #2055 wiring guard: BOTH runtime modes must wire the registration
+    /// observer next to their existing `set_on_terminal` call. Source-scan
+    /// needle in the `commands::serve::tests` tradition — the closures
+    /// themselves are exercised by the supervisor-driven tests above; this
+    /// pins that production actually installs them.
+    #[test]
+    fn runtime_modes_wire_the_registration_observer() {
+        let session_actor = include_str!("../session_actor.rs");
+        assert!(
+            session_actor.contains("set_on_register"),
+            "session_actor (gateway mode) must wire TaskSupervisor::set_on_register"
+        );
+        let ui_protocol_transport = include_str!("../api/ui_protocol_transport.rs");
+        assert!(
+            ui_protocol_transport.contains("set_on_register"),
+            "ui_protocol_transport (WS/serve mode) must wire TaskSupervisor::set_on_register"
         );
     }
 

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -3415,32 +3415,19 @@ impl ActorFactory {
         // on ledger I/O). `self.data_dir` is the profile data dir this path
         // already hands to the goal-ledger sync (see
         // `maybe_advance_goal_runtime_after_turn`).
-        let register_session_key = session_key.clone();
-        let register_profile_id = session_key
-            .profile_id()
-            .unwrap_or(MAIN_PROFILE_ID)
-            .to_owned();
-        let register_data_dir = self.data_dir.clone();
-        supervisor.set_on_register(move |task| {
-            let orchestrator = default_agent_orchestrator();
-            let Some(goal_id) =
-                orchestrator.active_goal_id(&register_session_key, &register_profile_id)
-            else {
-                return;
-            };
-            orchestrator.record_goal_task_registration(
-                &register_data_dir,
-                &register_profile_id,
-                &goal_id,
-                task,
-            );
-        });
-        // #2054 (review round 2) — the settle half rides the change feed as
-        // a NAMED listener (not the `on_terminal` sink below): `cancel`
-        // emits only `notify_change`, and the sink's once-per-task dedupe
-        // would swallow the owner's failed→complete correction. Inherited
-        // by nested child supervisors together with `on_register`.
-        crate::autonomy::agent_orchestrator::install_goal_task_row_settle_listener(&supervisor);
+        // Round 3 — the SHARED installer wires both halves (recorder +
+        // change-feed settle listener), so this site cannot drift from the
+        // WS / cached-supervisor wiring or from the effect tests. The settle
+        // rides the change feed as a NAMED listener (not the `on_terminal`
+        // sink below): `cancel` emits only `notify_change`, and the sink's
+        // once-per-task dedupe would swallow the owner's failed→complete
+        // correction. Inherited by nested child supervisors.
+        crate::autonomy::agent_orchestrator::install_goal_task_row_observers_resolving_at_callback(
+            &supervisor,
+            &session_key,
+            session_key.profile_id().unwrap_or(MAIN_PROFILE_ID),
+            &self.data_dir,
+        );
         // Gap-1 unification: the single terminal sink, also wired BEFORE
         // `enable_persistence` (see the combined ordering note above). Routes
         // BOTH success (ChildCompleted) AND failure (recovery) re-entry

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -3403,6 +3403,38 @@ impl ActorFactory {
         supervisor.set_on_change(move |task| {
             forward_task_status_to_actor_inbox(&status_tx, &task_data_dir, task);
         });
+        // #2055 — create the goal-ledger task row at registration time,
+        // wired next to the unified terminal sink below (whose settle half,
+        // #2054, flips the row at terminal). The gateway actor wires its
+        // callbacks ONCE at init while goals come and go over the session's
+        // life, so the goal binding resolves at CALLBACK time via
+        // `active_goal_id` — the same resolver the #1935 interactive
+        // binding snapshot uses on the WS path. No active goal ⇒ no row;
+        // that is correct behavior, not an error. The recorder swallows
+        // every ledger error (registration must never fail, block, or panic
+        // on ledger I/O). `self.data_dir` is the profile data dir this path
+        // already hands to the goal-ledger sync (see
+        // `maybe_advance_goal_runtime_after_turn`).
+        let register_session_key = session_key.clone();
+        let register_profile_id = session_key
+            .profile_id()
+            .unwrap_or(MAIN_PROFILE_ID)
+            .to_owned();
+        let register_data_dir = self.data_dir.clone();
+        supervisor.set_on_register(move |task| {
+            let orchestrator = default_agent_orchestrator();
+            let Some(goal_id) =
+                orchestrator.active_goal_id(&register_session_key, &register_profile_id)
+            else {
+                return;
+            };
+            orchestrator.record_goal_task_registration(
+                &register_data_dir,
+                &register_profile_id,
+                &goal_id,
+                task,
+            );
+        });
         // Gap-1 unification: the single terminal sink, also wired BEFORE
         // `enable_persistence` (see the combined ordering note above). Routes
         // BOTH success (ChildCompleted) AND failure (recovery) re-entry

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -3435,6 +3435,12 @@ impl ActorFactory {
                 task,
             );
         });
+        // #2054 (review round 2) — the settle half rides the change feed as
+        // a NAMED listener (not the `on_terminal` sink below): `cancel`
+        // emits only `notify_change`, and the sink's once-per-task dedupe
+        // would swallow the owner's failed→complete correction. Inherited
+        // by nested child supervisors together with `on_register`.
+        crate::autonomy::agent_orchestrator::install_goal_task_row_settle_listener(&supervisor);
         // Gap-1 unification: the single terminal sink, also wired BEFORE
         // `enable_persistence` (see the combined ordering note above). Routes
         // BOTH success (ChildCompleted) AND failure (recovery) re-entry

--- a/crates/octos-fleet/src/lib.rs
+++ b/crates/octos-fleet/src/lib.rs
@@ -60,7 +60,7 @@ pub use records::{
     PlanTask, SCHEMA_VERSION, Verifier, WorkerKind,
 };
 pub use sqlite_ledger::{
-    Decision, Escalation, Finding, Goal, GoalLedger, Task, digest_from_ledger,
+    Decision, Escalation, Finding, Goal, GoalLedger, Task, TaskSettleAuthority, digest_from_ledger,
 };
 pub use store::{
     AckOutcome, CompleteOutcome, DenyEscalationOutcome, FleetKernelStore, FleetSnapshot,

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -227,13 +227,13 @@ impl GoalLedger {
             // #2055 review round 4 — the `authority` schema migration runs
             // HERE, inside the attempt (never in the common `open`, which
             // executes on tokio workers): this profile is only ever called
-            // from blocking contexts, and a migration ALTER that loses a
-            // lock race is retried exactly like a contended open.
+            // from blocking contexts, and a migration transaction that loses
+            // a lock race is retried exactly like a contended open.
             let attempt_result = Self::open_inner(path, Some(std::time::Duration::from_secs(1)))
                 .and_then(|ledger| {
                     {
-                        let conn = ledger.conn.lock().unwrap();
-                        Self::migrate_tasks_authority_column(&conn)?;
+                        let mut conn = ledger.conn.lock().unwrap();
+                        Self::migrate_tasks_authority_column(&mut conn)?;
                     }
                     Ok(ledger)
                 });
@@ -382,45 +382,69 @@ impl GoalLedger {
         Ok(())
     }
 
-    /// #2055 review round 4 — bring an existing `tasks` table onto the
-    /// `authority` schema. Three steps, each with an explicit error policy
-    /// (SQLite reports both expected failures as generic `SQLITE_ERROR`, so
-    /// the message text is the only discriminator — documented rusqlite
-    /// behavior for DDL):
+    /// Whether the `tasks` table currently carries `column` — schema
+    /// inspection via `pragma_table_info`, which never references the column
+    /// itself and returns an empty set for a missing table, so it is safe on
+    /// every schema generation.
+    fn tasks_has_column(conn: &Connection, column: &str) -> Result<bool> {
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('tasks') WHERE name = ?1",
+            params![column],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
+    /// #2055 review round 5 — bring an existing `tasks` table onto the
+    /// `authority` schema, ATOMICALLY. All steps run inside ONE
+    /// `BEGIN IMMEDIATE` transaction and are decided by SCHEMA INSPECTION
+    /// (`pragma_table_info`), never by error-message substrings:
     ///
-    /// 1. Add the column (fresh default `-1`, identical to the
-    ///    `CREATE TABLE` shape). A duplicate-column error means the table is
-    ///    already migrated — swallowed; every OTHER error propagates.
-    /// 2. Only when step 1 actually added the column: stamp every
-    ///    pre-existing terminal row as FINAL (`authority = 2`) — a legacy
-    ///    `failed` row must NOT become correctable, and a legacy `complete`
-    ///    row is equally settled history. Rows the round-4 code writes carry
-    ///    their real rank from the start, and this backfill can never touch
-    ///    them because it runs only in the same breath as the column
-    ///    creation.
-    /// 3. Drop the short-lived round-3 `correctable` column if present
-    ///    (this branch never shipped; the column exists only on databases
-    ///    created from it). A missing column is swallowed; other errors
-    ///    propagate.
-    fn migrate_tasks_authority_column(conn: &Connection) -> Result<()> {
-        match conn.execute(
-            "ALTER TABLE tasks ADD COLUMN authority INTEGER NOT NULL DEFAULT -1",
-            [],
-        ) {
-            Ok(_) => {
-                conn.execute(
-                    "UPDATE tasks SET authority = 2 WHERE status IN ('complete', 'failed')",
-                    [],
-                )?;
-            }
-            Err(error) if error.to_string().contains("duplicate column name") => {}
-            Err(error) => return Err(error.into()),
+    /// - the previous statement-by-statement shape could commit the
+    ///   ALTER-ADD and then fail before the backfill; every later opener
+    ///   then saw the column present, skipped the backfill forever, and
+    ///   legacy terminal rows sat at authority `-1` (correctable).
+    /// - the `"no such column"` substring also matched REAL failures (a
+    ///   dependent index on the dropped column reports
+    ///   `error in index … no such column`), silently eating them.
+    ///
+    /// Steps, inside the transaction: (1) when `authority` is absent, add
+    /// it (default `-1`, identical to the `CREATE TABLE` shape) and stamp
+    /// every pre-existing terminal row FINAL (`authority = 2`) — a legacy
+    /// `failed` row must NOT become correctable, and the backfill can never
+    /// touch rows the current code writes because it runs only in the same
+    /// transaction as the column creation; (2) when the short-lived round-3
+    /// `correctable` column is present, drop it. Any statement failure
+    /// rolls the WHOLE migration back (the `Transaction` drop path), so no
+    /// partial schema state can persist; any error propagates to the caller
+    /// (`open_with_busy_retry`'s attempt loop, which retries the
+    /// lock-contention class and surfaces the rest).
+    ///
+    /// The pre-transaction fast path skips the write lock entirely on a
+    /// fully-migrated database; the checks are REPEATED inside the
+    /// transaction because two blocking-context openers can race the fast
+    /// path, and only the in-transaction view is serialized.
+    fn migrate_tasks_authority_column(conn: &mut Connection) -> Result<()> {
+        if Self::tasks_has_column(conn, "authority")?
+            && !Self::tasks_has_column(conn, "correctable")?
+        {
+            return Ok(());
         }
-        match conn.execute("ALTER TABLE tasks DROP COLUMN correctable", []) {
-            Ok(_) => {}
-            Err(error) if error.to_string().contains("no such column") => {}
-            Err(error) => return Err(error.into()),
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        if !Self::tasks_has_column(&tx, "authority")? {
+            tx.execute(
+                "ALTER TABLE tasks ADD COLUMN authority INTEGER NOT NULL DEFAULT -1",
+                [],
+            )?;
+            tx.execute(
+                "UPDATE tasks SET authority = 2 WHERE status IN ('complete', 'failed')",
+                [],
+            )?;
         }
+        if Self::tasks_has_column(&tx, "correctable")? {
+            tx.execute("ALTER TABLE tasks DROP COLUMN correctable", [])?;
+        }
+        tx.commit()?;
         Ok(())
     }
 
@@ -633,23 +657,63 @@ impl GoalLedger {
         Ok(rows.next().transpose()?)
     }
 
+    /// #2055 review round 5 — the authority rank a freshly CREATED row
+    /// starts at, derived from the status it is created with: a terminal
+    /// status written at creation is an owner-recorded fact, so `complete`
+    /// starts at the completion rank and `failed` at the FINAL-failure rank
+    /// (an observer-provisional failure is only ever expressible through
+    /// [`Self::settle_task_status`], never at creation). Without this, a
+    /// terminal creation sat at `-1` and the nonterminal-refresh guard
+    /// admitted a plain `running` write over a valid terminal row.
+    fn creation_authority_for_status(status: &str) -> i64 {
+        match status {
+            "complete" => TaskSettleAuthority::Completion.rank(),
+            "failed" => TaskSettleAuthority::FinalFailure.rank(),
+            _ => -1,
+        }
+    }
+
     /// Create a new task.
+    ///
+    /// Round 5: the initial `authority` is derived from `task.status` (see
+    /// [`Self::creation_authority_for_status`]) when the column exists; on a
+    /// not-yet-migrated legacy database (reachable through the plain
+    /// [`Self::open`], which deliberately runs no migration) the statement
+    /// falls back to the legacy shape and never references the column.
     pub fn create_task(&self, task: &Task) -> Result<()> {
         let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT INTO tasks (task_id, goal_id, title, detail, status, assigned_peer, created_at_ms, updated_at_ms)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-            params![
-                task.task_id,
-                task.goal_id,
-                task.title,
-                task.detail,
-                task.status,
-                task.assigned_peer,
-                task.created_at_ms,
-                task.updated_at_ms,
-            ],
-        )?;
+        if Self::tasks_has_column(&conn, "authority")? {
+            conn.execute(
+                "INSERT INTO tasks (task_id, goal_id, title, detail, status, assigned_peer, created_at_ms, updated_at_ms, authority)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    task.task_id,
+                    task.goal_id,
+                    task.title,
+                    task.detail,
+                    task.status,
+                    task.assigned_peer,
+                    task.created_at_ms,
+                    task.updated_at_ms,
+                    Self::creation_authority_for_status(&task.status),
+                ],
+            )?;
+        } else {
+            conn.execute(
+                "INSERT INTO tasks (task_id, goal_id, title, detail, status, assigned_peer, created_at_ms, updated_at_ms)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    task.task_id,
+                    task.goal_id,
+                    task.title,
+                    task.detail,
+                    task.status,
+                    task.assigned_peer,
+                    task.created_at_ms,
+                    task.updated_at_ms,
+                ],
+            )?;
+        }
         Ok(())
     }
 
@@ -664,23 +728,46 @@ impl GoalLedger {
     /// [`Self::update_task_status`]), title, and timestamps — rather than
     /// error or overwrite. Returns `Ok(true)` when a row was inserted,
     /// `Ok(false)` for the preserve-existing no-op.
+    ///
+    /// Round 5: the initial `authority` is derived from `task.status` (see
+    /// [`Self::creation_authority_for_status`]) when the column exists; the
+    /// legacy fallback mirrors [`Self::create_task`].
     pub fn create_task_if_absent(&self, task: &Task) -> Result<bool> {
         let conn = self.conn.lock().unwrap();
-        let inserted = conn.execute(
-            "INSERT INTO tasks (task_id, goal_id, title, detail, status, assigned_peer, created_at_ms, updated_at_ms)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-             ON CONFLICT(task_id) DO NOTHING",
-            params![
-                task.task_id,
-                task.goal_id,
-                task.title,
-                task.detail,
-                task.status,
-                task.assigned_peer,
-                task.created_at_ms,
-                task.updated_at_ms,
-            ],
-        )?;
+        let inserted = if Self::tasks_has_column(&conn, "authority")? {
+            conn.execute(
+                "INSERT INTO tasks (task_id, goal_id, title, detail, status, assigned_peer, created_at_ms, updated_at_ms, authority)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                 ON CONFLICT(task_id) DO NOTHING",
+                params![
+                    task.task_id,
+                    task.goal_id,
+                    task.title,
+                    task.detail,
+                    task.status,
+                    task.assigned_peer,
+                    task.created_at_ms,
+                    task.updated_at_ms,
+                    Self::creation_authority_for_status(&task.status),
+                ],
+            )?
+        } else {
+            conn.execute(
+                "INSERT INTO tasks (task_id, goal_id, title, detail, status, assigned_peer, created_at_ms, updated_at_ms)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                 ON CONFLICT(task_id) DO NOTHING",
+                params![
+                    task.task_id,
+                    task.goal_id,
+                    task.title,
+                    task.detail,
+                    task.status,
+                    task.assigned_peer,
+                    task.created_at_ms,
+                    task.updated_at_ms,
+                ],
+            )?
+        };
         Ok(inserted > 0)
     }
 
@@ -3594,21 +3681,23 @@ mod digest_integration_tests {
         );
     }
 
-    /// #2055 review round 4 — the migration swallows exactly the
-    /// duplicate-column error; every other failure propagates. Forced here
-    /// by presenting a connection whose `tasks` table does not exist.
+    /// #2055 review round 4/5 — a migration failure propagates; nothing is
+    /// swallowed by error-message matching (steps are decided by schema
+    /// inspection). Forced here by presenting a connection whose `tasks`
+    /// table does not exist.
     #[test]
     fn should_propagate_non_duplicate_migration_failures() {
-        let conn = rusqlite::Connection::open_in_memory().unwrap();
-        // No `tasks` table at all: the ALTER fails with "no such table",
-        // which is NOT the ignorable duplicate-column case.
-        let error = GoalLedger::migrate_tasks_authority_column(&conn)
-            .expect_err("a non-duplicate migration failure must propagate");
+        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        // No `tasks` table at all: the inspection reports the column absent
+        // and the in-transaction ALTER fails with "no such table".
+        let error = GoalLedger::migrate_tasks_authority_column(&mut conn)
+            .expect_err("a migration failure must propagate");
         assert!(
             error.to_string().contains("no such table"),
             "unexpected error: {error}"
         );
-        // And on an already-migrated table the helper is a clean no-op.
+        // And on an already-migrated table the helper is a clean no-op that
+        // takes no write transaction at all (fast path).
         conn.execute_batch(
             "CREATE TABLE tasks (
                  task_id TEXT PRIMARY KEY, goal_id TEXT NOT NULL,
@@ -3618,8 +3707,213 @@ mod digest_integration_tests {
                  authority INTEGER NOT NULL DEFAULT -1);",
         )
         .unwrap();
-        GoalLedger::migrate_tasks_authority_column(&conn)
+        GoalLedger::migrate_tasks_authority_column(&mut conn)
             .expect("an already-migrated table is a no-op");
+    }
+
+    /// The raw pre-#2055 schema (no `authority`, no `correctable`), used by
+    /// the atomicity fixtures below.
+    fn create_legacy_schema(conn: &rusqlite::Connection, extra: &str) {
+        conn.execute_batch(&format!(
+            "CREATE TABLE goals (
+                 goal_id TEXT PRIMARY KEY, objective TEXT NOT NULL,
+                 status TEXT NOT NULL, tokens_used INTEGER NOT NULL DEFAULT 0,
+                 token_budget INTEGER NOT NULL,
+                 continuations_used INTEGER NOT NULL DEFAULT 0,
+                 revision INTEGER NOT NULL DEFAULT 0,
+                 created_at_ms INTEGER NOT NULL, updated_at_ms INTEGER NOT NULL);
+             CREATE TABLE tasks (
+                 task_id TEXT PRIMARY KEY, goal_id TEXT NOT NULL,
+                 title TEXT NOT NULL, detail TEXT NOT NULL,
+                 status TEXT NOT NULL, assigned_peer TEXT,
+                 created_at_ms INTEGER NOT NULL, updated_at_ms INTEGER NOT NULL{extra},
+                 FOREIGN KEY (goal_id) REFERENCES goals(goal_id));
+             INSERT INTO goals VALUES ('g1', 'ship', 'active', 0, 1000, 0, 0, 1, 1);
+             INSERT INTO tasks (task_id, goal_id, title, detail, status, assigned_peer, created_at_ms, updated_at_ms)
+             VALUES ('legacy-failed', 'g1', '', '', 'failed', NULL, 1, 1);",
+        ))
+        .unwrap();
+    }
+
+    /// #2055 review round 5 (migration atomicity) — a failure AFTER the
+    /// ALTER-ADD rolls the WHOLE migration back: the pre-migration shape is
+    /// restored, so the next opener re-runs everything instead of seeing
+    /// the column present and skipping the terminal backfill forever. The
+    /// mid-migration failure is forced with an aborting trigger on the
+    /// backfill's UPDATE — a real table, a real partial-failure point.
+    #[test]
+    fn should_roll_back_whole_migration_when_a_step_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ledger.db");
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            create_legacy_schema(&conn, "");
+            conn.execute_batch(
+                "CREATE TRIGGER abort_backfill BEFORE UPDATE ON tasks
+                 BEGIN SELECT RAISE(ABORT, 'backfill aborted by test trigger'); END;",
+            )
+            .unwrap();
+        }
+
+        let error = GoalLedger::open_with_busy_retry(&path)
+            .err()
+            .expect("the aborted backfill must fail the open");
+        assert!(
+            error.to_string().contains("backfill aborted"),
+            "unexpected error: {error}"
+        );
+        // Partial state must NOT persist: the ALTER-ADD was rolled back
+        // together with the failed backfill.
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        let authority_present: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('tasks') WHERE name = 'authority'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            authority_present, 0,
+            "a failed migration must leave the pre-migration shape intact"
+        );
+
+        // With the trigger gone, the SAME database migrates cleanly and the
+        // legacy terminal row is FINAL — the backfill was not lost.
+        conn.execute_batch("DROP TRIGGER abort_backfill;").unwrap();
+        drop(conn);
+        let ledger = GoalLedger::open_with_busy_retry(&path).unwrap();
+        assert!(
+            !ledger
+                .update_task_status("legacy-failed", "complete", 2_000)
+                .unwrap(),
+            "the re-run migration stamps the legacy terminal row FINAL"
+        );
+    }
+
+    /// #2055 review round 5 — a second opener after a completed migration is
+    /// a clean no-op (the fast path sees the migrated shape and takes no
+    /// write transaction).
+    #[test]
+    fn should_treat_second_open_after_migration_as_clean_no_op() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ledger.db");
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            create_legacy_schema(&conn, "");
+        }
+        let first = GoalLedger::open_with_busy_retry(&path).expect("first open migrates");
+        drop(first);
+        let second = GoalLedger::open_with_busy_retry(&path).expect("second open is a no-op");
+        assert!(
+            !second
+                .update_task_status("legacy-failed", "complete", 2_000)
+                .unwrap(),
+            "the migrated FINAL stamp survives the second open"
+        );
+    }
+
+    /// #2055 review round 5 — a dependent index on the round-3 column makes
+    /// the DROP fail LOUDLY (the old substring match ate exactly this error),
+    /// and the failure rolls back the whole migration.
+    #[test]
+    fn should_propagate_drop_failure_when_an_index_depends_on_the_old_column() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ledger.db");
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            create_legacy_schema(&conn, ", correctable INTEGER NOT NULL DEFAULT 0");
+            conn.execute_batch("CREATE INDEX idx_tasks_correctable ON tasks(correctable);")
+                .unwrap();
+        }
+
+        let error = GoalLedger::open_with_busy_retry(&path)
+            .err()
+            .expect("a dependent index must fail the column drop loudly");
+        assert!(
+            error.to_string().contains("index"),
+            "unexpected error: {error}"
+        );
+        // The whole migration rolled back: `correctable` is still there and
+        // `authority` never landed.
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        let count_columns = |name: &str| -> i64 {
+            conn.query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('tasks') WHERE name = ?1",
+                params![name],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(count_columns("correctable"), 1);
+        assert_eq!(count_columns("authority"), 0);
+    }
+
+    /// #2055 review round 5 (terminal-creation authority) — a row CREATED
+    /// with a terminal status starts at the matching authority rank, so the
+    /// nonterminal-refresh guard cannot let a plain `running` write
+    /// overwrite it (the reproduced `failed/-1 → running/-1` hole).
+    #[test]
+    fn should_refuse_running_refresh_on_freshly_created_terminal_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
+        ledger
+            .create_goal(&Goal {
+                goal_id: "g1".to_string(),
+                objective: "ship".to_string(),
+                status: "active".to_string(),
+                tokens_used: 0,
+                token_budget: 10_000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1_000,
+                updated_at_ms: 1_000,
+            })
+            .unwrap();
+        let terminal_task = |id: &str, status: &str| Task {
+            task_id: id.to_string(),
+            goal_id: "g1".to_string(),
+            title: String::new(),
+            detail: String::new(),
+            status: status.to_string(),
+            assigned_peer: None,
+            created_at_ms: 1_000,
+            updated_at_ms: 1_000,
+        };
+        ledger
+            .create_task_if_absent(&terminal_task("t-failed", "failed"))
+            .unwrap();
+        ledger
+            .create_task(&terminal_task("t-complete", "complete"))
+            .unwrap();
+
+        for late in ["running", "pending"] {
+            assert!(
+                !ledger.update_task_status("t-failed", late, 2_000).unwrap(),
+                "a created terminal row refuses the nonterminal refresh {late:?}"
+            );
+        }
+        assert_eq!(
+            ledger.get_task("t-failed").unwrap().unwrap().status,
+            "failed"
+        );
+        // Rank consistency: a created `failed` is FINAL (refuses completion),
+        // a created `complete` sits at the completion rank (a final failure
+        // still outranks it, per the order-independence rule).
+        assert!(
+            !ledger
+                .update_task_status("t-failed", "complete", 2_000)
+                .unwrap()
+        );
+        assert!(
+            !ledger
+                .update_task_status("t-complete", "running", 2_000)
+                .unwrap()
+        );
+        assert!(
+            ledger
+                .settle_task_status("t-complete", TaskSettleAuthority::FinalFailure, 2_000)
+                .unwrap()
+        );
     }
 
     /// #2055 review round 4 — fresh-schema and migrated-schema databases

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -3352,7 +3352,7 @@ mod digest_integration_tests {
     // guard admits equal timestamps, so a delayed stale `active` snapshot
     // could overwrite a same-millisecond administrative transition
     // (`paused` / `blocked` / `cleared`) and regress counters. The
-    // registration recorder therefore only ever INSERTs the FK parent when
+    // registration recorder therefore only ever inserts the FK parent when
     // no row exists; the goal engine's own transition sync remains the only
     // goals-row updater.
     // ---------------------------------------------------------------------

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -233,7 +233,7 @@ impl GoalLedger {
                 .and_then(|ledger| {
                     {
                         let mut conn = ledger.conn.lock().unwrap();
-                        Self::migrate_tasks_authority_column(&mut conn)?;
+                        Self::migrate_tasks_authority_column(&mut conn, path)?;
                     }
                     Ok(ledger)
                 });
@@ -382,6 +382,23 @@ impl GoalLedger {
         Ok(())
     }
 
+    /// #2055 review round 7 (W3 test hook) — a test-only hook invoked INSIDE
+    /// the migration transaction, between the schema statements and the
+    /// commit, keyed by ledger path so parallel tests' migrations pass
+    /// through untouched. `None` in production builds by construction
+    /// (`cfg(test)` — zero cost). The callback is cloned out of the slot
+    /// before invocation so a blocking hook cannot stall other migrations
+    /// on the slot lock.
+    #[cfg(test)]
+    #[allow(clippy::type_complexity)]
+    fn migration_mid_transaction_hook()
+    -> &'static Mutex<Option<(std::path::PathBuf, Arc<dyn Fn() + Send + Sync>)>> {
+        static HOOK: std::sync::OnceLock<
+            Mutex<Option<(std::path::PathBuf, Arc<dyn Fn() + Send + Sync>)>>,
+        > = std::sync::OnceLock::new();
+        HOOK.get_or_init(|| Mutex::new(None))
+    }
+
     /// Whether the `tasks` table currently carries `column` — schema
     /// inspection via `pragma_table_info`, which never references the column
     /// itself and returns an empty set for a missing table, so it is safe on
@@ -424,7 +441,9 @@ impl GoalLedger {
     /// fully-migrated database; the checks are REPEATED inside the
     /// transaction because two blocking-context openers can race the fast
     /// path, and only the in-transaction view is serialized.
-    fn migrate_tasks_authority_column(conn: &mut Connection) -> Result<()> {
+    fn migrate_tasks_authority_column(conn: &mut Connection, path: &Path) -> Result<()> {
+        #[cfg(not(test))]
+        let _ = path;
         if Self::tasks_has_column(conn, "authority")?
             && !Self::tasks_has_column(conn, "correctable")?
         {
@@ -443,6 +462,21 @@ impl GoalLedger {
         }
         if Self::tasks_has_column(&tx, "correctable")? {
             tx.execute("ALTER TABLE tasks DROP COLUMN correctable", [])?;
+        }
+        // W3 test hook: lets a test hold THIS transaction provably open
+        // while it fires concurrent creation attempts. Path-keyed; absent
+        // in production builds.
+        #[cfg(test)]
+        {
+            let hook = Self::migration_mid_transaction_hook()
+                .lock()
+                .unwrap()
+                .as_ref()
+                .filter(|(hook_path, _)| hook_path == path)
+                .map(|(_, callback)| Arc::clone(callback));
+            if let Some(callback) = hook {
+                callback();
+            }
         }
         tx.commit()?;
         Ok(())
@@ -3712,8 +3746,9 @@ mod digest_integration_tests {
         let mut conn = rusqlite::Connection::open_in_memory().unwrap();
         // No `tasks` table at all: the inspection reports the column absent
         // and the in-transaction ALTER fails with "no such table".
-        let error = GoalLedger::migrate_tasks_authority_column(&mut conn)
-            .expect_err("a migration failure must propagate");
+        let error =
+            GoalLedger::migrate_tasks_authority_column(&mut conn, Path::new("unused-in-memory"))
+                .expect_err("a migration failure must propagate");
         assert!(
             error.to_string().contains("no such table"),
             "unexpected error: {error}"
@@ -3729,7 +3764,7 @@ mod digest_integration_tests {
                  authority INTEGER NOT NULL DEFAULT -1);",
         )
         .unwrap();
-        GoalLedger::migrate_tasks_authority_column(&mut conn)
+        GoalLedger::migrate_tasks_authority_column(&mut conn, Path::new("unused-in-memory"))
             .expect("an already-migrated table is a no-op");
     }
 
@@ -3870,80 +3905,121 @@ mod digest_integration_tests {
         assert_eq!(count_columns("authority"), 0);
     }
 
-    /// #2055 review round 6 (V3) — creation-vs-migration concurrency pin.
-    /// The STRUCTURAL argument is what closes the race: the creation APIs
-    /// run inspection + insert inside `BEGIN IMMEDIATE`, which serializes
-    /// against the migration's own `BEGIN IMMEDIATE` transaction, so a
-    /// creation either fully precedes the migration (legacy shape, then the
-    /// backfill stamps the row FINAL) or fully follows it (derived-authority
-    /// shape) — the poisoned interleaving (inspect legacy → migration
-    /// commits → legacy insert on the migrated table → terminal row at
-    /// authority `-1` after the backfill already ran) cannot be scheduled.
-    /// This test is a TRIPWIRE, not the proof: a creation hammer races the
-    /// migration mid-hammer (barrier-started so they verifiably overlap)
-    /// and no terminal row may ever end at authority `-1`.
+    /// #2055 review round 6/7 (V3/W3) — creation-vs-migration concurrency
+    /// pin, DETERMINISTIC: the STRUCTURAL argument is what closes the race
+    /// (the creation APIs run inspection + insert inside `BEGIN IMMEDIATE`,
+    /// which serializes against the migration's own `BEGIN IMMEDIATE`
+    /// transaction, so a creation either fully precedes the migration —
+    /// legacy shape, then the backfill stamps the row FINAL — or fully
+    /// follows it, taking the derived-authority shape; the poisoned
+    /// interleaving cannot be scheduled). This test PROVES the mid-
+    /// transaction interleaving actually happened rather than hoping for
+    /// it: a test-only hook holds the migration transaction verifiably open
+    /// while the creation fires, the creation must complete only AFTER the
+    /// hook releases (blocked for the full hold, i.e. it observed the busy
+    /// wait), and the created terminal row must carry its real rank.
     #[test]
     fn should_never_leave_terminal_rows_unranked_when_creation_races_migration() {
-        for iteration in 0..20 {
-            let dir = tempfile::tempdir().unwrap();
-            let path = dir.path().join("ledger.db");
-            {
-                let conn = rusqlite::Connection::open(&path).unwrap();
-                conn.pragma_update(None, "journal_mode", "WAL").unwrap();
-                create_legacy_schema(&conn, "");
-            }
-
-            let (warmed_tx, warmed_rx) = std::sync::mpsc::channel::<()>();
-            let hammer_path = path.clone();
-            let hammer = std::thread::spawn(move || {
-                let ledger = GoalLedger::open(&hammer_path).unwrap();
-                for i in 0..300 {
-                    if i == 50 {
-                        let _ = warmed_tx.send(());
-                    }
-                    let task = Task {
-                        task_id: format!("race-{i}"),
-                        goal_id: "g1".to_string(),
-                        title: String::new(),
-                        detail: String::new(),
-                        status: "failed".to_string(),
-                        assigned_peer: None,
-                        created_at_ms: 1_000,
-                        updated_at_ms: 1_000,
-                    };
-                    // Busy collisions with the migration transaction are
-                    // expected; retry until this create lands.
-                    let mut attempts = 0;
-                    while ledger.create_task(&task).is_err() {
-                        attempts += 1;
-                        assert!(attempts < 200, "create retry budget exceeded");
-                        std::thread::sleep(std::time::Duration::from_millis(5));
-                    }
-                }
-            });
-            // Start the migration only once the hammer is verifiably
-            // mid-flight, so the two genuinely overlap every iteration.
-            warmed_rx.recv().expect("hammer warmup");
-            let migrated =
-                GoalLedger::open_with_busy_retry(&path).expect("migration open succeeds");
-            hammer.join().expect("hammer thread");
-
-            let unranked: i64 = migrated
-                .conn
-                .lock()
-                .unwrap()
-                .query_row(
-                    "SELECT COUNT(*) FROM tasks
-                     WHERE status IN ('complete', 'failed') AND authority = -1",
-                    [],
-                    |row| row.get(0),
-                )
-                .unwrap();
-            assert_eq!(
-                unranked, 0,
-                "iteration {iteration}: no terminal row may ever end at authority -1"
-            );
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ledger.db");
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.pragma_update(None, "journal_mode", "WAL").unwrap();
+            create_legacy_schema(&conn, "");
         }
+        // The creator's connection is opened BEFORE the migration starts so
+        // the only step that can block below is its creation transaction.
+        let creator_ledger = GoalLedger::open(&path).unwrap();
+
+        // Install the in-transaction hook: signals the test, then blocks
+        // this migration open until released.
+        let (in_transaction_tx, in_transaction_rx) = std::sync::mpsc::channel::<()>();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let release_rx = Mutex::new(release_rx);
+        *GoalLedger::migration_mid_transaction_hook().lock().unwrap() = Some((
+            path.clone(),
+            Arc::new(move || {
+                let _ = in_transaction_tx.send(());
+                let _ = release_rx
+                    .lock()
+                    .unwrap()
+                    .recv_timeout(std::time::Duration::from_secs(30));
+            }),
+        ));
+
+        let migration_path = path.clone();
+        let migration =
+            std::thread::spawn(move || GoalLedger::open_with_busy_retry(migration_path));
+        in_transaction_rx
+            .recv_timeout(std::time::Duration::from_secs(30))
+            .expect("the migration transaction is provably open");
+
+        // Fire the creation WHILE the migration transaction is open.
+        let creator = std::thread::spawn(move || {
+            let begun = std::time::Instant::now();
+            creator_ledger
+                .create_task(&Task {
+                    task_id: "race-task".to_string(),
+                    goal_id: "g1".to_string(),
+                    title: String::new(),
+                    detail: String::new(),
+                    status: "failed".to_string(),
+                    assigned_peer: None,
+                    created_at_ms: 1_000,
+                    updated_at_ms: 1_000,
+                })
+                .expect("creation succeeds after the migration commits");
+            (begun, std::time::Instant::now())
+        });
+        // Hold the open transaction across the creation attempt, then
+        // release and let everything settle.
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        let released_at = std::time::Instant::now();
+        release_tx.send(()).expect("release the migration hook");
+        let migrated = migration
+            .join()
+            .expect("migration thread")
+            .expect("migration open succeeds");
+        let (create_begun, create_done) = creator.join().expect("creator thread");
+        *GoalLedger::migration_mid_transaction_hook().lock().unwrap() = None;
+
+        // The interleaving is PROVEN, not hoped: the creation observed the
+        // busy wait (blocked for essentially the whole hold) and completed
+        // only after the release.
+        assert!(
+            create_done >= released_at,
+            "the creation must complete only after the migration transaction released"
+        );
+        assert!(
+            create_done.duration_since(create_begun) >= std::time::Duration::from_millis(250),
+            "the creation must have been blocked by the open migration transaction \
+             (took {:?})",
+            create_done.duration_since(create_begun)
+        );
+        // And the outcome invariant: no terminal row at authority -1 — the
+        // legacy row was backfilled FINAL and the racing creation took the
+        // derived-authority shape.
+        let conn = migrated.conn.lock().unwrap();
+        let unranked: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM tasks
+                 WHERE status IN ('complete', 'failed') AND authority = -1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(unranked, 0, "no terminal row may ever end at authority -1");
+        let raced_authority: i64 = conn
+            .query_row(
+                "SELECT authority FROM tasks WHERE task_id = 'race-task'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            raced_authority, 2,
+            "the racing terminal creation lands post-migration with its real rank"
+        );
     }
 
     /// #2055 review round 5 (terminal-creation authority) — a row CREATED

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -3954,9 +3954,14 @@ mod digest_integration_tests {
             .recv_timeout(std::time::Duration::from_secs(30))
             .expect("the migration transaction is provably open");
 
-        // Fire the creation WHILE the migration transaction is open.
+        // Fire the creation WHILE the migration transaction is open. The
+        // creator signals immediately before calling `create_task` (round 8
+        // start-barrier), so the release below happens provably AFTER the
+        // creation began.
+        let (creation_begun_tx, creation_begun_rx) = std::sync::mpsc::channel::<()>();
         let creator = std::thread::spawn(move || {
             let begun = std::time::Instant::now();
+            let _ = creation_begun_tx.send(());
             creator_ledger
                 .create_task(&Task {
                     task_id: "race-task".to_string(),
@@ -3971,6 +3976,9 @@ mod digest_integration_tests {
                 .expect("creation succeeds after the migration commits");
             (begun, std::time::Instant::now())
         });
+        creation_begun_rx
+            .recv_timeout(std::time::Duration::from_secs(30))
+            .expect("the creation attempt has begun");
         // Hold the open transaction across the creation attempt, then
         // release and let everything settle.
         std::thread::sleep(std::time::Duration::from_millis(300));
@@ -3983,9 +3991,14 @@ mod digest_integration_tests {
         let (create_begun, create_done) = creator.join().expect("creator thread");
         *GoalLedger::migration_mid_transaction_hook().lock().unwrap() = None;
 
-        // The interleaving is PROVEN, not hoped: the creation observed the
-        // busy wait (blocked for essentially the whole hold) and completed
-        // only after the release.
+        // The interleaving is PROVEN, not hoped: the creation BEGAN before
+        // the release (a slow sequential post-release creation cannot
+        // masquerade), observed the busy wait (blocked for essentially the
+        // whole hold), and completed only after the release.
+        assert!(
+            create_begun < released_at,
+            "the creation must have begun while the migration transaction was still open"
+        );
         assert!(
             create_done >= released_at,
             "the creation must complete only after the migration transaction released"

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -392,6 +392,39 @@ impl GoalLedger {
         Ok(admitted > 0)
     }
 
+    /// #2055 review round 2 — create a goals row only when none exists yet
+    /// (`INSERT … ON CONFLICT(goal_id) DO NOTHING`), the goals-side twin of
+    /// [`Self::create_task_if_absent`].
+    ///
+    /// For FK-parent seeding by the task-row registration recorder, which
+    /// must NEVER update a goals row: [`Self::upsert_goal`]'s monotonic
+    /// guard admits equal `updated_at_ms` (millisecond resolution), so a
+    /// delayed stale `active` snapshot could overwrite a same-millisecond
+    /// `paused`/`blocked`/`budget_limited`/`cleared` row and regress its
+    /// counters. This can't: an existing row — whatever its state — is
+    /// preserved byte-for-byte. Returns `Ok(true)` when a row was inserted,
+    /// `Ok(false)` for the preserve-existing no-op.
+    pub fn create_goal_if_absent(&self, goal: &Goal) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let inserted = conn.execute(
+            "INSERT INTO goals (goal_id, objective, status, tokens_used, token_budget, continuations_used, revision, created_at_ms, updated_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+             ON CONFLICT(goal_id) DO NOTHING",
+            params![
+                goal.goal_id,
+                goal.objective,
+                goal.status,
+                goal.tokens_used,
+                goal.token_budget,
+                goal.continuations_used,
+                goal.revision,
+                goal.created_at_ms,
+                goal.updated_at_ms,
+            ],
+        )?;
+        Ok(inserted > 0)
+    }
+
     /// #1973 fix-round 3/4 — targeted STATUS compare-and-swap for an
     /// administrative transition (park/clear) whose guarded [`Self::upsert_goal`]
     /// was rejected by the monotonic-token clause. Flips ONLY the status (+
@@ -577,14 +610,23 @@ impl GoalLedger {
     /// - `running` → terminal  → 1 row  → `true`
     /// - terminal → same       → guard excludes → `false` (redelivery)
     /// - terminal → `running`  → guard excludes → `false` (late refresh)
-    /// - terminal → other terminal → guard excludes → `false`
+    /// - `failed` → `complete` → 1 row  → `true` (owner correction — below)
+    /// - any other terminal → terminal → guard excludes → `false`
     ///
-    /// `updated_at_ms` therefore records the FIRST terminal, never a duplicate
-    /// or a straggler, and cannot regress.
+    /// #2055 review round 2 — `failed → complete` is the ONE admitted
+    /// terminal→terminal transition, mirroring the supervisor's own
+    /// authority model: `TaskSupervisor::mark_completed` overrides an
+    /// OBSERVER-derived provisional failure when the owner watched the
+    /// worker actually finish (task_supervisor.rs:2527's correction
+    /// semantics), and the ledger must be able to receive that correction.
+    /// `complete` remains immutable; `failed` refuses every non-`complete`
+    /// write; `updated_at_ms` records the LATEST admitted write and cannot
+    /// regress to a straggler.
     ///
-    /// Fidelity note: `TerminalOutcome` collapses `Cancelled` into `Failed`
-    /// upstream, so a cancelled task lands here as `"failed"` and the two are
-    /// indistinguishable in the ledger.
+    /// Fidelity note: cancellation is collapsed into failure upstream
+    /// (`TerminalOutcome` has no `Cancelled`; the change-feed settle maps
+    /// `TaskStatus::Cancelled` to `"failed"` too), so a cancelled task lands
+    /// here as `"failed"` and the two are indistinguishable in the ledger.
     pub fn update_task_status(
         &self,
         task_id: &str,
@@ -594,7 +636,9 @@ impl GoalLedger {
         let conn = self.conn.lock().unwrap();
         let changed = conn.execute(
             "UPDATE tasks SET status = ?1, updated_at_ms = ?2
-             WHERE task_id = ?3 AND status NOT IN ('complete', 'failed')",
+             WHERE task_id = ?3
+               AND (status NOT IN ('complete', 'failed')
+                    OR (status = 'failed' AND ?1 = 'complete'))",
             params![new_status, updated_at_ms, task_id],
         )?;
         Ok(changed > 0)
@@ -3091,13 +3135,47 @@ mod digest_integration_tests {
                 "a terminal task refuses the late non-terminal write {late:?}"
             );
         }
-        // `complete` after `failed` is equally a regression: the first
-        // terminal wins, so a disagreeing second terminal cannot flip it.
-        assert!(!ledger.update_task_status("t1", "complete", 4_000).unwrap());
+        // #2055 review round 2 — `complete` after `failed` is now the ONE
+        // admitted terminal→terminal transition (this test originally
+        // asserted it refused): the supervisor's own authority model allows
+        // exactly it — `TaskSupervisor::mark_completed` overrides an
+        // OBSERVER-derived provisional failure when the owner watched the
+        // worker actually finish (task_supervisor.rs:2527's correction
+        // semantics), and the ledger must be able to receive that
+        // correction. `complete` remains immutable, and `failed` still
+        // refuses every non-`complete` write (asserted above).
+        assert!(ledger.update_task_status("t1", "complete", 4_000).unwrap());
 
         let task = ledger.get_task("t1").unwrap().unwrap();
-        assert_eq!(task.status, "failed");
-        assert_eq!(task.updated_at_ms, 2_000);
+        assert_eq!(task.status, "complete");
+        assert_eq!(task.updated_at_ms, 4_000);
+    }
+
+    /// #2055 review round 2 — the correction transition in full: a
+    /// provisional observer failure lands `failed`, the owner's completion
+    /// corrects it to `complete`, and from there the row is immutable
+    /// (a straggler `failed` redelivery cannot undo the correction).
+    #[test]
+    fn should_allow_exactly_failed_to_complete_and_keep_complete_immutable() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
+        seed_goal_with_task(&ledger, "g1", "t1", "running");
+
+        ledger.update_task_status("t1", "failed", 2_000).unwrap();
+        assert!(
+            ledger.update_task_status("t1", "complete", 3_000).unwrap(),
+            "failed → complete is the owner-correction transition"
+        );
+        for late in ["failed", "running", "pending"] {
+            assert!(
+                !ledger.update_task_status("t1", late, 4_000).unwrap(),
+                "complete refuses every subsequent write ({late:?})"
+            );
+        }
+
+        let task = ledger.get_task("t1").unwrap().unwrap();
+        assert_eq!(task.status, "complete");
+        assert_eq!(task.updated_at_ms, 3_000);
     }
 
     /// The goal-facing point of the whole exercise: `task_status_counts` is
@@ -3265,5 +3343,87 @@ mod digest_integration_tests {
         let task = ledger.get_task("t1").unwrap().unwrap();
         assert_eq!(task.status, "complete", "terminal status survives");
         assert_eq!(task.updated_at_ms, 2_000);
+    }
+
+    // ---------------------------------------------------------------------
+    // #2055 review round 2 — FK-parent goals row via if-absent insert.
+    //
+    // Registration must NEVER update a goals row: `upsert_goal`'s monotonic
+    // guard admits equal timestamps, so a delayed stale `active` snapshot
+    // could overwrite a same-millisecond administrative transition
+    // (`paused` / `blocked` / `cleared`) and regress counters. The
+    // registration recorder therefore only ever INSERTs the FK parent when
+    // no row exists; the goal engine's own transition sync remains the only
+    // goals-row updater.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn should_insert_goal_row_when_goal_is_new() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
+        assert!(
+            ledger
+                .create_goal_if_absent(&Goal {
+                    goal_id: "g1".to_string(),
+                    objective: "ship".to_string(),
+                    status: "active".to_string(),
+                    tokens_used: 5,
+                    token_budget: 10_000,
+                    continuations_used: 1,
+                    revision: 0,
+                    created_at_ms: 1_000,
+                    updated_at_ms: 1_000,
+                })
+                .unwrap(),
+            "a fresh goal id inserts a row"
+        );
+        let goal = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!(goal.status, "active");
+        assert_eq!(goal.objective, "ship");
+    }
+
+    #[test]
+    fn should_preserve_existing_goal_row_even_with_equal_timestamps() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
+        // The row a same-millisecond administrative transition just wrote.
+        ledger
+            .create_goal(&Goal {
+                goal_id: "g1".to_string(),
+                objective: "ship".to_string(),
+                status: "paused".to_string(),
+                tokens_used: 500,
+                token_budget: 10_000,
+                continuations_used: 3,
+                revision: 7,
+                created_at_ms: 1_000,
+                updated_at_ms: 2_000,
+            })
+            .unwrap();
+
+        // The delayed stale registration snapshot: same updated_at_ms,
+        // higher tokens — exactly the shape `upsert_goal`'s guard admits.
+        assert!(
+            !ledger
+                .create_goal_if_absent(&Goal {
+                    goal_id: "g1".to_string(),
+                    objective: "ship".to_string(),
+                    status: "active".to_string(),
+                    tokens_used: 600,
+                    token_budget: 10_000,
+                    continuations_used: 4,
+                    revision: 0,
+                    created_at_ms: 1_000,
+                    updated_at_ms: 2_000,
+                })
+                .unwrap(),
+            "an existing goal row reports no-op"
+        );
+
+        let goal = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!(goal.status, "paused", "the administrative status survives");
+        assert_eq!(goal.tokens_used, 500, "counters are untouched");
+        assert_eq!(goal.continuations_used, 3);
+        assert_eq!(goal.revision, 7);
     }
 }

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -680,10 +680,25 @@ impl GoalLedger {
     /// not-yet-migrated legacy database (reachable through the plain
     /// [`Self::open`], which deliberately runs no migration) the statement
     /// falls back to the legacy shape and never references the column.
+    ///
+    /// Round 6 (V3): the schema inspection and the insert run inside ONE
+    /// `BEGIN IMMEDIATE` transaction. As two autocommit statements they were
+    /// a TOCTOU: a concurrent connection could commit the migration between
+    /// the check and the insert, and the busy handler makes that the COMMON
+    /// interleaving, not a rare one — the legacy-shape insert blocks on the
+    /// migration's write lock and then executes on the migrated table,
+    /// landing a terminal row at authority `-1` AFTER the backfill already
+    /// ran (permanently wrong-ranked). `BEGIN IMMEDIATE` serializes against
+    /// the migration's own `BEGIN IMMEDIATE` transaction, so the pair
+    /// either runs fully before the migration (and the backfill stamps the
+    /// row) or fully after it (and the derived-authority shape is chosen) —
+    /// the interleaving is impossible, not merely unlikely. Structural
+    /// argument only; the concurrency test is a tripwire.
     pub fn create_task(&self, task: &Task) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
-        if Self::tasks_has_column(&conn, "authority")? {
-            conn.execute(
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        if Self::tasks_has_column(&tx, "authority")? {
+            tx.execute(
                 "INSERT INTO tasks (task_id, goal_id, title, detail, status, assigned_peer, created_at_ms, updated_at_ms, authority)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
                 params![
@@ -699,7 +714,7 @@ impl GoalLedger {
                 ],
             )?;
         } else {
-            conn.execute(
+            tx.execute(
                 "INSERT INTO tasks (task_id, goal_id, title, detail, status, assigned_peer, created_at_ms, updated_at_ms)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
                 params![
@@ -714,6 +729,7 @@ impl GoalLedger {
                 ],
             )?;
         }
+        tx.commit()?;
         Ok(())
     }
 
@@ -732,10 +748,15 @@ impl GoalLedger {
     /// Round 5: the initial `authority` is derived from `task.status` (see
     /// [`Self::creation_authority_for_status`]) when the column exists; the
     /// legacy fallback mirrors [`Self::create_task`].
+    ///
+    /// Round 6 (V3): inspection + insert in ONE `BEGIN IMMEDIATE`
+    /// transaction — see [`Self::create_task`] for the TOCTOU this closes
+    /// and the serialization argument.
     pub fn create_task_if_absent(&self, task: &Task) -> Result<bool> {
-        let conn = self.conn.lock().unwrap();
-        let inserted = if Self::tasks_has_column(&conn, "authority")? {
-            conn.execute(
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        let inserted = if Self::tasks_has_column(&tx, "authority")? {
+            tx.execute(
                 "INSERT INTO tasks (task_id, goal_id, title, detail, status, assigned_peer, created_at_ms, updated_at_ms, authority)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
                  ON CONFLICT(task_id) DO NOTHING",
@@ -752,7 +773,7 @@ impl GoalLedger {
                 ],
             )?
         } else {
-            conn.execute(
+            tx.execute(
                 "INSERT INTO tasks (task_id, goal_id, title, detail, status, assigned_peer, created_at_ms, updated_at_ms)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
                  ON CONFLICT(task_id) DO NOTHING",
@@ -768,6 +789,7 @@ impl GoalLedger {
                 ],
             )?
         };
+        tx.commit()?;
         Ok(inserted > 0)
     }
 
@@ -3846,6 +3868,82 @@ mod digest_integration_tests {
         };
         assert_eq!(count_columns("correctable"), 1);
         assert_eq!(count_columns("authority"), 0);
+    }
+
+    /// #2055 review round 6 (V3) — creation-vs-migration concurrency pin.
+    /// The STRUCTURAL argument is what closes the race: the creation APIs
+    /// run inspection + insert inside `BEGIN IMMEDIATE`, which serializes
+    /// against the migration's own `BEGIN IMMEDIATE` transaction, so a
+    /// creation either fully precedes the migration (legacy shape, then the
+    /// backfill stamps the row FINAL) or fully follows it (derived-authority
+    /// shape) — the poisoned interleaving (inspect legacy → migration
+    /// commits → legacy insert on the migrated table → terminal row at
+    /// authority `-1` after the backfill already ran) cannot be scheduled.
+    /// This test is a TRIPWIRE, not the proof: a creation hammer races the
+    /// migration mid-hammer (barrier-started so they verifiably overlap)
+    /// and no terminal row may ever end at authority `-1`.
+    #[test]
+    fn should_never_leave_terminal_rows_unranked_when_creation_races_migration() {
+        for iteration in 0..20 {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("ledger.db");
+            {
+                let conn = rusqlite::Connection::open(&path).unwrap();
+                conn.pragma_update(None, "journal_mode", "WAL").unwrap();
+                create_legacy_schema(&conn, "");
+            }
+
+            let (warmed_tx, warmed_rx) = std::sync::mpsc::channel::<()>();
+            let hammer_path = path.clone();
+            let hammer = std::thread::spawn(move || {
+                let ledger = GoalLedger::open(&hammer_path).unwrap();
+                for i in 0..300 {
+                    if i == 50 {
+                        let _ = warmed_tx.send(());
+                    }
+                    let task = Task {
+                        task_id: format!("race-{i}"),
+                        goal_id: "g1".to_string(),
+                        title: String::new(),
+                        detail: String::new(),
+                        status: "failed".to_string(),
+                        assigned_peer: None,
+                        created_at_ms: 1_000,
+                        updated_at_ms: 1_000,
+                    };
+                    // Busy collisions with the migration transaction are
+                    // expected; retry until this create lands.
+                    let mut attempts = 0;
+                    while ledger.create_task(&task).is_err() {
+                        attempts += 1;
+                        assert!(attempts < 200, "create retry budget exceeded");
+                        std::thread::sleep(std::time::Duration::from_millis(5));
+                    }
+                }
+            });
+            // Start the migration only once the hammer is verifiably
+            // mid-flight, so the two genuinely overlap every iteration.
+            warmed_rx.recv().expect("hammer warmup");
+            let migrated =
+                GoalLedger::open_with_busy_retry(&path).expect("migration open succeeds");
+            hammer.join().expect("hammer thread");
+
+            let unranked: i64 = migrated
+                .conn
+                .lock()
+                .unwrap()
+                .query_row(
+                    "SELECT COUNT(*) FROM tasks
+                     WHERE status IN ('complete', 'failed') AND authority = -1",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(
+                unranked, 0,
+                "iteration {iteration}: no terminal row may ever end at authority -1"
+            );
+        }
     }
 
     /// #2055 review round 5 (terminal-creation authority) — a row CREATED

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -44,6 +44,56 @@ pub struct Task {
     pub updated_at_ms: u64,
 }
 
+/// #2055 review round 4 — the terminal authority of a task-settle write.
+/// Ranked to make the settled outcome ORDER-INDEPENDENT across scrambled
+/// write delivery (offloaded/retried writes give no ordering guarantee):
+/// a write lands iff its rank is strictly greater than the row's stored
+/// rank, first-wins within equal rank. The ledger status is DERIVED from
+/// the authority, so an illegal status/authority pairing is
+/// unrepresentable.
+///
+/// The ranking mirrors the authority model `TaskSupervisor` enforces
+/// internally (task_supervisor.rs:2575): an observer-provisional failure is
+/// the weakest verdict (the owner's completion corrects it), and a final
+/// failure — owner-reported failure or cancellation — refuses a later
+/// completion. Rank 2 beating rank 1 additionally makes the D-present
+/// orderings converge on `failed` even when the completion write was
+/// DELIVERED first; within one supervisor a final failure after a
+/// completion cannot be emitted at all (the supervisor's terminal guard
+/// refuses it), and whether a STALE supervisor copy's cancel should outrank
+/// the true owner's completion is cross-supervisor truth — #2060's problem,
+/// not this rule's.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskSettleAuthority {
+    /// An OBSERVER classified a mid-run signal as fatal without watching
+    /// the worker stop; the owner may still correct it. Lands `failed`.
+    ProvisionalFailure,
+    /// The owner watched its worker actually finish. Lands `complete`.
+    Completion,
+    /// Owner-reported failure or cancellation. Lands `failed`.
+    FinalFailure,
+}
+
+impl TaskSettleAuthority {
+    /// The persisted rank (`tasks.authority`); `-1` in the column means no
+    /// terminal verdict has been recorded yet.
+    pub fn rank(self) -> i64 {
+        match self {
+            TaskSettleAuthority::ProvisionalFailure => 0,
+            TaskSettleAuthority::Completion => 1,
+            TaskSettleAuthority::FinalFailure => 2,
+        }
+    }
+
+    /// The ledger status this authority writes.
+    pub fn ledger_status(self) -> &'static str {
+        match self {
+            TaskSettleAuthority::ProvisionalFailure | TaskSettleAuthority::FinalFailure => "failed",
+            TaskSettleAuthority::Completion => "complete",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Finding {
     /// Monotonic row ID (SQLite rowid, assigned on insert, never changes).
@@ -174,7 +224,20 @@ impl GoalLedger {
             if attempt > 0 {
                 std::thread::sleep(std::time::Duration::from_millis(50));
             }
-            match Self::open_inner(path, Some(std::time::Duration::from_secs(1))) {
+            // #2055 review round 4 — the `authority` schema migration runs
+            // HERE, inside the attempt (never in the common `open`, which
+            // executes on tokio workers): this profile is only ever called
+            // from blocking contexts, and a migration ALTER that loses a
+            // lock race is retried exactly like a contended open.
+            let attempt_result = Self::open_inner(path, Some(std::time::Duration::from_secs(1)))
+                .and_then(|ledger| {
+                    {
+                        let conn = ledger.conn.lock().unwrap();
+                        Self::migrate_tasks_authority_column(&conn)?;
+                    }
+                    Ok(ledger)
+                });
+            match attempt_result {
                 Ok(ledger) => return Ok(ledger),
                 Err(err) if error_is_lock_contention(&err) && attempt + 1 < ATTEMPTS => {
                     last_err = Some(err);
@@ -235,12 +298,13 @@ impl GoalLedger {
                 assigned_peer TEXT,
                 created_at_ms INTEGER NOT NULL,
                 updated_at_ms INTEGER NOT NULL,
-                -- #2055 review round 3: provenance mark for the ONE admitted
-                -- terminal-to-terminal transition. 1 = this `failed` row is an
-                -- OBSERVER-provisional verdict the owner may still correct to
-                -- `complete` (task_supervisor.rs:2527); 0 = final (owner
-                -- failure, cancellation, or any non-failed status).
-                correctable INTEGER NOT NULL DEFAULT 0,
+                -- #2055 review round 4: persisted TERMINAL AUTHORITY rank.
+                -- -1 = no terminal verdict recorded; 0 = observer-provisional
+                -- failure; 1 = completion; 2 = final failure (owner failure /
+                -- cancellation). A settle write lands iff its rank is
+                -- STRICTLY greater than the stored rank, making the outcome
+                -- order-independent across scrambled write delivery.
+                authority INTEGER NOT NULL DEFAULT -1,
                 FOREIGN KEY (goal_id) REFERENCES goals(goal_id)
             );
 
@@ -307,16 +371,56 @@ impl GoalLedger {
             CREATE INDEX IF NOT EXISTS idx_decisions_goal ON decisions(goal_id, decided_at_ms);
             ",
         )?;
-        // #2055 review round 3 — best-effort migration for a tasks table
-        // created before `correctable` existed (`CREATE TABLE IF NOT EXISTS`
-        // never alters an existing table). The duplicate-column error on an
-        // already-migrated database is expected and swallowed; any other
-        // failure is also non-fatal here because the first statement that
-        // actually touches the column surfaces it loudly.
-        let _ = conn.execute(
-            "ALTER TABLE tasks ADD COLUMN correctable INTEGER NOT NULL DEFAULT 0",
+        // #2055 review round 4: NO column migration here. `create_tables`
+        // runs inside the COMMON `open`, which executes on tokio workers
+        // (`goal_get` and every inline reader), and migration DDL is exactly
+        // the synchronous work this PR keeps off the executor. The
+        // `authority` migration lives in [`Self::open_with_busy_retry`],
+        // which is only ever called from blocking contexts — and every code
+        // path that references the column opens through it. Plain-`open`
+        // readers reference only pre-migration columns by name.
+        Ok(())
+    }
+
+    /// #2055 review round 4 — bring an existing `tasks` table onto the
+    /// `authority` schema. Three steps, each with an explicit error policy
+    /// (SQLite reports both expected failures as generic `SQLITE_ERROR`, so
+    /// the message text is the only discriminator — documented rusqlite
+    /// behavior for DDL):
+    ///
+    /// 1. Add the column (fresh default `-1`, identical to the
+    ///    `CREATE TABLE` shape). A duplicate-column error means the table is
+    ///    already migrated — swallowed; every OTHER error propagates.
+    /// 2. Only when step 1 actually added the column: stamp every
+    ///    pre-existing terminal row as FINAL (`authority = 2`) — a legacy
+    ///    `failed` row must NOT become correctable, and a legacy `complete`
+    ///    row is equally settled history. Rows the round-4 code writes carry
+    ///    their real rank from the start, and this backfill can never touch
+    ///    them because it runs only in the same breath as the column
+    ///    creation.
+    /// 3. Drop the short-lived round-3 `correctable` column if present
+    ///    (this branch never shipped; the column exists only on databases
+    ///    created from it). A missing column is swallowed; other errors
+    ///    propagate.
+    fn migrate_tasks_authority_column(conn: &Connection) -> Result<()> {
+        match conn.execute(
+            "ALTER TABLE tasks ADD COLUMN authority INTEGER NOT NULL DEFAULT -1",
             [],
-        );
+        ) {
+            Ok(_) => {
+                conn.execute(
+                    "UPDATE tasks SET authority = 2 WHERE status IN ('complete', 'failed')",
+                    [],
+                )?;
+            }
+            Err(error) if error.to_string().contains("duplicate column name") => {}
+            Err(error) => return Err(error.into()),
+        }
+        match conn.execute("ALTER TABLE tasks DROP COLUMN correctable", []) {
+            Ok(_) => {}
+            Err(error) if error.to_string().contains("no such column") => {}
+            Err(error) => return Err(error.into()),
+        }
         Ok(())
     }
 
@@ -622,71 +726,82 @@ impl GoalLedger {
     /// fire-and-forget. Encoding the rule in the `WHERE` clause makes
     /// redelivery and out-of-order delivery both harmless in one statement:
     ///
-    /// - absent row            → 0 rows → `false`
-    /// - `running` → terminal  → 1 row  → `true`
-    /// - terminal → same       → guard excludes → `false` (redelivery)
-    /// - terminal → `running`  → guard excludes → `false` (late refresh)
-    /// - correctable `failed` → `complete` → 1 row → `true` (correction)
-    /// - any other terminal → terminal → guard excludes → `false`
+    /// - absent row                   → 0 rows → `false`
+    /// - no verdict (`-1`) → any rank → 1 row  → `true`
+    /// - equal rank redelivery        → guard excludes → `false` (first wins)
+    /// - lower rank after higher      → guard excludes → `false`
+    /// - higher rank after lower      → 1 row  → `true`
+    /// - non-terminal refresh after any verdict → guard excludes → `false`
     ///
-    /// #2055 review round 3 — the ONE admitted terminal→terminal transition
-    /// is PROVENANCE-GATED: `failed → complete` requires the row to carry
-    /// `correctable = 1`, which only
-    /// [`Self::update_task_status_with_provenance`] can stamp and only for a
-    /// `failed` write. That mirrors the supervisor's authority model —
-    /// `TaskSupervisor::mark_completed` overrides exactly an
-    /// OBSERVER-derived provisional failure (task_supervisor.rs:2527) — and
-    /// keeps every FINAL `failed` row (owner failure, cancellation) closed:
-    /// blanket failed→complete admission would let a genuinely-cancelled
-    /// row be flipped by a racing completion from another supervisor copy
-    /// (#2060). The correction clears the mark; `complete` is immutable;
-    /// `updated_at_ms` records the latest admitted write and cannot regress
-    /// to a straggler.
+    /// #2055 review round 4 — terminal writes route through
+    /// [`Self::settle_task_status`]'s authority-rank rule (see
+    /// [`TaskSettleAuthority`]); this string-status compatibility form maps
+    /// `"complete"` → `Completion` and `"failed"` → `FinalFailure`
+    /// (owner-final — the historical semantics of this API), and treats any
+    /// other status as a non-terminal refresh admitted only while the row
+    /// carries no terminal verdict.
+    ///
+    /// Requires the migrated schema: every statement here references the
+    /// `authority` column, so production callers reach this only through
+    /// connections opened by [`Self::open_with_busy_retry`] (which runs the
+    /// migration) or on databases created by the current schema batch.
     ///
     /// Fidelity note: cancellation is collapsed into failure upstream
     /// (`TerminalOutcome` has no `Cancelled`; the change-feed settle maps
-    /// `TaskStatus::Cancelled` to `"failed"` too), so a cancelled task lands
-    /// here as `"failed"` and the two are indistinguishable in the ledger —
-    /// distinguishable only through the provenance mark.
-    ///
-    /// This plain form writes owner-final provenance (`correctable = 0`).
+    /// `TaskStatus::Cancelled` to `FinalFailure` too), so a cancelled task
+    /// lands here as `"failed"` and the two are indistinguishable in the
+    /// ledger — distinguishable only through the authority rank.
     pub fn update_task_status(
         &self,
         task_id: &str,
         new_status: &str,
         updated_at_ms: u64,
     ) -> Result<bool> {
-        self.update_task_status_with_provenance(task_id, new_status, false, updated_at_ms)
+        match new_status {
+            "complete" => {
+                self.settle_task_status(task_id, TaskSettleAuthority::Completion, updated_at_ms)
+            }
+            "failed" => {
+                self.settle_task_status(task_id, TaskSettleAuthority::FinalFailure, updated_at_ms)
+            }
+            _ => {
+                let conn = self.conn.lock().unwrap();
+                let changed = conn.execute(
+                    "UPDATE tasks SET status = ?1, updated_at_ms = ?2
+                     WHERE task_id = ?3 AND authority < 0",
+                    params![new_status, updated_at_ms, task_id],
+                )?;
+                Ok(changed > 0)
+            }
+        }
     }
 
-    /// #2055 review round 3 — [`Self::update_task_status`] with explicit
-    /// correction provenance. `correctable = true` is meaningful only for a
-    /// `"failed"` write (the observer-provisional verdict); it is clamped to
-    /// `0` for every other status, so a completion can never re-open a row.
+    /// #2055 review round 4 — the ONE terminal admission rule: the write
+    /// lands iff its authority rank is STRICTLY greater than the row's
+    /// stored rank (first-wins within equal rank), and both the status and
+    /// the stored rank come from the [`TaskSettleAuthority`] itself, so an
+    /// illegal status/authority pairing cannot be expressed. `Ok(false)` is
+    /// a normal no-op (absent row, redelivery, or an outranked write).
     ///
-    /// Besides the correction itself, a correctable `failed` row also admits
-    /// an owner-final `failed` DOWNGRADE (`correctable 1 → 0`, status
-    /// unchanged): when the owner re-marks an observer-failed task, the
-    /// supervisor clears the provisional stamp, and the row must follow —
-    /// otherwise the correction window would stay open forever on a failure
-    /// the owner already confirmed. A provisional redelivery (`1 → 1`) stays
-    /// a no-op.
-    pub fn update_task_status_with_provenance(
+    /// Order-independence this buys (P = provisional failure, C =
+    /// completion, D = final failure): every delivery order containing a D
+    /// ends `failed`; P and C alone end `complete` in either order.
+    pub fn settle_task_status(
         &self,
         task_id: &str,
-        new_status: &str,
-        correctable: bool,
+        authority: TaskSettleAuthority,
         updated_at_ms: u64,
     ) -> Result<bool> {
         let conn = self.conn.lock().unwrap();
-        let stamp_correctable = i64::from(correctable && new_status == "failed");
         let changed = conn.execute(
-            "UPDATE tasks SET status = ?1, updated_at_ms = ?2, correctable = ?4
-             WHERE task_id = ?3
-               AND (status NOT IN ('complete', 'failed')
-                    OR (status = 'failed' AND correctable = 1 AND ?1 = 'complete')
-                    OR (status = 'failed' AND correctable = 1 AND ?1 = 'failed' AND ?4 = 0))",
-            params![new_status, updated_at_ms, task_id, stamp_correctable],
+            "UPDATE tasks SET status = ?1, updated_at_ms = ?2, authority = ?4
+             WHERE task_id = ?3 AND ?4 > authority",
+            params![
+                authority.ledger_status(),
+                updated_at_ms,
+                task_id,
+                authority.rank()
+            ],
         )?;
         Ok(changed > 0)
     }
@@ -3210,14 +3325,13 @@ mod digest_integration_tests {
                 "a terminal task refuses the late non-terminal write {late:?}"
             );
         }
-        // #2055 review round 3 — `complete` after an OWNER-reported `failed`
-        // is refused again: the correction admission is provenance-gated on
-        // the `correctable` column, and the plain writer stamps
-        // `correctable = 0` (owner-final). Only a row written through
-        // `update_task_status_with_provenance(.., correctable = true, ..)` —
-        // the observer-provisional case — admits the later completion.
-        // Blanket failed→complete admission would let a genuinely-cancelled
-        // row (cancellation also lands as `failed`) be flipped by a racing
+        // #2055 review round 4 — `complete` after an OWNER-reported `failed`
+        // is refused: the plain writer maps `"failed"` to `FinalFailure`
+        // (rank 2), which outranks `Completion` (rank 1). Only an
+        // observer-provisional failure (rank 0, written through
+        // `settle_task_status`) admits the later completion. Blanket
+        // failed→complete admission would let a genuinely-cancelled row
+        // (cancellation also lands as `failed`) be flipped by a racing
         // completion from another supervisor copy (#2060).
         assert!(!ledger.update_task_status("t1", "complete", 4_000).unwrap());
 
@@ -3226,58 +3340,68 @@ mod digest_integration_tests {
         assert_eq!(task.updated_at_ms, 2_000);
     }
 
-    /// #2055 review round 3 — the provenance-gated correction in full: an
-    /// observer-provisional failure (written with `correctable = true`)
-    /// admits exactly the owner's later `complete`
-    /// (task_supervisor.rs:2527's correction semantics); the correction
-    /// clears the provenance mark, and from there the row is immutable
-    /// (a straggler `failed` redelivery cannot undo the correction).
+    /// #2055 review round 4 — the authority-gated correction: an
+    /// observer-provisional failure (rank 0) admits exactly the owner's
+    /// later completion (rank 1, task_supervisor.rs:2527's correction
+    /// semantics); afterwards the row refuses provisional redeliveries,
+    /// non-terminal refreshes, and completion redeliveries — only a FINAL
+    /// failure (rank 2) can still land, which is the deliberate
+    /// order-independence rule verified exhaustively below.
     #[test]
-    fn should_allow_failed_to_complete_only_with_correctable_provenance() {
+    fn should_allow_failed_to_complete_only_with_provisional_authority() {
         let dir = tempfile::tempdir().unwrap();
         let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
         seed_goal_with_task(&ledger, "g1", "t1", "running");
 
         assert!(
             ledger
-                .update_task_status_with_provenance("t1", "failed", true, 2_000)
+                .settle_task_status("t1", TaskSettleAuthority::ProvisionalFailure, 2_000)
                 .unwrap(),
-            "the provisional failure lands with correctable provenance"
+            "the provisional failure lands at rank 0"
         );
         assert!(
             ledger.update_task_status("t1", "complete", 3_000).unwrap(),
-            "failed → complete is admitted for a correctable row"
+            "failed → complete is admitted over a provisional verdict"
         );
-        for late in ["failed", "running", "pending", "complete"] {
+        assert!(
+            !ledger
+                .settle_task_status("t1", TaskSettleAuthority::ProvisionalFailure, 4_000)
+                .unwrap(),
+            "a straggler provisional write cannot undo the correction"
+        );
+        assert!(
+            !ledger.update_task_status("t1", "complete", 4_000).unwrap(),
+            "a completion redelivery is a no-op (first wins within a rank)"
+        );
+        for late in ["running", "pending"] {
             assert!(
                 !ledger.update_task_status("t1", late, 4_000).unwrap(),
-                "complete refuses every subsequent write ({late:?})"
+                "a settled row refuses the non-terminal refresh {late:?}"
             );
         }
 
         let task = ledger.get_task("t1").unwrap().unwrap();
         assert_eq!(task.status, "complete");
         assert_eq!(task.updated_at_ms, 3_000);
-        // The correction cleared the provenance mark (defense in depth —
-        // `complete` is immutable regardless). Same-module test, so the raw
+        // The stored rank is the completion's. Same-module test, so the raw
         // column read is fine.
-        let correctable: i64 = ledger
+        let authority: i64 = ledger
             .conn
             .lock()
             .unwrap()
             .query_row(
-                "SELECT correctable FROM tasks WHERE task_id = 't1'",
+                "SELECT authority FROM tasks WHERE task_id = 't1'",
                 [],
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(correctable, 0, "the correction clears correctable");
+        assert_eq!(authority, 1);
     }
 
-    /// #2055 review round 3 — the owner's authoritative re-failure closes
-    /// the correction window: a correctable `failed` row admits the
-    /// owner-final `failed` downgrade (provenance cleared), after which the
-    /// completion is refused like any other final failure.
+    /// #2055 review round 4 — the owner's authoritative re-failure closes
+    /// the correction window: rank 2 lands over the provisional rank 0,
+    /// after which the completion (rank 1) is refused. A provisional
+    /// redelivery in between is a no-op, not a retention refresh.
     #[test]
     fn should_close_correction_window_when_owner_confirms_the_failure() {
         let dir = tempfile::tempdir().unwrap();
@@ -3286,19 +3410,19 @@ mod digest_integration_tests {
 
         assert!(
             ledger
-                .update_task_status_with_provenance("t1", "failed", true, 2_000)
+                .settle_task_status("t1", TaskSettleAuthority::ProvisionalFailure, 2_000)
                 .unwrap()
         );
         // A provisional redelivery is a no-op, not a churn write.
         assert!(
             !ledger
-                .update_task_status_with_provenance("t1", "failed", true, 2_500)
+                .settle_task_status("t1", TaskSettleAuthority::ProvisionalFailure, 2_500)
                 .unwrap()
         );
-        // The owner's confirming failure downgrades the provenance mark.
+        // The owner's confirming failure outranks the provisional verdict.
         assert!(
             ledger.update_task_status("t1", "failed", 3_000).unwrap(),
-            "the owner-final downgrade of a correctable row is admitted"
+            "the owner-final failure is admitted over the provisional rank"
         );
         assert!(
             !ledger.update_task_status("t1", "complete", 4_000).unwrap(),
@@ -3310,14 +3434,64 @@ mod digest_integration_tests {
         assert_eq!(task.updated_at_ms, 3_000);
     }
 
-    /// #2055 review round 3 — the `correctable` column arrives via a
-    /// best-effort `ALTER TABLE` for databases created before the column
-    /// existed; the provenance-gated correction works on such a ledger.
+    /// #2055 review round 4 — the load-bearing order-independence matrix:
+    /// with P = provisional failure, C = completion, D = final failure,
+    /// EVERY delivery order containing a D ends `failed`, and P/C alone end
+    /// `complete` in either order. The write layer alone guarantees this —
+    /// no delivery-order assumptions anywhere above it.
     #[test]
-    fn should_migrate_tasks_table_missing_the_correctable_column() {
+    fn should_converge_every_authority_delivery_order() {
+        use TaskSettleAuthority::{Completion, FinalFailure, ProvisionalFailure};
+        let three_event_orders: [[TaskSettleAuthority; 3]; 6] = [
+            [ProvisionalFailure, Completion, FinalFailure],
+            [ProvisionalFailure, FinalFailure, Completion],
+            [Completion, ProvisionalFailure, FinalFailure],
+            [Completion, FinalFailure, ProvisionalFailure],
+            [FinalFailure, ProvisionalFailure, Completion],
+            [FinalFailure, Completion, ProvisionalFailure],
+        ];
+        for (index, order) in three_event_orders.iter().enumerate() {
+            let dir = tempfile::tempdir().unwrap();
+            let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
+            seed_goal_with_task(&ledger, "g1", "t1", "running");
+            for authority in order {
+                let _ = ledger.settle_task_status("t1", *authority, 2_000).unwrap();
+            }
+            let task = ledger.get_task("t1").unwrap().unwrap();
+            assert_eq!(
+                task.status, "failed",
+                "order #{index} {order:?} contains a final failure and must end failed"
+            );
+        }
+        for order in [
+            [ProvisionalFailure, Completion],
+            [Completion, ProvisionalFailure],
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
+            seed_goal_with_task(&ledger, "g1", "t1", "running");
+            for authority in order {
+                let _ = ledger.settle_task_status("t1", authority, 2_000).unwrap();
+            }
+            let task = ledger.get_task("t1").unwrap().unwrap();
+            assert_eq!(
+                task.status, "complete",
+                "{order:?} has no final failure and must end complete"
+            );
+        }
+    }
+
+    /// #2055 review round 4 — the `authority` column arrives via the
+    /// migration in `open_with_busy_retry` (never the common `open`, which
+    /// runs on tokio workers). Pre-existing terminal rows are stamped FINAL
+    /// — a legacy `failed` row must NOT become correctable — while legacy
+    /// non-terminal rows settle exactly like fresh ones.
+    #[test]
+    fn should_migrate_tasks_table_missing_the_authority_column() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("ledger.db");
-        // A pre-round-3 database shape: tasks table WITHOUT `correctable`.
+        // A pre-#2055 database shape: tasks table with neither `authority`
+        // nor the short-lived round-3 `correctable`.
         {
             let conn = rusqlite::Connection::open(&path).unwrap();
             conn.execute_batch(
@@ -3335,23 +3509,168 @@ mod digest_integration_tests {
                      created_at_ms INTEGER NOT NULL, updated_at_ms INTEGER NOT NULL,
                      FOREIGN KEY (goal_id) REFERENCES goals(goal_id));
                  INSERT INTO goals VALUES ('g1', 'ship', 'active', 0, 1000, 0, 0, 1, 1);
-                 INSERT INTO tasks VALUES ('t1', 'g1', '', '', 'running', NULL, 1, 1);",
+                 INSERT INTO tasks VALUES ('legacy-failed', 'g1', '', '', 'failed', NULL, 1, 1);
+                 INSERT INTO tasks VALUES ('legacy-live', 'g1', '', '', 'running', NULL, 1, 1);",
             )
             .unwrap();
         }
 
-        let ledger = GoalLedger::open(&path).unwrap();
+        let ledger = GoalLedger::open_with_busy_retry(&path).unwrap();
+        assert!(
+            !ledger
+                .update_task_status("legacy-failed", "complete", 2_000)
+                .unwrap(),
+            "a legacy failed row is stamped FINAL by the migration backfill \
+             and must not become correctable"
+        );
+        assert_eq!(
+            ledger.get_task("legacy-failed").unwrap().unwrap().status,
+            "failed"
+        );
+        // A legacy live row settles exactly like a fresh one.
         assert!(
             ledger
-                .update_task_status_with_provenance("t1", "failed", true, 2_000)
-                .unwrap(),
-            "the migrated column accepts the provenance write"
+                .settle_task_status(
+                    "legacy-live",
+                    TaskSettleAuthority::ProvisionalFailure,
+                    2_000
+                )
+                .unwrap()
         );
         assert!(
-            ledger.update_task_status("t1", "complete", 3_000).unwrap(),
-            "the correction works on a migrated ledger"
+            ledger
+                .update_task_status("legacy-live", "complete", 3_000)
+                .unwrap(),
+            "the provisional-then-correction flow works on a migrated ledger"
         );
-        assert_eq!(ledger.get_task("t1").unwrap().unwrap().status, "complete");
+    }
+
+    /// #2055 review round 4 — a database created from the short-lived
+    /// round-3 shape (with `correctable`) migrates too: the column is
+    /// dropped and its terminal rows are stamped FINAL alongside the
+    /// `authority` addition.
+    #[test]
+    fn should_migrate_round3_correctable_column_away() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ledger.db");
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE goals (
+                     goal_id TEXT PRIMARY KEY, objective TEXT NOT NULL,
+                     status TEXT NOT NULL, tokens_used INTEGER NOT NULL DEFAULT 0,
+                     token_budget INTEGER NOT NULL,
+                     continuations_used INTEGER NOT NULL DEFAULT 0,
+                     revision INTEGER NOT NULL DEFAULT 0,
+                     created_at_ms INTEGER NOT NULL, updated_at_ms INTEGER NOT NULL);
+                 CREATE TABLE tasks (
+                     task_id TEXT PRIMARY KEY, goal_id TEXT NOT NULL,
+                     title TEXT NOT NULL, detail TEXT NOT NULL,
+                     status TEXT NOT NULL, assigned_peer TEXT,
+                     created_at_ms INTEGER NOT NULL, updated_at_ms INTEGER NOT NULL,
+                     correctable INTEGER NOT NULL DEFAULT 0,
+                     FOREIGN KEY (goal_id) REFERENCES goals(goal_id));
+                 INSERT INTO goals VALUES ('g1', 'ship', 'active', 0, 1000, 0, 0, 1, 1);
+                 INSERT INTO tasks VALUES ('t1', 'g1', '', '', 'failed', NULL, 1, 1, 1);",
+            )
+            .unwrap();
+        }
+
+        let ledger = GoalLedger::open_with_busy_retry(&path).unwrap();
+        let correctable_exists: i64 = ledger
+            .conn
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('tasks') WHERE name = 'correctable'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(correctable_exists, 0, "the round-3 column is dropped");
+        assert!(
+            !ledger.update_task_status("t1", "complete", 2_000).unwrap(),
+            "the round-3 terminal row is stamped FINAL, not carried over as correctable"
+        );
+    }
+
+    /// #2055 review round 4 — the migration swallows exactly the
+    /// duplicate-column error; every other failure propagates. Forced here
+    /// by presenting a connection whose `tasks` table does not exist.
+    #[test]
+    fn should_propagate_non_duplicate_migration_failures() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        // No `tasks` table at all: the ALTER fails with "no such table",
+        // which is NOT the ignorable duplicate-column case.
+        let error = GoalLedger::migrate_tasks_authority_column(&conn)
+            .expect_err("a non-duplicate migration failure must propagate");
+        assert!(
+            error.to_string().contains("no such table"),
+            "unexpected error: {error}"
+        );
+        // And on an already-migrated table the helper is a clean no-op.
+        conn.execute_batch(
+            "CREATE TABLE tasks (
+                 task_id TEXT PRIMARY KEY, goal_id TEXT NOT NULL,
+                 title TEXT NOT NULL, detail TEXT NOT NULL,
+                 status TEXT NOT NULL, assigned_peer TEXT,
+                 created_at_ms INTEGER NOT NULL, updated_at_ms INTEGER NOT NULL,
+                 authority INTEGER NOT NULL DEFAULT -1);",
+        )
+        .unwrap();
+        GoalLedger::migrate_tasks_authority_column(&conn)
+            .expect("an already-migrated table is a no-op");
+    }
+
+    /// #2055 review round 4 — fresh-schema and migrated-schema databases
+    /// behave identically under the same write sequence.
+    #[test]
+    fn should_behave_identically_on_fresh_and_migrated_schemas() {
+        let dir = tempfile::tempdir().unwrap();
+        // Fresh: created by the current schema batch.
+        let fresh = GoalLedger::open_with_busy_retry(dir.path().join("fresh.db")).unwrap();
+        // Migrated: created without the column, then opened through the
+        // migrating profile.
+        let migrated_path = dir.path().join("migrated.db");
+        {
+            let conn = rusqlite::Connection::open(&migrated_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE goals (
+                     goal_id TEXT PRIMARY KEY, objective TEXT NOT NULL,
+                     status TEXT NOT NULL, tokens_used INTEGER NOT NULL DEFAULT 0,
+                     token_budget INTEGER NOT NULL,
+                     continuations_used INTEGER NOT NULL DEFAULT 0,
+                     revision INTEGER NOT NULL DEFAULT 0,
+                     created_at_ms INTEGER NOT NULL, updated_at_ms INTEGER NOT NULL);
+                 CREATE TABLE tasks (
+                     task_id TEXT PRIMARY KEY, goal_id TEXT NOT NULL,
+                     title TEXT NOT NULL, detail TEXT NOT NULL,
+                     status TEXT NOT NULL, assigned_peer TEXT,
+                     created_at_ms INTEGER NOT NULL, updated_at_ms INTEGER NOT NULL,
+                     FOREIGN KEY (goal_id) REFERENCES goals(goal_id));",
+            )
+            .unwrap();
+        }
+        let migrated = GoalLedger::open_with_busy_retry(&migrated_path).unwrap();
+
+        for ledger in [&fresh, &migrated] {
+            seed_goal_with_task(ledger, "g1", "t1", "running");
+            assert!(
+                ledger
+                    .settle_task_status("t1", TaskSettleAuthority::ProvisionalFailure, 2_000)
+                    .unwrap()
+            );
+            assert!(ledger.update_task_status("t1", "complete", 3_000).unwrap());
+            assert!(
+                ledger
+                    .settle_task_status("t1", TaskSettleAuthority::FinalFailure, 4_000)
+                    .unwrap(),
+                "a final failure outranks the completion on both shapes"
+            );
+            let task = ledger.get_task("t1").unwrap().unwrap();
+            assert_eq!(task.status, "failed");
+            assert_eq!(task.updated_at_ms, 4_000);
+        }
     }
 
     /// #2055 review round 3 — goal-scoped task listing (used by effect

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -500,6 +500,37 @@ impl GoalLedger {
         Ok(())
     }
 
+    /// #2055 — create a task row only when none exists yet
+    /// (`INSERT … ON CONFLICT(task_id) DO NOTHING`).
+    ///
+    /// Registration is the caller: the same task can be registered,
+    /// relaunched, and re-registered across a restart, and findings /
+    /// denials / escalations still write FK stubs for tasks that may already
+    /// have a row. All of those must PRESERVE an existing row — its status
+    /// (including a status that already went terminal via
+    /// [`Self::update_task_status`]), title, and timestamps — rather than
+    /// error or overwrite. Returns `Ok(true)` when a row was inserted,
+    /// `Ok(false)` for the preserve-existing no-op.
+    pub fn create_task_if_absent(&self, task: &Task) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let inserted = conn.execute(
+            "INSERT INTO tasks (task_id, goal_id, title, detail, status, assigned_peer, created_at_ms, updated_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(task_id) DO NOTHING",
+            params![
+                task.task_id,
+                task.goal_id,
+                task.title,
+                task.detail,
+                task.status,
+                task.assigned_peer,
+                task.created_at_ms,
+                task.updated_at_ms,
+            ],
+        )?;
+        Ok(inserted > 0)
+    }
+
     /// Get a task by ID.
     pub fn get_task(&self, task_id: &str) -> Result<Option<Task>> {
         let conn = self.conn.lock().unwrap();
@@ -3123,5 +3154,116 @@ mod digest_integration_tests {
             .collect();
         assert_eq!(g2.get("running"), Some(&1));
         assert_eq!(g2.get("complete"), None);
+    }
+
+    // ---------------------------------------------------------------------
+    // #2055 — idempotent row creation at task registration.
+    //
+    // Registration legitimately repeats (relaunch, restart, re-registration
+    // of a task the supervisor restored), so row creation must be an upsert
+    // that PRESERVES an existing row — including its status and timestamps,
+    // and including a row that already went terminal — instead of relying on
+    // a swallowed UNIQUE violation.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn should_insert_row_when_task_is_new() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
+        // FK enforcement is on (bundled SQLite defaults foreign_keys=1):
+        // the parent goals row must exist before any task row.
+        ledger
+            .create_goal(&Goal {
+                goal_id: "g1".to_string(),
+                objective: "test".to_string(),
+                status: "active".to_string(),
+                tokens_used: 0,
+                token_budget: 10_000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1_000,
+                updated_at_ms: 1_000,
+            })
+            .unwrap();
+        assert!(
+            ledger
+                .create_task_if_absent(&Task {
+                    task_id: "t1".to_string(),
+                    goal_id: "g1".to_string(),
+                    title: "web_probe".to_string(),
+                    detail: String::new(),
+                    status: "running".to_string(),
+                    assigned_peer: None,
+                    created_at_ms: 1_000,
+                    updated_at_ms: 1_000,
+                })
+                .unwrap(),
+            "a fresh task id inserts a row"
+        );
+
+        let task = ledger.get_task("t1").unwrap().unwrap();
+        assert_eq!(task.status, "running");
+        assert_eq!(task.title, "web_probe");
+    }
+
+    #[test]
+    fn should_preserve_existing_row_when_task_is_reregistered() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
+        seed_goal_with_task(&ledger, "g1", "t1", "running");
+
+        assert!(
+            !ledger
+                .create_task_if_absent(&Task {
+                    task_id: "t1".to_string(),
+                    goal_id: "g1".to_string(),
+                    title: "replacement title".to_string(),
+                    detail: "replacement detail".to_string(),
+                    status: "pending".to_string(),
+                    assigned_peer: Some("peer-a".to_string()),
+                    created_at_ms: 9_000,
+                    updated_at_ms: 9_000,
+                })
+                .unwrap(),
+            "re-registration reports no-op"
+        );
+
+        let task = ledger.get_task("t1").unwrap().unwrap();
+        assert_eq!(task.status, "running", "existing status is preserved");
+        assert_eq!(task.title, "", "existing title is preserved");
+        assert_eq!(task.assigned_peer, None);
+        assert_eq!(task.updated_at_ms, 1_000);
+    }
+
+    /// The load-bearing half of idempotency: a re-registration AFTER the row
+    /// went terminal (relaunch/restart replaying an old registration) must
+    /// not resurrect it to `running` — first-terminal-wins extends across
+    /// the create path, not just `update_task_status`.
+    #[test]
+    fn should_preserve_terminal_row_when_task_is_reregistered() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
+        seed_goal_with_task(&ledger, "g1", "t1", "running");
+        ledger.update_task_status("t1", "complete", 2_000).unwrap();
+
+        assert!(
+            !ledger
+                .create_task_if_absent(&Task {
+                    task_id: "t1".to_string(),
+                    goal_id: "g1".to_string(),
+                    title: String::new(),
+                    detail: String::new(),
+                    status: "running".to_string(),
+                    assigned_peer: None,
+                    created_at_ms: 3_000,
+                    updated_at_ms: 3_000,
+                })
+                .unwrap(),
+            "re-registration of a terminal row reports no-op"
+        );
+
+        let task = ledger.get_task("t1").unwrap().unwrap();
+        assert_eq!(task.status, "complete", "terminal status survives");
+        assert_eq!(task.updated_at_ms, 2_000);
     }
 }

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -3905,19 +3905,20 @@ mod digest_integration_tests {
         assert_eq!(count_columns("authority"), 0);
     }
 
-    /// #2055 review round 6/7 (V3/W3) — creation-vs-migration concurrency
-    /// pin, DETERMINISTIC: the STRUCTURAL argument is what closes the race
-    /// (the creation APIs run inspection + insert inside `BEGIN IMMEDIATE`,
-    /// which serializes against the migration's own `BEGIN IMMEDIATE`
-    /// transaction, so a creation either fully precedes the migration —
-    /// legacy shape, then the backfill stamps the row FINAL — or fully
-    /// follows it, taking the derived-authority shape; the poisoned
-    /// interleaving cannot be scheduled). This test PROVES the mid-
-    /// transaction interleaving actually happened rather than hoping for
-    /// it: a test-only hook holds the migration transaction verifiably open
-    /// while the creation fires, the creation must complete only AFTER the
-    /// hook releases (blocked for the full hold, i.e. it observed the busy
-    /// wait), and the created terminal row must carry its real rank.
+    /// #2055 review rounds 6/7/9 (V3/W3/Y4) — creation-vs-migration
+    /// concurrency pin, deterministic BY CONSTRUCTION: the STRUCTURAL
+    /// argument is what closes the race (the creation APIs run inspection +
+    /// insert inside `BEGIN IMMEDIATE`, which serializes against the
+    /// migration's own `BEGIN IMMEDIATE` transaction, so a creation either
+    /// fully precedes the migration — legacy shape, then the backfill
+    /// stamps the row FINAL — or fully follows it, taking the
+    /// derived-authority shape; the poisoned interleaving cannot be
+    /// scheduled). This test PROVES contention with a single-threaded
+    /// busy-probe rather than timing: while a test-only hook parks the
+    /// migration transaction verifiably open, a zero-busy-timeout terminal
+    /// creation ON THE TEST THREAD must fail with lock contention — an
+    /// assertion no thread schedule can fake or break — and after release
+    /// the same creation succeeds with its real rank.
     #[test]
     fn should_never_leave_terminal_rows_unranked_when_creation_races_migration() {
         let dir = tempfile::tempdir().unwrap();
@@ -3927,9 +3928,12 @@ mod digest_integration_tests {
             conn.pragma_update(None, "journal_mode", "WAL").unwrap();
             create_legacy_schema(&conn, "");
         }
-        // The creator's connection is opened BEFORE the migration starts so
-        // the only step that can block below is its creation transaction.
-        let creator_ledger = GoalLedger::open(&path).unwrap();
+        // The probe's connection is opened at test start, BEFORE the hook is
+        // installed and the migration can take the write lock, so the open
+        // itself (a plain `GoalLedger::open` — no migration attempt, which
+        // would deadlock against the parked transaction) cannot block on
+        // anything below.
+        let probe_ledger = GoalLedger::open(&path).unwrap();
 
         // Install the in-transaction hook: signals the test, then blocks
         // this migration open until released.
@@ -3954,64 +3958,66 @@ mod digest_integration_tests {
             .recv_timeout(std::time::Duration::from_secs(30))
             .expect("the migration transaction is provably open");
 
-        // Fire the creation WHILE the migration transaction is open. The
-        // creator signals immediately before calling `create_task` (round 8
-        // start-barrier), so the release below happens provably AFTER the
-        // creation began.
-        let (creation_begun_tx, creation_begun_rx) = std::sync::mpsc::channel::<()>();
-        let creator = std::thread::spawn(move || {
-            let begun = std::time::Instant::now();
-            let _ = creation_begun_tx.send(());
-            creator_ledger
-                .create_task(&Task {
-                    task_id: "race-task".to_string(),
-                    goal_id: "g1".to_string(),
-                    title: String::new(),
-                    detail: String::new(),
-                    status: "failed".to_string(),
-                    assigned_peer: None,
-                    created_at_ms: 1_000,
-                    updated_at_ms: 1_000,
-                })
-                .expect("creation succeeds after the migration commits");
-            (begun, std::time::Instant::now())
-        });
-        creation_begun_rx
-            .recv_timeout(std::time::Duration::from_secs(30))
-            .expect("the creation attempt has begun");
-        // Hold the open transaction across the creation attempt, then
-        // release and let everything settle.
-        std::thread::sleep(std::time::Duration::from_millis(300));
-        let released_at = std::time::Instant::now();
+        // Round 9 — the busy-probe, ON THIS THREAD, deterministic by
+        // construction: with the hook parked the migration transaction is
+        // provably holding the write lock AT THIS INSTANT, so a zero-
+        // busy-timeout terminal creation can only fail SQLITE_BUSY — and it
+        // can only fail SQLITE_BUSY because that lock is held. Both sides
+        // of the interleaving are sequenced by the test thread itself: no
+        // schedule can fake the contention and no deschedule can break it.
+        // (The previous timing shape could pass under a valid schedule that
+        // descheduled a creator thread between its begun-signal and its
+        // create call, running the whole creation post-release — timestamps
+        // cannot prove blocking.)
+        probe_ledger
+            .conn
+            .lock()
+            .unwrap()
+            .busy_timeout(std::time::Duration::ZERO)
+            .unwrap();
+        let probe_error = probe_ledger
+            .create_task(&Task {
+                task_id: "race-task".to_string(),
+                goal_id: "g1".to_string(),
+                title: String::new(),
+                detail: String::new(),
+                status: "failed".to_string(),
+                assigned_peer: None,
+                created_at_ms: 1_000,
+                updated_at_ms: 1_000,
+            })
+            .expect_err("a zero-timeout creation must observe the held migration lock");
+        assert!(
+            error_is_lock_contention(&probe_error),
+            "the probe must fail with lock contention, not a structural error: {probe_error}"
+        );
+
         release_tx.send(()).expect("release the migration hook");
         let migrated = migration
             .join()
             .expect("migration thread")
             .expect("migration open succeeds");
-        let (create_begun, create_done) = creator.join().expect("creator thread");
         *GoalLedger::migration_mid_transaction_hook().lock().unwrap() = None;
 
-        // The interleaving is PROVEN, not hoped: the creation BEGAN before
-        // the release (a slow sequential post-release creation cannot
-        // masquerade), observed the busy wait (blocked for essentially the
-        // whole hold), and completed only after the release.
-        assert!(
-            create_begun < released_at,
-            "the creation must have begun while the migration transaction was still open"
-        );
-        assert!(
-            create_done >= released_at,
-            "the creation must complete only after the migration transaction released"
-        );
-        assert!(
-            create_done.duration_since(create_begun) >= std::time::Duration::from_millis(250),
-            "the creation must have been blocked by the open migration transaction \
-             (took {:?})",
-            create_done.duration_since(create_begun)
-        );
+        // With the migration committed, the same terminal creation succeeds
+        // on a normal-timeout connection and takes the derived-authority
+        // shape.
+        migrated
+            .create_task(&Task {
+                task_id: "race-task".to_string(),
+                goal_id: "g1".to_string(),
+                title: String::new(),
+                detail: String::new(),
+                status: "failed".to_string(),
+                assigned_peer: None,
+                created_at_ms: 1_000,
+                updated_at_ms: 1_000,
+            })
+            .expect("creation succeeds after the migration commits");
+
         // And the outcome invariant: no terminal row at authority -1 — the
-        // legacy row was backfilled FINAL and the racing creation took the
-        // derived-authority shape.
+        // legacy row was backfilled FINAL and the post-migration creation
+        // took the derived-authority shape.
         let conn = migrated.conn.lock().unwrap();
         let unranked: i64 = conn
             .query_row(

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -235,6 +235,12 @@ impl GoalLedger {
                 assigned_peer TEXT,
                 created_at_ms INTEGER NOT NULL,
                 updated_at_ms INTEGER NOT NULL,
+                -- #2055 review round 3: provenance mark for the ONE admitted
+                -- terminal-to-terminal transition. 1 = this `failed` row is an
+                -- OBSERVER-provisional verdict the owner may still correct to
+                -- `complete` (task_supervisor.rs:2527); 0 = final (owner
+                -- failure, cancellation, or any non-failed status).
+                correctable INTEGER NOT NULL DEFAULT 0,
                 FOREIGN KEY (goal_id) REFERENCES goals(goal_id)
             );
 
@@ -301,6 +307,16 @@ impl GoalLedger {
             CREATE INDEX IF NOT EXISTS idx_decisions_goal ON decisions(goal_id, decided_at_ms);
             ",
         )?;
+        // #2055 review round 3 — best-effort migration for a tasks table
+        // created before `correctable` existed (`CREATE TABLE IF NOT EXISTS`
+        // never alters an existing table). The duplicate-column error on an
+        // already-migrated database is expected and swallowed; any other
+        // failure is also non-fatal here because the first statement that
+        // actually touches the column surfaces it loudly.
+        let _ = conn.execute(
+            "ALTER TABLE tasks ADD COLUMN correctable INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
         Ok(())
     }
 
@@ -610,38 +626,97 @@ impl GoalLedger {
     /// - `running` → terminal  → 1 row  → `true`
     /// - terminal → same       → guard excludes → `false` (redelivery)
     /// - terminal → `running`  → guard excludes → `false` (late refresh)
-    /// - `failed` → `complete` → 1 row  → `true` (owner correction — below)
+    /// - correctable `failed` → `complete` → 1 row → `true` (correction)
     /// - any other terminal → terminal → guard excludes → `false`
     ///
-    /// #2055 review round 2 — `failed → complete` is the ONE admitted
-    /// terminal→terminal transition, mirroring the supervisor's own
-    /// authority model: `TaskSupervisor::mark_completed` overrides an
-    /// OBSERVER-derived provisional failure when the owner watched the
-    /// worker actually finish (task_supervisor.rs:2527's correction
-    /// semantics), and the ledger must be able to receive that correction.
-    /// `complete` remains immutable; `failed` refuses every non-`complete`
-    /// write; `updated_at_ms` records the LATEST admitted write and cannot
-    /// regress to a straggler.
+    /// #2055 review round 3 — the ONE admitted terminal→terminal transition
+    /// is PROVENANCE-GATED: `failed → complete` requires the row to carry
+    /// `correctable = 1`, which only
+    /// [`Self::update_task_status_with_provenance`] can stamp and only for a
+    /// `failed` write. That mirrors the supervisor's authority model —
+    /// `TaskSupervisor::mark_completed` overrides exactly an
+    /// OBSERVER-derived provisional failure (task_supervisor.rs:2527) — and
+    /// keeps every FINAL `failed` row (owner failure, cancellation) closed:
+    /// blanket failed→complete admission would let a genuinely-cancelled
+    /// row be flipped by a racing completion from another supervisor copy
+    /// (#2060). The correction clears the mark; `complete` is immutable;
+    /// `updated_at_ms` records the latest admitted write and cannot regress
+    /// to a straggler.
     ///
     /// Fidelity note: cancellation is collapsed into failure upstream
     /// (`TerminalOutcome` has no `Cancelled`; the change-feed settle maps
     /// `TaskStatus::Cancelled` to `"failed"` too), so a cancelled task lands
-    /// here as `"failed"` and the two are indistinguishable in the ledger.
+    /// here as `"failed"` and the two are indistinguishable in the ledger —
+    /// distinguishable only through the provenance mark.
+    ///
+    /// This plain form writes owner-final provenance (`correctable = 0`).
     pub fn update_task_status(
         &self,
         task_id: &str,
         new_status: &str,
         updated_at_ms: u64,
     ) -> Result<bool> {
+        self.update_task_status_with_provenance(task_id, new_status, false, updated_at_ms)
+    }
+
+    /// #2055 review round 3 — [`Self::update_task_status`] with explicit
+    /// correction provenance. `correctable = true` is meaningful only for a
+    /// `"failed"` write (the observer-provisional verdict); it is clamped to
+    /// `0` for every other status, so a completion can never re-open a row.
+    ///
+    /// Besides the correction itself, a correctable `failed` row also admits
+    /// an owner-final `failed` DOWNGRADE (`correctable 1 → 0`, status
+    /// unchanged): when the owner re-marks an observer-failed task, the
+    /// supervisor clears the provisional stamp, and the row must follow —
+    /// otherwise the correction window would stay open forever on a failure
+    /// the owner already confirmed. A provisional redelivery (`1 → 1`) stays
+    /// a no-op.
+    pub fn update_task_status_with_provenance(
+        &self,
+        task_id: &str,
+        new_status: &str,
+        correctable: bool,
+        updated_at_ms: u64,
+    ) -> Result<bool> {
         let conn = self.conn.lock().unwrap();
+        let stamp_correctable = i64::from(correctable && new_status == "failed");
         let changed = conn.execute(
-            "UPDATE tasks SET status = ?1, updated_at_ms = ?2
+            "UPDATE tasks SET status = ?1, updated_at_ms = ?2, correctable = ?4
              WHERE task_id = ?3
                AND (status NOT IN ('complete', 'failed')
-                    OR (status = 'failed' AND ?1 = 'complete'))",
-            params![new_status, updated_at_ms, task_id],
+                    OR (status = 'failed' AND correctable = 1 AND ?1 = 'complete')
+                    OR (status = 'failed' AND correctable = 1 AND ?1 = 'failed' AND ?4 = 0))",
+            params![new_status, updated_at_ms, task_id, stamp_correctable],
         )?;
         Ok(changed > 0)
+    }
+
+    /// #2055 review round 3 — every task row bound to `goal_id`, oldest
+    /// first. Read-side companion to [`Self::task_status_counts`] for
+    /// callers that need titles/status rather than aggregates.
+    pub fn tasks_for_goal(&self, goal_id: &str) -> Result<Vec<Task>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT task_id, goal_id, title, detail, status, assigned_peer, created_at_ms, updated_at_ms
+             FROM tasks WHERE goal_id = ?1 ORDER BY created_at_ms, task_id",
+        )?;
+        let rows = stmt.query_map(params![goal_id], |row| {
+            Ok(Task {
+                task_id: row.get(0)?,
+                goal_id: row.get(1)?,
+                title: row.get(2)?,
+                detail: row.get(3)?,
+                status: row.get(4)?,
+                assigned_peer: row.get(5)?,
+                created_at_ms: row.get(6)?,
+                updated_at_ms: row.get(7)?,
+            })
+        })?;
+        let mut tasks = Vec::new();
+        for task in rows {
+            tasks.push(task?);
+        }
+        Ok(tasks)
     }
 
     /// Update goal status.
@@ -3135,38 +3210,45 @@ mod digest_integration_tests {
                 "a terminal task refuses the late non-terminal write {late:?}"
             );
         }
-        // #2055 review round 2 — `complete` after `failed` is now the ONE
-        // admitted terminal→terminal transition (this test originally
-        // asserted it refused): the supervisor's own authority model allows
-        // exactly it — `TaskSupervisor::mark_completed` overrides an
-        // OBSERVER-derived provisional failure when the owner watched the
-        // worker actually finish (task_supervisor.rs:2527's correction
-        // semantics), and the ledger must be able to receive that
-        // correction. `complete` remains immutable, and `failed` still
-        // refuses every non-`complete` write (asserted above).
-        assert!(ledger.update_task_status("t1", "complete", 4_000).unwrap());
+        // #2055 review round 3 — `complete` after an OWNER-reported `failed`
+        // is refused again: the correction admission is provenance-gated on
+        // the `correctable` column, and the plain writer stamps
+        // `correctable = 0` (owner-final). Only a row written through
+        // `update_task_status_with_provenance(.., correctable = true, ..)` —
+        // the observer-provisional case — admits the later completion.
+        // Blanket failed→complete admission would let a genuinely-cancelled
+        // row (cancellation also lands as `failed`) be flipped by a racing
+        // completion from another supervisor copy (#2060).
+        assert!(!ledger.update_task_status("t1", "complete", 4_000).unwrap());
 
         let task = ledger.get_task("t1").unwrap().unwrap();
-        assert_eq!(task.status, "complete");
-        assert_eq!(task.updated_at_ms, 4_000);
+        assert_eq!(task.status, "failed");
+        assert_eq!(task.updated_at_ms, 2_000);
     }
 
-    /// #2055 review round 2 — the correction transition in full: a
-    /// provisional observer failure lands `failed`, the owner's completion
-    /// corrects it to `complete`, and from there the row is immutable
+    /// #2055 review round 3 — the provenance-gated correction in full: an
+    /// observer-provisional failure (written with `correctable = true`)
+    /// admits exactly the owner's later `complete`
+    /// (task_supervisor.rs:2527's correction semantics); the correction
+    /// clears the provenance mark, and from there the row is immutable
     /// (a straggler `failed` redelivery cannot undo the correction).
     #[test]
-    fn should_allow_exactly_failed_to_complete_and_keep_complete_immutable() {
+    fn should_allow_failed_to_complete_only_with_correctable_provenance() {
         let dir = tempfile::tempdir().unwrap();
         let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
         seed_goal_with_task(&ledger, "g1", "t1", "running");
 
-        ledger.update_task_status("t1", "failed", 2_000).unwrap();
+        assert!(
+            ledger
+                .update_task_status_with_provenance("t1", "failed", true, 2_000)
+                .unwrap(),
+            "the provisional failure lands with correctable provenance"
+        );
         assert!(
             ledger.update_task_status("t1", "complete", 3_000).unwrap(),
-            "failed → complete is the owner-correction transition"
+            "failed → complete is admitted for a correctable row"
         );
-        for late in ["failed", "running", "pending"] {
+        for late in ["failed", "running", "pending", "complete"] {
             assert!(
                 !ledger.update_task_status("t1", late, 4_000).unwrap(),
                 "complete refuses every subsequent write ({late:?})"
@@ -3176,6 +3258,116 @@ mod digest_integration_tests {
         let task = ledger.get_task("t1").unwrap().unwrap();
         assert_eq!(task.status, "complete");
         assert_eq!(task.updated_at_ms, 3_000);
+        // The correction cleared the provenance mark (defense in depth —
+        // `complete` is immutable regardless). Same-module test, so the raw
+        // column read is fine.
+        let correctable: i64 = ledger
+            .conn
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT correctable FROM tasks WHERE task_id = 't1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(correctable, 0, "the correction clears correctable");
+    }
+
+    /// #2055 review round 3 — the owner's authoritative re-failure closes
+    /// the correction window: a correctable `failed` row admits the
+    /// owner-final `failed` downgrade (provenance cleared), after which the
+    /// completion is refused like any other final failure.
+    #[test]
+    fn should_close_correction_window_when_owner_confirms_the_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
+        seed_goal_with_task(&ledger, "g1", "t1", "running");
+
+        assert!(
+            ledger
+                .update_task_status_with_provenance("t1", "failed", true, 2_000)
+                .unwrap()
+        );
+        // A provisional redelivery is a no-op, not a churn write.
+        assert!(
+            !ledger
+                .update_task_status_with_provenance("t1", "failed", true, 2_500)
+                .unwrap()
+        );
+        // The owner's confirming failure downgrades the provenance mark.
+        assert!(
+            ledger.update_task_status("t1", "failed", 3_000).unwrap(),
+            "the owner-final downgrade of a correctable row is admitted"
+        );
+        assert!(
+            !ledger.update_task_status("t1", "complete", 4_000).unwrap(),
+            "after the owner confirmed the failure, the completion is refused"
+        );
+
+        let task = ledger.get_task("t1").unwrap().unwrap();
+        assert_eq!(task.status, "failed");
+        assert_eq!(task.updated_at_ms, 3_000);
+    }
+
+    /// #2055 review round 3 — the `correctable` column arrives via a
+    /// best-effort `ALTER TABLE` for databases created before the column
+    /// existed; the provenance-gated correction works on such a ledger.
+    #[test]
+    fn should_migrate_tasks_table_missing_the_correctable_column() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ledger.db");
+        // A pre-round-3 database shape: tasks table WITHOUT `correctable`.
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE goals (
+                     goal_id TEXT PRIMARY KEY, objective TEXT NOT NULL,
+                     status TEXT NOT NULL, tokens_used INTEGER NOT NULL DEFAULT 0,
+                     token_budget INTEGER NOT NULL,
+                     continuations_used INTEGER NOT NULL DEFAULT 0,
+                     revision INTEGER NOT NULL DEFAULT 0,
+                     created_at_ms INTEGER NOT NULL, updated_at_ms INTEGER NOT NULL);
+                 CREATE TABLE tasks (
+                     task_id TEXT PRIMARY KEY, goal_id TEXT NOT NULL,
+                     title TEXT NOT NULL, detail TEXT NOT NULL,
+                     status TEXT NOT NULL, assigned_peer TEXT,
+                     created_at_ms INTEGER NOT NULL, updated_at_ms INTEGER NOT NULL,
+                     FOREIGN KEY (goal_id) REFERENCES goals(goal_id));
+                 INSERT INTO goals VALUES ('g1', 'ship', 'active', 0, 1000, 0, 0, 1, 1);
+                 INSERT INTO tasks VALUES ('t1', 'g1', '', '', 'running', NULL, 1, 1);",
+            )
+            .unwrap();
+        }
+
+        let ledger = GoalLedger::open(&path).unwrap();
+        assert!(
+            ledger
+                .update_task_status_with_provenance("t1", "failed", true, 2_000)
+                .unwrap(),
+            "the migrated column accepts the provenance write"
+        );
+        assert!(
+            ledger.update_task_status("t1", "complete", 3_000).unwrap(),
+            "the correction works on a migrated ledger"
+        );
+        assert_eq!(ledger.get_task("t1").unwrap().unwrap().status, "complete");
+    }
+
+    /// #2055 review round 3 — goal-scoped task listing (used by effect
+    /// tests that identify rows by title when the task id is internal to a
+    /// detached child supervisor).
+    #[test]
+    fn should_list_tasks_for_exactly_one_goal() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
+        seed_goal_with_task(&ledger, "g1", "t1", "running");
+        seed_goal_with_task(&ledger, "g2", "t2", "running");
+
+        let tasks = ledger.tasks_for_goal("g1").unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].task_id, "t1");
+        assert!(ledger.tasks_for_goal("g3").unwrap().is_empty());
     }
 
     /// The goal-facing point of the whole exercise: `task_status_counts` is


### PR DESCRIPTION
Closes #2055. Closes #2054.

## What / why

A goal-ledger `tasks` row was created only as an FK side effect of three peer-specific paths, and no code path ever updated a row's status — so background tasks and sub-agents never appeared in the ledger at all, and every row that did exist stayed `"running"` forever. This PR creates the row when `TaskSupervisor` registers a task and settles it when the task reaches a terminal state.

Architecture after nine review rounds (commits 1, 2, 4, 5, 6, 7, 8, 9, 10; commit 3 is a typo-gate chore):

1. **octos-agent — registration observer.** `TaskSupervisor::set_on_register`, fired from `register_full`'s single success path — one call site covers every registration kind; refused registrations never fire it; no supervisor locks held at invocation. Child/nested supervisors inherit `on_register` + the NAMED `on_change_listeners` map at all three fresh-supervisor sites (`snapshot_excluding`, sync nested spawn, DETACHED background nested spawn — the default mode). Wake callbacks stay per-instance. No octos-fleet dependency added.
2. **octos-fleet — idempotent creation, authority-ranked settlement, atomic migration.** `create_task_if_absent` / `create_goal_if_absent` preserve existing rows unconditionally, and (round 5) both creation APIs derive the row's initial `authority` from the status they write (`complete`→completion rank, `failed`→final-failure rank, nonterminal→none), so a created terminal row refuses a later `running` refresh. Settlement persists the authority rank (−1/0/1/2) with one admission rule — strictly-greater rank wins, first-wins within a rank — via `settle_task_status(TaskSettleAuthority)`; all six scrambled P/C/D orders containing a final failure end `failed` (tested at the SQL layer and through the real blocking cores). The migration (round 5) runs as ONE `BEGIN IMMEDIATE` transaction inside `open_with_busy_retry`'s attempt loop, decided by `pragma_table_info` schema inspection — never error-message substrings; any statement failure rolls the whole migration back and propagates; pre-existing terminal rows are stamped FINAL in the same transaction as the column creation; the plain `open` (tokio-worker paths) runs no migration and legacy fallbacks never reference the column.
3. **octos-cli, #2055 — registration recording.** ONE shared installer wires the observer pair for every production site AND the effect tests (dispatch-time snapshot per WS turn; callback-time `active_goal_id` for the gateway actor and cached out-of-turn supervisor). `record_goal_task_registration` synchronously stashes a binding and offloads all SQLite I/O to the blocking pool.
4. **octos-cli, #2054 — change-feed settlement.** Settling rides a NAMED change listener (cancel emits only `notify_change`; the `on_terminal` sink's dedupe would swallow the owner's correction). Self-sufficient (seeds FK parent + row when creation hasn't landed; either ordering converges), bounded retry (5 attempts, 100/200/400/800ms backoff on the executor timer, fresh `spawn_blocking` per attempt), and a per-binding generation fence re-checked before every write attempt. Provisional failures retain their binding as a 30-minute correction window; the purge consults worker liveness, (round 5) NEVER drops an entry with a settle flight in progress — the flight counter is taken atomically with the binding fetch when work is enqueued and released generation-matched on chain end — and all success-path map mutations are generation-gated so a chain racing a re-stash cannot touch the new incarnation's entry. No continuation, event, notification, or wake is emitted anywhere.

## Codex findings — nine rounds

Round 2 on 1: H1/H2/H5/H8/H10 refuted — held. Round 3 on 2: R1/R5/R6/R10 refuted — held. Round 4 on 3: F1/F3/F7 + the owner-downgrade judgment call held/accepted; cross-supervisor cancellation authority → #2060. **Round 5 on 4: G1 (authority ordering), G4 (generation-fence design, residual → #2056), G7 (wiring) held; wall-clock margins tracked as a test-hardening note; four MUST-FIX items below.** **Round 6 on 5: V1 (migration atomicity) and V4 (scoped retry proof) closed; V2/V3 point fixes below.** **Round 7 (W-pass): W1 (re-arm hand-off) and W4 (diff scope) closed; W2/orphan/W3-test point fixes below.** **Round 8 (X-pass): X4 closed and every PRODUCTION path verified sound across all three passes — the remaining items were test scaffolding plus one stale comment, fixed in commit 9: test guards route through the real acquire (a fabricated guard was an unbalanced release masked by `saturating_sub`); the re-stash simulations go through the real stash path with stale holds taken while their incarnation was live; the placeholder zero-initializers live in one documented constructor; the migration pin asserts the creation BEGAN before the release (start-barriered), closing the sequential-execution masquerade; the flight-guard doc reflects the hand-through ownership and the generation counter documents why u64 wrap is a non-concern (~5.8 × 10^5 years at a million stashes per second). No production behavior change; the accounting/ABA/pin suites all pass with the honest scaffolding.** **Round 9 (Y-pass): Y1/Y2/Y3/Y5/Y6 closed; Y4 fixed in commit 10 — the migration pin's timing-based creator thread (defeatable by a valid deschedule that ran the whole creation post-release) is replaced by a single-threaded busy-probe: with the hook verifiably parking the migration transaction, a zero-busy-timeout terminal creation on the test thread must fail with lock contention (an assertion no schedule can fake or break), then succeeds after release with its real rank. octos-fleet-test-only diff; fleet suite 170 green; hook-bypass mutation fails the probe assertion.**

| finding | fix (commit) |
|---|---|
| Rounds 2–3 (summarized) | change-feed settle; observer inheritance incl. the detached default branch; `spawn_blocking` offload; self-sufficient settle; bounded retry; retention deadline; shared installer; effect tests through real paths (2, 4) |
| Round 4: terminal authority; purge liveness/ordering/refresh; generation fence; migration relocation + classification; contention handshakes | persisted rank + strict-greater rule; `task_is_live` consult, fetch-before-purge, stamp-once; per-binding generation; migration in `open_with_busy_retry`; barriered contention tests (5) |
| **R5 G5+G8 (P1): migration not atomic; substring matching ate real errors** | one `BEGIN IMMEDIATE` transaction, schema-inspection-driven steps, full rollback on any failure; tests: aborting-trigger rollback restores the pre-migration shape and the re-run completes, second opener is a clean no-op, a dependent index on the round-3 column fails the drop loudly with full rollback (6) |
| **R5 G3 (P1): purge could kill a queued/backing-off correction** (liveness clears before the final transition) | per-binding flight counter, incremented atomically with the fetch at enqueue, released generation-matched at chain end; purge skips in-flight entries regardless of expiry; barriered test proves the spared correction lands and the SETTLE (not the purge) removes the entry (6) |
| **R5 G2 (P2): terminal creation at authority −1 admitted a `running` overwrite** | creation-time authority derivation in both creation APIs (legacy-schema fallback preserved); test pins the reproduced `failed → running` hole shut (6) |
| **R5 G6 (P2): retry proof released on a process-global counter delta — false pass possible** | attempt counter keyed per task id; the release gate waits for THIS task's second attempt; scoping pinned by a dedicated test (6) |
| **R6 V2a (P1): retry re-arm queued the next attempt without a flight hold — purge could kill the chain inside a backoff gap** | the re-arm takes the next attempt's hold (map lock, generation-matched) before the timer is queued; the purge-during-retry test now verifiably crosses a backoff gap under a purge hammer (7) |
| **R6 V2b (P1): the fence-kill exit skipped the flight release** | ONE structural release point — a drop-guard at blocking-core entry releases on every exit (success, exhaustion, fence-kill, panic-unwind) exactly once, generation-matched; zero-balance pinned per exit by a dedicated accounting test. Convinced no exit skips it because the guard is constructed before the first early return and Drop is unconditional; the fence-kill release is additionally a provable no-op today (the fence only trips when the hold's entry was removed or re-keyed, and the hold dies with its entry) — verified by mutation: a fence-only release skip changes nothing in isolation, while neutralizing the release point itself fails the accounting test (7) |
| **R6 V3 (P1): creation's schema inspection and insert were separate autocommit statements — the busy handler made the poisoned interleaving COMMON (legacy insert blocks on the migration's lock, then lands a terminal row at authority `-1` after the backfill)** | inspection + insert in one `BEGIN IMMEDIATE` transaction per creation call, serializing against the migration's own immediate transaction — the interleaving is impossible, not unlikely (structural argument in the code comment); barrier-started concurrency pin as a tripwire (7) |
| **R7 W2 (ABA): per-entry generations restarted at 0 after remove-then-re-stash of the same task id — a stale generation-0 hold could steal the new incarnation's live flight** | generations from ONE process-wide monotonic counter, assigned at a single stash point shared by production and tests (also pre-covers #2056's same-id restoration); ABA test pins that a stale hold cannot touch the re-stashed entry or its purge protection (8) |
| **R7 blast-radius orphan: holds acquired at enqueue/re-arm had no RAII owner until core entry — a dropped timer future or never-run closure orphaned the hold, leaving the entry permanently unpurgeable** | `acquire` returns the OWNING guard; the enqueue constructs it atomically with the flight mark; it rides the timer future and blocking closure into the core (which receives instead of constructs); dropped-future test pins that the hold dies with the future and the entry purges again; exactly-once accounting re-verified (8) |
| **R7 W3 (test only; production fix already closed): the concurrency pin was not actually barriered — it could pass under fully sequential execution** | cfg-gated, path-keyed hook inside the migration transaction (between the schema statements and commit; `None` in production) holds it verifiably open while the test fires a terminal creation; asserts the creation was blocked for the full hold, completed only after release, and landed with its real rank — mid-transaction interleaving proven, not hoped (8) |

Known residual (unchanged): production installer call-site presence is not testable without serve-boot integration infra — deleting a wiring call would not be caught today; behavior drift IS covered because all sites and tests share the one installer.

## Coverage

| task kind | WS/serve | gateway |
|---|---|---|
| background / spawn_only (per-turn registry) | rows + settle | rows + settle |
| sub-agents incl. nested children — sync AND default background branches | rows + settle | rows + settle |
| peers / native specialists (`native_agent`, `assigned_peer` = agent id) | rows + settle | rows + settle |
| native-review swarm / background skill actions (cached supervisor + inheritance) | rows + settle | n/a |
| cancelled tasks | `failed`, FINAL rank, binding released | same |
| observer-provisional failures | `failed`, provisional rank; owner completion corrects, owner re-failure finalizes; 30-minute window, never purged while the worker is live or a settle flight is in progress | same |
| MCP sessions (`octos mcp-serve`) | — (no observers wired; no goal binding) | — |

Not covered, stated plainly: `octos mcp-serve` and `octos chat` runtimes; no-goal sessions (by design); restart replay and offload delivery durability (**#2056**, which also tracks the generation-fence residual); cross-supervisor cancellation authority (**#2060**); installer call-site presence (residual above).

## CI filters (#2029)

Tests live in non-gated `autonomy::agent_orchestrator::tests` → the unfiltered `cargo test -p octos-cli --lib` step (verified with `-- --list` under both invocations). `octos-fleet` was absent from CI entirely; this PR adds the missing `Test octos-fleet` step.

## Gates (round 8, after commit 9)

```
cargo fmt --all -- --check                                 → PASS
cargo test -p octos-fleet                                  → ok. 170 passed; 0 failed; 0 ignored
cargo test -p octos-agent --lib                            → ok. 2572 passed; 0 failed; 3 ignored
cargo test -p octos-cli --lib --features api (1 thread)    → 2980 passed; 1 failed; 6 ignored
cargo test -p {octos-fleet,octos-agent,octos-cli} --doc    → ok (0/1/0 passed; 0 failed)
cargo clippy --workspace --all-targets                     → clean (exit 0)
cargo clippy -p octos-cli --all-targets --features api     → clean (exit 0)
```

The single octos-cli failure remains `process_manager::tests::should_allocate_bridge_ports_as_consecutive_pair` — environmental (an ssh tunnel listens on 127.0.0.1:3101 and the allocator probes real port availability), file untouched by this PR. One additional pre-existing standalone flake surfaced during round-6 verification: `session_actor::tests::master_continuation_tick_reenters_actor_loop` (a paused-clock tick race) fails roughly one run in ten when run alone — reproduced identically on the pre-round-6 commit with this round's changes stashed, and its code path does not touch this PR's diff.

## Mutation checks

Round 7:
1. Generation assignment reverted to per-entry reset-to-0 → `rebound_task_id_cannot_be_stolen_by_a_stale_hold` failed on the never-reused assertion. Restored.
2. Guard hand-through reverted (the re-arm's hold forgotten by the timer future; a replacement constructed at core entry, the pre-round-7 shape) → `dropped_retry_future_releases_its_flight_hold` failed with the hold orphaned at 1. Restored.
3. Migration hook bypassed (no install, no in-transaction wait) → the pin's blocked-duration/ordering assertion failed in 0.32s (the migration completed unhindered and the creation was never blocked). Restored.

Round 6:
1. Re-arm flight hand-off removed → `purge_spares_in_flight_correction_and_the_settle_lands_it` failed (the purge hammer kills the binding inside the now-unprotected backoff gap; the correction never lands). Verified against the strengthened test, in isolation. Restored.
2. The single release point neutralized (drop-guard made a no-op) → `settle_flight_hold_returns_to_zero_on_every_chain_exit` failed. The literal fence-only variant (`mem::forget` of the guard on the fence exit alone) changes nothing in isolation — the structural no-op argument above, verified empirically. Restored.
3. Creation transaction removed (inspection + insert back to autocommit) → the concurrency pin failed 5 runs out of 5, at iteration 0 or 1 of 20 each time — the busy handler makes the poisoned interleaving near-certain once the hammer and migration overlap, so no further tightening was needed beyond the existing warmup barrier. Restored.

Round 5:
1. Migration statements moved outside the transaction (autocommit) → `should_roll_back_whole_migration_when_a_step_fails` and `should_propagate_drop_failure_when_an_index_depends_on_the_old_column` both failed on persisted partial state. Restored.
2. In-flight purge protection removed → `purge_spares_in_flight_correction_and_the_settle_lands_it` failed. Restored.
3. Creation-time authority derivation removed (always −1) → `should_refuse_running_refresh_on_freshly_created_terminal_row` failed. Restored.
4. Scoped-signal verification: the counter increment re-keyed to a constant (the un-scoped/global shape) → `settle_attempt_counter_is_scoped_per_task` failed — that failing mutation is the concrete proof the signal is genuinely per-task; the contended-settle release gate reads only its own task's key.

Earlier rounds (all previously stated, all restored): round 4 — rank flattened, liveness consult removed, generation check disabled, all migration errors swallowed; round 3 — detached-branch inheritance removed, provisional provenance zeroed, retry disabled; round 2 — inheritance gutted, correction admission reverted; round 1 — `notify_register` deleted, settle writing `running`.
