### PR TITLE
fix(ui-protocol): scope goal, loop and monitor frames to the connection's profile

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -5462,6 +5462,7 @@ async fn stdio_binding_updates_only_after_successful_session_open() {
         &questions,
         &forwarders,
         candidate.as_deref(),
+        None,
         features,
         "open-missing".into(),
         missing_params,
@@ -5517,6 +5518,7 @@ async fn stdio_binding_updates_only_after_successful_session_open() {
         &questions,
         &forwarders,
         candidate.as_deref(),
+        None,
         features,
         "open-grace".into(),
         grace_params,
@@ -5736,6 +5738,7 @@ async fn stdio_multi_profile_open_status_reads_isolated_runtime_policy_stamps() 
             &PendingQuestionStore::default(),
             ConnectionId::next(),
             Some(profile_id),
+            None,
             features,
             SessionOpenParams {
                 session_id: session_id.clone(),
@@ -5851,6 +5854,7 @@ async fn session_open_writes_active_profile_marker_only_with_flag_and_cwd() {
                 questions,
                 ConnectionId::next(),
                 Some(profile),
+                None,
                 features,
                 SessionOpenParams {
                     session_id,
@@ -12774,8 +12778,14 @@ fn skill_action_job_events_are_visible_only_to_their_profile() {
         },
     ));
 
-    assert!(ledger_event_matches_profile_scope(&event, "profile-a"));
-    assert!(!ledger_event_matches_profile_scope(&event, "profile-b"));
+    assert!(ledger_event_matches_profile_scope(
+        &event,
+        Some("profile-a")
+    ));
+    assert!(!ledger_event_matches_profile_scope(
+        &event,
+        Some("profile-b")
+    ));
 }
 
 // ---------------------------------------------------------------------------
@@ -12937,6 +12947,7 @@ async fn should_retain_only_same_profile_goal_events_when_open_session_result_re
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         Some("alpha"),
+        None,
         ConnectionUiFeatures::default(),
         SessionOpenParams {
             session_id: session_id.clone(),
@@ -12953,7 +12964,7 @@ async fn should_retain_only_same_profile_goal_events_when_open_session_result_re
     .await
     .expect("alpha opens the shared session");
 
-    assert_eq!(outcome.profile_id, "alpha");
+    assert_eq!(outcome.profile_scope.as_deref(), Some("alpha"));
     let retained: Vec<&str> = outcome
         .replay
         .iter()
@@ -13025,6 +13036,7 @@ async fn should_drop_cross_profile_goal_frames_when_connection_scopes_another_pr
         &questions,
         &forwarders,
         Some("alpha"),
+        None,
         ConnectionUiFeatures::default(),
         "open-alpha".into(),
         SessionOpenParams {
@@ -13132,6 +13144,7 @@ async fn should_replay_main_and_legacy_goal_frames_when_connection_is_unprofiled
         &approvals,
         &questions,
         &forwarders,
+        None,
         None,
         ConnectionUiFeatures::default(),
         "open-main".into(),
@@ -13328,6 +13341,7 @@ async fn should_drop_cross_profile_loop_and_monitor_frames_when_connection_scope
         &questions,
         &forwarders,
         Some("alpha"),
+        None,
         ConnectionUiFeatures::default(),
         "open-alpha-autonomy".into(),
         SessionOpenParams {
@@ -13484,6 +13498,7 @@ async fn should_keep_delivering_first_session_frames_when_a_second_session_opens
             &questions,
             &forwarders,
             None,
+            None,
             ConnectionUiFeatures::default(),
             rpc_id.into(),
             SessionOpenParams {
@@ -13600,6 +13615,7 @@ async fn should_drop_cross_profile_session_opened_frames_when_connection_scopes_
         &questions,
         &forwarders,
         Some("alpha"),
+        None,
         ConnectionUiFeatures::default(),
         "open-alpha-shared".into(),
         SessionOpenParams {
@@ -13716,6 +13732,7 @@ async fn should_drop_cross_profile_background_activity_frames_when_connection_sc
         &questions,
         &forwarders,
         Some("alpha"),
+        None,
         features,
         "open-alpha-activity".into(),
         SessionOpenParams {
@@ -13771,6 +13788,141 @@ async fn should_drop_cross_profile_background_activity_frames_when_connection_sc
         next_frame_within(&mut rx, 250).await.is_none(),
         "beta's live activity must not reach an alpha-scoped connection"
     );
+
+    abort_live_forwarders(&forwarders, &ledger).await;
+}
+
+/// #2067 round 3 — the connection's resolved session scope is NOT a tenant
+/// boundary on a routed admin connection, and using it as a delivery filter
+/// starves that connection.
+///
+/// `validate_session_scope` never consults `routed_profile_id`
+/// (`ui_protocol_transport.rs:16694`), but the turn path resolves its runtime
+/// from `connection_profile_id.or(routed_profile_id)`. So an admin connection
+/// (`connection_profile_id == None`) routed to tenant `beta` by `Host`
+/// subdomain or `X-Profile-Id` opens a bare session key that resolves to
+/// `_main`, while its own turns run under `beta`'s `ProfileRuntime` — and the
+/// model tools that runtime registers hard-bind `beta` onto every record they
+/// create (`runtime/profile.rs:1321` -> `goal_tool.rs:1802`). The durable
+/// frames those records later emit are stamped `beta`, so a `_main` filter
+/// drops the connection's OWN data.
+///
+/// `background/activity` is the worst case: its sink appends over a detached
+/// connection whose writer is discarded, so replay and live forwarding are its
+/// only delivery paths — a filter drop there is total.
+#[tokio::test]
+async fn should_deliver_routed_profile_frames_when_the_connection_scope_is_not_authoritative() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = local_profile_state_with_sessions(temp.path());
+    create_or_get_local_solo_profile(
+        &state,
+        local_profile_params("Beta Owner", "beta", "beta@example.com"),
+    )
+    .expect("create beta profile");
+
+    let (ws, mut rx) = ws_connection_for_test(64);
+    let ledger = Arc::new(UiProtocolLedger::new(64));
+    let approvals = PendingApprovalStore::default();
+    let questions = PendingQuestionStore::default();
+    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    // A BARE key on an admin connection: `validate_session_scope` resolves it
+    // to `_main` even though the turn will run as `beta`.
+    let session_id = SessionKey("web-routed-admin".into());
+    let features = ConnectionUiFeatures {
+        background_activity: true,
+        ..Default::default()
+    };
+
+    let monitor_fired = |monitor_id: &str| {
+        UiNotification::MonitorFired(octos_core::ui_protocol::MonitorFiredEvent {
+            session_id: session_id.clone(),
+            profile_id: Some("beta".to_owned()),
+            monitor_id: monitor_id.to_owned(),
+            name: Some(monitor_id.to_owned()),
+            line_count: Some(1),
+            fired_at_ms: None,
+        })
+    };
+    let activity = |text: &str| {
+        UiNotification::BackgroundActivity(octos_core::ui_protocol::BackgroundActivityEvent {
+            session_id: session_id.clone(),
+            profile_id: Some("beta".to_owned()),
+            origin_kind: "monitor".to_owned(),
+            origin_id: "monitor-model-made".to_owned(),
+            origin_label: Some("ci-tail".to_owned()),
+            text: text.to_owned(),
+            emitted_at_ms: 1_760_000_000_000,
+            dropped_count: None,
+            suppressed: false,
+        })
+    };
+
+    // Durable history produced by THIS connection's own model-created monitor.
+    ledger.append_notification(monitor_fired("monitor-model-made"));
+    ledger.append_notification(activity("replayed log line"));
+    ledger.append_notification(goal_updated_notification(
+        &session_id,
+        Some("beta"),
+        "routed objective",
+    ));
+
+    let opened = handle_session_open(
+        &ws,
+        &state,
+        &ledger,
+        &approvals,
+        &questions,
+        &forwarders,
+        // admin / unscoped …
+        None,
+        // … but routed to `beta` by subdomain or header.
+        Some("beta"),
+        features,
+        "open-routed-admin".into(),
+        SessionOpenParams {
+            session_id: session_id.clone(),
+            topic: None,
+            profile_id: None,
+            cwd: None,
+            sandbox: None,
+            after: Some(UiCursor {
+                stream: session_id.0.clone(),
+                seq: 0,
+            }),
+        },
+        false,
+    )
+    .await;
+    assert!(opened, "a routed admin connection must be able to open");
+
+    let frames = drain_session_open_frames(&mut rx).await;
+    let methods: Vec<&str> = frames
+        .iter()
+        .filter_map(|frame| frame.get("method").and_then(Value::as_str))
+        .collect();
+    assert!(
+        methods.contains(&octos_core::ui_protocol::methods::MONITOR_FIRED),
+        "the connection's own routed monitor/fired must be replayed: {methods:?}"
+    );
+    assert!(
+        methods.contains(&octos_core::ui_protocol::methods::BACKGROUND_ACTIVITY),
+        "background/activity has no other delivery path and must be replayed: {methods:?}"
+    );
+    assert!(
+        methods.contains(&octos_core::ui_protocol::methods::SESSION_GOAL_UPDATED),
+        "the connection's own routed goal frame must be replayed: {methods:?}"
+    );
+
+    // Same property on the live forwarder.
+    ledger.append_notification(activity("live log line"));
+    let live = next_frame_within(&mut rx, 2_000)
+        .await
+        .expect("a routed admin connection must keep receiving its own live frames");
+    assert_eq!(
+        live.get("method").and_then(Value::as_str),
+        Some(octos_core::ui_protocol::methods::BACKGROUND_ACTIVITY),
+    );
+    assert_eq!(live["params"]["text"], json!("live log line"));
 
     abort_live_forwarders(&forwarders, &ledger).await;
 }
@@ -14107,6 +14259,7 @@ async fn session_open_replays_notifications_after_cursor_and_returns_ledger_curs
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         None,
+        None,
         ConnectionUiFeatures::default(),
         SessionOpenParams {
             session_id: session_id.clone(),
@@ -14170,6 +14323,7 @@ async fn session_open_topic_scope_replays_only_matching_topic_bucket() {
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         None,
+        None,
         ConnectionUiFeatures::default(),
         SessionOpenParams {
             session_id: base_session.clone(),
@@ -14200,6 +14354,7 @@ async fn session_open_topic_scope_replays_only_matching_topic_bucket() {
         &approvals,
         &PendingQuestionStore::default(),
         ConnectionId::next(),
+        None,
         None,
         ConnectionUiFeatures::default(),
         SessionOpenParams {
@@ -14240,6 +14395,7 @@ async fn session_open_rejects_after_cursor_from_other_stream() {
         &approvals,
         &PendingQuestionStore::default(),
         ConnectionId::next(),
+        None,
         None,
         ConnectionUiFeatures::default(),
         SessionOpenParams {
@@ -14302,6 +14458,7 @@ async fn session_open_rejects_stale_after_cursor() {
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         None,
+        None,
         ConnectionUiFeatures::default(),
         SessionOpenParams {
             session_id: session_id.clone(),
@@ -14358,6 +14515,7 @@ async fn session_open_replays_pending_approval_after_reconnect_without_cursor() 
         &approvals,
         &PendingQuestionStore::default(),
         ConnectionId::next(),
+        None,
         None,
         ConnectionUiFeatures::default(),
         SessionOpenParams {
@@ -14441,6 +14599,7 @@ async fn session_open_replays_pending_question_for_negotiated_client() {
         &approvals,
         &questions,
         ConnectionId::next(),
+        None,
         None,
         features_with_user_question_v1(),
         SessionOpenParams {
@@ -14776,6 +14935,7 @@ async fn session_open_does_not_duplicate_pending_question_already_in_cursor_repl
         &questions,
         ConnectionId::next(),
         None,
+        None,
         features_with_user_question_v1(),
         SessionOpenParams {
             session_id: session_id.clone(),
@@ -15014,6 +15174,7 @@ async fn session_open_does_not_duplicate_pending_approval_already_in_cursor_repl
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         None,
+        None,
         ConnectionUiFeatures::default(),
         SessionOpenParams {
             session_id: session_id.clone(),
@@ -15060,6 +15221,7 @@ async fn session_open_includes_pane_snapshot_after_negotiation() {
         &approvals,
         &PendingQuestionStore::default(),
         ConnectionId::next(),
+        None,
         None,
         ConnectionUiFeatures {
             typed_approvals: false,
@@ -15144,6 +15306,7 @@ async fn session_open_rejects_cwd_without_negotiated_feature() {
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         None,
+        None,
         ConnectionUiFeatures::default(),
         SessionOpenParams {
             session_id,
@@ -15182,6 +15345,7 @@ async fn session_open_result_advertises_full_protocol_when_no_header() {
         &approvals,
         &PendingQuestionStore::default(),
         ConnectionId::next(),
+        None,
         None,
         ConnectionUiFeatures::default(),
         SessionOpenParams {
@@ -15255,6 +15419,7 @@ async fn session_open_result_advertises_intersection_when_header_subset() {
         &approvals,
         &PendingQuestionStore::default(),
         ConnectionId::next(),
+        None,
         None,
         features,
         SessionOpenParams {
@@ -18608,6 +18773,7 @@ async fn cancelled_approval_replays_on_reconnect() {
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         None,
+        None,
         ConnectionUiFeatures::default(),
         SessionOpenParams {
             session_id: session_id.clone(),
@@ -18633,6 +18799,7 @@ async fn cancelled_approval_replays_on_reconnect() {
         &approvals,
         &PendingQuestionStore::default(),
         ConnectionId::next(),
+        None,
         None,
         ConnectionUiFeatures::default(),
         SessionOpenParams {
@@ -20658,6 +20825,7 @@ async fn reconnect_after_decision_replays_decided_event() {
         &approvals,
         &PendingQuestionStore::default(),
         ConnectionId::next(),
+        None,
         None,
         ConnectionUiFeatures::default(),
         SessionOpenParams {
@@ -23472,7 +23640,7 @@ async fn live_forwarder_topic_scope_drops_other_topic_events() {
         ws_alpha.connection_id(),
         ConnectionUiFeatures::default(),
         Some("alpha".into()),
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         alpha_live_rx,
         forwarders_alpha.clone(),
     )
@@ -23487,7 +23655,7 @@ async fn live_forwarder_topic_scope_drops_other_topic_events() {
         ws_beta.connection_id(),
         ConnectionUiFeatures::default(),
         Some("beta".into()),
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         beta_live_rx,
         forwarders_beta.clone(),
     )
@@ -23594,7 +23762,7 @@ async fn live_forwarder_delivers_file_attached_to_topic_scoped_subscriber() {
         ws.connection_id(),
         features_for_file_attached_test(true),
         Some("slides".into()),
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         live_rx,
         forwarders.clone(),
     )
@@ -23647,7 +23815,7 @@ async fn live_forwarder_delivers_tool_and_approval_events_to_topic_scoped_subscr
         ws.connection_id(),
         ConnectionUiFeatures::default(),
         Some("slides".into()),
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         live_rx,
         forwarders.clone(),
     )
@@ -23773,7 +23941,7 @@ async fn live_forwarder_drops_mismatched_topic_for_tool_and_approval_events() {
         ws.connection_id(),
         ConnectionUiFeatures::default(),
         Some("slides".into()),
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         live_rx,
         forwarders.clone(),
     )
@@ -23867,7 +24035,7 @@ async fn live_forwarder_pushes_v2_assistant_persisted_to_subscribed_ws() {
         ws.connection_id(),
         features_for_v2_delivery(),
         None,
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         live_rx,
         forwarders.clone(),
     )
@@ -23912,7 +24080,7 @@ async fn live_forwarder_skips_events_at_or_below_baseline_seq() {
         ws.connection_id(),
         features_for_v2_delivery(),
         None,
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         live_rx,
         forwarders.clone(),
     )
@@ -23958,7 +24126,7 @@ async fn live_forwarder_delivers_v2_without_a_capability_flag() {
         ws.connection_id(),
         features_for_v2_delivery(),
         None,
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         live_rx,
         forwarders.clone(),
     )
@@ -24308,7 +24476,7 @@ async fn v2_connection_receives_v2_envelopes_with_stage_one_fields() {
         ws.connection_id(),
         features_for_projection_envelope_v2_test(),
         None,
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         live_rx,
         forwarders,
     )
@@ -24486,7 +24654,7 @@ async fn v2_background_child_never_appends_to_parent_after_terminal() {
         ws.connection_id(),
         features_for_projection_envelope_v2_test(),
         None,
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         live_rx,
         forwarders,
     )
@@ -24578,7 +24746,7 @@ async fn unnegotiated_connection_receives_only_canonical_v2_wire_shape() {
         ws.connection_id(),
         ConnectionUiFeatures::default(),
         None,
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         live_rx,
         forwarders.clone(),
     )
@@ -25092,7 +25260,7 @@ async fn live_forwarder_routes_background_child_as_canonical_v2() {
         ws.connection_id(),
         ConnectionUiFeatures::default(),
         None,
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         live_rx,
         forwarders.clone(),
     )
@@ -25880,7 +26048,7 @@ async fn live_forwarder_delivers_background_child_without_legacy_fallback() {
         ws.connection_id(),
         ConnectionUiFeatures::default(),
         None,
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         live_rx,
         forwarders.clone(),
     )
@@ -25925,7 +26093,7 @@ async fn live_forwarder_fans_out_to_two_concurrent_ws_connections() {
         ws_a.connection_id(),
         features_for_v2_delivery(),
         None,
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         rx_a_live,
         forwarders_a.clone(),
     )
@@ -25939,7 +26107,7 @@ async fn live_forwarder_fans_out_to_two_concurrent_ws_connections() {
         ws_b.connection_id(),
         features_for_v2_delivery(),
         None,
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         rx_b_live,
         forwarders_b.clone(),
     )
@@ -26051,7 +26219,7 @@ async fn live_forwarder_emits_event_appended_between_replay_and_forwarder_instal
         ws.connection_id(),
         features_for_v2_delivery(),
         None,
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         live_rx,
         forwarders.clone(),
     )
@@ -26098,7 +26266,7 @@ async fn send_notification_durable_does_not_double_deliver_via_live_forwarder() 
         ws.connection_id(),
         features_for_v2_delivery(),
         None,
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         live_rx,
         forwarders.clone(),
     )
@@ -26136,7 +26304,7 @@ async fn send_notification_durable_does_not_double_deliver_via_live_forwarder() 
         ws_other.connection_id(),
         features_for_v2_delivery(),
         None,
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         live_rx_other,
         forwarders_other.clone(),
     )
@@ -26297,7 +26465,7 @@ async fn live_forwarder_survives_broadcast_lag_and_keeps_pumping() {
         ws.connection_id(),
         features_for_v2_delivery(),
         None,
-        MAIN_PROFILE_ID.to_owned(),
+        Some(MAIN_PROFILE_ID.to_owned()),
         live_rx,
         forwarders.clone(),
     )
@@ -27350,6 +27518,7 @@ async fn appui_session_with_custom_cwd_reads_supplied_workspace() {
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         Some("m11e-custom-cwd"),
+        None,
         features,
         SessionOpenParams {
             session_id: session_id.clone(),
@@ -27582,6 +27751,7 @@ async fn session_sandbox_open_override_materializes_distinct_session_policies() 
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         Some("m11-session-sandbox"),
+        None,
         features,
         SessionOpenParams {
             session_id: gamma.clone(),
@@ -27605,6 +27775,7 @@ async fn session_sandbox_open_override_materializes_distinct_session_policies() 
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         Some("m11-session-sandbox"),
+        None,
         features,
         SessionOpenParams {
             session_id: delta.clone(),
@@ -27674,6 +27845,7 @@ async fn two_appui_sessions_on_same_profile_with_different_cwds_isolated() {
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         Some("m11e-multi-cwd"),
+        None,
         features,
         SessionOpenParams {
             session_id: session_a.clone(),
@@ -27695,6 +27867,7 @@ async fn two_appui_sessions_on_same_profile_with_different_cwds_isolated() {
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         Some("m11e-multi-cwd"),
+        None,
         features,
         SessionOpenParams {
             session_id: session_b.clone(),
@@ -27845,6 +28018,7 @@ async fn second_session_open_with_new_cwd_reports_cached_workspace_root() {
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         Some("m11e-rebind-attempt"),
+        None,
         features,
         SessionOpenParams {
             session_id: session_id.clone(),
@@ -27865,6 +28039,7 @@ async fn second_session_open_with_new_cwd_reports_cached_workspace_root() {
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         Some("m11e-rebind-attempt"),
+        None,
         features,
         SessionOpenParams {
             session_id: session_id.clone(),
@@ -27941,6 +28116,7 @@ async fn session_open_with_cwd_for_unregistered_profile_is_rejected() {
         // No connection identity so the routed id falls to the
         // session-id-embedded "m11e-not-registered".
         None,
+        None,
         features,
         SessionOpenParams {
             session_id,
@@ -28010,6 +28186,7 @@ async fn parent_directory_symlink_escapes_per_session_workspace_documents_gap() 
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         Some("m11e-symlink"),
+        None,
         features,
         SessionOpenParams {
             session_id: session_a.clone(),
@@ -28135,6 +28312,7 @@ async fn appui_session_without_client_cwd_respects_operator_default_session_cwd(
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         Some("m11f-tier2-default"),
+        None,
         features,
         SessionOpenParams {
             session_id: session_id.clone(),
@@ -28228,6 +28406,7 @@ async fn appui_no_cwd_workspace_does_not_become_a_transcript_store_hint() {
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         Some(profile_id),
+        None,
         ConnectionUiFeatures {
             session_workspace_cwd: false,
             header_present: true,
@@ -28290,6 +28469,7 @@ async fn appui_explicit_cwd_remains_a_transcript_store_hint() {
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         Some(profile_id),
+        None,
         ConnectionUiFeatures {
             session_workspace_cwd: true,
             header_present: true,

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -13436,6 +13436,345 @@ async fn should_drop_cross_profile_loop_and_monitor_frames_when_connection_scope
     abort_live_forwarders(&forwarders, &ledger).await;
 }
 
+/// #2067 round 2 (H2) — the live forwarder's profile scope must be captured
+/// PER FORWARDER, exactly like `topic_scope`.
+///
+/// `WsConnection` holds ONE shared `live_profile_id` cell, every successful
+/// `session/open` overwrites it, and a connection keeps one forwarder PER
+/// SESSION. An unscoped/admin connection that opens session A under profile A
+/// and then session B under profile B therefore rewrites the scope that A's
+/// already-running forwarder observes — starving session A of every
+/// profile-carrying frame from that moment on. Reading the connection-wide
+/// mutable cell inside the pump is the defect; the fix is to capture the
+/// resolved profile at spawn time.
+#[tokio::test]
+async fn should_keep_delivering_first_session_frames_when_a_second_session_opens_another_profile() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = local_profile_state_with_sessions(temp.path());
+    create_or_get_local_solo_profile(
+        &state,
+        local_profile_params("Alpha Owner", "alpha", "alpha@example.com"),
+    )
+    .expect("create alpha profile");
+    create_or_get_local_solo_profile(
+        &state,
+        local_profile_params("Beta Owner", "beta", "beta@example.com"),
+    )
+    .expect("create beta profile");
+
+    // An UNSCOPED (admin) connection: `connection_profile_id` is `None`, so
+    // each `session/open` may name its own profile.
+    let (ws, mut rx) = ws_connection_for_test(64);
+    let ledger = Arc::new(UiProtocolLedger::new(64));
+    let approvals = PendingApprovalStore::default();
+    let questions = PendingQuestionStore::default();
+    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let session_alpha = SessionKey("web-alpha-session".into());
+    let session_beta = SessionKey("web-beta-session".into());
+
+    for (session_id, profile_id, rpc_id) in [
+        (&session_alpha, "alpha", "open-alpha"),
+        (&session_beta, "beta", "open-beta"),
+    ] {
+        let opened = handle_session_open(
+            &ws,
+            &state,
+            &ledger,
+            &approvals,
+            &questions,
+            &forwarders,
+            None,
+            ConnectionUiFeatures::default(),
+            rpc_id.into(),
+            SessionOpenParams {
+                session_id: session_id.clone(),
+                topic: None,
+                profile_id: Some(profile_id.into()),
+                cwd: None,
+                sandbox: None,
+                after: Some(UiCursor {
+                    stream: session_id.0.clone(),
+                    seq: 0,
+                }),
+            },
+            false,
+        )
+        .await;
+        assert!(opened, "{profile_id} session must open");
+        drain_session_open_frames(&mut rx).await;
+    }
+
+    // Session A's forwarder is still installed and still owns profile alpha —
+    // opening session B under profile beta must not have retargeted it.
+    ledger.append_notification(goal_updated_notification(
+        &session_alpha,
+        Some("alpha"),
+        "alpha objective",
+    ));
+
+    let live = next_frame_within(&mut rx, 2_000).await.expect(
+        "session A's forwarder must still deliver alpha's goal frames after session B opened \
+         under another profile",
+    );
+    assert_eq!(
+        live.get("method").and_then(Value::as_str),
+        Some(octos_core::ui_protocol::methods::SESSION_GOAL_UPDATED),
+    );
+    assert_eq!(live["params"]["session_id"], json!(session_alpha.0));
+    assert_eq!(
+        live["params"]["goal"]["objective"],
+        json!("alpha objective")
+    );
+
+    // …and session B's forwarder is still scoped to beta: an alpha-owned frame
+    // on B's stream stays out.
+    ledger.append_notification(goal_updated_notification(
+        &session_beta,
+        Some("alpha"),
+        "alpha objective on beta's session",
+    ));
+    assert!(
+        next_frame_within(&mut rx, 250).await.is_none(),
+        "session B's forwarder must still reject alpha-owned frames"
+    );
+
+    abort_live_forwarders(&forwarders, &ledger).await;
+}
+
+/// #2067 round 2 (H4) — `session/open` is ledger-appended for BROADCAST
+/// (`open_session_result` tags it with the opening connection id precisely so
+/// other connections observe it), and it carries `workspace_root`, the context
+/// snapshot and pane snapshots. On a shared wire key those are another
+/// tenant's paths and buffers.
+///
+/// Filtering it cannot starve its own opener: the opener's forwarder skips the
+/// broadcast copy via `from_connection`, and its own frame arrives through the
+/// UNFILTERED `send_ledger_event_durable` direct send at the end of
+/// `handle_session_open`. And the scopes agree by construction —
+/// `active_profile_id` is the same `Option` that `ledger_profile_id` is
+/// `unwrap_or(_main)`-ed from, which is exactly how this filter normalizes.
+#[tokio::test]
+async fn should_drop_cross_profile_session_opened_frames_when_connection_scopes_another_profile() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = local_profile_state_with_sessions(temp.path());
+    create_or_get_local_solo_profile(
+        &state,
+        local_profile_params("Alpha Owner", "alpha", "alpha@example.com"),
+    )
+    .expect("create alpha profile");
+    create_or_get_local_solo_profile(
+        &state,
+        local_profile_params("Beta Owner", "beta", "beta@example.com"),
+    )
+    .expect("create beta profile");
+
+    let (ws, mut rx) = ws_connection_for_test(64);
+    let ledger = Arc::new(UiProtocolLedger::new(64));
+    let approvals = PendingApprovalStore::default();
+    let questions = PendingQuestionStore::default();
+    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let session_id = SessionKey("web-shared-opened".into());
+
+    let beta_opened = |workspace_root: &str| {
+        UiNotification::SessionOpened(SessionOpened {
+            session_id: session_id.clone(),
+            active_profile_id: Some("beta".to_owned()),
+            workspace_root: Some(workspace_root.to_owned()),
+            context: None,
+            context_state: None,
+            cursor: None,
+            panes: None,
+            capabilities: UiProtocolCapabilities::first_server_slice(),
+            reasoning_effort: None,
+        })
+    };
+
+    // Beta opened this shared key first; its open frame is durable history.
+    ledger.append_notification(beta_opened("/home/beta/secret-workspace"));
+
+    let opened = handle_session_open(
+        &ws,
+        &state,
+        &ledger,
+        &approvals,
+        &questions,
+        &forwarders,
+        Some("alpha"),
+        ConnectionUiFeatures::default(),
+        "open-alpha-shared".into(),
+        SessionOpenParams {
+            session_id: session_id.clone(),
+            topic: None,
+            profile_id: None,
+            cwd: None,
+            sandbox: None,
+            after: Some(UiCursor {
+                stream: session_id.0.clone(),
+                seq: 0,
+            }),
+        },
+        false,
+    )
+    .await;
+    assert!(opened, "alpha must be able to open the shared session");
+
+    // The drain stops at the first `session/open` NOTIFICATION. Alpha must see
+    // exactly one — its own — and never beta's workspace root.
+    let frames = drain_session_open_frames(&mut rx).await;
+    let opened_frames: Vec<&Value> = frames
+        .iter()
+        .filter(|frame| {
+            frame.get("id").is_none()
+                && frame.get("method").and_then(Value::as_str)
+                    == Some(octos_core::ui_protocol::methods::SESSION_OPEN)
+        })
+        .collect();
+    assert_eq!(
+        opened_frames.len(),
+        1,
+        "alpha must receive exactly one session/open notification: {frames:#?}"
+    );
+    assert_eq!(
+        opened_frames[0]["params"]["active_profile_id"],
+        json!("alpha"),
+        "the session/open alpha receives must be its OWN, not beta's replayed frame"
+    );
+
+    // Live: beta re-opens the shared key from another connection.
+    ledger.append_notification(beta_opened("/home/beta/second-workspace"));
+    assert!(
+        next_frame_within(&mut rx, 250).await.is_none(),
+        "beta's live session/open must not reach an alpha-scoped connection"
+    );
+
+    abort_live_forwarders(&forwarders, &ledger).await;
+}
+
+/// #2067 round 2 (H4) — `background/activity` carries RAW observed text (a
+/// monitor's stdout lines, a fleet summary) and the ledger is its ENTIRE
+/// delivery mechanism: the sink appends it over a detached `WsConnection`
+/// whose writer is drained to nowhere, so every real client gets it from
+/// replay or its live forwarder — both of which run this filter.
+///
+/// Filtering is safe because no production emitter passes `None`: the monitor
+/// origin stamps `AutonomyMonitorRecord.profile_id` and the fleet origin
+/// stamps `FleetRecord.profile_id`, both concrete and both normalized through
+/// `resolve_autonomy_profile_id`. The monitor origin in particular carries the
+/// SAME id as `monitor/fired`, which is already filtered — so this arm adds no
+/// new starvation surface for it.
+#[tokio::test]
+async fn should_drop_cross_profile_background_activity_frames_when_connection_scopes_another_profile()
+ {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = local_profile_state_with_sessions(temp.path());
+    create_or_get_local_solo_profile(
+        &state,
+        local_profile_params("Alpha Owner", "alpha", "alpha@example.com"),
+    )
+    .expect("create alpha profile");
+    create_or_get_local_solo_profile(
+        &state,
+        local_profile_params("Beta Owner", "beta", "beta@example.com"),
+    )
+    .expect("create beta profile");
+
+    let (ws, mut rx) = ws_connection_for_test(64);
+    let ledger = Arc::new(UiProtocolLedger::new(64));
+    let approvals = PendingApprovalStore::default();
+    let questions = PendingQuestionStore::default();
+    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let session_id = SessionKey("web-shared-activity".into());
+    // `background/activity` is capability-gated; negotiate it or the frames
+    // never reach the wire for reasons unrelated to profile scope.
+    let features = ConnectionUiFeatures {
+        background_activity: true,
+        ..Default::default()
+    };
+
+    let activity = |profile_id: &str, text: &str| {
+        UiNotification::BackgroundActivity(octos_core::ui_protocol::BackgroundActivityEvent {
+            session_id: session_id.clone(),
+            profile_id: Some(profile_id.to_owned()),
+            origin_kind: "monitor".to_owned(),
+            origin_id: format!("monitor-{profile_id}"),
+            origin_label: Some(format!("{profile_id}-tail")),
+            text: text.to_owned(),
+            emitted_at_ms: 1_760_000_000_000,
+            dropped_count: None,
+            suppressed: false,
+        })
+    };
+
+    ledger.append_notification(activity("beta", "beta secret log line"));
+    ledger.append_notification(activity("alpha", "alpha log line"));
+
+    let opened = handle_session_open(
+        &ws,
+        &state,
+        &ledger,
+        &approvals,
+        &questions,
+        &forwarders,
+        Some("alpha"),
+        features,
+        "open-alpha-activity".into(),
+        SessionOpenParams {
+            session_id: session_id.clone(),
+            topic: None,
+            profile_id: None,
+            cwd: None,
+            sandbox: None,
+            after: Some(UiCursor {
+                stream: session_id.0.clone(),
+                seq: 0,
+            }),
+        },
+        false,
+    )
+    .await;
+    assert!(opened, "alpha must be able to open the shared session");
+
+    let frames = drain_session_open_frames(&mut rx).await;
+    let replayed: Vec<String> = frames
+        .iter()
+        .filter(|frame| {
+            frame.get("method").and_then(Value::as_str)
+                == Some(octos_core::ui_protocol::methods::BACKGROUND_ACTIVITY)
+        })
+        .map(|frame| {
+            frame["params"]["text"]
+                .as_str()
+                .unwrap_or_default()
+                .to_owned()
+        })
+        .collect();
+    assert_eq!(
+        replayed,
+        vec!["alpha log line".to_owned()],
+        "replay must not put another tenant's observed text on an alpha connection"
+    );
+
+    // Live forwarder leg.
+    ledger.append_notification(activity("beta", "beta live log line"));
+    ledger.append_notification(activity("alpha", "alpha live log line"));
+
+    let live = next_frame_within(&mut rx, 2_000)
+        .await
+        .expect("alpha's own live activity must still be forwarded");
+    assert_eq!(
+        live.get("method").and_then(Value::as_str),
+        Some(octos_core::ui_protocol::methods::BACKGROUND_ACTIVITY),
+        "the only live activity frame alpha may see is its own: {live}"
+    );
+    assert_eq!(live["params"]["text"], json!("alpha live log line"));
+    assert!(
+        next_frame_within(&mut rx, 250).await.is_none(),
+        "beta's live activity must not reach an alpha-scoped connection"
+    );
+
+    abort_live_forwarders(&forwarders, &ledger).await;
+}
+
 #[test]
 fn session_scope_allows_matching_authenticated_profile() {
     let session_id = SessionKey::with_profile("profile-a", "api", "chat-1");
@@ -23133,6 +23472,7 @@ async fn live_forwarder_topic_scope_drops_other_topic_events() {
         ws_alpha.connection_id(),
         ConnectionUiFeatures::default(),
         Some("alpha".into()),
+        MAIN_PROFILE_ID.to_owned(),
         alpha_live_rx,
         forwarders_alpha.clone(),
     )
@@ -23147,6 +23487,7 @@ async fn live_forwarder_topic_scope_drops_other_topic_events() {
         ws_beta.connection_id(),
         ConnectionUiFeatures::default(),
         Some("beta".into()),
+        MAIN_PROFILE_ID.to_owned(),
         beta_live_rx,
         forwarders_beta.clone(),
     )
@@ -23253,6 +23594,7 @@ async fn live_forwarder_delivers_file_attached_to_topic_scoped_subscriber() {
         ws.connection_id(),
         features_for_file_attached_test(true),
         Some("slides".into()),
+        MAIN_PROFILE_ID.to_owned(),
         live_rx,
         forwarders.clone(),
     )
@@ -23305,6 +23647,7 @@ async fn live_forwarder_delivers_tool_and_approval_events_to_topic_scoped_subscr
         ws.connection_id(),
         ConnectionUiFeatures::default(),
         Some("slides".into()),
+        MAIN_PROFILE_ID.to_owned(),
         live_rx,
         forwarders.clone(),
     )
@@ -23430,6 +23773,7 @@ async fn live_forwarder_drops_mismatched_topic_for_tool_and_approval_events() {
         ws.connection_id(),
         ConnectionUiFeatures::default(),
         Some("slides".into()),
+        MAIN_PROFILE_ID.to_owned(),
         live_rx,
         forwarders.clone(),
     )
@@ -23523,6 +23867,7 @@ async fn live_forwarder_pushes_v2_assistant_persisted_to_subscribed_ws() {
         ws.connection_id(),
         features_for_v2_delivery(),
         None,
+        MAIN_PROFILE_ID.to_owned(),
         live_rx,
         forwarders.clone(),
     )
@@ -23567,6 +23912,7 @@ async fn live_forwarder_skips_events_at_or_below_baseline_seq() {
         ws.connection_id(),
         features_for_v2_delivery(),
         None,
+        MAIN_PROFILE_ID.to_owned(),
         live_rx,
         forwarders.clone(),
     )
@@ -23612,6 +23958,7 @@ async fn live_forwarder_delivers_v2_without_a_capability_flag() {
         ws.connection_id(),
         features_for_v2_delivery(),
         None,
+        MAIN_PROFILE_ID.to_owned(),
         live_rx,
         forwarders.clone(),
     )
@@ -23961,6 +24308,7 @@ async fn v2_connection_receives_v2_envelopes_with_stage_one_fields() {
         ws.connection_id(),
         features_for_projection_envelope_v2_test(),
         None,
+        MAIN_PROFILE_ID.to_owned(),
         live_rx,
         forwarders,
     )
@@ -24138,6 +24486,7 @@ async fn v2_background_child_never_appends_to_parent_after_terminal() {
         ws.connection_id(),
         features_for_projection_envelope_v2_test(),
         None,
+        MAIN_PROFILE_ID.to_owned(),
         live_rx,
         forwarders,
     )
@@ -24229,6 +24578,7 @@ async fn unnegotiated_connection_receives_only_canonical_v2_wire_shape() {
         ws.connection_id(),
         ConnectionUiFeatures::default(),
         None,
+        MAIN_PROFILE_ID.to_owned(),
         live_rx,
         forwarders.clone(),
     )
@@ -24742,6 +25092,7 @@ async fn live_forwarder_routes_background_child_as_canonical_v2() {
         ws.connection_id(),
         ConnectionUiFeatures::default(),
         None,
+        MAIN_PROFILE_ID.to_owned(),
         live_rx,
         forwarders.clone(),
     )
@@ -25529,6 +25880,7 @@ async fn live_forwarder_delivers_background_child_without_legacy_fallback() {
         ws.connection_id(),
         ConnectionUiFeatures::default(),
         None,
+        MAIN_PROFILE_ID.to_owned(),
         live_rx,
         forwarders.clone(),
     )
@@ -25573,6 +25925,7 @@ async fn live_forwarder_fans_out_to_two_concurrent_ws_connections() {
         ws_a.connection_id(),
         features_for_v2_delivery(),
         None,
+        MAIN_PROFILE_ID.to_owned(),
         rx_a_live,
         forwarders_a.clone(),
     )
@@ -25586,6 +25939,7 @@ async fn live_forwarder_fans_out_to_two_concurrent_ws_connections() {
         ws_b.connection_id(),
         features_for_v2_delivery(),
         None,
+        MAIN_PROFILE_ID.to_owned(),
         rx_b_live,
         forwarders_b.clone(),
     )
@@ -25697,6 +26051,7 @@ async fn live_forwarder_emits_event_appended_between_replay_and_forwarder_instal
         ws.connection_id(),
         features_for_v2_delivery(),
         None,
+        MAIN_PROFILE_ID.to_owned(),
         live_rx,
         forwarders.clone(),
     )
@@ -25743,6 +26098,7 @@ async fn send_notification_durable_does_not_double_deliver_via_live_forwarder() 
         ws.connection_id(),
         features_for_v2_delivery(),
         None,
+        MAIN_PROFILE_ID.to_owned(),
         live_rx,
         forwarders.clone(),
     )
@@ -25780,6 +26136,7 @@ async fn send_notification_durable_does_not_double_deliver_via_live_forwarder() 
         ws_other.connection_id(),
         features_for_v2_delivery(),
         None,
+        MAIN_PROFILE_ID.to_owned(),
         live_rx_other,
         forwarders_other.clone(),
     )
@@ -25940,6 +26297,7 @@ async fn live_forwarder_survives_broadcast_lag_and_keeps_pumping() {
         ws.connection_id(),
         features_for_v2_delivery(),
         None,
+        MAIN_PROFILE_ID.to_owned(),
         live_rx,
         forwarders.clone(),
     )

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -12947,7 +12947,7 @@ async fn should_retain_only_same_profile_goal_events_when_open_session_result_re
         &PendingQuestionStore::default(),
         ConnectionId::next(),
         Some("alpha"),
-        None,
+        Some("alpha"),
         ConnectionUiFeatures::default(),
         SessionOpenParams {
             session_id: session_id.clone(),
@@ -13036,7 +13036,7 @@ async fn should_drop_cross_profile_goal_frames_when_connection_scopes_another_pr
         &questions,
         &forwarders,
         Some("alpha"),
-        None,
+        Some("alpha"),
         ConnectionUiFeatures::default(),
         "open-alpha".into(),
         SessionOpenParams {
@@ -13100,13 +13100,18 @@ async fn should_drop_cross_profile_goal_frames_when_connection_scopes_another_pr
     abort_live_forwarders(&forwarders, &ledger).await;
 }
 
-/// #2067 compatibility: an unprofiled connection resolves to `_main`
-/// (`WsConnection::new` seeds `MAIN_PROFILE_ID`; `open_session_result` returns
-/// `active_profile_id.unwrap_or(MAIN_PROFILE_ID)`), and every goal emitter
-/// stamps `_main` explicitly for an unprofiled deployment. A LEGACY row that
-/// predates the stamp carries no `profile_id` at all — it must normalize to
-/// `_main` so single-tenant deployments keep every frame they have today,
-/// while a genuinely foreign profile is still dropped.
+/// #2067 compatibility: an unprofiled connection must keep every frame it has
+/// today. It resolves to `_main`, every goal emitter stamps `_main` explicitly
+/// for an unprofiled deployment, and a LEGACY row predating the stamp carries
+/// no `profile_id` at all.
+///
+/// Such a connection is also not FILTERED at all — it has no frozen profile
+/// pin, so its session scope is not a tenant boundary (see
+/// `ledger_event_matches_profile_scope`) — which is why the foreign frame below
+/// is delivered too. That costs no isolation: an unscoped connection is an
+/// admin/operator authorized for every profile. The isolation guarantee lives
+/// on authenticated connections, pinned by the `should_drop_cross_profile_*`
+/// tests.
 #[tokio::test]
 async fn should_replay_main_and_legacy_goal_frames_when_connection_is_unprofiled() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -13170,13 +13175,17 @@ async fn should_replay_main_and_legacy_goal_frames_when_connection_is_unprofiled
     let frames = drain_session_open_frames(&mut rx).await;
     assert_eq!(
         replayed_goal_objectives(&frames),
-        vec!["main objective".to_owned(), "legacy objective".to_owned()],
-        "a `_main` connection keeps both `_main` and legacy unstamped goal frames"
+        vec![
+            "main objective".to_owned(),
+            "legacy objective".to_owned(),
+            "beta secret objective".to_owned(),
+        ],
+        "an unfiltered connection keeps `_main`, legacy unstamped AND foreign goal frames"
     );
     assert_eq!(
         replayed_cleared_profiles(&frames),
         vec![Value::Null],
-        "a legacy `session/goal/cleared` with no profile must still reach `_main`"
+        "a legacy `session/goal/cleared` with no profile must still be replayed"
     );
 
     // Live forwarder: same compatibility contract on the live path.
@@ -13191,20 +13200,26 @@ async fn should_replay_main_and_legacy_goal_frames_when_connection_is_unprofiled
         "legacy live objective",
     ));
 
-    let live = next_frame_within(&mut rx, 2_000)
-        .await
-        .expect("a legacy live goal frame must still reach a `_main` connection");
+    let mut live_objectives: Vec<String> = Vec::new();
+    while let Some(frame) = next_frame_within(&mut rx, 500).await {
+        if frame.get("method").and_then(Value::as_str)
+            == Some(octos_core::ui_protocol::methods::SESSION_GOAL_UPDATED)
+        {
+            live_objectives.push(
+                frame["params"]["goal"]["objective"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_owned(),
+            );
+        }
+    }
     assert_eq!(
-        live.get("method").and_then(Value::as_str),
-        Some(octos_core::ui_protocol::methods::SESSION_GOAL_UPDATED),
-    );
-    assert_eq!(
-        live["params"]["goal"]["objective"],
-        json!("legacy live objective")
-    );
-    assert!(
-        next_frame_within(&mut rx, 250).await.is_none(),
-        "profile-b's live goal frame must not reach a `_main` connection"
+        live_objectives,
+        vec![
+            "beta live objective".to_owned(),
+            "legacy live objective".to_owned(),
+        ],
+        "the live path applies the same no-filter contract as replay"
     );
 
     abort_live_forwarders(&forwarders, &ledger).await;
@@ -13341,7 +13356,7 @@ async fn should_drop_cross_profile_loop_and_monitor_frames_when_connection_scope
         &questions,
         &forwarders,
         Some("alpha"),
-        None,
+        Some("alpha"),
         ConnectionUiFeatures::default(),
         "open-alpha-autonomy".into(),
         SessionOpenParams {
@@ -13450,107 +13465,95 @@ async fn should_drop_cross_profile_loop_and_monitor_frames_when_connection_scope
     abort_live_forwarders(&forwarders, &ledger).await;
 }
 
-/// #2067 round 2 (H2) — the live forwarder's profile scope must be captured
-/// PER FORWARDER, exactly like `topic_scope`.
+/// #2067 round 2 (H2) — a forwarder's profile scope must be captured PER
+/// FORWARDER, exactly like `topic_scope`.
 ///
-/// `WsConnection` holds ONE shared `live_profile_id` cell, every successful
-/// `session/open` overwrites it, and a connection keeps one forwarder PER
-/// SESSION. An unscoped/admin connection that opens session A under profile A
-/// and then session B under profile B therefore rewrites the scope that A's
-/// already-running forwarder observes — starving session A of every
-/// profile-carrying frame from that moment on. Reading the connection-wide
-/// mutable cell inside the pump is the defect; the fix is to capture the
-/// resolved profile at spawn time.
+/// The pump originally read a single `live_profile_id` cell on `WsConnection`
+/// that every `session/open` overwrote, while a connection keeps one forwarder
+/// PER SESSION — so opening a second session under another profile retargeted
+/// the first session's pump. The scope is now a `spawn_live_forwarder`
+/// parameter, owned by the spawned task.
+///
+/// Driven at the forwarder boundary because that is where the invariant lives:
+/// round 4 made an unscoped connection non-filterable, and an AUTHENTICATED
+/// connection forces every session it opens to the one frozen profile, so no
+/// `session/open` sequence can exhibit two live scopes on one connection any
+/// more. The invariant still has to hold — it becomes load-bearing again the
+/// moment the scope-resolution divergence in #2081 is closed.
 #[tokio::test]
-async fn should_keep_delivering_first_session_frames_when_a_second_session_opens_another_profile() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let state = local_profile_state_with_sessions(temp.path());
-    create_or_get_local_solo_profile(
-        &state,
-        local_profile_params("Alpha Owner", "alpha", "alpha@example.com"),
-    )
-    .expect("create alpha profile");
-    create_or_get_local_solo_profile(
-        &state,
-        local_profile_params("Beta Owner", "beta", "beta@example.com"),
-    )
-    .expect("create beta profile");
-
-    // An UNSCOPED (admin) connection: `connection_profile_id` is `None`, so
-    // each `session/open` may name its own profile.
+async fn should_scope_each_forwarder_independently_when_one_connection_pumps_two_profiles() {
     let (ws, mut rx) = ws_connection_for_test(64);
     let ledger = Arc::new(UiProtocolLedger::new(64));
-    let approvals = PendingApprovalStore::default();
-    let questions = PendingQuestionStore::default();
     let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
     let session_alpha = SessionKey("web-alpha-session".into());
     let session_beta = SessionKey("web-beta-session".into());
 
-    for (session_id, profile_id, rpc_id) in [
-        (&session_alpha, "alpha", "open-alpha"),
-        (&session_beta, "beta", "open-beta"),
-    ] {
-        let opened = handle_session_open(
-            &ws,
-            &state,
-            &ledger,
-            &approvals,
-            &questions,
-            &forwarders,
-            None,
-            None,
+    for (session_id, profile_id) in [(&session_alpha, "alpha"), (&session_beta, "beta")] {
+        let live_rx = ledger.subscribe(session_id);
+        spawn_live_forwarder(
+            ws.clone(),
+            ledger.clone(),
+            session_id.clone(),
+            0,
+            ws.connection_id(),
             ConnectionUiFeatures::default(),
-            rpc_id.into(),
-            SessionOpenParams {
-                session_id: session_id.clone(),
-                topic: None,
-                profile_id: Some(profile_id.into()),
-                cwd: None,
-                sandbox: None,
-                after: Some(UiCursor {
-                    stream: session_id.0.clone(),
-                    seq: 0,
-                }),
-            },
-            false,
+            None,
+            Some(profile_id.to_owned()),
+            live_rx,
+            forwarders.clone(),
         )
         .await;
-        assert!(opened, "{profile_id} session must open");
-        drain_session_open_frames(&mut rx).await;
     }
 
-    // Session A's forwarder is still installed and still owns profile alpha —
-    // opening session B under profile beta must not have retargeted it.
+    // Each forwarder keeps its OWN scope: the second spawn must not retarget
+    // the first, in either direction.
     ledger.append_notification(goal_updated_notification(
         &session_alpha,
         Some("alpha"),
         "alpha objective",
     ));
-
-    let live = next_frame_within(&mut rx, 2_000).await.expect(
-        "session A's forwarder must still deliver alpha's goal frames after session B opened \
-         under another profile",
-    );
-    assert_eq!(
-        live.get("method").and_then(Value::as_str),
-        Some(octos_core::ui_protocol::methods::SESSION_GOAL_UPDATED),
-    );
-    assert_eq!(live["params"]["session_id"], json!(session_alpha.0));
-    assert_eq!(
-        live["params"]["goal"]["objective"],
-        json!("alpha objective")
-    );
-
-    // …and session B's forwarder is still scoped to beta: an alpha-owned frame
-    // on B's stream stays out.
+    ledger.append_notification(goal_updated_notification(
+        &session_beta,
+        Some("beta"),
+        "beta objective",
+    ));
+    // …and each still rejects the other's profile on its own stream.
+    ledger.append_notification(goal_updated_notification(
+        &session_alpha,
+        Some("beta"),
+        "beta objective on alpha's session",
+    ));
     ledger.append_notification(goal_updated_notification(
         &session_beta,
         Some("alpha"),
         "alpha objective on beta's session",
     ));
-    assert!(
-        next_frame_within(&mut rx, 250).await.is_none(),
-        "session B's forwarder must still reject alpha-owned frames"
+
+    let mut delivered: Vec<(String, String)> = Vec::new();
+    while let Some(frame) = next_frame_within(&mut rx, 500).await {
+        if frame.get("method").and_then(Value::as_str)
+            == Some(octos_core::ui_protocol::methods::SESSION_GOAL_UPDATED)
+        {
+            delivered.push((
+                frame["params"]["session_id"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_owned(),
+                frame["params"]["goal"]["objective"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_owned(),
+            ));
+        }
+    }
+    delivered.sort();
+    assert_eq!(
+        delivered,
+        vec![
+            (session_alpha.0.clone(), "alpha objective".to_owned()),
+            (session_beta.0.clone(), "beta objective".to_owned()),
+        ],
+        "each forwarder must apply its own captured scope, not a shared one"
     );
 
     abort_live_forwarders(&forwarders, &ledger).await;
@@ -13615,7 +13618,7 @@ async fn should_drop_cross_profile_session_opened_frames_when_connection_scopes_
         &questions,
         &forwarders,
         Some("alpha"),
-        None,
+        Some("alpha"),
         ConnectionUiFeatures::default(),
         "open-alpha-shared".into(),
         SessionOpenParams {
@@ -13732,7 +13735,7 @@ async fn should_drop_cross_profile_background_activity_frames_when_connection_sc
         &questions,
         &forwarders,
         Some("alpha"),
-        None,
+        Some("alpha"),
         features,
         "open-alpha-activity".into(),
         SessionOpenParams {
@@ -13807,6 +13810,11 @@ async fn should_drop_cross_profile_background_activity_frames_when_connection_sc
 /// frames those records later emit are stamped `beta`, so a `_main` filter
 /// drops the connection's OWN data.
 ///
+/// Round 4 generalised the guard: an unscoped connection has no frozen profile
+/// pin at all, however it was routed, so it is never filtered. This case is
+/// what motivated that guard, and it still pins it across three variants at
+/// once.
+///
 /// `background/activity` is the worst case: its sink appends over a detached
 /// connection whose writer is discarded, so replay and live forwarding are its
 /// only delivery paths — a filter drop there is total.
@@ -13873,10 +13881,11 @@ async fn should_deliver_routed_profile_frames_when_the_connection_scope_is_not_a
         &approvals,
         &questions,
         &forwarders,
-        // admin / unscoped …
+        // Admin / unscoped: no authenticated profile …
         None,
-        // … but routed to `beta` by subdomain or header.
-        Some("beta"),
+        // … and therefore no frozen profile pin either, however the connection
+        // was routed. The WS handler passes `connection_profile_id` for both.
+        None,
         features,
         "open-routed-admin".into(),
         SessionOpenParams {
@@ -13923,6 +13932,175 @@ async fn should_deliver_routed_profile_frames_when_the_connection_scope_is_not_a
         Some(octos_core::ui_protocol::methods::BACKGROUND_ACTIVITY),
     );
     assert_eq!(live["params"]["text"], json!("live log line"));
+
+    abort_live_forwarders(&forwarders, &ledger).await;
+}
+
+/// #2067 round 4 — an UNSCOPED connection's per-session scope diverges from the
+/// profile its own turns run under, with no routing header involved.
+///
+/// `session_open_profile_id` is a single per-connection cell overwritten by
+/// every successful open, and every later `turn/start` — including one on an
+/// EARLIER session — receives that latest value and selects that runtime. So:
+/// open bare A (resolves `_main`), open bare B as `beta`, then run a turn on A.
+/// A's forwarder still holds `_main` while the turn runs under `beta`, and a
+/// monitor the model creates in that turn is stamped `beta`
+/// (`runtime/profile.rs` -> `goal_tool.rs`). The turn misrouting is pre-existing;
+/// the DELIVERY DROP is not — it exists only because the frame is filtered.
+///
+/// `background/activity` is the worst case: its sink appends over a detached
+/// connection whose writer is discarded, so replay and live fan-out are its
+/// only delivery paths and the drop is total.
+#[tokio::test]
+async fn should_deliver_later_profile_frames_when_an_unscoped_connection_opened_two_sessions() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = local_profile_state_with_sessions(temp.path());
+    create_or_get_local_solo_profile(
+        &state,
+        local_profile_params("Beta Owner", "beta", "beta@example.com"),
+    )
+    .expect("create beta profile");
+
+    let (ws, mut rx) = ws_connection_for_test(64);
+    let ledger = Arc::new(UiProtocolLedger::new(64));
+    let approvals = PendingApprovalStore::default();
+    let questions = PendingQuestionStore::default();
+    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let session_a = SessionKey("web-two-open-a".into());
+    let session_b = SessionKey("web-two-open-b".into());
+    let features = ConnectionUiFeatures {
+        background_activity: true,
+        ..Default::default()
+    };
+
+    let beta_activity = |text: &str| {
+        UiNotification::BackgroundActivity(octos_core::ui_protocol::BackgroundActivityEvent {
+            session_id: session_a.clone(),
+            profile_id: Some("beta".to_owned()),
+            origin_kind: "monitor".to_owned(),
+            origin_id: "monitor-model-made".to_owned(),
+            origin_label: Some("ci-tail".to_owned()),
+            text: text.to_owned(),
+            emitted_at_ms: 1_760_000_000_000,
+            dropped_count: None,
+            suppressed: false,
+        })
+    };
+
+    // No routing header anywhere: this connection is plain unscoped.
+    let open = |session_id: SessionKey, profile_id: Option<&str>, rpc_id: &str| {
+        let params = SessionOpenParams {
+            session_id: session_id.clone(),
+            topic: None,
+            profile_id: profile_id.map(ToOwned::to_owned),
+            cwd: None,
+            sandbox: None,
+            after: Some(UiCursor {
+                stream: session_id.0.clone(),
+                seq: 0,
+            }),
+        };
+        (params, rpc_id.to_owned())
+    };
+
+    let (params_a, id_a) = open(session_a.clone(), None, "open-a");
+    assert!(
+        handle_session_open(
+            &ws,
+            &state,
+            &ledger,
+            &approvals,
+            &questions,
+            &forwarders,
+            None,
+            None,
+            features,
+            id_a,
+            params_a,
+            false,
+        )
+        .await,
+        "bare session A must open on an unscoped connection"
+    );
+    drain_session_open_frames(&mut rx).await;
+
+    let (params_b, id_b) = open(session_b.clone(), Some("beta"), "open-b");
+    assert!(
+        handle_session_open(
+            &ws,
+            &state,
+            &ledger,
+            &approvals,
+            &questions,
+            &forwarders,
+            None,
+            None,
+            features,
+            id_b,
+            params_b,
+            false,
+        )
+        .await,
+        "bare session B must open under beta on the same connection"
+    );
+    drain_session_open_frames(&mut rx).await;
+
+    // A turn on session A now runs under beta's runtime, so the monitor it
+    // creates emits beta-stamped activity onto session A's stream.
+    ledger.append_notification(beta_activity("live log line"));
+
+    let live = next_frame_within(&mut rx, 2_000).await.expect(
+        "session A must still receive the activity its own turn produced, even though the turn \
+         ran under the profile a later open bound",
+    );
+    assert_eq!(
+        live.get("method").and_then(Value::as_str),
+        Some(octos_core::ui_protocol::methods::BACKGROUND_ACTIVITY),
+    );
+    assert_eq!(live["params"]["text"], json!("live log line"));
+
+    // Same property on reconnect replay — the only other delivery path this
+    // notification has.
+    let (params_reconnect, id_reconnect) = open(session_a.clone(), None, "reopen-a");
+    assert!(
+        handle_session_open(
+            &ws,
+            &state,
+            &ledger,
+            &approvals,
+            &questions,
+            &forwarders,
+            None,
+            None,
+            features,
+            id_reconnect,
+            params_reconnect,
+            false,
+        )
+        .await,
+        "session A must reopen"
+    );
+    // Drain everything the reopen queued rather than stopping at the first
+    // `session/open` notification — on a reconnect the REPLAYED historical open
+    // frame precedes the activity we are looking for.
+    let mut replayed: Vec<String> = Vec::new();
+    while let Some(frame) = next_frame_within(&mut rx, 500).await {
+        if frame.get("method").and_then(Value::as_str)
+            == Some(octos_core::ui_protocol::methods::BACKGROUND_ACTIVITY)
+        {
+            replayed.push(
+                frame["params"]["text"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_owned(),
+            );
+        }
+    }
+    assert_eq!(
+        replayed,
+        vec!["live log line".to_owned()],
+        "reconnect replay must not drop session A's own activity"
+    );
 
     abort_live_forwarders(&forwarders, &ledger).await;
 }

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -12778,6 +12778,664 @@ fn skill_action_job_events_are_visible_only_to_their_profile() {
     assert!(!ledger_event_matches_profile_scope(&event, "profile-b"));
 }
 
+// ---------------------------------------------------------------------------
+// #2067 — cross-profile goal frames must not cross the profile scope filter.
+//
+// `SessionGoalUpdated` / `SessionGoalCleared` are appended DURABLY (the
+// `record_autonomy_rpc_evidence` -> `send_notification_durable` path at the raw
+// autonomy RPC dispatch), so they reach every connection subscribed to the wire
+// session key through all three delivery boundaries: the `replay.retain` in
+// `open_session_result`, the session/open replay send loop, and the live
+// forwarder pump. Before the fix all three passed them through `_ => true`.
+// ---------------------------------------------------------------------------
+
+/// A durable `session/goal/updated` for `profile_id`. `None` models a LEGACY
+/// row: the wire field is `skip_serializing_if = "Option::is_none"`, so a
+/// ledger line written by a backend that predates the profile stamp decodes
+/// back as `None`.
+fn goal_updated_notification(
+    session_id: &SessionKey,
+    profile_id: Option<&str>,
+    objective: &str,
+) -> UiNotification {
+    UiNotification::SessionGoalUpdated(octos_core::ui_protocol::SessionGoalUpdatedEvent {
+        session_id: session_id.clone(),
+        profile_id: profile_id.map(ToOwned::to_owned),
+        goal: octos_core::ui_protocol::UiGoalRecord {
+            profile_id: profile_id.map(ToOwned::to_owned),
+            goal_id: format!("goal-{objective}"),
+            objective: objective.to_owned(),
+            status: "active".to_owned(),
+            token_budget: 1_000,
+            tokens_used: 0,
+            time_used_seconds: 0,
+            created_at_ms: 0,
+            updated_at_ms: 0,
+        },
+        transition_actor: "user".to_owned(),
+        generation: 0,
+    })
+}
+
+/// A durable `session/goal/cleared` for `profile_id`. The clear RPC emits
+/// `"goal": null`, so the nested record is absent and the top-level
+/// `profile_id` is the only scope the frame carries.
+fn goal_cleared_notification(session_id: &SessionKey, profile_id: Option<&str>) -> UiNotification {
+    UiNotification::SessionGoalCleared(octos_core::ui_protocol::SessionGoalClearedEvent {
+        session_id: session_id.clone(),
+        profile_id: profile_id.map(ToOwned::to_owned),
+        cleared: true,
+        goal: None,
+        transition_actor: "user".to_owned(),
+        generation: 0,
+    })
+}
+
+/// Drain every frame `handle_session_open` queued, up to and including the
+/// `session/open` NOTIFICATION it direct-sends last (distinguished from the
+/// RPC result frame by having no `id`). Frames the replay loop filtered out
+/// simply never appear.
+async fn drain_session_open_frames(rx: &mut mpsc::Receiver<WsMessage>) -> Vec<Value> {
+    let mut frames = Vec::new();
+    loop {
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("session/open frames arrive within the timeout")
+            .expect("ws stays open");
+        let WsMessage::Text(text) = &frame else {
+            panic!("expected a text frame, got {frame:?}");
+        };
+        let value: Value = serde_json::from_str(text).expect("json frame");
+        let opened = value.get("id").is_none()
+            && value.get("method").and_then(Value::as_str)
+                == Some(octos_core::ui_protocol::methods::SESSION_OPEN);
+        frames.push(value);
+        if opened {
+            return frames;
+        }
+    }
+}
+
+/// The `objective` of every `session/goal/updated` frame in `frames`, in order.
+fn replayed_goal_objectives(frames: &[Value]) -> Vec<String> {
+    frames
+        .iter()
+        .filter(|frame| {
+            frame.get("method").and_then(Value::as_str)
+                == Some(octos_core::ui_protocol::methods::SESSION_GOAL_UPDATED)
+        })
+        .map(|frame| {
+            frame["params"]["goal"]["objective"]
+                .as_str()
+                .unwrap_or_default()
+                .to_owned()
+        })
+        .collect()
+}
+
+/// The `profile_id` of every `session/goal/cleared` frame in `frames`.
+fn replayed_cleared_profiles(frames: &[Value]) -> Vec<Value> {
+    frames
+        .iter()
+        .filter(|frame| {
+            frame.get("method").and_then(Value::as_str)
+                == Some(octos_core::ui_protocol::methods::SESSION_GOAL_CLEARED)
+        })
+        .map(|frame| frame["params"]["profile_id"].clone())
+        .collect()
+}
+
+/// Read the next frame, or `None` when nothing arrives within `ms`.
+async fn next_frame_within(rx: &mut mpsc::Receiver<WsMessage>, ms: u64) -> Option<Value> {
+    match tokio::time::timeout(std::time::Duration::from_millis(ms), rx.recv()).await {
+        Ok(Some(WsMessage::Text(text))) => Some(serde_json::from_str(&text).expect("json frame")),
+        Ok(other) => panic!("expected a text frame, got {other:?}"),
+        Err(_) => None,
+    }
+}
+
+/// #2067 boundary 1 (retained events): `open_session_result`'s `replay.retain`
+/// must strip a durable goal frame bound to another profile before the outcome
+/// is ever handed to the send loop.
+#[tokio::test]
+async fn should_retain_only_same_profile_goal_events_when_open_session_result_replays() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = local_profile_state_with_sessions(temp.path());
+    create_or_get_local_solo_profile(
+        &state,
+        local_profile_params("Alpha Owner", "alpha", "alpha@example.com"),
+    )
+    .expect("create alpha profile");
+    create_or_get_local_solo_profile(
+        &state,
+        local_profile_params("Beta Owner", "beta", "beta@example.com"),
+    )
+    .expect("create beta profile");
+
+    let ledger = UiProtocolLedger::new(64);
+    let approvals = PendingApprovalStore::default();
+    // A SHARED, unprofiled wire key: `validate_authenticated_session_scope`
+    // accepts a bare `web-N` id under profile auth, so two tenants can open it.
+    let session_id = SessionKey("web-shared-retain".into());
+
+    ledger.append_notification(goal_updated_notification(
+        &session_id,
+        Some("beta"),
+        "beta secret objective",
+    ));
+    ledger.append_notification(goal_cleared_notification(&session_id, Some("beta")));
+    ledger.append_notification(goal_updated_notification(
+        &session_id,
+        Some("alpha"),
+        "alpha objective",
+    ));
+
+    let outcome = open_session_result(
+        &state,
+        &ledger,
+        &approvals,
+        &PendingQuestionStore::default(),
+        ConnectionId::next(),
+        Some("alpha"),
+        ConnectionUiFeatures::default(),
+        SessionOpenParams {
+            session_id: session_id.clone(),
+            topic: None,
+            profile_id: None,
+            cwd: None,
+            sandbox: None,
+            after: Some(UiCursor {
+                stream: session_id.0.clone(),
+                seq: 0,
+            }),
+        },
+    )
+    .await
+    .expect("alpha opens the shared session");
+
+    assert_eq!(outcome.profile_id, "alpha");
+    let retained: Vec<&str> = outcome
+        .replay
+        .iter()
+        .map(|event| ledger_event_method(&event.event))
+        .collect();
+    assert!(
+        !retained.contains(&octos_core::ui_protocol::methods::SESSION_GOAL_CLEARED),
+        "profile-b `session/goal/cleared` must not survive the retain filter: {retained:?}"
+    );
+    let objectives: Vec<String> = outcome
+        .replay
+        .iter()
+        .filter_map(|event| match &event.event {
+            UiProtocolLedgerEvent::Notification(UiNotification::SessionGoalUpdated(goal)) => {
+                Some(goal.goal.objective.clone())
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        objectives,
+        vec!["alpha objective".to_owned()],
+        "only alpha's goal may be retained for an alpha-scoped open"
+    );
+}
+
+/// #2067 boundaries 2 and 3 (session/open replay send loop + live forwarder):
+/// neither may put profile-b's durable goal frames on a profile-a connection.
+#[tokio::test]
+async fn should_drop_cross_profile_goal_frames_when_connection_scopes_another_profile() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = local_profile_state_with_sessions(temp.path());
+    create_or_get_local_solo_profile(
+        &state,
+        local_profile_params("Alpha Owner", "alpha", "alpha@example.com"),
+    )
+    .expect("create alpha profile");
+    create_or_get_local_solo_profile(
+        &state,
+        local_profile_params("Beta Owner", "beta", "beta@example.com"),
+    )
+    .expect("create beta profile");
+
+    let (ws, mut rx) = ws_connection_for_test(64);
+    let ledger = Arc::new(UiProtocolLedger::new(64));
+    let approvals = PendingApprovalStore::default();
+    let questions = PendingQuestionStore::default();
+    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let session_id = SessionKey("web-shared-live".into());
+
+    // Durable history on the SHARED wire key, laid down before alpha connects.
+    ledger.append_notification(goal_updated_notification(
+        &session_id,
+        Some("beta"),
+        "beta secret objective",
+    ));
+    ledger.append_notification(goal_cleared_notification(&session_id, Some("beta")));
+    ledger.append_notification(goal_updated_notification(
+        &session_id,
+        Some("alpha"),
+        "alpha objective",
+    ));
+
+    let opened = handle_session_open(
+        &ws,
+        &state,
+        &ledger,
+        &approvals,
+        &questions,
+        &forwarders,
+        Some("alpha"),
+        ConnectionUiFeatures::default(),
+        "open-alpha".into(),
+        SessionOpenParams {
+            session_id: session_id.clone(),
+            topic: None,
+            profile_id: None,
+            cwd: None,
+            sandbox: None,
+            after: Some(UiCursor {
+                stream: session_id.0.clone(),
+                seq: 0,
+            }),
+        },
+        false,
+    )
+    .await;
+    assert!(opened, "alpha must be able to open the shared session");
+
+    // Boundary 2 — the replay send loop.
+    let frames = drain_session_open_frames(&mut rx).await;
+    assert_eq!(
+        replayed_goal_objectives(&frames),
+        vec!["alpha objective".to_owned()],
+        "replay must not put profile-b's objective on an alpha-scoped connection"
+    );
+    assert!(
+        replayed_cleared_profiles(&frames).is_empty(),
+        "replay must not put profile-b's `session/goal/cleared` on an alpha connection"
+    );
+
+    // Boundary 3 — the live forwarder pump.
+    ledger.append_notification(goal_updated_notification(
+        &session_id,
+        Some("beta"),
+        "beta live objective",
+    ));
+    ledger.append_notification(goal_cleared_notification(&session_id, Some("beta")));
+    ledger.append_notification(goal_updated_notification(
+        &session_id,
+        Some("alpha"),
+        "alpha live objective",
+    ));
+
+    let live = next_frame_within(&mut rx, 2_000)
+        .await
+        .expect("alpha's own live goal frame must still be forwarded");
+    assert_eq!(
+        live.get("method").and_then(Value::as_str),
+        Some(octos_core::ui_protocol::methods::SESSION_GOAL_UPDATED),
+        "the only live goal frame alpha may see is its own: {live}"
+    );
+    assert_eq!(
+        live["params"]["goal"]["objective"],
+        json!("alpha live objective")
+    );
+    assert!(
+        next_frame_within(&mut rx, 250).await.is_none(),
+        "no further live frames may reach an alpha-scoped connection"
+    );
+
+    abort_live_forwarders(&forwarders, &ledger).await;
+}
+
+/// #2067 compatibility: an unprofiled connection resolves to `_main`
+/// (`WsConnection::new` seeds `MAIN_PROFILE_ID`; `open_session_result` returns
+/// `active_profile_id.unwrap_or(MAIN_PROFILE_ID)`), and every goal emitter
+/// stamps `_main` explicitly for an unprofiled deployment. A LEGACY row that
+/// predates the stamp carries no `profile_id` at all — it must normalize to
+/// `_main` so single-tenant deployments keep every frame they have today,
+/// while a genuinely foreign profile is still dropped.
+#[tokio::test]
+async fn should_replay_main_and_legacy_goal_frames_when_connection_is_unprofiled() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = state_with_sessions(temp.path());
+
+    let (ws, mut rx) = ws_connection_for_test(64);
+    let ledger = Arc::new(UiProtocolLedger::new(64));
+    let approvals = PendingApprovalStore::default();
+    let questions = PendingQuestionStore::default();
+    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let session_id = SessionKey("web-unprofiled".into());
+
+    ledger.append_notification(goal_updated_notification(
+        &session_id,
+        Some(MAIN_PROFILE_ID),
+        "main objective",
+    ));
+    // Legacy row: no `profile_id` on the wire at all.
+    ledger.append_notification(goal_updated_notification(
+        &session_id,
+        None,
+        "legacy objective",
+    ));
+    ledger.append_notification(goal_cleared_notification(&session_id, None));
+    ledger.append_notification(goal_updated_notification(
+        &session_id,
+        Some("beta"),
+        "beta secret objective",
+    ));
+
+    let opened = handle_session_open(
+        &ws,
+        &state,
+        &ledger,
+        &approvals,
+        &questions,
+        &forwarders,
+        None,
+        ConnectionUiFeatures::default(),
+        "open-main".into(),
+        SessionOpenParams {
+            session_id: session_id.clone(),
+            topic: None,
+            profile_id: None,
+            cwd: None,
+            sandbox: None,
+            after: Some(UiCursor {
+                stream: session_id.0.clone(),
+                seq: 0,
+            }),
+        },
+        false,
+    )
+    .await;
+    assert!(
+        opened,
+        "an unprofiled connection must still open the session"
+    );
+
+    let frames = drain_session_open_frames(&mut rx).await;
+    assert_eq!(
+        replayed_goal_objectives(&frames),
+        vec!["main objective".to_owned(), "legacy objective".to_owned()],
+        "a `_main` connection keeps both `_main` and legacy unstamped goal frames"
+    );
+    assert_eq!(
+        replayed_cleared_profiles(&frames),
+        vec![Value::Null],
+        "a legacy `session/goal/cleared` with no profile must still reach `_main`"
+    );
+
+    // Live forwarder: same compatibility contract on the live path.
+    ledger.append_notification(goal_updated_notification(
+        &session_id,
+        Some("beta"),
+        "beta live objective",
+    ));
+    ledger.append_notification(goal_updated_notification(
+        &session_id,
+        None,
+        "legacy live objective",
+    ));
+
+    let live = next_frame_within(&mut rx, 2_000)
+        .await
+        .expect("a legacy live goal frame must still reach a `_main` connection");
+    assert_eq!(
+        live.get("method").and_then(Value::as_str),
+        Some(octos_core::ui_protocol::methods::SESSION_GOAL_UPDATED),
+    );
+    assert_eq!(
+        live["params"]["goal"]["objective"],
+        json!("legacy live objective")
+    );
+    assert!(
+        next_frame_within(&mut rx, 250).await.is_none(),
+        "profile-b's live goal frame must not reach a `_main` connection"
+    );
+
+    abort_live_forwarders(&forwarders, &ledger).await;
+}
+
+/// A durable `loop/updated` shaped like the one `loop/pause`, `loop/resume`
+/// and `loop/delete` produce: the RPC result omits the top-level `profile_id`,
+/// so the nested `loop` record is the ONLY thing that names the owner.
+fn loop_updated_notification_without_top_level_profile(
+    session_id: &SessionKey,
+    record_profile_id: Option<&str>,
+    loop_id: &str,
+) -> UiNotification {
+    UiNotification::LoopUpdated(octos_core::ui_protocol::LoopUpdatedEvent {
+        session_id: session_id.clone(),
+        profile_id: None,
+        loop_id: Some(loop_id.to_owned()),
+        loop_state: octos_core::ui_protocol::UiLoopRecord {
+            loop_id: loop_id.to_owned(),
+            session_id: session_id.clone(),
+            profile_id: record_profile_id.map(ToOwned::to_owned),
+            prompt: format!("{loop_id} prompt"),
+            mode: "interval".to_owned(),
+            interval_seconds: Some(60),
+            status: "paused".to_owned(),
+            next_run_at_ms: None,
+            last_run_at_ms: None,
+            expires_at_ms: 0,
+            created_at_ms: 0,
+            updated_at_ms: 0,
+        },
+        ok: Some(true),
+        status: Some("paused".to_owned()),
+        deleted: None,
+    })
+}
+
+/// A durable `monitor/updated`, which DOES carry the top-level stamp.
+fn monitor_updated_notification(
+    session_id: &SessionKey,
+    profile_id: Option<&str>,
+    monitor_id: &str,
+) -> UiNotification {
+    UiNotification::MonitorUpdated(octos_core::ui_protocol::MonitorUpdatedEvent {
+        session_id: session_id.clone(),
+        profile_id: profile_id.map(ToOwned::to_owned),
+        monitor_id: Some(monitor_id.to_owned()),
+        monitor_state: octos_core::ui_protocol::UiMonitorRecord {
+            monitor_id: monitor_id.to_owned(),
+            session_id: session_id.clone(),
+            profile_id: profile_id.map(ToOwned::to_owned),
+            name: monitor_id.to_owned(),
+            argv: vec![
+                "tail".to_owned(),
+                "-f".to_owned(),
+                "/var/log/secret".to_owned(),
+            ],
+            filter_regex: None,
+            mode: "stream".to_owned(),
+            interval_seconds: None,
+            batch_ms: 250,
+            max_events_per_hour: 60,
+            persistent: false,
+            status: "active".to_owned(),
+            pause_reason: None,
+            goal_id: None,
+            last_fired_at_ms: None,
+            fires_used: 0,
+            expires_at_ms: None,
+            created_at_ms: 0,
+            updated_at_ms: 0,
+        },
+        ok: Some(true),
+        status: Some("active".to_owned()),
+        deleted: None,
+    })
+}
+
+/// #2067 — the `loop/*` and `monitor/*` frames ride the SAME durable dispatch
+/// as the goal frames (`record_autonomy_rpc_evidence` ->
+/// `send_notification_durable`) and carry the same class of tenant text (loop
+/// prompt, monitor argv). They must be scoped the same way — including the
+/// `loop/pause`-shaped event whose top-level `profile_id` is absent and whose
+/// only owner stamp is the nested `loop` record.
+#[tokio::test]
+async fn should_drop_cross_profile_loop_and_monitor_frames_when_connection_scopes_another_profile()
+{
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state = local_profile_state_with_sessions(temp.path());
+    create_or_get_local_solo_profile(
+        &state,
+        local_profile_params("Alpha Owner", "alpha", "alpha@example.com"),
+    )
+    .expect("create alpha profile");
+    create_or_get_local_solo_profile(
+        &state,
+        local_profile_params("Beta Owner", "beta", "beta@example.com"),
+    )
+    .expect("create beta profile");
+
+    let (ws, mut rx) = ws_connection_for_test(64);
+    let ledger = Arc::new(UiProtocolLedger::new(64));
+    let approvals = PendingApprovalStore::default();
+    let questions = PendingQuestionStore::default();
+    let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let session_id = SessionKey("web-shared-autonomy".into());
+
+    ledger.append_notification(loop_updated_notification_without_top_level_profile(
+        &session_id,
+        Some("beta"),
+        "loop-beta",
+    ));
+    ledger.append_notification(monitor_updated_notification(
+        &session_id,
+        Some("beta"),
+        "monitor-beta",
+    ));
+    ledger.append_notification(loop_updated_notification_without_top_level_profile(
+        &session_id,
+        Some("alpha"),
+        "loop-alpha",
+    ));
+    ledger.append_notification(monitor_updated_notification(
+        &session_id,
+        Some("alpha"),
+        "monitor-alpha",
+    ));
+
+    let opened = handle_session_open(
+        &ws,
+        &state,
+        &ledger,
+        &approvals,
+        &questions,
+        &forwarders,
+        Some("alpha"),
+        ConnectionUiFeatures::default(),
+        "open-alpha-autonomy".into(),
+        SessionOpenParams {
+            session_id: session_id.clone(),
+            topic: None,
+            profile_id: None,
+            cwd: None,
+            sandbox: None,
+            after: Some(UiCursor {
+                stream: session_id.0.clone(),
+                seq: 0,
+            }),
+        },
+        false,
+    )
+    .await;
+    assert!(opened, "alpha must be able to open the shared session");
+
+    let frames = drain_session_open_frames(&mut rx).await;
+    let replayed: Vec<(String, String)> = frames
+        .iter()
+        .filter_map(|frame| {
+            let method = frame.get("method").and_then(Value::as_str)?;
+            match method {
+                octos_core::ui_protocol::methods::LOOP_UPDATED => Some((
+                    method.to_owned(),
+                    frame["params"]["loop"]["loop_id"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .to_owned(),
+                )),
+                octos_core::ui_protocol::methods::MONITOR_UPDATED => Some((
+                    method.to_owned(),
+                    frame["params"]["monitor"]["monitor_id"]
+                        .as_str()
+                        .unwrap_or_default()
+                        .to_owned(),
+                )),
+                _ => None,
+            }
+        })
+        .collect();
+    assert_eq!(
+        replayed,
+        vec![
+            (
+                octos_core::ui_protocol::methods::LOOP_UPDATED.to_owned(),
+                "loop-alpha".to_owned()
+            ),
+            (
+                octos_core::ui_protocol::methods::MONITOR_UPDATED.to_owned(),
+                "monitor-alpha".to_owned()
+            ),
+        ],
+        "replay must deliver only alpha's loop/monitor frames"
+    );
+
+    // Live forwarder: `loop/fired` and `monitor/fired` are stamped at the
+    // scheduler drain, so they always carry a concrete top-level profile.
+    ledger.append_notification(UiNotification::LoopFired(
+        octos_core::ui_protocol::LoopFiredEvent {
+            session_id: session_id.clone(),
+            profile_id: Some("beta".to_owned()),
+            loop_id: "loop-beta".to_owned(),
+            loop_state: None,
+            fire: None,
+            ok: Some(true),
+            status: Some("queued".to_owned()),
+        },
+    ));
+    ledger.append_notification(UiNotification::MonitorFired(
+        octos_core::ui_protocol::MonitorFiredEvent {
+            session_id: session_id.clone(),
+            profile_id: Some("beta".to_owned()),
+            monitor_id: "monitor-beta".to_owned(),
+            name: Some("monitor-beta".to_owned()),
+            line_count: Some(3),
+            fired_at_ms: None,
+        },
+    ));
+    ledger.append_notification(UiNotification::MonitorFired(
+        octos_core::ui_protocol::MonitorFiredEvent {
+            session_id: session_id.clone(),
+            profile_id: Some("alpha".to_owned()),
+            monitor_id: "monitor-alpha".to_owned(),
+            name: Some("monitor-alpha".to_owned()),
+            line_count: Some(1),
+            fired_at_ms: None,
+        },
+    ));
+
+    let live = next_frame_within(&mut rx, 2_000)
+        .await
+        .expect("alpha's own live monitor frame must still be forwarded");
+    assert_eq!(
+        live.get("method").and_then(Value::as_str),
+        Some(octos_core::ui_protocol::methods::MONITOR_FIRED),
+        "the only live autonomy frame alpha may see is its own: {live}"
+    );
+    assert_eq!(live["params"]["monitor_id"], json!("monitor-alpha"));
+    assert!(
+        next_frame_within(&mut rx, 250).await.is_none(),
+        "beta's live loop/monitor frames must not reach an alpha-scoped connection"
+    );
+
+    abort_live_forwarders(&forwarders, &ledger).await;
+}
+
 #[test]
 fn session_scope_allows_matching_authenticated_profile() {
     let session_id = SessionKey::with_profile("profile-a", "api", "chat-1");

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -556,7 +556,6 @@ pub(crate) struct WsConnection {
     /// [`update_live_features`]). Reads are far more frequent than
     /// writes, so `RwLock` is the right fit.
     live_features: Arc<std::sync::RwLock<ConnectionUiFeatures>>,
-    live_profile_id: Arc<std::sync::RwLock<String>>,
 }
 
 impl WsConnection {
@@ -569,7 +568,6 @@ impl WsConnection {
             failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             failed_notify: Arc::new(tokio::sync::Notify::new()),
             live_features: Arc::new(std::sync::RwLock::new(ConnectionUiFeatures::default())),
-            live_profile_id: Arc::new(std::sync::RwLock::new(MAIN_PROFILE_ID.to_owned())),
         }
     }
 
@@ -585,7 +583,6 @@ impl WsConnection {
             live_features: Arc::new(std::sync::RwLock::new(
                 ConnectionUiFeatures::stdio_defaults(),
             )),
-            live_profile_id: Arc::new(std::sync::RwLock::new(MAIN_PROFILE_ID.to_owned())),
         }
     }
 
@@ -610,21 +607,6 @@ impl WsConnection {
             Err(poisoned) => poisoned.into_inner(),
         };
         *guard = features;
-    }
-
-    fn snapshot_live_profile_id(&self) -> String {
-        match self.live_profile_id.read() {
-            Ok(guard) => guard.clone(),
-            Err(poisoned) => poisoned.into_inner().clone(),
-        }
-    }
-
-    fn update_live_profile_id(&self, profile_id: String) {
-        let mut guard = match self.live_profile_id.write() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        *guard = profile_id;
     }
 
     pub(crate) fn is_failed(&self) -> bool {
@@ -16873,7 +16855,14 @@ async fn handle_session_open(
             return false;
         }
     };
-    ws.update_live_profile_id(outcome.profile_id.clone());
+    // #2067 (H2) — this session's resolved profile, captured for the live
+    // forwarder installed at the end of this function. It is deliberately a
+    // per-forwarder value and NOT connection-wide state: a connection keeps one
+    // forwarder PER SESSION, and an unscoped connection may open a second
+    // session under a different profile. Sharing one mutable cell across
+    // forwarders let the second open silently retarget the first session's
+    // pump, starving it of every profile-carrying frame.
+    let live_profile_scope = outcome.profile_id.clone();
 
     // #1594 follow-up: a session-ingress connection may only call the
     // session-scoped surface, so the SessionOpened reply it receives must not
@@ -17012,6 +17001,7 @@ async fn handle_session_open(
         ws.connection_id,
         features,
         topic_scope,
+        live_profile_scope,
         live_rx,
         live_forwarders.clone(),
     )
@@ -17084,6 +17074,16 @@ fn ledger_event_matches_topic_scope(
 /// profile" is deployment-dependent — see the KNOWN LIMITATION on the
 /// interactive goal-charge binding.
 ///
+/// NOT filtered, deliberately: `AgentUpdated`, `PeerStaged` and `PeerClosed`.
+/// All three are durable and all three leak, but they are stamped from the
+/// TURN's `ProfileRuntime` rather than from `validate_session_scope`, and those
+/// two resolutions diverge when an unscoped connection carries a routed profile
+/// (`connection_profile_id.or(routed_profile_id)` — `validate_session_scope`
+/// never consults the routed id). Filtering them before that divergence is
+/// closed would starve exactly the reconnect-replay path they exist for. See
+/// issue #2081. `LoopCompleted` / `MonitorExpired` have no producer at all
+/// (issue #2080).
+///
 /// Every arm below prefers the event's top-level stamp and falls back to the
 /// profile on the record it carries. The fallback is not cosmetic: the
 /// `loop/pause`, `loop/resume` and `loop/delete` results omit the top-level
@@ -17140,6 +17140,30 @@ fn ledger_event_matches_profile_scope(event: &UiProtocolLedgerEvent, profile_id:
         ),
         UiNotification::MonitorFired(fired) => {
             optional_profile_scope_matches(fired.profile_id.as_deref(), profile_id)
+        }
+        // `session/open` is appended for BROADCAST — the emit site tags it with
+        // the opening connection id specifically so OTHER connections observe
+        // it — and it carries `workspace_root`, the context snapshot and pane
+        // snapshots, i.e. another tenant's paths and buffers on a shared key.
+        // Filtering it cannot starve its own opener: that connection's
+        // forwarder skips the broadcast copy via `from_connection`, and its own
+        // frame arrives through the UNFILTERED `send_ledger_event_durable`
+        // direct send in `handle_session_open`. The scopes also agree by
+        // construction — `ledger_profile_id` IS `active_profile_id
+        // .unwrap_or(MAIN_PROFILE_ID)`, which is exactly this normalization.
+        UiNotification::SessionOpened(opened) => {
+            optional_profile_scope_matches(opened.active_profile_id.as_deref(), profile_id)
+        }
+        // `background/activity` is raw OBSERVED text — a monitor's stdout, a
+        // fleet summary — and the ledger is its entire delivery mechanism: the
+        // sink appends it over a detached connection whose writer is drained to
+        // nowhere, so every real client receives it through replay or its own
+        // forwarder. Both production emitters stamp a concrete id that descends
+        // from `resolve_autonomy_profile_id` (the monitor origin carries the
+        // very id `monitor/fired` carries, already filtered above), so this arm
+        // adds no starvation surface that the monitor arm did not already.
+        UiNotification::BackgroundActivity(activity) => {
+            optional_profile_scope_matches(activity.profile_id.as_deref(), profile_id)
         }
         _ => true,
     }
@@ -17198,6 +17222,12 @@ async fn spawn_live_forwarder(
     self_connection_id: ConnectionId,
     features: ConnectionUiFeatures,
     topic_scope: Option<String>,
+    // #2067 (H2) — the profile this SESSION resolved to at `session/open`,
+    // captured immutably for the lifetime of this forwarder exactly like
+    // `topic_scope`. Never re-read from the connection: a later
+    // `session/open` on the same connection can resolve a different profile,
+    // and a shared cell would retarget this pump mid-flight.
+    profile_scope: String,
     mut rx: tokio::sync::broadcast::Receiver<LedgeredUiProtocolEvent>,
     forwarders: SharedLiveForwarders,
 ) {
@@ -17237,10 +17267,7 @@ async fn spawn_live_forwarder(
                     if !ledger_event_matches_topic_scope(&event.event, topic_scope.as_deref()) {
                         continue;
                     }
-                    if !ledger_event_matches_profile_scope(
-                        &event.event,
-                        &ws.snapshot_live_profile_id(),
-                    ) {
+                    if !ledger_event_matches_profile_scope(&event.event, &profile_scope) {
                         continue;
                     }
                     // Stage 1 v2 is a wire projection of this existing

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -6016,7 +6016,9 @@ async fn ui_protocol_connection(
                     &contracts.user_questions,
                     &live_forwarders,
                     connection_profile_id,
-                    routed_profile_id,
+                    // Frozen at WS upgrade (and at session-ingress upgrade),
+                    // never rebound for the life of this connection.
+                    connection_profile_id,
                     features,
                     id,
                     params,
@@ -6788,8 +6790,10 @@ where
                     &contracts.user_questions,
                     &live_forwarders,
                     next_connection_profile_id.as_deref(),
-                    // stdio builds an EMPTY `HeaderMap`, so there is never a
-                    // routed profile to diverge from the session scope.
+                    // NOT pinned: stdio rebinds `connection_profile_id_owned`
+                    // after every successful open, so a later open under
+                    // another profile retargets this session's turns exactly
+                    // as `session_open_profile_id` does on the WS path.
                     None,
                     features,
                     id,
@@ -16817,12 +16821,11 @@ async fn handle_session_open(
     questions: &PendingQuestionStore,
     live_forwarders: &SharedLiveForwarders,
     connection_profile_id: Option<&str>,
-    // #2067 R3 — the profile this connection is ROUTED to by `Host`
-    // subdomain / `X-Profile-Id` header, which `validate_session_scope`
-    // deliberately does not consult. Needed here only to decide whether the
-    // resolved session scope may be used as a DELIVERY filter; it never
-    // changes what the session resolves to. `None` for stdio (no headers).
-    routed_profile_id: Option<&str>,
+    // #2067 — the profile this connection is FROZEN to for its whole lifetime,
+    // or `None` when the transport has no such pin. Used only to decide whether
+    // the session scope may serve as a DELIVERY filter; it never changes what
+    // the session resolves to. See `ledger_event_matches_profile_scope`.
+    pinned_profile_id: Option<&str>,
     features: ConnectionUiFeatures,
     id: String,
     mut params: SessionOpenParams,
@@ -16848,7 +16851,7 @@ async fn handle_session_open(
         questions,
         ws.connection_id,
         connection_profile_id,
-        routed_profile_id,
+        pinned_profile_id,
         features,
         params,
     )
@@ -17109,55 +17112,48 @@ fn ledger_event_matches_topic_scope(
 /// `profile_id` entirely (see `AgentOrchestrator::control_loop`) and only the
 /// nested `loop` record names the owner. A fallback can only ever NARROW an
 /// event's audience, never widen it.
-/// #2067 R3 — may this connection's resolved session scope be used as a
-/// DELIVERY filter at all?
+/// #2067 — the profile scope a connection may be FILTERED against, or `None`
+/// when it has none and every delivery must pass.
 ///
-/// It may, precisely when the scope provably equals the profile the connection's
-/// own turns run under. Otherwise filtering starves the connection of its own
-/// data, because a turn's `ProfileRuntime` hard-binds its profile onto every
-/// record the model's tools create (`runtime/profile.rs` registers
-/// `MonitorCreateTool::new(profile.id)`, and the tool persists that id), and the
-/// durable frames those records emit carry it.
+/// Filtering is sound only when the scope a forwarder captured at
+/// `session/open` provably equals the profile that session's TURNS run under,
+/// for the whole life of the forwarder. That matters because a turn's
+/// `ProfileRuntime` hard-binds its profile onto every record the model's tools
+/// create (`runtime/profile.rs` registers `MonitorCreateTool::new(profile.id)`,
+/// and the tool persists that id), and the durable frames those records emit
+/// carry it. Filter against a scope the turn does not share and the connection
+/// is starved of its OWN data — fatally so for `background/activity`, whose
+/// sink appends over a detached connection and therefore has no delivery path
+/// except replay and live fan-out.
 ///
-/// The two resolutions:
-///   scope = `validate_session_scope(session, params.profile_id, connection)`
-///           `.unwrap_or(_main)`
-///   turn  = `session.profile_id().or(connection.or(routed)).unwrap_or(_main)`,
-///           where the caller passes `routed = header_routed.or(session_open)`
-///           and `session_open` is the scope of the last successful open.
+/// The turn resolves
+/// `session.profile_id().or(connection.or(routed.or(session_open)))`, and both
+/// `routed` and `session_open` are per-CONNECTION mutable state: `session_open`
+/// is a single cell that every successful open overwrites, so opening a second
+/// bare session under another profile retargets the turns of the FIRST one.
+/// A per-session captured scope can never track that.
 ///
-/// They agree in every case EXCEPT one:
-///   * `connection = Some(P)` — `validate_session_scope` returns `P`, and it
-///     rejects a session key belonging to any other profile, so
-///     `session.profile_id()` is `None` or `P` and the turn is `P` too. Equal.
-///     (A routed profile is authorized against the identity at WS upgrade, so
-///     for an authenticated identity it can only be `P`.)
-///   * `connection = None`, `header_routed = None` — the turn falls through to
-///     `session_open`, which is `params.profile_id.or(session.profile_id())
-///     .unwrap_or(_main)`: the same expression the scope resolves. Equal.
-///   * `connection = None`, `header_routed = Some(P)` — the scope is `_main`
-///     (or an explicitly requested id) while the turn is `P`. NOT equal, and
-///     this is the case we must not filter.
+/// The one binding that cannot drift is an authenticated connection profile:
+/// it is frozen at WS upgrade, and `validate_authenticated_session_scope`
+/// forces every session opened on that connection to it or rejects the open
+/// outright. So the whole connection has exactly one profile, every forwarder
+/// captures it, and `connection.or(..)` short-circuits onto it for every turn.
+/// That is the only case this filter may act on, and it is exactly the case
+/// #2067 reports: a tenant is an authenticated user.
 ///
-/// That last case is an admin/unauthenticated connection reached through a
-/// `Host` subdomain or `X-Profile-Id` header. Such a connection is already
-/// explicitly authorized across profiles by the WS upgrade gate, so its session
-/// scope was never a tenant boundary — treating it as one is the category
-/// error. Delivering unfiltered there costs no tenant isolation: the viewer is
-/// an operator already entitled to the data.
+/// A routed profile cannot break this even when it names a DIFFERENT profile —
+/// which it legitimately can, since an admin-role user is authorized for every
+/// profile and a parent user for its owned subaccounts, and both still present
+/// an authenticated `connection_profile_id`. `connection.or(routed)` never
+/// reaches `routed` while the connection profile is set, and a session key
+/// belonging to another profile is rejected before any turn starts.
 ///
-/// KNOWN RESIDUAL: `session_open` is last-writer-wins per connection, so an
-/// unscoped connection that opens several BARE keys under different explicit
-/// `params.profile_id`s runs the earlier sessions' turns under the latest
-/// profile. That is a pre-existing turn-routing defect, not one this filter
-/// creates, and it is tracked with the rest of the divergence in #2081.
-fn connection_filterable_profile_scope(
-    connection_profile_id: Option<&str>,
-    routed_profile_id: Option<&str>,
-) -> bool {
-    connection_profile_id.is_some() || routed_profile_id.is_none()
-}
-
+/// Callers pass `None` for a transport whose binding is NOT frozen — stdio
+/// rebinds `connection_profile_id_owned` after every successful open, so it
+/// drifts exactly as `session_open` does and must not be filtered. Declining to
+/// filter costs no tenant isolation: an unscoped WS connection is an
+/// admin/operator authorized for every profile (or auth is disabled and every
+/// route is deliberately open), and stdio is a single local user.
 fn ledger_event_matches_profile_scope(
     event: &UiProtocolLedgerEvent,
     profile_id: Option<&str>,
@@ -17866,7 +17862,7 @@ async fn open_session_result(
     questions: &PendingQuestionStore,
     connection_id: ConnectionId,
     connection_profile_id: Option<&str>,
-    routed_profile_id: Option<&str>,
+    pinned_profile_id: Option<&str>,
     features: ConnectionUiFeatures,
     mut params: SessionOpenParams,
 ) -> Result<SessionOpenOutcome, RpcError> {
@@ -17880,9 +17876,11 @@ async fn open_session_result(
     let ledger_profile_id = active_profile_id
         .clone()
         .unwrap_or_else(|| MAIN_PROFILE_ID.to_owned());
-    let profile_scope =
-        connection_filterable_profile_scope(connection_profile_id, routed_profile_id)
-            .then(|| ledger_profile_id.clone());
+    // #2067 — see `ledger_event_matches_profile_scope`. `validate_session_scope`
+    // returns the connection profile verbatim when there is one, so this equals
+    // `ledger_profile_id` in that case; naming the pin directly keeps the
+    // invariant (scope == the turn's profile) visible at the resolution site.
+    let profile_scope = pinned_profile_id.map(ToOwned::to_owned);
     if let Some(profile_id) = active_profile_id.as_deref() {
         ensure_known_profile(state, profile_id)?;
     }

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -6016,6 +6016,7 @@ async fn ui_protocol_connection(
                     &contracts.user_questions,
                     &live_forwarders,
                     connection_profile_id,
+                    routed_profile_id,
                     features,
                     id,
                     params,
@@ -6787,6 +6788,9 @@ where
                     &contracts.user_questions,
                     &live_forwarders,
                     next_connection_profile_id.as_deref(),
+                    // stdio builds an EMPTY `HeaderMap`, so there is never a
+                    // routed profile to diverge from the session scope.
+                    None,
                     features,
                     id,
                     params,
@@ -16813,6 +16817,12 @@ async fn handle_session_open(
     questions: &PendingQuestionStore,
     live_forwarders: &SharedLiveForwarders,
     connection_profile_id: Option<&str>,
+    // #2067 R3 — the profile this connection is ROUTED to by `Host`
+    // subdomain / `X-Profile-Id` header, which `validate_session_scope`
+    // deliberately does not consult. Needed here only to decide whether the
+    // resolved session scope may be used as a DELIVERY filter; it never
+    // changes what the session resolves to. `None` for stdio (no headers).
+    routed_profile_id: Option<&str>,
     features: ConnectionUiFeatures,
     id: String,
     mut params: SessionOpenParams,
@@ -16838,6 +16848,7 @@ async fn handle_session_open(
         questions,
         ws.connection_id,
         connection_profile_id,
+        routed_profile_id,
         features,
         params,
     )
@@ -16862,7 +16873,7 @@ async fn handle_session_open(
     // session under a different profile. Sharing one mutable cell across
     // forwarders let the second open silently retarget the first session's
     // pump, starving it of every profile-carrying frame.
-    let live_profile_scope = outcome.profile_id.clone();
+    let live_profile_scope = outcome.profile_scope.clone();
 
     // #1594 follow-up: a session-ingress connection may only call the
     // session-scoped surface, so the SessionOpened reply it receives must not
@@ -16904,7 +16915,7 @@ async fn handle_session_open(
     //
     // Reusing the helper keeps replay and live capability behavior in lockstep.
     for event in outcome.replay {
-        if !ledger_event_matches_profile_scope(&event.event, &outcome.profile_id) {
+        if !ledger_event_matches_profile_scope(&event.event, outcome.profile_scope.as_deref()) {
             continue;
         }
         let projected = features
@@ -17059,10 +17070,18 @@ fn ledger_event_matches_topic_scope(
 /// loop, and the live forwarder pump), so a variant it does not recognise
 /// leaks across tenants on every shared/unprofiled wire session key — which is
 /// exactly what `session/goal/updated` and `session/goal/cleared` did — and
-/// what the `loop/*` and `monitor/*` frames beside them did, since all of them
+/// what the `loop/*` and `monitor/*` frames beside them did, since most of them
 /// are appended DURABLY by the same `record_autonomy_rpc_evidence` ->
 /// `send_notification_durable` dispatch and all of them carry tenant text
 /// (goal objective, loop prompt, monitor argv/name).
+///
+/// `MonitorFired` and `BackgroundActivity` are the exceptions to "stamped by
+/// `resolve_autonomy_profile_id`": both are emitted off the continuation drain
+/// from a stored record, and that record's profile is the TURN's
+/// `ProfileRuntime` id whenever the monitor or fleet was created by a model
+/// tool. Filtering them is safe only because
+/// [`connection_filterable_profile_scope`] refuses to filter on a scope that
+/// can disagree with the turn's profile.
 ///
 /// `profile_id` is the connection's RESOLVED scope and is always a concrete
 /// string — [`WsConnection`] seeds [`MAIN_PROFILE_ID`] and `session/open`
@@ -17090,7 +17109,64 @@ fn ledger_event_matches_topic_scope(
 /// `profile_id` entirely (see `AgentOrchestrator::control_loop`) and only the
 /// nested `loop` record names the owner. A fallback can only ever NARROW an
 /// event's audience, never widen it.
-fn ledger_event_matches_profile_scope(event: &UiProtocolLedgerEvent, profile_id: &str) -> bool {
+/// #2067 R3 — may this connection's resolved session scope be used as a
+/// DELIVERY filter at all?
+///
+/// It may, precisely when the scope provably equals the profile the connection's
+/// own turns run under. Otherwise filtering starves the connection of its own
+/// data, because a turn's `ProfileRuntime` hard-binds its profile onto every
+/// record the model's tools create (`runtime/profile.rs` registers
+/// `MonitorCreateTool::new(profile.id)`, and the tool persists that id), and the
+/// durable frames those records emit carry it.
+///
+/// The two resolutions:
+///   scope = `validate_session_scope(session, params.profile_id, connection)`
+///           `.unwrap_or(_main)`
+///   turn  = `session.profile_id().or(connection.or(routed)).unwrap_or(_main)`,
+///           where the caller passes `routed = header_routed.or(session_open)`
+///           and `session_open` is the scope of the last successful open.
+///
+/// They agree in every case EXCEPT one:
+///   * `connection = Some(P)` — `validate_session_scope` returns `P`, and it
+///     rejects a session key belonging to any other profile, so
+///     `session.profile_id()` is `None` or `P` and the turn is `P` too. Equal.
+///     (A routed profile is authorized against the identity at WS upgrade, so
+///     for an authenticated identity it can only be `P`.)
+///   * `connection = None`, `header_routed = None` — the turn falls through to
+///     `session_open`, which is `params.profile_id.or(session.profile_id())
+///     .unwrap_or(_main)`: the same expression the scope resolves. Equal.
+///   * `connection = None`, `header_routed = Some(P)` — the scope is `_main`
+///     (or an explicitly requested id) while the turn is `P`. NOT equal, and
+///     this is the case we must not filter.
+///
+/// That last case is an admin/unauthenticated connection reached through a
+/// `Host` subdomain or `X-Profile-Id` header. Such a connection is already
+/// explicitly authorized across profiles by the WS upgrade gate, so its session
+/// scope was never a tenant boundary — treating it as one is the category
+/// error. Delivering unfiltered there costs no tenant isolation: the viewer is
+/// an operator already entitled to the data.
+///
+/// KNOWN RESIDUAL: `session_open` is last-writer-wins per connection, so an
+/// unscoped connection that opens several BARE keys under different explicit
+/// `params.profile_id`s runs the earlier sessions' turns under the latest
+/// profile. That is a pre-existing turn-routing defect, not one this filter
+/// creates, and it is tracked with the rest of the divergence in #2081.
+fn connection_filterable_profile_scope(
+    connection_profile_id: Option<&str>,
+    routed_profile_id: Option<&str>,
+) -> bool {
+    connection_profile_id.is_some() || routed_profile_id.is_none()
+}
+
+fn ledger_event_matches_profile_scope(
+    event: &UiProtocolLedgerEvent,
+    profile_id: Option<&str>,
+) -> bool {
+    // `None` = this connection's scope is not a tenant boundary (see
+    // `connection_filterable_profile_scope`); deliver everything.
+    let Some(profile_id) = profile_id else {
+        return true;
+    };
     let UiProtocolLedgerEvent::Notification(notification) = event else {
         return true;
     };
@@ -17158,10 +17234,19 @@ fn ledger_event_matches_profile_scope(event: &UiProtocolLedgerEvent, profile_id:
         // fleet summary — and the ledger is its entire delivery mechanism: the
         // sink appends it over a detached connection whose writer is drained to
         // nowhere, so every real client receives it through replay or its own
-        // forwarder. Both production emitters stamp a concrete id that descends
-        // from `resolve_autonomy_profile_id` (the monitor origin carries the
-        // very id `monitor/fired` carries, already filtered above), so this arm
-        // adds no starvation surface that the monitor arm did not already.
+        // forwarder.
+        //
+        // Its profile is NOT resolver-derived. The fleet origin is stamped from
+        // `FleetRecord.profile_id`, and the single production fleet-creation
+        // site is reached only from the model's `goal_plan` tool, so that id is
+        // always the TURN's `ProfileRuntime` id; the monitor origin is likewise
+        // `ProfileRuntime`-derived whenever the monitor came from
+        // `monitor_create` rather than the `monitor/create` RPC. Together with
+        // `MonitorFired` below, these are the only two arms here whose stamp can
+        // come from the turn rather than from `resolve_autonomy_profile_id` —
+        // which is exactly why filtering is gated on
+        // `connection_filterable_profile_scope`, under which the two resolutions
+        // provably agree.
         UiNotification::BackgroundActivity(activity) => {
             optional_profile_scope_matches(activity.profile_id.as_deref(), profile_id)
         }
@@ -17227,7 +17312,7 @@ async fn spawn_live_forwarder(
     // `topic_scope`. Never re-read from the connection: a later
     // `session/open` on the same connection can resolve a different profile,
     // and a shared cell would retarget this pump mid-flight.
-    profile_scope: String,
+    profile_scope: Option<String>,
     mut rx: tokio::sync::broadcast::Receiver<LedgeredUiProtocolEvent>,
     forwarders: SharedLiveForwarders,
 ) {
@@ -17267,7 +17352,7 @@ async fn spawn_live_forwarder(
                     if !ledger_event_matches_topic_scope(&event.event, topic_scope.as_deref()) {
                         continue;
                     }
-                    if !ledger_event_matches_profile_scope(&event.event, &profile_scope) {
+                    if !ledger_event_matches_profile_scope(&event.event, profile_scope.as_deref()) {
                         continue;
                     }
                     // Stage 1 v2 is a wire projection of this existing
@@ -17764,7 +17849,10 @@ struct SessionOpenOutcome {
     /// where an event landing between replay and the session/open append
     /// would otherwise be filtered out (codex PR #761 MUST-FIX-1).
     replay_baseline_seq: u64,
-    profile_id: String,
+    /// #2067 R3 — the profile scope this connection may be FILTERED against,
+    /// or `None` when its scope is not a tenant boundary and filtering it
+    /// would starve it. See `connection_filterable_profile_scope`.
+    profile_scope: Option<String>,
 }
 
 // Threading both the approval store and the (UPCR-2026-023) question store
@@ -17778,6 +17866,7 @@ async fn open_session_result(
     questions: &PendingQuestionStore,
     connection_id: ConnectionId,
     connection_profile_id: Option<&str>,
+    routed_profile_id: Option<&str>,
     features: ConnectionUiFeatures,
     mut params: SessionOpenParams,
 ) -> Result<SessionOpenOutcome, RpcError> {
@@ -17791,6 +17880,9 @@ async fn open_session_result(
     let ledger_profile_id = active_profile_id
         .clone()
         .unwrap_or_else(|| MAIN_PROFILE_ID.to_owned());
+    let profile_scope =
+        connection_filterable_profile_scope(connection_profile_id, routed_profile_id)
+            .then(|| ledger_profile_id.clone());
     if let Some(profile_id) = active_profile_id.as_deref() {
         ensure_known_profile(state, profile_id)?;
     }
@@ -17997,7 +18089,7 @@ async fn open_session_result(
         ledger.replay_after_with_head(&params.session_id, params.after.as_ref())?;
     replay.retain(|event| {
         ledger_event_matches_topic_scope(&event.event, topic_scope.as_deref())
-            && ledger_event_matches_profile_scope(&event.event, &ledger_profile_id)
+            && ledger_event_matches_profile_scope(&event.event, profile_scope.as_deref())
     });
     let replayed_approval_ids = replay
         .iter()
@@ -18106,7 +18198,7 @@ async fn open_session_result(
         pending_questions,
         opened_event,
         replay_baseline_seq,
-        profile_id: ledger_profile_id,
+        profile_scope,
     })
 }
 

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -17063,13 +17063,110 @@ fn ledger_event_matches_topic_scope(
     }
 }
 
+/// #2067 — a durable event that names a profile must reach ONLY connections
+/// resolved to that profile. This filter runs at all three delivery boundaries
+/// (the `replay.retain` in `open_session_result`, the session/open replay send
+/// loop, and the live forwarder pump), so a variant it does not recognise
+/// leaks across tenants on every shared/unprofiled wire session key — which is
+/// exactly what `session/goal/updated` and `session/goal/cleared` did — and
+/// what the `loop/*` and `monitor/*` frames beside them did, since all of them
+/// are appended DURABLY by the same `record_autonomy_rpc_evidence` ->
+/// `send_notification_durable` dispatch and all of them carry tenant text
+/// (goal objective, loop prompt, monitor argv/name).
+///
+/// `profile_id` is the connection's RESOLVED scope and is always a concrete
+/// string — [`WsConnection`] seeds [`MAIN_PROFILE_ID`] and `session/open`
+/// overwrites it with `open_session_result`'s
+/// `active_profile_id.unwrap_or(MAIN_PROFILE_ID)`. `_main` is therefore a real
+/// scope on both sides of the wire, NOT a wildcard: the emitters normalize the
+/// same way (`resolve_autonomy_profile_id` returns `_main` for an unprofiled
+/// deployment), and treating an unscoped connection as "authorized for any
+/// profile" is deployment-dependent — see the KNOWN LIMITATION on the
+/// interactive goal-charge binding.
+///
+/// Every arm below prefers the event's top-level stamp and falls back to the
+/// profile on the record it carries. The fallback is not cosmetic: the
+/// `loop/pause`, `loop/resume` and `loop/delete` results omit the top-level
+/// `profile_id` entirely (see `AgentOrchestrator::control_loop`) and only the
+/// nested `loop` record names the owner. A fallback can only ever NARROW an
+/// event's audience, never widen it.
 fn ledger_event_matches_profile_scope(event: &UiProtocolLedgerEvent, profile_id: &str) -> bool {
-    match event {
-        UiProtocolLedgerEvent::Notification(UiNotification::SkillActionJobUpdated(update)) => {
-            update.profile_id == profile_id
+    let UiProtocolLedgerEvent::Notification(notification) = event else {
+        return true;
+    };
+    match notification {
+        UiNotification::SkillActionJobUpdated(update) => update.profile_id == profile_id,
+        // The goal chip's reducers are session-keyed and apply `updated`
+        // unconditionally, so a foreign profile's objective/budget would paint
+        // straight into this connection's chip.
+        UiNotification::SessionGoalUpdated(update) => optional_profile_scope_matches(
+            update
+                .profile_id
+                .as_deref()
+                .or(update.goal.profile_id.as_deref()),
+            profile_id,
+        ),
+        UiNotification::SessionGoalCleared(cleared) => optional_profile_scope_matches(
+            cleared.profile_id.as_deref().or_else(|| {
+                cleared
+                    .goal
+                    .as_ref()
+                    .and_then(|goal| goal.profile_id.as_deref())
+            }),
+            profile_id,
+        ),
+        UiNotification::LoopUpdated(update) => optional_profile_scope_matches(
+            update
+                .profile_id
+                .as_deref()
+                .or(update.loop_state.profile_id.as_deref()),
+            profile_id,
+        ),
+        UiNotification::LoopFired(fired) => optional_profile_scope_matches(
+            fired.profile_id.as_deref().or_else(|| {
+                fired
+                    .loop_state
+                    .as_ref()
+                    .and_then(|loop_state| loop_state.profile_id.as_deref())
+            }),
+            profile_id,
+        ),
+        UiNotification::MonitorUpdated(update) => optional_profile_scope_matches(
+            update
+                .profile_id
+                .as_deref()
+                .or(update.monitor_state.profile_id.as_deref()),
+            profile_id,
+        ),
+        UiNotification::MonitorFired(fired) => {
+            optional_profile_scope_matches(fired.profile_id.as_deref(), profile_id)
         }
         _ => true,
     }
+}
+
+/// #2067 — compare an OPTIONAL wire profile id against a connection's resolved
+/// scope.
+///
+/// `event_profile_id` is the result of the caller's top-level-then-nested
+/// fallback, so a `None` here means the frame names no profile ANYWHERE. That
+/// is a LEGACY row: the field is `skip_serializing_if = "Option::is_none"`, and
+/// every current producer stamps a concrete id somewhere on the frame
+/// (`resolve_autonomy_profile_id` never returns an empty or absent id, and the
+/// stored `AutonomyGoalRecord` / `AutonomyLoopRecord` / `AutonomyMonitorRecord`
+/// hold a non-optional `profile_id`), so a fully unstamped frame can only have
+/// been persisted by a backend that predates the stamp. Only an
+/// unprofiled/single-tenant deployment could have produced one, and every
+/// connection there resolves to `_main` — so normalizing `None` to `_main` is
+/// lossless exactly where such rows exist, while still refusing to hand a
+/// legacy row to a real tenant. An empty/whitespace id normalizes the same way
+/// rather than becoming an accidental wildcard.
+fn optional_profile_scope_matches(event_profile_id: Option<&str>, profile_id: &str) -> bool {
+    event_profile_id
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .unwrap_or(MAIN_PROFILE_ID)
+        == profile_id
 }
 
 fn stdio_session_open_candidate_profile(


### PR DESCRIPTION
Closes #2067

Four commits. The leak fix, then three rounds of adversarial review, each of which found starvation the previous round had introduced.

| commit | what it does |
|---|---|
| 1 | Scope goal / loop / monitor frames to the connection's profile — the reported leak. |
| 2 | Capture the forwarder's scope **per session** instead of from a shared per-connection cell; scope `session/open` + `background/activity`. |
| 3 | Stop filtering when a routing header makes the scope disagree with the turn's profile. |
| 4 | Filter only on a profile the connection **cannot drift from** — round 3's exemption was too narrow. |

## The bug

`ledger_event_matches_profile_scope` recognized one variant, `SkillActionJobUpdated`; everything else fell through `_ => true`. It runs at three delivery boundaries — the `replay.retain` in `open_session_result`, the session/open replay send loop, and the live forwarder pump — and `session/goal/updated` / `session/goal/cleared` are appended **durably** via `record_autonomy_rpc_evidence` → `send_notification_durable`, so they crossed all three.

A bare `web-N` key is deliberately accepted under profile auth (`:16767-16773` — "SPA convention: a fresh session uses a raw `web-N` id with no profile prefix"), so two tenants sharing one wire key is the normal case. The chip reducers are session-keyed and apply `updated` unconditionally, so profile B's objective text painted into profile A's chip. RED, through the real delivery paths:

```
assertion `left == right` failed: replay must not put profile-b's objective on an alpha-scoped connection
  left: ["beta secret objective", "alpha objective"]
 right: ["alpha objective"]
```

The class was already acknowledged in-code: the three *interactive* goal pushes use `send_notification_ephemeral` because "a durable append would fan the goal to every subscriber of an unprofiled shared session id regardless of profile" (`:33648-33652`). The RPC path never got that treatment.

## What the review rounds found

**Round 2 — the forwarder's scope was per-connection, not per-session.** `WsConnection` held one shared `Arc<RwLock<String>>` that every `session/open` overwrote, while a connection keeps one forwarder per session. Fixed by threading `profile_scope` into `spawn_live_forwarder`, captured at open exactly like `topic_scope`; the shared cell and its accessors are removed rather than left as a trap. The replay boundaries never shared the hazard — both use per-call locals.

**Round 3 — routed admin connections were being starved.** `validate_session_scope` never consults `routed_profile_id`, but the turn path resolves its runtime from `connection_profile_id.or(routed_profile_id)`. An admin connection routed to a tenant by `Host` subdomain or `X-Profile-Id` opened a bare key resolving to `_main` while its turns ran under the tenant's `ProfileRuntime`. RED showed total starvation — the connection received nothing but its own open frame:

```
the connection's own routed monitor/fired must be replayed: ["session/open"]
```

**Round 4 — the same divergence has a second source, with no header involved.** `session_open_profile_id` is a single per-connection cell overwritten by every successful open (`:6035`), and every later `turn/start` — including one on an *earlier* session — receives that latest value (`:6050`) and selects that runtime (`:29332`). Open bare A (`_main`), open bare B as `beta`, run a turn on A: A's forwarder holds `_main` while the turn runs under `beta`, and a model-created monitor is stamped `beta`. Round 3's exemption did not fire. RED, on both delivery paths independently:

```
session A must still receive the activity its own turn produced, even though the turn ran under the profile a later open bound
...
assertion `left == right` failed: reconnect replay must not drop session A's own activity
  left: []
 right: ["live log line"]
```

The turn misrouting predates this branch; the **delivery drop did not**, which is what put it in scope.

## The guard

Filtering is gated on the only binding that provably cannot drift — an authenticated connection profile:

```rust
// callers pass the pin; `None` means "do not filter"
let profile_scope = pinned_profile_id.map(ToOwned::to_owned);
```

It is frozen at WS upgrade (`:5766`, and the comment at `:5769-5770` says so), and `validate_authenticated_session_scope` forces every session opened on that connection to it or rejects the open outright. So the whole connection has exactly one profile, every forwarder captures it, and `connection.or(..)` short-circuits onto it for every turn.

- **WS and session-ingress** pass their frozen `connection_profile_id`.
- **stdio passes `None`** — and this is where I disagreed with the review. Codex recommended preserving filtering on stdio; stdio rebinds `connection_profile_id_owned` after every successful open (`:6801`) and passes it to `turn/start` (`:6771`), so it has *exactly* the drift that round 4 is fixing. Preserving it there would have reintroduced the same starvation on a different transport.
- **Unscoped WS passes `None`** — no pin exists, however it was routed.

**This costs no tenant isolation.** A tenant is an authenticated user, which is precisely the case still filtered — and precisely what #2067 reports. An unscoped WS connection is an admin/operator authorized for every profile (or auth is disabled and every route is deliberately open); stdio is a single local user.

Because the guard sits above the variant match, correctness does not depend on enumerating affected variants right — which matters, since round 2's enumeration was wrong.

## Two justification comments were factually wrong, and are corrected

- Commit 2 claimed both `background/activity` emitters "descend from `resolve_autonomy_profile_id`". They do not: `agent_orchestrator.rs:7022` is the only production fleet-creation site in the repo (every other `Fleet::create*` is `#[cfg(test)]`; there is no `fleet/*` RPC), reached solely from `model_create_fleet_plan`, whose profile is `ProfileRuntime.profile.id`.
- Commit 3 claimed a routed profile "can only be `P`" for an authenticated identity. Also false — an admin-role user is authorized for every profile and a parent user for its owned subaccounts (`auth_handlers.rs:3834`), and both still present an authenticated `connection_profile_id`. It creates no divergence, but because `connection.or(routed)` never reaches `routed` while the connection profile is set, not because routing is constrained.

Both behaviours were fine; the stated reasons would have been cited as precedent.

## `ProfileRuntime`-stamped set — established, not assumed

Of the nine filtered variants, exactly **two** can be stamped from the turn's runtime rather than `resolve_autonomy_profile_id`:

| variant | stamped by the turn? | why |
|---|---|---|
| `MonitorFired` | **yes** | tool → request (`goal_tool.rs:1802`) → record (`agent_orchestrator.rs:9369`) → `Phase1::Fire` (`:10111`) → continuation (`:10154-10158`) → drain (`:2994-3010`) → event. The resolver is never called. |
| `BackgroundActivity` | **yes** | fleet origin unconditionally; monitor origin whenever model-created. |
| `SessionGoalUpdated` / `SessionGoalCleared` | no | the model-tool goal mutations are **never ledgered** — all three turn-path pushes use `send_notification_ephemeral` ("NOT appended to the ledger — non-durable per spec § 9"), and the durable sites decode resolver-stamped RPC results. The goal tools never touch `ws` or `ledger`. |
| `LoopUpdated` / `LoopFired` | no | no model tool creates loops. |
| `MonitorUpdated`, `SkillActionJobUpdated`, `SessionOpened` | no | RPC-derived, or the scope itself. |

Recorded in #2081: the goal *record*'s profile genuinely can be `ProfileRuntime`-derived — it just never reaches a durable frame today. Promote the post-turn chip repaint to `send_notification_durable` and `SessionGoalUpdated` joins the `MonitorFired` class.

## Compatibility questions

**1. What must `profile_id: None` match? `_main`.** No emitter writes `None`: `goal/set` and `goal/clear` route through `resolve_autonomy_profile_id` (`_main` fallback) into `GoalSetRequest.profile_id: String`, and the nested record is non-optional. A wire `None` can only be a **legacy ledger row** — the field is `skip_serializing_if = "Option::is_none"` and the ledger is JSON-Lines persisted across restarts. Only a backend predating the stamp wrote those, in deployments where every connection resolves to `_main`.

**2. What must an unprofiled connection receive?** Everything — it has no frozen pin, so its scope is not a tenant boundary. (Rounds 1–3 filtered it against `_main`; round 4 established that is unsound.)

**3. Does `_main` appear explicitly on the wire?** Both — `resolve_autonomy_profile_id` returns the literal `_main`, and it is also the connection-side default. The only absent-vs-`"_main"` split is across a version upgrade, which is why `None` must normalize rather than be dropped.

**Where the evidence corrected the issue's fix sketch:** the sketch assumed the top-level `profile_id` is what to compare. That fails for `loop/updated` — `loop/pause`, `loop/resume` and `loop/delete` return result JSON with no top-level `profile_id` (`agent_orchestrator.rs:9145-9152`, `:9158-9163`, `:9192-9198`); only `loop/create` has it. Each arm falls back to the profile on the record it carries, which can only ever **narrow** an audience.

## Variant audit

| variant | leaks? | this PR |
|---|---|---|
| `SkillActionJobUpdated` | no | already filtered; unchanged |
| `SessionGoalUpdated` / `SessionGoalCleared` | **yes** — objective text | **FIXED** |
| `LoopUpdated` | **yes** — `loop.prompt` | **FIXED** (nested fallback load-bearing) |
| `LoopFired`, `MonitorUpdated`, `MonitorFired` | **yes** — `argv`, `name`, `filter_regex` | **FIXED** |
| `SessionOpened` | **yes** — `workspace_root`, context + pane snapshots | **FIXED** |
| `BackgroundActivity` | **yes** — raw observed text | **FIXED** |
| `AgentUpdated`, `PeerStaged`, `PeerClosed` | **yes** | **DEFERRED** → #2081 |
| `LoopCompleted` / `MonitorExpired` | no — no producer exists | **DEFERRED** → #2080 |

`SessionOpened` is safe to filter because the opener's forwarder skips the broadcast copy via `from_connection` and its own frame arrives through the **unfiltered** direct send at `:16990`; the scopes are tautological, since `ledger_profile_id` *is* `active_profile_id.unwrap_or(_main)`.

## Tracking issues

- **#2081** — the turn-side/connection-side divergence, updated with both drift sources and the stdio analogue.
- **#2080** — `LoopCompleted` / `MonitorExpired` have no producer.
- **#2078** — the boundary-2 replay-send check is dead: same predicate, same already-retained vector, same scope as boundary 1.

Noted, not chased: `resolve_autonomy_profile_id` checks `is_empty()` rather than `trim().is_empty()` (`:15546-15548`) while `optional_profile_scope_matches` trims. Harmless — registered ids exclude whitespace (`profiles.rs:2605`).

Out of scope and untouched: the interactive-charge KNOWN LIMITATION at `:19498-19507`.

## Tests

All drive the real delivery paths — `handle_session_open` over a live `WsConnection` with frames read off the writer channel, `open_session_result`, and `spawn_live_forwarder`. None calls the filter directly; none is an `include_str!` grep.

| test | property |
|---|---|
| `should_retain_only_same_profile_goal_events_when_open_session_result_replays` | B1 retained events |
| `should_drop_cross_profile_goal_frames_when_connection_scopes_another_profile` | B2 + B3, `updated` and `cleared` |
| `should_drop_cross_profile_loop_and_monitor_frames_when_connection_scopes_another_profile` | B2 + B3 for `loop/updated` (top-level-absent pause shape), `monitor/updated`, `loop/fired`, `monitor/fired` |
| `should_drop_cross_profile_session_opened_frames_when_connection_scopes_another_profile` | B2 + B3 for `session/open`; opener still receives exactly one — its own |
| `should_drop_cross_profile_background_activity_frames_when_connection_scopes_another_profile` | B2 + B3 for `background/activity` |
| `should_replay_main_and_legacy_goal_frames_when_connection_is_unprofiled` | compat: `_main`, legacy `None` **and** foreign frames all delivered on an unpinned connection |
| `should_scope_each_forwarder_independently_when_one_connection_pumps_two_profiles` | round 2: two forwarders on one connection keep their own captured scopes |
| `should_deliver_routed_profile_frames_when_the_connection_scope_is_not_authoritative` | round 3: routed admin connection keeps `monitor/fired` + `background/activity` + goal frames |
| `should_deliver_later_profile_frames_when_an_unscoped_connection_opened_two_sessions` | **round 4**: open A `_main`, open B `beta`, beta-stamped `background/activity` on A delivered — replay **and** live |

Every one was watched fail before its fix. For the loop/monitor arms, the round-2 fix and the round-4 fix the production change was re-removed to confirm RED for the right reason; for round 4 the live leg was additionally neutralised so the replay leg could be observed failing independently.

Two tests changed meaning under the round-4 guard and were re-pinned rather than left vacuous, which is called out in their doc comments: the unprofiled-connection test now asserts the no-filter contract it actually has, and the per-forwarder scope invariant moved to the forwarder boundary — where it is still observable, and where it becomes load-bearing again once #2081 is closed.

## Verification

Run sequentially (never concurrently — the build lock deadlocks):

```
$ cargo clippy -p octos-cli --features api --all-targets -- -D warnings
CLIPPY_EXIT=0

$ cargo test -p octos-cli --features api --lib -- --test-threads=1
test result: ok. 3009 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 504.42s

$ cargo fmt --all -- --check
FMT_CLEAN
```

The nine scope tests by fully-qualified name (a name matching no filter runs zero tests and still reports green, so they are pinned explicitly):

```
test api::ui_protocol_transport::tests::should_deliver_later_profile_frames_when_an_unscoped_connection_opened_two_sessions ... ok
test api::ui_protocol_transport::tests::should_deliver_routed_profile_frames_when_the_connection_scope_is_not_authoritative ... ok
test api::ui_protocol_transport::tests::should_drop_cross_profile_background_activity_frames_when_connection_scopes_another_profile ... ok
test api::ui_protocol_transport::tests::should_drop_cross_profile_goal_frames_when_connection_scopes_another_profile ... ok
test api::ui_protocol_transport::tests::should_drop_cross_profile_loop_and_monitor_frames_when_connection_scopes_another_profile ... ok
test api::ui_protocol_transport::tests::should_drop_cross_profile_session_opened_frames_when_connection_scopes_another_profile ... ok
test api::ui_protocol_transport::tests::should_replay_main_and_legacy_goal_frames_when_connection_is_unprofiled ... ok
test api::ui_protocol_transport::tests::should_retain_only_same_profile_goal_events_when_open_session_result_replays ... ok
test api::ui_protocol_transport::tests::should_scope_each_forwarder_independently_when_one_connection_pumps_two_profiles ... ok
```

Not verified: no live multi-tenant soak — the evidence is the delivery-path tests plus the emit-site traces, not a running deployment.
