### PR TITLE
fix(api,e2e): correct inventory notification names; count sentinel methods as covered in soak

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_WIRE_INVENTORY_2026-05-24.md
+++ b/api/OCTOS_UI_PROTOCOL_WIRE_INVENTORY_2026-05-24.md
@@ -138,8 +138,8 @@ spec and UPCR documents. The authoritative source remains code:
 | `message/delta` | shipped base notification |
 | `message/reasoning_delta` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
 | `tool/started` | shipped base notification |
-| `tool_progress` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
-| `tool_completed` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `tool/progress` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
+| `tool/completed` | shipped; backfilled from code constants (spec-vs-impl audit 2026-08-21) |
 | `approval/requested` | shipped base notification, UPCR-2026-001 |
 | `approval/auto_resolved` | shipped durable approval notification |
 | `approval/decided` | shipped durable approval notification |

--- a/e2e/scripts/m18-appui-transport-parity-soak.mjs
+++ b/e2e/scripts/m18-appui-transport-parity-soak.mjs
@@ -1083,7 +1083,12 @@ function routeProbeParams(method) {
 async function captureRouteInventoryProbes(client, routeInventory, probes, probedMethods) {
   for (const method of routeInventoryMethods(routeInventory)) {
     const params = routeProbeParams(method);
-    if (params === PROBED_ELSEWHERE) continue;
+    if (params === PROBED_ELSEWHERE) {
+      // Covered by a dedicated scenario step elsewhere in this soak; count it
+      // as covered so it is not reported uncovered by inventory - probed.
+      probedMethods.add(method);
+      continue;
+    }
     await captureProbe(client, probes, `route:${method}`, method, params, 5000);
     probedMethods.add(method);
   }


### PR DESCRIPTION
Follow-up to #2098 and #2099, both merged with defects:

**inventory (#2098):** the backfilled notification rows wrote `tool_progress` / `tool_completed` — underscore names are LLM stream progress *kinds*, not protocol methods. The actual `UI_PROTOCOL_NOTIFICATION_METHODS` constants are `tool/progress` and `tool/completed` (crates/octos-core/src/ui_protocol.rs:1116-1117). Fixed both rows.

**soak (#2099):** `PROBED_ELSEWHERE` methods hit `continue` without being added to the probed Set, so `uncoveredRouteMethods = inventory − probed` deterministically reported all 18 sentinel methods as uncovered on every clean run and set exitCode=1. The PR CI never runs this soak, so it slipped through. Sentinel methods are now added to the Set (covered) before continuing; only methods that never probed on either transport remain uncovered and fail the run.