### PR TITLE
fix(api): let keyless families through admin test-provider and provider-models

### DIFF
--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -1034,20 +1034,27 @@ pub async fn test_provider(
     use octos_llm::{ChatConfig, LlmProvider};
 
     // Resolve the API key: prefer raw api_key, fall back to reading from saved profile
-    let api_key = if let Some(ref key) = req.api_key {
+    let keyless = octos_llm::registry::is_keyless(&req.provider);
+    let resolved = if let Some(ref key) = req.api_key {
         if !key.is_empty() && !key.contains("***") {
-            key.clone()
+            Ok(key.clone())
         } else {
-            resolve_saved_key(&state, &identity, &req)?
+            resolve_saved_key(&state, &identity, &req)
         }
     } else {
-        resolve_saved_key(&state, &identity, &req)?
+        resolve_saved_key(&state, &identity, &req)
+    };
+    // Keyless local families (local/ollama/vllm) construct without a key —
+    // both an EMPTY key and an UNRESOLVABLE key (no api_key/api_key_env in
+    // the request at all) are fine for them. Dead-ending here blocked the
+    // keyless onboarding flow entirely (red-team pass + live test).
+    let api_key = match resolved {
+        Ok(key) => key,
+        Err(_) if keyless => String::new(),
+        Err(error) => return Err(error),
     };
 
-    // Keyless local families (local/ollama/vllm) construct without a key —
-    // dead-ending them on "No API key provided" blocked the keyless
-    // onboarding flow entirely (red-team pass).
-    if api_key.is_empty() && !octos_llm::registry::is_keyless(&req.provider) {
+    if api_key.is_empty() && !keyless {
         return Ok(Json(TestProviderResponse {
             ok: false,
             message: String::new(),
@@ -1148,16 +1155,24 @@ pub async fn provider_models(
     identity: Option<axum::Extension<super::router::AuthIdentity>>,
     Json(req): Json<TestProviderRequest>,
 ) -> Result<Json<Vec<String>>, (StatusCode, String)> {
-    let api_key = if let Some(ref key) = req.api_key {
+    let keyless = octos_llm::registry::is_keyless(&req.provider);
+    let resolved = if let Some(ref key) = req.api_key {
         if !key.is_empty() && !key.contains("***") {
-            key.clone()
+            Ok(key.clone())
         } else {
-            resolve_saved_key(&state, &identity, &req)?
+            resolve_saved_key(&state, &identity, &req)
         }
     } else {
-        resolve_saved_key(&state, &identity, &req)?
+        resolve_saved_key(&state, &identity, &req)
     };
-    if api_key.is_empty() {
+    // Keyless local families (local/ollama/vllm) list models without a key —
+    // their /v1/models answers unauthenticated (octos#2096 review round).
+    let api_key = match resolved {
+        Ok(key) => key,
+        Err(_) if keyless => String::new(),
+        Err(error) => return Err(error),
+    };
+    if api_key.is_empty() && !keyless {
         return Err((StatusCode::BAD_REQUEST, "No API key".into()));
     }
     let models = fetch_provider_models(&req.provider, &api_key, req.base_url.as_deref())

--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -1062,6 +1062,20 @@ pub async fn test_provider(
         }));
     }
 
+    // Link-local (cloud metadata) targets are never model servers — refuse
+    // before any outbound request (adversarial review, octos#2097).
+    if req
+        .base_url
+        .as_deref()
+        .is_some_and(base_url_targets_link_local)
+    {
+        return Ok(Json(TestProviderResponse {
+            ok: false,
+            message: String::new(),
+            error: Some("base_url targets a link-local/metadata address — refused".into()),
+        }));
+    }
+
     let provider: Arc<dyn LlmProvider> = {
         let params = octos_llm::registry::CreateParams {
             // Empty means "keyless family" — let the factory apply its own
@@ -1175,6 +1189,18 @@ pub async fn provider_models(
     if api_key.is_empty() && !keyless {
         return Err((StatusCode::BAD_REQUEST, "No API key".into()));
     }
+    // Link-local (cloud metadata) targets are never model servers — refuse
+    // before any outbound request (adversarial review, octos#2097).
+    if req
+        .base_url
+        .as_deref()
+        .is_some_and(base_url_targets_link_local)
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "base_url targets a link-local/metadata address".into(),
+        ));
+    }
     let models = fetch_provider_models(&req.provider, &api_key, req.base_url.as_deref())
         .await
         .unwrap_or_default();
@@ -1182,6 +1208,32 @@ pub async fn provider_models(
 }
 
 /// Fetch available models from a provider's /v1/models endpoint.
+/// Whether a caller-supplied `base_url` targets a LINK-LOCAL address —
+/// 169.254/16 (cloud metadata endpoints like 169.254.169.254), fe80::/10, or
+/// their IPv4-mapped forms. These are never legitimate model-server addresses,
+/// while loopback and RFC1918 ARE (local/ollama/vllm servers), so this is
+/// deliberately narrower than the agent-side `tools/ssrf.rs` checker (which
+/// blocks loopback too and would break the local family). Literal-IP check
+/// only: a hostname passes (the probe endpoints require auth; this closes the
+/// sharpest credential-theft target, not every probe vector).
+fn base_url_targets_link_local(base_url: &str) -> bool {
+    let Ok(url) = reqwest::Url::parse(base_url) else {
+        return false;
+    };
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    let host = host.trim_start_matches('[').trim_end_matches(']');
+    match host.parse::<std::net::IpAddr>() {
+        Ok(std::net::IpAddr::V4(v4)) => v4.is_link_local(),
+        Ok(std::net::IpAddr::V6(v6)) => {
+            (v6.segments()[0] & 0xffc0) == 0xfe80
+                || v6.to_ipv4_mapped().is_some_and(|v4| v4.is_link_local())
+        }
+        Err(_) => false,
+    }
+}
+
 pub(crate) async fn fetch_provider_models(
     provider: &str,
     api_key: &str,
@@ -1205,7 +1257,9 @@ pub(crate) async fn fetch_provider_models(
         req = req
             .header("x-api-key", api_key)
             .header("anthropic-version", "2023-06-01");
-    } else {
+    } else if !api_key.is_empty() {
+        // Keyless families pass an empty key — suppress the header instead of
+        // sending a literal `Bearer ` (mirrors test_provider's factory path).
         req = req.header("Authorization", format!("Bearer {api_key}"));
     }
     let resp = req.send().await.ok()?;
@@ -5445,6 +5499,27 @@ mod register_flow_tests {
 mod tests {
     use super::*;
     use tokio::io::AsyncWriteExt;
+
+    /// The guard blocks exactly the link-local (metadata) ranges and nothing
+    /// a local model server legitimately uses (loopback, RFC1918, hostnames).
+    #[test]
+    fn should_block_only_link_local_base_urls() {
+        // Metadata endpoints — blocked.
+        assert!(base_url_targets_link_local("http://169.254.169.254/latest"));
+        assert!(base_url_targets_link_local("http://169.254.0.1:8080/v1"));
+        assert!(base_url_targets_link_local("http://[fe80::1]:8080/v1"));
+        assert!(base_url_targets_link_local(
+            "http://[::ffff:169.254.169.254]/v1"
+        ));
+        // Legitimate local model servers — allowed.
+        assert!(!base_url_targets_link_local("http://127.0.0.1:8080/v1"));
+        assert!(!base_url_targets_link_local("http://localhost:11434/v1"));
+        assert!(!base_url_targets_link_local("http://192.168.1.10:11434/v1"));
+        assert!(!base_url_targets_link_local("http://10.0.0.5:8000/v1"));
+        assert!(!base_url_targets_link_local("https://api.openai.com/v1"));
+        // Garbage never panics.
+        assert!(!base_url_targets_link_local("not a url"));
+    }
 
     #[test]
     fn relocate_keychain_backed_secrets_never_persists_raw_vertex_json_off_macos() {


### PR DESCRIPTION
## Summary

Live octoscode onboarding against a llama.cpp server caught two residual keyless dead ends that the #2096 review round missed:

- **admin::test_provider**: when the request carries neither api_key nor api_key_env, resolve_saved_key errors with "No api_key or api_key_env provided" *before* the keyless gate added in #2096 — so the local family still could not be connection-tested.
- **provider_models** (POST /api/my/provider-models): the same unauthenticated-key dead end, entirely ungated.

Both handlers now treat a missing or unresolvable key as an empty key for registry families with requires_api_key=false (local/ollama/vllm), matching the raw_profile_llm_test / raw_profile_llm_fetch_models gates from #2096.

## Test plan

- [x] Verified live: POST /api/admin/test-provider with {"provider":"local","model":""} and no key returns {"ok":true} against a llama-server on 127.0.0.1:8080 (previously: "No api_key or api_key_env provided")
- [x] Full keyless octoscode TUI onboarding walked end-to-end against this build (family pick, empty-key Test connection, Save, session turn through the local model)
- [x] cargo test -p octos-cli --lib (default features, the CI gate) — 1549 passed
- [x] clippy + fmt clean; the 2 full-suite --features api flakes reproduce identically on clean main (pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EktkNBvEhD82cYemLdDW7V