### PR TITLE
docs(api): regenerate UI Protocol wire inventory from code constants

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_WIRE_INVENTORY_2026-05-24.md
+++ b/api/OCTOS_UI_PROTOCOL_WIRE_INVENTORY_2026-05-24.md
@@ -9,7 +9,7 @@ spec and UPCR documents. The authoritative source remains code:
 
 - commands: `crates/octos-core/src/ui_protocol.rs::UI_PROTOCOL_COMMAND_METHODS`,
   `UI_PROTOCOL_FIRST_SERVER_METHODS`, plus
-  `crates/octos-cli/src/api/ui_protocol.rs::APPUI_EXTRA_METHODS`
+  `crates/octos-cli/src/api/ui_protocol_transport.rs::APPUI_EXTRA_METHODS`
 - notifications:
   `crates/octos-core/src/ui_protocol.rs::UI_PROTOCOL_NOTIFICATION_METHODS`
 - executable route fixture:
@@ -97,68 +97,97 @@ spec and UPCR documents. The authoritative source remains code:
 | `skill/action/job/list` | shipped AppUI extra, UPCR-2026-027 |
 | `skill/action/job/read` | shipped AppUI extra, UPCR-2026-027 |
 | `onboarding/workspace_probe` | shipped local-solo AppUI extra |
+| `session/btw` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `user_question/respond` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `session/rollback` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `session/fork` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `monitor/create` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `monitor/list` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `monitor/pause` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `monitor/resume` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `monitor/delete` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `memory/overview` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `memory/entity` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `cron/list` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `cron/toggle` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `launch/resolve` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `smart_home/status.get` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `smart_home/device.list` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `smart_home/device.command` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `smart_home/camera.stream_start` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `smart_home/camera.stream_stop` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `profile/sub_providers/list` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `profile/sub_providers/upsert` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `profile/sub_providers/remove` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `snapshot/list` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `snapshot/restore` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `peer/prepare` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `peer/gather` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `turn/steer` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `session/compact` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `session/compact/mode/set` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
 
 ## Notifications
 
 | Method | Status |
 |---|---|
-| `session/open` | shipped open/resume notification | |
-| `turn/started` | shipped base notification | |
-| `turn/completed` | shipped base notification | |
-| `turn/error` | shipped base notification | |
-| `message/delta` | shipped base notification | |
-| `message/reasoning_delta` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
-| `tool/started` | shipped base notification | |
-| `approval/requested` | shipped base notification, UPCR-2026-001 | |
-| `approval/auto_resolved` | shipped durable approval notification | |
-| `approval/decided` | shipped durable approval notification | |
-| `approval/cancelled` | shipped durable approval notification | |
-| `user_question/requested` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
-| `task/updated` | shipped, UPCR-2026-004 | |
-| `plan/updated` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
-| `task/output/delta` | shipped task output notification | |
-| `progress/updated` | shipped typed progress notification | |
-| `warning` | shipped base notification | |
-| `protocol/replay_lossy` | shipped backpressure/replay notification | |
-| `turn/spawn_complete` | shipped background completion notification | |
-| `file/attached` | shipped, UPCR-2026-014 | |
-| `visual/generating` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
-| `visual/succeeded` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
-| `visual/failed` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
-| `voice/exit` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
-| `skill/action/job/updated` | shipped AppUI extra notification, UPCR-2026-027 | |
-| `voice/audio_chunk` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
-| `projection/envelope` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
-| `session/event` | shipped, UPCR-2026-014 | |
-| `router/status` | shipped adaptive-router notification | |
-| `router/failover` | shipped adaptive-router notification | |
-| `queue/state` | known client-emitted queue notification | |
-| `agent/updated` | shipped, UPCR-2026-019 / UPCR-2026-021 | |
-| `agent/output/delta` | shipped, UPCR-2026-019 / UPCR-2026-021 | |
-| `agent/artifact/updated` | shipped, UPCR-2026-019 / UPCR-2026-021 | |
-| `session/goal/updated` | shipped, UPCR-2026-021 | |
-| `session/goal/cleared` | shipped, UPCR-2026-021 | |
-| `loop/updated` | shipped, UPCR-2026-021 | |
-| `loop/fired` | shipped, UPCR-2026-021 | |
-| `loop/completed` | shipped, UPCR-2026-021 | |
-| `monitor/fired` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
-| `monitor/updated` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
-| `monitor/expired` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
-| `context/compaction_completed` | shipped M16 context lifecycle notification | |
-| `context/compaction_started` | shipped M16 context lifecycle notification | |
-| `context/normalization_reported` | shipped M16 context lifecycle notification | |
-| `peer/staged` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
-| `peer/closed` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
-| `background/activity` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `session/open` | shipped open/resume notification |
+| `turn/started` | shipped base notification |
+| `turn/completed` | shipped base notification |
+| `turn/error` | shipped base notification |
+| `message/delta` | shipped base notification |
+| `message/reasoning_delta` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `tool/started` | shipped base notification |
+| `tool_progress` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `tool_completed` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `approval/requested` | shipped base notification, UPCR-2026-001 |
+| `approval/auto_resolved` | shipped durable approval notification |
+| `approval/decided` | shipped durable approval notification |
+| `approval/cancelled` | shipped durable approval notification |
+| `user_question/requested` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `task/updated` | shipped, UPCR-2026-004 |
+| `plan/updated` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `task/output/delta` | shipped task output notification |
+| `progress/updated` | shipped typed progress notification |
+| `warning` | shipped base notification |
+| `protocol/replay_lossy` | shipped backpressure/replay notification |
+| `turn/spawn_complete` | shipped background completion notification |
+| `file/attached` | shipped, UPCR-2026-014 |
+| `visual/generating` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `visual/succeeded` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `visual/failed` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `voice/exit` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `skill/action/job/updated` | shipped AppUI extra notification, UPCR-2026-027 |
+| `voice/audio_chunk` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `projection/envelope` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `session/event` | shipped, UPCR-2026-014 |
+| `router/status` | shipped adaptive-router notification |
+| `router/failover` | shipped adaptive-router notification |
+| `queue/state` | known client-emitted queue notification |
+| `agent/updated` | shipped, UPCR-2026-019 / UPCR-2026-021 |
+| `agent/output/delta` | shipped, UPCR-2026-019 / UPCR-2026-021 |
+| `agent/artifact/updated` | shipped, UPCR-2026-019 / UPCR-2026-021 |
+| `session/goal/updated` | shipped, UPCR-2026-021 |
+| `session/goal/cleared` | shipped, UPCR-2026-021 |
+| `loop/updated` | shipped, UPCR-2026-021 |
+| `loop/fired` | shipped, UPCR-2026-021 |
+| `loop/completed` | shipped, UPCR-2026-021 |
+| `monitor/fired` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `monitor/updated` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `monitor/expired` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `context/compaction_completed` | shipped M16 context lifecycle notification |
+| `context/compaction_started` | shipped M16 context lifecycle notification |
+| `context/normalization_reported` | shipped M16 context lifecycle notification |
+| `peer/staged` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `peer/closed` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `background/activity` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
 
-> **Audit note (2026-08-21, spec-vs-impl review):** this inventory was regenerated from the code
-> constants of truth (`UI_PROTOCOL_COMMAND_METHODS` + `APPUI_EXTRA_METHODS`,
-> `UI_PROTOCOL_NOTIFICATION_METHODS` in `crates/octos-core/src/ui_protocol.rs` and
-> `crates/octos-cli/src/api/ui_protocol_transport.rs`).
-> `message/persisted` (UPCR-2026-012) was **retired**: the ledger explicitly skips it
-> (`ui_protocol_ledger.rs:1001`) and tests assert no new frame carries it; its successor is
-> `projection/envelope` (v2 form). The stale file reference `octos-cli/src/api/ui_protocol.rs`
-> is corrected to `octos-cli/src/api/ui_protocol_transport.rs`.
+> **Audit note (2026-08-21):** commands were backfilled from the code constants of
+> truth (`UI_PROTOCOL_COMMAND_METHODS` in `crates/octos-core/src/ui_protocol.rs` plus
+> `APPUI_EXTRA_METHODS`). Notifications above are now the full
+> `UI_PROTOCOL_NOTIFICATION_METHODS` list. `message/persisted` (UPCR-2026-012) was
+> **retired**: the ledger explicitly skips it (`ui_protocol_ledger.rs:1001`) and tests
+> assert no new frame carries it; its successor is `projection/envelope`.
 
 ## Reconciliation Decisions
 

--- a/api/OCTOS_UI_PROTOCOL_WIRE_INVENTORY_2026-05-24.md
+++ b/api/OCTOS_UI_PROTOCOL_WIRE_INVENTORY_2026-05-24.md
@@ -102,42 +102,63 @@ spec and UPCR documents. The authoritative source remains code:
 
 | Method | Status |
 |---|---|
-| `session/open` | shipped open/resume notification |
-| `turn/started` | shipped base notification |
-| `turn/completed` | shipped base notification |
-| `turn/error` | shipped base notification |
-| `message/delta` | shipped base notification |
-| `tool/started` | shipped base notification |
-| `tool/progress` | shipped base notification |
-| `tool/completed` | shipped base notification |
-| `approval/requested` | shipped base notification, UPCR-2026-001 |
-| `approval/auto_resolved` | shipped durable approval notification |
-| `approval/decided` | shipped durable approval notification |
-| `approval/cancelled` | shipped durable approval notification |
-| `task/updated` | shipped, UPCR-2026-004 |
-| `task/output/delta` | shipped task output notification |
-| `progress/updated` | shipped typed progress notification |
-| `warning` | shipped base notification |
-| `protocol/replay_lossy` | shipped backpressure/replay notification |
-| `message/persisted` | shipped, UPCR-2026-012 |
-| `turn/spawn_complete` | shipped background completion notification |
-| `file/attached` | shipped, UPCR-2026-014 |
-| `session/event` | shipped, UPCR-2026-014 |
-| `router/status` | shipped adaptive-router notification |
-| `router/failover` | shipped adaptive-router notification |
-| `queue/state` | known client-emitted queue notification |
-| `agent/updated` | shipped, UPCR-2026-019 / UPCR-2026-021 |
-| `agent/output/delta` | shipped, UPCR-2026-019 / UPCR-2026-021 |
-| `agent/artifact/updated` | shipped, UPCR-2026-019 / UPCR-2026-021 |
-| `skill/action/job/updated` | shipped AppUI extra notification, UPCR-2026-027 |
-| `session/goal/updated` | shipped, UPCR-2026-021 |
-| `session/goal/cleared` | shipped, UPCR-2026-021 |
-| `loop/updated` | shipped, UPCR-2026-021 |
-| `loop/fired` | shipped, UPCR-2026-021 |
-| `loop/completed` | shipped, UPCR-2026-021 |
-| `context/compaction_completed` | shipped M16 context lifecycle notification |
-| `context/compaction_started` | shipped M16 context lifecycle notification |
-| `context/normalization_reported` | shipped M16 context lifecycle notification |
+| `session/open` | shipped open/resume notification | |
+| `turn/started` | shipped base notification | |
+| `turn/completed` | shipped base notification | |
+| `turn/error` | shipped base notification | |
+| `message/delta` | shipped base notification | |
+| `message/reasoning_delta` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `tool/started` | shipped base notification | |
+| `approval/requested` | shipped base notification, UPCR-2026-001 | |
+| `approval/auto_resolved` | shipped durable approval notification | |
+| `approval/decided` | shipped durable approval notification | |
+| `approval/cancelled` | shipped durable approval notification | |
+| `user_question/requested` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `task/updated` | shipped, UPCR-2026-004 | |
+| `plan/updated` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `task/output/delta` | shipped task output notification | |
+| `progress/updated` | shipped typed progress notification | |
+| `warning` | shipped base notification | |
+| `protocol/replay_lossy` | shipped backpressure/replay notification | |
+| `turn/spawn_complete` | shipped background completion notification | |
+| `file/attached` | shipped, UPCR-2026-014 | |
+| `visual/generating` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `visual/succeeded` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `visual/failed` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `voice/exit` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `skill/action/job/updated` | shipped AppUI extra notification, UPCR-2026-027 | |
+| `voice/audio_chunk` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `projection/envelope` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `session/event` | shipped, UPCR-2026-014 | |
+| `router/status` | shipped adaptive-router notification | |
+| `router/failover` | shipped adaptive-router notification | |
+| `queue/state` | known client-emitted queue notification | |
+| `agent/updated` | shipped, UPCR-2026-019 / UPCR-2026-021 | |
+| `agent/output/delta` | shipped, UPCR-2026-019 / UPCR-2026-021 | |
+| `agent/artifact/updated` | shipped, UPCR-2026-019 / UPCR-2026-021 | |
+| `session/goal/updated` | shipped, UPCR-2026-021 | |
+| `session/goal/cleared` | shipped, UPCR-2026-021 | |
+| `loop/updated` | shipped, UPCR-2026-021 | |
+| `loop/fired` | shipped, UPCR-2026-021 | |
+| `loop/completed` | shipped, UPCR-2026-021 | |
+| `monitor/fired` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `monitor/updated` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `monitor/expired` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `context/compaction_completed` | shipped M16 context lifecycle notification | |
+| `context/compaction_started` | shipped M16 context lifecycle notification | |
+| `context/normalization_reported` | shipped M16 context lifecycle notification | |
+| `peer/staged` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `peer/closed` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `background/activity` | shipped; missing from prior inventory — backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+
+> **Audit note (2026-08-21, spec-vs-impl review):** this inventory was regenerated from the code
+> constants of truth (`UI_PROTOCOL_COMMAND_METHODS` + `APPUI_EXTRA_METHODS`,
+> `UI_PROTOCOL_NOTIFICATION_METHODS` in `crates/octos-core/src/ui_protocol.rs` and
+> `crates/octos-cli/src/api/ui_protocol_transport.rs`).
+> `message/persisted` (UPCR-2026-012) was **retired**: the ledger explicitly skips it
+> (`ui_protocol_ledger.rs:1001`) and tests assert no new frame carries it; its successor is
+> `projection/envelope` (v2 form). The stale file reference `octos-cli/src/api/ui_protocol.rs`
+> is corrected to `octos-cli/src/api/ui_protocol_transport.rs`.
 
 ## Reconciliation Decisions
 


### PR DESCRIPTION
Spec-vs-impl audit (3 parallel review agents) found the 2026-05-24 wire inventory lagging the implementation.

- backfill 29 implemented commands missing from the inventory (session/rollback|fork|btw|compact, turn/steer, monitor/*, smart_home/*, peer/prepare|gather, snapshot/*, cron/*, memory/*, profile/sub_providers/*, user_question/respond, launch/resolve, session/compact/mode/set)
- backfill 15 implemented notifications (voice/*, visual/*, monitor/*, peer/*, plan/updated, projection/envelope, background/activity, message/reasoning_delta, user_question/requested)
- retire message/persisted (UPCR-2026-012): ledger skips it (ui_protocol_ledger.rs:1001) and tests assert no new frame carries it; successor is projection/envelope v2
- correct stale source path: octos-cli/src/api/ui_protocol.rs -> octos-cli/src/api/ui_protocol_transport.rs

Generated directly from the code constants of truth (UI_PROTOCOL_COMMAND_METHODS, APPUI_EXTRA_METHODS, UI_PROTOCOL_NOTIFICATION_METHODS).