### PR TITLE
fix(agent): stop terminal tool retries per turn

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
-use std::{collections::HashMap, collections::VecDeque};
+use std::{collections::HashMap, collections::HashSet, collections::VecDeque};
 
 use eyre::Result;
 use octos_core::{Message, MessageRole, Task, TaskResult, TokenUsage};
@@ -996,6 +996,12 @@ impl Agent {
                 let mut retry_state =
                     PersistentRetryStateGuard::new(self.persistent_retry_state.clone());
                 let mut loop_detector = LoopDetector::new(12);
+                // Tools may report that they have already exhausted all
+                // meaningful retries for this user turn. Keep that fact in
+                // the host, not in the model: a later call with rewritten
+                // arguments is still the same terminal operation and must
+                // not execute again.
+                let mut terminal_tools_for_turn = HashSet::new();
                 let mut turn_ledger = self.new_turn_ledger();
                 // #1691 (codex gap G6): fire the in-band budget reminder once,
                 // when the run first crosses ~80% of its iteration cap.
@@ -1427,6 +1433,27 @@ impl Agent {
                         StopReason::ToolUse => {
                             // Check for loop detection before executing
                             for tc in &response.tool_calls {
+                                if terminal_tools_for_turn.contains(&tc.name) {
+                                    self.emit_cost_update(&turn, &response, attributed_cost);
+                                    warn!(
+                                        tool = %tc.name,
+                                        "terminal tool retried in the same turn; stopping before execution"
+                                    );
+                                    return Ok(ConversationResponse {
+                                        content: terminal_tool_retry_message(&tc.name),
+                                        reasoning_content: None,
+                                        provider_metadata: None,
+                                        token_usage: turn.total_usage().clone(),
+                                        estimated_spend_usd: turn.priced_spend(),
+                                        files_modified,
+                                        files_to_send,
+                                        streamed,
+                                        messages: turn_output_log.clone(),
+                                        tool_results: tool_structured_metadata.clone(),
+                                        synthesized_from_spawn_only: false,
+                                        pending_approval: None,
+                                    });
+                                }
                                 // #1765 doom-loop guard: 3+ CONSECUTIVE
                                 // identical tool calls (same name + identical
                                 // arguments JSON) abort the turn before the
@@ -1692,6 +1719,7 @@ impl Agent {
                                     Some(&mut turn_output_log),
                                     &mut loop_detector,
                                     turn_ledger.as_mut(),
+                                    Some(&mut terminal_tools_for_turn),
                                     Some(&mut iter_pending_approval),
                                 )
                                 .await
@@ -2421,6 +2449,7 @@ impl Agent {
                                 None,
                                 &mut loop_detector,
                                 turn_ledger.as_mut(),
+                                None,
                                 // Background task loop: no resume host —
                                 // rule-matched tools are denied, not
                                 // suspended (see handle_tool_use doc).
@@ -2610,6 +2639,11 @@ impl Agent {
         // conversation continues.
         loop_detector: &mut LoopDetector,
         turn_ledger: Option<&mut TurnLedger>,
+        // A failed tool can set structured_metadata.do_not_retry_same_turn.
+        // The conversation loop stores the tool name here and rejects any
+        // later call before execution, even when the model changes arguments.
+        // Background task loops pass None because they have no user turn.
+        terminal_tools_for_turn: Option<&mut HashSet<String>>,
         // Phase 4 (docs/ROBRIX-PHASE4-APPROVAL-FLOW-ADR.md): out-parameter
         // for the suspend-and-resume human-approval flow. When a tool call
         // matches a configured `human_approval_rules` rule:
@@ -2819,6 +2853,24 @@ impl Agent {
             tool_tokens.cache_write_tokens += batch_tokens.cache_write_tokens;
             tool_metadata.extend(batch_metadata);
             tool_success.extend(batch_success);
+        }
+        if let Some(terminal_tools) = terminal_tools_for_turn {
+            let tool_name_by_id: HashMap<&str, &str> = limited_response
+                .tool_calls
+                .iter()
+                .map(|call| (call.id.as_str(), call.name.as_str()))
+                .collect();
+            for (tool_call_id, metadata) in &tool_metadata {
+                if metadata
+                    .get("do_not_retry_same_turn")
+                    .and_then(serde_json::Value::as_bool)
+                    == Some(true)
+                {
+                    if let Some(tool_name) = tool_name_by_id.get(tool_call_id.as_str()) {
+                        terminal_tools.insert((*tool_name).to_string());
+                    }
+                }
+            }
         }
         if let Some(sink) = tool_structured_metadata {
             sink.extend(tool_metadata);
@@ -3584,6 +3636,18 @@ fn doom_loop_terminal_message(tool_name: &str, streak: usize) -> String {
          call. Repeating the exact same call cannot produce a different result. Try a \
          different approach — vary the arguments, use a different tool, or rephrase the \
          request."
+    )
+}
+
+/// A tool that has already exhausted its own retries can mark the failure as
+/// terminal for the current user turn. If the model asks for it again, stop
+/// before execution even when it rewrites the arguments. This message is
+/// intentionally free of internal error details: the first tool result
+/// already carries those details in the transcript and the user only needs
+/// to know that the repeated wait was prevented.
+fn terminal_tool_retry_message(tool_name: &str) -> String {
+    format!(
+        "The requested operation already exhausted its internal retries. I stopped a repeated '{tool_name}' call in this turn so you do not have to wait for the same work again. Please send a new message if you want to retry."
     )
 }
 

--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -885,6 +885,81 @@ impl Tool for CountingEchoTool {
     }
 }
 
+struct TerminalFailureTool {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Tool for TerminalFailureTool {
+    fn name(&self) -> &str {
+        "oll_generate_lesson"
+    }
+
+    fn description(&self) -> &str {
+        "Generate one complete lesson"
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": { "tutor_context": { "type": "string" } }
+        })
+    }
+
+    async fn execute(&self, _args: &serde_json::Value) -> Result<ToolResult> {
+        self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+        Ok(ToolResult {
+            output: "lesson generation exhausted its internal attempts".to_string(),
+            success: false,
+            structured_metadata: Some(serde_json::json!({
+                "retryable": false,
+                "do_not_retry_same_turn": true
+            })),
+            ..Default::default()
+        })
+    }
+}
+
+struct TerminalLessonRetryProvider {
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl LlmProvider for TerminalLessonRetryProvider {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &octos_llm::ChatConfig,
+    ) -> Result<ChatResponse> {
+        let call = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+        let suffix = if call == 0 { "first" } else { "rewritten" };
+        Ok(ChatResponse {
+            content: None,
+            reasoning_content: None,
+            tool_calls: vec![ToolCall {
+                id: format!("call_lesson_{call}"),
+                name: "oll_generate_lesson".to_string(),
+                // The actual incident changed context strings on every retry.
+                // The guard must key on terminal tool identity, not exact args.
+                arguments: serde_json::json!({ "tutor_context": suffix }),
+                metadata: None,
+            }],
+            stop_reason: StopReason::ToolUse,
+            usage: LlmTokenUsage::default(),
+            provider_index: None,
+        })
+    }
+
+    fn model_id(&self) -> &str {
+        "mock"
+    }
+
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
 struct PodcastGenerateTwiceProvider {
     calls: AtomicUsize,
 }
@@ -1252,6 +1327,42 @@ async fn process_message_blocks_second_podcast_generate_when_session_limit_is_on
             && content.contains("podcast_generate")
             && content.contains("max 1")
     }));
+}
+
+#[tokio::test]
+async fn terminal_tool_failure_blocks_a_rewritten_retry_in_the_same_turn() {
+    let dir = tempfile::tempdir().unwrap();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut tools = ToolRegistry::with_builtins(dir.path());
+    tools.register(TerminalFailureTool {
+        calls: Arc::clone(&calls),
+    });
+
+    let provider: Arc<dyn LlmProvider> = Arc::new(TerminalLessonRetryProvider {
+        calls: AtomicUsize::new(0),
+    });
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let agent = Agent::new(AgentId::new("test-agent"), provider, tools, memory);
+
+    let result = agent
+        .process_message("teach me", &[], vec![])
+        .await
+        .unwrap();
+
+    assert_eq!(calls.load(AtomicOrdering::SeqCst), 1);
+    assert_eq!(
+        result.content,
+        terminal_tool_retry_message("oll_generate_lesson"),
+    );
+    assert_eq!(
+        result
+            .messages
+            .iter()
+            .filter(|message| message.role == MessageRole::Tool)
+            .count(),
+        1,
+        "the rewritten second call must be stopped before it creates another tool result",
+    );
 }
 
 #[tokio::test]

--- a/crates/octos-agent/src/agent/loop_runner_tests.rs
+++ b/crates/octos-agent/src/agent/loop_runner_tests.rs
@@ -892,7 +892,7 @@ struct TerminalFailureTool {
 #[async_trait]
 impl Tool for TerminalFailureTool {
     fn name(&self) -> &str {
-        "oll_generate_lesson"
+        "lesson_generate"
     }
 
     fn description(&self) -> &str {
@@ -939,7 +939,7 @@ impl LlmProvider for TerminalLessonRetryProvider {
             reasoning_content: None,
             tool_calls: vec![ToolCall {
                 id: format!("call_lesson_{call}"),
-                name: "oll_generate_lesson".to_string(),
+                name: "lesson_generate".to_string(),
                 // The actual incident changed context strings on every retry.
                 // The guard must key on terminal tool identity, not exact args.
                 arguments: serde_json::json!({ "tutor_context": suffix }),
@@ -1352,7 +1352,7 @@ async fn terminal_tool_failure_blocks_a_rewritten_retry_in_the_same_turn() {
     assert_eq!(calls.load(AtomicOrdering::SeqCst), 1);
     assert_eq!(
         result.content,
-        terminal_tool_retry_message("oll_generate_lesson"),
+        terminal_tool_retry_message("lesson_generate"),
     );
     assert_eq!(
         result


### PR DESCRIPTION
## Summary
- honor a tool structured-metadata flag that marks its failure terminal for the current user turn
- block later calls to the same tool before execution even when the model rewrites arguments
- keep the policy generic and host-enforced instead of matching lesson text or arguments

## Verification
- cargo test -p octos-agent terminal_tool_failure_blocks_a_rewritten_retry_in_the_same_turn
- cargo fmt --all -- --check
- cargo clippy -p octos-agent --all-targets -- -D warnings