### PR TITLE
test(goals): wait for both nested-spawn task rows instead of breaking on one

### DIFF
--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -18429,6 +18429,31 @@ mod tests {
         });
     }
 
+    /// #2053 / #2082 — scale a test's WAITING budget on Windows, where the
+    /// runners routinely miss fixed-duration waits that pass everywhere else.
+    /// Mirrors `session_actor_tests::waiting_budget`.
+    ///
+    /// Apply to DEADLINES only — the upper bound on how long a test is
+    /// willing to wait. Never to a duration that drives behaviour: scaling a
+    /// stimulus changes what the test proves, while scaling a deadline costs
+    /// a passing run nothing and still fails a broken one, just later.
+    ///
+    /// NB (#2077): a larger ceiling is NOT what fixes
+    /// `default_mode_background_nested_spawn_lands_grandchild_row` — its
+    /// break condition was. This only sizes the ceiling that the corrected
+    /// break condition made load-bearing, on the one runner already on
+    /// record missing waits of this class.
+    fn waiting_budget(base: std::time::Duration) -> std::time::Duration {
+        #[cfg(windows)]
+        {
+            base * 4
+        }
+        #[cfg(not(windows))]
+        {
+            base
+        }
+    }
+
     fn goal_task_ledger_path(data_dir: &std::path::Path, goal_id: &str) -> std::path::PathBuf {
         InProcessAgentOrchestrator::goal_ledger_dir(data_dir)
             .join(format!("{}.db", sanitize_filename_for_ledger(goal_id)))
@@ -18763,8 +18788,28 @@ mod tests {
         // The grandchild's task id lives on the DETACHED child registry's
         // private supervisor (invisible from here), so identify its row by
         // title — registration records the tool label.
+        //
+        // #2077 — wait for BOTH titles, not just the grandchild's. Each row
+        // is produced by two INDEPENDENT racing writers: the task's
+        // registration offload
+        // ([`InProcessAgentOrchestrator::record_goal_task_row_blocking`]) and
+        // its settle chain
+        // ([`InProcessAgentOrchestrator::settle_goal_task_row_blocking`],
+        // which seeds the row itself with `create_task_if_absent` before
+        // ranking the status). All four run on the blocking pool against the
+        // same SQLite file, so which of the two ROWS appears first is not
+        // determined. Breaking on the grandchild alone and then asserting the
+        // outer child made this test fail whenever the outer row lost that
+        // race — under a full-parallel `cargo test -p octos-cli --lib` the
+        // outer row was observed landing 78ms AFTER the grandchild's, with
+        // every registration and settle write reporting success (nothing was
+        // dropped; the row was simply still in flight). Waiting for both
+        // leaves the assertions exactly as strong: a row that never lands
+        // still fails the test, just at the end of the budget.
         let mut titles = Vec::new();
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        let wanted = ["outer-background-child", "nested-grandchild"];
+        let deadline =
+            std::time::Instant::now() + waiting_budget(std::time::Duration::from_secs(60));
         while std::time::Instant::now() < deadline {
             let path = ledger_path.clone();
             let gid = goal_id.clone();
@@ -18779,7 +18824,10 @@ mod tests {
             })
             .await
             .unwrap();
-            if titles.iter().any(|title| title == "nested-grandchild") {
+            if wanted
+                .iter()
+                .all(|want| titles.iter().any(|title| title == want))
+            {
                 break;
             }
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;


### PR DESCRIPTION
Closes #2077.

`default_mode_background_nested_spawn_lands_grandchild_row` polled the goal ledger until the **grandchild's** row appeared, broke, and then asserted the **outer child's** row was there too. Nothing guarantees that order, so the test failed whenever the outer row landed second.

Reproduced on this branch's base (`origin/main` @ 92910f39a), macOS arm64, 16 cores, default `--test-threads`:

```
run 1: FAIL rc=101 (49s)   the outer background child has a row (parent supervisor wiring); rows: ["nested-grandchild"]
run 2..8: pass
TOTAL FAILURES: 1 / 8
```

## The three questions

### 1. Lost write or late write? — **LATE.**

I instrumented `record_goal_task_row_blocking`, `settle_goal_task_row_blocking` and the test's poll loop, restored the ORIGINAL break condition (grandchild only), recorded the verdict the original assertion would have produced, and then kept polling for the outer row for another 120s. Caught the failing interleaving on run 7 of 16:

```
[DIAG 1787202175884] OFFLOAD-enqueue title=outer-background-child  task=01a01d8d-038c-…
[DIAG 1787202177703] SETTLE-ok      title=nested-grandchild        moved=true attempt=0
[DIAG 1787202177703] POLL-break     original=FAIL outer_at=None gc_at=Some(1.741198958s) rows=["nested-grandchild"]
[DIAG 1787202177774] SETTLE-ok      title=outer-background-child   moved=true attempt=0
[DIAG 1787202177781] POLL-extended  outer_at=Some(1.819078916s) gc_at=Some(1.741198958s) rows=["outer-background-child", "nested-grandchild"]
[DIAG 1787202177836] WRITE-ok       title=outer-background-child   inserted=false
[DIAG 1787202177953] WRITE-ok       title=nested-grandchild        inserted=false
```

The outer row arrives **78 ms after** the grandchild's — inside the existing 60s budget, and 770× under it. `original=FAIL` on the same line confirms this is exactly the interleaving the stock test panics on.

Across every instrumented run, `grep -c "WRITE-err\|SETTLE-err\|SKIP-no-goal"` returned **0**. No write failed, no write was swallowed, no goal record went missing.

### 2. Where is it lost? — **Nowhere. Nothing is lost.**

This contradicts #2077's "Likely area", which was written from observation: it guessed the outer registration was either losing a lock race whose error is debug-logged away (`agent_orchestrator.rs:6287-6299`) or had not fired yet. Neither is what happens.

Each row has **two** writers, and each row lands via whichever finishes first:

- registration — `record_goal_task_registration` (`agent_orchestrator.rs:6164`) fires synchronously from `TaskSupervisor::notify_register` (`task_supervisor.rs:3450`), stashes the binding, then hands the row write to the blocking pool via `offload_goal_ledger_io` (`agent_orchestrator.rs:6231`, `:950`);
- settle — `settle_goal_task_row_blocking` (`agent_orchestrator.rs:6505`) is **self-sufficient** by design: `create_goal_if_absent` + `create_task_if_absent` + `settle_task_status` (`:6561-6565`), i.e. it seeds the row itself if the creation offload has not landed.

That is four detached blocking-pool chains contending for one SQLite file (plus the test's own `GoalLedger::open` every 50 ms). In the captured failure the outer's registration write took **1.95 s** from enqueue to `WRITE-ok`, so the grandchild's settle chain got its row in first and the outer row came from its own settle chain 71 ms later. Both `inserted=false` at the end simply record that the settle chains beat the registration writes to the insert — the documented converge-in-either-order contract (`agent_orchestrator.rs:6474-6481`) working correctly.

### 3. Product bug or harness race? — **Harness race, product path is fine.**

The product contract is that registration is best-effort and never blocks (`agent_orchestrator.rs:6156-6163`), and that the settle side converges the row on its own. Both halves demonstrably did their job in the failing run — the ledger ended up with both rows, correct titles, correct statuses. The only thing that was wrong is that the test sampled the ledger at a moment it had no reason to believe was final.

## The fix

Break the poll when **both** titles are present, instead of on the grandchild alone. One condition, one line of logic; the rest of the diff is the rationale comment and the ceiling.

This does not assert less. Verified by mutation, both run in isolation on this branch:

| mutation | result |
|---|---|
| delete `inherit_registration_observers` from spawn.rs's detached branch (`spawn.rs:4520-4524`) — the thing the test exists to prove | `FAILED … the DEFAULT-mode nested grandchild must land a row via detached-branch observer inheritance; rows: ["outer-background-child"]` after 60.14s |
| drop the parent-supervisor `wire_supervisor_for_goal_task_rows` call | `FAILED … the outer background child has a row (parent supervisor wiring); rows: []` after 60.13s |

Both mutations were reverted; neither is in the diff.

### About the ceiling

The 60s deadline was never reached before — the loop broke at ~0.5s. Correcting the break condition makes it load-bearing for the first time, so it is sized through the #2082 `waiting_budget` helper: 60s everywhere, 240s on Windows, where this test already burned a 42-minute `check-windows` job. **The ceiling is not what fixes the flake** — the observed miss was 78 ms, and no ceiling would have helped a poll that stopped looking. Per #2082 the helper is applied to a waiting budget only, never to a stimulus; there is no stimulus duration in this test.

## Verification

`cargo test -p octos-cli --lib`, default parallelism, macOS arm64, 16 cores — **12 consecutive runs, 0 failures**:

```
run 1: pass (54s)    run 5: pass (49s)    run  9: pass (49s)
run 2: pass (49s)    run 6: pass (49s)    run 10: pass (49s)
run 3: pass (54s)    run 7: pass (50s)    run 11: pass (49s)
run 4: pass (49s)    run 8: pass (51s)    run 12: pass (49s)
TOTAL FAILURES: 0 / 12
```

Same harness that produced 1/8 on the base commit. 12 clean runs against a ~1-in-8 flake is roughly a 4-in-5 chance of having caught it if it were unchanged — suggestive, not proof; the mechanism above is the argument.

```
cargo clippy -p octos-cli --features api --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 23s

cargo fmt --all -- --check
    (clean, no output)
```
