### PR TITLE
test(windows): scale the two remaining fixed-duration waits that flake check-windows

### DIFF
--- a/crates/octos-agent/src/tools/spawn_tests.rs
+++ b/crates/octos-agent/src/tools/spawn_tests.rs
@@ -13,7 +13,17 @@ use crate::{HookConfig, HookEvent};
 /// while the only change under test was one line of `.github/workflows/ci.yml`.
 /// These loops spawn real subprocesses, so their wall-clock cost tracks host
 /// load rather than anything the test controls.
+///
+/// #2053: the Windows runners miss fixed-duration waits that pass everywhere
+/// else — `test_background_spawn_persists_workflow_phase_transitions` failed
+/// this ceiling on `check-windows` while an in-job retry of the SAME job
+/// produced a different failure set, and a plain re-run went green. These
+/// loops break on content the instant it appears, so a larger Windows ceiling
+/// costs a passing run nothing.
+#[cfg(not(windows))]
 const BACKGROUND_DEADLINE: std::time::Duration = std::time::Duration::from_secs(60);
+#[cfg(windows)]
+const BACKGROUND_DEADLINE: std::time::Duration = std::time::Duration::from_secs(240);
 
 #[test]
 fn frame_subagent_task_leads_with_identity_and_directive() {

--- a/crates/octos-cli/src/session_actor_tests.rs
+++ b/crates/octos-cli/src/session_actor_tests.rs
@@ -7,6 +7,28 @@ use async_trait::async_trait;
 /// nothing, and a broken run (hook never fires) still fails — just later.
 /// Mirrors `octos_agent`'s `spawn_tests::BACKGROUND_DEADLINE`.
 const HOOK_DEADLINE: Duration = Duration::from_secs(60);
+
+/// #2053 — scale a test's WAITING budget on Windows, where the runners
+/// routinely miss fixed-duration waits that pass everywhere else
+/// (`test_speculative_overflow_concurrent` failed `check-windows` while the
+/// diff under test could not affect it; a plain re-run went green).
+///
+/// Apply this to DEADLINES only — the upper bound on how long a test is
+/// willing to wait. Never apply it to a duration that drives behaviour (a
+/// mock's response delay, a sleep sized against a production patience
+/// window): scaling a stimulus changes what the test proves, while scaling a
+/// deadline costs a passing run nothing and still fails a broken one, just
+/// later.
+fn waiting_budget(base: Duration) -> Duration {
+    #[cfg(windows)]
+    {
+        base * 4
+    }
+    #[cfg(not(windows))]
+    {
+        base
+    }
+}
 #[cfg(unix)]
 use octos_agent::{HookConfig, HookEvent};
 use octos_llm::{AdaptiveConfig, ChatConfig, ChatResponse, StopReason, TokenUsage, ToolSpec};
@@ -3501,7 +3523,7 @@ async fn test_speculative_overflow_concurrent() {
     for i in 0..5 {
         tx.send(make_inbound(&format!("warmup {i}"))).await.unwrap();
         // Wait for response
-        let resp = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        let resp = tokio::time::timeout(waiting_budget(Duration::from_secs(5)), rx.recv())
             .await
             .expect("warmup response timeout")
             .expect("channel closed");
@@ -3524,7 +3546,7 @@ async fn test_speculative_overflow_concurrent() {
     // user-message session_result emission added by #616 fix carries
     // routing metadata in `_session_result` but no body).
     let mut responses = Vec::new();
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    let deadline = tokio::time::Instant::now() + waiting_budget(Duration::from_secs(15));
     while responses.len() < 2 {
         match tokio::time::timeout_at(deadline, rx.recv()).await {
             Ok(Some(msg)) => {
@@ -3596,7 +3618,7 @@ async fn test_speculative_overflow_concurrent() {
 
     // Clean shutdown
     drop(tx);
-    let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    let _ = tokio::time::timeout(waiting_budget(Duration::from_secs(5)), handle).await;
 }
 
 /// FA-11 defect B regression: the overflow assistant reply MUST carry


### PR DESCRIPTION
Closes the remaining two families in #2053. The rustfmt 5s budget was fixed in #2022; these are `test_background_spawn_persists_workflow_phase_transitions` and `test_speculative_overflow_concurrent`.

Both failed `check-windows` on PRs whose diffs could not affect them, both went green on a plain re-run, and one produced a **different** failure set on an in-job retry of the same job. The workaround has been to re-run until green — the same route-around-a-red-check habit that let #1923 sit unnoticed for months, at 45 minutes a round.

## The distinction this encodes

Both budgets are runaway guards, not latency assertions: the loops break on content the instant it appears, so a larger Windows ceiling costs a passing run nothing and a genuinely broken run still fails, just later.

The new `waiting_budget` helper scales **deadlines** — how long a test is willing to wait — and deliberately not **stimuli**. The speculative-overflow test's 12s mock delay and its 11s sleep are sized against the production 10s patience window; scaling those would change what the test proves. Only three waiting budgets are scaled in that test: the warmup response timeout, the response-collection deadline, and the shutdown timeout. `BACKGROUND_DEADLINE` gets the same treatment (60s → 240s on Windows only).

## Verification

Run on macOS, i.e. the unscaled path, so this confirms the change is inert everywhere except Windows:

```
cargo test -p octos-cli --lib test_speculative_overflow_concurrent
  → test result: ok. 1 passed; 0 failed; finished in 18.75s
cargo test -p octos-agent --lib test_background_spawn
  → test result: ok. 7 passed; 0 failed; 1 ignored
cargo clippy -p octos-agent -p octos-cli --all-targets -- -D warnings
  → Finished, no warnings
cargo fmt --all -- --check
  → clean
```

**Not verified locally:** the Windows branch itself. `aws-lc-sys` fails to cross-compile its C sources for `x86_64-pc-windows-msvc` on this host, so the usual local `cargo check --target` trick is unavailable. `check-windows` on this PR is the verification — though note that a green run does not by itself prove the fix, since the failure it addresses is intermittent. What it does prove is that the cfg'd code compiles and the tests still pass there.