### PR TITLE
fix(autonomy): explicit scatter-join dedupe key + persisted join epoch (Refs #2102, Gap 3)

### DIFF
--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -2149,6 +2149,30 @@ impl InProcessAgentOrchestrator {
             .get(&upsert.agent_id)
             .map(|agent| agent.status.clone());
         let (agent, payload, transitioned_terminal) = {
+            // Refs #2102 (Gap 3): live spawn admission. A NEW agent record
+            // entering an ALREADY-JOINED group bumps the join epoch BEFORE
+            // the entry is created, under the same state lock — the crash
+            // window is empty and the bump is single-writer.
+            let existing = state.agents.contains_key(&upsert.agent_id);
+            if !existing {
+                let group = format!(
+                    "agent-group:{}:{}:{}",
+                    upsert.profile_id,
+                    upsert.session_id,
+                    upsert.parent_agent_id.as_deref().unwrap_or("master")
+                );
+                let already_joined = state
+                    .scatter_join_state
+                    .get(&group)
+                    .is_some_and(|s| s.last_joined_key.is_some());
+                if already_joined {
+                    state
+                        .scatter_join_state
+                        .entry(group)
+                        .or_default()
+                        .join_epoch += 1;
+                }
+            }
             let entry = state
                 .agents
                 .entry(upsert.agent_id.clone())

--- a/crates/octos-cli/src/autonomy/agent_orchestrator.rs
+++ b/crates/octos-cli/src/autonomy/agent_orchestrator.rs
@@ -10993,6 +10993,14 @@ pub(crate) fn clear_default_agent_orchestrator_for_test() {
 #[derive(Debug, Default)]
 struct AutonomyRuntimeState {
     agents: HashMap<String, AutonomyAgentRecord>,
+    /// Refs #2102 (Gap 3) — per-group scatter-join bookkeeping. `join_epoch`
+    /// increments when a child is admitted into an already-joined group
+    /// (spawn-admission path, under the state lock, BEFORE insertion);
+    /// `last_joined_key` records the explicit dedupe key of the last
+    /// ScatterJoinComplete actually enqueued, so the all-terminal edge can
+    /// skip an already-joined epoch even across a restart. Defaults are
+    /// additive — legacy persisted state deserializes with epoch 0 / None.
+    scatter_join_state: HashMap<String, ScatterJoinState>,
     goals: HashMap<SessionKey, AutonomyGoalRecord>,
     loops: HashMap<String, AutonomyLoopRecord>,
     /// #1977 — durable monitor records (specs + wake accounting). The live
@@ -11099,6 +11107,13 @@ struct AutonomyRuntimeState {
     /// `monitor/resume` landing in the unlocked gap (defect 2). Per-instance.
     #[cfg(test)]
     reset_window_before_accounting: bool,
+}
+
+/// Refs #2102 (Gap 3): join bookkeeping for one scatter-join group.
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+struct ScatterJoinState {
+    join_epoch: u64,
+    last_joined_key: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -12549,13 +12564,36 @@ fn enqueue_agent_terminal_continuations(
     {
         return;
     }
-    // NOTE: the `ScatterJoinComplete` continuation deliberately keeps the
-    // auto-derived `stable_dedupe_key` (which folds in the
-    // `terminal_children` count). The join only enqueues on the
-    // all-siblings-terminal edge, and a re-expanded group that finishes
-    // again SHOULD be able to re-join — so an identity-only key would be a
-    // behavior change here. Only the per-child `ChildCompleted` gets the
-    // explicit Gap-1 step-3 key.
+    // Refs #2102 (Gap 3): the auto-derived `stable_dedupe_key` folds every
+    // metadata pair into the key — including `terminal_children` — so a
+    // group that re-reaches all-terminal with a different child count
+    // enqueued a NEW join continuation and the master re-emitted the joined
+    // answer (duplicate output). Replaced by an EXPLICIT key
+    // `scatter_join/{group}/{session}/{profile}/{cwd_hash}/{epoch}`:
+    // same epoch joins exactly once (persisted `last_joined_key` equality
+    // check skips re-observation, restart-safe); a genuinely re-expanded
+    // group gets a new epoch at spawn admission and joins again.
+    let join_group_key = agent_continuation_group_id(agent);
+    let join_state = state
+        .scatter_join_state
+        .entry(join_group_key)
+        .or_default();
+    let mut cwd_hasher = std::collections::hash_map::DefaultHasher::new();
+    std::hash::Hash::hash(&agent.cwd, &mut cwd_hasher);
+    let cwd_hash = std::hash::Hasher::finish(&cwd_hasher);
+    let join_key = format!(
+        "scatter_join/{group}/{session}/{profile}/{cwd_hash}/{epoch}",
+        group = group_id.as_str(),
+        session = agent.session_id.0,
+        profile = agent.profile_id,
+        cwd_hash = cwd_hash,
+        epoch = join_state.join_epoch,
+    );
+    if join_state.last_joined_key.as_deref() == Some(join_key.as_str()) {
+        // This epoch already joined — skip enqueue entirely (also covers the
+        // re-marked-terminal-with-no-new-child case and restart replay).
+        return;
+    }
     let scatter = MasterContinuationRequest::new(
         group_id,
         agent.session_id.to_string(),
@@ -12563,6 +12601,7 @@ fn enqueue_agent_terminal_continuations(
         MasterContinuationReason::ScatterJoinComplete,
         SystemTime::now(),
     )
+    .with_dedupe_key(join_key.clone())
     .with_metadata(
         "parent_agent_id",
         agent
@@ -12577,6 +12616,12 @@ fn enqueue_agent_terminal_continuations(
         None => scatter,
     };
     enqueue_and_persist_continuation(state, scatter);
+    let join_group_key = agent_continuation_group_id(agent);
+    let join_state = state
+        .scatter_join_state
+        .entry(join_group_key)
+        .or_default();
+    join_state.last_joined_key = Some(join_key);
 }
 
 /// Gap-1 step 3: explicit `ChildCompleted` dedupe key, symmetric to the
@@ -13301,6 +13346,24 @@ fn restore_agents_from_supervisor_state(
             context_contract: None,
             restored: true,
         };
+        // Refs #2102 (Gap 3): spawn admission into an ALREADY-JOINED group
+        // bumps the join epoch BEFORE insertion, under the same state lock —
+        // a crash can never land between admission and the increment. The
+        // child's group comes from the supervisor record (`child.group_id`).
+        {
+            let group = child.group_id.clone();
+            let already_joined = state
+                .scatter_join_state
+                .get(&group)
+                .is_some_and(|s| s.last_joined_key.is_some());
+            if already_joined {
+                state
+                    .scatter_join_state
+                    .entry(group)
+                    .or_default()
+                    .join_epoch += 1;
+            }
+        }
         state.agents.insert(agent.agent_id.clone(), agent);
     }
 }


### PR DESCRIPTION
Gap 3 of #2102. The auto-derived stable_dedupe_key folds terminal_children (and every metadata pair) into the key, so a group re-reaching all-terminal with a different child count enqueued a NEW ScatterJoinComplete — the master re-emitted the joined answer (the duplicate-output symptom in the issue). This PR adds per-group ScatterJoinState {join_epoch, last_joined_key} (serde-default, additive), an EXPLICIT dedupe key scatter_join/{group}/{session}/{profile}/{cwd_hash}/{epoch} that bypasses metadata folding, an equality skip that is restart-safe and covers the re-marked-terminal case, and an epoch bump at spawn admission (before insertion, under the state lock). cargo test -p octos-cli --lib autonomy: 370/370 pass. See #2102 for the double-reviewed fix plan; companion PRs #2103 (Gap 1) and #2104 (Gap 2).