### PR TITLE
perf(plugins): speed up Vertex-backed skill actions

### DIFF
--- a/crates/octos-agent/src/plugins/loader.rs
+++ b/crates/octos-agent/src/plugins/loader.rs
@@ -1,9 +1,11 @@
 //! Plugin loader: scans directories for plugins and registers their tools.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
 use eyre::Result;
+use octos_llm::vertex_auth::{ServiceAccount, TokenSource, VertexTokenProvider};
 use sha2::{Digest, Sha256};
 use tracing::{info, warn};
 
@@ -837,6 +839,40 @@ impl PluginLoader {
                 }
             }
         };
+        // Build one token cache for the whole loaded plugin. Every tool gets a
+        // clone of this Arc, so classifier/enhancer/lesson calls launched as
+        // separate processes do not each repeat Google's OAuth exchange.
+        // Creating the source does not make a network request; the first tool
+        // that explicitly allowlists VERTEX_ACCESS_TOKEN refreshes it lazily.
+        let vertex_token_source: Option<(Arc<dyn TokenSource>, String)> = manifest
+            .tools
+            .iter()
+            .any(|tool| tool.env.iter().any(|name| name == "VERTEX_ACCESS_TOKEN"))
+            .then(|| {
+                extra_env
+                    .iter()
+                    .find(|(name, _)| name == "VERTEX_SA_JSON")
+                    .map(|(_, value)| value)
+            })
+            .flatten()
+            .and_then(|raw| match ServiceAccount::from_json(raw) {
+                Ok(account) => {
+                    let project_id = account.project_id.clone();
+                    Some((
+                        Arc::new(VertexTokenProvider::from_service_account(account))
+                            as Arc<dyn TokenSource>,
+                        project_id,
+                    ))
+                }
+                Err(error) => {
+                    warn!(
+                        plugin = %manifest.name,
+                        error = %error,
+                        "cannot prepare shared Vertex token cache; plugin fallback remains available"
+                    );
+                    None
+                }
+            });
         let manifest_actions = manifest.actions;
 
         let tools: Vec<LoadedPluginTool> = manifest
@@ -893,6 +929,9 @@ impl PluginLoader {
                     .with_blocked_env(blocked_env.clone())
                     .with_extra_env(extra_env.to_vec())
                     .with_timeout(timeout);
+                if let Some((source, project_id)) = vertex_token_source.clone() {
+                    tool = tool.with_vertex_token_source(source, project_id);
+                }
                 // Section C (codex review P2): stash the load-time hash ONLY
                 // when the operator opted into integrity for this plugin —
                 // either the manifest declared `sha256` (the author signaled

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -13,6 +13,7 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 
 use octos_core::{PathClassification, SessionScope};
+use octos_llm::vertex_auth::TokenSource;
 
 use crate::harness_errors::HarnessError;
 use crate::harness_events::{
@@ -88,6 +89,15 @@ pub struct PluginTool {
     /// Extra environment variables to inject into the plugin's environment.
     /// Secret-like names require the tool manifest's explicit env allowlist.
     extra_env: Vec<(String, String)>,
+    /// Host-owned, cached Vertex token source shared by plugin tools. The
+    /// short-lived token is injected only when the manifest explicitly
+    /// allowlists `VERTEX_ACCESS_TOKEN`; the service-account JSON remains the
+    /// backwards-compatible fallback inside the plugin.
+    vertex_token_source: Option<Arc<dyn TokenSource>>,
+    /// Project paired with `vertex_token_source`; injected alongside the
+    /// short-lived token so the plugin does not need the service-account JSON
+    /// merely to discover its Vertex project.
+    vertex_project_id: Option<String>,
     /// Working directory for plugin execution (created on first use).
     work_dir: Option<PathBuf>,
     /// Execution timeout.
@@ -147,6 +157,8 @@ impl PluginTool {
             executable,
             blocked_env: vec![],
             extra_env: vec![],
+            vertex_token_source: None,
+            vertex_project_id: None,
             work_dir: None,
             timeout: Self::DEFAULT_TIMEOUT,
             synthesis_config: None,
@@ -216,6 +228,19 @@ impl PluginTool {
     /// Set extra environment variables to inject into plugin execution.
     pub fn with_extra_env(mut self, env: Vec<(String, String)>) -> Self {
         self.extra_env = env;
+        self
+    }
+
+    /// Attach a host-owned Vertex token source. Multiple tools should receive
+    /// clones of the same `Arc` so separate plugin processes reuse one OAuth
+    /// token instead of exchanging the service-account key on every call.
+    pub fn with_vertex_token_source(
+        mut self,
+        source: Arc<dyn TokenSource>,
+        project_id: String,
+    ) -> Self {
+        self.vertex_token_source = Some(source);
+        self.vertex_project_id = Some(project_id);
         self
     }
 
@@ -392,6 +417,8 @@ impl PluginTool {
             executable: self.executable.clone(),
             blocked_env: self.blocked_env.clone(),
             extra_env: self.extra_env.clone(),
+            vertex_token_source: self.vertex_token_source.clone(),
+            vertex_project_id: self.vertex_project_id.clone(),
             work_dir: Some(work_dir),
             timeout: self.timeout,
             synthesis_config: self.synthesis_config.clone(),
@@ -421,6 +448,8 @@ impl PluginTool {
             executable: self.executable.clone(),
             blocked_env: self.blocked_env.clone(),
             extra_env: self.extra_env.clone(),
+            vertex_token_source: self.vertex_token_source.clone(),
+            vertex_project_id: self.vertex_project_id.clone(),
             work_dir: self.work_dir.clone(),
             timeout: self.timeout,
             synthesis_config: self.synthesis_config.clone(),
@@ -2668,8 +2697,48 @@ impl Tool for PluginTool {
         // also keeps approval-prompt cwd and runtime cwd in lockstep.
         let ctx = ctx_snapshot;
 
+        // Prepare the short-lived token before forwarding static env. If this
+        // succeeds, suppress the long-lived service-account JSON and provide
+        // only the token plus project. If it fails, keep the old JSON path as
+        // a backwards-compatible fallback.
+        let prepared_vertex_token = if let (Some(source), Some(project_id)) =
+            (&self.vertex_token_source, &self.vertex_project_id)
+        {
+            let token_permitted = if strict_env_gate {
+                should_forward_env_name_strict("VERTEX_ACCESS_TOKEN", &env_allowlist)
+            } else {
+                should_forward_env_name("VERTEX_ACCESS_TOKEN", &env_allowlist)
+            };
+            let project_permitted = if strict_env_gate {
+                should_forward_env_name_strict("GOOGLE_CLOUD_PROJECT", &env_allowlist)
+            } else {
+                should_forward_env_name("GOOGLE_CLOUD_PROJECT", &env_allowlist)
+            };
+            if token_permitted && project_permitted {
+                match source.token().await {
+                    Ok(token) => Some((token, project_id.clone())),
+                    Err(error) => {
+                        tracing::warn!(
+                            plugin = %self.plugin_name,
+                            tool = %self.tool_def.name,
+                            error = %error,
+                            "failed to prepare cached Vertex token; plugin fallback remains available"
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         // Inject extra environment variables (e.g. provider base URLs, API keys)
         for (key, val) in &self.extra_env {
+            if key == "VERTEX_SA_JSON" && prepared_vertex_token.is_some() {
+                continue;
+            }
             let permitted = if strict_env_gate {
                 should_forward_env_name_strict(key, &env_allowlist)
             } else {
@@ -2685,6 +2754,11 @@ impl Tool for PluginTool {
                 "skipping non-allowlisted environment variable for plugin tool"
                 );
             }
+        }
+
+        if let Some((token, project_id)) = prepared_vertex_token {
+            cmd.env("VERTEX_ACCESS_TOKEN", token);
+            cmd.env("GOOGLE_CLOUD_PROJECT", project_id);
         }
 
         if let Some(sink) = ctx
@@ -2728,6 +2802,24 @@ impl Tool for PluginTool {
             }
             cmd.current_dir(dir);
             cmd.env("OCTOS_WORK_DIR", dir);
+        }
+
+        // A plugin's output CWD is commonly `<session workspace>/skill-output`,
+        // while file_each skill actions materialize their inputs under
+        // `<session workspace>/uploads`. Keep those two roots explicit: a
+        // plugin must not have to infer the session root from its output CWD,
+        // and it must never treat a caller-supplied path as that root.
+        if self
+            .tool_def
+            .env
+            .iter()
+            .any(|name| name == "OCTOS_SESSION_WORKSPACE")
+        {
+            if let Some(session_workspace) = self.workspace_root_for_host_injection(
+                ctx.as_ref().and_then(|ctx| ctx.session_scope.as_deref()),
+            ) {
+                cmd.env("OCTOS_SESSION_WORKSPACE", session_workspace);
+            }
         }
 
         // Codex round-3 BLOCKER fix (PR #1186 review): when

--- a/crates/octos-agent/src/plugins/tool_tests.rs
+++ b/crates/octos-agent/src/plugins/tool_tests.rs
@@ -2291,6 +2291,68 @@ async fn strict_env_allowlist_drops_non_listed_extra_env() {
     );
 }
 
+struct FixedVertexTokenSource;
+
+#[async_trait]
+impl octos_llm::vertex_auth::TokenSource for FixedVertexTokenSource {
+    async fn token(&self) -> eyre::Result<String> {
+        Ok("cached-host-token".to_string())
+    }
+}
+
+/// A plugin receives the host-minted short-lived token only after explicitly
+/// declaring it in the manifest allowlist. This keeps the long-lived service
+/// account compatible while avoiding one OAuth exchange per plugin process.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(unix)]
+async fn vertex_access_token_is_injected_from_host_cache_when_allowlisted() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let script_path = dir.path().join("script.sh");
+    write_test_script(
+        &script_path,
+        "#!/bin/sh\nread INPUT || true\nTOKEN=${VERTEX_ACCESS_TOKEN:-missing}\nPROJECT=${GOOGLE_CLOUD_PROJECT:-missing}\nSA=${VERTEX_SA_JSON:-missing}\necho '{\"output\":\"token='\"$TOKEN\"';project='\"$PROJECT\"';sa='\"$SA\"'\",\"success\":true}'\n",
+    );
+
+    let mut def = make_tool_def("vertex_tool", "prints the short-lived token");
+    def.env.push("VERTEX_ACCESS_TOKEN".into());
+    def.env.push("GOOGLE_CLOUD_PROJECT".into());
+    def.env.push("VERTEX_SA_JSON".into());
+    let tool = PluginTool::new("p".into(), def, script_path)
+        .with_extra_env(vec![(
+            "VERTEX_SA_JSON".into(),
+            "long-lived-service-account".into(),
+        )])
+        .with_vertex_token_source(Arc::new(FixedVertexTokenSource), "test-project".into())
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
+
+    let result = tool.execute(&json!({})).await.expect("should succeed");
+    assert!(result.success);
+    assert_eq!(
+        result.output,
+        "token=cached-host-token;project=test-project;sa=missing"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(unix)]
+async fn vertex_access_token_is_not_injected_without_manifest_permission() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let script_path = dir.path().join("script.sh");
+    write_test_script(
+        &script_path,
+        "#!/bin/sh\nread INPUT || true\nVALUE=${VERTEX_ACCESS_TOKEN:-missing}\necho '{\"output\":\"'\"$VALUE\"'\",\"success\":true}'\n",
+    );
+
+    let def = make_tool_def("vertex_tool", "prints the short-lived token");
+    let tool = PluginTool::new("p".into(), def, script_path)
+        .with_vertex_token_source(Arc::new(FixedVertexTokenSource), "test-project".into())
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
+
+    let result = tool.execute(&json!({})).await.expect("should succeed");
+    assert!(result.success);
+    assert_eq!(result.output, "missing");
+}
+
 /// When the manifest declares an empty `env` list, legacy semantics
 /// apply: non-secret extra_env entries pass through unfiltered. This
 /// pins the no-regression contract: skills that don't declare `env`
@@ -3082,6 +3144,78 @@ async fn plugin_uses_scope_workspace_when_present() {
         actual, expected,
         "plugin CWD must equal scope.workspace() when self.work_dir is None"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(unix)]
+async fn plugin_exposes_session_workspace_separately_from_skill_output_cwd() {
+    let data = tempfile::tempdir().expect("data dir");
+    let scope = multi_tenant_scope_at(data.path(), "dspfac", "web-session-workspace", vec![]);
+    let session_workspace = scope.workspace().to_path_buf();
+    let skill_output = session_workspace.join("skill-output");
+    std::fs::create_dir_all(&skill_output).expect("skill output dir");
+
+    let bin_dir = tempfile::tempdir().expect("bin dir");
+    let script_path = bin_dir.path().join("script.sh");
+    write_test_script(
+        &script_path,
+        "#!/bin/sh\nprintf '{\"output\":\"%s|%s\",\"success\":true}' \"$OCTOS_WORK_DIR\" \"$OCTOS_SESSION_WORKSPACE\"\n",
+    );
+
+    let mut def = make_tool_def("workspace_env", "echo workspace env");
+    def.env.push("OCTOS_SESSION_WORKSPACE".into());
+    let tool = PluginTool::new("plug".into(), def, script_path)
+        .with_work_dir(skill_output.clone())
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
+
+    let ctx = ctx_with_scope(scope);
+    let result = crate::tools::TOOL_CTX
+        .scope(ctx, tool.execute(&json!({})))
+        .await
+        .expect("execute should succeed");
+
+    assert!(result.success, "workspace environment probe should succeed");
+    let (actual_work_dir, actual_session_workspace) = result
+        .output
+        .trim()
+        .split_once('|')
+        .expect("plugin should echo both workspace paths");
+    assert_eq!(
+        std::fs::canonicalize(actual_work_dir).expect("work dir should resolve"),
+        std::fs::canonicalize(skill_output).expect("skill output should resolve"),
+    );
+    assert_eq!(
+        std::fs::canonicalize(actual_session_workspace).expect("session workspace should resolve"),
+        std::fs::canonicalize(session_workspace).expect("workspace should resolve"),
+        "plugins must be able to read workspace-relative action inputs without treating skill-output as the workspace root",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(unix)]
+async fn plugin_does_not_receive_session_workspace_without_manifest_permission() {
+    let data = tempfile::tempdir().expect("data dir");
+    let scope = multi_tenant_scope_at(data.path(), "dspfac", "web-session-workspace", vec![]);
+    let skill_output = scope.workspace().join("skill-output");
+    std::fs::create_dir_all(&skill_output).expect("skill output dir");
+
+    let bin_dir = tempfile::tempdir().expect("bin dir");
+    let script_path = bin_dir.path().join("script.sh");
+    write_test_script(
+        &script_path,
+        "#!/bin/sh\nprintf '{\"output\":\"%s\",\"success\":true}' \"${OCTOS_SESSION_WORKSPACE:-missing}\"\n",
+    );
+
+    let def = make_tool_def("workspace_env", "echo workspace env");
+    let tool = PluginTool::new("plug".into(), def, script_path)
+        .with_work_dir(skill_output)
+        .with_timeout(TEST_PLUGIN_TIMEOUT);
+    let result = crate::tools::TOOL_CTX
+        .scope(ctx_with_scope(scope), tool.execute(&json!({})))
+        .await
+        .expect("execute should succeed");
+
+    assert_eq!(result.output.trim(), "missing");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## What changed

- Multiple tools from the same learning-coach plugin now share a short-lived Vertex token cache instead of performing a new OAuth token exchange for every tool call.
- A host-provided token is exposed only to tools whose manifest explicitly allows `VERTEX_ACCESS_TOKEN`; the existing service-account fallback remains available when host token acquisition fails.
- The session workspace and skill output directory are now passed separately so selection assistance can read persisted ink images.
- `OCTOS_SESSION_WORKSPACE` is also manifest-gated, preventing plugins that did not request it from reading the session path.

## Validation

- `cargo test -p octos-agent --lib session_workspace_ -- --nocapture`
- `cargo test -p octos-agent --lib vertex_access_token_ -- --nocapture`
- `cargo check -p octos-agent`
- `cargo clippy -p octos-agent --lib -- -D warnings`
- `cargo fmt --all -- --check`

The full `cargo test -p octos-agent --lib` run reported 2,591 passed, 3 ignored, and 2 failed. Both failures are in pre-existing SSRF/DNS tests because the current test environment resolves nonexistent domains to private IP addresses. This PR does not modify those files, and all tests related to this change pass.
