### PR TITLE
chore(release): v2.0.3-rc.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4531,7 +4531,7 @@ dependencies = [
 
 [[package]]
 name = "octos-agent"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "async-trait",
  "base64",
@@ -4592,7 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "octos-bus"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "aes",
  "async-imap",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "octos-cli"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "agent-client-protocol",
  "argon2",
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "octos-core"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "chrono",
  "eyre",
@@ -4731,7 +4731,7 @@ dependencies = [
 
 [[package]]
 name = "octos-diagnostics"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4743,14 +4743,14 @@ dependencies = [
 
 [[package]]
 name = "octos-dora-mcp"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "octos-agent",
 ]
 
 [[package]]
 name = "octos-embed-llama"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "octos-ffi"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "libc",
  "octos-agent",
@@ -4780,7 +4780,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4796,7 +4796,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet-worker"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4813,7 +4813,7 @@ dependencies = [
 
 [[package]]
 name = "octos-llm"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "async-trait",
  "base64",
@@ -4837,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "octos-memory"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "bincode",
  "chrono",
@@ -4857,7 +4857,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pipeline"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "octos-plugin"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "eyre",
  "metrics",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pyo3"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "octos-ffi",
  "pyo3",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "octos-server"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "async-trait",
  "axum",
@@ -4955,7 +4955,7 @@ dependencies = [
 
 [[package]]
 name = "octos-services"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "chrono",
  "dirs",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "octos-store"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "base64",
  "chrono",
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "octos-swarm"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "octos-uniffi"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "octos-ffi",
  "uniffi",
@@ -5024,7 +5024,7 @@ dependencies = [
 
 [[package]]
 name = "octos-wasm"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -5040,7 +5040,7 @@ dependencies = [
 
 [[package]]
 name = "octos-workflows"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "chrono",
  "eyre",
@@ -8475,7 +8475,7 @@ dependencies = [
 
 [[package]]
 name = "wechat-bridge"
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 dependencies = [
  "clap",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.3-rc.6"
+version = "2.0.3-rc.7"
 edition = "2024"
 rust-version = "1.85.0"
 authors = ["octos team"]


### PR DESCRIPTION
Version bump 2.0.3-rc.6 → 2.0.3-rc.7. Same shape as #2044 (workspace version + lock).

Since rc.6, main gained: the e2e root-cause fix + admin-shell CI enablement (#2043), Phase-4 queue-drain routing (#2048), the serve wiring guard (#2041), the sysinfo fd-leak fix (#2051), the Windows formatter-timeout fix (#2058), the goal-ledger task-status writer (#2057), the interrupt/steer server fixes (#2049/#2050/#2052), and goal↔task state sync (#2059, closes #2054/#2055).