### PR TITLE
fix(ci): unbreak main — rustfmt, the 1.98 result_large_err lint, and the keyless `local` family

### DIFF
--- a/crates/octos-bus/src/bus.rs
+++ b/crates/octos-bus/src/bus.rs
@@ -25,6 +25,16 @@ impl AgentHandle {
         msgs
     }
 
+    /// `clippy::result_large_err` fires here on Rust 1.98+: tokio's
+    /// `SendError<T>` is `T`-sized, and `OutboundMessage` is ~192 bytes.
+    ///
+    /// Allowed rather than boxed, because the size IS the contract. `SendError`
+    /// hands the un-sent message back so a caller can recover or requeue it;
+    /// boxing would force every caller to unbox to reach it, and would change a
+    /// public signature to satisfy a lint about a type this crate does not own.
+    /// The error path is also the rare one — a closed outbound channel — so the
+    /// stack cost it warns about is not paid on the hot path.
+    #[allow(clippy::result_large_err)]
     pub async fn send_outbound(
         &self,
         msg: OutboundMessage,

--- a/crates/octos-cli/src/autonomy/master_continuation_scheduler.rs
+++ b/crates/octos-cli/src/autonomy/master_continuation_scheduler.rs
@@ -883,11 +883,7 @@ fn within_recent_claim_window(claimed_at: SystemTime, candidate: SystemTime) -> 
     within_claim_window(claimed_at, candidate, RECENT_CLAIM_GUARD_WINDOW)
 }
 
-fn within_claim_window(
-    claimed_at: SystemTime,
-    candidate: SystemTime,
-    window: Duration,
-) -> bool {
+fn within_claim_window(claimed_at: SystemTime, candidate: SystemTime, window: Duration) -> bool {
     match candidate.duration_since(claimed_at) {
         Ok(elapsed) => elapsed <= window,
         // `candidate` is at or before `claimed_at`: same instant or reordered
@@ -999,25 +995,30 @@ mod tests {
         ));
     }
 
-
     #[test]
     fn child_reclaim_window_collapses_same_transition_refire() {
         // Refs #2102 (Gap 2): a ChildCompleted drained between the legacy and
         // unified terminal enqueues of ONE transition must not re-enqueue
         // within the short reclaim window.
         let mut scheduler = MasterContinuationScheduler::new();
-        let req = request(MasterContinuationReason::ChildCompleted, "c")
-            .with_child_agent_id("child-9");
+        let req =
+            request(MasterContinuationReason::ChildCompleted, "c").with_child_agent_id("child-9");
         let item = queued(scheduler.enqueue_at(req.clone(), ts(20)));
         // simulate a claim: record + remove from pending
-        scheduler.recently_claimed_external.insert(item.dedupe_key.clone(), ts(20));
+        scheduler
+            .recently_claimed_external
+            .insert(item.dedupe_key.clone(), ts(20));
         scheduler.pending_by_key.remove(&item.dedupe_key);
         let dup = scheduler.enqueue_at(req, ts(21)); // 1s later < 2s window
         assert!(dup.is_duplicate(), "same-transition refire must collapse");
         // after the window expires the key is reusable
-        scheduler.recently_claimed_external.insert(item.dedupe_key.clone(), ts(20));
-        let later = scheduler
-            .enqueue_at(request(MasterContinuationReason::ChildCompleted, "c2").with_child_agent_id("child-9"), ts(60));
+        scheduler
+            .recently_claimed_external
+            .insert(item.dedupe_key.clone(), ts(20));
+        let later = scheduler.enqueue_at(
+            request(MasterContinuationReason::ChildCompleted, "c2").with_child_agent_id("child-9"),
+            ts(60),
+        );
         assert!(!later.is_duplicate(), "post-window enqueue must pass");
     }
 
@@ -1028,7 +1029,9 @@ mod tests {
         let mut scheduler = MasterContinuationScheduler::new();
         let req = request(MasterContinuationReason::LoopFire, "lp");
         let item = queued(scheduler.enqueue_at(req.clone(), ts(20)));
-        scheduler.recently_claimed_external.insert(item.dedupe_key.clone(), ts(20));
+        scheduler
+            .recently_claimed_external
+            .insert(item.dedupe_key.clone(), ts(20));
         scheduler.pending_by_key.remove(&item.dedupe_key);
         let again = scheduler.enqueue_at(req, ts(21));
         assert!(!again.is_duplicate(), "loop refire must not be suppressed");

--- a/dashboard/src/providers.json
+++ b/dashboard/src/providers.json
@@ -260,5 +260,11 @@
       { "id": "deepseek-ai/deepseek-v4-flash", "input": 0, "output": 0, "max_output": 384000 },
       { "id": "mistralai/Mistral-Small-24B-Instruct-2501", "input": 0, "output": 0, "max_output": 8192 }
     ]
+  },
+  "local": {
+    "env": "",
+    "models": [
+      { "id": "local-default", "input": 0, "output": 0, "max_output": 8192 }
+    ]
   }
 }


### PR DESCRIPTION
**`main` has been red since 2026-08-21** — five failing jobs, three of them independent real causes.

```
failure  check          <- cargo fmt --check
failure  check-matrix   <- clippy result_large_err
failure  dashboard      <- providers.json parity
failure  check-arm      <- known ARM runner infra
failure  e2e-live-nightly <- known, non-blocking (#2073)
```

## 1. `check` — genuinely unformatted code, not a toolchain artifact

`cargo fmt --check` fails on `autonomy/master_continuation_scheduler.rs`. I checked whether this was a rustfmt version difference: **local rustfmt 1.9.0 (Rust 1.95) produces the identical diff**, so the code merged unformatted in `2a381331e`. Fixed by running `cargo fmt --all`.

## 2. `check-matrix` — this one IS a toolchain difference

clippy `result_large_err` on `octos-bus/src/bus.rs:31`, where tokio's `SendError<OutboundMessage>` is ~192 bytes. **Local clippy 0.1.95 passes the same crate clean**; CI's 1.98 rejects it.

Allowed rather than boxed, because **the size is the contract**: `SendError` hands the un-sent message back so a caller can recover or requeue it, and boxing would force every caller to unbox to reach it — changing a public signature to satisfy a lint about a type this crate does not own. The error path is the rare one (a closed outbound channel), so the stack cost the lint warns about is not paid on the hot path.

This also matches existing convention rather than inventing one: `api/handlers.rs` already carries four `#[allow(clippy::result_large_err)]`.

## 3. `dashboard` — the script's wording is what misleads

```
WARNING: family 'local' is in the catalog but NOT in providers.json (needs an env var)
```

It does **not** need an env var. `local` is keyless **by design** — `octos_llm::registry::is_keyless` returns true for it alongside `ollama` and `vllm` (`registry/mod.rs:221`), with a test asserting exactly that. What it needs is the representation `ollama` already uses: an empty `env`.

Added the family with `"env": ""` and let `sync-dashboard-providers.py` append `local-default` from the catalog — keeping the human decision (keyless) separate from the mechanical part (models). The script now exits 0.

## Verification

```
cargo fmt --all -- --check                  => clean
cargo clippy -p octos-bus --all-targets     => no warnings; the new #[allow]
                                               does not trip unknown_lints on 1.95
python3 scripts/sync-dashboard-providers.py => exit 0, appended 1 model
```

**Stated plainly:** I cannot verify locally that (2) satisfies CI's clippy, because the lint does not fire on 1.95 at all. CI is the check for that one. If `check-matrix` surfaces further `result_large_err` sites behind this one (it aborts at the first crate — "build failed, waiting for other jobs to finish"), they'll need the same treatment.