### PR TITLE
chore(release): v2.0.3-rc.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4531,7 +4531,7 @@ dependencies = [
 
 [[package]]
 name = "octos-agent"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "async-trait",
  "base64",
@@ -4592,7 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "octos-bus"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "aes",
  "async-imap",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "octos-cli"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "agent-client-protocol",
  "argon2",
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "octos-core"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "chrono",
  "eyre",
@@ -4731,7 +4731,7 @@ dependencies = [
 
 [[package]]
 name = "octos-diagnostics"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4743,14 +4743,14 @@ dependencies = [
 
 [[package]]
 name = "octos-dora-mcp"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "octos-agent",
 ]
 
 [[package]]
 name = "octos-embed-llama"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "octos-ffi"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "libc",
  "octos-agent",
@@ -4780,7 +4780,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "eyre",
  "octos-core",
@@ -4796,7 +4796,7 @@ dependencies = [
 
 [[package]]
 name = "octos-fleet-worker"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "async-trait",
  "eyre",
@@ -4813,7 +4813,7 @@ dependencies = [
 
 [[package]]
 name = "octos-llm"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "async-trait",
  "base64",
@@ -4837,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "octos-memory"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "bincode",
  "chrono",
@@ -4857,7 +4857,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pipeline"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "octos-plugin"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "eyre",
  "metrics",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "octos-pyo3"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "octos-ffi",
  "pyo3",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "octos-server"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "async-trait",
  "axum",
@@ -4955,7 +4955,7 @@ dependencies = [
 
 [[package]]
 name = "octos-services"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "chrono",
  "dirs",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "octos-store"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "base64",
  "chrono",
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "octos-swarm"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "octos-uniffi"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "octos-ffi",
  "uniffi",
@@ -5024,7 +5024,7 @@ dependencies = [
 
 [[package]]
 name = "octos-wasm"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
@@ -5040,7 +5040,7 @@ dependencies = [
 
 [[package]]
 name = "octos-workflows"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "chrono",
  "eyre",
@@ -8475,7 +8475,7 @@ dependencies = [
 
 [[package]]
 name = "wechat-bridge"
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 dependencies = [
  "clap",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.3-rc.8"
+version = "2.0.3-rc.9"
 edition = "2024"
 rust-version = "1.85.0"
 authors = ["octos team"]

--- a/crates/octos-bus/src/bus.rs
+++ b/crates/octos-bus/src/bus.rs
@@ -28,8 +28,8 @@ impl AgentHandle {
     pub async fn send_outbound(
         &self,
         msg: OutboundMessage,
-    ) -> Result<(), mpsc::error::SendError<OutboundMessage>> {
-        self.out_tx.send(msg).await
+    ) -> Result<(), Box<mpsc::error::SendError<OutboundMessage>>> {
+        self.out_tx.send(msg).await.map_err(Box::new)
     }
 
     /// Clone the outbound sender for use by tools (e.g. MessageTool).
@@ -124,6 +124,19 @@ mod tests {
             .unwrap();
         let msg = publisher.recv_outbound().await.unwrap();
         assert_eq!(msg.content, "response");
+    }
+
+    #[tokio::test]
+    async fn failed_outbound_send_preserves_the_unsent_message() {
+        let (agent, publisher) = create_bus();
+        drop(publisher);
+
+        let error = agent
+            .send_outbound(make_outbound("not-delivered"))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.0.content, "not-delivered");
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -1446,6 +1446,10 @@ pub async fn session_workspace_contract(
     Json(statuses).into_response()
 }
 
+// The error is a ready-to-return axum response. Keeping it inline avoids an
+// allocation on every rejected file request and matches the profile resolvers
+// below, whose handlers also return the response directly.
+#[allow(clippy::result_large_err)]
 async fn resolve_file_access_data_dir(
     state: &AppState,
     headers: &HeaderMap,
@@ -2360,6 +2364,10 @@ pub(crate) fn decide_resolved_profile_id(
     }
 }
 
+// The error is a fully-built axum response which callers return directly.
+// Boxing would add allocation and dereference churn without reducing retained
+// response state; use the same targeted exception as the by-id resolver below.
+#[allow(clippy::result_large_err)]
 async fn resolve_profile_data_dir(
     state: &AppState,
     headers: &HeaderMap,

--- a/crates/octos-cli/src/api/ui_protocol_transport.rs
+++ b/crates/octos-cli/src/api/ui_protocol_transport.rs
@@ -11834,8 +11834,7 @@ fn raw_profile_llm_delete(
         ));
     };
 
-    let applied: bool;
-    if llm
+    let applied = if llm
         .primary
         .as_ref()
         .is_some_and(|primary| same_llm_selection_address(primary, &target))
@@ -11847,13 +11846,13 @@ fn raw_profile_llm_delete(
         if !llm.fallbacks.is_empty() {
             llm.primary = Some(llm.fallbacks.remove(0));
         }
-        applied = true;
+        true
     } else {
         let before = llm.fallbacks.len();
         llm.fallbacks
             .retain(|fallback| !same_llm_selection_address(fallback, &target));
-        applied = llm.fallbacks.len() != before;
-    }
+        llm.fallbacks.len() != before
+    };
     profile.config.llm = Some(llm);
 
     if !applied {

--- a/crates/octos-cli/src/autonomy/master_continuation_scheduler.rs
+++ b/crates/octos-cli/src/autonomy/master_continuation_scheduler.rs
@@ -883,11 +883,7 @@ fn within_recent_claim_window(claimed_at: SystemTime, candidate: SystemTime) -> 
     within_claim_window(claimed_at, candidate, RECENT_CLAIM_GUARD_WINDOW)
 }
 
-fn within_claim_window(
-    claimed_at: SystemTime,
-    candidate: SystemTime,
-    window: Duration,
-) -> bool {
+fn within_claim_window(claimed_at: SystemTime, candidate: SystemTime, window: Duration) -> bool {
     match candidate.duration_since(claimed_at) {
         Ok(elapsed) => elapsed <= window,
         // `candidate` is at or before `claimed_at`: same instant or reordered
@@ -999,25 +995,30 @@ mod tests {
         ));
     }
 
-
     #[test]
     fn child_reclaim_window_collapses_same_transition_refire() {
         // Refs #2102 (Gap 2): a ChildCompleted drained between the legacy and
         // unified terminal enqueues of ONE transition must not re-enqueue
         // within the short reclaim window.
         let mut scheduler = MasterContinuationScheduler::new();
-        let req = request(MasterContinuationReason::ChildCompleted, "c")
-            .with_child_agent_id("child-9");
+        let req =
+            request(MasterContinuationReason::ChildCompleted, "c").with_child_agent_id("child-9");
         let item = queued(scheduler.enqueue_at(req.clone(), ts(20)));
         // simulate a claim: record + remove from pending
-        scheduler.recently_claimed_external.insert(item.dedupe_key.clone(), ts(20));
+        scheduler
+            .recently_claimed_external
+            .insert(item.dedupe_key.clone(), ts(20));
         scheduler.pending_by_key.remove(&item.dedupe_key);
         let dup = scheduler.enqueue_at(req, ts(21)); // 1s later < 2s window
         assert!(dup.is_duplicate(), "same-transition refire must collapse");
         // after the window expires the key is reusable
-        scheduler.recently_claimed_external.insert(item.dedupe_key.clone(), ts(20));
-        let later = scheduler
-            .enqueue_at(request(MasterContinuationReason::ChildCompleted, "c2").with_child_agent_id("child-9"), ts(60));
+        scheduler
+            .recently_claimed_external
+            .insert(item.dedupe_key.clone(), ts(20));
+        let later = scheduler.enqueue_at(
+            request(MasterContinuationReason::ChildCompleted, "c2").with_child_agent_id("child-9"),
+            ts(60),
+        );
         assert!(!later.is_duplicate(), "post-window enqueue must pass");
     }
 
@@ -1028,7 +1029,9 @@ mod tests {
         let mut scheduler = MasterContinuationScheduler::new();
         let req = request(MasterContinuationReason::LoopFire, "lp");
         let item = queued(scheduler.enqueue_at(req.clone(), ts(20)));
-        scheduler.recently_claimed_external.insert(item.dedupe_key.clone(), ts(20));
+        scheduler
+            .recently_claimed_external
+            .insert(item.dedupe_key.clone(), ts(20));
         scheduler.pending_by_key.remove(&item.dedupe_key);
         let again = scheduler.enqueue_at(req, ts(21));
         assert!(!again.is_duplicate(), "loop refire must not be suppressed");

--- a/crates/octos-swarm/src/dispatcher.rs
+++ b/crates/octos-swarm/src/dispatcher.rs
@@ -977,7 +977,7 @@ async fn dispatch_with_budget(
 ) -> SubtaskOutcome {
     if let Err(outcome) = enforce_or_outcome(policy, backend, contract, prior_attempts).await {
         record_dispatch_gate_metric(backend.backend_label(), &outcome.last_dispatch_outcome);
-        return outcome;
+        return *outcome;
     }
 
     let Some(budget) = budget else {

--- a/crates/octos-swarm/src/gate.rs
+++ b/crates/octos-swarm/src/gate.rs
@@ -27,7 +27,7 @@ pub(crate) async fn enforce_or_outcome(
     backend: &dyn McpAgentBackend,
     contract: &ContractSpec,
     prior_attempts: u32,
-) -> std::result::Result<(), SubtaskOutcome> {
+) -> std::result::Result<(), Box<SubtaskOutcome>> {
     let target = DispatchTarget {
         dispatch_id: &contract.contract_id,
         tool_name: &contract.tool_name,
@@ -35,7 +35,7 @@ pub(crate) async fn enforce_or_outcome(
     };
     match enforce_dispatch_gates(policy, backend, target).await {
         Ok(()) => Ok(()),
-        Err(denial) => Err(SubtaskOutcome {
+        Err(denial) => Err(Box::new(SubtaskOutcome {
             contract_id: contract.contract_id.clone(),
             label: contract.label.clone(),
             status: SubtaskStatus::TerminalFailed,
@@ -44,7 +44,7 @@ pub(crate) async fn enforce_or_outcome(
             output: denial.reason.clone(),
             files_to_send: Vec::new(),
             error: Some(denial.reason),
-        }),
+        })),
     }
 }
 

--- a/dashboard/src/providers.json
+++ b/dashboard/src/providers.json
@@ -260,5 +260,11 @@
       { "id": "deepseek-ai/deepseek-v4-flash", "input": 0, "output": 0, "max_output": 384000 },
       { "id": "mistralai/Mistral-Small-24B-Instruct-2501", "input": 0, "output": 0, "max_output": 8192 }
     ]
+  },
+  "local": {
+    "env": "",
+    "models": [
+      { "id": "local-default", "input": 0, "output": 0, "max_output": 8192 }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- bump the workspace from `2.0.3-rc.8` to `2.0.3-rc.9` and refresh workspace versions in `Cargo.lock` without dependency churn
- cut an RC containing the post-rc.8 goal, provider, protocol inventory, prompt-cache, terminal-tool, and Gemini fixes
- repair the pre-existing main blockers exposed by the release gate: rustfmt drift, the missing keyless `local` dashboard family, and Rust 1.98 default/matrix lint failures
- box outbound bus send failures and swarm gate denials while preserving their complete error payloads; retain direct Axum responses with documented targeted lint exceptions

## Release slice

- Issue served: main has accumulated release-ready fixes since `v2.0.3-rc.8` but could not produce a green RC because its fmt/dashboard/clippy gates had drifted.
- User-visible behavior: users can install one RC containing those merged fixes; the dashboard offers the unified local provider; octoscode can pin its server/protocol bundle to this exact release.
- Proof: locked metadata/core check, scheduler/bus/swarm tests, Rust 1.98 full and matrix clippy, catalog projection, formatting, and repository CI.

## Verification

- `cargo metadata --locked --offline --format-version 1 --no-deps`
- `cargo check --locked -p octos-core`
- `cargo test --locked -p octos-cli master_continuation_scheduler` — 14 passed
- `cargo test --locked -p octos-bus bus::tests` — 8 passed
- `cargo test --locked -p octos-swarm gate::tests` — 2 passed
- Rust 1.98: `cargo clippy --workspace --all-targets -- -D warnings`
- Rust 1.98 matrix: `cargo clippy -p octos-cli --all-targets --no-default-features --features api,telegram,discord,dingtalk,slack,whatsapp,feishu,email,matrix,audio_mp3 -- -D warnings`
- `python3 scripts/sync-dashboard-providers.py` — zero warnings, zero generated drift
- `cargo fmt --all -- --check`
- `git diff --check`
- repository CI is the final release gate.