### PR TITLE
feat(usage): make prompt-cache effectiveness observable

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -1355,6 +1355,15 @@ impl Agent {
                             response_content_len = response.content.as_ref().map(|c| c.len()).unwrap_or(0),
                             input_tokens = response.usage.input_tokens,
                             output_tokens = response.usage.output_tokens,
+                            // Prompt caching is the largest single cost lever
+                            // and is on by default, but it was unobservable
+                            // from the logs: these two were already parsed and
+                            // handed to `record_usage` below, just never
+                            // printed. `input_tokens` alone is misleading —
+                            // it EXCLUDES the cached portion, so a warm turn
+                            // looks like a tiny prompt rather than a cheap one.
+                            cache_read_tokens = response.usage.cache_read_tokens,
+                            cache_write_tokens = response.usage.cache_write_tokens,
                             "LLM response received"
                         );
                     }

--- a/crates/octos-cli/src/api/ui_protocol_tests.rs
+++ b/crates/octos-cli/src/api/ui_protocol_tests.rs
@@ -35156,3 +35156,64 @@ async fn connection_close_settles_steers_before_connection_closed_terminal() {
     );
     handle.abort();
 }
+
+/// `session/status/read` used to emit a hardcoded `"usage": {}`, so every
+/// field of octoscode's `SessionUsageStatus` decoded to `None` forever. These
+/// pin the field mapping that replaced it — in particular
+/// `cached_input_tokens`, without which an operator cannot tell whether prompt
+/// caching is working.
+#[test]
+fn should_report_cache_read_tokens_in_session_usage_status() {
+    let totals = UsageTotals {
+        run_count: 2,
+        input_tokens: 105,
+        output_tokens: 20,
+        cache_read_tokens: 95,
+        estimated_cost_usd: 0.25,
+    };
+    let usage = usage_status_json(&totals);
+    assert_eq!(usage["input_tokens"], 105);
+    assert_eq!(usage["output_tokens"], 20);
+    assert_eq!(usage["cached_input_tokens"], 95);
+    assert_eq!(usage["estimated_cost_micros_usd"], 250_000);
+}
+
+#[test]
+fn should_report_empty_usage_when_session_has_no_recorded_runs() {
+    let usage = usage_status_json(&UsageTotals::default());
+    assert_eq!(usage, serde_json::json!({}));
+}
+
+#[test]
+fn should_omit_cost_when_no_run_was_priced() {
+    // Tokens accrue but the model had no catalog pricing: report the tokens,
+    // stay silent on spend rather than claiming a confident $0.0000.
+    let totals = UsageTotals {
+        run_count: 1,
+        input_tokens: 100,
+        output_tokens: 10,
+        cache_read_tokens: 0,
+        estimated_cost_usd: 0.0,
+    };
+    let usage = usage_status_json(&totals);
+    assert_eq!(usage["input_tokens"], 100);
+    assert_eq!(usage["cached_input_tokens"], 0);
+    assert!(usage.get("estimated_cost_micros_usd").is_none());
+}
+
+/// A cold first turn reports zero cache reads. That is the correct reading,
+/// not a broken one — and it must be reported as an explicit `0` rather than
+/// omitted, because "absent" is what an unimplemented field looks like.
+#[test]
+fn should_report_zero_cache_reads_explicitly_on_a_cold_session() {
+    let totals = UsageTotals {
+        run_count: 1,
+        input_tokens: 13_302,
+        output_tokens: 76,
+        cache_read_tokens: 0,
+        estimated_cost_usd: 0.0,
+    };
+    let usage = usage_status_json(&totals);
+    assert_eq!(usage["cached_input_tokens"], 0);
+    assert!(usage.get("cached_input_tokens").is_some());
+}

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -144,7 +144,9 @@ use crate::context_manager::{
     PromptFrame, load_or_rebuild_context_manager, persist_context_manager_snapshot,
 };
 use crate::peers::*;
-use crate::usage_ledger::{PersistentUsageLedger, USAGE_LEDGER_FILE, UsageCostSource, UsageEvent};
+use crate::usage_ledger::{
+    PersistentUsageLedger, USAGE_LEDGER_FILE, UsageCostSource, UsageEvent, UsageTotals,
+};
 use crate::user_store::UserRole;
 
 const MAX_DIFF_PREVIEW_BYTES: usize = 256 * 1024;
@@ -9674,6 +9676,84 @@ fn raw_catalog_result(_state: &AppState, _profile_id: Option<&str>) -> Result<Va
     Ok(json!({ "families": Value::Object(families) }))
 }
 
+/// Cumulative token usage for one session, for the `usage` field of
+/// `session/status/read`.
+///
+/// This used to be a hardcoded `{}`, so every field of octoscode's
+/// `SessionUsageStatus` decoded to `None` on every read — the whole usage
+/// readout was dead, and `cached_input_tokens` in particular meant operators
+/// had no way to tell whether prompt caching (the largest cost lever, on by
+/// default) was working at all.
+///
+/// Sourced from the persistent usage ledger so the figures survive runtime
+/// rebuilds and restarts, matching the REST endpoints in `api::usage`. Reads
+/// are best-effort: a missing or unreadable ledger yields `{}` exactly as
+/// before rather than failing the whole status read, which also keeps
+/// deployments with no ledger configured working unchanged.
+///
+/// `session/status/read` is event-driven and deduped client-side
+/// (`enqueue_session_status_probe`), not interval-polled, so opening the
+/// ledger here costs roughly what the existing `/api/usage` handlers already
+/// pay per request.
+async fn session_usage_status(state: &Arc<AppState>, profile_id: &str, session_id: &str) -> Value {
+    let Some(store) = state.profile_store.as_ref() else {
+        return json!({});
+    };
+    let Ok(Some(profile)) = store.get(profile_id) else {
+        return json!({});
+    };
+    let data_dir = store.resolve_data_dir(&profile);
+    let ledger = match PersistentUsageLedger::open(&data_dir).await {
+        Ok(ledger) => ledger,
+        Err(error) => {
+            debug!(
+                data_dir = %data_dir.display(),
+                error = %error,
+                "usage ledger unavailable for session status; reporting empty usage"
+            );
+            return json!({});
+        }
+    };
+    let totals = match ledger.session_totals(session_id).await {
+        Ok(totals) => totals,
+        Err(error) => {
+            debug!(
+                session = %session_id,
+                error = %error,
+                "failed to read session usage totals; reporting empty usage"
+            );
+            return json!({});
+        }
+    };
+    usage_status_json(&totals)
+}
+
+/// Shape [`UsageTotals`] into the `usage` object octoscode's
+/// `SessionUsageStatus` decodes. Split out from [`session_usage_status`] so
+/// the field mapping is testable without standing up an `AppState`.
+fn usage_status_json(totals: &UsageTotals) -> Value {
+    // A session with no recorded runs reports `{}` rather than a row of
+    // zeroes: octoscode renders each field only when present, and zeroes
+    // would claim "0 tokens used" for a session whose usage simply has not
+    // been written yet.
+    if totals.run_count == 0 {
+        return json!({});
+    }
+    let mut usage = json!({
+        "input_tokens": totals.input_tokens,
+        "output_tokens": totals.output_tokens,
+        "cached_input_tokens": totals.cache_read_tokens,
+    });
+    // Only emit a cost when the ledger actually priced something. A session
+    // whose model has no catalog pricing accumulates tokens but no spend, and
+    // reporting a confident `$0.0000` there is worse than reporting nothing.
+    if totals.estimated_cost_usd > 0.0 {
+        usage["estimated_cost_micros_usd"] =
+            json!((totals.estimated_cost_usd * 1_000_000.0).round() as u64);
+    }
+    usage
+}
+
 async fn raw_session_status_result(
     state: &Arc<AppState>,
     request: &RpcRequest<Value>,
@@ -9735,7 +9815,10 @@ async fn raw_session_status_result(
         "health": { "status": "ok" },
         "mcp_summary": { "connected": 0, "connecting": 0, "failed": 0, "disabled": 0 },
         "tool_summary": { "visible": 0, "enabled": 0, "denied": 0, "policy_id": "profile" },
-        "usage": {},
+        // The ledger keys sessions by the `SessionKey`'s string form (see
+        // `SessionActor::record_usage_event`); match it exactly or every
+        // lookup silently returns zero totals.
+        "usage": session_usage_status(state, &profile_id, &session_id.to_string()).await,
         "cursor": { "healthy": true, "replay_supported": true },
         "capabilities": features.advertised_capabilities(state),
     });
@@ -23450,7 +23533,8 @@ async fn handle_session_btw(
                         cost_source,
                         "appui_btw",
                         None,
-                    );
+                    )
+                    .with_cache_read_tokens(u64::from(response.usage.cache_read_tokens));
                     if let Err(error) = usage_ledger.record(event).await {
                         warn!(
                             session = %session_id.0,
@@ -32382,7 +32466,8 @@ async fn run_standalone_turn(
                         cost_source,
                         "appui",
                         None,
-                    );
+                    )
+                    .with_cache_read_tokens(u64::from(response.token_usage.cache_read_tokens));
                     if let Err(error) = usage_ledger.record(event).await {
                         warn!(
                             session = %usage_session_id_for_result,

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -4654,7 +4654,8 @@ impl SessionActor {
             cost_source,
             self.channel.clone(),
             attribution.map(ToOwned::to_owned),
-        );
+        )
+        .with_cache_read_tokens(u64::from(response.token_usage.cache_read_tokens));
         if let Err(error) = usage_ledger.record(event).await {
             warn!(
                 session = %self.session_key,
@@ -8861,7 +8862,8 @@ impl SessionActor {
                         },
                         channel.clone(),
                         Some("speculative_overflow".to_string()),
-                    );
+                    )
+                    .with_cache_read_tokens(u64::from(conv_response.token_usage.cache_read_tokens));
                     if let Err(error) = ledger.record(event).await {
                         warn!(
                             session = %session_key,

--- a/crates/octos-llm/tests/deepseek_prompt_cache_live.rs
+++ b/crates/octos-llm/tests/deepseek_prompt_cache_live.rs
@@ -1,0 +1,131 @@
+//! Live prompt-cache validation against the official DeepSeek endpoint.
+//!
+//! DeepSeek's context caching is automatic and server-side — there is no flag
+//! a client can set. What a client CAN get wrong is prefix stability: if the
+//! serialized head of the request (system prompt, then the tool array) differs
+//! between rounds, every round is a full cache miss.
+//!
+//! This sends the same system prompt + tool array twice in a 2-round chat. On
+//! round 1 the cache is written and `cache_read_tokens` is legitimately 0; on
+//! round 2 the replayed prefix should come back from the cache. Reading round 1
+//! alone proves nothing, which is the whole point of this being a 2-round test.
+//!
+//! Ignored by default (needs a real key + network). Run with:
+//!   DEEPSEEK_API_KEY=... cargo test -p octos-llm --test deepseek_prompt_cache_live -- --ignored --nocapture
+
+use chrono::Utc;
+use octos_core::{Message, MessageRole};
+use octos_llm::openai::OpenAIProvider;
+use octos_llm::{ChatConfig, LlmProvider, ToolSpec};
+
+fn msg(role: MessageRole, content: impl Into<String>) -> Message {
+    Message {
+        role,
+        content: content.into(),
+        media: vec![],
+        tool_calls: None,
+        tool_call_id: None,
+        reasoning_content: None,
+        client_message_id: None,
+        thread_id: None,
+        timestamp: Utc::now(),
+    }
+}
+
+/// A tool array shaped like the real agent's — the registry sorts by name
+/// (`tools/registry.rs`), so mirror that here: identical order both rounds.
+fn tools() -> Vec<ToolSpec> {
+    let mut specs: Vec<ToolSpec> = ["exec_command", "glob", "grep", "list_dir", "read_file"]
+        .iter()
+        .map(|name| ToolSpec {
+            name: (*name).to_string(),
+            description: format!(
+                "The {name} tool. Use it to inspect the workspace. \
+                 Prefer it over guessing at file contents."
+            ),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string", "description": "Target path." },
+                    "pattern": { "type": "string", "description": "Match pattern." }
+                },
+                "required": ["path"]
+            }),
+        })
+        .collect();
+    specs.sort_by(|a, b| a.name.cmp(&b.name));
+    specs
+}
+
+#[tokio::test]
+#[ignore]
+async fn deepseek_two_round_chat_reports_cache_read_tokens_on_round_two() {
+    let key = std::env::var("DEEPSEEK_API_KEY").expect("DEEPSEEK_API_KEY not set");
+    let model = std::env::var("DEEPSEEK_MODEL").unwrap_or_else(|_| "deepseek-v4-flash".to_string());
+    let base_url = std::env::var("DEEPSEEK_BASE_URL")
+        .unwrap_or_else(|_| "https://api.deepseek.com/v1".to_string());
+
+    let provider = OpenAIProvider::new(&key, &model)
+        .with_provider_label("deepseek")
+        .with_base_url(&base_url);
+
+    // DeepSeek caches on a 64-token block granularity with a 64-token minimum.
+    // Pad well past it so a hit is unambiguous and roughly the size of a real
+    // agent system prompt (~13k tokens as measured in the A/B run).
+    let filler =
+        "The quick brown fox jumps over the lazy dog near the riverbank at dawn. ".repeat(700);
+    let system = format!(
+        "You are a terse coding assistant; answer with a single word. \
+         Reference corpus (background only, do not quote): {filler}"
+    );
+
+    let tools = tools();
+    let config = ChatConfig {
+        max_tokens: Some(512),
+        ..Default::default()
+    };
+
+    let mut history = vec![
+        msg(MessageRole::System, system),
+        msg(MessageRole::User, "Reply with the single word: ping"),
+    ];
+
+    let r1 = provider
+        .chat(&history, &tools, &config)
+        .await
+        .expect("round 1 chat failed");
+    println!(
+        "round 1 usage: input={} output={} cache_read={} cache_write={}",
+        r1.usage.input_tokens,
+        r1.usage.output_tokens,
+        r1.usage.cache_read_tokens,
+        r1.usage.cache_write_tokens,
+    );
+
+    history.push(msg(
+        MessageRole::Assistant,
+        r1.content.clone().unwrap_or_else(|| "pong".to_string()),
+    ));
+    history.push(msg(MessageRole::User, "Reply with the single word: pong"));
+
+    let r2 = provider
+        .chat(&history, &tools, &config)
+        .await
+        .expect("round 2 chat failed");
+    println!(
+        "round 2 usage: input={} output={} cache_read={} cache_write={}",
+        r2.usage.input_tokens,
+        r2.usage.output_tokens,
+        r2.usage.cache_read_tokens,
+        r2.usage.cache_write_tokens,
+    );
+
+    assert!(
+        r2.usage.cache_read_tokens > 0,
+        "expected round 2 to be served from DeepSeek's automatic prompt cache \
+         (cache_read_tokens > 0). Either the replayed prefix is unstable between \
+         rounds, or this endpoint does not report \
+         `prompt_tokens_details.cached_tokens`: {:?}",
+        r2.usage
+    );
+}

--- a/crates/octos-store/src/usage_ledger.rs
+++ b/crates/octos-store/src/usage_ledger.rs
@@ -57,6 +57,21 @@ pub struct UsageEvent {
     pub input_tokens: u64,
     #[serde(default)]
     pub output_tokens: u64,
+    /// Prompt tokens served from the provider's cache (Anthropic
+    /// `cache_read_input_tokens`, OpenAI/DeepSeek automatic
+    /// `prompt_tokens_details.cached_tokens`).
+    ///
+    /// Disjoint from `input_tokens` — providers report the cached portion
+    /// INSIDE their prompt total, but `TokenUsage` subtracts it at the
+    /// provider boundary, so the full prompt is `input_tokens +
+    /// cache_read_tokens`. Recorded so cache effectiveness is answerable
+    /// after the fact instead of only from a live API probe.
+    ///
+    /// `#[serde(default)]`: ledger records written before this field
+    /// existed decode as 0, which is indistinguishable from a genuinely
+    /// uncached run and needs no migration.
+    #[serde(default)]
+    pub cache_read_tokens: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub estimated_cost_usd: Option<f64>,
     #[serde(default)]
@@ -95,11 +110,23 @@ impl UsageEvent {
             base_url,
             input_tokens,
             output_tokens,
+            cache_read_tokens: 0,
             estimated_cost_usd,
             cost_source,
             channel: channel.into(),
             attribution,
         }
+    }
+
+    /// Record the cache-served portion of this run's prompt.
+    ///
+    /// A builder rather than a 13th positional argument: [`Self::completed_run`]
+    /// is already `#[allow(clippy::too_many_arguments)]`, and most call sites
+    /// have no cache figure to contribute. Those keep the default of 0.
+    #[must_use]
+    pub fn with_cache_read_tokens(mut self, cache_read_tokens: u64) -> Self {
+        self.cache_read_tokens = cache_read_tokens;
+        self
     }
 }
 
@@ -116,6 +143,11 @@ pub struct UsageTotals {
     pub run_count: u64,
     pub input_tokens: u64,
     pub output_tokens: u64,
+    /// Cache-served prompt tokens, disjoint from `input_tokens` (see
+    /// [`UsageEvent::cache_read_tokens`]). Zero across a whole session
+    /// means every round paid full price for its prefix.
+    #[serde(default)]
+    pub cache_read_tokens: u64,
     pub estimated_cost_usd: f64,
 }
 
@@ -124,6 +156,9 @@ impl UsageTotals {
         self.run_count = self.run_count.saturating_add(1);
         self.input_tokens = self.input_tokens.saturating_add(event.input_tokens);
         self.output_tokens = self.output_tokens.saturating_add(event.output_tokens);
+        self.cache_read_tokens = self
+            .cache_read_tokens
+            .saturating_add(event.cache_read_tokens);
         if let Some(cost) = event.estimated_cost_usd {
             self.estimated_cost_usd += cost;
         }
@@ -133,6 +168,9 @@ impl UsageTotals {
         self.run_count = self.run_count.saturating_add(other.run_count);
         self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
         self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
+        self.cache_read_tokens = self
+            .cache_read_tokens
+            .saturating_add(other.cache_read_tokens);
         self.estimated_cost_usd += other.estimated_cost_usd;
     }
 }
@@ -498,6 +536,71 @@ fn event_matches_query(event: &UsageEvent, query: &UsageQuery) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn cache_event(input_tokens: u64, cache_read_tokens: u64) -> UsageEvent {
+        UsageEvent::completed_run(
+            "p",
+            "s",
+            "r",
+            None,
+            None,
+            None,
+            input_tokens,
+            10,
+            None,
+            UsageCostSource::Unavailable,
+            "test",
+            None,
+        )
+        .with_cache_read_tokens(cache_read_tokens)
+    }
+
+    #[test]
+    fn should_default_cache_read_tokens_to_zero_when_not_set() {
+        let event = cache_event(100, 0);
+        assert_eq!(event.cache_read_tokens, 0);
+    }
+
+    #[test]
+    fn should_accumulate_cache_read_tokens_across_events() {
+        let mut totals = UsageTotals::default();
+        totals.add_event(&cache_event(100, 0)); // cold: whole prefix billed
+        totals.add_event(&cache_event(5, 95)); // warm: prefix served from cache
+        assert_eq!(totals.input_tokens, 105);
+        assert_eq!(totals.cache_read_tokens, 95);
+    }
+
+    #[test]
+    fn should_carry_cache_read_tokens_through_merge() {
+        let mut left = UsageTotals::default();
+        left.add_event(&cache_event(10, 40));
+        let mut right = UsageTotals::default();
+        right.add_event(&cache_event(20, 60));
+        left.merge(&right);
+        assert_eq!(left.cache_read_tokens, 100);
+    }
+
+    /// Records written before `cache_read_tokens` existed must keep decoding.
+    /// `#[serde(default)]` is what makes this a no-migration change, so it is
+    /// worth pinning rather than trusting.
+    #[test]
+    fn should_decode_pre_cache_field_records_as_zero() {
+        let legacy = serde_json::json!({
+            "schema_version": USAGE_EVENT_SCHEMA_VERSION,
+            "event_id": "e1",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "profile_id": "p",
+            "session_id": "s",
+            "run_id": "r",
+            "input_tokens": 100,
+            "output_tokens": 10,
+            "cost_source": "unavailable",
+            "channel": "test"
+        });
+        let decoded: UsageEvent = serde_json::from_value(legacy).expect("legacy record decodes");
+        assert_eq!(decoded.cache_read_tokens, 0);
+        assert_eq!(decoded.input_tokens, 100);
+    }
 
     #[allow(clippy::too_many_arguments)]
     fn event(


### PR DESCRIPTION
## Why

Prompt caching is the single largest cost lever in octos and it is **on by default**, but there is currently no way for an operator to confirm it is working. That gap is not theoretical — it produced a concrete false alarm.

An A/B run comparing octos against another agent on `deepseek-v4-flash` measured 13,302 fresh input tokens per turn against the other tool's ~114, and concluded octos was failing to exploit DeepSeek's prompt cache. That conclusion was wrong. The two arms were not warmed equally: the octos arm was a fresh session's *first* call, which necessarily reports zero cache hits, while the comparison arm was warm from earlier runs.

Settling that took a live API probe, because nothing in the running system could answer it. Three separate places drop the number:

1. **The server log never printed it.** `loop_runner.rs` logs `input_tokens` and `output_tokens` on every `"LLM response received"`, then hands `cache_read_tokens` and `cache_write_tokens` to `record_usage` five lines later without ever logging them. Worse, `input_tokens` alone is actively misleading here: it *excludes* the cached portion (subtracted at the provider boundary so `TokenUsage` stays disjoint), so a warm turn looks like a suspiciously tiny prompt rather than a cheap one.

2. **`session/status/read` returned a hardcoded `"usage": {}`.** Every field of octoscode's `SessionUsageStatus` — `input_tokens`, `output_tokens`, `cached_input_tokens`, `cached_output_tokens`, `estimated_cost_micros_usd` — decoded to `None` on every read. octoscode already *renders* `cached_input_tokens` (`menu/providers.rs`), so the client half was built and wired to a field the server never sent. The entire usage readout was dead, not just the cache part.

3. **The usage ledger had no cache column**, so even after the fact the question was unanswerable from recorded data.

## What this does

- `UsageEvent.cache_read_tokens` + `UsageTotals.cache_read_tokens` in the ledger, threaded from `TokenUsage` at the three sites that record completed runs (session actor, AppUI turn result, `btw` aside).
- `session/status/read` now populates `usage` from the ledger's session totals, replacing the hardcoded `{}`.
- `loop_runner.rs` logs the two cache fields it was already holding.
- A live 2-round probe (`octos-llm/tests/deepseek_prompt_cache_live.rs`, `#[ignore]`) that proves the numbers are real, mirroring the existing `prompt_cache_live.rs` for the OpenAI-shaped path it does not cover.

Running that probe against the official DeepSeek endpoint:

```
round 1 usage: input=11953 output=36 cache_read=0     cache_write=0
round 2 usage: input=63    output=14 cache_read=11904 cache_write=0
```

Caching works correctly — 99.5% of the prefix served from cache on round 2. `11904 = 186 × 64` lands exactly on DeepSeek's 64-token cache-block granularity, and round 2's total prompt (`63 + 11904 = 11967`) reconciles with round 1's `11953` plus the appended exchange. This PR is what makes that visible without a probe.

## Deliberate scope decisions

- **No migration.** `cache_read_tokens` is `#[serde(default)]`, so ledger records written before this field decode as `0`. A test pins that.
- **Cost stays absent when nothing was priced.** A session whose model has no catalog pricing accumulates tokens but no spend; reporting a confident `$0.0000` there is worse than reporting nothing.
- **`{}` for a session with no recorded runs**, rather than a row of zeroes that would claim "0 tokens used" for a session whose usage simply has not been written yet.
- **A cold turn reports an explicit `0`, never an omitted field.** This is the exact ambiguity that caused the original false alarm: on the wire, `EnvelopeTokenUsage` marks `cache_read_tokens` `skip_serializing_if = "is_zero_u64"`, so in a JSON-RPC capture a cold turn is byte-identical to an unimplemented one. The status readout deliberately does not repeat that.
- **Ledger reads are best-effort.** A missing or unreadable ledger yields `{}` exactly as before rather than failing the whole status read, so deployments with no ledger configured are unaffected.
- **Builder, not a 13th argument.** `UsageEvent::completed_run` is already `#[allow(clippy::too_many_arguments)]` at 12 params; `with_cache_read_tokens` leaves the call sites that have no cache figure untouched.
- **Sibling stubs left alone.** `health`, `mcp_summary`, and `tool_summary` in the same handler are also hardcoded placeholders. They are out of scope here — fixing them is a separate change and a separate judgement call.

## Not addressed

`cached_output_tokens` remains unpopulated. No provider in the stack reports a cache-write figure the field could carry, so wiring it would mean inventing a number.

## Verification

- `cargo fmt --all`, `cargo clippy -p octos-store -p octos-agent --all-targets` and `cargo clippy -p octos-cli --features api --all-targets` clean.
- 4 new tests in `octos-store` (accumulation, merge, default-on-set, legacy-record decode) and 4 in `octos-cli` (field mapping, empty-session, unpriced-cost, explicit-zero-on-cold). All pass.
- `cargo test -p octos-store --lib`: 33 passed, 0 failed.
- `cargo test -p octos-cli --features api --lib`: 3003 passed, 38 failed. **The 38 failures are pre-existing and unrelated** — network-dependent tests (`smart_home_bridge`, `doctor`, `voice_turn`, `mcp_serve`). Verified by `git stash -u` and re-running on clean `origin/main`: the failure sets are byte-identical.
- The live probe is `#[ignore]` and needs `DEEPSEEK_API_KEY`; it is not part of CI.
