### PR TITLE
fix(goal): budget-guarded resume + clear that settles in-flight charges (#2063, #2064)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -4380,6 +4380,12 @@ impl Drop for AbortOnDrop {
 /// (`tick % 8 == 0`) so the cadence feels identical across surfaces.
 const STATUS_WORD_INTERVAL: std::time::Duration = std::time::Duration::from_secs(8);
 
+/// #2066 round 4 (codex fix 2) — cadence of the AppUI goal-turn in-flight
+/// heartbeat, mirroring the session actor's `IN_FLIGHT_HEARTBEAT_INTERVAL`
+/// (#2003): well under the 30-minute staleness horizon, coarse enough to be
+/// free.
+const APPUI_IN_FLIGHT_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
 /// CJK code-point check shared with `status_indicator::has_cjk` — kept
 /// inline here to avoid pulling the channel-aware status_indicator
 /// module into the WS turn path.
@@ -31426,6 +31432,38 @@ async fn run_standalone_turn(
     // task future is dropped.
     let token_tracker = std::sync::Arc::new(octos_agent::TokenTracker::new());
     let token_tracker_task = std::sync::Arc::clone(&token_tracker);
+    // #2066 round 4 (codex fix 2) — the AppUI twin of the session actor's
+    // #2003 in-flight heartbeat: keep this goal turn's dispatch marker fresh
+    // WHILE the turn is genuinely producing. AppUI had NO refresh at all, so
+    // a legitimately long (>30min) goal turn's marker read stale — its settle
+    // tombstone purged before the late charge arrived, and a concurrent
+    // `/goal clear` could claim the "free" slot without parking a tombstone.
+    // Progress-gated exactly like the actor's: the refresh fires only when
+    // the shared TokenTracker has ADVANCED since the last tick, so a wedged
+    // turn stops being refreshed and ages out normally (#2003's contract).
+    // Touches the SCOPED goal store key — the key the drain claimed the
+    // marker under — not the wire session id. Aborted on every exit with the
+    // turn (AbortOnDrop).
+    let _in_flight_heartbeat = goal_context.as_ref().map(|ctx| {
+        let tracker = std::sync::Arc::clone(&token_tracker);
+        let marker_key = ctx.goal_session_key.clone();
+        let heartbeat = tokio::spawn(async move {
+            use std::sync::atomic::Ordering as AtomicOrdering;
+            let mut last = 0_u64;
+            loop {
+                tokio::time::sleep(APPUI_IN_FLIGHT_HEARTBEAT_INTERVAL).await;
+                let seen = u64::from(tracker.input_tokens.load(AtomicOrdering::Relaxed))
+                    + u64::from(tracker.output_tokens.load(AtomicOrdering::Relaxed));
+                if seen > last {
+                    last = seen;
+                    default_agent_orchestrator().touch_goal_dispatch_in_flight(&marker_key);
+                }
+            }
+        });
+        AbortOnDrop {
+            abort: heartbeat.abort_handle(),
+        }
+    });
     // task-turn-interrupt-steer-correlation-logs: every agent-side log line
     // (LLM calls, tool batches, steer drains, EndTurn rounds) inherits
     // `session`/`turn` from this span (postfix `.instrument` keeps the block

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -19997,6 +19997,7 @@ async fn maybe_spawn_appui_master_continuation_runner(
                     .goal_id
                     .as_ref()
                     .map(|goal_id| goal_id.as_str().to_owned()),
+                claim_generation: claim_guard.as_ref().map(|guard| guard.generation()),
             })
         }
         _ => None,
@@ -28647,6 +28648,11 @@ struct GoalContinuationContext {
     /// goal's tombstone instead of the replacement. `None` for legacy
     /// persisted continuations without a stamped goal id.
     bound_goal_id: Option<String>,
+    /// #2066 round 5 (codex fix 1) — the marker incarnation the atomic
+    /// drain-and-claim took for THIS turn. The in-flight heartbeat refreshes
+    /// generation-matched so a stale predecessor turn resuming production
+    /// can never keep a replacement turn's marker alive.
+    claim_generation: Option<u64>,
 }
 
 /// #1134 — pick the LAST non-empty assistant row after `pre` from a
@@ -31442,9 +31448,14 @@ async fn run_standalone_turn(
     // the shared TokenTracker has ADVANCED since the last tick, so a wedged
     // turn stops being refreshed and ages out normally (#2003's contract).
     // Touches the SCOPED goal store key — the key the drain claimed the
-    // marker under — not the wire session id. Aborted on every exit with the
-    // turn (AbortOnDrop).
-    let _in_flight_heartbeat = goal_context.as_ref().map(|ctx| {
+    // marker under — not the wire session id. #2066 round 5 (codex fix 1):
+    // GENERATION-MATCHED — the refresh names the marker incarnation THIS
+    // turn's drain-and-claim took, so a stale predecessor that resumes
+    // producing after eviction can never keep a replacement turn's marker
+    // alive (no generation ⇒ no claim was taken ⇒ no heartbeat). Aborted on
+    // every exit with the turn (AbortOnDrop).
+    let _in_flight_heartbeat = goal_context.as_ref().and_then(|ctx| {
+        let claim_generation = ctx.claim_generation?;
         let tracker = std::sync::Arc::clone(&token_tracker);
         let marker_key = ctx.goal_session_key.clone();
         let heartbeat = tokio::spawn(async move {
@@ -31456,13 +31467,14 @@ async fn run_standalone_turn(
                     + u64::from(tracker.output_tokens.load(AtomicOrdering::Relaxed));
                 if seen > last {
                     last = seen;
-                    default_agent_orchestrator().touch_goal_dispatch_in_flight(&marker_key);
+                    default_agent_orchestrator()
+                        .touch_goal_dispatch_in_flight_generation(&marker_key, claim_generation);
                 }
             }
         });
-        AbortOnDrop {
+        Some(AbortOnDrop {
             abort: heartbeat.abort_handle(),
-        }
+        })
     });
     // task-turn-interrupt-steer-correlation-logs: every agent-side log line
     // (LLM calls, tool batches, steer drains, EndTurn rounds) inherits

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -19826,27 +19826,33 @@ async fn maybe_spawn_appui_master_continuation_runner(
     if occupied {
         return false;
     }
-    // Cross-subsystem occupancy (#1529): a session actor draining a
-    // continuation turn for this session marks it in-flight but has no entry
-    // in this connection's `active_turns` map. Without this check the serve
-    // tick would drain + spawn a SECOND concurrent turn on the same session
-    // while the actor's turn runs. The actor clears the marker (RAII guard)
-    // when its turn ends, so the next tick re-dispatches normally.
-    if default_agent_orchestrator().is_goal_dispatch_in_flight(&goal_storage_key) {
-        return false;
-    }
-
     let runtime_state = MasterContinuationRuntimeState::idle().with_approval_pending(
         !contracts
             .approvals
             .pending_for_session(&session_id)
             .is_empty(),
     );
-    let Some(continuation) = default_agent_orchestrator()
-        .drain_ready_continuations_for_session(&goal_storage_key, &profile_id, runtime_state, 1)
-        .into_iter()
-        .next()
-    else {
+    // #2066 round 3 (codex fix 2) — ATOMIC drain-and-claim, the same
+    // primitive the session actor uses: the in-flight claim and the pop
+    // happen under ONE state lock, so this path can never pop a one-shot it
+    // does not own. The round-2 shape (separate occupancy check → pop →
+    // claim inside the spawned task) could pop an item, lose the claim race
+    // to another dispatcher, and complete the popped item UNEXECUTED — for a
+    // latched GoalWrapUp that meant permanently dropping the wrap-up
+    // (`wrap_up_emitted` never re-mints on a budget_limited goal). A held
+    // marker now drains NOTHING here (cross-subsystem occupancy, #1529,
+    // subsumed: the claim check is inside the same lock as the pop), and the
+    // returned guard travels into the spawned turn, released on every exit.
+    let (mut drained, claim_guard) = default_agent_orchestrator()
+        .drain_and_claim_ready_continuation_for_session(
+            &goal_storage_key,
+            &profile_id,
+            runtime_state,
+            1,
+        );
+    let Some(continuation) = drained.pop() else {
+        // Nothing owned: nothing was popped, nothing to complete. The guard
+        // (if any) drops here and releases immediately.
         return false;
     };
 
@@ -20016,53 +20022,30 @@ async fn maybe_spawn_appui_master_continuation_runner(
         // post-turn `record_goal_turn` call below (which runs with
         // real token usage).
         //
-        // #1140 codex P2 re-review #3: mark the goal session as
-        // in-flight so `due_loop_targets`'s goal sweep + the
-        // `enqueue_due_goal_continuations` enqueue path both skip
-        // it until the post-turn accountant clears it. The
-        // timestamp alone isn't enough for goal turns > 30s.
+        // #1140 codex P2 re-review #3/#4: the in-flight claim keeps
+        // `due_loop_targets`'s goal sweep + the enqueue paths off this
+        // session until the post-turn accountant finishes, and the RAII
+        // guard clears it on every exit (abort, early terminal, panic).
         //
-        // #1140 codex P1 re-review #4: use the RAII drop-guard shape
-        // so the marker is cleared even if the spawned turn task is
-        // aborted (e.g. `abort_connection_turns` on connection close)
-        // or returns through an early terminal path. The Drop becomes
-        // the single canonical clear-point (codex P2 re-review #5).
+        // #2066 round 3 (codex fix 2) — the claim is no longer taken here:
+        // it was taken ATOMICALLY WITH THE POP by
+        // `drain_and_claim_ready_continuation_for_session` and travels into
+        // this task. Claim-failure therefore pops nothing and completes
+        // nothing (the round-2 try-claim-in-task shape popped first and
+        // completed the item UNEXECUTED on claim failure — permanently
+        // dropping a latched GoalWrapUp). Held for EVERY continuation
+        // reason, matching the session actor's claim semantics.
         //
-        // #2066 round 2 (codex R2 — the round-1 root defect): the claim is
-        // now an ATOMIC TRY-claim, not the unconditional mark. The old
-        // `goal_dispatch_in_flight_guard` INSERTED over whatever marker
-        // existed — so a `/goal clear` that claimed the slot (or another
-        // dispatcher's live turn) in the gap between this path's pre-drain
-        // check and this spawned task was silently overwritten, and the turn
-        // launched from state being destroyed with its charge landing
-        // nowhere (the clear saw the slot free, so no settle tombstone was
-        // parked). Now: (1) try-claim — if the slot is held, the launch
-        // ABORTS without emitting anything; (2) after claiming, RE-CHECK
-        // that the goal record still exists and is the same incarnation the
-        // continuation was enqueued for — a clear that already claimed,
-        // stamped and released leaves the goal gone, and launching the
-        // drained prompt anyway would run a turn for a deleted goal. Both
-        // aborts stamp the internal turn slot Terminal (no wire event was
-        // emitted for this turn yet — the client never saw it) so the
-        // session's `active_turns` slot frees for the next dispatch, and
-        // mark the continuation completed so a restart never replays it.
-        let _in_flight_guard = if let Some(ref ctx) = goal_context_for_appui {
+        // The post-claim goal RECHECK stays: with the claim held, a
+        // gone/mismatched goal is genuinely cleared/replaced (not a racing
+        // dispatcher), so completing the popped item is correct — launching
+        // the drained prompt would run a turn for a deleted goal. The abort
+        // stamps the internal turn slot Terminal (no wire event was emitted
+        // for this turn yet — the client never saw it) so the session's
+        // `active_turns` slot frees for the next dispatch.
+        let _in_flight_guard = claim_guard;
+        if let Some(ref ctx) = goal_context_for_appui {
             let session_key = SessionKey(continuation.session_id.as_str().to_owned());
-            let Some(guard) = default_agent_orchestrator().try_claim_goal_in_flight(&session_key)
-            else {
-                info!(
-                    session = %params.session_id,
-                    continuation_id = continuation.id.as_u64(),
-                    "goal dispatch slot already claimed (another turn or a clear \
-                     in progress); aborting this launch"
-                );
-                *turn_state_for_task.lock().await = TurnState::Terminal(TerminalReason::Completed);
-                default_agent_orchestrator().mark_continuation_completed(
-                    &continuation,
-                    Some("dispatch_slot_claimed_launch_aborted".to_owned()),
-                );
-                return;
-            };
             if !default_agent_orchestrator().goal_dispatch_target_matches(
                 &session_key,
                 &ctx.profile_id,
@@ -20071,8 +20054,8 @@ async fn maybe_spawn_appui_master_continuation_runner(
                 info!(
                     session = %params.session_id,
                     continuation_id = continuation.id.as_u64(),
-                    "goal was cleared/replaced between drain and claim; \
-                     aborting this launch"
+                    "goal was cleared/replaced between drain and launch; \
+                     aborting this turn"
                 );
                 *turn_state_for_task.lock().await = TurnState::Terminal(TerminalReason::Completed);
                 default_agent_orchestrator().mark_continuation_completed(
@@ -20084,10 +20067,7 @@ async fn maybe_spawn_appui_master_continuation_runner(
             }
             default_agent_orchestrator()
                 .record_goal_dispatch_timestamp_only(&session_key, &ctx.profile_id);
-            Some(guard)
-        } else {
-            None
-        };
+        }
         // #436 P1 #2 — for a peer_send_input injection, track whether the turn
         // actually dispatched the agent, so an UNDELIVERED injection (e.g. a
         // failed `TurnStarted`) is NOT marked completed and stays durable for

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -19981,6 +19981,10 @@ async fn maybe_spawn_appui_master_continuation_runner(
                 // enqueued under; the post-turn accountant must charge THAT
                 // record, not the plain wire id.
                 goal_session_key: SessionKey(continuation.session_id.as_str().to_owned()),
+                bound_goal_id: continuation
+                    .goal_id
+                    .as_ref()
+                    .map(|goal_id| goal_id.as_str().to_owned()),
             })
         }
         _ => None,
@@ -20024,15 +20028,63 @@ async fn maybe_spawn_appui_master_continuation_runner(
         // or returns through an early terminal path. The Drop becomes
         // the single canonical clear-point (codex P2 re-review #5).
         //
-        // GoalWrapUp doesn't go through this guard because the
-        // goal is already `budget_limited` — `due_loop_targets`'s
-        // goal sweep already excludes non-active goals, and the
-        // pending-queue sweep handles wrap-up via #1141's path.
+        // #2066 round 2 (codex R2 — the round-1 root defect): the claim is
+        // now an ATOMIC TRY-claim, not the unconditional mark. The old
+        // `goal_dispatch_in_flight_guard` INSERTED over whatever marker
+        // existed — so a `/goal clear` that claimed the slot (or another
+        // dispatcher's live turn) in the gap between this path's pre-drain
+        // check and this spawned task was silently overwritten, and the turn
+        // launched from state being destroyed with its charge landing
+        // nowhere (the clear saw the slot free, so no settle tombstone was
+        // parked). Now: (1) try-claim — if the slot is held, the launch
+        // ABORTS without emitting anything; (2) after claiming, RE-CHECK
+        // that the goal record still exists and is the same incarnation the
+        // continuation was enqueued for — a clear that already claimed,
+        // stamped and released leaves the goal gone, and launching the
+        // drained prompt anyway would run a turn for a deleted goal. Both
+        // aborts stamp the internal turn slot Terminal (no wire event was
+        // emitted for this turn yet — the client never saw it) so the
+        // session's `active_turns` slot frees for the next dispatch, and
+        // mark the continuation completed so a restart never replays it.
         let _in_flight_guard = if let Some(ref ctx) = goal_context_for_appui {
             let session_key = SessionKey(continuation.session_id.as_str().to_owned());
+            let Some(guard) = default_agent_orchestrator().try_claim_goal_in_flight(&session_key)
+            else {
+                info!(
+                    session = %params.session_id,
+                    continuation_id = continuation.id.as_u64(),
+                    "goal dispatch slot already claimed (another turn or a clear \
+                     in progress); aborting this launch"
+                );
+                *turn_state_for_task.lock().await = TurnState::Terminal(TerminalReason::Completed);
+                default_agent_orchestrator().mark_continuation_completed(
+                    &continuation,
+                    Some("dispatch_slot_claimed_launch_aborted".to_owned()),
+                );
+                return;
+            };
+            if !default_agent_orchestrator().goal_dispatch_target_matches(
+                &session_key,
+                &ctx.profile_id,
+                ctx.bound_goal_id.as_deref(),
+            ) {
+                info!(
+                    session = %params.session_id,
+                    continuation_id = continuation.id.as_u64(),
+                    "goal was cleared/replaced between drain and claim; \
+                     aborting this launch"
+                );
+                *turn_state_for_task.lock().await = TurnState::Terminal(TerminalReason::Completed);
+                default_agent_orchestrator().mark_continuation_completed(
+                    &continuation,
+                    Some("goal_removed_before_launch".to_owned()),
+                );
+                // The claim guard drops here, releasing the slot.
+                return;
+            }
             default_agent_orchestrator()
                 .record_goal_dispatch_timestamp_only(&session_key, &ctx.profile_id);
-            Some(default_agent_orchestrator().goal_dispatch_in_flight_guard(session_key))
+            Some(guard)
         } else {
             None
         };
@@ -28601,6 +28653,14 @@ struct GoalContinuationContext {
     /// A goal turn would charge nothing (the wire key finds no scoped goal) and
     /// recur forever without ever hitting its budget.
     goal_session_key: SessionKey,
+    /// #2066 round 2 (codex R1c/R2) — the goal identity this continuation was
+    /// enqueued under (`QueuedMasterContinuation::goal_id`). Used twice: the
+    /// post-claim dispatch recheck refuses to launch when the live goal is no
+    /// longer this incarnation, and the post-turn accountant charges
+    /// goal-id-bound so a mid-turn clear(+recreate) settles the cleared
+    /// goal's tombstone instead of the replacement. `None` for legacy
+    /// persisted continuations without a stamped goal id.
+    bound_goal_id: Option<String>,
 }
 
 /// #1134 — pick the LAST non-empty assistant row after `pre` from a
@@ -33465,6 +33525,10 @@ async fn run_standalone_turn(
         if let Some(snapshot) = orchestrator.record_goal_turn(
             goal_key,
             &goal_ctx.profile_id,
+            // #2066 round 2 (codex R1c) — goal-id-bound charge: a mid-turn
+            // clear(+recreate) settles the cleared goal's tombstone, never
+            // the replacement goal.
+            goal_ctx.bound_goal_id.as_deref(),
             final_tokens_consumed,
             elapsed_seconds,
         ) {

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -3071,6 +3071,13 @@ impl InProcessAgentOrchestrator {
     /// in-flight sessions so a long-running goal turn (> 30s) can't
     /// be re-dispatched in the await gap between turn-terminal
     /// emission and `record_goal_turn`. Idempotent.
+    ///
+    /// #2066 round 2 (codex R2) — TEST ONLY: the unconditional mark
+    /// OVERWRITES whatever marker exists, which is exactly the overwrite
+    /// hazard R2 removed from production (every production claim is atomic
+    /// now — try-claim / drain-and-claim / clear-claim). Tests use it to
+    /// simulate a foreign dispatcher's turn being in flight.
+    #[cfg(test)]
     pub(crate) fn mark_goal_dispatch_in_flight(&self, session_id: &SessionKey) -> u64 {
         // #2003 — (re)stamp the marker. A live long-running turn that re-marks
         // keeps a FRESH timestamp, so the staleness sweep never evicts it.
@@ -3169,32 +3176,23 @@ impl InProcessAgentOrchestrator {
         in_flight_marker_is_held(&self.state(), session_id)
     }
 
-    /// #1140 codex P1 re-review #4 — RAII drop-guard for the
-    /// in-flight marker. Use this from the AppUI tick path so the
-    /// marker is cleared on ANY exit path (cancellation,
-    /// early-terminal-error, panic), not just the happy
-    /// post-accounting path. The guard captures a 'static reference
-    /// to the orchestrator singleton, so it's safe to move across
-    /// await points / into spawned tasks.
-    pub(crate) fn goal_dispatch_in_flight_guard(
-        &'static self,
-        session_id: SessionKey,
-    ) -> GoalDispatchInFlightGuard {
-        let generation = self.mark_goal_dispatch_in_flight(&session_id);
-        GoalDispatchInFlightGuard {
-            orchestrator: self,
-            session_id,
-            generation,
-            disarmed: false,
-        }
-    }
+    // #2066 round 2 (codex R2) — `goal_dispatch_in_flight_guard` (the
+    // UNCONDITIONAL mark-and-guard, #1140) is deleted: its one production
+    // caller — the AppUI continuation spawn — silently OVERWROTE whatever
+    // marker existed (a clear's claim, another dispatcher's live turn) and
+    // was the root of the launch-from-destroyed-state race. Every production
+    // claim is now atomic: [`Self::try_claim_goal_in_flight`] (dispatch +
+    // interactive), [`Self::drain_and_claim_ready_continuation_for_session`]
+    // (session actor), and `claim_clear_dispatch_slot` (the clear path). The
+    // source guard `appui_continuation_spawn_should_use_atomic_try_claim_
+    // source_guard` pins the spawn site against reintroduction.
 
     /// #1650 — atomic, OWNER-AWARE claim of the in-flight marker for an
     /// interactive turn, returning a drop-guard ONLY if the marker was
     /// free.
     ///
-    /// Unlike [`Self::goal_dispatch_in_flight_guard`] (which marks
-    /// unconditionally), this checks-and-inserts under a single lock and
+    /// Unlike the deleted unconditional `goal_dispatch_in_flight_guard`,
+    /// this checks-and-inserts under a single lock and
     /// returns `None` if another dispatcher already owns the marker —
     /// e.g. a `SessionActor` `GoalContinue` running for the same session
     /// on the CLI/gateway path (which AppUI's `active_turns` can't see).
@@ -9648,7 +9646,9 @@ fn in_flight_marker_is_held(state: &AutonomyRuntimeState, session_id: &SessionKe
 }
 
 /// #1140 codex P1 re-review #4 — RAII drop-guard returned by
-/// `InProcessAgentOrchestrator::goal_dispatch_in_flight_guard`. On
+/// `InProcessAgentOrchestrator::try_claim_goal_in_flight` (#2066 round 2:
+/// the unconditional `goal_dispatch_in_flight_guard` constructor is deleted
+/// — every production claim is atomic now). On
 /// `Drop` it clears the in-flight marker for the captured session
 /// id, so the marker is removed even when the AppUI turn is
 /// aborted, panics, or returns through an early-terminal path

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -2782,9 +2782,46 @@ impl InProcessAgentOrchestrator {
             if drained.is_empty() {
                 break;
             }
-            for item in drained {
+            for mut item in drained {
                 if pending_continuation_is_schedulable(&*state, &item) {
-                    kept.push(item);
+                    // #2066 round 3 (codex fix 3) — bind-at-drain for legacy
+                    // UNBOUND goal continuations. A persisted `goal_id: None`
+                    // item passed every identity gate as a WILDCARD (the
+                    // schedulability check binds identity only for `Some`,
+                    // the dispatch recheck treats `None` as match-any, and
+                    // `record_goal_turn`'s live path charges unbound), so a
+                    // legacy item enqueued for a since-cleared goal would
+                    // launch against — and charge — a create-after-clear
+                    // REPLACEMENT. Resolve the binding here, under the same
+                    // lock as the pop: the live goal takes the binding ONLY
+                    // if it already existed when the item was enqueued
+                    // (goal.created_at_ms <= the item's creation time);
+                    // otherwise the item predates the live goal — it belongs
+                    // to a cleared predecessor — and is completed as stale
+                    // without launching or charging anything.
+                    match bind_unbound_goal_continuation_at_drain(state, session_id, &mut item) {
+                        UnboundGoalBinding::Keep => kept.push(item),
+                        UnboundGoalBinding::Stale => {
+                            if let Some(store) = state.supervisor_store.as_ref() {
+                                let _ = store.record_continuation_completed(
+                                    item.group_id.as_str(),
+                                    item.dedupe_key.as_str(),
+                                    now_ms_u64(),
+                                    Some(
+                                        "discarded:unbound_goal_continuation_stale (#2066)".into(),
+                                    ),
+                                );
+                            }
+                            tracing::debug!(
+                                session_key = %session_id.0,
+                                profile_id = %profile_id,
+                                reason = ?item.reason,
+                                continuation_id = ?item.id,
+                                "dropping legacy unbound goal continuation at drain: \
+                                 the live goal postdates it (#2066 round 3)"
+                            );
+                        }
+                    }
                 } else {
                     // #1159 codex P2 follow-up: only TOMBSTONE drops whose
                     // owning entity is genuinely gone (goal cleared and
@@ -5093,8 +5130,13 @@ impl InProcessAgentOrchestrator {
                 updated_at_ms: base_snapshot.updated_at_ms.max(0) as u64,
             };
             let _ = ledger.create_goal_if_absent(&base);
+            // #2066 round 3 (codex fix 1) — the settle MAX-folds the frozen
+            // clear-time base before adding its delta, so a settle that
+            // lands ahead of the clear stamp already carries the pre-clear
+            // lag and a later stamp MAX-merges to the identical total.
             match ledger.settle_cleared_goal_cost_delta(
                 &base_snapshot.goal_id,
+                base_snapshot.tokens_used,
                 tokens_delta,
                 now_ms_u64(),
             ) {
@@ -5111,6 +5153,91 @@ impl InProcessAgentOrchestrator {
                     "post-clear settle: delta write failed (best-effort; charge dropped)"),
             }
         });
+    }
+
+    /// #2066 round 3 (codex fix 1) — the CLEAR path's durable stamp, replacing
+    /// its round-1/2 use of the generic [`Self::sync_transition_to_ledger_blocking`]
+    /// (whose all-or-nothing guarded upsert is exactly what made stamp-vs-settle
+    /// order-dependent: a same-millisecond stamp landing after the settle
+    /// overwrote the settled delta; a newer-timestamp settle made a later
+    /// stamp reject and lose the entire pre-clear lag). The dedicated writer
+    /// ([`octos_fleet::GoalLedger::stamp_goal_cleared`]) MAX-merges counters
+    /// per column and CASEs status, so it commutes with the settle deltas in
+    /// every arrival order. The audit decision is gated on the STORED status
+    /// (a `complete` row keeps `complete` and gets no `cleared` decision —
+    /// the same honest-audit gate the generic sync applied). Best-effort like
+    /// every ledger stamp; the other transitions keep the generic sync
+    /// unchanged.
+    fn stamp_goal_cleared_blocking(
+        &self,
+        profile_data_dir: &std::path::Path,
+        snapshot: &AutonomyGoalRecord,
+        decided_by: &SessionKey,
+    ) {
+        let ledger_dir = Self::goal_ledger_dir(profile_data_dir);
+        if std::fs::create_dir_all(&ledger_dir).is_err() {
+            return;
+        }
+        let ledger_path = ledger_dir.join(format!(
+            "{}.db",
+            sanitize_filename_for_ledger(&snapshot.goal_id)
+        ));
+        let ledger = match octos_fleet::GoalLedger::open(&ledger_path) {
+            Ok(ledger) => ledger,
+            Err(error) => {
+                tracing::warn!(%error, ledger = %ledger_path.display(),
+                    "goal-ledger open failed; clear stamp skipped (best-effort)");
+                return;
+            }
+        };
+        let row = octos_fleet::Goal {
+            goal_id: snapshot.goal_id.clone(),
+            objective: snapshot.objective.clone(),
+            status: "cleared".to_owned(),
+            tokens_used: snapshot.tokens_used,
+            token_budget: snapshot.token_budget,
+            continuations_used: snapshot.continuations_used,
+            revision: 0,
+            created_at_ms: snapshot.created_at_ms.max(0) as u64,
+            updated_at_ms: snapshot.updated_at_ms.max(0) as u64,
+        };
+        let stored = match ledger.stamp_goal_cleared(&row) {
+            Ok(stored) => stored,
+            Err(error) => {
+                tracing::warn!(%error, goal_id = %snapshot.goal_id,
+                    "goal-ledger clear stamp failed (best-effort)");
+                return;
+            }
+        };
+        if stored != "cleared" {
+            // `complete` outranks `cleared`; the counters still merged, and
+            // the audit trail must not claim a status the row refused.
+            tracing::warn!(
+                goal_id = %snapshot.goal_id,
+                stored_status = %stored,
+                "goal ledger clear stamp: the row kept its terminal status; \
+                 no cleared decision appended"
+            );
+            return;
+        }
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let decision = octos_fleet::Decision {
+            decision_id: format!("dec-{}-{}", snapshot.goal_id, uuid::Uuid::now_v7()),
+            goal_id: snapshot.goal_id.clone(),
+            task_id: None,
+            question: "transition goal to `cleared`".to_owned(),
+            options_considered: None,
+            choice: "cleared".to_owned(),
+            rationale: "goal cleared by user".to_owned(),
+            based_on_findings: None,
+            based_on_rev: 0,
+            decided_at_ms: now_ms,
+            decided_by: decided_by.to_string(),
+        };
+        let _ = ledger.append_decision(&decision);
     }
 
     /// #2066 round 2 (codex R2) — the post-claim dispatch recheck: after a
@@ -5263,15 +5390,10 @@ impl InProcessAgentOrchestrator {
                 // SYNC caller (the clear RPC arm): blocking core, plain open
                 // profile — same inline best-effort class as the pre-existing
                 // finding/escalation writers (#1865 keeps the bounded retry
-                // exclusive to the spawn_blocking facade).
-                self.sync_transition_to_ledger_blocking(
-                    data_dir,
-                    &snapshot,
-                    "goal cleared by user",
-                    &request.session_id,
-                    true,
-                    false,
-                );
+                // exclusive to the spawn_blocking facade). #2066 round 3 —
+                // the clear uses its dedicated MAX-merge stamp writer, which
+                // commutes with the tombstone settle deltas in every order.
+                self.stamp_goal_cleared_blocking(data_dir, &snapshot, &request.session_id);
             }
         }
         // #2064(a)/#2066 round 2 (codex R4) — release the clear's own claim
@@ -9387,6 +9509,65 @@ fn in_flight_marker_is_live(
     })
 }
 
+/// #2066 round 3 (codex fix 3) — outcome of resolving a legacy UNBOUND
+/// (`goal_id: None`) goal continuation against the session's live goal at
+/// drain time. See the call site in `drain_ready_continuations_locked`.
+enum UnboundGoalBinding {
+    /// Item is not a goal continuation, already bound, or was bound here to
+    /// the live goal (which provably existed when the item was enqueued).
+    Keep,
+    /// The live goal POSTDATES the item (a create-after-clear replacement),
+    /// belongs to another profile, or the item's timestamp is
+    /// unrepresentable — the item belongs to a cleared predecessor and must
+    /// be completed without launching or charging.
+    Stale,
+}
+
+/// #2066 round 3 (codex fix 3) — bind-at-drain: stamp a legacy unbound goal
+/// continuation with the live goal's id IFF that goal already existed when
+/// the continuation was enqueued (`goal.created_at_ms <= item.created_at`,
+/// `<=` because `set_goal` enqueues in the same `now_ms()` tick it creates
+/// the record). Downstream everything then sees `Some` and the wildcard
+/// paths never fire. Item creation time (`created_at`, preserved across
+/// reinsert) is the comparison anchor, not `enqueued_at`.
+fn bind_unbound_goal_continuation_at_drain(
+    state: &AutonomyRuntimeState,
+    session_id: &SessionKey,
+    item: &mut QueuedMasterContinuation,
+) -> UnboundGoalBinding {
+    if !matches!(
+        item.reason,
+        MasterContinuationReason::GoalContinue | MasterContinuationReason::GoalWrapUp
+    ) {
+        return UnboundGoalBinding::Keep;
+    }
+    if item.goal_id.is_some() {
+        return UnboundGoalBinding::Keep;
+    }
+    // Schedulability already required a live goal for goal reasons; a miss
+    // here (racing removal) is conservatively stale.
+    let Some(goal) = state.goals.get(session_id) else {
+        return UnboundGoalBinding::Stale;
+    };
+    if goal.profile_id != item.profile_id.as_str() {
+        return UnboundGoalBinding::Stale;
+    }
+    let item_created_ms = item
+        .created_at
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .and_then(|elapsed| i64::try_from(elapsed.as_millis()).ok());
+    match item_created_ms {
+        Some(created_ms) if goal.created_at_ms <= created_ms => {
+            item.goal_id = Some(
+                crate::autonomy::master_continuation_scheduler::GoalId::from(goal.goal_id.as_str()),
+            );
+            UnboundGoalBinding::Keep
+        }
+        _ => UnboundGoalBinding::Stale,
+    }
+}
+
 /// #2064(b) — upper bound on parked [`ClearedGoalTombstone`]s. A tombstone
 /// stays parked after settling (the turn charge AND its verifier charge must
 /// both land) and is replaced by the next clear on its key, so the cap only
@@ -9430,20 +9611,44 @@ struct ClearedGoalTombstone {
 /// Opportunistic: called on the map's own touch points (park + accrue), so a
 /// quiet orchestrator retains at most [`MAX_CLEARED_GOAL_TOMBSTONES`] inert
 /// entries and an active one self-cleans.
+///
+/// #2066 round 3 (codex fix 4) — expiry alone is NOT sufficient: the
+/// in-flight marker is REFRESHED by real turn output
+/// (`touch_goal_dispatch_in_flight`) and kept live by nonterminal supervised
+/// work, so a legitimately long (>30min) turn can outlive the tombstone's
+/// parked_at horizon and would then lose its charge. Purge eligibility is
+/// therefore expired AND the session's marker is no longer held — the same
+/// liveness consult the marker's own staleness rescue uses
+/// ([`in_flight_marker_is_held`] covers both the fresh-stamp and
+/// supervised-work halves). Once the marker is gone, no legitimate late
+/// charge for that turn can arrive.
 fn purge_stale_cleared_goal_tombstones(state: &mut AutonomyRuntimeState) {
     let now = now_ms_u64();
-    state.cleared_goal_tombstones.retain(|key, tombstone| {
-        let live = now.saturating_sub(tombstone.parked_at_ms) < CLEARED_GOAL_TOMBSTONE_TTL_MS;
-        if !live {
+    let expired: Vec<SessionKey> = state
+        .cleared_goal_tombstones
+        .iter()
+        .filter(|(_, tombstone)| {
+            now.saturating_sub(tombstone.parked_at_ms) >= CLEARED_GOAL_TOMBSTONE_TTL_MS
+        })
+        .map(|(key, _)| key.clone())
+        .collect();
+    for key in expired {
+        if in_flight_marker_is_held(state, &key) {
+            // The turn that justified parking is still provably alive
+            // (refreshed marker or live supervised work) — its charge may
+            // still arrive; keep the tombstone.
+            continue;
+        }
+        if let Some(dropped) = state.cleared_goal_tombstones.remove(&key) {
             tracing::debug!(
                 session = %key,
-                goal_id = %tombstone.snapshot.goal_id,
-                settled_tokens = tombstone.settled_tokens,
-                "cleared-goal tombstone aged past the settle horizon; dropping it"
+                goal_id = %dropped.snapshot.goal_id,
+                settled_tokens = dropped.settled_tokens,
+                "cleared-goal tombstone aged past the settle horizon with no \
+                 live in-flight marker; dropping it"
             );
         }
-        live
-    });
+    }
 }
 
 /// #2064(a) — the clear path's half of the dispatcher serialization: claim
@@ -22735,41 +22940,349 @@ mod tests {
         assert!(!orchestrator.goal_dispatch_target_matches(&key, "tenant-b", Some(&new_goal_id)));
     }
 
-    /// #2066 round 2 (codex R2/R7) — source guard for the AppUI dispatch
-    /// wiring: the spawned continuation task must claim ATOMICALLY
-    /// (`try_claim_goal_in_flight`) and re-check the goal
-    /// (`goal_dispatch_target_matches`) before launching — never the
-    /// unconditional `goal_dispatch_in_flight_guard`, which overwrites a
-    /// clear's (or another dispatcher's) claim. Scans the spawn region of
-    /// `ui_protocol_transport.rs` so reverting the wiring fails even though
-    /// that module is feature-gated out of this build (mutation check 1).
+    /// #2066 round 2 (codex R2/R7) + round 3 (codex fix 2) — source guard for
+    /// the AppUI dispatch wiring: the continuation runner must pop and claim
+    /// ATOMICALLY (`drain_and_claim_ready_continuation_for_session`, the same
+    /// primitive the session actor uses — claim-failure pops nothing, so no
+    /// one-shot can be completed unexecuted), never the non-atomic pop
+    /// (`drain_ready_continuations_for_session`) nor an unconditional mark;
+    /// and it must re-check the goal (`goal_dispatch_target_matches`) before
+    /// launching. Scans `ui_protocol_transport.rs` so reverting the wiring
+    /// fails even though that module is feature-gated out of this build
+    /// (mutation checks 1 and 2 of the respective rounds).
     #[test]
     fn appui_continuation_spawn_should_use_atomic_try_claim_source_guard() {
         let transport = include_str!("../api/ui_protocol_transport.rs");
-        let spawn_marker = "draining queued master continuation into AppUI turn runtime";
+        let fn_marker = "async fn maybe_spawn_appui_master_continuation_runner";
         let start = transport
-            .find(spawn_marker)
-            .expect("the AppUI continuation spawn log line exists");
+            .find(fn_marker)
+            .expect("the AppUI continuation runner exists");
         let end = transport[start..]
             .find("run_standalone_turn(")
             .map(|offset| start + offset)
-            .expect("the spawn region ends at the turn launch");
-        let spawn_region = &transport[start..end];
+            .expect("the runner region ends at the turn launch");
+        let runner_region = &transport[start..end];
         assert!(
-            spawn_region.contains("try_claim_goal_in_flight"),
-            "the continuation spawn must claim the dispatch slot atomically \
-             (try-claim), not mark unconditionally"
+            runner_region.contains("drain_and_claim_ready_continuation_for_session"),
+            "the continuation runner must pop-and-claim under ONE lock \
+             (atomic drain-and-claim), so a failed claim pops nothing"
         );
         assert!(
-            spawn_region.contains("goal_dispatch_target_matches"),
-            "the continuation spawn must re-check the goal after claiming, \
+            !runner_region.contains("drain_ready_continuations_for_session("),
+            "the non-atomic pop must not return to the continuation runner \
+             (pop-before-claim completes unexecuted one-shots on claim failure)"
+        );
+        assert!(
+            runner_region.contains("goal_dispatch_target_matches"),
+            "the continuation runner must re-check the goal after claiming, \
              before launching"
         );
         assert!(
-            !spawn_region.contains("goal_dispatch_in_flight_guard("),
+            !runner_region.contains("goal_dispatch_in_flight_guard(")
+                && !runner_region.contains("mark_goal_dispatch_in_flight"),
             "the unconditional marker overwrite must not return to the \
-             continuation spawn path (it silently steals a clear's claim)"
+             continuation runner (it silently steals a clear's claim)"
         );
+    }
+
+    /// #2066 round 3 (codex fix 2) — two dispatchers, DIFFERENT pending
+    /// reasons: while one dispatcher's atomic drain-and-claim holds the
+    /// slot, the other pops NOTHING (and therefore completes nothing); after
+    /// release it drains the remaining item. Both one-shots execute exactly
+    /// once — the round-2 shape completed the loser's popped item
+    /// unexecuted, permanently dropping a latched GoalWrapUp.
+    #[test]
+    fn concurrent_dispatchers_should_never_complete_an_unexecuted_one_shot() {
+        use crate::autonomy::master_continuation_scheduler::MasterContinuationRequest;
+        // drain_and_claim takes &'static self (guards borrow the
+        // orchestrator); leak a test-local instance instead of sharing the
+        // process singleton with parallel tests.
+        let orchestrator: &'static InProcessAgentOrchestrator =
+            Box::leak(Box::new(InProcessAgentOrchestrator::default()));
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-two-dispatchers");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "two dispatchers".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        // A second pending one-shot with a DIFFERENT reason (codex's loss
+        // case pairs a goal item with a ChildCompleted).
+        {
+            let mut state = orchestrator.state();
+            let request = MasterContinuationRequest::new(
+                "coding-autonomy-child",
+                session_id.to_string(),
+                "tenant-a".to_owned(),
+                MasterContinuationReason::ChildCompleted,
+                SystemTime::now(),
+            );
+            let _ = enqueue_and_persist_continuation(&mut state, request);
+        }
+        let pending_before =
+            orchestrator.pending_continuation_count_for_session_for_test(&session_id, "tenant-a");
+        assert_eq!(pending_before, 2, "goal continuation + child completion");
+
+        // Dispatcher 1 pops-and-claims one item.
+        let (first, guard1) = orchestrator.drain_and_claim_ready_continuation_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            1,
+        );
+        assert_eq!(first.len(), 1);
+        let guard1 = guard1.expect("claim taken with the pop");
+
+        // Dispatcher 2 races in while the slot is held: it must pop NOTHING
+        // — the second one-shot stays pending, nothing is completed.
+        let (second, guard2) = orchestrator.drain_and_claim_ready_continuation_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            1,
+        );
+        assert!(
+            second.is_empty() && guard2.is_none(),
+            "a held slot must drain nothing (pop-before-claim is the bug)"
+        );
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_session_for_test(&session_id, "tenant-a"),
+            1,
+            "the un-owned one-shot must still be pending, not completed-unexecuted"
+        );
+
+        // Dispatcher 1's turn ends; dispatcher 2 now drains the second item.
+        drop(guard1);
+        let (third, guard3) = orchestrator.drain_and_claim_ready_continuation_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            1,
+        );
+        assert_eq!(third.len(), 1);
+        assert!(guard3.is_some());
+        assert_ne!(
+            std::mem::discriminant(&first[0].reason),
+            std::mem::discriminant(&third[0].reason),
+            "both one-shots executed exactly once, each by one dispatcher"
+        );
+    }
+
+    /// #2066 round 3 (codex fix 3) — legacy UNBOUND (`goal_id: None`)
+    /// continuations must not wildcard onto a create-after-clear
+    /// replacement. Negative: an unbound item enqueued for a since-cleared
+    /// goal is completed STALE at drain (never launched, replacement never
+    /// charged). Positive: an unbound item drained under its original
+    /// still-live goal binds to it at drain and charges it.
+    #[test]
+    fn unbound_goal_continuation_should_bind_at_drain_or_die_stale() {
+        use crate::autonomy::master_continuation_scheduler::MasterContinuationRequest;
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-unbound-legacy");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "old goal".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        // Drain the initial bound continuation out of the way.
+        let _ = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        // A LEGACY persisted item: no goal_id stamped. Legacy items are by
+        // definition OLD (restored from a pre-restart queue), so model that:
+        // the item's creation time predates a same-tick clear+recreate. A
+        // goal created in the SAME millisecond as the item still binds
+        // (`<=` — set_goal's own tick), which only the replacement case
+        // below must not hit.
+        let enqueue_unbound = |orchestrator: &InProcessAgentOrchestrator| {
+            let mut state = orchestrator.state();
+            let request = MasterContinuationRequest::new(
+                "coding-autonomy-goal",
+                session_id.to_string(),
+                "tenant-a".to_owned(),
+                MasterContinuationReason::GoalContinue,
+                SystemTime::now() - std::time::Duration::from_secs(1),
+            );
+            let _ = enqueue_and_persist_continuation(&mut state, request);
+        };
+        // The original goal clearly predates the legacy item.
+        {
+            let mut state = orchestrator.state();
+            let key = orchestrator.scoped_goal_key(&session_id);
+            state
+                .goals
+                .get_mut(&key)
+                .expect("goal exists")
+                .created_at_ms -= 5_000;
+        }
+
+        // POSITIVE: the original goal is still live → the drain BINDS the
+        // item to it (downstream sees Some, the wildcard paths never fire).
+        enqueue_unbound(&orchestrator);
+        let old_goal_id = orchestrator.goal_id_for_test(&session_id).expect("goal id");
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        let bound: Vec<_> = drained
+            .iter()
+            .filter(|c| matches!(c.reason, MasterContinuationReason::GoalContinue))
+            .collect();
+        // The drain's own due-scan may enqueue a fresh (already-bound)
+        // continuation alongside; the property under test is that NOTHING
+        // comes out unbound and everything is bound to the live goal.
+        assert!(!bound.is_empty());
+        assert!(
+            bound
+                .iter()
+                .all(|c| c.goal_id.as_ref().map(|goal_id| goal_id.as_str())
+                    == Some(old_goal_id.as_str())),
+            "an unbound item drained under its original live goal binds to it \
+             (and nothing drains unbound): {drained:?}"
+        );
+
+        // NEGATIVE: enqueue unbound → clear → create a REPLACEMENT → drain.
+        enqueue_unbound(&orchestrator);
+        orchestrator
+            .clear_goal(GoalSessionRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+            })
+            .expect("clear");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "replacement".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set replacement");
+        // Both the legacy unbound item AND the replacement's own initial
+        // continuation are queued now (distinct dedupe keys); drain
+        // everything and inspect which survived.
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        let new_goal_id = orchestrator.goal_id_for_test(&session_id).expect("goal id");
+        let goal_items: Vec<_> = drained
+            .iter()
+            .filter(|c| matches!(c.reason, MasterContinuationReason::GoalContinue))
+            .collect();
+        assert_eq!(
+            goal_items.len(),
+            1,
+            "the legacy unbound item must be completed STALE at drain — only \
+             the replacement's own continuation may come out: {drained:?}"
+        );
+        assert_eq!(
+            goal_items[0]
+                .goal_id
+                .as_ref()
+                .map(|goal_id| goal_id.as_str()),
+            Some(new_goal_id.as_str()),
+            "the surviving item is the replacement's own, bound to it"
+        );
+        // And the replacement was never charged by anything stale.
+        let (new_tokens, _, _) = orchestrator
+            .goal_counters_for_test(&session_id)
+            .expect("replacement exists");
+        assert_eq!(new_tokens, 0);
+    }
+
+    /// #2066 round 3 (codex fix 4) — tombstone TTL consults marker liveness:
+    /// a tombstone past its horizon SURVIVES while the session's in-flight
+    /// marker is still held (a legitimately long turn may still charge), and
+    /// is purged once the marker is gone.
+    #[test]
+    fn expired_tombstone_should_survive_while_the_dispatch_marker_is_held() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-ttl-liveness");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "very long turn".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        let goal_id = orchestrator.goal_id_for_test(&session_id).expect("goal id");
+        let key = orchestrator.scoped_goal_key(&session_id);
+        let dispatcher_generation = orchestrator.mark_goal_dispatch_in_flight(&key);
+        orchestrator
+            .clear_goal_with_ledger_sync(
+                GoalSessionRequest {
+                    session_id: session_id.clone(),
+                    profile_id: "tenant-a".into(),
+                },
+                Some(data_dir.path()),
+            )
+            .expect("clear");
+        // Age the tombstone past its horizon while the marker stays FRESH
+        // (the turn keeps proving progress via the touch/refresh path).
+        {
+            let mut state = orchestrator.state();
+            state
+                .cleared_goal_tombstones
+                .get_mut(&key)
+                .expect("tombstone parked")
+                .parked_at_ms = now_ms_u64().saturating_sub(CLEARED_GOAL_TOMBSTONE_TTL_MS + 1);
+            purge_stale_cleared_goal_tombstones(&mut state);
+            assert!(
+                state.cleared_goal_tombstones.contains_key(&key),
+                "an expired tombstone must SURVIVE while the marker is held \
+                 (the >30min turn can still charge)"
+            );
+        }
+        // The long turn's charge still settles.
+        assert!(
+            orchestrator
+                .charge_active_goal_tokens(&session_id, "tenant-a", &goal_id, 5_000, 7)
+                .is_none()
+        );
+        let ledger_path = InProcessAgentOrchestrator::goal_ledger_dir(data_dir.path())
+            .join(format!("{}.db", sanitize_filename_for_ledger(&goal_id)));
+        let ledger = octos_fleet::GoalLedger::open(&ledger_path).expect("open ledger");
+        assert_eq!(
+            ledger
+                .get_goal(&goal_id)
+                .expect("query")
+                .expect("row")
+                .tokens_used,
+            5_000,
+        );
+        // Marker released (turn over) → the expired tombstone purges on the
+        // next touch.
+        assert!(orchestrator.clear_goal_dispatch_in_flight_generation(&key, dispatcher_generation));
+        {
+            let mut state = orchestrator.state();
+            purge_stale_cleared_goal_tombstones(&mut state);
+            assert!(
+                !state.cleared_goal_tombstones.contains_key(&key),
+                "with the marker gone, the expired tombstone purges"
+            );
+        }
     }
 
     /// Codex LOW (zero-budget consistency): a `token_budget` of 0 is not a

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -2642,6 +2642,15 @@ impl InProcessAgentOrchestrator {
         Ok(autonomy_agent_json(&agent))
     }
 
+    /// #2066 round 3 (codex fix 2) — TEST ONLY: the non-atomic pop lost its
+    /// last production caller when the AppUI runner moved to
+    /// [`Self::drain_and_claim_ready_continuation_for_session`]. Popping
+    /// without claiming is exactly the pop-before-claim hazard fix 2 removed
+    /// (a dispatcher that pops and then loses the claim race completes the
+    /// popped one-shot unexecuted), so no production path may use this; the
+    /// AppUI source guard additionally forbids it at the runner site. Tests
+    /// keep it as a convenient queue-inspection harness.
+    #[cfg(test)]
     pub(crate) fn drain_ready_continuations_for_session(
         &self,
         session_id: &SessionKey,
@@ -3204,11 +3213,12 @@ impl InProcessAgentOrchestrator {
     }
 
     /// True when a continuation turn for `session_id` is currently in flight
-    /// (the in-flight marker is set). The due-scan already excludes such
-    /// sessions; this accessor lets a SECOND dispatch surface — the AppUI
-    /// serve tick — also skip a session whose continuation turn is running in
-    /// the session actor, closing the cross-subsystem drain race where both
-    /// spawn a concurrent turn on the same session (#1529).
+    /// (the in-flight marker is set). #2066 round 3 — TEST ONLY: the AppUI
+    /// serve tick's separate occupancy pre-check (#1529) was subsumed by the
+    /// atomic [`Self::drain_and_claim_ready_continuation_for_session`], which
+    /// performs the same check under the same lock as the pop; a standalone
+    /// read is inherently TOCTOU and no production path should decide on it.
+    #[cfg(test)]
     pub(crate) fn is_goal_dispatch_in_flight(&self, session_id: &SessionKey) -> bool {
         in_flight_marker_is_held(&self.state(), session_id)
     }

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -3163,6 +3163,38 @@ impl InProcessAgentOrchestrator {
         }
     }
 
+    /// #2066 round 5 (codex fix 1) — GENERATION-MATCHED marker refresh: a
+    /// heartbeat may only refresh the marker incarnation its OWN turn
+    /// claimed. The key-only [`Self::touch_goal_dispatch_in_flight`] let a
+    /// stale turn A — evicted at the staleness horizon and replaced by turn
+    /// B on the same scoped key — refresh B's marker whenever A resumed
+    /// producing, keeping a wedged replacement protected indefinitely (the
+    /// same A/B incarnation hazard the claim guard's generation exists for,
+    /// #2003). No-ops with a debug log when the held marker's generation
+    /// differs from the caller's; never creates a marker.
+    pub(crate) fn touch_goal_dispatch_in_flight_generation(
+        &self,
+        session_id: &SessionKey,
+        generation: u64,
+    ) {
+        let mut state = self.state();
+        match state.in_flight_goal_sessions.get_mut(session_id) {
+            Some(marker) if marker.generation == generation => {
+                marker.marked_at_ms = now_ms_u64();
+            }
+            Some(marker) => {
+                tracing::debug!(
+                    session = %session_id,
+                    held_generation = marker.generation,
+                    caller_generation = generation,
+                    "in-flight refresh skipped: the marker belongs to a different \
+                     turn incarnation"
+                );
+            }
+            None => {}
+        }
+    }
+
     /// #2003 — test hook: age an existing marker so the staleness path can be
     /// exercised without sleeping.
     #[cfg(test)]
@@ -9901,6 +9933,13 @@ impl GoalDispatchInFlightGuard {
     pub(crate) fn disarm(mut self) {
         self.disarmed = true;
     }
+
+    /// #2066 round 5 (codex fix 1) — the marker incarnation this guard owns,
+    /// for generation-matched refreshes
+    /// ([`InProcessAgentOrchestrator::touch_goal_dispatch_in_flight_generation`]).
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation
+    }
 }
 
 impl Drop for GoalDispatchInFlightGuard {
@@ -12452,8 +12491,21 @@ fn master_continuation_request_from_persisted(
     // rebound to a post-clear replacement. `created_at` has no other
     // behavioral consumer (the scheduler orders by priority/sequence, dedupe
     // is key-based), so restoring the truthful time needs no second field.
-    let restored_created_at =
-        SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(continuation.queued_at_ms);
+    // #2066 round 5 (codex fix 2) — CHECKED addition: `+` on SystemTime
+    // panics on overflow, and a parseable extreme `queued_at_ms` overflows
+    // narrower SystemTime representations (Windows). Clamp to UNIX_EPOCH —
+    // conservatively ANCIENT, so the bind-at-drain predicate classifies the
+    // item stale (the safe direction: drop, never misattribute).
+    let restored_created_at = SystemTime::UNIX_EPOCH
+        .checked_add(std::time::Duration::from_millis(continuation.queued_at_ms))
+        .unwrap_or_else(|| {
+            tracing::debug!(
+                queued_at_ms = continuation.queued_at_ms,
+                "restored continuation timestamp overflows SystemTime; clamping \
+                 to UNIX_EPOCH (item will classify stale)"
+            );
+            SystemTime::UNIX_EPOCH
+        });
     let mut request = MasterContinuationRequest::new(
         continuation.group_id.clone(),
         session_id.to_owned(),
@@ -23325,14 +23377,24 @@ mod tests {
         assert_eq!(new_tokens, 0, "the replacement is never charged");
     }
 
-    /// #2066 round 4 (codex fix 1b) — the same-millisecond tie: a replacement
-    /// goal minted in the exact millisecond the unbound item was created must
-    /// NOT steal it (strict `<`; on a tie the item dies stale — dropping a
-    /// charge beats misattributing it).
+    /// #2066 round 4 (codex fix 1b) / round 5 (codex fix 3) — the
+    /// same-millisecond tie: a replacement goal minted in the exact
+    /// millisecond the unbound item was created must NOT steal it (strict
+    /// `<`; on a tie the item dies stale — dropping a charge beats
+    /// misattributing it). Round 5 rewrote the assertions to pin the
+    /// OUTCOME, not the key shape: the tie item never drains (by its own
+    /// dedupe key), the pending queue empties without a launch, the
+    /// replacement is never charged, and the durable completion carries the
+    /// STALE reason — so a `<`→`<=` mutation (the item binds and drains)
+    /// fails this test.
     #[test]
     fn same_millisecond_replacement_should_not_steal_an_unbound_continuation() {
         use crate::autonomy::master_continuation_scheduler::MasterContinuationRequest;
         let orchestrator = InProcessAgentOrchestrator::default();
+        let store_dir = tempfile::TempDir::new().unwrap();
+        orchestrator
+            .configure_supervisor_store(store_dir.path())
+            .expect("supervisor store");
         let session_id = SessionKey::with_profile("tenant-a", "api", "goal-tie-unbound");
         orchestrator
             .set_goal(GoalSetRequest {
@@ -23351,7 +23413,8 @@ mod tests {
             MasterContinuationRuntimeState::idle(),
             usize::MAX,
         );
-        // An unbound item created in EXACTLY the goal's creation millisecond.
+        // An unbound item created in EXACTLY the goal's creation millisecond,
+        // with a KNOWN dedupe key so the outcome is identifiable.
         let goal_created_ms = {
             let state = orchestrator.state();
             let key = orchestrator.scoped_goal_key(&session_id);
@@ -23366,7 +23429,8 @@ mod tests {
                 MasterContinuationReason::GoalContinue,
                 SystemTime::UNIX_EPOCH
                     + std::time::Duration::from_millis(goal_created_ms.max(0) as u64),
-            );
+            )
+            .with_dedupe_key("tie-unbound-1");
             let _ = enqueue_and_persist_continuation(&mut state, request);
         }
         let drained = orchestrator.drain_ready_continuations_for_session(
@@ -23375,21 +23439,138 @@ mod tests {
             MasterContinuationRuntimeState::idle(),
             usize::MAX,
         );
-        assert!(
-            drained
-                .iter()
-                .filter(|c| matches!(c.reason, MasterContinuationReason::GoalContinue))
-                .all(|c| c.goal_id.is_some()),
-            "nothing drains unbound: {drained:?}"
-        );
-        // The tie item itself died stale — it is not among the drained items
-        // as a bound-to-this-goal charge carrier with its dedupe key.
+        // OUTCOME 1: the tie item itself never drains — no launch can happen.
         assert!(
             !drained
                 .iter()
-                .any(|c| c.dedupe_key.as_str().contains("legacy") || c.goal_id.is_none()),
-            "the same-millisecond item must die stale, not be stolen: {drained:?}"
+                .any(|c| c.dedupe_key.as_str() == "tie-unbound-1"),
+            "the same-millisecond item must die stale, not drain: {drained:?}"
         );
+        // OUTCOME 2: the queue emptied — the item was consumed (completed),
+        // not left pending.
+        assert_eq!(
+            orchestrator.pending_continuation_count_for_session_for_test(&session_id, "tenant-a"),
+            0,
+            "the stale item is completed, not stranded"
+        );
+        // OUTCOME 3: the replacement goal was never charged.
+        let (new_tokens, new_continuations, _) = orchestrator
+            .goal_counters_for_test(&session_id)
+            .expect("goal exists");
+        assert_eq!((new_tokens, new_continuations), (0, 0));
+        // OUTCOME 4: the durable completion carries the STALE reason — the
+        // item died on the stale path, it was not executed.
+        let store = SupervisorStore::new(store_dir.path());
+        let persisted = store.load_state().expect("reload supervisor state");
+        let record = persisted
+            .continuations
+            .values()
+            .find(|record| record.continuation_id == "tie-unbound-1")
+            .expect("the tie item's durable record exists");
+        assert_eq!(record.status, ContinuationStatus::Completed);
+        assert!(
+            record
+                .result
+                .as_deref()
+                .is_some_and(|result| result.contains("unbound_goal_continuation_stale")),
+            "the completion must be the STALE path, not an execution: {:?}",
+            record.result
+        );
+    }
+
+    /// #2066 round 5 (codex fix 1) — the heartbeat refresh is
+    /// GENERATION-MATCHED: a stale predecessor turn (evicted at the horizon
+    /// and replaced on the same key) that resumes producing must NOT refresh
+    /// the replacement's marker; only the marker's own incarnation may.
+    /// Removing the generation match fails this test (round-5 mutation 1).
+    #[test]
+    fn heartbeat_touch_should_refresh_only_its_own_marker_generation() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let key = SessionKey::with_profile("tenant-a", "api", "goal-heartbeat-generation");
+        // Turn A claims, wedges, and is evicted-then-replaced by turn B.
+        let generation_a = orchestrator.mark_goal_dispatch_in_flight(&key);
+        let generation_b = orchestrator.mark_goal_dispatch_in_flight(&key);
+        assert_ne!(generation_a, generation_b);
+        // B's marker ages past the horizon (B is now the one wedged).
+        orchestrator.force_in_flight_marked_at_for_test(
+            &key,
+            now_ms_u64().saturating_sub(IN_FLIGHT_STALE_AFTER_MS + 1),
+        );
+        assert!(!orchestrator.is_goal_dispatch_in_flight(&key));
+        // A resumes producing and its late heartbeat fires with A's
+        // generation: it must NOT revive B's marker.
+        orchestrator.touch_goal_dispatch_in_flight_generation(&key, generation_a);
+        assert!(
+            !orchestrator.is_goal_dispatch_in_flight(&key),
+            "a stale predecessor's heartbeat must not keep the replacement's \
+             marker alive"
+        );
+        // B's own heartbeat refreshes it.
+        orchestrator.touch_goal_dispatch_in_flight_generation(&key, generation_b);
+        assert!(orchestrator.is_goal_dispatch_in_flight(&key));
+        assert!(orchestrator.clear_goal_dispatch_in_flight_generation(&key, generation_b));
+    }
+
+    /// #2066 round 5 (codex fix 2) — an extreme durable `queued_at_ms`
+    /// restores WITHOUT panicking (checked SystemTime addition; overflow
+    /// clamps to UNIX_EPOCH) and classifies STALE at drain in either
+    /// direction (clamped-ancient, or unrepresentable-as-ms on platforms
+    /// whose SystemTime can hold it).
+    #[test]
+    fn extreme_restored_timestamp_should_not_panic_and_dies_stale() {
+        use crate::autonomy::supervisor_store::{ContinuationStatus, PendingContinuationRecord};
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-extreme-ts");
+        let mut metadata = serde_json::Map::new();
+        metadata.insert("session_id".to_owned(), json!(session_id.to_string()));
+        metadata.insert("profile_id".to_owned(), json!("tenant-a"));
+        metadata.insert("reason".to_owned(), json!("goal_continue"));
+        metadata.insert("dedupe_key".to_owned(), json!("extreme-ts-1"));
+        let record = PendingContinuationRecord {
+            group_id: "coding-autonomy-goal".to_owned(),
+            continuation_id: "extreme-ts-1".to_owned(),
+            child_id: None,
+            prompt: None,
+            status: ContinuationStatus::Queued,
+            queued_at_ms: u64::MAX,
+            started_at_ms: None,
+            completed_at_ms: None,
+            result: None,
+            attempt: 1,
+            metadata,
+        };
+        let request =
+            master_continuation_request_from_persisted(&record).expect("restores without panic");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "live goal".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        {
+            let mut state = orchestrator.state();
+            let _ = state.continuations.enqueue(request);
+        }
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        assert!(
+            !drained
+                .iter()
+                .any(|c| c.dedupe_key.as_str() == "extreme-ts-1"),
+            "an extreme-timestamp unbound item dies stale: {drained:?}"
+        );
+        let (tokens, _, _) = orchestrator
+            .goal_counters_for_test(&session_id)
+            .expect("goal exists");
+        assert_eq!(tokens, 0);
     }
 
     /// #2066 round 4 (codex fix 2) — the AppUI heartbeat's semantics at the
@@ -23481,11 +23662,12 @@ mod tests {
             .expect("the standalone turn runner exists");
         let turn_region = &transport[start..];
         assert!(
-            turn_region.contains("touch_goal_dispatch_in_flight"),
+            turn_region.contains("touch_goal_dispatch_in_flight_generation"),
             "the AppUI standalone turn must refresh the goal dispatch marker \
-             on token progress (the session actor's #2003 heartbeat twin) — \
-             without it a >30min goal turn loses its tombstone and a clear \
-             can claim the slot mid-turn"
+             on token progress, GENERATION-MATCHED (#2066 round 5) — without \
+             the refresh a >30min goal turn loses its tombstone and a clear \
+             can claim the slot mid-turn; without the generation match a \
+             stale predecessor could keep a replacement's marker alive"
         );
     }
 

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -3283,40 +3283,56 @@ impl InProcessAgentOrchestrator {
     /// [`Self::reconcile_terminal_goal_ledger`]. Non-terminal goals return
     /// `None`: their next transition re-syncs the ledger, so a per-turn ledger
     /// write would be wasteful.
+    /// #2066 round 2 (codex R1c) — `expected_goal_id` is the goal identity
+    /// the continuation was DISPATCHED under (`QueuedMasterContinuation::
+    /// goal_id`, threaded through both autonomous accountant call sites).
+    /// The live charge is now identity-bound like the interactive path: when
+    /// the binding is `Some` and the session's live goal is a DIFFERENT
+    /// incarnation (the old goal was cleared and a new one created
+    /// mid-turn), the charge must not land on the replacement — it routes to
+    /// the cleared goal's tombstone instead (which enforces the same
+    /// binding). `None` keeps the pre-existing unbound live charge for
+    /// legacy persisted continuations, but is REFUSED by the tombstone
+    /// settle — an unbound charge can never be attributed to a cleared goal.
     pub(crate) fn record_goal_turn(
         &self,
         session_id: &SessionKey,
         profile_id: &str,
+        expected_goal_id: Option<&str>,
         tokens_consumed: u64,
         elapsed_seconds: u64,
     ) -> Option<AutonomyGoalRecord> {
         let now = now_ms();
         let now_system = SystemTime::now();
         let mut state = self.state();
-        let Some(goal) = state.goals.get_mut(session_id) else {
-            // #2064(b) — same settle for the autonomous accountant: the
-            // continuation turn that was already running when the user
-            // cleared lands its spend on the cleared row. No goal-identity
-            // binding on this path (mirrors its live lookup); profile
-            // isolation still applies inside the accrual. Returns None —
-            // `cleared` is not the complete/blocked reconcile family.
+        let live_chargeable = state.goals.get(session_id).is_some_and(|goal| {
+            goal.profile_id == profile_id
+                && expected_goal_id.is_none_or(|goal_id| goal_id == goal.goal_id)
+        });
+        if !live_chargeable {
+            // #2064(b) — the goal may have been CLEARED (or cleared and
+            // REPLACED) while this continuation turn was in flight: settle
+            // the charge into the parked tombstone (profile-checked,
+            // goal-id-bound; unbound settlement refused). Returns None —
+            // `cleared` is not the complete/blocked reconcile family, and a
+            // replacement goal must never absorb the old turn's spend.
             let settle = accrue_cleared_goal_tombstone_charge(
                 &mut state,
                 session_id,
                 profile_id,
-                None,
+                expected_goal_id,
                 tokens_consumed,
-                elapsed_seconds,
             );
             drop(state);
-            if let Some((snapshot, ledger_data_dir)) = settle {
-                self.offload_cleared_goal_settle(snapshot, ledger_data_dir, session_id.clone());
+            if let Some((base, ledger_data_dir, tokens_delta)) = settle {
+                Self::offload_cleared_goal_settle(base, ledger_data_dir, tokens_delta);
             }
             return None;
-        };
-        if goal.profile_id != profile_id {
-            return None;
         }
+        let goal = state
+            .goals
+            .get_mut(session_id)
+            .expect("live_chargeable checked the record exists under this lock");
         let wrap_up = record_goal_turn_internal(goal, tokens_consumed, elapsed_seconds, now);
         let goal_snapshot = goal.clone();
         persist_goal_state(&state, session_id, &goal_snapshot, false);
@@ -3491,42 +3507,42 @@ impl InProcessAgentOrchestrator {
         let now = now_ms();
         let now_system = SystemTime::now();
         let mut state = self.state();
-        let Some(goal) = state.goals.get_mut(&key) else {
-            // #2064(b) — the goal may have been CLEARED while this turn was
-            // in flight: settle the charge into the parked tombstone
-            // (profile-checked, bound to the goal_id this turn captured at
-            // start) so the cleared row's recorded cost stays true.
-            // Deliberately NO wire event, NO wrap-up, NO continuation — the
-            // goal is gone for the client and terminal for scheduling.
+        // The live record is chargeable only when it exists, belongs to this
+        // profile (isolation — never charge or leak a goal owned by a
+        // different profile on a shared session key), AND is the same
+        // incarnation the caller bound at TURN START (a mid-turn
+        // clear+recreate must not charge the replacement).
+        let live_chargeable = state
+            .goals
+            .get(&key)
+            .is_some_and(|goal| goal.profile_id == profile_id && goal.goal_id == expected_goal_id);
+        if !live_chargeable {
+            // #2064(b) — the bound goal may have been CLEARED (absent) or
+            // cleared and REPLACED (identity mismatch — #2066 round 2, codex
+            // R1b: this branch used to drop the old goal's cost outright)
+            // while this turn was in flight: settle the charge into the
+            // parked tombstone keyed by the charge's OWN goal_id
+            // (profile-checked inside the accrual) so the cleared row's
+            // recorded cost stays true. Deliberately NO wire event, NO
+            // wrap-up, NO continuation — the goal is gone for the client and
+            // terminal for scheduling.
             let settle = accrue_cleared_goal_tombstone_charge(
                 &mut state,
                 &key,
                 profile_id,
                 Some(expected_goal_id),
                 tokens_consumed,
-                elapsed_seconds,
             );
             drop(state);
-            if let Some((snapshot, ledger_data_dir)) = settle {
-                self.offload_cleared_goal_settle(snapshot, ledger_data_dir, key.clone());
+            if let Some((base, ledger_data_dir, tokens_delta)) = settle {
+                Self::offload_cleared_goal_settle(base, ledger_data_dir, tokens_delta);
             }
             return None;
-        };
-        // Profile isolation: never charge or leak a goal owned by a
-        // different profile on the same (possibly unprofiled/shared)
-        // session key. Mirrors `record_goal_turn`.
-        if goal.profile_id != profile_id {
-            return None;
         }
-        // Goal-identity binding: the caller captured the goal_id at TURN
-        // START. If the user cleared that goal and created a new one
-        // mid-turn, the session key now points at a different goal_id —
-        // charging this turn's spend to the replacement would let a
-        // large prior turn instantly consume or budget-limit a goal it
-        // never worked toward. Reject the mismatch.
-        if goal.goal_id != expected_goal_id {
-            return None;
-        }
+        let goal = state
+            .goals
+            .get_mut(&key)
+            .expect("live_chargeable checked the record exists under this lock");
         // Only an actively-accruing goal advances on a TURN charge. A paused /
         // budget_limited / complete goal must not creep forward on a stray
         // interactive turn. The verifier charge (`allow_budget_limited`)
@@ -5024,37 +5040,99 @@ impl InProcessAgentOrchestrator {
     }
 
     /// #2064(b) — durably settle a late (post-clear) turn charge into the
-    /// cleared goals-row. Counters-only by construction: `status_changed ==
-    /// false` routes the guarded `upsert_goal` (which admits the higher
-    /// tokens + newer stamp on the `cleared` row) and appends NO decision —
-    /// the clear already wrote its one audit row. Runs through
-    /// [`offload_goal_ledger_io`] so the accountants (which fire on tokio
-    /// worker threads) never do ledger I/O inline; without a runtime the
-    /// settle runs synchronously (plain-thread/test callers).
+    /// cleared goals-row. #2066 round 2 (codex R6): the settle is a
+    /// COUNTERS-ONLY additive delta
+    /// ([`octos_fleet::GoalLedger::settle_cleared_goal_cost_delta`]) — never
+    /// an absolute snapshot. The round-1 snapshot upsert was arrival-order
+    /// dependent (its monotonic `updated_at >= AND tokens >=` clauses meant a
+    /// clear-stamp landing AFTER the settle could reject or a settle landing
+    /// after a fresher stamp could be refused, losing the charge); additive
+    /// deltas and the clear's status stamp commute by arithmetic, so the
+    /// settled total is identical in every order. The frozen base row is
+    /// inserted first via `create_goal_if_absent` (only fires when the goal
+    /// never synced a ledger row; never updates an existing one). No
+    /// decision row — the clear already wrote its one audit entry.
     ///
-    /// Arrival order against the clear's own stamp is free: if the settle
-    /// lands second its snapshot carries a newer stamp and higher tokens
-    /// (admitted); if the clear's stamp lands second its LOWER counters are
-    /// rejected by the monotonic clause and its status-CAS retry is
-    /// ordering-gated off — either order converges on
-    /// `cleared` + true totals.
+    /// Runs through [`offload_goal_ledger_io`] so the accountants (which
+    /// fire on tokio worker threads) never do ledger I/O inline; without a
+    /// runtime the settle runs synchronously (plain-thread/test callers).
+    /// Best-effort like every ledger sync: failures warn, never propagate.
+    ///
+    /// Idempotency assumption (codex R6 note): per-charge SINGLE DELIVERY —
+    /// each in-process accountant charge settles exactly once (one offload
+    /// per charge); the delta write has no dedupe key.
     fn offload_cleared_goal_settle(
-        &self,
-        snapshot: AutonomyGoalRecord,
+        base_snapshot: AutonomyGoalRecord,
         ledger_data_dir: std::path::PathBuf,
-        decided_by: SessionKey,
+        tokens_delta: u64,
     ) {
-        let this = self.clone();
         offload_goal_ledger_io(move || {
-            this.sync_transition_to_ledger_blocking(
-                &ledger_data_dir,
-                &snapshot,
-                "post-clear in-flight turn charge settled",
-                &decided_by,
-                false,
-                false,
-            );
+            let ledger_dir = Self::goal_ledger_dir(&ledger_data_dir);
+            if std::fs::create_dir_all(&ledger_dir).is_err() {
+                return;
+            }
+            let ledger_path = ledger_dir.join(format!(
+                "{}.db",
+                sanitize_filename_for_ledger(&base_snapshot.goal_id)
+            ));
+            let ledger = match octos_fleet::GoalLedger::open(&ledger_path) {
+                Ok(ledger) => ledger,
+                Err(error) => {
+                    tracing::warn!(%error, ledger = %ledger_path.display(),
+                        "post-clear settle: goal-ledger open failed (best-effort; charge dropped)");
+                    return;
+                }
+            };
+            let base = octos_fleet::Goal {
+                goal_id: base_snapshot.goal_id.clone(),
+                objective: base_snapshot.objective.clone(),
+                status: "cleared".to_owned(),
+                tokens_used: base_snapshot.tokens_used,
+                token_budget: base_snapshot.token_budget,
+                continuations_used: base_snapshot.continuations_used,
+                revision: 0,
+                created_at_ms: base_snapshot.created_at_ms.max(0) as u64,
+                updated_at_ms: base_snapshot.updated_at_ms.max(0) as u64,
+            };
+            let _ = ledger.create_goal_if_absent(&base);
+            match ledger.settle_cleared_goal_cost_delta(
+                &base_snapshot.goal_id,
+                tokens_delta,
+                now_ms_u64(),
+            ) {
+                Ok(true) => {}
+                Ok(false) => tracing::warn!(
+                    goal_id = %base_snapshot.goal_id,
+                    tokens_delta,
+                    "post-clear settle: no goals row matched even after \
+                     create-if-absent; charge dropped"
+                ),
+                Err(error) => tracing::warn!(%error,
+                    goal_id = %base_snapshot.goal_id,
+                    tokens_delta,
+                    "post-clear settle: delta write failed (best-effort; charge dropped)"),
+            }
         });
+    }
+
+    /// #2066 round 2 (codex R2) — the post-claim dispatch recheck: after a
+    /// dispatcher atomically claims the in-flight slot it must confirm, under
+    /// current state, that the goal it drained a continuation for still
+    /// exists (same profile, and the same incarnation when the continuation
+    /// carries a `goal_id`). A clear landing between the drain and the claim
+    /// removes the record; launching from the drained prompt anyway would
+    /// run a turn for a deleted goal whose charge lands nowhere.
+    pub(crate) fn goal_dispatch_target_matches(
+        &self,
+        session_id: &SessionKey,
+        profile_id: &str,
+        expected_goal_id: Option<&str>,
+    ) -> bool {
+        let state = self.state();
+        state.goals.get(session_id).is_some_and(|goal| {
+            goal.profile_id == profile_id
+                && expected_goal_id.is_none_or(|goal_id| goal_id == goal.goal_id)
+        })
     }
 
     /// #1973 fix B — the shared body behind both `clear_goal` trait entry
@@ -5088,7 +5166,13 @@ impl InProcessAgentOrchestrator {
         // #1666 residue — clear the cwd-scoped goal for this wire session id so
         // `goal_clear` in folder B never removes folder A's goal.
         let key = self.scoped_goal_key(&request.session_id);
-        let (removed, generation, fleet_store, clear_claim) = {
+        // #2066 round 2 (codex R4) — the claim guard is DECLARED before the
+        // state-lock scope: on unwind, locals drop in reverse declaration
+        // order, so the MutexGuard inside the block releases before this
+        // guard's Drop re-locks the state (no self-deadlock), and the claim
+        // is released on every exit path, panic included.
+        let mut clear_claim_guard: Option<ClearDispatchClaimGuard> = None;
+        let (removed, generation, fleet_store) = {
             let mut state = self.state();
             let removed = match state.goals.get(&key) {
                 Some(goal) if goal.profile_id == request.profile_id => state.goals.remove(&key),
@@ -5104,23 +5188,28 @@ impl InProcessAgentOrchestrator {
                 }
                 None => None,
             };
-            let mut clear_claim = None;
             if let Some(goal) = removed.as_ref() {
                 persist_goal_cleared(&state, &key, &request.profile_id);
                 // #2064(a) — serialize with the continuation dispatcher,
                 // under the SAME lock that removed the record: claim the
-                // dispatch marker when it is free (released after the
-                // durable stamp below, generation-keyed), so a dispatcher
-                // racing this clear cannot claim-and-launch from the state
-                // being destroyed. When a turn is already IN FLIGHT the
-                // marker is left untouched (stealing it would strip the
-                // running turn's #1529 protection); the clear stamps
-                // `cleared` immediately and parks the settle tombstone
-                // instead, so the turn's charge lands on the cleared row
-                // (#2064(b)). No tombstone without a ledger dir — there is
-                // no durable row to settle into.
-                clear_claim = claim_clear_dispatch_slot(&mut state, &key);
-                if clear_claim.is_none() {
+                // dispatch marker when it is free (released by the guard
+                // after the durable stamp below, generation-keyed), so a
+                // dispatcher racing this clear cannot claim-and-launch from
+                // the state being destroyed. When a turn is already IN
+                // FLIGHT the marker is left untouched (stealing it would
+                // strip the running turn's #1529 protection); the clear
+                // stamps `cleared` immediately and parks the settle
+                // tombstone instead, so the turn's charge lands on the
+                // cleared row (#2064(b)). No tombstone without a ledger dir
+                // — there is no durable row to settle into.
+                clear_claim_guard = claim_clear_dispatch_slot(&mut state, &key).map(|generation| {
+                    ClearDispatchClaimGuard {
+                        orchestrator: self.clone(),
+                        key: key.clone(),
+                        generation,
+                    }
+                });
+                if clear_claim_guard.is_none() {
                     if let Some(data_dir) = ledger_data_dir {
                         park_cleared_goal_tombstone(&mut state, &key, goal, data_dir);
                     }
@@ -5133,7 +5222,7 @@ impl InProcessAgentOrchestrator {
             // `update.generation < clear.generation`.
             let generation = next_goal_event_generation(&mut state);
             let fleet_store = state.fleet_store.clone();
-            (removed, generation, fleet_store, clear_claim)
+            (removed, generation, fleet_store)
         };
         let cleared = removed.is_some();
         if let Some(goal) = removed {
@@ -5187,14 +5276,14 @@ impl InProcessAgentOrchestrator {
                 );
             }
         }
-        if let Some(claim_generation) = clear_claim {
-            // #2064(a) — release the clear's own claim now that the durable
-            // stamp landed. Generation-keyed: this can never wipe a marker a
-            // newer turn claimed in the meantime. An unwind between claim and
-            // release would leak the marker; the #2003 staleness horizon
-            // rescues the session after `IN_FLIGHT_STALE_AFTER_MS`.
-            self.clear_goal_dispatch_in_flight_generation(&key, claim_generation);
-        }
+        // #2064(a)/#2066 round 2 (codex R4) — release the clear's own claim
+        // now that the durable stamp landed. The guard's Drop is
+        // generation-keyed (never wipes a marker a newer turn claimed) and
+        // fires on EVERY exit path, unwind included — the raw generation it
+        // replaces leaked the marker on a panic between claim and release,
+        // and the #2003 staleness horizon is only a conditional backstop
+        // (a stale marker survives while nonterminal supervised work exists).
+        drop(clear_claim_guard);
         Ok(json!({
             "session_id": request.session_id,
             "profile_id": request.profile_id,
@@ -8663,6 +8752,24 @@ impl AgentOrchestrator for InProcessAgentOrchestrator {
             }
             goal.clone()
         } else {
+            // #2066 round 2 (codex R1a) — create-after-clear: a tombstone
+            // parked for THIS key keeps serving the CLEARED goal's
+            // still-in-flight turn and cannot absorb the new goal's charges
+            // by construction — settlement is goal-id-bound with unbound
+            // charges refused (R1c), and the fresh goal_id minted below can
+            // never collide with the tombstone's (the sequence is monotonic
+            // in-process, and cleared ids are folded into the restart
+            // high-water mark — R1d). Dropping the tombstone here would
+            // break R1b/c's routing of the old turn's late charge, so it
+            // stays parked; logged for visibility.
+            if let Some(tombstone) = state.cleared_goal_tombstones.get(&key) {
+                tracing::debug!(
+                    session = %key,
+                    cleared_goal_id = %tombstone.snapshot.goal_id,
+                    "creating a new goal while the cleared predecessor's settle \
+                     tombstone is still parked (its in-flight turn may still charge)"
+                );
+            }
             state.next_goal_seq += 1;
             let goal = AutonomyGoalRecord {
                 profile_id: request.profile_id.clone(),
@@ -9287,22 +9394,58 @@ fn in_flight_marker_is_live(
 /// both land) and is replaced by the next clear on its key, so the cap only
 /// matters when cleared-mid-turn turns keep dying without charging.
 /// Oldest-parked is evicted first — dropping one merely restores the pre-fix
-/// behavior for that turn (its late charge lands nowhere).
+/// behavior for that turn (its late charge lands nowhere); the eviction is
+/// debug-logged (#2066 round 2).
 const MAX_CLEARED_GOAL_TOMBSTONES: usize = 16;
+
+/// #2066 round 2 (codex R1) — settle horizon for a parked tombstone,
+/// deliberately the SAME horizon as the dispatch marker
+/// ([`IN_FLIGHT_STALE_AFTER_MS`]): once the in-flight marker that justified
+/// parking has aged out (its turn is treated as abandoned and the session is
+/// rescued), no legitimate late charge for that turn can arrive either.
+/// Purged opportunistically on map touches (park/accrue), mirroring the
+/// #2059 retention pattern.
+const CLEARED_GOAL_TOMBSTONE_TTL_MS: u64 = IN_FLIGHT_STALE_AFTER_MS;
 
 /// #2064(b) — the settle context for a goal cleared while its dispatched turn
 /// was still in flight. See the field doc on
 /// `AutonomyRuntimeState::cleared_goal_tombstones`.
 #[derive(Debug, Clone)]
 struct ClearedGoalTombstone {
-    /// The removed record with `status == "cleared"`; the accountants accrue
-    /// the late charge into `tokens_used`/`time_used_seconds` here before the
-    /// durable settle.
+    /// The removed record, FROZEN at clear time with `status == "cleared"` —
+    /// the base row for `create_goal_if_absent` when the goal never synced a
+    /// ledger row. #2066 round 2 (codex R6): late charges are NOT folded in
+    /// here; each charge settles as a COUNTERS-ONLY additive delta
+    /// ([`octos_fleet::GoalLedger::settle_cleared_goal_cost_delta`]), which
+    /// commutes with the clear's status stamp in every arrival order.
     snapshot: AutonomyGoalRecord,
     /// The profile data dir the clear RPC resolved — the settle writes the
     /// same `<data_dir>/goal-ledgers/<goal_id>.db` row the clear stamped.
     ledger_data_dir: std::path::PathBuf,
     parked_at_ms: u64,
+    /// Total tokens settled through this tombstone so far (observability —
+    /// surfaced in the eviction/purge debug logs).
+    settled_tokens: u64,
+}
+
+/// #2066 round 2 (codex R1) — drop tombstones past the settle horizon.
+/// Opportunistic: called on the map's own touch points (park + accrue), so a
+/// quiet orchestrator retains at most [`MAX_CLEARED_GOAL_TOMBSTONES`] inert
+/// entries and an active one self-cleans.
+fn purge_stale_cleared_goal_tombstones(state: &mut AutonomyRuntimeState) {
+    let now = now_ms_u64();
+    state.cleared_goal_tombstones.retain(|key, tombstone| {
+        let live = now.saturating_sub(tombstone.parked_at_ms) < CLEARED_GOAL_TOMBSTONE_TTL_MS;
+        if !live {
+            tracing::debug!(
+                session = %key,
+                goal_id = %tombstone.snapshot.goal_id,
+                settled_tokens = tombstone.settled_tokens,
+                "cleared-goal tombstone aged past the settle horizon; dropping it"
+            );
+        }
+        live
+    });
 }
 
 /// #2064(a) — the clear path's half of the dispatcher serialization: claim
@@ -9339,6 +9482,33 @@ fn claim_clear_dispatch_slot(state: &mut AutonomyRuntimeState, key: &SessionKey)
     Some(generation)
 }
 
+/// #2066 round 2 (codex R4) — RAII for the clear path's dispatch claim (the
+/// #2059 flight-guard pattern). The raw generation had no unwind protection:
+/// a panic between claim and release leaked the marker, and the #2003
+/// staleness horizon is only a CONDITIONAL backstop — a stale marker stays
+/// live while the session has any nonterminal supervised work
+/// (`in_flight_marker_is_held`'s second arm), so it is not a guaranteed
+/// rescue. This guard releases exactly once on every exit, unwind included,
+/// generation-keyed (never wipes a marker a newer turn claimed).
+///
+/// Holds a CLONE of the (Arc-backed) orchestrator, so it needs no `'static`
+/// borrow and works on test-local instances. Drop re-locks the state mutex —
+/// the guard must therefore never be dropped while the caller still holds
+/// the state lock (declare it BEFORE the lock scope; see `clear_goal_impl`).
+#[must_use = "the clear's dispatch claim is released on drop"]
+struct ClearDispatchClaimGuard {
+    orchestrator: InProcessAgentOrchestrator,
+    key: SessionKey,
+    generation: u64,
+}
+
+impl Drop for ClearDispatchClaimGuard {
+    fn drop(&mut self) {
+        self.orchestrator
+            .clear_goal_dispatch_in_flight_generation(&self.key, self.generation);
+    }
+}
+
 /// #2064(b) — park the settle context for the in-flight turn of a goal that
 /// was just cleared. Bounded (see [`MAX_CLEARED_GOAL_TOMBSTONES`]); a newer
 /// clear on the same key replaces the older tombstone (whose turn's late
@@ -9349,6 +9519,7 @@ fn park_cleared_goal_tombstone(
     goal: &AutonomyGoalRecord,
     ledger_data_dir: &Path,
 ) {
+    purge_stale_cleared_goal_tombstones(state);
     if state.cleared_goal_tombstones.len() >= MAX_CLEARED_GOAL_TOMBSTONES
         && !state.cleared_goal_tombstones.contains_key(key)
     {
@@ -9358,7 +9529,17 @@ fn park_cleared_goal_tombstone(
             .min_by_key(|(_, tombstone)| tombstone.parked_at_ms)
             .map(|(key, _)| key.clone())
         {
-            state.cleared_goal_tombstones.remove(&oldest);
+            if let Some(dropped) = state.cleared_goal_tombstones.remove(&oldest) {
+                // #2066 round 2 (codex R1) — the cap eviction silently
+                // discarded the oldest late charge; make the discard visible.
+                tracing::debug!(
+                    session = %oldest,
+                    goal_id = %dropped.snapshot.goal_id,
+                    settled_tokens = dropped.settled_tokens,
+                    "cleared-goal tombstone cap reached; evicting the oldest \
+                     (its turn's remaining late charges will be dropped)"
+                );
+            }
         }
     }
     let mut snapshot = goal.clone();
@@ -9370,48 +9551,52 @@ fn park_cleared_goal_tombstone(
             snapshot,
             ledger_data_dir: ledger_data_dir.to_path_buf(),
             parked_at_ms: now_ms_u64(),
+            settled_tokens: 0,
         },
     );
 }
 
-/// #2064(b) — accrue a turn-end charge into the key's parked tombstone (if
-/// any) and hand back the updated snapshot + ledger dir for the durable
-/// settle. Guards mirror the live charge path: profile isolation always;
-/// goal-identity binding when the caller captured one at turn start
-/// (`expected_goal_id`). The tombstone STAYS parked so a turn charge and its
-/// verifier charge can both settle; it is replaced by the next clear on the
-/// key or evicted by the cap. Returns `None` when there is nothing to settle
-/// — the charge is then dropped exactly as before this fix.
+/// #2064(b) — resolve a turn-end charge against the key's parked tombstone
+/// (if any) and hand back the settle work: the frozen base row (for
+/// `create_goal_if_absent` when the goal never synced a ledger row), the
+/// ledger dir, and the charge's DELTA. Guards mirror the live charge path:
+/// profile isolation always, and — #2066 round 2 (codex R1c) — a MANDATORY
+/// goal-identity binding: unbound (`None`) settlement is REFUSED outright,
+/// so a stale tombstone can never absorb a charge that was not provably made
+/// under the cleared goal. The tombstone stays parked (turn charge + verifier
+/// charge both settle); it is replaced by the next clear on the key, evicted
+/// by the cap, or purged past [`CLEARED_GOAL_TOMBSTONE_TTL_MS`]. `None` ⇒
+/// nothing to settle — the charge is dropped exactly as before this fix.
+///
+/// #2066 round 2 (codex MEDIUM) — deliberately tokens-only: the ledger
+/// schema has no time column anywhere (not a cleared-goal gap), so accruing
+/// wall-clock here could never persist; the schema addition is #2068 —
+/// accumulating dead state would be worse than not accruing.
 fn accrue_cleared_goal_tombstone_charge(
     state: &mut AutonomyRuntimeState,
     key: &SessionKey,
     profile_id: &str,
     expected_goal_id: Option<&str>,
     tokens_consumed: u64,
-    elapsed_seconds: u64,
-) -> Option<(AutonomyGoalRecord, std::path::PathBuf)> {
-    if tokens_consumed == 0 && elapsed_seconds == 0 {
+) -> Option<(AutonomyGoalRecord, std::path::PathBuf, u64)> {
+    // R1c — refuse unbound settlement: no goal identity, no settle.
+    let expected_goal_id = expected_goal_id?;
+    if tokens_consumed == 0 {
         return None;
     }
+    purge_stale_cleared_goal_tombstones(state);
     let tombstone = state.cleared_goal_tombstones.get_mut(key)?;
     if tombstone.snapshot.profile_id != profile_id {
         return None;
     }
-    if expected_goal_id.is_some_and(|goal_id| goal_id != tombstone.snapshot.goal_id) {
+    if expected_goal_id != tombstone.snapshot.goal_id {
         return None;
     }
-    tombstone.snapshot.tokens_used = tombstone
-        .snapshot
-        .tokens_used
-        .saturating_add(tokens_consumed);
-    tombstone.snapshot.time_used_seconds = tombstone
-        .snapshot
-        .time_used_seconds
-        .saturating_add(elapsed_seconds);
-    tombstone.snapshot.updated_at_ms = now_ms();
+    tombstone.settled_tokens = tombstone.settled_tokens.saturating_add(tokens_consumed);
     Some((
         tombstone.snapshot.clone(),
         tombstone.ledger_data_dir.clone(),
+        tokens_consumed,
     ))
 }
 
@@ -12176,6 +12361,16 @@ fn restore_goal_from_group(state: &mut AutonomyRuntimeState, group: &SupervisedG
     };
     let session_id = SessionKey(session_id.to_owned());
     if supervisor_metadata_bool(&group.metadata, AUTONOMY_GOAL_CLEARED).unwrap_or(false) {
+        // #2066 round 2 (codex R1d) — fold the CLEARED goal's sequence into
+        // the high-water mark BEFORE returning: the pre-fix early return
+        // rebuilt `next_goal_seq` only from SURVIVING goals, so after
+        // clear + restart a fresh goal could re-mint the cleared goal's
+        // `goal_NN` — colliding with its still-existing per-goal ledger file
+        // and (post-#2064) its settle tombstone. Same reused-sequence hazard
+        // the fleet ids dodged with a uuid suffix (#1857 PR 5a H3).
+        if let Some(goal_id) = supervisor_metadata_str(&group.metadata, "goal_id") {
+            state.next_goal_seq = state.next_goal_seq.max(sequence_suffix(goal_id));
+        }
         state.goals.remove(&session_id);
         return;
     }
@@ -15618,7 +15813,7 @@ mod tests {
             .expect("complete");
 
         // The full turn's spend is charged to the now-complete goal post-turn.
-        let terminal = orchestrator.record_goal_turn(&wire, "tenant-a", 191_064, 30);
+        let terminal = orchestrator.record_goal_turn(&wire, "tenant-a", None, 191_064, 30);
 
         let live = orchestrator.model_goal_snapshot(&wire, "tenant-a")["tokens_used"]
             .as_u64()
@@ -20407,7 +20602,7 @@ mod tests {
         // Recording a turn advances `last_continued_at_ms` to now, so the
         // next fire is gated by the 30s min-delay policy. Force it back to
         // 0 so the policy permits an immediate re-queue.
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 0, 1);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 0, 1);
         {
             if let Some(goal) = orchestrator.state().goals.get_mut(&session_id) {
                 goal.last_continued_at_ms = 0;
@@ -20459,7 +20654,7 @@ mod tests {
         );
 
         // Record a turn (this stamps `last_continued_at_ms = now`).
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 0, 1);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 0, 1);
 
         // Right after the turn, the drain path is still gated by the
         // 30s min-delay — no new continuation should be queued.
@@ -20549,7 +20744,7 @@ mod tests {
             MasterContinuationRuntimeState::idle(),
             usize::MAX,
         );
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 0, 1);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 0, 1);
 
         // last_continued_at_ms is now wall-clock now → re-queue must be
         // denied by the min-delay gate.
@@ -20873,7 +21068,7 @@ mod tests {
         // budget) must not overwrite the model's terminal state with
         // budget_limited.
         orchestrator.force_goal_tokens_used_for_test(&session_id, 900);
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 500, 5);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 500, 5);
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
             Some("complete"),
@@ -22005,7 +22200,10 @@ mod tests {
             )
             .expect("clear");
 
-        let settled = orchestrator.record_goal_turn(&session_id, "tenant-a", 4_000, 9);
+        // #2066 round 2 (codex R1c) — the autonomous charge is GOAL-ID-BOUND:
+        // the continuation carries the goal id it was dispatched under.
+        let settled =
+            orchestrator.record_goal_turn(&session_id, "tenant-a", Some(&goal_id), 4_000, 9);
         assert!(
             settled.is_none(),
             "a cleared goal yields no complete/blocked reconcile snapshot"
@@ -22135,6 +22333,445 @@ mod tests {
         );
     }
 
+    /// #2066 round 2 (codex R7) — the settle must land through the REAL
+    /// detached path too: inside a tokio runtime `offload_goal_ledger_io`
+    /// routes the ledger write to `spawn_blocking`, so the charge returns
+    /// before the row is reconciled and the test must poll to a deadline
+    /// (the runtime-less tests exercise the inline branch only).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cleared_goal_settle_should_land_through_the_detached_offload_path() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-clear-detached");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "detached settle".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        let goal_id = orchestrator.goal_id_for_test(&session_id).expect("goal id");
+        let key = orchestrator.scoped_goal_key(&session_id);
+        orchestrator.mark_goal_dispatch_in_flight(&key);
+        orchestrator
+            .clear_goal_with_ledger_sync(
+                GoalSessionRequest {
+                    session_id: session_id.clone(),
+                    profile_id: "tenant-a".into(),
+                },
+                Some(data_dir.path()),
+            )
+            .expect("clear");
+        assert!(
+            orchestrator
+                .charge_active_goal_tokens(&session_id, "tenant-a", &goal_id, 5_000, 7)
+                .is_none()
+        );
+        let ledger_path = InProcessAgentOrchestrator::goal_ledger_dir(data_dir.path())
+            .join(format!("{}.db", sanitize_filename_for_ledger(&goal_id)));
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            if let Ok(ledger) = octos_fleet::GoalLedger::open(&ledger_path) {
+                if let Ok(Some(row)) = ledger.get_goal(&goal_id) {
+                    if row.tokens_used == 5_000 && row.status == "cleared" {
+                        break;
+                    }
+                }
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the detached (spawn_blocking) settle did not land within 10s"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+    }
+
+    /// #2066 round 2 (codex R1c) — UNBOUND settlement is refused: a charge
+    /// that cannot prove which goal it ran under (no dispatch-time goal_id)
+    /// must not be attributed to a cleared goal's tombstone. Re-allowing
+    /// `None`-keyed settlement fails this test (mutation check 3).
+    #[test]
+    fn record_goal_turn_should_refuse_unbound_tombstone_settlement() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-clear-unbound");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "unbound refusal".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        let goal_id = orchestrator.goal_id_for_test(&session_id).expect("goal id");
+        let key = orchestrator.scoped_goal_key(&session_id);
+        orchestrator.mark_goal_dispatch_in_flight(&key);
+        orchestrator
+            .clear_goal_with_ledger_sync(
+                GoalSessionRequest {
+                    session_id: session_id.clone(),
+                    profile_id: "tenant-a".into(),
+                },
+                Some(data_dir.path()),
+            )
+            .expect("clear");
+        // An UNBOUND autonomous charge (legacy continuation without a stamped
+        // goal id) must not settle into the tombstone.
+        assert!(
+            orchestrator
+                .record_goal_turn(&session_id, "tenant-a", None, 9_000, 3)
+                .is_none()
+        );
+        let ledger_path = InProcessAgentOrchestrator::goal_ledger_dir(data_dir.path())
+            .join(format!("{}.db", sanitize_filename_for_ledger(&goal_id)));
+        let ledger = octos_fleet::GoalLedger::open(&ledger_path).expect("open ledger");
+        assert_eq!(
+            ledger
+                .get_goal(&goal_id)
+                .expect("query")
+                .expect("row")
+                .tokens_used,
+            0,
+            "an unbound charge must never be attributed to a cleared goal"
+        );
+        // The BOUND charge still settles (the tombstone survived the refusal).
+        assert!(
+            orchestrator
+                .record_goal_turn(&session_id, "tenant-a", Some(&goal_id), 4_000, 3)
+                .is_none()
+        );
+        assert_eq!(
+            ledger
+                .get_goal(&goal_id)
+                .expect("query")
+                .expect("row")
+                .tokens_used,
+            4_000,
+        );
+    }
+
+    /// #2066 round 2 (codex R1a/R1b + the AO misattribution) — clear the goal
+    /// mid-turn, create a REPLACEMENT goal, then let the old turn's charges
+    /// arrive: they must settle the CLEARED goal's ledger row (goal-id-bound
+    /// tombstone), never the replacement's counters — and the replacement's
+    /// own bound charges still land live. This is also the create-after-clear
+    /// pin: the tombstone survives the create (dropping it would orphan the
+    /// old turn's cost) while remaining unabsorbable by the new goal.
+    #[test]
+    fn cleared_goal_charge_should_settle_old_tombstone_not_the_replacement_goal() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-clear-replace");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "old goal".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        let old_goal_id = orchestrator.goal_id_for_test(&session_id).expect("goal id");
+        orchestrator.force_goal_tokens_used_for_test(&session_id, 100);
+        let key = orchestrator.scoped_goal_key(&session_id);
+        orchestrator.mark_goal_dispatch_in_flight(&key);
+        orchestrator
+            .clear_goal_with_ledger_sync(
+                GoalSessionRequest {
+                    session_id: session_id.clone(),
+                    profile_id: "tenant-a".into(),
+                },
+                Some(data_dir.path()),
+            )
+            .expect("clear");
+        // Replacement goal on the same key.
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "replacement goal".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set replacement");
+        let new_goal_id = orchestrator.goal_id_for_test(&session_id).expect("goal id");
+        assert_ne!(old_goal_id, new_goal_id, "monotonic seq mints a fresh id");
+
+        // The old turn's charges arrive — interactive-shaped and
+        // autonomous-shaped — bound to the OLD goal id.
+        assert!(
+            orchestrator
+                .charge_active_goal_tokens(&session_id, "tenant-a", &old_goal_id, 5_000, 7)
+                .is_none()
+        );
+        assert!(
+            orchestrator
+                .record_goal_turn(&session_id, "tenant-a", Some(&old_goal_id), 2_000, 9)
+                .is_none()
+        );
+        let ledger_path = InProcessAgentOrchestrator::goal_ledger_dir(data_dir.path())
+            .join(format!("{}.db", sanitize_filename_for_ledger(&old_goal_id)));
+        let ledger = octos_fleet::GoalLedger::open(&ledger_path).expect("open ledger");
+        let old_row = ledger
+            .get_goal(&old_goal_id)
+            .expect("query")
+            .expect("row present");
+        assert_eq!(old_row.status, "cleared");
+        assert_eq!(
+            old_row.tokens_used, 7_100,
+            "base 100 + 5000 + 2000 — the old turn's full cost lands on the cleared row"
+        );
+        let (new_tokens, new_continuations, _) = orchestrator
+            .goal_counters_for_test(&session_id)
+            .expect("replacement exists");
+        assert_eq!(
+            new_tokens, 0,
+            "the replacement goal must not absorb the old turn's spend (the \
+             pre-fix misattribution)"
+        );
+        assert_eq!(new_continuations, 0, "nor its continuation accounting");
+        // The replacement's own bound charge still lands live.
+        assert!(
+            orchestrator
+                .charge_active_goal_tokens(&session_id, "tenant-a", &new_goal_id, 300, 1)
+                .is_some()
+        );
+        let (new_tokens, _, _) = orchestrator
+            .goal_counters_for_test(&session_id)
+            .expect("replacement exists");
+        assert_eq!(new_tokens, 300);
+    }
+
+    /// #2066 round 2 (codex R1) — tombstone retention: entries past the
+    /// settle horizon are purged on map touches, and the size cap evicts the
+    /// OLDEST parked entry.
+    #[test]
+    fn cleared_goal_tombstones_should_purge_past_horizon_and_cap_evict_oldest() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let dir = tempfile::TempDir::new().unwrap();
+        let record = |goal_id: &str| AutonomyGoalRecord {
+            profile_id: "tenant-a".into(),
+            goal_id: goal_id.to_owned(),
+            objective: "retention".into(),
+            status: "cleared".into(),
+            token_budget: 100_000,
+            tokens_used: 0,
+            time_used_seconds: 0,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+            continuations_used: 0,
+            last_continued_at_ms: 0,
+            rate_window_start_ms: 0,
+            rate_window_count: 0,
+            wrap_up_emitted: false,
+            consecutive_failed_turns: 0,
+            fleet_id: None,
+            controller_workspace_root: None,
+            controller_workspace_has_runtime_hint: None,
+            revision: 0,
+            wrap_up_generation: 0,
+        };
+        // Age-based purge: an entry past the horizon is dropped on the next
+        // map touch (here: the purge invoked by a fresh park).
+        {
+            let mut state = orchestrator.state();
+            park_cleared_goal_tombstone(
+                &mut state,
+                &SessionKey("aged".into()),
+                &record("goal_90"),
+                dir.path(),
+            );
+            state
+                .cleared_goal_tombstones
+                .get_mut(&SessionKey("aged".into()))
+                .expect("parked")
+                .parked_at_ms = now_ms_u64().saturating_sub(CLEARED_GOAL_TOMBSTONE_TTL_MS + 1);
+            park_cleared_goal_tombstone(
+                &mut state,
+                &SessionKey("fresh".into()),
+                &record("goal_91"),
+                dir.path(),
+            );
+            assert!(
+                !state
+                    .cleared_goal_tombstones
+                    .contains_key(&SessionKey("aged".into())),
+                "an entry past the settle horizon is purged on the next touch"
+            );
+            assert!(
+                state
+                    .cleared_goal_tombstones
+                    .contains_key(&SessionKey("fresh".into()))
+            );
+            state.cleared_goal_tombstones.clear();
+        }
+        // Cap eviction: fill to the cap with strictly increasing parked_at,
+        // then park one more — the OLDEST is evicted, the rest survive.
+        {
+            let mut state = orchestrator.state();
+            for i in 0..MAX_CLEARED_GOAL_TOMBSTONES {
+                let key = SessionKey(format!("cap-{i}"));
+                park_cleared_goal_tombstone(
+                    &mut state,
+                    &key,
+                    &record(&format!("goal_{i}")),
+                    dir.path(),
+                );
+                state
+                    .cleared_goal_tombstones
+                    .get_mut(&key)
+                    .expect("parked")
+                    .parked_at_ms = now_ms_u64() + i as u64;
+            }
+            park_cleared_goal_tombstone(
+                &mut state,
+                &SessionKey("cap-overflow".into()),
+                &record("goal_99"),
+                dir.path(),
+            );
+            assert_eq!(
+                state.cleared_goal_tombstones.len(),
+                MAX_CLEARED_GOAL_TOMBSTONES,
+                "the map never exceeds the cap"
+            );
+            assert!(
+                !state
+                    .cleared_goal_tombstones
+                    .contains_key(&SessionKey("cap-0".into())),
+                "the oldest parked entry is the one evicted"
+            );
+            assert!(
+                state
+                    .cleared_goal_tombstones
+                    .contains_key(&SessionKey("cap-overflow".into()))
+            );
+        }
+    }
+
+    /// #2066 round 2 (codex R2) — the launch-after-clear seam: the dispatch
+    /// claim is mutually exclusive (a slot held by a clear refuses a second
+    /// claim), and the post-claim recheck refuses to launch once the goal is
+    /// gone or replaced. Reverting the dispatch site to an unconditional
+    /// mark (or dropping the recheck) fails this test together with the
+    /// source guard below (mutation check 1).
+    #[test]
+    fn dispatch_claim_should_refuse_launch_when_goal_cleared_between_drain_and_claim() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-launch-abort");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "drain then clear".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        let goal_id = orchestrator.goal_id_for_test(&session_id).expect("goal id");
+        let key = orchestrator.scoped_goal_key(&session_id);
+        // The dispatcher drained a continuation for this goal…
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            1,
+        );
+        assert_eq!(drained.len(), 1, "the set enqueued one GoalContinue");
+
+        // …and a clear claims the slot before the spawned task does: the
+        // claim is exclusive, so a concurrent dispatch claim must refuse.
+        let clear_claim = {
+            let mut state = orchestrator.state();
+            let claim = claim_clear_dispatch_slot(&mut state, &key).expect("slot free");
+            assert!(
+                claim_clear_dispatch_slot(&mut state, &key).is_none(),
+                "the dispatch claim is mutually exclusive while the clear holds it"
+            );
+            claim
+        };
+        assert!(orchestrator.clear_goal_dispatch_in_flight_generation(&key, clear_claim));
+
+        // The clear completes (goal removed). The spawned task's post-claim
+        // recheck must now refuse the launch: the drained continuation's
+        // goal is gone.
+        orchestrator
+            .clear_goal(GoalSessionRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+            })
+            .expect("clear");
+        assert!(
+            !orchestrator.goal_dispatch_target_matches(&key, "tenant-a", Some(&goal_id)),
+            "a cleared goal must fail the post-claim dispatch recheck"
+        );
+        assert!(
+            !orchestrator.goal_dispatch_target_matches(&key, "tenant-a", None),
+            "even an unbound continuation must not launch for an absent goal"
+        );
+
+        // A replacement goal fails the OLD binding but passes its own.
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "replacement".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set replacement");
+        let new_goal_id = orchestrator.goal_id_for_test(&session_id).expect("goal id");
+        assert!(!orchestrator.goal_dispatch_target_matches(&key, "tenant-a", Some(&goal_id)));
+        assert!(orchestrator.goal_dispatch_target_matches(&key, "tenant-a", Some(&new_goal_id)));
+        // Profile isolation holds on the recheck too.
+        assert!(!orchestrator.goal_dispatch_target_matches(&key, "tenant-b", Some(&new_goal_id)));
+    }
+
+    /// #2066 round 2 (codex R2/R7) — source guard for the AppUI dispatch
+    /// wiring: the spawned continuation task must claim ATOMICALLY
+    /// (`try_claim_goal_in_flight`) and re-check the goal
+    /// (`goal_dispatch_target_matches`) before launching — never the
+    /// unconditional `goal_dispatch_in_flight_guard`, which overwrites a
+    /// clear's (or another dispatcher's) claim. Scans the spawn region of
+    /// `ui_protocol_transport.rs` so reverting the wiring fails even though
+    /// that module is feature-gated out of this build (mutation check 1).
+    #[test]
+    fn appui_continuation_spawn_should_use_atomic_try_claim_source_guard() {
+        let transport = include_str!("../api/ui_protocol_transport.rs");
+        let spawn_marker = "draining queued master continuation into AppUI turn runtime";
+        let start = transport
+            .find(spawn_marker)
+            .expect("the AppUI continuation spawn log line exists");
+        let end = transport[start..]
+            .find("run_standalone_turn(")
+            .map(|offset| start + offset)
+            .expect("the spawn region ends at the turn launch");
+        let spawn_region = &transport[start..end];
+        assert!(
+            spawn_region.contains("try_claim_goal_in_flight"),
+            "the continuation spawn must claim the dispatch slot atomically \
+             (try-claim), not mark unconditionally"
+        );
+        assert!(
+            spawn_region.contains("goal_dispatch_target_matches"),
+            "the continuation spawn must re-check the goal after claiming, \
+             before launching"
+        );
+        assert!(
+            !spawn_region.contains("goal_dispatch_in_flight_guard("),
+            "the unconditional marker overwrite must not return to the \
+             continuation spawn path (it silently steals a clear's claim)"
+        );
+    }
+
     /// Codex LOW (zero-budget consistency): a `token_budget` of 0 is not a
     /// legitimate "unlimited" budget — it would produce an `active` goal that
     /// `is_exhausted()` denies immediately. `set_goal` must reject it so the
@@ -22231,9 +22868,9 @@ mod tests {
             .expect("set active goal");
 
         // Two failures then a real turn: streak resets, goal stays active.
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 0, 1);
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 0, 1);
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 50_000, 30);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 0, 1);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 0, 1);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 50_000, 30);
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
             Some("active"),
@@ -22241,9 +22878,9 @@ mod tests {
         );
 
         // Three consecutive failures: blocked.
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 0, 1);
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 0, 1);
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 0, 1);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 0, 1);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 0, 1);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 0, 1);
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
             Some("blocked"),
@@ -22278,8 +22915,8 @@ mod tests {
             orchestrator.goal_status_for_test(&session_id).as_deref(),
             Some("active")
         );
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 0, 1);
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 0, 1);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 0, 1);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 0, 1);
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
             Some("active"),
@@ -22356,7 +22993,7 @@ mod tests {
         // Force tokens_used near the budget so the next recorded turn
         // exhausts it.
         orchestrator.force_goal_tokens_used_for_test(&session_id, 900);
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 200, 5);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 200, 5);
 
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
@@ -22389,7 +23026,7 @@ mod tests {
 
         // Idempotency — a second turn record after exhaustion must NOT
         // emit a duplicate wrap-up.
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 100, 1);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 100, 1);
         assert_eq!(orchestrator.pending_continuation_count_for_test(), 0);
     }
 
@@ -22730,7 +23367,7 @@ mod tests {
             usize::MAX,
         );
         orchestrator.force_goal_tokens_used_for_test(&limited, 900);
-        orchestrator.record_goal_turn(&limited, "tenant-a", 200, 5);
+        orchestrator.record_goal_turn(&limited, "tenant-a", None, 200, 5);
         let drained = orchestrator.drain_ready_continuations_for_session(
             &limited,
             "tenant-a",
@@ -22760,7 +23397,7 @@ mod tests {
             usize::MAX,
         );
         orchestrator.force_goal_tokens_used_for_test(&completed, 900);
-        orchestrator.record_goal_turn(&completed, "tenant-a", 200, 5);
+        orchestrator.record_goal_turn(&completed, "tenant-a", None, 200, 5);
         assert_eq!(
             orchestrator.goal_status_for_test(&completed).as_deref(),
             Some("budget_limited"),
@@ -23038,7 +23675,7 @@ mod tests {
         // Trip the #1693 breaker through the production accountant: three
         // consecutive zero-token turns flip active → blocked.
         for _ in 0..GOAL_MAX_CONSECUTIVE_FAILED_TURNS {
-            orchestrator.record_goal_turn(&session_id, "tenant-a", 0, 1);
+            orchestrator.record_goal_turn(&session_id, "tenant-a", None, 0, 1);
         }
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
@@ -23836,7 +24473,7 @@ mod tests {
         // exhausts it — this transitions the goal to `budget_limited`
         // AND enqueues the wrap-up continuation.
         orchestrator.force_goal_tokens_used_for_test(&session_id, 900);
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 200, 5);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 200, 5);
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
             Some("budget_limited"),
@@ -23898,7 +24535,7 @@ mod tests {
                 usize::MAX,
             );
             orchestrator.force_goal_tokens_used_for_test(session, 900);
-            orchestrator.record_goal_turn(session, tenant, 200, 5);
+            orchestrator.record_goal_turn(session, tenant, None, 200, 5);
         }
 
         let targets_a = orchestrator.due_loop_targets(Some("tenant-a"), 8);
@@ -24450,7 +25087,7 @@ mod tests {
         // crossing), then pause the goal — through the PRODUCTION persisted
         // `set_goal` path — before it drains.
         orchestrator.force_goal_tokens_used_for_test(&session_id, 900);
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 200, 5);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 200, 5);
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
             Some("budget_limited"),
@@ -24511,7 +25148,7 @@ mod tests {
         // REMINT: spend across the NEW budget. The fresh wrap-up rides the
         // gen-1 dedupe key, so the gen-0 tombstone cannot mask its Queued
         // event on replay.
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 900, 5);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 900, 5);
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
             Some("budget_limited"),
@@ -24720,7 +25357,7 @@ mod tests {
         );
 
         orchestrator.force_goal_tokens_used_for_test(&session_id, 900);
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 200, 5);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 200, 5);
 
         let drained = orchestrator.drain_ready_continuations_for_session(
             &session_id,
@@ -24823,7 +25460,7 @@ mod tests {
             usize::MAX,
         );
         orchestrator.force_goal_tokens_used_for_test(&session_id, 500);
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 0, 1);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 0, 1);
         // Drain the wrap-up turn enqueued by the exhaustion above.
         let _ = orchestrator.drain_ready_continuations_for_session(
             &session_id,
@@ -25126,7 +25763,7 @@ mod tests {
             usize::MAX,
         );
         orchestrator.force_goal_tokens_used_for_test(&session_id, 500);
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 0, 1);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 0, 1);
         assert_eq!(
             orchestrator.goal_status_for_test(&session_id).as_deref(),
             Some("budget_limited"),
@@ -26762,7 +27399,7 @@ mod tests {
         // Post-turn AppUI behavior: record a turn that actually consumed
         // tokens (this is what `run_standalone_turn` does once goal
         // context + token accounting are wired through).
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 1234, 7);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 1234, 7);
 
         let (tokens_after, continuations_after, window_after) = orchestrator
             .goal_counters_for_test(&session_id)
@@ -26872,7 +27509,7 @@ mod tests {
         // Simulate the NEW (#1133 option b) AppUI dispatch path: do NOT
         // call `record_goal_dispatch_only` at dispatch time. Only call
         // `record_goal_turn` once the turn returns with real tokens.
-        orchestrator.record_goal_turn(&session_id, "tenant-a", 500, 3);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", None, 500, 3);
 
         let (_, continuations_after, window_after) = orchestrator
             .goal_counters_for_test(&session_id)
@@ -27094,7 +27731,7 @@ mod tests {
         // Post-turn accounting addresses the scoped key (what the AppUI
         // dispatch passes via `goal_context.goal_session_key`) and charges the
         // scoped goal exactly once — the fire path stays intact end-to-end.
-        orchestrator.record_goal_turn(&scoped, "tenant-a", 500, 3);
+        orchestrator.record_goal_turn(&scoped, "tenant-a", None, 500, 3);
         let (_, continuations_after, _) = orchestrator
             .goal_counters_for_test(&scoped)
             .expect("scoped goal exists");

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -9535,11 +9535,18 @@ enum UnboundGoalBinding {
 
 /// #2066 round 3 (codex fix 3) — bind-at-drain: stamp a legacy unbound goal
 /// continuation with the live goal's id IFF that goal already existed when
-/// the continuation was enqueued (`goal.created_at_ms <= item.created_at`,
-/// `<=` because `set_goal` enqueues in the same `now_ms()` tick it creates
-/// the record). Downstream everything then sees `Some` and the wildcard
-/// paths never fire. Item creation time (`created_at`, preserved across
-/// reinsert) is the comparison anchor, not `enqueued_at`.
+/// the continuation was enqueued. #2066 round 4 (codex fix 1b) — the
+/// predicate is STRICT (`goal.created_at_ms < item.created_at`): a
+/// replacement goal minted in the same millisecond as the item must NOT
+/// steal it. The round-3 `<=` was justified by "set_goal enqueues in its own
+/// creation tick" — but set_goal's own enqueues are BOUND (`Some(goal_id)`)
+/// and never take this `None` path; legacy unbound items predate goal_id
+/// threading entirely, so a same-tick unbound item cannot legitimately
+/// belong to a goal created in that tick. On a tie the item dies stale —
+/// dropping a charge beats misattributing it. Item creation time
+/// (`created_at`, preserved across reinsert AND restored from the durable
+/// `queued_at_ms` on restart — fix 1a) is the comparison anchor, not
+/// `enqueued_at`.
 fn bind_unbound_goal_continuation_at_drain(
     state: &AutonomyRuntimeState,
     session_id: &SessionKey,
@@ -9568,7 +9575,7 @@ fn bind_unbound_goal_continuation_at_drain(
         .ok()
         .and_then(|elapsed| i64::try_from(elapsed.as_millis()).ok());
     match item_created_ms {
-        Some(created_ms) if goal.created_at_ms <= created_ms => {
+        Some(created_ms) if goal.created_at_ms < created_ms => {
             item.goal_id = Some(
                 crate::autonomy::master_continuation_scheduler::GoalId::from(goal.goal_id.as_str()),
             );
@@ -12435,12 +12442,24 @@ fn master_continuation_request_from_persisted(
     )?)?;
     let dedupe_key = supervisor_metadata_str(&continuation.metadata, "dedupe_key")
         .unwrap_or(&continuation.continuation_id);
+    // #2066 round 4 (codex fix 1a) — the reconstructed item keeps its DURABLE
+    // enqueue time (`queued_at_ms`, stamped by `persist_continuation_queued`
+    // at the original enqueue), NOT `SystemTime::now()`. The bind-at-drain
+    // temporal predicate compares the item's creation time against the live
+    // goal's `created_at_ms`; goals restore with their original timestamps
+    // (the metadata bag), so a now()-stamped item looked NEWER than every
+    // restored goal after ANY restart and an old unbound item ROUTINELY
+    // rebound to a post-clear replacement. `created_at` has no other
+    // behavioral consumer (the scheduler orders by priority/sequence, dedupe
+    // is key-based), so restoring the truthful time needs no second field.
+    let restored_created_at =
+        SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(continuation.queued_at_ms);
     let mut request = MasterContinuationRequest::new(
         continuation.group_id.clone(),
         session_id.to_owned(),
         profile_id.to_owned(),
         reason,
-        SystemTime::now(),
+        restored_created_at,
     )
     .with_dedupe_key(dedupe_key.to_owned());
     if let Some(child_id) = continuation.child_id.clone() {
@@ -23216,6 +23235,258 @@ mod tests {
             .goal_counters_for_test(&session_id)
             .expect("replacement exists");
         assert_eq!(new_tokens, 0);
+    }
+
+    /// #2066 round 4 (codex fix 1a) — RESTART: a restored continuation keeps
+    /// its DURABLE enqueue time as the bind-at-drain comparison anchor. The
+    /// pre-fix restore stamped `created_at = SystemTime::now()`, and goals
+    /// restore with their ORIGINAL timestamps — so after any restart every
+    /// old unbound item looked newer than the restored replacement and
+    /// ROUTINELY rebound to it. Reverting the restore to now() fails this
+    /// test (round-4 mutation 1).
+    #[test]
+    fn restored_unbound_continuation_should_keep_durable_time_and_die_stale() {
+        use crate::autonomy::supervisor_store::{ContinuationStatus, PendingContinuationRecord};
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-restart-unbound");
+        // The durable record of a LEGACY unbound goal continuation, enqueued
+        // long before this "boot" (60s in the past).
+        let queued_at_ms = now_ms_u64().saturating_sub(60_000);
+        let mut metadata = serde_json::Map::new();
+        metadata.insert("session_id".to_owned(), json!(session_id.to_string()));
+        metadata.insert("profile_id".to_owned(), json!("tenant-a"));
+        metadata.insert("reason".to_owned(), json!("goal_continue"));
+        metadata.insert("dedupe_key".to_owned(), json!("legacy-unbound-1"));
+        let record = PendingContinuationRecord {
+            group_id: "coding-autonomy-goal".to_owned(),
+            continuation_id: "legacy-unbound-1".to_owned(),
+            child_id: None,
+            prompt: None,
+            status: ContinuationStatus::Queued,
+            queued_at_ms,
+            started_at_ms: None,
+            completed_at_ms: None,
+            result: None,
+            attempt: 1,
+            metadata,
+        };
+        let request = master_continuation_request_from_persisted(&record).expect("record restores");
+        // codex round-4 assert: the restored item's binder-time equals its
+        // original durable enqueue time — never now().
+        assert_eq!(
+            request.created_at,
+            SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(queued_at_ms),
+            "the restored item must carry its DURABLE enqueue time"
+        );
+        // The post-clear REPLACEMENT goal exists at boot (goals restore
+        // before continuations enqueue — created strictly after queued_at).
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "replacement after restart".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set replacement");
+        let new_goal_id = orchestrator.goal_id_for_test(&session_id).expect("goal id");
+        // Re-enqueue exactly as `configure_supervisor_store` does.
+        {
+            let mut state = orchestrator.state();
+            let _ = state.continuations.enqueue(request);
+        }
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        let goal_items: Vec<_> = drained
+            .iter()
+            .filter(|c| matches!(c.reason, MasterContinuationReason::GoalContinue))
+            .collect();
+        assert_eq!(
+            goal_items.len(),
+            1,
+            "the restored legacy item dies STALE; only the replacement's own \
+             continuation drains: {drained:?}"
+        );
+        assert_eq!(
+            goal_items[0]
+                .goal_id
+                .as_ref()
+                .map(|goal_id| goal_id.as_str()),
+            Some(new_goal_id.as_str()),
+        );
+        let (new_tokens, _, _) = orchestrator
+            .goal_counters_for_test(&session_id)
+            .expect("replacement exists");
+        assert_eq!(new_tokens, 0, "the replacement is never charged");
+    }
+
+    /// #2066 round 4 (codex fix 1b) — the same-millisecond tie: a replacement
+    /// goal minted in the exact millisecond the unbound item was created must
+    /// NOT steal it (strict `<`; on a tie the item dies stale — dropping a
+    /// charge beats misattributing it).
+    #[test]
+    fn same_millisecond_replacement_should_not_steal_an_unbound_continuation() {
+        use crate::autonomy::master_continuation_scheduler::MasterContinuationRequest;
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-tie-unbound");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "tie goal".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        // Drain the initial bound continuation out of the way.
+        let _ = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        // An unbound item created in EXACTLY the goal's creation millisecond.
+        let goal_created_ms = {
+            let state = orchestrator.state();
+            let key = orchestrator.scoped_goal_key(&session_id);
+            state.goals.get(&key).expect("goal exists").created_at_ms
+        };
+        {
+            let mut state = orchestrator.state();
+            let request = MasterContinuationRequest::new(
+                "coding-autonomy-goal",
+                session_id.to_string(),
+                "tenant-a".to_owned(),
+                MasterContinuationReason::GoalContinue,
+                SystemTime::UNIX_EPOCH
+                    + std::time::Duration::from_millis(goal_created_ms.max(0) as u64),
+            );
+            let _ = enqueue_and_persist_continuation(&mut state, request);
+        }
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        assert!(
+            drained
+                .iter()
+                .filter(|c| matches!(c.reason, MasterContinuationReason::GoalContinue))
+                .all(|c| c.goal_id.is_some()),
+            "nothing drains unbound: {drained:?}"
+        );
+        // The tie item itself died stale — it is not among the drained items
+        // as a bound-to-this-goal charge carrier with its dedupe key.
+        assert!(
+            !drained
+                .iter()
+                .any(|c| c.dedupe_key.as_str().contains("legacy") || c.goal_id.is_none()),
+            "the same-millisecond item must die stale, not be stolen: {drained:?}"
+        );
+    }
+
+    /// #2066 round 4 (codex fix 2) — the AppUI heartbeat's semantics at the
+    /// orchestrator: a marker aged past the horizon is REVIVED by the
+    /// progress touch, which keeps the expired tombstone alive and keeps a
+    /// concurrent clear from claiming the slot; once progress stops (no more
+    /// touches) the marker ages out and the tombstone purges as before.
+    #[test]
+    fn touched_marker_should_keep_aged_tombstone_and_block_clear_claims() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-heartbeat");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "very long producing turn".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        let key = orchestrator.scoped_goal_key(&session_id);
+        let dispatcher_generation = orchestrator.mark_goal_dispatch_in_flight(&key);
+        orchestrator
+            .clear_goal_with_ledger_sync(
+                GoalSessionRequest {
+                    session_id: session_id.clone(),
+                    profile_id: "tenant-a".into(),
+                },
+                Some(data_dir.path()),
+            )
+            .expect("clear");
+        // The turn outlives every horizon: age BOTH the marker and the
+        // tombstone past their (shared) staleness horizon…
+        orchestrator.force_in_flight_marked_at_for_test(
+            &key,
+            now_ms_u64().saturating_sub(IN_FLIGHT_STALE_AFTER_MS + 1),
+        );
+        {
+            let mut state = orchestrator.state();
+            state
+                .cleared_goal_tombstones
+                .get_mut(&key)
+                .expect("tombstone parked")
+                .parked_at_ms = now_ms_u64().saturating_sub(CLEARED_GOAL_TOMBSTONE_TTL_MS + 1);
+        }
+        // …then the heartbeat observes token progress and touches.
+        orchestrator.touch_goal_dispatch_in_flight(&key);
+        {
+            let mut state = orchestrator.state();
+            purge_stale_cleared_goal_tombstones(&mut state);
+            assert!(
+                state.cleared_goal_tombstones.contains_key(&key),
+                "a touched (producing) turn keeps its expired tombstone alive"
+            );
+            // A concurrent clear-shaped claim must also see the slot as HELD.
+            assert!(
+                claim_clear_dispatch_slot(&mut state, &key).is_none(),
+                "the refreshed marker keeps a clear from claiming the slot"
+            );
+        }
+        // Progress stops: the marker ages out and the tombstone purges.
+        orchestrator.force_in_flight_marked_at_for_test(
+            &key,
+            now_ms_u64().saturating_sub(IN_FLIGHT_STALE_AFTER_MS + 1),
+        );
+        {
+            let mut state = orchestrator.state();
+            purge_stale_cleared_goal_tombstones(&mut state);
+            assert!(
+                !state.cleared_goal_tombstones.contains_key(&key),
+                "with progress stopped and the horizon passed, the tombstone purges"
+            );
+        }
+        let _ = orchestrator.clear_goal_dispatch_in_flight_generation(&key, dispatcher_generation);
+    }
+
+    /// #2066 round 4 (codex fix 2) — source guard for the AppUI heartbeat
+    /// wiring: `run_standalone_turn` must refresh the dispatch marker on
+    /// token progress (`touch_goal_dispatch_in_flight`), the exact hook the
+    /// session actor drives. Removing the AppUI touch fails this test
+    /// (round-4 mutation 2).
+    #[test]
+    fn appui_standalone_turn_should_heartbeat_the_dispatch_marker_source_guard() {
+        let transport = include_str!("../api/ui_protocol_transport.rs");
+        let start = transport
+            .find("async fn run_standalone_turn")
+            .expect("the standalone turn runner exists");
+        let turn_region = &transport[start..];
+        assert!(
+            turn_region.contains("touch_goal_dispatch_in_flight"),
+            "the AppUI standalone turn must refresh the goal dispatch marker \
+             on token progress (the session actor's #2003 heartbeat twin) — \
+             without it a >30min goal turn loses its tombstone and a clear \
+             can claim the slot mid-turn"
+        );
     }
 
     /// #2066 round 3 (codex fix 4) — tombstone TTL consults marker liveness:

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -3293,7 +3293,27 @@ impl InProcessAgentOrchestrator {
         let now = now_ms();
         let now_system = SystemTime::now();
         let mut state = self.state();
-        let goal = state.goals.get_mut(session_id)?;
+        let Some(goal) = state.goals.get_mut(session_id) else {
+            // #2064(b) — same settle for the autonomous accountant: the
+            // continuation turn that was already running when the user
+            // cleared lands its spend on the cleared row. No goal-identity
+            // binding on this path (mirrors its live lookup); profile
+            // isolation still applies inside the accrual. Returns None —
+            // `cleared` is not the complete/blocked reconcile family.
+            let settle = accrue_cleared_goal_tombstone_charge(
+                &mut state,
+                session_id,
+                profile_id,
+                None,
+                tokens_consumed,
+                elapsed_seconds,
+            );
+            drop(state);
+            if let Some((snapshot, ledger_data_dir)) = settle {
+                self.offload_cleared_goal_settle(snapshot, ledger_data_dir, session_id.clone());
+            }
+            return None;
+        };
         if goal.profile_id != profile_id {
             return None;
         }
@@ -3471,7 +3491,27 @@ impl InProcessAgentOrchestrator {
         let now = now_ms();
         let now_system = SystemTime::now();
         let mut state = self.state();
-        let goal = state.goals.get_mut(&key)?;
+        let Some(goal) = state.goals.get_mut(&key) else {
+            // #2064(b) — the goal may have been CLEARED while this turn was
+            // in flight: settle the charge into the parked tombstone
+            // (profile-checked, bound to the goal_id this turn captured at
+            // start) so the cleared row's recorded cost stays true.
+            // Deliberately NO wire event, NO wrap-up, NO continuation — the
+            // goal is gone for the client and terminal for scheduling.
+            let settle = accrue_cleared_goal_tombstone_charge(
+                &mut state,
+                &key,
+                profile_id,
+                Some(expected_goal_id),
+                tokens_consumed,
+                elapsed_seconds,
+            );
+            drop(state);
+            if let Some((snapshot, ledger_data_dir)) = settle {
+                self.offload_cleared_goal_settle(snapshot, ledger_data_dir, key.clone());
+            }
+            return None;
+        };
         // Profile isolation: never charge or leak a goal owned by a
         // different profile on the same (possibly unprofiled/shared)
         // session key. Mirrors `record_goal_turn`.
@@ -4983,6 +5023,40 @@ impl InProcessAgentOrchestrator {
         let _ = ledger.append_decision(&decision);
     }
 
+    /// #2064(b) — durably settle a late (post-clear) turn charge into the
+    /// cleared goals-row. Counters-only by construction: `status_changed ==
+    /// false` routes the guarded `upsert_goal` (which admits the higher
+    /// tokens + newer stamp on the `cleared` row) and appends NO decision —
+    /// the clear already wrote its one audit row. Runs through
+    /// [`offload_goal_ledger_io`] so the accountants (which fire on tokio
+    /// worker threads) never do ledger I/O inline; without a runtime the
+    /// settle runs synchronously (plain-thread/test callers).
+    ///
+    /// Arrival order against the clear's own stamp is free: if the settle
+    /// lands second its snapshot carries a newer stamp and higher tokens
+    /// (admitted); if the clear's stamp lands second its LOWER counters are
+    /// rejected by the monotonic clause and its status-CAS retry is
+    /// ordering-gated off — either order converges on
+    /// `cleared` + true totals.
+    fn offload_cleared_goal_settle(
+        &self,
+        snapshot: AutonomyGoalRecord,
+        ledger_data_dir: std::path::PathBuf,
+        decided_by: SessionKey,
+    ) {
+        let this = self.clone();
+        offload_goal_ledger_io(move || {
+            this.sync_transition_to_ledger_blocking(
+                &ledger_data_dir,
+                &snapshot,
+                "post-clear in-flight turn charge settled",
+                &decided_by,
+                false,
+                false,
+            );
+        });
+    }
+
     /// #1973 fix B — the shared body behind both `clear_goal` trait entry
     /// points. On top of the original remove + `persist_goal_cleared`, a clear
     /// now also:
@@ -5014,7 +5088,7 @@ impl InProcessAgentOrchestrator {
         // #1666 residue — clear the cwd-scoped goal for this wire session id so
         // `goal_clear` in folder B never removes folder A's goal.
         let key = self.scoped_goal_key(&request.session_id);
-        let (removed, generation, fleet_store) = {
+        let (removed, generation, fleet_store, clear_claim) = {
             let mut state = self.state();
             let removed = match state.goals.get(&key) {
                 Some(goal) if goal.profile_id == request.profile_id => state.goals.remove(&key),
@@ -5030,8 +5104,27 @@ impl InProcessAgentOrchestrator {
                 }
                 None => None,
             };
-            if removed.is_some() {
+            let mut clear_claim = None;
+            if let Some(goal) = removed.as_ref() {
                 persist_goal_cleared(&state, &key, &request.profile_id);
+                // #2064(a) — serialize with the continuation dispatcher,
+                // under the SAME lock that removed the record: claim the
+                // dispatch marker when it is free (released after the
+                // durable stamp below, generation-keyed), so a dispatcher
+                // racing this clear cannot claim-and-launch from the state
+                // being destroyed. When a turn is already IN FLIGHT the
+                // marker is left untouched (stealing it would strip the
+                // running turn's #1529 protection); the clear stamps
+                // `cleared` immediately and parks the settle tombstone
+                // instead, so the turn's charge lands on the cleared row
+                // (#2064(b)). No tombstone without a ledger dir — there is
+                // no durable row to settle into.
+                clear_claim = claim_clear_dispatch_slot(&mut state, &key);
+                if clear_claim.is_none() {
+                    if let Some(data_dir) = ledger_data_dir {
+                        park_cleared_goal_tombstone(&mut state, &key, goal, data_dir);
+                    }
+                }
             }
             // #1959 — stamp the same monotonic generation as
             // `SessionGoalUpdated` so the client can order a clear against a
@@ -5040,7 +5133,7 @@ impl InProcessAgentOrchestrator {
             // `update.generation < clear.generation`.
             let generation = next_goal_event_generation(&mut state);
             let fleet_store = state.fleet_store.clone();
-            (removed, generation, fleet_store)
+            (removed, generation, fleet_store, clear_claim)
         };
         let cleared = removed.is_some();
         if let Some(goal) = removed {
@@ -5093,6 +5186,14 @@ impl InProcessAgentOrchestrator {
                     false,
                 );
             }
+        }
+        if let Some(claim_generation) = clear_claim {
+            // #2064(a) — release the clear's own claim now that the durable
+            // stamp landed. Generation-keyed: this can never wipe a marker a
+            // newer turn claimed in the meantime. An unwind between claim and
+            // release would leak the marker; the #2003 staleness horizon
+            // rescues the session after `IN_FLIGHT_STALE_AFTER_MS`.
+            self.clear_goal_dispatch_in_flight_generation(&key, claim_generation);
         }
         Ok(json!({
             "session_id": request.session_id,
@@ -9181,6 +9282,139 @@ fn in_flight_marker_is_live(
     })
 }
 
+/// #2064(b) — upper bound on parked [`ClearedGoalTombstone`]s. A tombstone
+/// stays parked after settling (the turn charge AND its verifier charge must
+/// both land) and is replaced by the next clear on its key, so the cap only
+/// matters when cleared-mid-turn turns keep dying without charging.
+/// Oldest-parked is evicted first — dropping one merely restores the pre-fix
+/// behavior for that turn (its late charge lands nowhere).
+const MAX_CLEARED_GOAL_TOMBSTONES: usize = 16;
+
+/// #2064(b) — the settle context for a goal cleared while its dispatched turn
+/// was still in flight. See the field doc on
+/// `AutonomyRuntimeState::cleared_goal_tombstones`.
+#[derive(Debug, Clone)]
+struct ClearedGoalTombstone {
+    /// The removed record with `status == "cleared"`; the accountants accrue
+    /// the late charge into `tokens_used`/`time_used_seconds` here before the
+    /// durable settle.
+    snapshot: AutonomyGoalRecord,
+    /// The profile data dir the clear RPC resolved — the settle writes the
+    /// same `<data_dir>/goal-ledgers/<goal_id>.db` row the clear stamped.
+    ledger_data_dir: std::path::PathBuf,
+    parked_at_ms: u64,
+}
+
+/// #2064(a) — the clear path's half of the dispatcher serialization: claim
+/// the SAME in-flight marker the continuation dispatcher holds, under the
+/// same state lock that removes the goal record.
+///
+/// - Marker free → claim it (fresh generation, returned for the
+///   generation-keyed release). While the clear holds the claim, a racing
+///   dispatcher's `try_claim_goal_in_flight` / due-scan sees the session as
+///   busy and cannot claim-and-launch from the state being destroyed; by the
+///   time the claim frees, the goal is gone and nothing is schedulable
+///   (`pending_continuation_is_schedulable` refuses absent goals).
+/// - Marker held (a turn is in flight) → `None`, and the marker is NOT
+///   touched: stealing it would strip the running turn's #1529 protection.
+///   The caller stamps `cleared` immediately and parks a tombstone instead
+///   (stamp-and-accept-late-charge; deferring the stamp until the claim
+///   frees would leave the durable row claiming `active` through a crash —
+///   the exact lie #1973 fix B exists to prevent).
+///
+/// The claim STAYS a lock — folding it into goal status would reopen the
+/// #1529 double-dispatch (established by the #2059-era review).
+fn claim_clear_dispatch_slot(state: &mut AutonomyRuntimeState, key: &SessionKey) -> Option<u64> {
+    if in_flight_marker_is_held(state, key) {
+        return None;
+    }
+    let generation = next_in_flight_generation();
+    state.in_flight_goal_sessions.insert(
+        key.clone(),
+        InFlightMarker {
+            generation,
+            marked_at_ms: now_ms_u64(),
+        },
+    );
+    Some(generation)
+}
+
+/// #2064(b) — park the settle context for the in-flight turn of a goal that
+/// was just cleared. Bounded (see [`MAX_CLEARED_GOAL_TOMBSTONES`]); a newer
+/// clear on the same key replaces the older tombstone (whose turn's late
+/// charge then lands nowhere — exactly the pre-fix behavior for that turn).
+fn park_cleared_goal_tombstone(
+    state: &mut AutonomyRuntimeState,
+    key: &SessionKey,
+    goal: &AutonomyGoalRecord,
+    ledger_data_dir: &Path,
+) {
+    if state.cleared_goal_tombstones.len() >= MAX_CLEARED_GOAL_TOMBSTONES
+        && !state.cleared_goal_tombstones.contains_key(key)
+    {
+        if let Some(oldest) = state
+            .cleared_goal_tombstones
+            .iter()
+            .min_by_key(|(_, tombstone)| tombstone.parked_at_ms)
+            .map(|(key, _)| key.clone())
+        {
+            state.cleared_goal_tombstones.remove(&oldest);
+        }
+    }
+    let mut snapshot = goal.clone();
+    snapshot.status = "cleared".to_owned();
+    snapshot.updated_at_ms = now_ms();
+    state.cleared_goal_tombstones.insert(
+        key.clone(),
+        ClearedGoalTombstone {
+            snapshot,
+            ledger_data_dir: ledger_data_dir.to_path_buf(),
+            parked_at_ms: now_ms_u64(),
+        },
+    );
+}
+
+/// #2064(b) — accrue a turn-end charge into the key's parked tombstone (if
+/// any) and hand back the updated snapshot + ledger dir for the durable
+/// settle. Guards mirror the live charge path: profile isolation always;
+/// goal-identity binding when the caller captured one at turn start
+/// (`expected_goal_id`). The tombstone STAYS parked so a turn charge and its
+/// verifier charge can both settle; it is replaced by the next clear on the
+/// key or evicted by the cap. Returns `None` when there is nothing to settle
+/// — the charge is then dropped exactly as before this fix.
+fn accrue_cleared_goal_tombstone_charge(
+    state: &mut AutonomyRuntimeState,
+    key: &SessionKey,
+    profile_id: &str,
+    expected_goal_id: Option<&str>,
+    tokens_consumed: u64,
+    elapsed_seconds: u64,
+) -> Option<(AutonomyGoalRecord, std::path::PathBuf)> {
+    if tokens_consumed == 0 && elapsed_seconds == 0 {
+        return None;
+    }
+    let tombstone = state.cleared_goal_tombstones.get_mut(key)?;
+    if tombstone.snapshot.profile_id != profile_id {
+        return None;
+    }
+    if expected_goal_id.is_some_and(|goal_id| goal_id != tombstone.snapshot.goal_id) {
+        return None;
+    }
+    tombstone.snapshot.tokens_used = tombstone
+        .snapshot
+        .tokens_used
+        .saturating_add(tokens_consumed);
+    tombstone.snapshot.time_used_seconds = tombstone
+        .snapshot
+        .time_used_seconds
+        .saturating_add(elapsed_seconds);
+    tombstone.snapshot.updated_at_ms = now_ms();
+    Some((
+        tombstone.snapshot.clone(),
+        tombstone.ledger_data_dir.clone(),
+    ))
+}
+
 /// #2003 — whether a marked session still has SUPERVISED WORK running, i.e.
 /// non-terminal background-task agents.
 ///
@@ -9916,6 +10150,24 @@ struct AutonomyRuntimeState {
     /// four different reason kinds stuck `queued` for 35 minutes, including the
     /// `goal_wrap_up` that would have explained the stall to the user).
     in_flight_goal_sessions: std::collections::HashMap<SessionKey, InFlightMarker>,
+    /// #2064(b) — goals cleared WHILE a dispatched turn was still in flight
+    /// (the in-flight marker was held at clear time), keyed by the scoped
+    /// goal-store key. `clear_goal` removes the live record and stamps the
+    /// durable row `cleared` immediately (crash-safe: the row must stop
+    /// claiming `active` the moment the user cleared, #1973 fix B), but the
+    /// running turn's spend is unknowable until the turn ends — octos charges
+    /// from turn OUTPUT, so there is nothing to flush at clear time. The
+    /// tombstone keeps the cleared snapshot + the resolved ledger dir so the
+    /// turn-end accountants (`charge_goal_tokens_gated`, `record_goal_turn`)
+    /// can settle the late charge into the cleared row via the guarded
+    /// upsert; the monotonic clauses make the settle commutative with the
+    /// clear's own stamp in either arrival order. Entries are parked only
+    /// when a turn is actually in flight AND a ledger dir was resolved,
+    /// replaced by a newer clear on the same key, and bounded by
+    /// [`MAX_CLEARED_GOAL_TOMBSTONES`] (an unsettled leftover — the turn
+    /// died without charging — is inert: the charge paths consult it only
+    /// when the key has no live goal, profile-checked and goal-id-bound).
+    cleared_goal_tombstones: std::collections::HashMap<SessionKey, ClearedGoalTombstone>,
     /// #1977 codex round 2 — test-only switch that makes the next monitor wake
     /// persist be treated as FAILED, simulating a crash exactly at the durable
     /// wake write. Per-instance (fresh `InProcessAgentOrchestrator::default()`
@@ -21323,6 +21575,38 @@ mod tests {
             "a rejected re-activation must not mutate the goal"
         );
 
+        // #2063 — raising the budget to a value STILL at or below tokens_used
+        // is not a resume either: the guard evaluates the EFFECTIVE budget
+        // (the one the caller is asking for), so 2_500 < 3_000 spent rejects.
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "huge world cup site".into(),
+                status: Some("active".into()),
+                token_budget: Some(2_500),
+                transition_actor: Some("user".into()),
+            })
+            .expect_err("raising the budget below tokens already used must still be rejected");
+        assert_eq!(
+            orchestrator.goal_status_for_test(&session_id).as_deref(),
+            Some("budget_limited"),
+        );
+        // #2063 — and the failed resumes enqueued NOTHING: no continuation
+        // may drain for the still-limited goal.
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        assert!(
+            !drained
+                .iter()
+                .any(|c| matches!(c.reason, MasterContinuationReason::GoalContinue)),
+            "a rejected resume must enqueue zero continuations: {drained:?}"
+        );
+
         // Raising the budget ABOVE tokens_used is the legitimate resume path.
         let resumed = orchestrator
             .set_goal(GoalSetRequest {
@@ -21515,6 +21799,339 @@ mod tests {
                 .iter()
                 .any(|c| matches!(c.reason, MasterContinuationReason::GoalWrapUp)),
             "no second wrap-up may be queued once one was already emitted"
+        );
+    }
+
+    /// #2064(a) — `/goal clear` serializes with the continuation dispatcher
+    /// through the SAME in-flight claim the dispatcher holds. With the marker
+    /// free the clear CLAIMS it (a racing dispatcher cannot claim-and-launch
+    /// from state being destroyed) and releases it generation-keyed; with the
+    /// marker HELD the clear must not steal the running turn's #1529
+    /// protection. Removing the claim from the clear path fails this test.
+    #[test]
+    fn clear_goal_should_claim_dispatch_marker_when_free_and_never_steal_a_held_one() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-clear-serialize");
+        let set_goal = |objective: &str| {
+            orchestrator
+                .set_goal(GoalSetRequest {
+                    session_id: session_id.clone(),
+                    profile_id: "tenant-a".into(),
+                    objective: objective.into(),
+                    status: Some("active".into()),
+                    token_budget: Some(10_000),
+                    transition_actor: None,
+                })
+                .expect("set goal");
+        };
+        set_goal("serialize me");
+        let key = orchestrator.scoped_goal_key(&session_id);
+
+        // The serialization seam itself: with the marker free the claim must
+        // HOLD the marker (this is what a concurrent dispatcher observes
+        // while the clear runs) and hand back its generation for release.
+        {
+            let mut state = orchestrator.state();
+            let claim = claim_clear_dispatch_slot(&mut state, &key)
+                .expect("a clear with no turn in flight must claim the dispatch marker");
+            assert!(
+                in_flight_marker_is_held(&state, &key),
+                "while the clear holds the claim, dispatchers must see the session as busy"
+            );
+            drop(state);
+            assert!(
+                orchestrator.clear_goal_dispatch_in_flight_generation(&key, claim),
+                "the clear releases exactly the claim it took (generation-keyed)"
+            );
+        }
+        // With the marker HELD, the claim must refuse and leave the running
+        // turn's marker untouched.
+        let dispatcher_generation = orchestrator.mark_goal_dispatch_in_flight(&key);
+        {
+            let mut state = orchestrator.state();
+            assert!(
+                claim_clear_dispatch_slot(&mut state, &key).is_none(),
+                "a clear during an in-flight turn must not claim (stamp-and-settle instead)"
+            );
+        }
+        // End-to-end: a full clear with the marker held leaves the
+        // dispatcher's own generation in place …
+        orchestrator
+            .clear_goal(GoalSessionRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+            })
+            .expect("clear");
+        assert!(
+            orchestrator.clear_goal_dispatch_in_flight_generation(&key, dispatcher_generation),
+            "the clear must leave the running turn's marker intact (same generation)"
+        );
+        // … and a full clear with the marker FREE claims and releases without
+        // leaking the marker.
+        set_goal("serialize me again");
+        orchestrator
+            .clear_goal(GoalSessionRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+            })
+            .expect("clear");
+        assert!(
+            !orchestrator.is_goal_dispatch_in_flight(&key),
+            "a clear that claimed the free marker must release it (no leak)"
+        );
+    }
+
+    /// #2064(b) — THE invariant: the cost recorded on a cleared goal equals
+    /// the cost of every turn that ran under it, cleared-mid-turn included.
+    /// A goal-bound turn is in flight (the dispatch marker is held), the user
+    /// clears, and the durable row is stamped `cleared` with the pre-turn
+    /// total. When the turn's charge lands it must SETTLE into the cleared
+    /// row — before the fix it found no record (`state.goals` entry removed)
+    /// and was silently dropped, so the tombstone under-reported forever.
+    #[test]
+    fn cleared_goal_ledger_row_should_include_a_mid_flight_turn_charge() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-clear-midflight");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "audit the tree".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        let goal_id = orchestrator.goal_id_for_test(&session_id).expect("goal id");
+        orchestrator.force_goal_tokens_used_for_test(&session_id, 1_234);
+        let key = orchestrator.scoped_goal_key(&session_id);
+
+        // A dispatched turn is in flight for this goal.
+        let dispatcher_generation = orchestrator.mark_goal_dispatch_in_flight(&key);
+
+        // Mid-turn clear stamps the durable row `cleared` at the pre-turn total.
+        orchestrator
+            .clear_goal_with_ledger_sync(
+                GoalSessionRequest {
+                    session_id: session_id.clone(),
+                    profile_id: "tenant-a".into(),
+                },
+                Some(data_dir.path()),
+            )
+            .expect("clear");
+        let ledger_path = InProcessAgentOrchestrator::goal_ledger_dir(data_dir.path())
+            .join(format!("{}.db", sanitize_filename_for_ledger(&goal_id)));
+        let ledger = octos_fleet::GoalLedger::open(&ledger_path).expect("open ledger");
+        let row = ledger
+            .get_goal(&goal_id)
+            .expect("query")
+            .expect("row present");
+        assert_eq!(row.status, "cleared");
+        assert_eq!(
+            row.tokens_used, 1_234,
+            "the clear stamps the pre-turn total"
+        );
+
+        // The in-flight turn finishes and its charge arrives: it must settle
+        // into the cleared row — with NO goal chip event, NO wrap-up, NO
+        // continuation (the goal stays gone for the client).
+        let event =
+            orchestrator.charge_active_goal_tokens(&session_id, "tenant-a", &goal_id, 5_000, 7);
+        assert!(
+            event.is_none(),
+            "a settled post-clear charge must not emit a goal-updated event"
+        );
+        // Runtime-less test: the settle offload runs inline, so the row is
+        // already reconciled when the charge returns.
+        let row = ledger
+            .get_goal(&goal_id)
+            .expect("query")
+            .expect("row present");
+        assert_eq!(row.status, "cleared", "settling never resurrects the goal");
+        assert_eq!(
+            row.tokens_used, 6_234,
+            "the cleared row's tokens_used must include the mid-flight turn's charge"
+        );
+        // Exactly the clear's ONE decision — the settle appends no audit row.
+        assert_eq!(ledger.count_decisions(&goal_id).expect("count"), 1);
+        // No wake from the clear/settle path.
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        assert!(
+            drained.is_empty(),
+            "no continuation may be emitted from the clear/settle path: {drained:?}"
+        );
+        // The dispatcher still owns its marker — the clear did not steal it.
+        assert!(
+            orchestrator.clear_goal_dispatch_in_flight_generation(&key, dispatcher_generation),
+            "the running turn's dispatch claim must survive the clear (same generation)"
+        );
+    }
+
+    /// #2064(b) — the AUTONOMOUS accountant (`record_goal_turn`) settles the
+    /// same way: a continuation turn already running when the user cleared
+    /// lands its spend on the cleared row, and returns NO terminal snapshot
+    /// (cleared is not the complete/blocked reconcile family).
+    #[test]
+    fn record_goal_turn_should_settle_charge_into_cleared_goal_row() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-clear-autonomous");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "long continuation".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        let goal_id = orchestrator.goal_id_for_test(&session_id).expect("goal id");
+        let key = orchestrator.scoped_goal_key(&session_id);
+        let dispatcher_generation = orchestrator.mark_goal_dispatch_in_flight(&key);
+        orchestrator
+            .clear_goal_with_ledger_sync(
+                GoalSessionRequest {
+                    session_id: session_id.clone(),
+                    profile_id: "tenant-a".into(),
+                },
+                Some(data_dir.path()),
+            )
+            .expect("clear");
+
+        let settled = orchestrator.record_goal_turn(&session_id, "tenant-a", 4_000, 9);
+        assert!(
+            settled.is_none(),
+            "a cleared goal yields no complete/blocked reconcile snapshot"
+        );
+        let ledger_path = InProcessAgentOrchestrator::goal_ledger_dir(data_dir.path())
+            .join(format!("{}.db", sanitize_filename_for_ledger(&goal_id)));
+        let ledger = octos_fleet::GoalLedger::open(&ledger_path).expect("open ledger");
+        let row = ledger
+            .get_goal(&goal_id)
+            .expect("query")
+            .expect("row present");
+        assert_eq!(row.status, "cleared");
+        assert_eq!(
+            row.tokens_used, 4_000,
+            "the autonomous turn's spend must land on the cleared row"
+        );
+        assert!(orchestrator.clear_goal_dispatch_in_flight_generation(&key, dispatcher_generation));
+    }
+
+    /// #2064(b) — the settle is BOUND and SCOPED: a charge carrying a foreign
+    /// goal_id must not land on the tombstone (goal-identity binding, exactly
+    /// like the live charge path), and a clear with NO turn in flight parks
+    /// nothing — a later stray charge is dropped exactly as today.
+    #[test]
+    fn cleared_goal_tombstone_should_reject_foreign_charges_and_idle_clears() {
+        // (1) Foreign goal_id: the tombstone refuses, then still settles the
+        // rightful charge (one rejection must not consume the tombstone).
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-clear-binding");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "bound turn".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        let goal_id = orchestrator.goal_id_for_test(&session_id).expect("goal id");
+        let key = orchestrator.scoped_goal_key(&session_id);
+        orchestrator.mark_goal_dispatch_in_flight(&key);
+        orchestrator
+            .clear_goal_with_ledger_sync(
+                GoalSessionRequest {
+                    session_id: session_id.clone(),
+                    profile_id: "tenant-a".into(),
+                },
+                Some(data_dir.path()),
+            )
+            .expect("clear");
+        let ledger_path = InProcessAgentOrchestrator::goal_ledger_dir(data_dir.path())
+            .join(format!("{}.db", sanitize_filename_for_ledger(&goal_id)));
+        let ledger = octos_fleet::GoalLedger::open(&ledger_path).expect("open ledger");
+        assert!(
+            orchestrator
+                .charge_active_goal_tokens(&session_id, "tenant-a", "goal_zz", 5_000, 7)
+                .is_none()
+        );
+        assert_eq!(
+            ledger
+                .get_goal(&goal_id)
+                .expect("query")
+                .expect("row")
+                .tokens_used,
+            0,
+            "a charge bound to a DIFFERENT goal incarnation must not settle here"
+        );
+        assert!(
+            orchestrator
+                .charge_active_goal_tokens(&session_id, "tenant-a", &goal_id, 5_000, 7)
+                .is_none()
+        );
+        assert_eq!(
+            ledger
+                .get_goal(&goal_id)
+                .expect("query")
+                .expect("row")
+                .tokens_used,
+            5_000,
+            "the rightful charge still settles after a foreign one was refused"
+        );
+
+        // (2) Idle clear: no turn in flight, nothing to settle later — the
+        // tombstone is not parked and a stray charge stays dropped.
+        let idle_session = SessionKey::with_profile("tenant-a", "api", "goal-clear-idle");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: idle_session.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "idle clear".into(),
+                status: Some("active".into()),
+                token_budget: Some(100_000),
+                transition_actor: None,
+            })
+            .expect("set goal");
+        let idle_goal_id = orchestrator
+            .goal_id_for_test(&idle_session)
+            .expect("goal id");
+        orchestrator
+            .clear_goal_with_ledger_sync(
+                GoalSessionRequest {
+                    session_id: idle_session.clone(),
+                    profile_id: "tenant-a".into(),
+                },
+                Some(data_dir.path()),
+            )
+            .expect("clear");
+        assert!(
+            orchestrator
+                .charge_active_goal_tokens(&idle_session, "tenant-a", &idle_goal_id, 9_000, 3)
+                .is_none()
+        );
+        let idle_ledger_path = InProcessAgentOrchestrator::goal_ledger_dir(data_dir.path()).join(
+            format!("{}.db", sanitize_filename_for_ledger(&idle_goal_id)),
+        );
+        let idle_ledger = octos_fleet::GoalLedger::open(&idle_ledger_path).expect("open ledger");
+        assert_eq!(
+            idle_ledger
+                .get_goal(&idle_goal_id)
+                .expect("query")
+                .expect("row")
+                .tokens_used,
+            0,
+            "no turn was in flight at clear time — a stray charge stays dropped"
         );
     }
 

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -5211,8 +5211,19 @@ impl SessionActor {
                 Some("processed_by_session_actor".to_owned()),
             );
             if is_goal_turn {
-                self.maybe_advance_goal_runtime_after_turn(&profile_id, goal_turn_start)
-                    .await;
+                // #2066 round 2 (codex R1c) — thread the continuation's bound
+                // goal identity into the accountant so a post-clear charge is
+                // goal-id-bound (settles the cleared goal's tombstone, never a
+                // replacement goal).
+                self.maybe_advance_goal_runtime_after_turn(
+                    &profile_id,
+                    continuation
+                        .goal_id
+                        .as_ref()
+                        .map(|goal_id| goal_id.as_str()),
+                    goal_turn_start,
+                )
+                .await;
             }
         }
         drained
@@ -5234,6 +5245,7 @@ impl SessionActor {
     async fn maybe_advance_goal_runtime_after_turn(
         &mut self,
         profile_id: &str,
+        bound_goal_id: Option<&str>,
         goal_turn_start: Instant,
     ) {
         let elapsed_seconds = goal_turn_start.elapsed().as_secs();
@@ -5242,6 +5254,7 @@ impl SessionActor {
         if let Some(snapshot) = orchestrator.record_goal_turn(
             &self.session_key,
             profile_id,
+            bound_goal_id,
             tokens_consumed,
             elapsed_seconds,
         ) {

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -1516,14 +1516,66 @@ impl GoalLedger {
         Ok(stored_status)
     }
 
-    /// #2066 round 2 (codex R6) — COUNTERS-ONLY additive settle for a
-    /// post-clear turn charge. `tokens_used` grows by a DELTA (never an
-    /// absolute), the status is stamped `cleared` unless the row is the
-    /// stronger `complete` terminal, and `updated_at_ms` only ever moves
-    /// forward. Additive deltas commute with each other and with the clear's
-    /// status stamp by arithmetic, so the settled total is identical in every
-    /// arrival order — the property the snapshot-upsert settle could not give
-    /// (its monotonic absolute clauses made the outcome order-dependent).
+    /// #2066 round 3 (codex fix 1) — the CLEAR STAMP: per-column MAX-merge on
+    /// counters, CASE on status, insert-if-absent. This writer deliberately
+    /// drops the row-level all-or-nothing guard of [`Self::upsert_goal`] —
+    /// that reject-whole-row shape is exactly what made the round-2 mixed
+    /// model order-dependent (a same-millisecond stamp landing after the
+    /// settle OVERWROTE the settled delta; a newer-timestamp settle made a
+    /// later stamp reject and lose the entire pre-clear lag). With both the
+    /// stamp and the settle MAX-merging on `tokens_used`, order-independence
+    /// is arithmetic: for row lag `L`, frozen clear-time base `B`, late
+    /// delta `D` — stamp→settle = `MAX(L,B)+D = B+D`; settle→stamp =
+    /// `MAX(MAX(L,B)+D, B) = B+D` (deltas are positive); every interleaving
+    /// of further deltas commutes the same way.
+    ///
+    /// Status: `cleared` unless the row is the stronger `complete` terminal
+    /// (clearing an already-complete goal keeps the row `complete`).
+    /// `objective`/`token_budget` take the clear-time values — the clear is
+    /// this row's single stamp writer, and the settle never touches them.
+    ///
+    /// Returns the STORED status so the caller can gate its audit decision
+    /// on what actually landed (`cleared` ⇒ append; `complete` ⇒ skip).
+    pub fn stamp_goal_cleared(&self, goal: &Goal) -> Result<String> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO goals (goal_id, objective, status, tokens_used, token_budget, continuations_used, revision, created_at_ms, updated_at_ms)
+             VALUES (?1, ?2, 'cleared', ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(goal_id) DO UPDATE SET
+                 objective = excluded.objective,
+                 status = CASE WHEN goals.status = 'complete' THEN goals.status ELSE 'cleared' END,
+                 tokens_used = MAX(goals.tokens_used, excluded.tokens_used),
+                 token_budget = excluded.token_budget,
+                 continuations_used = MAX(goals.continuations_used, excluded.continuations_used),
+                 updated_at_ms = MAX(goals.updated_at_ms, excluded.updated_at_ms)",
+            params![
+                goal.goal_id,
+                goal.objective,
+                goal.tokens_used,
+                goal.token_budget,
+                goal.continuations_used,
+                goal.revision,
+                goal.created_at_ms,
+                goal.updated_at_ms,
+            ],
+        )?;
+        let stored: String = conn.query_row(
+            "SELECT status FROM goals WHERE goal_id = ?1",
+            params![goal.goal_id],
+            |row| row.get(0),
+        )?;
+        Ok(stored)
+    }
+
+    /// #2066 round 2 (codex R6) / round 3 (codex fix 1 + 5) — GENUINELY
+    /// counters-only settle for a post-clear turn charge: `tokens_used`
+    /// MAX-merges the frozen clear-time base and adds the charge's DELTA,
+    /// `updated_at_ms` only ever moves forward, and STATUS is never touched
+    /// (round 3 removed the round-2 `cleared` CASE — the stamp owns the
+    /// status dimension, and a settle must never stamp a row it races). The
+    /// MAX-fold of the base is what makes settle-first converge: a stamp
+    /// arriving later MAX-merges to the same total (see
+    /// [`Self::stamp_goal_cleared`] for the arithmetic).
     ///
     /// Idempotency assumption: per-charge SINGLE DELIVERY — each in-process
     /// accountant charge settles exactly once (one offload per charge); this
@@ -1534,16 +1586,16 @@ impl GoalLedger {
     pub fn settle_cleared_goal_cost_delta(
         &self,
         goal_id: &str,
+        frozen_base_tokens: u64,
         tokens_delta: u64,
         updated_at_ms: u64,
     ) -> Result<bool> {
         let conn = self.conn.lock().unwrap();
         let changed = conn.execute(
-            "UPDATE goals SET tokens_used = tokens_used + ?1,
-                 status = CASE WHEN status = 'complete' THEN status ELSE 'cleared' END,
-                 updated_at_ms = MAX(updated_at_ms, ?2)
-             WHERE goal_id = ?3",
-            params![tokens_delta, updated_at_ms, goal_id],
+            "UPDATE goals SET tokens_used = MAX(tokens_used, ?1) + ?2,
+                 updated_at_ms = MAX(updated_at_ms, ?3)
+             WHERE goal_id = ?4",
+            params![frozen_base_tokens, tokens_delta, updated_at_ms, goal_id],
         )?;
         Ok(changed > 0)
     }
@@ -2256,7 +2308,7 @@ mod tests {
         // The counters-only settle still lands on the cleared tombstone.
         assert!(
             ledger
-                .settle_cleared_goal_cost_delta("g1", 4_000, 6000)
+                .settle_cleared_goal_cost_delta("g1", 500, 4_000, 6000)
                 .unwrap()
         );
         let row = ledger.get_goal("g1").unwrap().unwrap();
@@ -2319,67 +2371,55 @@ mod tests {
         assert_eq!(ledger.count_decisions("g1").unwrap(), 1);
     }
 
-    /// #2066 round 2 (codex R6) — the clear's status stamp and the settle's
-    /// counters delta are SEPARATE write dimensions, so the final row is
-    /// identical in both arrival orders. Order A replicates the production
-    /// clear-stamp-first path (guarded upsert admits); order B replicates the
-    /// race (delta lands first, then the sync's upsert is refused and its
-    /// ordering-gated CAS retry declines) — both converge on the same row.
+    /// #2066 round 3 (codex fix 1) — THE order-independence pin, with the
+    /// adversarial fixture the round-2 test masked (it seeded ledger == base):
+    /// row lag `L=0` STRICTLY BELOW the frozen clear-time base `B=100`, late
+    /// delta `D=10`, and ALL writers stamping the SAME millisecond (the tie
+    /// that let the round-2 guarded upsert overwrite a settled delta). Every
+    /// order must land exactly `B + ΣD` with status `cleared`:
+    /// stamp→delta = `MAX(0,100)+10`; delta→stamp = `MAX(MAX(0,100)+10,100)`;
+    /// delta-only then a late stamp retry converges the same way.
     #[test]
     fn should_settle_identical_rows_for_clear_stamp_and_delta_in_both_orders() {
+        // Frozen clear-time snapshot: B=100 (the ledger row lags at L=0
+        // because ordinary nonterminal turns deliberately never sync it).
         let clear_snapshot = Goal {
             goal_id: "g1".to_string(),
             objective: "both orders".to_string(),
             status: "cleared".to_string(),
-            tokens_used: 500,
+            tokens_used: 100,
             token_budget: 100_000,
             continuations_used: 0,
             revision: 0,
             created_at_ms: 1000,
-            updated_at_ms: 2000, // clear time
+            updated_at_ms: 2000, // clear time == charge time (same-ms tie)
         };
-        // Replicates `sync_transition_to_ledger_blocking`: guarded upsert,
-        // then the ordering-gated status-CAS retry on rejection.
         let stamp_cleared = |ledger: &GoalLedger| {
-            let admitted = ledger.upsert_goal(&clear_snapshot).unwrap();
-            if !admitted {
-                if let Some(current) = ledger.get_goal("g1").unwrap() {
-                    let retry_admissible = clear_snapshot.updated_at_ms >= current.updated_at_ms
-                        && current.status != "complete"
-                        && current.status != clear_snapshot.status;
-                    if retry_admissible {
-                        let _ = ledger
-                            .cas_goal_status(
-                                "g1",
-                                &clear_snapshot.status,
-                                &current.status,
-                                current.updated_at_ms,
-                                clear_snapshot.updated_at_ms,
-                            )
-                            .unwrap();
-                    }
-                }
-            }
+            let stored = ledger.stamp_goal_cleared(&clear_snapshot).unwrap();
+            assert_eq!(stored, "cleared");
         };
-        let settle = |ledger: &GoalLedger| {
-            // The production settle: create-if-absent (base), then the delta.
+        let settle = |ledger: &GoalLedger, delta: u64| {
+            // The production settle: create-if-absent (frozen base), then the
+            // MAX-merged delta — same-millisecond timestamp as the stamp.
             assert!(ledger.create_goal_if_absent(&clear_snapshot).is_ok());
             assert!(
                 ledger
-                    .settle_cleared_goal_cost_delta("g1", 4_000, 3000)
+                    .settle_cleared_goal_cost_delta("g1", 100, delta, 2000)
                     .unwrap()
             );
         };
 
-        // Order A: stamp, then settle.
-        let (_dir_a, ledger_a) = ledger_with_goal(500, 100_000, "active");
+        // Order A: stamp, then delta.
+        let (_dir_a, ledger_a) = ledger_with_goal(0, 100_000, "active");
         stamp_cleared(&ledger_a);
-        settle(&ledger_a);
+        settle(&ledger_a, 10);
         let row_a = ledger_a.get_goal("g1").unwrap().unwrap();
 
-        // Order B: settle, then stamp.
-        let (_dir_b, ledger_b) = ledger_with_goal(500, 100_000, "active");
-        settle(&ledger_b);
+        // Order B: delta first, then the SAME-MILLISECOND stamp (the round-2
+        // loss case: the all-or-nothing upsert admitted and overwrote 110
+        // back to 100; the MAX-merge stamp must not).
+        let (_dir_b, ledger_b) = ledger_with_goal(0, 100_000, "active");
+        settle(&ledger_b, 10);
         stamp_cleared(&ledger_b);
         let row_b = ledger_b.get_goal("g1").unwrap().unwrap();
 
@@ -2390,22 +2430,46 @@ mod tests {
             "the settled row must be identical in both arrival orders"
         );
         assert_eq!(
-            row_b.tokens_used, 4_500,
-            "base 500 + delta 4000, never lost"
+            row_b.tokens_used, 110,
+            "B(100) + D(10): neither the late delta nor the pre-clear lag may be lost"
         );
+
+        // Multi-delta interleaving: delta, delta, stamp — still B + ΣD.
+        let (_dir_c, ledger_c) = ledger_with_goal(0, 100_000, "active");
+        settle(&ledger_c, 10);
+        settle(&ledger_c, 5);
+        stamp_cleared(&ledger_c);
+        assert_eq!(
+            ledger_c.get_goal("g1").unwrap().unwrap().tokens_used,
+            115,
+            "B(100) + D1(10) + D2(5) in every interleaving"
+        );
+
+        // Fix 5 pin: the settle is GENUINELY counters-only — before the stamp
+        // lands, a settled row keeps whatever status it had (the stamp owns
+        // the status dimension).
+        let (_dir_d, ledger_d) = ledger_with_goal(0, 100_000, "active");
+        settle(&ledger_d, 10);
+        assert_eq!(
+            ledger_d.get_goal("g1").unwrap().unwrap().status,
+            "active",
+            "a settle racing ahead of the stamp must not flip status"
+        );
+        stamp_cleared(&ledger_d);
+        assert_eq!(ledger_d.get_goal("g1").unwrap().unwrap().status, "cleared");
     }
 
     /// #2066 round 2 (codex R6) — the settle sequence on a goal whose ledger
     /// row does not exist yet: the delta alone matches nothing; the caller's
-    /// create-if-absent + delta sequence creates the cleared tombstone and
-    /// lands the charge.
+    /// create-if-absent + delta sequence creates the cleared tombstone (the
+    /// frozen base INSERT carries status `cleared`) and lands the charge.
     #[test]
     fn should_create_the_cleared_row_when_settling_without_one() {
         let dir = tempfile::tempdir().unwrap();
         let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
         assert!(
             !ledger
-                .settle_cleared_goal_cost_delta("g1", 4_000, 3000)
+                .settle_cleared_goal_cost_delta("g1", 500, 4_000, 3000)
                 .unwrap(),
             "a bare delta on a missing row changes nothing"
         );
@@ -2426,11 +2490,36 @@ mod tests {
         );
         assert!(
             ledger
-                .settle_cleared_goal_cost_delta("g1", 4_000, 3000)
+                .settle_cleared_goal_cost_delta("g1", 500, 4_000, 3000)
                 .unwrap()
         );
         let row = ledger.get_goal("g1").unwrap().unwrap();
         assert_eq!((row.status.as_str(), row.tokens_used), ("cleared", 4_500));
+    }
+
+    /// #2066 round 3 (codex fix 1) — the stamp keeps `complete` (terminal
+    /// parity) while still MAX-merging counters, and reports the stored
+    /// status so the caller's decision gate can skip the audit row.
+    #[test]
+    fn should_keep_complete_when_stamping_cleared_over_a_complete_row() {
+        let (_dir, ledger) = ledger_with_goal(500, 100_000, "complete");
+        let stored = ledger
+            .stamp_goal_cleared(&Goal {
+                goal_id: "g1".to_string(),
+                objective: "clear a finished goal".to_string(),
+                status: "cleared".to_string(),
+                tokens_used: 700,
+                token_budget: 100_000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1000,
+                updated_at_ms: 2000,
+            })
+            .unwrap();
+        assert_eq!(stored, "complete", "complete is the stronger terminal");
+        let row = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!(row.status, "complete");
+        assert_eq!(row.tokens_used, 700, "counters still MAX-merge");
     }
 
     #[test]

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -540,11 +540,21 @@ impl GoalLedger {
     /// lower counters can detect the loss and retry once with max'd monotonic
     /// fields — instead of silently leaving the row on its old status while a
     /// decision row claims the transition happened.
+    /// #2063 — the VALUES status expression enforces the activation guard on
+    /// the snapshot's OWN arithmetic (`active` while `tokens_used >=
+    /// token_budget` lands `budget_limited`); `excluded.status` picks up the
+    /// transformed value, so the guard covers the insert arm AND the update
+    /// arm with one expression. Defense-in-depth here — the reachable hole is
+    /// the status-only [`Self::cas_goal_status`] — but the invariant lives in
+    /// every write of this family, not in its callers.
     pub fn upsert_goal(&self, goal: &Goal) -> Result<bool> {
         let conn = self.conn.lock().unwrap();
         let admitted = conn.execute(
             "INSERT INTO goals (goal_id, objective, status, tokens_used, token_budget, continuations_used, revision, created_at_ms, updated_at_ms)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+             VALUES (?1, ?2,
+                 CASE WHEN ?3 = 'active' AND ?5 > 0 AND ?4 >= ?5
+                 THEN 'budget_limited' ELSE ?3 END,
+                 ?4, ?5, ?6, ?7, ?8, ?9)
              ON CONFLICT(goal_id) DO UPDATE SET
                  objective = excluded.objective,
                  status = excluded.status,
@@ -629,6 +639,18 @@ impl GoalLedger {
     /// cannot detect — an equal-timestamp, same-status write (counters-only,
     /// same millisecond) — is safe by construction: the CAS writes only
     /// status + timestamp, so the interleaved counters survive untouched.
+    ///
+    /// #2063 — activation is CONDITIONAL ON THE ROW'S OWN ARITHMETIC:
+    /// `active` while `tokens_used >= token_budget` (budget > 0) writes
+    /// `budget_limited` instead, in the same statement. This is a status-only
+    /// write over counters the CALLER cannot see (the ledger is multi-process
+    /// WAL, and the #1973 retry that reaches this CAS fires precisely when
+    /// the caller's snapshot carries STALE LOWER counters than the row) — so
+    /// the in-memory resume guard is structurally unable to protect this
+    /// write, and the invariant must live here. The CAS still reports
+    /// `changed` (the pair matched and a stamp landed); the transition-sync
+    /// caller re-reads the row before appending its decision, so a flip to
+    /// the safe status suppresses the `active` audit row.
     pub fn cas_goal_status(
         &self,
         goal_id: &str,
@@ -639,7 +661,10 @@ impl GoalLedger {
     ) -> Result<bool> {
         let conn = self.conn.lock().unwrap();
         let changed = conn.execute(
-            "UPDATE goals SET status = ?1, updated_at_ms = ?2
+            "UPDATE goals SET status = CASE
+                 WHEN ?1 = 'active' AND token_budget > 0 AND tokens_used >= token_budget
+                 THEN 'budget_limited' ELSE ?1 END,
+                 updated_at_ms = ?2
              WHERE goal_id = ?3 AND status = ?4 AND updated_at_ms = ?5
                AND status <> 'complete'",
             params![
@@ -983,6 +1008,9 @@ impl GoalLedger {
     /// Uses revision for compare-and-swap: only updates if the current revision
     /// matches expected_revision. Returns error if goal not found or revision mismatch
     /// (stale writer).
+    ///
+    /// #2063 — carries the same activation guard as [`Self::cas_goal_status`]:
+    /// `active` over an exhausted row writes `budget_limited` instead.
     pub fn update_goal_status(
         &self,
         goal_id: &str,
@@ -992,7 +1020,11 @@ impl GoalLedger {
     ) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         let rows_affected = conn.execute(
-            "UPDATE goals SET status = ?1, revision = revision + 1, updated_at_ms = ?2 WHERE goal_id = ?3 AND revision = ?4",
+            "UPDATE goals SET status = CASE
+                 WHEN ?1 = 'active' AND token_budget > 0 AND tokens_used >= token_budget
+                 THEN 'budget_limited' ELSE ?1 END,
+                 revision = revision + 1, updated_at_ms = ?2
+             WHERE goal_id = ?3 AND revision = ?4",
             params![status, updated_at_ms, goal_id, expected_revision],
         )?;
 
@@ -1388,9 +1420,15 @@ impl GoalLedger {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
 
-        // Step 1: Update goal state (CAS)
+        // Step 1: Update goal state (CAS). #2063 — same activation guard as
+        // `cas_goal_status`: `active` over an exhausted row lands
+        // `budget_limited` in the same statement.
         let rows_affected = tx.execute(
-            "UPDATE goals SET status = ?1, revision = revision + 1, updated_at_ms = ?2 WHERE goal_id = ?3 AND revision = ?4",
+            "UPDATE goals SET status = CASE
+                 WHEN ?1 = 'active' AND token_budget > 0 AND tokens_used >= token_budget
+                 THEN 'budget_limited' ELSE ?1 END,
+                 revision = revision + 1, updated_at_ms = ?2
+             WHERE goal_id = ?3 AND revision = ?4",
             params![new_status, updated_at_ms, goal_id, expected_revision],
         )?;
 
@@ -1891,6 +1929,181 @@ mod tests {
         // CAS failure: nonexistent goal
         let result = ledger.update_goal_status("g999", "complete", 0, 3000);
         assert!(result.is_err());
+    }
+
+    /// #2063 — helper: a ledger with one goal row at the given spend/budget.
+    /// Returns the tempdir alongside so the db file outlives the helper.
+    fn ledger_with_goal(
+        tokens_used: u64,
+        token_budget: u64,
+        status: &str,
+    ) -> (tempfile::TempDir, GoalLedger) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ledger.db");
+        let ledger = GoalLedger::open(&path).unwrap();
+        ledger
+            .create_goal(&Goal {
+                goal_id: "g1".to_string(),
+                objective: "budget-guarded".to_string(),
+                status: status.to_string(),
+                tokens_used,
+                token_budget,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1000,
+                updated_at_ms: 1000,
+            })
+            .unwrap();
+        (dir, ledger)
+    }
+
+    /// #2063 — `budget_limited` exists to stop spend, and whether a resume is
+    /// safe depends on an arithmetic fact (`tokens_used < token_budget`) the
+    /// status-only CAS cannot see in its caller: the in-memory guard evaluates
+    /// MEMORY's counters, but the multi-process row can be AHEAD of them (the
+    /// exact stale-lower-counters case the #1973 CAS retry exists for). The
+    /// write itself must therefore refuse to produce an active-and-exhausted
+    /// row: activating a row whose own counters are exhausted writes
+    /// `budget_limited` instead, in the same statement.
+    #[test]
+    fn should_write_budget_limited_when_cas_activates_exhausted_row() {
+        let (_dir, ledger) = ledger_with_goal(1_500, 1_000, "budget_limited");
+        let changed = ledger
+            .cas_goal_status("g1", "active", "budget_limited", 1000, 2000)
+            .unwrap();
+        assert!(
+            changed,
+            "the CAS fired (pair matched) — it wrote the SAFE status"
+        );
+        let row = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!(
+            row.status, "budget_limited",
+            "activating an exhausted row must land budget_limited, never active-and-exhausted"
+        );
+        assert_eq!(row.updated_at_ms, 2000, "the stamp still lands");
+    }
+
+    /// #2063 — the legitimate resume: once the row's own budget covers its
+    /// spend, the same CAS writes `active` unchanged.
+    #[test]
+    fn should_write_active_when_cas_activates_row_within_budget() {
+        let (_dir, ledger) = ledger_with_goal(500, 1_000, "budget_limited");
+        let changed = ledger
+            .cas_goal_status("g1", "active", "budget_limited", 1000, 2000)
+            .unwrap();
+        assert!(changed);
+        let row = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!(row.status, "active");
+    }
+
+    /// #2063 — same invariant on the snapshot writer: an incoming snapshot
+    /// whose own arithmetic is exhausted must not land `active`, on either the
+    /// insert arm (fresh row) or the update arm (existing row).
+    #[test]
+    fn should_flip_exhausted_active_snapshot_to_budget_limited_on_upsert() {
+        let (_dir, ledger) = ledger_with_goal(500, 1_000, "active");
+        // Update arm: the snapshot claims active but its own counters are
+        // exhausted (e.g. the budget field was lowered below the spend).
+        let admitted = ledger
+            .upsert_goal(&Goal {
+                goal_id: "g1".to_string(),
+                objective: "budget-guarded".to_string(),
+                status: "active".to_string(),
+                tokens_used: 1_500,
+                token_budget: 1_000,
+                continuations_used: 1,
+                revision: 0,
+                created_at_ms: 1000,
+                updated_at_ms: 2000,
+            })
+            .unwrap();
+        assert!(admitted);
+        let row = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!(row.status, "budget_limited");
+        assert_eq!(row.tokens_used, 1_500, "the counters land verbatim");
+        // Insert arm: a fresh goal_id with an exhausted active snapshot.
+        assert!(
+            ledger
+                .upsert_goal(&Goal {
+                    goal_id: "g2".to_string(),
+                    objective: "fresh but exhausted".to_string(),
+                    status: "active".to_string(),
+                    tokens_used: 900,
+                    token_budget: 800,
+                    continuations_used: 0,
+                    revision: 0,
+                    created_at_ms: 3000,
+                    updated_at_ms: 3000,
+                })
+                .unwrap()
+        );
+        assert_eq!(
+            ledger.get_goal("g2").unwrap().unwrap().status,
+            "budget_limited",
+            "the insert arm enforces the same arithmetic"
+        );
+        // Control: an under-budget active snapshot still lands active.
+        assert!(
+            ledger
+                .upsert_goal(&Goal {
+                    goal_id: "g1".to_string(),
+                    objective: "budget-guarded".to_string(),
+                    status: "active".to_string(),
+                    tokens_used: 1_500,
+                    token_budget: 5_000,
+                    continuations_used: 1,
+                    revision: 0,
+                    created_at_ms: 1000,
+                    updated_at_ms: 4000,
+                })
+                .unwrap()
+        );
+        assert_eq!(ledger.get_goal("g1").unwrap().unwrap().status, "active");
+    }
+
+    /// #2063 — the remaining status writers of the same family
+    /// (`update_goal_status`, `commit_state_with_audit`) carry the identical
+    /// guard: no code path may produce an active-and-exhausted row. A zero
+    /// budget is exempt (matches the in-memory guards' `token_budget > 0`).
+    #[test]
+    fn should_write_budget_limited_when_revision_cas_activates_exhausted_row() {
+        let (_dir, ledger) = ledger_with_goal(1_500, 1_000, "budget_limited");
+        ledger.update_goal_status("g1", "active", 0, 2000).unwrap();
+        assert_eq!(
+            ledger.get_goal("g1").unwrap().unwrap().status,
+            "budget_limited"
+        );
+        // Raise the budget above the spend (upsert), then the same transition
+        // legitimately activates.
+        ledger
+            .upsert_goal(&Goal {
+                goal_id: "g1".to_string(),
+                objective: "budget-guarded".to_string(),
+                status: "budget_limited".to_string(),
+                tokens_used: 1_500,
+                token_budget: 5_000,
+                continuations_used: 0,
+                revision: 0,
+                created_at_ms: 1000,
+                updated_at_ms: 3000,
+            })
+            .unwrap();
+        ledger.update_goal_status("g1", "active", 1, 4000).unwrap();
+        assert_eq!(ledger.get_goal("g1").unwrap().unwrap().status, "active");
+    }
+
+    /// #2063 — `commit_state_with_audit`'s in-transaction status write is the
+    /// same UPDATE shape; it must carry the same activation guard.
+    #[test]
+    fn should_write_budget_limited_when_audited_commit_activates_exhausted_row() {
+        let (_dir, ledger) = ledger_with_goal(1_500, 1_000, "budget_limited");
+        ledger
+            .commit_state_with_audit("g1", "active", 0, 2000, None, None)
+            .unwrap();
+        assert_eq!(
+            ledger.get_goal("g1").unwrap().unwrap().status,
+            "budget_limited"
+        );
     }
 
     #[test]

--- a/crates/octos-fleet/src/sqlite_ledger.rs
+++ b/crates/octos-fleet/src/sqlite_ledger.rs
@@ -483,11 +483,18 @@ impl GoalLedger {
     }
 
     /// Create a new goal.
+    /// #2066 round 2 (codex R3) — creation writers carry the same #2063
+    /// activation guard as the update writers: an `active` snapshot whose own
+    /// arithmetic is exhausted lands `budget_limited`. No code path may
+    /// produce an active-and-exhausted row, including the very first insert.
     pub fn create_goal(&self, goal: &Goal) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
             "INSERT INTO goals (goal_id, objective, status, tokens_used, token_budget, continuations_used, revision, created_at_ms, updated_at_ms)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+             VALUES (?1, ?2,
+                 CASE WHEN ?3 = 'active' AND ?5 > 0 AND ?4 >= ?5
+                 THEN 'budget_limited' ELSE ?3 END,
+                 ?4, ?5, ?6, ?7, ?8, ?9)",
             params![
                 goal.goal_id,
                 goal.objective,
@@ -532,6 +539,11 @@ impl GoalLedger {
     ///     writer ever moves an existing `complete` row back to active/blocked.
     ///     `blocked` is deliberately NOT protected — a blocked goal is
     ///     user-resumable to `active` under the same id.
+    ///     #2066 round 2 (codex R3) — `cleared` joins `complete` as an
+    ///     immutable STATUS: an under-budget snapshot must not resurrect a
+    ///     cleared row to `active`. Counters on a cleared row may still
+    ///     accrue via [`Self::settle_cleared_goal_cost_delta`] (the
+    ///     post-clear settle path), which never touches status.
     ///
     /// #1973 fix-round — returns whether the write was ADMITTED (`true`: the
     /// row was inserted, or the guarded update fired), via SQLite's
@@ -564,7 +576,8 @@ impl GoalLedger {
                  updated_at_ms = excluded.updated_at_ms
              WHERE excluded.updated_at_ms >= goals.updated_at_ms
                AND excluded.tokens_used >= goals.tokens_used
-               AND NOT (goals.status = 'complete' AND excluded.status <> 'complete')",
+               AND NOT (goals.status = 'complete' AND excluded.status <> 'complete')
+               AND NOT (goals.status = 'cleared' AND excluded.status <> 'cleared')",
             params![
                 goal.goal_id,
                 goal.objective,
@@ -596,7 +609,10 @@ impl GoalLedger {
         let conn = self.conn.lock().unwrap();
         let inserted = conn.execute(
             "INSERT INTO goals (goal_id, objective, status, tokens_used, token_budget, continuations_used, revision, created_at_ms, updated_at_ms)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+             VALUES (?1, ?2,
+                 CASE WHEN ?3 = 'active' AND ?5 > 0 AND ?4 >= ?5
+                 THEN 'budget_limited' ELSE ?3 END,
+                 ?4, ?5, ?6, ?7, ?8, ?9)
              ON CONFLICT(goal_id) DO NOTHING",
             params![
                 goal.goal_id,
@@ -666,7 +682,7 @@ impl GoalLedger {
                  THEN 'budget_limited' ELSE ?1 END,
                  updated_at_ms = ?2
              WHERE goal_id = ?3 AND status = ?4 AND updated_at_ms = ?5
-               AND status <> 'complete'",
+               AND status NOT IN ('complete', 'cleared')",
             params![
                 new_status,
                 updated_at_ms,
@@ -1011,6 +1027,9 @@ impl GoalLedger {
     ///
     /// #2063 — carries the same activation guard as [`Self::cas_goal_status`]:
     /// `active` over an exhausted row writes `budget_limited` instead.
+    /// #2066 round 2 (codex R3) — and the same terminal protection: a
+    /// `complete`/`cleared` row refuses any revision-CAS status overwrite
+    /// (surfaces as the same Err as a revision mismatch).
     pub fn update_goal_status(
         &self,
         goal_id: &str,
@@ -1024,7 +1043,8 @@ impl GoalLedger {
                  WHEN ?1 = 'active' AND token_budget > 0 AND tokens_used >= token_budget
                  THEN 'budget_limited' ELSE ?1 END,
                  revision = revision + 1, updated_at_ms = ?2
-             WHERE goal_id = ?3 AND revision = ?4",
+             WHERE goal_id = ?3 AND revision = ?4
+               AND status NOT IN ('complete', 'cleared')",
             params![status, updated_at_ms, goal_id, expected_revision],
         )?;
 
@@ -1408,6 +1428,18 @@ impl GoalLedger {
     ///
     /// This is the TRUE cross-table transaction: state transition and audit log
     /// are committed together, or both roll back.
+    ///
+    /// #2066 round 2 (codex R3 + HIGH) — the status write carries the #2063
+    /// activation guard and the terminal protection, and the AUDIT row is
+    /// derived from the STORED outcome, not the caller's request: when the
+    /// guard overrode the requested status (asked `active`, stored
+    /// `budget_limited`), inserting the caller's decision unchanged would
+    /// make the audit trail contradict the goals row. The override is
+    /// surfaced instead — the decision insert is SKIPPED and the returned
+    /// stored status tells the caller what actually landed (the finding, if
+    /// any, still lands: it is evidence, not a status claim).
+    ///
+    /// Returns the status the row carries after the commit.
     pub fn commit_state_with_audit(
         &self,
         goal_id: &str,
@@ -1416,57 +1448,104 @@ impl GoalLedger {
         updated_at_ms: u64,
         finding: Option<&Finding>,
         decision: Option<&Decision>,
-    ) -> Result<()> {
+    ) -> Result<String> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
 
         // Step 1: Update goal state (CAS). #2063 — same activation guard as
-        // `cas_goal_status`: `active` over an exhausted row lands
-        // `budget_limited` in the same statement.
+        // `cas_goal_status`; #2066 round 2 — same terminal protection.
         let rows_affected = tx.execute(
             "UPDATE goals SET status = CASE
                  WHEN ?1 = 'active' AND token_budget > 0 AND tokens_used >= token_budget
                  THEN 'budget_limited' ELSE ?1 END,
                  revision = revision + 1, updated_at_ms = ?2
-             WHERE goal_id = ?3 AND revision = ?4",
+             WHERE goal_id = ?3 AND revision = ?4
+               AND status NOT IN ('complete', 'cleared')",
             params![new_status, updated_at_ms, goal_id, expected_revision],
         )?;
 
         if rows_affected == 0 {
             return Err(eyre::eyre!(
-                "commit_state_with_audit failed: goal {} not found or revision mismatch",
+                "commit_state_with_audit failed: goal {} not found, revision mismatch, \
+                 or terminal status",
                 goal_id
             ));
         }
+
+        // The STORED status — re-read inside the same transaction so the
+        // audit decision below can never claim a status the row does not
+        // carry (the activation guard may have written `budget_limited`
+        // instead of a requested `active`).
+        let stored_status: String = tx.query_row(
+            "SELECT status FROM goals WHERE goal_id = ?1",
+            params![goal_id],
+            |row| row.get(0),
+        )?;
 
         // Step 2: Append finding (if provided) — uses SHARED validated insert
         if let Some(f) = finding {
             Self::insert_finding_validated(&tx, f, goal_id)?;
         }
 
-        // Step 3: Append decision (if provided)
+        // Step 3: Append decision (if provided) — ONLY when the stored status
+        // matches the caller's request; a guard override skips the insert so
+        // the audit trail cannot contradict the goals row.
         if let Some(d) = decision {
-            tx.execute(
-                "INSERT INTO decisions (decision_id, goal_id, task_id, question, options_considered, choice, rationale, based_on_findings, based_on_rev, decided_at_ms, decided_by)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
-                params![
-                    d.decision_id,
-                    goal_id,
-                    d.task_id,
-                    d.question,
-                    d.options_considered,
-                    d.choice,
-                    d.rationale,
-                    d.based_on_findings,
-                    d.based_on_rev,
-                    d.decided_at_ms,
-                    d.decided_by,
-                ],
-            )?;
+            if stored_status == new_status {
+                tx.execute(
+                    "INSERT INTO decisions (decision_id, goal_id, task_id, question, options_considered, choice, rationale, based_on_findings, based_on_rev, decided_at_ms, decided_by)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                    params![
+                        d.decision_id,
+                        goal_id,
+                        d.task_id,
+                        d.question,
+                        d.options_considered,
+                        d.choice,
+                        d.rationale,
+                        d.based_on_findings,
+                        d.based_on_rev,
+                        d.decided_at_ms,
+                        d.decided_by,
+                    ],
+                )?;
+            }
         }
 
         tx.commit()?;
-        Ok(())
+        Ok(stored_status)
+    }
+
+    /// #2066 round 2 (codex R6) — COUNTERS-ONLY additive settle for a
+    /// post-clear turn charge. `tokens_used` grows by a DELTA (never an
+    /// absolute), the status is stamped `cleared` unless the row is the
+    /// stronger `complete` terminal, and `updated_at_ms` only ever moves
+    /// forward. Additive deltas commute with each other and with the clear's
+    /// status stamp by arithmetic, so the settled total is identical in every
+    /// arrival order — the property the snapshot-upsert settle could not give
+    /// (its monotonic absolute clauses made the outcome order-dependent).
+    ///
+    /// Idempotency assumption: per-charge SINGLE DELIVERY — each in-process
+    /// accountant charge settles exactly once (one offload per charge); this
+    /// write has no dedupe key, so a replayed delta would double-count.
+    ///
+    /// Returns whether a row changed (false ⇒ no such goal row — the caller
+    /// creates it first via [`Self::create_goal_if_absent`] and retries).
+    pub fn settle_cleared_goal_cost_delta(
+        &self,
+        goal_id: &str,
+        tokens_delta: u64,
+        updated_at_ms: u64,
+    ) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let changed = conn.execute(
+            "UPDATE goals SET tokens_used = tokens_used + ?1,
+                 status = CASE WHEN status = 'complete' THEN status ELSE 'cleared' END,
+                 updated_at_ms = MAX(updated_at_ms, ?2)
+             WHERE goal_id = ?3",
+            params![tokens_delta, updated_at_ms, goal_id],
+        )?;
+        Ok(changed > 0)
     }
 
     /// List findings for a goal (level-triggered: only changes since `since_rowid`).
@@ -2093,17 +2172,265 @@ mod tests {
     }
 
     /// #2063 — `commit_state_with_audit`'s in-transaction status write is the
-    /// same UPDATE shape; it must carry the same activation guard.
+    /// same UPDATE shape; it must carry the same activation guard. #2066
+    /// round 2 — the returned status is the STORED outcome, so the caller
+    /// learns about the override.
     #[test]
     fn should_write_budget_limited_when_audited_commit_activates_exhausted_row() {
         let (_dir, ledger) = ledger_with_goal(1_500, 1_000, "budget_limited");
-        ledger
+        let stored = ledger
             .commit_state_with_audit("g1", "active", 0, 2000, None, None)
             .unwrap();
+        assert_eq!(stored, "budget_limited", "the caller sees what landed");
         assert_eq!(
             ledger.get_goal("g1").unwrap().unwrap().status,
             "budget_limited"
         );
+    }
+
+    /// #2066 round 2 (codex R3) — the CREATION writers enforce the same
+    /// activation guard: the very first insert of an exhausted `active`
+    /// snapshot lands `budget_limited`, on both `create_goal` and
+    /// `create_goal_if_absent`.
+    #[test]
+    fn should_write_budget_limited_when_creation_writers_insert_exhausted_active() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
+        let exhausted = |goal_id: &str| Goal {
+            goal_id: goal_id.to_string(),
+            objective: "born exhausted".to_string(),
+            status: "active".to_string(),
+            tokens_used: 1_500,
+            token_budget: 1_000,
+            continuations_used: 0,
+            revision: 0,
+            created_at_ms: 1000,
+            updated_at_ms: 1000,
+        };
+        ledger.create_goal(&exhausted("g1")).unwrap();
+        assert_eq!(
+            ledger.get_goal("g1").unwrap().unwrap().status,
+            "budget_limited"
+        );
+        assert!(ledger.create_goal_if_absent(&exhausted("g2")).unwrap());
+        assert_eq!(
+            ledger.get_goal("g2").unwrap().unwrap().status,
+            "budget_limited"
+        );
+    }
+
+    /// #2066 round 2 (codex R3) — `cleared` is an immutable STATUS on every
+    /// writer: an under-budget `active` write must not resurrect a cleared
+    /// row, while the counters-only delta settle still accrues on it.
+    #[test]
+    fn should_refuse_to_resurrect_a_cleared_row() {
+        let (_dir, ledger) = ledger_with_goal(500, 100_000, "cleared");
+        // upsert: whole write refused (status clause), counters untouched.
+        assert!(
+            !ledger
+                .upsert_goal(&Goal {
+                    goal_id: "g1".to_string(),
+                    objective: "resurrect?".to_string(),
+                    status: "active".to_string(),
+                    tokens_used: 9_000,
+                    token_budget: 100_000,
+                    continuations_used: 0,
+                    revision: 0,
+                    created_at_ms: 1000,
+                    updated_at_ms: 5000,
+                })
+                .unwrap(),
+            "an under-budget active snapshot must not resurrect a cleared row"
+        );
+        // status CAS: refused by the terminal clause.
+        assert!(
+            !ledger
+                .cas_goal_status("g1", "active", "cleared", 1000, 5000)
+                .unwrap()
+        );
+        // revision CAS: refused (same Err class as a revision mismatch).
+        assert!(ledger.update_goal_status("g1", "active", 0, 5000).is_err());
+        let row = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!(row.status, "cleared");
+        assert_eq!(row.tokens_used, 500);
+        // The counters-only settle still lands on the cleared tombstone.
+        assert!(
+            ledger
+                .settle_cleared_goal_cost_delta("g1", 4_000, 6000)
+                .unwrap()
+        );
+        let row = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!(row.status, "cleared");
+        assert_eq!(row.tokens_used, 4_500);
+        assert_eq!(row.updated_at_ms, 6000);
+    }
+
+    /// #2066 round 2 (codex HIGH) — the audit row derives from the STORED
+    /// outcome: when the activation guard overrides a requested `active` to
+    /// `budget_limited`, the supplied decision is SKIPPED (an inserted
+    /// "active" decision would contradict the goals row) and the returned
+    /// status surfaces the override. A non-overridden transition still
+    /// inserts its decision.
+    #[test]
+    fn should_skip_contradicting_decision_when_audited_commit_overrides_activation() {
+        let (_dir, ledger) = ledger_with_goal(1_500, 1_000, "budget_limited");
+        let decision = |id: &str, choice: &str| Decision {
+            decision_id: id.to_string(),
+            goal_id: "g1".to_string(),
+            task_id: None,
+            question: format!("transition goal to `{choice}`"),
+            options_considered: None,
+            choice: choice.to_string(),
+            rationale: "test".to_string(),
+            based_on_findings: None,
+            based_on_rev: 0,
+            decided_at_ms: 2000,
+            decided_by: "tester".to_string(),
+        };
+        let stored = ledger
+            .commit_state_with_audit(
+                "g1",
+                "active",
+                0,
+                2000,
+                None,
+                Some(&decision("d1", "active")),
+            )
+            .unwrap();
+        assert_eq!(stored, "budget_limited");
+        assert_eq!(
+            ledger.count_decisions("g1").unwrap(),
+            0,
+            "a decision claiming `active` must not land beside a budget_limited row"
+        );
+        // Control: a legitimate transition (paused — no guard involvement)
+        // inserts its decision and returns the requested status.
+        let stored = ledger
+            .commit_state_with_audit(
+                "g1",
+                "paused",
+                1,
+                3000,
+                None,
+                Some(&decision("d2", "paused")),
+            )
+            .unwrap();
+        assert_eq!(stored, "paused");
+        assert_eq!(ledger.count_decisions("g1").unwrap(), 1);
+    }
+
+    /// #2066 round 2 (codex R6) — the clear's status stamp and the settle's
+    /// counters delta are SEPARATE write dimensions, so the final row is
+    /// identical in both arrival orders. Order A replicates the production
+    /// clear-stamp-first path (guarded upsert admits); order B replicates the
+    /// race (delta lands first, then the sync's upsert is refused and its
+    /// ordering-gated CAS retry declines) — both converge on the same row.
+    #[test]
+    fn should_settle_identical_rows_for_clear_stamp_and_delta_in_both_orders() {
+        let clear_snapshot = Goal {
+            goal_id: "g1".to_string(),
+            objective: "both orders".to_string(),
+            status: "cleared".to_string(),
+            tokens_used: 500,
+            token_budget: 100_000,
+            continuations_used: 0,
+            revision: 0,
+            created_at_ms: 1000,
+            updated_at_ms: 2000, // clear time
+        };
+        // Replicates `sync_transition_to_ledger_blocking`: guarded upsert,
+        // then the ordering-gated status-CAS retry on rejection.
+        let stamp_cleared = |ledger: &GoalLedger| {
+            let admitted = ledger.upsert_goal(&clear_snapshot).unwrap();
+            if !admitted {
+                if let Some(current) = ledger.get_goal("g1").unwrap() {
+                    let retry_admissible = clear_snapshot.updated_at_ms >= current.updated_at_ms
+                        && current.status != "complete"
+                        && current.status != clear_snapshot.status;
+                    if retry_admissible {
+                        let _ = ledger
+                            .cas_goal_status(
+                                "g1",
+                                &clear_snapshot.status,
+                                &current.status,
+                                current.updated_at_ms,
+                                clear_snapshot.updated_at_ms,
+                            )
+                            .unwrap();
+                    }
+                }
+            }
+        };
+        let settle = |ledger: &GoalLedger| {
+            // The production settle: create-if-absent (base), then the delta.
+            assert!(ledger.create_goal_if_absent(&clear_snapshot).is_ok());
+            assert!(
+                ledger
+                    .settle_cleared_goal_cost_delta("g1", 4_000, 3000)
+                    .unwrap()
+            );
+        };
+
+        // Order A: stamp, then settle.
+        let (_dir_a, ledger_a) = ledger_with_goal(500, 100_000, "active");
+        stamp_cleared(&ledger_a);
+        settle(&ledger_a);
+        let row_a = ledger_a.get_goal("g1").unwrap().unwrap();
+
+        // Order B: settle, then stamp.
+        let (_dir_b, ledger_b) = ledger_with_goal(500, 100_000, "active");
+        settle(&ledger_b);
+        stamp_cleared(&ledger_b);
+        let row_b = ledger_b.get_goal("g1").unwrap().unwrap();
+
+        assert_eq!(row_a.status, "cleared");
+        assert_eq!(
+            (row_a.status, row_a.tokens_used, row_a.updated_at_ms),
+            (row_b.status, row_b.tokens_used, row_b.updated_at_ms),
+            "the settled row must be identical in both arrival orders"
+        );
+        assert_eq!(
+            row_b.tokens_used, 4_500,
+            "base 500 + delta 4000, never lost"
+        );
+    }
+
+    /// #2066 round 2 (codex R6) — the settle sequence on a goal whose ledger
+    /// row does not exist yet: the delta alone matches nothing; the caller's
+    /// create-if-absent + delta sequence creates the cleared tombstone and
+    /// lands the charge.
+    #[test]
+    fn should_create_the_cleared_row_when_settling_without_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = GoalLedger::open(dir.path().join("ledger.db")).unwrap();
+        assert!(
+            !ledger
+                .settle_cleared_goal_cost_delta("g1", 4_000, 3000)
+                .unwrap(),
+            "a bare delta on a missing row changes nothing"
+        );
+        assert!(
+            ledger
+                .create_goal_if_absent(&Goal {
+                    goal_id: "g1".to_string(),
+                    objective: "late row".to_string(),
+                    status: "cleared".to_string(),
+                    tokens_used: 500,
+                    token_budget: 100_000,
+                    continuations_used: 0,
+                    revision: 0,
+                    created_at_ms: 1000,
+                    updated_at_ms: 2000,
+                })
+                .unwrap()
+        );
+        assert!(
+            ledger
+                .settle_cleared_goal_cost_delta("g1", 4_000, 3000)
+                .unwrap()
+        );
+        let row = ledger.get_goal("g1").unwrap().unwrap();
+        assert_eq!((row.status.as_str(), row.tokens_used), ("cleared", 4_500));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2063, fixes #2064. One PR — both live in the goal engine (`crates/octos-cli/src/autonomy/agent_orchestrator.rs` + `crates/octos-fleet/src/sqlite_ledger.rs`).

## Verify-first findings

### #2063 — resume writing `active` on an exhausted budget

**In-memory layer: REFUTED.** The single user/RPC status+budget write is `set_goal` (`SESSION_GOAL_SET`; `/goal resume` arrives as `session/goal/set` with `status: "active"`), and it already enforces the invariant in the write:

- Over-budget re-activation guard (mini5 durable-ledger seq-454): non-active → `active` with `tokens_used >= effective_budget` is **rejected** with `AUTONOMY_QUOTA_EXCEEDED` and the actionable "resume by raising the token budget above the tokens already used" — goal untouched, zero continuations enqueued (the enqueue is gated on the resulting status being `active`). The guard evaluates the **effective** budget (the requested update or the current value), so raise-below-used is also rejected.
- Fix A (codex HIGH): any mutation leaving an **already-active** goal with `used >= budget` flips it to `budget_limited` + wrap-up in the same write.
- The model path cannot write `active` at all (`MODEL_ALLOWED_TRANSITIONS = ["complete","blocked"]`, re-enforced server-side in `model_transition_goal_at_key`).
- Already pinned by `set_goal_rejects_over_budget_reactivation_unless_budget_raised`, `set_goal_flips_active_goal_to_budget_limited_when_budget_lowered_below_used`, `charge_re_arms_budget_flip_after_raised_budget_reactivation`.

**Ledger layer: CONFIRMED — and reachable, not just theoretical.** No SQL status writer enforced the arithmetic, and `sync_transition_to_ledger_blocking`'s #1973 retry fires **exactly when the in-memory snapshot carries STALE LOWER counters than the multi-process row** (its own doc: "a peer charge pushed the row ahead of the in-memory record"). In that state the in-memory guard passes on memory's counters, computes `active`, the guarded upsert is rejected by the monotonic-token clause, and the status-only `cas_goal_status` retry stamps `active` onto a row whose own `tokens_used >= token_budget` — the exact active-and-exhausted row codex makes unrepresentable.

### #2064 — clear vs. dispatcher, and the lying tombstone

**(a) CONFIRMED.** `clear_goal_impl` took no mutual exclusion against the continuation dispatcher: state lock → remove record → drop lock → stamp ledger `cleared`. It never read `in_flight_goal_sessions`. Interleaving mapped: dispatcher claims the in-flight marker → launches the turn → clear removes the goal mid-turn and stamps `cleared` at the **pre-turn** total → the turn keeps running → its charge finds no record and is silently dropped. The dispatch claim itself survives (generation-keyed guard) and queued continuations die at drain (`pending_continuation_is_schedulable` refuses absent goals) — the damage lands in (b).

**(b) CONFIRMED empirically, RED test first.** Goal-bound turn in flight (marker held), clear stamps the row `cleared` at 1,234 tokens, the turn's 5,000-token charge arrives → dropped (`charge_goal_tokens_gated` and `record_goal_turn` both bail on the removed record) → row stays 1,234 forever. Nothing re-syncs a `cleared` row (`reconcile_terminal_goal_ledger` is complete/blocked-only).

## Fixes

### #2063 — the invariant lives in the write (ledger layer only; no in-memory change needed)

All four status writers in `sqlite_ledger.rs` now make activation conditional on the write's own arithmetic, in the same statement:

- `cas_goal_status` (the reachable hole): `status = CASE WHEN ?1 = 'active' AND token_budget > 0 AND tokens_used >= token_budget THEN 'budget_limited' ELSE ?1 END` — the **row's** counters decide, which is the point: this is a status-only write over counters the caller cannot see.
- `upsert_goal`: the CASE lives in the VALUES status expression on the **snapshot's** arithmetic; `excluded.status` picks up the transformed value, so one expression covers the insert and update arms. Defense-in-depth (guarded in-memory snapshots cannot be active-and-exhausted today).
- `update_goal_status` / `commit_state_with_audit`: same guard — same family, public writers of the same row (no production callers today; callers multiply, the write is one place).
- `create_goal` / `create_goal_if_absent` untouched: registration-time inserts from guarded snapshots; `if_absent` never updates a row.

`set_goal`'s in-memory behavior unchanged (the caller keeps the truthful "raise the budget first" rejection). The model-facing `goal_update` matrix untouched. Added the one listed test leg that was not yet pinned: raise-to-still-below-used stays rejected + zero continuations enqueued.

### #2064 — clear serializes with the dispatcher and the tombstone stops lying

**(a) Serialize.** `clear_goal_impl` now takes the **same claim the dispatcher holds**, under the same state lock that removes the record (`claim_clear_dispatch_slot`):

- Marker **free** → clear claims it (fresh generation), so a racing dispatcher cannot claim-and-launch from state being destroyed; released generation-keyed after the durable stamp. An unwind between claim and release is rescued by the #2003 staleness horizon.
- Marker **held** (turn in flight) → the clear must NOT steal it (that would strip the running turn's #1529 protection). It stamps `cleared` immediately and parks a settle tombstone instead. The claim stays a lock — not folded into status.

Chosen over defer-the-stamp: deferring until the claim frees would leave the durable row claiming `active` through a crash mid-turn — the exact lie #1973 fix B exists to prevent — and the in-flight turn's spend is unknowable at clear time anyway.

**Why clear only, not edit/resume:** `model_create_goal` calls `set_goal` **during a turn that itself holds the marker** — a claim there would misread its own turn's marker as a foreign dispatcher and reject mid-turn goal creation. Edit preserves `goal_id` and bumps `revision` (verifier ABA guard), resume's continuation drains only when the marker frees, and charges bind by `goal_id`. Clear is the only mutation that destroys the record the accountants need.

**(b) Charge-after-clear** (dispatch-time binding, the #1935 `interactive_goal_binding` idiom) — chosen over flush-before-clear because octos charges from turn **output**: at clear time the in-flight turn's spend is unknowable, so there is nothing to flush (codex can flush because it meters continuously):

- A clear that finds a turn in flight (and has a resolved ledger dir) parks a bounded `ClearedGoalTombstone` (cleared snapshot + ledger dir), keyed by the scoped goal key; replaced by the next clear on the key; capped at 16 with oldest-evicted.
- Both accountants, on record-miss, settle into it: profile-checked always, `goal_id`-bound when the turn captured one at start; accrue tokens/time; reconcile the cleared row via the existing guarded upsert (`sync_transition_to_ledger_blocking`, `status_changed = false` → counters-only, **no decision row**) through `offload_goal_ledger_io` — no sync ledger I/O added to tokio workers.
- The guarded upsert's monotonic clauses make settle-vs-stamp **commutative**: either arrival order converges on `cleared` + true totals.
- Deliberately NO wire event, NO wrap-up, NO continuation from the settle — the cleared notification behavior visible to clients is unchanged.

Invariant pinned: **the cost recorded on a cleared goal equals the cost of every turn that ran under it, cleared-mid-turn included.**

## Tests (RED → GREEN)

octos-fleet (`sqlite_ledger.rs`): `should_write_budget_limited_when_cas_activates_exhausted_row` (RED pre-fix), `should_write_active_when_cas_activates_row_within_budget` (control), `should_flip_exhausted_active_snapshot_to_budget_limited_on_upsert` (RED), `should_write_budget_limited_when_revision_cas_activates_exhausted_row` (RED), `should_write_budget_limited_when_audited_commit_activates_exhausted_row` (RED).

octos-cli (`agent_orchestrator.rs`, non-api-gated `autonomy` module): `cleared_goal_ledger_row_should_include_a_mid_flight_turn_charge` (RED — the (b) reproduction), `record_goal_turn_should_settle_charge_into_cleared_goal_row` (RED), `cleared_goal_tombstone_should_reject_foreign_charges_and_idle_clears` (RED), `clear_goal_should_claim_dispatch_marker_when_free_and_never_steal_a_held_one` (the (a) seam), extended `set_goal_rejects_over_budget_reactivation_unless_budget_raised` (raise-below-used leg + zero-enqueue assertion).

## Mutation checks (all killed)

1. **#2063 guard removed** — `cas_goal_status` CASE reverted → `should_write_budget_limited_when_cas_activates_exhausted_row` FAILS; in-memory reactivation guard disabled → `set_goal_rejects_over_budget_reactivation_unless_budget_raised` FAILS.
2. **Serialization removed** — claim call dropped from `clear_goal_impl` → `cleared_goal_tombstone_should_reject_foreign_charges_and_idle_clears` FAILS (an idle clear would park a tombstone and a stray charge settles); claim helper neutered (returns a generation without holding the marker) → `clear_goal_should_claim_dispatch_marker_when_free_and_never_steal_a_held_one` FAILS ("dispatchers must see the session as busy").
3. **Late-charge settle removed** — accrual short-circuited → all three tombstone-cost tests FAIL.

## Gates (serial)

- `cargo fmt --all -- --check`: clean
- `cargo test -p octos-fleet`: **175 passed, 0 failed** (CI runs this crate unfiltered — every new test executes)
- `cargo test -p octos-cli --lib` (CI-exact, unfeatured): **1507 passed, 0 failed** — all new octos-cli tests live in the non-api-gated `autonomy` module and run in this step
- `cargo test -p octos-cli --lib --features api` (this task's stated gate): 2983 passed, 2 failed — `should_allocate_bridge_ports_as_consecutive_pair` (the declared-ignorable environmental failure) and `closed_peer_park_produces_neither_wake_nor_escalation_row`. The latter is **pre-existing parallel shared-static contention, not this change**: it passes in isolation on this branch, passes in CI's actual `peer`-filter step on this branch (146 passed, 0 failed), and the identical full invocation on the BASE commit e9c5ae973 fails **4** tests (the same two plus `default_mode_background_nested_spawn_lands_grandchild_row` and `second_serve_on_same_data_dir_is_refused_with_a_greppable_marker`) — this branch fails a strict subset of base. Mechanism: that test's goal and escalation writer both live on the `default_agent_orchestrator()` singleton, which other tests reset concurrently (the #2029 shared-static class); CI never runs the full-parallel api invocation.
- `cargo clippy --workspace --all-targets`: clean (exit 0, no warnings)
- `cargo clippy -p octos-cli --all-targets --features api`: clean (exit 0, no warnings)
- `typos`: clean

#2029 filter proof — every new test runs in a CI-executed step:

- octos-cli: CI's `cargo test -p octos-cli --lib` is **unfiltered**; `-- --list` on that exact binary matches **5/5** new/extended test names (all under non-api-gated `autonomy::agent_orchestrator::tests`).
- octos-fleet: CI's `cargo test -p octos-fleet` is **unfiltered**; `-- --list` matches **5/5** new test names.

## Round 2 — codex review fixes (DO-NOT-MERGE review: "the clear state machine is not serializable")

| # | Finding | Fix | Test |
|---|---------|-----|------|
| R2 (root) | AppUI dispatch not atomic: pre-drain marker check → non-atomic drain → spawned task's UNCONDITIONAL `mark_goal_dispatch_in_flight` overwrote a clear's (or another dispatcher's) claim, no goal recheck — launch from destroyed state, charge dropped (clear saw slot free → no tombstone) | Spawned task now TRY-claims (`try_claim_goal_in_flight`; held ⇒ abort, nothing emitted) and re-checks the goal after claiming (`goal_dispatch_target_matches`: exists + profile + same incarnation as the continuation's `goal_id`); on failure the internal turn slot is stamped Terminal (no wire event was ever emitted for it) and the continuation marked completed. Confined to the continuation-drain/spawn path | `dispatch_claim_should_refuse_launch_when_goal_cleared_between_drain_and_claim` + `appui_continuation_spawn_should_use_atomic_try_claim_source_guard` (source guard — kills the unconditional-mark revert even in unfeatured builds) |
| R6 | Round-1 "commutativity" was false: the guarded upsert needs `ts >= AND tokens >=`, so settle-snapshot vs clear-stamp was arrival-order-dependent (C-second could overwrite or reject the settled charge) | STRUCTURAL split: clear's stamp owns the STATUS dimension (unchanged snapshot-stamp + ordering-gated CAS — it still refreshes counters when admitted, see pushback below); the settle owns the COUNTERS dimension as an additive delta (`settle_cleared_goal_cost_delta`: `tokens_used = tokens_used + ?`, status only ever `cleared`-or-keep-`complete`, ts monotone via MAX) after `create_goal_if_absent` of the frozen base. Deltas commute with the stamp by arithmetic; per-charge single-delivery is the documented idempotency assumption | `should_settle_identical_rows_for_clear_stamp_and_delta_in_both_orders` (both orders, identical final rows incl. the never-lost delta), `should_create_the_cleared_row_when_settling_without_one`, `cleared_goal_settle_should_land_through_the_detached_offload_path` (real spawn_blocking path, polled) |
| R1a | create-after-clear vs tombstone | Tombstone KEPT (debug-logged), not dropped — see pushback below | `cleared_goal_charge_should_settle_old_tombstone_not_the_replacement_goal` |
| R1b | Interactive id-mismatch branch dropped the old goal's cost | Absent/profile-mismatch/id-mismatch now all route to the tombstone attempt, bound by the charge's OWN goal_id | same test (interactive leg) |
| R1c | Autonomous accountant unbound (`None`) | `record_goal_turn` gains `expected_goal_id`; both call sites (session actor + AppUI ctx) thread `QueuedMasterContinuation::goal_id`; live charge is now identity-bound (mismatch ⇒ tombstone, never the replacement — fixes the AO misattribution); tombstone helper REFUSES `None` | `record_goal_turn_should_refuse_unbound_tombstone_settlement` (mutation 3), replacement test above |
| R1d | Restart seq reuse: cleared groups returned before the `next_goal_seq` high-water fold | Cleared branch folds `sequence_suffix(goal_id)` before returning | covered by the fold being load-bearing for R1a's no-collision argument; restore-path change is 3 lines beside the existing fold |
| R1 retention | 16-cap eviction silently discarded; no age purge | `CLEARED_GOAL_TOMBSTONE_TTL_MS` (= the marker horizon: once the marker that justified parking aged out, no legitimate charge can arrive) purged on map touches; cap eviction debug-logs the discarded tombstone | `cleared_goal_tombstones_should_purge_past_horizon_and_cap_evict_oldest` |
| R3 | SIX writers, cleared unprotected | Creation writers (`create_goal`, `create_goal_if_absent`) get the exhaustion CASE; `upsert_goal` + `cas_goal_status` protect `cleared` like `complete`; both revision-CAS writers (`update_goal_status`, `commit_state_with_audit`) refuse terminal overwrites. Writer census: 6 statements total (3 UPDATE + 3 INSERT), all guarded or insert-only-by-construction; the new delta-settle is the 7th and stamps only `cleared`/keeps `complete` | `should_write_budget_limited_when_creation_writers_insert_exhausted_active`, `should_refuse_to_resurrect_a_cleared_row` (mutation 4) |
| R4 | Raw claim leaked on unwind; #2003 horizon is conditional | `ClearDispatchClaimGuard` (the #2059 flight-guard shape, orchestrator-clone-backed): releases exactly once on every exit incl. unwind, generation-keyed; declared before the state-lock scope so an unwind cannot Drop-relock under the held mutex. Crash-ordering divergence (supervisor vs SQLite) deliberately NOT solved here — commented on #2056 with refs | round-1 claim tests unchanged (release semantics identical) |
| HIGH | `commit_state_with_audit` inserted the caller's decision even when the CASE stored a different status | The decision derives from the STORED outcome (re-read inside the same transaction): stored ≠ requested ⇒ decision insert SKIPPED and the override surfaced via the new `Result<String>` return (findings still land — evidence, not a status claim) | `should_skip_contradicting_decision_when_audited_commit_overrides_activation` (with a decision supplied) |
| MEDIUM | tombstone accrued `time_used_seconds` that can never persist (no schema column anywhere) | Chose the review's second option: filed #2068 (schema migration via the #2059 pattern) and DELETED the dead accrual — the settle is tokens-only and says why. Justification: the missing column is a schema-wide gap for every goal, orthogonal to this PR's charge-loss bug; a wide schema+serde+API change does not belong in a race-fix round | n/a (dead code removed) |

### Pushback (with evidence)

- **R1a "drop/flush the tombstone at create-after-clear"**: implemented as KEEP-parked + debug log, not drop. Evidence: R1c's own acceptance sentence — "if a newer live goal exists and the charge's goal_id doesn't match it, the charge goes to the matching tombstone" — requires the tombstone to SURVIVE the create; dropping it would orphan exactly the cost R1b/R1c route. The absorption hazard (a) targets is closed structurally instead: settlement is goal-id-bound, unbound settlement is refused, and the new goal's id can never equal the tombstone's (monotonic in-process seq + the R1d restart fold). There is nothing to "flush" either — settles are per-charge immediate; the tombstone holds no unsettled state.
- **R6 "clear stamp becomes STATUS-ONLY"**: implemented the split with the settle as a pure counters delta, but the clear stamp keeps its existing guarded snapshot upsert (with CAS fallback) rather than becoming literally status-only. Evidence: the ledger row lags memory between transitions (interactive/autonomous charges do not sync the ledger per-charge), so the clear stamp is the LAST chance to fold the pre-clear spend into the row — a status-only stamp would freeze every ordinary (no-race) clear at its last-transition counters, recreating #2064(b)'s under-reporting for the pre-clear dimension, and the round-1 test `cleared_goal_ledger_row_should_include_a_mid_flight_turn_charge` pins that the stamp lands the clear-time total (1,234). Commutation with the delta settle holds regardless of the stamp's counters: stamp-admitted-then-delta adds on top; delta-then-stamp is refused by the monotonic clauses / ts-gated CAS while the delta already stamped `cleared` — both orders converge (pinned by the both-orders test). The only residual order dependence is the pre-clear sync-lag refresh inside the sub-millisecond stamp-vs-settle race window (the charge delta itself is never lost in any order), which is the pre-round-1 status quo for that window.

### Round-2 mutation checks (all killed)

1. Try-claim reverted to the unconditional mark (spawn block restored to `goal_dispatch_in_flight_guard`, recheck dropped) → `appui_continuation_spawn_should_use_atomic_try_claim_source_guard` FAILS (and the claim-exclusivity leg of `dispatch_claim_should_refuse_launch_when_goal_cleared_between_drain_and_claim` pins the primitive).
2. Counters split reverted (delta write made absolute) → `should_settle_identical_rows_for_clear_stamp_and_delta_in_both_orders` FAILS (base lost: 4,000 ≠ 4,500).
3. `None`-keyed settlement re-allowed → `record_goal_turn_should_refuse_unbound_tombstone_settlement` FAILS.
4. Cleared-protection removed from cas/upsert → `should_refuse_to_resurrect_a_cleared_row` FAILS.

### Round-2 gates (serial)

- `cargo fmt --all -- --check`: clean
- `cargo test -p octos-fleet`: **180 passed, 0 failed**
- `cargo test -p octos-cli --lib` (CI-exact, unfeatured): **1513 passed, 0 failed**
- `cargo test -p octos-cli --lib --features api`: 2988 passed, 3 failed — all three pre-existing parallel/environmental, none reachable from this diff: `bridge_ports` (declared-ignorable environmental), `closed_peer_park…` (proven pre-existing on base in round 1; passes isolated + passes CI's `peer` filter step), and `master_continuation_tick_reenters_actor_loop` — whose own #2029 comment documents "failed in roughly one full parallel run in three" under full parallelism (process-global agent registry); it passes in isolation and in 2 of 3 module-scoped runs on this branch, exercises the ChildCompleted path (`is_goal_turn == false` — never touches this PR's goal accounting), and never runs in CI at all (api-gated, matches no CI filter).
- `cargo clippy --workspace --all-targets`: clean
- `cargo clippy -p octos-cli --all-targets --features api`: clean (after deleting the now-dead unconditional claim constructor — every production claim is atomic, so `goal_dispatch_in_flight_guard` lost its last caller by design; `mark_goal_dispatch_in_flight` is `#[cfg(test)]` for simulating a foreign dispatcher)
- `typos` (repo config): my diff clean; local typos 1.45.1 flags one pre-existing word (a plural of "pending") in a #1967-era comment that CI's pinned v1.33.1 does not flag (0 occurrences in this PR's diff)
- #2029 filter proof: round-2 tests match **6/6** in the CI-unfiltered `cargo test -p octos-cli --lib` binary and **5/5** in the unfiltered `cargo test -p octos-fleet` run (round-1 counts unchanged)

### Known residuals

- Crash-ordering divergence between the supervisor store (append result discarded) and the SQLite goals-row on clear — #2056 territory, commented there with refs (codex R4).
- `time_used_seconds` has no ledger column anywhere — filed #2068; the tombstone's dead time accrual is deleted rather than left accumulating unpersistable state (codex MEDIUM, option 2).
- The pre-clear sync-lag counter refresh inside the sub-millisecond stamp-vs-settle race window is order-dependent (the charge delta itself never is) — see the R6 pushback above.
## Round 3 — codex round-2 verdict fixes (both round-2 pushbacks REJECTED; the rejections' arithmetic/case-analyses are accepted and implemented)

| # | codex round-2 finding | Round-3 fix | Test (mutation kill) |
|---|---|---|---|
| 1 (BLOCKER) | Mixed snapshot/delta model is order-dependent — proven with L=0, B=100, D=10: delta→same-ms stamp let the guarded upsert pass both `>=` clauses and OVERWRITE the settled delta (110→100); delta→newer-ts made the stamp reject and lose the whole pre-clear lag. The round-2 both-orders test masked it by seeding L==B | BOTH writers MAX-merge on counters, making order-independence arithmetic: the clear uses a dedicated `stamp_goal_cleared` (per-column `tokens_used = MAX(row, frozen_base)`, ts MAX, status CASE keeping `complete`; the all-or-nothing row guard is dropped for THIS writer only — the generic transition sync is untouched for complete/blocked/paused), and the settle becomes `tokens_used = MAX(row, frozen_base) + delta` (the tombstone's frozen base folds the pre-clear lag in even when the settle lands first). All orders = B + ΣD | `should_settle_identical_rows_for_clear_stamp_and_delta_in_both_orders` REWRITTEN with L=0 < B=100, D=10, all writers stamping the SAME millisecond (the adversarial tie); asserts 110 in both orders + 115 for multi-delta interleavings |
| 2 (HIGH) | AppUI popped BEFORE claiming (pop → claim inside the spawned task → claim-failure completed the popped one-shot UNEXECUTED — permanently dropping a latched GoalWrapUp) | AppUI now uses the SAME atomic `drain_and_claim_ready_continuation_for_session` the session actor uses: claim and pop under ONE state lock; claim-failure pops nothing and completes nothing; the guard travels into the spawned turn (held for every reason, matching the actor) and releases on every exit. The round-2 try-claim abort branch is GONE (nothing popped ⇒ nothing to abort); the post-claim goal recheck stays — with the claim held, gone/mismatched means genuinely cleared/replaced, so completing the popped item is correct per codex's case analysis. The separate pre-drain occupancy check is subsumed by the atomic primitive | `concurrent_dispatchers_should_never_complete_an_unexecuted_one_shot` (goal item + ChildCompleted; while one claim is held the second drain pops NOTHING and the pending count proves nothing was completed; after release both execute exactly once) + the source guard now requires `drain_and_claim…` and forbids the non-atomic pop in the runner |
| 3 (HIGH) | Legacy `None` continuations wildcard onto a create-after-clear replacement and charge it (schedulability binds only `Some`; the dispatch recheck treats `None` as match-any; `record_goal_turn`'s live wildcard wins before the tombstone's None-refusal ever runs) | BIND-AT-DRAIN in the shared locked drain core: an unbound GoalContinue/GoalWrapUp resolves against the session's live goal ONLY IF that goal already existed when the item was created (`goal.created_at_ms <= item.created_at`, `<=` because `set_goal` enqueues in its own creation tick) — match ⇒ the item is stamped `Some(goal_id)` and every downstream identity gate engages; live goal newer (a replacement), profile mismatch, or unrepresentable timestamp ⇒ the item is completed STALE under the same lock (supervisor tombstone, mirroring the #1150 stale-drop) without launching or charging | `unbound_goal_continuation_should_bind_at_drain_or_die_stale` — negative: unbound item + clear + replacement ⇒ only the replacement's own bound continuation drains, replacement uncharged; positive: unbound item under its original live goal drains BOUND to it |
| 4 (MEDIUM) | Tombstone TTL purged on `parked_at_ms` alone while the marker was legitimately refreshed or held by supervised work — a >30min turn lost its charge | Purge eligibility = expired AND `in_flight_marker_is_held` is false for that session (that predicate already encodes BOTH liveness halves: fresh-stamp refresh and nonterminal supervised work — the same consult the marker's own staleness rescue uses) | `expired_tombstone_should_survive_while_the_dispatch_marker_is_held` (backdated tombstone + held marker ⇒ survives and the late charge still settles; marker released ⇒ purges) |
| 5 (Y6) | The round-2 settle writer flipped status (`ELSE 'cleared'` CASE), contradicting the split-dimensions claim | The settle is now GENUINELY counters-only: status never appears in its UPDATE; the `create_goal_if_absent` frozen-base INSERT carries `cleared` at insert; the MAX-merge stamp owns the status dimension | both-orders test pins that a settle racing ahead of the stamp leaves the row's status untouched (`active` until the stamp lands) |

Also acknowledged from the round-2 verdict: Y4/Y5/Y7 held; both round-2 pushbacks are withdrawn as originally argued — the R6 pushback's evidence (status-only stamps would freeze pre-clear lag; ordinary turns deliberately never sync SQLite) was accepted by codex and is honored by fix 1's MAX-merge (which preserves the lag-fold WITHOUT the order-dependence), and the R1a keep-the-tombstone stance survives intact because fix 3 closes the wildcard hole that made "drop at create" attractive.

### Round-3 mutation checks (all killed)

1. Settle's MAX-fold reverted to a bare `+ delta` → the L<B both-orders test FAILS (order B lands 100, order A lands 110).
2. Runner reverted to the non-atomic pop → the source guard FAILS; the concurrent-dispatchers test pins the primitive (a held claim drains nothing).
3. Binder removed (unbound items kept as wildcards) → the bind-at-drain test FAILS (negative leg drains 2 goal items).
4. Liveness consult removed from the purge → the TTL test FAILS (the held-marker tombstone is dropped and the late charge is lost).

### Round-3 gates (serial)

- `cargo fmt --all -- --check`: clean
- `cargo test -p octos-fleet`: **181 passed, 0 failed**
- `cargo test -p octos-cli --lib` (CI-exact, unfeatured): **1516 passed, 0 failed**
- `cargo test -p octos-cli --lib --features api`: 2992 passed, 2 failed — exactly the two established pre-existing failures (`bridge_ports` declared-ignorable environmental; `closed_peer_park…` proven pre-existing on base in round 1, passes isolated and passes CI's `peer` step). The round-2 third flake did not recur.
- `cargo test -p octos-cli --features api peer` (the CI step that runs the peer test): **146 passed, 0 failed**
- `cargo clippy --workspace --all-targets` and `cargo clippy -p octos-cli --all-targets --features api`: clean — after test-gating `drain_ready_continuations_for_session` (the non-atomic pop) and `is_goal_dispatch_in_flight` (a standalone TOCTOU read), both of which lost their last production callers to the atomic drain-and-claim by design
- `typos`: my diff clean (the one local-1.45.1-only hit remains the pre-existing #1967-era word, 0 occurrences in this PR's diff)
- #2029 filter proof: round-3 tests match **4/4** in the CI-unfiltered `cargo test -p octos-cli --lib` binary and **3/3** in the unfiltered `cargo test -p octos-fleet` run (rounds 1–2 counts unchanged)
- Diff vs main touches exactly 4 files (`sqlite_ledger.rs`, `agent_orchestrator.rs`, `session_actor.rs`, `ui_protocol_transport.rs`) — the round-2 push's `check-windows` failure was in `octos-agent` integration tests (`validator_runner`: Timeout-vs-Fail on a slow Windows runner), a crate absent from this diff, and the same job passed on this branch's round-1 push.
## Round 4 — codex closure-gate fixes (V1/V2/V5/V6/V7 CLOSED and untouched; round 4 is exactly the two remaining items)

| # | codex round-3 finding | Round-4 fix | Test (mutation kill) |
|---|---|---|---|
| 1 HIGH (blocker) | Bind-at-drain temporal predicate leaked two ways. (a) RESTART: persistence stores `queued_at_ms` but restore reconstructed every continuation with `created_at = SystemTime::now()` while goals restore with their ORIGINAL timestamps — after any restart an old unbound item looked NEWER than the restored replacement and ROUTINELY rebound to it. (b) EQUALITY: `<=` let a same-millisecond replacement steal a legacy item; the round-3 justification ("set_goal enqueues in its creation tick") was wrong because set_goal's own enqueues are BOUND and never take the `None` path | (a) `master_continuation_request_from_persisted` now stamps `created_at = UNIX_EPOCH + queued_at_ms` — the durable enqueue time. No second field: `created_at`'s only behavioral consumer is the binder (the scheduler orders by priority/sequence, dedupe is key-based), so restoring the truthful time is strictly more correct for every reader. (b) The predicate is STRICT (`goal.created_at_ms < item.created_at`), documented with exactly the corrected argument: legacy unbound items predate goal_id threading entirely, so a same-tick unbound item cannot legitimately belong to a goal created in that tick — on a tie the item dies stale (dropping a charge beats misattributing it) | (i) `restored_unbound_continuation_should_keep_durable_time_and_die_stale` — drives the REAL restore reconstruction (the exact fn `configure_supervisor_store` calls), asserts the restored item's binder-time equals its durable `queued_at_ms`, then replacement + drain ⇒ stale, replacement at 0 tokens. (ii) `same_millisecond_replacement_should_not_steal_an_unbound_continuation` — exact-tie item dies stale |
| 2 MEDIUM | AppUI never refreshes the dispatch marker (the only production `touch_goal_dispatch_in_flight` was the session actor's token-progress heartbeat) — a >30min AppUI goal turn's marker read stale, so its settle tombstone purged before the late charge AND a clear could claim the "free" slot without parking one | `run_standalone_turn` now spawns the actor's #2003 heartbeat twin for goal-context turns: a 60s tick that touches the marker ONLY when the shared `TokenTracker` advanced since the last tick (progress-gated — a wedged turn stops being refreshed and ages out normally), keyed by the SCOPED goal store key the drain claimed under, aborted with the turn on every exit (`AbortOnDrop`) | `touched_marker_should_keep_aged_tombstone_and_block_clear_claims` — marker + tombstone aged past the shared horizon, one touch ⇒ tombstone survives the purge AND `claim_clear_dispatch_slot` refuses (a clear would park a tombstone instead); progress stops ⇒ purges as before. Wiring pinned by `appui_standalone_turn_should_heartbeat_the_dispatch_marker_source_guard` |

### Round-4 mutation checks (all killed)

1. Restore reverted to `SystemTime::now()` → `restored_unbound_continuation_should_keep_durable_time_and_die_stale` FAILS (binder-time assert + the replacement steals the item).
2. The AppUI touch removed → `appui_standalone_turn_should_heartbeat_the_dispatch_marker_source_guard` FAILS (and the semantics test pins what the touch must do).

### Round-4 gates (serial)

- `cargo fmt --all -- --check`: clean
- `cargo test -p octos-fleet`: **181 passed, 0 failed**
- `cargo test -p octos-cli --lib` (CI-exact, unfeatured): **1520 passed, 0 failed**
- `cargo test -p octos-cli --lib --features api`: 2996 passed, 2 failed — exactly the two established pre-existing failures (`bridge_ports` declared-ignorable environmental; `closed_peer_park…` proven pre-existing on base in round 1), same profile as round 3
- `cargo test -p octos-cli --features api peer` (the CI peer step): **146 passed, 0 failed**
- `cargo clippy --workspace --all-targets` + `cargo clippy -p octos-cli --all-targets --features api`: clean
- `typos`: my diff clean (0 occurrences of the one pre-existing local-only hit)
- #2029 filter proof: round-4 tests match **4/4** in the CI-unfiltered `cargo test -p octos-cli --lib` binary (rounds 1–3 counts unchanged)
- Round-3 push's CI on this branch: **success** (including check-windows, corroborating that the round-2 windows failure was runner variance in the untouched `octos-agent`)
## Round 5 — codex U-gate fixes (U5 closed; strict-< production reasoning, heartbeat wiring/scope/RAII confirmed; round 5 is exactly the three remaining items)

| # | codex round-4 finding | Round-5 fix | Test (mutation kill) |
|---|---|---|---|
| 1 BLOCKER (round-4 regression) | The heartbeat touch was KEY-ONLY while the claim guard owns a GENERATION: stale turn A, evicted at the horizon and replaced by turn B on the same scoped key, could refresh B's marker whenever A resumed producing — keeping a wedged replacement protected indefinitely | New `touch_goal_dispatch_in_flight_generation` refreshes ONLY the marker incarnation whose generation matches (debug-logged no-op otherwise, never creates a marker); the AppUI heartbeat threads its own turn's generation from the drain-and-claim guard (`GoalDispatchInFlightGuard::generation()` → `GoalContinuationContext::claim_generation`); no generation ⇒ no claim was taken ⇒ no heartbeat spawns. The source guard now requires the generation-matched form at the turn site | `heartbeat_touch_should_refresh_only_its_own_marker_generation` — A claims (G1), B replaces (G2), B's marker aged stale; A's touch with G1 does NOT revive it, B's touch with G2 does. **Mutation re-run: generation match removed → FAILS** at "a stale predecessor's heartbeat must not keep the replacement's marker alive" |
| 2 (round-4 regression) | `UNIX_EPOCH + Duration::from_millis(queued_at_ms)` is panicking SystemTime addition — a parseable extreme u64 panics on narrower SystemTime targets (Windows) | `checked_add`, overflow clamps to `UNIX_EPOCH` with a debug log — conservatively ANCIENT, so the bind-at-drain predicate classifies the item stale (the safe direction: drop, never misattribute). On platforms whose SystemTime can hold the huge value, the binder's existing unrepresentable-as-ms arm classifies it stale too — same outcome either way | `extreme_restored_timestamp_should_not_panic_and_dies_stale` — `queued_at_ms: u64::MAX` restores without panic, dies stale at drain, live goal uncharged |
| 3 (false-positive test) | The tie test asserted key SHAPE (a "legacy" substring / `goal_id == None`) that a `<`→`<=` mutation never produces — the mutated (stolen) item binds `Some(goal_id)` with a generated dedupe key and the test still passed | Rewritten to assert the OUTCOME: the tie item (by its OWN `.with_dedupe_key`) never drains; the pending queue empties without a launch; the replacement's counters stay (0, 0); and the durable supervisor completion carries the STALE reason (`discarded:unbound_goal_continuation_stale`) — read back through a fresh `SupervisorStore::load_state()` | **Mutation re-run as demanded: `<`→`<=` now FAILS the reworked test** — the panic output shows the tie item drained BOUND to the replacement (`goal_id: Some("goal_01")`, dedupe `tie-unbound-1`), exactly the theft the outcome assertions catch |

### Known-residual (codex classification: acceptable-with-tracking, no code change)

- **No absolute marker lifetime**: the progress-gated heartbeat can extend the in-flight marker indefinitely while a turn keeps producing tokens. Codex ruled this contract parity with the session actor's #2003 heartbeat (whose refresh has the same property by design — observable progress IS the liveness definition) and classified it acceptable-with-tracking rather than a defect.

### Round-5 gates (serial)

- `cargo fmt --all -- --check`: clean
- `cargo test -p octos-fleet`: **181 passed, 0 failed**
- `cargo test -p octos-cli --lib` (CI-exact, unfeatured): **1522 passed, 0 failed**
- `cargo test -p octos-cli --lib --features api`: 2998 passed, 2 failed — exactly the two established pre-existing failures (`bridge_ports` declared-ignorable environmental; `closed_peer_park…` proven pre-existing on base in round 1), same profile as rounds 3–4
- `cargo test -p octos-cli --features api peer`: **146 passed, 0 failed**
- `cargo clippy --workspace --all-targets` + `cargo clippy -p octos-cli --all-targets --features api`: clean
- `typos`: my diff clean
- #2029 filter proof: round-5 tests match **2/2** in the CI-unfiltered `cargo test -p octos-cli --lib` binary (earlier rounds unchanged)
