### PR TITLE
feat(sandbox): prompt to escalate when a confined command is denied

### DIFF
--- a/crates/octos-agent/src/sandbox/denial.rs
+++ b/crates/octos-agent/src/sandbox/denial.rs
@@ -1,0 +1,175 @@
+//! Recognising sandbox denials in command output.
+//!
+//! A confined command can fail in a way the tool layer never sees: the wrapper
+//! shell exits 0 while a child deep inside the pipeline was refused by the
+//! kernel and printed `ls: ../octos: Operation not permitted` to stderr. The
+//! exit status says success, so nothing upstream knows a policy boundary was
+//! hit, and the model is left to guess — in practice it narrates the denial
+//! back to the user and gives up.
+//!
+//! Detection is textual because that is the only signal available: seatbelt and
+//! Landlock report denials to the *child* as a plain errno, and the child's own
+//! error message is all that reaches us. That makes this a heuristic, and it is
+//! deliberately only consulted when a real backend is active ([`Sandbox::is_noop`]
+//! is false) — under no confinement an EPERM is a genuine filesystem error, not
+//! a policy decision, and prompting for it would be noise.
+//!
+//! [`Sandbox::is_noop`]: super::Sandbox::is_noop
+
+/// Signatures a confined child prints when the kernel refuses it.
+///
+/// EPERM (`Operation not permitted`) is what macOS seatbelt returns. EACCES
+/// (`Permission denied`) is what Landlock and bwrap return, and is also what an
+/// ordinary unreadable file returns — the `is_noop` gate above is what keeps
+/// the second case from producing spurious prompts.
+const DENIAL_SIGNATURES: &[&str] = &[
+    "Operation not permitted",
+    "operation not permitted",
+    "Permission denied",
+    "permission denied",
+    "(os error 1)",
+    "(os error 13)",
+];
+
+/// One line of output that looks like a sandbox denial.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxDenial {
+    /// The offending line, trimmed and length-capped.
+    pub line: String,
+    /// Path the line blamed, when one could be recovered.
+    pub path: Option<String>,
+}
+
+/// Longest denial line we echo into an approval prompt. Long enough for a
+/// realistic `prog: /some/path: Operation not permitted`, short enough that a
+/// pathological line cannot dominate the dialog.
+const MAX_LINE: usize = 200;
+
+/// Scan command output for lines that look like sandbox denials.
+///
+/// Returns at most `limit` distinct denials, in the order they appeared. Callers
+/// are expected to have checked that a real sandbox backend is active.
+pub fn detect_sandbox_denials(output: &str, limit: usize) -> Vec<SandboxDenial> {
+    let mut found: Vec<SandboxDenial> = Vec::new();
+
+    for raw in output.lines() {
+        if found.len() >= limit {
+            break;
+        }
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if !DENIAL_SIGNATURES.iter().any(|sig| line.contains(sig)) {
+            continue;
+        }
+
+        let mut line = line.to_owned();
+        if line.chars().count() > MAX_LINE {
+            line = line.chars().take(MAX_LINE).collect::<String>() + "…";
+        }
+        // Same path refused by several commands in one pipeline is one fact to
+        // show the user, not three.
+        let path = extract_path(&line);
+        if found
+            .iter()
+            .any(|seen| seen.line == line || (path.is_some() && seen.path == path))
+        {
+            continue;
+        }
+        found.push(SandboxDenial { line, path });
+    }
+
+    found
+}
+
+/// Recover the path a denial line blamed.
+///
+/// Handles the common `prog: /path: Operation not permitted` shape, then falls
+/// back to the first path-looking whitespace-delimited token on the line.
+fn extract_path(line: &str) -> Option<String> {
+    // `ls: ../octos: Operation not permitted` -> the middle colon-field.
+    let fields: Vec<&str> = line.split(':').map(str::trim).collect();
+    if fields.len() >= 3 {
+        for field in &fields[1..fields.len() - 1] {
+            if looks_like_path(field) {
+                return Some((*field).to_owned());
+            }
+        }
+    }
+
+    line.split_whitespace()
+        .map(|token| token.trim_matches(|c| matches!(c, '"' | '\'' | ',' | ':' | '(' | ')')))
+        .find(|token| looks_like_path(token))
+        .map(str::to_owned)
+}
+
+/// Whether a token is plausibly a filesystem path rather than prose.
+fn looks_like_path(token: &str) -> bool {
+    if token.is_empty() || token.contains(char::is_whitespace) {
+        return false;
+    }
+    token.starts_with('/')
+        || token.starts_with("./")
+        || token.starts_with("../")
+        || token.starts_with("~/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_seatbelt_denial_and_blamed_path() {
+        let out = "fatal: Not a valid object name 9c18efd\nls: ../octos: Operation not permitted\nExit code: 0";
+        let found = detect_sandbox_denials(out, 8);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].path.as_deref(), Some("../octos"));
+        assert!(found[0].line.contains("Operation not permitted"));
+    }
+
+    #[test]
+    fn finds_absolute_path_denial() {
+        let found = detect_sandbox_denials("sh: /tmp/rust195.txt: Operation not permitted", 8);
+        assert_eq!(found[0].path.as_deref(), Some("/tmp/rust195.txt"));
+    }
+
+    #[test]
+    fn finds_rust_io_error_form() {
+        // `std::io::Error` renders EPERM as `(os error 1)` with no colon-path.
+        let found = detect_sandbox_denials("Error: failed to read settings.toml (os error 1)", 8);
+        assert_eq!(found.len(), 1);
+    }
+
+    #[test]
+    fn clean_output_yields_nothing() {
+        let found = detect_sandbox_denials("all tests passed\nExit code: 0", 8);
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn same_path_reported_twice_is_one_denial() {
+        let out = "ls: /a/b: Operation not permitted\nstat: /a/b: Operation not permitted";
+        assert_eq!(detect_sandbox_denials(out, 8).len(), 1);
+    }
+
+    #[test]
+    fn respects_the_limit() {
+        let out = "ls: /a: Operation not permitted\nls: /b: Operation not permitted\nls: /c: Operation not permitted";
+        assert_eq!(detect_sandbox_denials(out, 2).len(), 2);
+    }
+
+    #[test]
+    fn overlong_line_is_capped() {
+        let out = format!("ls: /{}: Operation not permitted", "x".repeat(500));
+        let found = detect_sandbox_denials(&out, 8);
+        assert!(found[0].line.chars().count() <= MAX_LINE + 1);
+    }
+
+    #[test]
+    fn prose_without_a_path_still_reports_the_line() {
+        let found = detect_sandbox_denials("bind: Operation not permitted", 8);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].path, None);
+    }
+}

--- a/crates/octos-agent/src/sandbox/mod.rs
+++ b/crates/octos-agent/src/sandbox/mod.rs
@@ -4,6 +4,7 @@
 //! sandbox-exec on macOS, AppContainer on Windows, or no sandbox (pass-through).
 
 mod bwrap;
+mod denial;
 mod docker;
 #[cfg(target_os = "linux")]
 mod landlock;
@@ -12,6 +13,7 @@ mod macos;
 mod windows;
 
 pub use bwrap::BwrapSandbox;
+pub use denial::{SandboxDenial, detect_sandbox_denials};
 pub use docker::DockerSandbox;
 #[cfg(target_os = "linux")]
 pub use landlock::LinuxContainerSandbox;

--- a/crates/octos-agent/src/tools/coding_tools.rs
+++ b/crates/octos-agent/src/tools/coding_tools.rs
@@ -27,7 +27,7 @@ use super::{
     ToolContext, ToolResult,
 };
 use crate::policy::{ApprovalPolicy, CommandPolicy, Decision, FileAccessMode, FilesystemScope};
-use crate::sandbox::Sandbox;
+use crate::sandbox::{NoSandbox, Sandbox, detect_sandbox_denials};
 use crate::subprocess_env::{EnvAllowlist, sanitize_command_env};
 use crate::task_supervisor::{RelaunchOpts, TaskRelaunchError, TaskStatus};
 
@@ -235,6 +235,34 @@ pub struct ExecCommandTool {
     sandbox: Arc<dyn Sandbox>,
 }
 
+/// How many denied paths an escalation prompt lists before it stops. A command
+/// that trips the sandbox on a dozen paths is the same decision as one that
+/// trips on three, and the dialog has to stay readable in a terminal.
+const MAX_REPORTED_DENIALS: usize = 5;
+
+/// Outcome of a single attempt at a command.
+///
+/// `completed` distinguishes "the child ran and exited" from a spawn failure or
+/// a timeout. Only the former can be a sandbox denial worth escalating — the
+/// other two are not policy decisions and re-running unconfined would not fix
+/// them.
+struct ExecRun {
+    text: String,
+    success: bool,
+    completed: bool,
+}
+
+impl ExecRun {
+    /// An attempt that never produced a process exit status.
+    fn failed(text: String) -> Self {
+        Self {
+            text,
+            success: false,
+            completed: false,
+        }
+    }
+}
+
 impl ExecCommandTool {
     pub fn new(base_dir: impl Into<PathBuf>, sandbox: Arc<dyn Sandbox>) -> Self {
         Self {
@@ -350,7 +378,129 @@ impl ExecCommandTool {
             .timeout_secs
             .unwrap_or(DEFAULT_EXEC_TIMEOUT_SECS)
             .clamp(1, MAX_EXEC_TIMEOUT_SECS);
-        let mut cmd = self.sandbox.wrap_command(&command, &cwd);
+        let max = input.max_output_tokens.unwrap_or(MAX_CAPTURE_BYTES);
+
+        let run = Self::run_once(self.sandbox.as_ref(), &command, &cwd, timeout_secs).await;
+
+        // A confined run that *completed* can still have been refused a path
+        // partway through while the wrapper shell exited 0. Offer the user the
+        // escalation now, rather than handing the model an error it can only
+        // narrate back. A spawn failure or a timeout is not a policy decision,
+        // so neither is escalated.
+        if run.completed {
+            if let Some(escalated) = self
+                .escalate_if_denied(&command, &cwd, timeout_secs, max, &run)
+                .await
+            {
+                return Ok(escalated);
+            }
+        }
+
+        Ok(ToolResult {
+            output: truncate_output(run.text, max),
+            success: run.success,
+            ..Default::default()
+        })
+    }
+
+    /// Ask the user whether to re-run a sandbox-denied command unconfined, and
+    /// do it if they agree.
+    ///
+    /// `None` means there was nothing to escalate — no confinement in force, no
+    /// denial in the output, or no interactive client attached to ask — and the
+    /// caller should report the original run unchanged.
+    async fn escalate_if_denied(
+        &self,
+        command: &str,
+        cwd: &Path,
+        timeout_secs: u64,
+        max: usize,
+        run: &ExecRun,
+    ) -> Option<ToolResult> {
+        // Without a real backend an EPERM is a genuine filesystem error rather
+        // than a policy decision, and re-running would change nothing.
+        if self.sandbox.is_noop() {
+            return None;
+        }
+
+        let denials = detect_sandbox_denials(&run.text, MAX_REPORTED_DENIALS);
+        if denials.is_empty() {
+            return None;
+        }
+
+        // Non-interactive callers (cron fires, headless runs) have nobody to
+        // ask; they keep today's behaviour.
+        let requester = TOOL_APPROVAL_CTX.try_with(Arc::clone).ok()?;
+        let tool_id = TOOL_CTX
+            .try_with(|inner| inner.tool_id.clone())
+            .unwrap_or_default();
+
+        let blocked = denials
+            .iter()
+            .map(|denial| format!("  {}", denial.line))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let decision = requester
+            .request_approval(ToolApprovalRequest {
+                tool_id,
+                tool_name: self.name().to_owned(),
+                title: "Allow command to run outside the sandbox?".to_owned(),
+                body: format!(
+                    "The sandbox refused part of this command:\n{blocked}\n\n\
+                     Approving re-runs the whole command with no confinement, so it can \
+                     read and write anything this account can. Denying keeps the output above.",
+                ),
+                command: Some(command.to_owned()),
+                cwd: Some(cwd.to_string_lossy().into_owned()),
+            })
+            .await;
+
+        if matches!(decision, ToolApprovalDecision::Deny) {
+            tracing::info!(command = %command, "sandbox escalation denied by user");
+            // Keep the original exit status: the command ran, and the user
+            // declining the retry does not retroactively change how it ended.
+            return Some(ToolResult {
+                output: truncate_output(
+                    format!(
+                        "{}\n\n[sandbox] The user declined to re-run this command outside \
+                         the sandbox. The paths above stay unreadable for this session — \
+                         do not retry the same command expecting a different result.",
+                        run.text
+                    ),
+                    max,
+                ),
+                success: run.success,
+                ..Default::default()
+            });
+        }
+
+        tracing::warn!(
+            command = %command,
+            "re-running command outside the sandbox after user approval",
+        );
+        let rerun = Self::run_once(&NoSandbox, command, cwd, timeout_secs).await;
+        Some(ToolResult {
+            output: truncate_output(
+                format!(
+                    "[sandbox] Re-ran outside the sandbox with the user's approval.\n\n{}",
+                    rerun.text
+                ),
+                max,
+            ),
+            success: rerun.success,
+            ..Default::default()
+        })
+    }
+
+    /// Run `command` to completion under `sandbox`, capturing merged output.
+    async fn run_once(
+        sandbox: &dyn Sandbox,
+        command: &str,
+        cwd: &Path,
+        timeout_secs: u64,
+    ) -> ExecRun {
+        let mut cmd = sandbox.wrap_command(command, cwd);
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
         // Put the child in its own process group so the timeout path can
         // signal the WHOLE tree (wrapper shell + grandchildren) with a
@@ -364,11 +514,7 @@ impl ExecCommandTool {
         let child = match cmd.spawn() {
             Ok(child) => child,
             Err(error) => {
-                return Ok(ToolResult {
-                    output: format!("Failed to execute command: {error}"),
-                    success: false,
-                    ..Default::default()
-                });
+                return ExecRun::failed(format!("Failed to execute command: {error}"));
             }
         };
         // Capture the pid BEFORE `wait_with_output` consumes the child — the
@@ -397,18 +543,13 @@ impl ExecCommandTool {
                     "\n\nExit code: {}",
                     output.status.code().unwrap_or(-1)
                 ));
-                let max = input.max_output_tokens.unwrap_or(MAX_CAPTURE_BYTES);
-                Ok(ToolResult {
-                    output: truncate_output(text, max),
+                ExecRun {
+                    text,
                     success: output.status.success(),
-                    ..Default::default()
-                })
+                    completed: true,
+                }
             }
-            Ok(Err(error)) => Ok(ToolResult {
-                output: format!("Failed to execute command: {error}"),
-                success: false,
-                ..Default::default()
-            }),
+            Ok(Err(error)) => ExecRun::failed(format!("Failed to execute command: {error}")),
             Err(_) => {
                 // Dropping the wait future does NOT kill a tokio child, so
                 // the wrapper shell and any grandchildren keep running. Kill
@@ -416,11 +557,7 @@ impl ExecCommandTool {
                 // SIGKILL on Unix, `taskkill /F /T` on Windows) — the same
                 // helper the `bash` tool uses.
                 kill_timed_out_child(child_pid).await;
-                Ok(ToolResult {
-                    output: format!("Command timed out after {timeout_secs} seconds"),
-                    success: false,
-                    ..Default::default()
-                })
+                ExecRun::failed(format!("Command timed out after {timeout_secs} seconds"))
             }
         }
     }

--- a/crates/octos-agent/src/tools/coding_tools_tests.rs
+++ b/crates/octos-agent/src/tools/coding_tools_tests.rs
@@ -2641,3 +2641,187 @@ fn should_declare_element_schema_when_spawn_agent_items_is_array() {
     assert!(items["items"]["properties"]["type"].is_object());
     assert!(items["items"]["properties"]["text"].is_object());
 }
+
+// ---------------------------------------------------------------------------
+// Sandbox-denial escalation
+// ---------------------------------------------------------------------------
+
+/// Stands in for a confining backend that refuses everything: whatever command
+/// it is handed, the child prints the denial a real seatbelt/Landlock child
+/// would print and exits 0 — the exact shape that used to reach the model
+/// unnoticed.
+struct DenyingSandbox;
+
+impl Sandbox for DenyingSandbox {
+    fn wrap_command(&self, _shell_command: &str, cwd: &Path) -> tokio::process::Command {
+        let mut cmd = tokio::process::Command::new("sh");
+        cmd.arg("-c")
+            .arg("echo 'ls: ../blocked: Operation not permitted'")
+            .current_dir(cwd);
+        cmd
+    }
+}
+
+/// Records the prompt it was shown and answers with a fixed decision.
+struct ScriptedApprover {
+    decision: ToolApprovalDecision,
+    seen: std::sync::Mutex<Vec<ToolApprovalRequest>>,
+}
+
+impl ScriptedApprover {
+    fn new(decision: ToolApprovalDecision) -> Arc<Self> {
+        Arc::new(Self {
+            decision,
+            seen: std::sync::Mutex::new(Vec::new()),
+        })
+    }
+}
+
+#[async_trait]
+impl crate::tools::ToolApprovalRequester for ScriptedApprover {
+    async fn request_approval(&self, request: ToolApprovalRequest) -> ToolApprovalDecision {
+        self.seen.lock().unwrap().push(request);
+        self.decision
+    }
+}
+
+fn exec_tool_with(sandbox: Arc<dyn Sandbox>) -> (ExecCommandTool, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let tool = ExecCommandTool::new(dir.path().to_path_buf(), sandbox);
+    (tool, dir)
+}
+
+#[tokio::test]
+async fn approved_escalation_reruns_the_command_outside_the_sandbox() {
+    let (tool, _dir) = exec_tool_with(Arc::new(DenyingSandbox));
+    let approver = ScriptedApprover::new(ToolApprovalDecision::Approve);
+    let requester: Arc<dyn crate::tools::ToolApprovalRequester> = approver.clone();
+
+    let result = TOOL_APPROVAL_CTX
+        .scope(
+            requester,
+            tool.execute(&json!({ "cmd": "echo escalated-ok" })),
+        )
+        .await
+        .expect("execute should succeed");
+
+    // The re-run is unconfined, so the real command finally runs.
+    assert!(
+        result.output.contains("escalated-ok"),
+        "approved escalation should report the unconfined output; got: {}",
+        result.output
+    );
+    assert!(
+        result.output.contains("outside the sandbox"),
+        "the model must be told the run was escalated; got: {}",
+        result.output
+    );
+    assert!(result.success);
+
+    let seen = approver.seen.lock().unwrap();
+    assert_eq!(seen.len(), 1, "exactly one prompt per denied command");
+    assert!(
+        seen[0].body.contains("Operation not permitted"),
+        "prompt should quote what was refused; got: {}",
+        seen[0].body
+    );
+    assert_eq!(seen[0].command.as_deref(), Some("echo escalated-ok"));
+}
+
+#[tokio::test]
+async fn denied_escalation_keeps_the_original_output_and_says_so() {
+    let (tool, _dir) = exec_tool_with(Arc::new(DenyingSandbox));
+    let approver = ScriptedApprover::new(ToolApprovalDecision::Deny);
+    let requester: Arc<dyn crate::tools::ToolApprovalRequester> = approver.clone();
+
+    let result = TOOL_APPROVAL_CTX
+        .scope(
+            requester,
+            tool.execute(&json!({ "cmd": "echo escalated-ok" })),
+        )
+        .await
+        .expect("execute should succeed");
+
+    assert!(
+        result.output.contains("Operation not permitted"),
+        "the original denial must survive; got: {}",
+        result.output
+    );
+    assert!(
+        result.output.contains("declined"),
+        "the model must learn the retry was refused so it stops trying; got: {}",
+        result.output
+    );
+    assert!(
+        !result.output.contains("escalated-ok"),
+        "a denied escalation must not run the command; got: {}",
+        result.output
+    );
+}
+
+#[tokio::test]
+async fn unconfined_runs_never_prompt() {
+    // Under NoSandbox an EPERM is a real filesystem error, not a policy
+    // decision — prompting would be noise, and re-running changes nothing.
+    let (tool, _dir) = exec_tool_with(Arc::new(NoSandbox));
+    let approver = ScriptedApprover::new(ToolApprovalDecision::Approve);
+    let requester: Arc<dyn crate::tools::ToolApprovalRequester> = approver.clone();
+
+    let result = TOOL_APPROVAL_CTX
+        .scope(
+            requester,
+            tool.execute(&json!({
+                "cmd": "echo 'ls: /x: Operation not permitted'"
+            })),
+        )
+        .await
+        .expect("execute should succeed");
+
+    assert!(result.output.contains("Operation not permitted"));
+    assert!(
+        approver.seen.lock().unwrap().is_empty(),
+        "no sandbox in force means no escalation prompt",
+    );
+}
+
+#[tokio::test]
+async fn clean_confined_output_never_prompts() {
+    struct QuietSandbox;
+    impl Sandbox for QuietSandbox {
+        fn wrap_command(&self, shell_command: &str, cwd: &Path) -> tokio::process::Command {
+            let mut cmd = tokio::process::Command::new("sh");
+            cmd.arg("-c").arg(shell_command).current_dir(cwd);
+            cmd
+        }
+    }
+
+    let (tool, _dir) = exec_tool_with(Arc::new(QuietSandbox));
+    let approver = ScriptedApprover::new(ToolApprovalDecision::Approve);
+    let requester: Arc<dyn crate::tools::ToolApprovalRequester> = approver.clone();
+
+    let result = TOOL_APPROVAL_CTX
+        .scope(requester, tool.execute(&json!({ "cmd": "echo fine" })))
+        .await
+        .expect("execute should succeed");
+
+    assert!(result.output.contains("fine"));
+    assert!(
+        approver.seen.lock().unwrap().is_empty(),
+        "a command that was never refused must not prompt",
+    );
+}
+
+#[tokio::test]
+async fn non_interactive_runs_fall_back_to_todays_behaviour() {
+    // No TOOL_APPROVAL_CTX in scope: cron fires and headless runs have nobody
+    // to ask, and must not hang or fail differently than before.
+    let (tool, _dir) = exec_tool_with(Arc::new(DenyingSandbox));
+
+    let result = tool
+        .execute(&json!({ "cmd": "echo escalated-ok" }))
+        .await
+        .expect("execute should succeed");
+
+    assert!(result.output.contains("Operation not permitted"));
+    assert!(!result.output.contains("escalated-ok"));
+}


### PR DESCRIPTION
## The bug

A sandboxed command can be refused a path partway through while the wrapper shell still exits `0`. The denial lands in stderr, the tool layer sees success, and the model is left to narrate it back to the user:

```
⏺ Bash($ ... ls ../octos 2>&1 | head -3")  41ms
  ⎿ ls: ../octos: Operation not permitted
  ⎿ ls: /Users/alanpoon/.cargo/git/checkouts/: Operation not permitted
  ⎿ Exit code: 0
• Still can't run it — ../octos is unreadable in this sandbox. Options if you
  want it run: grant read access to ../octos, or cherry-pick …
```

That is a dead end the user never gets asked about. Across a 13-probe TUI capture matrix, **every** octoscode pane that touched a path outside the workspace hit this; **no** Claude Code pane did, because Claude asks whether to retry outside the sandbox.

## Why the dialog never appeared

This is the part worth flagging: the client side was already finished.

- `ApprovalSandboxEscalationDetails` and `approval_kinds::SANDBOX_ESCALATION` already exist in `octos-core::ui_protocol`.
- octoscode already renders **all five** approval kinds, escalation included, and already round-trips `approval/respond`.
- But `sandbox_escalation` appears nowhere outside its own type definition and unit tests — **no code ever raised one**, so the dialog was unreachable.

So this isn't a new UI. It's the missing server half of a flow that was already built and wired at both other ends.

## The change

`exec_command` scans a *completed* confined run for denial signatures. On a hit it asks through the existing `ToolApprovalRequest` bridge — the same one the shell tool's dangerous-command gate uses, so it reaches the dialog octoscode already draws:

> **Allow command to run outside the sandbox?**
> The sandbox refused part of this command:
> &nbsp;&nbsp;`ls: ../octos: Operation not permitted`
>
> Approving re-runs the whole command with no confinement, so it can read and write anything this account can. Denying keeps the output above.

Approve re-runs under `NoSandbox` and says so in the output. Deny keeps the original output and tells the model the paths stay unreadable, so it stops retrying the same command.

`run_to_completion` was split into a reusable `run_once(&dyn Sandbox, …)` so the retry reuses the existing process-group and timeout handling verbatim rather than duplicating it.

## On the detection being textual

It has to be. Seatbelt and Landlock report denials to the **child** as a bare errno — the child's own error message is the only signal that reaches us, so there is no structured event to match on.

That makes it a heuristic, and it's scoped accordingly: it is consulted **only when a real backend is active** (`!sandbox.is_noop()`). Under no confinement an EPERM is a genuine filesystem error rather than a policy decision, and prompting for it would be noise. This matters most for the EACCES signature (`Permission denied`), which Landlock and bwrap emit but so does an ordinary unreadable file — the `is_noop` gate is what keeps that from producing spurious prompts.

## Deliberately unchanged

- **Spawn failures and timeouts never escalate.** Neither is a policy decision, and re-running unconfined would not fix them. That's what `ExecRun::completed` tracks.
- **Non-interactive callers keep today's behaviour exactly.** Cron fires and headless runs have no approval context in scope; they get the original output and never block.
- **A denied escalation preserves the original exit status.** The user declining a retry does not retroactively change how the command ended.
- **One prompt per denied command**, capped at 5 reported paths — a command that trips on a dozen paths is the same decision as one that trips on three.

## Tests

13 new tests, all passing:

- `sandbox::denial` (8) — seatbelt/EACCES/`(os error N)` forms, path recovery from `prog: path: msg`, dedup of one path blamed by several commands, limit, overlong-line capping, clean output yielding nothing.
- `tools::coding_tools` (5) — approved escalation actually re-runs and reports it; denied escalation keeps the original output, says it was declined, and does **not** run the command; `NoSandbox` never prompts; clean confined output never prompts; no approval context falls back to today's behaviour.

`cargo fmt` and `cargo clippy --all-targets` are clean.

**Pre-existing failures unrelated to this branch:** `cargo test -p octos-agent --lib` reports 26 failures on this branch — and the same 26 on a clean `origin/main` (verified by stashing). They are all network-dependent (`plugins::http_discovery`, `tools::http`, `tools::web_fetch`, `tools::ssrf`, `validators`) and fail with local `502`s. Passing count goes 2563 → 2576, which is exactly the 13 added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
