### PR TITLE
test(e2e): fix the ambiguous wizard locator, gate two specs on prerequisites CI never had

### DIFF
--- a/e2e/tests/admin-setup-wizard.spec.ts
+++ b/e2e/tests/admin-setup-wizard.spec.ts
@@ -175,7 +175,13 @@ async function walkWizardAndAssertSmtpGating(page: Page, baseURL: string) {
       response.request().method() === 'POST' &&
       response.status() === 204,
   );
-  await page.getByLabel('Tenant').check();
+  // NOT `getByLabel('Tenant')`: Playwright matches label text as a
+  // case-insensitive SUBSTRING, and the Cloud option's description reads
+  // "terminates tunnels from tenants and issues subdomains" — so 'Tenant'
+  // resolves to BOTH radios and `.check()` fails with a strict mode
+  // violation. That is a prose edit breaking a test, not a UI change; target
+  // the radio by value, exactly as the assertion two lines down already does.
+  await page.locator('input[name="deployment-mode"][value="tenant"]').check();
   await modeSave;
   await expect(page.locator('input[name="deployment-mode"][value="tenant"]')).toBeChecked();
   await page.getByRole('button', { name: 'Back' }).click();

--- a/e2e/tests/run-pipeline-ir-delivery.spec.ts
+++ b/e2e/tests/run-pipeline-ir-delivery.spec.ts
@@ -14,6 +14,19 @@ const TOKEN =
   '';
 const PROFILE = process.env.OCTOS_PROFILE || 'admin';
 
+// The default profile above is a LOCAL-HARNESS default, not something CI has.
+// `e2e-live-nightly` sets no OCTOS_PROFILE and its serve configures no
+// `admin` profile, so every nightly run failed at session/open with
+// `-32602 profile 'admin' is not configured for this AppUI session` — before
+// reaching a single assertion. Require the profile to be named explicitly so
+// the missing prerequisite reads as skipped rather than as a failing
+// pipeline. See #2073.
+test.skip(
+  !process.env.OCTOS_PROFILE,
+  'set OCTOS_PROFILE to a profile the target server actually has ' +
+    "(the 'admin' default is a local-harness convention, not a CI fixture)",
+);
+
 test.setTimeout(180_000);
 
 function waitForMatchingNotification(

--- a/e2e/tests/solo-login.spec.ts
+++ b/e2e/tests/solo-login.spec.ts
@@ -17,6 +17,22 @@ import { test, expect } from '@playwright/test';
  *   - `vite dev` on :5173 serving the dashboard at /admin/, proxying /api
  *     to :8080. Set OCTOS_TEST_URL=http://localhost:5173.
  */
+// Those prerequisites are NOT provided by any CI job: `e2e-live-nightly`
+// starts `octos serve --port 3000` with no `--solo` and no vite dev server,
+// and points the suite at :3000. Solo login is off by default, so
+// `solo-continue` never renders and this spec has failed on every nightly
+// run rather than testing anything. Skipping on an explicit opt-in keeps the
+// reason visible instead of burning it as permanent red — see #2073 for
+// giving CI the prerequisites so it can run for real.
+const SOLO_E2E = process.env.OCTOS_SOLO_E2E === '1';
+
+test.skip(
+  !SOLO_E2E,
+  'needs `octos serve --solo` on a fresh data dir plus a vite dev server ' +
+    'proxying /api to it, with OCTOS_TEST_URL pointed at vite. Set ' +
+    'OCTOS_SOLO_E2E=1 once both are running.',
+);
+
 test('solo no-password login creates a local profile and enters the dashboard', async ({
   page,
 }) => {


### PR DESCRIPTION
Triage of three more of the 40 nightly failures from #2073. None is a product regression.

## `admin-setup-wizard` — a prose edit broke a selector

```
Error: locator.check: strict mode violation: getByLabel('Tenant') resolved to 2 elements:
  1) <input type="radio" value="tenant"> aka getByRole('radio', { name: 'Tenant Joins a central VPS' })
  2) <input type="radio" value="cloud">  aka getByRole('radio', { name: 'Cloud This node IS the VPS' })
```

Playwright matches label text as a **case-insensitive substring**, and the Cloud option's description reads *"terminates tunnels from **tenants** and issues subdomains"* (`dashboard/src/pages/wizard/StepDeploymentMode.tsx:133`). So `'Tenant'` matches both.

The markup is fine — each radio has its own wrapping `<label>` — and nothing about the wizard changed. Fixed by targeting the radio by value, exactly as the assertion two lines below already does. The `Password` field on the same page already used an anchored regex for precisely this reason, so the pattern was known.

## `solo-login` — prerequisites no CI job provides

Its own docblock says what it needs: `octos serve --solo` on a fresh data dir, plus a `vite dev` server proxying `/api` to it, with `OCTOS_TEST_URL` pointed at vite. `e2e-live-nightly` provides **none** of them — it starts serve with no `--solo` and points the suite at :3000. Solo login is off by default, so `solo-continue` never renders and the spec has never tested anything.

Now skipped unless `OCTOS_SOLO_E2E=1`, with the requirement stated in the skip message.

## `run-pipeline-ir-delivery` — a local-harness default, not a CI fixture

It defaults `PROFILE` to `'admin'`. CI sets no `OCTOS_PROFILE` and configures no such profile, so every run failed at `session/open` with `-32602 profile 'admin' is not configured for this AppUI session` before reaching a single assertion.

Now skipped unless `OCTOS_PROFILE` is set explicitly.

## On skipping

Skipping is not the end state for either — #2073 tracks giving CI the prerequisites so they run for real. But a spec that fails every night for a missing fixture is indistinguishable from no coverage, and it buries the failures that do matter. That is exactly how the m9 suite stayed invisible for months.

## Verification

```
npx playwright test tests/solo-login.spec.ts tests/run-pipeline-ir-delivery.spec.ts
  → 2 skipped
npx playwright test --list <all three files>
  → Total: 3 tests in 3 files
```

**Not verified:** `admin-setup-wizard` end-to-end. It spawns its own `octos serve` from a release binary at the repo root, which this worktree does not have built. The locator fix is established by the strict-mode error listing both matched elements plus the substring in the Cloud description; the run itself will confirm it on the next nightly.